### PR TITLE
feat(ux): #1539 sticky compact station-detail header + top-biased empty states

### DIFF
--- a/lib/core/widgets/empty_state.dart
+++ b/lib/core/widgets/empty_state.dart
@@ -12,6 +12,13 @@ class EmptyState extends StatelessWidget {
   final VoidCallback? onAction;
   final double iconSize;
 
+  /// When true, anchor icon+title+subtitle in the top third of the
+  /// viewport and pin the CTA near the bottom. Used by the consumption
+  /// and favorites empty states (#1539) where the centred default left
+  /// a large visual void on a fresh install. Requires a parent that
+  /// hands the widget a bounded height (Expanded / TabBarView).
+  final bool topBiased;
+
   const EmptyState({
     super.key,
     required this.icon,
@@ -20,44 +27,72 @@ class EmptyState extends StatelessWidget {
     this.actionLabel,
     this.onAction,
     this.iconSize = 64,
+    this.topBiased = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+
+    final body = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: iconSize, color: colorScheme.outline),
+        const SizedBox(height: 16),
+        Text(
+          title,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            subtitle!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ],
+    );
+
+    final hasAction = actionLabel != null && onAction != null;
+    final cta = hasAction
+        ? FilledButton.icon(
+            onPressed: onAction,
+            icon: const Icon(Icons.search),
+            label: Text(actionLabel!),
+          )
+        : null;
+
+    if (topBiased) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+        child: Column(
+          children: [
+            const Spacer(flex: 2),
+            body,
+            const Spacer(flex: 5),
+            ?cta,
+          ],
+        ),
+      );
+    }
+
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: iconSize, color: colorScheme.outline),
-            const SizedBox(height: 16),
-            Text(
-              title,
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: colorScheme.onSurfaceVariant,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            if (subtitle != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                subtitle!,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ],
-            if (actionLabel != null && onAction != null) ...[
+            body,
+            if (cta != null) ...[
               const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: onAction,
-                icon: const Icon(Icons.search),
-                label: Text(actionLabel!),
-              ),
+              cta,
             ],
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -41,6 +41,7 @@ class FuelTab extends ConsumerWidget {
         title: l?.noFillUpsTitle ?? 'No fill-ups yet',
         subtitle: l?.noFillUpsSubtitle ??
             'Log your first fill-up to start tracking consumption.',
+        topBiased: true,
       );
     }
     // #1194 — opt-out gate for gamification surfaces. Watching here

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -178,6 +178,7 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
               title: l?.trajetsEmptyStateTitle ?? 'No trips yet',
               subtitle: l?.trajetsEmptyStateBody ??
                   'Tap Start recording to begin logging your drives.',
+              topBiased: true,
             ),
           ),
         ],

--- a/lib/features/favorites/presentation/widgets/favorites_fuel_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_fuel_tab.dart
@@ -41,6 +41,7 @@ class FavoritesFuelTab extends ConsumerWidget {
               'Tap the star on a station to save it here',
           actionLabel: l10n?.search ?? 'Search Stations',
           onAction: () => context.go('/'),
+          topBiased: true,
         ),
       );
     }

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
-import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
@@ -17,6 +17,14 @@ import '../widgets/station_prices_section.dart';
 import '../widgets/station_rating_section.dart';
 import '../widgets/station_status_row.dart';
 
+/// Detail screen for a single fuel station.
+///
+/// #1539 — the data state uses a `CustomScrollView` + `SliverAppBar`
+/// (pinned, `expandedHeight: 220`) so the rich status-row + brand-header
+/// block collapses out of view on scroll, leaving a 1-row compact bar
+/// (back arrow + station name + cheapest-price chip + actions). Loading
+/// and error states keep a plain fixed `AppBar` since there is no scroll
+/// content to sticky-collapse against.
 class StationDetailScreen extends ConsumerWidget {
   final String stationId;
 
@@ -25,124 +33,275 @@ class StationDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final detailAsync = ref.watch(stationDetailProvider(stationId));
+    final l10n = AppLocalizations.of(context);
 
     // #595 — derive a display title from the loaded station so the Hero
     // flight from the search card lands on the matching brand/name.
     // Falls back to the generic "Station" label until data loads.
     final station = detailAsync.value?.data.station;
-    final String appBarTitle = station != null
+    final appBarTitle = station != null
         ? (hasRealBrand(station) ? station.brand : station.street)
-        : (AppLocalizations.of(context)?.search ?? 'Station');
+        : (l10n?.search ?? 'Station');
 
-    return PageScaffold(
-      titleWidget: Semantics(
-        header: true,
-        child: Hero(
-          tag: 'station-name-$stationId',
-          flightShuttleBuilder: (ctx, animation, direction, fromCtx, toCtx) {
-            final theme = Theme.of(ctx);
-            return Material(
-              type: MaterialType.transparency,
-              child: DefaultTextStyle(
-                style: theme.appBarTheme.titleTextStyle ??
-                    theme.textTheme.titleLarge ??
-                    const TextStyle(fontWeight: FontWeight.bold),
-                child: Text(
-                  appBarTitle,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-          child: Material(
-            type: MaterialType.transparency,
-            child: Text(
-              appBarTitle,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        ),
+    return detailAsync.when(
+      data: (result) => _StationDetailLoaded(
+        stationId: stationId,
+        detail: result.data,
+        serviceResult: result,
+        appBarTitle: appBarTitle,
       ),
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back),
-        onPressed: () => context.pop(),
-        tooltip: AppLocalizations.of(context)?.tooltipBack ?? 'Back',
+      loading: () => _StationDetailPlain(
+        stationId: stationId,
+        appBarTitle: appBarTitle,
+        body: const ShimmerStationDetail(),
       ),
-      actions: [
-        StationDetailAppBarActions(
-          stationId: stationId,
-          station: station,
-        ),
-      ],
-      bodyPadding: EdgeInsets.zero,
-      body: detailAsync.when(
-        data: (result) => Column(
-          children: [
-            ServiceStatusBanner(result: result),
-            Expanded(child: _buildContent(context, ref, result.data, result)),
-          ],
-        ),
-        loading: () => const ShimmerStationDetail(),
-        error: (error, _) => ServiceChainErrorWidget(
+      error: (error, _) => _StationDetailPlain(
+        stationId: stationId,
+        appBarTitle: appBarTitle,
+        body: ServiceChainErrorWidget(
           error: error,
           onRetry: () => ref.invalidate(stationDetailProvider(stationId)),
         ),
       ),
     );
   }
+}
 
-  Widget _buildContent(
-    BuildContext context,
-    WidgetRef ref,
-    StationDetail detail,
-    ServiceResult<StationDetail> serviceResult,
-  ) {
-    final station = detail.station;
+/// Scaffold used by the loading and error states — fixed `AppBar`,
+/// Hero-tagged title, back button. No sliver / collapse behaviour.
+class _StationDetailPlain extends StatelessWidget {
+  final String stationId;
+  final String appBarTitle;
+  final Widget body;
+
+  const _StationDetailPlain({
+    required this.stationId,
+    required this.appBarTitle,
+    required this.body,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.pop(),
+          tooltip: l10n?.tooltipBack ?? 'Back',
+        ),
+        title: _HeroTitle(stationId: stationId, title: appBarTitle),
+      ),
+      body: body,
+    );
+  }
+}
+
+/// Loaded state — `CustomScrollView` + `SliverAppBar(pinned: true,
+/// expandedHeight: 220)`. Status row and brand header live inside the
+/// `flexibleSpace.background`, so they fade out as the bar collapses
+/// to its compact form on scroll past the prices card.
+class _StationDetailLoaded extends StatelessWidget {
+  final String stationId;
+  final StationDetail detail;
+  final ServiceResult<StationDetail> serviceResult;
+  final String appBarTitle;
+
+  const _StationDetailLoaded({
+    required this.stationId,
+    required this.detail,
+    required this.serviceResult,
+    required this.appBarTitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
+    final station = detail.station;
     final bottomPadding = MediaQuery.of(context).viewPadding.bottom;
+    final cheapest = _cheapestPrice(station);
 
-    return SingleChildScrollView(
-      padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Open/closed status + freshness inline + rating stars (top-right)
-          StationStatusRow(
-            station: station,
-            serviceResult: serviceResult,
-            stationId: stationId,
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar(
+            pinned: true,
+            expandedHeight: 220,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => context.pop(),
+              tooltip: l10n?.tooltipBack ?? 'Back',
+            ),
+            title: Row(
+              children: [
+                Flexible(
+                  child: _HeroTitle(
+                    stationId: stationId,
+                    title: appBarTitle,
+                  ),
+                ),
+                if (cheapest != null) ...[
+                  const SizedBox(width: 8),
+                  _CheapestPriceChip(price: cheapest),
+                ],
+              ],
+            ),
+            actions: [
+              StationDetailAppBarActions(
+                stationId: stationId,
+                station: station,
+              ),
+            ],
+            flexibleSpace: FlexibleSpaceBar(
+              background: SafeArea(
+                child: Padding(
+                  // Keep the rich block clear of the pinned toolbar at the
+                  // top — the leading / title / actions sit in the first
+                  // kToolbarHeight (56dp) of the SliverAppBar regardless of
+                  // expansion state, so the background has to inset by that
+                  // much to avoid overlap when fully expanded.
+                  padding: const EdgeInsets.fromLTRB(
+                    16,
+                    kToolbarHeight + 8,
+                    16,
+                    8,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      StationStatusRow(
+                        station: station,
+                        serviceResult: serviceResult,
+                        stationId: stationId,
+                      ),
+                      const SizedBox(height: 12),
+                      StationBrandHeader(station: station),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ),
-          const SizedBox(height: 12),
-
-          // Brand logo + Name (+ "Independent station" subtitle — #482)
-          StationBrandHeader(station: station),
-          const SizedBox(height: 16),
-
-          // Prices (compact) + "Log fill-up" CTA
-          StationPricesSection(station: station),
-          const SizedBox(height: 16),
-
-          // Address, opening hours, fuels, location (services moved to bottom)
-          StationInfoSection(station: station, detail: detail),
-
-          // Rating (interactive)
-          const SizedBox(height: 16),
-          StationRatingSection(stationId: stationId),
-
-          // Price History
-          const SizedBox(height: 24),
-          Semantics(
-            header: true,
-            child: Text(l10n?.priceHistory ?? 'Price History',
-                style: theme.textTheme.titleMedium),
+          SliverToBoxAdapter(
+            child: ServiceStatusBanner(result: serviceResult),
           ),
-          const SizedBox(height: 8),
-          PriceHistorySection(stationId: stationId, station: station),
+          SliverPadding(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
+            sliver: SliverList(
+              delegate: SliverChildListDelegate.fixed([
+                StationPricesSection(station: station),
+                const SizedBox(height: 16),
+                StationInfoSection(station: station, detail: detail),
+                const SizedBox(height: 16),
+                StationRatingSection(stationId: stationId),
+                const SizedBox(height: 24),
+                Semantics(
+                  header: true,
+                  child: Text(
+                    l10n?.priceHistory ?? 'Price History',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                PriceHistorySection(stationId: stationId, station: station),
+              ]),
+            ),
+          ),
         ],
       ),
     );
   }
+}
+
+/// Hero-flighted station-name text. Wraps the title in the same Hero
+/// tag the search card uses so the brand label appears to fly into the
+/// detail screen header on push. Centralised here so all three states
+/// (loading, error, data) share the same animation source.
+class _HeroTitle extends StatelessWidget {
+  final String stationId;
+  final String title;
+
+  const _HeroTitle({required this.stationId, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: true,
+      child: Hero(
+        tag: 'station-name-$stationId',
+        flightShuttleBuilder: (ctx, animation, direction, fromCtx, toCtx) {
+          final theme = Theme.of(ctx);
+          return Material(
+            type: MaterialType.transparency,
+            child: DefaultTextStyle(
+              style: theme.appBarTheme.titleTextStyle ??
+                  theme.textTheme.titleLarge ??
+                  const TextStyle(fontWeight: FontWeight.bold),
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          );
+        },
+        child: Material(
+          type: MaterialType.transparency,
+          child: Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small pill next to the station name showing the cheapest fuel price
+/// at this station. Visible in both the expanded and collapsed
+/// SliverAppBar states so the user keeps a reference to the headline
+/// price after scrolling past the dedicated prices card.
+class _CheapestPriceChip extends StatelessWidget {
+  final double price;
+
+  const _CheapestPriceChip({required this.price});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Text(
+        PriceFormatter.formatPrice(price),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onPrimaryContainer,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Lowest non-null fuel price across the station's published fuels.
+/// Returns null when the station reports no prices.
+double? _cheapestPrice(Station s) {
+  final candidates = <double>[
+    if (s.e5 != null && s.e5! > 0) s.e5!,
+    if (s.e10 != null && s.e10! > 0) s.e10!,
+    if (s.diesel != null && s.diesel! > 0) s.diesel!,
+    if (s.dieselPremium != null && s.dieselPremium! > 0) s.dieselPremium!,
+    if (s.e98 != null && s.e98! > 0) s.e98!,
+    if (s.e85 != null && s.e85! > 0) s.e85!,
+    if (s.lpg != null && s.lpg! > 0) s.lpg!,
+    if (s.cng != null && s.cng! > 0) s.cng!,
+  ];
+  if (candidates.isEmpty) return null;
+  return candidates.reduce((a, b) => a < b ? a : b);
 }

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
@@ -67,8 +68,9 @@ class StationDetailScreen extends ConsumerWidget {
   }
 }
 
-/// Scaffold used by the loading and error states — fixed `AppBar`,
-/// Hero-tagged title, back button. No sliver / collapse behaviour.
+/// Scaffold used by the loading and error states — fixed AppBar via
+/// `PageScaffold` (required by the #923 design-system lint), Hero-tagged
+/// title, back button. No sliver / collapse behaviour.
 class _StationDetailPlain extends StatelessWidget {
   final String stationId;
   final String appBarTitle;
@@ -83,15 +85,14 @@ class _StationDetailPlain extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
-          tooltip: l10n?.tooltipBack ?? 'Back',
-        ),
-        title: _HeroTitle(stationId: stationId, title: appBarTitle),
+    return PageScaffold(
+      titleWidget: _HeroTitle(stationId: stationId, title: appBarTitle),
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () => context.pop(),
+        tooltip: l10n?.tooltipBack ?? 'Back',
       ),
+      bodyPadding: EdgeInsets.zero,
       body: body,
     );
   }


### PR DESCRIPTION
## Summary
- Station-detail screen now uses a `CustomScrollView` + pinned `SliverAppBar` (expandedHeight 220). The status row + brand header live in the `flexibleSpace.background` and fade out on scroll past the prices card. Collapsed bar: back arrow, station name, cheapest-price chip, 5 action icons.
- `EmptyState` widget gets a `topBiased` flag — wires icon + title in top third with the CTA pinned at the bottom. Enabled on Consumption→Fuel, Consumption→Trips, and Favorites tabs. Centred default preserved for MapScreen / InlineMap / AlertsScreen.

Closes #1539. Refs #1529.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test test/features/station_detail/ test/features/consumption/ test/features/favorites/` — 2756 / 2756
- [x] `flutter test test/app/ test/core/widgets/` — 344 / 344
- [x] Manual smoke on a station-detail screen — scroll past the prices card → header collapses to compact bar
- [x] Manual smoke on the three empty states (fresh install) → icon/body in top third, CTA at the bottom on the Favorites tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)