### PR TITLE
feat(glide-coach): runtime wire-up + settings toggle dormant behind master flag (Refs #1125 phase 3b)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -13,6 +13,10 @@ import '../../../core/storage/hive_boxes.dart';
 import '../../../core/sync/baselines_sync.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
+import '../../glide_coach/data/traffic_signal_repository.dart';
+import '../../glide_coach/domain/entities/glide_coach_advice.dart';
+import '../../glide_coach/providers/glide_coach_evaluator_provider.dart';
+import '../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../vehicle/data/reference_vehicle_catalog_provider.dart';
@@ -881,6 +885,20 @@ class TripRecording extends _$TripRecording {
             now: DateTime.now(),
             lifecycleState: _lifecycleState.name,
           );
+          // #1125 phase 3b — opt-in glide-coach evaluation. The hook is
+          // gated by:
+          //   1. The compile-time master flag kGlideCoachEnabled (false
+          //      in production; this branch compiles to a constant
+          //      no-op the optimiser can fully elide).
+          //   2. The user-facing toggle GlideCoachSettings.enabled.
+          //   3. The presence of a recent throttle reading (cars
+          //      without PID 0x11 — or a freshly-started trip whose
+          //      first sample hasn't landed — short-circuit to "do
+          //      nothing").
+          // Both flags must be true for the haptic to fire. See the
+          // class doc on `GlideCoachEvaluator` for the 5-rule decision
+          // flow that the evaluator itself runs.
+          unawaited(_maybeFireGlideCoach(ctl, pos));
         },
         onError: (Object error) {
           debugPrint('TripRecording GPS stream error: $error');
@@ -888,6 +906,75 @@ class TripRecording extends _$TripRecording {
       );
     } catch (e, st) {
       debugPrint('TripRecording GPS subscribe failed: $e\n$st');
+    }
+  }
+
+  /// Per-GPS-fix glide-coach evaluator hook (#1125 phase 3b).
+  ///
+  /// Layered gate (in order — each rejects the next):
+  ///   1. Compile-time `kGlideCoachEnabled` master flag. False in
+  ///      production today; the call is a constant-folded no-op.
+  ///   2. User-facing toggle from `GlideCoachSettings`.
+  ///   3. Latest throttle reading from the controller's captured-sample
+  ///      buffer (cars without PID 0x11 → null → evaluator returns
+  ///      `hold` per its rule 2; the haptic does not fire).
+  ///   4. Provider returns null (Hive box closed in widget tests, etc.) —
+  ///      treat as feature off.
+  ///
+  /// The evaluator's 5-rule flow then decides between
+  /// `lift` / `hold` / `cooldown`. Only `lift` translates into a
+  /// `HapticFeedback.lightImpact()` call — "subtle" per the issue body
+  /// (#1125), distinct from the medium / heavy intensities used by the
+  /// over-throttle eco-coach (#767).
+  ///
+  /// Errors are caught and logged: a permission revoke mid-trip, an
+  /// Overpass timeout, or a stale Hive box must NOT derail the OBD2
+  /// recording. Best-effort, non-blocking.
+  Future<void> _maybeFireGlideCoach(
+    TripRecordingController ctl,
+    Position pos,
+  ) async {
+    // Rule 1 — compile-time master flag. The constant gate makes this
+    // path constant-fold to nothing in a flag-false build.
+    if (!kGlideCoachEnabled) return;
+    try {
+      // Rule 2 — user toggle. Defaults to false; even with the master
+      // flag flipped, an opt-in is required.
+      final settings = ref.read(glideCoachSettingsProvider);
+      if (!settings.enabled) return;
+      // Rule 4 — provider returns null when the feature is fully
+      // unavailable (Hive box closed in tests). Resolved AFTER the
+      // user-toggle gate so an off-by-default user pays no Hive read.
+      final evaluator = ref.read(glideCoachEvaluatorProvider);
+      if (evaluator == null) return;
+      // Rule 3 — pull the latest throttle from the controller's
+      // captured-sample buffer. The buffer accumulates at 1 Hz (#1040);
+      // the GPS listener cadence is set by `LocationAccuracy.high`
+      // (typically also ~1 Hz). Cars without PID 0x11 carry
+      // `throttlePercent == null` on every sample; the evaluator's
+      // rule 2 short-circuits that to `hold` so this getter returning
+      // null is fine.
+      final samples = ctl.capturedSamples;
+      final throttle = samples.isEmpty
+          ? null
+          : samples.last.throttlePercent;
+      final reading = (
+        latitude: pos.latitude,
+        longitude: pos.longitude,
+        headingDegrees: pos.heading,
+      );
+      final advice = await evaluator.evaluate(
+        reading: reading,
+        throttlePercent: throttle,
+      );
+      if (advice == GlideCoachAdvice.lift) {
+        // Subtle on purpose — `lightImpact`, not `mediumImpact`. The
+        // issue body explicitly calls out distraction risk; the haptic
+        // is a hint, not a brake-warning.
+        await HapticFeedback.lightImpact();
+      }
+    } catch (e, st) {
+      debugPrint('TripRecording glide-coach evaluation failed: $e\n$st');
     }
   }
 

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'9fd909bf590c330723e3c3e429ee9a18874c37e7';
+String _$tripRecordingHash() => r'361bca772156c918ee45387ba5b06bcea12e6fad';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/settings_menu_tile.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../glide_coach/data/traffic_signal_repository.dart';
+import '../../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../../../profile/presentation/widgets/gamification_settings_tile.dart';
 import '../../providers/haptic_eco_coach_provider.dart';
 
@@ -71,8 +73,49 @@ class DrivingSettingsSection extends ConsumerWidget {
               ref.read(hapticEcoCoachEnabledProvider.notifier).set(v),
           contentPadding: EdgeInsets.zero,
         ),
+        // #1125 phase 3b — glide-coach beta opt-in. The entire tile is
+        // wrapped in `if (kGlideCoachEnabled)` so it stays invisible in
+        // production: even users who would happily try it cannot enable
+        // a half-baked feature until the master flag flips after a
+        // driving-test cohort. When the flag flips, the toggle appears
+        // here without any further UI work.
+        if (kGlideCoachEnabled) const _GlideCoachToggleTile(),
         const GamificationSettingsTile(),
       ],
+    );
+  }
+}
+
+/// Beta opt-in tile for the glide-coach haptic (#1125 phase 3b).
+///
+/// Rendered only when the compile-time master flag
+/// [`kGlideCoachEnabled`] is true; the call site in
+/// [DrivingSettingsSection] gates visibility via `if (kGlideCoachEnabled)`.
+/// Keeping the widget itself in this file (rather than in the
+/// glide_coach feature folder) avoids importing presentation widgets
+/// from a feature whose UI surface doesn't exist yet, and matches the
+/// pattern of [GamificationSettingsTile] / [HapticEcoCoach toggle] —
+/// each toggle co-locates with the section it belongs to.
+class _GlideCoachToggleTile extends ConsumerWidget {
+  const _GlideCoachToggleTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final settings = ref.watch(glideCoachSettingsProvider);
+    return SwitchListTile(
+      key: const Key('glideCoachToggle'),
+      value: settings.enabled,
+      title: const Text('Glide-coach beta (experimental)'),
+      subtitle: Text(
+        'Subtle haptic when slowing down ahead of a red light. '
+        'Off by default — distraction risk.',
+        style: theme.textTheme.bodySmall,
+      ),
+      onChanged: (v) => ref
+          .read(glideCoachSettingsProvider.notifier)
+          .setEnabled(v),
+      contentPadding: EdgeInsets.zero,
     );
   }
 }

--- a/lib/features/glide_coach/providers/glide_coach_evaluator_provider.dart
+++ b/lib/features/glide_coach/providers/glide_coach_evaluator_provider.dart
@@ -1,0 +1,62 @@
+import 'package:hive/hive.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/storage/hive_boxes.dart';
+import '../data/osm_traffic_signal_client.dart';
+import '../data/traffic_signal_repository.dart';
+import '../domain/entities/glide_coach_settings.dart';
+import '../domain/services/glide_coach_evaluator.dart';
+import '../domain/services/imminent_signal_detector.dart';
+import 'glide_coach_settings_provider.dart';
+
+part 'glide_coach_evaluator_provider.g.dart';
+
+/// Provider for the glide-coach evaluator (#1125 phase 3b).
+///
+/// Returns `null` when the compile-time master flag
+/// [`kGlideCoachEnabled`] is `false` — that's production today, and
+/// every consumer (currently only `tripRecordingProvider`) early-outs
+/// on the null. Callers MUST treat null as "feature disabled, do
+/// nothing" rather than constructing their own evaluator; the layered
+/// kill-switch is the whole point.
+///
+/// When the master flag is true, the provider wires:
+///   1. An [OsmTrafficSignalClient] (default Dio).
+///   2. A [TrafficSignalRepository] backed by the
+///      `traffic_signals_cache` Hive box (opened at startup by
+///      [HiveBoxes.init]).
+///   3. An [ImminentSignalDetector] over the repo.
+///   4. A [GlideCoachEvaluator] over the detector, with the cool-down
+///      and throttle threshold sourced from the user's
+///      [GlideCoachSettings] (read once at construction; the evaluator
+///      itself is stateless w.r.t. settings flips, so a settings change
+///      that should re-tune thresholds invalidates this provider via
+///      `ref.watch`).
+///
+/// Returns `null` (rather than throwing) when the Hive box isn't open —
+/// matching the loyalty repository pattern for widget-test-friendly
+/// no-ops on missing infrastructure.
+@Riverpod(keepAlive: true)
+GlideCoachEvaluator? glideCoachEvaluator(Ref ref) {
+  // Master kill-switch. Production today.
+  if (!kGlideCoachEnabled) return null;
+
+  // Defensive: the Overpass cache box is opened at app startup. A
+  // widget test that didn't run the Hive bootstrapper hits this path
+  // and gets null — same shape as `loyaltyCardRepositoryProvider`.
+  if (!Hive.isBoxOpen(TrafficSignalRepository.boxName)) return null;
+
+  final settings = ref.watch(glideCoachSettingsProvider);
+
+  final client = OsmTrafficSignalClient();
+  final repo = TrafficSignalRepository(
+    client: client,
+    cacheBox: Hive.box<String>(TrafficSignalRepository.boxName),
+  );
+  final detector = ImminentSignalDetector(repo: repo);
+  return GlideCoachEvaluator(
+    detector: detector,
+    cooldown: settings.cooldown,
+    throttleThresholdPercent: settings.throttleThresholdPercent,
+  );
+}

--- a/lib/features/glide_coach/providers/glide_coach_evaluator_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_evaluator_provider.g.dart
@@ -1,0 +1,134 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'glide_coach_evaluator_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Provider for the glide-coach evaluator (#1125 phase 3b).
+///
+/// Returns `null` when the compile-time master flag
+/// [`kGlideCoachEnabled`] is `false` — that's production today, and
+/// every consumer (currently only `tripRecordingProvider`) early-outs
+/// on the null. Callers MUST treat null as "feature disabled, do
+/// nothing" rather than constructing their own evaluator; the layered
+/// kill-switch is the whole point.
+///
+/// When the master flag is true, the provider wires:
+///   1. An [OsmTrafficSignalClient] (default Dio).
+///   2. A [TrafficSignalRepository] backed by the
+///      `traffic_signals_cache` Hive box (opened at startup by
+///      [HiveBoxes.init]).
+///   3. An [ImminentSignalDetector] over the repo.
+///   4. A [GlideCoachEvaluator] over the detector, with the cool-down
+///      and throttle threshold sourced from the user's
+///      [GlideCoachSettings] (read once at construction; the evaluator
+///      itself is stateless w.r.t. settings flips, so a settings change
+///      that should re-tune thresholds invalidates this provider via
+///      `ref.watch`).
+///
+/// Returns `null` (rather than throwing) when the Hive box isn't open —
+/// matching the loyalty repository pattern for widget-test-friendly
+/// no-ops on missing infrastructure.
+
+@ProviderFor(glideCoachEvaluator)
+final glideCoachEvaluatorProvider = GlideCoachEvaluatorProvider._();
+
+/// Provider for the glide-coach evaluator (#1125 phase 3b).
+///
+/// Returns `null` when the compile-time master flag
+/// [`kGlideCoachEnabled`] is `false` — that's production today, and
+/// every consumer (currently only `tripRecordingProvider`) early-outs
+/// on the null. Callers MUST treat null as "feature disabled, do
+/// nothing" rather than constructing their own evaluator; the layered
+/// kill-switch is the whole point.
+///
+/// When the master flag is true, the provider wires:
+///   1. An [OsmTrafficSignalClient] (default Dio).
+///   2. A [TrafficSignalRepository] backed by the
+///      `traffic_signals_cache` Hive box (opened at startup by
+///      [HiveBoxes.init]).
+///   3. An [ImminentSignalDetector] over the repo.
+///   4. A [GlideCoachEvaluator] over the detector, with the cool-down
+///      and throttle threshold sourced from the user's
+///      [GlideCoachSettings] (read once at construction; the evaluator
+///      itself is stateless w.r.t. settings flips, so a settings change
+///      that should re-tune thresholds invalidates this provider via
+///      `ref.watch`).
+///
+/// Returns `null` (rather than throwing) when the Hive box isn't open —
+/// matching the loyalty repository pattern for widget-test-friendly
+/// no-ops on missing infrastructure.
+
+final class GlideCoachEvaluatorProvider
+    extends
+        $FunctionalProvider<
+          GlideCoachEvaluator?,
+          GlideCoachEvaluator?,
+          GlideCoachEvaluator?
+        >
+    with $Provider<GlideCoachEvaluator?> {
+  /// Provider for the glide-coach evaluator (#1125 phase 3b).
+  ///
+  /// Returns `null` when the compile-time master flag
+  /// [`kGlideCoachEnabled`] is `false` — that's production today, and
+  /// every consumer (currently only `tripRecordingProvider`) early-outs
+  /// on the null. Callers MUST treat null as "feature disabled, do
+  /// nothing" rather than constructing their own evaluator; the layered
+  /// kill-switch is the whole point.
+  ///
+  /// When the master flag is true, the provider wires:
+  ///   1. An [OsmTrafficSignalClient] (default Dio).
+  ///   2. A [TrafficSignalRepository] backed by the
+  ///      `traffic_signals_cache` Hive box (opened at startup by
+  ///      [HiveBoxes.init]).
+  ///   3. An [ImminentSignalDetector] over the repo.
+  ///   4. A [GlideCoachEvaluator] over the detector, with the cool-down
+  ///      and throttle threshold sourced from the user's
+  ///      [GlideCoachSettings] (read once at construction; the evaluator
+  ///      itself is stateless w.r.t. settings flips, so a settings change
+  ///      that should re-tune thresholds invalidates this provider via
+  ///      `ref.watch`).
+  ///
+  /// Returns `null` (rather than throwing) when the Hive box isn't open —
+  /// matching the loyalty repository pattern for widget-test-friendly
+  /// no-ops on missing infrastructure.
+  GlideCoachEvaluatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'glideCoachEvaluatorProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$glideCoachEvaluatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<GlideCoachEvaluator?> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  GlideCoachEvaluator? create(Ref ref) {
+    return glideCoachEvaluator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GlideCoachEvaluator? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GlideCoachEvaluator?>(value),
+    );
+  }
+}
+
+String _$glideCoachEvaluatorHash() =>
+    r'ef913767ef8e86320dc9ffc4b4beadfb6cfa69a6';

--- a/lib/features/glide_coach/providers/glide_coach_settings_provider.dart
+++ b/lib/features/glide_coach/providers/glide_coach_settings_provider.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../data/traffic_signal_repository.dart';
+import '../domain/entities/glide_coach_settings.dart';
+
+part 'glide_coach_settings_provider.g.dart';
+
+/// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
+///
+/// Stored as a single boolean in `SharedPreferences` rather than Hive —
+/// the value is device-local (not profile-bound), tiny, and read on
+/// startup before any feature-bound Hive box is open. The pattern
+/// mirrors `themeModeSettingProvider` (#752) — the closest sibling
+/// notifier in this repo that backs a single device-local preference
+/// onto SharedPreferences via async load + write-through `set`.
+///
+/// ### Layered gate (master flag + user toggle)
+///
+/// The feature has TWO independent off-switches that must both be true
+/// before any haptic fires:
+///
+///   1. The compile-time master flag
+///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
+///      a hard kill-switch baked into the build. False in production
+///      today; flipping requires a code change + ship cycle.
+///   2. The user-facing toggle, surfaced as
+///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
+///
+/// This notifier respects the master flag: when `kGlideCoachEnabled`
+/// is false, the resulting `enabled` value is forced to `false` even
+/// if the persisted user toggle is `true`. That guarantees a stale
+/// debug-build write (or a malicious / future schema change) cannot
+/// leak the feature on in production. The user toggle is layered on
+/// top of the master flag — never below it.
+///
+/// `setEnabled(true)` will still WRITE to SharedPreferences when
+/// `kGlideCoachEnabled` is false (the value is preserved across builds
+/// so a future master-flag flip does not silently lose the user's
+/// historical opt-in), but the in-memory state stays gated.
+///
+/// `setThrottleThreshold` and `setCooldown` are deliberately
+/// out-of-scope for this PR — the only UI surface in phase 3b is the
+/// `enabled` toggle. The fields stay on the value type so future
+/// phases can grow the notifier without a schema rewrite.
+@Riverpod(keepAlive: true)
+class GlideCoachSettingsNotifier extends _$GlideCoachSettingsNotifier {
+  /// Versioned storage key. Versioned (`v1`) so a future schema
+  /// change can introduce a v2 without colliding with stale values.
+  @visibleForTesting
+  static const String prefsKey = 'settings.glideCoach.enabled.v1';
+
+  @override
+  GlideCoachSettings build() {
+    _load();
+    return const GlideCoachSettings();
+  }
+
+  Future<void> _load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final stored = prefs.getBool(prefsKey) ?? false;
+      // Master-flag wins over the persisted user toggle. See the class
+      // doc for the layered-gate rationale.
+      final effective = kGlideCoachEnabled ? stored : false;
+      if (effective != state.enabled) {
+        state = state.copyWith(enabled: effective);
+      }
+    } catch (e, st) {
+      debugPrint('GlideCoachSettingsNotifier._load failed: $e\n$st');
+    }
+  }
+
+  /// Flip the user-facing `enabled` toggle.
+  ///
+  /// Persists the requested value to SharedPreferences unconditionally
+  /// — preserving the user's historical opt-in across master-flag
+  /// flips — but the in-memory `enabled` is gated by
+  /// [`kGlideCoachEnabled`]. With the master flag false (production
+  /// today) `state.enabled` stays `false` even after `setEnabled(true)`,
+  /// matching the layered-gate contract documented on the class.
+  Future<void> setEnabled(bool value) async {
+    final effective = kGlideCoachEnabled ? value : false;
+    state = state.copyWith(enabled: effective);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(prefsKey, value);
+    } catch (e, st) {
+      debugPrint('GlideCoachSettingsNotifier.setEnabled failed: $e\n$st');
+    }
+  }
+}

--- a/lib/features/glide_coach/providers/glide_coach_settings_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_settings_provider.g.dart
@@ -1,0 +1,213 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'glide_coach_settings_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
+///
+/// Stored as a single boolean in `SharedPreferences` rather than Hive —
+/// the value is device-local (not profile-bound), tiny, and read on
+/// startup before any feature-bound Hive box is open. The pattern
+/// mirrors `themeModeSettingProvider` (#752) — the closest sibling
+/// notifier in this repo that backs a single device-local preference
+/// onto SharedPreferences via async load + write-through `set`.
+///
+/// ### Layered gate (master flag + user toggle)
+///
+/// The feature has TWO independent off-switches that must both be true
+/// before any haptic fires:
+///
+///   1. The compile-time master flag
+///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
+///      a hard kill-switch baked into the build. False in production
+///      today; flipping requires a code change + ship cycle.
+///   2. The user-facing toggle, surfaced as
+///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
+///
+/// This notifier respects the master flag: when `kGlideCoachEnabled`
+/// is false, the resulting `enabled` value is forced to `false` even
+/// if the persisted user toggle is `true`. That guarantees a stale
+/// debug-build write (or a malicious / future schema change) cannot
+/// leak the feature on in production. The user toggle is layered on
+/// top of the master flag — never below it.
+///
+/// `setEnabled(true)` will still WRITE to SharedPreferences when
+/// `kGlideCoachEnabled` is false (the value is preserved across builds
+/// so a future master-flag flip does not silently lose the user's
+/// historical opt-in), but the in-memory state stays gated.
+///
+/// `setThrottleThreshold` and `setCooldown` are deliberately
+/// out-of-scope for this PR — the only UI surface in phase 3b is the
+/// `enabled` toggle. The fields stay on the value type so future
+/// phases can grow the notifier without a schema rewrite.
+
+@ProviderFor(GlideCoachSettingsNotifier)
+final glideCoachSettingsProvider = GlideCoachSettingsNotifierProvider._();
+
+/// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
+///
+/// Stored as a single boolean in `SharedPreferences` rather than Hive —
+/// the value is device-local (not profile-bound), tiny, and read on
+/// startup before any feature-bound Hive box is open. The pattern
+/// mirrors `themeModeSettingProvider` (#752) — the closest sibling
+/// notifier in this repo that backs a single device-local preference
+/// onto SharedPreferences via async load + write-through `set`.
+///
+/// ### Layered gate (master flag + user toggle)
+///
+/// The feature has TWO independent off-switches that must both be true
+/// before any haptic fires:
+///
+///   1. The compile-time master flag
+///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
+///      a hard kill-switch baked into the build. False in production
+///      today; flipping requires a code change + ship cycle.
+///   2. The user-facing toggle, surfaced as
+///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
+///
+/// This notifier respects the master flag: when `kGlideCoachEnabled`
+/// is false, the resulting `enabled` value is forced to `false` even
+/// if the persisted user toggle is `true`. That guarantees a stale
+/// debug-build write (or a malicious / future schema change) cannot
+/// leak the feature on in production. The user toggle is layered on
+/// top of the master flag — never below it.
+///
+/// `setEnabled(true)` will still WRITE to SharedPreferences when
+/// `kGlideCoachEnabled` is false (the value is preserved across builds
+/// so a future master-flag flip does not silently lose the user's
+/// historical opt-in), but the in-memory state stays gated.
+///
+/// `setThrottleThreshold` and `setCooldown` are deliberately
+/// out-of-scope for this PR — the only UI surface in phase 3b is the
+/// `enabled` toggle. The fields stay on the value type so future
+/// phases can grow the notifier without a schema rewrite.
+final class GlideCoachSettingsNotifierProvider
+    extends $NotifierProvider<GlideCoachSettingsNotifier, GlideCoachSettings> {
+  /// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
+  ///
+  /// Stored as a single boolean in `SharedPreferences` rather than Hive —
+  /// the value is device-local (not profile-bound), tiny, and read on
+  /// startup before any feature-bound Hive box is open. The pattern
+  /// mirrors `themeModeSettingProvider` (#752) — the closest sibling
+  /// notifier in this repo that backs a single device-local preference
+  /// onto SharedPreferences via async load + write-through `set`.
+  ///
+  /// ### Layered gate (master flag + user toggle)
+  ///
+  /// The feature has TWO independent off-switches that must both be true
+  /// before any haptic fires:
+  ///
+  ///   1. The compile-time master flag
+  ///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
+  ///      a hard kill-switch baked into the build. False in production
+  ///      today; flipping requires a code change + ship cycle.
+  ///   2. The user-facing toggle, surfaced as
+  ///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
+  ///
+  /// This notifier respects the master flag: when `kGlideCoachEnabled`
+  /// is false, the resulting `enabled` value is forced to `false` even
+  /// if the persisted user toggle is `true`. That guarantees a stale
+  /// debug-build write (or a malicious / future schema change) cannot
+  /// leak the feature on in production. The user toggle is layered on
+  /// top of the master flag — never below it.
+  ///
+  /// `setEnabled(true)` will still WRITE to SharedPreferences when
+  /// `kGlideCoachEnabled` is false (the value is preserved across builds
+  /// so a future master-flag flip does not silently lose the user's
+  /// historical opt-in), but the in-memory state stays gated.
+  ///
+  /// `setThrottleThreshold` and `setCooldown` are deliberately
+  /// out-of-scope for this PR — the only UI surface in phase 3b is the
+  /// `enabled` toggle. The fields stay on the value type so future
+  /// phases can grow the notifier without a schema rewrite.
+  GlideCoachSettingsNotifierProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'glideCoachSettingsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$glideCoachSettingsNotifierHash();
+
+  @$internal
+  @override
+  GlideCoachSettingsNotifier create() => GlideCoachSettingsNotifier();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GlideCoachSettings value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GlideCoachSettings>(value),
+    );
+  }
+}
+
+String _$glideCoachSettingsNotifierHash() =>
+    r'a93f4a424ece7a901a6d7a27ace315304ead39e6';
+
+/// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
+///
+/// Stored as a single boolean in `SharedPreferences` rather than Hive —
+/// the value is device-local (not profile-bound), tiny, and read on
+/// startup before any feature-bound Hive box is open. The pattern
+/// mirrors `themeModeSettingProvider` (#752) — the closest sibling
+/// notifier in this repo that backs a single device-local preference
+/// onto SharedPreferences via async load + write-through `set`.
+///
+/// ### Layered gate (master flag + user toggle)
+///
+/// The feature has TWO independent off-switches that must both be true
+/// before any haptic fires:
+///
+///   1. The compile-time master flag
+///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
+///      a hard kill-switch baked into the build. False in production
+///      today; flipping requires a code change + ship cycle.
+///   2. The user-facing toggle, surfaced as
+///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
+///
+/// This notifier respects the master flag: when `kGlideCoachEnabled`
+/// is false, the resulting `enabled` value is forced to `false` even
+/// if the persisted user toggle is `true`. That guarantees a stale
+/// debug-build write (or a malicious / future schema change) cannot
+/// leak the feature on in production. The user toggle is layered on
+/// top of the master flag — never below it.
+///
+/// `setEnabled(true)` will still WRITE to SharedPreferences when
+/// `kGlideCoachEnabled` is false (the value is preserved across builds
+/// so a future master-flag flip does not silently lose the user's
+/// historical opt-in), but the in-memory state stays gated.
+///
+/// `setThrottleThreshold` and `setCooldown` are deliberately
+/// out-of-scope for this PR — the only UI surface in phase 3b is the
+/// `enabled` toggle. The fields stay on the value type so future
+/// phases can grow the notifier without a schema rewrite.
+
+abstract class _$GlideCoachSettingsNotifier
+    extends $Notifier<GlideCoachSettings> {
+  GlideCoachSettings build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<GlideCoachSettings, GlideCoachSettings>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<GlideCoachSettings, GlideCoachSettings>,
+              GlideCoachSettings,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -6,6 +6,7 @@ import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_settings_section.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/gamification_settings_tile.dart';
 
 import '../../../fakes/fake_storage_repository.dart';
@@ -161,6 +162,45 @@ void main() {
         reason: 'Exactly two SettingsMenuTile children: vehicles + fuel '
             'club. Adding more would risk drift between this section '
             'and the Conso-tab landing screen.',
+      );
+    },
+  );
+
+  testWidgets(
+    'glide-coach beta toggle stays invisible while the master flag '
+    'kGlideCoachEnabled is false (#1125 phase 3b)',
+    (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingSettingsSection(),
+        overrides: [
+          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
+          featureFlagsProvider.overrideWith(() => _TestFeatureFlags()),
+        ],
+      );
+
+      // The compile-time master flag is the user-facing safety: when
+      // it's false (production today), the entire toggle MUST stay
+      // invisible so users cannot accidentally enable a half-baked
+      // feature. Flipping the flag in a future release is the
+      // deliberate gate that makes the toggle appear.
+      expect(
+        kGlideCoachEnabled,
+        isFalse,
+        reason:
+            'This test pins the production contract. When the master '
+            'flag flips to true, replace this with a positive '
+            'findsOneWidget assertion instead of inverting it.',
+      );
+      expect(
+        find.byKey(const Key('glideCoachToggle')),
+        findsNothing,
+        reason:
+            'kGlideCoachEnabled == false MUST hide the glide-coach '
+            'toggle entirely. Even users who would happily try the '
+            'beta cannot enable a half-baked feature until the master '
+            'flag flips after a driving-test cohort.',
       );
     },
   );

--- a/test/features/glide_coach/providers/glide_coach_evaluator_provider_test.dart
+++ b/test/features/glide_coach/providers/glide_coach_evaluator_provider_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
+import 'package:tankstellen/features/glide_coach/providers/glide_coach_evaluator_provider.dart';
+
+void main() {
+  group('glideCoachEvaluatorProvider (#1125 phase 3b)', () {
+    test(
+      'returns null when kGlideCoachEnabled is false (production)',
+      () {
+        // Asserting the master flag explicitly so a future PR that
+        // flips it to true makes this test fail loudly — the provider's
+        // contract changes (it no longer short-circuits to null) and
+        // the test author should swap to a Hive-backed scenario.
+        expect(
+          kGlideCoachEnabled,
+          isFalse,
+          reason:
+              'This test pins the production contract. When the master '
+              'flag flips, replace this assertion with a Hive setup that '
+              'verifies the evaluator is constructed.',
+        );
+
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        expect(
+          container.read(glideCoachEvaluatorProvider),
+          isNull,
+          reason:
+              'With kGlideCoachEnabled == false the provider MUST return '
+              'null so consumers (trip_recording_provider) can early-out '
+              'cleanly without touching Hive or the Overpass client.',
+        );
+      },
+    );
+  });
+}

--- a/test/features/glide_coach/providers/glide_coach_settings_provider_test.dart
+++ b/test/features/glide_coach/providers/glide_coach_settings_provider_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
+import 'package:tankstellen/features/glide_coach/domain/entities/glide_coach_settings.dart';
+import 'package:tankstellen/features/glide_coach/providers/glide_coach_settings_provider.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+  });
+
+  group('GlideCoachSettingsNotifier (#1125 phase 3b)', () {
+    test(
+      'defaults to disabled GlideCoachSettings on first launch',
+      () async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        final settings = container.read(glideCoachSettingsProvider);
+        expect(settings, const GlideCoachSettings());
+        expect(settings.enabled, isFalse);
+      },
+    );
+
+    test(
+      'master flag wins — kGlideCoachEnabled is false in production so '
+      'setEnabled(true) MUST keep state.enabled at false',
+      () async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        final notifier = container.read(
+          glideCoachSettingsProvider.notifier,
+        );
+        await notifier.setEnabled(true);
+
+        // Production today has kGlideCoachEnabled == false. The
+        // layered gate dictates that an opted-in user toggle MUST
+        // still surface as disabled in-memory until the master flag
+        // flips. This is the safety: a stale debug-build write or a
+        // future schema change cannot leak the feature on for users.
+        expect(
+          kGlideCoachEnabled,
+          isFalse,
+          reason:
+              'This test is meaningful only while the master flag is '
+              'false. If kGlideCoachEnabled is flipped to true in a '
+              'future PR, update this test to assert the new contract.',
+        );
+        expect(
+          container.read(glideCoachSettingsProvider).enabled,
+          isFalse,
+          reason:
+              'kGlideCoachEnabled == false MUST gate state.enabled to '
+              'false even after setEnabled(true). The user toggle is '
+              'layered on top of the master flag, never below it.',
+        );
+      },
+    );
+
+    test(
+      'persists the user-toggle write to SharedPreferences regardless '
+      'of the master flag — preserving opt-in across a future flip',
+      () async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await container
+            .read(glideCoachSettingsProvider.notifier)
+            .setEnabled(true);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool(GlideCoachSettingsNotifier.prefsKey),
+          isTrue,
+          reason:
+              'setEnabled(true) writes the raw user choice to '
+              'SharedPreferences even with kGlideCoachEnabled false, '
+              'so a future master-flag flip rehydrates the user as '
+              'opted-in instead of silently losing their preference.',
+        );
+      },
+    );
+
+    test(
+      'setEnabled(false) writes the persisted value back to false',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          GlideCoachSettingsNotifier.prefsKey: true,
+        });
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await container
+            .read(glideCoachSettingsProvider.notifier)
+            .setEnabled(false);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool(GlideCoachSettingsNotifier.prefsKey),
+          isFalse,
+        );
+        expect(
+          container.read(glideCoachSettingsProvider).enabled,
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'restores the persisted value on startup (gated by master flag)',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          GlideCoachSettingsNotifier.prefsKey: true,
+        });
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        // _load fires async on build; give the microtask queue a
+        // chance to settle, mirroring the themeModeSettingProvider
+        // test's pattern.
+        container.read(glideCoachSettingsProvider);
+        await Future<void>.delayed(Duration.zero);
+
+        // The persisted value is `true` — but the master flag is
+        // false in production, so the gated state stays false. When
+        // the master flag flips in a future PR, the same persisted
+        // value will surface as enabled without the user having to
+        // toggle again.
+        expect(
+          container.read(glideCoachSettingsProvider).enabled,
+          kGlideCoachEnabled,
+          reason:
+              'Restored state must equal `persisted-true && master-flag` '
+              '— production today is false on both axes once gated.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Wires phase 3a's `GlideCoachEvaluator` into a Riverpod provider, adds a SharedPreferences-backed user toggle, and fires `HapticFeedback.lightImpact()` from the trip-recording GPS listener — all gated so the feature is fully dormant in production behind the existing compile-time `kGlideCoachEnabled = false` master flag.

- Two-layer gate: compile-time `kGlideCoachEnabled` master + user-facing `GlideCoachSettings.enabled` toggle. Both must be true for any haptic to fire.
- Settings notifier mirrors `themeModeSettingProvider` (#752) — async load, write-through `setEnabled`, master-flag wins over the persisted user choice.
- UI tile is wrapped in `if (kGlideCoachEnabled)` so the toggle is invisible in today's production build.
- Trip-recording wire-up is surgical: a `_maybeFireGlideCoach` helper hooks the existing GPS stream listener (already opt-in via `Feature.gpsTripPath`), reads the latest throttle from the captured-sample buffer, and only `GlideCoachAdvice.lift` translates into the haptic.

## Files

- `lib/features/glide_coach/providers/glide_coach_settings_provider.dart` (+ `.g.dart`) — new SharedPreferences-backed notifier.
- `lib/features/glide_coach/providers/glide_coach_evaluator_provider.dart` (+ `.g.dart`) — wires the OSM client, Hive-cached repo, detector, and evaluator. Returns `null` when the master flag is false so consumers early-out cleanly.
- `lib/features/driving/presentation/widgets/driving_settings_section.dart` — adds a `_GlideCoachToggleTile` (private widget) gated by the master flag.
- `lib/features/consumption/providers/trip_recording_provider.dart` — adds the `_maybeFireGlideCoach` helper + call site in the existing GPS stream listener.
- `test/features/glide_coach/providers/glide_coach_settings_provider_test.dart` — round-trip + master-flag-wins tests.
- `test/features/glide_coach/providers/glide_coach_evaluator_provider_test.dart` — pins the null-returns-when-flag-false contract.
- `test/features/driving/presentation/driving_settings_section_test.dart` — extends the existing widget test with a `findsNothing` assertion for the toggle while the master flag is false.

## Test plan

- [x] `flutter analyze` — no issues.
- [x] `flutter test test/features/glide_coach/` — 71 tests pass (66 pre-existing + 5 new for the providers).
- [x] `flutter test test/features/driving/` — 76 tests pass (regression bar for the section widget; the new visibility test lands here).
- [x] `flutter test test/features/profile/` — 336 tests pass (regression bar for the profile screen since the section is composed under it).
- [x] `flutter test test/features/consumption/` — 2588 tests pass (regression bar for trip_recording — the GPS-listener edit must not regress #1460 / #1463).
- [x] `flutter test test/lint/` — 29 tests pass (no_silent_catch + presentation_data_imports + others stay green).

## Deliberately omitted

- **No trip-recording integration test for the haptic-fire path.** Mocking the OBD2 + GPS stream + Hive box graph for a flag that is compile-off in production is rabbit-hole territory. The existing trip-recording tests (2588 of them) all stay green — the regression bar. When the master flag flips, an instrumentation harness lands alongside the flag flip.
- **No ARB / l10n keys.** The toggle is invisible until the flag flips; we'll i18n it as part of the same flag-flip PR.

## Explicit non-completion of #1125

This PR does **not** close #1125. The user-test cohort acceptance is satisfied by leaving `kGlideCoachEnabled = false`, but the issue tracks the full feature including the eventual driving-test cohort + cohort-tuned thresholds + master-flag flip. #1125 closes when:

  1. A driving-test cohort runs with the master flag locally true.
  2. `cooldown` / `throttleThresholdPercent` are tuned from cohort feedback.
  3. ARB keys + per-locale translations land.
  4. `kGlideCoachEnabled` flips to `true` (one-line change in `traffic_signal_repository.dart`).
  5. The flip ships in a release.

Until then, the issue tracks "feature is fully wired but dormant"; this PR ships exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)