### PR TITLE
feat(consumption): GPS sample diagnostics inspector card (Refs #1458 phase 2.5)

### DIFF
--- a/lib/features/consumption/presentation/widgets/gps_diagnostics_card.dart
+++ b/lib/features/consumption/presentation/widgets/gps_diagnostics_card.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/gps_sample_diagnostic.dart';
+
+/// Read-only inspector card for the GPS sample diagnostics captured
+/// during a trip recording (#1458 phase 2.5).
+///
+/// Phase 2 of #1458 captured a [GpsSampleDiagnostic] per position fix
+/// with a wall-clock timestamp + the host app's lifecycle state at the
+/// time of the fix. Phase 2.5 surfaces those samples on the trip-detail
+/// screen so the user can verify GPS sampling cadence under phone-sleep
+/// conditions WITHOUT inspecting the persisted Hive JSON. The output of
+/// this card is the input to the phase-3 decision: if the median
+/// interval, gap count, and lifecycle-state breakdown look healthy, we
+/// can ship without an Android foreground service; otherwise phase 3 is
+/// required.
+///
+/// The card collapses by default — trip detail is already busy with the
+/// summary, map, insights, score, histogram and four time-series
+/// charts. The collapsed header gives an at-a-glance triple
+/// ("`samples · timeSpan · gapCount`") and the expanded body surfaces
+/// the full breakdown the user actually clicks for.
+///
+/// The card is purely presentational — all gap / median / lifecycle
+/// math lives in the top-level [computeGpsDiagnosticsSummary] helper so
+/// tests can assert on the math without pumping a widget tree.
+class GpsDiagnosticsCard extends StatelessWidget {
+  final List<GpsSampleDiagnostic> diagnostics;
+
+  const GpsDiagnosticsCard({super.key, required this.diagnostics});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final summary = computeGpsDiagnosticsSummary(diagnostics);
+
+    final title = l?.gpsDiagnosticsTitle ?? 'GPS sampling diagnostics';
+    final headerLine = l?.gpsDiagnosticsHeader(
+          summary.sampleCount.toString(),
+          _formatDuration(summary.timeSpan),
+          summary.gapCount,
+        ) ??
+        '${summary.sampleCount} samples · ${_formatDuration(summary.timeSpan)} · '
+            '${_pluralizeGaps(summary.gapCount)}';
+    final cadenceLine = l?.gpsDiagnosticsCadence(
+          summary.medianIntervalMs,
+        ) ??
+        'Median interval: ${summary.medianIntervalMs} ms';
+    final explainLine = l?.gpsDiagnosticsExplain ??
+        'Captured during recording to verify GPS cadence under phone-sleep.';
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      child: ExpansionTile(
+        // Locks down a stable selector for widget tests.
+        key: const Key('gps_diagnostics_tile'),
+        // Collapsed by default — the user opts in to the detail.
+        initiallyExpanded: false,
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16),
+        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        title: Text(title, style: theme.textTheme.titleMedium),
+        subtitle: Text(
+          headerLine,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        children: [
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(
+              cadenceLine,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(
+              _formatLifecycleBreakdown(summary.lifecyclePercent),
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(
+              'Largest gap: ${summary.largestGap.inSeconds} s',
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            explainLine,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Pure-function aggregate produced by [computeGpsDiagnosticsSummary].
+///
+/// Holds everything the card needs to render — kept as a value type
+/// (with `==` / `hashCode`) so tests can assert on a single equality
+/// check rather than reaching into many fields.
+@immutable
+class GpsDiagnosticsSummary {
+  /// Total number of [GpsSampleDiagnostic] records in the trip.
+  final int sampleCount;
+
+  /// Wall-clock duration between the FIRST and the LAST diagnostic.
+  /// [Duration.zero] when [sampleCount] is 0 or 1.
+  final Duration timeSpan;
+
+  /// Median sample-to-sample interval in milliseconds, rounded to the
+  /// nearest 100 ms (per the issue's "rounded to 100 ms" instruction).
+  /// 0 when there are fewer than two diagnostics.
+  final int medianIntervalMs;
+
+  /// Map from a lifecycle-state name (e.g. `'resumed'`) to its
+  /// percentage of the total sample count, rounded to the nearest
+  /// integer. The percentages may not sum to exactly 100 due to
+  /// rounding — the card's display copy is "92% · 5% · 3%" style and
+  /// readers don't expect a strict total.
+  final Map<String, int> lifecyclePercent;
+
+  /// Number of intervals whose delta exceeded `3 × medianInterval`
+  /// (heuristic threshold for a "GPS-throttled" gap). 0 when there
+  /// are fewer than two diagnostics or no median exists.
+  final int gapCount;
+
+  /// Largest interval observed across the whole trip. [Duration.zero]
+  /// when there are fewer than two diagnostics.
+  final Duration largestGap;
+
+  const GpsDiagnosticsSummary({
+    required this.sampleCount,
+    required this.timeSpan,
+    required this.medianIntervalMs,
+    required this.lifecyclePercent,
+    required this.gapCount,
+    required this.largestGap,
+  });
+
+  /// Stable empty value — used by the helper for empty / single-sample
+  /// inputs and by tests that want to assert the empty shape.
+  static const GpsDiagnosticsSummary empty = GpsDiagnosticsSummary(
+    sampleCount: 0,
+    timeSpan: Duration.zero,
+    medianIntervalMs: 0,
+    lifecyclePercent: <String, int>{},
+    gapCount: 0,
+    largestGap: Duration.zero,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! GpsDiagnosticsSummary) return false;
+    if (other.sampleCount != sampleCount) return false;
+    if (other.timeSpan != timeSpan) return false;
+    if (other.medianIntervalMs != medianIntervalMs) return false;
+    if (other.gapCount != gapCount) return false;
+    if (other.largestGap != largestGap) return false;
+    if (other.lifecyclePercent.length != lifecyclePercent.length) return false;
+    for (final entry in lifecyclePercent.entries) {
+      if (other.lifecyclePercent[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        sampleCount,
+        timeSpan,
+        medianIntervalMs,
+        gapCount,
+        largestGap,
+        Object.hashAllUnordered(lifecyclePercent.entries.map(
+          (e) => Object.hash(e.key, e.value),
+        )),
+      );
+}
+
+/// Compute the read-only diagnostic summary for a list of GPS sample
+/// diagnostics (#1458 phase 2.5).
+///
+/// Pure — does not allocate any platform handles, does not depend on
+/// the framework, safe to call from a unit test or a build method.
+///
+/// Heuristics:
+///   * Median interval is computed across consecutive sample deltas
+///     (sorted, mid-element on odd / average on even, like a textbook
+///     median). Rounded to the nearest 100 ms so the displayed value
+///     looks like a real cadence ("1000 ms") rather than a noisy
+///     timestamp diff ("1023 ms").
+///   * A "gap" is an interval whose delta is at least `3 × median`.
+///     `3×` lands somewhere between Android's typical 1 Hz cadence
+///     during normal sampling and the > 5 s pauses we see when the
+///     OS throttles the GPS stream during sleep — a coarse but useful
+///     signal for "did the OS throttle this trip?".
+///   * Lifecycle percentages are rounded to the nearest integer; the
+///     map preserves insertion order via [Map.toList] sort by count
+///     desc so the largest state shows up first when iterated.
+@visibleForTesting
+GpsDiagnosticsSummary computeGpsDiagnosticsSummary(
+  List<GpsSampleDiagnostic> diagnostics,
+) {
+  if (diagnostics.isEmpty) return GpsDiagnosticsSummary.empty;
+  if (diagnostics.length == 1) {
+    return GpsDiagnosticsSummary(
+      sampleCount: 1,
+      timeSpan: Duration.zero,
+      medianIntervalMs: 0,
+      lifecyclePercent: <String, int>{
+        diagnostics.first.lifecycleState: 100,
+      },
+      gapCount: 0,
+      largestGap: Duration.zero,
+    );
+  }
+
+  // Defensive copy + sort by timestamp — the recorder appends in
+  // arrival order which is normally already monotonic, but a clock
+  // adjustment mid-trip would technically violate that and this
+  // helper is meant to be safe against malformed inputs.
+  final sorted = [...diagnostics]
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  final timeSpan = sorted.last.timestamp.difference(sorted.first.timestamp);
+
+  // Per-interval deltas in milliseconds.
+  final intervals = <int>[];
+  for (var i = 1; i < sorted.length; i++) {
+    final ms = sorted[i].timestamp.difference(sorted[i - 1].timestamp).inMilliseconds;
+    // Defensive clamp: backwards-clock anomalies become 0 rather than
+    // contaminating the median.
+    intervals.add(ms < 0 ? 0 : ms);
+  }
+
+  // Median (textbook).
+  final sortedIntervals = [...intervals]..sort();
+  final n = sortedIntervals.length;
+  final medianRaw = n.isOdd
+      ? sortedIntervals[n ~/ 2].toDouble()
+      : (sortedIntervals[(n ~/ 2) - 1] + sortedIntervals[n ~/ 2]) / 2.0;
+  // Round to nearest 100 ms.
+  final medianMs = ((medianRaw / 100).round()) * 100;
+
+  // Largest gap.
+  final largestMs = sortedIntervals.last;
+
+  // Gap count: intervals at least 3× the (un-rounded) median. We use
+  // the un-rounded median here so a tiny rounding step doesn't flip a
+  // borderline interval in or out of the count.
+  final gapThreshold = medianRaw * 3;
+  // When the median is 0 (all samples on the same millisecond — degenerate
+  // input), gaps are not a meaningful signal, so report 0.
+  final gapCount =
+      medianRaw == 0 ? 0 : intervals.where((d) => d >= gapThreshold).length;
+
+  // Lifecycle breakdown.
+  final lifecycleCounts = <String, int>{};
+  for (final d in sorted) {
+    lifecycleCounts[d.lifecycleState] =
+        (lifecycleCounts[d.lifecycleState] ?? 0) + 1;
+  }
+  final total = sorted.length;
+  // Sort entries by count desc so the dominant state renders first.
+  final orderedEntries = lifecycleCounts.entries.toList(growable: false)
+    ..sort((a, b) => b.value.compareTo(a.value));
+  final lifecyclePercent = <String, int>{};
+  for (final e in orderedEntries) {
+    lifecyclePercent[e.key] = ((e.value / total) * 100).round();
+  }
+
+  return GpsDiagnosticsSummary(
+    sampleCount: total,
+    timeSpan: timeSpan,
+    medianIntervalMs: medianMs,
+    lifecyclePercent: lifecyclePercent,
+    gapCount: gapCount,
+    largestGap: Duration(milliseconds: largestMs),
+  );
+}
+
+/// Format a duration into "Hh Mmin" (e.g. "1h 23min", "12min", "0min").
+/// Hours are dropped when zero so short trips don't read "0h 12min".
+String _formatDuration(Duration d) {
+  if (d == Duration.zero) return '0min';
+  final hours = d.inHours;
+  final minutes = d.inMinutes - hours * 60;
+  if (hours == 0) return '${minutes}min';
+  return '${hours}h ${minutes}min';
+}
+
+/// Tiny English-only fallback used when [AppLocalizations] is not
+/// available (defensive — pumpApp tests always provide it). Never
+/// reached in production on non-English locales.
+String _pluralizeGaps(int gapCount) {
+  if (gapCount == 0) return 'no gaps';
+  if (gapCount == 1) return '1 gap';
+  return '$gapCount gaps';
+}
+
+/// Format the lifecycle-percent map into a "resumed 92% · paused 5% · …"
+/// line. The map is already sorted by count desc by the helper.
+String _formatLifecycleBreakdown(Map<String, int> lifecyclePercent) {
+  if (lifecyclePercent.isEmpty) return '';
+  return lifecyclePercent.entries
+      .map((e) => '${e.key} ${e.value}%')
+      .join(' · ');
+}

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -13,6 +13,7 @@ import '../../domain/services/throttle_rpm_histogram_calculator.dart';
 import '../../domain/trip_recorder.dart';
 import 'driving_insights_card.dart';
 import 'driving_score_card.dart';
+import 'gps_diagnostics_card.dart';
 import 'throttle_rpm_histogram_card.dart';
 import 'trip_detail_charts.dart';
 import 'trip_path_map_card.dart';
@@ -209,6 +210,16 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
         // empty-samples-skip rules.
         if (!widget.isEv && widget.samples.isNotEmpty)
           ThrottleRpmHistogramCard(histogram: _histogram),
+        // GPS sample diagnostics inspector (#1458 phase 2.5).
+        // Read-only — rendered only when at least one diagnostic was
+        // captured (legacy trips and flag-off trips skip this card so
+        // their layout is unchanged). Phase 3 (Android foreground GPS
+        // service) is conditional on what this card surfaces during
+        // field testing.
+        if (widget.entry.gpsSampleDiagnostics.isNotEmpty)
+          GpsDiagnosticsCard(
+            diagnostics: widget.entry.gpsSampleDiagnostics,
+          ),
         _ChartSection(
           title: l?.trajetDetailChartSpeed ?? 'Speed (km/h)',
           chart: TripDetailSpeedChart(samples: widget.samples),

--- a/lib/l10n/_fragments/gps_diagnostics_de.arb
+++ b/lib/l10n/_fragments/gps_diagnostics_de.arb
@@ -1,0 +1,34 @@
+{
+  "gpsDiagnosticsTitle": "GPS-Abtastungsdiagnose",
+  "@gpsDiagnosticsTitle": {
+    "description": "Title of the read-only GPS sample diagnostics card on the Trip detail screen (#1458 phase 2.5)."
+  },
+  "gpsDiagnosticsHeader": "{count} Messpunkte · {span} · {gaps, plural, =0{keine Lücken} =1{1 Lücke} other{{gaps} Lücken}}",
+  "@gpsDiagnosticsHeader": {
+    "description": "Collapsed-header summary line of the GPS diagnostics card (#1458 phase 2.5).",
+    "placeholders": {
+      "count": {
+        "type": "String"
+      },
+      "span": {
+        "type": "String"
+      },
+      "gaps": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsCadence": "Median-Intervall: {ms} ms",
+  "@gpsDiagnosticsCadence": {
+    "description": "Expanded-body line on the GPS diagnostics card (#1458 phase 2.5).",
+    "placeholders": {
+      "ms": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsExplain": "Wird während der Aufzeichnung erfasst, um die GPS-Abtastung im Standby-Modus zu prüfen.",
+  "@gpsDiagnosticsExplain": {
+    "description": "Subtle one-line explanation at the bottom of the GPS diagnostics card (#1458 phase 2.5)."
+  }
+}

--- a/lib/l10n/_fragments/gps_diagnostics_en.arb
+++ b/lib/l10n/_fragments/gps_diagnostics_en.arb
@@ -1,0 +1,34 @@
+{
+  "gpsDiagnosticsTitle": "GPS sampling diagnostics",
+  "@gpsDiagnosticsTitle": {
+    "description": "Title of the read-only GPS sample diagnostics card on the Trip detail screen — surfaces the cadence + lifecycle-state info captured by #1458 phase 2 so the user can verify that the OS did not throttle the GPS stream during phone-sleep, ahead of deciding whether phase 3 (foreground service) is needed."
+  },
+  "gpsDiagnosticsHeader": "{count} samples · {span} · {gaps, plural, =0{no gaps} =1{1 gap} other{{gaps} gaps}}",
+  "@gpsDiagnosticsHeader": {
+    "description": "Collapsed-header summary line of the GPS diagnostics card (#1458 phase 2.5). At-a-glance triple: total sample count, total trip time span, and the number of GPS gaps detected (intervals at least 3x the median). count and span are pre-formatted strings.",
+    "placeholders": {
+      "count": {
+        "type": "String"
+      },
+      "span": {
+        "type": "String"
+      },
+      "gaps": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsCadence": "Median interval: {ms} ms",
+  "@gpsDiagnosticsCadence": {
+    "description": "Expanded-body line on the GPS diagnostics card (#1458 phase 2.5) showing the median sample-to-sample interval (rounded to 100ms). A healthy ~1000ms median says the OS is not throttling; a 5000ms+ median means the GPS stream paused during sleep.",
+    "placeholders": {
+      "ms": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsExplain": "Captured during recording to verify GPS cadence under phone-sleep.",
+  "@gpsDiagnosticsExplain": {
+    "description": "Subtle one-line explanation at the bottom of the GPS diagnostics card (#1458 phase 2.5) reminding the user why this card exists — they probably opened the trip detail to look at consumption, not GPS plumbing."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1601,6 +1601,38 @@
   "@profileGamificationToggleSubtitle": {
     "description": "Subtitle explaining what the gamification opt-out toggle hides (#1194)."
   },
+  "gpsDiagnosticsTitle": "GPS-Abtastungsdiagnose",
+  "@gpsDiagnosticsTitle": {
+    "description": "Title of the read-only GPS sample diagnostics card on the Trip detail screen (#1458 phase 2.5)."
+  },
+  "gpsDiagnosticsHeader": "{count} Messpunkte · {span} · {gaps, plural, =0{keine Lücken} =1{1 Lücke} other{{gaps} Lücken}}",
+  "@gpsDiagnosticsHeader": {
+    "description": "Collapsed-header summary line of the GPS diagnostics card (#1458 phase 2.5).",
+    "placeholders": {
+      "count": {
+        "type": "String"
+      },
+      "span": {
+        "type": "String"
+      },
+      "gaps": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsCadence": "Median-Intervall: {ms} ms",
+  "@gpsDiagnosticsCadence": {
+    "description": "Expanded-body line on the GPS diagnostics card (#1458 phase 2.5).",
+    "placeholders": {
+      "ms": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsExplain": "Wird während der Aufzeichnung erfasst, um die GPS-Abtastung im Standby-Modus zu prüfen.",
+  "@gpsDiagnosticsExplain": {
+    "description": "Subtle one-line explanation at the bottom of the GPS diagnostics card (#1458 phase 2.5)."
+  },
   "hapticEcoCoachSectionTitle": "Fahrweise",
   "hapticEcoCoachSettingTitle": "Echtzeit-Eco-Coaching",
   "hapticEcoCoachSettingSubtitle": "Sanftes Vibrieren + Hinweis am Bildschirm, wenn du beim Cruisen aufs Pedal trittst",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2521,6 +2521,38 @@
   "@profileGamificationToggleSubtitle": {
     "description": "Subtitle explaining what the gamification opt-out toggle hides (#1194)."
   },
+  "gpsDiagnosticsTitle": "GPS sampling diagnostics",
+  "@gpsDiagnosticsTitle": {
+    "description": "Title of the read-only GPS sample diagnostics card on the Trip detail screen — surfaces the cadence + lifecycle-state info captured by #1458 phase 2 so the user can verify that the OS did not throttle the GPS stream during phone-sleep, ahead of deciding whether phase 3 (foreground service) is needed."
+  },
+  "gpsDiagnosticsHeader": "{count} samples · {span} · {gaps, plural, =0{no gaps} =1{1 gap} other{{gaps} gaps}}",
+  "@gpsDiagnosticsHeader": {
+    "description": "Collapsed-header summary line of the GPS diagnostics card (#1458 phase 2.5). At-a-glance triple: total sample count, total trip time span, and the number of GPS gaps detected (intervals at least 3x the median). count and span are pre-formatted strings.",
+    "placeholders": {
+      "count": {
+        "type": "String"
+      },
+      "span": {
+        "type": "String"
+      },
+      "gaps": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsCadence": "Median interval: {ms} ms",
+  "@gpsDiagnosticsCadence": {
+    "description": "Expanded-body line on the GPS diagnostics card (#1458 phase 2.5) showing the median sample-to-sample interval (rounded to 100ms). A healthy ~1000ms median says the OS is not throttling; a 5000ms+ median means the GPS stream paused during sleep.",
+    "placeholders": {
+      "ms": {
+        "type": "int"
+      }
+    }
+  },
+  "gpsDiagnosticsExplain": "Captured during recording to verify GPS cadence under phone-sleep.",
+  "@gpsDiagnosticsExplain": {
+    "description": "Subtle one-line explanation at the bottom of the GPS diagnostics card (#1458 phase 2.5) reminding the user why this card exists — they probably opened the trip detail to look at consumption, not GPS plumbing."
+  },
   "hapticEcoCoachSectionTitle": "Driving",
   "@hapticEcoCoachSectionTitle": {
     "description": "Section header on the Settings screen grouping wheel-lens (driving-behaviour) settings (#1122)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1233,5 +1233,21 @@
   "pickerHelpText": "Pré-remplir depuis 50+ véhicules pris en charge",
   "pickerEmptyResults": "Aucun résultat",
   "pickerCancel": "Annuler",
-  "pickerLoading": "Chargement du catalogue…"
+  "pickerLoading": "Chargement du catalogue…",
+  "gpsDiagnosticsTitle": "Diagnostic d'échantillonnage GPS",
+  "gpsDiagnosticsHeader": "{count} échantillons · {span} · {gaps, plural, =0{aucune lacune} =1{1 lacune} other{{gaps} lacunes}}",
+  "@gpsDiagnosticsHeader": {
+    "placeholders": {
+      "count": {"type": "String"},
+      "span": {"type": "String"},
+      "gaps": {"type": "int"}
+    }
+  },
+  "gpsDiagnosticsCadence": "Intervalle médian : {ms} ms",
+  "@gpsDiagnosticsCadence": {
+    "placeholders": {
+      "ms": {"type": "int"}
+    }
+  },
+  "gpsDiagnosticsExplain": "Capturé pendant l'enregistrement pour vérifier la cadence GPS en veille."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7214,6 +7214,30 @@ abstract class AppLocalizations {
   /// **'When off, badges, scores and trophy icons are hidden across the app.'**
   String get profileGamificationToggleSubtitle;
 
+  /// Title of the read-only GPS sample diagnostics card on the Trip detail screen — surfaces the cadence + lifecycle-state info captured by #1458 phase 2 so the user can verify that the OS did not throttle the GPS stream during phone-sleep, ahead of deciding whether phase 3 (foreground service) is needed.
+  ///
+  /// In en, this message translates to:
+  /// **'GPS sampling diagnostics'**
+  String get gpsDiagnosticsTitle;
+
+  /// Collapsed-header summary line of the GPS diagnostics card (#1458 phase 2.5). At-a-glance triple: total sample count, total trip time span, and the number of GPS gaps detected (intervals at least 3x the median). count and span are pre-formatted strings.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} samples · {span} · {gaps, plural, =0{no gaps} =1{1 gap} other{{gaps} gaps}}'**
+  String gpsDiagnosticsHeader(String count, String span, int gaps);
+
+  /// Expanded-body line on the GPS diagnostics card (#1458 phase 2.5) showing the median sample-to-sample interval (rounded to 100ms). A healthy ~1000ms median says the OS is not throttling; a 5000ms+ median means the GPS stream paused during sleep.
+  ///
+  /// In en, this message translates to:
+  /// **'Median interval: {ms} ms'**
+  String gpsDiagnosticsCadence(int ms);
+
+  /// Subtle one-line explanation at the bottom of the GPS diagnostics card (#1458 phase 2.5) reminding the user why this card exists — they probably opened the trip detail to look at consumption, not GPS plumbing.
+  ///
+  /// In en, this message translates to:
+  /// **'Captured during recording to verify GPS cadence under phone-sleep.'**
+  String get gpsDiagnosticsExplain;
+
   /// Section header on the Settings screen grouping wheel-lens (driving-behaviour) settings (#1122).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3921,6 +3921,30 @@ class AppLocalizationsBg extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3921,6 +3921,30 @@ class AppLocalizationsCs extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3919,6 +3919,30 @@ class AppLocalizationsDa extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3959,6 +3959,30 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wenn aus, sind Abzeichen, Punkte und Pokal-Symbole überall ausgeblendet.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS-Abtastungsdiagnose';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps Lücken',
+      one: '1 Lücke',
+      zero: 'keine Lücken',
+    );
+    return '$count Messpunkte · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median-Intervall: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Wird während der Aufzeichnung erfasst, um die GPS-Abtastung im Standby-Modus zu prüfen.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Fahrweise';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3923,6 +3923,30 @@ class AppLocalizationsEl extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3914,6 +3914,30 @@ class AppLocalizationsEn extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3922,6 +3922,30 @@ class AppLocalizationsEs extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3916,6 +3916,30 @@ class AppLocalizationsEt extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3919,6 +3919,30 @@ class AppLocalizationsFi extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3962,6 +3962,30 @@ class AppLocalizationsFr extends AppLocalizations {
       'Désactivé, les badges, scores et trophées sont masqués dans toute l\'app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'Diagnostic d\'échantillonnage GPS';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps lacunes',
+      one: '1 lacune',
+      zero: 'aucune lacune',
+    );
+    return '$count échantillons · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Intervalle médian : $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Capturé pendant l\'enregistrement pour vérifier la cadence GPS en veille.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3918,6 +3918,30 @@ class AppLocalizationsHr extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3923,6 +3923,30 @@ class AppLocalizationsHu extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3922,6 +3922,30 @@ class AppLocalizationsIt extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3920,6 +3920,30 @@ class AppLocalizationsLt extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3922,6 +3922,30 @@ class AppLocalizationsLv extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3918,6 +3918,30 @@ class AppLocalizationsNb extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3923,6 +3923,30 @@ class AppLocalizationsNl extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3921,6 +3921,30 @@ class AppLocalizationsPl extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3922,6 +3922,30 @@ class AppLocalizationsPt extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3921,6 +3921,30 @@ class AppLocalizationsRo extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3922,6 +3922,30 @@ class AppLocalizationsSk extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3916,6 +3916,30 @@ class AppLocalizationsSl extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3920,6 +3920,30 @@ class AppLocalizationsSv extends AppLocalizations {
       'When off, badges, scores and trophy icons are hidden across the app.';
 
   @override
+  String get gpsDiagnosticsTitle => 'GPS sampling diagnostics';
+
+  @override
+  String gpsDiagnosticsHeader(String count, String span, int gaps) {
+    String _temp0 = intl.Intl.pluralLogic(
+      gaps,
+      locale: localeName,
+      other: '$gaps gaps',
+      one: '1 gap',
+      zero: 'no gaps',
+    );
+    return '$count samples · $span · $_temp0';
+  }
+
+  @override
+  String gpsDiagnosticsCadence(int ms) {
+    return 'Median interval: $ms ms';
+  }
+
+  @override
+  String get gpsDiagnosticsExplain =>
+      'Captured during recording to verify GPS cadence under phone-sleep.';
+
+  @override
   String get hapticEcoCoachSectionTitle => 'Driving';
 
   @override

--- a/test/features/consumption/presentation/widgets/gps_diagnostics_card_test.dart
+++ b/test/features/consumption/presentation/widgets/gps_diagnostics_card_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/gps_diagnostics_card.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Coverage for the GPS sample diagnostics inspector card
+/// (#1458 phase 2.5).
+///
+/// Splits into three groups:
+///   * `computeGpsDiagnosticsSummary` — the pure-function helper that
+///     does all the math, exercised directly so the assertions don't
+///     have to pump a widget tree.
+///   * `GpsDiagnosticsCard — collapsed` — what the card looks like in
+///     its default (collapsed) state.
+///   * `GpsDiagnosticsCard — expansion` — tap the tile, the body
+///     content appears.
+void main() {
+  // Helper to build a list of diagnostics with a fixed cadence + a
+  // single optional inserted gap. Keeps each test's setup short.
+  List<GpsSampleDiagnostic> buildDiagnostics({
+    required int count,
+    required Duration interval,
+    String lifecycle = 'resumed',
+    Duration? injectedGapAt2,
+  }) {
+    final start = DateTime.utc(2026, 1, 1, 12);
+    final list = <GpsSampleDiagnostic>[];
+    var t = start;
+    for (var i = 0; i < count; i++) {
+      list.add(
+        GpsSampleDiagnostic(timestamp: t, lifecycleState: lifecycle, index: i),
+      );
+      // After the second sample is appended, optionally inject the gap
+      // before computing the next timestamp.
+      if (injectedGapAt2 != null && i == 1) {
+        t = t.add(injectedGapAt2);
+      } else {
+        t = t.add(interval);
+      }
+    }
+    return list;
+  }
+
+  group('computeGpsDiagnosticsSummary', () {
+    test('empty input returns the empty summary', () {
+      expect(
+        computeGpsDiagnosticsSummary(const []),
+        equals(GpsDiagnosticsSummary.empty),
+      );
+    });
+
+    test('single sample reports zero span and 100% lifecycle', () {
+      final summary = computeGpsDiagnosticsSummary([
+        GpsSampleDiagnostic(
+          timestamp: DateTime.utc(2026, 1, 1),
+          lifecycleState: 'resumed',
+          index: 0,
+        ),
+      ]);
+
+      expect(summary.sampleCount, 1);
+      expect(summary.timeSpan, Duration.zero);
+      expect(summary.gapCount, 0);
+      expect(summary.lifecyclePercent, equals({'resumed': 100}));
+    });
+
+    test('reports sample count and time span for a steady 1 Hz cadence', () {
+      // 11 samples at 1000 ms each → 10 s span, no gaps.
+      final diagnostics = buildDiagnostics(
+        count: 11,
+        interval: const Duration(milliseconds: 1000),
+      );
+      final summary = computeGpsDiagnosticsSummary(diagnostics);
+
+      expect(summary.sampleCount, 11);
+      expect(summary.timeSpan, const Duration(seconds: 10));
+      expect(summary.medianIntervalMs, 1000);
+      expect(summary.gapCount, 0);
+      expect(summary.largestGap, const Duration(seconds: 1));
+    });
+
+    test('rounds the median to the nearest 100 ms', () {
+      // 5 samples at 1023 ms each → median 1023 ms → rounds to 1000 ms.
+      final diagnostics = buildDiagnostics(
+        count: 5,
+        interval: const Duration(milliseconds: 1023),
+      );
+      final summary = computeGpsDiagnosticsSummary(diagnostics);
+
+      expect(summary.medianIntervalMs, 1000);
+    });
+
+    test('lifecycle breakdown uses correct percentages', () {
+      // 10 samples: 8 'resumed', 2 'paused' → 80% / 20%.
+      final start = DateTime.utc(2026, 1, 1);
+      final diagnostics = <GpsSampleDiagnostic>[];
+      for (var i = 0; i < 10; i++) {
+        diagnostics.add(GpsSampleDiagnostic(
+          timestamp: start.add(Duration(seconds: i)),
+          lifecycleState: i < 8 ? 'resumed' : 'paused',
+          index: i,
+        ));
+      }
+
+      final summary = computeGpsDiagnosticsSummary(diagnostics);
+
+      expect(summary.lifecyclePercent['resumed'], 80);
+      expect(summary.lifecyclePercent['paused'], 20);
+      // Dominant state renders first when iterated.
+      expect(summary.lifecyclePercent.keys.first, 'resumed');
+    });
+
+    test('detects gaps when an interval is at least 3x the median', () {
+      // 6 samples at 1000 ms with a 5000 ms gap injected after sample 2.
+      // Intervals: [1000, 5000, 1000, 1000, 1000] → median 1000, gap
+      // count 1, largest 5000 ms.
+      final diagnostics = buildDiagnostics(
+        count: 6,
+        interval: const Duration(milliseconds: 1000),
+        injectedGapAt2: const Duration(milliseconds: 5000),
+      );
+      final summary = computeGpsDiagnosticsSummary(diagnostics);
+
+      expect(summary.medianIntervalMs, 1000);
+      expect(summary.gapCount, 1);
+      expect(summary.largestGap, const Duration(milliseconds: 5000));
+    });
+
+    test('returns 0 gap count when median is 0 (degenerate input)', () {
+      // Three samples on the SAME ms — median is 0, so the >= 3x rule
+      // is meaningless and we report no gaps.
+      final t = DateTime.utc(2026, 1, 1);
+      final diagnostics = [
+        GpsSampleDiagnostic(timestamp: t, lifecycleState: 'resumed', index: 0),
+        GpsSampleDiagnostic(timestamp: t, lifecycleState: 'resumed', index: 1),
+        GpsSampleDiagnostic(timestamp: t, lifecycleState: 'resumed', index: 2),
+      ];
+
+      final summary = computeGpsDiagnosticsSummary(diagnostics);
+      expect(summary.gapCount, 0);
+      expect(summary.medianIntervalMs, 0);
+    });
+  });
+
+  group('GpsDiagnosticsCard — collapsed', () {
+    testWidgets('renders the localized title', (tester) async {
+      final diagnostics = buildDiagnostics(
+        count: 5,
+        interval: const Duration(seconds: 1),
+      );
+
+      await pumpApp(tester, GpsDiagnosticsCard(diagnostics: diagnostics));
+
+      expect(find.text('GPS sampling diagnostics'), findsOneWidget);
+    });
+
+    testWidgets('shows sample count and time span in the header line',
+        (tester) async {
+      // 13 samples at 60 s each → 12 min span.
+      final diagnostics = buildDiagnostics(
+        count: 13,
+        interval: const Duration(minutes: 1),
+      );
+
+      await pumpApp(tester, GpsDiagnosticsCard(diagnostics: diagnostics));
+
+      expect(find.textContaining('13 samples'), findsOneWidget);
+      expect(find.textContaining('12min'), findsOneWidget);
+      expect(find.textContaining('no gaps'), findsOneWidget);
+    });
+
+    testWidgets('expansion body content is hidden by default', (tester) async {
+      final diagnostics = buildDiagnostics(
+        count: 5,
+        interval: const Duration(seconds: 1),
+      );
+
+      await pumpApp(tester, GpsDiagnosticsCard(diagnostics: diagnostics));
+
+      // The cadence + explanation lines are inside the collapsed
+      // ExpansionTile — they're not yet built into the tree.
+      expect(find.textContaining('Median interval'), findsNothing);
+      expect(
+        find.textContaining('Captured during recording'),
+        findsNothing,
+      );
+    });
+  });
+
+  group('GpsDiagnosticsCard — expansion', () {
+    testWidgets('tapping the tile reveals the cadence + explanation lines',
+        (tester) async {
+      final diagnostics = buildDiagnostics(
+        count: 11,
+        interval: const Duration(milliseconds: 1000),
+      );
+
+      await pumpApp(tester, GpsDiagnosticsCard(diagnostics: diagnostics));
+
+      // Tap the tile to expand.
+      await tester.tap(find.byKey(const Key('gps_diagnostics_tile')));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Median interval: 1000 ms'), findsOneWidget);
+      expect(find.textContaining('resumed 100%'), findsOneWidget);
+      expect(find.textContaining('Largest gap'), findsOneWidget);
+      expect(
+        find.textContaining('Captured during recording'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 2 (#1463) of #1458 captured a `GpsSampleDiagnostic` per position fix while a trip recorded — wall-clock timestamp, host-app `AppLifecycleState`, monotonic index. Phase 2.5 surfaces those samples on the trip-detail screen so the user can validate GPS cadence + spot sleep-related drops **without inspecting Hive JSON**. The output of this card drives the phase-3 (Android foreground service) decision: heal-thy ~1 Hz cadence + low gap count → ship as-is; throttled stream + sleep-state drops → phase 3 is required.

The card is collapsed by default (trip-detail is already busy with summary, map, insights, score, histogram + four time-series charts); the at-a-glance triple `samples · timeSpan · gaps` lives in the header, the breakdown lives in the body.

## Files

- `lib/features/consumption/presentation/widgets/gps_diagnostics_card.dart` — new stateless Card + ExpansionTile, plus pure-function `computeGpsDiagnosticsSummary` helper (`@visibleForTesting`) so tests assert on deterministic numbers without pumping the widget tree.
- `lib/features/consumption/presentation/widgets/trip_detail_body.dart` — slot the card after the throttle/RPM histogram, conditional on `widget.entry.gpsSampleDiagnostics.isNotEmpty` so legacy trips + flag-off trips don't see a layout change.
- `lib/l10n/_fragments/gps_diagnostics_en.arb` + `gps_diagnostics_de.arb` — four new keys (`gpsDiagnosticsTitle`, `gpsDiagnosticsHeader` with ICU plural for the gap count, `gpsDiagnosticsCadence`, `gpsDiagnosticsExplain`); merged via `dart run tool/build_arb.dart` (NOT direct app_*.arb edits — the consistency test enforces fragment ownership of feature keys).
- `lib/l10n/app_fr.arb` — French translations added directly so French does not regress on these strings.
- `test/features/consumption/presentation/widgets/gps_diagnostics_card_test.dart` — 11 tests across helper math (empty / single sample / steady cadence / median rounding / lifecycle percent / gap detection / degenerate input) and widget rendering (title, header line, collapsed-body hidden, tap-to-expand reveals body).

## Test plan

- [x] `flutter analyze` clean (zero issues).
- [x] `flutter test test/features/consumption/presentation/widgets/gps_diagnostics_card_test.dart` — 11/11 green.
- [x] `flutter test test/features/consumption/` — all green.
- [x] `flutter test test/lint/` — all 29 lint rules green (incl. ARB fragment consistency, no-silent-catch, prefer-const, raw-card-in-screens).

## Heuristic notes

- "Gap" = interval whose delta exceeds `3 × medianInterval`. Coarse but useful: distinguishes a healthy ~1 Hz cadence from a >3-5 s OS-throttled cadence during phone-sleep.
- Median is rounded to nearest 100 ms in the displayed value so the user reads "1000 ms" instead of a noisy "1023 ms" timestamp diff.
- Lifecycle percentages are rounded to integer; entries are sorted by count desc so the dominant state renders first ("resumed 92% · paused 5% · ...").

## Out of scope

- **Phase 3 — Android foreground GPS service** is still **conditional on field-test data**. This card is the diagnostic that gates that decision, not a substitute for it. Do not implement phase 3 in a follow-up worker without first confirming gap counts from a real recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)