### PR TITLE
chore(branding): Tankerkönig API key URL → onboarding subdomain + clickable attribution

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -38,7 +38,14 @@ class AppConstants {
   static const String osmAttribution =
       '\u00a9 OpenStreetMap contributors';
 
+  /// Where the user requests a personal Tankerk\u00f6nig API key.
   static const String tankerkoenigRegistrationUrl =
+      'https://onboarding.tankerkoenig.de/';
+
+  /// Where the [tankerkoenigAttribution] string points \u2014 the project's
+  /// CC BY 4.0 page that documents the data licence + how the dataset
+  /// is built. Linked from the about / parameters screen.
+  static const String tankerkoenigCreativeCommonsUrl =
       'https://creativecommons.tankerkoenig.de/';
 
   static const String privacyPolicyUrl =

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -86,7 +86,7 @@ class Countries {
     postalCodeRegex: r'^\d{5}$',
     postalCodeLabel: 'PLZ',
     requiresApiKey: true,
-    apiKeyRegistrationUrl: 'https://creativecommons.tankerkoenig.de/',
+    apiKeyRegistrationUrl: 'https://onboarding.tankerkoenig.de/',
     apiProvider: 'Tankerkönig',
     attribution: 'Daten von Tankerkoenig.de (CC BY 4.0)',
     fuelTypes: ['Super E5', 'Super E10', 'Diesel'],

--- a/lib/core/services/service_providers.dart
+++ b/lib/core/services/service_providers.dart
@@ -114,7 +114,7 @@ GeocodingChain geocodingChain(Ref ref) {
 // ---------------------------------------------------------------------------
 
 // Key für den Zugriff auf die freie Tankerkönig-Spritpreis-API
-// Für eigenen Key bitte hier https://creativecommons.tankerkoenig.de
+// Für eigenen Key bitte hier https://onboarding.tankerkoenig.de
 // registrieren.
 class _ApiKeyInterceptor extends Interceptor {
   final Ref _ref;

--- a/lib/core/storage/stores/settings_hive_store.dart
+++ b/lib/core/storage/stores/settings_hive_store.dart
@@ -19,7 +19,7 @@ class SettingsHiveStore implements SettingsStorage, ApiKeyStorage {
   static String? _apiKeyCache;
 
   // Key für den Zugriff auf die freie Tankerkönig-Spritpreis-API
-  // Für eigenen Key bitte hier https://creativecommons.tankerkoenig.de
+  // Für eigenen Key bitte hier https://onboarding.tankerkoenig.de
   // registrieren.
   //
   // The Tankerkönig terms of service (#713) forbid publishing any API key

--- a/lib/features/profile/presentation/widgets/about_section.dart
+++ b/lib/features/profile/presentation/widgets/about_section.dart
@@ -119,9 +119,14 @@ class AboutSection extends StatelessWidget {
           ),
           const Divider(height: 1),
           // Attributions
-          const ListTile(
-            leading: Icon(Icons.data_usage),
-            title: Text(AppConstants.tankerkoenigAttribution),
+          ListTile(
+            leading: const Icon(Icons.data_usage),
+            title: const Text(AppConstants.tankerkoenigAttribution),
+            trailing: const Icon(Icons.open_in_new, size: 18),
+            onTap: () => launchUrl(
+              Uri.parse(AppConstants.tankerkoenigCreativeCommonsUrl),
+              mode: LaunchMode.externalApplication,
+            ),
           ),
           const ListTile(
             leading: Icon(Icons.map),

--- a/lib/features/station_services/germany/tankerkoenig_station_service.dart
+++ b/lib/features/station_services/germany/tankerkoenig_station_service.dart
@@ -9,7 +9,7 @@ import '../../../core/services/station_service.dart';
 import 'tankerkoenig_batch_price_fetcher.dart';
 
 // Key für den Zugriff auf die freie Tankerkönig-Spritpreis-API
-// Für eigenen Key bitte hier https://creativecommons.tankerkoenig.de
+// Für eigenen Key bitte hier https://onboarding.tankerkoenig.de
 // registrieren.
 //
 // Compliance notes (#713):

--- a/test/features/profile/presentation/widgets/about_section_test.dart
+++ b/test/features/profile/presentation/widgets/about_section_test.dart
@@ -67,5 +67,46 @@ void main() {
       expect(find.text('PayPal'), findsOneWidget);
       expect(find.text('Revolut'), findsOneWidget);
     });
+
+    testWidgets(
+        'Tankerkoenig attribution row is tappable + carries the open-in-new affordance',
+        (tester) async {
+      // Per #1473 the attribution must link to the CC BY 4.0 page so a
+      // user reading "Daten von Tankerkoenig.de" on the Parameters
+      // screen can jump to the licence + dataset documentation.
+      await pumpApp(
+        tester,
+        const SingleChildScrollView(child: AboutSection()),
+      );
+
+      final tile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text(AppConstants.tankerkoenigAttribution),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect(tile.onTap, isNotNull,
+          reason: 'attribution row must launch the CC BY 4.0 page on tap');
+      expect(tile.trailing, isA<Icon>(),
+          reason: 'attribution row should carry the open-in-new affordance');
+    });
+
+    test('CreativeCommons URL constant is HTTPS and points at the CC BY page',
+        () {
+      expect(AppConstants.tankerkoenigCreativeCommonsUrl,
+          'https://creativecommons.tankerkoenig.de/');
+    });
+
+    test(
+        'Registration URL constant points at the onboarding host '
+        '(not the legacy creativecommons one)', () {
+      // The onboarding subdomain is the post-2026 home for new API
+      // key requests; creativecommons remains the licence/data page,
+      // covered by [tankerkoenigCreativeCommonsUrl].
+      expect(AppConstants.tankerkoenigRegistrationUrl,
+          'https://onboarding.tankerkoenig.de/');
+      expect(AppConstants.tankerkoenigRegistrationUrl,
+          isNot(contains('creativecommons')));
+    });
   });
 }

--- a/test/features/setup/presentation/widgets/api_key_input_section_test.dart
+++ b/test/features/setup/presentation/widgets/api_key_input_section_test.dart
@@ -15,7 +15,7 @@ const _germany = CountryConfig(
   postalCodeLabel: 'PLZ',
   requiresApiKey: true,
   apiProvider: 'Tankerkoenig',
-  apiKeyRegistrationUrl: 'https://creativecommons.tankerkoenig.de/',
+  apiKeyRegistrationUrl: 'https://onboarding.tankerkoenig.de/',
 );
 
 const _germanyNoUrl = CountryConfig(

--- a/test/features/setup/presentation/widgets/api_key_step_test.dart
+++ b/test/features/setup/presentation/widgets/api_key_step_test.dart
@@ -49,7 +49,7 @@ const _germanyNoAttribution = CountryConfig(
   postalCodeLabel: 'PLZ',
   requiresApiKey: true,
   apiProvider: 'Tankerkoenig',
-  apiKeyRegistrationUrl: 'https://creativecommons.tankerkoenig.de/',
+  apiKeyRegistrationUrl: 'https://onboarding.tankerkoenig.de/',
 );
 
 void main() {


### PR DESCRIPTION
## Summary

Two related changes the user spotted on the live Play Store / app parameters screen:

1. **The "request a Tankerkönig API key" link** now points at `https://onboarding.tankerkoenig.de/` — the post-2026 home for new API key requests. The previous `creativecommons` subdomain still serves the licence + dataset documentation but no longer hosts the registration flow.

2. **The "Daten von Tankerkoenig.de (CC BY 4.0)" attribution row** in `AboutSection` (Profile / Parameters → About) is now tappable and links to `https://creativecommons.tankerkoenig.de/` so a curious user can jump straight to the licence + dataset documentation. Adds an `Icons.open_in_new` trailing affordance.

## Files

- `lib/core/constants/app_constants.dart` — `tankerkoenigRegistrationUrl` → onboarding URL; new `tankerkoenigCreativeCommonsUrl` constant for the attribution link.
- `lib/core/country/country_config.dart` — Germany's `apiKeyRegistrationUrl` → onboarding URL.
- `lib/features/profile/presentation/widgets/about_section.dart` — attribution `ListTile` gains `onTap` + open-in-new trailing icon.
- 3 source comments updated (`service_providers.dart`, `settings_hive_store.dart`, `tankerkoenig_station_service.dart`) — same "Für eigenen Key bitte hier" pointer.
- 2 test fixtures updated (`api_key_input_section_test.dart`, `api_key_step_test.dart`) + 3 new `about_section_test.dart` cases asserting the attribution row is tappable + the constants point at the correct hosts.

## Test plan

- [x] `flutter analyze` — clean (No issues found!)
- [ ] CI runs the full suite — local Windows test run blocked by an OS app-control policy on `dartaotruntime.exe`, doesn't affect Linux CI

## Out of scope

- `ApiConstants.baseUrl` + `ServiceConfigs.tankerkoenig.baseUrl` stay on `creativecommons.tankerkoenig.de/json` — that's the JSON **data API**, not the registration page; both endpoints continue to live on the same host.
- Test fixtures + reachability tests that reference `creativecommons.tankerkoenig.de` for the JSON API stay as-is for the same reason.