### PR TITLE
feat(glide-coach): throttle-correlated evaluator + settings entity (Refs #1125 phase 3a)

### DIFF
--- a/lib/features/glide_coach/domain/entities/glide_coach_advice.dart
+++ b/lib/features/glide_coach/domain/entities/glide_coach_advice.dart
@@ -1,0 +1,39 @@
+/// The decision returned by [GlideCoachEvaluator] (#1125 phase 3a) for
+/// a single GPS / throttle tick.
+///
+/// Pure data — no UI side-effects, no haptic call. Phase 3b maps these
+/// values onto a `HapticFeedback.lightImpact()` call gated behind the
+/// user-facing setting toggle. Until then the evaluator is dormant
+/// behind `kGlideCoachEnabled = false`.
+///
+/// ### Why an enum (and not a Freezed sealed union)
+///
+/// The evaluator's caller in phase 3b only needs a tri-state branch
+/// (`buzz` / `do nothing` / `do nothing because we just buzzed`). It
+/// does not need to know which specific signal triggered the advice —
+/// the detector keeps its own state and the user-test cohort scores
+/// the buzz outcome, not the upstream geometry. A pure enum keeps the
+/// surface tiny and avoids dragging build_runner / freezed into a
+/// value type that has no JSON, no copyWith, and no equality concerns
+/// beyond the language defaults.
+enum GlideCoachAdvice {
+  /// User is on throttle AND a red signal is imminent ahead. Phase 3b
+  /// will translate this into a `HapticFeedback.lightImpact()` call.
+  lift,
+
+  /// No advice. One of:
+  ///   - throttle data missing (car has no PID 0x11),
+  ///   - user is already coasting (throttle below threshold),
+  ///   - no signal within the forward cone / horizon.
+  /// Under-trigger is the safe default for a distraction-warning
+  /// feature; we never guess that the user is on throttle.
+  hold,
+
+  /// A `lift` was returned within the cool-down window. Suppress until
+  /// the window expires. Cool-down is deliberate over-trigger
+  /// suppression — the issue's acceptance criteria call for a strict
+  /// false-positive budget and long quiet between buzzes is the
+  /// cheapest way to hold the line until the user-test cohort tunes
+  /// the thresholds.
+  cooldown,
+}

--- a/lib/features/glide_coach/domain/entities/glide_coach_settings.dart
+++ b/lib/features/glide_coach/domain/entities/glide_coach_settings.dart
@@ -1,0 +1,67 @@
+/// User-facing settings for the glide-coach feature (#1125 phase 3a).
+///
+/// Wired into the runtime in phase 3b; defaulted to disabled per
+/// #1125 acceptance ("Setting toggle, default OFF"). Phase 3a only
+/// ships the data shape so the evaluator + tests can reference the
+/// same defaults the future Riverpod provider + Hive-backed settings
+/// store will hand out.
+///
+/// Immutable — phase 3b's settings notifier will emit a fresh
+/// instance on every change rather than mutate in place.
+class GlideCoachSettings {
+  /// Master on/off toggle. Default `false` — the feature stays off
+  /// until the user opts in, even after the kill-switch
+  /// (`kGlideCoachEnabled` in `traffic_signal_repository.dart`) flips
+  /// to `true`.
+  final bool enabled;
+
+  /// Throttle position (0–100) above which the evaluator considers
+  /// the user "on throttle" and therefore eligible for a lift hint.
+  /// Default 20.0 — slightly above the typical idle-creep
+  /// throttle-by-wire reading so we don't hint while the user has
+  /// already let off.
+  final double throttleThresholdPercent;
+
+  /// Minimum quiet window after firing a `lift` advice. Default 15s
+  /// — long enough that two close-spaced signals don't double-buzz,
+  /// short enough that a missed-then-corrected lift can re-fire on
+  /// the next signal.
+  final Duration cooldown;
+
+  const GlideCoachSettings({
+    this.enabled = false,
+    this.throttleThresholdPercent = 20.0,
+    this.cooldown = const Duration(seconds: 15),
+  });
+
+  GlideCoachSettings copyWith({
+    bool? enabled,
+    double? throttleThresholdPercent,
+    Duration? cooldown,
+  }) =>
+      GlideCoachSettings(
+        enabled: enabled ?? this.enabled,
+        throttleThresholdPercent:
+            throttleThresholdPercent ?? this.throttleThresholdPercent,
+        cooldown: cooldown ?? this.cooldown,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GlideCoachSettings &&
+          runtimeType == other.runtimeType &&
+          enabled == other.enabled &&
+          throttleThresholdPercent == other.throttleThresholdPercent &&
+          cooldown == other.cooldown;
+
+  @override
+  int get hashCode =>
+      Object.hash(enabled, throttleThresholdPercent, cooldown);
+
+  @override
+  String toString() =>
+      'GlideCoachSettings(enabled: $enabled, '
+      'throttleThresholdPercent: $throttleThresholdPercent, '
+      'cooldown: $cooldown)';
+}

--- a/lib/features/glide_coach/domain/services/glide_coach_evaluator.dart
+++ b/lib/features/glide_coach/domain/services/glide_coach_evaluator.dart
@@ -1,0 +1,105 @@
+import '../entities/glide_coach_advice.dart';
+import 'imminent_signal_detector.dart';
+
+/// Default throttle threshold (percent, 0–100). The evaluator treats a
+/// reading at or above this value as "user is on throttle" — a
+/// pre-condition for the lift hint. 20 % sits above the typical
+/// idle-creep throttle-by-wire reading so we don't hint while the user
+/// is already off-pedal but coasting in gear.
+const double kDefaultThrottleThresholdPercent = 20.0;
+
+/// Default cool-down window after firing a `lift` advice. Long enough
+/// that two close-spaced signals don't double-buzz, short enough that
+/// a missed-then-corrected lift can re-fire on the next signal.
+const Duration kDefaultGlideCoachCooldown = Duration(seconds: 15);
+
+/// Correlates the [ImminentSignalDetector] output with the OBD2
+/// throttle position to decide whether to suggest the user lift off
+/// the accelerator (#1125 phase 3a).
+///
+/// Pure logic — no platform channels, no UI, no Riverpod state, no
+/// haptic firing. The caller (phase 3b) is responsible for:
+///   - throttling invocations (e.g. once per N seconds of GPS samples);
+///   - gating on the user-facing setting toggle (`GlideCoachSettings.enabled`);
+///   - translating a `GlideCoachAdvice.lift` into the actual
+///     `HapticFeedback.lightImpact()` call.
+///
+/// ### Decision rules (first match wins)
+///
+/// 1. We fired `lift` within the last `cooldown` window → `cooldown`.
+///    Cool-down is deliberate over-trigger suppression: the issue
+///    explicitly demands a strict false-positive budget, and quiet
+///    windows between buzzes are the cheapest way to hold the line
+///    until the user-test cohort tunes the thresholds.
+/// 2. `throttlePercent == null` (car has no PID 0x11 / sample dropped)
+///    → `hold`. Under-trigger preference per the detector's existing
+///    doctrine; never guess that throttle is high.
+/// 3. `throttlePercent < throttleThresholdPercent` (already coasting)
+///    → `hold`. Lifting advice while the user is already off-throttle
+///    is noise.
+/// 4. Detector returns `null` (no signal in the forward cone within
+///    the horizon) → `hold`.
+/// 5. Detector returned a signal → `lift`. Record the wall-clock time
+///    so the next tick within `cooldown` short-circuits at rule 1.
+///
+/// ### Cool-down state machine
+///
+/// State is a single nullable `DateTime` of the last `lift`. Only
+/// `lift` advices update the state; subsequent `cooldown` returns do
+/// not extend the window (so a flurry of GPS ticks during the
+/// cool-down does not push the next eligible buzz further out).
+///
+/// The injectable [now] callback lets tests advance "wall clock"
+/// deterministically without `Future.delayed`.
+class GlideCoachEvaluator {
+  final ImminentSignalDetector _detector;
+  final Duration _cooldown;
+  final double _throttleThresholdPercent;
+  final DateTime Function() _now;
+
+  /// Wall-clock time of the most recent `lift` advice, or `null` when
+  /// no advice has fired yet (or after a manual reset).
+  DateTime? _lastLiftAt;
+
+  GlideCoachEvaluator({
+    required ImminentSignalDetector detector,
+    Duration cooldown = kDefaultGlideCoachCooldown,
+    double throttleThresholdPercent = kDefaultThrottleThresholdPercent,
+    DateTime Function() now = DateTime.now,
+  })  : _detector = detector,
+        _cooldown = cooldown,
+        _throttleThresholdPercent = throttleThresholdPercent,
+        _now = now;
+
+  /// Evaluate one tick. See the class doc for the 5-rule decision
+  /// flow. The detector call is awaited; the caller throttles
+  /// invocation cadence.
+  Future<GlideCoachAdvice> evaluate({
+    required GpsReading reading,
+    required double? throttlePercent,
+  }) async {
+    // Rule 1 — cool-down short-circuit.
+    final lastLift = _lastLiftAt;
+    if (lastLift != null && _now().difference(lastLift) < _cooldown) {
+      return GlideCoachAdvice.cooldown;
+    }
+
+    // Rule 2 — throttle data missing (car without PID 0x11).
+    if (throttlePercent == null) return GlideCoachAdvice.hold;
+
+    // Rule 3 — user already coasting.
+    if (throttlePercent < _throttleThresholdPercent) {
+      return GlideCoachAdvice.hold;
+    }
+
+    // Rule 4 — no signal ahead. The detector swallows repository
+    // errors and returns null on its own (phase 2 contract); the
+    // evaluator inherits that under-trigger preference for free.
+    final signal = await _detector.nextSignalAhead(reading);
+    if (signal == null) return GlideCoachAdvice.hold;
+
+    // Rule 5 — fire and arm cool-down.
+    _lastLiftAt = _now();
+    return GlideCoachAdvice.lift;
+  }
+}

--- a/test/features/glide_coach/domain/entities/glide_coach_settings_test.dart
+++ b/test/features/glide_coach/domain/entities/glide_coach_settings_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/glide_coach/domain/entities/glide_coach_settings.dart';
+
+void main() {
+  group('GlideCoachSettings (#1125 phase 3a)', () {
+    test('defaults match the issue acceptance criteria', () {
+      const settings = GlideCoachSettings();
+      // "Setting toggle, default OFF" — the master toggle MUST default
+      // to false so the feature stays dormant until the user opts in.
+      expect(settings.enabled, isFalse);
+      // Throttle threshold matches the evaluator default (kept in
+      // sync via the entity-side default).
+      expect(settings.throttleThresholdPercent, 20.0);
+      // 15-second cool-down matches the issue's "long quiet between
+      // buzzes" preference.
+      expect(settings.cooldown, const Duration(seconds: 15));
+    });
+
+    test('equality and hashCode agree for equal-valued instances', () {
+      const a = GlideCoachSettings(
+        enabled: true,
+        throttleThresholdPercent: 25.0,
+        cooldown: Duration(seconds: 20),
+      );
+      const b = GlideCoachSettings(
+        enabled: true,
+        throttleThresholdPercent: 25.0,
+        cooldown: Duration(seconds: 20),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('equality is field-sensitive (enabled flip is not equal)', () {
+      const enabled = GlideCoachSettings(enabled: true);
+      const disabled = GlideCoachSettings();
+      expect(enabled, isNot(equals(disabled)));
+    });
+
+    test('copyWith overrides only the fields supplied', () {
+      const base = GlideCoachSettings();
+      final flipped = base.copyWith(enabled: true);
+      expect(flipped.enabled, isTrue);
+      expect(
+        flipped.throttleThresholdPercent,
+        base.throttleThresholdPercent,
+      );
+      expect(flipped.cooldown, base.cooldown);
+    });
+
+    test('toString surfaces all three fields (debug-friendly)', () {
+      const s = GlideCoachSettings();
+      final out = s.toString();
+      expect(out, contains('enabled: false'));
+      expect(out, contains('throttleThresholdPercent: 20.0'));
+      expect(out, contains('cooldown'));
+    });
+  });
+}

--- a/test/features/glide_coach/domain/services/glide_coach_evaluator_test.dart
+++ b/test/features/glide_coach/domain/services/glide_coach_evaluator_test.dart
@@ -1,0 +1,368 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/glide_coach/data/osm_traffic_signal_client.dart';
+import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
+import 'package:tankstellen/features/glide_coach/domain/entities/glide_coach_advice.dart';
+import 'package:tankstellen/features/glide_coach/domain/entities/traffic_signal.dart';
+import 'package:tankstellen/features/glide_coach/domain/services/glide_coach_evaluator.dart';
+import 'package:tankstellen/features/glide_coach/domain/services/imminent_signal_detector.dart';
+
+/// Test double for [TrafficSignalRepository] mirroring the pattern in
+/// `imminent_signal_detector_test.dart`. The evaluator never calls the
+/// repo directly — it always goes through the detector — so the stub
+/// only needs to drive the bbox response that the detector will
+/// inspect.
+class _StubRepo implements TrafficSignalRepository {
+  List<TrafficSignal> response;
+  Object? errorToThrow;
+
+  _StubRepo({this.response = const <TrafficSignal>[], this.errorToThrow});
+
+  @override
+  Future<List<TrafficSignal>> getSignalsForBoundingBox({
+    required double south,
+    required double west,
+    required double north,
+    required double east,
+  }) async {
+    final err = errorToThrow;
+    if (err != null) throw err;
+    return response;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// Convenience: a [GpsReading] anchored on the Paris reference point
+/// the detector tests use, with a configurable heading. The exact
+/// coordinates are irrelevant for the evaluator — what matters is
+/// that the detector reaches into the (stubbed) repo.
+GpsReading _reading({double heading = 0.0}) =>
+    (latitude: 48.8566, longitude: 2.3522, headingDegrees: heading);
+
+/// A traffic signal that lies ~80 m due north of the Paris anchor —
+/// inside the detector's default 200 m horizon and ±20° forward cone
+/// when the user heads north. We hand-pick a tiny lat offset that
+/// keeps every test deterministic without dragging in the metre-offset
+/// helper from the detector test.
+TrafficSignal _aheadSignal() {
+  // 80 m of latitude ≈ 0.0007°. Due north of (48.8566, 2.3522).
+  return const TrafficSignal(id: 'ahead', lat: 48.8573, lng: 2.3522);
+}
+
+void main() {
+  group('GlideCoachEvaluator (#1125 phase 3a)', () {
+    test(
+      'rule 5 — throttle above threshold + signal ahead → lift',
+      () async {
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        final evaluator = GlideCoachEvaluator(detector: detector);
+
+        final advice = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(advice, GlideCoachAdvice.lift);
+      },
+    );
+
+    test(
+      'rule 2 — null throttle (no PID 0x11) → hold (under-trigger)',
+      () async {
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        final evaluator = GlideCoachEvaluator(detector: detector);
+
+        final advice = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: null,
+        );
+        expect(advice, GlideCoachAdvice.hold);
+      },
+    );
+
+    test(
+      'rule 3 — throttle below threshold (already coasting) → hold',
+      () async {
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        final evaluator = GlideCoachEvaluator(detector: detector);
+
+        final advice = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 5.0,
+        );
+        expect(advice, GlideCoachAdvice.hold);
+      },
+    );
+
+    test('rule 4 — detector returns null (no signal ahead) → hold', () async {
+      final repo = _StubRepo(response: const <TrafficSignal>[]);
+      final detector = ImminentSignalDetector(repo: repo);
+      final evaluator = GlideCoachEvaluator(detector: detector);
+
+      final advice = await evaluator.evaluate(
+        reading: _reading(),
+        throttlePercent: 45.0,
+      );
+      expect(advice, GlideCoachAdvice.hold);
+    });
+
+    test(
+      'rule 1 — second call within cool-down → cooldown (no re-fire)',
+      () async {
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        var clock = DateTime(2026, 5, 6, 12, 0, 0);
+        final evaluator = GlideCoachEvaluator(
+          detector: detector,
+          now: () => clock,
+        );
+
+        final first = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(first, GlideCoachAdvice.lift);
+
+        // 5 seconds later — well inside the default 15s cool-down.
+        clock = clock.add(const Duration(seconds: 5));
+        final second = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(second, GlideCoachAdvice.cooldown);
+      },
+    );
+
+    test(
+      'rule 1 — call after cool-down expires → lift again',
+      () async {
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        var clock = DateTime(2026, 5, 6, 12, 0, 0);
+        final evaluator = GlideCoachEvaluator(
+          detector: detector,
+          now: () => clock,
+        );
+
+        final first = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(first, GlideCoachAdvice.lift);
+
+        // 16 seconds — one second past the default 15s cool-down.
+        clock = clock.add(const Duration(seconds: 16));
+        final second = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(second, GlideCoachAdvice.lift);
+      },
+    );
+
+    test('custom cool-down (5s) — exact-boundary behaviour', () async {
+      final repo = _StubRepo(response: [_aheadSignal()]);
+      final detector = ImminentSignalDetector(repo: repo);
+      var clock = DateTime(2026, 5, 6, 12, 0, 0);
+      final evaluator = GlideCoachEvaluator(
+        detector: detector,
+        cooldown: const Duration(seconds: 5),
+        now: () => clock,
+      );
+
+      final first = await evaluator.evaluate(
+        reading: _reading(),
+        throttlePercent: 45.0,
+      );
+      expect(first, GlideCoachAdvice.lift);
+
+      // 4s later — still inside the 5s window.
+      clock = clock.add(const Duration(seconds: 4));
+      final inside = await evaluator.evaluate(
+        reading: _reading(),
+        throttlePercent: 45.0,
+      );
+      expect(inside, GlideCoachAdvice.cooldown);
+
+      // Exactly 5s after the lift — boundary is "strictly less than
+      // cooldown", so we are no longer suppressed.
+      clock = clock.add(const Duration(seconds: 1));
+      final boundary = await evaluator.evaluate(
+        reading: _reading(),
+        throttlePercent: 45.0,
+      );
+      expect(
+        boundary,
+        GlideCoachAdvice.lift,
+        reason:
+            'cool-down boundary is strict less-than; at exactly the '
+            'window length the next lift is allowed.',
+      );
+    });
+
+    test(
+      'custom throttle threshold (40%) — 35% holds, 45% lifts',
+      () async {
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        final below = GlideCoachEvaluator(
+          detector: detector,
+          throttleThresholdPercent: 40.0,
+        );
+
+        final adviceBelow = await below.evaluate(
+          reading: _reading(),
+          throttlePercent: 35.0,
+        );
+        expect(adviceBelow, GlideCoachAdvice.hold);
+
+        // Fresh evaluator so the cool-down state from below doesn't
+        // leak.
+        final above = GlideCoachEvaluator(
+          detector: detector,
+          throttleThresholdPercent: 40.0,
+        );
+        final adviceAbove = await above.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(adviceAbove, GlideCoachAdvice.lift);
+      },
+    );
+
+    test(
+      'detector errors are swallowed by phase-2 contract → evaluator returns hold',
+      () async {
+        // The phase-2 detector swallows repo exceptions internally and
+        // returns null. The evaluator inherits that under-trigger
+        // preference for free; verify the chain end-to-end so a future
+        // detector refactor that re-throws is caught here.
+        final repo = _StubRepo(
+          errorToThrow: const OsmTrafficSignalException('overpass down'),
+        );
+        final detector = ImminentSignalDetector(repo: repo);
+        final evaluator = GlideCoachEvaluator(detector: detector);
+
+        final advice = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(advice, GlideCoachAdvice.hold);
+      },
+    );
+
+    test(
+      'sequence: hold → lift → cooldown → cooldown → lift (after time)',
+      () async {
+        // Empty response first → hold; then signal appears → lift;
+        // two ticks inside cool-down → cooldown × 2; advance past
+        // cool-down → lift again.
+        final repo = _StubRepo(response: const <TrafficSignal>[]);
+        final detector = ImminentSignalDetector(repo: repo);
+        var clock = DateTime(2026, 5, 6, 12, 0, 0);
+        final evaluator = GlideCoachEvaluator(
+          detector: detector,
+          now: () => clock,
+        );
+
+        // Tick 1 — no signal in the bbox.
+        final tick1 = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(tick1, GlideCoachAdvice.hold);
+
+        // Signal appears in the bbox; advance the clock a touch so
+        // sequencing is realistic.
+        repo.response = [_aheadSignal()];
+        clock = clock.add(const Duration(seconds: 1));
+
+        // Tick 2 — first lift.
+        final tick2 = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(tick2, GlideCoachAdvice.lift);
+
+        // Tick 3 — 5s into the 15s cool-down.
+        clock = clock.add(const Duration(seconds: 5));
+        final tick3 = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(tick3, GlideCoachAdvice.cooldown);
+
+        // Tick 4 — 10s into cool-down. Still suppressed.
+        clock = clock.add(const Duration(seconds: 5));
+        final tick4 = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(tick4, GlideCoachAdvice.cooldown);
+
+        // Tick 5 — 16s after the lift, cool-down expired.
+        clock = clock.add(const Duration(seconds: 6));
+        final tick5 = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(tick5, GlideCoachAdvice.lift);
+      },
+    );
+
+    test(
+      'cool-down state is NOT extended by repeated cooldown returns',
+      () async {
+        // Regression: a flurry of GPS ticks during the cool-down
+        // window must not push the next eligible buzz further out —
+        // only `lift` updates the timestamp.
+        final repo = _StubRepo(response: [_aheadSignal()]);
+        final detector = ImminentSignalDetector(repo: repo);
+        var clock = DateTime(2026, 5, 6, 12, 0, 0);
+        final evaluator = GlideCoachEvaluator(
+          detector: detector,
+          now: () => clock,
+        );
+
+        final first = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(first, GlideCoachAdvice.lift);
+
+        // Spam ticks every second through the cool-down.
+        for (var i = 1; i <= 14; i++) {
+          clock = clock.add(const Duration(seconds: 1));
+          final tick = await evaluator.evaluate(
+            reading: _reading(),
+            throttlePercent: 45.0,
+          );
+          expect(
+            tick,
+            GlideCoachAdvice.cooldown,
+            reason: 'tick=$i should still be suppressed',
+          );
+        }
+
+        // 15s after the lift — boundary, no longer suppressed.
+        clock = clock.add(const Duration(seconds: 1));
+        final reFire = await evaluator.evaluate(
+          reading: _reading(),
+          throttlePercent: 45.0,
+        );
+        expect(
+          reFire,
+          GlideCoachAdvice.lift,
+          reason:
+              'cool-down should NOT have been extended by the 14 '
+              'cooldown returns; the second lift fires exactly at the '
+              'window boundary.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Phase 3a of the glide-coach feature (#1125): pure-logic evaluator that correlates Phase 2's `ImminentSignalDetector` output with OBD2 throttle position, plus a `GlideCoachSettings` value type. Ships **dormant** behind the existing `kGlideCoachEnabled = false` kill switch — no UI, no Riverpod provider, no haptic call.

The separation is mandatory per the issue's acceptance criteria: distraction-warning territory, strict false-positive budget, setting toggle defaulted OFF, user-test cohort before broad release. Phase 3a makes the false-positive logic reviewable + testable WITHOUT shipping any UX surface that could fire.

## Files

- `lib/features/glide_coach/domain/entities/glide_coach_advice.dart` — pure enum with three states: `lift`, `hold`, `cooldown`. Pure enum (no Freezed payload) keeps the surface tiny.
- `lib/features/glide_coach/domain/entities/glide_coach_settings.dart` — immutable settings value type. Defaults match the issue acceptance: `enabled: false`, `throttleThresholdPercent: 20.0`, `cooldown: 15s`.
- `lib/features/glide_coach/domain/services/glide_coach_evaluator.dart` — the evaluator itself. 5-rule decision flow + cool-down state machine, both documented inline.
- `test/features/glide_coach/domain/entities/glide_coach_settings_test.dart` — defaults, equality, hashCode, copyWith, toString.
- `test/features/glide_coach/domain/services/glide_coach_evaluator_test.dart` — every rule, custom threshold/cool-down boundaries, detector-error inheritance, full state-machine sequence.

## Decision flow (first match wins)

1. We fired `lift` within the last `cooldown` window -> `cooldown`.
2. `throttlePercent == null` (no PID 0x11) -> `hold` (under-trigger preference).
3. `throttlePercent < threshold` (already coasting) -> `hold`.
4. Detector returns `null` (no signal in the forward cone within horizon) -> `hold`.
5. Detector returned a signal -> `lift`, arm cool-down.

Cool-down state is a single nullable `DateTime` of the most recent `lift`. Only `lift` advices update the timestamp; `cooldown` returns do NOT extend the window — guarded by an explicit regression test.

## Test plan

- [x] `flutter analyze` clean (zero warnings/infos/errors)
- [x] `flutter test test/features/glide_coach/` green (65 tests; 16 new + Phase 1+2 still pass)
- [x] `flutter test test/lint/` green (29 tests)
- [x] Worktree verified before commit (`git rev-parse --show-toplevel`)
- [x] No `.g.dart` / `.freezed.dart` drift (pure enum, no build_runner)
- [x] No silent catches added (none — evaluator delegates error-handling to Phase 2's detector)

## Out of scope (deferred to phase 3b)

- Wiring the evaluator into `trip_recording_provider` / `trip_recording_controller`
- Riverpod provider for `GlideCoachSettings`
- Hive-backed settings persistence
- UI toggle in the settings screen
- The actual `HapticFeedback.lightImpact()` call when `lift` is returned
- User-test cohort rollout

Phase 3b is intentionally a focused user-test session — Phase 3a's job is to make the false-positive logic reviewable + testable in isolation, NOT to ship a UX surface that could fire prematurely.

Refs #1125

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>