### PR TITLE
feat(vehicle): η_v catalog origin tag shows engine-tech basis (Closes #1422 phase 2)

### DIFF
--- a/lib/features/vehicle/domain/entities/reference_vehicle.dart
+++ b/lib/features/vehicle/domain/entities/reference_vehicle.dart
@@ -53,6 +53,31 @@ double defaultVolumetricEfficiency(ReferenceVehicle v) {
   return v.directInjection ? 0.88 : 0.85;
 }
 
+/// Optional human-readable basis for the helper-derived η_v default
+/// (#1422 phase 2).
+///
+/// Returns one of 5 ARB keys to look up via `AppLocalizations`, or
+/// `null` for the NA + no-DI baseline (no enrichment needed — the
+/// helper output is the legacy 0.85 default and the plain
+/// `(catalog: <make model>)` label already conveys everything the user
+/// needs to know).
+///
+/// Mirrors the 5 distinct paths in [defaultVolumetricEfficiency]; the
+/// `CalibrationSection` consumer uses this to extend the
+/// `(catalog: Dacia Duster)` origin tag into
+/// `(catalog: Dacia Duster — VNT diesel + DI default)`.
+String? volumetricEfficiencyBasisKey(ReferenceVehicle v) {
+  if (v.atkinsonCycle) return 'calibrationBasisAtkinson';
+  if (v.inductionType == InductionType.vnt) return 'calibrationBasisVnt';
+  if (v.inductionType == InductionType.turbocharged ||
+      v.inductionType == InductionType.supercharged) {
+    return v.directInjection
+        ? 'calibrationBasisTurboDi'
+        : 'calibrationBasisTurbo';
+  }
+  return v.directInjection ? 'calibrationBasisNaDi' : null;
+}
+
 /// A single entry in the reference vehicle catalog (#950 phase 1).
 ///
 /// The catalog ships ~30 popular EU passenger cars compiled from

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -7,6 +7,8 @@ import '../../../../core/utils/brand_logo_mapper.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/obd2_vin_reader.dart';
+import '../../data/reference_vehicle_catalog_provider.dart';
+import '../../data/vehicle_profile_catalog_matcher.dart';
 import '../../domain/entities/reference_vehicle.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../domain/entities/vin_data.dart';
@@ -726,8 +728,32 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
                     .where((v) => v.id == _existingId)
                     .firstOrNull;
                 if (profile == null) return const SizedBox.shrink();
+                // #1422 phase 2 — resolve the matching ReferenceVehicle
+                // (by stored slug, or via the matcher as a fallback)
+                // so the η_v helper-text origin tag can show the
+                // engine-tech basis. The catalog provider is keep-alive,
+                // so this watch is cheap.
+                final catalog = ref
+                        .watch(referenceVehicleCatalogProvider)
+                        .value ??
+                    const <ReferenceVehicle>[];
+                ReferenceVehicle? referenceVehicle;
+                if (profile.referenceVehicleId != null) {
+                  for (final entry in catalog) {
+                    if (VehicleProfileCatalogMatcher.slugFor(entry) ==
+                        profile.referenceVehicleId) {
+                      referenceVehicle = entry;
+                      break;
+                    }
+                  }
+                }
+                referenceVehicle ??= VehicleProfileCatalogMatcher.bestMatch(
+                  profile: profile,
+                  catalog: catalog,
+                );
                 return CalibrationSection(
                   profile: profile,
+                  referenceVehicle: referenceVehicle,
                   onDisplacementChanged: (v) => _saveCalibrationOverride(
                     manualEngineDisplacementCcOverride: v,
                   ),

--- a/lib/features/vehicle/presentation/widgets/calibration_section.dart
+++ b/lib/features/vehicle/presentation/widgets/calibration_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/reference_vehicle.dart';
 import '../../domain/entities/vehicle_profile.dart';
 
 /// One of the four manual-override calibration fields surfaced by
@@ -77,6 +78,19 @@ class CalibrationSection extends StatefulWidget {
   /// `volumetricEfficiencySamples`.
   final VoidCallback onResetLearner;
 
+  /// Optional resolved [ReferenceVehicle] for [profile] (#1422 phase 2).
+  ///
+  /// When non-null AND the volumetricEfficiency field is currently
+  /// sourced from the catalog, the helper-text origin tag is enriched
+  /// with the engine-tech basis label, e.g.
+  /// `(catalog: Dacia Duster — VNT diesel + DI default)`.
+  ///
+  /// Parents that already resolve the reference vehicle (e.g. the
+  /// edit-vehicle screen via [VehicleProfileCatalogMatcher]) pass it
+  /// through; callers that don't can leave this null and the widget
+  /// falls back to the plain `(catalog: ...)` label for every field.
+  final ReferenceVehicle? referenceVehicle;
+
   const CalibrationSection({
     super.key,
     required this.profile,
@@ -85,6 +99,7 @@ class CalibrationSection extends StatefulWidget {
     required this.onAfrChanged,
     required this.onFuelDensityChanged,
     required this.onResetLearner,
+    this.referenceVehicle,
   });
 
   @override
@@ -218,6 +233,7 @@ class _CalibrationSectionState extends State<CalibrationSection> {
   String _sourceLabel(
     AppLocalizations? l,
     CalibrationValueSource source,
+    _CalibrationField field,
   ) {
     final p = widget.profile;
     switch (source) {
@@ -231,10 +247,45 @@ class _CalibrationSectionState extends State<CalibrationSection> {
           if (p.model != null && p.model!.isNotEmpty) p.model,
         ].whereType<String>().join(' ');
         final label = makeModel.isEmpty ? 'catalog' : makeModel;
+        // #1422 phase 2 — for the η_v field specifically, enrich the
+        // catalog tag with the engine-tech basis (Atkinson / VNT / Turbo
+        // ± DI / NA + DI) so the user sees WHY the helper picked the
+        // value it did. Other fields keep the plain `(catalog: ...)`
+        // label — only η_v varies by induction + injection class.
+        final ref = widget.referenceVehicle;
+        if (field == _CalibrationField.volumetricEfficiency && ref != null) {
+          final basisKey = volumetricEfficiencyBasisKey(ref);
+          final basisLabel = _basisLabel(l, basisKey);
+          if (basisLabel != null) {
+            return l?.calibrationSourceCatalogWithBasis(label, basisLabel) ??
+                '(catalog: $label — $basisLabel default)';
+          }
+        }
         return l?.calibrationSourceCatalog(label) ?? '(catalog: $label)';
       case CalibrationValueSource.defaultConstant:
         return l?.calibrationSourceDefault ?? '(default)';
     }
+  }
+
+  /// Resolves the engine-tech basis ARB key into its localized label,
+  /// or `null` when the helper returned `null` (NA + no-DI baseline —
+  /// no enrichment needed). Falls back to the English literal if
+  /// localizations are unavailable, matching the rest of this widget.
+  String? _basisLabel(AppLocalizations? l, String? basisKey) {
+    if (basisKey == null) return null;
+    switch (basisKey) {
+      case 'calibrationBasisAtkinson':
+        return l?.calibrationBasisAtkinson ?? 'Atkinson cycle';
+      case 'calibrationBasisVnt':
+        return l?.calibrationBasisVnt ?? 'VNT diesel + DI';
+      case 'calibrationBasisTurboDi':
+        return l?.calibrationBasisTurboDi ?? 'Turbocharged + DI';
+      case 'calibrationBasisTurbo':
+        return l?.calibrationBasisTurbo ?? 'Turbocharged';
+      case 'calibrationBasisNaDi':
+        return l?.calibrationBasisNaDi ?? 'Naturally aspirated + DI';
+    }
+    return null;
   }
 
   String _formatDouble(double value) {
@@ -395,7 +446,7 @@ class _CalibrationSectionState extends State<CalibrationSection> {
           const TextInputType.numberWithOptions(decimal: true, signed: false),
       decoration: InputDecoration(
         labelText: labelText,
-        helperText: _sourceLabel(l, source),
+        helperText: _sourceLabel(l, source, field),
         suffixIcon: IconButton(
           icon: const Icon(Icons.restart_alt),
           tooltip: l?.calibrationResetToDetected ?? 'Reset to detected value',

--- a/lib/l10n/_fragments/calibration_de.arb
+++ b/lib/l10n/_fragments/calibration_de.arb
@@ -29,5 +29,17 @@
     }
   },
   "calibrationLearnerStatusNoSamples": "η_v: 0.85 (Standard – noch keine Volltankung)",
-  "calibrationResetLearner": "Lernalgorithmus zurücksetzen"
+  "calibrationResetLearner": "Lernalgorithmus zurücksetzen",
+  "calibrationBasisAtkinson": "Atkinson-Zyklus",
+  "calibrationBasisVnt": "VTG-Diesel + Direkteinspritzung",
+  "calibrationBasisTurboDi": "Turbo + Direkteinspritzung",
+  "calibrationBasisTurbo": "Turbo",
+  "calibrationBasisNaDi": "Saugmotor + Direkteinspritzung",
+  "calibrationSourceCatalogWithBasis": "(Katalog: {makeModel} — Standard für {basis})",
+  "@calibrationSourceCatalogWithBasis": {
+    "placeholders": {
+      "makeModel": {"type": "String"},
+      "basis": {"type": "String"}
+    }
+  }
 }

--- a/lib/l10n/_fragments/calibration_en.arb
+++ b/lib/l10n/_fragments/calibration_en.arb
@@ -68,5 +68,33 @@
   "calibrationResetLearner": "Reset learner",
   "@calibrationResetLearner": {
     "description": "OutlinedButton label that resets η_v back to 0.85 and clears the sample counter."
+  },
+  "calibrationBasisAtkinson": "Atkinson cycle",
+  "@calibrationBasisAtkinson": {
+    "description": "Engine-tech basis label for η_v (#1422 phase 2). Shown inside the catalog origin tag when the reference vehicle is an Atkinson-cycle hybrid (Toyota Hybrid, Mazda Skyactiv-X)."
+  },
+  "calibrationBasisVnt": "VNT diesel + DI",
+  "@calibrationBasisVnt": {
+    "description": "Engine-tech basis label for η_v. VNT = variable-geometry turbocharger; DI = direct injection. Common on modern diesels (Renault/Dacia dCi, etc.)."
+  },
+  "calibrationBasisTurboDi": "Turbocharged + DI",
+  "@calibrationBasisTurboDi": {
+    "description": "Engine-tech basis label for η_v. Petrol / diesel turbo with direct injection (VW TSI, Audi TFSI, BlueHDi, etc.)."
+  },
+  "calibrationBasisTurbo": "Turbocharged",
+  "@calibrationBasisTurbo": {
+    "description": "Engine-tech basis label for η_v. Turbocharged with port injection (older turbo petrol)."
+  },
+  "calibrationBasisNaDi": "Naturally aspirated + DI",
+  "@calibrationBasisNaDi": {
+    "description": "Engine-tech basis label for η_v. Naturally aspirated petrol with direct injection (some Toyota / Mazda petrol)."
+  },
+  "calibrationSourceCatalogWithBasis": "(catalog: {makeModel} — {basis} default)",
+  "@calibrationSourceCatalogWithBasis": {
+    "description": "Helper text shown beneath the η_v field when value comes from the catalog AND the engine-tech basis is known (#1422 phase 2). Replaces the plain `calibrationSourceCatalog` for this field only.",
+    "placeholders": {
+      "makeModel": {"type": "String", "example": "Dacia Duster 1.5 dCi"},
+      "basis": {"type": "String", "example": "VNT diesel + DI"}
+    }
   }
 }

--- a/lib/l10n/_fragments/calibration_fr.arb
+++ b/lib/l10n/_fragments/calibration_fr.arb
@@ -29,5 +29,17 @@
     }
   },
   "calibrationLearnerStatusNoSamples": "η_v : 0.85 (par défaut — aucun plein complet)",
-  "calibrationResetLearner": "Réinitialiser l'apprentissage"
+  "calibrationResetLearner": "Réinitialiser l'apprentissage",
+  "calibrationBasisAtkinson": "cycle Atkinson",
+  "calibrationBasisVnt": "diesel à turbo VGT + injection directe",
+  "calibrationBasisTurboDi": "turbo + injection directe",
+  "calibrationBasisTurbo": "turbo",
+  "calibrationBasisNaDi": "atmosphérique + injection directe",
+  "calibrationSourceCatalogWithBasis": "(catalogue : {makeModel} — valeur par défaut pour {basis})",
+  "@calibrationSourceCatalogWithBasis": {
+    "placeholders": {
+      "makeModel": {"type": "String"},
+      "basis": {"type": "String"}
+    }
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1318,6 +1318,22 @@
   },
   "calibrationLearnerStatusNoSamples": "η_v: 0.85 (Standard – noch keine Volltankung)",
   "calibrationResetLearner": "Lernalgorithmus zurücksetzen",
+  "calibrationBasisAtkinson": "Atkinson-Zyklus",
+  "calibrationBasisVnt": "VTG-Diesel + Direkteinspritzung",
+  "calibrationBasisTurboDi": "Turbo + Direkteinspritzung",
+  "calibrationBasisTurbo": "Turbo",
+  "calibrationBasisNaDi": "Saugmotor + Direkteinspritzung",
+  "calibrationSourceCatalogWithBasis": "(Katalog: {makeModel} — Standard für {basis})",
+  "@calibrationSourceCatalogWithBasis": {
+    "placeholders": {
+      "makeModel": {
+        "type": "String"
+      },
+      "basis": {
+        "type": "String"
+      }
+    }
+  },
   "catalogReresolveSnackbarMessage": "Dein {makeModel} ist als Diesel markiert, passt aber zu einem Benziner-Eintrag im Katalog. Tippe zum Aktualisieren.",
   "@catalogReresolveSnackbarMessage": {
     "description": "One-time snackbar (#1396) shown when a diesel-marked vehicle profile resolves to a non-diesel reference catalog row. The placeholder is the make + model, e.g. 'Dacia Duster'.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1642,6 +1642,40 @@
   "@calibrationResetLearner": {
     "description": "OutlinedButton label that resets η_v back to 0.85 and clears the sample counter."
   },
+  "calibrationBasisAtkinson": "Atkinson cycle",
+  "@calibrationBasisAtkinson": {
+    "description": "Engine-tech basis label for η_v (#1422 phase 2). Shown inside the catalog origin tag when the reference vehicle is an Atkinson-cycle hybrid (Toyota Hybrid, Mazda Skyactiv-X)."
+  },
+  "calibrationBasisVnt": "VNT diesel + DI",
+  "@calibrationBasisVnt": {
+    "description": "Engine-tech basis label for η_v. VNT = variable-geometry turbocharger; DI = direct injection. Common on modern diesels (Renault/Dacia dCi, etc.)."
+  },
+  "calibrationBasisTurboDi": "Turbocharged + DI",
+  "@calibrationBasisTurboDi": {
+    "description": "Engine-tech basis label for η_v. Petrol / diesel turbo with direct injection (VW TSI, Audi TFSI, BlueHDi, etc.)."
+  },
+  "calibrationBasisTurbo": "Turbocharged",
+  "@calibrationBasisTurbo": {
+    "description": "Engine-tech basis label for η_v. Turbocharged with port injection (older turbo petrol)."
+  },
+  "calibrationBasisNaDi": "Naturally aspirated + DI",
+  "@calibrationBasisNaDi": {
+    "description": "Engine-tech basis label for η_v. Naturally aspirated petrol with direct injection (some Toyota / Mazda petrol)."
+  },
+  "calibrationSourceCatalogWithBasis": "(catalog: {makeModel} — {basis} default)",
+  "@calibrationSourceCatalogWithBasis": {
+    "description": "Helper text shown beneath the η_v field when value comes from the catalog AND the engine-tech basis is known (#1422 phase 2). Replaces the plain `calibrationSourceCatalog` for this field only.",
+    "placeholders": {
+      "makeModel": {
+        "type": "String",
+        "example": "Dacia Duster 1.5 dCi"
+      },
+      "basis": {
+        "type": "String",
+        "example": "VNT diesel + DI"
+      }
+    }
+  },
   "catalogReresolveSnackbarMessage": "Your {makeModel} is marked as diesel but matches a petrol catalog entry. Tap to update.",
   "@catalogReresolveSnackbarMessage": {
     "description": "One-time snackbar (#1396) shown when a diesel-marked vehicle profile resolves to a non-diesel reference catalog row. The placeholder is the make + model, e.g. 'Dacia Duster'.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1208,6 +1208,18 @@
   "calibrationLearnerStatusLearning": "η_v : {eta} (apprentissage, {samples} pleins)",
   "calibrationLearnerStatusNoSamples": "η_v : 0.85 (par défaut — aucun plein complet)",
   "calibrationResetLearner": "Réinitialiser l'apprentissage",
+  "calibrationBasisAtkinson": "cycle Atkinson",
+  "calibrationBasisVnt": "diesel à turbo VGT + injection directe",
+  "calibrationBasisTurboDi": "turbo + injection directe",
+  "calibrationBasisTurbo": "turbo",
+  "calibrationBasisNaDi": "atmosphérique + injection directe",
+  "calibrationSourceCatalogWithBasis": "(catalogue : {makeModel} — valeur par défaut pour {basis})",
+  "@calibrationSourceCatalogWithBasis": {
+    "placeholders": {
+      "makeModel": {"type": "String"},
+      "basis": {"type": "String"}
+    }
+  },
   "pickerButtonLabel": "Choisir dans le catalogue",
   "pickerSearchHint": "Rechercher marque ou modèle",
   "pickerHelpText": "Pré-remplir depuis 50+ véhicules pris en charge",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6038,6 +6038,42 @@ abstract class AppLocalizations {
   /// **'Reset learner'**
   String get calibrationResetLearner;
 
+  /// Engine-tech basis label for η_v (#1422 phase 2). Shown inside the catalog origin tag when the reference vehicle is an Atkinson-cycle hybrid (Toyota Hybrid, Mazda Skyactiv-X).
+  ///
+  /// In en, this message translates to:
+  /// **'Atkinson cycle'**
+  String get calibrationBasisAtkinson;
+
+  /// Engine-tech basis label for η_v. VNT = variable-geometry turbocharger; DI = direct injection. Common on modern diesels (Renault/Dacia dCi, etc.).
+  ///
+  /// In en, this message translates to:
+  /// **'VNT diesel + DI'**
+  String get calibrationBasisVnt;
+
+  /// Engine-tech basis label for η_v. Petrol / diesel turbo with direct injection (VW TSI, Audi TFSI, BlueHDi, etc.).
+  ///
+  /// In en, this message translates to:
+  /// **'Turbocharged + DI'**
+  String get calibrationBasisTurboDi;
+
+  /// Engine-tech basis label for η_v. Turbocharged with port injection (older turbo petrol).
+  ///
+  /// In en, this message translates to:
+  /// **'Turbocharged'**
+  String get calibrationBasisTurbo;
+
+  /// Engine-tech basis label for η_v. Naturally aspirated petrol with direct injection (some Toyota / Mazda petrol).
+  ///
+  /// In en, this message translates to:
+  /// **'Naturally aspirated + DI'**
+  String get calibrationBasisNaDi;
+
+  /// Helper text shown beneath the η_v field when value comes from the catalog AND the engine-tech basis is known (#1422 phase 2). Replaces the plain `calibrationSourceCatalog` for this field only.
+  ///
+  /// In en, this message translates to:
+  /// **'(catalog: {makeModel} — {basis} default)'**
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis);
+
   /// One-time snackbar (#1396) shown when a diesel-marked vehicle profile resolves to a non-diesel reference catalog row. The placeholder is the make + model, e.g. 'Dacia Duster'.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3233,6 +3233,26 @@ class AppLocalizationsBg extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3233,6 +3233,26 @@ class AppLocalizationsCs extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3231,6 +3231,26 @@ class AppLocalizationsDa extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3260,6 +3260,26 @@ class AppLocalizationsDe extends AppLocalizations {
   String get calibrationResetLearner => 'Lernalgorithmus zurücksetzen';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson-Zyklus';
+
+  @override
+  String get calibrationBasisVnt => 'VTG-Diesel + Direkteinspritzung';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbo + Direkteinspritzung';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbo';
+
+  @override
+  String get calibrationBasisNaDi => 'Saugmotor + Direkteinspritzung';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(Katalog: $makeModel — Standard für $basis)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Dein $makeModel ist als Diesel markiert, passt aber zu einem Benziner-Eintrag im Katalog. Tippe zum Aktualisieren.';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3235,6 +3235,26 @@ class AppLocalizationsEl extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3226,6 +3226,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3234,6 +3234,26 @@ class AppLocalizationsEs extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3228,6 +3228,26 @@ class AppLocalizationsEt extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3231,6 +3231,26 @@ class AppLocalizationsFi extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3262,6 +3262,26 @@ class AppLocalizationsFr extends AppLocalizations {
   String get calibrationResetLearner => 'Réinitialiser l\'apprentissage';
 
   @override
+  String get calibrationBasisAtkinson => 'cycle Atkinson';
+
+  @override
+  String get calibrationBasisVnt => 'diesel à turbo VGT + injection directe';
+
+  @override
+  String get calibrationBasisTurboDi => 'turbo + injection directe';
+
+  @override
+  String get calibrationBasisTurbo => 'turbo';
+
+  @override
+  String get calibrationBasisNaDi => 'atmosphérique + injection directe';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalogue : $makeModel — valeur par défaut pour $basis)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Votre $makeModel est marqué comme diesel mais correspond à une entrée essence du catalogue. Touchez pour mettre à jour.';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3230,6 +3230,26 @@ class AppLocalizationsHr extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3235,6 +3235,26 @@ class AppLocalizationsHu extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3234,6 +3234,26 @@ class AppLocalizationsIt extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3232,6 +3232,26 @@ class AppLocalizationsLt extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3234,6 +3234,26 @@ class AppLocalizationsLv extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3230,6 +3230,26 @@ class AppLocalizationsNb extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3235,6 +3235,26 @@ class AppLocalizationsNl extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3233,6 +3233,26 @@ class AppLocalizationsPl extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3234,6 +3234,26 @@ class AppLocalizationsPt extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3233,6 +3233,26 @@ class AppLocalizationsRo extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3234,6 +3234,26 @@ class AppLocalizationsSk extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3228,6 +3228,26 @@ class AppLocalizationsSl extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3232,6 +3232,26 @@ class AppLocalizationsSv extends AppLocalizations {
   String get calibrationResetLearner => 'Reset learner';
 
   @override
+  String get calibrationBasisAtkinson => 'Atkinson cycle';
+
+  @override
+  String get calibrationBasisVnt => 'VNT diesel + DI';
+
+  @override
+  String get calibrationBasisTurboDi => 'Turbocharged + DI';
+
+  @override
+  String get calibrationBasisTurbo => 'Turbocharged';
+
+  @override
+  String get calibrationBasisNaDi => 'Naturally aspirated + DI';
+
+  @override
+  String calibrationSourceCatalogWithBasis(String makeModel, String basis) {
+    return '(catalog: $makeModel — $basis default)';
+  }
+
+  @override
   String catalogReresolveSnackbarMessage(String makeModel) {
     return 'Your $makeModel is marked as diesel but matches a petrol catalog entry. Tap to update.';
   }

--- a/test/features/vehicle/domain/entities/reference_vehicle_test.dart
+++ b/test/features/vehicle/domain/entities/reference_vehicle_test.dart
@@ -210,6 +210,75 @@ void main() {
       });
     });
 
+    group('volumetricEfficiencyBasisKey helper (#1422 phase 2)', () {
+      const baseRow = ReferenceVehicle(
+        make: 'X',
+        model: 'Y',
+        generation: 'I',
+        yearStart: 2020,
+        displacementCc: 1500,
+        fuelType: 'petrol',
+        transmission: 'manual',
+      );
+
+      test('atkinsonCycle short-circuits to calibrationBasisAtkinson '
+          '(takes precedence over induction + DI flags)', () {
+        final v = baseRow.copyWith(
+          atkinsonCycle: true,
+          inductionType: InductionType.turbocharged,
+          directInjection: true,
+        );
+        expect(volumetricEfficiencyBasisKey(v), 'calibrationBasisAtkinson');
+      });
+
+      test('VNT induction returns calibrationBasisVnt', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.vnt,
+          directInjection: true,
+        );
+        expect(volumetricEfficiencyBasisKey(v), 'calibrationBasisVnt');
+      });
+
+      test('turbocharged + DI returns calibrationBasisTurboDi', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.turbocharged,
+          directInjection: true,
+        );
+        expect(volumetricEfficiencyBasisKey(v), 'calibrationBasisTurboDi');
+      });
+
+      test('supercharged + DI also returns calibrationBasisTurboDi', () {
+        // Supercharged + turbocharged share the same basis label since
+        // they share the same η_v default in the helper.
+        final v = baseRow.copyWith(
+          inductionType: InductionType.supercharged,
+          directInjection: true,
+        );
+        expect(volumetricEfficiencyBasisKey(v), 'calibrationBasisTurboDi');
+      });
+
+      test('turbocharged + no DI returns calibrationBasisTurbo', () {
+        final v = baseRow.copyWith(
+          inductionType: InductionType.turbocharged,
+        );
+        expect(volumetricEfficiencyBasisKey(v), 'calibrationBasisTurbo');
+      });
+
+      test('NA + DI returns calibrationBasisNaDi', () {
+        final v = baseRow.copyWith(directInjection: true);
+        expect(volumetricEfficiencyBasisKey(v), 'calibrationBasisNaDi');
+      });
+
+      test('NA + no DI returns null (legacy 0.85 baseline — no '
+          'enrichment needed)', () {
+        // The helper falls through to 0.85, the same value the catalog
+        // shipped before #1422 — the plain `(catalog: <make model>)`
+        // label already conveys everything, so we suppress the basis
+        // suffix on this branch.
+        expect(volumetricEfficiencyBasisKey(baseRow), isNull);
+      });
+    });
+
     group('coversYear', () {
       test('returns true for the start year', () {
         const v = ReferenceVehicle(

--- a/test/features/vehicle/presentation/widgets/calibration_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/calibration_section_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/presentation/widgets/calibration_section.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
@@ -19,7 +20,11 @@ class _CapturedCalls {
   bool densityFired = false;
 }
 
-Widget _harness(VehicleProfile profile, _CapturedCalls calls) {
+Widget _harness(
+  VehicleProfile profile,
+  _CapturedCalls calls, {
+  ReferenceVehicle? referenceVehicle,
+}) {
   return MaterialApp(
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
@@ -27,6 +32,7 @@ Widget _harness(VehicleProfile profile, _CapturedCalls calls) {
       body: SingleChildScrollView(
         child: CalibrationSection(
           profile: profile,
+          referenceVehicle: referenceVehicle,
           onDisplacementChanged: (v) {
             calls.lastDisplacement = v;
             calls.displacementFired = true;
@@ -213,6 +219,156 @@ void main() {
       await tester.tap(find.text('Reset learner'));
       await tester.pump();
       expect(calls.resetLearnerFired, isTrue);
+    });
+  });
+
+  group('CalibrationSection η_v origin tag enrichment (#1422 phase 2)', () {
+    // A reference vehicle wired to the profile by populating
+    // referenceVehicleId — calibration_section uses
+    // `referenceVehicleId != null` to flag the catalog source. The basis
+    // enrichment then comes from the passed-in `referenceVehicle`.
+    const turboDiRef = ReferenceVehicle(
+      make: 'Volkswagen',
+      model: 'Golf',
+      generation: 'VIII (2019-)',
+      yearStart: 2019,
+      displacementCc: 1498,
+      fuelType: 'petrol',
+      transmission: 'manual',
+      inductionType: InductionType.turbocharged,
+      directInjection: true,
+    );
+
+    const naLegacyRef = ReferenceVehicle(
+      make: 'Peugeot',
+      model: '107',
+      generation: 'I (2005-2014)',
+      yearStart: 2005,
+      yearEnd: 2014,
+      displacementCc: 998,
+      fuelType: 'petrol',
+      transmission: 'manual',
+    );
+
+    testWidgets(
+        'η_v field on a known turbo+DI vehicle renders the enriched '
+        '"(catalog: VW Golf — Turbocharged + DI default)" label',
+        (tester) async {
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Golf',
+        make: 'Volkswagen',
+        model: 'Golf',
+        // referenceVehicleId is what the source resolver keys off of.
+        referenceVehicleId: 'volkswagen-golf-viii-2019',
+      );
+      await tester.pumpWidget(_harness(
+        profile,
+        _CapturedCalls(),
+        referenceVehicle: turboDiRef,
+      ));
+      await tester.pump();
+      await tester.tap(find.text('Advanced calibration'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(
+        find.text('(catalog: Volkswagen Golf — Turbocharged + DI default)'),
+        findsOneWidget,
+        reason: 'η_v field must show the enriched basis-aware label',
+      );
+    });
+
+    testWidgets(
+        'η_v field on a NA + no-DI legacy vehicle falls back to the '
+        'plain "(catalog: <make model>)" label (no enrichment when '
+        'helper basis is null)', (tester) async {
+      const profile = VehicleProfile(
+        id: 'v',
+        name: '107',
+        make: 'Peugeot',
+        model: '107',
+        referenceVehicleId: 'peugeot-107-i-2005',
+      );
+      await tester.pumpWidget(_harness(
+        profile,
+        _CapturedCalls(),
+        referenceVehicle: naLegacyRef,
+      ));
+      await tester.pump();
+      await tester.tap(find.text('Advanced calibration'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Plain catalog label (no em-dash, no "default" suffix) — every
+      // catalog-sourced field on this vehicle gets this label.
+      expect(find.text('(catalog: Peugeot 107)'), findsWidgets);
+      expect(find.textContaining('Naturally aspirated'), findsNothing);
+      expect(find.textContaining('default)'), findsNothing);
+    });
+
+    testWidgets(
+        'other catalog-sourced fields (displacement, AFR, fuel density) '
+        'STILL render the plain catalog label even when the η_v field '
+        'is enriched — basis enrichment is η_v-only', (tester) async {
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Golf',
+        make: 'Volkswagen',
+        model: 'Golf',
+        referenceVehicleId: 'volkswagen-golf-viii-2019',
+      );
+      await tester.pumpWidget(_harness(
+        profile,
+        _CapturedCalls(),
+        referenceVehicle: turboDiRef,
+      ));
+      await tester.pump();
+      await tester.tap(find.text('Advanced calibration'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Three other fields (displacement, AFR, fuel density) are also
+      // catalog-sourced for this profile. They MUST render the plain
+      // `(catalog: Volkswagen Golf)` label, not the enriched one.
+      expect(find.text('(catalog: Volkswagen Golf)'), findsNWidgets(3),
+          reason:
+              'displacement + AFR + fuel density share the plain label');
+      // The enriched label appears exactly once (η_v only).
+      expect(
+        find.text('(catalog: Volkswagen Golf — Turbocharged + DI default)'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'no enrichment leaks to non-catalog sources — manual override '
+        'on η_v still renders "(manual)"', (tester) async {
+      const profile = VehicleProfile(
+        id: 'v',
+        name: 'Golf',
+        make: 'Volkswagen',
+        model: 'Golf',
+        referenceVehicleId: 'volkswagen-golf-viii-2019',
+        manualVolumetricEfficiencyOverride: 0.92,
+      );
+      await tester.pumpWidget(_harness(
+        profile,
+        _CapturedCalls(),
+        referenceVehicle: turboDiRef,
+      ));
+      await tester.pump();
+      await tester.tap(find.text('Advanced calibration'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Manual override beats catalog source — η_v field reads (manual),
+      // never the enriched catalog label.
+      expect(find.text('(manual)'), findsOneWidget);
+      expect(
+        find.text('(catalog: Volkswagen Golf — Turbocharged + DI default)'),
+        findsNothing,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 2 of #1422 (closes the epic). Section E of the spec — `CalibrationSection` origin tag enrichment.

The volumetricEfficiency field's catalog origin tag now shows the engine-tech basis when known: `(catalog: Dacia Duster — VNT diesel + DI default)`. Mirrors the 5 helper paths from phase 1 (Atkinson, VNT, Turbo+DI, Turbo, NA+DI). NA-no-DI keeps the plain `(catalog: <make model>)` label since the helper output is the legacy 0.85 default — no enrichment needed.

- New `volumetricEfficiencyBasisKey(ReferenceVehicle)` helper returning one of 5 ARB keys (or null for the baseline)
- 6 new ARB keys (5 basis labels + 1 enriched-source label) — fragments en/de/fr (French parity enforced for calibration*)
- `calibration_section.dart` rewires `_sourceLabel` to use the enriched key for the η_v field when basis resolves; other fields and other sources (manual/detected/default) unchanged
- `edit_vehicle_screen.dart` resolves the matching `ReferenceVehicle` via `referenceVehicleId` slug or `VehicleProfileCatalogMatcher` and threads it into the widget as a constructor param
- Widget tests pin the enriched render + fallback + cross-field non-leakage

## Test plan

- [x] Helper covers all 6 paths (5 keys + null baseline)
- [x] CalibrationSection renders enriched label for known turbo+DI reference
- [x] CalibrationSection falls back to plain catalog label for NA-no-DI
- [x] Other calibration fields (displacement/AFR/fuelDensity) unaffected
- [x] French parity test green for new calibration* keys
- [x] Existing `calibration_section_test.dart` cases still green

Closes #1422