### PR TITLE
ci(ios): select Xcode 26 (latest-stable) on iOS runners

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -180,6 +180,14 @@ jobs:
         with:
           ref: master
 
+      - name: Select Xcode 26+
+        # See ios-testflight.yml for the long-form rationale: Apple rejects
+        # TestFlight uploads built with anything older than Xcode 26 (iOS
+        # 26 SDK) post-iOS-26 release.
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -39,6 +39,19 @@ jobs:
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
           echo "Daily build number: $BN"
 
+      - name: Select Xcode 26+
+        # macos-latest selects Xcode 16.4 (iOS 18.5 SDK) by default. Apple
+        # rejects TestFlight uploads built with anything older than Xcode 26
+        # since the iOS 26 release: altool returns
+        #   "SDK version issue. This app was built with the iOS 18.5 SDK.
+        #    All iOS and iPadOS apps must be built with the iOS 26 SDK or
+        #    later, included in Xcode 26 or later"
+        # The runner image ships multiple Xcodes side-by-side; this picks
+        # the newest stable and points DEVELOPER_DIR at it.
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable


### PR DESCRIPTION
## Summary
iOS run [25596745653](https://github.com/fdittgen-png/tankstellen/actions/runs/25596745653) (post-#1509) finally got past the bundle ID gate — the `-19000` is gone, altool found Sparkilo. New error:

\`\`\`
Validation failed (409) SDK version issue. This app was built with the
iOS 18.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK
or later, included in Xcode 26 or later
\`\`\`

Apple flipped the cutoff for new uploads after iOS 26 shipped: anything older than Xcode 26 / iOS 26 SDK is rejected. macos-latest selects Xcode 16.4 by default but the runner ships multiple Xcodes side-by-side. `maxim-lobanov/setup-xcode@v1` with `latest-stable` points `DEVELOPER_DIR` at the newest stable Xcode (Xcode 26.x), making xcodebuild + codesign + altool all use the iOS 26 SDK.

## Changes
- `ios-testflight.yml`: add `Select Xcode 26+` step before flutter setup.
- `daily-github-release.yml` build-ios job: same.

## Side note
`connectivity_plus` is still pinned `>=7.0.0 <7.1.0` from #1505. That pin was correct under Xcode 16 (no `NWPath.isUltraConstrained` symbol) but isn't strictly needed under Xcode 26. Leaving it for this PR — will relax in a follow-up once TestFlight is happy.

## Test plan
- [ ] CI green
- [ ] After merge: re-trigger \"iOS TestFlight Build\"; expect altool's 409 SDK error to be gone, IPA to upload, build to start processing on TestFlight at https://appstoreconnect.apple.com/apps/6766543414/testflight

🤖 Generated with [Claude Code](https://claude.com/claude-code)