### PR TITLE
feat(consumption): wire OBD2 fuel-level capture into FillUp save flow (Closes #1434)

### DIFF
--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -15,6 +15,7 @@ import '../../domain/entities/fill_up.dart';
 import '../../domain/fill_up_auto_cost_calculator.dart';
 import '../../domain/fill_up_variance.dart';
 import '../../providers/consumption_providers.dart';
+import '../../providers/current_obd2_fuel_level_provider.dart';
 import '../widgets/add_fill_up_form_fields.dart';
 import '../widgets/fill_up_no_vehicle_cta.dart';
 import '../widgets/fill_up_pinned_save_bar.dart';
@@ -94,6 +95,20 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   ReceiptScanOutcome? _lastScan;
   FillUpAutoCostCalculator? _autoCostCalc;
 
+  /// Adapter-captured tank level (litres) snapshotted at form-open
+  /// (#1434). Closes the producer-wiring gap from #1401 — paired with
+  /// [_fuelLevelAfterL] (captured at save) so the persisted [FillUp]
+  /// carries both reads, lighting up the verified-by-adapter badge
+  /// (#1430) and the variance prompt when the user-typed liters
+  /// disagrees with the adapter delta by >5 %.
+  ///
+  /// Null when no trip is recording, the adapter doesn't surface
+  /// PID 0x2F, or the active vehicle has no tankCapacityL configured.
+  /// Test seam [AddFillUpScreen.initialFuelLevelBeforeL] takes
+  /// precedence when set, so widget tests can drive the dialog flow
+  /// without standing up a live OBD2 stack.
+  double? _fuelLevelBeforeL;
+
   @override
   void initState() {
     super.initState();
@@ -105,6 +120,26 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     // #953 — accept an injected scan service so widget tests can drive
     // the failure flow without touching the platform camera channel.
     _scanService = widget.scanService;
+    // #1434 — snapshot the OBD2 tank level NOW so the persisted FillUp
+    // remembers what the adapter saw at form-open. The widget's test
+    // seam takes precedence so widget tests can pin a deterministic
+    // value without spinning up the trip-recording graph.
+    _fuelLevelBeforeL =
+        widget.initialFuelLevelBeforeL ?? _readObd2FuelLevelLitres();
+  }
+
+  /// One-shot read of the OBD2 fuel-level provider at the current
+  /// instant. `ref.read` (not `watch`) — we capture a single snapshot,
+  /// not a reactive subscription. Returns null when the provider is
+  /// unavailable in the test container or any other read-time failure
+  /// (defensive: a missing OBD2 reading must never block save).
+  double? _readObd2FuelLevelLitres() {
+    try {
+      return ref.read(currentObd2FuelLevelLitresProvider);
+    } catch (e, st) {
+      debugPrint('AddFillUp: OBD2 fuel-level read failed: $e\n$st');
+      return null;
+    }
   }
 
   /// Resolve the initial vehicle selection: prefer the profile's
@@ -220,6 +255,15 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     final userLiters = AddFillUpValidators.parseDouble(_litersCtrl.text);
+    // #1434 — capture the post-fill tank level NOW (form-submit). The
+    // before-fill capture happened in initState and lives on the
+    // state field. The test seam takes precedence so widget tests can
+    // exercise the variance / no-variance flows without a live OBD2
+    // chain. Both nulls on a no-OBD2 phone leave the FillUp in the
+    // legacy "user-entered only" shape — variance prompt skips itself
+    // (FillUpVariance.hasAdapterCapture returns false).
+    final afterL =
+        widget.initialFuelLevelAfterL ?? _readObd2FuelLevelLitres();
     var fillUp = FillUp(
       id: DateTime.now().microsecondsSinceEpoch.toString(),
       date: _date,
@@ -232,8 +276,8 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       notes: _notesCtrl.text.trim().isEmpty ? null : _notesCtrl.text.trim(),
       vehicleId: _vehicleId,
       isFullTank: _isFullTank,
-      fuelLevelBeforeL: widget.initialFuelLevelBeforeL,
-      fuelLevelAfterL: widget.initialFuelLevelAfterL,
+      fuelLevelBeforeL: _fuelLevelBeforeL,
+      fuelLevelAfterL: afterL,
     );
 
     // #1401 phase 7b — when both adapter fuel-level captures are

--- a/lib/features/consumption/providers/current_obd2_fuel_level_provider.dart
+++ b/lib/features/consumption/providers/current_obd2_fuel_level_provider.dart
@@ -1,0 +1,61 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../vehicle/providers/vehicle_providers.dart';
+import 'trip_recording_provider.dart';
+
+part 'current_obd2_fuel_level_provider.g.dart';
+
+/// Most recent OBD2 tank-level reading, expressed in litres (#1434).
+///
+/// Closes the producer-wiring gap from #1401 — PR #1430 shipped the
+/// consumer side (verified-by-adapter badge + variance prompt on the
+/// fill-up form) but no producer was capturing tank levels at form
+/// open / save time, so the badge never fired in production.
+///
+/// Source chain (read-only — no upstream tampering):
+///   1. The trip-recording controller already populates
+///      [TripLiveReading.fuelLevelPercent] on every debounced tick
+///      from PID `0x2F`. We surface that value through
+///      [TripRecording]'s state.
+///   2. To convert percent → litres we multiply by the active
+///      vehicle's [VehicleProfile.tankCapacityL]. Resulting precision
+///      is bounded by the PID's 1/255 step (~0.4 % of tank) plus the
+///      user-entered tank-capacity figure — typically ±5 % of the
+///      true reading on coarse PIDs. Good enough to anchor the
+///      verified-by-adapter badge / variance prompt; insufficient for
+///      tankful reconciliation, which keeps using fill-up arithmetic.
+///
+/// Returns `null` when any one of the following holds:
+///   * no trip is currently recording (`!state.isActive`)
+///     — TripLiveReading has no per-sample timestamp, so an active
+///       recording is the simplest, correct staleness proxy: the
+///       controller emits at ~4 Hz so any non-null `state.live` is
+///       sub-second fresh, and a stopped recording's stale value is
+///       hidden by the `isActive` gate;
+///   * the trip's latest [TripLiveReading.fuelLevelPercent] is null
+///     (the car / adapter doesn't surface PID `0x2F`);
+///   * no active vehicle profile, or its [tankCapacityL] is null /
+///     non-positive (we can't convert).
+///
+/// PSA OEM-PID / passive-CAN paths (#1415, #1417, #1420) emit litres
+/// natively but their producer wiring into Riverpod is not yet
+/// complete — the data-layer service that owns those streams is
+/// privately held by the trip-recording stack today (see comments in
+/// [psaFuelLevelObd2ServiceProvider]). When that wiring lands, this
+/// provider can prefer the native litres source and skip the
+/// percent×capacity conversion entirely.
+@riverpod
+double? currentObd2FuelLevelLitres(Ref ref) {
+  final tripState = ref.watch(tripRecordingProvider);
+  if (!tripState.isActive) return null;
+
+  final percent = tripState.live?.fuelLevelPercent;
+  if (percent == null) return null;
+  if (percent < 0 || percent > 100) return null;
+
+  final vehicle = ref.watch(activeVehicleProfileProvider);
+  final capacity = vehicle?.tankCapacityL;
+  if (capacity == null || capacity <= 0) return null;
+
+  return (percent / 100.0) * capacity;
+}

--- a/lib/features/consumption/providers/current_obd2_fuel_level_provider.g.dart
+++ b/lib/features/consumption/providers/current_obd2_fuel_level_provider.g.dart
@@ -1,0 +1,171 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'current_obd2_fuel_level_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Most recent OBD2 tank-level reading, expressed in litres (#1434).
+///
+/// Closes the producer-wiring gap from #1401 — PR #1430 shipped the
+/// consumer side (verified-by-adapter badge + variance prompt on the
+/// fill-up form) but no producer was capturing tank levels at form
+/// open / save time, so the badge never fired in production.
+///
+/// Source chain (read-only — no upstream tampering):
+///   1. The trip-recording controller already populates
+///      [TripLiveReading.fuelLevelPercent] on every debounced tick
+///      from PID `0x2F`. We surface that value through
+///      [TripRecording]'s state.
+///   2. To convert percent → litres we multiply by the active
+///      vehicle's [VehicleProfile.tankCapacityL]. Resulting precision
+///      is bounded by the PID's 1/255 step (~0.4 % of tank) plus the
+///      user-entered tank-capacity figure — typically ±5 % of the
+///      true reading on coarse PIDs. Good enough to anchor the
+///      verified-by-adapter badge / variance prompt; insufficient for
+///      tankful reconciliation, which keeps using fill-up arithmetic.
+///
+/// Returns `null` when any one of the following holds:
+///   * no trip is currently recording (`!state.isActive`)
+///     — TripLiveReading has no per-sample timestamp, so an active
+///       recording is the simplest, correct staleness proxy: the
+///       controller emits at ~4 Hz so any non-null `state.live` is
+///       sub-second fresh, and a stopped recording's stale value is
+///       hidden by the `isActive` gate;
+///   * the trip's latest [TripLiveReading.fuelLevelPercent] is null
+///     (the car / adapter doesn't surface PID `0x2F`);
+///   * no active vehicle profile, or its [tankCapacityL] is null /
+///     non-positive (we can't convert).
+///
+/// PSA OEM-PID / passive-CAN paths (#1415, #1417, #1420) emit litres
+/// natively but their producer wiring into Riverpod is not yet
+/// complete — the data-layer service that owns those streams is
+/// privately held by the trip-recording stack today (see comments in
+/// [psaFuelLevelObd2ServiceProvider]). When that wiring lands, this
+/// provider can prefer the native litres source and skip the
+/// percent×capacity conversion entirely.
+
+@ProviderFor(currentObd2FuelLevelLitres)
+final currentObd2FuelLevelLitresProvider =
+    CurrentObd2FuelLevelLitresProvider._();
+
+/// Most recent OBD2 tank-level reading, expressed in litres (#1434).
+///
+/// Closes the producer-wiring gap from #1401 — PR #1430 shipped the
+/// consumer side (verified-by-adapter badge + variance prompt on the
+/// fill-up form) but no producer was capturing tank levels at form
+/// open / save time, so the badge never fired in production.
+///
+/// Source chain (read-only — no upstream tampering):
+///   1. The trip-recording controller already populates
+///      [TripLiveReading.fuelLevelPercent] on every debounced tick
+///      from PID `0x2F`. We surface that value through
+///      [TripRecording]'s state.
+///   2. To convert percent → litres we multiply by the active
+///      vehicle's [VehicleProfile.tankCapacityL]. Resulting precision
+///      is bounded by the PID's 1/255 step (~0.4 % of tank) plus the
+///      user-entered tank-capacity figure — typically ±5 % of the
+///      true reading on coarse PIDs. Good enough to anchor the
+///      verified-by-adapter badge / variance prompt; insufficient for
+///      tankful reconciliation, which keeps using fill-up arithmetic.
+///
+/// Returns `null` when any one of the following holds:
+///   * no trip is currently recording (`!state.isActive`)
+///     — TripLiveReading has no per-sample timestamp, so an active
+///       recording is the simplest, correct staleness proxy: the
+///       controller emits at ~4 Hz so any non-null `state.live` is
+///       sub-second fresh, and a stopped recording's stale value is
+///       hidden by the `isActive` gate;
+///   * the trip's latest [TripLiveReading.fuelLevelPercent] is null
+///     (the car / adapter doesn't surface PID `0x2F`);
+///   * no active vehicle profile, or its [tankCapacityL] is null /
+///     non-positive (we can't convert).
+///
+/// PSA OEM-PID / passive-CAN paths (#1415, #1417, #1420) emit litres
+/// natively but their producer wiring into Riverpod is not yet
+/// complete — the data-layer service that owns those streams is
+/// privately held by the trip-recording stack today (see comments in
+/// [psaFuelLevelObd2ServiceProvider]). When that wiring lands, this
+/// provider can prefer the native litres source and skip the
+/// percent×capacity conversion entirely.
+
+final class CurrentObd2FuelLevelLitresProvider
+    extends $FunctionalProvider<double?, double?, double?>
+    with $Provider<double?> {
+  /// Most recent OBD2 tank-level reading, expressed in litres (#1434).
+  ///
+  /// Closes the producer-wiring gap from #1401 — PR #1430 shipped the
+  /// consumer side (verified-by-adapter badge + variance prompt on the
+  /// fill-up form) but no producer was capturing tank levels at form
+  /// open / save time, so the badge never fired in production.
+  ///
+  /// Source chain (read-only — no upstream tampering):
+  ///   1. The trip-recording controller already populates
+  ///      [TripLiveReading.fuelLevelPercent] on every debounced tick
+  ///      from PID `0x2F`. We surface that value through
+  ///      [TripRecording]'s state.
+  ///   2. To convert percent → litres we multiply by the active
+  ///      vehicle's [VehicleProfile.tankCapacityL]. Resulting precision
+  ///      is bounded by the PID's 1/255 step (~0.4 % of tank) plus the
+  ///      user-entered tank-capacity figure — typically ±5 % of the
+  ///      true reading on coarse PIDs. Good enough to anchor the
+  ///      verified-by-adapter badge / variance prompt; insufficient for
+  ///      tankful reconciliation, which keeps using fill-up arithmetic.
+  ///
+  /// Returns `null` when any one of the following holds:
+  ///   * no trip is currently recording (`!state.isActive`)
+  ///     — TripLiveReading has no per-sample timestamp, so an active
+  ///       recording is the simplest, correct staleness proxy: the
+  ///       controller emits at ~4 Hz so any non-null `state.live` is
+  ///       sub-second fresh, and a stopped recording's stale value is
+  ///       hidden by the `isActive` gate;
+  ///   * the trip's latest [TripLiveReading.fuelLevelPercent] is null
+  ///     (the car / adapter doesn't surface PID `0x2F`);
+  ///   * no active vehicle profile, or its [tankCapacityL] is null /
+  ///     non-positive (we can't convert).
+  ///
+  /// PSA OEM-PID / passive-CAN paths (#1415, #1417, #1420) emit litres
+  /// natively but their producer wiring into Riverpod is not yet
+  /// complete — the data-layer service that owns those streams is
+  /// privately held by the trip-recording stack today (see comments in
+  /// [psaFuelLevelObd2ServiceProvider]). When that wiring lands, this
+  /// provider can prefer the native litres source and skip the
+  /// percent×capacity conversion entirely.
+  CurrentObd2FuelLevelLitresProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'currentObd2FuelLevelLitresProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$currentObd2FuelLevelLitresHash();
+
+  @$internal
+  @override
+  $ProviderElement<double?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  double? create(Ref ref) {
+    return currentObd2FuelLevelLitres(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(double? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<double?>(value),
+    );
+  }
+}
+
+String _$currentObd2FuelLevelLitresHash() =>
+    r'7e989a3321f641df7c42a0e95822850224bddb7d';

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_obd2_capture_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_obd2_capture_test.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/add_fill_up_screen.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_numeric_field.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/consumption/providers/current_obd2_fuel_level_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for the OBD2-fuel-level capture wiring on
+/// [AddFillUpScreen] (#1434).
+///
+/// The screen calls [currentObd2FuelLevelLitresProvider] twice:
+///   1. In `initState` → cached as `_fuelLevelBeforeL`
+///   2. In `_save` → captured as `fuelLevelAfterL`
+///
+/// Both values are stamped onto the persisted [FillUp] so the
+/// verified-by-adapter badge (#1430) and the variance prompt fire in
+/// production. These tests pin that contract end-to-end through the
+/// real screen and a fake [FillUpList] that captures what `add` was
+/// invoked with.
+
+const _stubVehicle = VehicleProfile(
+  id: 'stub-vehicle',
+  name: 'Stub Car',
+  type: VehicleType.combustion,
+  tankCapacityL: 50,
+);
+
+class _StubVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [_stubVehicle];
+}
+
+/// Stub `ActiveVehicleProfile` so the fuel-level provider's
+/// `tankCapacityL` lookup doesn't fall through to Hive (which the
+/// widget-test environment doesn't initialise).
+class _StubActiveVehicle extends ActiveVehicleProfile {
+  @override
+  VehicleProfile? build() => _stubVehicle;
+}
+
+/// Captures every fill-up handed to `add` so the test can inspect
+/// the OBD2 fields. We deliberately bypass the production `add`
+/// pipeline (repo, calibration, link-window) — those have their own
+/// coverage; this test pins only the screen-side capture contract.
+class _CapturingFillUpList extends FillUpList {
+  final List<FillUp> captured = [];
+
+  @override
+  List<FillUp> build() => const [];
+
+  @override
+  Future<void> add(FillUp fillUp) async {
+    captured.add(fillUp);
+  }
+}
+
+/// Manual trip-recording fake — same pattern as the eco-coach tests.
+/// We pin `state` directly so the test stays free of OBD2 / Hive
+/// setup.
+class _ManualTripRecording extends TripRecording {
+  _ManualTripRecording(this._initial);
+  final TripRecordingState _initial;
+
+  @override
+  TripRecordingState build() => _initial;
+}
+
+/// A minimal go_router-driven scaffold: pushes `AddFillUpScreen` as a
+/// child route so `context.pop()` inside `_save` resolves cleanly. The
+/// initial route is a launcher button that pushes the form, so the
+/// pop after save returns to the launcher rather than throwing
+/// "tried to pop the root navigator".
+Future<void> pumpAddFillUpInRouter(
+  WidgetTester tester, {
+  required List<Object> overrides,
+  AddFillUpScreen? screen,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(
+          body: Center(
+            child: Builder(
+              builder: (ctx) => ElevatedButton(
+                onPressed: () => ctx.push('/add'),
+                child: const Text('open-form'),
+              ),
+            ),
+          ),
+        ),
+      ),
+      GoRoute(
+        path: '/add',
+        builder: (context, state) => screen ?? const AddFillUpScreen(),
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides.cast(),
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('open-form'));
+  await tester.pumpAndSettle();
+}
+
+Finder _fieldByLabel(String label) => find.ancestor(
+      of: find.text(label),
+      matching: find.byType(FillUpNumericField),
+    );
+
+void _typeInto(WidgetTester tester, String label, String value) {
+  final fieldFinder = find.descendant(
+    of: _fieldByLabel(label),
+    matching: find.byType(TextField),
+  );
+  final field = tester.widget<TextField>(fieldFinder);
+  field.controller!.text = value;
+}
+
+TripRecordingState _recordingWithPercent(double percent) {
+  return TripRecordingState(
+    phase: TripRecordingPhase.recording,
+    live: TripLiveReading(
+      fuelLevelPercent: percent,
+      distanceKmSoFar: 0,
+      elapsed: const Duration(seconds: 1),
+    ),
+  );
+}
+
+Future<void> _fillFormAndSave(WidgetTester tester) async {
+  _typeInto(tester, 'Liters', '40');
+  _typeInto(tester, 'Total cost', '70');
+  _typeInto(tester, 'Odometer (km)', '12345');
+  await tester.pump();
+  await tester.tap(find.text('Save'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('AddFillUpScreen — OBD2 fuel-level capture (#1434)', () {
+    testWidgets(
+        'persists the provider value as fuelLevelBeforeL/After when active',
+        (tester) async {
+      // 75 % × 50 L = 37.5 L. The provider snapshots the same value
+      // both at initState and at save (no state change in between in
+      // this test), so before == after — that's fine for this contract:
+      // we only need to prove BOTH fields land on the FillUp non-null.
+      // The sibling test below pins the no-OBD2 case where both stay
+      // null, which is the actual differential.
+      final fillUpList = _CapturingFillUpList();
+      await pumpAddFillUpInRouter(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _StubVehicleList()),
+          activeVehicleProfileProvider
+              .overrideWith(() => _StubActiveVehicle()),
+          tripRecordingProvider.overrideWith(
+              () => _ManualTripRecording(_recordingWithPercent(75))),
+          fillUpListProvider.overrideWith(() => fillUpList),
+        ],
+      );
+
+      await _fillFormAndSave(tester);
+
+      expect(fillUpList.captured, hasLength(1));
+      final saved = fillUpList.captured.single;
+      expect(saved.fuelLevelBeforeL, closeTo(37.5, 0.001));
+      expect(saved.fuelLevelAfterL, closeTo(37.5, 0.001));
+      // User-entered fields survive untouched.
+      expect(saved.liters, closeTo(40, 0.001));
+      expect(saved.totalCost, closeTo(70, 0.001));
+    });
+
+    testWidgets(
+        'leaves fuelLevelBeforeL/After null when no trip is recording',
+        (tester) async {
+      // Idle phase → provider returns null both at initState and at
+      // save. The persisted FillUp must keep the legacy "user-entered
+      // only" shape so the variance prompt skips itself
+      // (FillUpVariance.hasAdapterCapture returns false) and the
+      // verified-by-adapter badge stays hidden.
+      final fillUpList = _CapturingFillUpList();
+      await pumpAddFillUpInRouter(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _StubVehicleList()),
+          tripRecordingProvider.overrideWith(
+              () => _ManualTripRecording(const TripRecordingState())),
+          fillUpListProvider.overrideWith(() => fillUpList),
+        ],
+      );
+
+      await _fillFormAndSave(tester);
+
+      expect(fillUpList.captured, hasLength(1));
+      final saved = fillUpList.captured.single;
+      expect(saved.fuelLevelBeforeL, isNull);
+      expect(saved.fuelLevelAfterL, isNull);
+    });
+
+    testWidgets(
+        'widget seam initialFuelLevelBeforeL/After takes precedence over '
+        'the live provider value', (tester) async {
+      // Pre-existing test seam (#1401 phase 7b). The provider would
+      // yield 37.5 L (75 % × 50 L) but the test seam pins 15.0 / 55.0
+      // — those values must reach the FillUp untouched so widget tests
+      // can exercise the verified-by-adapter path deterministically
+      // without a live OBD2 chain. delta = 40 L matches the user-typed
+      // 40 L exactly, so the variance prompt does NOT fire.
+      final fillUpList = _CapturingFillUpList();
+      await pumpAddFillUpInRouter(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _StubVehicleList()),
+          activeVehicleProfileProvider
+              .overrideWith(() => _StubActiveVehicle()),
+          tripRecordingProvider.overrideWith(
+              () => _ManualTripRecording(_recordingWithPercent(75))),
+          fillUpListProvider.overrideWith(() => fillUpList),
+        ],
+        screen: const AddFillUpScreen(
+          initialFuelLevelBeforeL: 15.0,
+          initialFuelLevelAfterL: 55.0,
+        ),
+      );
+
+      await _fillFormAndSave(tester);
+
+      expect(fillUpList.captured, hasLength(1));
+      final saved = fillUpList.captured.single;
+      expect(saved.fuelLevelBeforeL, 15.0);
+      expect(saved.fuelLevelAfterL, 55.0);
+    });
+  });
+}

--- a/test/features/consumption/providers/current_obd2_fuel_level_provider_test.dart
+++ b/test/features/consumption/providers/current_obd2_fuel_level_provider_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+import 'package:tankstellen/features/consumption/providers/current_obd2_fuel_level_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+/// Unit tests for [currentObd2FuelLevelLitresProvider] (#1434).
+///
+/// The provider's only job is to bridge:
+///   * [tripRecordingProvider]'s `state.live?.fuelLevelPercent`
+///   * [activeVehicleProfileProvider]'s `tankCapacityL`
+///
+/// into a litres value — gating on isActive (staleness proxy) and
+/// dropping any null / out-of-range input. These tests pin the gates
+/// + the conversion math.
+
+/// Manual trip-recording fake — same pattern the haptic-eco-coach
+/// provider tests use. We bypass `start`/`stop` and pin the state
+/// directly so the test stays free of OBD2 / Hive setup.
+class _ManualTripRecording extends TripRecording {
+  _ManualTripRecording(this._initial);
+  final TripRecordingState _initial;
+
+  @override
+  TripRecordingState build() => _initial;
+}
+
+/// Stub `ActiveVehicleProfile` — same pattern as [tank_level_provider_test].
+class _StubActiveVehicle extends ActiveVehicleProfile {
+  _StubActiveVehicle(this._value);
+  final VehicleProfile? _value;
+
+  @override
+  VehicleProfile? build() => _value;
+}
+
+void main() {
+  TripRecordingState recordingWith({
+    double? fuelLevelPercent,
+  }) {
+    return TripRecordingState(
+      phase: TripRecordingPhase.recording,
+      live: TripLiveReading(
+        fuelLevelPercent: fuelLevelPercent,
+        distanceKmSoFar: 0,
+        elapsed: const Duration(seconds: 1),
+      ),
+    );
+  }
+
+  const vehicleWithCapacity = VehicleProfile(
+    id: 'v1',
+    name: 'Test Car',
+    type: VehicleType.combustion,
+    tankCapacityL: 50,
+  );
+
+  const vehicleNoCapacity = VehicleProfile(
+    id: 'v2',
+    name: 'No-tank Car',
+    type: VehicleType.combustion,
+  );
+
+  ProviderContainer makeContainer({
+    required TripRecordingState tripState,
+    VehicleProfile? activeVehicle,
+  }) {
+    final c = ProviderContainer(overrides: [
+      tripRecordingProvider
+          .overrideWith(() => _ManualTripRecording(tripState)),
+      activeVehicleProfileProvider
+          .overrideWith(() => _StubActiveVehicle(activeVehicle)),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('currentObd2FuelLevelLitresProvider — null gates', () {
+    test('returns null when no trip is recording (idle phase)', () {
+      // Even with a vehicle + a fuelLevelPercent in the live reading,
+      // an idle phase means isActive == false and the provider must
+      // refuse the value (staleness guard). The default
+      // TripRecordingState constructor is idle.
+      final c = makeContainer(
+        tripState: const TripRecordingState(),
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+
+    test('returns null when trip is finished (post-stop, stale state)', () {
+      // Finished phase keeps the last live reading on the state but
+      // isActive is false — the gate must reject this stale value.
+      const state = TripRecordingState(
+        phase: TripRecordingPhase.finished,
+        live: TripLiveReading(
+          fuelLevelPercent: 75,
+          distanceKmSoFar: 0,
+          elapsed: Duration(seconds: 1),
+        ),
+      );
+
+      final c = makeContainer(
+        tripState: state,
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+
+    test('returns null when fuelLevelPercent is null (PID unsupported)', () {
+      // Active recording but no PID 0x2F → live.fuelLevelPercent is
+      // null. The provider must surface that through, not throw.
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: null),
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+
+    test('returns null when no active vehicle is selected', () {
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50),
+        activeVehicle: null,
+      );
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+
+    test('returns null when active vehicle has null tankCapacityL', () {
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50),
+        activeVehicle: vehicleNoCapacity,
+      );
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+
+    test('returns null when active vehicle has zero tankCapacityL', () {
+      // Defensive: a malformed vehicle row with capacity 0 must not
+      // multiply through to 0 L — null is the honest answer.
+      const zeroCapacity = VehicleProfile(
+        id: 'v3',
+        name: 'Bad Car',
+        type: VehicleType.combustion,
+        tankCapacityL: 0,
+      );
+
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50),
+        activeVehicle: zeroCapacity,
+      );
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+
+    test('returns null when fuelLevelPercent is out of [0, 100] range', () {
+      // PID 0x2F encodes 0-100% by spec; an out-of-range read is a
+      // decoder bug or transport corruption — refuse rather than
+      // multiply through to a nonsense value.
+      final overRange = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 120),
+        activeVehicle: vehicleWithCapacity,
+      );
+      expect(overRange.read(currentObd2FuelLevelLitresProvider), isNull);
+
+      final underRange = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: -5),
+        activeVehicle: vehicleWithCapacity,
+      );
+      expect(underRange.read(currentObd2FuelLevelLitresProvider), isNull);
+    });
+  });
+
+  group('currentObd2FuelLevelLitresProvider — happy path conversion', () {
+    test('50% on a 50 L tank yields 25 L', () {
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50),
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(
+        c.read(currentObd2FuelLevelLitresProvider),
+        closeTo(25, 0.0001),
+      );
+    });
+
+    test('full tank reading yields full capacity', () {
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 100),
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(
+        c.read(currentObd2FuelLevelLitresProvider),
+        closeTo(50, 0.0001),
+      );
+    });
+
+    test('empty tank reading yields 0 L (not null)', () {
+      // 0% is a valid in-range reading — the gate is "out of [0,100]",
+      // not "0 is null". A truly empty tank is information.
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 0),
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(
+        c.read(currentObd2FuelLevelLitresProvider),
+        closeTo(0, 0.0001),
+      );
+    });
+
+    test('fractional percent on a different capacity converts correctly',
+        () {
+      // 37.5 % × 60 L = 22.5 L. Pins the math against a vehicle whose
+      // capacity differs from the 50 L base fixture.
+      const sixtyLCar = VehicleProfile(
+        id: 'v-sixty',
+        name: 'Big Tank',
+        type: VehicleType.combustion,
+        tankCapacityL: 60,
+      );
+
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 37.5),
+        activeVehicle: sixtyLCar,
+      );
+
+      expect(
+        c.read(currentObd2FuelLevelLitresProvider),
+        closeTo(22.5, 0.0001),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Why

Closes the producer-wiring gap from #1401's epic. PR #1430 shipped the consumer side of the verified-by-adapter feature (badge + variance prompt) but no producer was populating `FillUp.fuelLevelBeforeL` / `fuelLevelAfterL` in production, so both features stayed dark. This PR wires the simplest correct producer so the badge and variance prompt light up in production.

## Changes

- **New provider** `currentObd2FuelLevelLitresProvider` (`lib/features/consumption/providers/current_obd2_fuel_level_provider.dart`)
  - Reads `tripRecordingProvider.state.live?.fuelLevelPercent` (PID 0x2F, populated by the existing trip-recording controller — no upstream tampering)
  - Multiplies by `activeVehicleProfileProvider.tankCapacityL`
  - Gates on `state.isActive` as the staleness proxy (controller emits at ~4 Hz so any active reading is sub-second fresh)
  - Returns null on any missing input (no trip, no PID, no vehicle, no capacity, out-of-range %)

- **`add_fill_up_screen.dart`** snapshots the provider value at `initState` (`_fuelLevelBeforeL`) and again at save (`fuelLevelAfterL`), passing both into the `FillUp` constructor. Existing test seams (`initialFuelLevelBeforeL` / `initialFuelLevelAfterL`) take precedence so widget tests work unchanged.

- **Tests** (14 new + 1 regression-checked):
  - 11 tests pinning the provider's null gates + conversion math
  - 3 widget tests covering the screen-side capture contract end-to-end (provider value lands on FillUp; null when no trip; test seam wins)
  - Re-ran existing `fill_up_variance_prompt_test.dart` — no regression

## Precision caveat

Percent x capacity gives ~5 % precision on the coarse 0x2F PID — good enough to anchor the verified-by-adapter badge and the >5 % variance prompt; insufficient for tankful reconciliation (which keeps using fill-up arithmetic). PSA OEM-PID / passive-CAN paths (#1415, #1417, #1420) emit litres natively but their producer wiring into Riverpod is still incomplete (the live service is privately owned by the trip-recording stack today). Swapping the source can happen later without touching consumer code.

## Out of scope

- A "pump-start vs pump-end" detector that brackets the operation via fuel-level deltas (tracked in #1434's body).
- PSA passive-CAN integration into TripLiveReading.
- Refactoring `TripLiveReading.fuelLevelPercent` to litres (future cleanup).

## Test plan

- [x] `flutter analyze` clean (zero issues)
- [x] `flutter test test/features/consumption/providers/current_obd2_fuel_level_provider_test.dart` — 11/11 pass
- [x] `flutter test test/features/consumption/presentation/screens/add_fill_up_screen_obd2_capture_test.dart` — 3/3 pass
- [x] `flutter test test/features/consumption/presentation/widgets/fill_up_variance_prompt_test.dart` — 4/4 pass (no regression)
- [x] `flutter test test/features/consumption/presentation/screens/` — 88/88 pass (no regression on sibling screen tests)
- [x] `flutter test test/lint/` — 29/29 pass
- [ ] Device test once merged: drive briefly, fill up, verify badge appears on saved fill-up