### PR TITLE
feat(settings): group dependent features under their parent (Closes #1440)

### DIFF
--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -10,22 +10,28 @@ import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../../../feature_management/domain/feature_manifest.dart';
 
 /// Settings-screen section that exposes every [Feature] as a toggle
-/// (#1373 phase 2).
+/// (#1373 phase 2; #1440 grouping).
 ///
-/// Renders one [SwitchListTile] per entry in [featureManifestProvider]. The
-/// dependency graph is consulted BEFORE attempting a transition so the
-/// provider's `StateError` never reaches the UI:
+/// Renders one [SwitchListTile] per entry in [featureManifestProvider],
+/// VISUALLY GROUPED so dependent features sit indented under the parent
+/// they require (#1440). Each group is a [Card] containing the parent
+/// row at full width followed by indented dependent rows separated by a
+/// subtle divider.
+///
+/// The dependency graph is consulted BEFORE attempting a transition so
+/// the provider's `StateError` never reaches the UI:
 /// - When a disabled feature's prerequisites are missing the switch is
 ///   disabled and wrapped in a [Tooltip] naming the missing prerequisite
-///   via `featureBlockedEnable_<feature.name>`.
-/// - When an enabled feature has dependents that are still on, the switch
-///   is disabled and the tooltip lists the dependents using the
+///   via `featureBlockedEnable_<feature.name>`. A single tap on the
+///   disabled row also surfaces the same message via [SnackBar] (#1440).
+/// - When an enabled feature has dependents that are still on, the
+///   switch is disabled and the tooltip lists the dependents using the
 ///   `featureBlockedDisable_<feature.name>` template.
 ///
-/// Phase 1 of #1373 ships the engine in PARALLEL with the existing
+/// Phase 1 of #1373 shipped the engine in PARALLEL with the existing
 /// scattered toggles — this section therefore does NOT yet replace
-/// `autoRecord` / `gamificationEnabled` / etc. Phase 3 will migrate
-/// them one PR at a time.
+/// `autoRecord` / `gamificationEnabled` / etc. Phase 3 migrated them
+/// one PR at a time.
 class FeatureManagementSection extends ConsumerWidget {
   const FeatureManagementSection({super.key});
 
@@ -36,10 +42,14 @@ class FeatureManagementSection extends ConsumerWidget {
     final manifest = ref.watch(featureManifestProvider);
     final enabled = ref.watch(featureFlagsProvider);
 
-    // Iterate in manifest declaration order so the UI matches the order
-    // chosen in [FeatureManifest.defaultManifest] (foundation features
-    // first, follow-on / future features last).
-    final features = manifest.entries.keys.toList(growable: false);
+    // Build groups in manifest declaration order (#1440). A feature with
+    // no `requires` (or whose `requires` does not reference an already-
+    // seen parent) becomes a new group; otherwise it is appended to the
+    // first matching parent's group. Most dependents in the active
+    // manifest depend on a single parent, but multi-parent dependents
+    // attach to the first parent they reference in declaration order so
+    // grouping placement is deterministic.
+    final groups = _buildGroups(manifest);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8),
@@ -56,14 +66,120 @@ class FeatureManagementSection extends ConsumerWidget {
               style: theme.textTheme.bodySmall,
             ),
           ),
-          for (final feature in features)
-            _FeatureToggle(
-              feature: feature,
-              isEnabled: enabled.contains(feature),
+          for (final group in groups)
+            _FeatureGroupCard(
+              group: group,
               manifest: manifest,
               currentlyEnabled: enabled,
             ),
         ],
+      ),
+    );
+  }
+}
+
+/// A parent feature plus the dependents that should render indented
+/// beneath it (#1440). The parent itself is always the first row in the
+/// rendered Card; [children] is empty for stand-alone parents.
+class _FeatureGroup {
+  final Feature parent;
+  final List<Feature> children;
+
+  const _FeatureGroup({required this.parent, required this.children});
+}
+
+/// Walks [manifest] in declaration order and produces a list of groups
+/// in the same order. A feature with empty `requires` ALWAYS opens a
+/// new group; a feature with `requires` is appended to the first parent
+/// it references — falling back to a stand-alone group when none of its
+/// prerequisites are themselves declared in [manifest] (defensive: this
+/// should never happen in practice but the function stays total).
+List<_FeatureGroup> _buildGroups(FeatureManifest manifest) {
+  final groups = <_FeatureGroup>[];
+  // Index of the group whose parent is `Feature`, for O(1) child append.
+  final parentIndex = <Feature, int>{};
+
+  for (final feature in manifest.entries.keys) {
+    final entry = manifest.entries[feature]!;
+    if (entry.requires.isEmpty) {
+      parentIndex[feature] = groups.length;
+      groups.add(_FeatureGroup(parent: feature, children: <Feature>[]));
+      continue;
+    }
+    // Pick the first prerequisite that is itself a parent we have
+    // already seen — keeps ordering stable and predictable.
+    int? targetIndex;
+    for (final required in entry.requires) {
+      final idx = parentIndex[required];
+      if (idx != null) {
+        targetIndex = idx;
+        break;
+      }
+    }
+    if (targetIndex == null) {
+      // Defensive: dependent whose prerequisite is missing from the
+      // manifest — render as its own group so the user still sees the
+      // toggle.
+      parentIndex[feature] = groups.length;
+      groups.add(_FeatureGroup(parent: feature, children: <Feature>[]));
+    } else {
+      groups[targetIndex].children.add(feature);
+    }
+  }
+  return groups;
+}
+
+/// Renders one [_FeatureGroup] as a [Card] containing the parent toggle
+/// at full width followed by any dependent rows indented beneath it
+/// (#1440). When the group has no children the card collapses to just
+/// the parent row — no divider, no indent.
+class _FeatureGroupCard extends StatelessWidget {
+  final _FeatureGroup group;
+  final FeatureManifest manifest;
+  final Set<Feature> currentlyEnabled;
+
+  const _FeatureGroupCard({
+    required this.group,
+    required this.manifest,
+    required this.currentlyEnabled,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasChildren = group.children.isNotEmpty;
+    return Card(
+      key: Key('featureGroup_${group.parent.name}'),
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _FeatureToggle(
+              feature: group.parent,
+              isEnabled: currentlyEnabled.contains(group.parent),
+              manifest: manifest,
+              currentlyEnabled: currentlyEnabled,
+            ),
+            if (hasChildren)
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: theme.dividerColor.withValues(alpha: 0.4),
+              ),
+            for (final child in group.children)
+              Padding(
+                padding: const EdgeInsets.only(left: 24),
+                child: _FeatureToggle(
+                  feature: child,
+                  isEnabled: currentlyEnabled.contains(child),
+                  manifest: manifest,
+                  currentlyEnabled: currentlyEnabled,
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }
@@ -131,9 +247,29 @@ class _FeatureToggle extends ConsumerWidget {
     if (blockedReason == null) {
       return tile;
     }
+    // The switch's onChanged is null (disabled) so taps would be
+    // swallowed silently. Wrap the row in a GestureDetector that
+    // surfaces the blocker via SnackBar (#1440) — long-press still
+    // shows the existing Tooltip.
+    final reason = blockedReason;
     return Tooltip(
-      message: blockedReason,
-      child: tile,
+      message: reason,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          final messenger = ScaffoldMessenger.maybeOf(context);
+          if (messenger == null) return;
+          messenger
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(
+                content: Text(reason),
+                duration: const Duration(seconds: 3),
+              ),
+            );
+        },
+        child: tile,
+      ),
     );
   }
 }

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -125,7 +125,17 @@ void main() {
         container.read(featureFlagsProvider),
         isNot(contains(Feature.tankSync)),
       );
-      await tester.tap(find.byKey(const Key('featureToggle_tankSync')));
+      // Post-#1440 the section renders grouped cards which can push
+      // the tankSync row below the 800x600 default surface. Scroll it
+      // into view before tapping so the hit test lands on the switch.
+      final tankSyncFinder = find.byKey(const Key('featureToggle_tankSync'));
+      await tester.scrollUntilVisible(
+        tankSyncFinder,
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(tankSyncFinder);
       // Pump the synchronous state update + the in-flight Future. We
       // don't pumpAndSettle because the section has no animations.
       await tester.pump();

--- a/test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart
+++ b/test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/profile/presentation/widgets/feature_management_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Widget tests for #1440 — visual grouping of dependent features under
+/// their parent in the Settings → Feature management section, plus the
+/// new tap-to-snackbar behaviour on disabled (blocked) toggles.
+///
+/// These tests pump [FeatureManagementSection] inside a vanilla
+/// MaterialApp+Scaffold (no profile screen, no Hive) so the assertions
+/// stay focused on the widget tree the section produces.
+void main() {
+  group('FeatureManagementSection — grouping (#1440)', () {
+    /// Pump the section with a freshly-constructed container so we can
+    /// preconfigure feature-flag state via the notifier before laying
+    /// out the widget tree. Returns the container so the test can
+    /// dispose it.
+    Future<ProviderContainer> pumpSection(
+      WidgetTester tester, {
+      List<Object> overrides = const [],
+    }) async {
+      final container = ProviderContainer(
+        overrides: [
+          // Skip Hive; the notifier's synchronous initial state will be
+          // `manifest.defaultEnabledSet()`.
+          featureFlagsRepositoryProvider.overrideWithValue(null),
+          ...overrides,
+        ].cast(),
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: Locale('en'),
+            home: Scaffold(
+              body: SingleChildScrollView(child: FeatureManagementSection()),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    /// Asserts that [child]'s `_FeatureToggle` is rendered inside the
+    /// group card whose parent is [parent]. Uses the public
+    /// `featureGroup_<parent>` and `featureToggle_<child>` keys.
+    void expectChildInGroup(Feature parent, Feature child) {
+      final groupFinder = find.byKey(Key('featureGroup_${parent.name}'));
+      final childFinder = find.byKey(Key('featureToggle_${child.name}'));
+      expect(groupFinder, findsOneWidget,
+          reason: 'expected a group card for ${parent.name}');
+      expect(childFinder, findsOneWidget,
+          reason: 'expected a toggle for ${child.name}');
+      expect(
+        find.descendant(of: groupFinder, matching: childFinder),
+        findsOneWidget,
+        reason: '${child.name} must be rendered inside the '
+            '${parent.name} group card',
+      );
+    }
+
+    testWidgets('obd2TripRecording group contains its 7 dependents',
+        (tester) async {
+      await pumpSection(tester);
+
+      // Every feature whose `requires` set is `{obd2TripRecording}` must
+      // render as a descendant of the obd2TripRecording group card.
+      const dependents = <Feature>[
+        Feature.gamification,
+        Feature.hapticEcoCoach,
+        Feature.consumptionAnalytics,
+        Feature.glideCoach,
+        Feature.gpsTripPath,
+        Feature.autoRecord,
+        Feature.showConsumptionTab,
+      ];
+      for (final child in dependents) {
+        expectChildInGroup(Feature.obd2TripRecording, child);
+      }
+
+      // The parent toggle itself must be inside its group.
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('featureGroup_obd2TripRecording')),
+          matching: find.byKey(const Key('featureToggle_obd2TripRecording')),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tankSync group contains baselineSync', (tester) async {
+      await pumpSection(tester);
+      expectChildInGroup(Feature.tankSync, Feature.baselineSync);
+    });
+
+    testWidgets(
+        'unifiedSearchResults is a stand-alone group (no children)',
+        (tester) async {
+      await pumpSection(tester);
+
+      // The unifiedSearchResults card exists ...
+      final groupFinder =
+          find.byKey(const Key('featureGroup_unifiedSearchResults'));
+      expect(groupFinder, findsOneWidget);
+
+      // ... and contains exactly one toggle: itself.
+      final togglesInside = find.descendant(
+        of: groupFinder,
+        matching: find.byWidgetPredicate(
+          (w) => w is SwitchListTile,
+        ),
+      );
+      expect(togglesInside, findsOneWidget,
+          reason: 'unifiedSearchResults has no dependents — its card '
+              'must contain exactly one SwitchListTile (itself)');
+    });
+
+    testWidgets('parent toggles render before their children in the card',
+        (tester) async {
+      await pumpSection(tester);
+
+      // Topology check: in the obd2TripRecording group the parent's
+      // toggle key must appear before any dependent toggle key in
+      // widget-tree order. Use rect.top as the order proxy because the
+      // card is a Column.
+      final parentRect = tester.getRect(
+        find.byKey(const Key('featureToggle_obd2TripRecording')),
+      );
+      final childRect = tester.getRect(
+        find.byKey(const Key('featureToggle_gamification')),
+      );
+      expect(parentRect.top, lessThan(childRect.top),
+          reason: 'parent must render above its dependent inside the card');
+    });
+
+    testWidgets('children are visually indented relative to the parent',
+        (tester) async {
+      await pumpSection(tester);
+
+      final parentRect = tester.getRect(
+        find.byKey(const Key('featureToggle_obd2TripRecording')),
+      );
+      final childRect = tester.getRect(
+        find.byKey(const Key('featureToggle_gamification')),
+      );
+      expect(childRect.left, greaterThan(parentRect.left),
+          reason: 'dependent rows must be indented right of the parent '
+              'so the hierarchy is visually obvious');
+    });
+  });
+
+  group('FeatureManagementSection — snackbar on blocked tap (#1440)', () {
+    testWidgets(
+        'tapping gamification while obd2TripRecording is OFF surfaces a '
+        'snackbar with the localised "Enable OBD2 trip recording first" '
+        'message', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          featureFlagsRepositoryProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Gamification defaults ON; turn it off first so we can simulate
+      // a user trying to re-enable it while the prerequisite is missing.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.gamification);
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.gamification)),
+      );
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.obd2TripRecording)),
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: Locale('en'),
+            home: Scaffold(
+              body: SingleChildScrollView(child: FeatureManagementSection()),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The toggle is disabled — onChanged is null — so tapping the
+      // SwitchListTile would normally do nothing. The wrapping
+      // GestureDetector must intercept the tap and fire a SnackBar.
+      // Scroll the row into view before tapping so the hit test lands
+      // on the wrapper.
+      final toggleFinder = find.byKey(const Key('featureToggle_gamification'));
+      await tester.scrollUntilVisible(
+        toggleFinder,
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(toggleFinder, warnIfMissed: false);
+      // Pump the SnackBar reveal animation to completion.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.byType(SnackBar), findsOneWidget,
+          reason: 'a snackbar must surface the blocker when the user '
+              'taps a disabled (unmet-requires) toggle');
+      // The English message includes "OBD2 trip recording".
+      expect(
+        find.descendant(
+          of: find.byType(SnackBar),
+          matching: find.textContaining('OBD2 trip recording'),
+        ),
+        findsOneWidget,
+        reason: 'the snackbar must name the blocking prerequisite so '
+            'the user knows which switch to flip first',
+      );
+    });
+
+    testWidgets(
+        'tapping an unblocked toggle does NOT surface a snackbar',
+        (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          featureFlagsRepositoryProvider.overrideWithValue(null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: Locale('en'),
+            home: Scaffold(
+              body: SingleChildScrollView(child: FeatureManagementSection()),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // tankSync has no prerequisites — its toggle is enabled. Tap it
+      // and verify nothing surfaces. The default 800x600 surface clips
+      // the bottom of the section so we scroll the toggle into view
+      // first; behaviour is independent of viewport size.
+      final toggleFinder = find.byKey(const Key('featureToggle_tankSync'));
+      await tester.scrollUntilVisible(
+        toggleFinder,
+        100,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(toggleFinder);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byType(SnackBar), findsNothing,
+          reason: 'unblocked toggles must NOT trigger the snackbar — '
+              'the snackbar is only the blocked-tap path');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Restructures Settings → Feature management so dependent features render indented under the parent they require, inside a per-group Card. Also fires a SnackBar on tap of a disabled toggle so the blocker reason surfaces without a long-press.

Closes #1440.

## Changes

- `lib/features/profile/presentation/widgets/feature_management_section.dart`
  - New `_FeatureGroup` model + `_buildGroups(manifest)` walker that produces parent → children groups in manifest declaration order. A feature with empty `requires` opens a new group; a dependent attaches to the first parent it references.
  - New `_FeatureGroupCard` renders a Card per group: parent toggle full width on top, divider, then dependents indented 24 px. Stand-alone parents get just the parent row.
  - `_FeatureToggle` now wraps blocked rows in a `GestureDetector` that fires `ScaffoldMessenger.showSnackBar(...)` with the same `_blockedEnableMessage` / `_blockedDisableMessage` text the existing Tooltip already uses. Tooltip stays — long-press still works.
- `test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart` (new)
  - 5 grouping tests: `obd2TripRecording` group contains its 7 dependents, `tankSync` group contains `baselineSync`, `unifiedSearchResults` is stand-alone, parent renders above child, child is indented right of parent.
  - 2 SnackBar tests: tapping `gamification` while `obd2TripRecording` is OFF surfaces a SnackBar containing "OBD2 trip recording"; tapping an unblocked toggle does NOT surface a SnackBar.
- `test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart` — scrolls `tankSync` into view before tapping (the grouped layout is taller than the 800x600 default test surface).

## ARB

No new keys. Re-uses the existing `featureBlockedEnable_<feature>` / `featureBlockedDisable_<feature>` strings already in `app_en.arb` / `app_de.arb` / etc.

## Test plan

- [x] `flutter test test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart` — 7/7 pass
- [x] `flutter test test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart` — 4/4 pass
- [x] `flutter test test/features/feature_management/` — 53/53 pass
- [x] `flutter test test/lint/` — 29/29 pass
- [x] `flutter analyze` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)