### PR TITLE
feat(sync): #1479 phase 1 — consent toggle for TankSync trip sync

### DIFF
--- a/lib/core/providers/app_state_provider.dart
+++ b/lib/core/providers/app_state_provider.dart
@@ -145,7 +145,8 @@ bool hasGdprConsent(Ref ref) {
 }
 
 /// GDPR consent state: location, error reporting, cloud sync,
-/// community wait-time pings (#1119), VIN online decode (#1399).
+/// community wait-time pings (#1119), VIN online decode (#1399),
+/// trip-sync to TankSync (#1479 phase 1).
 @Riverpod(keepAlive: true)
 class GdprConsent extends _$GdprConsent {
   @override
@@ -155,6 +156,7 @@ class GdprConsent extends _$GdprConsent {
     bool cloudSync,
     bool communityWaitTime,
     bool vinOnlineDecode,
+    bool syncTrips,
   }) build() {
     final storage = ref.watch(storageRepositoryProvider);
     return (
@@ -165,6 +167,8 @@ class GdprConsent extends _$GdprConsent {
           storage.getSetting(StorageKeys.consentCommunityWaitTime) as bool? ?? false,
       vinOnlineDecode:
           storage.getSetting(StorageKeys.consentVinOnlineDecode) as bool? ?? false,
+      syncTrips:
+          storage.getSetting(StorageKeys.consentSyncTrips) as bool? ?? false,
     );
   }
 
@@ -174,6 +178,7 @@ class GdprConsent extends _$GdprConsent {
     required bool cloudSync,
     required bool communityWaitTime,
     required bool vinOnlineDecode,
+    bool syncTrips = false,
   }) async {
     final storage = ref.read(storageRepositoryProvider);
     await storage.putSetting(StorageKeys.gdprConsentGiven, true);
@@ -188,6 +193,14 @@ class GdprConsent extends _$GdprConsent {
       StorageKeys.consentVinOnlineDecode,
       vinOnlineDecode,
     );
+    // #1479 — trip-sync consent gates the trip → cloud upload path.
+    // Force off when the master cloudSync consent is off so a stale
+    // syncTrips=true value can't ride past a cloudSync=false toggle.
+    final effectiveSyncTrips = cloudSync ? syncTrips : false;
+    await storage.putSetting(
+      StorageKeys.consentSyncTrips,
+      effectiveSyncTrips,
+    );
     // Also update the legacy location_consent key for backward compatibility
     await storage.putSetting('location_consent', location);
     state = (
@@ -196,6 +209,7 @@ class GdprConsent extends _$GdprConsent {
       cloudSync: cloudSync,
       communityWaitTime: communityWaitTime,
       vinOnlineDecode: vinOnlineDecode,
+      syncTrips: effectiveSyncTrips,
     );
   }
 }

--- a/lib/core/providers/app_state_provider.g.dart
+++ b/lib/core/providers/app_state_provider.g.dart
@@ -624,13 +624,15 @@ final class HasGdprConsentProvider extends $FunctionalProvider<bool, bool, bool>
 String _$hasGdprConsentHash() => r'712d0d516ea832af3bc75b97776e595ce699d2dc';
 
 /// GDPR consent state: location, error reporting, cloud sync,
-/// community wait-time pings (#1119), VIN online decode (#1399).
+/// community wait-time pings (#1119), VIN online decode (#1399),
+/// trip-sync to TankSync (#1479 phase 1).
 
 @ProviderFor(GdprConsent)
 final gdprConsentProvider = GdprConsentProvider._();
 
 /// GDPR consent state: location, error reporting, cloud sync,
-/// community wait-time pings (#1119), VIN online decode (#1399).
+/// community wait-time pings (#1119), VIN online decode (#1399),
+/// trip-sync to TankSync (#1479 phase 1).
 final class GdprConsentProvider
     extends
         $NotifierProvider<
@@ -640,11 +642,13 @@ final class GdprConsentProvider
             bool communityWaitTime,
             bool errorReporting,
             bool location,
+            bool syncTrips,
             bool vinOnlineDecode,
           })
         > {
   /// GDPR consent state: location, error reporting, cloud sync,
-  /// community wait-time pings (#1119), VIN online decode (#1399).
+  /// community wait-time pings (#1119), VIN online decode (#1399),
+  /// trip-sync to TankSync (#1479 phase 1).
   GdprConsentProvider._()
     : super(
         from: null,
@@ -670,6 +674,7 @@ final class GdprConsentProvider
       bool communityWaitTime,
       bool errorReporting,
       bool location,
+      bool syncTrips,
       bool vinOnlineDecode,
     })
     value,
@@ -683,6 +688,7 @@ final class GdprConsentProvider
               bool communityWaitTime,
               bool errorReporting,
               bool location,
+              bool syncTrips,
               bool vinOnlineDecode,
             })
           >(value),
@@ -690,10 +696,11 @@ final class GdprConsentProvider
   }
 }
 
-String _$gdprConsentHash() => r'db485b9d7fdb29445d66a954a7162f6dff704b0c';
+String _$gdprConsentHash() => r'd373fc8312c1d19d065507cb41b695b86fe3eb2e';
 
 /// GDPR consent state: location, error reporting, cloud sync,
-/// community wait-time pings (#1119), VIN online decode (#1399).
+/// community wait-time pings (#1119), VIN online decode (#1399),
+/// trip-sync to TankSync (#1479 phase 1).
 
 abstract class _$GdprConsent
     extends
@@ -703,6 +710,7 @@ abstract class _$GdprConsent
             bool communityWaitTime,
             bool errorReporting,
             bool location,
+            bool syncTrips,
             bool vinOnlineDecode,
           })
         > {
@@ -711,6 +719,7 @@ abstract class _$GdprConsent
     bool communityWaitTime,
     bool errorReporting,
     bool location,
+    bool syncTrips,
     bool vinOnlineDecode,
   })
   build();
@@ -725,6 +734,7 @@ abstract class _$GdprConsent
                 bool communityWaitTime,
                 bool errorReporting,
                 bool location,
+                bool syncTrips,
                 bool vinOnlineDecode,
               }),
               ({
@@ -732,6 +742,7 @@ abstract class _$GdprConsent
                 bool communityWaitTime,
                 bool errorReporting,
                 bool location,
+                bool syncTrips,
                 bool vinOnlineDecode,
               })
             >;
@@ -744,6 +755,7 @@ abstract class _$GdprConsent
                   bool communityWaitTime,
                   bool errorReporting,
                   bool location,
+                  bool syncTrips,
                   bool vinOnlineDecode,
                 }),
                 ({
@@ -751,6 +763,7 @@ abstract class _$GdprConsent
                   bool communityWaitTime,
                   bool errorReporting,
                   bool location,
+                  bool syncTrips,
                   bool vinOnlineDecode,
                 })
               >,
@@ -759,6 +772,7 @@ abstract class _$GdprConsent
                 bool communityWaitTime,
                 bool errorReporting,
                 bool location,
+                bool syncTrips,
                 bool vinOnlineDecode,
               }),
               Object?,

--- a/lib/core/storage/storage_keys.dart
+++ b/lib/core/storage/storage_keys.dart
@@ -26,6 +26,14 @@ class StorageKeys {
   /// year-from-position-10) always runs locally regardless of this
   /// flag; only the network call is gated.
   static const String consentVinOnlineDecode = 'consent_vin_online_decode';
+
+  /// #1479 phase 1 — opt-in consent for syncing OBD2 + GPS trip
+  /// recordings to TankSync (cross-device backup). Defaults to false.
+  /// Gated on `consentCloudSync` at the toggle UI layer — without
+  /// the master TankSync consent the trip-sync toggle cannot be
+  /// enabled at all.
+  static const String consentSyncTrips = 'consent_sync_trips';
+
   static const String swipeTutorialShown = 'swipe_tutorial_shown';
   static const String consumptionLog = 'consumption_log';
   static const String vehicleProfiles = 'vehicle_profiles';

--- a/lib/features/consent/presentation/widgets/consent_settings_section.dart
+++ b/lib/features/consent/presentation/widgets/consent_settings_section.dart
@@ -7,6 +7,12 @@ import '../../../../l10n/app_localizations.dart';
 ///
 /// Reads current consent state from [gdprConsentProvider] and allows
 /// the user to toggle individual consents on/off.
+///
+/// #1479 phase 1 — adds the `Sync trip recordings` toggle, gated on
+/// the master `Cloud Sync` consent. Disabling Cloud Sync also force-
+/// disables Sync trips at the provider layer (`save()`'s
+/// `effectiveSyncTrips`), so the UI stays in sync with the persisted
+/// state without an extra round-trip.
 class ConsentSettingsSection extends ConsumerWidget {
   const ConsentSettingsSection({super.key});
 
@@ -45,6 +51,7 @@ class ConsentSettingsSection extends ConsumerWidget {
                 cloudSync: consent.cloudSync,
                 communityWaitTime: consent.communityWaitTime,
                 vinOnlineDecode: consent.vinOnlineDecode,
+                syncTrips: consent.syncTrips,
               ),
         ),
         SwitchListTile(
@@ -62,6 +69,7 @@ class ConsentSettingsSection extends ConsumerWidget {
                 cloudSync: consent.cloudSync,
                 communityWaitTime: consent.communityWaitTime,
                 vinOnlineDecode: consent.vinOnlineDecode,
+                syncTrips: consent.syncTrips,
               ),
         ),
         SwitchListTile(
@@ -79,6 +87,7 @@ class ConsentSettingsSection extends ConsumerWidget {
                 cloudSync: v,
                 communityWaitTime: consent.communityWaitTime,
                 vinOnlineDecode: consent.vinOnlineDecode,
+                syncTrips: consent.syncTrips,
               ),
         ),
         SwitchListTile(
@@ -97,6 +106,7 @@ class ConsentSettingsSection extends ConsumerWidget {
                 cloudSync: consent.cloudSync,
                 communityWaitTime: v,
                 vinOnlineDecode: consent.vinOnlineDecode,
+                syncTrips: consent.syncTrips,
               ),
         ),
         SwitchListTile(
@@ -114,7 +124,37 @@ class ConsentSettingsSection extends ConsumerWidget {
                 cloudSync: consent.cloudSync,
                 communityWaitTime: consent.communityWaitTime,
                 vinOnlineDecode: v,
+                syncTrips: consent.syncTrips,
               ),
+        ),
+        // #1479 phase 1 — trip-sync consent. Sits LAST so the
+        // historical 0..4 SwitchListTile indices in older tests stay
+        // stable. Gated on the master Cloud Sync above; the toggle
+        // is disabled (onChanged: null) when cloudSync is off and the
+        // provider's `save()` enforces effective-false when
+        // cloudSync=false so the visible position stays honest.
+        SwitchListTile(
+          key: const Key('consentSyncTripsToggle'),
+          secondary: const Icon(Icons.route_outlined, size: 20),
+          title: const Text('Sync trip recordings'),
+          subtitle: Text(
+            consent.cloudSync
+                ? 'Back up OBD2 + GPS trips to TankSync. '
+                    'Cross-device, opt-in.'
+                : 'Enable Cloud Sync above to back up trips.',
+            style: theme.textTheme.bodySmall,
+          ),
+          value: consent.syncTrips,
+          onChanged: consent.cloudSync
+              ? (v) => ref.read(gdprConsentProvider.notifier).save(
+                    location: consent.location,
+                    errorReporting: consent.errorReporting,
+                    cloudSync: consent.cloudSync,
+                    communityWaitTime: consent.communityWaitTime,
+                    vinOnlineDecode: consent.vinOnlineDecode,
+                    syncTrips: v,
+                  )
+              : null,
         ),
       ],
     );

--- a/test/features/consent/presentation/widgets/consent_settings_section_test.dart
+++ b/test/features/consent/presentation/widgets/consent_settings_section_test.dart
@@ -21,6 +21,7 @@ void main() {
     bool cloudSync = false,
     bool communityWaitTime = false,
     bool vinOnlineDecode = false,
+    bool syncTrips = false,
   }) {
     fakeStorage.putSetting(StorageKeys.consentLocation, location);
     fakeStorage.putSetting(StorageKeys.consentErrorReporting, errorReporting);
@@ -29,6 +30,7 @@ void main() {
         StorageKeys.consentCommunityWaitTime, communityWaitTime);
     fakeStorage.putSetting(
         StorageKeys.consentVinOnlineDecode, vinOnlineDecode);
+    fakeStorage.putSetting(StorageKeys.consentSyncTrips, syncTrips);
 
     return ProviderScope(
       overrides: [
@@ -44,12 +46,38 @@ void main() {
   }
 
   group('ConsentSettingsSection', () {
-    testWidgets('shows five toggle switches', (tester) async {
+    testWidgets('shows six toggle switches', (tester) async {
+      // #1479 phase 1 added the 6th toggle (Sync trip recordings).
       await tester.pumpWidget(buildWidget());
       await tester.pumpAndSettle();
 
-      expect(find.byType(SwitchListTile), findsNWidgets(5));
+      expect(find.byType(SwitchListTile), findsNWidgets(6));
     });
+
+    testWidgets(
+      '#1479 — sync trip recordings toggle is disabled until Cloud Sync is on',
+      (tester) async {
+        await tester.pumpWidget(buildWidget(cloudSync: false));
+        await tester.pumpAndSettle();
+        final tile = tester.widget<SwitchListTile>(
+            find.byKey(const Key('consentSyncTripsToggle')));
+        expect(tile.onChanged, isNull,
+            reason: 'syncTrips toggle must be disabled while cloudSync is off');
+      },
+    );
+
+    testWidgets(
+      '#1479 — sync trip recordings toggle becomes enabled when Cloud Sync is on',
+      (tester) async {
+        await tester.pumpWidget(buildWidget(cloudSync: true));
+        await tester.pumpAndSettle();
+        final tile = tester.widget<SwitchListTile>(
+            find.byKey(const Key('consentSyncTripsToggle')));
+        expect(tile.onChanged, isNotNull,
+            reason:
+                'syncTrips toggle must be tappable once cloudSync consent is on');
+      },
+    );
 
     testWidgets('shows correct labels', (tester) async {
       await tester.pumpWidget(buildWidget());


### PR DESCRIPTION
Lands the consent half of #1479 phase 1 (the schema half — \`public.trip_summaries\` + \`public.trip_details\` with RLS + indexes — already shipped in PR #1480).

## What changes

- New \`StorageKeys.consentSyncTrips\`, default false.
- \`GdprConsent\` provider extends its record + \`save()\` signature with \`syncTrips: bool\`. Defaults false; \`save()\` enforces effective-false when the master \`cloudSync\` consent is also off — a stale \`syncTrips=true\` cannot ride past a \`cloudSync=false\` toggle.
- \`ConsentSettingsSection\` adds a 6th toggle (\`Sync trip recordings\`), placed last to preserve the existing 0..4 SwitchListTile indices in older tests. Disabled (onChanged: null) until cloudSync is on; subtitle pivots when the master is off.
- 2 new tests pin the gate: tile is non-tappable when cloudSync=false, becomes tappable when cloudSync=true. All 33 existing consent tests still pass.

## Out of scope (next phases of #1479)

- Phase 2: \`TripSyncClient\` upload-on-stop wiring + first-opt-in backfill
- Phase 3: app-launch summary download + cross-device merge
- Phase 4: \`trip_details\` upload + lazy fetch on detail-screen open
- Phase 5: per-trip exclusion + 90-day detail retention + 'Forget all synced trips' button

Refs #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)