### PR TITLE
fix(supabase): edge functions read from 'alerts' (Closes #1476)

### DIFF
--- a/supabase/functions/check-alerts/index.ts
+++ b/supabase/functions/check-alerts/index.ts
@@ -1,7 +1,16 @@
 // Edge Function: check-alerts
 // Evaluates all active price alerts, fetches current prices, and sends
-// ntfy notifications when thresholds are met. Intended to be called by
+// ntfy notifications when targets are met. Intended to be called by
 // pg_cron every 5-15 minutes.
+//
+// Schema notes (#1476):
+//   - The alerts table tracks alert config; ntfy delivery preferences
+//     live on push_tokens keyed by user_id. We fetch them in two
+//     queries and join client-side: alerts and push_tokens share a
+//     user_id that points at users.id, but no direct FK exists between
+//     the two, so PostgREST can't infer an embedded resource.
+//   - alerts has no country_code column; we fall back to 'DE'. A future
+//     migration to add country_code is tracked separately.
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { fetchPricesByCountry, type CountryCode, type StationPrices } from '../_shared/api-clients.ts';
@@ -10,50 +19,89 @@ import { sendPriceAlertNotification } from '../_shared/ntfy.ts';
 // Minimum time between re-triggering the same alert (ms).
 const COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
-Deno.serve(async (req: Request) => {
+interface AlertRow {
+  id: string;
+  user_id: string;
+  station_id: string;
+  station_name: string | null;
+  fuel_type: string;
+  target_price: number;
+  last_triggered_at: string | null;
+}
+
+interface PushTokenRow {
+  user_id: string;
+  ntfy_topic: string;
+  enabled: boolean;
+}
+
+Deno.serve(async (_req: Request) => {
   try {
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
     );
 
-    // 1. Fetch all active alerts that have an ntfy topic configured
-    const { data: alerts, error: alertsError } = await supabase
-      .from('price_alerts')
-      .select('id, user_id, station_id, country_code, fuel_type, threshold_price, ntfy_topic, last_triggered_at, station_name')
-      .eq('is_active', true)
-      .not('ntfy_topic', 'is', null);
+    // 1a. Fetch active alerts.
+    const { data: alertRows, error: alertsError } = await supabase
+      .from('alerts')
+      .select('id, user_id, station_id, station_name, fuel_type, target_price, last_triggered_at')
+      .eq('is_active', true);
 
     if (alertsError) {
       console.error('Failed to fetch alerts:', alertsError);
       return new Response(JSON.stringify({ error: 'Failed to fetch alerts' }), { status: 500 });
     }
 
-    if (!alerts || alerts.length === 0) {
+    const alerts: AlertRow[] = (alertRows ?? []) as AlertRow[];
+    if (alerts.length === 0) {
       return new Response(JSON.stringify({ checked: 0, triggered: 0 }));
     }
 
-    // 2. Group station IDs by country to batch API calls
+    // 1b. Fetch ntfy topics for the alert owners.
+    const userIds = Array.from(new Set(alerts.map((a) => a.user_id)));
+    const { data: pushRows, error: pushError } = await supabase
+      .from('push_tokens')
+      .select('user_id, ntfy_topic, enabled')
+      .in('user_id', userIds)
+      .eq('enabled', true)
+      .not('ntfy_topic', 'is', null);
+
+    if (pushError) {
+      console.error('Failed to fetch push tokens:', pushError);
+      return new Response(JSON.stringify({ error: 'Failed to fetch push tokens' }), { status: 500 });
+    }
+
+    const ntfyByUser = new Map<string, string>();
+    for (const row of (pushRows ?? []) as PushTokenRow[]) {
+      if (row.ntfy_topic) ntfyByUser.set(row.user_id, row.ntfy_topic);
+    }
+
+    // Drop alerts whose owner has no enabled ntfy topic — nothing to deliver.
+    const deliverable = alerts.filter((a) => ntfyByUser.has(a.user_id));
+    if (deliverable.length === 0) {
+      return new Response(JSON.stringify({ checked: alerts.length, triggered: 0 }));
+    }
+
+    // 2. Group station IDs by country to batch API calls. alerts has no
+    // country_code column today; everything falls through to 'DE' until
+    // the schema migration lands.
     const stationsByCountry = new Map<CountryCode, Set<string>>();
-    for (const alert of alerts) {
-      const country = (alert.country_code ?? 'DE') as CountryCode;
+    for (const alert of deliverable) {
+      const country: CountryCode = 'DE';
       if (!stationsByCountry.has(country)) {
         stationsByCountry.set(country, new Set());
       }
       stationsByCountry.get(country)!.add(alert.station_id);
     }
 
-    // 3. Fetch current prices per country
+    // 3. Fetch current prices per country.
     const tankerkoenigKey = Deno.env.get('TANKERKOENIG_API_KEY');
     const allPrices = new Map<string, StationPrices>();
 
     for (const [country, stationIdSet] of stationsByCountry.entries()) {
       try {
-        const prices = await fetchPricesByCountry(
-          country,
-          Array.from(stationIdSet),
-          tankerkoenigKey,
-        );
+        const prices = await fetchPricesByCountry(country, Array.from(stationIdSet), tankerkoenigKey);
         for (const [id, p] of prices.entries()) {
           allPrices.set(id, p);
         }
@@ -62,12 +110,11 @@ Deno.serve(async (req: Request) => {
       }
     }
 
-    // 4. Evaluate each alert against current prices
+    // 4. Evaluate each alert against current prices.
     let triggered = 0;
     const now = Date.now();
 
-    for (const alert of alerts) {
-      // Respect cooldown: skip if triggered recently
+    for (const alert of deliverable) {
       if (alert.last_triggered_at) {
         const lastTriggered = new Date(alert.last_triggered_at).getTime();
         if (now - lastTriggered < COOLDOWN_MS) continue;
@@ -76,24 +123,24 @@ Deno.serve(async (req: Request) => {
       const stationPrices = allPrices.get(alert.station_id);
       if (!stationPrices) continue;
 
-      // Look up the price for the requested fuel type
       const currentPrice = getFuelPrice(stationPrices, alert.fuel_type);
       if (currentPrice === undefined) continue;
 
-      // Trigger if current price is at or below the threshold
-      if (currentPrice <= alert.threshold_price) {
+      if (currentPrice <= alert.target_price) {
+        const ntfyTopic = ntfyByUser.get(alert.user_id);
+        if (!ntfyTopic) continue;
+
         try {
           await sendPriceAlertNotification(
-            alert.ntfy_topic,
+            ntfyTopic,
             alert.station_name ?? alert.station_id,
             alert.fuel_type,
             currentPrice,
-            alert.threshold_price,
+            alert.target_price,
           );
 
-          // Update last_triggered_at
           await supabase
-            .from('price_alerts')
+            .from('alerts')
             .update({ last_triggered_at: new Date().toISOString() })
             .eq('id', alert.id);
 
@@ -110,39 +157,23 @@ Deno.serve(async (req: Request) => {
     );
   } catch (err) {
     console.error('check-alerts unhandled error:', err);
-    return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
-      { status: 500 },
-    );
+    return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 });
   }
 });
 
-/**
- * Extract a specific fuel type price from StationPrices.
- */
 function getFuelPrice(prices: StationPrices, fuelType: string): number | undefined {
   const key = fuelType.toLowerCase();
   switch (key) {
-    case 'e5':
-      return prices.e5;
-    case 'e10':
-      return prices.e10;
-    case 'diesel':
-      return prices.diesel;
-    case 'e98':
-      return prices.e98;
-    case 'sp95':
-      return prices.sp95;
-    case 'sp98':
-      return prices.sp98;
-    case 'gplc':
-      return prices.gplc;
-    case 'super':
-      return prices.super;
+    case 'e5': return prices.e5;
+    case 'e10': return prices.e10;
+    case 'diesel': return prices.diesel;
+    case 'e98': return prices.e98;
+    case 'sp95': return prices.sp95;
+    case 'sp98': return prices.sp98;
+    case 'gplc': return prices.gplc;
+    case 'super': return prices.super;
     case 'superplus':
-    case 'super_plus':
-      return prices.superPlus;
-    default:
-      return undefined;
+    case 'super_plus': return prices.superPlus;
+    default: return undefined;
   }
 }

--- a/supabase/functions/record-prices/index.ts
+++ b/supabase/functions/record-prices/index.ts
@@ -1,24 +1,35 @@
 // Edge Function: record-prices
 // Records price snapshots for all stations referenced by active alerts.
-// Intended to be called by pg_cron every 15 minutes.
-// Also cleans up snapshots older than 90 days.
+// Intended to be called by pg_cron hourly. Also cleans up snapshots
+// older than 90 days.
+//
+// Schema notes (#1476):
+//   - Reads station_ids from `alerts` (the canonical table; the prior
+//     deploy referenced a non-existent `price_alerts`).
+//   - alerts has no country_code; defaults to 'DE'. Tracked alongside
+//     check-alerts for a future migration that adds it.
+//   - price_snapshots is wide-table — one row per (station, recorded_at)
+//     with one nullable column per fuel type. Map the StationPrices
+//     fields that exist as columns; the rest are dropped (the schema
+//     covers e5/e10/e98/diesel and the long-tail biofuel/lpg/cng prices
+//     we don't currently fetch).
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { fetchPricesByCountry, type CountryCode, type StationPrices } from '../_shared/api-clients.ts';
 
 const RETENTION_DAYS = 90;
 
-Deno.serve(async (req: Request) => {
+Deno.serve(async (_req: Request) => {
   try {
     const supabase = createClient(
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
     );
 
-    // 1. Get distinct station IDs from active alerts
-    const { data: activeStations, error: stationsError } = await supabase
-      .from('price_alerts')
-      .select('station_id, country_code')
+    // 1. Get distinct station IDs from active alerts.
+    const { data: activeAlerts, error: stationsError } = await supabase
+      .from('alerts')
+      .select('station_id')
       .eq('is_active', true);
 
     if (stationsError) {
@@ -26,77 +37,57 @@ Deno.serve(async (req: Request) => {
       return new Response(JSON.stringify({ error: 'Failed to fetch stations' }), { status: 500 });
     }
 
-    if (!activeStations || activeStations.length === 0) {
+    if (!activeAlerts || activeAlerts.length === 0) {
       return new Response(JSON.stringify({ recorded: 0, cleaned: 0 }));
     }
 
-    // Deduplicate stations and group by country
-    const stationsByCountry = new Map<CountryCode, Set<string>>();
-    for (const row of activeStations) {
-      const country = (row.country_code ?? 'DE') as CountryCode;
-      if (!stationsByCountry.has(country)) {
-        stationsByCountry.set(country, new Set());
-      }
-      stationsByCountry.get(country)!.add(row.station_id);
+    // Deduplicate stations. country_code isn't on alerts; default to DE
+    // until the schema migration adds it.
+    const country: CountryCode = 'DE';
+    const stationIds = new Set<string>();
+    for (const row of activeAlerts) {
+      if (row.station_id) stationIds.add(row.station_id as string);
     }
 
-    // 2. Fetch current prices per country
+    // 2. Fetch current prices for the country.
     const tankerkoenigKey = Deno.env.get('TANKERKOENIG_API_KEY');
-    const allPrices = new Map<string, { prices: StationPrices; country: CountryCode }>();
+    const allPrices = new Map<string, StationPrices>();
 
-    for (const [country, stationIdSet] of stationsByCountry.entries()) {
-      try {
-        const prices = await fetchPricesByCountry(
-          country,
-          Array.from(stationIdSet),
-          tankerkoenigKey,
-        );
-        for (const [id, p] of prices.entries()) {
-          allPrices.set(id, { prices: p, country });
-        }
-      } catch (err) {
-        console.error(`Failed to fetch prices for country ${country}:`, err);
+    try {
+      const prices = await fetchPricesByCountry(
+        country,
+        Array.from(stationIds),
+        tankerkoenigKey,
+      );
+      for (const [id, p] of prices.entries()) {
+        allPrices.set(id, p);
       }
+    } catch (err) {
+      console.error(`Failed to fetch prices for country ${country}:`, err);
     }
 
-    // 3. Insert price snapshots
+    // 3. Insert one snapshot row per station — wide-table format.
     const now = new Date().toISOString();
     const snapshots: Array<Record<string, unknown>> = [];
 
-    for (const [stationId, { prices, country }] of allPrices.entries()) {
-      // Create one row per fuel type that has a price
-      const fuelEntries: Array<[string, number | undefined]> = [
-        ['e5', prices.e5],
-        ['e10', prices.e10],
-        ['diesel', prices.diesel],
-        ['e98', prices.e98],
-        ['sp95', prices.sp95],
-        ['sp98', prices.sp98],
-        ['gplc', prices.gplc],
-        ['super', prices.super],
-        ['super_plus', prices.superPlus],
-      ];
-
-      for (const [fuelType, price] of fuelEntries) {
-        if (price !== undefined) {
-          snapshots.push({
-            station_id: stationId,
-            country_code: country,
-            fuel_type: fuelType,
-            price,
-            recorded_at: now,
-          });
-        }
-      }
+    for (const [stationId, prices] of allPrices.entries()) {
+      snapshots.push({
+        station_id: stationId,
+        country_code: country,
+        recorded_at: now,
+        e5: prices.e5 ?? null,
+        e10: prices.e10 ?? null,
+        e98: prices.e98 ?? null,
+        diesel: prices.diesel ?? null,
+      });
     }
 
     let recorded = 0;
     if (snapshots.length > 0) {
-      // Insert in batches of 500 to stay within payload limits
       const batchSize = 500;
       for (let i = 0; i < snapshots.length; i += batchSize) {
         const batch = snapshots.slice(i, i + batchSize);
-        const { error: insertError, count } = await supabase
+        const { error: insertError } = await supabase
           .from('price_snapshots')
           .insert(batch);
 


### PR DESCRIPTION
## Summary

Both `check-alerts` and `record-prices` Edge Functions referenced a non-existent `price_alerts` table since the April deploy — bug surfaced by #1475 once pg_cron + Vault wired the schedules properly.

### check-alerts
- Read from `alerts` with `target_price` (was `threshold_price`)
- Two-query JS-side join to `push_tokens` for `ntfy_topic` (no FK between the two — both reference `users.id` — so PostgREST can't auto-infer an embedded resource)
- Country defaults to `'DE'` (alerts has no country_code; follow-up needed)

### record-prices
- Read station_ids from `alerts`
- Insert into `price_snapshots` in **wide-table** format (one column per fuel), matching the actual schema instead of long-table `{fuel_type, price}`
- Same `'DE'` country default

## Deployed + smoke-tested

Both deployed via Supabase MCP (versions 2/3/3 respectively for `aggregate-wait-times` / `check-alerts` / `record-prices`). Manual `net.http_post` with vault-backed bearer:

| function              | status | body                                                            |
|-----------------------|--------|-----------------------------------------------------------------|
| aggregate-wait-times  | 200    | `{"sessions_paired":0,"buckets_written":0,"sparse_buckets_dropped":0}` |
| check-alerts          | 200    | `{"checked":0,"triggered":0}`                                   |
| record-prices         | 200    | `{"recorded":0,"cleaned":0}`                                    |

Empty responses are correct — there are 0 alerts in the live DB.

## Follow-up (not in this PR)

Add `country_code` to `alerts` so non-DE users get correct prices. Will need:
- Migration adding the column (default 'DE' for existing rows, NOT NULL after backfill)
- `lib/core/sync/alerts_sync.dart` upsert payload to include it
- Re-deploy both functions to read it from the row instead of hardcoding 'DE'

## Test plan
- [x] `flutter analyze` — N/A, no Dart changed
- [x] Smoke test all three Edge Functions via `net.http_post` → all 200
- [ ] Wait one cron boundary (next `:00` or `:15`) and confirm `cron.job_run_details` shows `succeeded` for all three jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)