### PR TITLE
ci(ios): pass explicit app_identifier/apple_id/team_id to pilot

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -110,8 +110,17 @@ platform :ios do
   desc "Upload the IPA at build/ios/ipa/Runner.ipa to TestFlight (no review submission)."
   lane :upload_testflight do |options|
     changelog = options[:changelog] || ENV["TESTFLIGHT_CHANGELOG"] || "Daily build."
+    # Explicit app/team IDs — without them pilot tries to enumerate apps
+    # from the ASC API key alone and on the very first build hit:
+    #   Couldn't find app 'de.tankstellen.fuelprices' on the account of ''
+    # Passing the IDs skips the lookup and points pilot directly at the
+    # app entry. Numeric Apple ID and team ID are stable for the lifetime
+    # of the app, so hard-coding here is safe.
     pilot(
       api_key: asc_api_key,
+      app_identifier: "de.tankstellen.fuelprices",
+      apple_id: "6766543414",
+      team_id: "C4Y5RDF8P9",
       ipa: "../build/ios/ipa/Runner.ipa",
       skip_waiting_for_build_processing: true,
       changelog: changelog,


### PR DESCRIPTION
## Summary
iOS run [25588870654](https://github.com/fdittgen-png/tankstellen/actions/runs/25588870654) (post-#1507) finally produced a signed IPA — match, xcodebuild archive, and manual signing all worked. The pilot upload step then failed:

\`\`\`
Couldn't find app 'de.tankstellen.fuelprices' on the account of '' on App Store Connect
\`\`\`

The empty \`''\` account name is the giveaway: given only the ASC API key, pilot tried to enumerate the team's apps and got nothing back through that lookup path. Pass the IDs explicitly to skip the lookup.

## Changes
\`upload_testflight\` lane now calls \`pilot\` with:
- \`app_identifier: \"de.tankstellen.fuelprices\"\`
- \`apple_id: \"6766543414\"\` (the numeric ASC ID from the session handoff)
- \`team_id: \"C4Y5RDF8P9\"\`

Hard-coded — these are stable for the lifetime of the app entry.

## Test plan
- [x] \`ruby -c ios/fastlane/Fastfile\` → Syntax OK
- [ ] CI green
- [ ] After merge: re-trigger \`iOS TestFlight Build\`; expect IPA upload to succeed and processing to start in App Store Connect TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)