### PR TITLE
fix(map): float ServiceStatusBanner as overlay so it stops cutting the map

### DIFF
--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -14,8 +14,13 @@ import 'station_map_layers.dart';
 
 /// Displays a map of nearby stations from the current search results.
 ///
-/// Shows the service status banner, station markers on the map,
-/// and a bottom info bar with station count and search radius.
+/// Layout: station markers fill the body, the bottom info bar pins to
+/// the bottom, and any [ServiceStatusBanner] (cache / fallback /
+/// offline) floats as a Positioned overlay at the top so it never
+/// pushes the map down. Pre-#1428 the banner was the first child of a
+/// Column and produced a visible grey strip between the AppBar and
+/// the map whenever a fallback fired — a permanent ~32 dp tax on
+/// every "stations were fetched via the secondary API" session.
 class NearbyMapView extends ConsumerWidget {
   final AsyncValue searchState;
   final dynamic selectedFuel;
@@ -103,28 +108,42 @@ class NearbyMapView extends ConsumerWidget {
           }
         });
 
-        return Column(
+        return Stack(
           children: [
-            ServiceStatusBanner(result: result),
-            Expanded(
-              child: StationMapLayers(
-                mapController: mapController,
-                stations: stations,
-                center: center,
-                zoom: zoom,
-                searchRadiusKm: searchRadiusKm,
-                selectedFuel: selectedFuel,
-                showRecenterButton: true,
-                onRecenter: () => mapController.fitCamera(
-                  CameraFit.bounds(
-                    bounds: bounds,
-                    padding: const EdgeInsets.all(32),
+            Column(
+              children: [
+                Expanded(
+                  child: StationMapLayers(
+                    mapController: mapController,
+                    stations: stations,
+                    center: center,
+                    zoom: zoom,
+                    searchRadiusKm: searchRadiusKm,
+                    selectedFuel: selectedFuel,
+                    showRecenterButton: true,
+                    onRecenter: () => mapController.fitCamera(
+                      CameraFit.bounds(
+                        bounds: bounds,
+                        padding: const EdgeInsets.all(32),
+                      ),
+                    ),
+                    extraLayers: extraLayers,
                   ),
                 ),
-                extraLayers: extraLayers,
-              ),
+                _buildInfoBar(context, l10n, stations, result),
+              ],
             ),
-            _buildInfoBar(context, l10n, stations, result),
+            // Stale / fallback banner as a floating overlay so it
+            // never steals vertical space from the map. Self-hides
+            // (returns SizedBox.shrink) when the result has neither
+            // staleness nor fallbacks, so the overlay is invisible
+            // on the happy path.
+            Positioned(
+              top: 8,
+              left: 8,
+              right: 8,
+              child: _OverlayBanner(result: result),
+            ),
           ],
         );
       },
@@ -174,6 +193,36 @@ class NearbyMapView extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Floating wrapper for [ServiceStatusBanner] used by the map view.
+///
+/// [ServiceStatusBanner] returns [SizedBox.shrink] when the result is
+/// neither stale nor used a fallback, so this widget is invisible on
+/// the happy path. When a banner IS rendered, the [Material] envelope
+/// gives it elevation + rounded corners so it reads as a floating
+/// chip overlaying the map rather than a full-bleed strip cutting the
+/// screen in half. [SafeArea] keeps the chip clear of the AppBar's
+/// shadow without inflating its size when the AppBar already provides
+/// its own SafeArea padding (the bottom side is disabled — the bottom
+/// info bar already pins to the safe area).
+class _OverlayBanner extends StatelessWidget {
+  final dynamic result;
+
+  const _OverlayBanner({required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      bottom: false,
+      child: Material(
+        elevation: 4,
+        borderRadius: BorderRadius.circular(8),
+        clipBehavior: Clip.antiAlias,
+        child: ServiceStatusBanner(result: result),
       ),
     );
   }


### PR DESCRIPTION
## Summary

The grey strip between the AppBar and the map when the primary station API has been failing over to a backup. `NearbyMapView` wrapped `ServiceStatusBanner` as the first child of a `Column`, so a full-bleed `tertiaryContainer`-coloured strip pushed the map down ~32 dp every "primary API failed, used backup" session — visible to the user as an empty grey bar above the map.

## Fix

Stack the banner as a `Positioned` overlay over the map. The banner already returns `SizedBox.shrink` on the happy path so the overlay is invisible when there's nothing to report. When it does fire, a `Material(elevation: 4, borderRadius: 8)` envelope frames it as a floating chip rather than a full-bleed strip — the map keeps every pixel of vertical space.

## Test plan

- [x] `flutter analyze` clean
- [x] All 150 existing map tests pass (no test changes — pure layout fix)
- [ ] Device-test: trigger a fallback (e.g. force the primary German API into rate-limit, or switch to a country whose primary is offline) and confirm the banner now floats above the map instead of cutting it

🤖 Generated with [Claude Code](https://claude.com/claude-code)