### PR TITLE
ci(release): use RELEASE_TOKEN PAT secret to bypass GITHUB_TOKEN 403

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -385,7 +385,25 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ github.token }}
+          # The default GITHUB_TOKEN started returning HTTP 403 ("Resource
+          # not accessible by integration") on `POST /repos/.../releases`
+          # in May 2026 even with workflow-level `permissions: contents:
+          # write` (verified identical token grants `Contents: write,
+          # Metadata: read` on a working May-7 run vs. a failing May-9
+          # re-run, and the repo-level `default_workflow_permissions`
+          # being read OR write made no difference). The error means
+          # the GitHub App installation token (= GITHUB_TOKEN) is being
+          # rejected at the resource level, not on token scope.
+          #
+          # Workaround: use a Personal Access Token saved as the
+          # `RELEASE_TOKEN` repo secret. The token needs `contents:
+          # read/write` on this repo and nothing else. Falling back to
+          # `github.token` if RELEASE_TOKEN is absent so a fresh fork
+          # without the secret still attempts the workflow (it'll fail
+          # the same way the default token does today, but at least the
+          # error message stays self-explanatory rather than the workflow
+          # silently noop'ing).
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
         run: |
           set -euo pipefail
           # Collect every artifact that's actually present — `find`-based so


### PR DESCRIPTION
## Why

Daily GitHub Release workflow started failing in May 2026 with:

\`\`\`
HTTP 403: Resource not accessible by integration
(https://api.github.com/repos/fdittgen-png/tankstellen/releases)
\`\`\`

### What we verified

| Diagnostic | Result |
| --- | --- |
| Token scope on May 7 success | \`Contents: write, Metadata: read\` |
| Token scope today failure | identical |
| \`permissions: contents: write\` declared at workflow level | yes |
| Repo \`default_workflow_permissions\` flipped read → write | no behaviour change |
| Repo Actions config | all-allowed, no rulesets, no branch protection |
| Org / org restrictions | personal repo, not in any org |
| Workflow drift between May 7 and today | none on the release step |

The phrase \"Resource not accessible by integration\" specifically means **the GitHub App installation token (= GITHUB_TOKEN) is being rejected at the resource level**, not on token scope. Likely a recent GitHub-side change for releases on user-owned repos.

## Fix

Switch the \`Create GitHub release\` step to a Personal Access Token:

\`\`\`yaml
GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
\`\`\`

Falls back to \`github.token\` when the secret is absent so a fresh fork still attempts the workflow with the same (failing) behaviour as today, rather than silently noop-ing.

## Setup (you do this, once)

1. Generate a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - **Resource owner:** fdittgen-png
   - **Repository access:** Only select repositories → tankstellen
   - **Permissions → Repository permissions → Contents:** Read and write
   - (No other scopes — least-privilege)
2. Add as repo secret \`RELEASE_TOKEN\`: https://github.com/fdittgen-png/tankstellen/settings/secrets/actions
3. Merge this PR.
4. Dispatch \`Daily GitHub Release\` to verify.

## Test plan
- [ ] CI green
- [ ] After merge + secret: \`gh workflow run \"Daily GitHub Release\"\` succeeds and uploads the AAB + 3 APKs + IPA + dSYMs to a fresh release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)