### PR TITLE
feat(consumption): GPS sleep instrumentation + unpinned-recording warning (Refs #1458 phase 2)

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -59,6 +59,18 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
+    // #1458 phase 2 — push every lifecycle transition into the trip
+    // provider so the GPS sampling diagnostics recorder can tag each
+    // fix with the right state. Cheap (single field write) so always
+    // fire regardless of recording state.
+    try {
+      ref
+          .read(tripRecordingProvider.notifier)
+          .onAppLifecycleStateChanged(state);
+    } catch (e, st) {
+      debugPrint(
+          'TankstellenApp: onAppLifecycleStateChanged failed: $e\n$st');
+    }
     if (state != AppLifecycleState.paused &&
         state != AppLifecycleState.inactive) {
       return;

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -6,6 +6,7 @@ import 'package:hive/hive.dart';
 import '../../../../core/storage/hive_boxes.dart';
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../domain/entities/gps_sample_diagnostic.dart';
 import '../../domain/services/gear_inference.dart';
 import '../../domain/trip_recorder.dart';
 import '../trip_history_repository.dart';
@@ -336,6 +337,28 @@ class TripRecordingController {
   /// [TripHistoryEntry] at stop time.
   List<TripSample> get capturedSamples => List.unmodifiable(_capturedSamples);
 
+  /// Per-trip GPS cadence diagnostics buffer (#1458 phase 2). Appended
+  /// to by [recordGpsSampleDiagnostic] every time the provider's
+  /// position-stream listener fires; persisted onto the saved
+  /// [TripHistoryEntry] at stop time. Capped at
+  /// [_gpsSampleDiagnosticCap] so a forgotten recording can't eat
+  /// unbounded memory.
+  final List<GpsSampleDiagnostic> _gpsSampleDiagnostics =
+      <GpsSampleDiagnostic>[];
+
+  /// Cap on the GPS diagnostics buffer (#1458 phase 2). At ~1 Hz GPS
+  /// fix cadence the cap covers ~33 hours — comfortably above any
+  /// plausible single trip and well below the trip-detail JSON
+  /// size budget.
+  static const int _gpsSampleDiagnosticCap = 120000;
+
+  /// Read-only snapshot of the GPS cadence diagnostics buffer
+  /// (#1458 phase 2). The list is unmodifiable so callers can't
+  /// accidentally mutate the controller's state — the provider clones
+  /// it into the persisted [TripHistoryEntry] at stop time.
+  List<GpsSampleDiagnostic> get capturedGpsSampleDiagnostics =>
+      List.unmodifiable(_gpsSampleDiagnostics);
+
   /// Latest parsed values, keyed by PID command. Written by scheduler
   /// callbacks, read by [_emit] when assembling [TripLiveReading]. Not
   /// using a typed struct because most fields are optional doubles
@@ -519,6 +542,48 @@ class TripRecordingController {
   void updateGpsFix({double? latitude, double? longitude}) {
     _latestLatitude = latitude;
     _latestLongitude = longitude;
+  }
+
+  /// #1458 phase 2 — append one cadence-diagnostic record at [now]
+  /// with the given app [lifecycleState]. The provider calls this from
+  /// its position-stream listener immediately AFTER [updateGpsFix] so
+  /// the two streams stay aligned: the user-facing
+  /// [TripSample.latitude]/[TripSample.longitude] capture path is
+  /// unchanged, and the diagnostic is a strictly additive observation
+  /// of "did this fix arrive while the app was foreground or paused".
+  ///
+  /// The index assigned to the diagnostic is the buffer's length at
+  /// insertion time so it is monotonic per trip and stable across
+  /// process restarts (a forgotten recording that bumps into
+  /// [_gpsSampleDiagnosticCap] drops the OLDEST samples first — the
+  /// `index` field surfaces those gaps).
+  void recordGpsSampleDiagnostic({
+    required DateTime now,
+    required String lifecycleState,
+  }) {
+    final entry = GpsSampleDiagnostic(
+      timestamp: now,
+      lifecycleState: lifecycleState,
+      index: _gpsSampleDiagnostics.length,
+    );
+    _gpsSampleDiagnostics.add(entry);
+    if (_gpsSampleDiagnostics.length > _gpsSampleDiagnosticCap) {
+      // Drop the oldest slice — losing the early stretch is preferable
+      // to letting a forgotten overnight recording eat unbounded memory.
+      _gpsSampleDiagnostics.removeRange(
+        0,
+        _gpsSampleDiagnostics.length - _gpsSampleDiagnosticCap,
+      );
+    }
+  }
+
+  /// Exposed for tests: append a cadence diagnostic without going
+  /// through [recordGpsSampleDiagnostic]. Lets the provider tests
+  /// pre-seed a controller's buffer + drive [stop] end-to-end without
+  /// needing a real Geolocator stream.
+  @visibleForTesting
+  void debugCaptureGpsSampleDiagnostic(GpsSampleDiagnostic diagnostic) {
+    _gpsSampleDiagnostics.add(diagnostic);
   }
 
   /// Read-only snapshot of the most recent GPS latitude pushed in via

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
+import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/trip_recorder.dart';
 
 /// One finalised trip as shown in the Trip history list (#726).
@@ -58,6 +59,16 @@ class TripHistoryEntry {
   /// migrate the trip-history schema again.
   final String? adapterFirmware;
 
+  /// Per-sample GPS cadence diagnostics captured under phone-sleep
+  /// conditions (#1458 phase 2). Records the wall-clock timestamp and
+  /// app-lifecycle state at every position fix, plus a monotonic index
+  /// — lets a future diagnostics sheet (or a power user inspecting
+  /// the persisted entry) reconstruct exactly when the OS throttled or
+  /// paused the GPS stream during an unpinned recording. Empty for
+  /// trips recorded before #1458 phase 2 landed and for trips whose
+  /// `Feature.gpsTripPath` flag was off at recording start.
+  final List<GpsSampleDiagnostic> gpsSampleDiagnostics;
+
   const TripHistoryEntry({
     required this.id,
     required this.vehicleId,
@@ -67,6 +78,7 @@ class TripHistoryEntry {
     this.adapterMac,
     this.adapterName,
     this.adapterFirmware,
+    this.gpsSampleDiagnostics = const [],
   });
 
   Map<String, dynamic> toJson() => {
@@ -84,6 +96,14 @@ class TripHistoryEntry {
         if (adapterMac != null) 'adapterMac': adapterMac,
         if (adapterName != null) 'adapterName': adapterName,
         if (adapterFirmware != null) 'adapterFirmware': adapterFirmware,
+        // #1458 phase 2 — GPS cadence diagnostics. Compact key 'gpsd'
+        // keeps the per-trip JSON tight; emitted only when at least one
+        // diagnostic was recorded so legacy trips and flag-off trips
+        // round-trip unchanged.
+        if (gpsSampleDiagnostics.isNotEmpty)
+          'gpsd': gpsSampleDiagnostics
+              .map((d) => d.toJson())
+              .toList(growable: false),
       };
 
   static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
@@ -106,6 +126,15 @@ class TripHistoryEntry {
         adapterMac: json['adapterMac'] as String?,
         adapterName: json['adapterName'] as String?,
         adapterFirmware: json['adapterFirmware'] as String?,
+        // #1458 phase 2 — GPS cadence diagnostics. Missing key →
+        // empty list so trips recorded before this PR (and flag-off
+        // trips that never recorded a diagnostic) deserialise cleanly.
+        gpsSampleDiagnostics: (json['gpsd'] as List?)
+                ?.map((e) => GpsSampleDiagnostic.fromJson(
+                      (e as Map).cast<String, dynamic>(),
+                    ))
+                .toList(growable: false) ??
+            const [],
       );
 }
 

--- a/lib/features/consumption/domain/entities/gps_sample_diagnostic.dart
+++ b/lib/features/consumption/domain/entities/gps_sample_diagnostic.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+
+/// One per-sample GPS-cadence diagnostic record (#1458 phase 2).
+///
+/// Captured every time the trip recording provider receives a
+/// `Geolocator.getPositionStream()` event while a recording is active.
+/// Persisted as a sibling list on the trip history entry so the user
+/// (or a future "diagnostics" sheet) can inspect the actual sampling
+/// cadence after a trip — in particular: did Android keep delivering
+/// position updates while the screen was unpinned and the phone went to
+/// sleep, or did the OS throttle / pause the stream?
+///
+/// The recorder DOES NOT touch the user's persisted GPS path data — the
+/// existing per-tick [TripSample.latitude]/[TripSample.longitude] keep
+/// their semantics. This entity is a strictly additive observation
+/// channel: timestamp + lifecycle state + a monotonically increasing
+/// index, nothing else.
+@immutable
+class GpsSampleDiagnostic {
+  /// Wall-clock timestamp at the moment the position fix arrived in
+  /// the provider's stream listener. Uses the same `DateTime.now()`
+  /// source as [TripSample.timestamp] so the two streams can be
+  /// cross-referenced post-trip.
+  final DateTime timestamp;
+
+  /// Snapshot of the host app's lifecycle state at the time the fix
+  /// arrived. Stored as a string (the [AppLifecycleState] enum's
+  /// `name`) so the JSON round-trip is stable across SDK upgrades that
+  /// might add new states. Known values today: `'resumed'`, `'inactive'`,
+  /// `'paused'`, `'detached'`, `'hidden'` (Flutter 3.13+).
+  final String lifecycleState;
+
+  /// Monotonically increasing index assigned by the controller's
+  /// per-trip counter — first diagnostic in a trip is index 0, second
+  /// is index 1, etc. Lets a future diagnostics sheet detect gaps if
+  /// the underlying stream skipped fixes (e.g. the OS killed and
+  /// restarted the GPS service mid-trip).
+  final int index;
+
+  const GpsSampleDiagnostic({
+    required this.timestamp,
+    required this.lifecycleState,
+    required this.index,
+  });
+
+  /// Compact JSON encoding mirroring the [TripSample] convention
+  /// already used by [TripHistoryEntry]: short keys keep per-trip
+  /// payload bytes low ('t', 'ls', 'i'). Timestamp goes through
+  /// `millisecondsSinceEpoch` for fast parse + lossless round-trip.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        't': timestamp.millisecondsSinceEpoch,
+        'ls': lifecycleState,
+        'i': index,
+      };
+
+  static GpsSampleDiagnostic fromJson(Map<String, dynamic> json) =>
+      GpsSampleDiagnostic(
+        timestamp: DateTime.fromMillisecondsSinceEpoch(
+          (json['t'] as num).toInt(),
+        ),
+        lifecycleState: json['ls'] as String,
+        index: (json['i'] as num).toInt(),
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is GpsSampleDiagnostic &&
+      other.timestamp == timestamp &&
+      other.lifecycleState == lifecycleState &&
+      other.index == index;
+
+  @override
+  int get hashCode => Object.hash(timestamp, lifecycleState, index);
+
+  @override
+  String toString() =>
+      'GpsSampleDiagnostic(t=$timestamp, ls=$lifecycleState, i=$index)';
+}

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -85,6 +85,19 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   /// user opts back in each drive so battery-drain never lingers.
   bool _pinned = false;
 
+  /// #1458 phase 2 — sticky guard so the unpinned-recording GPS
+  /// warning SnackBar fires AT MOST once per recording-screen mount.
+  /// Pinning + unpinning + leaving + returning intentionally re-fires
+  /// because it's a fresh mount each time; what we want to avoid is
+  /// spamming on every rebuild that re-enters the post-frame check.
+  bool _unpinnedWarningShown = false;
+
+  /// #1458 phase 2 — deferred-show timer for the unpinned-recording
+  /// warning. Cancelled on dispose so the SnackBar never fires after
+  /// the screen has been popped (which would inject the warning into
+  /// the next route's messenger, polluting unrelated screens).
+  Timer? _unpinnedWarningTimer;
+
   /// Cached facade handle so [dispose] can release the wake lock
   /// without touching `ref` (Riverpod forbids `ref.read` after the
   /// widget is deactivated). Populated the first time the user pins.
@@ -106,6 +119,20 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     // so a `setState`-light listener is fine here.
     final lifecycle = ref.read(hapticEcoCoachLifecycleProvider.notifier);
     _coachEventsSub = lifecycle.coachEvents.listen(_onCoachEvent);
+    // #1458 phase 2 — schedule the unpinned-recording GPS warning
+    // shortly after the screen has settled. We defer rather than fire
+    // in the immediate post-frame callback for two reasons:
+    //   1. Other on-mount SnackBars (broken-MAP belief crossings,
+    //      eco-coach live events) win the race and own the messenger
+    //      slot during the first frame; queueing ours behind theirs
+    //      would let them clobber each other.
+    //   2. Production users see the warning ~0.6 s after landing —
+    //      late enough that it doesn't compete with other initial
+    //      animations, early enough that they read it before the
+    //      first GPS sample interval.
+    _unpinnedWarningTimer = Timer(const Duration(milliseconds: 600), () {
+      _maybeShowUnpinnedWarning();
+    });
   }
 
   @override
@@ -128,6 +155,11 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     }
     _coachEventsSub?.cancel();
     _coachEventsSub = null;
+    // #1458 phase 2 — cancel any pending unpinned-warning fire so the
+    // SnackBar never lands in the next route's messenger after the
+    // user has popped this screen.
+    _unpinnedWarningTimer?.cancel();
+    _unpinnedWarningTimer = null;
     super.dispose();
   }
 
@@ -155,6 +187,67 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
               child: Text(
                 l?.hapticEcoCoachSnackBarMessage ??
                     'Easy on the throttle — coasting saves more',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// #1458 phase 2 — surface a one-shot SnackBar warning when the user
+  /// arrives at the recording screen with the pin toggle OFF AND a
+  /// trip is currently active. Pinning keeps the screen on + hides
+  /// system bars; without it, Android may throttle GPS during sleep
+  /// and the trip path heatmap will show gaps. Production telemetry
+  /// (issue #1458 phase 2) feeds the persisted [GpsSampleDiagnostic]
+  /// list so a future iteration can quantify the throttle rate per
+  /// device — the warning is the upfront mitigation while we
+  /// instrument the live behaviour.
+  ///
+  /// Suppressed when [_pinned] is true because pinning is the actual
+  /// fix; nagging the user who already opted in would be noise. The
+  /// [_unpinnedWarningShown] guard prevents re-firing within a single
+  /// screen mount even if the post-frame callback runs multiple
+  /// times (it fires once per [WidgetsBinding.instance] schedule —
+  /// the guard is a defence against the observed case where a parent
+  /// rebuild re-enters initState during pumpAndSettle in widget
+  /// tests).
+  void _maybeShowUnpinnedWarning() {
+    if (!mounted) return;
+    if (_unpinnedWarningShown) return;
+    if (_pinned) return;
+    final notifier = ref.read(tripRecordingProvider.notifier);
+    final recordingState = ref.read(tripRecordingProvider);
+    if (!recordingState.isActive) return;
+    // Only fire on a FRESH recording mount — i.e. the user just tapped
+    // Start Recording in the trajets tab and was navigated here. When
+    // they return to the screen later via the banner (after backing
+    // out mid-trip), `lastTripStartedAt` is well in the past and the
+    // warning would just be noise. We use a 10 s window so the
+    // 600 ms post-mount delay + any test-pump + any production
+    // initState→post-frame race comfortably falls inside.
+    final startedAt = notifier.lastTripStartedAt;
+    if (startedAt == null) return;
+    final age = DateTime.now().difference(startedAt);
+    if (age > const Duration(seconds: 10)) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    final l = AppLocalizations.of(context);
+    _unpinnedWarningShown = true;
+    messenger.showSnackBar(
+      SnackBar(
+        key: const Key('tripRecordingUnpinnedWarningSnackBar'),
+        duration: const Duration(seconds: 8),
+        content: Row(
+          children: [
+            const Icon(Icons.gps_off, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                l?.tripRecordingUnpinnedWarning ??
+                    'Pin the screen to keep GPS active during the trip '
+                        '— Android may throttle GPS during sleep.',
               ),
             ),
           ],
@@ -202,6 +295,12 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
   Future<void> _onStop() async {
     if (_stopping) return;
     setState(() => _stopping = true);
+    // #1458 phase 2 — hide the unpinned-recording warning if it's still
+    // visible. The warning is about an in-progress recording; once the
+    // user has tapped Stop, the recording is over and the SnackBar
+    // would just be sitting on top of the summary view's discard /
+    // save buttons until its auto-dismiss timer elapsed.
+    ScaffoldMessenger.maybeOf(context)?.hideCurrentSnackBar();
     final result = await ref.read(tripRecordingProvider.notifier).stop();
     if (!mounted) return;
     // #891 — when the recording ends, auto-release the wake lock

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -32,6 +32,7 @@ import '../data/obd2/trip_recording_controller.dart';
 import 'obd2_breadcrumb_provider.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/cold_start_baselines.dart';
+import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/situation_classifier.dart';
 import '../domain/trip_recorder.dart';
 import 'haptic_feedback_policy.dart';
@@ -94,6 +95,16 @@ class TripRecording extends _$TripRecording {
   String? _adapterMac;
   String? _adapterName;
   String? _adapterFirmware;
+
+  // #1458 phase 2 — most recent app lifecycle state observed by the
+  // wiring layer's [WidgetsBindingObserver]. Read by the GPS stream
+  // listener every time a position fix arrives so the resulting
+  // [GpsSampleDiagnostic] carries an accurate "was the phone awake?"
+  // tag. Defaults to `resumed` so the very first sample on a freshly
+  // started recording (where no lifecycle event has fired yet) is
+  // tagged optimistically — the user just tapped Start, the app is
+  // certainly foreground.
+  AppLifecycleState _lifecycleState = AppLifecycleState.resumed;
 
   /// Tests count haptic fires via these instead of hooking the
   /// platform channel. The production path also still calls
@@ -693,6 +704,14 @@ class TripRecording extends _$TripRecording {
     // the controller — without this the trip-detail charts render the
     // "No samples recorded" empty state on every saved trip (#1040).
     final capturedSamples = List<TripSample>.unmodifiable(ctl.capturedSamples);
+    // #1458 phase 2 — snapshot the GPS cadence diagnostics buffer
+    // BEFORE the controller is torn down, same reason as the sample
+    // buffer above. Always captured (empty list when the GPS feature
+    // flag was off for this trip) so the persistence path stays
+    // unconditional and the JSON encoder elides the key when empty.
+    final capturedGpsDiagnostics = List<GpsSampleDiagnostic>.unmodifiable(
+      ctl.capturedGpsSampleDiagnostics,
+    );
     final summary = await ctl.stop();
     final odometerStartKm = ctl.odometerStartKm;
     final odometerLatestKm = ctl.odometerLatestKm;
@@ -714,6 +733,7 @@ class TripRecording extends _$TripRecording {
     await _saveToHistory(
       summary,
       samples: capturedSamples,
+      gpsSampleDiagnostics: capturedGpsDiagnostics,
       automatic: automatic,
     );
     // #769 — flush learned baselines before releasing the service so
@@ -846,10 +866,22 @@ class TripRecording extends _$TripRecording {
         ),
       )
           .listen(
-        (pos) => ctl.updateGpsFix(
-          latitude: pos.latitude,
-          longitude: pos.longitude,
-        ),
+        (pos) {
+          ctl.updateGpsFix(
+            latitude: pos.latitude,
+            longitude: pos.longitude,
+          );
+          // #1458 phase 2 — record one cadence-diagnostic per fix so the
+          // user can see, post-trip, whether the OS kept delivering
+          // position updates while the phone was asleep / unpinned. The
+          // call is cheap (one allocation + one list append, capped) so
+          // it's safe on the hot path; the in-memory buffer is flushed
+          // onto the persisted [TripHistoryEntry] at trip-stop time.
+          ctl.recordGpsSampleDiagnostic(
+            now: DateTime.now(),
+            lifecycleState: _lifecycleState.name,
+          );
+        },
         onError: (Object error) {
           debugPrint('TripRecording GPS stream error: $error');
         },
@@ -1163,6 +1195,27 @@ class TripRecording extends _$TripRecording {
     await _flushActiveSnapshot(force: true);
   }
 
+  /// #1458 phase 2 — track every app-lifecycle transition so the GPS
+  /// diagnostic recorder knows whether each fix arrived while the
+  /// phone was foreground (`resumed`) or backgrounded (`paused` /
+  /// `inactive` / `hidden`). Wired in from the same
+  /// [WidgetsBindingObserver] that fires [onAppBackgrounded] so the
+  /// two hooks stay in lock-step. Cheap (a single field write) so it's
+  /// safe to fire on every transition regardless of recording state —
+  /// reading [_lifecycleState] from the GPS stream listener is then a
+  /// pure local read.
+  void onAppLifecycleStateChanged(AppLifecycleState state) {
+    _lifecycleState = state;
+  }
+
+  /// Exposed for tests — reads back the most recent lifecycle state
+  /// pushed in via [onAppLifecycleStateChanged]. Lets a test verify
+  /// that a diagnostic was tagged with the right state at the moment
+  /// the GPS fix arrived without depending on platform-channel
+  /// plumbing.
+  @visibleForTesting
+  AppLifecycleState get debugLifecycleState => _lifecycleState;
+
   /// Surface the recovered snapshot from a previous cold-start
   /// recovery walk. Phase 2 of #1303: hands the user back into a
   /// `pausedDueToDrop`-shaped state with their captured samples
@@ -1293,6 +1346,7 @@ class TripRecording extends _$TripRecording {
     TripSummary summary, {
     bool automatic = false,
     List<TripSample> samples = const [],
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
   }) async {
     // Skip empty trips — the user tapped Stop without any usable
     // sample, or the service disconnected immediately. No signal, no
@@ -1315,6 +1369,10 @@ class TripRecording extends _$TripRecording {
         adapterMac: _adapterMac,
         adapterName: _adapterName,
         adapterFirmware: _adapterFirmware,
+        // #1458 phase 2 — GPS cadence diagnostics captured during
+        // recording. Empty when the GPS feature flag was off for this
+        // trip; the entry's JSON serialiser elides the key in that case.
+        gpsSampleDiagnostics: gpsSampleDiagnostics,
       ));
       ref.read(tripHistoryListProvider.notifier).refresh();
       // Phase 5 (#1004): bump the launcher-icon badge so the user sees

--- a/lib/l10n/_fragments/trip_recording_pin_de.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_de.arb
@@ -15,5 +15,6 @@
   "tripRecordingPinHelpTitle": "Über das Anpinnen",
   "tripRecordingPinHelpBody": "Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.",
   "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.",
-  "tripBannerOpenFromConsumptionTab": "Aktive Fahrt aus dem Verbrauchs-Tab öffnen"
+  "tripBannerOpenFromConsumptionTab": "Aktive Fahrt aus dem Verbrauchs-Tab öffnen",
+  "tripRecordingUnpinnedWarning": "Bildschirm anpinnen, damit das GPS während der Fahrt aktiv bleibt — Android kann das GPS im Ruhezustand drosseln."
 }

--- a/lib/l10n/_fragments/trip_recording_pin_en.arb
+++ b/lib/l10n/_fragments/trip_recording_pin_en.arb
@@ -30,5 +30,9 @@
   "tripBannerOpenFromConsumptionTab": "Open the active trip from the Conso tab",
   "@tripBannerOpenFromConsumptionTab": {
     "description": "Snackbar shown when the user taps the trip-recording banner on a screen whose context is above the GoRouter ancestor (#1322). Falls back from a navigation push to a hint pointing the user at the consumption tab."
+  },
+  "tripRecordingUnpinnedWarning": "Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.",
+  "@tripRecordingUnpinnedWarning": {
+    "description": "One-shot SnackBar shown the moment the user lands on the trip-recording screen with the pin toggle OFF (#1458 phase 2). Warns that without pinning, Android may suspend or throttle GPS while the screen sleeps and the captured path will show gaps."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1797,6 +1797,7 @@
   "tripRecordingPinHelpBody": "Anpinnen hält den Bildschirm an und blendet die Systemleisten aus, damit das Formular auf einer Armaturenhalterung lesbar bleibt. Erneut tippen, um zu lösen. Wird automatisch beendet, wenn die Fahrt stoppt.",
   "tripRecordingResumeHintMessage": "Die Aufnahme läuft im Hintergrund weiter. Tippe oben auf das rote Banner, um zurückzukehren.",
   "tripBannerOpenFromConsumptionTab": "Aktive Fahrt aus dem Verbrauchs-Tab öffnen",
+  "tripRecordingUnpinnedWarning": "Bildschirm anpinnen, damit das GPS während der Fahrt aktiv bleibt — Android kann das GPS im Ruhezustand drosseln.",
   "unifiedFilterFuel": "Kraftstoff",
   "unifiedFilterEv": "EV",
   "unifiedFilterBoth": "Beide",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3319,6 +3319,10 @@
   "@tripBannerOpenFromConsumptionTab": {
     "description": "Snackbar shown when the user taps the trip-recording banner on a screen whose context is above the GoRouter ancestor (#1322). Falls back from a navigation push to a hint pointing the user at the consumption tab."
   },
+  "tripRecordingUnpinnedWarning": "Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.",
+  "@tripRecordingUnpinnedWarning": {
+    "description": "One-shot SnackBar shown the moment the user lands on the trip-recording screen with the pin toggle OFF (#1458 phase 2). Warns that without pinning, Android may suspend or throttle GPS while the screen sleeps and the captured path will show gaps."
+  },
   "unifiedFilterFuel": "Fuel",
   "@unifiedFilterFuel": {
     "description": "Filter chip label that narrows the unified search list to fuel pumps only (#1116 phase 3c)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -806,6 +806,7 @@
   "tripBannerRecording": "Enregistrement en cours",
   "tripBannerPaused": "Trajet en pause — toucher pour reprendre",
   "tripBannerOpenFromConsumptionTab": "Ouvrez le trajet actif depuis l'onglet Conso",
+  "tripRecordingUnpinnedWarning": "Épinglez l'écran pour garder le GPS actif pendant le trajet — Android peut limiter le GPS en veille.",
   "navConsumption": "Conso",
   "vehicleBaselineSectionTitle": "Calibrage de la baseline",
   "vehicleBaselineEmpty": "Aucun échantillon pour l'instant — lancez un trajet OBD2 pour commencer à apprendre le profil de consommation de ce véhicule.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8270,6 +8270,12 @@ abstract class AppLocalizations {
   /// **'Open the active trip from the Conso tab'**
   String get tripBannerOpenFromConsumptionTab;
 
+  /// One-shot SnackBar shown the moment the user lands on the trip-recording screen with the pin toggle OFF (#1458 phase 2). Warns that without pinning, Android may suspend or throttle GPS while the screen sleeps and the captured path will show gaps.
+  ///
+  /// In en, this message translates to:
+  /// **'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.'**
+  String get tripRecordingUnpinnedWarning;
+
   /// Filter chip label that narrows the unified search list to fuel pumps only (#1116 phase 3c).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4515,6 +4515,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4515,6 +4515,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4513,6 +4513,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4557,6 +4557,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Aktive Fahrt aus dem Verbrauchs-Tab öffnen';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Bildschirm anpinnen, damit das GPS während der Fahrt aktiv bleibt — Android kann das GPS im Ruhezustand drosseln.';
+
+  @override
   String get unifiedFilterFuel => 'Kraftstoff';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4517,6 +4517,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4508,6 +4508,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4516,6 +4516,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4510,6 +4510,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4513,6 +4513,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4564,6 +4564,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ouvrez le trajet actif depuis l\'onglet Conso';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Épinglez l\'écran pour garder le GPS actif pendant le trajet — Android peut limiter le GPS en veille.';
+
+  @override
   String get unifiedFilterFuel => 'Carburant';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4512,6 +4512,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4517,6 +4517,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4516,6 +4516,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4514,6 +4514,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4516,6 +4516,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4512,6 +4512,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4517,6 +4517,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4515,6 +4515,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4516,6 +4516,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4515,6 +4515,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4516,6 +4516,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4510,6 +4510,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4514,6 +4514,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Open the active trip from the Conso tab';
 
   @override
+  String get tripRecordingUnpinnedWarning =>
+      'Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.';
+
+  @override
   String get unifiedFilterFuel => 'Fuel';
 
   @override

--- a/test/features/consumption/presentation/screens/trip_recording_screen_unpinned_warning_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_unpinned_warning_test.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
+import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Regression coverage for #1458 phase 2 — when the user lands on the
+/// trip-recording screen with the pin toggle OFF AND a recording is
+/// active, a one-shot SnackBar must surface explaining that the screen
+/// has to be pinned to keep GPS active.
+///
+/// Three contracts:
+///   1. The SnackBar fires the moment the screen mounts on an active
+///      recording with `_pinned` defaulting to false.
+///   2. A non-active state (e.g. provider in `idle` because the test
+///      harness hasn't started a recording) does NOT fire the warning
+///      — there's nothing to warn about.
+///   3. The SnackBar must NOT fire twice for the same screen mount —
+///      a guard prevents the post-frame check from re-entering on a
+///      rebuild and spamming the user.
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+
+  @override
+  Future<void> disable() async {}
+}
+
+/// Minimal fake [TripRecording] that lets tests pin the provider's
+/// initial state without needing the OBD2 stack. The base class is the
+/// real Riverpod-generated notifier; we only override [build] so the
+/// screen sees the right phase + flags.
+class _FakeTripRecording extends TripRecording {
+  _FakeTripRecording(this._initialState, {this.fakeStartedAt});
+
+  final TripRecordingState _initialState;
+
+  /// Override the `lastTripStartedAt` clock so the recording-screen's
+  /// "fresh recording start" gate passes (the warning fires only when
+  /// the trip kicked off in the recent past — see the screen's
+  /// `_maybeShowUnpinnedWarning` for the gate semantics). Pass null
+  /// to simulate the "screen mounted long after recording started"
+  /// case.
+  final DateTime? fakeStartedAt;
+
+  @override
+  DateTime? get lastTripStartedAt => fakeStartedAt;
+
+  @override
+  TripRecordingState build() => _initialState;
+
+  // The screen calls these in response to AppBar buttons; defaulting
+  // to no-ops keeps the harness honest — the tests don't exercise
+  // pause/stop, so any call here would be a regression.
+  @override
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
+    state = state.copyWith(phase: TripRecordingPhase.finished);
+    return const StoppedTripResult.empty();
+  }
+
+  @override
+  void reset() {
+    state = const TripRecordingState();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TripRecordingScreen unpinned-recording warning (#1458 phase 2)', () {
+    testWidgets(
+      'fires the SnackBar when the user lands on the recording screen '
+      'with pin OFF and a trip is active',
+      (tester) async {
+        final notifier = _FakeTripRecording(
+          const TripRecordingState(
+            phase: TripRecordingPhase.recording,
+            situation: DrivingSituation.urbanCruise,
+            band: ConsumptionBand.normal,
+          ),
+          fakeStartedAt: DateTime.now(),
+        );
+        await pumpApp(
+          tester,
+          const TripRecordingScreen(),
+          overrides: [
+            tripRecordingProvider.overrideWith(() => notifier),
+            wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          ],
+        );
+        // The warning is deferred ~600 ms post-mount so it doesn't
+        // race against other on-mount SnackBars (broken-MAP /
+        // eco-coach). Pump past the deferred-fire timer + give the
+        // SnackBar entry animation room to land.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(
+          find.byKey(const Key('tripRecordingUnpinnedWarningSnackBar')),
+          findsOneWidget,
+          reason:
+              'Unpinned recording must surface the GPS-throttle warning; '
+              'this is the upfront mitigation while the diagnostics '
+              'instrumentation collects evidence (#1458 phase 2).',
+        );
+      },
+    );
+
+    testWidgets(
+      'does NOT fire the SnackBar when no trip is active',
+      (tester) async {
+        // Provider in idle phase — there's no recording to warn about.
+        // We deliberately pass `fakeStartedAt: DateTime.now()` to prove
+        // that the active-state check fires BEFORE the start-age gate;
+        // a "started just now" timestamp without an active recording
+        // must still be filtered out.
+        final notifier = _FakeTripRecording(
+          const TripRecordingState(),
+          fakeStartedAt: DateTime.now(),
+        );
+        await pumpApp(
+          tester,
+          const TripRecordingScreen(),
+          overrides: [
+            tripRecordingProvider.overrideWith(() => notifier),
+            wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          ],
+        );
+        // Pump past the deferred-fire timer so the post-mount path
+        // has every chance to fire — and assert it didn't.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(
+          find.byKey(const Key('tripRecordingUnpinnedWarningSnackBar')),
+          findsNothing,
+          reason:
+              'No active recording means no GPS subscription; the warning '
+              'would be misleading.',
+        );
+      },
+    );
+
+    testWidgets(
+      'does NOT fire when the user re-enters the recording screen '
+      'long after the trip started (banner re-entry)',
+      (tester) async {
+        // Simulate the banner-reentry case: the recording started
+        // 5 minutes ago, the user backed out, came back via the
+        // persistent banner. The warning is for fresh recording
+        // starts — re-entry is noise.
+        final notifier = _FakeTripRecording(
+          const TripRecordingState(
+            phase: TripRecordingPhase.recording,
+            situation: DrivingSituation.urbanCruise,
+            band: ConsumptionBand.normal,
+          ),
+          fakeStartedAt:
+              DateTime.now().subtract(const Duration(minutes: 5)),
+        );
+        await pumpApp(
+          tester,
+          const TripRecordingScreen(),
+          overrides: [
+            tripRecordingProvider.overrideWith(() => notifier),
+            wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          ],
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(
+          find.byKey(const Key('tripRecordingUnpinnedWarningSnackBar')),
+          findsNothing,
+          reason:
+              'Banner re-entry must NOT re-show the warning — the user '
+              'has already been driving for a while; the toast would be '
+              'noise rather than the upfront mitigation it is designed '
+              'to be.',
+        );
+      },
+    );
+
+    testWidgets(
+      'does NOT fire twice on a single screen mount',
+      (tester) async {
+        final notifier = _FakeTripRecording(
+          const TripRecordingState(
+            phase: TripRecordingPhase.recording,
+            situation: DrivingSituation.urbanCruise,
+            band: ConsumptionBand.normal,
+          ),
+          fakeStartedAt: DateTime.now(),
+        );
+        await pumpApp(
+          tester,
+          const TripRecordingScreen(),
+          overrides: [
+            tripRecordingProvider.overrideWith(() => notifier),
+            wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+          ],
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 700));
+        await tester.pump(const Duration(milliseconds: 250));
+
+        // First fire is expected — verify it's there.
+        expect(
+          find.byKey(const Key('tripRecordingUnpinnedWarningSnackBar')),
+          findsOneWidget,
+        );
+
+        // Force a rebuild without unmounting. The post-frame path must
+        // NOT re-show the SnackBar because the guard sticks for the
+        // lifetime of this state object.
+        notifier.state = notifier.state.copyWith(
+          band: ConsumptionBand.heavy,
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Wait for the SnackBar's auto-dismiss timer (8 s in production)
+        // to elapse so we can verify nothing replaced it. We pump
+        // 9 seconds in 100 ms slices to keep the test deterministic
+        // without pumpAndSettle (which would hang on indeterminate
+        // animations).
+        for (var i = 0; i < 90; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+        }
+        expect(
+          find.byKey(const Key('tripRecordingUnpinnedWarningSnackBar')),
+          findsNothing,
+          reason:
+              'After the SnackBar auto-dismisses, the guard must keep it '
+              'from re-firing on subsequent rebuilds within the same mount.',
+        );
+      },
+    );
+  });
+}

--- a/test/features/consumption/providers/trip_recording_gps_diagnostics_persistence_test.dart
+++ b/test/features/consumption/providers/trip_recording_gps_diagnostics_persistence_test.dart
@@ -1,0 +1,254 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+/// Regression coverage for #1458 phase 2 — the GPS cadence
+/// diagnostics buffer captured during a recording must round-trip
+/// through `TripHistoryRepository.save` + `loadAll` so a future
+/// diagnostics sheet (and any user inspecting the persisted JSON) can
+/// see exactly when each fix arrived and what app-lifecycle state was
+/// in effect at the time.
+///
+/// Three contracts:
+///   1. `TripHistoryEntry.toJson` + `fromJson` round-trip the
+///      diagnostics list with every field preserved (timestamp to ms,
+///      lifecycle state string, monotonic index).
+///   2. Legacy entries (no `gpsd` key) deserialise with an empty
+///      diagnostics list so trips recorded before #1458 phase 2 don't
+///      throw on load.
+///   3. `TripRecording.stop()` plumbs the controller's captured
+///      diagnostics buffer onto the saved entry — i.e. the in-memory
+///      observation channel is durable, not lost at trip-stop.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('gps_diagnostics_test_');
+    Hive.init(tmpDir.path);
+    await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test('TripHistoryEntry round-trips GpsSampleDiagnostic list', () {
+    // Use a local-time DateTime so the millisecondsSinceEpoch
+    // serialisation round-trip is exact — UTC DateTimes deserialise as
+    // local-time on the wire-format the entity uses (matches the
+    // existing per-sample TripSample convention).
+    final start = DateTime(2026, 5, 1, 8);
+    final diagnostics = <GpsSampleDiagnostic>[
+      GpsSampleDiagnostic(
+        timestamp: start,
+        lifecycleState: AppLifecycleState.resumed.name,
+        index: 0,
+      ),
+      GpsSampleDiagnostic(
+        timestamp: start.add(const Duration(seconds: 10)),
+        lifecycleState: AppLifecycleState.inactive.name,
+        index: 1,
+      ),
+      GpsSampleDiagnostic(
+        timestamp: start.add(const Duration(seconds: 25)),
+        lifecycleState: AppLifecycleState.paused.name,
+        index: 2,
+      ),
+    ];
+    final entry = TripHistoryEntry(
+      id: start.toIso8601String(),
+      vehicleId: 'veh-1',
+      summary: TripSummary(
+        distanceKm: 1.2,
+        maxRpm: 2000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: start,
+        endedAt: start.add(const Duration(seconds: 25)),
+      ),
+      gpsSampleDiagnostics: diagnostics,
+    );
+
+    final json = entry.toJson();
+    final restored = TripHistoryEntry.fromJson(json);
+
+    expect(restored.gpsSampleDiagnostics, hasLength(3));
+    expect(restored.gpsSampleDiagnostics[0].timestamp, start);
+    expect(
+      restored.gpsSampleDiagnostics[0].lifecycleState,
+      AppLifecycleState.resumed.name,
+    );
+    expect(restored.gpsSampleDiagnostics[0].index, 0);
+    expect(
+      restored.gpsSampleDiagnostics[1].lifecycleState,
+      AppLifecycleState.inactive.name,
+    );
+    expect(restored.gpsSampleDiagnostics[1].index, 1);
+    expect(
+      restored.gpsSampleDiagnostics[2].lifecycleState,
+      AppLifecycleState.paused.name,
+    );
+    expect(
+      restored.gpsSampleDiagnostics[2].timestamp,
+      start.add(const Duration(seconds: 25)),
+    );
+  });
+
+  test('legacy entries without `gpsd` key deserialise to empty list', () {
+    // A pre-#1458 phase 2 payload — no `gpsd` field. Must NOT throw
+    // and must surface an empty diagnostics list rather than null,
+    // matching the convention used for the per-tick samples list.
+    final legacy = <String, dynamic>{
+      'id': 'legacy-2',
+      'vehicleId': 'veh-1',
+      'summary': <String, dynamic>{
+        'distanceKm': 12.0,
+        'maxRpm': 3000.0,
+        'highRpmSeconds': 0.0,
+        'idleSeconds': 0.0,
+        'harshBrakes': 0,
+        'harshAccelerations': 0,
+        'distanceSource': 'virtual',
+      },
+    };
+    final restored = TripHistoryEntry.fromJson(legacy);
+    expect(restored.gpsSampleDiagnostics, isEmpty);
+  });
+
+  test(
+    'TripRecording.stop() persists the controller diagnostics buffer '
+    'onto the saved TripHistoryEntry',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull,
+          reason: 'provider must own a controller while recording');
+
+      // Drive the recorder so the resulting summary has a startedAt
+      // and a non-zero distance — `_saveToHistory` short-circuits
+      // empty trips and would never reach the persistence path
+      // without this.
+      final start = DateTime.now();
+      for (int i = 0; i < 4; i++) {
+        ctl!.debugInjectSample(
+          speedKmh: 40 + i.toDouble(),
+          rpm: 1800 + i * 5,
+          at: start.add(Duration(seconds: i)),
+          fuelRateLPerHour: 5.5,
+        );
+        ctl.debugCaptureSample(TripSample(
+          timestamp: start.add(Duration(seconds: i)),
+          speedKmh: 40 + i.toDouble(),
+          rpm: 1800 + i * 5,
+          fuelRateLPerHour: 5.5,
+        ));
+      }
+
+      // Pre-seed a diagnostic buffer that mixes lifecycle states —
+      // this simulates "recording started while the user was looking
+      // at the screen, then they backgrounded the app halfway through".
+      ctl!.debugCaptureGpsSampleDiagnostic(GpsSampleDiagnostic(
+        timestamp: start,
+        lifecycleState: AppLifecycleState.resumed.name,
+        index: 0,
+      ));
+      ctl.debugCaptureGpsSampleDiagnostic(GpsSampleDiagnostic(
+        timestamp: start.add(const Duration(seconds: 1)),
+        lifecycleState: AppLifecycleState.inactive.name,
+        index: 1,
+      ));
+      ctl.debugCaptureGpsSampleDiagnostic(GpsSampleDiagnostic(
+        timestamp: start.add(const Duration(seconds: 3)),
+        lifecycleState: AppLifecycleState.paused.name,
+        index: 2,
+      ));
+
+      await notifier.stop();
+
+      final repo = container.read(tripHistoryRepositoryProvider);
+      expect(repo, isNotNull);
+      final history = repo!.loadAll();
+      expect(history, isNotEmpty,
+          reason: 'stop() must persist a TripHistoryEntry');
+      final saved = history.first;
+      expect(saved.gpsSampleDiagnostics, hasLength(3),
+          reason:
+              'every captured GPS diagnostic must round-trip into Hive');
+      expect(
+        saved.gpsSampleDiagnostics[0].lifecycleState,
+        AppLifecycleState.resumed.name,
+      );
+      expect(
+        saved.gpsSampleDiagnostics[1].lifecycleState,
+        AppLifecycleState.inactive.name,
+      );
+      expect(
+        saved.gpsSampleDiagnostics[2].lifecycleState,
+        AppLifecycleState.paused.name,
+      );
+      // Indices must be monotonic + preserved.
+      expect(saved.gpsSampleDiagnostics.map((d) => d.index).toList(),
+          equals([0, 1, 2]));
+    },
+  );
+
+  test(
+    'onAppLifecycleStateChanged updates the provider field tagged onto '
+    'subsequent diagnostics',
+    () async {
+      // Pure provider-level test — no Geolocator stream needed. We
+      // verify that pushing a new lifecycle state into the provider
+      // makes it the value the GPS listener WOULD tag onto a future
+      // diagnostic.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      // Default is resumed — the first sample on a freshly-started
+      // recording is tagged optimistically.
+      expect(notifier.debugLifecycleState, AppLifecycleState.resumed);
+
+      notifier.onAppLifecycleStateChanged(AppLifecycleState.paused);
+      expect(notifier.debugLifecycleState, AppLifecycleState.paused);
+
+      notifier.onAppLifecycleStateChanged(AppLifecycleState.inactive);
+      expect(notifier.debugLifecycleState, AppLifecycleState.inactive);
+
+      notifier.onAppLifecycleStateChanged(AppLifecycleState.resumed);
+      expect(notifier.debugLifecycleState, AppLifecycleState.resumed);
+    },
+  );
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };


### PR DESCRIPTION
## Summary

Phase 2 of #1458 — two small deliverables shipped together:

- **Unpinned-recording warning toast** — when the user lands on the trip-recording screen with the pin toggle OFF and a fresh recording is active, surface a one-shot SnackBar: \"Pin the screen to keep GPS active during the trip — Android may throttle GPS during sleep.\" Deferred 600 ms post-mount so it doesn't race on-mount SnackBars (broken-MAP / eco-coach); gated on `lastTripStartedAt` < 10 s so banner re-entry doesn't re-fire it.
- **GPS sampling cadence instrumentation** — every `Geolocator.getPositionStream` fix during recording is paired with a `GpsSampleDiagnostic` carrying timestamp + `AppLifecycleState` name + monotonic index, persisted as a sibling list on the `TripHistoryEntry` (`gpsSampleDiagnostics`). Backward-compatible JSON: legacy entries without the `gpsd` key deserialise to an empty list.

The Android foreground-service for keeping GPS alive during sleep is **explicitly deferred to phase 3** — that decision is conditional on what the diagnostics reveal in field testing. The issue stays open after merge; coordinator decides on close.

## Files

- `lib/features/consumption/domain/entities/gps_sample_diagnostic.dart` — new entity (compact JSON `'t' / 'ls' / 'i'` mirroring `TripSample`).
- `lib/features/consumption/data/obd2/trip_recording_controller.dart` — `recordGpsSampleDiagnostic` + capped buffer + `debugCaptureGpsSampleDiagnostic` for tests.
- `lib/features/consumption/providers/trip_recording_provider.dart` — tracks `AppLifecycleState`, tags every GPS-stream sample, plumbs diagnostics through `stop()` onto the saved entry.
- `lib/features/consumption/data/trip_history_repository.dart` — `gpsSampleDiagnostics` field + JSON round-trip.
- `lib/features/consumption/presentation/screens/trip_recording_screen.dart` — deferred warning fire + cleanup on dispose / stop.
- `lib/app/app.dart` — wires lifecycle-state pushes from the existing `WidgetsBindingObserver`.
- `lib/l10n/_fragments/trip_recording_pin_{en,de}.arb` + `lib/l10n/app_fr.arb` — `tripRecordingUnpinnedWarning` key in en/de/fr.

## Test plan

- [x] `flutter analyze` — clean (no issues).
- [x] `flutter test test/features/consumption/` — all 2550 tests pass.
- [x] `flutter test test/lint/` — all 29 tests pass (ARB consistency, silent-catch scanner).
- [ ] Skip full `flutter test` per `feedback_worker_skip_full_suite_before_push.md` — let CI run the whole suite.

## Out of scope (deferred)

- Phase 3 — Android foreground service to keep GPS alive during phone sleep. Decision conditional on the cadence diagnostics this PR captures.
- A diagnostics-sheet UI surface for inspecting `gpsSampleDiagnostics` on the trip-detail screen — phase 3 territory; the data is persistent and inspectable in JSON for now.