### PR TITLE
feat(ci): iOS workflow — build IPA + upload to TestFlight

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,116 @@
+name: iOS TestFlight Build
+
+# Build a signed iOS IPA on a macOS runner and upload it to TestFlight via the
+# App Store Connect API. Mirror of `daily-beta.yml` but for iOS.
+#
+# Build numbers are date-based (YYYYMMDD) computed at build time, so there's no
+# commit pushed back to master.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: 'TestFlight changelog (max 4000 chars)'
+        required: false
+        type: string
+        default: 'Daily build.'
+  # Schedule trigger intentionally left commented until we've confirmed two
+  # consecutive manual runs land in TestFlight cleanly. Then uncomment to
+  # mirror Android's nightly cadence.
+  # schedule:
+  #   - cron: '0 16 * * *'
+
+concurrency:
+  group: ios-testflight
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute date-based build number
+        id: bn
+        run: |
+          BN=$(TZ=Europe/Paris date +%Y%m%d)
+          echo "build_number=$BN" >> "$GITHUB_OUTPUT"
+          echo "Daily build number: $BN"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ios/Pods
+          key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Pod install
+        run: cd ios && pod install --repo-update
+
+      - name: Decode App Store Connect API key
+        env:
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          if [ -z "$ASC_KEY_BASE64" ]; then
+            echo "::error::APP_STORE_CONNECT_API_KEY_BASE64 secret is not set." >&2
+            exit 1
+          fi
+          KEY_PATH="$RUNNER_TEMP/asc-api-key.p8"
+          echo "$ASC_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "ASC_API_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Validate match-repo auth secret
+        env:
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        run: |
+          if [ -z "$MATCH_GIT_BASIC_AUTHORIZATION" ]; then
+            echo "::error::MATCH_GIT_BASIC_AUTHORIZATION secret is not set. See docs/guides/ios-codesigning.md." >&2
+            exit 1
+          fi
+
+      - name: fastlane release_testflight
+        working-directory: ios
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          # ASC_API_KEY_FILEPATH was exported by the decode step above so the
+          # Fastfile's `asc_api_key` helper picks up the on-disk .p8.
+          IOS_BUILD_NUMBER: ${{ steps.bn.outputs.build_number }}
+          TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.release_notes || 'Daily build.' }}
+          FASTLANE_DISABLE_COLORS: '1'
+          FASTLANE_HIDE_CHANGELOG: '1'
+        run: bundle exec fastlane release_testflight build_number:"${IOS_BUILD_NUMBER}" changelog:"${TESTFLIGHT_CHANGELOG}"
+
+      - name: Clean up decoded API key
+        if: always()
+        run: rm -f "$ASC_API_KEY_FILEPATH"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## iOS TestFlight Release"
+            echo ""
+            echo "- **Build number:** ${{ steps.bn.outputs.build_number }}"
+            echo "- **Bundle ID:** de.tankstellen.fuelprices"
+            echo "- **Trigger:** ${{ github.event_name }}"
+            echo "- **Changelog:** ${{ github.event.inputs.release_notes || 'Daily build.' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/guides/ios-codesigning.md
+++ b/docs/guides/ios-codesigning.md
@@ -101,6 +101,37 @@ bundle exec fastlane match development --force
 The first command registers the device with Apple; the second regenerates
 the development profile to include it.
 
+## CI auth — `MATCH_GIT_BASIC_AUTHORIZATION`
+
+CI on `macos-latest` doesn't have your local git credential helper, so it
+needs an explicit token to clone the encrypted match repo. The convention
+is a fine-grained Personal Access Token scoped to **just the match repo**,
+stored in main-repo Actions secrets and base64-encoded the way fastlane
+match auto-detects.
+
+One-time setup:
+
+1. Go to <https://github.com/settings/personal-access-tokens/new>.
+2. Token name: `tankstellen-ios-certs read-only`.
+3. Resource owner: `fdittgen-png`.
+4. Expiration: 1 year (renewing yearly is the cost of scoping the token).
+5. Repository access: **Only select repositories** → tick
+   `fdittgen-png/tankstellen-ios-certs`.
+6. Permissions → Repository permissions → **Contents: Read-only**. Leave
+   every other category at the default of "No access".
+7. Generate token. Copy the value (`github_pat_…`) immediately — GitHub
+   only shows it once.
+8. From a terminal that has `gh` authenticated, paste the token into:
+
+   ```bash
+   echo -n "fdittgen-png:<paste the github_pat_… here>" | base64 \
+     | gh secret set MATCH_GIT_BASIC_AUTHORIZATION --repo fdittgen-png/tankstellen
+   ```
+
+The CI workflow consumes the secret as an env var; fastlane match auto-
+detects the env var and rewrites HTTPS git ops to attach the token as a
+basic auth header.
+
 ## If something is wrong
 
 - **Match repo cannot be cloned**: verify your local git auth has read access

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -40,4 +40,61 @@ platform :ios do
     match(type: "development", api_key: key, readonly: false)
     match(type: "appstore", api_key: key, readonly: false)
   end
+
+  desc "Build a signed appstore-distribution IPA. Expects match_appstore to have populated the keychain first."
+  lane :build_appstore do |options|
+    build_number = options[:build_number] || ENV["IOS_BUILD_NUMBER"] || Time.now.strftime("%Y%m%d")
+    profile_name = ENV["sigh_de.tankstellen.fuelprices_appstore_profile-name"] || "match AppStore de.tankstellen.fuelprices"
+
+    # Bump CFBundleVersion in the project so each TestFlight upload has a
+    # unique build number — App Store Connect rejects re-uploads of the
+    # same number.
+    increment_build_number(
+      xcodeproj: "Runner.xcodeproj",
+      build_number: build_number,
+    )
+
+    # `flutter build ipa` is a thin wrapper that doesn't expose the manual-
+    # signing options we need for match-managed certs, so drive xcodebuild
+    # directly through gym after Flutter has produced the precompiled host
+    # artifacts.
+    sh("flutter build ios --release --no-codesign")
+
+    build_app(
+      workspace: "Runner.xcworkspace",
+      scheme: "Runner",
+      configuration: "Release",
+      output_directory: "../build/ios/ipa",
+      output_name: "Runner.ipa",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "de.tankstellen.fuelprices" => profile_name,
+        },
+        signingStyle: "manual",
+        teamID: "C4Y5RDF8P9",
+      },
+      clean: false,
+      include_symbols: true,
+      include_bitcode: false,
+    )
+  end
+
+  desc "Upload the IPA at build/ios/ipa/Runner.ipa to TestFlight (no review submission)."
+  lane :upload_testflight do |options|
+    changelog = options[:changelog] || ENV["TESTFLIGHT_CHANGELOG"] || "Daily build."
+    pilot(
+      api_key: asc_api_key,
+      ipa: "../build/ios/ipa/Runner.ipa",
+      skip_waiting_for_build_processing: true,
+      changelog: changelog,
+    )
+  end
+
+  desc "End-to-end CI release: fetch certs, build, and upload to TestFlight."
+  lane :release_testflight do |options|
+    match(type: "appstore", api_key: asc_api_key)
+    build_appstore(build_number: options[:build_number])
+    upload_testflight(changelog: options[:changelog])
+  end
 end


### PR DESCRIPTION
## Summary

GitHub Actions workflow that builds a signed iOS IPA on a macOS runner and uploads it to TestFlight via the App Store Connect API. The iOS mirror of `daily-beta.yml` (Android Daily Open-Testing Build).

Closes #1489. Refs #9, #1488.

> **PR base is `feat/ios-fastlane-match` (PR #1491)**, which is itself stacked on `feat/ios-testflight-prep` (PR #1490). Merge order: #1490 → #1491 → this PR.

## Workflow shape

- **Trigger**: `workflow_dispatch` only for now, with a `release_notes` input. **Schedule is intentionally commented out** — wire it up only after two consecutive manual runs land cleanly in TestFlight, so we don't burn macos-runner minutes during pipeline iteration.
- **Concurrency**: `group: ios-testflight, cancel-in-progress: false` — two builds can't race for the same TestFlight slot.
- **Build number**: `YYYYMMDD` computed at run time, no commit pushed back. Same convention as the Android daily build.
- **Runner**: `macos-latest`, **45 min timeout**.
- **Caches**: Flutter SDK (subosito/flutter-action), CocoaPods (`Podfile.lock`-keyed), Ruby gems (`bundler-cache: true`).
- **Pre-flight validation**: a step verifies `APP_STORE_CONNECT_API_KEY_BASE64` and `MATCH_GIT_BASIC_AUTHORIZATION` exist before burning compute on pod install / xcodebuild.

## Three new fastlane lanes back the workflow

- **`build_appstore`** — runs `flutter build ios --release --no-codesign` for the precompiled host artifacts, then `gym` for `xcodebuild archive` + `-exportArchive` with manual signing tied to the match-managed appstore profile. Bumps `CFBundleVersion` in-place via `increment_build_number` so each upload is unique.
- **`upload_testflight`** — `pilot upload` against the ASC API key from secrets, `skip_waiting_for_build_processing: true` so the workflow exits as soon as the upload completes (App Store Connect processes async).
- **`release_testflight`** — composite lane: `match appstore` (readonly) → `build_appstore` → `upload_testflight`. This is what the workflow calls.

## Outstanding manual step

Owner must create a fine-grained PAT scoped to read-only access on `fdittgen-png/tankstellen-ios-certs` and store it as `MATCH_GIT_BASIC_AUTHORIZATION`. **The workflow's pre-flight step exits with a pointer to `docs/guides/ios-codesigning.md` if the secret is missing.** Documented in this PR's diff to that file.

## After the PAT is in place

1. New build with `CFBundleVersion = YYYYMMDD` visible in App Store Connect → TestFlight → Builds within ~10 min.
2. Install on the iPhone via the TestFlight iOS app.

## Test plan

- [ ] Owner creates PAT and stores `MATCH_GIT_BASIC_AUTHORIZATION` (instructions in `docs/guides/ios-codesigning.md`)
- [ ] First `workflow_dispatch` run completes with all steps green
- [ ] New build visible in App Store Connect → TestFlight → Builds
- [ ] Owner can install via TestFlight iOS app

🤖 Generated with [Claude Code](https://claude.com/claude-code)