### PR TITLE
ci(ios): align iOS bundle ID to the existing ASC entry (de.tankstellen.tankstellen)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -124,7 +124,7 @@ jobs:
             echo "## iOS TestFlight Release"
             echo ""
             echo "- **Build number:** ${{ steps.bn.outputs.build_number }}"
-            echo "- **Bundle ID:** de.tankstellen.fuelprices"
+            echo "- **Bundle ID:** de.tankstellen.tankstellen"
             echo "- **Trigger:** ${{ github.event_name }}"
             echo "- **Changelog:** ${{ github.event.inputs.release_notes || 'Daily build.' }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 5.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -531,7 +531,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -549,7 +549,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -565,7 +565,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -703,7 +703,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 5.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -737,9 +737,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 5.0;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.fuelprices;
+				PRODUCT_BUNDLE_IDENTIFIER = de.tankstellen.tankstellen;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore de.tankstellen.fuelprices";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore de.tankstellen.tankstellen";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -81,7 +81,7 @@
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>de.tankstellen.fuelprices.background</string>
+		<string>de.tankstellen.tankstellen.background</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,2 +1,2 @@
-app_identifier("de.tankstellen.fuelprices")
+app_identifier("de.tankstellen.tankstellen")
 team_id("C4Y5RDF8P9")

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -58,7 +58,7 @@ platform :ios do
   desc "Build a signed appstore-distribution IPA. Expects match_appstore to have populated the keychain first."
   lane :build_appstore do |options|
     build_number = options[:build_number] || ENV["IOS_BUILD_NUMBER"] || Time.now.strftime("%Y%m%d")
-    profile_name = ENV["sigh_de.tankstellen.fuelprices_appstore_profile-name"] || "match AppStore de.tankstellen.fuelprices"
+    profile_name = ENV["sigh_de.tankstellen.tankstellen_appstore_profile-name"] || "match AppStore de.tankstellen.tankstellen"
 
     # Bump CFBundleVersion in the project so each TestFlight upload has a
     # unique build number — App Store Connect rejects re-uploads of the
@@ -96,7 +96,7 @@ platform :ios do
       export_method: "app-store",
       export_options: {
         provisioningProfiles: {
-          "de.tankstellen.fuelprices" => profile_name,
+          "de.tankstellen.tankstellen" => profile_name,
         },
         signingStyle: "manual",
         teamID: "C4Y5RDF8P9",
@@ -112,13 +112,13 @@ platform :ios do
     changelog = options[:changelog] || ENV["TESTFLIGHT_CHANGELOG"] || "Daily build."
     # Explicit app/team IDs — without them pilot tries to enumerate apps
     # from the ASC API key alone and on the very first build hit:
-    #   Couldn't find app 'de.tankstellen.fuelprices' on the account of ''
+    #   Couldn't find app 'de.tankstellen.tankstellen' on the account of ''
     # Passing the IDs skips the lookup and points pilot directly at the
     # app entry. Numeric Apple ID and team ID are stable for the lifetime
     # of the app, so hard-coding here is safe.
     pilot(
       api_key: asc_api_key,
-      app_identifier: "de.tankstellen.fuelprices",
+      app_identifier: "de.tankstellen.tankstellen",
       apple_id: "6766543414",
       team_id: "C4Y5RDF8P9",
       ipa: "../build/ios/ipa/Runner.ipa",

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -6,7 +6,7 @@ git_url("git@github.com:fdittgen-png/tankstellen-ios-certs.git")
 storage_mode("git")
 
 type("appstore")
-app_identifier(["de.tankstellen.fuelprices"])
+app_identifier(["de.tankstellen.tankstellen"])
 team_id("C4Y5RDF8P9")
 
 # CI must always run match in readonly mode — only humans on a trusted


### PR DESCRIPTION
## Summary
The actual cause of the `-19000` TestFlight upload error: Sparkilo on App Store Connect (Apple ID 6766543414, the value we already pass to `pilot`) is registered under **`de.tankstellen.tankstellen`**, not `de.tankstellen.fuelprices`. Bundle IDs are immutable on ASC, so the iOS project must roll back to what Sparkilo already owns.

This is a **partial revert of #1490 — iOS only**. Android stays on `de.tankstellen.fuelprices` because that AAB is already live on Play Console Open Testing (versionCode 2026050823) and changing applicationId would create a new Play Store app and orphan testers.

## Changes (all iOS)
- `ios/Runner.xcodeproj/project.pbxproj`: 4× `PRODUCT_BUNDLE_IDENTIFIER` for Runner + 3× for RunnerTests + 1× `PROVISIONING_PROFILE_SPECIFIER` on Release.
- `ios/Runner/Info.plist`: `BGTaskSchedulerPermittedIdentifiers` entry.
- `ios/fastlane/Appfile`, `Matchfile`, `Fastfile`: `app_identifier`, `provisioningProfiles` map key, sigh env var name + fallback profile name, pilot's `app_identifier` parameter.
- `.github/workflows/ios-testflight.yml`: cosmetic Bundle ID line in workflow Summary.

## Match re-mint (done locally on this Mac)
- Already-registered identifier on Apple Developer Portal (Sparkilo's creation registered it); no manual registration needed.
- `bundle exec fastlane ios match_appstore` minted profile **`match AppStore de.tankstellen.tankstellen`** (UUID `929ac73c-1ad7-4311-a5fd-8939d3fb76c7`) and pushed it encrypted to `fdittgen-png/tankstellen-ios-certs` over HTTPS using the local `gh` token (no SSH key on this Mac).
- The old `de.tankstellen.fuelprices` certs stay in the match repo — harmless, can be cleaned up later.
- CI continues to use the read-only deploy key from #1502 to download.

## Test plan
- [x] `plutil -lint ios/Runner.xcodeproj/project.pbxproj` → OK
- [x] `ruby -c ios/fastlane/Fastfile`, `ruby -c ios/fastlane/Matchfile` → both Syntax OK
- [x] `grep -rn de\.tankstellen\.fuelprices ios/` → no matches (Android-only references remain)
- [x] `bundle exec fastlane ios match_appstore` → \"All required keys, certificates and provisioning profiles are installed 🙌\"
- [ ] CI green
- [ ] After merge: re-trigger \"iOS TestFlight Build\"; expect IPA to upload to TestFlight under bundle ID `de.tankstellen.tankstellen` matching Sparkilo (Apple ID 6766543414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)