### PR TITLE
fix(ci/play-store-listing): skip changelog upload (no version_code in metadata-only mode)

### DIFF
--- a/.github/workflows/play-store-listing.yml
+++ b/.github/workflows/play-store-listing.yml
@@ -161,16 +161,23 @@ jobs:
           set -euo pipefail
           # --skip_upload_aab / --skip_upload_apk: metadata-only run.
           # AABs ship from daily-beta.yml + daily-github-release.yml.
-          # The defaults push title + descriptions + changelogs +
-          # icon + featureGraphic + phoneScreenshots from the metadata
-          # tree at $SUPPLY_METADATA_PATH/<locale>/.
+          # --skip_upload_changelogs: this listing workflow pushes
+          # title + descriptions + icon + featureGraphic +
+          # phoneScreenshots only. Changelogs travel WITH each AAB
+          # (the AAB-upload workflows already handle them keyed by
+          # versionCode), and `supply` rejects a metadata-only run
+          # that touches `default.txt` without a `--version_code`
+          # to attach it to (run 25608959525).
+          # The defaults still push everything else from the
+          # metadata tree at $SUPPLY_METADATA_PATH/<locale>/.
           bundle exec fastlane supply \
             --json_key "$SUPPLY_JSON_KEY" \
             --package_name "$SUPPLY_PACKAGE_NAME" \
             --track "$SUPPLY_TRACK" \
             --metadata_path "$SUPPLY_METADATA_PATH" \
             --skip_upload_aab \
-            --skip_upload_apk
+            --skip_upload_apk \
+            --skip_upload_changelogs
 
       - name: Dry-run summary
         if: steps.track.outputs.dry_run == 'true'


### PR DESCRIPTION
## Summary

After the metadata_path fix landed (#1522), supply got past the locale-discovery step but immediately failed on every locale (run 25608959525):

\`\`\`
[!] fr-FR - Cannot find changelog because no version code given - please specify :version_code
[!] de-DE - Cannot find changelog because no version code given - please specify :version_code
[!] en-US - Cannot find changelog because no version code given - please specify :version_code
\`\`\`

\`supply\`'s changelog uploader keys each line in \`default.txt\` against a versionCode the user is supposed to pass via \`--version_code\`. This listing workflow is metadata-only (no AAB), so there's no versionCode to anchor a changelog to.

## Fix

Add \`--skip_upload_changelogs\`. Changelogs already travel WITH each AAB push (\`daily-beta.yml\` / \`daily-github-release.yml\` read \`default.txt\` next to the freshly-built AAB and key it by the new versionCode), so this workflow doesn't need to push them separately. Title + descriptions + icon + featureGraphic + phoneScreenshots still ride through the default upload flags.

## Test plan
- [ ] CI green
- [ ] After merge: dispatch \`Play Store listing\` workflow → expect Sparkilo title + green icon + featureGraphic on the public Play Store page within ~5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)