### PR TITLE
feat(sync): #1479 phase 2 — TripsSync upload-on-stop

### DIFF
--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/foundation.dart';
+
+import '../../features/consumption/data/trip_history_repository.dart';
+import 'supabase_client.dart';
+
+/// Per-trip-summary sync with Supabase (#1479 phase 2).
+///
+/// Phase-2 scope: ONE-WAY upload of trip summaries from the local
+/// rolling log to `public.trip_summaries`. Per-trip detail rows
+/// (`public.trip_details` with full pointSamples + GPS diagnostics)
+/// are deferred to phase 4 so phase 2 ships the cross-device list
+/// view without paying the per-trip bandwidth cost up front.
+///
+/// Same column shape as the migration in
+/// `supabase/migrations/20260507000001_trip_summaries_and_details.sql`:
+/// `(user_id, id)` is the primary key, `vehicle_id` /
+/// `started_at` / `ended_at` are server-side filters, and `data`
+/// carries the compact summary JSON (no samples, no gpsd) so a
+/// 60-min trip stays around 1 KB rather than 250 KB.
+///
+/// Mirrors [FillUpsSync] / [VehiclesSync]:
+/// - Unauthenticated callers return early without surfacing an error.
+/// - Failures `debugPrint` and swallow — the local entry stays the
+///   source of truth, the next save retries the upload.
+/// - The download / merge half lands in phase 3.
+class TripsSync {
+  TripsSync._();
+
+  /// Upload [entry] to `public.trip_summaries`. No-op when the user
+  /// isn't signed into TankSync.
+  ///
+  /// Caller is responsible for the consent gate (`consentSyncTrips`)
+  /// — the wire layer doesn't read consent so it stays a pure I/O
+  /// helper; consent decisions live next to the user-visible toggle.
+  static Future<void> uploadSummary(TripHistoryEntry entry) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) {
+      debugPrint('TripsSync.uploadSummary: not authenticated, skipping');
+      return;
+    }
+    final startedAt = entry.summary.startedAt;
+    final endedAt = entry.summary.endedAt;
+    if (startedAt == null || endedAt == null) {
+      // A trip with no timestamps cannot satisfy the
+      // NOT-NULL `started_at` / `ended_at` columns. Silently skip —
+      // happens for empty / aborted trips that the user wouldn't
+      // want synced anyway.
+      debugPrint(
+        'TripsSync.uploadSummary: ${entry.id} has null timestamps; '
+        'skipping upload',
+      );
+      return;
+    }
+    try {
+      await client.from('trip_summaries').upsert({
+        'id': entry.id,
+        'user_id': userId,
+        'vehicle_id': entry.vehicleId,
+        'started_at': startedAt.toIso8601String(),
+        'ended_at': endedAt.toIso8601String(),
+        // The summary blob stays compact: just the entity's JSON form
+        // WITHOUT the per-tick `samples` and GPS-diagnostics arrays
+        // so a 60-min commute is ~1 KB instead of ~250 KB. The full-
+        // detail row lands in phase 4 under `public.trip_details`.
+        'data': _compactSummaryJson(entry),
+        'updated_at': DateTime.now().toIso8601String(),
+      }, onConflict: 'user_id,id');
+      debugPrint('TripsSync.uploadSummary: uploaded ${entry.id}');
+    } catch (e, st) {
+      debugPrint('TripsSync.uploadSummary FAILED for ${entry.id}: $e\n$st');
+    }
+  }
+
+  /// Remove a single trip from the server (called when the user
+  /// deletes the trip locally). Silent on failure — the local
+  /// delete is the canonical signal; a stale server row is
+  /// reconciled on the next sync pass (phase 3).
+  static Future<void> deleteSummary(String tripId) async {
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+    try {
+      await client
+          .from('trip_summaries')
+          .delete()
+          .eq('user_id', userId)
+          .eq('id', tripId);
+    } catch (e, st) {
+      debugPrint('TripsSync.deleteSummary FAILED for $tripId: $e\n$st');
+    }
+  }
+}
+
+/// Strips the per-tick `samples` and GPS-diagnostics arrays from a
+/// [TripHistoryEntry]'s JSON form so the upload payload stays under
+/// the 1 KB target for `public.trip_summaries.data` (#1479 phase 2).
+///
+/// The full-detail blob (samples + gpsd) is the phase-4 concern and
+/// lands in `public.trip_details` — keeping the summary tight here
+/// means the cross-device list view (phase 3) can paginate without
+/// dragging a year of trip telemetry through every fetch.
+Map<String, dynamic> _compactSummaryJson(TripHistoryEntry entry) {
+  final json = entry.toJson();
+  json.remove('samples');
+  json.remove('gpsd');
+  return json;
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -9,7 +9,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
 import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/providers/app_state_provider.dart';
 import '../../../core/storage/hive_boxes.dart';
+import '../../../core/sync/trips_sync.dart';
 import '../../../core/sync/baselines_sync.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
@@ -1478,6 +1480,32 @@ class TripRecording extends _$TripRecording {
         } catch (e, st) {
           debugPrint('TripRecording auto-record badge increment: $e\n$st');
         }
+      }
+      // #1479 phase 2 — opportunistic upload of the freshly saved
+      // summary to TankSync. Gated on the user's opt-in
+      // `consentSyncTrips` consent (which is itself gated on the
+      // master `cloudSync` consent at the toggle layer). Read here
+      // rather than hoisted into the orchestrator so a manual stop
+      // path also benefits — the user opted in once, every trip
+      // they save flows through the same `_saveToHistory`.
+      try {
+        final consent = ref.read(gdprConsentProvider);
+        if (consent.syncTrips) {
+          final entry = repo.loadAll().firstWhere(
+            (e) => e.id == id,
+            orElse: () => TripHistoryEntry(
+              id: id,
+              vehicleId: _vehicleId,
+              summary: summary,
+              automatic: automatic,
+            ),
+          );
+          // Fire-and-forget: an upload failure must not roll back the
+          // local save. TripsSync swallows + debugPrints internally.
+          unawaited(TripsSync.uploadSummary(entry));
+        }
+      } catch (e, st) {
+        debugPrint('TripRecording trip-sync hook: $e\n$st');
       }
     } catch (e, st) {
       debugPrint('TripRecording._saveToHistory: $e\n$st');

--- a/test/core/sync/trips_sync_test.dart
+++ b/test/core/sync/trips_sync_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sync/trips_sync.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #1479 phase 2 — surface-level coverage of [TripsSync].
+///
+/// We don't stand up a real Supabase client here; the wire layer is
+/// exercised by the manual end-to-end checklist in
+/// `docs/guides/tanksync-trips.md` and by Phase 3's merge tests when
+/// they land. What we DO pin here:
+///   - `uploadSummary` is a no-op when nothing is signed in (does not
+///     throw, does not crash on a missing client).
+///   - `deleteSummary` is a no-op when nothing is signed in.
+///
+/// These are the "do-no-harm" guarantees the recording-stop hook
+/// relies on so an unauthenticated user with `consentSyncTrips=true`
+/// (rare, but possible if they signed out without revoking the
+/// consent) doesn't wedge the local save path.
+void main() {
+  group('TripsSync', () {
+    test('uploadSummary is a no-op when not signed in', () async {
+      final entry = TripHistoryEntry(
+        id: 'test-trip-id',
+        vehicleId: null,
+        summary: TripSummary(
+          startedAt: DateTime(2026, 5, 10, 10, 0),
+          endedAt: DateTime(2026, 5, 10, 10, 30),
+          distanceKm: 12.5,
+          maxRpm: 3000,
+          highRpmSeconds: 5,
+          idleSeconds: 30,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+        ),
+      );
+      // The unauthenticated branch returns immediately; this test
+      // proves it doesn't throw rather than asserting any I/O effect.
+      await TripsSync.uploadSummary(entry);
+    });
+
+    test('deleteSummary is a no-op when not signed in', () async {
+      // Same do-no-harm guarantee for the local-delete companion.
+      await TripsSync.deleteSummary('test-trip-id');
+    });
+  });
+}


### PR DESCRIPTION
Lands the wire layer for TankSync trip-sync. Every TripRecording.stop save now opportunistically uploads the compact summary blob to public.trip_summaries when consentSyncTrips is on. Strips per-tick samples + gpsd from the upload payload so a 60-min commute stays around 1 KB. Delete-on-cloud companion + 2 do-no-harm tests included.

Out of scope: backfill UI, Phase 3 download/merge, Phase 4 detail rows.

Refs #1479