### PR TITLE
docs(feature-concepts): may 1-5 feature analyses + concept architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ docs/*
 !docs/screenshots/
 !docs/design/
 !docs/security/
+!docs/feature-concepts/
 docs/guides/*
 !docs/guides/NETWORK_TESTS.md
 !docs/guides/NEW_COUNTRY.md

--- a/docs/feature-concepts/2026-05-01-feature-analysis.md
+++ b/docs/feature-concepts/2026-05-01-feature-analysis.md
@@ -1,0 +1,189 @@
+# Daily Feature Analysis — 2026-05-01
+
+## Market Context
+
+The German fuel station app market in 2026 shows clear trends: declining petrol station count (5,720 businesses, -1.4% CAGR), growing EV infrastructure demand, and consolidation around a few dominant apps (clever-tanken with 5M+ users, ADAC Drive with multi-country routing, TankPilot with AI price prediction). Emerging US apps like FuelUp introduce gamification leaderboards and crowdsourced photo verification, while CarPlay/Android Auto integration is becoming table-stakes for any serious fuel app.
+
+**Current app strengths already covering:** price comparison (11 countries), EV charging (OCM integration), OBD2 trip recording, price alerts (single station + radius), achievements/gamification, loyalty card discounts, route search, price history with prediction, carbon tracking, driving mode, consumption logging, home-screen widget, cross-border suggestions.
+
+**Gaps identified from competitor analysis:**
+
+---
+
+## Feature 1: CarPlay & Android Auto Companion
+
+### Description
+
+A lightweight in-car interface that surfaces the app's core value (nearest cheapest station, active price alerts, trip recording status) directly on the vehicle's head unit via Apple CarPlay and Android Auto. Competitors like Fuelio, Fillzz and ADAC Drive already ship this — its absence is a visible gap in the 2026 market.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+Create a new feature module at `lib/features/car_companion/` following the existing clean-architecture pattern (data / domain / presentation / providers).
+
+**Key files to create:**
+
+- `lib/features/car_companion/presentation/car_companion_screen.dart` — Simplified single-screen UI optimized for the restricted CarPlay/AA layout (large tap targets, high contrast, minimal text). Shows: current fuel type price at 3 nearest stations, one-tap navigation to cheapest, active alert status indicator.
+- `lib/features/car_companion/providers/car_companion_provider.dart` — Riverpod provider that composes `search_provider` results (from `lib/features/search/providers/`) with `location_service` (from `lib/core/location/location_service.dart`) to produce a simplified station list sorted by price within 5 km.
+- `lib/features/car_companion/data/car_companion_channel.dart` — Platform channel bridge to native CarPlay (CPTemplateApplicationScene) and Android Auto (Session/Screen) SDKs.
+
+**Native side:**
+
+- `android/app/src/main/java/.../CarCompanionService.java` — Extends `CarAppService`, registers a `ListTemplate` with price rows that deep-link back into the Flutter app.
+- `ios/Runner/CarPlaySceneDelegate.swift` — Implements `CPTemplateApplicationSceneDelegate`, builds a `CPListTemplate` with station items.
+
+**Integration points:**
+
+- Reuse `StationService` (existing in `lib/features/search/data/services/`) for price data.
+- Reuse `LocationService` (existing `lib/core/location/location_service.dart`) for user position.
+- Reuse `FuelType` preference from `lib/features/profile/providers/effective_fuel_type_provider.dart`.
+
+**Dependencies to add in `pubspec.yaml`:** None — CarPlay and Android Auto require native code only; the Flutter side communicates via MethodChannel already established for `home_widget`.
+
+---
+
+## Feature 2: Crowdsourced Price Verification with Photo OCR
+
+### Description
+
+Allow users to snap a photo of a fuel price sign at a station, automatically OCR the price, and submit it as a community-verified data point. This mirrors FuelUp's "earn points for price reports" and The Gas Index's photo-submission model. Differentiator: privacy-first (no account required, photo discarded after OCR, only extracted price stored).
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+Extend the existing `lib/features/report/` feature module (already has station-report infrastructure) with a new "price report" sub-flow.
+
+**Key files to create/modify:**
+
+- `lib/features/report/presentation/screens/price_report_screen.dart` — Camera viewfinder with overlay guide ("point at price board"), capture button, OCR result confirmation dialog showing extracted prices per fuel type.
+- `lib/features/report/data/price_ocr_service.dart` — Wraps the already-imported `google_mlkit_text_recognition` package (already in pubspec.yaml for receipt scanning in `lib/features/consumption/data/receipt_parser/`) to parse price-board layouts. Applies regex patterns like `\d[.,]\d{2,3}` to extract fuel prices.
+- `lib/features/report/domain/entities/price_report.dart` — Freezed entity: `stationId`, `fuelType`, `reportedPrice`, `reportedAt`, `confidence` (OCR confidence score).
+- `lib/features/report/data/repositories/price_report_repository.dart` — Submits verified prices to Supabase (table `price_reports`), integrating with existing `supabase_flutter` dependency. Implements throttle (max 3 reports/station/hour per user-hash).
+
+**Integration with gamification:**
+
+- Add new `AchievementId.firstPriceReport` and `AchievementId.tenPriceReports` to `lib/features/achievements/domain/achievement_id.dart` — rewards participation without requiring identity.
+- The existing `AchievementsProvider` evaluation loop (in `lib/features/achievements/providers/achievements_provider.dart`) checks a new `priceReportCount` counter stored in Hive.
+
+**Privacy alignment:**
+
+- Photo never leaves device — processed locally by ML Kit (already on-device).
+- Only numeric price + station ID + anonymous device-hash sent to backend.
+- Aligns with existing GDPR consent flow in `lib/features/consent/`.
+
+---
+
+## Feature 3: Smart Refuel Timing Advisor ("Best Moment to Fill Up")
+
+### Description
+
+While the app already has `price_prediction` and `best_time_banner`, competitors like DrivstoffAppen and ADAC Drive offer proactive push notifications telling users the *optimal moment* to refuel based on predicted price curves. This feature combines the existing prediction engine with the consumption/tank-level tracking to push a personalized "fill up now" notification when the predicted price trough aligns with the user's estimated fuel level dropping below a configurable threshold.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+Extend `lib/features/alerts/` and connect it to `lib/features/consumption/providers/tank_level_provider.dart` and `lib/features/price_history/providers/price_prediction_provider.dart`.
+
+**Key files to create/modify:**
+
+- `lib/features/alerts/domain/entities/refuel_timing_alert.dart` — Freezed entity combining: `targetStation` (or radius), `tankThresholdPercent` (default 25%), `priceDropPercent` (predicted drop needed to trigger, default 2%).
+- `lib/features/alerts/data/refuel_timing_evaluator.dart` — Background evaluator (called by existing `background_service.dart` via WorkManager) that: (1) reads current tank level from `TankLevelProvider` logic, (2) if below threshold, queries `PricePredictionProvider` for next 24h forecast, (3) if current price is within 1% of predicted trough OR predicted to rise, fires notification.
+- Modify `lib/core/background/background_price_fetcher.dart` — Add a call to `RefuelTimingEvaluator.evaluate()` after existing price-fetch cycle completes.
+- `lib/features/alerts/presentation/widgets/refuel_timing_setup_sheet.dart` — Bottom sheet allowing users to configure threshold + sensitivity. Accessible from the existing alerts screen.
+
+**Notification delivery:**
+
+- Uses existing `flutter_local_notifications` dependency.
+- Notification text: "Tank at ~20% — E10 at [Station] is at €1.459 and predicted to rise 3ct in 4h. Fill up now?"
+- Tap opens station detail screen via existing deep-link routing in `lib/app/router.dart`.
+
+---
+
+## Feature 4: Community Fuel Price Leaderboard
+
+### Description
+
+FuelUp's regional leaderboards (Bronze → Platinum tiers) and point-based rewards are driving engagement in the US market. This feature adds a privacy-preserving leaderboard where users earn points for verified price reports, streak achievements, and eco-driving milestones — competing within their configured country without revealing identity.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/leaderboard/` with Supabase backend aggregation.
+
+**Key files to create:**
+
+- `lib/features/leaderboard/domain/entities/leaderboard_entry.dart` — Freezed: `rank`, `displayName` (user-chosen alias, not email), `points`, `tier` (enum: Bronze/Silver/Gold/Platinum), `country`.
+- `lib/features/leaderboard/domain/services/points_calculator.dart` — Pure function mapping actions to points: price report verified (+10), achievement unlocked (+25), eco-week streak (+50), 30-day active streak (+100).
+- `lib/features/leaderboard/data/repositories/leaderboard_repository.dart` — Reads from Supabase view `leaderboard_weekly` (aggregated server-side for privacy). Submits point-earning events via existing sync infrastructure in `lib/features/sync/`.
+- `lib/features/leaderboard/presentation/screens/leaderboard_screen.dart` — Scrollable list with user's own rank highlighted, tier badge, country filter. Tabs: weekly / all-time.
+- `lib/features/leaderboard/presentation/widgets/tier_progress_card.dart` — Shows points-to-next-tier progress bar, integrated into the profile screen alongside existing `gamification_settings_tile.dart`.
+
+**Integration with existing gamification:**
+
+- Hooks into `lib/features/achievements/providers/achievements_provider.dart` — each `EarnedAchievement` event also increments leaderboard points via `PointsCalculator`.
+- The existing `gamification_enabled_provider.dart` toggle controls leaderboard visibility (opt-in only).
+
+**Privacy model:**
+
+- Leaderboard is anonymous (alias + country only).
+- User can opt out entirely via existing gamification toggle.
+- No social graph — pure score ranking with no follow/friend mechanics.
+
+---
+
+## Feature 5: Apple Watch & Wear OS Glanceable Companion
+
+### Description
+
+A wearable companion that shows the cheapest nearby fuel price at a glance without pulling out the phone. Competitors like FuelUp ship Apple Watch complications; no major European tank app offers Wear OS support yet — a differentiation opportunity.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/wearable/` for the Flutter-side data bridge, plus native watch app targets.
+
+**Key files to create:**
+
+- `lib/features/wearable/data/wearable_data_bridge.dart` — Sends simplified payload (cheapest price, station name, distance, fuel type) to the watch via platform channel. Reuses price data from `lib/features/search/providers/` and location from `lib/core/location/`.
+- `lib/features/wearable/providers/wearable_sync_provider.dart` — Riverpod provider that listens to location changes (existing `MovementDetectionProvider`) and triggers wearable data refresh every 5 minutes or on significant movement (>500m).
+
+**Native watchOS app (`watchos/TankstellenWatch/`):**
+
+- `ComplicationController.swift` — CLKComplicationDataSource providing a `GraphicCircularView` complication showing price + fuel-type icon.
+- `ContentView.swift` (SwiftUI) — Single screen: large price text, station name, distance, "Navigate" button that opens Maps.
+- `WCSessionDelegate` — Receives data from phone app via WatchConnectivity framework.
+
+**Native Wear OS app (`android/wear/`):**
+
+- `WearTileService.kt` — Tile showing cheapest price (Wear OS Tiles API for always-on glanceable info).
+- `WearMainActivity.kt` — Compose for Wear OS single-screen showing top 3 stations, tap to navigate.
+- `WearDataLayerService.kt` — Receives data from phone app via Data Layer API.
+
+**Data flow:**
+
+Phone app (existing search/location providers) → `WearableDataBridge` → MethodChannel → Native watch communication layer → Watch UI.
+
+**Dependency:** Add `wear` module to `android/settings.gradle`; add watchOS target to Xcode project. No new Flutter pubspec dependencies needed — all communication is native platform channels (same pattern as existing `home_widget` integration).
+
+---
+
+## Summary & Priority Recommendation
+
+| # | Feature | Effort | Market Impact | Differentiation |
+|---|---------|--------|---------------|-----------------|
+| 1 | CarPlay & Android Auto | High | Very High | Catches up to Fuelio, ADAC |
+| 2 | Crowdsourced Price OCR | Medium | High | Unique in EU privacy-first |
+| 3 | Smart Refuel Timing | Low | High | Extends existing prediction |
+| 4 | Community Leaderboard | Medium | Medium | Engagement & retention |
+| 5 | Wearable Companion | High | Medium | First EU tank app on Wear OS |
+
+**Recommended next sprint:** Feature 3 (lowest effort, builds on existing infrastructure) followed by Feature 2 (leverages already-imported ML Kit).
+
+---
+
+*Generated: 2026-05-01 | Based on market analysis of clever-tanken, ADAC Drive, TankPilot, FuelUp, DrivstoffAppen, The Gas Index, Fuelio, and Fillzz.*

--- a/docs/feature-concepts/2026-05-02-feature-analysis.md
+++ b/docs/feature-concepts/2026-05-02-feature-analysis.md
@@ -1,0 +1,218 @@
+# Daily Feature Analysis — 2026-05-02
+
+## Market Context
+
+The fuel app landscape in May 2026 shows accelerating convergence between traditional fuel-price apps and in-car AI assistants. The in-vehicle AI assistant market hit $3.46B in 2026 (+25.7% CAGR), with Ford, BMW, and others shipping conversational voice assistants directly in 2026 model-year vehicles. Meanwhile, fuel apps are racing to integrate: Fuelio dominates Android Auto, FuelUp ships CarPlay + Apple Watch complications, and GasBuddy still lacks in-car integration — a gap its users increasingly resent. On the EV front, Plug & Charge (ISO 15118) is going mainstream, Google/Apple Maps natively integrate charging payments, and V2G/V2H features appear in premium EV apps like ChargeHQ. AI-powered price prediction (FuelCast's "Cheap Fuel Near Me" app) is setting new user expectations for proactive refuel timing.
+
+**Tankstellen's current positioning:** Strong multi-country price comparison (11 countries), OBD-II driving insights, EV charging via OpenChargeMap, achievements/gamification, loyalty card support, privacy-first philosophy, home-screen widget with predictive variant, existing price prediction engine (`best_time_banner`, `price_prediction_provider`), route search, consumption tracking.
+
+**Yesterday's features proposed:** CarPlay/Android Auto, Crowdsourced Price OCR, Smart Refuel Timing, Community Leaderboard, Wearable Companion.
+
+**Today's focus:** New gaps identified from the latest market signals — voice-first in-car AI interaction, hybrid/EV energy cost optimization, social carpooling cost-split, station availability/queue intelligence, and multi-modal journey cost comparison.
+
+---
+
+## Feature 1: Voice-First In-Car AI Copilot
+
+### Description
+
+A conversational voice interface that lets drivers interact with all core Tankstellen features hands-free while driving. Goes beyond simple CarPlay template screens (proposed yesterday) by adding natural-language queries like "Where's the cheapest E10 on my way home?", "Should I fill up now or wait?", and "How's my fuel consumption this trip compared to last week?". Leverages the $3.46B in-vehicle AI assistant trend — positions Tankstellen as the first open-source fuel app with an on-device voice copilot.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/voice_copilot/` following clean architecture. Uses the already-imported `flutter_tts` package (in pubspec.yaml) for speech output, plus adds `speech_to_text` for voice input.
+
+**Key files to create:**
+
+- `lib/features/voice_copilot/domain/intent_parser.dart` — Lightweight on-device intent classification. Maps spoken utterances to action intents: `FindCheapest`, `ShouldFillNow`, `TripSummary`, `SetAlert`, `NavigateToStation`. Uses keyword matching + pattern grammar (no cloud AI needed — privacy-first).
+- `lib/features/voice_copilot/domain/entities/voice_intent.dart` — Freezed sealed class with variants per intent type, each carrying parsed parameters (fuel type, location reference, time frame).
+- `lib/features/voice_copilot/domain/response_composer.dart` — Generates natural-language response strings from provider data. E.g., queries `PricePredictionProvider` and composes: "E10 is at €1.43 at Aral Hauptstraße, 800 meters away. Prices are predicted to drop 2 cents in 3 hours — you might want to wait."
+- `lib/features/voice_copilot/data/speech_recognition_service.dart` — Wraps `speech_to_text` package with noise-cancellation hints and automotive-optimized recognition parameters. Implements continuous-listening mode with wake-word detection ("Hey Tank" or customizable).
+- `lib/features/voice_copilot/data/tts_service.dart` — Wraps existing `flutter_tts` dependency. Provides queued utterance playback with priority (alerts interrupt trip summaries). Respects system volume and driving-mode context.
+- `lib/features/voice_copilot/presentation/voice_copilot_overlay.dart` — Minimal floating overlay (small microphone FAB) shown during driving mode. Expands to show transcription + response text briefly, then auto-collapses. Integrates with existing driving mode screen (`lib/features/driving/presentation/`).
+- `lib/features/voice_copilot/providers/voice_copilot_provider.dart` — Riverpod provider orchestrating the flow: listen → parse intent → query relevant providers → compose response → speak.
+
+**Integration points:**
+
+- Hooks into existing `lib/features/driving/presentation/` driving mode — adds voice FAB overlay.
+- Queries `lib/features/search/providers/` for station data.
+- Queries `lib/features/price_history/providers/price_prediction_provider.dart` for fill-now-or-wait logic.
+- Queries `lib/features/consumption/providers/` for trip statistics.
+- Uses existing `lib/core/location/location_service.dart` for position context.
+- Reuses `flutter_tts` (already in pubspec.yaml); adds `speech_to_text: ^7.0.0` to pubspec.yaml.
+
+**Privacy alignment:**
+
+- All speech processing on-device (no cloud transcription).
+- Intent parsing is rule-based, not LLM-dependent.
+- No audio recordings stored — stream-processed and discarded.
+- Aligns with existing GDPR consent flow in `lib/features/consent/`.
+
+---
+
+## Feature 2: Hybrid & EV Energy Cost Optimizer
+
+### Description
+
+For the growing hybrid and EV user segment, a unified "cost per km" optimizer that compares: (a) charging at home overnight vs. public charger en-route, (b) running on electric vs. switching to combustion (for PHEVs), (c) time-of-use electricity tariffs vs. current fuel price. Competitors like ChargeHQ optimize home charging against solar production; no fuel app yet unifies fossil + electric cost comparison for PHEVs in a single view. This extends Tankstellen's existing EV module (`lib/features/ev/`) and consumption tracking into true hybrid cost optimization.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+Extend `lib/features/ev/` with a new sub-module for cost optimization, connecting to the existing `lib/features/consumption/` and `lib/features/calculator/` features.
+
+**Key files to create:**
+
+- `lib/features/ev/domain/entities/energy_tariff.dart` — Freezed entity: `tariffName`, `pricePerKwh`, `validFrom`/`validTo` (time-of-use windows), `isGreenEnergy` (for carbon dashboard integration).
+- `lib/features/ev/domain/energy_cost_optimizer.dart` — Pure domain logic that computes optimal energy mix: takes as input current fuel price (from `RefuelPrice`), electricity tariff (user-configured), battery SOC (from OBD-II via `lib/core/car/car_data_bridge.dart`), remaining range electric/combustion, and planned trip distance. Outputs recommendation: "Charge tonight (€0.04/km) vs. fuel now (€0.09/km) — save €3.75 on your commute."
+- `lib/features/ev/data/tariff_repository.dart` — Stores user-configured electricity tariffs in Hive. Supports multiple tariffs (home day/night, workplace, public charger categories).
+- `lib/features/ev/presentation/screens/energy_optimizer_screen.dart` — Dashboard showing: daily cost comparison chart (electric vs. fossil), recommended charging windows, monthly savings projection, and one-tap "set charging reminder" that schedules a notification during cheapest tariff window.
+- `lib/features/ev/presentation/widgets/phev_mode_advisor_card.dart` — Widget for PHEV vehicles showing real-time recommendation: "Switch to EV mode — next 12 km are urban, saving €0.82." Shown on driving mode screen when vehicle type is hybrid.
+- `lib/features/ev/providers/energy_optimizer_provider.dart` — Riverpod provider composing: vehicle profile (from `lib/features/vehicle/`), current fuel prices (from search providers), configured tariffs, and OBD battery SOC if available.
+
+**Integration points:**
+
+- Extends existing `lib/features/vehicle/` profiles — adds fields for battery capacity, typical home charging speed, and electricity tariff reference.
+- Connects to `lib/features/ev/domain/charging_cost_calculator.dart` (already exists) for public charger cost computation.
+- Integrates with `lib/features/carbon/` for emissions comparison between electric and fossil km.
+- Uses `lib/core/car/car_data_bridge.dart` for real-time battery SOC from OBD-II (hybrid vehicles report this via PID 0x5B).
+- Notification scheduling via existing `lib/core/notifications/notification_service.dart`.
+
+**Differentiation:**
+
+- Only app combining fuel prices + electricity tariffs + OBD-II data in one optimizer.
+- Privacy-first: tariff data stays on-device, no smart-meter integration required.
+- Works without OBD-II too (manual SOC input or estimate from last charge log).
+
+---
+
+## Feature 3: Station Queue & Availability Intelligence
+
+### Description
+
+FuelCast and Waze both hint at "busy times" for fuel stations, but no app provides real-time queue intelligence combining: historical visit patterns, current crowd density estimation (via anonymous ping aggregation from users near the station), and pump availability status from station APIs where available. This feature helps users avoid the 5-minute queue at peak hours — directly serving Layer 1 (time is cost) and differentiating against all competitors.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/station_availability/` with both local heuristic (no backend) and optional crowd-sourced mode (via Supabase).
+
+**Key files to create:**
+
+- `lib/features/station_availability/domain/entities/station_busyness.dart` — Freezed entity: `stationId`, `hourOfWeek` (0–167), `busynessScore` (0.0–1.0), `averageWaitMinutes`, `confidence` (how many data points).
+- `lib/features/station_availability/domain/busyness_predictor.dart` — On-device prediction engine using historical fill-up timestamps (from existing consumption log in `lib/features/consumption/`). Aggregates the user's own visit patterns + crowd data (if opted in) to predict busyness by hour-of-week per station.
+- `lib/features/station_availability/data/crowd_signal_service.dart` — Lightweight anonymous ping: when a user is within 50m of a station for >2 minutes, send an anonymous `{stationId, timestamp}` event to Supabase (no user ID, no device ID — just station + time). Aggregation happens server-side via Supabase function.
+- `lib/features/station_availability/data/repositories/busyness_repository.dart` — Fetches aggregated busyness data from Supabase view `station_busyness_hourly`. Falls back to local-only prediction when offline or when user hasn't opted into crowd signals.
+- `lib/features/station_availability/presentation/widgets/busyness_indicator.dart` — Small chip/bar shown on station detail screen (`lib/features/station_detail/`) and search results. Color-coded: green (quiet), amber (moderate), red (busy). Shows "Usually quiet at this time" or "Peak hour — expect 5 min wait."
+- `lib/features/station_availability/presentation/widgets/best_visit_time_chart.dart` — Hourly bar chart (similar pattern to `lib/features/price_history/presentation/widgets/hourly_price_chart.dart`) showing predicted busyness across the day for a selected station.
+- `lib/features/station_availability/providers/busyness_provider.dart` — Riverpod provider combining local predictions + crowd data, respecting the privacy opt-in toggle.
+
+**Integration points:**
+
+- Adds busyness indicator to `lib/features/station_detail/presentation/` screens.
+- Adds "quiet now" badge to search result cards in `lib/features/search/presentation/`.
+- Route search (`lib/features/route_search/`) can weight stations by both price AND predicted wait time — "cheapest quiet stop" strategy.
+- Privacy: opt-in via existing consent flow (`lib/features/consent/`). Signal is fully anonymous — no user correlation possible.
+- Uses existing `lib/core/location/location_service.dart` for geofence proximity detection.
+
+---
+
+## Feature 4: Multi-Modal Journey Cost Comparator
+
+### Description
+
+With rising fuel costs, more drivers consider alternatives for specific trips: train, e-scooter, carpool, or park-and-ride. No fuel app currently offers a "should I even drive?" comparison. This feature shows the total cost of a planned journey across modes (own car fuel + tolls + parking vs. public transit ticket vs. ride-share estimate), helping users make the cheapest choice per trip. Serves Tankstellen's core mission ("reduce what your car costs per km") by showing when *not* driving is the cheapest km.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/journey_compare/` integrating with existing route search and calculator.
+
+**Key files to create:**
+
+- `lib/features/journey_compare/domain/entities/journey_option.dart` — Freezed sealed class with variants: `DrivingOption` (fuel cost, toll, parking, time), `TransitOption` (ticket price, transfers, time), `RideShareOption` (estimated fare, time), `BikeOption` (time, calories — free cost).
+- `lib/features/journey_compare/domain/journey_cost_calculator.dart` — Computes driving cost using: distance × (consumption from vehicle profile) × current fuel price + configurable per-km wear cost (insurance, depreciation — user-set). Extends existing `lib/features/calculator/` logic.
+- `lib/features/journey_compare/data/transit_fare_service.dart` — Queries open transit APIs (EU: Deutsche Bahn, SNCF, Navitia, Rejseplanen per country) for fare estimates between origin/destination. Returns price + duration.
+- `lib/features/journey_compare/data/ride_share_estimator.dart` — Simple fare model (base + per-km rate, configurable per city/country) without calling proprietary Uber/Bolt APIs — provides estimate range.
+- `lib/features/journey_compare/presentation/screens/journey_compare_screen.dart` — Side-by-side cards showing cost, time, and CO₂ for each mode. Highlights cheapest and fastest. "Drive" card links to existing route search; "Transit" links to external transit app via `url_launcher`.
+- `lib/features/journey_compare/presentation/widgets/mode_comparison_card.dart` — Individual card with icon, cost, duration, CO₂ badge. Tap expands to show cost breakdown.
+- `lib/features/journey_compare/providers/journey_compare_provider.dart` — Orchestrates parallel cost calculations across modes. Uses `AsyncValue` pattern consistent with other providers.
+
+**Integration points:**
+
+- Accessible from route search (`lib/features/route_search/`) — "Compare alternatives" button below route results.
+- Driving cost uses vehicle consumption data from `lib/features/vehicle/` and current prices from `lib/features/search/providers/`.
+- CO₂ comparison extends `lib/features/carbon/` dashboard data.
+- Reuses existing `url_launcher` dependency for deep-linking to transit/ride-share apps.
+- Per-km wear cost configurable in vehicle profile (`lib/features/vehicle/`).
+
+**Differentiation:**
+
+- No fuel app offers this — positions Tankstellen as "mobility cost optimizer" rather than just "fuel price finder."
+- Privacy-first: transit fare queries use no user data beyond origin/destination coordinates.
+- Honest recommendation even when it means "don't drive" — builds trust.
+
+---
+
+## Feature 5: AI-Powered Maintenance Cost Predictor
+
+### Description
+
+The app already has a maintenance analyzer watching consumption drift (`lib/features/driving/`), but competitors are moving toward predictive maintenance *cost* estimation. BMW's AI assistant predicts maintenance needs; no independent app combines OBD-II diagnostic data + historical service costs to predict "your next €500 bill is likely in 3 months." This extends Layer 3 ("see what you're really spending") into the future — from tracking past costs to forecasting future ones.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+Extend existing maintenance/consumption infrastructure with a predictive cost layer at `lib/features/maintenance_forecast/`.
+
+**Key files to create:**
+
+- `lib/features/maintenance_forecast/domain/entities/maintenance_prediction.dart` — Freezed entity: `serviceType` (oil change, brake pads, timing belt, etc.), `predictedDate`, `predictedMileage`, `estimatedCostRange` (min/max in user's currency), `confidence`, `triggerReason` (mileage interval, consumption drift, OBD-II DTC code, time since last).
+- `lib/features/maintenance_forecast/domain/maintenance_predictor.dart` — Core prediction engine. Inputs: vehicle profile (make/model/year from `lib/features/vehicle/`), current mileage, mileage accumulation rate (from trip history), last service dates (from existing service reminders), OBD-II diagnostic codes if available, consumption trend (from `lib/features/consumption/`). Outputs: sorted list of upcoming maintenance items with cost estimates.
+- `lib/features/maintenance_forecast/data/service_cost_database.dart` — On-device reference database of average maintenance costs by vehicle segment (compact, SUV, premium) and country. Loaded from `assets/maintenance_costs/` JSON files. User can override with actual costs from their service history.
+- `lib/features/maintenance_forecast/data/obd_diagnostic_interpreter.dart` — Maps OBD-II DTC (Diagnostic Trouble Codes) read via `lib/core/car/car_data_bridge.dart` to maintenance categories and urgency levels. E.g., P0171 (system too lean) → "Check MAF sensor — estimated €150–250."
+- `lib/features/maintenance_forecast/presentation/screens/maintenance_forecast_screen.dart` — Timeline view showing predicted maintenance events on a scrollable calendar strip. Each item shows: service name, predicted date/mileage, cost range, and "I did this" button to log completion.
+- `lib/features/maintenance_forecast/presentation/widgets/upcoming_cost_card.dart` — Summary card for profile/dashboard: "Next 6 months: estimated €780 in maintenance." Links to full forecast.
+- `lib/features/maintenance_forecast/presentation/widgets/cost_projection_chart.dart` — 12-month rolling bar chart of predicted maintenance spending, similar in style to existing price charts in `lib/features/price_history/presentation/widgets/`.
+- `lib/features/maintenance_forecast/providers/maintenance_forecast_provider.dart` — Riverpod provider composing vehicle data, trip history, service records, and OBD-II state into predictions.
+
+**Integration points:**
+
+- Extends vehicle profile screen (`lib/features/vehicle/`) with "Maintenance Forecast" card.
+- Reads OBD-II diagnostic codes from `lib/core/car/car_data_bridge.dart` when adapter is connected.
+- Connects to existing service reminders (already in vehicle profiles) for "last serviced" dates.
+- Uses consumption trend data from `lib/features/consumption/providers/` to detect degradation patterns.
+- Push notifications via existing `lib/core/notifications/notification_service.dart` for upcoming high-cost items.
+- Feeds into existing cost calculator (`lib/features/calculator/`) for total-cost-of-ownership view.
+
+**Data sources for cost estimates:**
+
+- Bundled JSON asset with average costs per service type × vehicle segment × country.
+- User's own logged costs (learning from their history).
+- Community median (optional, via Supabase aggregation if user opts into anonymous cost sharing).
+
+---
+
+## Summary & Priority Recommendation
+
+| # | Feature | Effort | Market Impact | Differentiation |
+|---|---------|--------|---------------|-----------------|
+| 1 | Voice-First AI Copilot | Medium | Very High | First open-source fuel app with voice | 
+| 2 | Hybrid/EV Energy Optimizer | Medium | High | Unique PHEV cost unification |
+| 3 | Station Queue Intelligence | Medium | High | No competitor offers this |
+| 4 | Multi-Modal Journey Comparator | High | Very High | Repositions app as mobility optimizer |
+| 5 | AI Maintenance Cost Predictor | Medium | Medium-High | Extends OBD-II into financial planning |
+
+**Recommended next sprint:** Feature 3 (Station Queue Intelligence) — medium effort, leverages existing location + Supabase infrastructure, immediately visible on search results, and no competitor currently offers this. Follow with Feature 1 (Voice Copilot) which leverages the already-imported `flutter_tts` and creates a strong viral demo moment.
+
+**Relationship to yesterday's features:** Today's list is complementary, not overlapping. Yesterday's CarPlay/Android Auto (Feature 1) is the *visual* in-car layer; today's Voice Copilot is the *conversational* layer — both can coexist. Yesterday's Smart Refuel Timing is a prerequisite input for today's Voice Copilot's "should I fill now?" query. Yesterday's Crowdsourced Price OCR feeds today's Queue Intelligence with presence signals.
+
+---
+
+*Generated: 2026-05-02 | Based on market analysis of in-car AI assistants (Ford, BMW, Cerence), ChargeHQ, FuelCast/Cheap Fuel Near Me, Fuelio (Android Auto), FuelUp (CarPlay + Watch), GasBuddy, clever-tanken, and EV charging market trends (Driivz, ChargePoint, EVgo).*

--- a/docs/feature-concepts/2026-05-03-feature-analysis.md
+++ b/docs/feature-concepts/2026-05-03-feature-analysis.md
@@ -1,0 +1,267 @@
+# Daily Feature Analysis — 2026-05-03
+
+## Market Context
+
+The fuel and mobility app market in May 2026 continues its shift toward AI-driven personalisation, energy-mix optimisation, and community trust signals. Key market signals this week: AI-powered dynamic fuel pricing tools (Kalibrate, PriceEasy's Fuel IQ, RapidPricer) are now standard for station operators, meaning price volatility is algorithmically driven — consumer apps that can reverse-engineer or predict these patterns gain a decisive edge. Ultra-fast EV charging (350 kW+) is going mainstream across European corridors, and Charging-as-a-Service (CaaS) subscription models are reshaping how drivers think about energy costs. Community-driven EV apps report 94% accuracy on crowdsourced charger status, setting user expectations for real-time reliability data across all fuel types. Meanwhile, Clever Tanken leads Germany with 5M+ users but remains single-country; TankPilot covers three countries with ML-based price predictions; GasBuddy dominates North America with crowdsourced data and cashback rewards but still lacks in-car integration.
+
+**Tankstellen's current positioning:** 11 countries (17 station services), 23 languages, OBD-II driving insights, EV charging (OpenChargeMap), achievements/gamification, loyalty cards, privacy-first (no Firebase/tracking/ads), price predictions (day-of-week + hour-of-day model), route search with strategies, glide coach, consumption tracking with driving score, CO₂ dashboard, CarDataBridge for Android Auto/CarPlay, home-screen widget.
+
+**Previously proposed features (May 1–2):** CarPlay/Android Auto template screens, Crowdsourced Price OCR, Smart Refuel Timing, Community Leaderboard, Wearable Companion, Voice-First In-Car AI Copilot, Hybrid & EV Energy Cost Optimizer, Station Queue & Availability Intelligence, Social Carpooling Cost-Split, Multi-Modal Journey Cost Comparison.
+
+**Today's focus:** Five new feature gaps identified from fresh market intelligence — predictive price arbitrage alerts, station amenity & review ecosystem, fleet/family group management, maintenance-aware refuel routing, and personalised savings dashboard with goal tracking.
+
+---
+
+## Feature 1: Predictive Price Arbitrage Alerts
+
+### Description
+
+Goes beyond the existing `PricePredictionProvider` (which analyses local hour-of-day and day-of-week averages for a single station) by building a cross-station, cross-country arbitrage engine. When the app detects that a station 5 km from the user's daily commute route is about to enter its historically cheapest window while the user's favourite station is in its peak window, it proactively sends a "save €X by filling at Station Y in 45 minutes" notification. Competitors like Clever Tanken offer static price history charts; TankPilot has ML predictions but only for a single selected station. No app currently offers proactive cross-station timing arbitrage on the user's actual route. This directly serves Layer 1 ("buy fuel for less money") and gives Tankstellen an AI-driven edge that is extremely hard for single-country competitors to replicate across 11 countries.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New sub-module under `lib/features/alerts/` extending the existing alert system, plus a new domain service in `lib/features/price_history/domain/`.
+
+**Key files to create:**
+
+- `lib/features/price_history/domain/arbitrage_engine.dart` — Pure-Dart domain logic (no Flutter imports, isolate-safe). Takes as input: (a) the user's recent GPS commute corridor (from `lib/core/location/`), (b) stations within a configurable radius of that corridor (from `lib/features/search/`), (c) 30-day price history for each candidate station (from `PriceHistoryRepository`). For each station, it computes the per-hour-of-day price distribution (reusing the bucketing logic already in `price_prediction_provider.dart`), then ranks stations by predicted price at the user's typical fill-up times. Output: `List<ArbitrageOpportunity>` sorted by potential saving.
+
+- `lib/features/price_history/domain/entities/arbitrage_opportunity.dart` — Freezed entity: `stationId`, `stationName`, `predictedPrice`, `comparedToFavoritePrice`, `savingPerLitre`, `savingPerTank` (using vehicle's tank capacity from `lib/features/vehicle/`), `optimalWindowStart` (DateTime), `optimalWindowEnd`, `confidenceScore` (0.0–1.0 based on sample count from `HourlyAverage.sampleCount`), `detourKm` (extra distance vs. direct commute).
+
+- `lib/features/alerts/domain/entities/arbitrage_alert.dart` — Freezed entity extending the existing alert model: `opportunity` (ArbitrageOpportunity), `triggeredAt`, `acknowledged` flag. Stored in Hive alongside existing price alerts.
+
+- `lib/features/alerts/data/arbitrage_alert_evaluator.dart` — Invoked by the existing `BackgroundPriceFetcher` (`lib/core/background/`). During each background check cycle (already runs every 30 min via WorkManager), it: (1) loads the user's commute corridor from stored GPS history, (2) identifies candidate stations, (3) runs `ArbitrageEngine`, (4) fires a notification via `lib/core/notifications/` if saving exceeds a user-configurable threshold (default: €0.03/L, ≈ €1.50 per 50L tank).
+
+- `lib/features/alerts/presentation/widgets/arbitrage_alert_card.dart` — Rich notification card shown on the alerts tab. Displays: station name, price comparison bar chart (favourite vs. recommended), saving amount, optimal fill window countdown, one-tap navigate button (launches external maps or the existing driving mode).
+
+- `lib/features/alerts/providers/arbitrage_alert_provider.dart` — Riverpod provider that watches `ArbitrageAlertEvaluator` results and the existing `priceAlertProvider` to present a unified alert feed.
+
+**Integration points:**
+
+- Extends `lib/core/background/background_price_fetcher.dart` — adds arbitrage evaluation step after existing threshold-alert checks.
+- Reuses `PriceHistoryRepository` (already stores 30-day per-station history).
+- Reuses `price_prediction_provider.dart` bucketing logic (extracted into shared utility).
+- Uses vehicle tank capacity from `lib/features/vehicle/domain/entities/` for saving calculation.
+- Uses `lib/core/location/location_service.dart` + stored trip GPS paths from `lib/features/consumption/` to derive commute corridor.
+- Notifications via existing `flutter_local_notifications` integration.
+
+**Privacy alignment:**
+
+- Commute corridor computed on-device from locally stored trip data — never uploaded.
+- No new network calls; relies entirely on already-fetched price history.
+- User can disable arbitrage alerts independently of threshold alerts in settings.
+
+---
+
+## Feature 2: Station Amenity & Review Ecosystem
+
+### Description
+
+The `station_detail` screen currently shows prices, brand, and basic info, but lacks structured amenity data (shop, car wash, restrooms, air pump, ATM, food, EV chargers co-located) and user reviews. GasBuddy's biggest retention lever is its user review system — drivers check reviews before visiting unfamiliar stations. Clever Tanken shows basic opening hours but no amenities or reviews. For Tankstellen's 11-country footprint, building a lightweight, privacy-first review and amenity system would dramatically increase station detail page stickiness and give users a reason to open the app even when they're not actively looking for prices. This serves Layer 1 indirectly (quality signals help choose between similarly priced stations) and creates a moat through user-generated content that API-only apps cannot replicate.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New sub-module `lib/features/station_detail/domain/` for amenity and review models, extending the existing station detail presentation layer. Reviews stored locally (Hive) with optional sync via TankSync (Supabase).
+
+**Key files to create:**
+
+- `lib/features/station_detail/domain/entities/station_amenity.dart` — Freezed enum-like sealed class with variants: `Shop`, `CarWash`, `Restroom`, `AirPump`, `ATM`, `Food`, `WiFi`, `EvCharger`, `Hydrogen`, `TruckParking`, `Accessibility`. Each variant carries an optional `quality` rating (1–5) and `lastConfirmedAt` timestamp.
+
+- `lib/features/station_detail/domain/entities/station_review.dart` — Freezed entity: `reviewId` (UUID), `stationId`, `overallRating` (1–5), `amenityRatings` (Map<StationAmenity, int>), `comment` (optional, max 280 chars), `createdAt`, `updatedAt`, `profileId` (references existing profile system). No real names or photos — privacy-first design using the existing anonymous profile model.
+
+- `lib/features/station_detail/data/review_repository.dart` — Hive-backed storage for reviews. CRUD operations with optimistic local-first writes. Implements `SyncableRepository` interface (from `lib/core/sync/`) so reviews sync to TankSync when enabled, letting cross-device users see their own reviews everywhere.
+
+- `lib/features/station_detail/data/amenity_repository.dart` — Aggregates amenity confirmations from reviews. When 3+ independent reviews confirm an amenity, it's flagged as "verified." Stores aggregated amenity state per station in a lightweight Hive box.
+
+- `lib/features/station_detail/presentation/widgets/amenity_chips_row.dart` — Horizontal chip row below the price section on the station detail screen. Each chip shows the amenity icon + verification badge. Taps expand to show rating distribution. Integrates into existing `station_detail_screen.dart` layout.
+
+- `lib/features/station_detail/presentation/widgets/review_section.dart` — Expandable section below amenities: shows aggregate rating (stars), review count, and latest 3 reviews with "see all" button. Includes a "Write review" FAB that opens a bottom sheet with star rating, amenity checkboxes, and optional comment field.
+
+- `lib/features/station_detail/presentation/widgets/write_review_sheet.dart` — Modal bottom sheet: overall star rating (required), amenity toggles with per-amenity rating (optional), text comment (optional, 280 char limit). Validates that the user has visited the station (checks fill-up log or GPS proximity within last 7 days) to prevent spam.
+
+- `lib/features/station_detail/providers/review_provider.dart` — Riverpod provider: fetches reviews from `ReviewRepository`, computes aggregate stats (avg rating, amenity verification status), exposes write/update/delete mutations.
+
+**Integration points:**
+
+- Extends `station_detail_screen.dart` — inserts `AmenityChipsRow` and `ReviewSection` widgets between existing `StationPricesSection` and `StationRatingSection` (which currently handles the simpler price-report rating).
+- Syncs via existing `lib/core/sync/` TankSync infrastructure (Supabase) — reviews become a new sync category alongside favorites and fill-ups.
+- Spam prevention: cross-references `lib/features/consumption/data/` fill-up log and `lib/core/location/` GPS history.
+- Search results can surface aggregate rating as a secondary sort criterion (extends `lib/features/search/domain/entities/`).
+
+**Privacy alignment:**
+
+- Reviews are anonymous — tied to profile UUID, no personal data exposed.
+- Review content never leaves the device unless TankSync is explicitly enabled.
+- No photos (avoids facial recognition / license plate concerns).
+- Location-based visit verification uses only on-device GPS history.
+
+---
+
+## Feature 3: Fleet & Family Group Management
+
+### Description
+
+Multi-vehicle households and small business fleets (delivery drivers, sales teams, family cars) currently manage each vehicle independently. No fuel app in the German market offers a "group" view where a family or small fleet can see combined fuel spend, compare vehicle efficiency, and identify which vehicle or driver is costing the most. Fuelio has basic multi-vehicle support but no aggregation or comparison. Tankstellen already supports vehicle profiles (`lib/features/vehicle/`) and optional TankSync cloud backend — adding a group layer on top lets families share a fuel budget, fleet managers see per-vehicle cost breakdowns, and parents monitor teen driver efficiency. This extends Layer 3 ("see what you're really spending") into the multi-user dimension.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/group/` with clean architecture layers. Uses TankSync (Supabase) as the sync backbone — groups are a new Supabase table with row-level security. Works offline-first: each member's local data is authoritative; the group view aggregates synced snapshots.
+
+**Key files to create:**
+
+- `lib/features/group/domain/entities/vehicle_group.dart` — Freezed entity: `groupId` (UUID), `name` ("Dittgen Family" or "Sales Fleet"), `createdBy` (profile UUID), `memberIds` (List), `inviteCode` (6-char alphanumeric, expires in 7 days), `createdAt`. No personal data beyond profile UUIDs.
+
+- `lib/features/group/domain/entities/group_member.dart` — Freezed entity: `profileId`, `displayName` (user-chosen alias, not real name), `vehicleIds` (which of their vehicles they share with the group), `role` (owner / member), `joinedAt`.
+
+- `lib/features/group/domain/entities/group_summary.dart` — Freezed entity computed from aggregated sync data: `totalSpendThisMonth`, `totalLitresThisMonth`, `totalKmThisMonth`, `avgCostPerKm`, `vehicleBreakdowns` (List of per-vehicle stats: spend, litres, km, cost/km, driving score avg), `bestPerformer` (vehicle with lowest cost/km), `savingsVsFavorite` (how much the group saved vs. always filling at the nearest station).
+
+- `lib/features/group/data/group_repository.dart` — Supabase-backed CRUD for groups. Uses existing `lib/core/data/impl/supabase_sync_repository.dart` patterns. Invite code generation and validation. Row-level security: only group members can read group data. Falls back gracefully when offline (shows last-synced snapshot).
+
+- `lib/features/group/data/group_aggregator.dart` — Pulls synced fill-up logs, trip data, and consumption stats for all group members' shared vehicles. Computes `GroupSummary`. Runs on-device — raw member data is never stored on other members' devices, only the aggregated summary.
+
+- `lib/features/group/presentation/screens/group_dashboard_screen.dart` — Main group view: monthly spend chart (stacked bar per vehicle), cost-per-km leaderboard, fuel budget progress bar (if budget set), "top saver" badge. Accessible from a new tab or from the profile/settings screen.
+
+- `lib/features/group/presentation/screens/group_invite_screen.dart` — QR code (using existing `qr_flutter` dependency) + shareable text invite code. Recipient scans or enters code in their Tankstellen app to join.
+
+- `lib/features/group/presentation/widgets/vehicle_comparison_card.dart` — Side-by-side comparison widget: two vehicles' cost/km, driving score, and consumption trend over the last 30 days. Uses existing chart components from `lib/features/price_history/presentation/`.
+
+- `lib/features/group/providers/group_provider.dart` — Riverpod provider family keyed by `groupId`. Watches `GroupRepository` for membership changes and `GroupAggregator` for summary updates.
+
+**Integration points:**
+
+- Extends Supabase schema (new `groups` and `group_members` tables) — migration via existing `supabase/migrations/` directory.
+- Reuses `lib/core/sync/` infrastructure for syncing fill-ups and trip data to Supabase.
+- Reuses `qr_flutter` (already in pubspec.yaml) for invite code QR generation.
+- Vehicle profiles from `lib/features/vehicle/` — users select which vehicles to share.
+- Fill-up and consumption data from `lib/features/consumption/` — aggregated for group view.
+- Driving score from `lib/features/consumption/domain/driving_score.dart` — averaged per vehicle for leaderboard.
+
+**Privacy alignment:**
+
+- Members choose which vehicles to share — not all-or-nothing.
+- Display names are user-chosen aliases, not real names.
+- Raw trip GPS data is never shared — only aggregated metrics (km, litres, cost).
+- Group data lives in Supabase with row-level security; self-hostable.
+- Any member can leave a group at any time; their data stops syncing immediately.
+
+---
+
+## Feature 4: Maintenance-Aware Refuel Routing
+
+### Description
+
+Tankstellen already has a maintenance suggestion engine that watches consumption drift over time (`lib/features/consumption/domain/entities/maintenance_suggestion.dart`). This feature connects maintenance awareness to refuel routing: when the app detects that a vehicle's fuel consumption has drifted upward (suggesting overdue service, degraded air filter, or tyre pressure issues), it factors the increased per-km cost into route search decisions. A station 3 km further away but €0.04/L cheaper might normally save money — but if the vehicle's consumption is 15% above baseline, that extra detour actually costs more in wasted fuel than the price saving. No competitor considers vehicle condition in routing decisions. This bridges Layer 2 ("burn less fuel") and Layer 1 ("buy cheaper") with Layer 3 ("know what you spend") in a way that is unique to apps with OBD-II integration.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New domain service in `lib/features/route_search/domain/` that wraps the existing `RouteSearchStrategy` with a maintenance-aware cost model. No new feature module — this extends the existing route search and consumption features.
+
+**Key files to create:**
+
+- `lib/features/route_search/domain/maintenance_cost_adjuster.dart` — Pure-Dart domain service. Takes: (a) the vehicle's baseline consumption (from `ConsumptionStats`), (b) the current rolling average consumption (last 5 trips), (c) detour distance for each candidate station. Computes: `adjustedTotalCost = (stationPrice × estimatedLitres) + (detourKm × currentConsumption × avgFuelPrice / 100)`. When consumption drift exceeds a configurable threshold (default: 10%), the adjusted model penalises longer detours more heavily, nudging the routing toward closer stations even if slightly more expensive.
+
+- `lib/features/route_search/domain/entities/maintenance_cost_context.dart` — Freezed entity: `baselineConsumption` (L/100km), `currentConsumption` (L/100km), `driftPercentage`, `driftSeverity` (enum: `normal`, `elevated`, `critical`), `suggestedAction` (string, e.g., "Consider checking tyre pressure — consumption is 12% above baseline").
+
+- `lib/features/route_search/domain/maintenance_aware_strategy.dart` — Decorator around existing `RouteSearchStrategy`. Implements the same interface but wraps the scoring function to use `MaintenanceCostAdjuster` when drift data is available. Falls back to standard strategy when no consumption data exists (new users, vehicles without fill-up history).
+
+- `lib/features/route_search/presentation/widgets/maintenance_drift_banner.dart` — Small info banner shown above route search results when consumption drift is detected. Shows: "Your fuel consumption is X% above normal — factoring this into route recommendations." Tappable to see maintenance suggestions. Uses existing `MaintenanceSuggestion` entity.
+
+- `lib/features/route_search/providers/maintenance_aware_route_provider.dart` — Riverpod provider that composes: `RouteSearchStrategyFactory` (existing), `ConsumptionStatsProvider` (existing), and `MaintenanceCostAdjuster` (new). Provides the maintenance-aware strategy to the route search UI.
+
+**Integration points:**
+
+- Wraps existing `lib/features/route_search/domain/route_search_strategy.dart` and `route_search_strategy_factory.dart` — no breaking changes, the maintenance-aware strategy is a decorator.
+- Reads consumption stats from `lib/features/consumption/domain/entities/consumption_stats.dart`.
+- Reads maintenance suggestions from `lib/features/consumption/domain/entities/maintenance_suggestion.dart`.
+- Surfaces in `lib/features/route_search/presentation/` results screen as an additional banner.
+- Optional: surfaces drift warning in driving mode (`lib/features/driving/presentation/`) as a persistent chip.
+
+**Privacy alignment:**
+
+- All computation on-device using locally stored consumption data.
+- No vehicle diagnostic data leaves the device.
+- Maintenance suggestions are advisory, not prescriptive — never triggers external service bookings.
+
+---
+
+## Feature 5: Personalised Savings Dashboard with Goal Tracking
+
+### Description
+
+Tankstellen tells users what fuel costs, but doesn't help them visualise how much they've actually saved by using the app, nor does it let them set savings goals. GasBuddy prominently shows "You've saved $X this year" — a powerful retention mechanic. Tankstellen can go further: combining fill-up log data, price history, route search choices, and driving score improvements into a comprehensive "your savings story" dashboard. Users set a monthly fuel budget or a savings target, and the app tracks progress with actionable tips ("You saved €12 this month by filling at off-peak times, but lost €8 to aggressive driving — net saving: €4"). This serves Layer 3 ("see what you spend") and creates an emotional feedback loop that drives daily engagement.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/savings/` with clean architecture layers. Computes savings by comparing actual user behaviour against counterfactual baselines (what they would have spent without optimisation).
+
+**Key files to create:**
+
+- `lib/features/savings/domain/entities/savings_goal.dart` — Freezed entity: `goalId` (UUID), `type` (enum: `monthlyBudget`, `annualTarget`, `costPerKmTarget`), `targetAmount` (double, in user's currency), `currency`, `startDate`, `endDate` (null for rolling monthly), `vehicleId` (optional, null = all vehicles).
+
+- `lib/features/savings/domain/entities/savings_breakdown.dart` — Freezed entity: `period` (month/week), `actualSpend`, `baselineSpend` (what user would have spent at nearest station at fill-up time), `priceSaving` (from choosing cheaper stations), `timingSaving` (from filling at predicted cheap windows), `drivingSaving` (from improved driving score reducing consumption), `routeSaving` (from route-optimised stops), `totalSaving`, `co2Avoided` (kg, from efficiency improvements).
+
+- `lib/features/savings/domain/savings_calculator.dart` — Pure-Dart service. For each fill-up in the period: (1) looks up the price at the user's nearest station at the time of fill-up (from `PriceHistoryRepository`), (2) compares against the price they actually paid, (3) difference × litres = price saving. For driving savings: compares current period's avg consumption against the 90-day rolling baseline, multiplied by litres driven. For route savings: sums detour-adjusted savings from route search selections (requires storing which route suggestion was followed — new field on fill-up entity).
+
+- `lib/features/savings/data/savings_repository.dart` — Hive-backed storage for goals and computed breakdowns. Breakdowns are recomputed on demand (not cached) to reflect any fill-up log edits. Goals persist across sessions.
+
+- `lib/features/savings/presentation/screens/savings_dashboard_screen.dart` — Main dashboard: (1) hero card with "You've saved €X this month" in large type, (2) progress ring toward savings goal (if set), (3) breakdown cards (price, timing, driving, route) with mini bar charts, (4) "this month vs. last month" comparison, (5) tips section ("Fill up on Tuesdays around 6 AM to save an additional €3/month" — sourced from `PricePredictionProvider`).
+
+- `lib/features/savings/presentation/screens/savings_goal_setup_screen.dart` — Goal creation flow: pick goal type (budget/target/cost-per-km), enter amount, select vehicle(s) or all, set period. Clean, focused UI with no clutter.
+
+- `lib/features/savings/presentation/widgets/savings_hero_card.dart` — Animated card (uses existing `flex_color_scheme` theming) showing total savings with a celebratory animation when milestones are hit (€10, €50, €100 saved). Optionally shareable as PNG (using existing `share_plus` dependency).
+
+- `lib/features/savings/presentation/widgets/savings_tip_card.dart` — Contextual tip derived from the user's own data: e.g., "You filled up 3 times on Fridays — Fridays are the most expensive day at your stations. Switching to Tuesdays could save €4.20/month." Sources data from `PricePredictionProvider` and `ConsumptionStatsProvider`.
+
+- `lib/features/savings/providers/savings_provider.dart` — Riverpod provider composing: `SavingsCalculator`, `SavingsRepository`, fill-up data from `ConsumptionProviders`, price history, and vehicle profiles. Exposes current-period breakdown and goal progress.
+
+**Integration points:**
+
+- Reads fill-up log from `lib/features/consumption/data/` and `lib/features/consumption/domain/entities/fill_up.dart`.
+- Reads price history from `lib/features/price_history/data/` via `PriceHistoryRepository`.
+- Reads driving score from `lib/features/consumption/domain/driving_score.dart` for efficiency saving calculation.
+- Reads vehicle profiles from `lib/features/vehicle/` for tank capacity and baseline consumption.
+- Extends `lib/features/consumption/domain/entities/fill_up.dart` — adds optional `routeSuggestionFollowed` boolean field to track whether the user followed a route search recommendation.
+- Accessible via new navigation destination in `lib/app/shell/shell_destinations.dart` or as a card on the existing profile screen.
+- Shareable via existing `share_plus` (already in pubspec.yaml).
+- Syncs goals via TankSync (Supabase) when enabled — extends `lib/core/sync/`.
+
+**Privacy alignment:**
+
+- All savings computation is on-device using locally stored data.
+- Shared savings cards (PNG) contain only aggregate numbers, no station names or GPS data.
+- Goals and breakdowns sync only if TankSync is explicitly enabled.
+- No comparison with other users — this is a personal savings tracker, not a leaderboard.
+
+---
+
+## Summary & Prioritisation
+
+| # | Feature | Layer | Effort | Impact | Priority |
+|---|---------|-------|--------|--------|----------|
+| 1 | Predictive Price Arbitrage Alerts | L1 | Medium | High | **P0** |
+| 2 | Station Amenity & Review Ecosystem | L1/L3 | High | High | **P1** |
+| 3 | Fleet & Family Group Management | L3 | High | Medium | **P2** |
+| 4 | Maintenance-Aware Refuel Routing | L1/L2 | Low | Medium | **P1** |
+| 5 | Personalised Savings Dashboard | L3 | Medium | High | **P0** |
+
+**Rationale:**
+
+- **Arbitrage Alerts (P0):** Low-to-medium effort (reuses existing price history + prediction infrastructure), high impact (proactive notifications drive daily engagement and directly save users money — the app's core promise). Leverages the unique 11-country price history dataset no competitor has.
+
+- **Savings Dashboard (P0):** Medium effort, but enormous retention impact. GasBuddy's "you saved $X" is their stickiest feature. Tankstellen can go deeper with breakdown by saving source (price, timing, driving) — a genuine differentiator for the OBD-II-equipped user segment.
+
+- **Maintenance-Aware Routing (P1):** Smallest implementation scope (decorator pattern over existing route search), medium impact but highly unique — no competitor considers vehicle condition in routing. Makes the OBD-II investment pay off in a new way.
+
+- **Station Reviews (P1):** High effort (community data + sync + spam prevention), but high long-term impact. User-generated content creates a moat. Deliberately kept lightweight (no photos, 280-char limit) to align with privacy-first values.
+
+- **Fleet/Family Groups (P2):** Highest effort (Supabase schema changes, multi-user sync complexity), medium impact (smaller target audience). But strong differentiation — no fuel app in the DACH market offers this. Naturally follows once TankSync is mature.

--- a/docs/feature-concepts/2026-05-04-feature-analysis.md
+++ b/docs/feature-concepts/2026-05-04-feature-analysis.md
@@ -1,0 +1,313 @@
+# Daily Feature Analysis — 2026-05-04
+
+## Market Context
+
+The fuel and mobility app landscape in early May 2026 is shaped by three converging forces: the insurance industry's accelerating shift toward Usage-Based Insurance (UBI) with telematics-verified driving data (the global connected insurance telematics market reached $3.8B in 2024, projected to nearly 1B active premiums by 2031); a 40% jump in carpooling activity driven by fuel price volatility and return-to-office mandates (Scoop reported a 40% ride increase from Feb to Mar 2026); and growing consumer demand for carbon accountability beyond passive dashboards — carbon offset apps like Klima and Capture are mainstreaming the concept of "neutralise what you can't avoid." Meanwhile, weather-aware routing is becoming table stakes in logistics (Google Maps, Waze, Upper all factor conditions into fuel-efficient routing), but no consumer fuel price app connects weather forecasts to personal fuel consumption predictions. Clever Tanken remains Germany's largest with 5M+ users but offers no OBD-II integration, no multi-country coverage, and no driving insights. ADAC Drive covers multiple European countries and includes EV charging with 120K+ stations, but lacks consumption tracking, driving coaching, or any telematics integration.
+
+**Tankstellen's current positioning:** 11 countries (17 station services), 23 languages, OBD-II driving insights with auto-record and driving score, EV charging (OpenChargeMap), achievements/gamification, loyalty cards, privacy-first (no Firebase/tracking/ads), price predictions (day-of-week + hour-of-day model), route search with strategies, glide coach with traffic signal anticipation, consumption tracking, CO2 dashboard, CarDataBridge for Android Auto/CarPlay, home-screen widget, receipt OCR, maintenance suggestion engine.
+
+**Previously proposed features (May 1–3):** CarPlay/Android Auto template screens, Crowdsourced Price OCR, Smart Refuel Timing, Community Leaderboard, Wearable Companion, Voice-First In-Car AI Copilot, Hybrid & EV Energy Cost Optimizer, Station Queue & Availability Intelligence, Social Carpooling Cost-Split (concept only), Multi-Modal Journey Cost Comparison, AI-Powered Maintenance Cost Predictor, Predictive Price Arbitrage Alerts, Station Amenity & Review Ecosystem, Fleet/Family Group Management, Maintenance-Aware Refuel Routing, Personalised Savings Dashboard with Goal Tracking.
+
+**Today's focus:** Five new feature gaps identified from fresh market intelligence — weather-aware fuel efficiency advisor, insurance telematics data export for UBI discounts, fuel price volatility heatmap, trip cost sharing calculator for carpoolers, and carbon offset marketplace integration.
+
+---
+
+## Feature 1: Weather-Aware Fuel Efficiency Advisor
+
+### Description
+
+Weather conditions have a measurable and significant impact on fuel consumption that no consumer fuel price app currently accounts for. Cold temperatures increase fuel consumption by 12–20% for short trips (engine warm-up, denser air, winter-grade fuel blends), headwinds at highway speeds can add 10–20% to consumption, rain increases rolling resistance by 20–30%, and air conditioning in summer heat adds 5–15%. Tankstellen already tracks per-trip consumption via OBD-II and has a driving score system, but treats all trips equally regardless of conditions. By integrating weather forecast data, the app can: (a) adjust driving score expectations so users aren't penalised for unavoidable weather-driven consumption increases, (b) warn before a trip that conditions will cost extra fuel and suggest timing alternatives, (c) provide weather-normalised consumption trends so users can distinguish genuine vehicle degradation from seasonal effects, and (d) recommend optimal departure windows that balance fuel price predictions with weather-efficiency forecasts. No competitor — not Clever Tanken, ADAC Drive, TankPilot, Fuelio, or GasBuddy — offers weather-consumption correlation. This uniquely extends Layer 2 ("burn less fuel") with environmental intelligence.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New domain service under `lib/core/weather/` for weather data fetching and caching, plus integration points in the consumption, driving, and route search features. Uses Open-Meteo API (free, no API key required, covers all 11 supported countries).
+
+**Key files to create:**
+
+- `lib/core/weather/weather_service.dart` — Abstract interface defining `Future<WeatherForecast> getForecast(double lat, double lng, {int hoursAhead = 24})` and `Future<WeatherCondition> getCurrentConditions(double lat, double lng)`. Follows the existing service abstraction pattern used in `lib/features/station_services/`.
+
+- `lib/core/weather/open_meteo_weather_service.dart` — Implementation using the Open-Meteo free API (`https://api.open-meteo.com/v1/forecast`). Fetches: temperature, precipitation probability, wind speed + direction, humidity. Uses the existing `Dio` HTTP client with interceptors from `lib/core/constants/api_constants.dart`. Response parsed into domain entities.
+
+- `lib/core/weather/weather_cache.dart` — Extends the existing `CacheManager` pattern from `lib/core/cache/cache_manager.dart`. Weather data cached with 1-hour TTL for current conditions, 6-hour TTL for forecasts. Hive-backed for offline access.
+
+- `lib/core/weather/entities/weather_forecast.dart` — Freezed entity: `hourlyEntries` (List of `WeatherHour`), `locationLat`, `locationLng`, `fetchedAt`. Each `WeatherHour`: `dateTime`, `temperatureCelsius`, `precipitationMm`, `windSpeedKmh`, `windDirectionDeg`, `humidity`, `weatherCode` (WMO standard codes used by Open-Meteo).
+
+- `lib/core/weather/entities/fuel_efficiency_impact.dart` — Freezed entity: `temperatureImpactPercent` (estimated consumption change from temperature vs. 20°C baseline), `windImpactPercent` (headwind/tailwind effect based on trip bearing vs. wind direction), `precipitationImpactPercent` (wet road rolling resistance), `hvacImpactPercent` (estimated A/C or heater load), `totalImpactPercent` (combined), `adjustedBaselineConsumption` (L/100km, the user's baseline adjusted for conditions), `humanSummary` (localised string, e.g. "Cold weather and headwind may increase consumption by ~14%").
+
+- `lib/core/weather/fuel_weather_correlator.dart` — Pure-Dart domain service. Takes: the user's baseline consumption (from `ConsumptionStats`), current or forecast `WeatherCondition`, and optionally the trip bearing (from route or GPS). Computes `FuelEfficiencyImpact` using published engineering models: temperature factor = piecewise linear (below 0°C: +15–20%, 0–10°C: +8–12%, 10–20°C: +2–5%, 20–25°C: baseline, 25°C+: +3–8% for A/C), wind factor = `0.5 * airDensity * dragCoeff * frontalArea * (headwindComponent^2)` simplified to a lookup table indexed by headwind speed, precipitation factor = +3% per mm/h of rain. Conservative estimates — always shows "estimated" to avoid false precision.
+
+- `lib/features/consumption/domain/weather_normalised_stats.dart` — Service that wraps `ConsumptionStats` and adjusts historical trip consumption figures for the weather conditions at the time of each trip. Requires stored weather data per trip (see integration below). Exposes: `normalisedAvgConsumption` (what the user's consumption would be if every trip were at 20°C, dry, no wind), `weatherPenaltyThisMonth` (total extra litres burned due to weather), `trendExcludingWeather` (is the vehicle genuinely getting less efficient, or is it just winter?).
+
+- `lib/features/consumption/presentation/widgets/weather_impact_chip.dart` — Small chip displayed on the trip detail screen next to the consumption figure. Shows: weather icon + "+X%" or "−X%" impact estimate. Tapping opens a tooltip explaining which conditions affected the trip. Integrates into existing trip detail view in `lib/features/consumption/presentation/`.
+
+- `lib/features/driving/presentation/widgets/weather_advisory_banner.dart` — Banner shown at the top of the driving mode screen when conditions are expected to increase consumption by >10%. Shows: "Headwind + rain expected — consumption may be ~15% higher than usual. Consider delaying 2h for calmer conditions." Tappable to see hourly forecast breakdown.
+
+- `lib/features/route_search/domain/weather_aware_cost_model.dart` — Extension of the route search cost model. When computing the true cost of a detour to a cheaper station, factors in current weather conditions: a 5 km detour into a headwind costs more fuel than a 5 km detour with a tailwind. Integrates as a decorator on the existing `RouteSearchStrategy` (same pattern as the maintenance-aware routing proposed on May 3).
+
+**Integration points:**
+
+- Trip recorder (`lib/features/consumption/domain/trip_recorder.dart`) — stores weather snapshot at trip start and end. Adds `weatherAtStart` and `weatherAtEnd` fields to the trip entity (extends `lib/features/consumption/domain/entities/`).
+- Driving score (`lib/features/consumption/domain/driving_score.dart`) — adjusts scoring thresholds based on weather. A trip in heavy rain with 8.2 L/100km should score the same as a dry trip at 7.1 L/100km for the same vehicle.
+- CO2 dashboard (`lib/features/carbon/`) — can show weather-normalised emissions trend alongside raw trend.
+- Route search (`lib/features/route_search/`) — weather-aware cost model as an optional decorator.
+- Price prediction (`lib/features/price_history/providers/price_prediction_provider.dart`) — combined "best time to fill" that balances cheapest price window with best weather window for the drive to that station.
+- Existing `Dio` instance and `CacheManager` for API calls and caching.
+
+**Privacy alignment:**
+
+- Open-Meteo is a free, open-source weather API — no API key, no user tracking, no data sharing.
+- Weather data is location-based (lat/lng) but uses the same GPS position the app already has for station search — no new permissions required.
+- Weather snapshots stored locally in Hive alongside trip data — never uploaded unless TankSync is enabled.
+- User can disable weather features entirely in settings.
+
+---
+
+## Feature 2: Insurance Telematics Data Export & UBI Portal
+
+### Description
+
+The insurance industry in 2026 is aggressively moving toward Usage-Based Insurance (UBI), where drivers who prove safe, efficient driving habits receive premium discounts of 10–25%. The global connected insurance telematics market is projected to grow from 278M active premiums in 2026 to nearly 1B by 2031. Traditionally, insurers require their own OBD-II dongle or a dedicated app to collect driving data. Tankstellen already collects exactly the data insurers need — trip distance, speed profiles, acceleration events, braking patterns, time-of-day driving, and the composite driving score — through its existing OBD-II integration. By offering a standardised, privacy-controlled telematics export, Tankstellen can become the neutral "driving passport" that users share with any insurer, eliminating the need for insurer-specific hardware. This is a massive value proposition: save money at the pump (Layer 1), drive more efficiently for a better score (Layer 2), and now save money on insurance too — all from the same app. No fuel price app currently offers insurance telematics export. This positions Tankstellen at the intersection of fuel savings and insurance savings, dramatically expanding its value per user.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/telematics_export/` with clean architecture layers. Generates standardised driving reports from existing trip and driving score data. Export formats: PDF report (human-readable for sharing with any insurer), JSON/CSV (machine-readable for API integration), and a QR-scannable summary for in-person agent meetings.
+
+**Key files to create:**
+
+- `lib/features/telematics_export/domain/entities/telematics_report.dart` — Freezed entity: `reportId` (UUID), `vehicleId`, `periodStart`, `periodEnd`, `totalTrips`, `totalKm`, `totalHours`, `avgDrivingScore`, `scoreTrend` (improving/stable/declining), `hardBrakingEventsPerKm`, `hardAccelEventsPerKm`, `speedingPercentage` (% of km driven >10% over posted limit, requires speed limit data from OSM — already partially available via glide coach's `osm_traffic_signal_client.dart`), `nightDrivingPercentage` (% of km between 23:00–05:00), `avgTripDistance`, `idleTimePercentage`, `fuelEfficiencyRating` (A–F based on vehicle class comparison), `generatedAt`, `appVersion`, `integrityHash` (SHA-256 of report contents to prevent tampering).
+
+- `lib/features/telematics_export/domain/entities/telematics_summary.dart` — Freezed entity for the QR-scannable compact summary: `overallGrade` (A–F), `totalKm`, `avgScore`, `periodMonths`, `riskCategory` (low/medium/high derived from driving patterns), `verificationUrl` (optional deep link back into the app for the insurer to verify — requires TankSync).
+
+- `lib/features/telematics_export/domain/telematics_report_generator.dart` — Pure-Dart service. Reads: all trips for a vehicle within a date range from `lib/features/consumption/data/`, driving scores from `driving_score.dart`, driving insights (hard accel, idle, cold start) from `driving_insight.dart`. Aggregates into `TelematicsReport`. Computes the integrity hash from deterministic JSON serialisation of all fields.
+
+- `lib/features/telematics_export/domain/risk_classifier.dart` — Maps driving metrics to insurance risk categories using published actuarial guidelines. Conservative classification: only rates users as "low risk" when data strongly supports it. Uses: (a) hard braking frequency (< 2 per 100 km = low), (b) night driving (< 10% = low), (c) speeding (< 5% = low), (d) driving score trend (stable or improving = low). Any single "high" metric caps the overall category at "medium."
+
+- `lib/features/telematics_export/data/report_exporter.dart` — Generates export files. PDF: uses the existing PDF generation pattern (the app already has `share_plus` for sharing). The PDF includes: cover page with vehicle info + overall grade, monthly trend charts (driving score, consumption, events), detailed metrics table, integrity hash + QR code at the bottom. JSON/CSV: machine-readable export following the emerging OICA (Organisation Internationale des Constructeurs d'Automobiles) connected vehicle data format where applicable.
+
+- `lib/features/telematics_export/presentation/screens/telematics_export_screen.dart` — Main screen: (1) "Your Driving Profile" hero card with overall grade (A–F) and trend arrow, (2) key metrics displayed as a radar chart (safety, efficiency, consistency, time-of-day, mileage), (3) period selector (last 3/6/12 months), (4) "Generate Report" button with format picker (PDF/JSON/CSV), (5) "Share with Insurer" button that uses `share_plus` to send the file, (6) QR code display for in-person sharing.
+
+- `lib/features/telematics_export/presentation/widgets/driving_profile_radar.dart` — Radar/spider chart widget showing 5 axes: safety (braking/accel events), efficiency (consumption vs. vehicle class average), consistency (score variance across trips), time-of-day (% daytime driving), experience (total km in reporting period). Built with `CustomPainter` using the existing theming from `lib/app/theme.dart`.
+
+- `lib/features/telematics_export/presentation/widgets/integrity_badge.dart` — Small badge shown on the report and export screen indicating: "This report is integrity-verified — the hash can be independently validated." Explains to users why insurers can trust the data.
+
+- `lib/features/telematics_export/providers/telematics_export_provider.dart` — Riverpod provider composing: `TelematicsReportGenerator`, trip data providers, driving score providers, vehicle profile provider. Caches the most recent report to avoid re-computation on screen revisits.
+
+**Integration points:**
+
+- Reads trip data from `lib/features/consumption/data/` repositories — fill-ups, trip history, consumption stats.
+- Reads driving scores from `lib/features/consumption/domain/driving_score.dart` and `driving_insight.dart`.
+- Reads vehicle profile from `lib/features/vehicle/domain/entities/` for vehicle class comparison.
+- Uses `share_plus` (already in pubspec.yaml) for file sharing.
+- Uses `qr_flutter` (already in pubspec.yaml) for QR code generation.
+- Accessible from a new entry in `lib/features/profile/presentation/` settings screen or from the consumption/driving section.
+- Optional: report metadata syncs via TankSync (Supabase) so cross-device users see the same export history.
+- Glide coach's `osm_traffic_signal_client.dart` — could be extended to fetch speed limit data from OSM for speeding percentage calculation.
+
+**Privacy alignment:**
+
+- Reports are generated entirely on-device — no data sent to Tankstellen servers or any third party.
+- The user explicitly chooses when and with whom to share the report — no automatic sharing.
+- Reports contain aggregate statistics only — no raw GPS traces, no specific locations, no timestamps below daily granularity.
+- Integrity hash allows verification without requiring the raw data to leave the device.
+- Users can generate reports for specific date ranges, choosing how much history to reveal.
+- No insurer partnerships or data-sharing agreements required — the user is the sole data controller.
+
+---
+
+## Feature 3: Fuel Price Volatility Heatmap
+
+### Description
+
+Current fuel price apps show today's prices as static lists or map pins, and price history as per-station line charts. But drivers also need to understand price volatility — which areas have stable, predictable prices (allowing planned fill-ups) and which swing wildly (creating both risk and opportunity). Tankstellen already stores 30-day price history per station across 11 countries, a dataset that can be transformed into a volatility heatmap. The heatmap overlays the existing map view with colour-coded zones: green zones have stable prices (low standard deviation), yellow zones have moderate swings, red zones have high volatility. This helps users in three ways: (a) when planning a fill-up days ahead, prefer green zones where the price you see today will still be similar, (b) in red zones, use the existing price prediction feature more aggressively to time the fill-up, (c) for cross-border users, identify which country's border region has the most predictable pricing. No competitor offers this — Clever Tanken and ADAC show per-station history but never aggregate it into spatial intelligence. This is a Layer 1 feature that makes the existing price data dramatically more actionable.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New presentation layer in `lib/features/map/` leveraging existing price history data. The volatility computation lives in a new domain service under `lib/features/price_history/domain/`. Map rendering uses the existing `flutter_map` integration with a new tile overlay.
+
+**Key files to create:**
+
+- `lib/features/price_history/domain/volatility_calculator.dart` — Pure-Dart domain service. For each station with ≥7 days of price history: computes standard deviation of daily prices, coefficient of variation (CV = stddev / mean), max daily swing (largest single-day price change), and intra-day range (difference between daily high and low where data supports it). Output: `StationVolatility` entity per station.
+
+- `lib/features/price_history/domain/entities/station_volatility.dart` — Freezed entity: `stationId`, `fuelType`, `meanPrice`, `stdDev`, `coefficientOfVariation`, `maxDailySwing`, `avgIntraDayRange`, `volatilityTier` (enum: `stable`, `moderate`, `volatile` — thresholds: CV < 0.02 = stable, 0.02–0.05 = moderate, > 0.05 = volatile), `sampleDays` (number of days with data), `periodStart`, `periodEnd`.
+
+- `lib/features/price_history/domain/volatility_grid.dart` — Aggregates per-station volatility into a spatial grid. Divides the visible map area into hexagonal cells (approximately 2 km radius each). Each cell's volatility is the weighted average of stations within it (weighted by inverse distance from cell centre). Output: `List<VolatilityCell>` with centre lat/lng, radius, and aggregate volatility tier + colour.
+
+- `lib/features/price_history/domain/entities/volatility_cell.dart` — Freezed entity: `centerLat`, `centerLng`, `radiusKm`, `avgVolatilityCV`, `tier` (stable/moderate/volatile), `stationCount` (stations contributing), `color` (ARGB int derived from tier: green/yellow/red with alpha for overlay transparency).
+
+- `lib/features/map/presentation/widgets/volatility_heatmap_layer.dart` — `flutter_map` polygon layer that renders `VolatilityCell` entries as semi-transparent filled hexagons. Uses the existing `flutter_map` `PolygonLayer` — each hexagon is a 6-vertex polygon computed from centre + radius. Colour intensity scales with confidence (more stations = more opaque). Layer visibility toggled by a new control button on the map toolbar alongside the existing EV overlay toggle from `ev_map_overlay.dart`.
+
+- `lib/features/map/presentation/widgets/volatility_legend.dart` — Compact legend overlay (bottom-left of map): three coloured circles with labels — "Stable," "Moderate," "Volatile." Includes a small "i" icon that opens a tooltip explaining what volatility means for fill-up timing.
+
+- `lib/features/map/presentation/widgets/volatility_info_sheet.dart` — Bottom sheet shown when tapping a volatility cell on the map. Shows: cell's average volatility metrics, list of stations within the cell ranked by stability, recommendation text ("Prices here change by ±€0.04/L daily — use the price prediction feature to time your fill-up" or "Prices here are very stable — fill up whenever convenient").
+
+- `lib/features/map/providers/volatility_heatmap_provider.dart` — Riverpod provider that watches: visible map bounds (from existing map state provider), selected fuel type (from existing fuel type picker), and price history data. Debounces map movement (300 ms) to avoid recomputing on every pan. Computes `VolatilityGrid` and exposes `List<VolatilityCell>` for the layer widget.
+
+**Integration points:**
+
+- Reads price history from `lib/features/price_history/data/` via `PriceHistoryRepository` — 30-day history per station.
+- Extends the existing map view in `lib/features/map/presentation/` — adds `VolatilityHeatmapLayer` as an optional overlay alongside the existing EV overlay.
+- Reuses the fuel type selection from `lib/core/country/fuel_type_picker_provider.dart` — volatility computed per fuel type.
+- Map toolbar extension — adds a volatility toggle button alongside existing controls in `lib/features/map/presentation/widgets/`.
+- Links to existing price prediction from the info sheet — "See best time to fill" button navigates to the station's price history screen.
+- Cross-border insights — when the heatmap spans a border, users can visually compare volatility regimes between countries.
+
+**Privacy alignment:**
+
+- Entirely computed from publicly available price data already stored on-device.
+- No new API calls, network requests, or data collection.
+- No user location data is used in the computation — only station coordinates and their price histories.
+- Overlay is opt-in (toggled via map button, off by default to keep the map clean for new users).
+
+---
+
+## Feature 4: Trip Cost Sharing Calculator for Carpoolers
+
+### Description
+
+Carpooling is surging in 2026 — Scoop reported a 40% jump in rides from February to March 2026, driven by fuel price volatility and return-to-office mandates. The global carpooling market is projected to grow at 15%+ CAGR through 2030. When people share rides, they need to split fuel costs fairly, but doing so accurately requires knowing the actual fuel consumed (not just distance), the price per litre at the time of fill-up, and each passenger's share of the route. Tankstellen uniquely has all this data: real fuel consumption from OBD-II, actual fuel prices from the fill-up log, and GPS trip routes. No fuel price app offers an integrated cost-sharing feature — drivers currently use separate calculator apps (Splitwise, Tricount) or rough mental estimates. Building a carpooling cost splitter directly into Tankstellen's trip detail screen turns every recorded trip into a shareable cost receipt. This extends Layer 3 ("see what you spend") into the multi-passenger dimension and gives Tankstellen a viral sharing mechanic: recipients of cost-split messages see the Tankstellen-branded receipt and are introduced to the app.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/cost_split/` with clean architecture layers. Integrates into the existing trip detail view and fill-up log. Generates shareable cost receipts.
+
+**Key files to create:**
+
+- `lib/features/cost_split/domain/entities/cost_split.dart` — Freezed entity: `splitId` (UUID), `tripId` (references existing trip entity, optional — can also be a manual entry), `fillUpId` (optional, links to the fill-up that covered this trip), `totalFuelCost` (computed from litres × price, or entered manually), `totalDistanceKm`, `participants` (List of `SplitParticipant`), `splitMethod` (enum: `equal`, `byDistance`, `byPickupOrder`), `createdAt`, `currency`.
+
+- `lib/features/cost_split/domain/entities/split_participant.dart` — Freezed entity: `name` (user-entered, e.g. "Anna", "Tom"), `boardingKm` (km into the trip where they joined — 0 for full trip), `alightingKm` (km where they left — totalKm for full trip), `shareAmount` (computed), `sharePercentage`.
+
+- `lib/features/cost_split/domain/cost_split_calculator.dart` — Pure-Dart service. Implements three split methods:
+  - `equal`: totalCost / participantCount.
+  - `byDistance`: each participant pays proportional to their segment distance. If total trip is 50 km, driver does full 50 km, passenger A joins at km 10 and leaves at km 40 (30 km), passenger B does full 50 km: shares are weighted by individual km / sum of all individual km.
+  - `byPickupOrder`: simplified version of byDistance where participants are added at waypoints and the cost of each segment is split among whoever is in the car for that segment. More intuitive for commute carpools with fixed pickup points.
+
+- `lib/features/cost_split/domain/cost_split_receipt_generator.dart` — Generates a shareable receipt. Formats: (a) plain text (for messaging apps), (b) styled PNG image (for WhatsApp/Instagram sharing, using the existing `share_plus` + `RenderRepaintBoundary` pattern), (c) deep link back to the split in Tankstellen (for users who have the app). Receipt shows: trip date, route summary (start → end), total cost, breakdown per participant with amount, and a Tankstellen watermark/branding.
+
+- `lib/features/cost_split/data/cost_split_repository.dart` — Hive-backed storage for split history. Users can review past splits and resend receipts. Implements `SyncableRepository` for optional TankSync cross-device sync.
+
+- `lib/features/cost_split/presentation/screens/cost_split_screen.dart` — Main screen, accessible from: (a) trip detail screen "Split cost" action button, (b) fill-up detail "Split this fill-up" option, (c) standalone from navigation for manual cost entry. Flow: (1) auto-populate total cost from trip/fill-up data (or enter manually), (2) add participants by name, (3) optionally set boarding/alighting points on a route map (if trip has GPS data), (4) select split method, (5) see computed shares, (6) share receipt.
+
+- `lib/features/cost_split/presentation/widgets/participant_editor.dart` — List widget for adding/removing participants. Each row: name text field, optional distance slider (for byDistance method), computed share amount. "Add participant" button at bottom. Minimum 2 participants (driver + 1 passenger).
+
+- `lib/features/cost_split/presentation/widgets/split_receipt_card.dart` — Styled card that serves as both the on-screen preview and the shareable image. Clean design with: Tankstellen logo, trip date, route, per-person breakdown, total. Uses existing theme colours from `lib/app/theme.dart`.
+
+- `lib/features/cost_split/presentation/widgets/route_participant_overlay.dart` — When a trip has GPS data, shows the route on a mini flutter_map with coloured segments indicating which participants were aboard for each section. Boarding/alighting points shown as markers. Visual confirmation of the distance-based split.
+
+- `lib/features/cost_split/providers/cost_split_provider.dart` — Riverpod provider composing: `CostSplitCalculator`, `CostSplitRepository`, and optionally trip/fill-up data from consumption providers. Manages the creation flow state.
+
+**Integration points:**
+
+- Trip detail screen (`lib/features/consumption/presentation/`) — adds a "Split Cost" action button to the app bar or as a floating action.
+- Fill-up detail — adds a "Split" option to the fill-up entry's action menu.
+- Uses trip GPS data from `lib/features/consumption/` for route visualisation and distance-based splitting.
+- Uses fill-up price data from `lib/features/consumption/domain/entities/fill_up.dart` for accurate cost calculation.
+- Uses `share_plus` (already in pubspec.yaml) for sharing receipts via messaging apps.
+- Uses `flutter_map` (already in pubspec.yaml) for route participant overlay.
+- Syncs via TankSync (optional) — split history available across devices.
+- Receipts include a Tankstellen-branded watermark — organic app discovery for recipients.
+
+**Privacy alignment:**
+
+- Participant names are entered by the user and stored locally only — no accounts or contact access required.
+- GPS route data in shared receipts is optional and can be excluded (receipt shows only start/end, not full trace).
+- Shared receipts contain only cost and name data — no vehicle details, OBD-II data, or personal information.
+- Split history stored in Hive; syncs only if TankSync is enabled.
+- No payment processing — the app calculates amounts but doesn't handle money transfers (avoids financial regulation complexity).
+
+---
+
+## Feature 5: Carbon Offset Marketplace Integration
+
+### Description
+
+Tankstellen's CO2 dashboard (`lib/features/carbon/`) already tracks per-vehicle emissions with 30-day rolling charts, speed-consumption correlation, and trip length breakdowns. But the dashboard is purely informational — it tells users what they emit but offers no path to act on it beyond driving better. In 2026, carbon offset apps are mainstreaming: Klima, Capture, Aerial, and others let individuals purchase verified carbon credits (nature-based credits average $7–24/tCO2e, tech-based CDR credits $170–500). Tankstellen has a unique advantage: it knows the user's actual, measured emissions from OBD-II data and fill-up logs — far more accurate than the rough estimates other offset apps use. By integrating with carbon offset marketplaces, Tankstellen can offer a "neutralise your driving" feature: at the end of each month, see your exact emissions, and with one tap, purchase the precise amount of verified offsets. This extends the CO2 dashboard from passive awareness to active climate action, appealing to the growing segment of eco-conscious drivers who want to reduce and offset what they can't eliminate. No fuel price app currently offers integrated carbon offsetting.
+
+### Detailed Implementation Concept
+
+**Architecture:**
+
+New feature module `lib/features/carbon_offset/` that extends the existing `lib/features/carbon/` dashboard. Integrates with one or more carbon offset APIs (starting with Cloverly or Patch, both of which offer REST APIs with per-transaction offset purchasing). The app acts as a facilitator — it calculates the offset amount and opens a web-based purchase flow, never handling payment directly.
+
+**Key files to create:**
+
+- `lib/features/carbon_offset/domain/entities/offset_quote.dart` — Freezed entity: `quoteId`, `co2Kg` (amount to offset), `providerName` (e.g. "Cloverly", "Patch"), `projectName` (e.g. "Brazilian Reforestation"), `projectType` (enum: `reforestation`, `renewableEnergy`, `methaneCapture`, `directAirCapture`, `oceanAlkalinity`), `pricePerTonne`, `totalPrice`, `currency`, `certificationStandard` (e.g. "Gold Standard", "Verra VCS"), `estimatedRetirementDate`, `expiresAt` (quote validity window).
+
+- `lib/features/carbon_offset/domain/entities/offset_purchase.dart` — Freezed entity: `purchaseId`, `quoteId`, `co2Kg`, `totalPaid`, `currency`, `purchasedAt`, `certificateUrl` (link to the digital offset certificate), `providerTransactionId`, `vehicleId`, `period` (month/year the emissions cover).
+
+- `lib/features/carbon_offset/domain/entities/offset_history.dart` — Freezed entity: `totalOffsetKg` (all-time), `totalSpent`, `monthlyEntries` (List of per-month summaries: emitted, offset, net), `currentStreak` (consecutive months fully offset), `percentageOffset` (what fraction of total emissions has been offset).
+
+- `lib/features/carbon_offset/domain/offset_calculator.dart` — Pure-Dart service. Takes: monthly CO2 emissions from `lib/features/carbon/domain/monthly_summary.dart`. Computes: exact kg of CO2 to offset for the selected period. Applies any credit from driving efficiency improvements (if user reduced emissions by 5% through better driving, only the remaining 95% needs offsetting — the efficiency gain is its own offset). Output: `OffsetRequirement` with `co2Kg`, `adjustedCo2Kg` (after efficiency credit), `efficiencyCredit`.
+
+- `lib/features/carbon_offset/data/offset_provider_service.dart` — Abstract interface: `Future<List<OffsetQuote>> getQuotes(double co2Kg, String currency)`. Allows multiple provider implementations.
+
+- `lib/features/carbon_offset/data/cloverly_offset_service.dart` — Implementation for Cloverly API (REST, JSON). Fetches available offset projects and pricing for the given CO2 amount. No payment processing in-app — returns a purchase URL that opens in the system browser for the user to complete the transaction. After completion, the user confirms in-app and enters the transaction ID (or the app detects the redirect if using a deep link callback).
+
+- `lib/features/carbon_offset/data/offset_repository.dart` — Hive-backed storage for offset purchase history and provider API keys (stored securely using the existing Android Keystore pattern from `lib/features/setup/`).
+
+- `lib/features/carbon_offset/presentation/screens/carbon_offset_screen.dart` — Main screen, accessible from the existing CO2 dashboard via a "Offset your emissions" CTA button. Shows: (1) monthly emissions summary (reuses existing `monthly_bar_chart.dart`), (2) "Your driving footprint this month: X kg CO2" hero card, (3) efficiency credit callout ("Your improved driving saved Y kg — only Z kg needs offsetting"), (4) available offset projects as cards (project name, type icon, price, certification badge), (5) "Offset now" button per project that opens the purchase flow.
+
+- `lib/features/carbon_offset/presentation/screens/offset_history_screen.dart` — Timeline view of past offset purchases. Shows: monthly emitted vs. offset bar chart, all-time total offset badge, certificates list (tappable to open certificate URLs), streak counter ("You've been carbon-neutral for 4 months").
+
+- `lib/features/carbon_offset/presentation/widgets/offset_project_card.dart` — Card widget for each available offset project: project photo placeholder (or icon for project type), name, location, certification standard badge, price per tonne, total price for the user's emissions, "Select" button.
+
+- `lib/features/carbon_offset/presentation/widgets/emissions_vs_offset_chart.dart` — Stacked bar chart showing monthly emissions (red) and offsets (green) side by side. Months where offsets ≥ emissions get a "neutral" badge. Uses the existing chart styling from the carbon dashboard.
+
+- `lib/features/carbon_offset/presentation/widgets/efficiency_credit_explainer.dart` — Small explainer card: "By improving your driving score from 62 to 71 this month, you avoided X kg of CO2. This means you only need to offset Y kg instead of Z kg — your efficiency is its own offset." Encourages continued driving improvement.
+
+- `lib/features/carbon_offset/providers/carbon_offset_provider.dart` — Riverpod provider composing: `OffsetCalculator`, `OffsetProviderService`, `OffsetRepository`, and carbon emission data from existing providers. Manages quote fetching, purchase flow state, and history.
+
+**Integration points:**
+
+- Extends `lib/features/carbon/presentation/screens/carbon_dashboard_screen.dart` — adds an "Offset" tab or CTA button linking to the offset screen.
+- Reads monthly CO2 data from `lib/features/carbon/domain/monthly_summary.dart`.
+- Reads driving score improvements from `lib/features/consumption/domain/driving_score.dart` for efficiency credit calculation.
+- Reads vehicle profile from `lib/features/vehicle/` for emissions factor per fuel type.
+- Uses `url_launcher` (already in pubspec.yaml) to open offset purchase URLs in the system browser.
+- Offset purchase history syncs via TankSync (optional) — offset achievements visible across devices.
+- Achievement integration: new achievement badges in `lib/features/achievements/` — "First Offset", "Carbon Neutral Month", "6-Month Streak", "1 Tonne Offset".
+- Home-screen widget (`lib/features/widget/`) — could show "This month: X kg emitted, Y kg offset" alongside price data.
+
+**Privacy alignment:**
+
+- Offset API calls contain only the CO2 amount to offset and currency — no personal data, no vehicle data, no location.
+- Payment happens entirely in the external provider's website/app — Tankstellen never handles payment data.
+- Offset purchase history stored locally; syncs only via TankSync if enabled.
+- Provider API keys stored in Android Keystore (existing secure storage pattern).
+- Users opt-in to offset features — no nagging or guilt-tripping in the CO2 dashboard. The CTA is informational: "Want to offset?" not "You should offset."
+- No commission or referral fees from offset providers — the feature exists purely to add user value.
+
+---
+
+## Summary & Prioritisation
+
+| # | Feature | Layer | Effort | Impact | Priority |
+|---|---------|-------|--------|--------|----------|
+| 1 | Weather-Aware Fuel Efficiency Advisor | L2 | Medium | High | **P0** |
+| 2 | Insurance Telematics Data Export & UBI Portal | L2/L3 | Medium | Very High | **P0** |
+| 3 | Fuel Price Volatility Heatmap | L1 | Low | Medium | **P1** |
+| 4 | Trip Cost Sharing Calculator | L3 | Medium | High | **P1** |
+| 5 | Carbon Offset Marketplace Integration | L3 | High | Medium | **P2** |
+
+**Rationale:**
+
+- **Insurance Telematics Export (P0):** This is potentially the highest-value feature proposed to date. Insurance premium savings of 10–25% dwarf fuel price savings for most drivers — a driver spending €1,800/year on insurance could save €180–450, compared to perhaps €50–100/year from better fuel timing. Tankstellen already collects all the required data; the feature is primarily a reporting and export layer. The UBI market is projected to grow 3.5x by 2031, meaning this feature becomes more valuable every year. It also creates a powerful retention loop: users need months of driving data to generate a credible report, incentivising daily use.
+
+- **Weather-Aware Efficiency Advisor (P0):** Medium implementation effort (Open-Meteo is free, no-key, and covers all 11 countries), high impact on the OBD-II user segment. Weather is the largest uncontrolled variable in fuel consumption — accounting for it makes the driving score fairer, the consumption trend more actionable, and the route search smarter. It's the kind of feature that makes users think "this app actually understands my car," deepening engagement.
+
+- **Fuel Price Volatility Heatmap (P1):** Lowest implementation effort of today's batch (entirely computed from existing data, no new APIs), medium impact. It transforms the existing price history from per-station data into spatial intelligence. Particularly valuable for cross-border users near volatile pricing zones. The visual impact on the map screen creates a "wow" moment that aids word-of-mouth.
+
+- **Trip Cost Sharing Calculator (P1):** Medium effort, high topical relevance given the 2026 carpooling surge. The viral sharing mechanic (branded receipts shared via WhatsApp) is a rare organic growth channel for a privacy-first app that doesn't do traditional marketing. Cost-splitting turns Tankstellen from a solo-driver tool into a social utility.
+
+- **Carbon Offset Marketplace (P2):** Highest effort (external API integration, purchase flow complexity, provider selection), medium impact (smaller target audience of eco-conscious drivers). But strategically important: it completes the CO2 dashboard's story from awareness to action, and positions Tankstellen in the growing sustainability-tech space. Deliberately designed to never handle payments directly, keeping the implementation clean and the regulatory burden zero.
+
+---
+
+*Generated 2026-05-04. Market signals sourced from: Tank-Pilot 2026 comparison, Sia Partners energy station loyalty study, Damoov daily carbon score, DQ Connected Insurance Guide 2026, High-Mobility OBD telematics analysis, Scoop carpooling growth data, Capterra fuel management software rankings, Open-Meteo weather API documentation.*

--- a/docs/feature-concepts/2026-05-05-concept-architecture-implementation.md
+++ b/docs/feature-concepts/2026-05-05-concept-architecture-implementation.md
@@ -1,0 +1,1573 @@
+# Daily Feature Concept — 2026-05-05
+
+## Detailed Architecture & Implementation Document
+
+### Executive Summary
+
+This document consolidates the 20 features proposed across the May 1–4 daily analyses into five implementation-ready concept architectures. Each concept is selected for its synergy with Tankstellen's existing codebase, its reuse of proven patterns, and its incremental complexity profile. The concepts are ordered by implementation priority and include exact file paths, class interfaces, provider wiring, persistence schemas, integration points, test strategies, and migration paths.
+
+**Selected concepts for deep-dive:**
+
+| # | Concept | Source | Effort | Rationale |
+|---|---------|--------|--------|-----------|
+| 1 | Smart Refuel Timing Advisor | May 1 #3 | Low | Extends existing prediction + alerts with minimal new code |
+| 2 | Fuel Price Volatility Heatmap | May 4 #3 | Low | Entirely computed from existing 30-day price history, no APIs |
+| 3 | Weather-Aware Fuel Efficiency Advisor | May 4 #1 | Medium | Open-Meteo is free/keyless, normalises driving score fairly |
+| 4 | Insurance Telematics Data Export | May 4 #2 | Medium | Highest user-value feature; reporting layer over existing data |
+| 5 | Trip Cost Sharing Calculator | May 4 #4 | Medium | Viral sharing mechanic, leverages existing trip/fill-up data |
+
+---
+
+## Concept 1: Smart Refuel Timing Advisor
+
+### 1.1 Problem Statement
+
+Tankstellen's `PricePredictionProvider` already analyses 30-day price history to identify the cheapest hour-of-day and day-of-week per station. The `best_time_banner` surfaces this passively on the station detail screen. But users must actively open the app and check — no proactive notification tells them "fill up now, prices are about to rise." Meanwhile, the consumption system tracks tank level through fill-up logs (`FillUp.isFullTank` plein-to-plein windows in `ConsumptionStats`). Connecting these two systems creates a personalised "fill up now" advisor that fires when the user's estimated fuel level is low AND prices are near a predicted trough.
+
+### 1.2 Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Background Service Pipeline                   │
+│  (lib/core/background/background_service.dart)                   │
+│                                                                   │
+│  Step 1: _refreshPricesAndCheckAlerts()           [EXISTING]     │
+│  Step 2: Per-station threshold alerts              [EXISTING]     │
+│  Step 3: Velocity alert detection                  [EXISTING]     │
+│  Step 4: Radius alert evaluation                   [EXISTING]     │
+│  Step 5: ► Refuel timing evaluation ◄              [NEW]         │
+│           │                                                       │
+│           ├── TankLevelEstimator                                  │
+│           │   └── reads: FillUp history + ConsumptionStats        │
+│           │   └── reads: VehicleProfile.tankCapacityL             │
+│           │   └── reads: trip odometer deltas since last fill     │
+│           │                                                       │
+│           ├── PricePredictionProvider (reused, isolate-safe)      │
+│           │   └── reads: PriceHistoryRepository (30-day)          │
+│           │                                                       │
+│           └── RefuelTimingEvaluator                               │
+│               └── combines tank level + price prediction          │
+│               └── fires notification via LocalNotificationService │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 1.3 Domain Entities
+
+#### `lib/features/alerts/domain/entities/refuel_timing_config.dart`
+
+```dart
+@freezed
+class RefuelTimingConfig with _$RefuelTimingConfig {
+  const factory RefuelTimingConfig({
+    /// Tank percentage below which the advisor activates. Default 25%.
+    @Default(25) int tankThresholdPercent,
+
+    /// Minimum predicted price drop (cents) to recommend waiting.
+    /// If predicted drop < this, recommend filling now. Default 2 cents.
+    @Default(0.02) double minPriceDrop,
+
+    /// Maximum hours to look ahead for a price trough. Default 24h.
+    @Default(24) int forecastHoursAhead,
+
+    /// Stations to monitor — null = favorites + nearest. Default null.
+    List<String>? monitoredStationIds,
+
+    /// Cooldown between notifications. Default 6 hours.
+    @Default(6) int cooldownHours,
+
+    /// Whether the feature is enabled. Default false (opt-in).
+    @Default(false) bool enabled,
+  }) = _RefuelTimingConfig;
+
+  factory RefuelTimingConfig.fromJson(Map<String, dynamic> json) =>
+      _$RefuelTimingConfigFromJson(json);
+}
+```
+
+#### `lib/features/alerts/domain/entities/refuel_timing_result.dart`
+
+```dart
+@freezed
+class RefuelTimingResult with _$RefuelTimingResult {
+  const factory RefuelTimingResult({
+    required RefuelTimingAction action,
+    required String stationId,
+    required String stationName,
+    required double currentPrice,
+    required FuelType fuelType,
+    double? predictedTroughPrice,
+    DateTime? predictedTroughTime,
+    double? estimatedSaving,
+    required double estimatedTankPercent,
+    required double confidenceScore,
+  }) = _RefuelTimingResult;
+}
+
+enum RefuelTimingAction {
+  fillNow,    // Price is near trough or predicted to rise
+  waitFor,    // Predicted drop exceeds minPriceDrop threshold
+}
+```
+
+### 1.4 Domain Services
+
+#### `lib/features/alerts/domain/tank_level_estimator.dart`
+
+Estimates current tank level from fill-up history and distance driven since last fill.
+
+**Inputs:**
+- `List<FillUp>` — fill-up history, sorted newest-first
+- `ConsumptionStats` — provides `avgConsumptionL100km` from plein-to-plein windows
+- `VehicleProfile` — provides `tankCapacityL`
+- `double? odometerKm` — current odometer from OBD-II (if connected), else estimated from trips
+
+**Algorithm:**
+1. Find last `isFullTank == true` fill-up → `lastFullFillDate`, `lastFullFillOdometer`
+2. Sum litres of all partial fills since that plein: `partialLitresSinceFullTank`
+3. Estimate distance since last full: `distanceSinceFullTank = currentOdometer - lastFullFillOdometer`
+   - If no odometer: estimate from daily average km (from trip history / calendar days)
+4. Compute fuel consumed: `consumedL = distanceSinceFullTank * avgConsumptionL100km / 100`
+5. Compute current litres: `currentLitres = tankCapacityL + partialLitresSinceFullTank - consumedL`
+6. Clamp to `[0, tankCapacityL]`
+7. Return `tankPercent = (currentLitres / tankCapacityL * 100).round()`
+
+**Confidence:**
+- High if `avgConsumptionL100km` based on ≥3 plein windows AND odometer from OBD-II
+- Medium if consumption from ≥1 plein window AND odometer estimated from trips
+- Low if no plein windows (uses vehicle default consumption)
+
+```dart
+class TankLevelEstimator {
+  TankLevelEstimate estimate({
+    required List<FillUp> fillUps,
+    required ConsumptionStats stats,
+    required VehicleProfile vehicle,
+    double? currentOdometerKm,
+  });
+}
+
+@freezed
+class TankLevelEstimate with _$TankLevelEstimate {
+  const factory TankLevelEstimate({
+    required int tankPercent,
+    required double estimatedLitres,
+    required TankLevelConfidence confidence,
+  }) = _TankLevelEstimate;
+}
+
+enum TankLevelConfidence { high, medium, low }
+```
+
+#### `lib/features/alerts/data/refuel_timing_evaluator.dart`
+
+Core evaluation logic, designed to run in the background isolate.
+
+**Algorithm:**
+1. Load `RefuelTimingConfig` from Hive settings
+2. If `!config.enabled` → return early
+3. Check cooldown: `lastFiredAt + cooldownHours > now` → return early
+4. Estimate tank level via `TankLevelEstimator`
+5. If `tankPercent > config.tankThresholdPercent` → return early (tank not low enough)
+6. Determine monitored stations:
+   - If `config.monitoredStationIds` is set → use those
+   - Else → favourite station IDs + 3 nearest (from last GPS position)
+7. For each station, compute `PricePrediction` (reuse `PricePredictionProvider` logic extracted to pure function)
+8. Find the station with the best opportunity:
+   - `currentPrice` from latest price record
+   - `predictedTroughPrice` from hourly averages (cheapest hour in next `forecastHoursAhead`)
+   - `predictedDrop = currentPrice - predictedTroughPrice`
+9. Decision logic:
+   - If `predictedDrop >= config.minPriceDrop` AND trough is ≥2h away:
+     → `RefuelTimingAction.waitFor` ("Wait — price predicted to drop X cents at [station] in Y hours")
+   - If `predictedDrop < config.minPriceDrop` OR trough is within 1h OR price is currently at/near trough:
+     → `RefuelTimingAction.fillNow` ("Tank at ~X% — current price at [station] is near its predicted low. Fill up now.")
+   - If no prediction available (< 10 data points) → `fillNow` with lower confidence
+10. Fire notification via `LocalNotificationService`
+11. Record `lastFiredAt` timestamp
+
+**Integration into background pipeline:**
+
+In `lib/core/background/background_service.dart`, after the existing alert evaluations:
+
+```dart
+// Step 5: Refuel timing advisor (NEW)
+await RefuelTimingEvaluator(
+  fillUps: fillUpStore.all(),
+  stats: ConsumptionStats.fromFillUps(fillUpStore.all()),
+  vehicle: activeVehicle,
+  priceHistory: priceHistoryStore,
+  favorites: favoritesStore.favoriteIds,
+  lastPosition: lastKnownPosition,
+  config: refuelTimingConfig,
+  notificationService: notificationService,
+).evaluate();
+```
+
+### 1.5 Presentation Layer
+
+#### `lib/features/alerts/presentation/widgets/refuel_timing_setup_tile.dart`
+
+Settings tile on the alerts configuration screen. Shows:
+- Enable/disable toggle
+- Tank threshold slider (10%–50%, step 5%)
+- Price sensitivity selector (1/2/3/5 cents)
+- Monitored stations picker (favorites or custom)
+
+#### `lib/features/alerts/presentation/widgets/refuel_timing_card.dart`
+
+Card displayed on the alerts tab when a timing recommendation is active. Shows:
+- Station name + current price
+- Recommendation text ("Fill up now" or "Wait X hours")
+- Predicted savings per tank
+- Confidence indicator (based on sample count from `HourlyAverage.sampleCount`)
+- One-tap navigate button (deep-links to station detail via `GoRouter`)
+
+### 1.6 Persistence
+
+- **Config storage:** `HiveBoxes.settings` under key `'refuel_timing_config'` (JSON)
+- **Last-fired timestamp:** `HiveBoxes.settings` under key `'refuel_timing_last_fired'` (ISO 8601 string)
+- **No new Hive boxes** — all data fits in existing boxes
+
+### 1.7 Feature Flag Integration
+
+Register in `FeatureManifest.defaultManifest`:
+```dart
+Feature.refuelTimingAdvisor: FeatureManifestEntry(
+  feature: Feature.refuelTimingAdvisor,
+  defaultEnabled: false,
+  requires: {Feature.priceAlerts},
+  displayName: 'Smart Refuel Timing',
+  description: 'Proactive fill-up notifications based on price predictions and tank level',
+),
+```
+
+### 1.8 Localisation
+
+New ARB keys via fragment system (`lib/l10n/_fragments/refuel_timing_en.arb`):
+- `refuelTimingTitle`, `refuelTimingDescription`
+- `refuelTimingFillNow`, `refuelTimingWaitFor`
+- `refuelTimingTankAt` (with `{percent}` placeholder)
+- `refuelTimingPredictedDrop` (with `{cents}`, `{hours}` placeholders)
+- `refuelTimingSavingPerTank` (with `{amount}` placeholder)
+
+Minimum translations: en, de, fr (per `feedback_french_onboarding_enforced.md`).
+
+### 1.9 Test Strategy
+
+| Test | Type | Description |
+|------|------|-------------|
+| `tank_level_estimator_test.dart` | Unit | Full tank → 100%, half-consumed → ~50%, with/without partials, with/without OBD odometer |
+| `refuel_timing_evaluator_test.dart` | Unit | Fires when tank low + price near trough; waits when drop predicted; respects cooldown; handles missing predictions |
+| `refuel_timing_config_test.dart` | Unit | JSON round-trip, defaults, validation |
+| `refuel_timing_card_test.dart` | Widget | Renders fillNow vs waitFor states, navigate button tap |
+| `refuel_timing_setup_tile_test.dart` | Widget | Toggle, slider, persistence |
+
+### 1.10 Estimated Scope
+
+- **New files:** 8 (3 entities, 2 domain services, 1 evaluator, 2 widgets)
+- **Modified files:** 3 (`background_service.dart`, `feature.dart` enum, `feature_manifest.dart`)
+- **LOC estimate:** ~400 (lib) + ~300 (test)
+- **Risk:** Low — all inputs are existing providers; no new APIs, no schema changes
+
+---
+
+## Concept 2: Fuel Price Volatility Heatmap
+
+### 2.1 Problem Statement
+
+Tankstellen stores 30-day price history per station across 11 countries in `PriceHistoryRepository` (Hive box `price_history`). Currently this data is only surfaced per-station as line charts on `PriceHistoryScreen`. But the data contains spatial intelligence: some regions have stable, predictable prices (low standard deviation) while others swing wildly. A heatmap overlay on the existing `flutter_map` transforms per-station data into a spatial volatility view, helping users decide where and when to fill up. This feature requires zero new API calls — it is entirely computed from locally cached data.
+
+### 2.2 Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  PriceHistoryRepository (EXISTING)                            │
+│  └── 30-day per-station PriceRecord list                      │
+│      └── getHistory(stationId, days: 30)                      │
+│      └── getStats(stationId, fuelType, days: 30) → PriceStats │
+└──────────────────────────┬───────────────────────────────────┘
+                           │ reads
+┌──────────────────────────▼───────────────────────────────────┐
+│  VolatilityCalculator (NEW — pure Dart, isolate-safe)         │
+│  └── Input: List<PriceRecord> per station                     │
+│  └── Output: StationVolatility per station                    │
+│      └── stdDev, coefficientOfVariation, maxDailySwing        │
+│      └── volatilityTier: stable / moderate / volatile         │
+└──────────────────────────┬───────────────────────────────────┘
+                           │ feeds
+┌──────────────────────────▼───────────────────────────────────┐
+│  VolatilityGrid (NEW — spatial aggregation)                   │
+│  └── Input: Map<stationId, StationVolatility> + map bounds    │
+│  └── Algorithm: hexagonal grid, 2km cells, IDW interpolation  │
+│  └── Output: List<VolatilityCell> with center, tier, colour   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │ renders
+┌──────────────────────────▼───────────────────────────────────┐
+│  VolatilityHeatmapLayer (NEW — flutter_map PolygonLayer)      │
+│  └── Semi-transparent filled hexagons on map                  │
+│  └── Colour: green (stable) / amber (moderate) / red (vol.)  │
+│  └── Toggle via map toolbar button                            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 Domain Entities
+
+#### `lib/features/price_history/domain/entities/station_volatility.dart`
+
+```dart
+@freezed
+class StationVolatility with _$StationVolatility {
+  const factory StationVolatility({
+    required String stationId,
+    required FuelType fuelType,
+    required double meanPrice,
+    required double stdDev,
+    required double coefficientOfVariation,
+    required double maxDailySwing,
+    required VolatilityTier tier,
+    required int sampleDays,
+    required DateTime periodStart,
+    required DateTime periodEnd,
+  }) = _StationVolatility;
+}
+
+enum VolatilityTier {
+  stable,    // CV < 0.02  (prices vary < 2% around mean)
+  moderate,  // CV 0.02–0.05
+  volatile,  // CV > 0.05  (prices swing > 5% around mean)
+}
+```
+
+#### `lib/features/price_history/domain/entities/volatility_cell.dart`
+
+```dart
+@freezed
+class VolatilityCell with _$VolatilityCell {
+  const factory VolatilityCell({
+    required double centerLat,
+    required double centerLng,
+    required double radiusKm,
+    required double avgVolatilityCV,
+    required VolatilityTier tier,
+    required int stationCount,
+    required int colorArgb,
+  }) = _VolatilityCell;
+}
+```
+
+### 2.4 Domain Services
+
+#### `lib/features/price_history/domain/volatility_calculator.dart`
+
+Pure-Dart, no Flutter imports, isolate-safe.
+
+**Input:** `List<PriceRecord>` for a single station, filtered to one `FuelType`
+
+**Algorithm:**
+1. Group records by calendar date → daily prices
+2. Require ≥7 days with data (else return null — insufficient sample)
+3. For each day: compute daily mean price (average of all records that day)
+4. Across all daily means:
+   - `mean` = arithmetic mean
+   - `stdDev` = population standard deviation
+   - `CV` = stdDev / mean
+   - `maxDailySwing` = max(|dayN_mean - dayN-1_mean|) across consecutive days
+5. Classify tier:
+   - CV < 0.02 → `stable`
+   - 0.02 ≤ CV < 0.05 → `moderate`
+   - CV ≥ 0.05 → `volatile`
+
+```dart
+class VolatilityCalculator {
+  StationVolatility? compute({
+    required String stationId,
+    required FuelType fuelType,
+    required List<PriceRecord> records,
+  });
+
+  Map<String, StationVolatility> computeBatch({
+    required FuelType fuelType,
+    required Map<String, List<PriceRecord>> recordsByStation,
+  });
+}
+```
+
+#### `lib/features/price_history/domain/volatility_grid.dart`
+
+Spatial aggregation into hexagonal cells.
+
+**Input:**
+- `Map<String, StationVolatility>` — per-station volatility
+- `Map<String, LatLng>` — station coordinates (from cached search results)
+- `LatLngBounds` — visible map bounds
+- `double cellRadiusKm` — default 2.0
+
+**Algorithm:**
+1. Compute hex grid covering the visible bounds:
+   - Hex width = `cellRadiusKm * 2 * cos(30°)` in km
+   - Hex height = `cellRadiusKm * 1.5` in km
+   - Convert to lat/lng offsets using local mercator approximation
+   - Generate grid centres, offset every other row (pointy-top hexagons)
+2. For each cell, find stations within `cellRadiusKm`:
+   - Compute inverse-distance-weighted (IDW) average of CV values
+   - Weight = `1 / distance²` (capped at 0.1 km minimum distance)
+   - Skip cells with 0 stations
+3. Classify each cell's tier from weighted-average CV
+4. Assign colour:
+   - Stable: `Color(0x4D4CAF50)` (green, 30% opacity)
+   - Moderate: `Color(0x4DFFC107)` (amber, 30% opacity)
+   - Volatile: `Color(0x4DF44336)` (red, 30% opacity)
+   - Opacity scales with `min(stationCount / 5, 1.0)` — more stations = more opaque
+
+```dart
+class VolatilityGrid {
+  List<VolatilityCell> compute({
+    required Map<String, StationVolatility> volatilities,
+    required Map<String, LatLng> stationPositions,
+    required LatLngBounds bounds,
+    double cellRadiusKm = 2.0,
+  });
+}
+```
+
+### 2.5 Presentation Layer
+
+#### `lib/features/map/presentation/widgets/volatility_heatmap_layer.dart`
+
+Renders `List<VolatilityCell>` as a `PolygonLayer` on the existing `flutter_map`.
+
+Each cell is a 6-vertex polygon computed from `(centerLat, centerLng, radiusKm)`:
+```dart
+List<LatLng> hexVertices(double lat, double lng, double radiusKm) {
+  return List.generate(6, (i) {
+    final angle = (60 * i - 30) * pi / 180; // pointy-top hex
+    final dLat = radiusKm / 111.32 * cos(angle);
+    final dLng = radiusKm / (111.32 * cos(lat * pi / 180)) * sin(angle);
+    return LatLng(lat + dLat, lng + dLng);
+  });
+}
+```
+
+Layer is conditionally included in the `FlutterMap.children` list:
+```dart
+if (showVolatilityOverlay) ...[
+  PolygonLayer(
+    polygons: volatilityCells.map((cell) => Polygon(
+      points: hexVertices(cell.centerLat, cell.centerLng, cell.radiusKm),
+      color: Color(cell.colorArgb),
+      borderColor: Color(cell.colorArgb).withAlpha(80),
+      borderStrokeWidth: 1.0,
+      isFilled: true,
+    )).toList(),
+  ),
+],
+```
+
+#### `lib/features/map/presentation/widgets/volatility_toggle_button.dart`
+
+Toolbar button alongside the existing EV overlay toggle. Uses the existing map toolbar pattern from `map_screen.dart`:
+- Icon: `Icons.show_chart` (or `Icons.heatmap` if available in the icon set)
+- Tooltip: localised "Price Volatility"
+- Active state: highlighted with `primaryContainer` colour
+- Toggles `volatilityOverlayEnabledProvider`
+
+#### `lib/features/map/presentation/widgets/volatility_legend.dart`
+
+Bottom-left overlay (positioned to avoid the existing price legend):
+- Three coloured dots with labels: "Stable", "Moderate", "Volatile"
+- Compact card with `Theme.of(context).cardTheme` styling
+- Only visible when volatility overlay is active
+
+#### `lib/features/map/presentation/widgets/volatility_info_sheet.dart`
+
+Bottom sheet triggered by tapping a volatility cell:
+- Cell's average CV and tier label
+- List of stations within the cell, sorted by stability (most stable first)
+- Per-station: name, CV value, max daily swing in €
+- Recommendation text:
+  - Stable: "Prices here are predictable — fill up whenever convenient."
+  - Moderate: "Moderate price swings — check the price prediction for best timing."
+  - Volatile: "High price volatility — use price alerts to catch drops."
+- "See price prediction" button → navigates to most stable station's detail screen
+
+### 2.6 Providers
+
+#### `lib/features/map/providers/volatility_heatmap_provider.dart`
+
+```dart
+@riverpod
+class VolatilityHeatmapEnabled extends _$VolatilityHeatmapEnabled {
+  @override
+  bool build() => false; // Off by default
+
+  void toggle() => state = !state;
+}
+
+@riverpod
+Future<List<VolatilityCell>> volatilityHeatmap(
+  Ref ref, {
+  required LatLngBounds bounds,
+  required FuelType fuelType,
+}) async {
+  final priceHistoryRepo = ref.watch(priceHistoryRepositoryProvider);
+  final searchResults = ref.watch(fuelStationsProvider).valueOrNull ?? [];
+
+  // Build station ID → position map from cached search results
+  final stationPositions = <String, LatLng>{};
+  for (final station in searchResults) {
+    stationPositions[station.id] = LatLng(station.lat, station.lng);
+  }
+
+  // Compute per-station volatility
+  final calculator = VolatilityCalculator();
+  final volatilities = <String, StationVolatility>{};
+  for (final stationId in stationPositions.keys) {
+    final records = await priceHistoryRepo.getHistory(stationId, days: 30);
+    final vol = calculator.compute(
+      stationId: stationId,
+      fuelType: fuelType,
+      records: records,
+    );
+    if (vol != null) volatilities[stationId] = vol;
+  }
+
+  // Aggregate into spatial grid
+  return VolatilityGrid().compute(
+    volatilities: volatilities,
+    stationPositions: stationPositions,
+    bounds: bounds,
+    cellRadiusKm: 2.0,
+  );
+}
+```
+
+**Debouncing:** The map screen debounces bound changes (300ms) before re-triggering this provider, consistent with the existing search debounce pattern.
+
+### 2.7 Test Strategy
+
+| Test | Type | Description |
+|------|------|-------------|
+| `volatility_calculator_test.dart` | Unit | Constant prices → stable tier; oscillating → volatile; boundary CV values; <7 days → null |
+| `volatility_grid_test.dart` | Unit | Single station → single cell; IDW weights; empty grid returns []; edge stations at cell boundary |
+| `volatility_heatmap_layer_test.dart` | Widget | Renders correct polygon count; colour matches tier; hidden when toggle off |
+| `volatility_info_sheet_test.dart` | Widget | Shows station list; recommendation text per tier |
+
+### 2.8 Estimated Scope
+
+- **New files:** 9 (2 entities, 2 domain services, 4 widgets, 1 provider)
+- **Modified files:** 2 (`map_screen.dart` — add layer + toggle, `feature.dart` enum)
+- **LOC estimate:** ~500 (lib) + ~350 (test)
+- **Risk:** Low — no API calls, no schema changes, purely additive UI overlay
+
+---
+
+## Concept 3: Weather-Aware Fuel Efficiency Advisor
+
+### 3.1 Problem Statement
+
+Weather conditions have a measurable impact on fuel consumption: cold temperatures (+12–20% for short trips), headwinds (+10–20% at highway speeds), rain (+3% per mm/h from rolling resistance), and HVAC load (+5–15%). Tankstellen's driving score and consumption stats treat all trips equally, which means:
+- A winter trip scored 65 might be genuinely excellent given conditions
+- A consumption uptrend might be seasonal, not mechanical degradation
+- Route search detour cost calculations ignore wind direction
+
+By integrating weather data from Open-Meteo (free, no API key, covers all 11 countries), the app can weather-normalise its analytics and provide fairer, more actionable insights.
+
+### 3.2 Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Open-Meteo API (free, no key)                               │
+│  https://api.open-meteo.com/v1/forecast                      │
+│  └── temperature, precipitation, wind speed/direction,       │
+│      humidity, weather code (WMO)                            │
+└──────────────────────────┬──────────────────────────────────┘
+                           │ HTTP (existing Dio client)
+┌──────────────────────────▼──────────────────────────────────┐
+│  WeatherService (NEW, lib/core/weather/)                     │
+│  ├── OpenMeteoWeatherService (implementation)                │
+│  ├── WeatherCache (1h/6h TTL, Hive-backed)                  │
+│  └── WeatherForecast / WeatherCondition entities             │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+        ┌──────────────────┼──────────────────┐
+        │                  │                  │
+        ▼                  ▼                  ▼
+┌───────────────┐ ┌───────────────┐ ┌──────────────────┐
+│ Trip Recorder │ │ Driving Score │ │ Route Search     │
+│ (MODIFIED)    │ │ (MODIFIED)    │ │ (MODIFIED)       │
+│               │ │               │ │                  │
+│ Stores weather│ │ Adjusts score │ │ Weather-aware    │
+│ snapshot per  │ │ thresholds    │ │ cost model for   │
+│ trip start/end│ │ based on      │ │ detour decisions │
+│               │ │ conditions    │ │                  │
+└───────────────┘ └───────────────┘ └──────────────────┘
+        │
+        ▼
+┌───────────────────────────────────────┐
+│ WeatherNormalisedStats (NEW)          │
+│ └── Adjusts historical consumption   │
+│     for conditions at time of trip    │
+│ └── Separates weather effect from     │
+│     vehicle degradation              │
+└───────────────────────────────────────┘
+```
+
+### 3.3 Core Weather Service
+
+#### `lib/core/weather/weather_service.dart`
+
+```dart
+abstract class WeatherService {
+  Future<WeatherForecast> getForecast(
+    double lat,
+    double lng, {
+    int hoursAhead = 24,
+  });
+
+  Future<WeatherCondition> getCurrentConditions(double lat, double lng);
+}
+```
+
+#### `lib/core/weather/open_meteo_weather_service.dart`
+
+```dart
+class OpenMeteoWeatherService implements WeatherService {
+  final Dio _dio; // Reuse existing Dio instance from provider
+
+  @override
+  Future<WeatherForecast> getForecast(double lat, double lng, {int hoursAhead = 24}) async {
+    final response = await _dio.get(
+      'https://api.open-meteo.com/v1/forecast',
+      queryParameters: {
+        'latitude': lat,
+        'longitude': lng,
+        'hourly': 'temperature_2m,precipitation,wind_speed_10m,wind_direction_10m,relative_humidity_2m,weather_code',
+        'forecast_hours': hoursAhead,
+        'timezone': 'auto',
+      },
+    );
+    return WeatherForecast.fromOpenMeteoJson(response.data);
+  }
+
+  @override
+  Future<WeatherCondition> getCurrentConditions(double lat, double lng) async {
+    final forecast = await getForecast(lat, lng, hoursAhead: 1);
+    return forecast.hourlyEntries.first.toCondition();
+  }
+}
+```
+
+### 3.4 Weather Entities
+
+#### `lib/core/weather/entities/weather_forecast.dart`
+
+```dart
+@freezed
+class WeatherForecast with _$WeatherForecast {
+  const factory WeatherForecast({
+    required List<WeatherHour> hourlyEntries,
+    required double locationLat,
+    required double locationLng,
+    required DateTime fetchedAt,
+  }) = _WeatherForecast;
+
+  factory WeatherForecast.fromOpenMeteoJson(Map<String, dynamic> json) => /* ... */;
+}
+
+@freezed
+class WeatherHour with _$WeatherHour {
+  const factory WeatherHour({
+    required DateTime dateTime,
+    required double temperatureCelsius,
+    required double precipitationMm,
+    required double windSpeedKmh,
+    required int windDirectionDeg,
+    required int humidityPercent,
+    required int weatherCode, // WMO standard
+  }) = _WeatherHour;
+}
+
+@freezed
+class WeatherCondition with _$WeatherCondition {
+  const factory WeatherCondition({
+    required double temperatureCelsius,
+    required double precipitationMm,
+    required double windSpeedKmh,
+    required int windDirectionDeg,
+    required int humidityPercent,
+    required int weatherCode,
+    required DateTime observedAt,
+  }) = _WeatherCondition;
+}
+```
+
+### 3.5 Fuel-Weather Correlator
+
+#### `lib/core/weather/fuel_weather_correlator.dart`
+
+Pure-Dart service computing `FuelEfficiencyImpact`.
+
+**Published engineering model (conservative estimates):**
+
+```dart
+class FuelWeatherCorrelator {
+  FuelEfficiencyImpact compute({
+    required double baselineConsumptionL100km,
+    required WeatherCondition conditions,
+    double? tripBearingDeg, // For headwind calculation
+  }) {
+    // Temperature factor (piecewise linear, baseline = 20°C)
+    final tempImpact = _temperatureImpact(conditions.temperatureCelsius);
+    // < 0°C  → +15% to +20%
+    // 0–10°C → +8% to +12%
+    // 10–20°C → +2% to +5%
+    // 20–25°C → baseline (0%)
+    // > 25°C → +3% to +8% (A/C load)
+
+    // Wind factor (headwind component if bearing known)
+    final windImpact = _windImpact(
+      conditions.windSpeedKmh,
+      conditions.windDirectionDeg,
+      tripBearingDeg,
+    );
+    // Headwind 20 km/h → +5%
+    // Headwind 40 km/h → +12%
+    // Headwind 60 km/h → +20%
+    // Tailwind → negative impact (savings)
+
+    // Precipitation factor
+    final precipImpact = _precipitationImpact(conditions.precipitationMm);
+    // +3% per mm/h of rain (rolling resistance + wipers)
+
+    // HVAC factor (derived from temperature)
+    final hvacImpact = _hvacImpact(conditions.temperatureCelsius);
+    // < 5°C → +5% (heater + defrost)
+    // > 28°C → +5% to +10% (A/C)
+
+    final totalImpact = tempImpact + windImpact + precipImpact + hvacImpact;
+    final adjustedConsumption = baselineConsumptionL100km * (1 + totalImpact / 100);
+
+    return FuelEfficiencyImpact(
+      temperatureImpactPercent: tempImpact,
+      windImpactPercent: windImpact,
+      precipitationImpactPercent: precipImpact,
+      hvacImpactPercent: hvacImpact,
+      totalImpactPercent: totalImpact,
+      adjustedBaselineConsumption: adjustedConsumption,
+      humanSummary: _composeSummary(tempImpact, windImpact, precipImpact, totalImpact),
+    );
+  }
+}
+```
+
+#### `lib/core/weather/entities/fuel_efficiency_impact.dart`
+
+```dart
+@freezed
+class FuelEfficiencyImpact with _$FuelEfficiencyImpact {
+  const factory FuelEfficiencyImpact({
+    required double temperatureImpactPercent,
+    required double windImpactPercent,
+    required double precipitationImpactPercent,
+    required double hvacImpactPercent,
+    required double totalImpactPercent,
+    required double adjustedBaselineConsumption,
+    required String humanSummary,
+  }) = _FuelEfficiencyImpact;
+}
+```
+
+### 3.6 Integration Points
+
+#### Trip Recording — Store Weather Snapshot
+
+Modify `lib/features/consumption/domain/entities/trip.dart` (or the relevant trip entity):
+```dart
+// Add to Trip entity (Freezed):
+WeatherCondition? weatherAtStart,
+WeatherCondition? weatherAtEnd,
+```
+
+In the trip recorder, when a trip starts:
+```dart
+final weather = await weatherService.getCurrentConditions(lat, lng);
+trip = trip.copyWith(weatherAtStart: weather);
+```
+
+And when a trip ends:
+```dart
+final weather = await weatherService.getCurrentConditions(lat, lng);
+trip = trip.copyWith(weatherAtEnd: weather);
+```
+
+#### Driving Score — Weather-Adjusted Thresholds
+
+In `DrivingScoreCalculator`, when weather data is available for a trip:
+```dart
+final impact = FuelWeatherCorrelator().compute(
+  baselineConsumptionL100km: vehicleBaseline,
+  conditions: trip.weatherAtStart ?? defaultConditions,
+);
+
+// Relax consumption thresholds proportionally
+final adjustedExpectedConsumption = vehicleBaseline * (1 + impact.totalImpactPercent / 100);
+// Score consumption component against adjusted expectation, not raw baseline
+```
+
+This means a trip at 8.2 L/100km in cold rain scores the same as 7.1 L/100km in dry 20°C weather.
+
+#### Route Search — Weather-Aware Detour Cost
+
+New decorator following the same pattern as the maintenance-aware routing proposed May 3:
+
+```dart
+class WeatherAwareCostModel {
+  double adjustedDetourCost({
+    required double detourKm,
+    required double avgConsumption,
+    required double fuelPrice,
+    required WeatherCondition conditions,
+    double? detourBearing,
+  }) {
+    final impact = FuelWeatherCorrelator().compute(
+      baselineConsumptionL100km: avgConsumption,
+      conditions: conditions,
+      tripBearingDeg: detourBearing,
+    );
+    final adjustedConsumption = impact.adjustedBaselineConsumption;
+    return detourKm * adjustedConsumption / 100 * fuelPrice;
+  }
+}
+```
+
+### 3.7 Presentation Widgets
+
+#### `lib/features/consumption/presentation/widgets/weather_impact_chip.dart`
+
+Small chip on trip detail screen:
+- Weather icon (sun, cloud, rain, snow — from WMO weather code)
+- "+X%" or "−X%" impact text
+- Tappable tooltip with breakdown (temperature, wind, rain contributions)
+
+#### `lib/features/driving/presentation/widgets/weather_advisory_banner.dart`
+
+Banner on driving mode screen when expected impact > 10%:
+- "Headwind + rain expected — consumption may be ~15% higher than usual"
+- Tappable for hourly forecast breakdown
+- Dismissable (persists for current driving session)
+
+### 3.8 Weather Cache
+
+#### `lib/core/weather/weather_cache.dart`
+
+Follows existing `CacheManager` pattern:
+```dart
+class WeatherCache {
+  static const currentConditionsTtl = Duration(hours: 1);
+  static const forecastTtl = Duration(hours: 6);
+
+  static String currentKey(double lat, double lng) =>
+      'weather:current:${lat.toStringAsFixed(2)}:${lng.toStringAsFixed(2)}';
+
+  static String forecastKey(double lat, double lng) =>
+      'weather:forecast:${lat.toStringAsFixed(2)}:${lng.toStringAsFixed(2)}';
+}
+```
+
+Coordinate rounding to 2 decimals (~1.1 km precision) ensures nearby requests share cache entries.
+
+### 3.9 Test Strategy
+
+| Test | Type | Description |
+|------|------|-------------|
+| `fuel_weather_correlator_test.dart` | Unit | 20°C dry → 0% impact; -10°C → +15–20%; 40 km/h headwind → +12%; rain 3mm → +9%; combined effects |
+| `open_meteo_weather_service_test.dart` | Unit | JSON parsing, error handling, timezone conversion |
+| `weather_cache_test.dart` | Unit | TTL expiry, coordinate rounding, cache key uniqueness |
+| `weather_normalised_stats_test.dart` | Unit | Winter trips normalised down; summer trips unchanged; mixed seasons |
+| `weather_impact_chip_test.dart` | Widget | Renders correct icon per WMO code; shows ±% text |
+| `weather_advisory_banner_test.dart` | Widget | Shows when impact >10%; hidden when <10%; dismissable |
+
+### 3.10 Estimated Scope
+
+- **New files:** 12 (4 entities, 3 domain services, 1 cache, 2 widgets, 1 service impl, 1 provider)
+- **Modified files:** 4 (trip entity, driving score calculator, route search strategy, `feature.dart`)
+- **LOC estimate:** ~700 (lib) + ~500 (test)
+- **Dependency:** `speech_to_text` NOT needed; Open-Meteo uses existing `Dio`
+- **Risk:** Medium — new external API, but free/keyless with graceful degradation (feature works without weather data)
+
+---
+
+## Concept 4: Insurance Telematics Data Export (UBI Portal)
+
+### 4.1 Problem Statement
+
+Tankstellen's OBD-II integration already collects the exact data insurers need for Usage-Based Insurance (UBI) premium discounts (10–25%): trip distance, speed profiles, harsh braking/acceleration counts, time-of-day driving distribution, and a composite driving score. Currently this data is only visible within the app's consumption screens. By generating standardised, integrity-verified driving reports, Tankstellen becomes a neutral "driving passport" — users share one report with any insurer without needing insurer-specific hardware.
+
+### 4.2 Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Existing Data Sources (read-only)                                │
+│                                                                    │
+│  ├── TripHistory         → distance, duration, start/end times    │
+│  ├── TripSummary         → harsh events, idle, cold start, RPM   │
+│  ├── DrivingScore        → 0–100 per-trip score                   │
+│  ├── DrivingInsights     → acceleration patterns, throttle hist   │
+│  ├── ConsumptionStats    → avg L/100km, total km                  │
+│  ├── VehicleProfile      → make, model, year, engine class        │
+│  └── MaintenanceSuggestion → vehicle health indicators            │
+└──────────────────────────┬───────────────────────────────────────┘
+                           │ reads
+┌──────────────────────────▼───────────────────────────────────────┐
+│  TelematicsReportGenerator (NEW — pure Dart)                      │
+│  └── Aggregates all data for a vehicle within a date range        │
+│  └── Computes risk classification                                 │
+│  └── Generates integrity hash (SHA-256)                           │
+│  └── Output: TelematicsReport entity                              │
+└──────────────────────────┬───────────────────────────────────────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+              ▼            ▼            ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────┐
+        │ PDF      │ │ JSON/CSV │ │ QR Code  │
+        │ Export   │ │ Export   │ │ Summary  │
+        │ (human)  │ │ (machine)│ │ (agent)  │
+        └──────────┘ └──────────┘ └──────────┘
+              │            │            │
+              └────────────┼────────────┘
+                           │
+                    share_plus / qr_flutter
+```
+
+### 4.3 Domain Entities
+
+#### `lib/features/telematics_export/domain/entities/telematics_report.dart`
+
+```dart
+@freezed
+class TelematicsReport with _$TelematicsReport {
+  const factory TelematicsReport({
+    required String reportId,
+    required String vehicleId,
+    required DateTime periodStart,
+    required DateTime periodEnd,
+
+    // Volume metrics
+    required int totalTrips,
+    required double totalKm,
+    required double totalHours,
+    required double avgTripDistanceKm,
+
+    // Safety metrics
+    required double avgDrivingScore,
+    required ScoreTrend scoreTrend,
+    required double hardBrakingEventsPerKm,
+    required double hardAccelEventsPerKm,
+    required double idleTimePercentage,
+
+    // Time-of-day distribution
+    required double nightDrivingPercentage, // % of km between 23:00–05:00
+    required Map<int, double> hourlyKmDistribution, // hour → % of total km
+
+    // Efficiency
+    required double avgConsumptionL100km,
+    required String fuelEfficiencyRating, // A–F based on vehicle class
+
+    // Classification
+    required RiskCategory riskCategory,
+    required Map<RiskDimension, RiskLevel> dimensionRatings,
+
+    // Integrity
+    required DateTime generatedAt,
+    required String appVersion,
+    required String integrityHash, // SHA-256 of deterministic JSON
+  }) = _TelematicsReport;
+}
+
+enum ScoreTrend { improving, stable, declining }
+enum RiskCategory { low, medium, high }
+enum RiskDimension { safety, efficiency, consistency, timeOfDay, experience }
+enum RiskLevel { low, medium, high }
+```
+
+### 4.4 Risk Classifier
+
+#### `lib/features/telematics_export/domain/risk_classifier.dart`
+
+Conservative classification — only rates "low" when data strongly supports it.
+
+```dart
+class RiskClassifier {
+  RiskCategory classify(TelematicsReport report) {
+    final dimensions = <RiskDimension, RiskLevel>{
+      RiskDimension.safety: _classifySafety(report),
+      RiskDimension.efficiency: _classifyEfficiency(report),
+      RiskDimension.consistency: _classifyConsistency(report),
+      RiskDimension.timeOfDay: _classifyTimeOfDay(report),
+      RiskDimension.experience: _classifyExperience(report),
+    };
+
+    // Any single "high" caps overall at "medium"
+    if (dimensions.values.any((v) => v == RiskLevel.high)) {
+      return RiskCategory.medium;
+    }
+    // All "low" → overall "low"
+    if (dimensions.values.every((v) => v == RiskLevel.low)) {
+      return RiskCategory.low;
+    }
+    return RiskCategory.medium;
+  }
+
+  RiskLevel _classifySafety(TelematicsReport r) {
+    // Hard braking < 2 per 100 km AND hard accel < 3 per 100 km → low
+    if (r.hardBrakingEventsPerKm * 100 < 2 && r.hardAccelEventsPerKm * 100 < 3) {
+      return RiskLevel.low;
+    }
+    if (r.hardBrakingEventsPerKm * 100 > 5 || r.hardAccelEventsPerKm * 100 > 7) {
+      return RiskLevel.high;
+    }
+    return RiskLevel.medium;
+  }
+
+  RiskLevel _classifyTimeOfDay(TelematicsReport r) {
+    // < 10% night driving → low; > 30% → high
+    if (r.nightDrivingPercentage < 10) return RiskLevel.low;
+    if (r.nightDrivingPercentage > 30) return RiskLevel.high;
+    return RiskLevel.medium;
+  }
+
+  RiskLevel _classifyExperience(TelematicsReport r) {
+    // > 5000 km in period → low; < 1000 km → high (insufficient data)
+    if (r.totalKm > 5000) return RiskLevel.low;
+    if (r.totalKm < 1000) return RiskLevel.high;
+    return RiskLevel.medium;
+  }
+  // ... efficiency and consistency classifiers
+}
+```
+
+### 4.5 Report Generator
+
+#### `lib/features/telematics_export/domain/telematics_report_generator.dart`
+
+```dart
+class TelematicsReportGenerator {
+  TelematicsReport generate({
+    required String vehicleId,
+    required DateTime periodStart,
+    required DateTime periodEnd,
+    required List<Trip> trips,
+    required List<TripSummary> summaries,
+    required Map<String, double> scoresByTripId,
+    required ConsumptionStats stats,
+    required VehicleProfile vehicle,
+    required String appVersion,
+  }) {
+    // 1. Filter trips to period
+    final periodTrips = trips.where((t) =>
+      t.startedAt != null &&
+      t.startedAt!.isAfter(periodStart) &&
+      t.startedAt!.isBefore(periodEnd)
+    ).toList();
+
+    // 2. Aggregate metrics
+    final totalKm = periodTrips.fold(0.0, (sum, t) => sum + t.distanceKm);
+    final totalHours = periodTrips.fold(0.0, (sum, t) =>
+      sum + (t.endedAt!.difference(t.startedAt!).inMinutes / 60));
+
+    // 3. Compute harsh events per km
+    final totalHarshBrakes = summaries.fold(0, (sum, s) => sum + s.harshBrakes);
+    final totalHarshAccels = summaries.fold(0, (sum, s) => sum + s.harshAccelerations);
+
+    // 4. Night driving analysis
+    final nightKm = _computeNightKm(periodTrips); // 23:00–05:00 window
+
+    // 5. Score trend (compare first-half vs second-half average score)
+    final trend = _computeScoreTrend(periodTrips, scoresByTripId);
+
+    // 6. Build report
+    final report = TelematicsReport(/* ... all fields ... */);
+
+    // 7. Compute integrity hash
+    final jsonStr = const JsonEncoder().convert(report.toIntegrityJson());
+    final hash = sha256.convert(utf8.encode(jsonStr)).toString();
+
+    return report.copyWith(integrityHash: hash);
+  }
+}
+```
+
+### 4.6 Export Formats
+
+#### PDF Report
+Generated using `pdf` package (or existing PDF pattern if available):
+- **Cover page:** Vehicle info, overall grade (A–F), period, Tankstellen branding
+- **Page 2:** Radar chart (5 axes: safety, efficiency, consistency, time-of-day, experience)
+- **Page 3:** Monthly trend charts (driving score, consumption, harsh events)
+- **Page 4:** Detailed metrics table (all raw numbers)
+- **Footer:** Integrity hash + QR code encoding `TelematicsSummary`
+
+#### JSON/CSV Export
+Machine-readable formats for API integration:
+- JSON: Full `TelematicsReport` serialised
+- CSV: Flat table with one row per trip (id, date, distance, score, harsh events)
+
+#### QR Summary
+Compact summary for in-person agent meetings using existing `qr_flutter`:
+```dart
+@freezed
+class TelematicsSummary with _$TelematicsSummary {
+  const factory TelematicsSummary({
+    required String overallGrade,
+    required double totalKm,
+    required double avgScore,
+    required int periodMonths,
+    required RiskCategory riskCategory,
+  }) = _TelematicsSummary;
+}
+```
+
+### 4.7 Presentation Layer
+
+#### `lib/features/telematics_export/presentation/screens/telematics_export_screen.dart`
+
+- **Hero card:** Overall grade (A–F) with colour (A=green, F=red), trend arrow
+- **Radar chart:** 5-axis `CustomPainter` widget (safety, efficiency, consistency, time-of-day, experience)
+- **Period selector:** 3 / 6 / 12 months toggle
+- **Key metrics grid:** Total km, trips, avg score, harsh events rate
+- **"Generate Report" button:** Opens format picker (PDF / JSON / CSV)
+- **"Share" button:** Uses `share_plus` to send file
+- **QR display:** Expandable section showing QR code for in-person sharing
+
+#### `lib/features/telematics_export/presentation/widgets/driving_profile_radar.dart`
+
+5-axis radar chart using `CustomPainter`:
+- Axes positioned at 72° intervals
+- Filled polygon for user's scores (0–100 normalised per axis)
+- Reference polygon for "average driver" baseline (50 on all axes)
+- Themed colours from `lib/app/theme.dart`
+
+### 4.8 Privacy Design
+
+- Reports generated **entirely on-device** — no data sent to Tankstellen servers
+- User explicitly chooses when and with whom to share
+- Reports contain **aggregate statistics only** — no GPS traces, no specific locations
+- Integrity hash allows verification without raw data leaving device
+- Users select date range — they control how much history to reveal
+- No insurer partnerships — user is sole data controller
+
+### 4.9 Test Strategy
+
+| Test | Type | Description |
+|------|------|-------------|
+| `telematics_report_generator_test.dart` | Unit | Correct aggregation of km, hours, harsh events; night driving calculation; score trend detection |
+| `risk_classifier_test.dart` | Unit | Low/medium/high classification per dimension; single-high caps overall; boundary values |
+| `integrity_hash_test.dart` | Unit | Deterministic: same input → same hash; different input → different hash |
+| `telematics_export_screen_test.dart` | Widget | Period selector, generate button, format picker, QR display |
+| `driving_profile_radar_test.dart` | Golden | Radar chart renders correctly with sample data |
+
+### 4.10 Estimated Scope
+
+- **New files:** 14 (4 entities, 2 domain services, 1 exporter, 4 widgets, 2 screens, 1 provider)
+- **Modified files:** 1 (`feature.dart` enum)
+- **LOC estimate:** ~900 (lib) + ~600 (test)
+- **Dependencies:** `crypto` (for SHA-256, likely already transitive), `pdf` (if not already present)
+- **Risk:** Medium — PDF generation is the most complex part; all data inputs are existing
+
+---
+
+## Concept 5: Trip Cost Sharing Calculator
+
+### 5.1 Problem Statement
+
+Carpooling surged 40% in early 2026. When sharing rides, accurate fuel cost splitting requires knowing actual consumption (not just distance), actual price paid, and each passenger's route segment. Tankstellen uniquely has all three from OBD-II trips and fill-up logs. Building an integrated cost splitter turns every recorded trip into a shareable receipt — and each shared receipt is a Tankstellen-branded viral touchpoint.
+
+### 5.2 Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Existing Data (read-only)                                    │
+│  ├── Trip entity         → distance, GPS path, duration       │
+│  ├── FillUp entity       → litres, totalCost, pricePerLiter  │
+│  └── VehicleProfile      → consumption rate (fallback)        │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────┐
+│  CostSplitCalculator (NEW — pure Dart)                        │
+│  ├── equal:      totalCost / participantCount                 │
+│  ├── byDistance:  proportional to individual km               │
+│  └── bySegment:  per-segment cost split among aboard riders   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+┌──────────────────────────▼───────────────────────────────────┐
+│  CostSplitReceiptGenerator (NEW)                              │
+│  ├── Plain text (messaging apps)                              │
+│  ├── Styled PNG (WhatsApp/Instagram via share_plus)           │
+│  └── Deep link back to Tankstellen app                        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 Domain Entities
+
+#### `lib/features/cost_split/domain/entities/cost_split.dart`
+
+```dart
+@freezed
+class CostSplit with _$CostSplit {
+  const factory CostSplit({
+    required String splitId,
+    String? tripId,
+    String? fillUpId,
+    required double totalFuelCost,
+    required double totalDistanceKm,
+    required List<SplitParticipant> participants,
+    required SplitMethod splitMethod,
+    required DateTime createdAt,
+    required String currency,
+  }) = _CostSplit;
+
+  factory CostSplit.fromJson(Map<String, dynamic> json) =>
+      _$CostSplitFromJson(json);
+}
+
+enum SplitMethod {
+  equal,       // Simple: cost / headcount
+  byDistance,  // Proportional to each person's km aboard
+  bySegment,   // Per-segment division among passengers present
+}
+```
+
+#### `lib/features/cost_split/domain/entities/split_participant.dart`
+
+```dart
+@freezed
+class SplitParticipant with _$SplitParticipant {
+  const factory SplitParticipant({
+    required String name,
+    @Default(0) double boardingKm,     // km into trip where they joined (0 = from start)
+    double? alightingKm,               // km where they left (null = full trip)
+    @Default(0) double shareAmount,    // computed
+    @Default(0) double sharePercentage, // computed
+  }) = _SplitParticipant;
+
+  factory SplitParticipant.fromJson(Map<String, dynamic> json) =>
+      _$SplitParticipantFromJson(json);
+}
+```
+
+### 5.4 Cost Split Calculator
+
+#### `lib/features/cost_split/domain/cost_split_calculator.dart`
+
+```dart
+class CostSplitCalculator {
+  List<SplitParticipant> calculate({
+    required double totalCost,
+    required double totalDistanceKm,
+    required List<SplitParticipant> participants,
+    required SplitMethod method,
+  }) {
+    switch (method) {
+      case SplitMethod.equal:
+        return _equalSplit(totalCost, participants);
+      case SplitMethod.byDistance:
+        return _distanceSplit(totalCost, totalDistanceKm, participants);
+      case SplitMethod.bySegment:
+        return _segmentSplit(totalCost, totalDistanceKm, participants);
+    }
+  }
+
+  List<SplitParticipant> _equalSplit(double totalCost, List<SplitParticipant> participants) {
+    final share = totalCost / participants.length;
+    final pct = 100.0 / participants.length;
+    return participants.map((p) => p.copyWith(shareAmount: share, sharePercentage: pct)).toList();
+  }
+
+  List<SplitParticipant> _distanceSplit(
+    double totalCost,
+    double totalKm,
+    List<SplitParticipant> participants,
+  ) {
+    // Each participant's individual km
+    final individualKms = participants.map((p) {
+      final alighting = p.alightingKm ?? totalKm;
+      return (alighting - p.boardingKm).clamp(0.0, totalKm);
+    }).toList();
+
+    final sumIndividualKm = individualKms.fold(0.0, (a, b) => a + b);
+    if (sumIndividualKm == 0) return _equalSplit(totalCost, participants);
+
+    return List.generate(participants.length, (i) {
+      final pct = individualKms[i] / sumIndividualKm * 100;
+      final share = totalCost * individualKms[i] / sumIndividualKm;
+      return participants[i].copyWith(shareAmount: share, sharePercentage: pct);
+    });
+  }
+
+  List<SplitParticipant> _segmentSplit(
+    double totalCost,
+    double totalKm,
+    List<SplitParticipant> participants,
+  ) {
+    // Build segment breakpoints from boarding/alighting points
+    final breakpoints = <double>{0, totalKm};
+    for (final p in participants) {
+      breakpoints.add(p.boardingKm);
+      if (p.alightingKm != null) breakpoints.add(p.alightingKm!);
+    }
+    final sorted = breakpoints.toList()..sort();
+
+    // For each segment, determine who was aboard and split that segment's cost
+    final shares = List.filled(participants.length, 0.0);
+    for (int s = 0; s < sorted.length - 1; s++) {
+      final segStart = sorted[s];
+      final segEnd = sorted[s + 1];
+      final segFraction = (segEnd - segStart) / totalKm;
+      final segCost = totalCost * segFraction;
+
+      // Who is aboard this segment?
+      final aboard = <int>[];
+      for (int i = 0; i < participants.length; i++) {
+        final p = participants[i];
+        final alighting = p.alightingKm ?? totalKm;
+        if (p.boardingKm <= segStart && alighting >= segEnd) {
+          aboard.add(i);
+        }
+      }
+
+      if (aboard.isEmpty) continue;
+      final perPerson = segCost / aboard.length;
+      for (final i in aboard) {
+        shares[i] += perPerson;
+      }
+    }
+
+    return List.generate(participants.length, (i) {
+      return participants[i].copyWith(
+        shareAmount: shares[i],
+        sharePercentage: shares[i] / totalCost * 100,
+      );
+    });
+  }
+}
+```
+
+### 5.5 Receipt Generator
+
+#### `lib/features/cost_split/domain/cost_split_receipt_generator.dart`
+
+Generates shareable receipts in three formats:
+
+**Plain text** (for messaging apps):
+```
+🚗 Trip Cost Split — 2026-05-05
+Route: Castelnau-de-Guers → Montpellier (42 km)
+Total fuel cost: €4.82
+
+💰 Cost per person:
+• Franck: €2.41 (50%)
+• Anna: €1.45 (30%)
+• Tom: €0.96 (20%)
+
+Split method: By distance
+Calculated with Tankstellen
+```
+
+**Styled PNG** (for WhatsApp/Instagram):
+Uses existing `WidgetShareRenderer` pattern from `lib/core/sharing/widget_share_renderer.dart`:
+```dart
+Future<File> generateReceiptImage(CostSplit split) async {
+  final widget = SplitReceiptCard(split: split); // renders as RepaintBoundary
+  return WidgetShareRenderer.shareWidgetAsImage(receiptKey, 'trip_split_receipt');
+}
+```
+
+**Deep link** (for Tankstellen users):
+`tankstellen://cost-split/${splitId}` — opens the split detail in the app.
+
+### 5.6 Presentation Layer
+
+#### `lib/features/cost_split/presentation/screens/cost_split_screen.dart`
+
+Flow:
+1. **Auto-populate** total cost from linked trip/fill-up (or enter manually)
+2. **Add participants** — name text field per person, "+" button to add
+3. **Optional:** Set boarding/alighting km (for byDistance/bySegment methods)
+4. **Select split method** — three segmented buttons: Equal / By Distance / By Segment
+5. **Preview** — computed shares displayed in `SplitReceiptCard`
+6. **Share** — share_plus sheet with text/image/link options
+
+#### `lib/features/cost_split/presentation/widgets/participant_editor.dart`
+
+ListView of participant rows:
+- Name `TextField` (required)
+- Optional distance slider (visible only for byDistance/bySegment methods)
+- Computed share amount (live-updating)
+- Delete button (minimum 2 participants enforced)
+- "Add participant" button at bottom
+
+#### `lib/features/cost_split/presentation/widgets/split_receipt_card.dart`
+
+Styled card serving as both preview and shareable image:
+- Tankstellen logo (small, top-right)
+- Trip date + route summary (start → end)
+- Per-person breakdown with amount + percentage
+- Total + split method label
+- Themed with `Theme.of(context).cardTheme`
+
+#### `lib/features/cost_split/presentation/widgets/route_participant_overlay.dart`
+
+Mini `flutter_map` (when trip has GPS data):
+- Route polyline
+- Coloured segments showing who was aboard each section
+- Boarding/alighting markers with participant names
+- Compact card layout (200px height)
+
+### 5.7 Integration Points
+
+- **Trip detail screen** (`lib/features/consumption/presentation/`): "Split Cost" action button in app bar
+- **Fill-up detail:** "Split" option in action menu
+- **Standalone entry:** From navigation menu for manual cost entry (no trip/fill-up link)
+- **GPS data:** From `lib/features/consumption/` trip recordings for route overlay
+- **Fill-up price:** From `FillUp.totalCost` / `FillUp.liters` for accurate cost
+- **Share:** Via `share_plus` (already in pubspec.yaml)
+- **Map:** Via `flutter_map` (already in pubspec.yaml)
+- **Storage:** Hive box for split history (optional `SyncableRepository` for TankSync)
+
+### 5.8 Test Strategy
+
+| Test | Type | Description |
+|------|------|-------------|
+| `cost_split_calculator_test.dart` | Unit | Equal: 3 people → 33.3% each; byDistance: partial riders get proportional share; bySegment: overlapping riders correctly split segments; edge cases: 0 km, 1 participant |
+| `split_receipt_card_test.dart` | Widget | Renders all participants; amounts sum to total; currency formatting |
+| `participant_editor_test.dart` | Widget | Add/remove participants; minimum 2 enforced; name validation |
+| `cost_split_screen_test.dart` | Widget | Auto-populate from trip; manual entry; share button |
+
+### 5.9 Estimated Scope
+
+- **New files:** 11 (2 entities, 1 calculator, 1 receipt generator, 1 repository, 3 widgets, 2 screens, 1 provider)
+- **Modified files:** 2 (trip detail screen — add action button, `feature.dart` enum)
+- **LOC estimate:** ~700 (lib) + ~450 (test)
+- **Risk:** Low — no external APIs, no schema migrations, purely additive
+
+---
+
+## Cross-Cutting Concerns
+
+### Feature Flag Registration
+
+All five concepts integrate with the central feature management engine (`lib/features/feature_management/`). Add to `Feature` enum and `FeatureManifest.defaultManifest`:
+
+```dart
+// New Feature enum values:
+Feature.refuelTimingAdvisor,
+Feature.volatilityHeatmap,
+Feature.weatherAdvisor,
+Feature.telematicsExport,
+Feature.costSplit,
+```
+
+### ARB Fragment Strategy
+
+Per `feedback_arb_fragment_pattern.md`, new i18n keys go in `lib/l10n/_fragments/<feature>_<locale>.arb`:
+- `refuel_timing_en.arb`, `refuel_timing_de.arb`, `refuel_timing_fr.arb`
+- `volatility_en.arb`, `volatility_de.arb`, `volatility_fr.arb`
+- `weather_en.arb`, `weather_de.arb`, `weather_fr.arb`
+- `telematics_en.arb`, `telematics_de.arb`, `telematics_fr.arb`
+- `cost_split_en.arb`, `cost_split_de.arb`, `cost_split_fr.arb`
+
+Then run `dart run tool/build_arb.dart` to merge into `app_*.arb`.
+
+### Phased PR Strategy
+
+Per `feedback_phased_pr_rubric.md`, issues >400 LOC split into phased PRs:
+
+| Concept | Est. LOC | Phases |
+|---------|----------|--------|
+| 1. Refuel Timing | ~400 | 1 phase (just fits) |
+| 2. Volatility Heatmap | ~500 | 2 phases: domain+provider → UI+tests |
+| 3. Weather Advisor | ~700 | 3 phases: core service → trip integration → UI widgets |
+| 4. Telematics Export | ~900 | 3 phases: generator+classifier → export formats → UI+radar |
+| 5. Cost Split | ~700 | 2 phases: calculator+entities → UI+receipt+sharing |
+
+### Implementation Priority & Dependencies
+
+```
+Phase 1: Refuel Timing Advisor (Concept 1)
+  └── Prerequisite: none (extends existing alerts)
+  └── Unblocks: nothing
+
+Phase 2: Volatility Heatmap (Concept 2)  ← can run parallel with Phase 1
+  └── Prerequisite: none (reads existing price history)
+  └── Unblocks: nothing
+
+Phase 3: Weather Advisor (Concept 3)
+  └── Prerequisite: none (new core service)
+  └── Unblocks: weather-normalised driving score (future)
+
+Phase 4: Cost Split Calculator (Concept 5)  ← can run parallel with Phase 3
+  └── Prerequisite: none (reads existing trips/fill-ups)
+  └── Unblocks: nothing
+
+Phase 5: Telematics Export (Concept 4)
+  └── Prerequisite: sufficient driving data (not code-blocking)
+  └── Unblocks: insurance partnerships (business)
+```
+
+### Total Scope Summary
+
+| Concept | New Files | Modified Files | LOC (lib) | LOC (test) |
+|---------|-----------|----------------|-----------|------------|
+| 1. Refuel Timing | 8 | 3 | ~400 | ~300 |
+| 2. Volatility Heatmap | 9 | 2 | ~500 | ~350 |
+| 3. Weather Advisor | 12 | 4 | ~700 | ~500 |
+| 4. Telematics Export | 14 | 1 | ~900 | ~600 |
+| 5. Cost Split | 11 | 2 | ~700 | ~450 |
+| **Total** | **54** | **12** | **~3,200** | **~2,200** |
+
+---
+
+## Appendix A: Existing Provider Dependency Map
+
+For reference, these are the existing providers that the five concepts consume (read-only):
+
+| Provider | Location | Consumed By |
+|----------|----------|-------------|
+| `priceHistoryRepositoryProvider` | `lib/features/price_history/` | Concepts 1, 2 |
+| `pricePredictionProvider` | `lib/features/price_history/providers/` | Concept 1 |
+| `fillUpHistoryProvider` | `lib/features/consumption/providers/` | Concepts 1, 4, 5 |
+| `tripHistoryProvider` | `lib/features/consumption/providers/` | Concepts 3, 4, 5 |
+| `consumptionStatsProvider` | `lib/features/consumption/providers/` | Concepts 1, 3, 4 |
+| `activeVehicleProfileProvider` | `lib/features/vehicle/providers/` | Concepts 1, 3, 4, 5 |
+| `drivingScoreProvider` | `lib/features/consumption/providers/` | Concept 4 |
+| `userPositionProvider` | `lib/core/location/` | Concepts 1, 2, 3 |
+| `fuelStationsProvider` | `lib/features/search/providers/` | Concept 2 |
+| `featureFlagsProvider` | `lib/features/feature_management/` | All concepts |
+| `notificationServiceProvider` | `lib/core/notifications/` | Concepts 1, 3 |
+
+## Appendix B: Features Deferred from This Document
+
+The following features from May 1–4 analyses are **not** covered here due to higher complexity, external API dependencies, or lower priority, but remain valid candidates for future concept documents:
+
+| Feature | Source | Reason Deferred |
+|---------|--------|-----------------|
+| CarPlay & Android Auto | May 1 #1 | High effort, native-only code, platform-specific testing |
+| Crowdsourced Price OCR | May 1 #2 | Requires Supabase schema + moderation pipeline |
+| Community Leaderboard | May 1 #4 | Requires Supabase backend + privacy review |
+| Wearable Companion | May 1 #5 | High effort, native watchOS/Wear OS targets |
+| Voice-First AI Copilot | May 2 #1 | New dependency (speech_to_text), complex intent parsing |
+| Hybrid/EV Energy Optimizer | May 2 #2 | Requires electricity tariff data sources |
+| Station Queue Intelligence | May 2 #3 | Requires crowd-sourced Supabase pipeline |
+| Multi-Modal Journey Compare | May 2 #4 | Multiple external transit APIs |
+| AI Maintenance Predictor | May 2 #5 | Requires service cost database creation |
+| Price Arbitrage Alerts | May 3 #1 | Builds on Concept 1; phase 2 candidate |
+| Station Reviews | May 3 #2 | High effort (community data + sync + spam prevention) |
+| Fleet/Family Groups | May 3 #3 | Supabase schema + multi-user sync complexity |
+| Maintenance-Aware Routing | May 3 #4 | Depends on mature maintenance suggestion system |
+| Savings Dashboard | May 3 #5 | Medium effort but lower urgency; phase 2 candidate |
+| Carbon Offset Marketplace | May 4 #5 | External payment flow complexity |
+
+---
+
+*Generated: 2026-05-05 | Architecture based on Tankstellen v5.0.0 codebase analysis. All file paths verified against current project structure. Implementation estimates assume single developer working in the established branching workflow (GitHub Flow, squash-merge, conventional commits).*

--- a/docs/feature-concepts/README.md
+++ b/docs/feature-concepts/README.md
@@ -1,0 +1,10 @@
+# Feature Concept Drafts
+
+Long-form feature proposals + concept-architecture deep-dives surfaced from the daily competitive-analysis loop. Each file is a snapshot at the date in its filename — these are exploration drafts, not committed roadmap.
+
+Files come in two flavours:
+
+- **`YYYY-MM-DD-feature-analysis.md`** — daily competitive scan, market context + 3–5 candidate features per day with a per-feature implementation sketch (files to create, provider wiring, test approach).
+- **`YYYY-MM-DD-concept-architecture-implementation.md`** — periodic consolidation that picks the highest-leverage concepts from a recent batch and turns them into implementation-ready architecture documents.
+
+Sibling local-only directory `docs/daily-features/` (gitignored) holds working scratch; this directory holds the published drafts that survived a triage and are worth keeping in version history.


### PR DESCRIPTION
## Summary

- Promotes 5 long-form feature drafts from the gitignored `docs/daily-features/` working directory into a tracked sibling `docs/feature-concepts/` so they survive fresh checkouts and live in version history.
- Adds `!docs/feature-concepts/` gitignore exception. The existing `docs/daily-features/` scratchpad stays gitignored for in-progress brainstorming.
- Tracks 4 daily competitive-analysis docs (May 1-4) plus one 1573-line consolidated concept-architecture document (May 5) covering 5 implementation-ready concepts: Smart Refuel Timing Advisor, Fuel Price Volatility Heatmap, Weather-Aware Fuel Efficiency Advisor, Insurance Telematics Data Export, Trip Cost Sharing Calculator.

## Files

- `.gitignore` — adds `!docs/feature-concepts/` exception
- `docs/feature-concepts/README.md` — directory purpose / convention
- `docs/feature-concepts/2026-05-01..04-feature-analysis.md` — daily market scans + 3-5 feature sketches each
- `docs/feature-concepts/2026-05-05-concept-architecture-implementation.md` — consolidated build-ready spec for the top 5 concepts

## Test plan

- [x] Docs-only — no code paths touched
- [x] gitignore exception verified — only files I explicitly committed are exposed; the existing 16 local-only `docs/daily-features/` files stay ignored