### PR TITLE
feat(glide-coach): imminent-signal detector ahead of user heading (Refs #1125 phase 2)

### DIFF
--- a/lib/features/glide_coach/domain/services/imminent_signal_detector.dart
+++ b/lib/features/glide_coach/domain/services/imminent_signal_detector.dart
@@ -1,0 +1,246 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../data/traffic_signal_repository.dart';
+import '../entities/traffic_signal.dart';
+
+/// Forward-cone half-angle (degrees) — a signal must lie within
+/// ±[_kForwardConeHalfDeg] of the user's heading vector to count as
+/// "ahead". Tight enough that signals on parallel streets are excluded;
+/// loose enough that a slight path curvature still surfaces the next
+/// signal on the user's road. Tunable in phase-3 user-test.
+const double _kForwardConeHalfDeg = 20.0;
+
+/// Default search horizon (metres) — how far ahead of the user we
+/// consider signals "imminent". 200 m at urban speeds (50 km/h ≈
+/// 14 m/s) gives the user ~14 s of lead before the signal — enough to
+/// lift off throttle and coast in.
+const double _kDefaultHorizonMeters = 200.0;
+
+/// Lateral padding (metres) added around the horizon when building the
+/// search bounding box. Generous enough to absorb GPS noise (typical
+/// urban accuracy 5–15 m) and a few metres of cone-edge slop on the
+/// flanks; the forward-cone filter rejects anything spurious that
+/// sneaks in.
+const double _kBboxLateralPaddingMeters = 50.0;
+
+/// Mean Earth radius in metres (WGS-84 sphere approximation). Good to
+/// ~0.5 % at urban distances — well below the resolution that matters
+/// for fuel-coast decisions.
+const double _kEarthRadiusMeters = 6371000.0;
+
+/// Input record for [ImminentSignalDetector] — the minimal GPS shape
+/// the detector needs. Adapter providers (phase 3) will marshal a
+/// `geolocator` `Position` into this record so the detector stays free
+/// of platform-channel coupling and is unit-testable with hand-built
+/// inputs. `headingDegrees` follows compass convention: 0° = north,
+/// 90° = east.
+typedef GpsReading = ({
+  double latitude,
+  double longitude,
+  double headingDegrees,
+});
+
+/// Service that locates the next traffic signal ahead of a moving user
+/// (#1125 phase 2). Input: a [GpsReading] (position + heading) plus an
+/// optional horizon. Output: the closest signal that lies within the
+/// forward cone and the horizon, or `null` when no signal qualifies.
+///
+/// Pure logic — no platform channels, no UI, no Riverpod state. The
+/// caller owns: GPS subscription, repository instance, throttling, and
+/// downstream actions (phase 3 correlates the result with throttle and
+/// fires the haptic).
+///
+/// ### Forward-cone filter
+///
+/// A signal qualifies as "ahead" iff the bearing from the user to the
+/// signal is within ±[_kForwardConeHalfDeg] of the user's heading.
+/// Bearings wrap at 360°; the comparison uses the shortest arc.
+///
+/// ### Distance metric
+///
+/// Great-circle distance via the haversine formula on the WGS-84
+/// sphere (mean radius 6 371 000 m). Accurate to ~0.5 % at urban
+/// distances; well below the resolution that matters for fuel-coast
+/// decisions.
+///
+/// ### Why no `velocity` input
+///
+/// Phase-3 will use velocity to compute time-to-arrival; phase-2 just
+/// returns the closest signal so callers can spike on a static input
+/// (a queued GPS reading) or a live stream identically.
+///
+/// ### Under-trigger preference
+///
+/// This service feeds a distraction-warning (haptic-on-coast) so a
+/// false positive is worse than a missed signal. Whenever geometry is
+/// ambiguous — empty cache, repository error, NaN bearings, signals
+/// past the horizon — we bias toward `null` (nothing ahead) rather
+/// than guess. Phase 3's correlation step adds a second gate before
+/// any actual buzz fires.
+class ImminentSignalDetector {
+  final TrafficSignalRepository _repo;
+  final double _horizonMeters;
+
+  ImminentSignalDetector({
+    required TrafficSignalRepository repo,
+    double horizonMeters = _kDefaultHorizonMeters,
+  }) : _repo = repo,
+       _horizonMeters = horizonMeters;
+
+  /// Returns the closest [TrafficSignal] ahead of [reading] within the
+  /// horizon, or `null` when none qualify. The repository call is
+  /// awaited; the caller is responsible for throttling invocations
+  /// (e.g. once per N seconds of GPS samples).
+  ///
+  /// Repository errors are swallowed (and `debugPrint`-ed) so a brief
+  /// network blip does not throw inside a GPS callback. Under-trigger
+  /// is the safe default for a distraction-warning feature.
+  Future<TrafficSignal?> nextSignalAhead(GpsReading reading) async {
+    final user = LatLng(reading.latitude, reading.longitude);
+    final bbox = searchBoundingBox(user, _horizonMeters);
+
+    final List<TrafficSignal> signals;
+    try {
+      signals = await _repo.getSignalsForBoundingBox(
+        south: bbox.south,
+        west: bbox.west,
+        north: bbox.north,
+        east: bbox.east,
+      );
+    } catch (e, st) {
+      debugPrint(
+        'ImminentSignalDetector: repo lookup failed, '
+        'returning null: $e\n$st',
+      );
+      return null;
+    }
+
+    if (signals.isEmpty) return null;
+
+    final heading = reading.headingDegrees;
+    TrafficSignal? best;
+    double bestDistance = double.infinity;
+
+    for (final signal in signals) {
+      final pos = LatLng(signal.lat, signal.lng);
+      final distance = distanceMeters(user, pos);
+      if (distance > _horizonMeters) continue;
+      if (distance == 0.0) continue; // user standing on the signal
+
+      final bearing = bearingDegrees(user, pos);
+      if (!bearing.isFinite || !heading.isFinite) continue;
+
+      final delta = bearingDeltaDegrees(heading, bearing);
+      if (delta > _kForwardConeHalfDeg) continue;
+
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = signal;
+      }
+    }
+
+    return best;
+  }
+
+  // ---------- helpers ----------
+  // Static so unit tests can exercise them in isolation without
+  // constructing the repo.
+
+  /// Initial bearing from `from` to `to` in degrees [0, 360).
+  /// Forward-azimuth on the WGS-84 sphere.
+  ///
+  /// Returns `0.0` when both points are identical (the standard
+  /// great-circle formula yields `atan2(0, 0)` which is well-defined
+  /// as 0, but we short-circuit to keep the contract explicit).
+  @visibleForTesting
+  static double bearingDegrees(LatLng from, LatLng to) {
+    if (from.latitude == to.latitude && from.longitude == to.longitude) {
+      return 0.0;
+    }
+
+    final lat1 = _degToRad(from.latitude);
+    final lat2 = _degToRad(to.latitude);
+    final deltaLng = _degToRad(to.longitude - from.longitude);
+
+    final y = math.sin(deltaLng) * math.cos(lat2);
+    final x =
+        math.cos(lat1) * math.sin(lat2) -
+        math.sin(lat1) * math.cos(lat2) * math.cos(deltaLng);
+
+    final bearingRad = math.atan2(y, x);
+    final bearingDeg = _radToDeg(bearingRad);
+    // Normalise to [0, 360). `(x % 360 + 360) % 360` handles negative
+    // bearings without conditionals.
+    return (bearingDeg % 360 + 360) % 360;
+  }
+
+  /// Great-circle distance in metres via the haversine formula.
+  @visibleForTesting
+  static double distanceMeters(LatLng from, LatLng to) {
+    final lat1 = _degToRad(from.latitude);
+    final lat2 = _degToRad(to.latitude);
+    final deltaLat = _degToRad(to.latitude - from.latitude);
+    final deltaLng = _degToRad(to.longitude - from.longitude);
+
+    final a =
+        math.sin(deltaLat / 2) * math.sin(deltaLat / 2) +
+        math.cos(lat1) *
+            math.cos(lat2) *
+            math.sin(deltaLng / 2) *
+            math.sin(deltaLng / 2);
+    final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+    return _kEarthRadiusMeters * c;
+  }
+
+  /// Smallest absolute arc between two bearings in degrees [0, 180].
+  /// Wraps correctly at 360°: `bearingDeltaDegrees(355, 5)` is 10, not
+  /// 350.
+  @visibleForTesting
+  static double bearingDeltaDegrees(double a, double b) {
+    final diff = ((a - b) % 360 + 360) % 360;
+    return diff > 180 ? 360 - diff : diff;
+  }
+
+  /// Build a tight bounding box around the user that covers the
+  /// horizon distance plus enough lateral padding to absorb GPS noise.
+  ///
+  /// The box is square in metre-space (axis-aligned, no rotation) —
+  /// picking up a small superset is fine because the forward-cone
+  /// filter rejects irrelevant signals. We translate the metre padding
+  /// into degree-space using a flat-earth approximation: 1° latitude
+  /// ≈ 111 320 m everywhere; 1° longitude shrinks with `cos(lat)` so
+  /// near-equator and mid-latitude users get the same metric horizon.
+  ///
+  /// Near the poles `cos(lat)` approaches 0, which would blow the
+  /// longitude delta to infinity; we clamp the cosine away from zero
+  /// so the bbox stays finite. (The detector is not meant for polar
+  /// driving and the upstream repository would refuse such a bbox
+  /// anyway — this is purely so the math doesn't emit `NaN`.)
+  @visibleForTesting
+  static ({double south, double west, double north, double east})
+  searchBoundingBox(LatLng center, double horizonMeters) {
+    final padded = horizonMeters + _kBboxLateralPaddingMeters;
+
+    const metresPerDegLat = 111320.0;
+    final latDelta = padded / metresPerDegLat;
+
+    final cosLat = math.cos(_degToRad(center.latitude));
+    // Clamp |cos| ≥ 1e-6 so `padded / (metres * cosLat)` stays finite
+    // at the poles.
+    final clampedCosLat = cosLat.abs() < 1e-6 ? 1e-6 : cosLat.abs();
+    final lngDelta = padded / (metresPerDegLat * clampedCosLat);
+
+    return (
+      south: center.latitude - latDelta,
+      west: center.longitude - lngDelta,
+      north: center.latitude + latDelta,
+      east: center.longitude + lngDelta,
+    );
+  }
+
+  static double _degToRad(double deg) => deg * math.pi / 180.0;
+  static double _radToDeg(double rad) => rad * 180.0 / math.pi;
+}

--- a/test/features/glide_coach/domain/services/imminent_signal_detector_test.dart
+++ b/test/features/glide_coach/domain/services/imminent_signal_detector_test.dart
@@ -1,0 +1,375 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/glide_coach/data/osm_traffic_signal_client.dart';
+import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
+import 'package:tankstellen/features/glide_coach/domain/entities/traffic_signal.dart';
+import 'package:tankstellen/features/glide_coach/domain/services/imminent_signal_detector.dart';
+
+/// Test double for [TrafficSignalRepository] that lets each test stub
+/// the bbox response (or an error) without spinning up Hive. The real
+/// repo is exercised by `traffic_signal_repository_test.dart`; here we
+/// only care about the detector's filtering / ranking behaviour.
+class _StubRepo implements TrafficSignalRepository {
+  List<TrafficSignal> response;
+  Object? errorToThrow;
+  int callCount = 0;
+
+  ({double south, double west, double north, double east})? lastBbox;
+
+  _StubRepo({this.response = const <TrafficSignal>[], this.errorToThrow});
+
+  @override
+  Future<List<TrafficSignal>> getSignalsForBoundingBox({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+  }) async {
+    callCount++;
+    lastBbox = (south: south, west: west, north: north, east: east);
+    final err = errorToThrow;
+    if (err != null) throw err;
+    return response;
+  }
+
+  // The remaining repo members are not exercised by the detector;
+  // `noSuchMethod` lets this stub stay resilient to future repo
+  // additions without forcing us to mirror them all here.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Convert a metre offset along a compass `bearingDeg` (0=N, 90=E)
+/// into a `(dLat, dLng)` increment around `lat`. Mirrors the
+/// flat-earth approximation the bbox helper uses; accurate enough at
+/// ≤ 200 m to keep test inputs deterministic without depending on
+/// the production geodesy.
+({double dLat, double dLng}) _metreOffset({
+  required double lat,
+  required double metres,
+  required double bearingDeg,
+}) {
+  const metresPerDegLat = 111320.0;
+  final bearingRad = bearingDeg * math.pi / 180.0;
+  final cosLat = math.cos(lat * math.pi / 180.0);
+  final dLat = (metres * math.cos(bearingRad)) / metresPerDegLat;
+  final dLng = (metres * math.sin(bearingRad)) / (metresPerDegLat * cosLat);
+  return (dLat: dLat, dLng: dLng);
+}
+
+void main() {
+  // Reference points used by the geodesy tests below. Values come
+  // from standard great-circle references; tolerated to ±2° / ±1 %
+  // per the test plan in the issue brief.
+  const paris = LatLng(48.8566, 2.3522);
+  const london = LatLng(51.5074, -0.1278);
+  const berlin = LatLng(52.5200, 13.4050);
+
+  group('ImminentSignalDetector.bearingDegrees', () {
+    test('Paris → London is roughly 332° (NNW)', () {
+      final bearing = ImminentSignalDetector.bearingDegrees(paris, london);
+      expect(bearing, closeTo(332, 2));
+    });
+
+    test('Paris → Berlin is roughly 60° (ENE)', () {
+      final bearing = ImminentSignalDetector.bearingDegrees(paris, berlin);
+      expect(bearing, closeTo(60, 2));
+    });
+
+    test('identical points return 0.0 (no NaN)', () {
+      final bearing = ImminentSignalDetector.bearingDegrees(paris, paris);
+      expect(bearing, 0.0);
+      expect(bearing.isFinite, isTrue);
+    });
+
+    test('antipodal points return a finite bearing', () {
+      // Antipode of Paris, give or take.
+      const antipodeOfParis = LatLng(-48.8566, -177.6478);
+      final bearing = ImminentSignalDetector.bearingDegrees(
+        paris,
+        antipodeOfParis,
+      );
+      expect(bearing.isFinite, isTrue);
+      expect(bearing, inInclusiveRange(0, 360));
+    });
+
+    test('result is always in [0, 360)', () {
+      // A point due south crosses the 180° boundary.
+      const south = LatLng(40.0, 2.3522);
+      final bearing = ImminentSignalDetector.bearingDegrees(paris, south);
+      expect(bearing, inInclusiveRange(0, 360));
+      expect(bearing, lessThan(360));
+      expect(bearing, closeTo(180, 1));
+    });
+  });
+
+  group('ImminentSignalDetector.distanceMeters', () {
+    test('Paris → London is ~344 km within 1%', () {
+      final d = ImminentSignalDetector.distanceMeters(paris, london);
+      expect(d, closeTo(344000, 3440));
+    });
+
+    test('Paris → Berlin is ~877 km within 1%', () {
+      final d = ImminentSignalDetector.distanceMeters(paris, berlin);
+      expect(d, closeTo(877000, 8770));
+    });
+
+    test('same point returns 0', () {
+      expect(ImminentSignalDetector.distanceMeters(paris, paris), 0.0);
+    });
+
+    test('symmetric: A→B == B→A', () {
+      final ab = ImminentSignalDetector.distanceMeters(paris, london);
+      final ba = ImminentSignalDetector.distanceMeters(london, paris);
+      expect(ab, closeTo(ba, 0.001));
+    });
+  });
+
+  group('ImminentSignalDetector.bearingDeltaDegrees', () {
+    test('wraps around 360°: delta(355, 5) = 10', () {
+      expect(ImminentSignalDetector.bearingDeltaDegrees(355, 5), 10);
+    });
+
+    test('reverse: delta(5, 355) = 10', () {
+      expect(ImminentSignalDetector.bearingDeltaDegrees(5, 355), 10);
+    });
+
+    test('opposite: delta(180, 0) = 180', () {
+      expect(ImminentSignalDetector.bearingDeltaDegrees(180, 0), 180);
+    });
+
+    test('zero: delta(42, 42) = 0', () {
+      expect(ImminentSignalDetector.bearingDeltaDegrees(42, 42), 0);
+    });
+
+    test('symmetric: delta(a, b) == delta(b, a)', () {
+      expect(
+        ImminentSignalDetector.bearingDeltaDegrees(120, 250),
+        ImminentSignalDetector.bearingDeltaDegrees(250, 120),
+      );
+    });
+
+    test('result is always in [0, 180]', () {
+      const pairs = <(double, double)>[
+        (10.0, 350.0),
+        (90.0, 270.0),
+        (45.0, 135.0),
+        (0.0, 359.99),
+      ];
+      for (final pair in pairs) {
+        final delta = ImminentSignalDetector.bearingDeltaDegrees(
+          pair.$1,
+          pair.$2,
+        );
+        expect(
+          delta,
+          inInclusiveRange(0, 180),
+          reason: 'pair=${pair.$1},${pair.$2} delta=$delta',
+        );
+      }
+    });
+  });
+
+  group('ImminentSignalDetector.searchBoundingBox', () {
+    test('contains the centre point', () {
+      final bbox = ImminentSignalDetector.searchBoundingBox(paris, 200);
+      expect(bbox.south, lessThan(paris.latitude));
+      expect(bbox.north, greaterThan(paris.latitude));
+      expect(bbox.west, lessThan(paris.longitude));
+      expect(bbox.east, greaterThan(paris.longitude));
+    });
+
+    test('lat-delta scales with horizon', () {
+      final small = ImminentSignalDetector.searchBoundingBox(paris, 100);
+      final big = ImminentSignalDetector.searchBoundingBox(paris, 1000);
+      final smallLat = small.north - small.south;
+      final bigLat = big.north - big.south;
+      expect(bigLat, greaterThan(smallLat));
+    });
+
+    test('does not divide by zero at the equator', () {
+      const equator = LatLng(0.0, 0.0);
+      final bbox = ImminentSignalDetector.searchBoundingBox(equator, 200);
+      expect(bbox.south.isFinite, isTrue);
+      expect(bbox.north.isFinite, isTrue);
+      expect(bbox.east.isFinite, isTrue);
+      expect(bbox.west.isFinite, isTrue);
+    });
+
+    test('does not divide by zero near the poles', () {
+      const nearPole = LatLng(89.999999, 0.0);
+      final bbox = ImminentSignalDetector.searchBoundingBox(nearPole, 200);
+      expect(bbox.south.isFinite, isTrue);
+      expect(bbox.north.isFinite, isTrue);
+      expect(bbox.east.isFinite, isTrue);
+      expect(bbox.west.isFinite, isTrue);
+    });
+
+    test('horizon=200 m yields ~250 m of lat padding (within 10%)', () {
+      // padded = 200 + 50 = 250 m. 250 / 111 320 ≈ 0.002245°.
+      // Lat-delta is 2 × that.
+      final bbox = ImminentSignalDetector.searchBoundingBox(paris, 200);
+      final latDelta = bbox.north - bbox.south;
+      expect(latDelta, closeTo(0.00449, 0.0005));
+    });
+  });
+
+  group('ImminentSignalDetector.nextSignalAhead (#1125 phase 2)', () {
+    // Hand-built user reading: Paris reference point, heading due
+    // north (0°). We synthesise candidate signals at chosen
+    // bearings/distances via _metreOffset.
+    const userLat = 48.8566;
+    const userLng = 2.3522;
+    const headingNorth = 0.0;
+    const headingEast = 90.0;
+
+    GpsReading reading({double heading = headingNorth}) =>
+        (latitude: userLat, longitude: userLng, headingDegrees: heading);
+
+    TrafficSignal signalAt({
+      required String id,
+      required double metres,
+      required double bearing,
+    }) {
+      final off = _metreOffset(
+        lat: userLat,
+        metres: metres,
+        bearingDeg: bearing,
+      );
+      return TrafficSignal(
+        id: id,
+        lat: userLat + off.dLat,
+        lng: userLng + off.dLng,
+      );
+    }
+
+    test('no signals in bbox → null', () async {
+      final repo = _StubRepo(response: const []);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNull);
+      expect(repo.callCount, 1);
+    });
+
+    test('one signal directly ahead within horizon → returned', () async {
+      final ahead = signalAt(id: 'ahead', metres: 100, bearing: 0);
+      final repo = _StubRepo(response: [ahead]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNotNull);
+      expect(result!.id, 'ahead');
+    });
+
+    test('one signal directly behind → null (outside forward cone)', () async {
+      final behind = signalAt(id: 'behind', metres: 100, bearing: 180);
+      final repo = _StubRepo(response: [behind]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNull);
+    });
+
+    test('one signal 90° off to the side → null', () async {
+      final side = signalAt(id: 'side', metres: 100, bearing: 90);
+      final repo = _StubRepo(response: [side]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNull);
+    });
+
+    test('signal slightly off-cone (15°, within ±20°) → returned', () async {
+      final slight = signalAt(id: 'slight', metres: 100, bearing: 15);
+      final repo = _StubRepo(response: [slight]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNotNull);
+      expect(result!.id, 'slight');
+    });
+
+    test('signal at 25° (just outside cone) → null', () async {
+      final justOut = signalAt(id: 'justOut', metres: 100, bearing: 25);
+      final repo = _StubRepo(response: [justOut]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNull);
+    });
+
+    test('signal beyond the horizon → null', () async {
+      final tooFar = signalAt(id: 'tooFar', metres: 350, bearing: 0);
+      final repo = _StubRepo(response: [tooFar]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNull);
+    });
+
+    test('multiple signals ahead → closest is returned', () async {
+      final near = signalAt(id: 'near', metres: 80, bearing: 5);
+      final mid = signalAt(id: 'mid', metres: 120, bearing: 0);
+      final far = signalAt(id: 'far', metres: 180, bearing: -5);
+      final repo = _StubRepo(response: [far, mid, near]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNotNull);
+      expect(result!.id, 'near');
+    });
+
+    test(
+      'heading wrap: due-east heading picks signal due east, not north',
+      () async {
+        final east = signalAt(id: 'east', metres: 100, bearing: 90);
+        final north = signalAt(id: 'north', metres: 100, bearing: 0);
+        final repo = _StubRepo(response: [north, east]);
+        final detector = ImminentSignalDetector(repo: repo);
+        final result = await detector.nextSignalAhead(
+          reading(heading: headingEast),
+        );
+        expect(result, isNotNull);
+        expect(result!.id, 'east');
+      },
+    );
+
+    test('repo throws → returns null (under-trigger preference)', () async {
+      final repo = _StubRepo(
+        errorToThrow: const OsmTrafficSignalException('overpass down'),
+      );
+      final detector = ImminentSignalDetector(repo: repo);
+      final result = await detector.nextSignalAhead(reading());
+      expect(result, isNull);
+      expect(repo.callCount, 1);
+    });
+
+    test(
+      'custom horizon respected (50 m horizon excludes 100 m signal)',
+      () async {
+        final ahead = signalAt(id: 'ahead', metres: 100, bearing: 0);
+        final repo = _StubRepo(response: [ahead]);
+        final detector = ImminentSignalDetector(repo: repo, horizonMeters: 50);
+        final result = await detector.nextSignalAhead(reading());
+        expect(result, isNull);
+      },
+    );
+
+    test('detector forwards a sane bbox to the repository', () async {
+      final repo = _StubRepo(response: const []);
+      final detector = ImminentSignalDetector(repo: repo);
+      await detector.nextSignalAhead(reading());
+
+      final bbox = repo.lastBbox;
+      expect(bbox, isNotNull);
+      expect(bbox!.south, lessThan(userLat));
+      expect(bbox.north, greaterThan(userLat));
+      expect(bbox.west, lessThan(userLng));
+      expect(bbox.east, greaterThan(userLng));
+    });
+  });
+
+  // The hive-backed repository contract is exercised separately in
+  // traffic_signal_repository_test.dart. This sanity check pins the
+  // stub against the same interface so a future refactor that breaks
+  // the contract surfaces here too.
+  test('_StubRepo implements TrafficSignalRepository', () {
+    final repo = _StubRepo();
+    expect(repo, isA<TrafficSignalRepository>());
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 of #1125 (glide-coach). Pure-Dart `ImminentSignalDetector` that, given a `GpsReading` (position + heading), returns the next traffic signal directly ahead within a configurable horizon, or `null` when nothing qualifies. No UI, no providers, no platform channels — phase 3 will wire it to the live geolocator stream and the throttle-correlation gate.

## Contract

- Forward-cone half-angle ±20° from the user's heading vector — tight enough to exclude signals on parallel streets, loose enough to absorb a slight path curvature.
- Default horizon 200 m (~14 s lead at 50 km/h, enough to lift off and coast).
- Distance via the haversine formula on the WGS-84 sphere (mean radius 6 371 000 m); ~0.5 % accurate at urban distances.
- Search bbox padded by 50 m laterally so GPS noise doesn't push relevant signals out of the lookup window — the cone filter rejects whatever sneaks in.

## Under-trigger preference

This service feeds a haptic-on-coast distraction warning, so a false positive is worse than a missed signal. The detector biases toward `null` whenever geometry is ambiguous: empty cache, repository error, NaN bearings, signals past the horizon. Phase 3's correlation step adds a second gate before any actual buzz fires.

## Files

- `lib/features/glide_coach/domain/services/imminent_signal_detector.dart` (+246)
- `test/features/glide_coach/domain/services/imminent_signal_detector_test.dart` (+375)

## Test plan

- [x] `flutter analyze` clean (no issues found).
- [x] `flutter test test/features/glide_coach/` — 49/49 pass (16 phase-1 repo tests + 33 new detector tests).
- [x] Geodesy helpers covered: Paris→London/Berlin bearings within ±2°, distances within ±1 %, identical / antipodal edge cases, bearing-delta wrap-around, bbox doesn't divide by zero at equator or poles.
- [x] Detector integration covered: empty bbox, signal directly ahead, behind, 90° to the side, slightly off-cone (15°), just outside cone (25°), beyond horizon, multiple ahead (closest wins), heading wrap (east-bound picks east signal), repo throws → null, custom horizon respected, sane bbox forwarded.
- [ ] Phase 3 ships the live GPS adapter + throttle correlation + haptic.

Refs #1125