### PR TITLE
feat(obd2): #1004 phase 2b-3 — startTrip plumbs automatic flag

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -210,10 +210,17 @@ class TripRecording extends _$TripRecording {
   /// fill-up, does NOT block on one, and does NOT read any fill-up
   /// state. The fill-up save path (#888) derives the trip→tank link
   /// from the rolling trip-history log independently.
+  ///
+  /// [automatic] flags the controller so any [PausedTripEntry]
+  /// written on a mid-trip BLE drop (#1004 phase 4-WAL) carries the
+  /// auto-record provenance. Defaults to `false` so manual UI
+  /// callers are unchanged; the orchestrator no-picker path
+  /// (`AutoTripCoordinator`) passes `true`.
   Future<StartTripOutcome> startTrip({
     String? vehicleId,
     String? adapterMac,
     Obd2Service? service,
+    bool automatic = false,
   }) async {
     if (state.isActive) return StartTripOutcome.alreadyActive;
     final activeVehicle = _tryReadActiveVehicle();
@@ -222,16 +229,14 @@ class TripRecording extends _$TripRecording {
     _lastTripVehicleId = resolvedVehicleId;
     _lastTripStartedAt = DateTime.now();
     if (service != null) {
-      await start(service);
+      // #1004 phase 2b-3 — orchestrator-driven no-picker start path.
+      // The caller supplies the connected `Obd2Service` directly so
+      // `automatic: true` flows through to the controller and the
+      // resulting [PausedTripEntry] (if BLE drops mid-trip) carries
+      // the auto-record provenance at WAL recovery time.
+      await start(service, automatic: automatic);
       return StartTripOutcome.started;
     }
-    // TODO(#1004 phase 2b-3) — when the orchestrator's no-picker
-    // start lands, plumb `automatic: true` into the resulting [start]
-    // call here so the [PausedTripEntry] written on a mid-trip BLE
-    // drop carries the automatic flag at WAL recovery time. For now
-    // the picker fork below is the only orchestrator-driven path and
-    // it goes through UI before re-entering [start], which provides
-    // the [automatic] argument explicitly.
     if (resolvedMac == null || resolvedMac.isEmpty) {
       return StartTripOutcome.needsPicker;
     }

--- a/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
@@ -127,6 +127,81 @@ void main() {
   );
 
   test(
+    '#1004 phase 2b-3 — startTrip(service:..., automatic: true) plumbs '
+    'the flag through to the controller (orchestrator no-picker path)',
+    () async {
+      // Until the orchestrator no-picker call site lands,
+      // startTrip(service:, automatic:) is the public entry point that
+      // mirrors what the orchestrator will do directly. Verifying the
+      // flag plumbing here pins the contract so the orchestrator can
+      // wire up without re-discovering the seam.
+      final fakeBadge = _FakeAutoRecordBadgeService();
+      final container = ProviderContainer(overrides: [
+        autoRecordBadgeServiceProvider.overrideWith((ref) async => fakeBadge),
+      ]);
+      addTearDown(container.dispose);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+      final notifier = container.read(tripRecordingProvider.notifier);
+      final outcome = await notifier.startTrip(
+        service: service,
+        automatic: true,
+      );
+      expect(outcome.toString(), endsWith('.started'),
+          reason: 'startTrip with a service should resolve to started');
+      final ctl = notifier.debugController!;
+      final start = DateTime.now();
+      for (int i = 0; i < 5; i++) {
+        ctl.debugInjectSample(
+          speedKmh: 50 + i.toDouble(),
+          rpm: 2000 + i * 10,
+          at: start.add(Duration(seconds: i)),
+          fuelRateLPerHour: 6.0,
+        );
+      }
+      await notifier.stopAndSaveAutomatic();
+
+      final repo = container.read(tripHistoryRepositoryProvider)!;
+      final history = repo.loadAll();
+      expect(history.first.automatic, isTrue,
+          reason: 'startTrip(automatic: true) must make the resulting '
+              'persisted entry inherit the auto-record provenance');
+    },
+  );
+
+  test(
+    'startTrip(service:..., automatic: false) stays manual',
+    () async {
+      final fakeBadge = _FakeAutoRecordBadgeService();
+      final container = ProviderContainer(overrides: [
+        autoRecordBadgeServiceProvider.overrideWith((ref) async => fakeBadge),
+      ]);
+      addTearDown(container.dispose);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.startTrip(service: service);
+      final ctl = notifier.debugController!;
+      final start = DateTime.now();
+      for (int i = 0; i < 5; i++) {
+        ctl.debugInjectSample(
+          speedKmh: 50 + i.toDouble(),
+          rpm: 2000 + i * 10,
+          at: start.add(Duration(seconds: i)),
+          fuelRateLPerHour: 6.0,
+        );
+      }
+      await notifier.stop();
+
+      final repo = container.read(tripHistoryRepositoryProvider)!;
+      expect(repo.loadAll().first.automatic, isFalse,
+          reason: 'default automatic=false keeps the trip manual');
+    },
+  );
+
+  test(
     'stop() with no automatic flag stays manual — no badge increment',
     () async {
       final fakeBadge = _FakeAutoRecordBadgeService();


### PR DESCRIPTION
Resolves the explicit TODO at \`trip_recording_provider.dart:228\` — wires the auto-record provenance flag through \`startTrip\` so the AutoTripCoordinator's no-picker path can call it directly without losing the bookkeeping.

## What changes

- \`TripRecording.startTrip\` gains \`automatic: bool = false\`.
- When a service is supplied, forward \`start(service, automatic: automatic)\` so any PausedTripEntry written on a mid-trip BLE drop inherits the auto-record provenance at WAL recovery time.
- Manual UI callers default to \`automatic: false\` — unchanged.
- TODO comment dropped.

## Tests
2 new pin-the-contract cases on top of the existing 3:
- \`startTrip(service:..., automatic: true)\` → \`TripHistoryEntry.automatic = true\`
- \`startTrip(service:..., automatic: false)\` → entry stays manual

Refs #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)