### PR TITLE
feat(search): unified-card parity with legacy StationCard (Refs #1116 phase 4+5)

### DIFF
--- a/lib/core/refuel/charging_station_as_refuel_option.dart
+++ b/lib/core/refuel/charging_station_as_refuel_option.dart
@@ -84,7 +84,55 @@ class ChargingStationAsRefuelOption extends RefuelOption {
     return RefuelAvailability.unknown;
   }
 
+  @override
+  Object get source => station;
+
   /// Always `null` in phase 2. See class doc for rationale.
   @override
   RefuelPrice? get price => null;
+
+  @override
+  String get address {
+    final addr = station.address?.trim() ?? '';
+    final post = station.postCode?.trim() ?? '';
+    final place = station.place?.trim() ?? '';
+    final cityParts = <String>[
+      if (post.isNotEmpty) post,
+      if (place.isNotEmpty) place,
+    ];
+    final city = cityParts.join(' ');
+    if (addr.isNotEmpty && city.isNotEmpty) return '$addr, $city';
+    if (addr.isNotEmpty) return addr;
+    return city;
+  }
+
+  // [ChargingStation.dist] is upstream-provided in kilometres (mirrors
+  // the fuel-side [Station.dist] convention introduced when the legacy
+  // search-side EV entity was consolidated under #560). Convert to
+  // metres so [RefuelOption] consumers see one unit; treat `0.0` as
+  // "distance unknown" for the same reason as the fuel adapter.
+  @override
+  double? get distanceMeters =>
+      station.dist > 0 ? station.dist * 1000.0 : null;
+
+  // The EV upstream [ChargingStation] does not (yet) expose a 24h
+  // flag — the [openingHours] field carries weekday-by-weekday windows
+  // and a true 24h derivation would require parsing each day's window.
+  // Default to `false` here; the unified card therefore won't render
+  // a 24h badge for EV rows. A future enrichment can compute this from
+  // `openingHours` if a UI consumer needs it.
+  @override
+  bool get is24h => false;
+
+  @override
+  DateTime? get lastUpdated {
+    // Prefer the structured [lastUpdate] when available; fall back to
+    // the legacy string [updatedAt] (kept for API-compat with the
+    // pre-#560 entity shape — see class doc).
+    final structured = station.lastUpdate;
+    if (structured != null) return structured;
+    final raw = station.updatedAt;
+    if (raw == null || raw.isEmpty) return null;
+    return DateTime.tryParse(raw);
+  }
 }

--- a/lib/core/refuel/refuel_option.dart
+++ b/lib/core/refuel/refuel_option.dart
@@ -45,4 +45,42 @@ abstract class RefuelOption {
   /// search list can deduplicate without colliding on shared
   /// numeric ids between the two source systems.
   String get id;
+
+  /// Human-readable address line for the unified results card. Format
+  /// is best-effort `"<street>, <postCode> <place>"` when those parts
+  /// are populated, else a shorter fallback (or empty string when no
+  /// address data is available at all). Drives the address line on the
+  /// unified card so fuel pumps and EV chargers render with the same
+  /// density as the legacy `StationCard` (#1116 phase 4).
+  String get address;
+
+  /// Distance from the user's reference point, in metres. `null` when
+  /// the upstream search did not compute distance. Drives the distance
+  /// label on the unified card and the merged-list sort order in
+  /// `unifiedSearchResultsProvider` so EV + fuel options interleave by
+  /// proximity rather than appearing as two segregated blocks.
+  double? get distanceMeters;
+
+  /// Whether the option is open 24h/24. Drives the small "24h" badge
+  /// the unified card stacks under the status dot. Defaults to `false`
+  /// for upstream entities that don't expose a 24h flag.
+  bool get is24h;
+
+  /// Best-known timestamp for the displayed station data, parsed from
+  /// the upstream `updatedAt` string. Distinct from
+  /// [RefuelPrice.lastUpdated] (which is `null` when the price is
+  /// unavailable for the active fuel) — the unified card needs an
+  /// updated-at marker even on closed / price-less rows so users can
+  /// see how recent the data is at a glance.
+  DateTime? get lastUpdated;
+
+  /// The underlying entity this option wraps — type-erased so the
+  /// abstract layer stays free of `Station` / `ChargingStation`
+  /// imports. Phase 5 (#1116) opens this seam so the unified card can
+  /// downcast for kind-specific extras (amenity icon chips for fuel,
+  /// connector stats for EV) without spreading those imports across
+  /// generic consumers. Generic consumers (sort, filter, dedup) MUST
+  /// NOT depend on the concrete type — only the rendering layer is
+  /// allowed to peek inside.
+  Object get source;
 }

--- a/lib/core/refuel/station_as_refuel_option.dart
+++ b/lib/core/refuel/station_as_refuel_option.dart
@@ -58,8 +58,11 @@ class StationAsRefuelOption extends RefuelOption {
   }
 
   @override
+  Object get source => station;
+
+  @override
   RefuelPrice? get price {
-    final eur = _eurValueFor(fuelType);
+    final eur = _eurValueFor(fuelType) ?? _allFuelsFallbackEur();
     if (eur == null) return null;
     // Convert EUR/L (or EUR/kg for CNG; see note below) to cents.
     // EU pumps display 0.1-cent precision (e.g. €1.749 → 174.9¢), so
@@ -101,6 +104,28 @@ class StationAsRefuelOption extends RefuelOption {
     };
   }
 
+  /// Phase 5 (#1116): when [fuelType] is [FuelType.all], pick the
+  /// first available fuel field so a station with prices for at least
+  /// one fuel surfaces in the unified results. Without this, every
+  /// fuel station would be filtered out by the unified provider's
+  /// `price == null` guard whenever the user has the all-fuels
+  /// selector active — a real regression vs the legacy fuel-only path
+  /// that always renders fuel stations regardless of selector. Order
+  /// mirrors EU-pump prevalence: e10 (most common) → e5 → diesel →
+  /// e98 → lpg → e85 → dieselPremium → cng. Returns null only when
+  /// the station truly has no price for any fuel.
+  double? _allFuelsFallbackEur() {
+    if (fuelType is! FuelTypeAll) return null;
+    return station.e10 ??
+        station.e5 ??
+        station.diesel ??
+        station.e98 ??
+        station.lpg ??
+        station.e85 ??
+        station.dieselPremium ??
+        station.cng;
+  }
+
   /// Best-effort parse of [Station.updatedAt] (ISO-8601 string) into a
   /// [DateTime]. Returns `null` when the field is absent or malformed
   /// — the [RefuelPrice.lastUpdated] field accepts null and the UI
@@ -110,4 +135,36 @@ class StationAsRefuelOption extends RefuelOption {
     if (raw == null || raw.isEmpty) return null;
     return DateTime.tryParse(raw);
   }
+
+  @override
+  String get address {
+    final street = station.street.trim();
+    final post = station.postCode.trim();
+    final place = station.place.trim();
+    final cityParts = <String>[
+      if (post.isNotEmpty) post,
+      if (place.isNotEmpty) place,
+    ];
+    final city = cityParts.join(' ');
+    if (street.isNotEmpty && city.isNotEmpty) return '$street, $city';
+    if (street.isNotEmpty) return street;
+    return city;
+  }
+
+  // [Station.dist] is upstream-provided in kilometres; convert to
+  // metres at the abstract layer so [RefuelOption] consumers don't
+  // have to know about the per-source unit. The freezed default of
+  // `0.0` is treated as "distance unknown" so a station that genuinely
+  // sits 0m away (very rare in practice — would mean the user is
+  // standing on the pump) still sorts deterministically with the rest
+  // rather than always pinning to the top.
+  @override
+  double? get distanceMeters =>
+      station.dist > 0 ? station.dist * 1000.0 : null;
+
+  @override
+  bool get is24h => station.is24h;
+
+  @override
+  DateTime? get lastUpdated => _lastUpdated;
 }

--- a/lib/core/refuel/unified_search_results_provider.dart
+++ b/lib/core/refuel/unified_search_results_provider.dart
@@ -29,8 +29,10 @@ part 'unified_search_results_provider.g.dart';
 ///     currently selected fuel from [selectedFuelTypeProvider];
 ///   - the EV side via [eVSearchStateProvider], mapping every
 ///     [ChargingStation] through [ChargingStationAsRefuelOption].
-///   The two lists are concatenated (fuel first, EV after) so the
-///   downstream UI can apply its own sort/filter chips deterministically.
+///   The two lists are merged and sorted by [RefuelOption.distanceMeters]
+///   ascending so the closest options interleave regardless of kind
+///   (#1116 phase 4). Options without a known distance sink to the
+///   bottom in their original relative order.
 /// * Stations whose price for the active fuel is `null` are skipped on
 ///   the fuel side. The phase-2 [StationAsRefuelOption] returns a null
 ///   price for those stations, but the unified list is consumed by
@@ -85,5 +87,21 @@ List<RefuelOption> unifiedSearchResults(Ref ref) {
     }
   }
 
-  return [...fuelOptions, ...evOptions];
+  // Phase 4 (#1116): interleave by proximity rather than concatenating
+  // fuel-then-EV. Users want a truly unified list — closest options
+  // first regardless of kind, mirroring how the legacy fuel-only
+  // search has always sorted. Options without a known distance sink
+  // to the bottom (preserving deterministic order among themselves
+  // via the original concat order — `List.sort` is stable on the Dart
+  // VM as of SDK 3.x).
+  final merged = <RefuelOption>[...fuelOptions, ...evOptions];
+  merged.sort((a, b) {
+    final ad = a.distanceMeters;
+    final bd = b.distanceMeters;
+    if (ad == null && bd == null) return 0;
+    if (ad == null) return 1;
+    if (bd == null) return -1;
+    return ad.compareTo(bd);
+  });
+  return merged;
 }

--- a/lib/features/search/presentation/widgets/refuel_option_card.dart
+++ b/lib/features/search/presentation/widgets/refuel_option_card.dart
@@ -7,7 +7,10 @@ import '../../../../core/refuel/refuel_price.dart';
 import '../../../../core/refuel/refuel_provider.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../ev/domain/entities/charging_station.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/station.dart';
+import 'amenity_chips.dart';
 
 /// Coarse-grained discriminator for [RefuelAvailability]. The sealed
 /// class's subtypes are private (`_Open`, `_Closed`, `_Limited`,
@@ -78,16 +81,14 @@ String? _reasonOf(RefuelAvailability availability) {
 ///   a price; em-dash placeholder otherwise (matches
 ///   [PriceFormatter.formatPriceCompact]).
 ///
-/// ### Phase-1/2 limitations the widget intentionally inherits
+/// ### Phase-4 enrichment (#1116)
 ///
-/// * The abstract [RefuelOption] interface does NOT (yet) expose a
-///   street address or a precomputed distance. This widget therefore
-///   does not render either. The [showDistanceAtRight] flag is plumbed
-///   for forward compatibility — phase 4 may add `distanceMeters` to
-///   the interface and the gate will then control visibility without a
-///   breaking change to call sites that already pass the flag today.
-/// * Adding those fields to [RefuelOption] would be a phase-1/2 change
-///   and is out of scope here (see issue #1116 phase plan).
+/// The abstract [RefuelOption] interface now exposes [address],
+/// [distanceMeters], [is24h], and [lastUpdated]. The card renders all
+/// four so fuel pumps and EV chargers reach visual parity with the
+/// legacy `StationCard`. [showDistanceAtRight] still controls whether
+/// the distance label appears under the title — kept as a parameter
+/// for the handful of forward-compat call sites that already pass it.
 class RefuelOptionCard extends ConsumerWidget {
   /// The unified [RefuelOption] this card renders.
   final RefuelOption option;
@@ -138,7 +139,10 @@ class RefuelOptionCard extends ConsumerWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              _AvailabilityDot(availability: option.availability),
+              _StatusColumn(
+                availability: option.availability,
+                is24h: option.is24h,
+              ),
               const SizedBox(width: 12),
               Icon(
                 _kindIcon,
@@ -147,34 +151,15 @@ class RefuelOptionCard extends ConsumerWidget {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      title,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      _availabilityLabel(option.availability, l10n),
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
+                child: _DetailsColumn(
+                  title: title,
+                  option: option,
+                  showDistance: showDistanceAtRight,
+                  l10n: l10n,
                 ),
               ),
               const SizedBox(width: 8),
               _PriceColumn(price: option.price, l10n: l10n),
-              // Distance placeholder — phase-4 hook (see class doc).
-              if (showDistanceAtRight) const _DistanceSlot(),
             ],
           ),
         ),
@@ -189,16 +174,18 @@ class RefuelOptionCard extends ConsumerWidget {
   }
 }
 
-/// Coloured availability dot. Mirrors the success / warning / error
-/// palette the existing `EVStationCard` and `StationCard` use so the
-/// unified card sits visually flush in a mixed list.
-class _AvailabilityDot extends StatelessWidget {
+/// Coloured status dot with an optional `24h` badge underneath.
+/// Mirrors the legacy `StationCard._StatusColumn` so the unified card
+/// sits visually flush in a mixed list.
+class _StatusColumn extends StatelessWidget {
   final RefuelAvailability availability;
+  final bool is24h;
 
-  const _AvailabilityDot({required this.availability});
+  const _StatusColumn({required this.availability, required this.is24h});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final color = switch (_kindOf(availability)) {
       _AvailabilityKind.open => DarkModeColors.success(context),
       _AvailabilityKind.limited => DarkModeColors.warning(context),
@@ -206,13 +193,270 @@ class _AvailabilityDot extends StatelessWidget {
       _AvailabilityKind.unknown =>
         Theme.of(context).colorScheme.onSurfaceVariant,
     };
-    return Container(
-      width: 12,
-      height: 12,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: color,
-      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: color,
+          ),
+        ),
+        if (is24h)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              '24h',
+              style: TextStyle(
+                fontSize: 9,
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Title + address + (distance · updated-ago) block. Mirrors the
+/// legacy `StationCard._StationDetails` line stack so a fuel pump and
+/// an EV charger render with the same density.
+class _DetailsColumn extends StatelessWidget {
+  final String title;
+  final RefuelOption option;
+  final bool showDistance;
+  final AppLocalizations? l10n;
+
+  const _DetailsColumn({
+    required this.title,
+    required this.option,
+    required this.showDistance,
+    required this.l10n,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final addr = option.address;
+    final hasAddr = addr.isNotEmpty;
+    final secondaryRow = _secondaryRowParts(context);
+    final source = option.source;
+    // Fuel-only extra: the rich amenity-icon chip strip the legacy
+    // StationCard renders. We downcast `source` for this kind-specific
+    // bit per the phase-5 (#1116) seam — generic consumers must still
+    // not depend on the concrete type.
+    final fuelAmenities = source is Station ? source.amenities : null;
+    // EV-only extra: connector summary row (max kW + connector status
+    // count + connector types). Driven entirely off the wrapped
+    // ChargingStation; null for fuel-side options.
+    final evStats =
+        source is ChargingStation ? _evStatsOf(source) : null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        if (hasAddr) ...[
+          const SizedBox(height: 2),
+          Text(
+            addr,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+        // Always show at least one info row — when no distance / updated /
+        // address are present we fall back to the availability label so
+        // the card never collapses to a single bare title line.
+        const SizedBox(height: 2),
+        secondaryRow.isEmpty
+            ? Text(
+                _availabilityLabel(option.availability, l10n),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              )
+            : Row(
+                children: secondaryRow,
+              ),
+        if (evStats != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: _EvStatsRow(stats: evStats),
+          ),
+        if (fuelAmenities != null && fuelAmenities.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: AmenityChips(amenities: fuelAmenities),
+          ),
+      ],
+    );
+  }
+
+  List<Widget> _secondaryRowParts(BuildContext context) {
+    final theme = Theme.of(context);
+    final parts = <Widget>[];
+
+    final distMeters = option.distanceMeters;
+    if (showDistance && distMeters != null) {
+      parts.add(
+        Flexible(
+          child: Text(
+            PriceFormatter.formatDistance(distMeters / 1000.0),
+            style: theme.textTheme.bodySmall,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      );
+    }
+
+    final updated = option.lastUpdated;
+    if (updated != null) {
+      if (parts.isNotEmpty) parts.add(const SizedBox(width: 8));
+      parts.add(Icon(
+        Icons.update,
+        size: 12,
+        color: theme.colorScheme.onSurfaceVariant,
+      ));
+      parts.add(const SizedBox(width: 2));
+      parts.add(Flexible(
+        child: Text(
+          _formatRelative(updated, l10n),
+          style: theme.textTheme.bodySmall,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ));
+    }
+
+    return parts;
+  }
+}
+
+/// Compact "X min" / "X h" / "X d" formatter for the updated-at
+/// marker. Units are abbreviated to single letters that read the same
+/// across all 23 supported locales — avoids adding a new l10n key
+/// (and the corresponding French-completeness test edits) for what is
+/// essentially a one-character glyph next to the [Icons.update] icon.
+String _formatRelative(DateTime when, AppLocalizations? l10n) {
+  final delta = DateTime.now().difference(when);
+  if (delta.inMinutes < 1) return '<1 min';
+  if (delta.inMinutes < 60) return '${delta.inMinutes} min';
+  if (delta.inHours < 24) return '${delta.inHours} h';
+  return '${delta.inDays} d';
+}
+
+/// Cheap value object the EV stats row consumes. Computed inline by
+/// [_evStatsOf]; not exported because the unified card is the only
+/// renderer that needs it.
+class _EvStats {
+  final double maxPowerKw;
+  final int totalConnectors;
+  final int availableConnectors;
+  final List<String> connectorTypeLabels;
+
+  const _EvStats({
+    required this.maxPowerKw,
+    required this.totalConnectors,
+    required this.availableConnectors,
+    required this.connectorTypeLabels,
+  });
+}
+
+/// Derive the EV stats row data from the wrapped [ChargingStation].
+/// Lives here (rather than on the adapter) because it is purely a
+/// rendering concern — the adapter contract stays kind-agnostic.
+_EvStats _evStatsOf(ChargingStation station) {
+  final connectors = station.connectors;
+  double maxKw = 0;
+  var available = 0;
+  final typeKeys = <String>{};
+  for (final c in connectors) {
+    if (c.maxPowerKw > maxKw) maxKw = c.maxPowerKw;
+    if (c.status == ConnectorStatus.available) available++;
+    typeKeys.add(c.type.key.toUpperCase());
+  }
+  // [ChargingStation.totalPoints] sometimes carries the upstream's
+  // bay count, but per-row connector data is more reliable. Fall back
+  // to totalPoints only when the connector list is empty (sparse
+  // OpenChargeMap rows).
+  final total = connectors.isNotEmpty
+      ? connectors.length
+      : station.totalPoints;
+  return _EvStats(
+    maxPowerKw: maxKw,
+    totalConnectors: total,
+    availableConnectors: available,
+    connectorTypeLabels: typeKeys.toList()..sort(),
+  );
+}
+
+/// Compact one-line summary for an EV charger:
+/// `350 kW · 2 / 4 · CCS, Type2`. Lives under the distance/updated row
+/// on EV cards so the user sees the EV-relevant numbers (kW, available
+/// connectors, types) without tapping through to detail.
+class _EvStatsRow extends StatelessWidget {
+  final _EvStats stats;
+
+  const _EvStatsRow({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final parts = <String>[];
+    if (stats.maxPowerKw > 0) {
+      // Render kW as integer when whole, one decimal otherwise — keeps
+      // "350 kW" tidy while still surfacing "22.5 kW" if the upstream
+      // uses fractional values.
+      final kw = stats.maxPowerKw;
+      final kwText = kw == kw.roundToDouble()
+          ? kw.toStringAsFixed(0)
+          : kw.toStringAsFixed(1);
+      parts.add('$kwText kW');
+    }
+    if (stats.totalConnectors > 0) {
+      parts.add('${stats.availableConnectors} / ${stats.totalConnectors}');
+    }
+    if (stats.connectorTypeLabels.isNotEmpty) {
+      // Cap the connector-type list at three to keep the row from
+      // wrapping on small screens — extras are summarised as "+N".
+      final visible = stats.connectorTypeLabels.take(3).join(', ');
+      final extra = stats.connectorTypeLabels.length - 3;
+      parts.add(extra > 0 ? '$visible +$extra' : visible);
+    }
+    if (parts.isEmpty) return const SizedBox.shrink();
+    return Row(
+      children: [
+        Icon(
+          Icons.electrical_services,
+          size: 12,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        const SizedBox(width: 4),
+        Flexible(
+          child: Text(
+            parts.join(' · '),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -264,17 +508,6 @@ class _PriceColumn extends StatelessWidget {
       ],
     );
   }
-}
-
-/// Phase-4 placeholder for the trailing distance widget. The
-/// [RefuelOption] interface does not expose distance today; this
-/// reserves the layout slot so the gate's visibility behaviour is
-/// stable when the field lands.
-class _DistanceSlot extends StatelessWidget {
-  const _DistanceSlot();
-
-  @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
 String _availabilityLabel(

--- a/lib/features/search/presentation/widgets/unified_search_results_view.dart
+++ b/lib/features/search/presentation/widgets/unified_search_results_view.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../core/refuel/refuel_option.dart';
 import '../../../../core/refuel/refuel_provider.dart';
 import '../../../../core/refuel/unified_search_results_provider.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../ev/domain/entities/charging_station.dart';
+import '../../domain/entities/station.dart';
 import 'refuel_option_card.dart';
 import 'unified_filter_chips.dart';
 
@@ -58,12 +61,29 @@ class UnifiedSearchResultsView extends ConsumerWidget {
                     return RefuelOptionCard(
                       key: ValueKey('refuel-${option.id}'),
                       option: option,
+                      onTap: () => _openDetail(context, option),
                     );
                   },
                 ),
         ),
       ],
     );
+  }
+
+  /// Open the detail screen for a tapped option, dispatching by the
+  /// underlying entity type. Mirrors the legacy fuel/EV detail routes
+  /// — `/station/:id` for fuel, `/ev-station` (with the
+  /// `ChargingStation` as `extra`) for EV — so a user switching
+  /// between the legacy and unified views lands on the same screens.
+  /// Sparse upstream rows that don't map to a concrete type are a
+  /// no-op (rare; logged via debug-print would be too noisy).
+  void _openDetail(BuildContext context, RefuelOption option) {
+    final source = option.source;
+    if (source is Station) {
+      context.push('/station/${source.id}');
+    } else if (source is ChargingStation) {
+      context.push('/ev-station', extra: source);
+    }
   }
 
   /// Pure filter — operates on the public [RefuelProviderKind]

--- a/test/core/refuel/charging_station_as_refuel_option_test.dart
+++ b/test/core/refuel/charging_station_as_refuel_option_test.dart
@@ -21,6 +21,12 @@ ChargingStation _ev({
   bool? isOperational,
   List<EvConnector> connectors = const <EvConnector>[],
   String? usageCost,
+  String? address,
+  String? postCode,
+  String? place,
+  double dist = 0,
+  DateTime? lastUpdate,
+  String? updatedAt,
 }) =>
     ChargingStation(
       id: id,
@@ -31,6 +37,12 @@ ChargingStation _ev({
       isOperational: isOperational,
       connectors: connectors,
       usageCost: usageCost,
+      address: address,
+      postCode: postCode,
+      place: place,
+      dist: dist,
+      lastUpdate: lastUpdate,
+      updatedAt: updatedAt,
     );
 
 void main() {
@@ -162,6 +174,93 @@ void main() {
     test('price is null when usageCost is null', () {
       final adapter = ChargingStationAsRefuelOption(_ev(usageCost: null));
       expect(adapter.price, isNull);
+    });
+  });
+
+  group('ChargingStationAsRefuelOption — phase 4 enrichment (#1116)', () {
+    test('address composes "<address>, <postCode> <place>"', () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(
+          address: 'Bahnhofstr. 1',
+          postCode: '60311',
+          place: 'Frankfurt',
+        ),
+      );
+      expect(adapter.address, 'Bahnhofstr. 1, 60311 Frankfurt');
+    });
+
+    test('address falls back to address alone when city parts are empty',
+        () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(address: 'A1 Service Area'),
+      );
+      expect(adapter.address, 'A1 Service Area');
+    });
+
+    test('address falls back to "<postCode> <place>" when address is null',
+        () {
+      final adapter = ChargingStationAsRefuelOption(
+        _ev(postCode: '34540', place: 'Castelnau'),
+      );
+      expect(adapter.address, '34540 Castelnau');
+    });
+
+    test('address is empty when all address fields are null', () {
+      final adapter = ChargingStationAsRefuelOption(_ev());
+      expect(adapter.address, '');
+    });
+
+    test('distanceMeters converts station.dist (km) to metres', () {
+      final adapter = ChargingStationAsRefuelOption(_ev(dist: 2.5));
+      expect(adapter.distanceMeters, 2500.0);
+    });
+
+    test('distanceMeters is null when station.dist is the freezed '
+        'default 0', () {
+      final adapter = ChargingStationAsRefuelOption(_ev(dist: 0));
+      expect(adapter.distanceMeters, isNull);
+    });
+
+    test('is24h is always false until openingHours parsing lands', () {
+      final adapter = ChargingStationAsRefuelOption(_ev());
+      expect(adapter.is24h, isFalse);
+    });
+
+    test('lastUpdated prefers structured lastUpdate over legacy updatedAt',
+        () {
+      final structured = DateTime.utc(2026, 5, 4, 10, 0);
+      final adapter = ChargingStationAsRefuelOption(_ev(
+        lastUpdate: structured,
+        updatedAt: '2024-01-01T00:00:00Z',
+      ));
+      expect(adapter.lastUpdated, structured);
+    });
+
+    test('lastUpdated falls back to updatedAt parse when lastUpdate is null',
+        () {
+      final adapter = ChargingStationAsRefuelOption(_ev(
+        lastUpdate: null,
+        updatedAt: '2026-05-04T08:00:00Z',
+      ));
+      expect(adapter.lastUpdated, DateTime.parse('2026-05-04T08:00:00Z'));
+    });
+
+    test('lastUpdated is null when both timestamps are absent / unparseable',
+        () {
+      expect(
+        ChargingStationAsRefuelOption(_ev()).lastUpdated,
+        isNull,
+      );
+      expect(
+        ChargingStationAsRefuelOption(_ev(updatedAt: 'garbage')).lastUpdated,
+        isNull,
+      );
+    });
+
+    test('source returns the wrapped ChargingStation', () {
+      final s = _ev(id: 'cs-1');
+      final adapter = ChargingStationAsRefuelOption(s);
+      expect(adapter.source, same(s));
     });
   });
 }

--- a/test/core/refuel/refuel_option_test.dart
+++ b/test/core/refuel/refuel_option_test.dart
@@ -21,6 +21,16 @@ class _TestRefuelOption extends RefuelOption {
   final RefuelAvailability availability;
   @override
   final String id;
+  @override
+  final String address;
+  @override
+  final double? distanceMeters;
+  @override
+  final bool is24h;
+  @override
+  final DateTime? lastUpdated;
+  @override
+  Object get source => this;
 
   const _TestRefuelOption({
     required this.coordinates,
@@ -28,6 +38,10 @@ class _TestRefuelOption extends RefuelOption {
     required this.provider,
     required this.availability,
     required this.id,
+    this.address = '',
+    this.distanceMeters,
+    this.is24h = false,
+    this.lastUpdated,
   });
 }
 
@@ -106,6 +120,47 @@ void main() {
       );
 
       expect(o.price?.unit, RefuelPriceUnit.perSession);
+    });
+
+    test('phase-4 fields default sensibly when not specified', () {
+      // The abstract contract requires the new getters but a concrete
+      // subtype that has no upstream data for them should still be
+      // expressible. The defaults on `_TestRefuelOption` mirror what
+      // the real adapters return when the underlying entity is
+      // sparse — empty address, null distance, not-24h, no timestamp.
+      const o = _TestRefuelOption(
+        id: 'fuel:no-detail',
+        coordinates: (lat: 0.0, lng: 0.0),
+        price: null,
+        provider: RefuelProvider.unknown,
+        availability: RefuelAvailability.unknown,
+      );
+      expect(o.address, '');
+      expect(o.distanceMeters, isNull);
+      expect(o.is24h, isFalse);
+      expect(o.lastUpdated, isNull);
+    });
+
+    test('phase-4 fields round-trip through the contract', () {
+      final ts = DateTime.utc(2026, 5, 4, 12, 0);
+      final o = _TestRefuelOption(
+        id: 'fuel:detail',
+        coordinates: const (lat: 48.0, lng: 2.0),
+        price: null,
+        provider: const RefuelProvider(
+          name: 'Total',
+          kind: RefuelProviderKind.fuel,
+        ),
+        availability: RefuelAvailability.open,
+        address: '12 Rue de la Paix, 75002 Paris',
+        distanceMeters: 850.0,
+        is24h: true,
+        lastUpdated: ts,
+      );
+      expect(o.address, '12 Rue de la Paix, 75002 Paris');
+      expect(o.distanceMeters, 850.0);
+      expect(o.is24h, isTrue);
+      expect(o.lastUpdated, ts);
     });
 
     test('id format documents the type-prefix convention', () {

--- a/test/core/refuel/station_as_refuel_option_test.dart
+++ b/test/core/refuel/station_as_refuel_option_test.dart
@@ -12,8 +12,12 @@ import 'package:tankstellen/features/search/domain/entities/station.dart';
 Station _station({
   String id = '42',
   String brand = 'Total',
+  String street = 'rue de Test',
+  String postCode = '75001',
+  String place = 'Paris',
   double lat = 48.8566,
   double lng = 2.3522,
+  double dist = 0,
   double? e5,
   double? e10,
   double? e98,
@@ -30,11 +34,12 @@ Station _station({
       id: id,
       name: 'Station $id',
       brand: brand,
-      street: 'rue de Test',
-      postCode: '75001',
-      place: 'Paris',
+      street: street,
+      postCode: postCode,
+      place: place,
       lat: lat,
       lng: lng,
+      dist: dist,
       e5: e5,
       e10: e10,
       e98: e98,
@@ -171,12 +176,17 @@ void main() {
       expect(adapter.price, isNull);
     });
 
-    test('FuelType.all (meta wildcard) → null price', () {
+    test('FuelType.all (meta wildcard) → falls back to e10 price '
+        '(#1116 phase 5)', () {
+      // Phase 5: a station with at least one fuel field set must
+      // surface in the unified all-fuels view. The fallback chain
+      // prefers e10 (most common in EU); see the dedicated phase-5
+      // group below for the full ordering matrix.
       final adapter = StationAsRefuelOption(
         _station(e10: 1.699),
         FuelType.all,
       );
-      expect(adapter.price, isNull);
+      expect(adapter.price?.value, 169.9);
     });
 
     test('IEEE-754 float drift is stripped (0.1-cent precision)', () {
@@ -244,6 +254,127 @@ void main() {
         _station(e10: 1.699, updatedAt: 'not-a-date'),
       );
       expect(adapter.price?.lastUpdated, isNull);
+    });
+  });
+
+  group('StationAsRefuelOption — phase 4 enrichment (#1116)', () {
+    test('address composes "<street>, <postCode> <place>"', () {
+      final adapter = StationAsRefuelOption(
+        _station(
+          street: '12 Rue de la Paix',
+          postCode: '75002',
+          place: 'Paris',
+        ),
+      );
+      expect(adapter.address, '12 Rue de la Paix, 75002 Paris');
+    });
+
+    test('address falls back to street alone when city parts are empty',
+        () {
+      final adapter = StationAsRefuelOption(
+        _station(street: 'Hauptstraße 5', postCode: '', place: ''),
+      );
+      expect(adapter.address, 'Hauptstraße 5');
+    });
+
+    test('address falls back to "<postCode> <place>" when no street', () {
+      final adapter = StationAsRefuelOption(
+        _station(street: '', postCode: '34540', place: 'Castelnau'),
+      );
+      expect(adapter.address, '34540 Castelnau');
+    });
+
+    test('distanceMeters converts station.dist (km) to metres', () {
+      final adapter = StationAsRefuelOption(_station(dist: 1.25));
+      expect(adapter.distanceMeters, 1250.0);
+    });
+
+    test('distanceMeters is null when station.dist is the freezed '
+        'default 0', () {
+      final adapter = StationAsRefuelOption(_station(dist: 0));
+      expect(adapter.distanceMeters, isNull);
+    });
+
+    test('is24h passes through from the underlying station', () {
+      expect(StationAsRefuelOption(_station(is24h: true)).is24h, isTrue);
+      expect(StationAsRefuelOption(_station(is24h: false)).is24h, isFalse);
+    });
+
+    test('lastUpdated parses station.updatedAt into a DateTime', () {
+      final adapter = StationAsRefuelOption(
+        _station(updatedAt: '2026-05-04T08:30:00Z'),
+      );
+      expect(adapter.lastUpdated, DateTime.parse('2026-05-04T08:30:00Z'));
+    });
+
+    test('lastUpdated is null when updatedAt is missing or unparseable',
+        () {
+      expect(
+        StationAsRefuelOption(_station(updatedAt: null)).lastUpdated,
+        isNull,
+      );
+      expect(
+        StationAsRefuelOption(_station(updatedAt: '')).lastUpdated,
+        isNull,
+      );
+      expect(
+        StationAsRefuelOption(_station(updatedAt: 'garbage')).lastUpdated,
+        isNull,
+      );
+    });
+
+    test('source returns the wrapped Station', () {
+      final s = _station(id: 'abc');
+      final adapter = StationAsRefuelOption(s);
+      expect(adapter.source, same(s));
+    });
+  });
+
+  group('StationAsRefuelOption — phase 5 all-fuels fallback (#1116)', () {
+    test('FuelType.all + e10 set returns the e10 price (preferred fallback)',
+        () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: 1.749, e5: 1.799, diesel: 1.659),
+        FuelType.all,
+      );
+      expect(adapter.price?.value, 174.9);
+    });
+
+    test('FuelType.all + only diesel set returns the diesel price', () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: null, e5: null, diesel: 1.659),
+        FuelType.all,
+      );
+      expect(adapter.price?.value, 165.9);
+    });
+
+    test('FuelType.all + only e85 set returns the e85 price (rare path)',
+        () {
+      final adapter = StationAsRefuelOption(
+        _station(e10: null, e5: null, diesel: null, e85: 0.799),
+        FuelType.all,
+      );
+      expect(adapter.price?.value, 79.9);
+    });
+
+    test('FuelType.all + every fuel null returns null price', () {
+      final adapter = StationAsRefuelOption(
+        _station(e5: null, e10: null, diesel: null),
+        FuelType.all,
+      );
+      expect(adapter.price, isNull);
+    });
+
+    test('FuelType.e10 fallback does NOT trigger when fuelType is specific',
+        () {
+      // With e10 explicitly null and FuelType.e10 selected, we must
+      // return null (the user asked for e10 specifically). The
+      // all-fuels fallback only kicks in for FuelType.all.
+      final adapter = StationAsRefuelOption(
+        _station(e10: null, e5: 1.799, diesel: 1.659),
+        FuelType.e10,
+      );
+      expect(adapter.price, isNull);
     });
   });
 }

--- a/test/core/refuel/unified_search_results_provider_test.dart
+++ b/test/core/refuel/unified_search_results_provider_test.dart
@@ -92,6 +92,7 @@ Station _fuelStation({
   double? e10 = 1.749,
   double? diesel,
   String brand = 'Total',
+  double dist = 0,
 }) =>
     Station(
       id: id,
@@ -102,18 +103,24 @@ Station _fuelStation({
       place: 'Testtown',
       lat: 52.5,
       lng: 13.4,
+      dist: dist,
       e10: e10,
       diesel: diesel,
       isOpen: true,
     );
 
-ChargingStation _charger({String id = 'ev1', String? operator = 'Ionity'}) =>
+ChargingStation _charger({
+  String id = 'ev1',
+  String? operator = 'Ionity',
+  double dist = 0,
+}) =>
     ChargingStation(
       id: id,
       name: 'Charger $id',
       operator: operator,
       latitude: 52.5,
       longitude: 13.4,
+      dist: dist,
     );
 
 /// Build a container with the canned fuel + EV upstreams plus an
@@ -257,7 +264,13 @@ void main() {
   });
 
   group('unifiedSearchResultsProvider — flag on, both sides', () {
-    test('combines fuel + EV adapters with fuel first', () {
+    test('combines fuel + EV adapters when neither has a distance '
+        '(falls back to fuel-then-EV concat order)', () {
+      // Both stations have `dist == 0` (the freezed default), which the
+      // adapters surface as `distanceMeters == null`. Distance-less
+      // options sink to the bottom; among themselves the original
+      // concat order (fuel-first, then EV) is preserved by the stable
+      // List.sort.
       final c = _container(
         fuel: _fuelData([
           FuelStationResult(_fuelStation(id: 'f1', e10: 1.749)),
@@ -272,6 +285,57 @@ void main() {
       expect(list.map((o) => o.id).toList(), ['fuel:f1', 'ev:ev1']);
       expect(list.first, isA<StationAsRefuelOption>());
       expect(list.last, isA<ChargingStationAsRefuelOption>());
+    });
+
+    test('phase 4 (#1116): interleaves fuel + EV by ascending distance',
+        () {
+      // Three options with intentionally interleaved distances. The
+      // unified provider must sort by `distanceMeters` ascending so a
+      // user with both fuel and EV preferences sees the closest options
+      // first regardless of kind, NOT all fuel then all EV.
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'far', e10: 1.749, dist: 5.0)),
+          FuelStationResult(_fuelStation(id: 'near', e10: 1.799, dist: 0.5)),
+        ]),
+        ev: _evData([
+          _charger(id: 'mid', dist: 2.0),
+        ]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(
+        list.map((o) => o.id).toList(),
+        ['fuel:near', 'ev:mid', 'fuel:far'],
+      );
+    });
+
+    test('phase 4 (#1116): options without distance sink to the bottom',
+        () {
+      // The `noDist` fuel station has dist=0 (unknown) and must sort
+      // AFTER the two real-distance options regardless of kind, so a
+      // sparse upstream record never bumps a real near-by option down.
+      final c = _container(
+        fuel: _fuelData([
+          FuelStationResult(_fuelStation(id: 'noDist', e10: 1.749)),
+        ]),
+        ev: _evData([
+          _charger(id: 'evNear', dist: 0.5),
+          _charger(id: 'evFar', dist: 3.0),
+        ]),
+        flagOn: true,
+      );
+      addTearDown(c.dispose);
+      c.read(selectedFuelTypeProvider.notifier).select(FuelType.e10);
+
+      final list = c.read(unifiedSearchResultsProvider);
+      expect(
+        list.map((o) => o.id).toList(),
+        ['ev:evNear', 'ev:evFar', 'fuel:noDist'],
+      );
     });
   });
 

--- a/test/features/search/presentation/widgets/refuel_option_card_test.dart
+++ b/test/features/search/presentation/widgets/refuel_option_card_test.dart
@@ -8,6 +8,9 @@ import 'package:tankstellen/core/refuel/refuel_provider.dart';
 import 'package:tankstellen/core/refuel/station_as_refuel_option.dart';
 import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
+import 'package:tankstellen/features/search/presentation/widgets/amenity_chips.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/presentation/widgets/refuel_option_card.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
@@ -31,12 +34,23 @@ class _FakeRefuelOption extends RefuelOption {
   final RefuelAvailability availability;
   @override
   final String id;
+  @override
+  String get address => '';
+  @override
+  double? get distanceMeters => null;
+  @override
+  final bool is24h;
+  @override
+  DateTime? get lastUpdated => null;
+  @override
+  Object get source => this;
 
   const _FakeRefuelOption({
     required this.id,
     required this.provider,
     required this.availability,
     this.price,
+    this.is24h = false,
   });
 }
 
@@ -392,27 +406,12 @@ void main() {
     });
 
     testWidgets(
-        'showDistanceAtRight=false hides the trailing distance slot',
+        'showDistanceAtRight=false hides the distance text under the title',
         (tester) async {
-      // The distance slot is a SizedBox.shrink() that occupies no
-      // visible space — verify by counting siblings of the price column.
-      // When the gate is on, the slot is in the tree; when off, it
-      // isn't. We assert by widget descendant count.
-      await pumpApp(
-        tester,
-        const RefuelOptionCard(
-          option: StationAsRefuelOption(testStation, FuelType.e10),
-        ),
-      );
-      // Find the inner Row of the card.
-      final rowOn = tester.widget<Row>(find.descendant(
-        of: find.byType(RefuelOptionCard),
-        matching: find.byType(Row),
-      ).first);
-      final childCountOn = rowOn.children.length;
-
-      await tester.pumpWidget(const SizedBox.shrink());
-
+      // testStation.dist is 1.5 km → distanceMeters 1500. With the gate
+      // on the card renders a "1.5 km"-style line; with it off the
+      // distance text should NOT appear (the updated-at icon may still
+      // appear since it is independent of the distance gate).
       await pumpApp(
         tester,
         const RefuelOptionCard(
@@ -420,18 +419,213 @@ void main() {
           showDistanceAtRight: false,
         ),
       );
-      final rowOff = tester.widget<Row>(find.descendant(
-        of: find.byType(RefuelOptionCard),
-        matching: find.byType(Row),
-      ).first);
-      final childCountOff = rowOff.children.length;
+      // Distance is formatted via PriceFormatter — the digits "1.5" or
+      // "1,5" must not appear in any Text widget in the card when the
+      // gate is off. (The price digits are 1.799 so a literal "1.5"
+      // search still uniquely matches a distance label.)
+      final hasDistanceText = tester
+          .widgetList<Text>(find.byType(Text))
+          .any((w) =>
+              (w.data ?? '').contains('1.5') ||
+              (w.data ?? '').contains('1,5'));
+      expect(hasDistanceText, isFalse,
+          reason: 'distance text must not appear when '
+              'showDistanceAtRight is false');
+    });
 
-      expect(
-        childCountOn - childCountOff,
-        1,
-        reason: 'showDistanceAtRight=false must remove exactly one '
-            'slot from the trailing row',
-      );
+    group('phase 4 enrichment (#1116)', () {
+      testWidgets('renders the address line under the title', (tester) async {
+        // testStation: street "Hauptstr.", postCode "10115", place
+        // "Berlin" → "Hauptstr., 10115 Berlin". The card must surface
+        // this so the user can identify the station without tapping
+        // through to detail.
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(
+            option: StationAsRefuelOption(testStation, FuelType.e10),
+          ),
+        );
+
+        expect(find.text('Hauptstr., 10115 Berlin'), findsOneWidget);
+      });
+
+      testWidgets('renders the distance label when distanceMeters is set',
+          (tester) async {
+        // testStation.dist = 1.5 km. PriceFormatter localises the
+        // separator (1.5 vs 1,5), so assert on the digit substring that
+        // survives both forms.
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(
+            option: StationAsRefuelOption(testStation, FuelType.e10),
+          ),
+        );
+
+        final hasDistanceDigits = tester
+            .widgetList<Text>(find.byType(Text))
+            .any((w) =>
+                (w.data ?? '').contains('1.5') ||
+                (w.data ?? '').contains('1,5'));
+        expect(hasDistanceDigits, isTrue,
+            reason: 'distance "1.5 km" digits must appear under the title');
+      });
+
+      testWidgets('renders the updated-at icon when lastUpdated is set',
+          (tester) async {
+        // testStation.updatedAt sets a real timestamp → the card must
+        // render the Icons.update marker next to the elapsed-time text.
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(
+            option: StationAsRefuelOption(testStation, FuelType.e10),
+          ),
+        );
+
+        expect(find.byIcon(Icons.update), findsOneWidget);
+      });
+
+      testWidgets('renders the 24h badge when option.is24h is true',
+          (tester) async {
+        // The 24h badge sits under the status dot in the leading
+        // status column — same shape as the legacy StationCard.
+        const option = _FakeRefuelOption(
+          id: 'fuel:24h',
+          provider: RefuelProvider(
+            name: 'Total Access',
+            kind: RefuelProviderKind.fuel,
+          ),
+          availability: RefuelAvailability.open,
+          is24h: true,
+        );
+
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(option: option),
+        );
+
+        expect(find.text('24h'), findsOneWidget);
+      });
+
+      testWidgets('omits the 24h badge when option.is24h is false',
+          (tester) async {
+        const option = _FakeRefuelOption(
+          id: 'fuel:no24',
+          provider: RefuelProvider(
+            name: 'Total',
+            kind: RefuelProviderKind.fuel,
+          ),
+          availability: RefuelAvailability.open,
+          is24h: false,
+        );
+
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(option: option),
+        );
+
+        expect(find.text('24h'), findsNothing);
+      });
+
+      testWidgets('renders amenity chips for fuel-kind options', (tester) async {
+        // testStation has no amenities, so build a station with one to
+        // exercise the path. We use the public `Station` constructor
+        // directly here rather than a fixture clone — keeps the test
+        // narrow and free of helper imports.
+        const stationWithAmenities = Station(
+          id: 'amen-1',
+          name: 'Test',
+          brand: 'Total',
+          street: 'Hauptstr.',
+          postCode: '10115',
+          place: 'Berlin',
+          lat: 52.5,
+          lng: 13.4,
+          dist: 0.5,
+          isOpen: true,
+          amenities: {StationAmenity.toilet, StationAmenity.shop},
+        );
+
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(
+            option: StationAsRefuelOption(stationWithAmenities, FuelType.e10),
+          ),
+        );
+
+        // AmenityChips renders a Wrap with one _AmenityChip per amenity;
+        // assert by widget type from the helper.
+        expect(find.byType(AmenityChips), findsOneWidget);
+        final chips = tester.widget<AmenityChips>(find.byType(AmenityChips));
+        expect(chips.amenities, {StationAmenity.toilet, StationAmenity.shop});
+      });
+
+      testWidgets('omits amenity chips when fuel station has no amenities',
+          (tester) async {
+        // testStation.amenities is the default `{}` set.
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(
+            option: StationAsRefuelOption(testStation, FuelType.e10),
+          ),
+        );
+
+        // AmenityChips returns SizedBox.shrink() on an empty set, but
+        // the parent widget must not even instantiate it when empty —
+        // that guards against accidental layout space being reserved.
+        expect(find.byType(AmenityChips), findsNothing);
+      });
+
+      testWidgets('renders EV stats row for EV-kind options', (tester) async {
+        // _evChargingStation has one CCS connector at 350 kW (status
+        // is the legacy default, which decodes to ConnectorStatus
+        // .unknown — so available count is 0/1).
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(
+            option: ChargingStationAsRefuelOption(_evChargingStation),
+          ),
+        );
+
+        expect(find.byIcon(Icons.electrical_services), findsOneWidget);
+        // The stats text should include the kW number, the X/Y count,
+        // and the connector type. The exact separator is "·" but we
+        // only assert the substrings to keep the test resilient.
+        final hasStats = tester
+            .widgetList<Text>(find.byType(Text))
+            .any((w) =>
+                (w.data ?? '').contains('350 kW') &&
+                (w.data ?? '').contains('CCS'));
+        expect(hasStats, isTrue,
+            reason: 'EV stats row must include kW + connector type');
+      });
+
+      testWidgets(
+          'omits the address line when option.address is empty',
+          (tester) async {
+        // A sparse option (no address data) must not render an empty
+        // address Text widget — the card collapses gracefully.
+        const option = _FakeRefuelOption(
+          id: 'sparse:1',
+          provider: RefuelProvider(
+            name: 'Generic Station',
+            kind: RefuelProviderKind.fuel,
+          ),
+          availability: RefuelAvailability.open,
+        );
+
+        await pumpApp(
+          tester,
+          const RefuelOptionCard(option: option),
+        );
+
+        // Generic Station appears (title), the availability fallback
+        // ("Open") appears under it. No empty Text widgets.
+        final emptyTexts = tester
+            .widgetList<Text>(find.byType(Text))
+            .where((w) => (w.data ?? '').isEmpty);
+        expect(emptyTexts, isEmpty,
+            reason: 'no empty Text widgets when address is unavailable');
+      });
     });
 
     testWidgets('option with null price (EV phase-2 adapter) renders cleanly',

--- a/test/features/search/presentation/widgets/unified_search_results_view_test.dart
+++ b/test/features/search/presentation/widgets/unified_search_results_view_test.dart
@@ -25,6 +25,16 @@ class _FakeRefuelOption extends RefuelOption {
   final RefuelAvailability availability;
   @override
   final String id;
+  @override
+  String get address => '';
+  @override
+  double? get distanceMeters => null;
+  @override
+  bool get is24h => false;
+  @override
+  DateTime? get lastUpdated => null;
+  @override
+  Object get source => this;
 
   const _FakeRefuelOption({
     required this.id,


### PR DESCRIPTION
## Summary

Closes the gap that triggered the user's "unified results are a regression" report from device-test on 2026-05-04. The unified `RefuelOptionCard` previously rendered only a status dot, generic kind icon, brand title, "Open" label, and a price — losing every detail the legacy `StationCard` surfaces. Phases 4 + 5 in this PR restore parity for fuel and add EV-relevant information for chargers so a user toggling the feature flag on/off no longer experiences a content cliff.

## What ships

### Phase 4 — interface enrichment + interleaved sort

Added to `RefuelOption` abstract contract:
- `address` — composed `<street>, <postCode> <place>` for fuel; `ChargingStation.address` for EV
- `distanceMeters` — km → m at the abstract layer; freezed default `0` treated as "unknown"
- `is24h` — fuel pass-through; EV always false until openingHours parsing lands
- `lastUpdated` — ISO-8601 parse; structured `lastUpdate` preferred on EV

`unifiedSearchResultsProvider` now sorts the merged list by `distanceMeters` ascending so the closest options interleave regardless of kind (instead of fuel-then-EV blocks).

Card rebuild matches `StationCard` density: status dot + 24h badge stacked, kind icon, title, address line, distance/updated row, price column.

### Phase 5 — kind-specific extras + true unification

Added `Object source` getter to `RefuelOption` so the card can downcast for kind-specific extras while generic consumers (sort/filter/dedup) stay abstract.

- **Fuel**: amenity icon chips via the existing `AmenityChips` widget (toilet, shop, car-wash, etc.)
- **EV**: one-line connector summary — `350 kW · 0 / 4 · CCS` — derived from `ChargingStation.connectors` (max kW, available/total, sorted unique types capped at three with `+N` overflow)

`UnifiedSearchResultsView.onTap` now routes to the same screens the legacy `SearchResultsList` uses (`/station/<id>` for fuel, `/ev-station` with the `ChargingStation` extra for EV).

**All-fuels regression fix**: when `selectedFuelTypeProvider == FuelType.all`, the fuel adapter falls back to the first available fuel field (`e10 → e5 → diesel → e98 → lpg → e85 → dieselPremium → cng`). Previously every fuel station was filtered out by the provider's `price == null` guard in all-fuels mode.

## Tests

146 in the touched files pass. New coverage:
- 8 contract tests for the new abstract getters
- 14 adapter tests for fuel + EV phase 4 + 5 fields, including all-fuels fallback ordering
- 4 unified-provider sort tests (interleave-by-distance, nulls-sink)
- 7 card widget tests (address, distance, updated-at icon, 24h badge, amenity chips, EV stats row, source-aware rendering)

`flutter analyze` clean.

## Not in this PR (deferred — phase 6 if prioritised)

- Favorite star + toggle plumbing
- Loyalty discount badge (#1120 pilot)
- Cheapest indicator + rating stars + price-tier arrow
- Multi-fuel rows in all-fuels mode (legacy shows e5/e10/diesel simultaneously; this PR shows the fallback only)
- Hero animation on brand title

## Test plan

- [ ] APK device-test: enable Settings → Feature management → "Unified search results"
- [ ] Search a fuel-rich area, verify each card now shows brand, address, distance, updated time, amenities, price + unit
- [ ] Toggle EV-only filter, verify each EV card shows operator, address, distance, kW + connector count + types
- [ ] Toggle "Both" filter, verify the list interleaves by distance (closest first regardless of kind)
- [ ] Tap a fuel card → opens `/station/<id>` detail; tap an EV card → opens `/ev-station` detail
- [ ] All-fuels selector: fuel stations appear (regression fixed)