### PR TITLE
feat(ux): #1529 wrap-up — amenity chips horizontal scroll + baseline collapse

### DIFF
--- a/lib/features/consumption/presentation/widgets/vehicle_baseline_section.dart
+++ b/lib/features/consumption/presentation/widgets/vehicle_baseline_section.dart
@@ -12,7 +12,13 @@ import '../../providers/vehicle_baseline_summary_provider.dart';
 /// close each one is to full confidence (30 samples). A Reset button
 /// wipes the vehicle's baselines — useful when a car's fuel economy
 /// shifts (new tyres, new firmware, heavy load).
-class VehicleBaselineSection extends ConsumerWidget {
+///
+/// #1529 — collapsed by default to a single aggregate progress bar
+/// + sample tally. Tap the "Show details" affordance to reveal the
+/// per-driving-situation breakdown (the original 6-row view). Saves
+/// ~360 dp on the vehicle-edit screen for users who only care
+/// whether their baseline is "ready" or not.
+class VehicleBaselineSection extends ConsumerStatefulWidget {
   final String vehicleId;
 
   /// Sample count at which the baseline is considered fully learned —
@@ -21,16 +27,33 @@ class VehicleBaselineSection extends ConsumerWidget {
   /// 30 synthetic samples.
   final int fullConfidenceSamples;
 
+  /// Test/diagnostic seam: when true, the per-driving-situation
+  /// breakdown is visible from the first frame instead of behind the
+  /// "Show details" toggle (#1529). Production callers leave it
+  /// `false` so the user gets the compact aggregate view by default.
+  final bool expandDetailsByDefault;
+
   const VehicleBaselineSection({
     super.key,
     required this.vehicleId,
     this.fullConfidenceSamples = 30,
+    this.expandDetailsByDefault = false,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<VehicleBaselineSection> createState() =>
+      _VehicleBaselineSectionState();
+}
+
+class _VehicleBaselineSectionState
+    extends ConsumerState<VehicleBaselineSection> {
+  late bool _showDetails = widget.expandDetailsByDefault;
+
+  @override
+  Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final counts = ref.watch(vehicleBaselineSummaryProvider(vehicleId));
+    final counts =
+        ref.watch(vehicleBaselineSummaryProvider(widget.vehicleId));
     final theme = Theme.of(context);
 
     // Persisted situations only — transients never accumulate.
@@ -45,6 +68,7 @@ class VehicleBaselineSection extends ConsumerWidget {
 
     final totalSamples =
         situations.fold<int>(0, (acc, s) => acc + (counts[s] ?? 0));
+    final maxTotal = situations.length * widget.fullConfidenceSamples;
 
     return Card(
       margin: EdgeInsets.zero,
@@ -76,12 +100,55 @@ class VehicleBaselineSection extends ConsumerWidget {
               style: theme.textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
-            for (final s in situations)
-              _BaselineRow(
-                label: _label(s, l),
-                count: counts[s] ?? 0,
-                fullConfidenceSamples: fullConfidenceSamples,
+            // #1529 — aggregate progress bar shown always; per-
+            // situation breakdown only when the user taps Show
+            // details. Saves 5 of the 6 rows (~300 dp) on the
+            // common path.
+            ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: LinearProgressIndicator(
+                value: maxTotal == 0 ? 0 : totalSamples / maxTotal,
+                minHeight: 8,
               ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '$totalSamples / $maxTotal samples',
+              style: theme.textTheme.labelSmall,
+              textAlign: TextAlign.right,
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: TextButton.icon(
+                key: const Key('vehicleBaselineDetailsToggle'),
+                onPressed: () =>
+                    setState(() => _showDetails = !_showDetails),
+                icon: Icon(
+                  _showDetails ? Icons.expand_less : Icons.expand_more,
+                  size: 18,
+                ),
+                label: Text(
+                  // English-only inline; ARB pass to follow.
+                  _showDetails ? 'Hide per-situation breakdown' : 'Show per-situation breakdown',
+                ),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 8, vertical: 4),
+                  minimumSize: Size.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+              ),
+            ),
+            if (_showDetails) ...[
+              const SizedBox(height: 4),
+              for (final s in situations)
+                _BaselineRow(
+                  label: _label(s, l),
+                  count: counts[s] ?? 0,
+                  fullConfidenceSamples: widget.fullConfidenceSamples,
+                ),
+            ],
             const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerRight,
@@ -139,7 +206,7 @@ class VehicleBaselineSection extends ConsumerWidget {
       ),
     );
     if (confirm != true) return;
-    await ref.read(resetVehicleBaselinesProvider(vehicleId).future);
+    await ref.read(resetVehicleBaselinesProvider(widget.vehicleId).future);
   }
 
   String _label(DrivingSituation s, AppLocalizations? l) {

--- a/lib/features/search/presentation/widgets/amenity_filter_wrap.dart
+++ b/lib/features/search/presentation/widgets/amenity_filter_wrap.dart
@@ -3,14 +3,19 @@ import 'package:flutter/material.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/station_amenity.dart';
 
-/// Wrap of FilterChips, one per [StationAmenity], used by the Search
-/// criteria screen to let the user filter results by station equipment
-/// (shop, car wash, toilet, EV, …).
+/// FilterChips, one per [StationAmenity], used by the Search criteria
+/// screen to let the user filter results by station equipment (shop,
+/// car wash, toilet, EV, …).
 ///
 /// Stateless: the parent owns the selection set and forwards toggles
-/// via [onToggle]. Pulled out of `search_criteria_screen.dart` so the
-/// screen drops the inline private widget and so the chip wrap can be
-/// exercised by widget tests in isolation.
+/// via [onToggle].
+///
+/// #1529 — switched from a multi-row [Wrap] to a single horizontally-
+/// scrolling [Row]. The 8 chips at default chip width wrap to 3 rows
+/// on Samsung S20 portrait, eating ~180 dp. A horizontal scroll
+/// shows only ~3 chips at once but the user can pan to reveal the
+/// rest, and the screen reclaims two full rows of vertical space for
+/// the search-criteria controls below.
 class AmenityFilterWrap extends StatelessWidget {
   final Set<StationAmenity> selected;
   final ValueChanged<StationAmenity> onToggle;
@@ -24,19 +29,28 @@ class AmenityFilterWrap extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return Wrap(
-      spacing: 8,
-      runSpacing: 4,
-      children: [
-        for (final amenity in StationAmenity.values)
-          FilterChip(
-            key: ValueKey('criteria-amenity-${amenity.name}'),
-            avatar: Icon(amenityIcon(amenity), size: 18),
-            label: Text(_label(amenity, l10n)),
-            selected: selected.contains(amenity),
-            onSelected: (_) => onToggle(amenity),
-          ),
-      ],
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      // Negative left padding cancels the default ListTile-like inset
+      // when this widget sits inside a SectionContent, so the leftmost
+      // chip aligns with the section title above it.
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final amenity in StationAmenity.values) ...[
+            FilterChip(
+              key: ValueKey('criteria-amenity-${amenity.name}'),
+              avatar: Icon(amenityIcon(amenity), size: 18),
+              label: Text(_label(amenity, l10n)),
+              selected: selected.contains(amenity),
+              onSelected: (_) => onToggle(amenity),
+            ),
+            if (amenity != StationAmenity.values.last)
+              const SizedBox(width: 8),
+          ],
+        ],
+      ),
     );
   }
 

--- a/test/features/consumption/presentation/widgets/vehicle_baseline_section_test.dart
+++ b/test/features/consumption/presentation/widgets/vehicle_baseline_section_test.dart
@@ -10,11 +10,17 @@ const _vehicleId = 'car-a';
 
 /// Convenience: wraps the section in a sized container so the
 /// `LinearProgressIndicator`s have a real width to lay out against.
+///
+/// `expandDetailsByDefault: true` so existing tests written against
+/// the per-situation row view (#779) keep their assertions valid
+/// after the #1529 collapse-by-default change. Default-collapsed
+/// behaviour gets its own dedicated test below.
 Widget _host({int fullConfidenceSamples = 30}) => SizedBox(
       width: 600,
       child: VehicleBaselineSection(
         vehicleId: _vehicleId,
         fullConfidenceSamples: fullConfidenceSamples,
+        expandDetailsByDefault: true,
       ),
     );
 
@@ -43,9 +49,11 @@ void main() {
       expect(find.textContaining('OBD2 trip'), findsOneWidget);
 
       // Reset button is disabled when nothing has been learned —
-      // no point wiping a baseline that doesn't exist.
-      final resetBtn =
-          tester.widget<TextButton>(find.byType(TextButton).first);
+      // no point wiping a baseline that doesn't exist. Address by
+      // key (#1529 introduced a sibling show-details TextButton, so
+      // `byType(TextButton).first` no longer points at reset).
+      final resetBtn = tester.widget<TextButton>(
+          find.byKey(const Key('resetBaselinesButton')));
       expect(resetBtn.onPressed, isNull);
     });
 
@@ -72,15 +80,18 @@ void main() {
             find.byType(LinearProgressIndicator),
           )
           .toList();
-      expect(bars.length, 6);
-      // One of the bars must be at 0.5 — exact ordering is the widget's
-      // concern, not the test's.
+      // 6 per-situation bars + 1 aggregate bar (#1529).
+      expect(bars.length, 7);
+      // One of the per-situation bars must be at 0.5 — exact ordering
+      // is the widget's concern, not the test's.
       expect(
         bars.where((b) => (b.value ?? 0) == 0.5).length,
         1,
         reason: 'urbanCruise row should render at 50% progress',
       );
-      // The other 5 are at 0.
+      // The other 5 per-situation bars are at 0; the aggregate bar
+      // sits at 15 / (6 × 30) ≈ 0.083 — neither 0 nor 0.5 — so it
+      // doesn't disturb either count.
       expect(bars.where((b) => (b.value ?? -1) == 0.0).length, 5);
     });
 
@@ -164,9 +175,42 @@ void main() {
       expect(find.text('hardAccel'), findsNothing);
       expect(find.text('fuelCutCoast'), findsNothing);
 
-      // Exactly 6 progress bars — one per persisted situation.
-      expect(find.byType(LinearProgressIndicator), findsNWidgets(6));
+      // 6 per-situation bars + 1 aggregate progress bar (#1529).
+      expect(find.byType(LinearProgressIndicator), findsNWidgets(7));
     });
+
+    testWidgets(
+      '#1529 — per-situation rows are HIDDEN by default; show-details '
+      'toggle reveals them and bumps the bar count from 1 (aggregate) '
+      'to 7',
+      (tester) async {
+        // No `expandDetailsByDefault` override — this is the production
+        // default the user sees on the vehicle-edit screen.
+        await pumpApp(
+          tester,
+          const SizedBox(
+            width: 600,
+            child: VehicleBaselineSection(vehicleId: _vehicleId),
+          ),
+          overrides: [
+            _summaryOverride(const {DrivingSituation.idle: 4}),
+          ],
+        );
+        // Only the aggregate progress bar in the collapsed view.
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+        // Per-situation labels invisible until expand.
+        expect(find.text('Idle'), findsNothing);
+
+        await tester.tap(
+          find.byKey(const Key('vehicleBaselineDetailsToggle')),
+        );
+        await tester.pumpAndSettle();
+
+        // 1 aggregate + 6 per-situation = 7 bars; labels visible.
+        expect(find.byType(LinearProgressIndicator), findsNWidgets(7));
+        expect(find.text('Idle'), findsOneWidget);
+      },
+    );
 
     testWidgets(
         'reset button is enabled once any sample exists, and tapping '


### PR DESCRIPTION
Two more #1529 surfaces: amenity chips become a horizontal scroll (saves ~180 dp on the search-criteria modal) + baseline-calibration collapses to a single aggregate bar with show-details toggle (~300 dp saved on vehicle-edit). 11 baseline tests + 4 amenity tests still pass.

Refs #1529