### PR TITLE
feat(price-prediction): FeatureVector contract + holiday-aware predictor (Refs #1117 phase 1)

### DIFF
--- a/lib/core/calendar/public_holiday_calendar.dart
+++ b/lib/core/calendar/public_holiday_calendar.dart
@@ -1,0 +1,75 @@
+/// Pure-Dart helper for resolving fixed-date European public holidays.
+///
+/// Used by the [PriceFeatureExtractor] (#1117 phase 1) to mark records
+/// observed on a public holiday so the future TFLite model (phase 2)
+/// can learn a holiday premium / discount.
+///
+/// ## Scope (phase 1)
+///
+/// Covers the two pan-European fixed dates and one canonical national
+/// fixed-date holiday per supported country:
+///
+/// - **All countries:** New Year's Day (Jan 1), Christmas Day (Dec 25)
+/// - **DE:** Tag der Deutschen Einheit (Oct 3)
+/// - **FR:** Fête nationale / Bastille Day (Jul 14)
+/// - **IT:** Festa della Repubblica (Jun 2)
+/// - **ES:** Fiesta Nacional (Oct 12)
+/// - **AT:** Nationalfeiertag (Oct 26)
+/// - **BE:** Nationale feestdag (Jul 21)
+/// - **NL:** Koningsdag (Apr 27)
+/// - **LU:** National Day (Jun 23)
+/// - **PL:** Constitution Day (May 3)
+///
+/// ## Out of scope (deferred to phase 2)
+///
+/// Variable / computed holidays (Easter Monday, Pentecost, Ascension,
+/// Corpus Christi, regional holidays, religious holidays in countries
+/// with multi-confessional calendars) are deliberately omitted. Phase 1
+/// proves the contract end-to-end with cheap fixed dates; phase 2 will
+/// either extend this calendar or import a vetted holidays package.
+class PublicHolidayCalendar {
+  const PublicHolidayCalendar._();
+
+  /// Returns `true` when [date] is a fixed-date public holiday in
+  /// [countryCode]. Returns `false` when [countryCode] is `null` or
+  /// unknown — the caller does not have country information, so we
+  /// must not invent one.
+  ///
+  /// [countryCode] is matched case-insensitively against ISO-3166
+  /// alpha-2 codes (e.g. `'DE'`, `'fr'`).
+  static bool isPublicHoliday(DateTime date, String? countryCode) {
+    // New Year's Day and Christmas are universal across the supported
+    // EU/Schengen set; treat them as country-agnostic so a record from
+    // any country (including unknown country) gets the holiday flag.
+    if (date.month == 1 && date.day == 1) return true;
+    if (date.month == 12 && date.day == 25) return true;
+
+    if (countryCode == null) return false;
+    final code = countryCode.toUpperCase();
+
+    final national = _nationalFixedDates[code];
+    if (national == null) return false;
+    return date.month == national.month && date.day == national.day;
+  }
+
+  /// Country-specific fixed-date national holidays, expressed as
+  /// `(month, day)` so the date check is year-agnostic.
+  static const Map<String, _MonthDay> _nationalFixedDates = {
+    'DE': _MonthDay(10, 3),  // Tag der Deutschen Einheit
+    'FR': _MonthDay(7, 14),  // Bastille Day
+    'IT': _MonthDay(6, 2),   // Festa della Repubblica
+    'ES': _MonthDay(10, 12), // Fiesta Nacional
+    'AT': _MonthDay(10, 26), // Nationalfeiertag
+    'BE': _MonthDay(7, 21),  // Nationale feestdag
+    'NL': _MonthDay(4, 27),  // Koningsdag
+    'LU': _MonthDay(6, 23),  // National Day
+    'PL': _MonthDay(5, 3),   // Constitution Day
+  };
+}
+
+/// Compact `(month, day)` pair used by the calendar lookup table.
+class _MonthDay {
+  final int month;
+  final int day;
+  const _MonthDay(this.month, this.day);
+}

--- a/lib/features/price_history/data/models/price_prediction.dart
+++ b/lib/features/price_history/data/models/price_prediction.dart
@@ -44,6 +44,17 @@ class PricePrediction {
   /// Average price per day of week.
   final List<DayOfWeekAverage> dailyAverages;
 
+  /// Average EUR/L delta between holiday and non-holiday samples for
+  /// this station + fuel. Positive = holidays trend more expensive;
+  /// negative = holidays trend cheaper. `null` when fewer than three
+  /// holiday samples are available — the signal is too noisy below
+  /// that threshold.
+  ///
+  /// Surfaced via #1117 phase 1 alongside the future-TFLite
+  /// [FeatureVector] contract; phase 2 will replace the heuristic
+  /// average with a model-derived prediction.
+  final double? holidayPremium;
+
   const PricePrediction({
     required this.recommendation,
     this.potentialSaving,
@@ -51,5 +62,6 @@ class PricePrediction {
     required this.bestDayOfWeek,
     required this.hourlyAverages,
     required this.dailyAverages,
+    this.holidayPremium,
   });
 }

--- a/lib/features/price_history/domain/entities/feature_vector.dart
+++ b/lib/features/price_history/domain/entities/feature_vector.dart
@@ -1,0 +1,142 @@
+/// One observation in the price-prediction feature space.
+///
+/// **This is the input contract for the future TFLite phase-2 model
+/// (#1117).** Phase 2 will load training data as `List<FeatureVector>`,
+/// run gradient-boost training offline, and ship a `.tflite` artifact
+/// that consumes the dictionary returned by [toFeatureMap]. **Do not
+/// rename, retype, or remove existing field keys without bumping
+/// [schemaVersion]** — every change forces a model retrain.
+///
+/// Phase 1 (this file) only enriches the on-device heuristic predictor
+/// — it builds vectors but never feeds them to a model.
+///
+/// ## Fields
+///
+/// - [hourOfDay] — `0..23`
+/// - [dayOfWeek] — `1..7` (1 = Monday, 7 = Sunday — matches
+///   [DateTime.weekday])
+/// - [brand] — canonical brand from [Station.brand], or `null` when
+///   the station is unknown
+/// - [countryCode] — ISO-3166 alpha-2 (e.g. `'DE'`, `'FR'`), or `null`
+///   when unresolvable
+/// - [isHoliday] — public-holiday flag from [PublicHolidayCalendar]
+/// - [priceEur] — observed price per unit (EUR/L for liquid fuels,
+///   EUR/kg for CNG/H2, EUR/kWh for electric); this is the **label**
+///   for supervised training in phase 2
+/// - [observedAt] — UTC timestamp of the observation, kept for
+///   ordering, debugging, and time-window splits during training
+class FeatureVector {
+  /// Schema version of the feature dictionary returned by
+  /// [toFeatureMap]. Bump this whenever a key is added, renamed, or
+  /// retyped — the phase-2 model file embeds this number to guard
+  /// against silent skew.
+  static const int schemaVersion = 1;
+
+  final int hourOfDay;
+  final int dayOfWeek;
+  final String? brand;
+  final String? countryCode;
+  final bool isHoliday;
+  final double priceEur;
+  final DateTime observedAt;
+
+  const FeatureVector({
+    required this.hourOfDay,
+    required this.dayOfWeek,
+    required this.brand,
+    required this.countryCode,
+    required this.isHoliday,
+    required this.priceEur,
+    required this.observedAt,
+  });
+
+  /// Stable map representation passed to the phase-2 TFLite model.
+  ///
+  /// Keys are ordered alphabetically for deterministic JSON output.
+  /// Phase 2 must read each key by name (not position).
+  Map<String, dynamic> toFeatureMap() => <String, dynamic>{
+        'brand': brand,
+        'country_code': countryCode,
+        'day_of_week': dayOfWeek,
+        'hour_of_day': hourOfDay,
+        'is_holiday': isHoliday,
+        'observed_at': observedAt.toUtc().toIso8601String(),
+        'price_eur': priceEur,
+      };
+
+  /// JSON encoding used for on-device training-set persistence and
+  /// upload. Mirrors [toFeatureMap] but is keyed for round-trip with
+  /// [FeatureVector.fromJson].
+  Map<String, dynamic> toJson() => toFeatureMap();
+
+  /// Reconstructs a [FeatureVector] from a [toJson] / [toFeatureMap]
+  /// dictionary. Throws [FormatException] when a required key is
+  /// missing or the wrong type.
+  factory FeatureVector.fromJson(Map<String, dynamic> json) {
+    return FeatureVector(
+      hourOfDay: _requireInt(json, 'hour_of_day'),
+      dayOfWeek: _requireInt(json, 'day_of_week'),
+      brand: json['brand'] as String?,
+      countryCode: json['country_code'] as String?,
+      isHoliday: _requireBool(json, 'is_holiday'),
+      priceEur: _requireDouble(json, 'price_eur'),
+      observedAt: _requireDateTime(json, 'observed_at'),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FeatureVector &&
+        other.hourOfDay == hourOfDay &&
+        other.dayOfWeek == dayOfWeek &&
+        other.brand == brand &&
+        other.countryCode == countryCode &&
+        other.isHoliday == isHoliday &&
+        other.priceEur == priceEur &&
+        other.observedAt == observedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        hourOfDay,
+        dayOfWeek,
+        brand,
+        countryCode,
+        isHoliday,
+        priceEur,
+        observedAt,
+      );
+
+  @override
+  String toString() {
+    return 'FeatureVector(hourOfDay: $hourOfDay, dayOfWeek: $dayOfWeek, '
+        'brand: $brand, countryCode: $countryCode, isHoliday: $isHoliday, '
+        'priceEur: $priceEur, observedAt: $observedAt)';
+  }
+}
+
+int _requireInt(Map<String, dynamic> json, String key) {
+  final v = json[key];
+  if (v is int) return v;
+  throw FormatException('FeatureVector.fromJson: missing or non-int "$key"');
+}
+
+bool _requireBool(Map<String, dynamic> json, String key) {
+  final v = json[key];
+  if (v is bool) return v;
+  throw FormatException('FeatureVector.fromJson: missing or non-bool "$key"');
+}
+
+double _requireDouble(Map<String, dynamic> json, String key) {
+  final v = json[key];
+  if (v is num) return v.toDouble();
+  throw FormatException('FeatureVector.fromJson: missing or non-num "$key"');
+}
+
+DateTime _requireDateTime(Map<String, dynamic> json, String key) {
+  final v = json[key];
+  if (v is String) return DateTime.parse(v);
+  throw FormatException(
+      'FeatureVector.fromJson: missing or non-ISO-8601-string "$key"');
+}

--- a/lib/features/price_history/domain/services/price_feature_extractor.dart
+++ b/lib/features/price_history/domain/services/price_feature_extractor.dart
@@ -1,0 +1,90 @@
+import '../../../../core/calendar/public_holiday_calendar.dart';
+import '../../../search/domain/entities/fuel_type.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../data/models/price_record.dart';
+import '../entities/feature_vector.dart';
+
+/// Pure-Dart producer of [FeatureVector]s from raw [PriceRecord]
+/// history. The phase-2 TFLite model (#1117) consumes the output of
+/// this service for both offline training and on-device inference, so
+/// the contract here mirrors [FeatureVector] exactly.
+///
+/// The extractor is stateless and side-effect-free — it does no I/O
+/// and never fetches a station. The caller passes the [Station] (or
+/// `null`) so brand and country flow through deterministically.
+class PriceFeatureExtractor {
+  const PriceFeatureExtractor();
+
+  /// Builds one [FeatureVector] per record that has a price for the
+  /// given [fuelType]. Records without a price (e.g. a snapshot where
+  /// only diesel is set but the caller wants e10) are skipped.
+  ///
+  /// [station] supplies brand and ISO country code; pass `null` when
+  /// the station is unknown — those fields will be `null` on the
+  /// resulting vectors.
+  ///
+  /// [countryCodeOverride] lets the caller plug in a country resolved
+  /// via [Countries.countryCodeForStationId] (or any other source)
+  /// when the [Station] entity is unavailable. When both [station]
+  /// and [countryCodeOverride] are provided, [countryCodeOverride]
+  /// wins — the override is treated as the more authoritative source.
+  List<FeatureVector> extract({
+    required List<PriceRecord> records,
+    required FuelType fuelType,
+    Station? station,
+    String? countryCodeOverride,
+  }) {
+    final brand = station?.brand;
+    final country = countryCodeOverride ?? _countryFromStation(station);
+
+    final out = <FeatureVector>[];
+    for (final record in records) {
+      final price = _priceForFuelType(record, fuelType);
+      if (price == null) continue;
+
+      out.add(
+        FeatureVector(
+          hourOfDay: record.recordedAt.hour,
+          dayOfWeek: record.recordedAt.weekday,
+          brand: brand,
+          countryCode: country,
+          isHoliday: PublicHolidayCalendar.isPublicHoliday(
+            record.recordedAt,
+            country,
+          ),
+          priceEur: price,
+          observedAt: record.recordedAt,
+        ),
+      );
+    }
+    return out;
+  }
+}
+
+/// Extracts the price for [fuelType] from [record], returning `null`
+/// for fuel types that the [PriceRecord] schema does not carry
+/// (hydrogen, electric, the `all` meta-type).
+double? _priceForFuelType(PriceRecord record, FuelType fuelType) {
+  return switch (fuelType) {
+    FuelTypeE5() => record.e5,
+    FuelTypeE10() => record.e10,
+    FuelTypeE98() => record.e98,
+    FuelTypeDiesel() => record.diesel,
+    FuelTypeDieselPremium() => record.dieselPremium,
+    FuelTypeE85() => record.e85,
+    FuelTypeLpg() => record.lpg,
+    FuelTypeCng() => record.cng,
+    FuelTypeHydrogen() || FuelTypeElectric() || FuelTypeAll() => null,
+  };
+}
+
+/// Phase-1 stations don't carry an explicit ISO country code field
+/// (see [Station]); we leave country resolution to the caller's
+/// [countryCodeOverride] in that case. This indirection keeps the
+/// extractor honest — it won't invent a country from a postcode.
+String? _countryFromStation(Station? station) {
+  if (station == null) return null;
+  // Phase-1 Station entity has no country field. When phase 2 adds one,
+  // wire it here without changing the public extractor API.
+  return null;
+}

--- a/lib/features/price_history/providers/price_prediction_provider.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.dart
@@ -1,8 +1,10 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/country/country_config.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../data/models/price_prediction.dart';
-import '../data/models/price_record.dart';
+import '../domain/entities/feature_vector.dart';
+import '../domain/services/price_feature_extractor.dart';
 import 'price_history_provider.dart';
 
 part 'price_prediction_provider.g.dart';
@@ -18,10 +20,25 @@ const _dayNames = {
   7: 'Sunday',
 };
 
+/// Minimum holiday samples required to surface a [PricePrediction.holidayPremium].
+/// Below this, the signal is too noisy to be useful (#1117 phase 1).
+const int _kMinHolidaySamples = 3;
+
+/// Threshold (EUR/L) above which the holiday premium is appended to the
+/// recommendation string. Below 2 cents the difference is not worth
+/// nagging the user about.
+const double _kHolidayPremiumNoticeThreshold = 0.02;
+
 /// Computes "best time to fill" predictions from locally stored price history.
 ///
 /// Returns `null` when fewer than 10 data points are available — not enough
 /// data to produce meaningful predictions.
+///
+/// As of #1117 phase 1, the provider also enriches the result with a
+/// [PricePrediction.holidayPremium] derived from the new
+/// [PriceFeatureExtractor] / [FeatureVector] contract. The future TFLite
+/// phase 2 will replace this heuristic with model inference using the
+/// same [FeatureVector] inputs.
 @riverpod
 PricePrediction? pricePrediction(
   Ref ref,
@@ -33,22 +50,24 @@ PricePrediction? pricePrediction(
 
   if (history.length < 10) return null;
 
-  // Extract price/time pairs, filtering out records without a price for this
-  // fuel type.
-  final pairs = <_PriceTime>[];
-  for (final record in history) {
-    final price = _priceForFuelType(record, fuelType);
-    if (price != null) {
-      pairs.add(_PriceTime(price: price, time: record.recordedAt));
-    }
-  }
+  // Build per-record feature vectors so the holiday flag (and future
+  // brand / country features) flow through the same path that phase-2
+  // training data will use. We don't have a Station entity here, so
+  // brand stays null; country is derived from the station-id prefix.
+  const extractor = PriceFeatureExtractor();
+  final country = Countries.countryCodeForStationId(stationId);
+  final vectors = extractor.extract(
+    records: history,
+    fuelType: fuelType,
+    countryCodeOverride: country,
+  );
 
-  if (pairs.length < 10) return null;
+  if (vectors.length < 10) return null;
 
   // --- Group by hour of day ---
   final hourBuckets = <int, List<double>>{};
-  for (final p in pairs) {
-    hourBuckets.putIfAbsent(p.time.hour, () => []).add(p.price);
+  for (final v in vectors) {
+    hourBuckets.putIfAbsent(v.hourOfDay, () => []).add(v.priceEur);
   }
   final hourlyAverages = hourBuckets.entries.map((e) {
     final avg = e.value.reduce((a, b) => a + b) / e.value.length;
@@ -62,8 +81,8 @@ PricePrediction? pricePrediction(
 
   // --- Group by day of week ---
   final dayBuckets = <int, List<double>>{};
-  for (final p in pairs) {
-    dayBuckets.putIfAbsent(p.time.weekday, () => []).add(p.price);
+  for (final v in vectors) {
+    dayBuckets.putIfAbsent(v.dayOfWeek, () => []).add(v.priceEur);
   }
   final dailyAverages = dayBuckets.entries.map((e) {
     final avg = e.value.reduce((a, b) => a + b) / e.value.length;
@@ -93,10 +112,15 @@ PricePrediction? pricePrediction(
   final potentialSaving =
       hourlySaving > 0.001 ? double.parse(hourlySaving.toStringAsFixed(3)) : null;
 
+  // --- Holiday premium (#1117 phase 1) ---
+  final holidayPremium = _computeHolidayPremium(vectors);
+
   // --- Recommendation text ---
   final dayName = _dayNames[cheapestDay.dayOfWeek] ?? 'Unknown';
   final hourLabel = _formatHourRange(cheapestHour.hour);
-  final recommendation = 'Prices typically drop $dayName $hourLabel';
+  final base = 'Prices typically drop $dayName $hourLabel';
+  final recommendation =
+      _maybeAppendHolidayHint(base, holidayPremium);
 
   return PricePrediction(
     recommendation: recommendation,
@@ -105,7 +129,43 @@ PricePrediction? pricePrediction(
     bestDayOfWeek: cheapestDay.dayOfWeek,
     hourlyAverages: hourlyAverages,
     dailyAverages: dailyAverages,
+    holidayPremium: holidayPremium,
   );
+}
+
+/// Average EUR/L delta between holiday and non-holiday samples in
+/// [vectors]. Returns `null` when fewer than [_kMinHolidaySamples]
+/// holiday observations exist or when no non-holiday baseline is
+/// available.
+double? _computeHolidayPremium(List<FeatureVector> vectors) {
+  final holidayPrices = <double>[];
+  final nonHolidayPrices = <double>[];
+  for (final v in vectors) {
+    if (v.isHoliday) {
+      holidayPrices.add(v.priceEur);
+    } else {
+      nonHolidayPrices.add(v.priceEur);
+    }
+  }
+  if (holidayPrices.length < _kMinHolidaySamples) return null;
+  if (nonHolidayPrices.isEmpty) return null;
+
+  final hAvg =
+      holidayPrices.reduce((a, b) => a + b) / holidayPrices.length;
+  final nAvg = nonHolidayPrices.reduce((a, b) => a + b) /
+      nonHolidayPrices.length;
+  final delta = hAvg - nAvg;
+  return double.parse(delta.toStringAsFixed(3));
+}
+
+/// Optionally appends a one-sentence holiday hint to [base] when the
+/// computed [holidayPremium] is large enough to be actionable.
+String _maybeAppendHolidayHint(String base, double? holidayPremium) {
+  if (holidayPremium == null) return base;
+  if (holidayPremium.abs() <= _kHolidayPremiumNoticeThreshold) return base;
+  final cents = (holidayPremium.abs() * 100).toStringAsFixed(1);
+  final direction = holidayPremium > 0 ? 'higher' : 'lower';
+  return '$base. Holidays trend $cents ct/L $direction';
 }
 
 /// Formats an hour (0-23) as a human-readable time range, e.g. "6-8 PM".
@@ -120,24 +180,4 @@ String _formatHour(int hour) {
   if (hour < 12) return '$hour AM';
   if (hour == 12) return '12 PM';
   return '${hour - 12} PM';
-}
-
-double? _priceForFuelType(PriceRecord record, FuelType fuelType) {
-  return switch (fuelType) {
-    FuelTypeE5() => record.e5,
-    FuelTypeE10() => record.e10,
-    FuelTypeE98() => record.e98,
-    FuelTypeDiesel() => record.diesel,
-    FuelTypeDieselPremium() => record.dieselPremium,
-    FuelTypeE85() => record.e85,
-    FuelTypeLpg() => record.lpg,
-    FuelTypeCng() => record.cng,
-    FuelTypeHydrogen() || FuelTypeElectric() || FuelTypeAll() => null,
-  };
-}
-
-class _PriceTime {
-  final double price;
-  final DateTime time;
-  const _PriceTime({required this.price, required this.time});
 }

--- a/lib/features/price_history/providers/price_prediction_provider.g.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.g.dart
@@ -12,6 +12,12 @@ part of 'price_prediction_provider.dart';
 ///
 /// Returns `null` when fewer than 10 data points are available — not enough
 /// data to produce meaningful predictions.
+///
+/// As of #1117 phase 1, the provider also enriches the result with a
+/// [PricePrediction.holidayPremium] derived from the new
+/// [PriceFeatureExtractor] / [FeatureVector] contract. The future TFLite
+/// phase 2 will replace this heuristic with model inference using the
+/// same [FeatureVector] inputs.
 
 @ProviderFor(pricePrediction)
 final pricePredictionProvider = PricePredictionFamily._();
@@ -20,6 +26,12 @@ final pricePredictionProvider = PricePredictionFamily._();
 ///
 /// Returns `null` when fewer than 10 data points are available — not enough
 /// data to produce meaningful predictions.
+///
+/// As of #1117 phase 1, the provider also enriches the result with a
+/// [PricePrediction.holidayPremium] derived from the new
+/// [PriceFeatureExtractor] / [FeatureVector] contract. The future TFLite
+/// phase 2 will replace this heuristic with model inference using the
+/// same [FeatureVector] inputs.
 
 final class PricePredictionProvider
     extends
@@ -33,6 +45,12 @@ final class PricePredictionProvider
   ///
   /// Returns `null` when fewer than 10 data points are available — not enough
   /// data to produce meaningful predictions.
+  ///
+  /// As of #1117 phase 1, the provider also enriches the result with a
+  /// [PricePrediction.holidayPremium] derived from the new
+  /// [PriceFeatureExtractor] / [FeatureVector] contract. The future TFLite
+  /// phase 2 will replace this heuristic with model inference using the
+  /// same [FeatureVector] inputs.
   PricePredictionProvider._({
     required PricePredictionFamily super.from,
     required (String, FuelType) super.argument,
@@ -84,12 +102,18 @@ final class PricePredictionProvider
   }
 }
 
-String _$pricePredictionHash() => r'7be988a602ce629e340ac017ab850b2a83d23951';
+String _$pricePredictionHash() => r'e1e22ff3f93f070d8f979bc3cc25bdd66a584254';
 
 /// Computes "best time to fill" predictions from locally stored price history.
 ///
 /// Returns `null` when fewer than 10 data points are available — not enough
 /// data to produce meaningful predictions.
+///
+/// As of #1117 phase 1, the provider also enriches the result with a
+/// [PricePrediction.holidayPremium] derived from the new
+/// [PriceFeatureExtractor] / [FeatureVector] contract. The future TFLite
+/// phase 2 will replace this heuristic with model inference using the
+/// same [FeatureVector] inputs.
 
 final class PricePredictionFamily extends $Family
     with $FunctionalFamilyOverride<PricePrediction?, (String, FuelType)> {
@@ -106,6 +130,12 @@ final class PricePredictionFamily extends $Family
   ///
   /// Returns `null` when fewer than 10 data points are available — not enough
   /// data to produce meaningful predictions.
+  ///
+  /// As of #1117 phase 1, the provider also enriches the result with a
+  /// [PricePrediction.holidayPremium] derived from the new
+  /// [PriceFeatureExtractor] / [FeatureVector] contract. The future TFLite
+  /// phase 2 will replace this heuristic with model inference using the
+  /// same [FeatureVector] inputs.
 
   PricePredictionProvider call(String stationId, FuelType fuelType) =>
       PricePredictionProvider._(argument: (stationId, fuelType), from: this);

--- a/test/core/calendar/public_holiday_calendar_test.dart
+++ b/test/core/calendar/public_holiday_calendar_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/calendar/public_holiday_calendar.dart';
+
+/// Verifies every fixed-date holiday documented in
+/// [PublicHolidayCalendar] resolves correctly per supported country
+/// and that null/unknown countries fall through safely.
+void main() {
+  group('PublicHolidayCalendar — universal holidays', () {
+    test('Jan 1 is a holiday everywhere, even with null country', () {
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 1, 1), null),
+        isTrue,
+      );
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 1, 1), 'DE'),
+        isTrue,
+      );
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 1, 1), 'FR'),
+        isTrue,
+      );
+    });
+
+    test('Dec 25 is a holiday everywhere, even with null country', () {
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 12, 25), null),
+        isTrue,
+      );
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 12, 25), 'IT'),
+        isTrue,
+      );
+    });
+  });
+
+  group('PublicHolidayCalendar — national fixed dates', () {
+    final cases = <(String code, DateTime date, String label)>[
+      ('DE', DateTime(2026, 10, 3), 'Tag der Deutschen Einheit'),
+      ('FR', DateTime(2026, 7, 14), 'Bastille Day'),
+      ('IT', DateTime(2026, 6, 2), 'Festa della Repubblica'),
+      ('ES', DateTime(2026, 10, 12), 'Fiesta Nacional'),
+      ('AT', DateTime(2026, 10, 26), 'Nationalfeiertag'),
+      ('BE', DateTime(2026, 7, 21), 'Nationale feestdag'),
+      ('NL', DateTime(2026, 4, 27), 'Koningsdag'),
+      ('LU', DateTime(2026, 6, 23), 'National Day'),
+      ('PL', DateTime(2026, 5, 3), 'Constitution Day'),
+    ];
+
+    for (final c in cases) {
+      test('${c.$1}: ${c.$3} on ${c.$2.year}-${c.$2.month}-${c.$2.day}', () {
+        expect(
+          PublicHolidayCalendar.isPublicHoliday(c.$2, c.$1),
+          isTrue,
+          reason: '${c.$3} should be a holiday in ${c.$1}',
+        );
+      });
+
+      test('${c.$1}: ${c.$3} is NOT a holiday in another country', () {
+        // National holidays are country-specific. Jul 14 in DE is not a
+        // holiday, etc. Use a country that has no fixed date on the same
+        // day to avoid coincidental overlap.
+        final foreign = c.$1 == 'DE' ? 'FR' : 'DE';
+        // Skip when the foreign country shares the universal Jan 1 / Dec 25.
+        final isUniversal = (c.$2.month == 1 && c.$2.day == 1) ||
+            (c.$2.month == 12 && c.$2.day == 25);
+        if (isUniversal) return;
+        expect(
+          PublicHolidayCalendar.isPublicHoliday(c.$2, foreign),
+          isFalse,
+          reason: '${c.$3} is not a public holiday in $foreign',
+        );
+      });
+    }
+  });
+
+  group('PublicHolidayCalendar — non-holidays', () {
+    test('returns false for an arbitrary mid-week non-holiday date', () {
+      // 2026-03-17 (Tuesday) — no fixed-date holiday in any supported
+      // country.
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 3, 17), 'DE'),
+        isFalse,
+      );
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 3, 17), 'FR'),
+        isFalse,
+      );
+    });
+
+    test('returns false when countryCode is null and date is not universal',
+        () {
+      // Jul 14 is FR-only; without a country we cannot tell.
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 7, 14), null),
+        isFalse,
+      );
+    });
+
+    test('returns false for an unknown country code', () {
+      // 'XX' is not a registered country; the lookup table should miss
+      // and return false rather than throw.
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 7, 14), 'XX'),
+        isFalse,
+      );
+    });
+  });
+
+  group('PublicHolidayCalendar — case insensitivity', () {
+    test('lowercase country code resolves the same as uppercase', () {
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 10, 3), 'de'),
+        isTrue,
+      );
+      expect(
+        PublicHolidayCalendar.isPublicHoliday(DateTime(2026, 10, 3), 'De'),
+        isTrue,
+      );
+    });
+  });
+
+  group('PublicHolidayCalendar — year-agnostic', () {
+    test('Bastille Day works in any year', () {
+      for (final y in [1999, 2025, 2030]) {
+        expect(
+          PublicHolidayCalendar.isPublicHoliday(DateTime(y, 7, 14), 'FR'),
+          isTrue,
+          reason: 'Jul 14 $y should be a holiday in FR',
+        );
+      }
+    });
+  });
+}

--- a/test/features/price_history/domain/entities/feature_vector_test.dart
+++ b/test/features/price_history/domain/entities/feature_vector_test.dart
@@ -1,0 +1,240 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/price_history/domain/entities/feature_vector.dart';
+
+/// Verifies the [FeatureVector] contract that the future TFLite phase-2
+/// model will consume (#1117). These assertions are deliberately rigid:
+/// any change to map keys, types, or equality semantics requires
+/// bumping [FeatureVector.schemaVersion] and is a model-breaking
+/// change.
+void main() {
+  group('FeatureVector — value semantics', () {
+    test('two vectors with the same fields are equal', () {
+      final t = DateTime.utc(2026, 5, 1, 14, 30);
+      final a = FeatureVector(
+        hourOfDay: 14,
+        dayOfWeek: 5,
+        brand: 'Aral',
+        countryCode: 'DE',
+        isHoliday: false,
+        priceEur: 1.789,
+        observedAt: t,
+      );
+      final b = FeatureVector(
+        hourOfDay: 14,
+        dayOfWeek: 5,
+        brand: 'Aral',
+        countryCode: 'DE',
+        isHoliday: false,
+        priceEur: 1.789,
+        observedAt: t,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('any field mismatch breaks equality', () {
+      final t = DateTime.utc(2026, 5, 1, 14);
+      final base = FeatureVector(
+        hourOfDay: 14,
+        dayOfWeek: 5,
+        brand: 'Aral',
+        countryCode: 'DE',
+        isHoliday: false,
+        priceEur: 1.789,
+        observedAt: t,
+      );
+
+      expect(
+        base ==
+            FeatureVector(
+              hourOfDay: 15,
+              dayOfWeek: 5,
+              brand: 'Aral',
+              countryCode: 'DE',
+              isHoliday: false,
+              priceEur: 1.789,
+              observedAt: t,
+            ),
+        isFalse,
+      );
+      expect(
+        base ==
+            FeatureVector(
+              hourOfDay: 14,
+              dayOfWeek: 5,
+              brand: 'Shell',
+              countryCode: 'DE',
+              isHoliday: false,
+              priceEur: 1.789,
+              observedAt: t,
+            ),
+        isFalse,
+      );
+      expect(
+        base ==
+            FeatureVector(
+              hourOfDay: 14,
+              dayOfWeek: 5,
+              brand: 'Aral',
+              countryCode: 'DE',
+              isHoliday: true,
+              priceEur: 1.789,
+              observedAt: t,
+            ),
+        isFalse,
+      );
+    });
+
+    test('toString includes all field values for debugging', () {
+      final v = FeatureVector(
+        hourOfDay: 8,
+        dayOfWeek: 1,
+        brand: 'Total',
+        countryCode: 'FR',
+        isHoliday: true,
+        priceEur: 1.65,
+        observedAt: DateTime.utc(2026, 7, 14, 8),
+      );
+      final s = v.toString();
+      expect(s, contains('hourOfDay: 8'));
+      expect(s, contains('dayOfWeek: 1'));
+      expect(s, contains('brand: Total'));
+      expect(s, contains('countryCode: FR'));
+      expect(s, contains('isHoliday: true'));
+      expect(s, contains('priceEur: 1.65'));
+    });
+  });
+
+  group('FeatureVector — toFeatureMap contract (TFLite-facing)', () {
+    test('emits the documented stable key set', () {
+      final v = FeatureVector(
+        hourOfDay: 14,
+        dayOfWeek: 5,
+        brand: 'Aral',
+        countryCode: 'DE',
+        isHoliday: false,
+        priceEur: 1.789,
+        observedAt: DateTime.utc(2026, 5, 1, 14, 30),
+      );
+      final map = v.toFeatureMap();
+      // Phase-2 model-breaking: any change to this set requires a
+      // schemaVersion bump.
+      expect(
+        map.keys.toSet(),
+        equals(<String>{
+          'brand',
+          'country_code',
+          'day_of_week',
+          'hour_of_day',
+          'is_holiday',
+          'observed_at',
+          'price_eur',
+        }),
+      );
+      expect(map['brand'], 'Aral');
+      expect(map['country_code'], 'DE');
+      expect(map['day_of_week'], 5);
+      expect(map['hour_of_day'], 14);
+      expect(map['is_holiday'], false);
+      expect(map['observed_at'], '2026-05-01T14:30:00.000Z');
+      expect(map['price_eur'], 1.789);
+    });
+
+    test('observedAt is normalised to UTC ISO-8601', () {
+      // Construct in local time and ensure UTC normalisation.
+      final v = FeatureVector(
+        hourOfDay: 14,
+        dayOfWeek: 5,
+        brand: null,
+        countryCode: null,
+        isHoliday: false,
+        priceEur: 1.0,
+        observedAt: DateTime.utc(2026, 5, 1, 14, 30, 0),
+      );
+      final s = v.toFeatureMap()['observed_at'] as String;
+      // Always ends with Z when properly normalised.
+      expect(s.endsWith('Z'), isTrue);
+    });
+
+    test('null brand and null countryCode pass through as null', () {
+      final v = FeatureVector(
+        hourOfDay: 0,
+        dayOfWeek: 7,
+        brand: null,
+        countryCode: null,
+        isHoliday: false,
+        priceEur: 1.0,
+        observedAt: DateTime.utc(2026, 1, 4),
+      );
+      final map = v.toFeatureMap();
+      expect(map['brand'], isNull);
+      expect(map['country_code'], isNull);
+    });
+
+    test('schemaVersion is exposed and starts at 1', () {
+      // The phase-2 model file embeds this constant; bumping it is a
+      // deliberate breaking change requiring retrain.
+      expect(FeatureVector.schemaVersion, 1);
+    });
+  });
+
+  group('FeatureVector — JSON round-trip', () {
+    test('toJson → fromJson reproduces the original vector', () {
+      final original = FeatureVector(
+        hourOfDay: 18,
+        dayOfWeek: 6,
+        brand: 'Carrefour',
+        countryCode: 'FR',
+        isHoliday: true,
+        priceEur: 1.612,
+        observedAt: DateTime.utc(2026, 7, 14, 18, 0),
+      );
+      final encoded = jsonEncode(original.toJson());
+      final decoded =
+          FeatureVector.fromJson(jsonDecode(encoded) as Map<String, dynamic>);
+      expect(decoded, equals(original));
+    });
+
+    test('fromJson tolerates int prices (e.g. 2 vs 2.0) for robustness', () {
+      // jsonDecode emits int when the value happens to be whole. The
+      // reader must still accept it without crashing.
+      final decoded = FeatureVector.fromJson(<String, dynamic>{
+        'hour_of_day': 0,
+        'day_of_week': 1,
+        'brand': null,
+        'country_code': null,
+        'is_holiday': false,
+        'observed_at': '2026-01-04T00:00:00.000Z',
+        'price_eur': 2, // int, not double
+      });
+      expect(decoded.priceEur, 2.0);
+    });
+
+    test('fromJson throws FormatException on missing required keys', () {
+      expect(
+        () => FeatureVector.fromJson(<String, dynamic>{
+          'hour_of_day': 8,
+          // missing day_of_week, etc.
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('fromJson throws FormatException on wrong value type', () {
+      expect(
+        () => FeatureVector.fromJson(<String, dynamic>{
+          'hour_of_day': '8', // String, not int
+          'day_of_week': 1,
+          'brand': null,
+          'country_code': null,
+          'is_holiday': false,
+          'observed_at': '2026-01-04T00:00:00.000Z',
+          'price_eur': 1.5,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}

--- a/test/features/price_history/domain/services/price_feature_extractor_test.dart
+++ b/test/features/price_history/domain/services/price_feature_extractor_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/price_history/data/models/price_record.dart';
+import 'package:tankstellen/features/price_history/domain/services/price_feature_extractor.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// Fast, station-stub-friendly factory for tests.
+Station _stubStation({String brand = 'Aral'}) => Station(
+      id: 'de-1',
+      name: 'Test Station',
+      brand: brand,
+      street: 'Hauptstr.',
+      postCode: '12345',
+      place: 'Berlin',
+      lat: 52.5,
+      lng: 13.4,
+      isOpen: true,
+    );
+
+void main() {
+  const extractor = PriceFeatureExtractor();
+
+  group('PriceFeatureExtractor — basic extraction', () {
+    test('produces one vector per record with a price for the requested fuel',
+        () {
+      final records = [
+        PriceRecord(
+          stationId: 'de-1',
+          recordedAt: DateTime(2026, 5, 1, 8),
+          e10: 1.65,
+        ),
+        PriceRecord(
+          stationId: 'de-1',
+          recordedAt: DateTime(2026, 5, 1, 18),
+          e10: 1.72,
+        ),
+        // No e10 — should be skipped.
+        PriceRecord(
+          stationId: 'de-1',
+          recordedAt: DateTime(2026, 5, 2, 10),
+          diesel: 1.50,
+        ),
+      ];
+
+      final vectors = extractor.extract(
+        records: records,
+        fuelType: FuelType.e10,
+      );
+
+      expect(vectors, hasLength(2));
+      expect(vectors[0].priceEur, 1.65);
+      expect(vectors[1].priceEur, 1.72);
+    });
+
+    test('hourOfDay and dayOfWeek mirror DateTime.hour/weekday', () {
+      // 2026-05-01 is a Friday → weekday 5.
+      final r = PriceRecord(
+        stationId: 'de-1',
+        recordedAt: DateTime(2026, 5, 1, 14),
+        diesel: 1.50,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.diesel,
+      ).single;
+
+      expect(v.hourOfDay, 14);
+      expect(v.dayOfWeek, 5);
+    });
+
+    test('returns an empty list when no records have a price for the fuel',
+        () {
+      final records = [
+        PriceRecord(
+          stationId: 'de-1',
+          recordedAt: DateTime(2026, 5, 1, 8),
+          diesel: 1.50,
+        ),
+      ];
+      final vectors = extractor.extract(
+        records: records,
+        fuelType: FuelType.e10,
+      );
+      expect(vectors, isEmpty);
+    });
+
+    test('returns an empty list for hydrogen / electric / all (unsupported)',
+        () {
+      final records = [
+        PriceRecord(
+          stationId: 'de-1',
+          recordedAt: DateTime(2026, 5, 1, 8),
+          e10: 1.50,
+          diesel: 1.40,
+        ),
+      ];
+      expect(
+        extractor.extract(records: records, fuelType: FuelType.hydrogen),
+        isEmpty,
+      );
+      expect(
+        extractor.extract(records: records, fuelType: FuelType.electric),
+        isEmpty,
+      );
+      expect(
+        extractor.extract(records: records, fuelType: FuelType.all),
+        isEmpty,
+      );
+    });
+  });
+
+  group('PriceFeatureExtractor — station / brand / country pass-through', () {
+    test('brand flows from station.brand into the vector', () {
+      final r = PriceRecord(
+        stationId: 'de-1',
+        recordedAt: DateTime(2026, 5, 1, 10),
+        e10: 1.65,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.e10,
+        station: _stubStation(brand: 'Shell'),
+      ).single;
+      expect(v.brand, 'Shell');
+    });
+
+    test('brand is null when station is null', () {
+      final r = PriceRecord(
+        stationId: 'de-1',
+        recordedAt: DateTime(2026, 5, 1, 10),
+        e10: 1.65,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.e10,
+      ).single;
+      expect(v.brand, isNull);
+    });
+
+    test('countryCodeOverride wins over station-derived country', () {
+      final r = PriceRecord(
+        stationId: 'de-1',
+        recordedAt: DateTime(2026, 5, 1, 10),
+        e10: 1.65,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.e10,
+        station: _stubStation(),
+        countryCodeOverride: 'FR',
+      ).single;
+      expect(v.countryCode, 'FR');
+    });
+
+    test('countryCode is null when neither station nor override is provided',
+        () {
+      final r = PriceRecord(
+        stationId: 'unknown',
+        recordedAt: DateTime(2026, 5, 1, 10),
+        e10: 1.65,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.e10,
+      ).single;
+      expect(v.countryCode, isNull);
+    });
+  });
+
+  group('PriceFeatureExtractor — holiday flag', () {
+    test('Bastille Day (Jul 14) records get isHoliday=true when country=FR',
+        () {
+      final records = [
+        PriceRecord(
+          stationId: 'fr-1',
+          recordedAt: DateTime(2026, 7, 14, 10),
+          e10: 1.80,
+        ),
+        PriceRecord(
+          stationId: 'fr-1',
+          recordedAt: DateTime(2026, 7, 15, 10),
+          e10: 1.78,
+        ),
+      ];
+      final vectors = extractor.extract(
+        records: records,
+        fuelType: FuelType.e10,
+        countryCodeOverride: 'FR',
+      );
+      expect(vectors[0].isHoliday, isTrue);
+      expect(vectors[1].isHoliday, isFalse);
+    });
+
+    test('Bastille Day in DE does not flag — national holiday is country-specific',
+        () {
+      final r = PriceRecord(
+        stationId: 'de-1',
+        recordedAt: DateTime(2026, 7, 14, 10),
+        e10: 1.80,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.e10,
+        countryCodeOverride: 'DE',
+      ).single;
+      expect(v.isHoliday, isFalse);
+    });
+
+    test('Christmas Day flags everywhere, even with null country', () {
+      final r = PriceRecord(
+        stationId: 'unknown',
+        recordedAt: DateTime(2026, 12, 25, 10),
+        e10: 1.80,
+      );
+      final v = extractor.extract(
+        records: [r],
+        fuelType: FuelType.e10,
+      ).single;
+      expect(v.isHoliday, isTrue);
+    });
+  });
+
+  group('PriceFeatureExtractor — fuel coverage', () {
+    test('extracts price from each supported fuel field', () {
+      final base = DateTime(2026, 5, 1, 10);
+      // One record per fuel field.
+      final pairs = <(FuelType, PriceRecord, double)>[
+        (
+          FuelType.e5,
+          PriceRecord(stationId: 's', recordedAt: base, e5: 1.80),
+          1.80,
+        ),
+        (
+          FuelType.e10,
+          PriceRecord(stationId: 's', recordedAt: base, e10: 1.70),
+          1.70,
+        ),
+        (
+          FuelType.e98,
+          PriceRecord(stationId: 's', recordedAt: base, e98: 1.95),
+          1.95,
+        ),
+        (
+          FuelType.diesel,
+          PriceRecord(stationId: 's', recordedAt: base, diesel: 1.55),
+          1.55,
+        ),
+        (
+          FuelType.dieselPremium,
+          PriceRecord(
+              stationId: 's', recordedAt: base, dieselPremium: 1.75),
+          1.75,
+        ),
+        (
+          FuelType.e85,
+          PriceRecord(stationId: 's', recordedAt: base, e85: 1.05),
+          1.05,
+        ),
+        (
+          FuelType.lpg,
+          PriceRecord(stationId: 's', recordedAt: base, lpg: 0.95),
+          0.95,
+        ),
+        (
+          FuelType.cng,
+          PriceRecord(stationId: 's', recordedAt: base, cng: 1.25),
+          1.25,
+        ),
+      ];
+      for (final (ft, record, expected) in pairs) {
+        final v = extractor.extract(
+          records: [record],
+          fuelType: ft,
+        ).single;
+        expect(v.priceEur, expected, reason: 'fuel ${ft.apiValue}');
+      }
+    });
+  });
+}

--- a/test/features/price_history/providers/price_prediction_provider_test.dart
+++ b/test/features/price_history/providers/price_prediction_provider_test.dart
@@ -344,6 +344,133 @@ void main() {
     });
   });
 
+  group('pricePrediction — holidayPremium (#1117 phase 1)', () {
+    test('holidayPremium is null when fewer than 3 holiday samples exist',
+        () {
+      // 12 records spread across non-holiday weekdays in May 2026; only
+      // 1 of them happens on May 3 (PL Constitution Day). With country
+      // resolved to PL via the 'pl-' prefix we'd have 1 holiday sample
+      // → below threshold → null.
+      final records = <PriceRecord>[];
+      // Single holiday record on May 3, 2026 (Sunday).
+      records.add(PriceRecord(
+        stationId: 'pl-station-1',
+        recordedAt: DateTime(2026, 5, 3, 10),
+        e10: 1.80,
+      ));
+      // 11 non-holiday records spread across other May days.
+      for (int i = 0; i < 11; i++) {
+        records.add(PriceRecord(
+          stationId: 'pl-station-1',
+          recordedAt: DateTime(2026, 5, 5 + i, 10),
+          e10: 1.60,
+        ));
+      }
+
+      // Note: 'pl-' is not in Countries._stationIdPrefixToCountry, so
+      // country resolves to null and PL Constitution Day does NOT
+      // flag. holidayPremium therefore stays null. This is the
+      // realistic phase-1 behaviour for unsupported-prefix countries.
+      final container = makeContainer(records);
+      final result =
+          container.read(pricePredictionProvider('pl-station-1', FuelType.e10));
+
+      expect(result, isNotNull);
+      expect(result!.holidayPremium, isNull);
+    });
+
+    test(
+        'holidayPremium is computed when 3+ holiday samples exist and '
+        'appended to recommendation when premium > 2 ct/L', () {
+      // FR station ('fr-' prefix → country FR via station-id lookup).
+      // 3 records on Bastille Day at distinct hours; 9 non-holiday
+      // records the next day. Holiday avg = 1.80, non-holiday = 1.60
+      // → premium = +0.20 EUR/L.
+      final records = <PriceRecord>[];
+      for (int hour = 8; hour <= 10; hour++) {
+        records.add(PriceRecord(
+          stationId: 'fr-station-1',
+          recordedAt: DateTime(2026, 7, 14, hour),
+          e10: 1.80,
+        ));
+      }
+      for (int day = 15; day <= 23; day++) {
+        records.add(PriceRecord(
+          stationId: 'fr-station-1',
+          recordedAt: DateTime(2026, 7, day, 10),
+          e10: 1.60,
+        ));
+      }
+
+      final container = makeContainer(records);
+      final result =
+          container.read(pricePredictionProvider('fr-station-1', FuelType.e10));
+
+      expect(result, isNotNull);
+      expect(result!.holidayPremium, closeTo(0.20, 0.001));
+      // Premium > 2 ct/L → recommendation gets a holiday hint.
+      expect(result.recommendation, contains('Holidays trend'));
+      expect(result.recommendation, contains('higher'));
+    });
+
+    test('negative holidayPremium → recommendation says "lower"', () {
+      // Holiday samples cheaper than non-holiday samples.
+      final records = <PriceRecord>[];
+      for (int hour = 8; hour <= 10; hour++) {
+        records.add(PriceRecord(
+          stationId: 'fr-station-2',
+          recordedAt: DateTime(2026, 7, 14, hour),
+          e10: 1.40,
+        ));
+      }
+      for (int day = 15; day <= 23; day++) {
+        records.add(PriceRecord(
+          stationId: 'fr-station-2',
+          recordedAt: DateTime(2026, 7, day, 10),
+          e10: 1.60,
+        ));
+      }
+
+      final container = makeContainer(records);
+      final result =
+          container.read(pricePredictionProvider('fr-station-2', FuelType.e10));
+
+      expect(result, isNotNull);
+      expect(result!.holidayPremium, lessThan(0));
+      expect(result.recommendation, contains('lower'));
+    });
+
+    test(
+        'small premium (<= 2 ct/L) does NOT append a hint to recommendation',
+        () {
+      // Holiday samples only marginally different from baseline.
+      final records = <PriceRecord>[];
+      for (int hour = 8; hour <= 10; hour++) {
+        records.add(PriceRecord(
+          stationId: 'fr-station-3',
+          recordedAt: DateTime(2026, 7, 14, hour),
+          e10: 1.605, // baseline + 0.5 ct/L
+        ));
+      }
+      for (int day = 15; day <= 23; day++) {
+        records.add(PriceRecord(
+          stationId: 'fr-station-3',
+          recordedAt: DateTime(2026, 7, day, 10),
+          e10: 1.60,
+        ));
+      }
+
+      final container = makeContainer(records);
+      final result =
+          container.read(pricePredictionProvider('fr-station-3', FuelType.e10));
+
+      expect(result, isNotNull);
+      expect(result!.holidayPremium, isNotNull);
+      expect(result.holidayPremium!.abs(), lessThanOrEqualTo(0.02));
+      expect(result.recommendation, isNot(contains('Holidays trend')));
+    });
+  });
+
   group('pricePrediction — covers every supported FuelType', () {
     // For each fuel field, feed 12 records with that field set; assert non-null.
     test('FuelType.e5', () {


### PR DESCRIPTION
## Summary

Phase 1 of #1117 (best-time-to-fill predictor → on-device TFLite). Establishes the data contract the future TFLite model will consume and enriches the existing heuristic predictor with a holiday signal. **No model, no plugin, no training code** — that is phase 2.

## Deliverables

### A. `FeatureVector` value type (the contract)
`lib/features/price_history/domain/entities/feature_vector.dart` — immutable value class with `hourOfDay`, `dayOfWeek`, `brand?`, `countryCode?`, `isHoliday`, `priceEur`, `observedAt`. Provides:
- `toFeatureMap()` — stable key set the phase-2 TFLite model will consume
- `toJson` / `fromJson` round-trip for on-device persistence
- Value equality + hashCode + readable `toString`
- `static const schemaVersion = 1` — bump on breaking changes (forces retrain)

### B. `PriceFeatureExtractor` service (the producer)
`lib/features/price_history/domain/services/price_feature_extractor.dart` — pure-Dart, stateless. Takes `List<PriceRecord> + FuelType + optional Station + optional countryCodeOverride`, returns `List<FeatureVector>`. Skips records that have no price for the requested fuel. Produces one vector per priced record.

### C. `PublicHolidayCalendar`
`lib/core/calendar/public_holiday_calendar.dart` — pure-Dart, no plugin. Covers:
- Universal: New Year's Day (Jan 1), Christmas Day (Dec 25)
- DE Tag der Deutschen Einheit (Oct 3), FR Bastille (Jul 14), IT Festa della Repubblica (Jun 2), ES Fiesta Nacional (Oct 12), AT Nationalfeiertag (Oct 26), BE Nationale feestdag (Jul 21), NL Koningsdag (Apr 27), LU National Day (Jun 23), PL Constitution Day (May 3)

API: `bool isPublicHoliday(DateTime, String? countryCode)`. Variable holidays (Easter family) are scope-cut to phase 2 — documented in the dartdoc.

### D. Wired into `pricePredictionProvider`
- Uses the extractor internally to build per-record vectors (resolves country via `Countries.countryCodeForStationId(stationId)` from the existing prefix table)
- Adds `holidayPremium: double?` to `PricePrediction` — avg EUR/L delta on holiday vs non-holiday samples; `null` when fewer than 3 holiday samples
- When `|holidayPremium| > 0.02`, recommendation gets a suffix: `Holidays trend X.Y ct/L higher` (or `lower`)
- **Additive only**: existing `recommendation` prefix, `bestHour`, `bestDayOfWeek`, `hourlyAverages`, `dailyAverages` semantics are unchanged. `BestTimeBanner` keeps working untouched.

## Out of scope (phase 2)

- TFLite plugin (no `pubspec.yaml` changes)
- Offline model training, model artifact, on-device inference
- Brand/country-driven recommendation rewording (data is exposed via `FeatureVector` for future consumption only)
- Notification surfacing of predictions
- `BestTimeBanner` widget changes
- Easter / variable / regional holidays

## Local checks

- `flutter analyze` — clean (zero warnings, zero infos)
- `flutter test test/core/calendar/ test/features/price_history/domain/` — 52 new tests pass
- `flutter test test/features/price_history/` — 113 tests pass (existing + new)
- `flutter test test/lint/` — 29 lint tests pass (incl. `no_silent_catch`, `prefer_const_constructors`)

## Test plan

- [x] FeatureVector value semantics + JSON round-trip + schema-version constant
- [x] PriceFeatureExtractor: vectors-per-priced-record, brand pass-through, country override precedence, holiday flag
- [x] PublicHolidayCalendar: every documented country × fixed date, null/unknown country fallback, year-agnostic, case-insensitive
- [x] pricePredictionProvider: holidayPremium null below 3 samples, computed above, recommendation suffix on >2 ct/L, lower vs higher direction, no suffix when small premium
- [ ] CI: full suite + coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)