### PR TITLE
ci: pod under active Ruby + drop FS perms to clear Play Store form gate

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -199,6 +199,12 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: pods-${{ runner.os }}-
 
+      - name: Install CocoaPods under active Ruby
+        # See ios-testflight.yml for the long-form rationale: the runner's
+        # system pod is bound to a different Ruby than ruby/setup-ruby's, so
+        # flutter's pod check fails. Reinstall pod under the active Ruby.
+        run: gem install cocoapods --no-document
+
       - name: Flutter pub get
         run: flutter pub get
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -58,6 +58,14 @@ jobs:
           key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: pods-${{ runner.os }}-
 
+      - name: Install CocoaPods under active Ruby
+        # The macos-latest runner ships a system pod bound to system Ruby; once
+        # `ruby/setup-ruby` switches the active Ruby to 3.3, that system pod's
+        # GEM_HOME no longer matches and flutter sees "CocoaPods is installed
+        # but broken." Reinstall under the active Ruby so `pod` on PATH works
+        # both for the explicit step below and for flutter's auto-pod fallback.
+        run: gem install cocoapods --no-document
+
       - name: Flutter pub get
         run: flutter pub get
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
@@ -36,19 +37,32 @@
     <uses-feature android:name="android.hardware.bluetooth_le"
         android:required="false"/>
 
-    <!-- Hands-free trip auto-record (#1004 phase 2b-1).
-         The AutoRecordForegroundService observes BLE auto-connect for
-         the paired adapter while the app is not in the foreground. It
-         requires:
-           * FOREGROUND_SERVICE              base permission since API 28
-           * FOREGROUND_SERVICE_CONNECTED_DEVICE  required by Android 14
-             (API 34+) for `connectedDevice` foreground service type
-           * POST_NOTIFICATIONS              Android 13+ runtime perm so
-             the persistent low-importance auto-record notification can
-             render. Without it the service still runs but the channel
-             is silenced. -->
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
+    <!-- Hands-free trip auto-record (#1004 phase 2b-1) and Android Auto
+         car-app integration both depend on foreground-service permissions.
+         Google Play's "Foreground Service Use" declaration form is a hard
+         gate on every reviewed track (Open Testing, Closed Testing,
+         Production): edits.commit returns 403 with
+         "You must let us know whether your app uses any Foreground Service
+         permissions." until the form is submitted via the web UI.
+         Mirroring the ACCESS_BACKGROUND_LOCATION precedent (line ~21):
+         the FOREGROUND_SERVICE* permissions and the foreground-service
+         components (AutoRecordForegroundService, TankstellenCarAppService,
+         the androidx.car.app meta-data) are dropped from the manifest so
+         the very-first public Open Testing build can ship.
+         tools:node="remove" defends against manifest-merge: androidx.car.app
+         declares FOREGROUND_SERVICE in its own manifest and would otherwise
+         pull it back in despite our line being commented out.
+         Functional impact while disabled:
+           * Hands-free trip auto-record (already off because BG location is
+             gone) calls invokeMethod('start') and gets a graceful failure.
+           * Android Auto integration is unreachable — the Auto host can't
+             find a CarAppService matching the intent-filter.
+         Restore all five lines below the moment the Foreground Service Use
+         form is approved (#1498). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"
+        tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
+        tools:node="remove"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
@@ -109,18 +123,17 @@
         </activity>
 
         <!-- Hands-free trip auto-record foreground service (#1004
-             phase 2b-1). Internal-only — exported=false so no other
-             app can bind. foregroundServiceType="connectedDevice"
-             matches the BLE listener's role: observe transitions on
-             the paired OBD2 adapter only. -->
+             phase 2b-1) and Android Auto CarAppService — both
+             commented out for the Open Testing release. See the
+             FOREGROUND_SERVICE permission block above for the full
+             rationale (Google Play "Foreground Service Use" form
+             gate); restore alongside the permissions when #1498's
+             form is approved.
         <service
             android:name=".autorecord.AutoRecordForegroundService"
             android:exported="false"
             android:foregroundServiceType="connectedDevice"/>
 
-        <!-- Android Auto car app service -->
-        <!-- exported=true required: Android Auto host binds via this intent-filter.
-             Permission restricts binding to holders of FOREGROUND_SERVICE permission. -->
         <service
             android:name=".TankstellenCarAppService"
             android:exported="true"
@@ -134,6 +147,7 @@
         <meta-data
             android:name="androidx.car.app.minCarApiLevel"
             android:value="1" />
+        -->
 
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/test/security/android_manifest_security_test.dart
+++ b/test/security/android_manifest_security_test.dart
@@ -37,19 +37,35 @@ void main() {
       );
     });
 
-    test('CarAppService has permission restriction', () {
-      // The TankstellenCarAppService must have a permission attribute
-      // to restrict which apps can bind to it.
+    test('CarAppService — when active — has permission restriction', () {
+      // While Google Play's Foreground Service Use form is unapproved
+      // (#1498), the TankstellenCarAppService entry is commented out so
+      // the AAB ships without foreground-service permissions. Skip the
+      // restriction check when the service is absent, but enforce it the
+      // moment the entry is restored.
+      final stripped =
+          manifestContent.replaceAll(RegExp(r'<!--[\s\S]*?-->'), '');
       final servicePattern = RegExp(
         r'<service[^>]*android:name="\.TankstellenCarAppService"[^>]*>',
         dotAll: true,
       );
 
-      final match = servicePattern.firstMatch(manifestContent);
-      expect(match, isNotNull,
-          reason: 'TankstellenCarAppService must exist in manifest');
+      final match = servicePattern.firstMatch(stripped);
+      if (match == null) {
+        // Service entry is currently commented out — verify it's actually
+        // commented (not silently deleted) so the restore path stays valid.
+        expect(
+          manifestContent,
+          contains('TankstellenCarAppService'),
+          reason:
+              'TankstellenCarAppService must remain in the manifest, even '
+              'if commented out, so the post-FS-form restore is a single '
+              'block uncomment.',
+        );
+        return;
+      }
 
-      final serviceTag = match!.group(0)!;
+      final serviceTag = match.group(0)!;
       expect(
         serviceTag,
         contains('android:permission='),


### PR DESCRIPTION
## Summary
- **iOS workflows** (`ios-testflight.yml`, `daily-github-release.yml`): add `gem install cocoapods --no-document` step under the active Ruby so the `pod` binary on PATH matches the Ruby `ruby/setup-ruby@v1` activates. Without this, the runner's preinstalled pod is bound to system Ruby and flutter's pod probe fails with *"CocoaPods is installed but broken"*.
- **AndroidManifest.xml**: drop `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_CONNECTED_DEVICE` permissions and the `AutoRecordForegroundService` / `TankstellenCarAppService` / `androidx.car.app.minCarApiLevel` entries until Google Play's *Foreground Service Use* declaration form is approved (tracked alongside BG location in #1498). Uses `tools:node=\"remove\"` to defend against `androidx.car.app:app:1.4.0`'s own merged manifest reintroducing the permission. Mirrors the `ACCESS_BACKGROUND_LOCATION` precedent from #1500.
- **Test**: `android_manifest_security_test.dart` strips XML comments before asserting on `TankstellenCarAppService` so the test passes while the entry is commented but flips back the moment it's restored.

## Why now
The two failing `workflow_dispatch` runs immediately after #1502:
- iOS run **25576314702** — fastlane crashed at `flutter build ios` with the broken-CocoaPods error.
- Android run **25576313373** — build + upload succeeded (versionCode `2026050821`, the new `YYYYMMDDHH` formula worked perfectly), then `edits.commit` returned 403: *"You must let us know whether your app uses any Foreground Service permissions."*

Both block the first public Open Testing + TestFlight uploads. Bundling because the alternative is two PRs gating the same release.

## Functional impact while FS perms are commented out
- Hands-free trip auto-record (`#1004`) was already off because BG location was already removed (`#1500`). Calling the auto-record start now returns a graceful failure on the platform channel.
- Android Auto host can't reach `TankstellenCarAppService`. First-day Open Testing audience has no Auto users yet — restore the moment Google approves the form.
- `POST_NOTIFICATIONS` stays untouched.

## Test plan
- [x] `flutter test test/security/android_manifest_security_test.dart` → 3/3 green
- [x] `flutter analyze` → No issues found
- [ ] CI green
- [ ] After merge: re-trigger Android Open-Testing + iOS TestFlight workflows; AAB lands on Play Console Open Testing track and IPA arrives at TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)