### PR TITLE
test(fix): un-flake the 2 Hive-box widget tests (#1545)

### DIFF
--- a/test/features/profile/presentation/screens/profile_screen_section_gating_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_section_gating_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart' show Size;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
@@ -117,37 +118,51 @@ void main() {
     testWidgets(
       'both foldables render when both root features are enabled',
       (tester) async {
+        // The ListView in ProfileScreen lazy-builds children based on
+        // viewport. The default 800×600 surface scrolls the
+        // Consumption foldable far off-stage, and the lazy delegate
+        // doesn't materialise it until it's near the viewport — so
+        // `skipOffstage: false` finds nothing. Set a tall surface so
+        // every foldable renders eagerly (#1545 fix).
+        await tester.binding.setSurfaceSize(const Size(1200, 3200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
         await pumpApp(
           tester,
           const ProfileScreen(),
           overrides: overridesWithFlags(<Feature>{
             Feature.tankSync,
             Feature.obd2TripRecording,
+            // #1520: Consumption section visibility now requires the
+            // `showConsumptionTab` flag in the stored set in addition
+            // to a data source (obd2TripRecording OR manualConsumption).
+            // Pin it so the foldable renders.
+            Feature.showConsumptionTab,
           }),
         );
 
-        // Settings list scrolls — section titles may be off-screen
-        // until scrolled into view, so probe the widget tree directly.
         expect(find.text('TankSync', skipOffstage: false), findsOneWidget);
         expect(find.text('Consumption', skipOffstage: false), findsOneWidget);
       },
-      // Pre-existing flake — passed in PR #1521 CI but fails locally and
-      // in subsequent PR CIs. Adding the Use mode section above the
-      // Consumption foldable in #1528 didn't introduce the flake (test
-      // also fails on master without #1528's changes), but the larger
-      // tree may have made the lazy-build-window edge case more likely
-      // to bite. Tracked separately; do not block #1528 on this.
-      skip: true,
     );
 
     testWidgets(
       'TankSync foldable hides without affecting Consumption when only '
       'tankSync is off (independent gates)',
       (tester) async {
+        // Same surface-size fix as the 'both foldables render' test
+        // above (#1545) — the lazy ListView won't materialise the
+        // Consumption row at the default 800×600 viewport.
+        await tester.binding.setSurfaceSize(const Size(1200, 3200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
         await pumpApp(
           tester,
           const ProfileScreen(),
-          overrides: overridesWithFlags(<Feature>{Feature.obd2TripRecording}),
+          overrides: overridesWithFlags(<Feature>{
+            Feature.obd2TripRecording,
+            // #1520: same gate change — pin showConsumptionTab so the
+            // foldable renders even when tankSync is off.
+            Feature.showConsumptionTab,
+          }),
         );
 
         expect(find.text('TankSync', skipOffstage: false), findsNothing);

--- a/test/features/vehicle/presentation/screens/edit_vehicle_screen_ve_reset_test.dart
+++ b/test/features/vehicle/presentation/screens/edit_vehicle_screen_ve_reset_test.dart
@@ -6,6 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 import 'package:tankstellen/features/vehicle/data/repositories/vehicle_profile_repository.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/presentation/screens/edit_vehicle_screen.dart';
@@ -132,10 +136,27 @@ Future<void> _pumpEditScreen(
   required VehicleProfileRepository repo,
   required String vehicleId,
 }) async {
+  // The edit-vehicle screen has grown tall (#779 baseline + #1529
+  // collapse toggle + service reminders + #815 reset button). The
+  // 800×600 default surface forces dragUntilVisible to scroll the
+  // button on/off-stage as the layout settles, racing pumpAndSettle
+  // and producing offstage taps. A tall surface lets every section
+  // render at once and avoids the race (#1545 root cause).
+  await tester.binding.setSurfaceSize(const Size(1200, 3200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         vehicleProfileRepositoryProvider.overrideWithValue(repo),
+        // The vehicle save-actions widget reads
+        // [fillUpListProvider] (for `latestOdometerKm`) and the
+        // post-save side-effect calls [activeProfileProvider] (for
+        // `syncActiveProfile`). Both production providers reach
+        // Hive boxes the widget-test setUp doesn't initialise.
+        // Stub them so the build + post-save flow succeed without
+        // touching Hive (#1545).
+        fillUpListProvider.overrideWith(() => _EmptyFillUpList()),
+        activeProfileProvider.overrideWith(() => _NullActiveProfile()),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -145,6 +166,24 @@ Future<void> _pumpEditScreen(
     ),
   );
   await tester.pumpAndSettle();
+}
+
+/// Test stub for [FillUpList] — returns an empty list so the
+/// odometer-lookup helper inside `vehicle_save_actions.dart` resolves
+/// to null without ever touching the production Hive-backed
+/// repository (#1545).
+class _EmptyFillUpList extends FillUpList {
+  @override
+  List<FillUp> build() => const [];
+}
+
+/// Test stub for [ActiveProfile] — returns null so
+/// `syncActiveProfile` short-circuits without reading the production
+/// `profileRepositoryProvider`, which itself depends on a Hive box
+/// the widget-test setUp doesn't initialise (#1545).
+class _NullActiveProfile extends ActiveProfile {
+  @override
+  UserProfile? build() => null;
 }
 
 class _FakeSettings implements SettingsStorage {


### PR DESCRIPTION
Two widget tests had been failing on master with `HiveError: Box not found` or with offstage taps that never reached the actual button. Both were viewport / provider-stub problems, not real product bugs.

## test/features/profile/presentation/screens/profile_screen_section_gating_test.dart
- Un-skip 'both foldables render when both root features are enabled' (skipped since #1528).
- Set a tall (1200×3200) test surface so the lazy ListView materialises every foldable.
- Pin `Feature.showConsumptionTab` in the two affected cases — the #1520 gate uses the `isConsumptionTabReachable` OR-helper, which requires it.

## test/features/vehicle/presentation/screens/edit_vehicle_screen_ve_reset_test.dart
- Set a tall test surface so `dragUntilVisible` doesn't race the layout and tap an offstage button.
- Override `fillUpListProvider` + `activeProfileProvider` with stubs so `vehicle_save_actions.dart` doesn't reach Hive-backed providers the widget-test setUp doesn't initialise.

Closes #1545