### PR TITLE
ci(ios): pin connectivity_plus below 7.1.0 to avoid iOS 26 SDK symbol

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -229,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.0.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,17 @@ dependencies:
   xml: ^6.6.1
   path_provider: ^2.1.5
   uuid: ^4.5.1
-  connectivity_plus: ^7.1.1
+  # Hold below 7.1.0: connectivity_plus 7.1.x's iOS PathMonitor source
+  # references `NWPath.isUltraConstrained`, an iOS 26 SDK symbol guarded by
+  # `#available(iOS 26.0, *)`. The runtime guard does NOT save us at compile
+  # time — Swift still type-checks the property access against whatever SDK
+  # Xcode is using, and the macos-latest GitHub runner has Xcode 16 (iOS 18
+  # SDK) which doesn't define `isUltraConstrained`. The build fails with
+  # "Value of type 'NWPath' has no member 'isUltraConstrained'". Restore to
+  # ^7.1.x once GitHub's macos-* runner image ships Xcode 26+ with the iOS
+  # 26 SDK (or once connectivity_plus moves the iOS 26 path behind a Swift
+  # `#if canImport(...)` / compiler-version gate).
+  connectivity_plus: '>=7.0.0 <7.1.0'
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.1
   http: ^1.3.0


### PR DESCRIPTION
## Summary
iOS run [25581563289](https://github.com/fdittgen-png/tankstellen/actions/runs/25581563289) (post-#1504) finally got past CocoaPods (the `Bundler.with_unbundled_env` wrapper worked) and reached actual Swift compilation, where it failed with:

```
Swift Compiler Error (Xcode):
  Value of type 'NWPath' has no member 'isUltraConstrained'
/…/connectivity_plus-7.1.1/ios/…/PathMonitorConnectivityProvider.swift:28
```

`connectivity_plus 7.1.x` added satellite detection guarded by `if #available(iOS 26.0, *), path.isUltraConstrained`. The runtime `#available` guard does NOT save us at compile time — Swift still type-checks the property access against whatever SDK Xcode uses. The macos-15-arm64 GitHub runner (image release `20260427.0018`) ships Xcode 16 / iOS 18 SDK, which doesn't define `isUltraConstrained` (an iOS 26 symbol).

Pin `connectivity_plus` to `>=7.0.0 <7.1.0`. The lock now resolves to 7.0.0. Restore to `^7.1.x` once the GitHub runner ships Xcode 26+ with the iOS 26 SDK, or once the package moves the iOS 26 path behind a `#if compiler(>=...)` / `canImport(...)` gate.

## Test plan
- [x] `flutter pub get` → resolves to 7.0.0
- [x] `grep -r isUltraConstrained ~/.pub-cache/.../connectivity_plus-7.0.0` → no matches
- [x] `flutter analyze` → No issues found
- [x] `flutter test test/core/services/api_connectivity_test.dart test/core/telemetry/collectors/network_state_collector_test.dart` → 16/16 green
- [ ] CI green
- [ ] After merge: re-trigger `iOS TestFlight Build`; expect IPA to upload and process on TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)