### PR TITLE
ci(ios): add fastlane setup_ci + bump iOS workflow timeout to 60min

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -174,7 +174,7 @@ jobs:
     needs: pre-check
     if: needs.pre-check.outputs.commit_count != '0'
     runs-on: macos-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build-and-upload:
     runs-on: macos-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -22,6 +22,20 @@ def asc_api_key
 end
 
 platform :ios do
+  # On CI, create + unlock a dedicated temporary keychain and set it as
+  # default before any signing-related action runs. Without this, fastlane
+  # match installs the distribution cert into ~/Library/Keychains/login
+  # .keychain-db (which is locked on a headless GitHub-hosted runner) —
+  # match warns "Could not configure imported keychain item to prevent UI
+  # permission popup when code signing", and later xcodebuild's codesign
+  # step hangs indefinitely waiting on a UI prompt that never arrives. The
+  # 45-min job timeout then cancels the run before the IPA is uploaded.
+  # `setup_ci` is fastlane's standard one-liner for this; it's a no-op
+  # locally so developer workflows are unaffected.
+  before_all do
+    setup_ci if ENV["CI"] == "true"
+  end
+
   desc "Fetch development cert + profile (readonly on CI)."
   lane :match_dev do
     match(type: "development", api_key: asc_api_key)


### PR DESCRIPTION
## Summary
iOS run [25585924843](https://github.com/fdittgen-png/tankstellen/actions/runs/25585924843) (post-#1506) finally got past Swift compile + Pods + the manual-signing config… and then timed out at the 45-minute job limit while `xcodebuild archive`'s codesign step hung silently for 34 minutes.

Match's earlier warning explains the hang:

```
Keychain password for ~/Library/Keychains/login.keychain-db was not
specified and not found in your keychain. Specify the 'keychain_password'
option to prevent the UI permission popup when code signing
Could not configure imported keychain item (certificate) to prevent UI
permission popup when code signing
```

Match installed the Apple Distribution cert into `login.keychain`, which is locked on a headless GitHub-hosted macOS runner. When xcodebuild's codesign later asked the keychain for the private key, macOS would normally show a UI permission prompt — there's no UI on CI, so codesign blocks indefinitely.

## Changes
- **Fastfile**: add a `before_all` block that calls fastlane's standard `setup_ci` action when `ENV[\"CI\"] == \"true\"`. `setup_ci` creates a dedicated temporary keychain with a known password, sets it as default, and unlocks it for the build. No-op locally — developer workflows unaffected.
- **`ios-testflight.yml`**: `timeout-minutes: 45` → `60`. Cold-cache first builds take ~25-35 min, plus an unpredictable upload tail; 60 min leaves headroom without being wasteful.
- **`daily-github-release.yml`** `build-ios` job: same 45 → 60 bump.

## Test plan
- [x] `ruby -c ios/fastlane/Fastfile` → Syntax OK
- [ ] CI green
- [ ] After merge: re-trigger `iOS TestFlight Build`; expect codesign to NOT hang and the IPA to upload to TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)