### PR TITLE
fix(test): adapt 2 tests broken by recent UI/API changes

### DIFF
--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -73,6 +73,7 @@ class _RecordingThrowsTripRecording extends TripRecording {
     String? vehicleId,
     String? adapterMac,
     Obd2Service? service,
+    bool automatic = false,
   }) async {
     startTripCallCount++;
     // Surfacing an Obd2ScanTimeout exercises the `on Obd2ConnectionError`
@@ -96,6 +97,7 @@ class _PendingTripRecording extends TripRecording {
     String? vehicleId,
     String? adapterMac,
     Obd2Service? service,
+    bool automatic = false,
   }) {
     return gate.future;
   }
@@ -112,6 +114,7 @@ class _IdleTripRecording extends TripRecording {
     String? vehicleId,
     String? adapterMac,
     Obd2Service? service,
+    bool automatic = false,
   }) async {
     return StartTripOutcome.alreadyActive;
   }
@@ -131,6 +134,7 @@ class _NeedsPickerTripRecording extends TripRecording {
     String? vehicleId,
     String? adapterMac,
     Obd2Service? service,
+    bool automatic = false,
   }) async {
     startTripCallCount++;
     return StartTripOutcome.needsPicker;
@@ -886,6 +890,7 @@ class _ActiveRecordingTrip extends TripRecording {
     String? vehicleId,
     String? adapterMac,
     Obd2Service? service,
+    bool automatic = false,
   }) async =>
       StartTripOutcome.alreadyActive;
 }

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -115,9 +115,14 @@ void main() {
         overrides: overrides(),
       );
 
-      // API key stored should show Yes
+      // hasApiKey=true → Yes row visible by default.
       expect(find.text('Yes'), findsOneWidget);
-      // EV API key should show No
+      // hasEvApiKey=false → No row hidden behind the #1530
+      // 'Show N empty rows' toggle. Reveal it to verify the No row
+      // is still present in the rendered tree.
+      await tester
+          .tap(find.byKey(const Key('privacyShowAllRowsToggle')));
+      await tester.pumpAndSettle();
       expect(find.text('No'), findsOneWidget);
     });
 


### PR DESCRIPTION
Two real test failures from recent merges + 2 pre-existing flakes left as-is.

## Real fixes
- **trajets_tab_test.dart** — 5 fake `TripRecording` notifier classes had outdated `startTrip` overrides after #1531 added `automatic: bool`. Add the param.
- **privacy_dashboard_screen_test.dart** — 'shows API key status' needs to tap the show-all toggle now that #1530 hides zero-value rows by default.

## Pre-existing (unchanged here)
- `edit_vehicle_screen_ve_reset_test.dart` and `profile_screen_section_gating_test.dart` both fail on master with HiveError 'Box not found' independent of any recent change. Tracked separately.