### PR TITLE
fix(app): kick off legacy-toggle migration at app startup (Refs #1373)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -33,6 +33,7 @@ import '../features/consumption/data/obd2/paused_trip_repository.dart';
 import '../features/consumption/data/trip_history_repository.dart';
 import '../features/consumption/providers/auto_record_orchestrator.dart';
 import '../features/consumption/providers/trip_recording_provider.dart';
+import '../features/feature_management/application/legacy_toggle_migration_provider.dart';
 import '../features/profile/data/repositories/profile_repository.dart';
 import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
@@ -61,9 +62,13 @@ import 'router.dart';
 ///    the main-isolate box opens already being done) (#795 phase 1).
 /// 3. **services** — notifications, background tasks, home widget.
 ///    Independent of each other → parallelised with `Future.wait`.
-/// 4. **optional (deferred)** — community config + TankSync. Scheduled for
-///    a post-first-frame microtask so the app paints before Supabase is
-///    touched (#795 phase 1). Failures are logged but never block startup.
+/// 4. **optional (deferred)** — community config + TankSync, plus
+///    one-shot migrations (vehicle reference-catalog backfill #950, and
+///    the feature-flag legacy-toggle promoter #1373 phase 3a/3b/3e/3f).
+///    All scheduled for a post-first-frame microtask so the app paints
+///    before Supabase is touched (#795 phase 1) and before any Hive
+///    walks for the migrators run. Failures are logged but never block
+///    startup.
 /// 5. **runApp** — wires global error handlers and hands control to the
 ///    Flutter framework. Wrapped in `SentryFlutter.init` when a DSN is
 ///    configured so framework + platform errors land in Sentry.
@@ -136,6 +141,29 @@ class AppInitializer {
             'VehicleProfileCatalogMigrator: matched $matched profile(s)');
       } catch (e, st) {
         debugPrint('VehicleProfileCatalogMigrator: deferred run failed: $e\n$st');
+      }
+    });
+
+    // #1373 phase 3a/3b/3e/3f — kick off the legacy-toggle migrations
+    // at every cold start. Reading the provider's future triggers its
+    // `build`, which runs `migrateLegacyToggles` + `migrateUserProfileToggles`
+    // inside a microtask. The provider is `keepAlive: true` and idempotent
+    // (each migrator is gated on its own `*Migrated` flag), so re-firing
+    // on subsequent launches is a cheap no-op once the flags are set.
+    //
+    // Non-awaited: failures are non-fatal (the provider itself swallows +
+    // `debugPrint`s), and we don't want a slow Hive read to delay any
+    // other deferred work scheduled on the post-first-frame microtask.
+    // Previously this only fired when the user navigated to the
+    // feature-flags settings screen — see the docstring on
+    // `legacyToggleMigrationProvider` for why startup wiring was deferred
+    // during the original phase-3 dispatches.
+    _deferPostFirstFrame(() async {
+      try {
+        unawaited(container.read(legacyToggleMigrationProvider.future));
+      } catch (e, st) {
+        debugPrint(
+            'AppInitializer: legacyToggleMigration kick-off failed: $e\n$st');
       }
     });
 

--- a/lib/features/feature_management/application/legacy_toggle_migration_provider.dart
+++ b/lib/features/feature_management/application/legacy_toggle_migration_provider.dart
@@ -45,12 +45,11 @@ const String _settingsBoxName = 'settings';
 ///
 /// Wiring: any provider / widget can `ref.watch(...)` this to
 /// guarantee the migrations have run before they read
-/// [featureFlagsProvider]. The default app-init path watches it from
-/// the central feature-flags screen so the migration runs the first
-/// time the user navigates there — there is no requirement to run it
-/// at app start. (#1373 phase 3a/3b defer the explicit startup
-/// wire-up because that path lives in `app_initializer.dart`, which
-/// is on the hot-file list.)
+/// [featureFlagsProvider]. As of the post-#1421 follow-up, the
+/// app-init path also kicks the provider's future in a post-first-frame
+/// microtask (see `app_initializer.dart` — phase 4 deferred work) so
+/// migrations run on every cold start instead of only the first time
+/// the user navigates to the feature-flags screen.
 @Riverpod(keepAlive: true)
 Future<void> legacyToggleMigration(Ref ref) async {
   final featureFlags = ref.watch(featureFlagsRepositoryProvider);

--- a/test/app/app_initializer_test.dart
+++ b/test/app/app_initializer_test.dart
@@ -136,6 +136,55 @@ void main() {
     });
   });
 
+  group('Legacy-toggle migration kick-off (#1373 phase 3a/3b/3e/3f follow-up)',
+      () {
+    test(
+        'AppInitializer.run schedules legacyToggleMigrationProvider on a '
+        'post-first-frame microtask via container.read(...future)', () {
+      // Source-level pin: the wiring must live inside a `_deferPostFirstFrame`
+      // block (so it never delays the first paint) AND it must read the
+      // provider's `.future` (not just `read(provider)` which would only
+      // observe the synchronous AsyncValue placeholder and never let the
+      // migrator microtask be scheduled at the framework level).
+      final runBody = _extractMethodBody(initSource, 'static Future<void> run');
+      expect(runBody, isNotNull);
+      expect(
+        runBody,
+        contains('legacyToggleMigrationProvider'),
+        reason: 'AppInitializer.run must reference the provider so the '
+            'legacy-toggle migrators fire at every cold start, not only when '
+            'the user opens the feature-flags settings screen',
+      );
+      expect(
+        runBody,
+        contains('legacyToggleMigrationProvider.future'),
+        reason: 'The kick-off must read `.future` so the underlying microtask '
+            'actually runs the migrators (a plain `read(provider)` returns '
+            'the synchronous AsyncValue placeholder without firing build())',
+      );
+
+      // The reference must sit inside a `_deferPostFirstFrame` block so it
+      // can never delay the first paint. We assert the textual order: the
+      // FIRST `_deferPostFirstFrame` opening brace must precede the
+      // legacyToggleMigrationProvider mention, AND the import must be
+      // present (otherwise the file wouldn't compile).
+      final deferIdx = runBody!.indexOf('_deferPostFirstFrame');
+      final providerIdx = runBody.indexOf('legacyToggleMigrationProvider');
+      expect(deferIdx, isNonNegative);
+      expect(providerIdx, isNonNegative);
+      expect(deferIdx, lessThan(providerIdx),
+          reason: 'legacy-toggle migration must be scheduled INSIDE a '
+              '_deferPostFirstFrame block so it never blocks the first paint');
+
+      expect(
+        initSource,
+        contains(
+            "import '../features/feature_management/application/legacy_toggle_migration_provider.dart';"),
+        reason: 'the provider must be imported so the wiring compiles',
+      );
+    });
+  });
+
   group('Sentry observability wiring (#476)', () {
     test(
         'resolveSentryDsn prefers the user-stored sentry_dsn setting over '

--- a/test/features/feature_management/application/legacy_toggle_migration_at_startup_wiring_test.dart
+++ b/test/features/feature_management/application/legacy_toggle_migration_at_startup_wiring_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/application/legacy_toggle_migration_provider.dart';
+import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/data/legacy_toggle_migrator.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+/// Runtime coverage for the post-#1421 follow-up that wires
+/// [legacyToggleMigrationProvider] into `AppInitializer` so the legacy-toggle
+/// migrators fire on every cold start.
+///
+/// We don't drive `AppInitializer.run` end-to-end here — that path needs a
+/// real platform binding for HiveStorage, secure-storage, notifications,
+/// etc. Instead this test exercises the smallest possible slice: a
+/// [ProviderContainer] with a stubbed [FeatureFlagsRepository], the
+/// `'settings'` Hive box opened with a known legacy value, and a manual
+/// `container.read(legacyToggleMigrationProvider.future)` — which is
+/// exactly the call `AppInitializer._deferPostFirstFrame` schedules.
+///
+/// If the migrators run, [Feature.hapticEcoCoach] (and its prerequisite
+/// [Feature.obd2TripRecording]) land in the central feature-flag set and
+/// the `*Migrated` gate flag flips to `true`. If the wiring is wrong (e.g.
+/// reading the synchronous `AsyncValue` placeholder instead of `.future`),
+/// neither side-effect fires and the test fails — protecting against the
+/// regression that motivated this PR.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late Box<dynamic> settings;
+  late Box<dynamic> flagsBox;
+  late FeatureFlagsRepository repo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync(
+        'legacy_toggle_migration_at_startup_wiring_');
+    Hive.init(tmpDir.path);
+    // The provider hard-codes `'settings'` as its box name (its docstring
+    // explains why hive_boxes.dart was off-limits during phase 3).
+    settings = await Hive.openBox<dynamic>('settings');
+    final suffix = DateTime.now().microsecondsSinceEpoch;
+    flagsBox = await Hive.openBox<dynamic>('feature_flags_$suffix');
+    repo = FeatureFlagsRepository(box: flagsBox);
+  });
+
+  tearDown(() async {
+    await settings.deleteFromDisk();
+    await flagsBox.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test(
+    'reading legacyToggleMigrationProvider.future runs the legacy-toggle '
+    'migrators — mirrors the AppInitializer post-first-frame kick-off',
+    () async {
+      // Seed the legacy key the same way a pre-#1373 install would have.
+      // ignore: deprecated_member_use_from_same_package
+      await settings.put(StorageKeys.hapticEcoCoachEnabled, true);
+      // Sanity-check the gate flag is absent so the migrator must run.
+      expect(settings.get(hapticEcoCoachMigratedKey), isNull);
+
+      final container = ProviderContainer(overrides: [
+        featureFlagsRepositoryProvider.overrideWithValue(repo),
+        featureManifestProvider
+            .overrideWithValue(FeatureManifest.defaultManifest),
+      ]);
+      addTearDown(container.dispose);
+
+      // This is the exact call AppInitializer._deferPostFirstFrame schedules.
+      // Awaiting it here makes the assertion deterministic — production
+      // fires it non-awaited because the migration is non-fatal and must
+      // not delay other deferred work.
+      await container.read(legacyToggleMigrationProvider.future);
+
+      final after = await repo.loadEnabled();
+      expect(
+        after,
+        contains(Feature.hapticEcoCoach),
+        reason:
+            'AppInitializer kicks legacyToggleMigrationProvider.future after '
+            'first frame; reading it must fire migrateLegacyToggles, which '
+            'promotes the legacy hapticEcoCoachEnabled=true into the central '
+            'feature-flag set. Failure here means the wiring observed only '
+            'the synchronous placeholder and never let the migrator '
+            'microtask run — the regression this PR exists to prevent.',
+      );
+      expect(
+        after,
+        contains(Feature.obd2TripRecording),
+        reason:
+            'hapticEcoCoach requires obd2TripRecording per the manifest; the '
+            'cascade must run as part of the same migration call.',
+      );
+      expect(
+        settings.get(hapticEcoCoachMigratedKey),
+        isTrue,
+        reason:
+            'The migration gate must be set so subsequent cold starts find '
+            'the flag and short-circuit the migrator.',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Wires `legacyToggleMigrationProvider` from `AppInitializer` (post-first-frame microtask) so legacy-toggle migrations fire at every cold start instead of only when the user opens the feature-flags settings screen. This is the follow-up acknowledged in the provider's own docstring (`legacy_toggle_migration_provider.dart` lines 46-53) which deferred startup wiring during the phase 3a/3b dispatches because `app_initializer.dart` was on the hot-file list.

Now that the l10n + feature_management dispatches have settled (#1421 merged), the wiring is safe.

- Non-awaited read so a slow migration cannot delay other deferred work
- Provider already swallows + `debugPrint`s its own failures, so the call is fire-and-forget at this layer
- Tests cover the wiring at the provider level (full AppInitializer e2e harness deferred to a future test infra refresh)

## Test plan

- [x] App-init wiring fires the migration on a fresh container
- [x] Existing `legacy_toggle_migrator_test.dart` cases still green
- [x] Existing `legacyToggleMigrationProvider` tests still green

Refs #1373