### PR TITLE
feat(ios): #1295 phase 1 — declare bluetooth-central + location BG modes

### DIFF
--- a/docs/guides/ios-auto-record.md
+++ b/docs/guides/ios-auto-record.md
@@ -1,12 +1,16 @@
 # iOS hands-free trip auto-record (port from #1004)
 
-Status: phase 2 — Dart-side scaffolding shipped. Native iOS layer
-NOT YET applied or verified — see "How to verify on a Mac" below.
+Status: **phase 1 + phase 2 scaffolding shipped**. Info.plist
+declarations for `bluetooth-central` + `location` UIBackgroundModes
+are in the tree (#1295 phase 1, this PR). The Dart-side scaffolding
+(`IosStateRestorationService`) is in place from a prior PR. **Real
+iOS verification still requires a Mac + iPhone + ELM327** — see
+"How to verify on a Mac" below.
 
 This document explains the iOS port of the hands-free trip
 auto-record flow tracked in #1295 (sibling of the Android flow in
-#1004), and the platform-side changes a Mac-equipped developer must
-apply before the iOS path can be exercised end-to-end.
+#1004), and the remaining platform-side changes a Mac-equipped
+developer must apply before the iOS path is exercised end-to-end.
 
 ## Why this scaffolding ships before iOS verification
 
@@ -23,7 +27,19 @@ background relaunch — requires a Mac, an iPhone, and an ELM327 BLE
 adapter. That work is a human-driven phase, not autonomous-worker
 territory.
 
-## Info.plist changes the developer must apply on a Mac
+## Info.plist changes — applied in this PR ✅
+
+`UIBackgroundModes` now includes `bluetooth-central` and `location`
+(in addition to the prior `fetch` / `processing` /
+`remote-notification`). The `NSBluetoothAlwaysUsageDescription` +
+`NSLocationAlwaysAndWhenInUseUsageDescription` +
+`NSLocationAlwaysUsageDescription` strings were already in place
+from prior iOS work — verified in this PR.
+
+What remains for the Mac-equipped developer is the **App Store
+review claim** for `bluetooth-central` (Apple asks why you need
+it during review) and validating the App Privacy answers under
+ASC's "Data Usage" tab — both are runtime-only, not source-tracked.
 
 The values below are quoted **verbatim** from the issue body of
 #1295:

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -80,6 +80,16 @@
 		<string>fetch</string>
 		<string>processing</string>
 		<string>remote-notification</string>
+		<!-- #1295 phase 1 — iOS hands-free auto-record. `bluetooth-central`
+		     gates Core Bluetooth State Preservation/Restoration so the OS
+		     can relaunch Sparkilo into the background when the paired
+		     ELM327 powers on. `location` is the partner mode that lets
+		     the relaunched app keep a CLLocationManager session open for
+		     trip GPS without losing it on first idle. Apple reviews both
+		     declarations against the actual usage; any time we add a
+		     non-OBD2 reason to keep BLE/GPS alive, document it here. -->
+		<string>bluetooth-central</string>
+		<string>location</string>
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>


### PR DESCRIPTION
First on-tree slice of #1295 (iOS hands-free auto-record port).

## What changes

- \`ios/Runner/Info.plist\`: adds \`bluetooth-central\` + \`location\` to \`UIBackgroundModes\` (alongside the existing fetch / processing / remote-notification).
- \`docs/guides/ios-auto-record.md\`: status moved from \"Info.plist NOT YET applied\" to \"applied ✅\". Remaining work itemised: ASC review claim + App Privacy answers + real on-device CBCentralManager state-restoration verification.

## Why this unblocks the iOS path

Without \`bluetooth-central\` in UIBackgroundModes, Core Bluetooth's State Preservation/Restoration cannot register — iOS will not relaunch Sparkilo into the background when the paired ELM327 powers on, and the entire hands-free flow is dead-on-arrival regardless of how good the Dart layer is.

The Dart-side \`IosStateRestorationService\` scaffolding from prior PRs already calls \`FlutterBluePlus.setOptions(restoreState: true)\` at startup; this commit ships the matching App-Store-reviewable claim that gates the OS behaviour.

## Out of scope (next phases)

- ASC review answer for bluetooth-central usage (runtime-only, not source-tracked)
- App Privacy answers under ASC \"Data Usage\"
- On-device verification that centralManager:willRestoreState: fires after a real BLE wake — needs a Mac + iPhone + ELM327
- flutter_blue_plus ^2.0.0 upgrade (current pinned at ^1.35.5; the \`setOptions(restoreState: true)\` call is in place but the v2.x major has tighter restoration guarantees)

Refs #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)