### PR TITLE
ci: fix Play Store version-code collision + iOS match repo 403

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -4,8 +4,12 @@ name: Daily Open-Testing Build
 # Cron is UTC: 16:00 UTC = 18:00 CEST (summer) / 17:00 CET (winter).
 # Adjust to '0 17 * * *' if you want 18:00 Paris during winter instead.
 #
-# Build numbers are date-based (YYYYMMDD) computed at build time, so there's no
-# commit pushed back to master. pubspec.yaml's +N keeps tracking manual releases.
+# Build numbers are date+hour-based (YYYYMMDDHH) computed at build time, so
+# there's no commit pushed back to master and re-runs on the same day get
+# distinct, monotonically-increasing version codes (Play Store version codes
+# are global across tracks, so YYYYMMDD alone collides if Internal and Open
+# Testing both upload on the same day). pubspec.yaml's +N keeps tracking
+# manual releases. Max value at year 2099 fits Android's 2,100,000,000 cap.
 on:
   schedule:
     - cron: '0 16 * * *'
@@ -42,7 +46,7 @@ jobs:
       - name: Compute date-based build number
         id: bn
         run: |
-          BN=$(TZ=Europe/Paris date +%Y%m%d)
+          BN=$(TZ=Europe/Paris date +%Y%m%d%H)
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "Daily build number: $BN"
 

--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -217,20 +217,22 @@ jobs:
           echo "$ASC_KEY_BASE64" | base64 --decode > "$KEY_PATH"
           echo "ASC_API_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Validate match-repo auth secret
-        env:
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      - name: Set up SSH agent with match deploy key
+        # Match repo is fetched via SSH using a deploy key stored as
+        # MATCH_DEPLOY_KEY (read-only, scoped to the certs repo).
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_DEPLOY_KEY }}
+
+      - name: Add github.com to known_hosts
         run: |
-          if [ -z "$MATCH_GIT_BASIC_AUTHORIZATION" ]; then
-            echo "::error::MATCH_GIT_BASIC_AUTHORIZATION secret is not set. See docs/guides/ios-codesigning.md." >&2
-            exit 1
-          fi
+          mkdir -p ~/.ssh
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
 
       - name: fastlane match_appstore + build_appstore
         working-directory: ios
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           IOS_BUILD_NUMBER: ${{ needs.pre-check.outputs.build_number }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -3,8 +3,9 @@ name: iOS TestFlight Build
 # Build a signed iOS IPA on a macOS runner and upload it to TestFlight via the
 # App Store Connect API. Mirror of `daily-beta.yml` but for iOS.
 #
-# Build numbers are date-based (YYYYMMDD) computed at build time, so there's no
-# commit pushed back to master.
+# Build numbers are date+hour-based (YYYYMMDDHH) computed at build time, so
+# there's no commit pushed back to master and re-runs on the same day get
+# distinct, monotonically-increasing CFBundleVersions.
 
 on:
   workflow_dispatch:
@@ -34,7 +35,7 @@ jobs:
       - name: Compute date-based build number
         id: bn
         run: |
-          BN=$(TZ=Europe/Paris date +%Y%m%d)
+          BN=$(TZ=Europe/Paris date +%Y%m%d%H)
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "Daily build number: $BN"
 
@@ -75,20 +76,25 @@ jobs:
           echo "$ASC_KEY_BASE64" | base64 --decode > "$KEY_PATH"
           echo "ASC_API_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Validate match-repo auth secret
-        env:
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      - name: Set up SSH agent with match deploy key
+        # The match repo (fdittgen-png/tankstellen-ios-certs) is fetched
+        # via SSH using a deploy key stored in MATCH_DEPLOY_KEY. PAT-based
+        # auth was tried first but GitHub's fine-grained PAT scope kept
+        # rejecting clone requests with 403; deploy keys bypass the PAT
+        # scoping entirely and are read-only by design (#1498).
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_DEPLOY_KEY }}
+
+      - name: Add github.com to known_hosts
         run: |
-          if [ -z "$MATCH_GIT_BASIC_AUTHORIZATION" ]; then
-            echo "::error::MATCH_GIT_BASIC_AUTHORIZATION secret is not set. See docs/guides/ios-codesigning.md." >&2
-            exit 1
-          fi
+          mkdir -p ~/.ssh
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
 
       - name: fastlane release_testflight
         working-directory: ios
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           # ASC_API_KEY_FILEPATH was exported by the decode step above so the

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,4 +1,8 @@
-git_url("https://github.com/fdittgen-png/tankstellen-ios-certs.git")
+# SSH URL: avoids relying on a fine-grained PAT (which kept hitting 403 even
+# with read-only Contents scope). Local devs need their personal GitHub SSH
+# key loaded; CI loads MATCH_DEPLOY_KEY (ed25519 deploy key on the certs
+# repo, read-only) via webfactory/ssh-agent in the workflow.
+git_url("git@github.com:fdittgen-png/tankstellen-ios-certs.git")
 storage_mode("git")
 
 type("appstore")


### PR DESCRIPTION
## Summary

Two unrelated CI break fixes that both block the first public Sparkilo release. Filed together because they surfaced from the same workflow_dispatch attempts and both need to land before public Open Testing / TestFlight uploads succeed.

### 1. Play Store version-code collision

Android Open Testing run failed with:

```
403 - Version code 20260508 has already been used.
```

Earlier Internal Testing run on 2026-05-08 used the same date-based build number; Play Store version codes are **global across tracks**. Switches the formula in `daily-beta.yml` AND `ios-testflight.yml` from `YYYYMMDD` → `YYYYMMDDHH`. 24 unique values per day, fits Android's 2.1B cap until year 2099.

### 2. iOS match repo 403 on clone

iOS TestFlight run failed with:

```
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/fdittgen-png/tankstellen-ios-certs.git/': 403
```

The PAT in `MATCH_GIT_BASIC_AUTHORIZATION` was created without resource-owner access to the certs repo (verified: `/user` returns 200, `/repos/fdittgen-png/tankstellen-ios-certs` returns 404). Rather than round-trip the GitHub UI to fix the PAT scope, this commit switches match to **SSH + a deploy key**:

- Deploy key **#150908530** added to `fdittgen-png/tankstellen-ios-certs` (read-only, ed25519).
- Private key stored as `MATCH_DEPLOY_KEY` secret on the main repo.
- `ios-testflight.yml` and `daily-github-release.yml` gain a `webfactory/ssh-agent@v0.9.0` step + `ssh-keyscan github.com` for known_hosts.
- `Matchfile` `git_url` flips to `git@github.com:fdittgen-png/tankstellen-ios-certs.git`.
- The legacy `MATCH_GIT_BASIC_AUTHORIZATION` env var is removed from both workflows (secret stays in place as a no-op fallback for now).

Refs #1498.

## Test plan

- [x] `flutter analyze` clean
- [x] Local `bundle exec fastlane match_appstore` clones via SSH using developer's existing key
- [ ] After merge: re-trigger `Daily Open-Testing Build` (track=beta) — expect a unique 2026050817 (or current hour) version code, 200 on upload
- [ ] After merge: re-trigger `iOS TestFlight Build` — expect SSH clone of certs repo to succeed, IPA to upload to App Store Connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)