### PR TITLE
ci(ios): wrap flutter build in Bundler.with_unbundled_env to unbreak pod

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -58,7 +58,20 @@ platform :ios do
     # signing options we need for match-managed certs, so drive xcodebuild
     # directly through gym after Flutter has produced the precompiled host
     # artifacts.
-    sh("flutter build ios --release --no-codesign")
+    #
+    # The `flutter build ios` step internally invokes `pod install`. We are
+    # running under `bundle exec fastlane` on CI, which clamps GEM_PATH and
+    # RUBYOPT to the bundler-managed `vendor/bundle`. CocoaPods is installed
+    # under the active Ruby (via `gem install cocoapods` in the workflow)
+    # and lives outside that clamped path, so when flutter's child shell
+    # calls `pod` it can find the binary on PATH but cannot load its gems —
+    # surfacing as "CocoaPods is installed but broken. Skipping pod install."
+    # `Bundler.with_unbundled_env` strips the bundler env vars for the
+    # duration of the block so the child process sees the normal Ruby
+    # environment where CocoaPods is loadable.
+    Bundler.with_unbundled_env do
+      sh("flutter build ios --release --no-codesign")
+    end
 
     build_app(
       workspace: "Runner.xcworkspace",


### PR DESCRIPTION
## Summary
- iOS run #25579486022 (post-#1503) failed at fastlane's `sh \"flutter build ios --release --no-codesign\"` with the same *\"CocoaPods is installed but broken. Skipping pod install.\"* warning we tried to fix in #1503.
- #1503's `gem install cocoapods --no-document` step **did** make the explicit `Pod install` step succeed (it ran outside `bundle exec`). But inside `bundle exec fastlane`, the flutter child inherits the bundler-clamped GEM_PATH/RUBYOPT, and `pod`'s gems live outside `vendor/bundle` — so flutter sees pod on PATH but can't load it.
- Fix: wrap the offending `sh` call in `Bundler.with_unbundled_env` so the flutter child (and its `pod` grandchild) sees the normal Ruby env where the gem-installed CocoaPods is loadable.

## Why this and not adding cocoapods to the Gemfile
A Gemfile-managed CocoaPods would still leave `pod` invisible on PATH inside fastlane's child shell unless we also add `bundle binstubs cocoapods` and put `bin/` on PATH. The `Bundler.with_unbundled_env` block is one line, scoped to the only `sh` call that needs it, and matches the standard fastlane pattern for shelling out to non-Ruby tooling.

## Test plan
- [x] `ruby -c ios/fastlane/Fastfile` → Syntax OK
- [ ] CI green
- [ ] After merge: re-trigger `iOS TestFlight Build`; expect IPA upload to App Store Connect TestFlight to succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)