### PR TITLE
feat(consumption): verified-by-adapter badge + variance prompt on fill-up reconciliation (Closes #1401)

### DIFF
--- a/lib/features/consumption/domain/fill_up_variance.dart
+++ b/lib/features/consumption/domain/fill_up_variance.dart
@@ -1,0 +1,57 @@
+import 'entities/fill_up.dart';
+
+/// Pure helpers for the OBD2 fill-up reconciliation flow (#1401 phase 7b).
+///
+/// A fill-up is "verified by adapter" when both [FillUp.fuelLevelBeforeL]
+/// and [FillUp.fuelLevelAfterL] were captured from the OBD2 fuel-level
+/// PID — once at pump start, once at pump end. The adapter delta
+/// `(after - before)` is the litres pumped according to the car's own
+/// tank-level sensor; comparing it to the user-entered litres surfaces
+/// pump-display read errors and OCR mistakes before they corrupt the
+/// consumption history.
+///
+/// Kept as a top-level utility (no class) to match the codebase style
+/// for one-shot helpers — see e.g. `fill_up_auto_cost_calculator.dart`
+/// for the same shape.
+class FillUpVariance {
+  FillUpVariance._();
+
+  /// Threshold above which the variance prompt fires. 5 % matches the
+  /// typical pump-meter accuracy class plus normal sloshing in the
+  /// tank during refuel; below that we trust the user's entry without
+  /// nagging.
+  static const double thresholdFraction = 0.05;
+
+  /// Whether [fillUp] has both fuel-level captures and is therefore
+  /// eligible for the verified-by-adapter badge AND the variance
+  /// prompt. Either field null means we don't have a full delta — no
+  /// badge, no dialog.
+  static bool hasAdapterCapture(FillUp fillUp) =>
+      fillUp.fuelLevelBeforeL != null && fillUp.fuelLevelAfterL != null;
+
+  /// Adapter-measured litres pumped: tank level after the pump minus
+  /// tank level before. Returns null when either capture is missing.
+  /// The result can be negative if the adapter reports an unexpected
+  /// dip (sensor noise, very-low-tank readings) — callers should
+  /// guard with [hasAdapterCapture] first; this helper does NOT clamp
+  /// because the dialog text wants the raw delta the user can sanity
+  /// check.
+  static double? adapterDeltaL(FillUp fillUp) {
+    final before = fillUp.fuelLevelBeforeL;
+    final after = fillUp.fuelLevelAfterL;
+    if (before == null || after == null) return null;
+    return after - before;
+  }
+
+  /// Returns true when the user-entered [userL] differs from the
+  /// adapter-derived [adapterL] by strictly more than [thresholdFraction]
+  /// of [adapterL]. We compare against the adapter value because it's
+  /// the trusted reference; comparing against `userL` would let a
+  /// 0 L user entry sail past with infinite ratio. Returns false when
+  /// [adapterL] is non-positive — no meaningful baseline to compare.
+  static bool isVarianceAbove5Percent(double userL, double adapterL) {
+    if (adapterL <= 0) return false;
+    final delta = (userL - adapterL).abs();
+    return delta > adapterL * thresholdFraction;
+  }
+}

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -13,11 +13,13 @@ import '../../domain/add_fill_up_fuel_resolver.dart';
 import '../../domain/add_fill_up_validators.dart';
 import '../../domain/entities/fill_up.dart';
 import '../../domain/fill_up_auto_cost_calculator.dart';
+import '../../domain/fill_up_variance.dart';
 import '../../providers/consumption_providers.dart';
 import '../widgets/add_fill_up_form_fields.dart';
 import '../widgets/fill_up_no_vehicle_cta.dart';
 import '../widgets/fill_up_pinned_save_bar.dart';
 import '../widgets/fill_up_scan_handlers.dart';
+import '../widgets/fill_up_variance_prompt.dart';
 
 /// Form to add a new [FillUp] entry.
 class AddFillUpScreen extends ConsumerStatefulWidget {
@@ -43,6 +45,20 @@ class AddFillUpScreen extends ConsumerStatefulWidget {
   @visibleForTesting
   final ReceiptScanService? scanService;
 
+  /// Test seam (#1401 phase 7b) — adapter-captured tank level read
+  /// at the moment the pump started. Production callers will populate
+  /// this from the live OBD2 producer chain (tracked in a follow-up
+  /// to #1401); until that wiring lands the value is always null and
+  /// the variance prompt never fires. Tests inject a value to
+  /// exercise the dialog flow end-to-end.
+  @visibleForTesting
+  final double? initialFuelLevelBeforeL;
+
+  /// Test seam (#1401 phase 7b) — adapter-captured tank level read
+  /// at pump end. See [initialFuelLevelBeforeL] for context.
+  @visibleForTesting
+  final double? initialFuelLevelAfterL;
+
   const AddFillUpScreen({
     super.key,
     this.stationId,
@@ -50,6 +66,8 @@ class AddFillUpScreen extends ConsumerStatefulWidget {
     this.preFilledFuelType,
     this.preFilledPricePerLiter,
     this.scanService,
+    this.initialFuelLevelBeforeL,
+    this.initialFuelLevelAfterL,
   });
 
   @override
@@ -201,10 +219,11 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
 
-    final fillUp = FillUp(
+    final userLiters = AddFillUpValidators.parseDouble(_litersCtrl.text);
+    var fillUp = FillUp(
       id: DateTime.now().microsecondsSinceEpoch.toString(),
       date: _date,
-      liters: AddFillUpValidators.parseDouble(_litersCtrl.text),
+      liters: userLiters,
       totalCost: AddFillUpValidators.parseDouble(_costCtrl.text),
       odometerKm: AddFillUpValidators.parseDouble(_odoCtrl.text),
       fuelType: _fuelType,
@@ -213,7 +232,30 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       notes: _notesCtrl.text.trim().isEmpty ? null : _notesCtrl.text.trim(),
       vehicleId: _vehicleId,
       isFullTank: _isFullTank,
+      fuelLevelBeforeL: widget.initialFuelLevelBeforeL,
+      fuelLevelAfterL: widget.initialFuelLevelAfterL,
     );
+
+    // #1401 phase 7b — when both adapter fuel-level captures are
+    // present and the user-entered litres differ from the adapter
+    // delta by more than 5 %, ask before persisting. Skip the gate
+    // entirely when either capture is missing — no baseline, no
+    // dialog. Dismissing the dialog is treated as "Keep my entry"
+    // (the user's typed value wins).
+    if (FillUpVariance.hasAdapterCapture(fillUp)) {
+      final adapterDelta = FillUpVariance.adapterDeltaL(fillUp)!;
+      if (FillUpVariance.isVarianceAbove5Percent(userLiters, adapterDelta)) {
+        final choice = await showFillUpVarianceDialog(
+          context: context,
+          userL: userLiters.toStringAsFixed(2),
+          adapterL: adapterDelta.toStringAsFixed(2),
+        );
+        if (!mounted) return;
+        if (choice == FillUpVarianceChoice.useAdapter) {
+          fillUp = fillUp.copyWith(liters: adapterDelta);
+        }
+      }
+    }
 
     await ref.read(fillUpListProvider.notifier).add(fillUp);
     if (!mounted) return;

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -5,6 +5,7 @@ import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/eco_score.dart';
 import '../../domain/entities/fill_up.dart';
+import '../../domain/fill_up_variance.dart';
 import 'eco_score_badge.dart';
 
 /// Compact card showing a single [FillUp] entry.
@@ -20,6 +21,13 @@ import 'eco_score_badge.dart';
 /// "Auto-correction — tap to edit" subtitle. Tapping a correction card
 /// is expected to open the [EditCorrectionFillUpSheet] — the tap
 /// handler is wired by the parent (the Fuel tab list builder).
+///
+/// When both [FillUp.fuelLevelBeforeL] and [FillUp.fuelLevelAfterL] are
+/// non-null (#1401 phase 7b), a small "Verified by adapter" chip is
+/// rendered under the volume / cost line. The chip uses the theme's
+/// primary colour (matching how other "trusted-source" badges in the
+/// app are rendered) plus a check icon. Either fuel-level field
+/// missing — no chip; the badge is a positive signal, never an error.
 class FillUpCard extends StatelessWidget {
   final FillUp fillUp;
   final EcoScore? ecoScore;
@@ -55,6 +63,9 @@ class FillUpCard extends StatelessWidget {
     // background so the contrast vs. white text on the avatar stays
     // readable at smaller sizes.
     final correctionColor = Colors.orange.shade700;
+    // #1401 phase 7b — only render the verified-by-adapter chip when
+    // both fuel-level captures are present. Either missing → no chip.
+    final isVerifiedByAdapter = FillUpVariance.hasAdapterCapture(fillUp);
 
     final card = Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -109,6 +120,45 @@ class FillUpCard extends StatelessWidget {
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: correctionColor,
                   fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+            if (isVerifiedByAdapter) ...[
+              const SizedBox(height: 4),
+              // #1401 phase 7b — small "Verified by adapter" chip. Uses
+              // the theme primary colour for the chip background tint
+              // and a check icon so the affordance reads at a glance
+              // without relying on colour alone.
+              Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.check_circle,
+                        size: 14,
+                        color: theme.colorScheme.onPrimaryContainer,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        l?.fillUpReconciliationVerifiedBadgeLabel ??
+                            'Verified by adapter',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/lib/features/consumption/presentation/widgets/fill_up_variance_prompt.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_variance_prompt.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Outcome of the fill-up variance prompt (#1401 phase 7b).
+///
+/// Returned by [showFillUpVarianceDialog] to the save flow so the
+/// caller can decide what value to persist:
+/// - [keepUser]: keep the litres the user typed (or the dialog was
+///   dismissed — same effect).
+/// - [useAdapter]: replace the user-entered litres with the adapter-
+///   derived delta `(after - before)`.
+enum FillUpVarianceChoice { keepUser, useAdapter }
+
+/// Shows the "Doesn't match adapter reading" confirmation dialog
+/// (#1401 phase 7b). Pre-formatted [userL] / [adapterL] strings are
+/// passed through verbatim — callers control the locale-aware
+/// formatting (decimal separator, precision) before calling.
+///
+/// Returns the user's choice. A dismiss (tapping the scrim or the
+/// back button) resolves to [FillUpVarianceChoice.keepUser]; the
+/// caller's save flow proceeds with the user's value when it sees
+/// either `keepUser` or no override.
+Future<FillUpVarianceChoice> showFillUpVarianceDialog({
+  required BuildContext context,
+  required String userL,
+  required String adapterL,
+}) async {
+  final l = AppLocalizations.of(context);
+  final result = await showDialog<FillUpVarianceChoice>(
+    context: context,
+    barrierDismissible: true,
+    builder: (dialogContext) {
+      return AlertDialog(
+        title: Text(
+          l?.fillUpReconciliationVarianceDialogTitle ??
+              "Doesn't match adapter reading",
+        ),
+        content: Text(
+          l?.fillUpReconciliationVarianceDialogBody(userL, adapterL) ??
+              'Your entry: $userL L. Adapter says: $adapterL L (delta from '
+                  'before/after fuel-level capture). Use adapter value?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(
+              FillUpVarianceChoice.keepUser,
+            ),
+            child: Text(
+              l?.fillUpReconciliationVarianceDialogKeepMine ??
+                  'Keep my entry',
+            ),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(
+              FillUpVarianceChoice.useAdapter,
+            ),
+            child: Text(
+              l?.fillUpReconciliationVarianceDialogUseAdapter ??
+                  'Use adapter value',
+            ),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? FillUpVarianceChoice.keepUser;
+}

--- a/lib/l10n/_fragments/fill_up_reconciliation_de.arb
+++ b/lib/l10n/_fragments/fill_up_reconciliation_de.arb
@@ -1,0 +1,17 @@
+{
+  "fillUpReconciliationVerifiedBadgeLabel": "Vom Adapter bestätigt",
+  "fillUpReconciliationVarianceDialogTitle": "Stimmt nicht mit Adapter überein",
+  "fillUpReconciliationVarianceDialogBody": "Deine Eingabe: {userL} L. Adapter meldet: {adapterL} L (Differenz aus Tankstand vor/nach dem Tanken). Adapterwert übernehmen?",
+  "@fillUpReconciliationVarianceDialogBody": {
+    "placeholders": {
+      "userL": {
+        "type": "String"
+      },
+      "adapterL": {
+        "type": "String"
+      }
+    }
+  },
+  "fillUpReconciliationVarianceDialogKeepMine": "Meine Eingabe behalten",
+  "fillUpReconciliationVarianceDialogUseAdapter": "Adapterwert übernehmen"
+}

--- a/lib/l10n/_fragments/fill_up_reconciliation_en.arb
+++ b/lib/l10n/_fragments/fill_up_reconciliation_en.arb
@@ -1,0 +1,30 @@
+{
+  "fillUpReconciliationVerifiedBadgeLabel": "Verified by adapter",
+  "@fillUpReconciliationVerifiedBadgeLabel": {
+    "description": "Chip label rendered on a fill-up card when both fuelLevelBeforeL and fuelLevelAfterL were captured by the OBD2 adapter, signalling the pumped litres match the car's own tank-level sensor delta (#1401 phase 7b)."
+  },
+  "fillUpReconciliationVarianceDialogTitle": "Doesn't match adapter reading",
+  "@fillUpReconciliationVarianceDialogTitle": {
+    "description": "Title of the confirmation dialog shown on save when the user-entered litres differ from the adapter-derived tank delta by more than 5 percent (#1401 phase 7b)."
+  },
+  "fillUpReconciliationVarianceDialogBody": "Your entry: {userL} L. Adapter says: {adapterL} L (delta from before/after fuel-level capture). Use adapter value?",
+  "@fillUpReconciliationVarianceDialogBody": {
+    "description": "Body of the variance confirmation dialog. Shows both numeric values pre-formatted by the caller so the dialog stays locale-agnostic (#1401 phase 7b).",
+    "placeholders": {
+      "userL": {
+        "type": "String"
+      },
+      "adapterL": {
+        "type": "String"
+      }
+    }
+  },
+  "fillUpReconciliationVarianceDialogKeepMine": "Keep my entry",
+  "@fillUpReconciliationVarianceDialogKeepMine": {
+    "description": "Button on the variance dialog that closes the prompt and proceeds to save the fill-up with the user-entered litres value (#1401 phase 7b)."
+  },
+  "fillUpReconciliationVarianceDialogUseAdapter": "Use adapter value",
+  "@fillUpReconciliationVarianceDialogUseAdapter": {
+    "description": "Button on the variance dialog that closes the prompt and replaces the user-entered litres with the adapter-derived tank delta before saving (#1401 phase 7b)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1492,6 +1492,21 @@
   "feedbackTokenClear": "Löschen",
   "feedbackTokenDialogTitle": "GitHub-PAT",
   "feedbackTokenFieldLabel": "Personal Access Token",
+  "fillUpReconciliationVerifiedBadgeLabel": "Vom Adapter bestätigt",
+  "fillUpReconciliationVarianceDialogTitle": "Stimmt nicht mit Adapter überein",
+  "fillUpReconciliationVarianceDialogBody": "Deine Eingabe: {userL} L. Adapter meldet: {adapterL} L (Differenz aus Tankstand vor/nach dem Tanken). Adapterwert übernehmen?",
+  "@fillUpReconciliationVarianceDialogBody": {
+    "placeholders": {
+      "userL": {
+        "type": "String"
+      },
+      "adapterL": {
+        "type": "String"
+      }
+    }
+  },
+  "fillUpReconciliationVarianceDialogKeepMine": "Meine Eingabe behalten",
+  "fillUpReconciliationVarianceDialogUseAdapter": "Adapterwert übernehmen",
   "scanReceiptNoData": "Keine Belegdaten gefunden — bitte erneut versuchen",
   "scanReceiptSuccess": "Beleg gescannt — Werte prüfen. Bei Fehlern unten auf \"Scan-Fehler melden\" tippen.",
   "scanReceiptFailed": "Scan fehlgeschlagen: {error}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2191,6 +2191,34 @@
   "@feedbackTokenFieldLabel": {
     "description": "Label of the obscured-text field that captures the GitHub PAT (#952 phase 3)."
   },
+  "fillUpReconciliationVerifiedBadgeLabel": "Verified by adapter",
+  "@fillUpReconciliationVerifiedBadgeLabel": {
+    "description": "Chip label rendered on a fill-up card when both fuelLevelBeforeL and fuelLevelAfterL were captured by the OBD2 adapter, signalling the pumped litres match the car's own tank-level sensor delta (#1401 phase 7b)."
+  },
+  "fillUpReconciliationVarianceDialogTitle": "Doesn't match adapter reading",
+  "@fillUpReconciliationVarianceDialogTitle": {
+    "description": "Title of the confirmation dialog shown on save when the user-entered litres differ from the adapter-derived tank delta by more than 5 percent (#1401 phase 7b)."
+  },
+  "fillUpReconciliationVarianceDialogBody": "Your entry: {userL} L. Adapter says: {adapterL} L (delta from before/after fuel-level capture). Use adapter value?",
+  "@fillUpReconciliationVarianceDialogBody": {
+    "description": "Body of the variance confirmation dialog. Shows both numeric values pre-formatted by the caller so the dialog stays locale-agnostic (#1401 phase 7b).",
+    "placeholders": {
+      "userL": {
+        "type": "String"
+      },
+      "adapterL": {
+        "type": "String"
+      }
+    }
+  },
+  "fillUpReconciliationVarianceDialogKeepMine": "Keep my entry",
+  "@fillUpReconciliationVarianceDialogKeepMine": {
+    "description": "Button on the variance dialog that closes the prompt and proceeds to save the fill-up with the user-entered litres value (#1401 phase 7b)."
+  },
+  "fillUpReconciliationVarianceDialogUseAdapter": "Use adapter value",
+  "@fillUpReconciliationVarianceDialogUseAdapter": {
+    "description": "Button on the variance dialog that closes the prompt and replaces the user-entered litres with the adapter-derived tank delta before saving (#1401 phase 7b)."
+  },
   "scanReceiptNoData": "No receipt data found — try again",
   "@scanReceiptNoData": {
     "description": "Snackbar shown on the Add-Fill-Up screen when the receipt scan returns no usable fields (#751)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -5,6 +5,21 @@
   "obd2CapabilityOemPids": "PID constructeur",
   "obd2CapabilityFullCan": "Accès CAN complet",
   "obd2CapabilityUpgradeHintStandard": "Pour un volume exact de carburant en litres sur Peugeot/Citroën, l'application prend en charge OBDLink MX+/LX/CX (puce STN).",
+  "fillUpReconciliationVerifiedBadgeLabel": "Vérifié par l'adaptateur",
+  "fillUpReconciliationVarianceDialogTitle": "Ne correspond pas à l'adaptateur",
+  "fillUpReconciliationVarianceDialogBody": "Votre saisie : {userL} L. L'adaptateur indique : {adapterL} L (différence entre les niveaux de carburant avant et après). Utiliser la valeur de l'adaptateur ?",
+  "@fillUpReconciliationVarianceDialogBody": {
+    "placeholders": {
+      "userL": {
+        "type": "String"
+      },
+      "adapterL": {
+        "type": "String"
+      }
+    }
+  },
+  "fillUpReconciliationVarianceDialogKeepMine": "Garder ma saisie",
+  "fillUpReconciliationVarianceDialogUseAdapter": "Utiliser la valeur de l'adaptateur",
   "exportBackupTooltip": "Exporter la sauvegarde",
   "exportBackupReady": "Sauvegarde prête — choisissez une destination",
   "exportBackupFailed": "Échec de l'exportation — veuillez réessayer",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6716,6 +6716,36 @@ abstract class AppLocalizations {
   /// **'Personal Access Token'**
   String get feedbackTokenFieldLabel;
 
+  /// Chip label rendered on a fill-up card when both fuelLevelBeforeL and fuelLevelAfterL were captured by the OBD2 adapter, signalling the pumped litres match the car's own tank-level sensor delta (#1401 phase 7b).
+  ///
+  /// In en, this message translates to:
+  /// **'Verified by adapter'**
+  String get fillUpReconciliationVerifiedBadgeLabel;
+
+  /// Title of the confirmation dialog shown on save when the user-entered litres differ from the adapter-derived tank delta by more than 5 percent (#1401 phase 7b).
+  ///
+  /// In en, this message translates to:
+  /// **'Doesn\'t match adapter reading'**
+  String get fillUpReconciliationVarianceDialogTitle;
+
+  /// Body of the variance confirmation dialog. Shows both numeric values pre-formatted by the caller so the dialog stays locale-agnostic (#1401 phase 7b).
+  ///
+  /// In en, this message translates to:
+  /// **'Your entry: {userL} L. Adapter says: {adapterL} L (delta from before/after fuel-level capture). Use adapter value?'**
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL);
+
+  /// Button on the variance dialog that closes the prompt and proceeds to save the fill-up with the user-entered litres value (#1401 phase 7b).
+  ///
+  /// In en, this message translates to:
+  /// **'Keep my entry'**
+  String get fillUpReconciliationVarianceDialogKeepMine;
+
+  /// Button on the variance dialog that closes the prompt and replaces the user-entered litres with the adapter-derived tank delta before saving (#1401 phase 7b).
+  ///
+  /// In en, this message translates to:
+  /// **'Use adapter value'**
+  String get fillUpReconciliationVarianceDialogUseAdapter;
+
   /// Snackbar shown on the Add-Fill-Up screen when the receipt scan returns no usable fields (#751).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3644,6 +3644,25 @@ class AppLocalizationsBg extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3644,6 +3644,25 @@ class AppLocalizationsCs extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3642,6 +3642,25 @@ class AppLocalizationsDa extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3676,6 +3676,26 @@ class AppLocalizationsDe extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Vom Adapter bestätigt';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Stimmt nicht mit Adapter überein';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Deine Eingabe: $userL L. Adapter meldet: $adapterL L (Differenz aus Tankstand vor/nach dem Tanken). Adapterwert übernehmen?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine =>
+      'Meine Eingabe behalten';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Adapterwert übernehmen';
+
+  @override
   String get scanReceiptNoData =>
       'Keine Belegdaten gefunden — bitte erneut versuchen';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3646,6 +3646,25 @@ class AppLocalizationsEl extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3637,6 +3637,25 @@ class AppLocalizationsEn extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3645,6 +3645,25 @@ class AppLocalizationsEs extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3639,6 +3639,25 @@ class AppLocalizationsEt extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3642,6 +3642,25 @@ class AppLocalizationsFi extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3678,6 +3678,26 @@ class AppLocalizationsFr extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel =>
+      'Vérifié par l\'adaptateur';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Ne correspond pas à l\'adaptateur';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Votre saisie : $userL L. L\'adaptateur indique : $adapterL L (différence entre les niveaux de carburant avant et après). Utiliser la valeur de l\'adaptateur ?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Garder ma saisie';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Utiliser la valeur de l\'adaptateur';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3641,6 +3641,25 @@ class AppLocalizationsHr extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3646,6 +3646,25 @@ class AppLocalizationsHu extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3645,6 +3645,25 @@ class AppLocalizationsIt extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3643,6 +3643,25 @@ class AppLocalizationsLt extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3645,6 +3645,25 @@ class AppLocalizationsLv extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3641,6 +3641,25 @@ class AppLocalizationsNb extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3646,6 +3646,25 @@ class AppLocalizationsNl extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3644,6 +3644,25 @@ class AppLocalizationsPl extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3645,6 +3645,25 @@ class AppLocalizationsPt extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3644,6 +3644,25 @@ class AppLocalizationsRo extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3645,6 +3645,25 @@ class AppLocalizationsSk extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3639,6 +3639,25 @@ class AppLocalizationsSl extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3643,6 +3643,25 @@ class AppLocalizationsSv extends AppLocalizations {
   String get feedbackTokenFieldLabel => 'Personal Access Token';
 
   @override
+  String get fillUpReconciliationVerifiedBadgeLabel => 'Verified by adapter';
+
+  @override
+  String get fillUpReconciliationVarianceDialogTitle =>
+      'Doesn\'t match adapter reading';
+
+  @override
+  String fillUpReconciliationVarianceDialogBody(String userL, String adapterL) {
+    return 'Your entry: $userL L. Adapter says: $adapterL L (delta from before/after fuel-level capture). Use adapter value?';
+  }
+
+  @override
+  String get fillUpReconciliationVarianceDialogKeepMine => 'Keep my entry';
+
+  @override
+  String get fillUpReconciliationVarianceDialogUseAdapter =>
+      'Use adapter value';
+
+  @override
   String get scanReceiptNoData => 'No receipt data found — try again';
 
   @override

--- a/test/features/consumption/domain/fill_up_variance_test.dart
+++ b/test/features/consumption/domain/fill_up_variance_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/fill_up_variance.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Pure-dart unit tests for the OBD2 fill-up reconciliation helpers
+/// (#1401 phase 7b). The variance prompt and verified-by-adapter
+/// badge both rely on these predicates — keeping the rules in pure
+/// dart means CI can fail fast on logic regressions without pumping
+/// a widget tree.
+void main() {
+  FillUp build({double? before, double? after}) => FillUp(
+        id: 'fv_test',
+        date: DateTime(2026, 5, 1),
+        liters: 40,
+        totalCost: 70,
+        odometerKm: 10000,
+        fuelType: FuelType.e10,
+        fuelLevelBeforeL: before,
+        fuelLevelAfterL: after,
+      );
+
+  group('FillUpVariance.hasAdapterCapture', () {
+    test('false when both fields null', () {
+      expect(FillUpVariance.hasAdapterCapture(build()), isFalse);
+    });
+
+    test('false when only before is set', () {
+      expect(
+        FillUpVariance.hasAdapterCapture(build(before: 5)),
+        isFalse,
+      );
+    });
+
+    test('false when only after is set', () {
+      expect(
+        FillUpVariance.hasAdapterCapture(build(after: 50)),
+        isFalse,
+      );
+    });
+
+    test('true when both fields are set', () {
+      expect(
+        FillUpVariance.hasAdapterCapture(build(before: 5, after: 50)),
+        isTrue,
+      );
+    });
+  });
+
+  group('FillUpVariance.adapterDeltaL', () {
+    test('returns null when either capture is missing', () {
+      expect(FillUpVariance.adapterDeltaL(build()), isNull);
+      expect(FillUpVariance.adapterDeltaL(build(before: 5)), isNull);
+      expect(FillUpVariance.adapterDeltaL(build(after: 50)), isNull);
+    });
+
+    test('returns after minus before (litres pumped)', () {
+      // Tank went from 5 L to 50 L → 45 L pumped.
+      expect(
+        FillUpVariance.adapterDeltaL(build(before: 5, after: 50)),
+        45.0,
+      );
+    });
+
+    test('does NOT clamp negative deltas — caller must guard', () {
+      // Sensor noise can produce after < before. The helper is
+      // deliberately raw so the dialog can show the user what the
+      // adapter actually said.
+      expect(
+        FillUpVariance.adapterDeltaL(build(before: 50, after: 45)),
+        -5.0,
+      );
+    });
+  });
+
+  group('FillUpVariance.isVarianceAbove5Percent', () {
+    test('false when adapter delta is exactly the user value', () {
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(40.0, 40.0),
+        isFalse,
+      );
+    });
+
+    test('false at exactly 5 % delta — strict greater-than', () {
+      // 40 ± 2 L = 5 % exactly → still acceptable, no prompt.
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(42.0, 40.0),
+        isFalse,
+      );
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(38.0, 40.0),
+        isFalse,
+      );
+    });
+
+    test('true just above 5 % delta', () {
+      // 40 ± 2.001 L → fires the prompt.
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(42.001, 40.0),
+        isTrue,
+      );
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(37.999, 40.0),
+        isTrue,
+      );
+    });
+
+    test('true on a large delta (e.g. wrong-pump scenario)', () {
+      // User typed 60 L into the form but adapter only sees 40 L
+      // pumped — way past 5 %.
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(60.0, 40.0),
+        isTrue,
+      );
+    });
+
+    test('false when adapter delta is non-positive (no baseline)', () {
+      // Avoid division-by-zero / negative-baseline weirdness — the
+      // dialog isn't useful when the adapter saw no fill or a dip.
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(40.0, 0.0),
+        isFalse,
+      );
+      expect(
+        FillUpVariance.isVarianceAbove5Percent(40.0, -3.0),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/fill_up_card_verified_badge_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_card_verified_badge_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_card.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the "Verified by adapter" badge on [FillUpCard]
+/// (#1401 phase 7b). The chip renders only when both
+/// [FillUp.fuelLevelBeforeL] and [FillUp.fuelLevelAfterL] are set — a
+/// positive signal that the OBD2 adapter captured the tank delta.
+/// Either field missing means we cannot verify and no chip should
+/// appear (avoids implying verification on partial data).
+void main() {
+  FillUp buildFillUp({double? before, double? after}) => FillUp(
+        id: 'fv_card_test',
+        date: DateTime(2026, 5, 1),
+        liters: 45,
+        totalCost: 75,
+        odometerKm: 10000,
+        fuelType: FuelType.e10,
+        stationName: 'Test Station',
+        fuelLevelBeforeL: before,
+        fuelLevelAfterL: after,
+      );
+
+  Future<void> pump(WidgetTester tester, FillUp fillUp) {
+    return tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Scaffold(body: FillUpCard(fillUp: fillUp)),
+      ),
+    );
+  }
+
+  testWidgets('no badge when both fuel-level fields are null',
+      (tester) async {
+    await pump(tester, buildFillUp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Verified by adapter'), findsNothing);
+    expect(find.byIcon(Icons.check_circle), findsNothing);
+  });
+
+  testWidgets('no badge when only fuelLevelBeforeL is set', (tester) async {
+    await pump(tester, buildFillUp(before: 5));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Verified by adapter'), findsNothing);
+  });
+
+  testWidgets('no badge when only fuelLevelAfterL is set', (tester) async {
+    await pump(tester, buildFillUp(after: 50));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Verified by adapter'), findsNothing);
+  });
+
+  testWidgets('badge renders when both fuel-level fields are set',
+      (tester) async {
+    await pump(tester, buildFillUp(before: 5, after: 50));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Verified by adapter'), findsOneWidget);
+    // The chip uses Icons.check_circle as the leading icon — verifies
+    // visual identity matches the design (check + label).
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+}

--- a/test/features/consumption/presentation/widgets/fill_up_variance_prompt_test.dart
+++ b/test/features/consumption/presentation/widgets/fill_up_variance_prompt_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_variance_prompt.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for [showFillUpVarianceDialog] (#1401 phase 7b).
+///
+/// The dialog is the gate between user-typed litres and the persisted
+/// [FillUp]. Three concrete outcomes:
+///   - "Keep my entry" → returns [FillUpVarianceChoice.keepUser]
+///   - "Use adapter value" → returns [FillUpVarianceChoice.useAdapter]
+///   - dismiss / barrier tap → returns [FillUpVarianceChoice.keepUser]
+///
+/// We pump a tiny harness that calls the dialog from a button so the
+/// dialog mounts inside a real Navigator + MaterialApp tree (the
+/// production path).
+void main() {
+  Future<FillUpVarianceChoice?> openAndChoose(
+    WidgetTester tester, {
+    required String userL,
+    required String adapterL,
+    String? buttonText,
+  }) async {
+    FillUpVarianceChoice? captured;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  captured = await showFillUpVarianceDialog(
+                    context: context,
+                    userL: userL,
+                    adapterL: adapterL,
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    if (buttonText != null) {
+      await tester.tap(find.text(buttonText));
+      await tester.pumpAndSettle();
+    }
+    return captured;
+  }
+
+  testWidgets('renders title, body and both action buttons (en)',
+      (tester) async {
+    await openAndChoose(tester, userL: '40.00', adapterL: '45.00');
+
+    expect(find.text("Doesn't match adapter reading"), findsOneWidget);
+    expect(
+      find.textContaining('Your entry: 40.00 L'),
+      findsOneWidget,
+      reason: 'body must show pre-formatted user value',
+    );
+    expect(
+      find.textContaining('Adapter says: 45.00 L'),
+      findsOneWidget,
+      reason: 'body must show pre-formatted adapter value',
+    );
+    expect(find.text('Keep my entry'), findsOneWidget);
+    expect(find.text('Use adapter value'), findsOneWidget);
+  });
+
+  testWidgets('Keep my entry returns FillUpVarianceChoice.keepUser',
+      (tester) async {
+    final result = await openAndChoose(
+      tester,
+      userL: '40.00',
+      adapterL: '45.00',
+      buttonText: 'Keep my entry',
+    );
+    expect(result, FillUpVarianceChoice.keepUser);
+  });
+
+  testWidgets('Use adapter value returns FillUpVarianceChoice.useAdapter',
+      (tester) async {
+    final result = await openAndChoose(
+      tester,
+      userL: '40.00',
+      adapterL: '45.00',
+      buttonText: 'Use adapter value',
+    );
+    expect(result, FillUpVarianceChoice.useAdapter);
+  });
+
+  testWidgets('dismiss (tap scrim) is treated as Keep my entry',
+      (tester) async {
+    FillUpVarianceChoice? captured;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  captured = await showFillUpVarianceDialog(
+                    context: context,
+                    userL: '40.00',
+                    adapterL: '45.00',
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Tap the scrim (offset outside the AlertDialog content) to
+    // dismiss without choosing — Flutter's barrierDismissible:true
+    // pops with null, which the helper coerces to keepUser so the
+    // user's typed value wins by default.
+    await tester.tapAt(const Offset(20, 20));
+    await tester.pumpAndSettle();
+
+    expect(captured, FillUpVarianceChoice.keepUser);
+  });
+}

--- a/test/l10n/localization_completeness_test.dart
+++ b/test/l10n/localization_completeness_test.dart
@@ -187,6 +187,22 @@ void main() {
               'the adapter-capability card on the Edit vehicle screen '
               'must not fall back to English for French users (#1401 '
               'phase 6)');
+
+      // #1401 phase 7b — the verified-by-adapter badge sits on every
+      // fill-up card and the variance dialog fires inside the Add
+      // fill-up flow, both reachable for French users. Every
+      // `fillUpReconciliation*` key must have a French translation
+      // so the chip label and confirmation prompt don't fall back to
+      // English on the Fuel tab.
+      final frenchMissingFillUpReconciliation = frenchMissing
+          .where((k) => k.startsWith('fillUpReconciliation'))
+          .toList()
+        ..sort();
+      expect(frenchMissingFillUpReconciliation, isEmpty,
+          reason: 'French (fr) must have every fillUpReconciliation* '
+              'key — the verified-by-adapter badge and variance prompt '
+              'on the fill-up flow must not fall back to English for '
+              'French users (#1401 phase 7b)');
     });
 
     test('no locale has extra keys not in app_en.arb', () {


### PR DESCRIPTION
## Summary

Final phase of the OBD2 exact-fuel-level epic — wires the consumer side of `FillUp.fuelLevelBeforeL` / `fuelLevelAfterL` (landed in phase 7a / #1425) into the visible UI.

- **"Verified by adapter" chip** on `FillUpCard`: renders only when both fuel-level fields on the entity are non-null. Theme primary-container colour + check icon, mirrors the visual weight of the existing `isCorrection` chip.
- **Variance prompt**: when both adapter captures are present AND the user-typed litres differ from `(after - before)` by more than 5%, a confirmation dialog asks the user to choose between `Keep my entry` and `Use adapter value` before persisting. Dismiss is treated as keep-mine.
- **ARB**: new `fillUpReconciliation*` keys (en + de fragments via `tool/build_arb.dart`, fr direct-edited per project convention), then `flutter gen-l10n` regenerates all 23 locales.
- **French parity guard** appended to `test/l10n/localization_completeness_test.dart` (mirrors the `obd2Capability*` block from #1401 phase 6) so any French translation gap fails CI.

## What's deliberately out of scope (follow-up)

- **Producer wiring** — the live OBD2 capture chain that populates `fuelLevelBeforeL` at pump-start and `fuelLevelAfterL` at pump-end is NOT in this PR. Today the entity ships with both fields null until producer code is added, so the badge / variance dialog never fire in production. The screen exposes `@visibleForTesting initialFuelLevelBeforeL` / `initialFuelLevelAfterL` seams so the dialog flow can be exercised end-to-end. To be tracked as a separate issue.
- **Auto-filling the litres field on entry from the adapter delta** — same reason: needs the producer chain first.

## Changes

- `lib/features/consumption/domain/fill_up_variance.dart` — pure predicates (`hasAdapterCapture`, `adapterDeltaL`, `isVarianceAbove5Percent`).
- `lib/features/consumption/presentation/widgets/fill_up_card.dart` — inline chip block (only renders when both fields set).
- `lib/features/consumption/presentation/widgets/fill_up_variance_prompt.dart` — `showFillUpVarianceDialog` + `FillUpVarianceChoice` enum.
- `lib/features/consumption/presentation/screens/add_fill_up_screen.dart` — wraps `_save()` with the variance gate; adds `@visibleForTesting` seams for the captures.
- `lib/l10n/_fragments/fill_up_reconciliation_{en,de}.arb` + `lib/l10n/app_fr.arb` direct edit + regen of all 23 locales.
- `test/l10n/localization_completeness_test.dart` — appended `fillUpReconciliation*` French parity assertion.
- New tests: `fill_up_variance_test` (12 cases), `fill_up_card_verified_badge_test` (4 cases), `fill_up_variance_prompt_test` (4 cases).

## Test plan

- [x] `flutter analyze` — 0 issues
- [x] `flutter test test/features/consumption/presentation/widgets/ test/l10n/` — 429 tests pass
- [x] `flutter test test/features/consumption/domain/fill_up_variance_test.dart` — 12 cases pass
- [x] French parity guard active (`fillUpReconciliation*` in fr/app_fr.arb)
- [ ] CI green
- [ ] Manual smoke once producer wiring lands (separate PR): badge appears on a recorded plein-to-plein fill-up, dialog fires when typed litres are >5 % off the adapter delta

Closes #1401 — final phase of the OBD2 exact-fuel-level epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)