### PR TITLE
feat(community): wait-time pings + aggregator Edge Function (Refs #1119 phase 1)

### DIFF
--- a/docs/security/SUPABASE_RLS_MATRIX.md
+++ b/docs/security/SUPABASE_RLS_MATRIX.md
@@ -64,6 +64,8 @@ Legend:
 | `vehicles`         | own          | own             | own        | own                | Single `vehicles_own` `FOR ALL`. |
 | `fill_ups`         | own          | own             | own        | own                | Single `fill_ups_own` `FOR ALL`. |
 | `obd2_baselines`   | own          | own             | own        | own                | Single `obd2_baselines_own` `FOR ALL`. |
+| `wait_time_pings`  | own          | own             | own        | own                | Single `wait_time_pings_own` `FOR ALL`. Aggregator runs as service_role and bypasses RLS. |
+| `wait_time_aggregates` | all      | (svc)           | (svc)      | (svc)              | Single `wait_aggregates_read` SELECT-only policy. Anonymized rolling-median rows are visible to every authenticated client; only Edge Functions write. |
 
 The migration source-of-truth lives in `supabase/migrations/`:
 
@@ -80,6 +82,10 @@ The migration source-of-truth lives in `supabase/migrations/`:
 - `20260418000001_vehicles_and_fillups.sql` — `vehicles`, `fill_ups`.
 - `20260421000001_obd2_baselines.sql` — `obd2_baselines`.
 - `20260403000001_pg_cron_alert_schedules.sql` — schedules only,
+  service-role-driven, no public-table RLS change.
+- `20260506000001_wait_time_pings.sql` — `wait_time_pings`,
+  `wait_time_aggregates` (#1119).
+- `20260506000002_wait_time_aggregator_schedule.sql` — schedule only,
   service-role-driven, no public-table RLS change.
 
 If a migration not listed above is found in `supabase/migrations/`,

--- a/supabase/functions/aggregate-wait-times/index.ts
+++ b/supabase/functions/aggregate-wait-times/index.ts
@@ -1,0 +1,226 @@
+// Edge Function: aggregate-wait-times
+//
+// Pairs "arrived"/"left" pings by session_id, computes a rolling
+// median wait per (station, hour) window, and upserts into
+// public.wait_time_aggregates. Sparse buckets (< 5 samples) are not
+// written, so the client sees nothing instead of a noisy hint.
+//
+// Privacy:
+//   - Aggregates carry no user_id. The function reads pings via the
+//     service-role key, computes per-session wait seconds, then groups
+//     by (station_id, hour) — user identity is dropped before any row
+//     is written to the aggregates table.
+//   - After aggregation, pings older than the retention window are
+//     deleted. The retention horizon is intentionally short (7 days
+//     by default) because once a ping has rolled into an aggregate
+//     bucket, the raw row is no longer needed.
+//
+// Scheduling:
+//   pg_cron triggers this every 30 minutes via
+//   supabase/migrations/20260506000002_wait_time_aggregator_schedule.sql.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+// How far back to recompute aggregates each invocation.
+const AGGREGATION_WINDOW_HOURS = 24;
+
+// Minimum samples per bucket before a row is written. Mirrors the
+// client-side sparse-data fallback in #1119.
+const MIN_SAMPLE_COUNT = 5;
+
+// Maximum plausible wait time. Sessions where "left" is more than this
+// far from "arrived" are dropped — almost certainly a forgotten "left"
+// ping rather than a real 4-hour pump session.
+const MAX_WAIT_SECONDS = 60 * 60; // 1 hour
+
+// How long raw pings are retained before deletion.
+const PING_RETENTION_DAYS = 7;
+
+interface PingRow {
+  session_id: string;
+  station_id: string;
+  country_code: string;
+  event_type: 'arrived' | 'left';
+  recorded_at: string;
+}
+
+interface SessionPair {
+  station_id: string;
+  country_code: string;
+  arrived_at: number;
+  left_at: number;
+}
+
+Deno.serve(async (_req: Request) => {
+  try {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+
+    const windowStart = new Date(
+      Date.now() - AGGREGATION_WINDOW_HOURS * 60 * 60 * 1000,
+    ).toISOString();
+
+    // 1. Pull every ping in the recompute window. The aggregator runs
+    // service-role so RLS does not apply; we still scope by recorded_at
+    // to keep the working set bounded.
+    const { data: pings, error: pingsError } = await supabase
+      .from('wait_time_pings')
+      .select('session_id, station_id, country_code, event_type, recorded_at')
+      .gte('recorded_at', windowStart);
+
+    if (pingsError) {
+      console.error('Failed to fetch pings:', pingsError);
+      return new Response(JSON.stringify({ error: 'fetch_failed' }), {
+        status: 500,
+      });
+    }
+
+    const sessions = pairSessions((pings ?? []) as PingRow[]);
+    const buckets = bucketByStationHour(sessions);
+
+    // 2. Upsert one row per (station, hour) bucket that meets the
+    // sample-count floor. Sparse buckets are silently dropped.
+    let written = 0;
+    const computedAt = new Date().toISOString();
+    const rows = Array.from(buckets.values())
+      .filter((b) => b.waits.length >= MIN_SAMPLE_COUNT)
+      .map((b) => ({
+        station_id: b.station_id,
+        hour_bucket: b.hour_bucket,
+        country_code: b.country_code,
+        median_wait_seconds: median(b.waits),
+        sample_count: b.waits.length,
+        computed_at: computedAt,
+      }));
+
+    if (rows.length > 0) {
+      const { error: upsertError } = await supabase
+        .from('wait_time_aggregates')
+        .upsert(rows, { onConflict: 'station_id,hour_bucket' });
+
+      if (upsertError) {
+        console.error('Failed to upsert aggregates:', upsertError);
+        return new Response(JSON.stringify({ error: 'upsert_failed' }), {
+          status: 500,
+        });
+      }
+      written = rows.length;
+    }
+
+    // 3. Trim raw pings older than the retention horizon. Once a ping
+    // has rolled into a bucket the raw row carries no further value
+    // and keeping it around just widens the privacy surface.
+    const trimBefore = new Date(
+      Date.now() - PING_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    const { error: trimError } = await supabase
+      .from('wait_time_pings')
+      .delete()
+      .lt('recorded_at', trimBefore);
+
+    if (trimError) {
+      console.error('Failed to trim old pings:', trimError);
+    }
+
+    return new Response(
+      JSON.stringify({
+        sessions_paired: sessions.length,
+        buckets_written: written,
+        sparse_buckets_dropped: buckets.size - written,
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    console.error('aggregate-wait-times unhandled error:', err);
+    return new Response(JSON.stringify({ error: 'internal' }), {
+      status: 500,
+    });
+  }
+});
+
+/**
+ * Pair each session_id's "arrived" with its matching "left" ping.
+ * Sessions without both events, or with implausibly long waits, are
+ * dropped — they would skew the median.
+ */
+export function pairSessions(pings: PingRow[]): SessionPair[] {
+  const bySession = new Map<string, { arrived?: PingRow; left?: PingRow }>();
+
+  for (const p of pings) {
+    const slot = bySession.get(p.session_id) ?? {};
+    if (p.event_type === 'arrived') {
+      slot.arrived = p;
+    } else if (p.event_type === 'left') {
+      slot.left = p;
+    }
+    bySession.set(p.session_id, slot);
+  }
+
+  const out: SessionPair[] = [];
+  for (const { arrived, left } of bySession.values()) {
+    if (!arrived || !left) continue;
+    const arrivedMs = Date.parse(arrived.recorded_at);
+    const leftMs = Date.parse(left.recorded_at);
+    if (!Number.isFinite(arrivedMs) || !Number.isFinite(leftMs)) continue;
+    const waitSeconds = Math.round((leftMs - arrivedMs) / 1000);
+    if (waitSeconds <= 0 || waitSeconds > MAX_WAIT_SECONDS) continue;
+
+    out.push({
+      station_id: arrived.station_id,
+      country_code: arrived.country_code,
+      arrived_at: arrivedMs,
+      left_at: leftMs,
+    });
+  }
+  return out;
+}
+
+interface Bucket {
+  station_id: string;
+  country_code: string;
+  hour_bucket: string;
+  waits: number[];
+}
+
+/**
+ * Group sessions into (station_id, hour-of-arrival) buckets. The hour
+ * bucket key is the ISO timestamp of the start of the arrival hour
+ * (UTC) — matches the storage shape of wait_time_aggregates.hour_bucket.
+ */
+export function bucketByStationHour(sessions: SessionPair[]): Map<string, Bucket> {
+  const buckets = new Map<string, Bucket>();
+
+  for (const s of sessions) {
+    const arrived = new Date(s.arrived_at);
+    arrived.setUTCMinutes(0, 0, 0);
+    const hour = arrived.toISOString();
+    const key = `${s.station_id}|${hour}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        station_id: s.station_id,
+        country_code: s.country_code,
+        hour_bucket: hour,
+        waits: [],
+      };
+      buckets.set(key, bucket);
+    }
+    bucket.waits.push(Math.round((s.left_at - s.arrived_at) / 1000));
+  }
+  return buckets;
+}
+
+/**
+ * Median of a non-empty list of integers. For even-sized lists,
+ * returns the rounded mean of the two middle values.
+ */
+export function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const mid = Math.floor(n / 2);
+  if (n % 2 === 1) return sorted[mid];
+  return Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+}

--- a/supabase/migrations/20260506000001_wait_time_pings.sql
+++ b/supabase/migrations/20260506000001_wait_time_pings.sql
@@ -1,0 +1,81 @@
+-- #1119 — Crowd-sourced station wait-time signal.
+--
+-- Why: TankSync already carries community-config plumbing for opt-in
+-- crowd signals; this migration adds the server side for the
+-- "~6 min wait" hint shown next to price. Two tables:
+--
+--   public.wait_time_pings       — raw "arrived"/"left" events,
+--                                  scoped to the reporting user (RLS).
+--                                  The Edge Function aggregator reads
+--                                  these via service_role and trims
+--                                  rows older than the retention
+--                                  window after each run.
+--
+--   public.wait_time_aggregates  — anonymized rolling-median wait per
+--                                  (station, hour). Readable by every
+--                                  authenticated client; only the
+--                                  service_role aggregator writes.
+--                                  Sparse buckets (sample_count < 5)
+--                                  are not written, so the client
+--                                  fallback is automatic.
+--
+-- Privacy:
+--   - No lat/lng — only `station_id` + `country_code`.
+--   - Aggregate rows carry no `user_id`. The pings table is owned by
+--     the user and the aggregator emits user-free buckets.
+--   - `session_id` pairs an "arrived" with the matching "left" event
+--     without re-exposing user identity downstream.
+--
+-- RLS impact:
+--   [x] Adds new public tables → ENABLE ROW LEVEL SECURITY + policies
+--       covering both anon (none) and authenticated (own / read-all).
+--
+-- RLS confirmed: [x]
+--   docs/security/SUPABASE_RLS_MATRIX.md and
+--   test/security/supabase_rls_test.dart updated in the same PR.
+
+CREATE TABLE IF NOT EXISTS public.wait_time_pings (
+  id UUID NOT NULL DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  session_id UUID NOT NULL,
+  station_id TEXT NOT NULL,
+  country_code TEXT NOT NULL,
+  event_type TEXT NOT NULL CHECK (event_type IN ('arrived', 'left')),
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, id)
+);
+
+ALTER TABLE public.wait_time_pings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY wait_time_pings_own ON public.wait_time_pings
+  FOR ALL USING (user_id = auth.uid());
+
+CREATE INDEX wait_time_pings_user_idx ON public.wait_time_pings(user_id);
+CREATE INDEX wait_time_pings_station_recorded_idx
+  ON public.wait_time_pings(station_id, recorded_at);
+CREATE INDEX wait_time_pings_session_idx
+  ON public.wait_time_pings(session_id);
+
+
+CREATE TABLE IF NOT EXISTS public.wait_time_aggregates (
+  station_id TEXT NOT NULL,
+  hour_bucket TIMESTAMPTZ NOT NULL,
+  country_code TEXT NOT NULL,
+  median_wait_seconds INTEGER NOT NULL,
+  sample_count INTEGER NOT NULL CHECK (sample_count >= 5),
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (station_id, hour_bucket)
+);
+
+ALTER TABLE public.wait_time_aggregates ENABLE ROW LEVEL SECURITY;
+
+-- Aggregates are intentionally readable by every authenticated user:
+-- the whole point of the feature is showing the wait hint to anyone
+-- looking at the station. Writes are service-role only (the aggregator
+-- Edge Function); RLS without an INSERT/UPDATE/DELETE policy denies
+-- those operations to anon and authenticated by default.
+CREATE POLICY wait_aggregates_read ON public.wait_time_aggregates
+  FOR SELECT USING (true);
+
+CREATE INDEX wait_time_aggregates_station_idx
+  ON public.wait_time_aggregates(station_id, hour_bucket DESC);

--- a/supabase/migrations/20260506000002_wait_time_aggregator_schedule.sql
+++ b/supabase/migrations/20260506000002_wait_time_aggregator_schedule.sql
@@ -1,0 +1,33 @@
+-- #1119 — pg_cron schedule for the wait-time aggregator.
+--
+-- Why: keep the wait_time_aggregates rolling-median rows fresh
+-- without round-tripping through the client. Mirrors the existing
+-- check-alerts and record-prices schedules in
+-- 20260403000001_pg_cron_alert_schedules.sql.
+--
+-- RLS impact:
+--   [x] No public-table RLS change (schedules only).
+--
+-- RLS confirmed: [x] No matrix change required.
+
+-- Schedule: aggregate wait-time pings every 30 minutes.
+-- Edge Function returns within seconds for typical traffic; the
+-- 30-minute cadence keeps the "~6 min wait" hint usefully fresh
+-- without hammering pg_net.
+SELECT cron.schedule(
+  'aggregate-wait-times-every-30min',
+  '*/30 * * * *',
+  $$
+  SELECT net.http_post(
+    url := current_setting('app.settings.supabase_url') || '/functions/v1/aggregate-wait-times',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.settings.service_role_key'),
+      'Content-Type', 'application/json'
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- To unschedule:
+-- SELECT cron.unschedule('aggregate-wait-times-every-30min');

--- a/test/security/supabase_rls_test.dart
+++ b/test/security/supabase_rls_test.dart
@@ -114,6 +114,12 @@ void main() {
     'obd2_baselines': {
       'obd2_baselines_own': 'ALL',
     },
+    'wait_time_pings': {
+      'wait_time_pings_own': 'ALL',
+    },
+    'wait_time_aggregates': {
+      'wait_aggregates_read': 'SELECT',
+    },
   };
 
   group('Supabase RLS matrix (#1110)', () {


### PR DESCRIPTION
## Summary
Server side for the #1119 crowd-sourced wait-time hint. Adds two Supabase tables, an aggregator Edge Function, and a pg_cron schedule.

- `public.wait_time_pings` — raw `arrived`/`left` events scoped to the reporting user (RLS = own). The aggregator reads them via `service_role` and trims rows older than 7 days each run.
- `public.wait_time_aggregates` — anonymized rolling-median wait per `(station_id, hour_bucket)`. Read-all-authenticated; service-role writes only. Buckets with fewer than 5 samples are not written, so the client sparse-data fallback is automatic.
- `aggregate-wait-times` Edge Function — pairs `arrived`/`left` by `session_id`, drops waits > 1h as forgotten "left" pings, upserts buckets, trims old pings.
- pg_cron schedule: every 30 minutes.

Privacy invariants:
- Aggregates carry no `user_id`.
- Only `station_id` + `country_code` — no lat/lng anywhere on the wire.
- Raw pings are owned by the reporting user (RLS) and deleted after 7 days.

`docs/security/SUPABASE_RLS_MATRIX.md` and `test/security/supabase_rls_test.dart` are updated in the same commit (per the matrix workflow).

## What's NOT in this PR (phase 2)
- Opt-in toggle in `consent_settings_section.dart`
- `arrived`/`left` ping calls from the app (geofence on station radius)
- UI surfacing the "~N min wait" hint next to price

## Hosted apply (manual — agent can't do)
1. `cd supabase && supabase db push` (or paste both `2026-05-06*.sql` files into the SQL editor)
2. `supabase functions deploy aggregate-wait-times`
3. The pg_cron schedule activates automatically once both migrations apply.

A follow-up `chore(supabase):` issue is filed separately to track the manual deploy (mirroring #713).

## Test plan
- [ ] `flutter analyze` — clean (verified locally)
- [ ] `flutter test test/security/supabase_rls_test.dart` — skips locally (no creds), but matrix + test stay in lock-step for the staging run
- [ ] After hosted apply: `SUPABASE_TEST_URL=… SUPABASE_TEST_SERVICE_KEY=… flutter test --tags network test/security/supabase_rls_test.dart` succeeds
- [ ] After deploy: aggregator returns `{ sessions_paired, buckets_written, sparse_buckets_dropped }` JSON when invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)