### PR TITLE
feat(obd2): plein-complet hook for broken-MAP belief (Refs #1423 phase 3)

### DIFF
--- a/lib/features/consumption/data/obd2/broken_map_detector.dart
+++ b/lib/features/consumption/data/obd2/broken_map_detector.dart
@@ -174,6 +174,87 @@ class BrokenMapDetector {
       return prior;
     }
   }
+
+  /// Weight on the discrepancy-severity term in the combined plein-
+  /// complet observation. Spec § E pairs this with a 0.4 weight on the
+  /// η_v implausibility term — discrepancy carries more signal because
+  /// it's measured against pump receipts (ground truth) while the η_v
+  /// path is one inferential step removed (depends on the integrator).
+  static const double _discrepancyWeight = 0.6;
+
+  /// Weight on the η_v-implausibility term. See [_discrepancyWeight].
+  static const double _etaWeight = 0.4;
+
+  /// Fold a plein-complet (full-tank reconciliation) observation into
+  /// [prior] (#1423 phase 3).
+  ///
+  /// Combined score per spec § E:
+  /// ```
+  /// observationScore = 0.6 * discrepancySeverityScore(ratio)
+  ///                  + 0.4 * etaImplausibilityScore(proposedEta)
+  /// ```
+  /// where `ratio = reconciledLPer100km / estimatedLPer100km`.
+  ///
+  /// When [proposedEta] is null (the [VeLearner] had no candidate to
+  /// propose this cycle — e.g. distance under the gate, no integrated
+  /// fuel) the η_v term drops out and the score collapses to the pure
+  /// discrepancy severity. This avoids spuriously punishing a sensor
+  /// just because the learner didn't have enough data to opine; it
+  /// also avoids needing to invent a sentinel η_v value.
+  ///
+  /// Returns [prior] unchanged when:
+  ///   * [estimatedLPer100km] is non-positive (can't form a ratio),
+  ///   * [reconciledLPer100km] is non-positive (degenerate window).
+  ///
+  /// Pure — no I/O, no Hive, no Riverpod. Phase 4 will wrap the call
+  /// in a persistence pathway; phase 3 stays caller-driven so unit
+  /// tests can assert the score math without mocking storage.
+  BrokenMapBelief recordPleinCompletObservation({
+    required BrokenMapBelief prior,
+    required double reconciledLPer100km,
+    required double estimatedLPer100km,
+    required double? proposedEta,
+    required DateTime now,
+  }) {
+    if (estimatedLPer100km <= 0 || reconciledLPer100km <= 0) {
+      return prior;
+    }
+    final ratio = reconciledLPer100km / estimatedLPer100km;
+    final discrepancyScore = BrokenMapBeliefUpdater.discrepancySeverityScore(
+      ratio: ratio,
+    );
+
+    double observationScore;
+    BrokenMapReason reason;
+    if (proposedEta == null) {
+      // Learner had nothing to propose — fall back to discrepancy-only
+      // weight (full weight on the only available signal). Reason tag
+      // mirrors the dominant input so the diagnostic overlay can
+      // explain the trigger.
+      observationScore = discrepancyScore;
+      reason = BrokenMapReason.pleinCompletDiscrepancy;
+    } else {
+      final etaScore = BrokenMapBeliefUpdater.etaImplausibilityScore(
+        proposedEta: proposedEta,
+      );
+      observationScore =
+          _discrepancyWeight * discrepancyScore + _etaWeight * etaScore;
+      // Attribute the trigger to whichever input contributed more.
+      // The updater gates [lastTrigger] on its own strong-observation
+      // threshold, so passing the reason unconditionally is safe: weak
+      // combined scores leave the prior trigger sticky.
+      reason = etaScore > discrepancyScore
+          ? BrokenMapReason.etaImplausible
+          : BrokenMapReason.pleinCompletDiscrepancy;
+    }
+
+    return BrokenMapBeliefUpdater.update(
+      prior,
+      observationScore,
+      now: now,
+      reason: reason,
+    );
+  }
 }
 
 /// Parse Mode 01 PID 0x33 (absolute barometric pressure) response.

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -5,6 +5,8 @@ import '../../../core/storage/storage_providers.dart';
 import '../../vehicle/data/ve_learner.dart';
 import '../../vehicle/providers/service_reminder_providers.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
+import '../data/obd2/broken_map_belief.dart';
+import '../data/obd2/broken_map_detector.dart';
 import '../data/repositories/fill_up_repository.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/entities/consumption_stats.dart';
@@ -12,6 +14,7 @@ import '../domain/entities/eco_score.dart';
 import '../domain/entities/fill_up.dart';
 import '../domain/services/eco_score_calculator.dart';
 import '../domain/services/reconciler.dart';
+import '../domain/trip_recorder.dart';
 import 'trip_history_provider.dart';
 
 part 'consumption_providers.g.dart';
@@ -38,6 +41,39 @@ VeLearner? veLearner(Ref ref) {
     profileRepository: profileRepo,
     tripHistoryRepository: history,
   );
+}
+
+/// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
+/// will swap this empty-prior factory for one that recalls the latest
+/// persisted belief; for phase 3 (logic-only) the detector is a single
+/// stateless instance shared across observations.
+@Riverpod(keepAlive: true)
+BrokenMapDetector brokenMapDetector(Ref ref) => const BrokenMapDetector();
+
+/// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
+///
+/// In-memory only — phase 4 will replace this with a Hive-backed
+/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
+/// state Riverpod-scoped so widget tests can inspect / seed prior
+/// beliefs without touching storage.
+///
+/// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
+/// the vehicle hasn't been observed yet.
+@Riverpod(keepAlive: true)
+class BrokenMapBeliefByVehicle extends _$BrokenMapBeliefByVehicle {
+  @override
+  Map<String, BrokenMapBelief> build() => <String, BrokenMapBelief>{};
+
+  /// Read the current belief for [vehicleId]; defaults to a fresh
+  /// [BrokenMapBelief] when nothing has been recorded yet.
+  BrokenMapBelief beliefFor(String vehicleId) =>
+      state[vehicleId] ?? const BrokenMapBelief();
+
+  /// Replace the belief for [vehicleId] with [belief]. Used by the
+  /// plein-complet hook after a reconciliation observation folds in.
+  void set(String vehicleId, BrokenMapBelief belief) {
+    state = {...state, vehicleId: belief};
+  }
 }
 
 /// Holds the most recent [VeLearnResult] (#815) so the UI can show a
@@ -101,10 +137,21 @@ class FillUpList extends _$FillUpList {
     await _relinkOpenWindow(linked);
     state = repo.getAll();
     await _evaluateReminders(linked);
-    await _reconcileVolumetricEfficiency(linked, previous);
+    final veResult = await _reconcileVolumetricEfficiency(linked, previous);
     // #1361 — trip-vs-pump reconciliation. Only runs on plein fills;
     // partials extend the open window and don't trigger a closing.
-    await _reconcileTripVsPump(linked);
+    final reconciliation = await _reconcileTripVsPump(linked);
+    // #1423 phase 3 — feed the plein-complet observation into the
+    // broken-MAP belief. Only when the trip-vs-pump reconciler
+    // actually evaluated the window (created OR skippedBelowThreshold —
+    // both produce a meaningful pumped/consumed pair). The
+    // skippedNoTrips and clampedNegative buckets carry no L/100km
+    // signal so we don't fold them in.
+    await _recordBrokenMapObservation(
+      fillUp: linked,
+      reconciliation: reconciliation,
+      veResult: veResult,
+    );
   }
 
   /// Compute the trip-history ids recorded for [fillUp.vehicleId]
@@ -275,14 +322,22 @@ class FillUpList extends _$FillUpList {
   /// without a bound vehicle, the synthesised correction itself, or
   /// when the trip-history repository isn't available. Errors are
   /// swallowed — a failed reconciliation must not break the save flow.
-  Future<void> _reconcileTripVsPump(FillUp fillUp) async {
-    if (fillUp.isCorrection) return;
-    if (!fillUp.isFullTank) return;
+  ///
+  /// Returns the [_TripVsPumpReconciliation] outcome so downstream
+  /// hooks (#1423 phase 3 broken-MAP belief) can score the same
+  /// reconciliation without redoing the window math. Returns `null`
+  /// when reconciliation was skipped (partial fill, no vehicle,
+  /// missing trip-history repo, throw).
+  Future<_TripVsPumpReconciliation?> _reconcileTripVsPump(
+    FillUp fillUp,
+  ) async {
+    if (fillUp.isCorrection) return null;
+    if (!fillUp.isFullTank) return null;
     final vehicleId = fillUp.vehicleId;
-    if (vehicleId == null) return;
+    if (vehicleId == null) return null;
     try {
       final tripRepo = ref.read(tripHistoryRepositoryProvider);
-      if (tripRepo == null) return;
+      if (tripRepo == null) return null;
       final fillRepo = ref.read(fillUpRepositoryProvider);
       final allFills = fillRepo.getAll();
       final history = tripRepo.loadAll();
@@ -296,13 +351,126 @@ class FillUpList extends _$FillUpList {
         allFillUpsForVehicle: allFills,
         tripsForVehicle: trips,
       );
-      final correction = result?.correction;
+      if (result == null) return null;
+      final correction = result.correction;
       if (correction != null) {
         await fillRepo.save(correction);
         state = fillRepo.getAll();
       }
+      // Sum the window-trip distances — used by the broken-MAP hook
+      // to convert pumped/consumed litres into L/100 km. Mirrors the
+      // window logic inside [Reconciler.reconcile]; we don't reach
+      // into the result for it because the reconciler stays pure (no
+      // distance field on [ReconciliationResult]).
+      final windowDistanceKm = _windowDistanceKm(
+        closingPlein: fillUp,
+        allFillUpsForVehicle: allFills,
+        tripsForVehicle: trips,
+      );
+      return _TripVsPumpReconciliation(
+        result: result,
+        windowDistanceKm: windowDistanceKm,
+      );
     } catch (e, st) {
       debugPrint('FillUpList: trip-vs-pump reconciliation failed: $e\n$st');
+      return null;
+    }
+  }
+
+  /// Sum the [TripSummary.distanceKm] across every trip in the same
+  /// plein-to-plein window the [Reconciler] uses. Inlined here so the
+  /// reconciler can stay pure and free of the L/100 km derivation.
+  double _windowDistanceKm({
+    required FillUp closingPlein,
+    required List<FillUp> allFillUpsForVehicle,
+    required List<TripSummary> tripsForVehicle,
+  }) {
+    final vehicleId = closingPlein.vehicleId;
+    final sameVehicleFills = allFillUpsForVehicle
+        .where(
+          (f) =>
+              f.vehicleId == vehicleId &&
+              !f.isCorrection &&
+              f.id != closingPlein.id,
+        )
+        .toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+    FillUp? previousPlein;
+    for (final f in sameVehicleFills) {
+      if (!f.date.isBefore(closingPlein.date)) continue;
+      if (!f.isFullTank) continue;
+      if (previousPlein == null || f.date.isAfter(previousPlein.date)) {
+        previousPlein = f;
+      }
+    }
+    DateTime windowStart;
+    bool inclusiveLower;
+    if (previousPlein != null) {
+      windowStart = previousPlein.date;
+      inclusiveLower = false;
+    } else {
+      windowStart = sameVehicleFills.isEmpty
+          ? closingPlein.date
+          : sameVehicleFills.first.date;
+      inclusiveLower = true;
+    }
+    double sum = 0;
+    for (final t in tripsForVehicle) {
+      final when = t.startedAt;
+      if (when == null) continue;
+      final afterStart = inclusiveLower
+          ? !when.isBefore(windowStart)
+          : when.isAfter(windowStart);
+      if (!afterStart) continue;
+      if (when.isAfter(closingPlein.date)) continue;
+      sum += t.distanceKm;
+    }
+    return sum;
+  }
+
+  /// #1423 phase 3 — fold the plein-complet observation into the
+  /// broken-MAP belief. No-op when the trip-vs-pump reconciler didn't
+  /// produce a usable pumped/consumed pair, when the closing fill
+  /// isn't a plein, or when the window distance is too small to form
+  /// a meaningful L/100 km. Errors are swallowed — a broken-MAP
+  /// scoring failure must not break the save flow.
+  Future<void> _recordBrokenMapObservation({
+    required FillUp fillUp,
+    required _TripVsPumpReconciliation? reconciliation,
+    required VeLearnResult? veResult,
+  }) async {
+    if (reconciliation == null) return;
+    final vehicleId = fillUp.vehicleId;
+    if (vehicleId == null) return;
+    if (!fillUp.isFullTank || fillUp.isCorrection) return;
+    final result = reconciliation.result;
+    // Only fold in observations where both sides of the ratio are
+    // populated. skippedNoTrips means consumed = 0 (degenerate), and
+    // clampedNegative means the integrator over-reported (the
+    // discrepancy score isn't meaningful in that direction).
+    if (result.action != ReconciliationAction.created &&
+        result.action != ReconciliationAction.skippedBelowThreshold) {
+      return;
+    }
+    if (result.consumed <= 0) return;
+    final distance = reconciliation.windowDistanceKm;
+    if (distance <= 0) return;
+    try {
+      final detector = ref.read(brokenMapDetectorProvider);
+      final beliefs = ref.read(brokenMapBeliefByVehicleProvider.notifier);
+      final prior = beliefs.beliefFor(vehicleId);
+      final reconciledLPer100km = result.pumped * 100.0 / distance;
+      final estimatedLPer100km = result.consumed * 100.0 / distance;
+      final updated = detector.recordPleinCompletObservation(
+        prior: prior,
+        reconciledLPer100km: reconciledLPer100km,
+        estimatedLPer100km: estimatedLPer100km,
+        proposedEta: veResult?.proposedEta,
+        now: DateTime.now(),
+      );
+      beliefs.set(vehicleId, updated);
+    } catch (e, st) {
+      debugPrint('FillUpList: broken-MAP observation failed: $e\n$st');
     }
   }
 
@@ -323,16 +491,20 @@ class FillUpList extends _$FillUpList {
     }
   }
 
-  Future<void> _reconcileVolumetricEfficiency(
+  /// Run the η_v learner against the new fill-up. Returns the resulting
+  /// [VeLearnResult] (or `null` when guards rejected) so downstream
+  /// hooks (#1423 phase 3 broken-MAP belief) can read
+  /// [VeLearnResult.proposedEta] without re-running the learner.
+  Future<VeLearnResult?> _reconcileVolumetricEfficiency(
     FillUp fillUp,
     FillUp? previous,
   ) async {
     final vehicleId = fillUp.vehicleId;
-    if (vehicleId == null) return;
-    if (fillUp.liters <= 0) return;
+    if (vehicleId == null) return null;
+    if (fillUp.liters <= 0) return null;
     try {
       final learner = ref.read(veLearnerProvider);
-      if (learner == null) return;
+      if (learner == null) return null;
       final result = await learner.reconcileAfterFillUp(
         vehicleId: vehicleId,
         pumpedLiters: fillUp.liters,
@@ -347,8 +519,10 @@ class FillUpList extends _$FillUpList {
         // bumped η_v sample count immediately.
         ref.invalidate(vehicleProfileListProvider);
       }
+      return result;
     } catch (e, st) {
       debugPrint('FillUpList: VE reconciliation failed: $e\n$st');
+      return null;
     }
   }
 
@@ -394,6 +568,20 @@ class FillUpList extends _$FillUpList {
 ConsumptionStats consumptionStats(Ref ref) {
   final fillUps = ref.watch(fillUpListProvider);
   return ConsumptionStats.fromFillUps(fillUps);
+}
+
+/// Bundle the [Reconciler] outcome with the per-window distance the
+/// broken-MAP hook (#1423 phase 3) needs to convert pumped/consumed
+/// litres into L/100 km. Private to this file — the public reconciler
+/// stays distance-agnostic.
+class _TripVsPumpReconciliation {
+  final ReconciliationResult result;
+  final double windowDistanceKm;
+
+  const _TripVsPumpReconciliation({
+    required this.result,
+    required this.windowDistanceKm,
+  });
 }
 
 /// Per-fill-up eco-score — compares this tank's L/100 km to the

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -120,6 +120,168 @@ final class VeLearnerProvider
 
 String _$veLearnerHash() => r'3ee7af1d1504ef129c160480ac732df0494e036f';
 
+/// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
+/// will swap this empty-prior factory for one that recalls the latest
+/// persisted belief; for phase 3 (logic-only) the detector is a single
+/// stateless instance shared across observations.
+
+@ProviderFor(brokenMapDetector)
+final brokenMapDetectorProvider = BrokenMapDetectorProvider._();
+
+/// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
+/// will swap this empty-prior factory for one that recalls the latest
+/// persisted belief; for phase 3 (logic-only) the detector is a single
+/// stateless instance shared across observations.
+
+final class BrokenMapDetectorProvider
+    extends
+        $FunctionalProvider<
+          BrokenMapDetector,
+          BrokenMapDetector,
+          BrokenMapDetector
+        >
+    with $Provider<BrokenMapDetector> {
+  /// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
+  /// will swap this empty-prior factory for one that recalls the latest
+  /// persisted belief; for phase 3 (logic-only) the detector is a single
+  /// stateless instance shared across observations.
+  BrokenMapDetectorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'brokenMapDetectorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$brokenMapDetectorHash();
+
+  @$internal
+  @override
+  $ProviderElement<BrokenMapDetector> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  BrokenMapDetector create(Ref ref) {
+    return brokenMapDetector(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BrokenMapDetector value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BrokenMapDetector>(value),
+    );
+  }
+}
+
+String _$brokenMapDetectorHash() => r'401fe3bdd10c78d2b90c351588fea002125d89a2';
+
+/// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
+///
+/// In-memory only — phase 4 will replace this with a Hive-backed
+/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
+/// state Riverpod-scoped so widget tests can inspect / seed prior
+/// beliefs without touching storage.
+///
+/// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
+/// the vehicle hasn't been observed yet.
+
+@ProviderFor(BrokenMapBeliefByVehicle)
+final brokenMapBeliefByVehicleProvider = BrokenMapBeliefByVehicleProvider._();
+
+/// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
+///
+/// In-memory only — phase 4 will replace this with a Hive-backed
+/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
+/// state Riverpod-scoped so widget tests can inspect / seed prior
+/// beliefs without touching storage.
+///
+/// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
+/// the vehicle hasn't been observed yet.
+final class BrokenMapBeliefByVehicleProvider
+    extends
+        $NotifierProvider<
+          BrokenMapBeliefByVehicle,
+          Map<String, BrokenMapBelief>
+        > {
+  /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
+  ///
+  /// In-memory only — phase 4 will replace this with a Hive-backed
+  /// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
+  /// state Riverpod-scoped so widget tests can inspect / seed prior
+  /// beliefs without touching storage.
+  ///
+  /// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
+  /// the vehicle hasn't been observed yet.
+  BrokenMapBeliefByVehicleProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'brokenMapBeliefByVehicleProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$brokenMapBeliefByVehicleHash();
+
+  @$internal
+  @override
+  BrokenMapBeliefByVehicle create() => BrokenMapBeliefByVehicle();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Map<String, BrokenMapBelief> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Map<String, BrokenMapBelief>>(value),
+    );
+  }
+}
+
+String _$brokenMapBeliefByVehicleHash() =>
+    r'd1f5bdc514ec49d5b419f659ef7c2e4baccb8d7a';
+
+/// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
+///
+/// In-memory only — phase 4 will replace this with a Hive-backed
+/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
+/// state Riverpod-scoped so widget tests can inspect / seed prior
+/// beliefs without touching storage.
+///
+/// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
+/// the vehicle hasn't been observed yet.
+
+abstract class _$BrokenMapBeliefByVehicle
+    extends $Notifier<Map<String, BrokenMapBelief>> {
+  Map<String, BrokenMapBelief> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref
+            as $Ref<Map<String, BrokenMapBelief>, Map<String, BrokenMapBelief>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<
+                Map<String, BrokenMapBelief>,
+                Map<String, BrokenMapBelief>
+              >,
+              Map<String, BrokenMapBelief>,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
 /// Holds the most recent [VeLearnResult] (#815) so the UI can show a
 /// one-shot calibration snackbar after the fill-up save flow closes.
 ///
@@ -242,7 +404,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'19fbdb49d46bcdac836823682343d66cc90b4594';
+String _$fillUpListHash() => r'ca9867e29fd5ba03e407a2fb44bda82a6c66687d';
 
 /// Mutable list of all fill-ups, newest first.
 
@@ -324,7 +486,7 @@ String _$consumptionStatsHash() => r'6613eff02126b04dc046d555deafd254b7211e9b';
 ///
 /// Keyed by fill-up id so the Riverpod graph invalidates just the
 /// affected card when a single fill-up is edited, not the whole list.
-/// See #676 and the project leitmotiv in CLAUDE.md.
+/// See #676 ("Smarter pump. Smarter drive. Save twice.").
 
 @ProviderFor(ecoScoreForFillUp)
 final ecoScoreForFillUpProvider = EcoScoreForFillUpFamily._();
@@ -338,7 +500,7 @@ final ecoScoreForFillUpProvider = EcoScoreForFillUpFamily._();
 ///
 /// Keyed by fill-up id so the Riverpod graph invalidates just the
 /// affected card when a single fill-up is edited, not the whole list.
-/// See #676 and the project leitmotiv in CLAUDE.md.
+/// See #676 ("Smarter pump. Smarter drive. Save twice.").
 
 final class EcoScoreForFillUpProvider
     extends $FunctionalProvider<EcoScore?, EcoScore?, EcoScore?>
@@ -352,7 +514,7 @@ final class EcoScoreForFillUpProvider
   ///
   /// Keyed by fill-up id so the Riverpod graph invalidates just the
   /// affected card when a single fill-up is edited, not the whole list.
-  /// See #676 and the project leitmotiv in CLAUDE.md.
+  /// See #676 ("Smarter pump. Smarter drive. Save twice.").
   EcoScoreForFillUpProvider._({
     required EcoScoreForFillUpFamily super.from,
     required String super.argument,
@@ -415,7 +577,7 @@ String _$ecoScoreForFillUpHash() => r'd73756e1f350917069211ef38a04a8d020682ca3';
 ///
 /// Keyed by fill-up id so the Riverpod graph invalidates just the
 /// affected card when a single fill-up is edited, not the whole list.
-/// See #676 and the project leitmotiv in CLAUDE.md.
+/// See #676 ("Smarter pump. Smarter drive. Save twice.").
 
 final class EcoScoreForFillUpFamily extends $Family
     with $FunctionalFamilyOverride<EcoScore?, String> {
@@ -437,7 +599,7 @@ final class EcoScoreForFillUpFamily extends $Family
   ///
   /// Keyed by fill-up id so the Riverpod graph invalidates just the
   /// affected card when a single fill-up is edited, not the whole list.
-  /// See #676 and the project leitmotiv in CLAUDE.md.
+  /// See #676 ("Smarter pump. Smarter drive. Save twice.").
 
   EcoScoreForFillUpProvider call(String fillUpId) =>
       EcoScoreForFillUpProvider._(argument: fillUpId, from: this);

--- a/lib/features/vehicle/data/ve_learner.dart
+++ b/lib/features/vehicle/data/ve_learner.dart
@@ -35,6 +35,17 @@ class VeLearnResult {
   /// Post-update sample count for the vehicle's η_v field.
   final int sampleCount;
 
+  /// Raw proposed η_v before EWMA blending and [VeLearner.minVe] /
+  /// [VeLearner.maxVe] clamping (#1423 phase 3). Equals
+  /// `previousVe × (pumpedLiters / integratedLiters)` — the first-order
+  /// estimate of the true η_v this tankful "wants". Surfaced so the
+  /// broken-MAP belief system (#1423) can score implausible values
+  /// (η_v ≫ 0.97 means the learner is compensating for a fuel under-
+  /// count that's actually MAP-derived). Always finite when this
+  /// result is non-null because [VeLearner.reconcileAfterFillUp]
+  /// rejects `integrated <= 0` upstream.
+  final double proposedEta;
+
   const VeLearnResult({
     required this.vehicleId,
     required this.previousVe,
@@ -43,6 +54,7 @@ class VeLearnResult {
     required this.pumpedLiters,
     required this.accuracyImprovementPct,
     required this.sampleCount,
+    required this.proposedEta,
   });
 }
 
@@ -286,6 +298,7 @@ class VeLearner {
       pumpedLiters: pumpedLiters,
       accuracyImprovementPct: improvement,
       sampleCount: updated.volumetricEfficiencySamples,
+      proposedEta: rawNewVe,
     );
   }
 

--- a/test/features/consumption/data/obd2/plein_complet_hook_test.dart
+++ b/test/features/consumption/data/obd2/plein_complet_hook_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_detector.dart';
+
+/// Reference EMA α used by the underlying updater. Mirrored here so
+/// each test's expected confidence has a self-explanatory derivation
+/// — assertions that would fail if α were retuned document the
+/// production constant they depend on.
+const double _alpha = 0.4;
+
+/// Helper: pumped / consumed = ratio = reconciledLPer100km /
+/// estimatedLPer100km. Build a `(reconciled, estimated)` pair from a
+/// target ratio and a fixed-but-arbitrary L/100 km baseline.
+({double reconciled, double estimated}) _pairForRatio(double ratio) {
+  const double baseline = 6.0;
+  return (reconciled: baseline * ratio, estimated: baseline);
+}
+
+void main() {
+  // Deterministic time injected into every observation so the EMA /
+  // lastUpdate assertions are reproducible.
+  final fixedNow = DateTime(2026, 5, 4, 10, 30);
+
+  group('recordPleinCompletObservation — combined-score math', () {
+    test(
+        'high discrepancy + implausible eta → strong observation pushes '
+        'confidence to ~α', () async {
+      // ratio 2.5 → discrepancyScore clamps to 1.0;
+      // eta 1.30 → etaScore clamps to 1.0 ((1.3 - 0.97) / 0.25 = 1.32 → 1.0).
+      // combined = 0.6 × 1 + 0.4 × 1 = 1.0.
+      // EMA from 0: α × 1 + (1-α) × 0 = 0.4.
+      final pair = _pairForRatio(2.5);
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: const BrokenMapBelief(),
+        reconciledLPer100km: pair.reconciled,
+        estimatedLPer100km: pair.estimated,
+        proposedEta: 1.30,
+        now: fixedNow,
+      );
+
+      expect(updated.confidence, closeTo(_alpha, 1e-9));
+      expect(updated.observationCount, 1);
+      expect(updated.lastUpdate, fixedNow);
+      // Strong combined score (1.0 > 0.5) — trigger MUST land. eta and
+      // discrepancy tied at 1.0 so the implementation prefers
+      // discrepancy (eta is not strictly greater).
+      expect(updated.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+    });
+
+    test(
+        'eta dominates over discrepancy → trigger tagged etaImplausible',
+        () async {
+      // ratio 1.4 → discrepancyScore = (1.4 - 1.3) / 0.9 ≈ 0.111.
+      // eta 1.22 → etaScore = 1.0.
+      // combined = 0.6 × 0.111 + 0.4 × 1.0 ≈ 0.467 — below strong (0.5).
+      // So the trigger is NOT updated — phase 1 spec gates the trigger
+      // on score > 0.5. Verify the score stays under the threshold but
+      // confidence still lifts via EMA.
+      final pair = _pairForRatio(1.4);
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: const BrokenMapBelief(),
+        reconciledLPer100km: pair.reconciled,
+        estimatedLPer100km: pair.estimated,
+        proposedEta: 1.22,
+        now: fixedNow,
+      );
+
+      // 0.4 × 0.467 ≈ 0.187
+      expect(updated.confidence, closeTo(0.4 * 0.467, 0.01));
+      expect(updated.observationCount, 1);
+      // Not strong enough for trigger to flip — stays at default.
+      expect(updated.lastTrigger, BrokenMapReason.none);
+    });
+
+    test(
+        'eta strongly dominant → strong observation tags etaImplausible',
+        () async {
+      // ratio 2.2 → discrepancyScore = 1.0
+      // eta 1.50 → etaScore clamps to 1.0
+      // combined = 1.0 — strong. eta NOT strictly > discrepancy
+      // (both 1.0) → label is pleinCompletDiscrepancy by tiebreak.
+      // To force etaImplausible we need eta > discrepancy: pick a
+      // moderate ratio with high eta.
+      // ratio 1.6 → discrepancyScore = (1.6 - 1.3) / 0.9 = 0.333.
+      // eta 1.22 → etaScore = 1.0. combined = 0.6 × 0.333 + 0.4 × 1.0 = 0.6
+      // — strong (>0.5). etaScore (1.0) > discrepancyScore (0.333).
+      final pair = _pairForRatio(1.6);
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: const BrokenMapBelief(),
+        reconciledLPer100km: pair.reconciled,
+        estimatedLPer100km: pair.estimated,
+        proposedEta: 1.22,
+        now: fixedNow,
+      );
+
+      // EMA: α × 0.6 = 0.24
+      expect(updated.confidence, closeTo(0.24, 1e-9));
+      expect(updated.lastTrigger, BrokenMapReason.etaImplausible);
+    });
+  });
+
+  group('recordPleinCompletObservation — null proposedEta fallback', () {
+    test(
+        'null eta + high ratio → discrepancy-only weight, score == '
+        'discrepancyScore (no NaN, no throw)', () async {
+      // ratio 2.2 → discrepancyScore clamps to 1.0.
+      // No eta → score == 1.0 (discrepancy-only weight).
+      final pair = _pairForRatio(2.2);
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: const BrokenMapBelief(),
+        reconciledLPer100km: pair.reconciled,
+        estimatedLPer100km: pair.estimated,
+        proposedEta: null,
+        now: fixedNow,
+      );
+
+      // EMA: α × 1.0 = 0.4
+      expect(updated.confidence, closeTo(_alpha, 1e-9));
+      expect(updated.confidence.isNaN, isFalse);
+      expect(updated.observationCount, 1);
+      expect(updated.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+    });
+
+    test('null eta + clean ratio → score 0, confidence stays 0', () {
+      // ratio 1.1 → discrepancyScore clamps to 0 (below 1.3 boundary).
+      final pair = _pairForRatio(1.1);
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: const BrokenMapBelief(),
+        reconciledLPer100km: pair.reconciled,
+        estimatedLPer100km: pair.estimated,
+        proposedEta: null,
+        now: fixedNow,
+      );
+
+      expect(updated.confidence, 0.0);
+      expect(updated.observationCount, 1);
+      expect(updated.lastTrigger, BrokenMapReason.none);
+    });
+  });
+
+  group('recordPleinCompletObservation — degenerate inputs', () {
+    test('zero estimatedLPer100km returns prior unchanged', () {
+      const prior = BrokenMapBelief(
+        confidence: 0.3,
+        observationCount: 5,
+        lastTrigger: BrokenMapReason.idleVacuumMissing,
+      );
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: prior,
+        reconciledLPer100km: 6.0,
+        estimatedLPer100km: 0,
+        proposedEta: null,
+        now: fixedNow,
+      );
+
+      expect(updated, equals(prior));
+    });
+
+    test('zero reconciledLPer100km returns prior unchanged', () {
+      const prior = BrokenMapBelief(confidence: 0.7, observationCount: 2);
+
+      final updated = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: prior,
+        reconciledLPer100km: 0,
+        estimatedLPer100km: 6.0,
+        proposedEta: null,
+        now: fixedNow,
+      );
+
+      expect(updated, equals(prior));
+    });
+  });
+
+  group('recordPleinCompletObservation — EMA decay', () {
+    test(
+        'after a strong observation, a clean ratio decays confidence via EMA',
+        () {
+      // First: strong observation lifts confidence to ~0.4.
+      final highPair = _pairForRatio(2.5);
+      final after1 = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: const BrokenMapBelief(),
+        reconciledLPer100km: highPair.reconciled,
+        estimatedLPer100km: highPair.estimated,
+        proposedEta: 1.30,
+        now: fixedNow,
+      );
+      expect(after1.confidence, closeTo(0.4, 1e-9));
+
+      // Second: clean ratio, healthy eta → score = 0.6 × 0 + 0.4 × 0 = 0.
+      // EMA: α × 0 + (1-α) × 0.4 = 0.24.
+      final cleanPair = _pairForRatio(1.0);
+      final after2 = const BrokenMapDetector().recordPleinCompletObservation(
+        prior: after1,
+        reconciledLPer100km: cleanPair.reconciled,
+        estimatedLPer100km: cleanPair.estimated,
+        proposedEta: 0.85,
+        now: fixedNow,
+      );
+
+      expect(after2.confidence, closeTo(0.24, 1e-9));
+      expect(after2.observationCount, 2);
+      // Strong trigger from observation 1 stays sticky — observation 2
+      // was weak (score 0 < 0.5) so the updater leaves lastTrigger
+      // alone.
+      expect(after1.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+      expect(after2.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+    });
+  });
+}

--- a/test/features/consumption/providers/plein_complet_belief_hook_test.dart
+++ b/test/features/consumption/providers/plein_complet_belief_hook_test.dart
@@ -1,0 +1,319 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Call-site integration tests for the broken-MAP belief hook
+/// (#1423 phase 3). Verifies that when [FillUpList.add] runs the
+/// trip-vs-pump reconciler against a closing plein-complet, the
+/// resulting pumped/consumed pair (plus optional VeLearner-proposed
+/// η_v) is folded into the broken-MAP belief via
+/// [BrokenMapDetector.recordPleinCompletObservation]. Uses real
+/// [TripHistoryRepository] (via in-memory Hive) so the hook traverses
+/// the same path production does.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late TripHistoryRepository historyRepo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('plein_complet_hook_');
+    Hive.init(tmpDir.path);
+    final box = await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+    historyRepo = TripHistoryRepository(box: box);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<void> seedTrip({
+    required String id,
+    required String vehicleId,
+    required DateTime startedAt,
+    required double distanceKm,
+    required double fuelLitersConsumed,
+  }) {
+    return historyRepo.save(TripHistoryEntry(
+      id: id,
+      vehicleId: vehicleId,
+      summary: TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuelLitersConsumed,
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(minutes: 30)),
+      ),
+    ));
+  }
+
+  FillUp mkFillUp({
+    required String id,
+    required DateTime date,
+    String vehicleId = 'veh-a',
+    double liters = 40,
+    double odometerKm = 10000,
+    bool isFullTank = true,
+  }) =>
+      FillUp(
+        id: id,
+        date: date,
+        liters: liters,
+        totalCost: liters * 1.5,
+        odometerKm: odometerKm,
+        fuelType: FuelType.e10,
+        vehicleId: vehicleId,
+        isFullTank: isFullTank,
+      );
+
+  test(
+      'high-discrepancy plein-complet (pumped 2.4× consumed) → broken-MAP '
+      'belief confidence rises after one observation', () async {
+    final container = makeContainer();
+
+    // Seed an OBD-integrated 5 L trip across 100 km. Then a plein
+    // pumps 12 L (consumption ratio 12/5 = 2.4 → discrepancy clamps to
+    // 1.0 in the score function).
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    // Opening plein on April 1 — establishes the window start.
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    // Closing plein on April 2 — pumps 12 L while integrator only saw
+    // 5 L, so the reconciler will create a correction AND the broken-
+    // MAP hook scores the discrepancy as conclusive.
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    final beliefs = container.read(brokenMapBeliefByVehicleProvider);
+    expect(beliefs['veh-a'], isNotNull);
+    final belief = beliefs['veh-a']!;
+    // Discrepancy alone (no VeLearner because no vehicle profile is
+    // wired in this test container — VeLearner returns null on missing
+    // profile) → score = discrepancyScore (1.0). EMA from 0: α × 1 = 0.4.
+    expect(belief.confidence, closeTo(0.4, 1e-9));
+    expect(belief.observationCount, 1);
+    expect(belief.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+  });
+
+  test(
+      'clean plein-complet (pumped ≈ consumed) leaves belief at 0 — single '
+      'clean observation produces score 0', () async {
+    final container = makeContainer();
+
+    // Integrator and pump match → ratio 1.0 → discrepancyScore = 0.
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 6,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 6,
+      odometerKm: 10100,
+    ));
+
+    final belief = container
+        .read(brokenMapBeliefByVehicleProvider.notifier)
+        .beliefFor('veh-a');
+    expect(belief.confidence, 0.0);
+    expect(belief.observationCount, 1);
+    expect(belief.lastTrigger, BrokenMapReason.none);
+  });
+
+  test('partial fill-up does NOT trigger the broken-MAP hook', () async {
+    final container = makeContainer();
+
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    // Closing entry is a PARTIAL fill — reconciler short-circuits, so
+    // the broken-MAP hook MUST NOT fire either.
+    await notifier.add(mkFillUp(
+      id: 'partial',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+      isFullTank: false,
+    ));
+
+    final beliefs = container.read(brokenMapBeliefByVehicleProvider);
+    expect(beliefs['veh-a'], isNull,
+        reason: 'partial fills must not seed a broken-MAP belief');
+  });
+
+  test(
+      'fill-up without a vehicleId is ignored by the broken-MAP hook',
+      () async {
+    final container = makeContainer();
+    final notifier = container.read(fillUpListProvider.notifier);
+
+    await notifier.add(FillUp(
+      id: 'no-vehicle',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 40,
+      totalCost: 60,
+      odometerKm: 100,
+      fuelType: FuelType.e10,
+    ));
+
+    expect(container.read(brokenMapBeliefByVehicleProvider), isEmpty);
+  });
+
+  test('skippedNoTrips outcome (no integrated fuel) skips the hook',
+      () async {
+    final container = makeContainer();
+    final notifier = container.read(fillUpListProvider.notifier);
+
+    // No trips seeded → reconciler returns skippedNoTrips. Hook MUST
+    // NOT fire on this branch (consumed = 0 → ratio undefined).
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    expect(container.read(brokenMapBeliefByVehicleProvider), isEmpty);
+  });
+
+  test(
+      'two consecutive high-discrepancy observations fold per EMA — '
+      'confidence rises monotonically', () async {
+    final container = makeContainer();
+
+    // First window — opening + closing plein with high discrepancy.
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing-1',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+    final after1 = container
+        .read(brokenMapBeliefByVehicleProvider.notifier)
+        .beliefFor('veh-a');
+    expect(after1.confidence, closeTo(0.4, 1e-9));
+
+    // Second window — another high-discrepancy plein.
+    await seedTrip(
+      id: 't2',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 3, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+    await notifier.add(mkFillUp(
+      id: 'closing-2',
+      date: DateTime(2026, 4, 4, 18),
+      liters: 12,
+      odometerKm: 10200,
+    ));
+    final after2 = container
+        .read(brokenMapBeliefByVehicleProvider.notifier)
+        .beliefFor('veh-a');
+    // EMA: α × 1 + (1-α) × 0.4 = 0.64.
+    expect(after2.confidence, closeTo(0.64, 1e-9));
+    expect(after2.observationCount, 2);
+  });
+}
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    _data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}


### PR DESCRIPTION
## Summary

Phase 3 of #1423 — wire the trip-vs-pump reconciler (#1361) into the broken-MAP belief system. Every plein-complet (full-tank reconciliation) now feeds a discrepancy + proposed-η observation into the `BrokenMapBelief` updater per spec § B / § E.

- New `BrokenMapDetector.recordPleinCompletObservation` pure orchestrator — combines `discrepancySeverityScore` (weight 0.6) with `etaImplausibilityScore` (weight 0.4); discrepancy-only fallback when the η_v learner had no candidate. Reconciler stays pure — no side effects added inside `reconcile()`.
- `VeLearnResult` gains `proposedEta` (the raw pre-clamp pre-blend `currentVe × pumped/integrated`) so the hook can score implausible learner proposals without poking learner internals.
- `FillUpList.add` now threads the η_v result + trip-vs-pump outcome into `_recordBrokenMapObservation`. Belief persistence is in-memory per vehicle via a new keepAlive Riverpod notifier; phase 4 will swap for Hive-backed storage.
- Belief observations only fire on `created` / `skippedBelowThreshold` reconciliations (both produce a meaningful pumped/consumed pair). `skippedNoTrips` and `clampedNegative` skip the hook because the ratio isn't defined / signed correctly.

## Refs #1423 phase 3 (phases 4-5 remain)

- Phase 4: Hive-backed persistence + auto-clear semantics for the per-vehicle belief.
- Phase 5: UI surfaces (chip / snackbar / banner / hard-disable based on confidence thresholds).

Phase 3 is logic-only — no ARB keys, no UI work.

## Test plan

- [x] 8 unit tests for `recordPleinCompletObservation` (combined score, null-eta fallback, EMA decay, degenerate inputs)
- [x] 6 call-site integration tests via real `TripHistoryRepository`/Hive (high-discrepancy lift, clean no-op, partial-skip, vehicle-less skip, no-trips skip, multi-observation EMA fold)
- [x] `flutter analyze` — clean
- [x] `flutter test test/features/consumption/` — 2500 tests passing
- [x] `flutter test test/features/vehicle/data/` — 215 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)