### PR TITLE
feat(obd2): persistent broken-MAP belief + adapter blocklist (Refs #1423 phase 4)

### DIFF
--- a/lib/features/consumption/data/obd2/broken_map_belief.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief.dart
@@ -24,6 +24,12 @@ enum BrokenMapReason {
   /// VeLearner converged to a η_v above what's physically possible.
   etaImplausible,
 
+  /// Recalled from a prior session via [ObdAdapterBlocklist] — the
+  /// adapter was already known to be suspect from earlier observations
+  /// (#1423 phase 4). Used by the populator to surface a warning at
+  /// the next pair attempt without re-probing.
+  priorObservation,
+
   /// Not yet triggered by a strong observation (default).
   none,
 }

--- a/lib/features/consumption/data/obd2/broken_map_belief.g.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief.g.dart
@@ -31,5 +31,6 @@ const _$BrokenMapReasonEnumMap = {
   BrokenMapReason.revDeltaMissing: 'revDeltaMissing',
   BrokenMapReason.pleinCompletDiscrepancy: 'pleinCompletDiscrepancy',
   BrokenMapReason.etaImplausible: 'etaImplausible',
+  BrokenMapReason.priorObservation: 'priorObservation',
   BrokenMapReason.none: 'none',
 };

--- a/lib/features/consumption/data/obd2/obd_adapter_blocklist.dart
+++ b/lib/features/consumption/data/obd2/obd_adapter_blocklist.dart
@@ -1,0 +1,47 @@
+import '../../../../core/data/storage_repository.dart';
+
+/// Persistent per-adapter broken-MAP blocklist (#1423 phase 4).
+///
+/// Stores the latest [BrokenMapBelief.confidence] keyed by ELM
+/// firmware identifier (whatever `ATI` returned during pair). The
+/// populator recalls this BEFORE running an idle probe at the next
+/// pair attempt — when a known-broken adapter is recognised, the
+/// warning surfaces immediately without a fresh probe round.
+///
+/// Backed by [SettingsStorage] (Hive `settings` box). One key per
+/// adapter under the [_keyPrefix] namespace, value is the raw
+/// `double` confidence in `[0.0, 1.0]`.
+///
+/// Stateless and idempotent: subsequent calls with a different
+/// confidence overwrite the previous value. Empty IDs are ignored
+/// (the populator falls back to a fresh probe).
+class ObdAdapterBlocklist {
+  final SettingsStorage _storage;
+
+  const ObdAdapterBlocklist(this._storage);
+
+  /// Settings-box key prefix; one entry per adapter ELM ID. Chosen
+  /// to avoid collisions with the existing `setupSkipped` /
+  /// `apiKey` / etc. keys in the same box.
+  static const _keyPrefix = 'obdAdapterBroken:';
+
+  /// Persists the latest belief for [elmId]. No-op when [elmId] is
+  /// empty — we won't have a stable key to recall by next session
+  /// either, so storing the value would just leak.
+  Future<void> recordBelief(String elmId, double brokenConfidence) async {
+    if (elmId.isEmpty) return;
+    await _storage.putSetting('$_keyPrefix$elmId', brokenConfidence);
+  }
+
+  /// Recalls the persisted belief for [elmId]. Returns null when no
+  /// observation has ever been recorded for this adapter, when
+  /// [elmId] is empty, or when the stored value isn't a `double`
+  /// (defensive against legacy entries / Hive type drift).
+  Future<double?> recall(String elmId) async {
+    if (elmId.isEmpty) return null;
+    final raw = _storage.getSetting('$_keyPrefix$elmId');
+    if (raw is double) return raw;
+    if (raw is num) return raw.toDouble();
+    return null;
+  }
+}

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -1,12 +1,17 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/data/storage_repository.dart';
+import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../vehicle/data/ve_learner.dart';
 import '../../vehicle/providers/service_reminder_providers.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/obd2/broken_map_belief.dart';
 import '../data/obd2/broken_map_detector.dart';
+import '../data/obd2/obd_adapter_blocklist.dart';
 import '../data/repositories/fill_up_repository.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/entities/consumption_stats.dart';
@@ -43,19 +48,43 @@ VeLearner? veLearner(Ref ref) {
   );
 }
 
-/// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
-/// will swap this empty-prior factory for one that recalls the latest
-/// persisted belief; for phase 3 (logic-only) the detector is a single
+/// Detector for the broken-MAP belief system (#1423 phase 3). Single
 /// stateless instance shared across observations.
 @Riverpod(keepAlive: true)
 BrokenMapDetector brokenMapDetector(Ref ref) => const BrokenMapDetector();
 
+/// Persistent per-adapter broken-MAP blocklist (#1423 phase 4). Reads
+/// and writes the latest belief confidence by ELM ID through the
+/// shared [SettingsStorage] (Hive `settings` box). The populator
+/// recalls before each pair attempt so a known-broken adapter
+/// surfaces a warning without re-probing.
+@Riverpod(keepAlive: true)
+ObdAdapterBlocklist obdAdapterBlocklist(Ref ref) =>
+    ObdAdapterBlocklist(ref.watch(settingsStorageProvider));
+
+/// Settings-box key prefix used by [BrokenMapBeliefByVehicle] for
+/// per-vehicle persistence (#1423 phase 4). Separate namespace from
+/// [ObdAdapterBlocklist]'s adapter-keyed entries — the two are
+/// orthogonal: vehicle-keyed survives an adapter change; adapter-keyed
+/// survives a vehicle change.
+@visibleForTesting
+const String brokenMapBeliefSettingsKeyPrefix = 'brokenMapBelief:';
+
+/// Threshold above which a belief is considered actionable enough to
+/// persist into the [ObdAdapterBlocklist] (#1423 phase 4). Mirrors the
+/// spec § C wording: "if matched and confidence > 0.7, surface the
+/// warning". Below this we still update the per-vehicle belief in
+/// settings, but don't pollute the adapter blocklist with weak signals.
+@visibleForTesting
+const double brokenMapBlocklistThreshold = 0.7;
+
 /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
 ///
-/// In-memory only — phase 4 will replace this with a Hive-backed
-/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
-/// state Riverpod-scoped so widget tests can inspect / seed prior
-/// beliefs without touching storage.
+/// Hive-backed via [SettingsStorage] (#1423 phase 4) — beliefs survive
+/// app restart. Lazy-loaded on first [beliefFor] call per vehicle;
+/// [set] writes back to settings fire-and-forget. Errors are logged
+/// via [errorLogger] but never propagate (a storage hiccup must not
+/// break the fill-up save flow that triggered the update).
 ///
 /// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
 /// the vehicle hasn't been observed yet.
@@ -65,15 +94,81 @@ class BrokenMapBeliefByVehicle extends _$BrokenMapBeliefByVehicle {
   Map<String, BrokenMapBelief> build() => <String, BrokenMapBelief>{};
 
   /// Read the current belief for [vehicleId]; defaults to a fresh
-  /// [BrokenMapBelief] when nothing has been recorded yet.
-  BrokenMapBelief beliefFor(String vehicleId) =>
-      state[vehicleId] ?? const BrokenMapBelief();
+  /// [BrokenMapBelief] when nothing has been recorded yet. Hydrates
+  /// lazily from [SettingsStorage] on first access — subsequent calls
+  /// hit the cached state.
+  BrokenMapBelief beliefFor(String vehicleId) {
+    final cached = state[vehicleId];
+    if (cached != null) return cached;
+    final stored = _loadFromStorage(vehicleId);
+    if (stored != null) {
+      // Cache without re-firing the setter's persistence path.
+      state = {...state, vehicleId: stored};
+      return stored;
+    }
+    return const BrokenMapBelief();
+  }
 
-  /// Replace the belief for [vehicleId] with [belief]. Used by the
-  /// plein-complet hook after a reconciliation observation folds in.
+  /// Replace the belief for [vehicleId] with [belief]. Persists to
+  /// [SettingsStorage] in the background; persistence failures are
+  /// logged but never thrown so the calling save flow stays atomic.
   void set(String vehicleId, BrokenMapBelief belief) {
     state = {...state, vehicleId: belief};
+    // ignore: discarded_futures
+    _persist(vehicleId, belief);
   }
+
+  /// Synchronously decode the persisted belief for [vehicleId]. Returns
+  /// null when no entry exists or when the JSON payload can't be
+  /// parsed (defensive against schema drift / hand-edited values).
+  BrokenMapBelief? _loadFromStorage(String vehicleId) {
+    try {
+      final storage = ref.read(settingsStorageProvider);
+      final raw = storage.getSetting(_keyFor(vehicleId));
+      if (raw is! String || raw.isEmpty) return null;
+      final json = jsonDecode(raw);
+      if (json is! Map<String, dynamic>) return null;
+      return BrokenMapBelief.fromJson(json);
+    } catch (e, st) {
+      // Fire-and-forget log so the diagnostic overlay can see why a
+      // belief defaulted to empty after a restart. Returning null
+      // falls back to a fresh belief — the worst case is one re-
+      // probed pair, not a crash.
+      // ignore: discarded_futures
+      errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: const {
+          'op': 'brokenMapBeliefByVehicle.load',
+        },
+      );
+      return null;
+    }
+  }
+
+  /// Persist [belief] under [vehicleId]. Async-throws are caught and
+  /// logged — the calling fill-up save must not be derailed by a
+  /// storage hiccup.
+  Future<void> _persist(String vehicleId, BrokenMapBelief belief) async {
+    try {
+      final SettingsStorage storage = ref.read(settingsStorageProvider);
+      final encoded = jsonEncode(belief.toJson());
+      await storage.putSetting(_keyFor(vehicleId), encoded);
+    } catch (e, st) {
+      await errorLogger.log(
+        ErrorLayer.background,
+        e,
+        st,
+        context: const {
+          'op': 'brokenMapBeliefByVehicle.persist',
+        },
+      );
+    }
+  }
+
+  String _keyFor(String vehicleId) =>
+      '$brokenMapBeliefSettingsKeyPrefix$vehicleId';
 }
 
 /// Holds the most recent [VeLearnResult] (#815) so the UI can show a
@@ -469,9 +564,52 @@ class FillUpList extends _$FillUpList {
         now: DateTime.now(),
       );
       beliefs.set(vehicleId, updated);
+      // #1423 phase 4 — when the belief crosses the actionable
+      // threshold, also persist into the per-adapter blocklist so a
+      // future pair attempt with the SAME adapter (possibly on a
+      // different vehicle) recalls without re-probing. The adapter
+      // identifier comes from the most recent trip for this vehicle
+      // — null when no trip has captured firmware yet, in which case
+      // we skip the adapter-keyed write but still kept the per-
+      // vehicle persistence above.
+      if (updated.confidence > brokenMapBlocklistThreshold) {
+        final adapterId = _latestAdapterFirmwareFor(vehicleId);
+        if (adapterId != null && adapterId.isNotEmpty) {
+          await ref
+              .read(obdAdapterBlocklistProvider)
+              .recordBelief(adapterId, updated.confidence);
+        }
+      }
     } catch (e, st) {
       debugPrint('FillUpList: broken-MAP observation failed: $e\n$st');
     }
+  }
+
+  /// Look up the most-recently captured `adapterFirmware` across the
+  /// trip history for [vehicleId] (#1423 phase 4). Returns null when
+  /// the vehicle has no trips, or every trip pre-dates the
+  /// `adapterFirmware` capture path landing — both cases result in
+  /// the blocklist staying out of the loop, which is harmless (the
+  /// per-vehicle belief still persisted in
+  /// [_recordBrokenMapObservation] above).
+  String? _latestAdapterFirmwareFor(String vehicleId) {
+    final repo = ref.read(tripHistoryRepositoryProvider);
+    if (repo == null) return null;
+    final history = repo.loadAll();
+    DateTime? bestWhen;
+    String? best;
+    for (final entry in history) {
+      if (entry.vehicleId != vehicleId) continue;
+      final firmware = entry.adapterFirmware;
+      if (firmware == null || firmware.isEmpty) continue;
+      final when = entry.summary.endedAt ?? entry.summary.startedAt;
+      if (when == null) continue;
+      if (bestWhen == null || when.isAfter(bestWhen)) {
+        bestWhen = when;
+        best = firmware;
+      }
+    }
+    return best;
   }
 
   Future<void> _evaluateReminders(FillUp fillUp) async {

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -120,17 +120,13 @@ final class VeLearnerProvider
 
 String _$veLearnerHash() => r'3ee7af1d1504ef129c160480ac732df0494e036f';
 
-/// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
-/// will swap this empty-prior factory for one that recalls the latest
-/// persisted belief; for phase 3 (logic-only) the detector is a single
+/// Detector for the broken-MAP belief system (#1423 phase 3). Single
 /// stateless instance shared across observations.
 
 @ProviderFor(brokenMapDetector)
 final brokenMapDetectorProvider = BrokenMapDetectorProvider._();
 
-/// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
-/// will swap this empty-prior factory for one that recalls the latest
-/// persisted belief; for phase 3 (logic-only) the detector is a single
+/// Detector for the broken-MAP belief system (#1423 phase 3). Single
 /// stateless instance shared across observations.
 
 final class BrokenMapDetectorProvider
@@ -141,9 +137,7 @@ final class BrokenMapDetectorProvider
           BrokenMapDetector
         >
     with $Provider<BrokenMapDetector> {
-  /// Detector for the broken-MAP belief system (#1423 phase 3). Phase 4
-  /// will swap this empty-prior factory for one that recalls the latest
-  /// persisted belief; for phase 3 (logic-only) the detector is a single
+  /// Detector for the broken-MAP belief system (#1423 phase 3). Single
   /// stateless instance shared across observations.
   BrokenMapDetectorProvider._()
     : super(
@@ -181,12 +175,78 @@ final class BrokenMapDetectorProvider
 
 String _$brokenMapDetectorHash() => r'401fe3bdd10c78d2b90c351588fea002125d89a2';
 
+/// Persistent per-adapter broken-MAP blocklist (#1423 phase 4). Reads
+/// and writes the latest belief confidence by ELM ID through the
+/// shared [SettingsStorage] (Hive `settings` box). The populator
+/// recalls before each pair attempt so a known-broken adapter
+/// surfaces a warning without re-probing.
+
+@ProviderFor(obdAdapterBlocklist)
+final obdAdapterBlocklistProvider = ObdAdapterBlocklistProvider._();
+
+/// Persistent per-adapter broken-MAP blocklist (#1423 phase 4). Reads
+/// and writes the latest belief confidence by ELM ID through the
+/// shared [SettingsStorage] (Hive `settings` box). The populator
+/// recalls before each pair attempt so a known-broken adapter
+/// surfaces a warning without re-probing.
+
+final class ObdAdapterBlocklistProvider
+    extends
+        $FunctionalProvider<
+          ObdAdapterBlocklist,
+          ObdAdapterBlocklist,
+          ObdAdapterBlocklist
+        >
+    with $Provider<ObdAdapterBlocklist> {
+  /// Persistent per-adapter broken-MAP blocklist (#1423 phase 4). Reads
+  /// and writes the latest belief confidence by ELM ID through the
+  /// shared [SettingsStorage] (Hive `settings` box). The populator
+  /// recalls before each pair attempt so a known-broken adapter
+  /// surfaces a warning without re-probing.
+  ObdAdapterBlocklistProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'obdAdapterBlocklistProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$obdAdapterBlocklistHash();
+
+  @$internal
+  @override
+  $ProviderElement<ObdAdapterBlocklist> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ObdAdapterBlocklist create(Ref ref) {
+    return obdAdapterBlocklist(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ObdAdapterBlocklist value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ObdAdapterBlocklist>(value),
+    );
+  }
+}
+
+String _$obdAdapterBlocklistHash() =>
+    r'56c0d8086fe53973b194d6ba305a520e91b9783b';
+
 /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
 ///
-/// In-memory only — phase 4 will replace this with a Hive-backed
-/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
-/// state Riverpod-scoped so widget tests can inspect / seed prior
-/// beliefs without touching storage.
+/// Hive-backed via [SettingsStorage] (#1423 phase 4) — beliefs survive
+/// app restart. Lazy-loaded on first [beliefFor] call per vehicle;
+/// [set] writes back to settings fire-and-forget. Errors are logged
+/// via [errorLogger] but never propagate (a storage hiccup must not
+/// break the fill-up save flow that triggered the update).
 ///
 /// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
 /// the vehicle hasn't been observed yet.
@@ -196,10 +256,11 @@ final brokenMapBeliefByVehicleProvider = BrokenMapBeliefByVehicleProvider._();
 
 /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
 ///
-/// In-memory only — phase 4 will replace this with a Hive-backed
-/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
-/// state Riverpod-scoped so widget tests can inspect / seed prior
-/// beliefs without touching storage.
+/// Hive-backed via [SettingsStorage] (#1423 phase 4) — beliefs survive
+/// app restart. Lazy-loaded on first [beliefFor] call per vehicle;
+/// [set] writes back to settings fire-and-forget. Errors are logged
+/// via [errorLogger] but never propagate (a storage hiccup must not
+/// break the fill-up save flow that triggered the update).
 ///
 /// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
 /// the vehicle hasn't been observed yet.
@@ -211,10 +272,11 @@ final class BrokenMapBeliefByVehicleProvider
         > {
   /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
   ///
-  /// In-memory only — phase 4 will replace this with a Hive-backed
-  /// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
-  /// state Riverpod-scoped so widget tests can inspect / seed prior
-  /// beliefs without touching storage.
+  /// Hive-backed via [SettingsStorage] (#1423 phase 4) — beliefs survive
+  /// app restart. Lazy-loaded on first [beliefFor] call per vehicle;
+  /// [set] writes back to settings fire-and-forget. Errors are logged
+  /// via [errorLogger] but never propagate (a storage hiccup must not
+  /// break the fill-up save flow that triggered the update).
   ///
   /// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
   /// the vehicle hasn't been observed yet.
@@ -246,14 +308,15 @@ final class BrokenMapBeliefByVehicleProvider
 }
 
 String _$brokenMapBeliefByVehicleHash() =>
-    r'd1f5bdc514ec49d5b419f659ef7c2e4baccb8d7a';
+    r'aff722180306e0f98424bbdcdbe47b0f46c68be5';
 
 /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
 ///
-/// In-memory only — phase 4 will replace this with a Hive-backed
-/// per-vehicle store so beliefs survive app restart. Phase 3 keeps the
-/// state Riverpod-scoped so widget tests can inspect / seed prior
-/// beliefs without touching storage.
+/// Hive-backed via [SettingsStorage] (#1423 phase 4) — beliefs survive
+/// app restart. Lazy-loaded on first [beliefFor] call per vehicle;
+/// [set] writes back to settings fire-and-forget. Errors are logged
+/// via [errorLogger] but never propagate (a storage hiccup must not
+/// break the fill-up save flow that triggered the update).
 ///
 /// Keyed by `vehicleId`. Beliefs default to [BrokenMapBelief()] when
 /// the vehicle hasn't been observed yet.
@@ -404,7 +467,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'ca9867e29fd5ba03e407a2fb44bda82a6c66687d';
+String _$fillUpListHash() => r'747131c8306e9ae42c11e49c6d6093d0d490251a';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
+++ b/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
@@ -5,6 +5,7 @@ import '../../consumption/data/obd2/broken_map_belief.dart';
 import '../../consumption/data/obd2/broken_map_detector.dart';
 import '../../consumption/data/obd2/obd2_connection_service.dart';
 import '../../consumption/data/obd2/obd2_service.dart';
+import '../../consumption/data/obd2/obd_adapter_blocklist.dart';
 import '../domain/entities/vehicle_profile.dart';
 import '../domain/entities/vin_data.dart';
 import 'vin_auto_populator.dart';
@@ -96,11 +97,33 @@ class VinAdapterPairAutoPopulator {
   /// flow then behaves exactly as before.
   final BrokenMapDetector? brokenMapDetector;
 
+  /// Optional persistent broken-MAP blocklist (#1423 phase 4). When
+  /// provided AND the connected adapter reports a stable ELM ID via
+  /// `ATI` (captured into [Obd2Service.adapterFirmware]), the
+  /// populator recalls a prior belief BEFORE running the probe — a
+  /// known-broken adapter (recalled confidence > 0.7) short-circuits
+  /// the probe and surfaces immediately. After the probe runs, beliefs
+  /// crossing the same threshold are persisted back to the blocklist
+  /// so future sessions inherit the warning. Null in tests / legacy
+  /// call sites that haven't opted in.
+  final ObdAdapterBlocklist? blocklist;
+
+  /// Threshold above which a recalled / freshly-probed belief is
+  /// considered actionable enough to:
+  ///   1. short-circuit the next pair-time probe (recall path), and
+  ///   2. land in the persistent blocklist for future sessions
+  ///      (probe-result path).
+  /// Mirrors [brokenMapBlocklistThreshold] in `consumption_providers`
+  /// — kept here as a private constant rather than imported to avoid
+  /// pulling in the providers layer from a data-layer class.
+  static const double _blocklistThreshold = 0.7;
+
   VinAdapterPairAutoPopulator({
     required this.connection,
     required this.decoder,
     this.populator = const VinAutoPopulator(),
     this.brokenMapDetector,
+    this.blocklist,
   });
 
   /// Run the post-pair flow against [pairedAdapterMac], merging into
@@ -165,29 +188,76 @@ class VinAdapterPairAutoPopulator {
         pidFuelType: pidFuelType,
       );
 
-      // Optional broken-MAP idle probe (#1423 phase 2). Runs against
-      // the live service before disconnect; never derails the pair
-      // flow on failure. Diesel branch is selected from whichever
+      // Optional broken-MAP idle probe (#1423 phase 2 + 4). Runs
+      // against the live service before disconnect; never derails the
+      // pair flow on failure. Diesel branch is selected from whichever
       // fuel-type signal we already resolved — PID 0x51 wins, the
       // populator's merged result wins next, then nothing (default
-      // petrol). Phase 4 will swap the empty `prior` for a recall
-      // from the persistent blocklist.
+      // petrol).
+      //
+      // Phase 4: when a [blocklist] is wired AND the adapter reported
+      // a stable firmware id, recall the prior belief BEFORE probing.
+      // A known-broken adapter (recalled confidence > 0.7) skips the
+      // probe entirely — we already know it's suspect, surface the
+      // warning immediately and let the user act. After the probe
+      // completes (or short-circuits), beliefs crossing the threshold
+      // are persisted back so future pair attempts inherit the
+      // warning.
       BrokenMapBelief? brokenMapBelief;
       final detector = brokenMapDetector;
+      final adapterId = service.adapterFirmware;
       if (detector != null) {
         try {
-          final fuelKey = (pidFuelType ??
-                  result.profile.preferredFuelType ??
-                  result.profile.detectedFuelType ??
-                  '')
-              .toLowerCase();
-          final isDiesel = fuelKey.contains('diesel');
-          brokenMapBelief = await detector.probe(
-            service,
-            isDiesel: isDiesel,
-            prior: const BrokenMapBelief(),
-            now: DateTime.now(),
-          );
+          // Recall path — short-circuit when the adapter is on the
+          // blocklist with actionable confidence.
+          final blocklistRef = blocklist;
+          if (blocklistRef != null &&
+              adapterId != null &&
+              adapterId.isNotEmpty) {
+            final priorConfidence = await blocklistRef.recall(adapterId);
+            if (priorConfidence != null &&
+                priorConfidence > _blocklistThreshold) {
+              brokenMapBelief = BrokenMapBelief(
+                confidence: priorConfidence,
+                // observationCount: 0 distinguishes "hydrated from a
+                // prior session" from a freshly-probed belief whose
+                // updater would have bumped the count.
+                observationCount: 0,
+                lastUpdate: DateTime.now(),
+                lastTrigger: BrokenMapReason.priorObservation,
+              );
+            }
+          }
+
+          // Probe path — only when the recall didn't short-circuit.
+          if (brokenMapBelief == null) {
+            final fuelKey = (pidFuelType ??
+                    result.profile.preferredFuelType ??
+                    result.profile.detectedFuelType ??
+                    '')
+                .toLowerCase();
+            final isDiesel = fuelKey.contains('diesel');
+            brokenMapBelief = await detector.probe(
+              service,
+              isDiesel: isDiesel,
+              prior: const BrokenMapBelief(),
+              now: DateTime.now(),
+            );
+
+            // Persist back to the blocklist when the freshly-probed
+            // confidence crosses the actionable threshold. Same
+            // adapter id used by the recall path above so future
+            // sessions short-circuit instead of re-probing.
+            if (blocklistRef != null &&
+                adapterId != null &&
+                adapterId.isNotEmpty &&
+                brokenMapBelief.confidence > _blocklistThreshold) {
+              await blocklistRef.recordBelief(
+                adapterId,
+                brokenMapBelief.confidence,
+              );
+            }
+          }
         } catch (e, st) {
           await errorLogger.log(
             ErrorLayer.background,

--- a/test/features/consumption/data/obd2/obd_adapter_blocklist_test.dart
+++ b/test/features/consumption/data/obd2/obd_adapter_blocklist_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd_adapter_blocklist.dart';
+
+/// In-memory [SettingsStorage] double for deterministic blocklist
+/// tests. Mirrors the shape used by the populator and plein-complet
+/// hook tests so the blocklist sees a real store implementation.
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = {};
+
+  @override
+  dynamic getSetting(String key) => data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+void main() {
+  group('ObdAdapterBlocklist', () {
+    late _FakeSettingsStorage storage;
+    late ObdAdapterBlocklist blocklist;
+
+    setUp(() {
+      storage = _FakeSettingsStorage();
+      blocklist = ObdAdapterBlocklist(storage);
+    });
+
+    test('recall returns null on miss', () async {
+      final v = await blocklist.recall('ELM327 v1.5');
+      expect(v, isNull);
+    });
+
+    test('recordBelief + recall round-trips a confidence value', () async {
+      await blocklist.recordBelief('ELM327 v1.5', 0.82);
+      final v = await blocklist.recall('ELM327 v1.5');
+      expect(v, closeTo(0.82, 1e-9));
+    });
+
+    test(
+        'recordBelief is idempotent — second call with a different value '
+        'overwrites the first', () async {
+      await blocklist.recordBelief('ELM327 v1.5', 0.4);
+      await blocklist.recordBelief('ELM327 v1.5', 0.9);
+      final v = await blocklist.recall('ELM327 v1.5');
+      expect(v, closeTo(0.9, 1e-9));
+    });
+
+    test('different ELM IDs are isolated in storage', () async {
+      await blocklist.recordBelief('ELM327 v1.5', 0.85);
+      await blocklist.recordBelief('STN1110 v4.0.4', 0.10);
+      expect(await blocklist.recall('ELM327 v1.5'), closeTo(0.85, 1e-9));
+      expect(await blocklist.recall('STN1110 v4.0.4'), closeTo(0.10, 1e-9));
+    });
+
+    test('empty ELM ID is a no-op for both record and recall', () async {
+      await blocklist.recordBelief('', 0.99);
+      // Record must not write anything.
+      expect(storage.data.keys, isEmpty);
+      // Recall on empty must be null without reading storage.
+      expect(await blocklist.recall(''), isNull);
+    });
+
+    test('settings-box key is namespaced under obdAdapterBroken:', () async {
+      await blocklist.recordBelief('ELM327 v2.2', 0.55);
+      expect(storage.data.keys, contains('obdAdapterBroken:ELM327 v2.2'));
+    });
+
+    test(
+        'recall tolerates legacy num values (int round-tripped to double)',
+        () async {
+      // Pre-existing entry stored as int (e.g. hand-edited or a stale
+      // schema). Recall must coerce to double rather than crashing.
+      storage.data['obdAdapterBroken:ELM327 v1.5'] = 1;
+      final v = await blocklist.recall('ELM327 v1.5');
+      expect(v, closeTo(1.0, 1e-9));
+    });
+
+    test('recall returns null on a non-numeric stored value', () async {
+      storage.data['obdAdapterBroken:ELM327 v1.5'] = 'corrupted';
+      final v = await blocklist.recall('ELM327 v1.5');
+      expect(v, isNull);
+    });
+  });
+}

--- a/test/features/consumption/providers/broken_map_belief_persistence_test.dart
+++ b/test/features/consumption/providers/broken_map_belief_persistence_test.dart
@@ -1,0 +1,283 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Hive-backed persistence tests for the [BrokenMapBeliefByVehicle]
+/// notifier (#1423 phase 4). Verifies that:
+///   1. a high-discrepancy plein-complet observation persists the
+///      updated belief into [SettingsStorage] under the
+///      [brokenMapBeliefSettingsKeyPrefix] namespace,
+///   2. a fresh notifier instance (different ProviderContainer)
+///      hydrates the same belief lazily on first [beliefFor] call —
+///      proving the round-trip survives an "app restart",
+///   3. legacy / corrupted JSON in storage falls back to a default
+///      belief without crashing.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late TripHistoryRepository historyRepo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('broken_map_persist_');
+    Hive.init(tmpDir.path);
+    final box = await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+    historyRepo = TripHistoryRepository(box: box);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    // Windows occasionally holds the box file open briefly after
+    // [Hive.close]. Suppress the deleteSync error so the suite stays
+    // green — the temp dir lives under [Directory.systemTemp] and the
+    // OS will reclaim it on next reboot. Mirrors the
+    // [feedback_hive_widget_test_teardown] guidance that bounded
+    // cleanup beats a PathAccessException race.
+    try {
+      tmpDir.deleteSync(recursive: true);
+    } on FileSystemException catch (e, st) {
+      debugPrint('persistence_test tearDown: $e\n$st');
+    }
+  });
+
+  Future<void> seedTrip({
+    required String id,
+    required String vehicleId,
+    required DateTime startedAt,
+    required double distanceKm,
+    required double fuelLitersConsumed,
+  }) {
+    return historyRepo.save(TripHistoryEntry(
+      id: id,
+      vehicleId: vehicleId,
+      summary: TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuelLitersConsumed,
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(minutes: 30)),
+      ),
+    ));
+  }
+
+  FillUp mkFillUp({
+    required String id,
+    required DateTime date,
+    String vehicleId = 'veh-a',
+    double liters = 40,
+    double odometerKm = 10000,
+    bool isFullTank = true,
+  }) =>
+      FillUp(
+        id: id,
+        date: date,
+        liters: liters,
+        totalCost: liters * 1.5,
+        odometerKm: odometerKm,
+        fuelType: FuelType.e10,
+        vehicleId: vehicleId,
+        isFullTank: isFullTank,
+      );
+
+  test(
+      'high-discrepancy plein persists the belief in settings storage '
+      'under the brokenMapBelief: prefix', () async {
+    final storage = _FakeSettingsStorage();
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    // Drain the persistence microtask the setter kicked off.
+    await Future<void>.delayed(Duration.zero);
+
+    const key = '${brokenMapBeliefSettingsKeyPrefix}veh-a';
+    expect(storage.data.containsKey(key), isTrue,
+        reason: 'belief must be persisted under the prefix-veh key');
+    final raw = storage.data[key];
+    expect(raw, isA<String>(), reason: 'belief is JSON-encoded');
+    final json = jsonDecode(raw as String) as Map<String, dynamic>;
+    final restored = BrokenMapBelief.fromJson(json);
+    expect(restored.confidence, closeTo(0.4, 1e-9));
+    expect(restored.observationCount, 1);
+    expect(restored.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+  });
+
+  test(
+      'a fresh ProviderContainer hydrates the belief lazily from settings '
+      'storage on first beliefFor call — round-trip survives "restart"',
+      () async {
+    // Seed storage directly as if a previous app session had persisted
+    // a belief — equivalent to opening the app after an upgrade.
+    final storage = _FakeSettingsStorage();
+    final priorBelief = BrokenMapBelief(
+      confidence: 0.82,
+      observationCount: 3,
+      lastUpdate: DateTime(2026, 4, 30),
+      lastTrigger: BrokenMapReason.pleinCompletDiscrepancy,
+    );
+    storage.data['${brokenMapBeliefSettingsKeyPrefix}veh-a'] =
+        jsonEncode(priorBelief.toJson());
+
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final hydrated = container
+        .read(brokenMapBeliefByVehicleProvider.notifier)
+        .beliefFor('veh-a');
+    expect(hydrated.confidence, closeTo(0.82, 1e-9));
+    expect(hydrated.observationCount, 3);
+    expect(hydrated.lastTrigger, BrokenMapReason.pleinCompletDiscrepancy);
+  });
+
+  test(
+      'corrupted JSON in storage falls back to a default belief without '
+      'crashing', () async {
+    final storage = _FakeSettingsStorage();
+    storage.data['${brokenMapBeliefSettingsKeyPrefix}veh-a'] = 'not-json';
+
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final hydrated = container
+        .read(brokenMapBeliefByVehicleProvider.notifier)
+        .beliefFor('veh-a');
+    expect(hydrated, const BrokenMapBelief());
+  });
+
+  test(
+      'high-discrepancy belief crossing 0.7 also lands in the per-adapter '
+      'blocklist when a trip with adapterFirmware exists', () async {
+    final storage = _FakeSettingsStorage();
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(storage),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // Seed an observed-firmware trip so the plein-complet hook can
+    // resolve the adapter id when persisting.
+    await historyRepo.save(TripHistoryEntry(
+      id: 't1',
+      vehicleId: 'veh-a',
+      adapterFirmware: 'ELM327 v1.5',
+      summary: TripSummary(
+        distanceKm: 100,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: 5,
+        startedAt: DateTime(2026, 4, 1, 9),
+        endedAt: DateTime(2026, 4, 1, 9, 30),
+      ),
+    ));
+
+    // Pre-seed a strong belief so a single high-discrepancy
+    // observation pushes confidence above 0.7 in one EMA fold.
+    // Starting at 0.85, observation = 1.0 → α(1.0) + (1-α)(0.85)
+    //                                       = 0.4 + 0.51 = 0.91.
+    storage.data['${brokenMapBeliefSettingsKeyPrefix}veh-a'] = jsonEncode(
+      const BrokenMapBelief(
+        confidence: 0.85,
+        observationCount: 5,
+        lastTrigger: BrokenMapReason.pleinCompletDiscrepancy,
+      ).toJson(),
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    await Future<void>.delayed(Duration.zero);
+
+    const blocklistKey = 'obdAdapterBroken:ELM327 v1.5';
+    expect(storage.data[blocklistKey], isNotNull,
+        reason: 'belief crossing the threshold must persist to the blocklist');
+    expect(
+      storage.data[blocklistKey] as double,
+      greaterThan(0.7),
+    );
+  });
+}
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = {};
+
+  @override
+  dynamic getSetting(String key) => data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
+++ b/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/features/consumption/data/obd2/broken_map_belief.dart';
 import 'package:tankstellen/features/consumption/data/obd2/broken_map_detector.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
@@ -15,6 +16,8 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_servi
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd_adapter_blocklist.dart';
+import 'package:tankstellen/features/consumption/data/obd2/oem_pid_table.dart';
 import 'package:tankstellen/features/vehicle/data/vin_adapter_pair_auto_populator.dart';
 import 'package:tankstellen/features/vehicle/data/vin_decoder.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
@@ -305,6 +308,257 @@ void main() {
       expect(outcome.brokenMapBelief, isNull);
     });
   });
+
+  group('persistent blocklist wiring (#1423 phase 4)', () {
+    test(
+        'a blocklist hit (recall confidence > 0.7) short-circuits the probe '
+        'and surfaces a priorObservation belief', () async {
+      const vin = 'VF36B8HZL8R123456';
+      final initResponses = {
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        'ATI': 'ELM327 v1.5>',
+      };
+      final transport = FakeObd2Transport({
+        ...initResponses,
+        '0902': buildValidVinResponse(vin),
+      });
+      final service = Obd2Service(transport);
+      final connection = _FakeConnection(connectByMacResult: service);
+
+      final storage = _FakeSettingsStorage()
+        ..data['obdAdapterBroken:ELM327 v1.5'] = 0.85;
+      final blocklist = ObdAdapterBlocklist(storage);
+
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+        brokenMapDetector: const BrokenMapDetector(),
+        blocklist: blocklist,
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(outcome.brokenMapBelief, isNotNull);
+      expect(outcome.brokenMapBelief!.confidence, closeTo(0.85, 1e-9));
+      expect(outcome.brokenMapBelief!.observationCount, 0,
+          reason:
+              'observationCount=0 signals "hydrated from a prior session" '
+              '— never bumped because no fresh probe ran.');
+      expect(outcome.brokenMapBelief!.lastTrigger,
+          BrokenMapReason.priorObservation);
+
+      // The probe issues 0111 (TPS), 010B (MAP), 0133 (baro). NONE of
+      // these may have been sent — the blocklist hit short-circuited
+      // the detector entirely.
+      final sent = transport.sentCommands;
+      expect(sent.any((c) => c.startsWith('0111')), isFalse,
+          reason: 'TPS probe must not run on blocklist hit');
+      expect(sent.any((c) => c.startsWith('010B')), isFalse,
+          reason: 'MAP probe must not run on blocklist hit');
+      expect(sent.any((c) => c.startsWith('0133')), isFalse,
+          reason: 'baro probe must not run on blocklist hit');
+    });
+
+    test(
+        'a blocklist value at-or-below 0.7 does NOT short-circuit — fresh '
+        'probe runs and overwrites the prior belief', () async {
+      const vin = 'VF36B8HZL8R123456';
+      // Healthy MAP fixture from the existing detector tests — vacuum
+      // delta 71 → score 0 → confidence stays at 0 after one fold.
+      final service = buildConnectedService({
+        '0902': buildValidVinResponse(vin),
+        '0151': '41 51 01>',
+        '0111': '41 11 03>',
+        '010B': '41 0B 1E>', // 0x1E = 30 kPa
+        '0133': '41 33 65>', // 0x65 = 101 kPa
+      });
+      final connection = _FakeConnection(connectByMacResult: service);
+      final storage = _FakeSettingsStorage()
+        ..data['obdAdapterBroken:ELM327 v1.5'] = 0.4;
+      final blocklist = ObdAdapterBlocklist(storage);
+
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+        brokenMapDetector: const BrokenMapDetector(),
+        blocklist: blocklist,
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(outcome.brokenMapBelief, isNotNull);
+      // Probe ran from a fresh prior — confidence 0 (healthy MAP).
+      expect(outcome.brokenMapBelief!.confidence, closeTo(0.0, 1e-9));
+      expect(outcome.brokenMapBelief!.observationCount, 1);
+      // Below-threshold probe result must NOT touch the blocklist.
+      expect(storage.data['obdAdapterBroken:ELM327 v1.5'], 0.4,
+          reason: 'sub-threshold probe result must not overwrite blocklist');
+    });
+
+    test(
+        'a probe that yields confidence > 0.7 is persisted into the '
+        'blocklist for the connected adapter', () async {
+      const vin = 'VF36B8HZL8R123456';
+      // Broken MAP fixture — vacuum delta 2 kPa → score 1.0 → after
+      // one EMA fold from prior 0.85 → confidence ~0.91 (> threshold).
+      final storage = _FakeSettingsStorage();
+      // Pre-seed a non-blocking entry so the recall doesn't short-
+      // circuit, and verify persistence overwrites cleanly.
+      final blocklist = ObdAdapterBlocklist(storage);
+      // Use an artificially-elevated prior via the detector's own
+      // `prior` parameter wouldn't help here — the populator always
+      // probes from `const BrokenMapBelief()`. To exercise the
+      // > 0.7 persistence branch with a single observation, drive the
+      // probe with an extreme broken-MAP fixture that pushes one-shot
+      // confidence to α (= 0.4)? That's below 0.7. So instead seed
+      // the blocklist below threshold and run the populator twice
+      // — but the populator is single-shot. Easiest path: use the
+      // detector directly with a strong prior to assert the
+      // populator's persistence call site, via a custom detector.
+      //
+      // Workaround: stub the detector to return a high-confidence
+      // belief unconditionally so the populator exercises the
+      // persistence branch. The integration of "real probe → strong
+      // confidence" is covered by the broken_map_detector tests; we
+      // just need to prove the populator wires recordBelief
+      // correctly.
+      final service = buildConnectedService({
+        '0902': buildValidVinResponse(vin),
+        '0151': '41 51 01>',
+      });
+      final connection = _FakeConnection(connectByMacResult: service);
+
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+        brokenMapDetector: const _StubHighConfidenceDetector(0.92),
+        blocklist: blocklist,
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(outcome.brokenMapBelief, isNotNull);
+      expect(outcome.brokenMapBelief!.confidence, closeTo(0.92, 1e-9));
+      // Persisted into the blocklist under the connected adapter's id.
+      expect(storage.data['obdAdapterBroken:ELM327 v1.5'], 0.92);
+    });
+
+    test(
+        'no blocklist + no detector → outcome.brokenMapBelief is null '
+        '(legacy behaviour preserved)', () async {
+      const vin = 'VF36B8HZL8R123456';
+      final service = buildConnectedService({
+        '0902': buildValidVinResponse(vin),
+      });
+      final connection = _FakeConnection(connectByMacResult: service);
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+        // Both omitted.
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(outcome.brokenMapBelief, isNull);
+    });
+
+    test(
+        'a blocklist with no entry for this adapter falls through to a '
+        'fresh probe', () async {
+      const vin = 'VF36B8HZL8R123456';
+      final service = buildConnectedService({
+        '0902': buildValidVinResponse(vin),
+        '0151': '41 51 01>',
+        '0111': '41 11 03>',
+        '010B': '41 0B 1E>',
+        '0133': '41 33 65>',
+      });
+      final connection = _FakeConnection(connectByMacResult: service);
+      final storage = _FakeSettingsStorage();
+      final blocklist = ObdAdapterBlocklist(storage);
+
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+        brokenMapDetector: const BrokenMapDetector(),
+        blocklist: blocklist,
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+
+      expect(outcome.brokenMapBelief, isNotNull);
+      expect(outcome.brokenMapBelief!.observationCount, 1,
+          reason: 'fresh probe ran — observationCount bumped from 0 to 1');
+      // Healthy MAP → no blocklist write.
+      expect(storage.data, isEmpty);
+    });
+  });
+}
+
+/// Detector double for the populator persistence test. The real
+/// detector's probe path is exercised in broken_map_detector_test;
+/// here we just need to assert the populator's wiring of
+/// [ObdAdapterBlocklist.recordBelief]. Returning a fixed high
+/// confidence keeps the test deterministic without recreating the
+/// full broken-MAP fixture in this file.
+class _StubHighConfidenceDetector extends BrokenMapDetector {
+  final double confidence;
+  const _StubHighConfidenceDetector(this.confidence);
+
+  @override
+  Future<BrokenMapBelief> probe(
+    Obd2RawCommandPort port, {
+    required bool isDiesel,
+    required BrokenMapBelief prior,
+    required DateTime now,
+  }) async {
+    return BrokenMapBelief(
+      confidence: confidence,
+      observationCount: 1,
+      lastUpdate: now,
+      lastTrigger: BrokenMapReason.idleVacuumMissing,
+    );
+  }
+}
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = {};
+
+  @override
+  dynamic getSetting(String key) => data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
 }
 
 class _FakeConnection extends Obd2ConnectionService {


### PR DESCRIPTION
## Summary

Phase 4 of #1423 — persists the broken-MAP belief into Hive `settingsBox` per vehicle and introduces a per-adapter blocklist keyed by ELM firmware id (the `ATI` response). The populator now **recalls the blocklist BEFORE running an idle probe** — a known-broken adapter (recalled confidence > 0.7) short-circuits the probe and surfaces a `priorObservation` belief immediately. Below the threshold the probe runs and overwrites; above it, the freshly-probed belief is also persisted back so future sessions inherit the warning.

Refs #1423 phase 4 (phase 5 remains: UI thresholds + ARB strings + diagnostic-overlay line).

## What changed

- **`lib/features/consumption/data/obd2/broken_map_belief.dart`** — added `BrokenMapReason.priorObservation` for the recall path. `.g.dart` updated by hand to add the enum value (single-line tweak; no broader codegen drift).
- **`lib/features/consumption/data/obd2/obd_adapter_blocklist.dart`** (new) — `ObdAdapterBlocklist` wraps `SettingsStorage` with `obdAdapterBroken:<elmId>` keys. Idempotent record/recall; empty ELM ids are no-ops. Tolerates legacy `num` values (int → double) and corrupted entries (returns null).
- **`lib/features/consumption/providers/consumption_providers.dart`** — `BrokenMapBeliefByVehicle` now reads/writes JSON-encoded beliefs through `SettingsStorage` under the `brokenMapBelief:<vehicleId>` prefix; hydrates lazily on first `beliefFor()` and persists fire-and-forget on `set()`. New `obdAdapterBlocklistProvider`. Plein-complet hook also persists into the blocklist when belief crosses the threshold AND a trip history entry has captured an `adapterFirmware` for this vehicle.
- **`lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart`** — gained an optional `blocklist` field. Recall short-circuits the probe on hit (confidence > 0.7), post-probe persistence writes back when fresh confidence crosses the same threshold.
- **Tests** —
  - `test/features/consumption/data/obd2/obd_adapter_blocklist_test.dart` (8 cases): happy path, miss returns null, idempotent overwrite, isolation across ELM ids, empty-id no-op, key namespace, legacy `num` tolerance, corrupted-value defensiveness.
  - `test/features/consumption/providers/broken_map_belief_persistence_test.dart` (4 cases): persistence on plein-complet, fresh-container hydration, corrupted-JSON fallback, blocklist write when confidence crosses 0.7.
  - Extended `test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart` (5 new cases): blocklist short-circuit (verifies probe PIDs are NOT sent), at-or-below-threshold falls through, post-probe persistence, no-blocklist legacy preservation, no-entry falls through.

## Storage choice

**Reused `settingsBox`** (option 1 from spec) — no new Hive box registration needed; `SettingsStorage` is the abstraction the rest of the codebase already uses for non-typed key/value persistence. Single read per pair attempt is well below the spec's "unbearably hot" threshold. `lib/core/storage/hive_boxes.dart` is unchanged.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test test/features/consumption/data/obd2/` — 853/853 pass
- [x] `flutter test test/features/consumption/providers/` — 171/171 pass
- [x] `flutter test test/features/vehicle/data/` — 220/220 pass
- [x] `flutter test test/features/consumption/` — 2512/2512 pass
- [x] `flutter test test/features/vehicle/` — 638/638 pass
- [x] `flutter test test/lint/` — 29/29 pass
- [x] `flutter test test/i18n/` — 68/68 pass
- [ ] CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)