### PR TITLE
docs: announce iPhone TestFlight + ADR 0009 cross-platform default rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Flutter](https://img.shields.io/badge/Flutter-3.41-blue.svg)](https://flutter.dev)
 
-<a href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices">
-  <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="80"/>
-</a>
+<p>
+  <a href="https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices">
+    <img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" height="64"/>
+  </a>
+  &nbsp;
+  <a href="https://apps.apple.com/app/id6766543414">
+    <img alt="Download on the App Store" src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" height="64"/>
+  </a>
+</p>
+
+<sub>iPhone listing currently in <strong>TestFlight beta</strong> — the App Store page will populate once Apple's first-build review clears.</sub>
 
 **A free, open-source companion app for cutting the running cost of your car.** 11 countries, 23 languages, privacy-first, no ads, no tracking.
 
@@ -80,8 +88,9 @@ Features that don't serve at least one of those three layers don't belong.
 
 - **Local-first** — Hive storage, smart caching, offline-capable
 - **Cross-device sync** — optional TankSync cloud backend (self-hostable via Supabase)
-- **Privacy** — no Firebase, no Google Play Services, no tracking, no ads, GDPR-compliant
-- **Accessibility** — meets Android tap-target guidelines, semantic labels throughout
+- **Privacy** — no Firebase, no Google Play Services, no Apple analytics SDKs, no tracking, no ads, GDPR-compliant
+- **Accessibility** — meets Android tap-target and Apple Human Interface tap-target guidelines, semantic labels throughout
+- **Platform parity** — iOS and Android share the same Dart codebase; platform-specific surfaces (BLE OBD2, background tasks, widgets) live behind plugin interfaces, never inline `Platform.isIOS` branches
 
 ## Screenshots
 
@@ -107,8 +116,8 @@ Captured on a Samsung S23 Ultra running the **Play** flavour against the live `P
 ### Prerequisites
 
 - [Flutter SDK](https://docs.flutter.dev/get-started/install) (stable channel, 3.41+)
-- Android SDK with at least one emulator or connected device
-- JDK 17
+- **For Android builds:** Android SDK with at least one emulator or connected device, plus JDK 17
+- **For iOS builds (macOS only):** Xcode 26+, CocoaPods 1.16+, Ruby 3.0+ with Bundler (see [docs/guides/ios-codesigning.md](docs/guides/ios-codesigning.md) for the fastlane match setup)
 
 ### Setup
 
@@ -139,7 +148,7 @@ Tankstellen uses official government fuel price APIs. Some require a free API ke
 | Spain | [MiTECO](https://sedeaplicaciones.mineco.gob.es/) | No |
 | Italy | [MISE](https://dgsaie.mise.gov.it/) | No |
 
-Keys are stored securely on-device (Android Keystore) — never embedded in source code.
+Keys are stored securely on-device (Android Keystore on Android, iOS Keychain on iOS via `flutter_secure_storage`) — never embedded in source code.
 
 ## Architecture
 

--- a/docs/decisions/0009-cross-platform-default-and-plugin-pattern.md
+++ b/docs/decisions/0009-cross-platform-default-and-plugin-pattern.md
@@ -1,0 +1,119 @@
+# ADR 0009: Cross-platform by default; platform-specific code lives in loosely-coupled plugins
+
+**Status:** Accepted
+**Date:** 2026-05-08
+
+## Context
+
+Tankstellen ships on both iOS and Android. The shared business logic lives
+in Dart, but a non-trivial set of capabilities — Bluetooth Low Energy
+(OBD2), continuous background fetch, home-screen widgets, in-vehicle
+infotainment integrations (Android Auto and CarPlay), local notifications,
+and platform credential stores — are exposed by very different APIs on the
+two operating systems.
+
+Up to now, with the iOS port still bootstrapping, almost every feature
+shipped Android-first. As of #1456 (iOS build pipeline) and the four PRs
+that close out epic #9 (#1490 / #1491 / #1492 / #1493), iOS is a peer
+target with its own signing, fastlane match, and TestFlight workflow.
+Owner directive on **2026-05-08**:
+
+> The Mac is now the main development and build server, and all builds
+> must happen for both iPhone and Android. Features are by default on both
+> platforms. If a feature is intentionally single-platform, the code must
+> be written as a plugin that is loosely bound to the app and not be mixed
+> with code that runs on both.
+
+We need a written rule so the next contributor doesn't shape platform
+divergence ad hoc.
+
+## Decision
+
+**1. Every feature targets iOS and Android by default.** When a new feature
+is proposed, the question "which platforms?" is *not* asked — both is the
+answer. Issues, PRs, and design docs only need to call out platform scope
+when the feature is intentionally restricted to one.
+
+**2. Platform-specific code is structured as a plugin.** When a feature
+*does* require a platform-specific API (BLE, BG location, BG tasks, home
+widgets, CarPlay/Android Auto), the implementation must follow the
+existing two-impl-one-interface pattern already used in
+`lib/core/background/`:
+
+- An abstract interface in shared code (e.g.
+  `BackgroundPriceFetcher`).
+- A concrete `_android_…` implementation that imports Android-only
+  packages.
+- A concrete `_ios_…` implementation (or a stub like
+  `ios_background_price_fetcher_stub.dart` if the iOS API isn't wired
+  yet) that *never* imports Android-only packages.
+- A Riverpod provider chooses the concrete impl at startup, typically via
+  `defaultTargetPlatform` or a feature flag.
+
+Shared business logic — the providers, the screens, the use cases —
+imports only the abstract interface. It must compile and run on a target
+where the platform-specific impl is a no-op.
+
+**3. No inline `if (Platform.isIOS) { ... } else { ... }` branches in
+shared code.** That pattern leaks platform APIs through the shared code's
+import graph and makes it impossible to delete a platform without
+rewriting half the codebase. The only acceptable use of `Platform.isIOS`
+or `defaultTargetPlatform` is in a provider that selects which concrete
+plugin impl to inject — never in a screen, controller, or service body.
+
+**4. Both CI workflows must stay green on every PR.** A regression in
+`daily-beta.yml` (Android nightly to Play Store) or `ios-testflight.yml`
+(iOS nightly to TestFlight) is treated as a release-blocking failure. A
+PR that intentionally trades one platform for the other is rejected.
+
+## Consequences
+
+**Positive:**
+
+- The codebase remains buildable on both platforms without surgical
+  per-feature carve-outs.
+- A reader of `lib/features/<name>/` doesn't need to mentally subtract
+  iOS-only or Android-only code paths to understand the feature.
+- New contributors can bring up either platform without an existing
+  contributor's knowledge of which features "secretly" don't run there.
+- Future deprecations (e.g., dropping the `foss` Android flavour) become
+  a matter of removing one plugin impl instead of unwinding `if`
+  branches throughout the code.
+
+**Negative:**
+
+- More files per platform-divergent feature (one interface + two impls +
+  one provider, instead of one inline `if`).
+- Forces an early architectural decision when the feature's complexity
+  is small. Contributors may grumble that a 30-line iOS-vs-Android split
+  feels over-engineered.
+- Stub maintenance: when an iOS feature is deferred, a no-op stub still
+  has to ship so shared code compiles on iOS.
+
+**Mitigations:**
+
+- The existing `lib/core/background/` split is the canonical worked
+  example — point reviewers to it.
+- For genuinely platform-only APIs (CarPlay, WidgetKit, Android Auto)
+  where there is no shared abstraction, the plugin is allowed to live
+  entirely under `ios/` or `android/` native code with a thin Dart
+  channel; the rule still applies — no shared Dart code touches the
+  platform channel directly.
+
+## Examples already in the codebase
+
+- **`BackgroundPriceFetcher`** — abstract interface, with
+  `AndroidBackgroundPriceFetcher` (Workmanager) and
+  `IosBackgroundPriceFetcherStub` (placeholder until BGTaskScheduler is
+  wired). Shared `BackgroundService` calls only the abstract interface.
+- **Notifications** — `flutter_local_notifications` already abstracts
+  iOS UNUserNotificationCenter from Android NotificationManager; we
+  inherit the plugin pattern via the package itself.
+- **Secure storage** — `flutter_secure_storage` does the same for
+  Android Keystore and iOS Keychain.
+
+## Out of scope
+
+This ADR doesn't say anything about *which* APIs we use on each platform
+(that's per-feature design), nor about test pyramid or layering. It only
+governs **where** platform-specific code is allowed to live.


### PR DESCRIPTION
## Summary

Two doc-only changes that codify the platform-parity policy declared on 2026-05-08.

- **README.md**: iPhone TestFlight callout next to the Play badge; iOS prereqs split out (pointing at `docs/guides/ios-codesigning.md`); privacy/accessibility lines made platform-neutral; "Platform parity" bullet pointing at the loosely-coupled plugin pattern as the rule of the road.
- **docs/decisions/0009-cross-platform-default-and-plugin-pattern.md**: new ADR in the same MADR shape as 0001–0008. Captures the owner directive ("features default to both iOS and Android; single-platform features must be plugins"), with examples already in-tree (`BackgroundPriceFetcher`, `flutter_local_notifications`, `flutter_secure_storage`). Explicitly forbids inline `if (Platform.isIOS)` branches in shared code and requires both CI workflows to stay green on every PR.

Refs #9.

## Wiki updates

The wiki lives in a separate git repo (`fdittgen-png/tankstellen.wiki`) and was pushed as commit `67ff57a`:

- `Home.md` — TestFlight callout, platform-parity bullet
- `Dev-Home.md` — pointer to ADR 0009 + `ios-codesigning.md`
- `User-en-Getting-Started.md` — TestFlight invite path, iOS minimum version, Keychain mention

Localized user pages (`User-{de,es,fr,it,nl,pt,da,…}-Getting-Started.md`) still say *"iOS is planned but not yet available"* and need a sweep — deliberately left for a follow-up so this PR isn't a translation marathon.

## Test plan

- [x] `cat README.md` — renders cleanly in plain markdown
- [ ] Reviewer confirms ADR 0009 captures the rule as stated
- [ ] Wiki landing page (`https://github.com/fdittgen-png/tankstellen/wiki`) shows the new TestFlight callout

🤖 Generated with [Claude Code](https://claude.com/claude-code)