### PR TITLE
ci(ios): switch Runner Release config to manual signing with match profile

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -723,13 +723,13 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = C4Y5RDF8P9;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Tankstellen;
+				INFOPLIST_KEY_CFBundleDisplayName = Sparkilo;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -739,7 +739,7 @@
 				MARKETING_VERSION = 5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore de.tankstellen.fuelprices";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
## Summary
iOS run [25584395370](https://github.com/fdittgen-png/tankstellen/actions/runs/25584395370) (post-#1505) finally got past Swift compilation, but `xcodebuild archive` failed:

```
No profiles for 'de.tankstellen.fuelprices' were found:
Xcode couldn't find any iOS App Development provisioning profiles
matching 'de.tankstellen.fuelprices'. Automatic signing is disabled
and unable to generate a profile.
```

`match_appstore` had successfully installed an `Apple Distribution` cert and the `match AppStore de.tankstellen.fuelprices` profile, but the project was still asking Xcode for an *iOS App Development* profile (because Release config was on `CODE_SIGN_IDENTITY = "Apple Development"` + `CODE_SIGN_STYLE = Automatic`).

## Changes
Three edits in the Runner target's **Release** config only (Debug + Profile stay automatic so local personal-Apple-ID development still works):
- `CODE_SIGN_IDENTITY = "Apple Development"` → `\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\" = \"Apple Distribution\"`
- `CODE_SIGN_STYLE = Automatic` → `CODE_SIGN_STYLE = Manual`
- `PROVISIONING_PROFILE_SPECIFIER = \"\"` → `PROVISIONING_PROFILE_SPECIFIER = \"match AppStore de.tankstellen.fuelprices\"`

Also flipped `INFOPLIST_KEY_CFBundleDisplayName = Tankstellen` → `Sparkilo` in the same Release config — leftover from the Flutter template that would have overridden the Sparkilo rebrand (#1497) at build time, writing \"Tankstellen\" back into the IPA's Info.plist.

## Test plan
- [x] `plutil -lint ios/Runner.xcodeproj/project.pbxproj` → OK
- [ ] CI green
- [ ] After merge: re-trigger `iOS TestFlight Build`; expect IPA to upload to TestFlight under display name **Sparkilo**

🤖 Generated with [Claude Code](https://claude.com/claude-code)