### PR TITLE
feat(features): shim providers + auto-record use isEffectivelyEnabled (Refs #1447 phase 2)

### DIFF
--- a/lib/core/refuel/unified_search_results_enabled.dart
+++ b/lib/core/refuel/unified_search_results_enabled.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../features/feature_management/application/feature_flags_provider.dart';
 import '../../features/feature_management/domain/feature.dart';
+import '../../features/feature_management/domain/feature_dependency_graph.dart';
 
 part 'unified_search_results_enabled.g.dart';
 
@@ -23,9 +24,17 @@ part 'unified_search_results_enabled.g.dart';
 class UnifiedSearchResultsEnabled extends _$UnifiedSearchResultsEnabled {
   @override
   bool build() {
-    return ref
-        .watch(featureFlagsProvider)
-        .contains(Feature.unifiedSearchResults);
+    // Routes through `isEffectivelyEnabled` for symmetry with the other
+    // shims and forward-compat (#1447). `Feature.unifiedSearchResults`
+    // has no requires today so the helper short-circuits to
+    // `state.contains` — identical observable behaviour.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(
+      Feature.unifiedSearchResults,
+      manifest,
+      enabled,
+    );
   }
 
   /// Flip the flag. Delegates to [set] so the toggle/set paths share a

--- a/lib/features/consumption/providers/auto_record_orchestrator.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/obd2/android_background_adapter_listener.dart';
@@ -153,17 +154,21 @@ class AutoRecordOrchestrator extends _$AutoRecordOrchestrator {
   }
 
   bool _isAutoRecordReady(VehicleProfile p) {
-    // Central master gate (#1373 phase 3d). The per-vehicle
-    // [VehicleProfile.autoRecord] bool stays — each vehicle keeps its
-    // own opt-in — but this central feature is consulted FIRST so a
-    // user can disable auto-record for the whole app from the central
-    // settings screen without flipping every vehicle's bool. When the
-    // central feature flips, the orchestrator's `build()` re-runs (via
-    // `ref.watch(featureFlagsProvider)`) and re-diffs the vehicle list,
-    // tearing down or re-arming coordinators as needed.
-    final centralEnabled = ref
-        .read(featureFlagsProvider)
-        .contains(Feature.autoRecord);
+    // Central master gate (#1373 phase 3d, cascading-disable #1447).
+    // The per-vehicle [VehicleProfile.autoRecord] bool stays — each
+    // vehicle keeps its own opt-in — but this central feature is
+    // consulted FIRST. Routing through `isEffectivelyEnabled` means
+    // disabling the parent (`Feature.obd2TripRecording`) also tears
+    // down every coordinator, regardless of the stored autoRecord
+    // value, so the user disabling consumption tracking gets a clean
+    // shutdown of the whole hands-free chain.
+    final manifest = ref.read(featureManifestProvider);
+    final enabled = ref.read(featureFlagsProvider);
+    final centralEnabled = isEffectivelyEnabled(
+      Feature.autoRecord,
+      manifest,
+      enabled,
+    );
     if (!centralEnabled) return false;
     if (!p.autoRecord) return false;
     final mac = p.pairedAdapterMac;

--- a/lib/features/driving/providers/haptic_eco_coach_provider.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.dart
@@ -6,6 +6,7 @@ import '../../consumption/data/obd2/trip_live_reading.dart';
 import '../../consumption/providers/trip_recording_provider.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 import '../haptic_eco_coach.dart';
 
 part 'haptic_eco_coach_provider.g.dart';
@@ -26,7 +27,13 @@ part 'haptic_eco_coach_provider.g.dart';
 class HapticEcoCoachEnabled extends _$HapticEcoCoachEnabled {
   @override
   bool build() {
-    return ref.watch(featureFlagsProvider).contains(Feature.hapticEcoCoach);
+    // Gates on the **effective** state (#1447): when `obd2TripRecording`
+    // (the parent) is off, this surfaces as `false` regardless of the
+    // stored haptic-coach value. The lifecycle provider re-runs and
+    // tears down its subscription on the next frame.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(Feature.hapticEcoCoach, manifest, enabled);
   }
 
   /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The

--- a/lib/features/profile/providers/gamification_enabled_provider.dart
+++ b/lib/features/profile/providers/gamification_enabled_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 
 part 'gamification_enabled_provider.g.dart';
 
@@ -35,7 +36,14 @@ part 'gamification_enabled_provider.g.dart';
 class GamificationEnabled extends _$GamificationEnabled {
   @override
   bool build() {
-    return ref.watch(featureFlagsProvider).contains(Feature.gamification);
+    // Gates on the **effective** state (#1447): if any ancestor on the
+    // `requires` chain is disabled, this surfaces as `false` regardless
+    // of the stored value. Disabling the parent (`obd2TripRecording`)
+    // therefore hides the gamification UI without touching the user's
+    // gamification preference; re-enabling the parent restores it.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(Feature.gamification, manifest, enabled);
   }
 
   /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The

--- a/lib/features/profile/providers/show_consumption_tab_enabled_provider.dart
+++ b/lib/features/profile/providers/show_consumption_tab_enabled_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 
 part 'show_consumption_tab_enabled_provider.g.dart';
 
@@ -33,9 +34,14 @@ part 'show_consumption_tab_enabled_provider.g.dart';
 class ShowConsumptionTabEnabled extends _$ShowConsumptionTabEnabled {
   @override
   bool build() {
-    return ref
-        .watch(featureFlagsProvider)
-        .contains(Feature.showConsumptionTab);
+    // Gates on the **effective** state (#1447): when `obd2TripRecording`
+    // (the parent) is off, the consumption tab is hidden from the
+    // bottom-nav regardless of the stored `showConsumptionTab` value.
+    // The user's tab-visibility preference is preserved so re-enabling
+    // trip recording restores the prior layout.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(Feature.showConsumptionTab, manifest, enabled);
   }
 
   /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The

--- a/lib/features/profile/providers/show_electric_enabled_provider.dart
+++ b/lib/features/profile/providers/show_electric_enabled_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 
 part 'show_electric_enabled_provider.g.dart';
 
@@ -32,7 +33,13 @@ part 'show_electric_enabled_provider.g.dart';
 class ShowElectricEnabled extends _$ShowElectricEnabled {
   @override
   bool build() {
-    return ref.watch(featureFlagsProvider).contains(Feature.showElectric);
+    // Routes through `isEffectivelyEnabled` for symmetry with the other
+    // shims and forward-compat (#1447). `Feature.showElectric` has no
+    // requires today so the helper short-circuits to `state.contains` —
+    // identical observable behaviour to the prior `.contains` call.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(Feature.showElectric, manifest, enabled);
   }
 
   /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The

--- a/lib/features/profile/providers/show_fuel_enabled_provider.dart
+++ b/lib/features/profile/providers/show_fuel_enabled_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 
 part 'show_fuel_enabled_provider.g.dart';
 
@@ -31,7 +32,13 @@ part 'show_fuel_enabled_provider.g.dart';
 class ShowFuelEnabled extends _$ShowFuelEnabled {
   @override
   bool build() {
-    return ref.watch(featureFlagsProvider).contains(Feature.showFuel);
+    // Routes through `isEffectivelyEnabled` for symmetry with the other
+    // shims and forward-compat (#1447). `Feature.showFuel` has no
+    // requires today so the helper short-circuits to `state.contains` —
+    // identical observable behaviour to the prior `.contains` call.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(Feature.showFuel, manifest, enabled);
   }
 
   /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The

--- a/lib/features/sync/providers/baseline_sync_enabled_provider.dart
+++ b/lib/features/sync/providers/baseline_sync_enabled_provider.dart
@@ -2,6 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
 
 part 'baseline_sync_enabled_provider.g.dart';
 
@@ -28,7 +29,13 @@ part 'baseline_sync_enabled_provider.g.dart';
 class BaselineSyncEnabled extends _$BaselineSyncEnabled {
   @override
   bool build() {
-    return ref.watch(featureFlagsProvider).contains(Feature.baselineSync);
+    // Gates on the **effective** state (#1447): when `tankSync` (the
+    // parent) is off, this surfaces as `false` regardless of the stored
+    // value. The trip-flush hook reads this via `ref.read` at flush
+    // time and skips the upload when the parent is gone.
+    final enabled = ref.watch(featureFlagsProvider);
+    final manifest = ref.watch(featureManifestProvider);
+    return isEffectivelyEnabled(Feature.baselineSync, manifest, enabled);
   }
 
   /// Delegate to [featureFlagsProvider]'s `enable` / `disable`. The

--- a/test/features/consumption/providers/auto_record_orchestrator_test.dart
+++ b/test/features/consumption/providers/auto_record_orchestrator_test.dart
@@ -203,12 +203,16 @@ void main() {
     required _FakeVehicleProfileList vehicleList,
     Set<Feature>? initialFeatureFlags,
   }) {
-    // Default: include Feature.autoRecord (manifest default-true) so
-    // existing tests that don't pin the central gate keep their
-    // pre-#1373-phase-3d behaviour. Tests that exercise the central
-    // gate pass a custom set.
+    // Default: include Feature.autoRecord (manifest default-true) AND
+    // Feature.obd2TripRecording (its prerequisite) so existing tests
+    // that don't pin the central gate observe the orchestrator as
+    // "effectively enabled" under #1447 cascading-disable. Tests that
+    // exercise the central gate or the parent edge pass a custom set.
     final flags = initialFeatureFlags ??
-        FeatureManifest.defaultManifest.defaultEnabledSet();
+        {
+          ...FeatureManifest.defaultManifest.defaultEnabledSet(),
+          Feature.obd2TripRecording,
+        };
     return ProviderContainer(
       overrides: [
         vehicleProfileListProvider.overrideWith(() => vehicleList),

--- a/test/features/profile/providers/gamification_enabled_provider_test.dart
+++ b/test/features/profile/providers/gamification_enabled_provider_test.dart
@@ -72,18 +72,47 @@ void main() {
   }
 
   group('gamificationEnabledProvider — shim over featureFlagsProvider', () {
-    test('defaults to true on a fresh install (manifest default)', () async {
-      final container = makeContainer();
-      await pumpLoad(container);
+    test(
+      'defaults to false on a fresh install — gamification is manifest '
+      'default-true but obd2TripRecording (its parent) is default-false, so '
+      'cascading-disable surfaces the shim as false (#1447 phase 2)',
+      () async {
+        final container = makeContainer();
+        await pumpLoad(container);
 
-      expect(
-        container.read(gamificationEnabledProvider),
-        isTrue,
-        reason:
-            'Default-ON is the contract: existing users see no behaviour '
-            'change. Manifest declares Feature.gamification defaultEnabled=true.',
-      );
-    });
+        expect(
+          container.read(gamificationEnabledProvider),
+          isFalse,
+          reason:
+              'Phase 2 of #1447 routes the shim through isEffectivelyEnabled. '
+              'Even though Feature.gamification is manifest default-true, '
+              'Feature.obd2TripRecording is default-false, so the cascade '
+              'returns false. Enabling the parent flips this back without '
+              'the user re-toggling gamification.',
+        );
+      },
+    );
+
+    test(
+      'turns true when both feature and parent are enabled (#1447 phase 2)',
+      () async {
+        await repo.saveEnabled(<Feature>{
+          Feature.obd2TripRecording,
+          Feature.gamification,
+        });
+
+        final container = makeContainer();
+        await pumpLoad(container);
+
+        expect(
+          container.read(gamificationEnabledProvider),
+          isTrue,
+          reason:
+              'Both feature itself and its parent enabled → cascade lets '
+              'the shim surface true.',
+        );
+      },
+    );
 
     test('reads the central enabled-set on build', () async {
       // Pre-seed central state with both prerequisite + dependent.
@@ -251,7 +280,12 @@ void main() {
         // not re-trigger the upstream's `build` on consecutive reads.
         // A non-keepAlive shim would dispose between reads and re-watch
         // the upstream, bumping the counter.
-        final fake = _BuildCountingFlags(<Feature>{Feature.gamification});
+        // Seed both gamification AND its prerequisite so the shim
+        // (post-#1447 phase 2) surfaces as effectively-enabled.
+        final fake = _BuildCountingFlags(<Feature>{
+          Feature.obd2TripRecording,
+          Feature.gamification,
+        });
         final container = makeContainer(extraOverrides: [
           featureFlagsProvider.overrideWith(() => fake),
         ]);

--- a/test/features/profile/providers/show_consumption_tab_enabled_provider_test.dart
+++ b/test/features/profile/providers/show_consumption_tab_enabled_provider_test.dart
@@ -58,23 +58,22 @@ void main() {
   group('showConsumptionTabEnabledProvider — shim over featureFlagsProvider',
       () {
     test(
-      'defaults to true on a fresh install (manifest default), even though '
-      'the prerequisite obd2TripRecording is off — the shim surfaces the '
-      'manifest default and the dependency-graph helpers gate the toggle '
-      'in the UI separately',
+      'defaults to false on a fresh install — showConsumptionTab is '
+      'manifest default-true but obd2TripRecording (its parent) is '
+      'default-false, so cascading-disable surfaces the shim as false '
+      '(#1447 phase 2)',
       () async {
         final container = makeContainer();
         await pumpLoad(container);
 
         expect(
           container.read(showConsumptionTabEnabledProvider),
-          isTrue,
+          isFalse,
           reason:
-              'Manifest declares Feature.showConsumptionTab default'
-              'Enabled=true. Even with the prerequisite obd2TripRecording '
-              'off, the shim surfaces the manifest default — bottom-nav '
-              'visibility logic should AND this with a separate '
-              'obd2TripRecording check.',
+              'Phase 2 of #1447 routes the shim through '
+              'isEffectivelyEnabled — the cascade returns false because '
+              'the parent obd2TripRecording is default-off. The bottom-'
+              'nav consumes this directly; no separate AND-check needed.',
         );
       },
     );
@@ -201,6 +200,11 @@ void main() {
     });
 
     test('external mutation on featureFlagsProvider propagates', () async {
+      // Seed the prerequisite so cascading lets the shim surface true.
+      await repo.saveEnabled(<Feature>{
+        Feature.obd2TripRecording,
+        Feature.showConsumptionTab,
+      });
       final container = makeContainer();
       await pumpLoad(container);
 
@@ -212,5 +216,44 @@ void main() {
 
       expect(container.read(showConsumptionTabEnabledProvider), isFalse);
     });
+
+    test(
+      'cascading-disable: disabling the parent obd2TripRecording flips the '
+      'shim to false even though showConsumptionTab is still in the stored '
+      'set (#1447 phase 2)',
+      () async {
+        await repo.saveEnabled(<Feature>{
+          Feature.obd2TripRecording,
+          Feature.showConsumptionTab,
+        });
+        final container = makeContainer();
+        await pumpLoad(container);
+
+        expect(container.read(showConsumptionTabEnabledProvider), isTrue);
+
+        // Disabling the parent must cascade — child stays in storage so
+        // re-enabling the parent restores the prior visible state, but
+        // the user-visible shim flips to false immediately.
+        await container
+            .read(featureFlagsProvider.notifier)
+            .disable(Feature.obd2TripRecording);
+
+        expect(container.read(showConsumptionTabEnabledProvider), isFalse);
+        expect(
+          container.read(featureFlagsProvider),
+          contains(Feature.showConsumptionTab),
+          reason:
+              'Stored child state must survive parent-disable so '
+              're-enabling the parent restores the user\'s preference '
+              'without an explicit re-toggle.',
+        );
+
+        // Re-enable the parent → shim flips back to true automatically.
+        await container
+            .read(featureFlagsProvider.notifier)
+            .enable(Feature.obd2TripRecording);
+        expect(container.read(showConsumptionTabEnabledProvider), isTrue);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Phase 2 of #1447. Routes every feature-flag shim and the auto-record orchestrator through the cascading helper from phase 1.

- 4 shims with parent edges (gamification, hapticEcoCoach, baselineSync, showConsumptionTab) — disabling the parent now silently propagates without touching stored child preferences
- 3 shims with no parent today (showFuel, showElectric, unifiedSearchResults) — converted for symmetry; helper short-circuits to .contains so behavior is identical
- auto_record_orchestrator central gate consults isEffectivelyEnabled(autoRecord), so disabling obd2TripRecording also tears down every coordinator

Tests for shims that asserted the pre-cascade shape are updated, plus a new explicit cascade test for showConsumptionTab covers the parent-disable → child-effectively-off → parent-re-enable → child-back round-trip.

## Test plan

- [x] flutter analyze clean
- [x] flutter test on test/features/profile/providers, test/features/driving/providers, test/features/sync/providers, test/core/refuel, test/features/consumption/providers/auto_record_orchestrator_test.dart (147/147 passing)
- [ ] Phase 3 will hide whole settings sections; phase 4 the search affordances

🤖 Generated with [Claude Code](https://claude.com/claude-code)