### PR TITLE
feat(obd2): BrokenMapBelief entity + EMA updater + membership functions (Refs #1423 phase 1)

### DIFF
--- a/lib/features/consumption/data/obd2/broken_map_belief.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief.dart
@@ -1,0 +1,71 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'broken_map_belief.freezed.dart';
+part 'broken_map_belief.g.dart';
+
+/// Reason tag set on the most recent strong observation that pushed
+/// [BrokenMapBelief.confidence] up. Useful for the diagnostic overlay
+/// (#1395) to surface which signal triggered (idle probe, plein-complet,
+/// rev delta).
+///
+/// Phase 1 establishes the enum surface; phase 2-3 producers (idle
+/// probe, reconciler hook) emit these.
+enum BrokenMapReason {
+  /// Idle vacuum measurement was suspiciously close to atmospheric.
+  idleVacuumMissing,
+
+  /// Diesel rev-step measurement showed the MAP barely changing.
+  revDeltaMissing,
+
+  /// Plein-complet reconciliation showed estimated L/100km wildly low
+  /// vs receipt math.
+  pleinCompletDiscrepancy,
+
+  /// VeLearner converged to a η_v above what's physically possible.
+  etaImplausible,
+
+  /// Not yet triggered by a strong observation (default).
+  none,
+}
+
+/// Persisted fuzzy belief about whether a paired OBD2 adapter's MAP
+/// sensor reads correctly (#1423). One belief per vehicle; persisted in
+/// the settings box (key wiring deferred to phase 4 — phase 1 only
+/// ships the entity + EMA math).
+///
+/// Confidence semantics:
+///   - 0.0 → trusted (no broken-MAP evidence)
+///   - 1.0 → certainly broken
+///
+/// UI thresholds (used by phase 5 consumers, documented here for
+/// reference):
+///   - < 0.4 → silent
+///   - 0.4–0.7 → "MAP sensor verifying..." chip
+///   - 0.7–0.9 → snackbar warning
+///   - ≥ 0.9 → hard-disable MAP-derived fuel-rate
+@freezed
+abstract class BrokenMapBelief with _$BrokenMapBelief {
+  const BrokenMapBelief._();
+
+  const factory BrokenMapBelief({
+    /// EMA-smoothed confidence in [0.0, 1.0]. Updater clamps on every
+    /// step.
+    @Default(0.0) double confidence,
+
+    /// Number of observations folded into [confidence]. Useful for
+    /// "verified" auto-clear (phase 2 of #1424 will gate on this).
+    @Default(0) int observationCount,
+
+    /// Last time [BrokenMapBeliefUpdater.update] was called. Null when
+    /// the belief was just constructed and has never been updated.
+    DateTime? lastUpdate,
+
+    /// Last reason that contributed a *strong* observation
+    /// (`observationScore > 0.5`). Sticky — only overwritten on the
+    /// next strong observation.
+    @Default(BrokenMapReason.none) BrokenMapReason lastTrigger,
+  }) = _BrokenMapBelief;
+
+  factory BrokenMapBelief.fromJson(Map<String, dynamic> json) =>
+      _$BrokenMapBeliefFromJson(json);
+}

--- a/lib/features/consumption/data/obd2/broken_map_belief.freezed.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief.freezed.dart
@@ -1,0 +1,304 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'broken_map_belief.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BrokenMapBelief {
+
+/// EMA-smoothed confidence in [0.0, 1.0]. Updater clamps on every
+/// step.
+ double get confidence;/// Number of observations folded into [confidence]. Useful for
+/// "verified" auto-clear (phase 2 of #1424 will gate on this).
+ int get observationCount;/// Last time [BrokenMapBeliefUpdater.update] was called. Null when
+/// the belief was just constructed and has never been updated.
+ DateTime? get lastUpdate;/// Last reason that contributed a *strong* observation
+/// (`observationScore > 0.5`). Sticky — only overwritten on the
+/// next strong observation.
+ BrokenMapReason get lastTrigger;
+/// Create a copy of BrokenMapBelief
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BrokenMapBeliefCopyWith<BrokenMapBelief> get copyWith => _$BrokenMapBeliefCopyWithImpl<BrokenMapBelief>(this as BrokenMapBelief, _$identity);
+
+  /// Serializes this BrokenMapBelief to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BrokenMapBelief&&(identical(other.confidence, confidence) || other.confidence == confidence)&&(identical(other.observationCount, observationCount) || other.observationCount == observationCount)&&(identical(other.lastUpdate, lastUpdate) || other.lastUpdate == lastUpdate)&&(identical(other.lastTrigger, lastTrigger) || other.lastTrigger == lastTrigger));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,confidence,observationCount,lastUpdate,lastTrigger);
+
+@override
+String toString() {
+  return 'BrokenMapBelief(confidence: $confidence, observationCount: $observationCount, lastUpdate: $lastUpdate, lastTrigger: $lastTrigger)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BrokenMapBeliefCopyWith<$Res>  {
+  factory $BrokenMapBeliefCopyWith(BrokenMapBelief value, $Res Function(BrokenMapBelief) _then) = _$BrokenMapBeliefCopyWithImpl;
+@useResult
+$Res call({
+ double confidence, int observationCount, DateTime? lastUpdate, BrokenMapReason lastTrigger
+});
+
+
+
+
+}
+/// @nodoc
+class _$BrokenMapBeliefCopyWithImpl<$Res>
+    implements $BrokenMapBeliefCopyWith<$Res> {
+  _$BrokenMapBeliefCopyWithImpl(this._self, this._then);
+
+  final BrokenMapBelief _self;
+  final $Res Function(BrokenMapBelief) _then;
+
+/// Create a copy of BrokenMapBelief
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? confidence = null,Object? observationCount = null,Object? lastUpdate = freezed,Object? lastTrigger = null,}) {
+  return _then(_self.copyWith(
+confidence: null == confidence ? _self.confidence : confidence // ignore: cast_nullable_to_non_nullable
+as double,observationCount: null == observationCount ? _self.observationCount : observationCount // ignore: cast_nullable_to_non_nullable
+as int,lastUpdate: freezed == lastUpdate ? _self.lastUpdate : lastUpdate // ignore: cast_nullable_to_non_nullable
+as DateTime?,lastTrigger: null == lastTrigger ? _self.lastTrigger : lastTrigger // ignore: cast_nullable_to_non_nullable
+as BrokenMapReason,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BrokenMapBelief].
+extension BrokenMapBeliefPatterns on BrokenMapBelief {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BrokenMapBelief value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BrokenMapBelief() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BrokenMapBelief value)  $default,){
+final _that = this;
+switch (_that) {
+case _BrokenMapBelief():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BrokenMapBelief value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BrokenMapBelief() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( double confidence,  int observationCount,  DateTime? lastUpdate,  BrokenMapReason lastTrigger)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BrokenMapBelief() when $default != null:
+return $default(_that.confidence,_that.observationCount,_that.lastUpdate,_that.lastTrigger);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( double confidence,  int observationCount,  DateTime? lastUpdate,  BrokenMapReason lastTrigger)  $default,) {final _that = this;
+switch (_that) {
+case _BrokenMapBelief():
+return $default(_that.confidence,_that.observationCount,_that.lastUpdate,_that.lastTrigger);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( double confidence,  int observationCount,  DateTime? lastUpdate,  BrokenMapReason lastTrigger)?  $default,) {final _that = this;
+switch (_that) {
+case _BrokenMapBelief() when $default != null:
+return $default(_that.confidence,_that.observationCount,_that.lastUpdate,_that.lastTrigger);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _BrokenMapBelief extends BrokenMapBelief {
+  const _BrokenMapBelief({this.confidence = 0.0, this.observationCount = 0, this.lastUpdate, this.lastTrigger = BrokenMapReason.none}): super._();
+  factory _BrokenMapBelief.fromJson(Map<String, dynamic> json) => _$BrokenMapBeliefFromJson(json);
+
+/// EMA-smoothed confidence in [0.0, 1.0]. Updater clamps on every
+/// step.
+@override@JsonKey() final  double confidence;
+/// Number of observations folded into [confidence]. Useful for
+/// "verified" auto-clear (phase 2 of #1424 will gate on this).
+@override@JsonKey() final  int observationCount;
+/// Last time [BrokenMapBeliefUpdater.update] was called. Null when
+/// the belief was just constructed and has never been updated.
+@override final  DateTime? lastUpdate;
+/// Last reason that contributed a *strong* observation
+/// (`observationScore > 0.5`). Sticky — only overwritten on the
+/// next strong observation.
+@override@JsonKey() final  BrokenMapReason lastTrigger;
+
+/// Create a copy of BrokenMapBelief
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BrokenMapBeliefCopyWith<_BrokenMapBelief> get copyWith => __$BrokenMapBeliefCopyWithImpl<_BrokenMapBelief>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BrokenMapBeliefToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BrokenMapBelief&&(identical(other.confidence, confidence) || other.confidence == confidence)&&(identical(other.observationCount, observationCount) || other.observationCount == observationCount)&&(identical(other.lastUpdate, lastUpdate) || other.lastUpdate == lastUpdate)&&(identical(other.lastTrigger, lastTrigger) || other.lastTrigger == lastTrigger));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,confidence,observationCount,lastUpdate,lastTrigger);
+
+@override
+String toString() {
+  return 'BrokenMapBelief(confidence: $confidence, observationCount: $observationCount, lastUpdate: $lastUpdate, lastTrigger: $lastTrigger)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BrokenMapBeliefCopyWith<$Res> implements $BrokenMapBeliefCopyWith<$Res> {
+  factory _$BrokenMapBeliefCopyWith(_BrokenMapBelief value, $Res Function(_BrokenMapBelief) _then) = __$BrokenMapBeliefCopyWithImpl;
+@override @useResult
+$Res call({
+ double confidence, int observationCount, DateTime? lastUpdate, BrokenMapReason lastTrigger
+});
+
+
+
+
+}
+/// @nodoc
+class __$BrokenMapBeliefCopyWithImpl<$Res>
+    implements _$BrokenMapBeliefCopyWith<$Res> {
+  __$BrokenMapBeliefCopyWithImpl(this._self, this._then);
+
+  final _BrokenMapBelief _self;
+  final $Res Function(_BrokenMapBelief) _then;
+
+/// Create a copy of BrokenMapBelief
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? confidence = null,Object? observationCount = null,Object? lastUpdate = freezed,Object? lastTrigger = null,}) {
+  return _then(_BrokenMapBelief(
+confidence: null == confidence ? _self.confidence : confidence // ignore: cast_nullable_to_non_nullable
+as double,observationCount: null == observationCount ? _self.observationCount : observationCount // ignore: cast_nullable_to_non_nullable
+as int,lastUpdate: freezed == lastUpdate ? _self.lastUpdate : lastUpdate // ignore: cast_nullable_to_non_nullable
+as DateTime?,lastTrigger: null == lastTrigger ? _self.lastTrigger : lastTrigger // ignore: cast_nullable_to_non_nullable
+as BrokenMapReason,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/consumption/data/obd2/broken_map_belief.g.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'broken_map_belief.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BrokenMapBelief _$BrokenMapBeliefFromJson(Map<String, dynamic> json) =>
+    _BrokenMapBelief(
+      confidence: (json['confidence'] as num?)?.toDouble() ?? 0.0,
+      observationCount: (json['observationCount'] as num?)?.toInt() ?? 0,
+      lastUpdate: json['lastUpdate'] == null
+          ? null
+          : DateTime.parse(json['lastUpdate'] as String),
+      lastTrigger:
+          $enumDecodeNullable(_$BrokenMapReasonEnumMap, json['lastTrigger']) ??
+          BrokenMapReason.none,
+    );
+
+Map<String, dynamic> _$BrokenMapBeliefToJson(_BrokenMapBelief instance) =>
+    <String, dynamic>{
+      'confidence': instance.confidence,
+      'observationCount': instance.observationCount,
+      'lastUpdate': instance.lastUpdate?.toIso8601String(),
+      'lastTrigger': _$BrokenMapReasonEnumMap[instance.lastTrigger]!,
+    };
+
+const _$BrokenMapReasonEnumMap = {
+  BrokenMapReason.idleVacuumMissing: 'idleVacuumMissing',
+  BrokenMapReason.revDeltaMissing: 'revDeltaMissing',
+  BrokenMapReason.pleinCompletDiscrepancy: 'pleinCompletDiscrepancy',
+  BrokenMapReason.etaImplausible: 'etaImplausible',
+  BrokenMapReason.none: 'none',
+};

--- a/lib/features/consumption/data/obd2/broken_map_belief_updater.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief_updater.dart
@@ -1,0 +1,92 @@
+import 'broken_map_belief.dart';
+
+/// Membership functions + EMA updater for [BrokenMapBelief] (#1423).
+/// Pure math — no I/O, no Riverpod, no Hive. Phase 1 ships these so
+/// downstream phases (idle probe, reconciler hook, blocklist) can
+/// build on a stable contract.
+///
+/// All membership functions return values in [0.0, 1.0] where 1.0 is
+/// strong evidence of a broken MAP sensor. Each is paired with a
+/// realistic boundary range derived from the issue spec (§ E).
+class BrokenMapBeliefUpdater {
+  /// Exponential smoothing factor (`α`). 0.4 weights the new
+  /// observation noticeably without making the belief jump on a
+  /// single noisy sample. Tuned in spec § E.
+  static const double _alpha = 0.4;
+
+  /// Threshold above which an observation is "strong" enough to set
+  /// [BrokenMapBelief.lastTrigger]. Below this the belief still
+  /// accumulates but the trigger tag isn't overwritten.
+  static const double _strongThreshold = 0.5;
+
+  /// Idle-vacuum-missing membership. On a healthy NA petrol engine,
+  /// `baro - map` at idle is typically 30-45 kPa (strong vacuum).
+  /// On a broken MAP that returns atmospheric, the delta is ≤ 5 kPa.
+  ///   - Returns 0.0 when delta ≥ 45 kPa (healthy vacuum).
+  ///   - Returns 1.0 when delta ≤ 15 kPa (no vacuum — likely broken).
+  ///   - Linear interp in between.
+  static double vacuumMissingScore({
+    required double baroKpa,
+    required double mapKpa,
+  }) {
+    final delta = baroKpa - mapKpa;
+    return (1.0 - ((delta - 15.0) / 30.0)).clamp(0.0, 1.0);
+  }
+
+  /// Diesel-rev-delta membership. Diesels run unthrottled so idle MAP
+  /// is near baro; the discriminator is how much MAP *changes* under
+  /// a brief rev. Healthy: ≥ 30 kPa swing. Broken: ≤ 8 kPa swing.
+  ///   - Returns 0.0 when |rev - idle| ≥ 30 kPa.
+  ///   - Returns 1.0 when |rev - idle| ≤ 8 kPa.
+  static double revDeltaMissingScore({
+    required double mapIdleKpa,
+    required double mapRevvedKpa,
+  }) {
+    final delta = (mapRevvedKpa - mapIdleKpa).abs();
+    return (1.0 - ((delta - 8.0) / 22.0)).clamp(0.0, 1.0);
+  }
+
+  /// Plein-complet ratio severity. Reconciler computes
+  /// `actualLPer100km / estimatedLPer100km`. Ratios > 1.3 are
+  /// suspicious (estimated is undercounting); > 2.2 is conclusive.
+  ///   - Returns 0.0 when ratio ≤ 1.3 (clean).
+  ///   - Returns 1.0 when ratio ≥ 2.2.
+  static double discrepancySeverityScore({required double ratio}) {
+    return ((ratio - 1.3) / 0.9).clamp(0.0, 1.0);
+  }
+
+  /// VeLearner-proposed-η_v implausibility. η_v above 0.97 is
+  /// physically suspicious for a typical engine; > 1.22 is
+  /// definitely impossible (the learner is compensating for a fuel
+  /// undercount that's actually MAP-derived).
+  ///   - Returns 0.0 when proposedEta ≤ 0.97.
+  ///   - Returns 1.0 when proposedEta ≥ 1.22.
+  static double etaImplausibilityScore({required double proposedEta}) {
+    return ((proposedEta - 0.97) / 0.25).clamp(0.0, 1.0);
+  }
+
+  /// Folds [observationScore] (already-combined, in [0.0, 1.0]) into
+  /// [prev] via EMA. Updates the trigger only when the score crosses
+  /// the strong threshold.
+  ///
+  /// `now` is injected for deterministic tests; production callers pass
+  /// `DateTime.now()`.
+  static BrokenMapBelief update(
+    BrokenMapBelief prev,
+    double observationScore, {
+    required DateTime now,
+    BrokenMapReason? reason,
+  }) {
+    final clampedScore = observationScore.clamp(0.0, 1.0);
+    final newConfidence =
+        (_alpha * clampedScore + (1.0 - _alpha) * prev.confidence)
+            .clamp(0.0, 1.0);
+    final isStrong = clampedScore > _strongThreshold;
+    return prev.copyWith(
+      confidence: newConfidence,
+      observationCount: prev.observationCount + 1,
+      lastUpdate: now,
+      lastTrigger: isStrong && reason != null ? reason : prev.lastTrigger,
+    );
+  }
+}

--- a/test/features/consumption/data/obd2/broken_map_belief_test.dart
+++ b/test/features/consumption/data/obd2/broken_map_belief_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief.dart';
+
+void main() {
+  group('BrokenMapBelief', () {
+    test('default constructor uses neutral baseline', () {
+      const belief = BrokenMapBelief();
+      expect(belief.confidence, 0.0);
+      expect(belief.observationCount, 0);
+      expect(belief.lastUpdate, isNull);
+      expect(belief.lastTrigger, BrokenMapReason.none);
+    });
+
+    test('JSON round-trip preserves every field', () {
+      final ts = DateTime.utc(2026, 5, 4, 12, 30);
+      final original = BrokenMapBelief(
+        confidence: 0.73,
+        observationCount: 12,
+        lastUpdate: ts,
+        lastTrigger: BrokenMapReason.idleVacuumMissing,
+      );
+
+      final json = original.toJson();
+      final parsed = BrokenMapBelief.fromJson(json);
+
+      expect(parsed.confidence, 0.73);
+      expect(parsed.observationCount, 12);
+      expect(parsed.lastUpdate, ts);
+      expect(parsed.lastTrigger, BrokenMapReason.idleVacuumMissing);
+      expect(parsed, original);
+    });
+
+    test('copyWith confidence change preserves other fields', () {
+      final ts = DateTime.utc(2026, 5, 4, 12, 30);
+      final original = BrokenMapBelief(
+        confidence: 0.2,
+        observationCount: 4,
+        lastUpdate: ts,
+        lastTrigger: BrokenMapReason.revDeltaMissing,
+      );
+
+      final updated = original.copyWith(confidence: 0.9);
+
+      expect(updated.confidence, 0.9);
+      expect(updated.observationCount, 4);
+      expect(updated.lastUpdate, ts);
+      expect(updated.lastTrigger, BrokenMapReason.revDeltaMissing);
+    });
+
+    test('every BrokenMapReason serializes to its enum name', () {
+      final cases = <BrokenMapReason, String>{
+        BrokenMapReason.idleVacuumMissing: 'idleVacuumMissing',
+        BrokenMapReason.revDeltaMissing: 'revDeltaMissing',
+        BrokenMapReason.pleinCompletDiscrepancy: 'pleinCompletDiscrepancy',
+        BrokenMapReason.etaImplausible: 'etaImplausible',
+        BrokenMapReason.none: 'none',
+      };
+
+      for (final entry in cases.entries) {
+        final belief = BrokenMapBelief(lastTrigger: entry.key);
+        final json = belief.toJson();
+        expect(
+          json['lastTrigger'],
+          entry.value,
+          reason: '${entry.key} should serialize to "${entry.value}"',
+        );
+        final back = BrokenMapBelief.fromJson(json);
+        expect(back.lastTrigger, entry.key);
+      }
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/broken_map_belief_updater_test.dart
+++ b/test/features/consumption/data/obd2/broken_map_belief_updater_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief_updater.dart';
+
+/// Reference EMA α used by [BrokenMapBeliefUpdater.update]. Kept here
+/// as a literal so test assertions are self-explanatory; if production
+/// retunes α the failing tests document the change.
+const double _alpha = 0.4;
+
+void main() {
+  group('vacuumMissingScore', () {
+    test('returns 0.0 when delta is at the healthy boundary (45 kPa)', () {
+      // baro 100 kPa, map 55 kPa → delta 45 kPa → healthy.
+      final s = BrokenMapBeliefUpdater.vacuumMissingScore(
+        baroKpa: 100,
+        mapKpa: 55,
+      );
+      expect(s, 0.0);
+    });
+
+    test('returns 1.0 when delta is at/below the suspicious boundary (15 kPa)',
+        () {
+      // baro 100 kPa, map 90 kPa → delta 10 kPa → strong evidence
+      // (clamped from a negative formula value).
+      final s = BrokenMapBeliefUpdater.vacuumMissingScore(
+        baroKpa: 100,
+        mapKpa: 90,
+      );
+      expect(s, 1.0);
+    });
+
+    test('linear interp at delta 30 returns 0.5', () {
+      // baro 100 kPa, map 70 kPa → delta 30 → midpoint between 15 and 45.
+      final s = BrokenMapBeliefUpdater.vacuumMissingScore(
+        baroKpa: 100,
+        mapKpa: 70,
+      );
+      expect(s, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('revDeltaMissingScore', () {
+    test('returns 0.0 when |rev - idle| is at healthy boundary (30 kPa)', () {
+      final s = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 70,
+      );
+      expect(s, 0.0);
+    });
+
+    test('returns 1.0 when |rev - idle| is at/below suspicious boundary (8 kPa)',
+        () {
+      final s = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 95,
+      );
+      expect(s, 1.0);
+    });
+
+    test('linear interp at delta 19 returns 0.5', () {
+      // |rev - idle| = 19 → midpoint between 8 and 30.
+      final s = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 81,
+      );
+      expect(s, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('discrepancySeverityScore', () {
+    test('returns 0.0 when ratio is at healthy boundary (1.3)', () {
+      final s = BrokenMapBeliefUpdater.discrepancySeverityScore(ratio: 1.3);
+      expect(s, 0.0);
+    });
+
+    test('returns 1.0 when ratio is at/above suspicious boundary (2.2)', () {
+      final s = BrokenMapBeliefUpdater.discrepancySeverityScore(ratio: 2.2);
+      expect(s, 1.0);
+    });
+
+    test('linear interp at ratio 1.75 returns 0.5', () {
+      final s = BrokenMapBeliefUpdater.discrepancySeverityScore(ratio: 1.75);
+      expect(s, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('etaImplausibilityScore', () {
+    test('returns 0.0 when proposedEta is at healthy boundary (0.97)', () {
+      final s = BrokenMapBeliefUpdater.etaImplausibilityScore(
+        proposedEta: 0.97,
+      );
+      expect(s, 0.0);
+    });
+
+    test('returns 1.0 when proposedEta is at/above suspicious boundary (1.22)',
+        () {
+      final s = BrokenMapBeliefUpdater.etaImplausibilityScore(
+        proposedEta: 1.22,
+      );
+      expect(s, 1.0);
+    });
+
+    test('linear interp at proposedEta 1.095 returns 0.5', () {
+      final s = BrokenMapBeliefUpdater.etaImplausibilityScore(
+        proposedEta: 1.095,
+      );
+      expect(s, closeTo(0.5, 1e-9));
+    });
+  });
+
+  group('update — EMA mechanics', () {
+    test('single update of score 1.0 yields confidence == α', () {
+      final now = DateTime.utc(2026, 5, 4, 12);
+      const prev = BrokenMapBelief();
+
+      final next = BrokenMapBeliefUpdater.update(prev, 1.0, now: now);
+
+      expect(next.confidence, closeTo(_alpha, 1e-9));
+      expect(next.observationCount, 1);
+      expect(next.lastUpdate, now);
+    });
+
+    test('five sequential 0.4 observations stay around 0.4 (no compounding)',
+        () {
+      // EMA with constant input converges to that input — it does NOT
+      // compound the way Bayesian accumulation does. Spec §E flags this.
+      // Closed form after n updates from 0: x × (1 - (1-α)^n)
+      // For n=5, α=0.4 → 0.4 × (1 - 0.6^5) ≈ 0.369. Confidence MUST stay
+      // bounded by the input — never exceed it — and asymptotically
+      // approach it.
+      final now = DateTime.utc(2026, 5, 4, 12);
+      BrokenMapBelief belief = const BrokenMapBelief();
+      final history = <double>[];
+      for (var i = 0; i < 5; i++) {
+        belief = BrokenMapBeliefUpdater.update(belief, 0.4, now: now);
+        history.add(belief.confidence);
+      }
+      // Never exceeds the input — would only happen if EMA compounded.
+      expect(history.every((c) => c <= 0.4 + 1e-9), isTrue);
+      // Approaching the input, not stuck.
+      expect(belief.confidence, greaterThan(0.3));
+      expect(belief.confidence, closeTo(0.369, 0.01));
+      expect(belief.observationCount, 5);
+
+      // Many more iterations get arbitrarily close to 0.4.
+      for (var i = 0; i < 50; i++) {
+        belief = BrokenMapBeliefUpdater.update(belief, 0.4, now: now);
+      }
+      expect(belief.confidence, closeTo(0.4, 1e-6));
+    });
+
+    test('strong observation with reason updates lastTrigger and stamps fields',
+        () {
+      final now = DateTime.utc(2026, 5, 4, 12);
+      const prev = BrokenMapBelief();
+
+      final next = BrokenMapBeliefUpdater.update(
+        prev,
+        0.9,
+        now: now,
+        reason: BrokenMapReason.idleVacuumMissing,
+      );
+
+      expect(next.lastTrigger, BrokenMapReason.idleVacuumMissing);
+      expect(next.observationCount, 1);
+      expect(next.lastUpdate, now);
+      // 0.4 × 0.9 + 0.6 × 0 = 0.36
+      expect(next.confidence, closeTo(0.36, 1e-9));
+    });
+
+    test('weak observation does NOT overwrite a previously-set lastTrigger',
+        () {
+      final t0 = DateTime.utc(2026, 5, 4, 12);
+      final t1 = DateTime.utc(2026, 5, 4, 12, 5);
+      const prev = BrokenMapBelief();
+
+      // Strong hit sets the trigger.
+      final after = BrokenMapBeliefUpdater.update(
+        prev,
+        0.9,
+        now: t0,
+        reason: BrokenMapReason.idleVacuumMissing,
+      );
+      expect(after.lastTrigger, BrokenMapReason.idleVacuumMissing);
+
+      // Weak follow-up — score below the strong threshold AND a different
+      // reason supplied. Trigger must remain sticky.
+      final later = BrokenMapBeliefUpdater.update(
+        after,
+        0.2,
+        now: t1,
+        reason: BrokenMapReason.revDeltaMissing,
+      );
+      expect(later.lastTrigger, BrokenMapReason.idleVacuumMissing);
+      expect(later.observationCount, 2);
+    });
+
+    test('belief at 0.8 decays toward 0 after five zero-score updates', () {
+      final now = DateTime.utc(2026, 5, 4, 12);
+      BrokenMapBelief belief = const BrokenMapBelief(confidence: 0.8);
+      for (var i = 0; i < 5; i++) {
+        belief = BrokenMapBeliefUpdater.update(belief, 0.0, now: now);
+      }
+      // (1 - α)^5 × 0.8 ≈ 0.6^5 × 0.8 ≈ 0.0622
+      expect(belief.confidence, lessThan(0.1));
+      expect(belief.confidence, greaterThan(0.0));
+    });
+
+    test('observationScore above 1.0 is clamped — confidence stays in [0,1]',
+        () {
+      final now = DateTime.utc(2026, 5, 4, 12);
+      const prev = BrokenMapBelief();
+
+      final next = BrokenMapBeliefUpdater.update(prev, 1.5, now: now);
+
+      expect(next.confidence, lessThanOrEqualTo(1.0));
+      expect(next.confidence, greaterThanOrEqualTo(0.0));
+      // Should equal α × 1.0 (clamped) = 0.4
+      expect(next.confidence, closeTo(_alpha, 1e-9));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 1 of #1423 — pure data-layer foundation. Ships the entity + math contract that phases 2-5 will consume:

- `BrokenMapBelief` Freezed entity with JSON round-trip (confidence, observationCount, lastUpdate, lastTrigger)
- `BrokenMapReason` enum: idleVacuumMissing, revDeltaMissing, pleinCompletDiscrepancy, etaImplausible, none
- `BrokenMapBeliefUpdater` static helpers:
  - 4 membership functions: vacuumMissingScore, revDeltaMissingScore, discrepancySeverityScore, etaImplausibilityScore
  - EMA `update(prev, observationScore, now, reason)` with α=0.4, _strongThreshold=0.5
- No Hive box registration (deferred to phase 4 to keep this PR small + avoid hot-file `hive_boxes.dart`)
- No consumer wiring (deferred — fuel_rate_estimator gating, idle probe, reconciler hook are phases 2-5)

## Phase plan

- Phase 1 (this PR): entity + math
- Phase 2: idle probe at adapter pair (transport hookup)
- Phase 3: plein-complet hook into reconciler (#1361)
- Phase 4: persistent adapter blocklist (Hive registration + recall path)
- Phase 5: capability tag + UI thresholds + ARB strings

## Test plan

- [x] Default constructor + JSON round-trip
- [x] All 4 membership functions: healthy boundary / suspicious boundary / interior interp
- [x] EMA single-update produces α × score
- [x] Five sequential 0.4 observations stay at ~0.4 (EMA doesn't compound — spec explicitly notes this)
- [x] Strong observation with reason updates lastTrigger; weak observation does not overwrite
- [x] Decay: belief at 0.8 followed by 5 zero-scores decays toward 0
- [x] observationScore is clamped to [0, 1]

Refs #1423