### PR TITLE
feat(features): cascading-disable + isEffectivelyEnabled (Refs #1447 phase 1)

### DIFF
--- a/lib/features/feature_management/application/feature_flags_provider.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.dart
@@ -80,25 +80,26 @@ class FeatureFlags extends _$FeatureFlags {
     state = next;
   }
 
-  /// Disables [feature], throwing [StateError] when one or more enabled
-  /// features depend on it. The error message names the dependents so
-  /// the Phase 2 UI can prompt the user to disable them first.
+  /// Disables [feature]. Always succeeds — children that `requires` this
+  /// feature stay in the stored set (their preferences are preserved) but
+  /// become **effectively** disabled via [isEffectivelyEnabled], so every
+  /// UI surface that gates on the helper hides them without prompting the
+  /// user (#1447).
+  ///
+  /// Re-enabling [feature] later restores those children to their previous
+  /// user-visible state, no manual re-toggling required.
   Future<void> disable(Feature feature) async {
-    final manifest = ref.read(featureManifestProvider);
     if (!state.contains(feature)) return;
-    final blockers = blockingDisable(feature, manifest, state);
-    if (blockers.isNotEmpty) {
-      final names = blockers.map((f) => f.name).join(', ');
-      throw StateError(
-        'Cannot disable ${feature.name}: $names depend on it',
-      );
-    }
     final next = {...state}..remove(feature);
     await _persist(next);
     state = next;
   }
 
-  /// True when [feature] is currently enabled.
+  /// True when [feature] is currently in the stored enabled set. Does NOT
+  /// walk the dependency chain — when the manifest declares prerequisites
+  /// for [feature] and the caller wants the user-visible "is this surface
+  /// reachable right now" answer, use the pure helper
+  /// `isEffectivelyEnabled` from `feature_dependency_graph.dart` (#1447).
   bool isEnabled(Feature feature) => state.contains(feature);
 
   Future<void> _persist(Set<Feature> next) async {

--- a/lib/features/feature_management/domain/feature_dependency_graph.dart
+++ b/lib/features/feature_management/domain/feature_dependency_graph.dart
@@ -25,11 +25,54 @@ bool canEnable(
   return true;
 }
 
+/// Returns `true` when [feature] is **effectively** enabled given
+/// [currentlyEnabled] (#1447).
+///
+/// "Effective" means the feature itself is in [currentlyEnabled] AND every
+/// ancestor on its `requires` chain is also effectively enabled. A feature
+/// whose stored state is `true` but whose parent has been disabled returns
+/// `false` — UI surfaces gate on this helper so disabling a parent silently
+/// hides every dependent without forcing the user to manually disable
+/// each child first.
+///
+/// Child stored state is intentionally preserved when an ancestor is off:
+/// re-enabling the parent restores the previous user-visible setup. The
+/// epic's contract — see #1447 — is "lazy/cascading-disable", not
+/// "strict-with-cascade-on-write".
+///
+/// Walking the chain is bounded by the manifest's acyclic invariant
+/// (`assertNoCycles`), so the recursion always terminates. Visited tracking
+/// is unnecessary for correctness but cheap insurance against a manifest
+/// loaded with a cycle that slipped past the assertion.
+bool isEffectivelyEnabled(
+  Feature feature,
+  FeatureManifest manifest,
+  Set<Feature> currentlyEnabled,
+) {
+  if (!currentlyEnabled.contains(feature)) return false;
+  final visited = <Feature>{feature};
+  bool walk(Feature node) {
+    final entry = manifest.entries[node];
+    if (entry == null) return true;
+    for (final required in entry.requires) {
+      if (!currentlyEnabled.contains(required)) return false;
+      if (visited.add(required) && !walk(required)) return false;
+    }
+    return true;
+  }
+
+  return walk(feature);
+}
+
 /// Returns the set of currently-enabled features that depend on [feature].
 ///
 /// When the returned set is empty, [feature] can be safely disabled.
 /// Otherwise the caller must disable each returned feature first (or refuse
 /// the operation).
+///
+/// Retained for diagnostics and tests; the runtime [FeatureFlags] notifier
+/// no longer consults this on `disable` (#1447 — disabling is lazy and
+/// cascades through [isEffectivelyEnabled]).
 Set<Feature> blockingDisable(
   Feature feature,
   FeatureManifest manifest,

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -10,7 +10,7 @@ import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../../../feature_management/domain/feature_manifest.dart';
 
 /// Settings-screen section that exposes every [Feature] as a toggle
-/// (#1373 phase 2; #1440 grouping).
+/// (#1373 phase 2; #1440 grouping; #1447 cascading-disable).
 ///
 /// Renders one [SwitchListTile] per entry in [featureManifestProvider],
 /// VISUALLY GROUPED so dependent features sit indented under the parent
@@ -18,20 +18,16 @@ import '../../../feature_management/domain/feature_manifest.dart';
 /// row at full width followed by indented dependent rows separated by a
 /// subtle divider.
 ///
-/// The dependency graph is consulted BEFORE attempting a transition so
-/// the provider's `StateError` never reaches the UI:
-/// - When a disabled feature's prerequisites are missing the switch is
-///   disabled and wrapped in a [Tooltip] naming the missing prerequisite
-///   via `featureBlockedEnable_<feature.name>`. A single tap on the
-///   disabled row also surfaces the same message via [SnackBar] (#1440).
-/// - When an enabled feature has dependents that are still on, the
-///   switch is disabled and the tooltip lists the dependents using the
-///   `featureBlockedDisable_<feature.name>` template.
+/// Cascading-disable model (#1447): disabling a parent always succeeds.
+/// Children stay in the stored set so re-enabling the parent restores the
+/// user's previous setup, but they render as disabled-with-tooltip while
+/// any ancestor is off — the tooltip names the missing prerequisite via
+/// `featureBlockedEnable_<feature.name>`. A single tap on a blocked row
+/// also surfaces the same message via [SnackBar] (#1440).
 ///
-/// Phase 1 of #1373 shipped the engine in PARALLEL with the existing
-/// scattered toggles — this section therefore does NOT yet replace
-/// `autoRecord` / `gamificationEnabled` / etc. Phase 3 migrated them
-/// one PR at a time.
+/// Enabling a child still requires its parent to be on; that path
+/// surfaces the same blocked-enable tooltip when the user taps a disabled
+/// child whose stored value is `false`.
 class FeatureManagementSection extends ConsumerWidget {
   const FeatureManagementSection({super.key});
 
@@ -208,22 +204,19 @@ class _FeatureToggle extends ConsumerWidget {
     final title = _featureLabel(l, feature);
     final subtitle = _featureDescription(l, feature);
 
-    // Pre-check the next transition. If turning the switch will throw,
-    // we render the row disabled and wrap it in a Tooltip naming the
-    // blocker so the user understands why.
+    // Pre-check the next transition. The row is disabled with a tooltip
+    // when:
+    //   * the feature is OFF and its prerequisites are missing — tapping
+    //     would call `enable(feature)` which throws, OR
+    //   * any ancestor on the `requires` chain is OFF (cascading-disable
+    //     #1447) — the row is effectively-disabled even when the stored
+    //     value is `true`. We let the child stay "switch-on visually" so
+    //     the user can see what their preference WAS, but the toggle is
+    //     non-interactive until they re-enable the parent.
     String? blockedReason;
-    if (isEnabled) {
-      // A user tap would call `disable(feature)` — find dependents.
-      final dependents = blockingDisable(feature, manifest, currentlyEnabled);
-      if (dependents.isNotEmpty) {
-        final names = dependents.map((f) => _featureLabel(l, f)).join(', ');
-        blockedReason = _blockedDisableMessage(l, feature, names);
-      }
-    } else {
-      // A user tap would call `enable(feature)` — check prerequisites.
-      if (!canEnable(feature, manifest, currentlyEnabled)) {
-        blockedReason = _blockedEnableMessage(l, feature);
-      }
+    if (!isEffectivelyEnabled(feature, manifest, currentlyEnabled) &&
+        !canEnable(feature, manifest, currentlyEnabled)) {
+      blockedReason = _blockedEnableMessage(l, feature);
     }
 
     final tile = SwitchListTile(
@@ -421,35 +414,3 @@ String _blockedEnableMessage(AppLocalizations? l, Feature f) {
   }
 }
 
-String _blockedDisableMessage(
-  AppLocalizations? l,
-  Feature f,
-  String dependents,
-) {
-  switch (f) {
-    case Feature.obd2TripRecording:
-      return l?.featureBlockedDisable_obd2TripRecording(dependents) ??
-          'Disable dependent features first: $dependents';
-    case Feature.tankSync:
-      return l?.featureBlockedDisable_tankSync(dependents) ??
-          'Disable dependent features first: $dependents';
-    // Features that nothing depends on never reach this branch — the
-    // graph helpers short-circuit. Generic fallback for safety.
-    case Feature.gamification:
-    case Feature.hapticEcoCoach:
-    case Feature.consumptionAnalytics:
-    case Feature.baselineSync:
-    case Feature.unifiedSearchResults:
-    case Feature.priceAlerts:
-    case Feature.priceHistory:
-    case Feature.routePlanning:
-    case Feature.evCharging:
-    case Feature.glideCoach:
-    case Feature.gpsTripPath:
-    case Feature.autoRecord:
-    case Feature.showFuel:
-    case Feature.showElectric:
-    case Feature.showConsumptionTab:
-      return 'Disable dependent features first: $dependents';
-  }
-}

--- a/test/features/feature_management/feature_dependency_graph_test.dart
+++ b/test/features/feature_management/feature_dependency_graph_test.dart
@@ -29,6 +29,112 @@ void main() {
     });
   });
 
+  group('isEffectivelyEnabled (#1447 cascading-disable)', () {
+    test('returns false when the feature itself is not enabled', () {
+      // Stored set empty → consumption analytics is not effectively on.
+      expect(
+        isEffectivelyEnabled(
+          Feature.consumptionAnalytics,
+          manifest,
+          <Feature>{},
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'returns false when the feature is enabled but a direct parent is off',
+        () {
+      // gamification stored on, but obd2TripRecording (parent) is off.
+      // The user's preference is preserved (still in the set) but the
+      // surface should not render.
+      expect(
+        isEffectivelyEnabled(
+          Feature.gamification,
+          manifest,
+          <Feature>{Feature.gamification},
+        ),
+        isFalse,
+        reason:
+            'Stored child state with parent off is the cascading-disable '
+            'sentinel — user re-enables parent to restore the surface.',
+      );
+    });
+
+    test('returns true when the feature and every ancestor are enabled', () {
+      expect(
+        isEffectivelyEnabled(
+          Feature.gamification,
+          manifest,
+          <Feature>{Feature.obd2TripRecording, Feature.gamification},
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns true for a root feature with no requires when enabled', () {
+      expect(
+        isEffectivelyEnabled(
+          Feature.tankSync,
+          manifest,
+          <Feature>{Feature.tankSync},
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'walks transitive ancestors — child is effectively-off when a '
+        'grandparent is off', () {
+      // Synthetic three-level chain to exercise the walk: g -> p -> r,
+      // with the root r missing from the enabled set.
+      const chain = FeatureManifest({
+        Feature.priceAlerts: FeatureManifestEntry(
+          feature: Feature.priceAlerts,
+          defaultEnabled: false,
+          displayName: 'root',
+          description: 'three-level chain root',
+        ),
+        Feature.priceHistory: FeatureManifestEntry(
+          feature: Feature.priceHistory,
+          defaultEnabled: false,
+          requires: {Feature.priceAlerts},
+          displayName: 'parent',
+          description: 'three-level chain parent',
+        ),
+        Feature.gamification: FeatureManifestEntry(
+          feature: Feature.gamification,
+          defaultEnabled: false,
+          requires: {Feature.priceHistory},
+          displayName: 'leaf',
+          description: 'three-level chain leaf',
+        ),
+      });
+
+      expect(
+        isEffectivelyEnabled(
+          Feature.gamification,
+          chain,
+          <Feature>{Feature.priceHistory, Feature.gamification},
+        ),
+        isFalse,
+        reason: 'Root priceAlerts is off, so the leaf is effectively-off.',
+      );
+      expect(
+        isEffectivelyEnabled(
+          Feature.gamification,
+          chain,
+          <Feature>{
+            Feature.priceAlerts,
+            Feature.priceHistory,
+            Feature.gamification,
+          },
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('blockingDisable', () {
     test('returns dependents that would break', () {
       // Disabling obd2TripRecording while gamification + glideCoach are on

--- a/test/features/feature_management/feature_flags_provider_test.dart
+++ b/test/features/feature_management/feature_flags_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:hive/hive.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_dependency_graph.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
 
 void main() {
@@ -103,27 +104,57 @@ void main() {
       expect(state, contains(Feature.gamification));
     });
 
-    test('disable(obd2TripRecording) throws when gamification is enabled',
+    test(
+        'disable(obd2TripRecording) succeeds while gamification is enabled — '
+        'gamification stays in stored set but is effectively disabled (#1447)',
         () async {
       final c = makeContainer();
       await pumpLoad(c);
       await c
           .read(featureFlagsProvider.notifier)
           .enable(Feature.obd2TripRecording);
-      // gamification is on by default; ensure it's still set after the
-      // pre-condition above.
       expect(c.read(featureFlagsProvider), contains(Feature.gamification));
 
+      // Cascading-disable: parent comes off, child stays in storage so the
+      // user's preference is preserved, but the user-visible "is this
+      // surface available" answer is false.
+      await c
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.obd2TripRecording);
+
+      final state = c.read(featureFlagsProvider);
+      expect(state, isNot(contains(Feature.obd2TripRecording)));
       expect(
-        () => c
-            .read(featureFlagsProvider.notifier)
-            .disable(Feature.obd2TripRecording),
-        throwsA(isA<StateError>().having(
-          (e) => e.message,
-          'message',
-          allOf(contains('Cannot disable obd2TripRecording'),
-              contains('gamification')),
-        )),
+        state,
+        contains(Feature.gamification),
+        reason:
+            'Child stored state must be preserved on parent-disable so '
+            're-enabling the parent restores the prior setup.',
+      );
+      expect(
+        isEffectivelyEnabled(
+          Feature.gamification,
+          FeatureManifest.defaultManifest,
+          state,
+        ),
+        isFalse,
+        reason:
+            'With obd2TripRecording off, gamification is not effectively '
+            'enabled regardless of its stored value.',
+      );
+
+      // Re-enabling the parent flips the child back to effectively-on
+      // without any explicit child re-toggle.
+      await c
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      expect(
+        isEffectivelyEnabled(
+          Feature.gamification,
+          FeatureManifest.defaultManifest,
+          c.read(featureFlagsProvider),
+        ),
+        isTrue,
       );
     });
 

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -13,10 +13,13 @@ import '../../../../helpers/pump_app.dart';
 import '../../../../mocks/mocks.dart';
 
 /// Widget tests for the #1373 phase-2 Feature management section on the
-/// Settings screen. The Phase-1 engine ships with `enable` / `disable`
-/// throwing `StateError` on illegal transitions; the UI must pre-check
-/// and disable + tooltip the switch instead of letting the error reach
-/// the user.
+/// Settings screen. The engine's `enable` still throws on a missing
+/// prerequisite; the UI must pre-check and render the switch disabled +
+/// tooltip in that case. As of #1447 phase 1 (cascading-disable),
+/// `disable` no longer throws — disabling a parent always succeeds and
+/// dependent switches become disabled-with-tooltip via
+/// `isEffectivelyEnabled`, with their stored state preserved so
+/// re-enabling the parent restores the prior surface.
 void main() {
   group('ProfileScreen — Feature management section (#1373 phase 2)', () {
     late MockHiveStorage mockStorage;
@@ -206,26 +209,23 @@ void main() {
     });
 
     testWidgets(
-        'disabling obd2TripRecording while gamification is ON is blocked '
-        '(switch disabled + tooltip names the dependent)', (tester) async {
+        'disabling obd2TripRecording while gamification is ON succeeds — '
+        'gamification switch then renders disabled-with-tooltip (#1447 '
+        'cascading-disable)', (tester) async {
       final container = ProviderContainer(
         overrides: baseOverrides.cast(),
       );
       addTearDown(container.dispose);
 
-      // Set up the state where obd2TripRecording is ON (so its switch
-      // shows ON) and gamification is also ON (depends on it).
       await container
           .read(featureFlagsProvider.notifier)
           .enable(Feature.obd2TripRecording);
-      // gamification is on by default; verify the precondition.
       expect(
         container.read(featureFlagsProvider),
-        contains(Feature.gamification),
-      );
-      expect(
-        container.read(featureFlagsProvider),
-        contains(Feature.obd2TripRecording),
+        containsAll(<Feature>[
+          Feature.obd2TripRecording,
+          Feature.gamification,
+        ]),
       );
 
       await tester.pumpWidget(
@@ -240,26 +240,52 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // The obd2TripRecording switch must be disabled (the user must
-      // turn dependents off first).
+      // Pre-disable: parent switch is interactive, child switch is
+      // interactive (everything is in the effectively-enabled state).
       final obd2Switch = tester.widget<SwitchListTile>(
         find.byKey(const Key('featureToggle_obd2TripRecording')),
       );
-      expect(obd2Switch.onChanged, isNull,
-          reason: 'obd2TripRecording switch must be disabled while '
-              'gamification still depends on it');
+      expect(obd2Switch.onChanged, isNotNull,
+          reason: 'parent switch must be interactive — disabling no '
+              'longer requires the user to clear dependents first.');
 
-      // The wrapping Tooltip must name `gamification` (English label).
+      // Disabling the parent succeeds — gamification stays in the
+      // stored set so re-enabling restores the prior surface, but the
+      // gamification row now renders disabled-with-tooltip.
+      await container
+          .read(featureFlagsProvider.notifier)
+          .disable(Feature.obd2TripRecording);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(featureFlagsProvider),
+        isNot(contains(Feature.obd2TripRecording)),
+      );
+      expect(
+        container.read(featureFlagsProvider),
+        contains(Feature.gamification),
+        reason: 'Stored child state must survive parent-disable so the '
+            'user does not lose their preference.',
+      );
+
+      final gamificationSwitchAfter = tester.widget<SwitchListTile>(
+        find.byKey(const Key('featureToggle_gamification')),
+      );
+      expect(gamificationSwitchAfter.onChanged, isNull,
+          reason: 'With parent off, the child switch must be '
+              'effectively-disabled (non-interactive) until the user '
+              're-enables the parent.');
+
       final tooltip = tester.widget<Tooltip>(
         find.ancestor(
-          of: find.byKey(const Key('featureToggle_obd2TripRecording')),
+          of: find.byKey(const Key('featureToggle_gamification')),
           matching: find.byType(Tooltip),
         ),
       );
       expect(tooltip.message, isNotNull);
-      expect(tooltip.message!, contains('Gamification'),
-          reason: 'tooltip must name the dependent feature so the user '
-              'knows which switch to flip first');
+      expect(tooltip.message!, contains('OBD2 trip recording'),
+          reason: 'tooltip must point the user at the parent they need '
+              'to flip back on to make the child reachable.');
     });
   });
 }


### PR DESCRIPTION
## Summary

Phase 1 of #1447. Switches the feature-flag engine from strict to lazy/cascading-disable.

- `isEffectivelyEnabled(feature, manifest, currentlyEnabled)` walks the `requires` chain — returns true only when every ancestor is also enabled
- `FeatureFlags.disable` no longer rejects when dependents are on; it just removes the feature from the set. Children's stored preferences are preserved so re-enabling the parent restores the prior surface
- `FeatureManagementSection` drops the strict-disable tooltip path. Indented child rows render disabled-with-tooltip when their stored value is true but a parent is off — identical UX to the existing missing-prerequisite case

Subsequent phases route the existing shim providers (gamification, hapticEcoCoach, baselineSync, show*, unifiedSearchResults, showConsumptionTab) and the actual settings/search surfaces through the new helper.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/feature_management/ test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart` (65/65 passing)
- [ ] Manual: device-test cascading behaviour after phase 2-4 land (this PR is pure infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)