### PR TITLE
feat(sync): trip_summaries + trip_details schema + RLS audit (Refs #1479 phase 1)

### DIFF
--- a/docs/security/SUPABASE_RLS_MATRIX.md
+++ b/docs/security/SUPABASE_RLS_MATRIX.md
@@ -64,6 +64,8 @@ Legend:
 | `vehicles`         | own          | own             | own        | own                | Single `vehicles_own` `FOR ALL`. |
 | `fill_ups`         | own          | own             | own        | own                | Single `fill_ups_own` `FOR ALL`. |
 | `obd2_baselines`   | own          | own             | own        | own                | Single `obd2_baselines_own` `FOR ALL`. |
+| `trip_summaries`   | own          | own             | own        | own                | Single `trip_summaries_own` `FOR ALL`. |
+| `trip_details`     | own          | own             | own        | own                | Single `trip_details_own` `FOR ALL`.   |
 | `wait_time_pings`  | own          | own             | own        | own                | Single `wait_time_pings_own` `FOR ALL`. Aggregator runs as service_role and bypasses RLS. |
 | `wait_time_aggregates` | all      | (svc)           | (svc)      | (svc)              | Single `wait_aggregates_read` SELECT-only policy. Anonymized rolling-median rows are visible to every authenticated client; only Edge Functions write. |
 
@@ -87,6 +89,7 @@ The migration source-of-truth lives in `supabase/migrations/`:
   `wait_time_aggregates` (#1119).
 - `20260506000002_wait_time_aggregator_schedule.sql` — schedule only,
   service-role-driven, no public-table RLS change.
+- `20260507000001_trip_summaries_and_details.sql` — `trip_summaries`, `trip_details`.
 
 If a migration not listed above is found in `supabase/migrations/`,
 this matrix is stale. See "How to update" below.

--- a/supabase/migrations/20260507000001_trip_summaries_and_details.sql
+++ b/supabase/migrations/20260507000001_trip_summaries_and_details.sql
@@ -1,0 +1,40 @@
+-- Trip recordings (OBD2 + GPS) synced across the user's linked devices.
+-- Two-row split (#1479 phase 1):
+--   public.trip_summaries — ~1 KB JSONB, queried for the trip-history list
+--   public.trip_details   — full pointSamples + gpsSampleDiagnostics, lazy-loaded
+-- Local-only by default; rows only land here once the user signs in to TankSync.
+
+CREATE TABLE IF NOT EXISTS public.trip_summaries (
+  id TEXT NOT NULL,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  vehicle_id TEXT,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ NOT NULL,
+  data JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, id)
+);
+
+ALTER TABLE public.trip_summaries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY trip_summaries_own ON public.trip_summaries
+  FOR ALL USING (user_id = auth.uid());
+
+CREATE INDEX trip_summaries_user_idx ON public.trip_summaries(user_id);
+CREATE INDEX trip_summaries_user_started_idx
+  ON public.trip_summaries(user_id, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.trip_details (
+  id TEXT NOT NULL,
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  data JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, id)
+);
+
+ALTER TABLE public.trip_details ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY trip_details_own ON public.trip_details
+  FOR ALL USING (user_id = auth.uid());
+
+CREATE INDEX trip_details_user_idx ON public.trip_details(user_id);

--- a/test/security/supabase_rls_test.dart
+++ b/test/security/supabase_rls_test.dart
@@ -114,6 +114,12 @@ void main() {
     'obd2_baselines': {
       'obd2_baselines_own': 'ALL',
     },
+    'trip_summaries': {
+      'trip_summaries_own': 'ALL',
+    },
+    'trip_details': {
+      'trip_details_own': 'ALL',
+    },
     'wait_time_pings': {
       'wait_time_pings_own': 'ALL',
     },

--- a/test/security/trip_sync_migration_test.dart
+++ b/test/security/trip_sync_migration_test.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// #1479 phase 1 — static smoke test for the trip-sync migration.
+///
+/// This is NOT a live Supabase call. It reads the migration SQL file
+/// from disk and asserts the four invariants TankSync sync tables
+/// MUST satisfy:
+///
+///   1. Both `public.trip_summaries` AND `public.trip_details` are
+///      created.
+///   2. RLS is explicitly enabled on each table (no Supabase table is
+///      allowed to ship RLS-disabled — see
+///      `docs/security/SUPABASE_RLS_MATRIX.md`).
+///   3. Each table has a `_own` policy attached. Without a policy the
+///      table is read-locked for authenticated users.
+///   4. The migration file is referenced from the RLS matrix doc so
+///      the audit trail stays in sync.
+///
+/// If a future migration drops one of these properties, the live
+/// `supabase_rls_test.dart` would catch it on next staging run, but
+/// that test is `@Tags(['network'])` and only runs on tag releases.
+/// This test runs in the default suite and surfaces the regression at
+/// PR-time.
+void main() {
+  group('trip-sync migration (#1479 phase 1)', () {
+    final migrationFile = File(
+      'supabase/migrations/20260507000001_trip_summaries_and_details.sql',
+    );
+
+    test('migration file exists', () {
+      expect(
+        migrationFile.existsSync(),
+        isTrue,
+        reason:
+            'Expected migration at ${migrationFile.path}. Did the file '
+            'get moved or renamed? Update this test in the same PR.',
+      );
+    });
+
+    test('creates both trip_summaries and trip_details tables', () {
+      final sql = migrationFile.readAsStringSync();
+
+      final summariesCreate = RegExp(
+        r'CREATE TABLE\s+IF NOT EXISTS\s+public\.trip_summaries',
+        caseSensitive: false,
+      );
+      final detailsCreate = RegExp(
+        r'CREATE TABLE\s+IF NOT EXISTS\s+public\.trip_details',
+        caseSensitive: false,
+      );
+
+      expect(
+        summariesCreate.hasMatch(sql),
+        isTrue,
+        reason: 'public.trip_summaries CREATE TABLE not found in migration.',
+      );
+      expect(
+        detailsCreate.hasMatch(sql),
+        isTrue,
+        reason: 'public.trip_details CREATE TABLE not found in migration.',
+      );
+    });
+
+    test('enables RLS on both tables', () {
+      final sql = migrationFile.readAsStringSync();
+
+      final summariesRls = RegExp(
+        r'ALTER TABLE\s+public\.trip_summaries\s+ENABLE ROW LEVEL SECURITY',
+        caseSensitive: false,
+      );
+      final detailsRls = RegExp(
+        r'ALTER TABLE\s+public\.trip_details\s+ENABLE ROW LEVEL SECURITY',
+        caseSensitive: false,
+      );
+
+      expect(
+        summariesRls.hasMatch(sql),
+        isTrue,
+        reason:
+            'trip_summaries is missing `ALTER TABLE ... ENABLE ROW LEVEL '
+            'SECURITY`. Without it the anon key reads every row.',
+      );
+      expect(
+        detailsRls.hasMatch(sql),
+        isTrue,
+        reason:
+            'trip_details is missing `ALTER TABLE ... ENABLE ROW LEVEL '
+            'SECURITY`. Without it the anon key reads every row.',
+      );
+    });
+
+    test('creates a per-table _own policy', () {
+      final sql = migrationFile.readAsStringSync();
+
+      final summariesPolicy = RegExp(
+        r'CREATE POLICY\s+trip_summaries_own\s+ON\s+public\.trip_summaries',
+        caseSensitive: false,
+      );
+      final detailsPolicy = RegExp(
+        r'CREATE POLICY\s+trip_details_own\s+ON\s+public\.trip_details',
+        caseSensitive: false,
+      );
+
+      expect(
+        summariesPolicy.hasMatch(sql),
+        isTrue,
+        reason:
+            'trip_summaries_own policy missing — table is RLS-enabled '
+            'with zero policies, which read-locks it for authenticated '
+            'users.',
+      );
+      expect(
+        detailsPolicy.hasMatch(sql),
+        isTrue,
+        reason:
+            'trip_details_own policy missing — table is RLS-enabled '
+            'with zero policies, which read-locks it for authenticated '
+            'users.',
+      );
+    });
+
+    test('migration is referenced from the RLS matrix doc', () {
+      final matrix = File('docs/security/SUPABASE_RLS_MATRIX.md');
+      expect(
+        matrix.existsSync(),
+        isTrue,
+        reason: 'docs/security/SUPABASE_RLS_MATRIX.md is missing.',
+      );
+
+      final body = matrix.readAsStringSync();
+      expect(
+        body.contains('20260507000001_trip_summaries_and_details.sql'),
+        isTrue,
+        reason:
+            'The trip-sync migration is not listed in the RLS matrix '
+            'doc. Add it under "Migrations that touch RLS".',
+      );
+      expect(
+        body.contains('`trip_summaries`'),
+        isTrue,
+        reason: 'trip_summaries row missing from the RLS matrix table.',
+      );
+      expect(
+        body.contains('`trip_details`'),
+        isTrue,
+        reason: 'trip_details row missing from the RLS matrix table.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 1 of #1479 — Supabase schema + RLS audit additions for syncing trip recordings (OBD2 + GPS) across the user's linked devices via TankSync. Schema-only; the Dart-side `TripsSync.merge(...)` is deferred to phase 2 and gates on this migration being live on hosted Supabase first.

Two-row split:
- `public.trip_summaries` — ~1 KB JSONB, queried for the trip-history list. Carries `vehicle_id` / `started_at` / `ended_at` columns so the history list can index without inflating the JSONB.
- `public.trip_details` — full `pointSamples` + `gpsSampleDiagnostics`, lazy-loaded when the user opens a single trip.

Both tables share `(user_id, id)` as the primary key so detail lookup is a cheap index hit. RLS shape mirrors the existing `vehicles` / `fill_ups` / `obd2_baselines` precedent — single `_own` `FOR ALL` policy keyed off `auth.uid()`, per-user index on `user_id`, plus a `(user_id, started_at DESC)` index on summaries for the history-list `ORDER BY`.

## Files

- `supabase/migrations/20260507000001_trip_summaries_and_details.sql` — new migration.
- `docs/security/SUPABASE_RLS_MATRIX.md` — two new rows in the matrix table + new entry under "Migrations that touch RLS".
- `test/security/supabase_rls_test.dart` — `_expectedPolicies` entries for `trip_summaries` and `trip_details` (network-tagged; runs on tag releases).
- `test/security/trip_sync_migration_test.dart` — new static smoke test that reads the migration SQL and asserts both tables get `CREATE TABLE`, `ENABLE ROW LEVEL SECURITY`, and a `_own` policy. Runs in the default suite — surfaces a dropped RLS at PR-time instead of waiting for the network-tagged audit on tag release.

## Test plan

- [x] `flutter analyze` — clean (zero warnings/infos/errors).
- [x] `flutter test test/security/` — 23 passed, 1 skipped (the `@Tags(['network'])` Supabase live audit, expected on local without `SUPABASE_TEST_URL`).
- [x] `flutter test test/lint/` — 29 passed.
- [ ] CI runs the same checks; full suite gated on green analyze + targeted tests here.

## Follow-up (post-merge)

After this merges, **a separate `chore` ticket needs to be opened** (mirroring the #1470 pattern for the wait-time migration) so the user runs `supabase db push` against hosted Supabase. Phase 2 dispatch (`TripsSync.merge(...)` + history-list hydration + lazy detail fetch) gates on that ticket completing.

Refs #1479

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Generated with Claude Code](https://claude.com/claude-code)