### PR TITLE
feat(search): cascading gate on route-planning toggle (Refs #1447 phase 4)

### DIFF
--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -10,6 +10,9 @@ import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../feature_management/application/feature_flags_provider.dart';
+import '../../../feature_management/domain/feature.dart';
+import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../route_search/domain/entities/route_info.dart';
 import '../../../route_search/presentation/widgets/route_input.dart';
@@ -131,9 +134,23 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final radius = ref.watch(searchRadiusProvider);
-    final mode = ref.watch(activeSearchModeProvider);
+    final storedMode = ref.watch(activeSearchModeProvider);
     final openOnly = ref.watch(openOnlyFilterProvider);
     final amenities = ref.watch(selectedAmenitiesProvider);
+
+    // Cascading-feature gate (#1447 phase 4). When `Feature.routePlanning`
+    // is effectively-disabled, the "Along route" mode is unreachable —
+    // hide the toggle entirely AND treat the persisted mode as Nearby
+    // so the body never renders the route input. The stored mode value
+    // is preserved (re-enabling the feature restores the prior choice).
+    final manifest = ref.watch(featureManifestProvider);
+    final enabledFlags = ref.watch(featureFlagsProvider);
+    final routePlanningOn = isEffectivelyEnabled(
+      Feature.routePlanning,
+      manifest,
+      enabledFlags,
+    );
+    final mode = routePlanningOn ? storedMode : SearchMode.nearby;
 
     return PageScaffold(
       title: l10n?.searchCriteriaTitle ?? 'Search criteria',
@@ -159,12 +176,14 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
                 message: l10n?.helpBannerCriteria ??
                     'Your profile defaults are pre-filled. Adjust criteria below to refine your search.',
               ),
-              SearchModeToggle(
-                mode: mode,
-                onChanged: (m) =>
-                    ref.read(activeSearchModeProvider.notifier).set(m),
-              ),
-              const SizedBox(height: 12),
+              if (routePlanningOn) ...[
+                SearchModeToggle(
+                  mode: mode,
+                  onChanged: (m) =>
+                      ref.read(activeSearchModeProvider.notifier).set(m),
+                ),
+                const SizedBox(height: 12),
+              ],
               if (mode == SearchMode.nearby) ...[
                 Text(
                   l10n?.gpsLocation ?? 'Location',

--- a/test/features/search/presentation/screens/search_criteria_route_planning_gate_test.dart
+++ b/test/features/search/presentation/screens/search_criteria_route_planning_gate_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/presentation/screens/search_criteria_screen.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_mode_toggle.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #1447 phase 4 — when `Feature.routePlanning` is effectively-disabled,
+/// the SearchModeToggle disappears and the criteria screen renders only
+/// the Nearby branch even if the persisted mode was previously Route.
+/// Re-enabling the feature restores the toggle and the prior mode.
+void main() {
+  group('SearchCriteriaScreen — route-planning gate (#1447 phase 4)', () {
+    testWidgets(
+      'SearchModeToggle hides when Feature.routePlanning is disabled',
+      (tester) async {
+        final test = standardTestOverrides();
+
+        await pumpApp(
+          tester,
+          const SearchCriteriaScreen(),
+          overrides: [
+            ...test.overrides,
+            selectedFuelTypeOverride(FuelType.e10),
+            searchRadiusOverride(8),
+            userPositionNullOverride(),
+            // Feature manifest default is routePlanning=true; pin it
+            // off via a featureFlagsProvider override to exercise the
+            // gate.
+            featureFlagsProvider.overrideWith(
+              () => _CriteriaGateFlags(<Feature>{}),
+            ),
+          ],
+        );
+
+        expect(
+          find.byType(SearchModeToggle),
+          findsNothing,
+          reason: 'SearchModeToggle must be absent when '
+              'Feature.routePlanning is effectively-disabled (#1447 phase 4).',
+        );
+        expect(
+          find.byKey(const ValueKey('criteria-mode-toggle')),
+          findsNothing,
+          reason: 'The toggle key must not appear in the tree either.',
+        );
+      },
+    );
+
+    testWidgets(
+      'SearchModeToggle renders when Feature.routePlanning is enabled',
+      (tester) async {
+        final test = standardTestOverrides();
+
+        await pumpApp(
+          tester,
+          const SearchCriteriaScreen(),
+          overrides: [
+            ...test.overrides,
+            selectedFuelTypeOverride(FuelType.e10),
+            searchRadiusOverride(8),
+            userPositionNullOverride(),
+            featureFlagsProvider.overrideWith(
+              () => _CriteriaGateFlags(<Feature>{Feature.routePlanning}),
+            ),
+          ],
+        );
+
+        expect(find.byType(SearchModeToggle), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// Test-only FeatureFlags notifier with a fixed enabled set. Skips the
+/// Hive load path for synchronous reads.
+class _CriteriaGateFlags extends FeatureFlags {
+  _CriteriaGateFlags(this._initial);
+
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() {
+    ref.watch(featureManifestProvider);
+    return _initial;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4 of #1447. The search criteria screen now hides the SearchModeToggle entirely when `Feature.routePlanning` is effectively-disabled, and forces the active mode to Nearby — even if the persisted value was Route.

- The user's stored mode choice is preserved so re-enabling the feature restores it
- Phase 2 already routed `showFuelEnabledProvider` and `showElectricEnabledProvider` through `isEffectivelyEnabled`, so fuel/EV chip and result gates inherit the cascading behaviour through their existing consumers (FuelTypeSelector, profile edit sheet)

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/search/presentation/screens/` (25/25 passing)
- [x] New `search_criteria_route_planning_gate_test.dart` covers both gate states
- [ ] Phase 5 (ARB cleanup of unused `featureBlockedDisable_*` keys) remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)