### PR TITLE
fix(map): clamp Carte zoom buttons to the OSM tile cap (Closes #1457)

### DIFF
--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -14,6 +14,14 @@ import '../../../search/domain/entities/station.dart';
 import 'price_legend.dart';
 import 'station_marker.dart';
 
+/// Camera zoom bounds (#1457). Top end matches the OSM tile cap so a
+/// `move(camera.zoom + 1)` past the cap doesn't park the user on a
+/// grey viewport with no tiles to draw. Bottom end is conservative —
+/// flutter_map wraps the world at zoom 0, but anything below ~3 puts
+/// every pin in a single pixel which is unhelpful UX.
+const double _kMinZoom = 3.0;
+const double _kMaxZoom = 19.0;
+
 /// Shared map widget containing all layers: tiles, search radius circle,
 /// center marker, station markers with clustering, attribution, zoom
 /// controls, and price legend.
@@ -107,6 +115,17 @@ class StationMapLayers extends StatefulWidget {
 
   @override
   State<StationMapLayers> createState() => _StationMapLayersState();
+
+  /// Camera zoom bounds for the +/− button handlers + the [MapOptions]
+  /// camera constraints. Aligned with the OSM tile cap (`maxNativeZoom: 19`)
+  /// so a programmatic zoom-in past the cap doesn't park the camera at
+  /// a level with no tiles to render. The min is conservative — flutter_map
+  /// itself wraps the world at zoom 0, but anything below ~3 puts every
+  /// pin in a single pixel, which is unhelpful UX. Per #1457.
+  @visibleForTesting
+  static const double minZoom = _kMinZoom;
+  @visibleForTesting
+  static const double maxZoom = _kMaxZoom;
 
   /// Calculate zoom level from search radius.
   static double zoomForRadius(double radiusKm) {
@@ -280,6 +299,16 @@ class _StationMapLayersState extends State<StationMapLayers> {
           options: MapOptions(
             initialCenter: widget.center,
             initialZoom: widget.zoom,
+            // #1457 — clamp the camera to the tile-layer's max zoom (19)
+            // so a programmatic `move(camera.zoom + 1)` past 19 doesn't
+            // leave the user staring at a grey viewport (tiles only
+            // render up to maxNativeZoom). The default flutter_map
+            // MapOptions.maxZoom is 25 — that lets the camera stride
+            // past where there are tiles to draw, which looks broken to
+            // the user. Min clamp guards against accidental zoom-out
+            // beyond the world wrap.
+            minZoom: _kMinZoom,
+            maxZoom: _kMaxZoom,
             interactionOptions: const InteractionOptions(
               flags: InteractiveFlag.all,
             ),
@@ -428,7 +457,16 @@ class _StationMapLayersState extends State<StationMapLayers> {
               ZoomButton(
                 icon: Icons.add,
                 onPressed: () {
-                  final z = widget.mapController.camera.zoom + 1;
+                  // #1457 — clamp to [_kMinZoom, _kMaxZoom]. Without
+                  // the clamp, a + tap at the cap silently no-ops AND
+                  // pushes the camera to a zoom level with no tiles
+                  // (the user sees a grey screen and assumes the button
+                  // is broken). The clamp turns it into a graceful
+                  // no-op AT the cap — the visible feedback is "I'm
+                  // already at max zoom" instead of "the button is
+                  // dead".
+                  final z = (widget.mapController.camera.zoom + 1)
+                      .clamp(_kMinZoom, _kMaxZoom);
                   widget.mapController
                       .move(widget.mapController.camera.center, z);
                 },
@@ -437,7 +475,8 @@ class _StationMapLayersState extends State<StationMapLayers> {
               ZoomButton(
                 icon: Icons.remove,
                 onPressed: () {
-                  final z = widget.mapController.camera.zoom - 1;
+                  final z = (widget.mapController.camera.zoom - 1)
+                      .clamp(_kMinZoom, _kMaxZoom);
                   widget.mapController
                       .move(widget.mapController.camera.center, z);
                 },

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -76,6 +76,55 @@ void main() {
     });
   });
 
+  group('StationMapLayers zoom bounds (#1457)', () {
+    test('maxZoom matches the OSM tile cap (19)', () {
+      // The TileLayer in StationMapLayers caps tile loads at zoom 19
+      // (`maxNativeZoom: 19, maxZoom: 19`). The camera's maxZoom MUST
+      // not exceed the tile cap — otherwise a programmatic
+      // `move(camera.zoom + 1)` past 19 parks the camera at a level
+      // with no tiles to draw, producing the "+ button does nothing"
+      // symptom that triggered #1457. Tile cap and camera cap MUST be
+      // updated together if either ever changes.
+      expect(StationMapLayers.maxZoom, 19.0);
+    });
+
+    test('minZoom keeps every pin from collapsing into a single pixel',
+        () {
+      // Zoom 3 shows a continent-scale viewport; below that, station
+      // markers cluster into a single illegible blob and the search
+      // affordances stop being meaningful.
+      expect(StationMapLayers.minZoom, 3.0);
+    });
+
+    test('the clamp expression in the +/− handlers is well-formed',
+        () {
+      // Mirror the exact expression both ZoomButton handlers use so a
+      // future rename or sign-flip in the production code is caught
+      // by this test rather than silently shipping. The clamp turns a
+      // tap-at-the-cap into a graceful no-op (camera stays at the
+      // bound) instead of pushing past where there are tiles.
+      double inc(double current) =>
+          (current + 1).clamp(StationMapLayers.minZoom, StationMapLayers.maxZoom);
+      double dec(double current) =>
+          (current - 1).clamp(StationMapLayers.minZoom, StationMapLayers.maxZoom);
+      // Below the cap → increment normally.
+      expect(inc(13.0), 14.0);
+      expect(dec(13.0), 12.0);
+      // At the upper cap → + becomes a no-op, − still moves.
+      expect(inc(StationMapLayers.maxZoom), StationMapLayers.maxZoom);
+      expect(dec(StationMapLayers.maxZoom),
+          StationMapLayers.maxZoom - 1.0);
+      // At the lower cap → − becomes a no-op, + still moves.
+      expect(dec(StationMapLayers.minZoom), StationMapLayers.minZoom);
+      expect(inc(StationMapLayers.minZoom),
+          StationMapLayers.minZoom + 1.0);
+      // Past the upper cap (e.g. via prior pinch-zoom that escaped
+      // the camera before #1457 set MapOptions.maxZoom) → the next
+      // tap snaps back to the cap rather than pushing further.
+      expect(inc(25.0), StationMapLayers.maxZoom);
+    });
+  });
+
   // The #496 `onMapReady` zoom-jiggle regression test was retired by
   // #757: the retry+evict tile provider makes the nudge unnecessary.
   // A failed tile now retries at the HTTP layer and, if still


### PR DESCRIPTION
## Summary

Fixes the Carte zoom-in (**+**) button silently no-opping when the camera escapes past the tile cap.

The +/− handlers' raw `move(camera.zoom ± 1)` allowed the camera to move past `TileLayer.maxNativeZoom = 19`. Past 19 there are no tiles to draw, so the button looked broken. **−** stayed visibly functional because it always brings the camera back into the tile-rendering range.

Two-part fix:

1. **`MapOptions.maxZoom: 19.0, minZoom: 3.0`** — aligns the camera bounds with the tile cap so pinch-zoom can't escape either.
2. **Explicit `.clamp(minZoom, maxZoom)`** in both ZoomButton handlers — a tap at the cap is now a graceful camera-stays-put no-op instead of a move-to-invisible-zoom.

Constants are exposed via `@visibleForTesting` so the regression test mirrors the exact production expression — a future sign-flip or rename in the handler is caught at unit-test time.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/map/presentation/widgets/station_map_layers_test.dart` — 13 tests pass (4 new in the `#1457` group)
- [ ] Device-test on Carte tab: tap **+** at default zoom, confirm camera zooms in. Pinch past where + used to break, tap **+**, confirm graceful no-op (no grey screen).