### PR TITLE
feat(consumption): mark hard-acceleration events on trip-detail map (Refs #1458 phase 1)

### DIFF
--- a/lib/features/consumption/data/driving_insights_analyzer.dart
+++ b/lib/features/consumption/data/driving_insights_analyzer.dart
@@ -16,6 +16,7 @@ library;
 
 import '../domain/driving_insight.dart';
 import '../domain/trip_recorder.dart';
+import '../presentation/widgets/trip_detail_charts.dart';
 
 /// RPM above which a sample counts as "high RPM".
 const double _highRpmThreshold = 3000;
@@ -193,6 +194,53 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
   candidates.sort((a, b) => b.litersWasted.compareTo(a.litersWasted));
   if (candidates.length <= _topN) return candidates;
   return candidates.sublist(0, _topN);
+}
+
+/// Returns the indices of samples (in the sorted-by-timestamp ordering)
+/// where a hard-acceleration event ended — i.e. where the speed delta
+/// from the previous sample exceeds [_hardAccelThresholdMps2]. Mirrors
+/// the detection logic in [analyzeTrip] so the trip-detail map can
+/// render markers at the matching positions (#1458 phase 1).
+///
+/// Sorting + dt-guard contract identical to [analyzeTrip]:
+///   * input is copied + sorted by timestamp before iteration so an
+///     out-of-order list never spuriously reports an event;
+///   * intervals with `dt <= 0` are skipped (duplicate timestamps);
+///   * the first sample (index 0) is never an event because there's
+///     no previous sample to derive an acceleration from.
+///
+/// IMPORTANT: the returned indices reference positions in the
+/// INTERNALLY-SORTED list, NOT the caller's input order. Callers that
+/// want to map indices back to coordinates must sort their own samples
+/// by timestamp the same way before indexing. The trip-detail map
+/// already passes timestamp-sorted samples (recorder writes monotonic
+/// timestamps), so it can use the indices directly.
+List<int> hardAccelSampleIndices(List<TripDetailSample> samples) {
+  if (samples.length < 2) return const <int>[];
+
+  // Copy + sort so out-of-order persistence (#1040 race conditions)
+  // doesn't blow up the integration. Same pattern as [analyzeTrip].
+  final sorted = [...samples]
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  final indices = <int>[];
+  for (var i = 1; i < sorted.length; i++) {
+    final prev = sorted[i - 1];
+    final cur = sorted[i];
+    final dt =
+        cur.timestamp.difference(prev.timestamp).inMicroseconds /
+            Duration.microsecondsPerSecond;
+    if (dt <= 0) continue;
+
+    // Same conversion as [analyzeTrip]: km/h → m/s by / 3.6, then
+    // divide by Δt to get acceleration in m/s².
+    final dvMps = (cur.speedKmh - prev.speedKmh) / 3.6;
+    final accelMps2 = dvMps / dt;
+    if (accelMps2 >= _hardAccelThresholdMps2) {
+      indices.add(i);
+    }
+  }
+  return indices;
 }
 
 /// Fallback when no fuel-rate samples are available during the

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -5,6 +5,7 @@ import 'package:latlong2/latlong.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../data/driving_insights_analyzer.dart';
 import 'trip_detail_charts.dart';
 
 // ---------------------------------------------------------------------------
@@ -286,6 +287,29 @@ class _TripPathMapState extends State<_TripPathMap> {
     final start = widget.points.first;
     final end = widget.points.last;
     final polylines = _buildHeatmapPolylines(context);
+
+    // Hard-acceleration markers (#1458 phase 1). The recorder writes
+    // monotonic timestamps so `widget.pointSamples` is already sorted
+    // by timestamp, which means [hardAccelSampleIndices]'s indices line
+    // up 1:1 with `widget.points`. The helper sorts defensively so a
+    // future caller that passes unsorted samples won't silently mismap
+    // markers — but if that ever changes we'd need to sort here too.
+    final hardAccelIndices = hardAccelSampleIndices(widget.pointSamples);
+    final hardAccelMarkers = <Marker>[
+      for (final idx in hardAccelIndices)
+        if (idx >= 0 && idx < widget.points.length)
+          Marker(
+            point: widget.points[idx],
+            width: 20,
+            height: 20,
+            child: Icon(
+              Icons.bolt,
+              size: 16,
+              color: theme.colorScheme.error,
+            ),
+          ),
+    ];
+
     return FlutterMap(
       mapController: _mapController,
       options: MapOptions(
@@ -329,6 +353,7 @@ class _TripPathMapState extends State<_TripPathMap> {
                 icon: Icons.flag,
               ),
             ),
+            ...hardAccelMarkers,
           ],
         ),
         const RichAttributionWidget(

--- a/test/features/consumption/data/driving_insights_analyzer_test.dart
+++ b/test/features/consumption/data/driving_insights_analyzer_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/driving_insights_analyzer.dart';
 import 'package:tankstellen/features/consumption/domain/driving_insight.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
 
 /// Pure-logic tests for the driving-insights analyzer (#1041 phase 1).
 ///
@@ -308,6 +309,110 @@ void main() {
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
       expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('hardAccelSampleIndices (#1458 phase 1)', () {
+    final start = DateTime.utc(2026);
+
+    TripDetailSample sample({
+      required int sec,
+      required double speedKmh,
+    }) =>
+        TripDetailSample(
+          timestamp: start.add(Duration(seconds: sec)),
+          speedKmh: speedKmh,
+        );
+
+    test('empty samples → empty list', () {
+      expect(hardAccelSampleIndices(const []), isEmpty);
+    });
+
+    test('single sample → empty list (no Δt to derive accel)', () {
+      expect(
+        hardAccelSampleIndices([sample(sec: 0, speedKmh: 0)]),
+        isEmpty,
+      );
+    });
+
+    test('two samples at constant speed → no events', () {
+      final samples = [
+        sample(sec: 0, speedKmh: 50),
+        sample(sec: 1, speedKmh: 50),
+      ];
+      expect(hardAccelSampleIndices(samples), isEmpty);
+    });
+
+    test('two samples crossing the threshold → index 1 reported', () {
+      // 0 → 50 km/h in 2 s: dv = 50/3.6 ≈ 13.89 m/s, accel ≈ 6.94 m/s²,
+      // well above the 3.0 m/s² threshold.
+      final samples = [
+        sample(sec: 0, speedKmh: 0),
+        sample(sec: 2, speedKmh: 50),
+      ];
+      expect(hardAccelSampleIndices(samples), [1]);
+    });
+
+    test(
+        'five samples with one accel event in the middle → only that index '
+        'is reported', () {
+      // Indices and segments:
+      //   0 → 1: 30 → 32 km/h over 1 s → accel ≈ 0.56 m/s² (below).
+      //   1 → 2: 32 → 80 km/h over 1 s → accel ≈ 13.33 m/s² (above).
+      //   2 → 3: 80 → 82 km/h over 1 s → accel ≈ 0.56 m/s² (below).
+      //   3 → 4: 82 → 80 km/h over 1 s → DECEL (negative, ignored).
+      // Only index 2 (the end of the middle interval) trips the
+      // threshold.
+      final samples = [
+        sample(sec: 0, speedKmh: 30),
+        sample(sec: 1, speedKmh: 32),
+        sample(sec: 2, speedKmh: 80),
+        sample(sec: 3, speedKmh: 82),
+        sample(sec: 4, speedKmh: 80),
+      ];
+      expect(hardAccelSampleIndices(samples), [2]);
+    });
+
+    test('intervals with dt == 0 are skipped (no spurious events)', () {
+      // Duplicate timestamps at sec=1 — the second pair has a huge
+      // speed delta but dt = 0, so the analyzer must NOT emit an event
+      // there. The genuine accel between sec=1 and sec=3 still fires.
+      final samples = [
+        sample(sec: 0, speedKmh: 0),
+        sample(sec: 1, speedKmh: 0),
+        sample(sec: 1, speedKmh: 80), // dt = 0 — must be skipped
+        sample(sec: 3, speedKmh: 80),
+      ];
+      // After internal sort by timestamp the dup-timestamp pair stays
+      // adjacent; only the (1s, 0) → (1s, 80) interval has dt == 0 and
+      // is skipped. The other intervals are below threshold.
+      expect(hardAccelSampleIndices(samples), isEmpty);
+    });
+
+    test(
+        'samples passed in reverse timestamp order are sorted internally '
+        'before detection', () {
+      // Same single-event setup as the two-sample test, but the caller
+      // hands the samples in REVERSE order. The helper must sort
+      // internally and still report the event at the post-sort index 1.
+      final samples = [
+        sample(sec: 2, speedKmh: 50),
+        sample(sec: 0, speedKmh: 0),
+      ];
+      expect(hardAccelSampleIndices(samples), [1]);
+    });
+
+    test('caller is not mutated when samples arrive out of order', () {
+      // Defensive contract — the helper must copy before sorting so
+      // the caller's list keeps its original order. Mirrors the same
+      // safety [analyzeTrip] provides.
+      final original = [
+        sample(sec: 2, speedKmh: 50),
+        sample(sec: 0, speedKmh: 0),
+      ];
+      final snapshot = List<TripDetailSample>.from(original);
+      hardAccelSampleIndices(original);
+      expect(original, snapshot);
     });
   });
 }

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -280,6 +280,50 @@ void main() {
       expect(layer.polylines, isEmpty);
     });
 
+    testWidgets(
+        'hard-acceleration events render bolt markers on top of the heatmap',
+        (tester) async {
+      // Two hard-accel events: 0 → 60 km/h in 1 s (≈ 16.67 m/s²) at the
+      // 0 → 1 boundary, and 30 → 80 km/h in 1 s (≈ 13.89 m/s²) at the
+      // 4 → 5 boundary. Both well above the 3.0 m/s² threshold. The
+      // segments between them stay calm so no other event fires.
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 0),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60), // hard accel #1
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60),
+        _sample(sec: 3, lat: 43.43, lng: 3.43, speed: 60),
+        _sample(sec: 4, lat: 43.44, lng: 3.44, speed: 30),
+        _sample(sec: 5, lat: 43.45, lng: 3.45, speed: 80), // hard accel #2
+        _sample(sec: 6, lat: 43.46, lng: 3.46, speed: 80),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      // Two bolt icons — one per detected event.
+      expect(find.byIcon(Icons.bolt), findsNWidgets(2));
+
+      // Regression guard: the start (play_arrow) and end (flag) pins
+      // are still rendered alongside the bolt overlays.
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(find.byIcon(Icons.flag), findsOneWidget);
+    });
+
+    testWidgets('no hard-acceleration events → no bolt markers',
+        (tester) async {
+      // Constant-speed cruise — analyzer reports zero events.
+      final samples = [
+        _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 60),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60),
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      expect(find.byIcon(Icons.bolt), findsNothing);
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(find.byIcon(Icons.flag), findsOneWidget);
+    });
+
     testWidgets('legend renders the three bucket labels', (tester) async {
       // The legend must surface all three colour buckets so a user
       // can decode the heatmap without referring to docs.


### PR DESCRIPTION
## Summary

- Phase 1 of #1458 surfaces hard-acceleration events as bolt-icon markers on the trip-detail map. The trip info-bar already shows e.g. "4 hard accelerations" but the existing fuel-rate heatmap colors only by L/100 km — the user reported they had no way to see WHERE those events happened on the route.
- Adds a new top-level `hardAccelSampleIndices(List<TripDetailSample>)` helper in `driving_insights_analyzer.dart` that mirrors the existing 3.0 m/s² threshold detection from `analyzeTrip` (same copy + sort + dt-guard contract).
- `TripPathMapCard` now appends one `Icons.bolt` Marker per detected event to the existing MarkerLayer. Size is 16 dp inside a 20×20 dp marker; color is `Theme.of(context).colorScheme.error` so the events read as warnings against the heatmap. Start/end pins are unchanged.
- Icon-only — no ARB additions, no legend change. The existing fuel-rate heatmap polylines (`_buildHeatmapPolylines`) are not touched.

User report: "trip shows '4 hard accelerations' but the map shows nothing about where they happened".

## Test plan

- [x] `flutter test test/features/consumption/data/driving_insights_analyzer_test.dart` — 8 new cases (empty, single, constant speed, two-sample threshold, five-sample middle event, dt==0 skip, reverse-order sort, no-mutation defensive copy) on top of the existing 9, all green.
- [x] `flutter test test/features/consumption/presentation/widgets/trip_path_map_card_test.dart` — new widget tests assert 2 bolt icons render for a 2-event sample series, and that the start (`Icons.play_arrow`) + end (`Icons.flag`) pins stay rendered alongside (regression guard). A no-event variant asserts zero bolt icons.
- [x] `flutter test test/features/consumption/` (all 2,542 tests in the consumption feature) — green.
- [x] `flutter analyze` (plain, including `test/`) — `No issues found!`
- [ ] Device validation — phase 2 will close the issue once a real recorded trip with known hard-accel events visually confirms the overlay placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)