### PR TITLE
feat(profile): hide TankSync + Consumption sections via cascading gates (Refs #1447 phase 3)

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -8,6 +8,9 @@ import '../../../../core/widgets/section_header.dart';
 import '../../../../core/widgets/settings_menu_tile.dart';
 import '../../../consent/presentation/widgets/consent_settings_section.dart';
 import '../../../driving/presentation/widgets/driving_settings_section.dart';
+import '../../../feature_management/application/feature_flags_provider.dart';
+import '../../../feature_management/domain/feature.dart';
+import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
 import '../widgets/feature_management_section.dart';
@@ -27,6 +30,22 @@ class ProfileScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
+    // Cascading-feature gates (#1447 phase 3). Sections whose root
+    // feature is effectively-disabled vanish entirely so the user does
+    // not see settings whose UI cannot do anything. Re-enabling the
+    // root from the Feature management section restores them.
+    final manifest = ref.watch(featureManifestProvider);
+    final enabledFlags = ref.watch(featureFlagsProvider);
+    final tankSyncOn = isEffectivelyEnabled(
+      Feature.tankSync,
+      manifest,
+      enabledFlags,
+    );
+    final consumptionOn = isEffectivelyEnabled(
+      Feature.obd2TripRecording,
+      manifest,
+      enabledFlags,
+    );
 
     return PageScaffold(
       title: l?.settings ?? 'Settings',
@@ -61,12 +80,18 @@ class ProfileScreen extends ConsumerWidget {
           const SizedBox(height: 8),
 
           // #534 — TankSync closed by default (was initiallyExpanded: true).
-          const _FoldableSection(
-            icon: Icons.cloud_outlined,
-            title: 'TankSync',
-            child: TankSyncSection(),
-          ),
-          const SizedBox(height: 8),
+          // #1447 phase 3 — hidden entirely when Feature.tankSync is
+          // effectively disabled. Stored TankSync config (account,
+          // mode, etc.) is preserved; re-enabling the feature surfaces
+          // the section with the prior configuration intact.
+          if (tankSyncOn) ...[
+            const _FoldableSection(
+              icon: Icons.cloud_outlined,
+              title: 'TankSync',
+              child: TankSyncSection(),
+            ),
+            const SizedBox(height: 8),
+          ],
 
           // #952 phase 3 — bad-scan reporter PAT entry. Closed by
           // default; users without a token continue to use the
@@ -112,12 +137,19 @@ class ProfileScreen extends ConsumerWidget {
           // entry points (#1122 follow-up). The standalone "My vehicles"
           // and "Fuel club cards" tiles were folded INTO this section
           // so per-vehicle controls cluster under one heading.
-          _FoldableSection(
-            icon: Icons.local_gas_station_outlined,
-            title: l?.navConsumption ?? 'Consumption',
-            child: const DrivingSettingsSection(),
-          ),
-          const SizedBox(height: 8),
+          // #1447 phase 3 — hidden entirely when the root feature
+          // (`obd2TripRecording`) is effectively disabled. Per-vehicle
+          // and eco-coach state stays persisted; re-enabling
+          // consumption restores the section with its previous
+          // configuration.
+          if (consumptionOn) ...[
+            _FoldableSection(
+              icon: Icons.local_gas_station_outlined,
+              title: l?.navConsumption ?? 'Consumption',
+              child: const DrivingSettingsSection(),
+            ),
+            const SizedBox(height: 8),
+          ],
 
           // Storage & Cache
           _FoldableSection(

--- a/test/features/profile/presentation/screens/profile_screen_section_gating_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_section_gating_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../mocks/mocks.dart';
+
+/// #1447 phase 3 — settings sections whose root feature is effectively
+/// disabled must vanish entirely from [ProfileScreen]. Re-enabling the
+/// root brings them back without the user touching any sub-state.
+///
+/// This test pins:
+///   1. `Feature.tankSync` off → the TankSync foldable is gone.
+///   2. `Feature.obd2TripRecording` off → the Consumption foldable is gone.
+///   3. Both on → both foldables render.
+void main() {
+  group('ProfileScreen — section gating (#1447 phase 3)', () {
+    late MockHiveStorage mockStorage;
+    late List<Object> baseOverrides;
+
+    setUp(() {
+      mockStorage = MockHiveStorage();
+      when(() => mockStorage.hasApiKey()).thenReturn(false);
+      when(() => mockStorage.getApiKey()).thenReturn(null);
+      when(() => mockStorage.getActiveProfileId()).thenReturn(null);
+      when(() => mockStorage.getAllProfiles()).thenReturn([]);
+      when(() => mockStorage.getRatings()).thenReturn({});
+      when(() => mockStorage.getIgnoredIds()).thenReturn([]);
+      when(() => mockStorage.getSetting(any())).thenReturn(null);
+      when(() => mockStorage.storageStats).thenReturn((
+        settings: 0,
+        profiles: 0,
+        favorites: 0,
+        cache: 0,
+        priceHistory: 0,
+        alerts: 0,
+        total: 0,
+      ));
+      when(() => mockStorage.profileCount).thenReturn(0);
+      when(() => mockStorage.favoriteCount).thenReturn(0);
+      when(() => mockStorage.cacheEntryCount).thenReturn(0);
+      when(() => mockStorage.priceHistoryEntryCount).thenReturn(0);
+      when(() => mockStorage.alertCount).thenReturn(0);
+      when(() => mockStorage.getFavoriteIds()).thenReturn([]);
+      when(() => mockStorage.getAlerts()).thenReturn([]);
+      when(() => mockStorage.getEvApiKey()).thenReturn(null);
+      when(() => mockStorage.hasCustomEvApiKey()).thenReturn(false);
+
+      final test = standardTestOverrides();
+      baseOverrides = [
+        hiveStorageProvider.overrideWithValue(mockStorage),
+        ...test.overrides.skip(1),
+        // Force the FeatureFlags notifier to skip the Hive load path so
+        // the synchronous initial state is `manifest.defaultEnabledSet()`
+        // — same pattern as the feature-mgmt section test.
+        featureFlagsRepositoryProvider.overrideWithValue(null),
+      ];
+    });
+
+    /// Builds a manifest override that pins the enabled set to [flags].
+    /// Done by overriding the repository with an in-memory fake — the
+    /// notifier loads the persisted set on first read.
+    List<Object> overridesWithFlags(Set<Feature> flags) {
+      return [
+        ...baseOverrides,
+        // Replace the repository override with a manifest pin so the
+        // FeatureFlags notifier resolves to exactly [flags]. Easiest
+        // path: override the notifier directly.
+        featureFlagsProvider.overrideWith(() => _PinnedFeatureFlags(flags)),
+      ];
+    }
+
+    testWidgets(
+      'TankSync foldable hides when Feature.tankSync is disabled',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const ProfileScreen(),
+          // Default-enabled set has tankSync OFF, obd2TripRecording OFF.
+          // Both gated sections should be absent.
+          overrides: overridesWithFlags(const <Feature>{}),
+        );
+
+        expect(
+          find.text('TankSync'),
+          findsNothing,
+          reason: 'Section title must not appear when Feature.tankSync '
+              'is effectively-disabled (#1447 phase 3).',
+        );
+      },
+    );
+
+    testWidgets(
+      'Consumption foldable hides when Feature.obd2TripRecording is disabled',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const ProfileScreen(),
+          overrides: overridesWithFlags(const <Feature>{}),
+        );
+
+        expect(
+          find.text('Consumption'),
+          findsNothing,
+          reason: 'Section title must not appear when '
+              'Feature.obd2TripRecording is effectively-disabled — the '
+              'whole consumption-settings group (vehicles, eco-coach, '
+              'fuel club cards) lives behind this gate.',
+        );
+      },
+    );
+
+    testWidgets(
+      'both foldables render when both root features are enabled',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const ProfileScreen(),
+          overrides: overridesWithFlags(<Feature>{
+            Feature.tankSync,
+            Feature.obd2TripRecording,
+          }),
+        );
+
+        // Settings list scrolls — section titles may be off-screen
+        // until scrolled into view, so probe the widget tree directly.
+        expect(find.text('TankSync', skipOffstage: false), findsOneWidget);
+        expect(find.text('Consumption', skipOffstage: false), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'TankSync foldable hides without affecting Consumption when only '
+      'tankSync is off (independent gates)',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const ProfileScreen(),
+          overrides: overridesWithFlags(<Feature>{Feature.obd2TripRecording}),
+        );
+
+        expect(find.text('TankSync', skipOffstage: false), findsNothing);
+        expect(find.text('Consumption', skipOffstage: false), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// Test-only FeatureFlags notifier that returns a fixed set on `build()`.
+/// Skips the Hive-load path entirely so synchronous reads observe the
+/// pinned set without a microtask drain.
+class _PinnedFeatureFlags extends FeatureFlags {
+  _PinnedFeatureFlags(this._initial);
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() {
+    // Watch the manifest so cycle assertions still run.
+    ref.watch(featureManifestProvider);
+    return _initial;
+  }
+}

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -7,6 +7,8 @@ import 'package:tankstellen/app/router.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
 import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 
@@ -282,10 +284,19 @@ void main() {
         '"Conso" tab and contains vehicles + fuel-club cards entries '
         '(#1242)',
         (tester) async {
+      // Phase 3 of #1447 hides the Consumption section when its root
+      // feature (`obd2TripRecording`) is effectively-disabled. Seed
+      // the central enabled-set so the section renders for this test.
+      final seededOverrides = [
+        ...overrides,
+        featureFlagsProvider.overrideWith(
+          () => _ProfileTestFeatureFlags(<Feature>{Feature.obd2TripRecording}),
+        ),
+      ];
       await pumpApp(
         tester,
         const ProfileScreen(),
-        overrides: overrides,
+        overrides: seededOverrides,
       );
 
       // The new section header replaces the old "Driving" copy. We
@@ -537,4 +548,18 @@ void main() {
       );
     });
   });
+}
+
+/// Pinned FeatureFlags notifier for tests that need to assert section
+/// visibility (#1447 phase 3) without waiting on the Hive load path.
+class _ProfileTestFeatureFlags extends FeatureFlags {
+  _ProfileTestFeatureFlags(this._initial);
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() {
+    ref.watch(featureManifestProvider);
+    return _initial;
+  }
 }


### PR DESCRIPTION
## Summary

Phase 3 of #1447. The Settings screen now hides whole foldables when their root feature is effectively-disabled.

- TankSync foldable hides when `Feature.tankSync` is off
- Consumption foldable hides when `Feature.obd2TripRecording` is off
- Profile, Location, Theme, Storage, Privacy, Feature management, About stay always-visible — Feature management is the path users take to flip features back on
- Stored sub-state (TankSync account, per-vehicle settings, eco-coach toggle) is preserved while the section is hidden so re-enabling the root brings back the prior configuration

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/profile/presentation/screens/` (47/47 passing)
- [x] New `profile_screen_section_gating_test.dart` covers each gate combination
- [ ] Phases 4 (search affordances) + 5 (ARB cleanup) remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)