### PR TITLE
ci(release): default Daily Open-Testing cron to internal track until Play Console form clears

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -101,11 +101,18 @@ jobs:
           echo "PLAY_KEY_PATH=$RUNNER_TEMP/play-key.json" >> "$GITHUB_ENV"
 
       - name: Upload to Play Store
+        # Cron-default track is `internal` until the ACCESS_BACKGROUND_LOCATION
+        # sensitive-permissions declaration is approved in Play Console (see
+        # issue #1498). The Open Testing (`beta`) track currently 403s at
+        # `edits.commit` because that declaration is missing. Internal Testing
+        # accepts the same AAB without the declaration. Manual workflow_dispatch
+        # runs can still pick `beta` / `alpha` / `production` from the input.
+        # Flip back to `'beta'` once Google approves the form.
         run: |
           python tools/upload_to_play.py \
             --aab build/app/outputs/bundle/playRelease/app-play-release.aab \
             --key "$PLAY_KEY_PATH" \
-            --track "${{ github.event.inputs.track || 'beta' }}" \
+            --track "${{ github.event.inputs.track || 'internal' }}" \
             ${{ github.event.inputs.release_notes && format('--release-notes "{0}"', github.event.inputs.release_notes) || '' }}
 
       - name: Clean up service-account key
@@ -118,5 +125,5 @@ jobs:
           echo "## Daily Open-Testing Release" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Build number:** ${{ steps.bn.outputs.build_number }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Track:** ${{ github.event.inputs.track || 'beta' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Track:** ${{ github.event.inputs.track || 'internal' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Trigger:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The Daily Open-Testing cron has been failing every day for ~10 days because the AAB requests `ACCESS_BACKGROUND_LOCATION` and Google requires a sensitive-permissions declaration before any track that's reviewed (Open Testing / closed / production) accepts the upload. The declaration is a manual web-UI task tracked in **#1498**; only the owner can fill it (use-case justification + screen recording).

Until that form is approved, this PR flips the cron-default track from `beta` to `internal`. Internal Testing accepts the same AAB without the declaration (max 100 testers, no review). Manual `workflow_dispatch` runs still let you pick `beta` / `alpha` / `production` from the existing `track` input.

Refs #1498.

## Reverting

Once Google approves the sensitive-permissions form, swap `'internal'` back to `'beta'` on the two lines this PR touches and the cron resumes its old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)