### PR TITLE
ci(release): prune old nightly releases — keep latest only

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -428,6 +428,40 @@ jobs:
             --target '${{ github.sha }}' \
             "${ASSETS[@]}"
 
+      - name: Prune old nightly releases (keep latest only)
+        env:
+          # Same RELEASE_TOKEN used by `gh release create` above — needs
+          # `contents: write` to delete releases AND tags.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+          NEW_TAG: ${{ needs.pre-check.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Storage hygiene: each nightly bundles ~300 MB of artifacts
+          # (AAB + 3 APK splits + IPA + dSYMs). Keeping every nightly
+          # forever balloons the GitHub release storage quota and the
+          # Releases page becomes noisy. Keep ONLY the just-published
+          # release; delete every other `nightly-*` tag along with its
+          # assets and git tag.
+          #
+          # We filter strictly on the `nightly-` tag prefix so:
+          #   - `permissions-evidence-2026-05-08` and other ad-hoc tags
+          #     are preserved (they document point-in-time evidence).
+          #   - Any future `v5.0.0` / real-release tags are preserved
+          #     (semver releases are not garbage).
+          #
+          # `--cleanup-tag` removes the underlying git tag too — without
+          # it the release would disappear but the tag would linger
+          # forever in `git tag -l`.
+          gh release list --limit 200 --json tagName \
+            --jq ".[] | select(.tagName | startswith(\"nightly-\")) | select(.tagName != \"$NEW_TAG\") | .tagName" \
+          | while read -r tag; do
+              [ -z "$tag" ] && continue
+              echo "Pruning old nightly release: $tag"
+              if ! gh release delete "$tag" --cleanup-tag --yes; then
+                echo "::warning::failed to delete release $tag — continuing"
+              fi
+            done
+
       - name: Summary
         if: always()
         run: |


### PR DESCRIPTION
Each nightly bundles ~300 MB of artifacts (AAB + 3 APK splits + IPA + dSYMs). Keeping every nightly forever balloons the GitHub release storage quota and clutters the Releases page.

After publishing the new nightly, delete every other \`nightly-*\` release along with its assets and git tag (\`--cleanup-tag\` to keep \`git tag -l\` tidy too).

## What's preserved

Strictly filtered on the \`nightly-\` tag prefix so:
- \`permissions-evidence-2026-05-08\` and other ad-hoc tags are preserved (they document point-in-time evidence)
- Future \`v5.0.0\` / real semver release tags are preserved
- Manual nightlies like \`nightly-20260509-manual\` and \`nightly-20260509-fresh-rebuild\` will get cleaned up since they share the \`nightly-\` prefix — that's intentional

## What's deleted

- Every \`nightly-*\` release older than the just-published one
- Their attached assets (the ~300 MB / release saved)
- Their git tags (via \`--cleanup-tag\`)

Failures on individual deletes log a warning rather than failing the workflow — the new release is already published either way.

## Test plan
- [ ] CI green
- [ ] After merge: dispatch \`Daily GitHub Release\` → verify the new release exists AND every old \`nightly-*\` release has been removed from \`gh release list\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)