### PR TITLE
docs(adr): add Alternatives Considered to ADR 0009 + register it in the index

### DIFF
--- a/docs/decisions/0009-cross-platform-default-and-plugin-pattern.md
+++ b/docs/decisions/0009-cross-platform-default-and-plugin-pattern.md
@@ -112,6 +112,32 @@ PR that intentionally trades one platform for the other is rejected.
 - **Secure storage** — `flutter_secure_storage` does the same for
   Android Keystore and iOS Keychain.
 
+## Alternatives Considered
+
+**Inline `if (Platform.isIOS) { ... }` branches in shared code.** Rejected
+— already covered in the Decision section. Short-term cheap, long-term
+ruinous: turns the shared code's import graph into a per-platform
+dependency soup, and makes deleting a platform an archaeological project
+rather than just removing one plugin file.
+
+**Separate Dart packages per platform-specific feature** (e.g. an
+`obd2_ble_android` and `obd2_ble_ios` package consumed by the main app).
+Rejected for v1: adds packaging overhead (path dependencies, version
+pinning, separate test runs) for plugins that today are all single-impl
+files. Reconsider if a third party ever wants to ship a platform impl
+without forking the whole repo.
+
+**Single platform target.** Rejected: the iOS bootstrap (#1456 + #9
+follow-ups) was already a deliberate, completed investment. Walking it
+back now would invalidate signing infra (fastlane match repo, ASC API
+key, App Store Connect record) and the Mac CI runner job that already
+exists.
+
+**Conditional imports** (Dart's `if (dart.library.io)` pattern). Useful
+for the web/io split but a poor fit for our iOS/Android divide —
+`dart.library.io` is true on both, so it can't carry the platform
+branch. The plugin pattern subsumes this anyway.
+
 ## Out of scope
 
 This ADR doesn't say anything about *which* APIs we use on each platform

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -37,3 +37,4 @@ reused. If a decision is reversed, the original ADR is marked
 | 0006 | 23-language i18n strategy          | Accepted |
 | 0007 | MIT license choice                 | Accepted |
 | 0008 | Storage migration evaluation (v5.x) | Accepted |
+| 0009 | Cross-platform default + plugin pattern | Accepted |


### PR DESCRIPTION
## Summary

Fixes the master CI breakage that's blocking every PR: `test/docs/adr_format_test.dart` has two assertions failing on every PR build because ADR 0009 (merged via #1494) is missing the required `## Alternatives Considered` heading and isn't listed in `docs/decisions/README.md`'s index table.

Refs #9.

## Test plan

- [x] `flutter test test/docs/adr_format_test.dart` — 8/8 pass locally
- [ ] Master CI green after merge — every blocked PR rebases onto fixed master

🤖 Generated with [Claude Code](https://claude.com/claude-code)