### PR TITLE
feat(ios): source-tracked WidgetKit extension scaffolding (partial)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ docs/guides/*
 !docs/guides/SCHEMA-BACKUP-XML.md
 !docs/guides/ios-auto-record.md
 !docs/guides/ios-codesigning.md
+!docs/guides/ios-widget-extension.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/ios-widget-extension.md
+++ b/docs/guides/ios-widget-extension.md
@@ -1,0 +1,159 @@
+# iOS Widget Extension — Mac-developer setup checklist
+
+This PR adds **source-tracked scaffolding** for an iOS WidgetKit
+extension that mirrors the Android home-screen widget. Everything that
+can ship blind ships in this PR. The remaining steps require:
+
+- Xcode (UI-driven target setup),
+- the Apple Developer Portal (App Group + provisioning),
+- a physical iPhone for verification.
+
+Until those steps are completed by a Mac-equipped developer, the iOS
+build still compiles and runs without the widget — the Swift sources
+sit on disk but the Xcode project doesn't compile them. Android is
+unaffected.
+
+## What's already in the tree
+
+```
+ios/
+├── Runner/
+│   └── Runner.entitlements                 ← App Group entitlement (NEW)
+└── TankstellenWidget/
+    ├── TankstellenWidget.swift             ← @main WidgetBundle
+    ├── NearestStationsProvider.swift       ← TimelineProvider
+    ├── NearestStationsEntry.swift          ← TimelineEntry
+    ├── NearestStationsWidgetView.swift     ← SwiftUI layout
+    ├── StationRow.swift                    ← Decodable mirror of Dart row
+    ├── Info.plist                          ← Extension Info.plist
+    ├── TankstellenWidget.entitlements      ← App Group entitlement (widget)
+    └── Assets.xcassets/
+        ├── AccentColor.colorset/
+        └── WidgetBackground.colorset/
+```
+
+Dart side:
+- `lib/features/widget/data/home_widget_service.dart` branches the
+  App Group ID by platform — Android keeps
+  `de.tankstellen.fuelprices.widget`, iOS uses
+  `group.de.tankstellen.tankstellen`.
+
+## Required Apple Developer Portal work
+
+1. **App Group identifier** —
+   *Certificates, Identifiers & Profiles → Identifiers → App Groups → +*
+   - Description: `Tankstellen Widget Shared Storage`
+   - Identifier: `group.de.tankstellen.tankstellen` ← exact value, no typos
+2. **App ID — main app** —
+   *Identifiers → de.tankstellen.tankstellen → Edit → enable "App Groups"
+   capability → select the group above*
+3. **App ID — widget extension** —
+   *Identifiers → +. Bundle ID:
+   `de.tankstellen.tankstellen.TankstellenWidget`. Enable "App Groups"
+   and select the same group.*
+4. **Provisioning profiles** — regenerate both the main-app and the
+   widget-extension profiles AFTER enabling App Groups. The old
+   profiles do NOT carry the capability.
+   - If you use **fastlane match**, run
+     `bundle exec fastlane match development --force` and
+     `match appstore --force` and copy the new profile UUIDs into
+     Xcode's "Signing & Capabilities" pane.
+
+## Required Xcode work
+
+These steps cannot be scripted reliably from outside Xcode — the
+`project.pbxproj` schema for embedded extensions includes target
+dependencies, copy-files build phases, and code-sign settings that
+break the project file when hand-edited.
+
+### Step 1 — Add the Widget Extension target
+
+1. `open ios/Runner.xcworkspace`
+2. *File → New → Target → iOS → Widget Extension*
+3. **Product Name:** `TankstellenWidget` (exact case — matches the
+   `ios/TankstellenWidget/` directory the Swift sources live in)
+4. **Bundle Identifier:** `de.tankstellen.tankstellen.TankstellenWidget`
+5. **Language:** Swift
+6. **Include Configuration Intent:** **NO** (the widget is static; we
+   do not need an Intent / Configuration UI right now)
+7. **Activate scheme when prompted:** No (we run the host app, not
+   the widget directly)
+
+### Step 2 — Replace Xcode's template sources with the tracked ones
+
+Xcode generates default template files inside `ios/TankstellenWidget/`
+when you add the target. **Delete the generated files** (from the
+file system, not just the Xcode reference) and let Xcode pick up the
+files this PR shipped:
+
+- `TankstellenWidget.swift` ← keep ours
+- `Info.plist` ← keep ours (mirrors the host app version vars)
+- `TankstellenWidget.entitlements` ← keep ours
+- Provider / Entry / View / StationRow ← keep ours
+
+To re-add the tracked files to the Xcode target:
+1. Right-click the `TankstellenWidget` group in the project navigator
+2. *Add Files to "Runner"…* → select all four Swift files + the
+   `Assets.xcassets` folder + `Info.plist` + the `.entitlements` file
+3. **Targets:** check ONLY `TankstellenWidget` (uncheck `Runner`).
+
+### Step 3 — Wire the App Group to both targets
+
+For **each** of `Runner` and `TankstellenWidget`:
+1. Select the target → *Signing & Capabilities* tab
+2. *+ Capability → App Groups*
+3. Tick `group.de.tankstellen.tankstellen` in the list
+4. If Xcode complains "no provisioning profile found": pick the
+   regenerated profile from Step 1.4 above
+
+Xcode will automatically point each target at the matching
+`.entitlements` file we shipped. Verify the path:
+- `Runner` → `ios/Runner/Runner.entitlements`
+- `TankstellenWidget` → `ios/TankstellenWidget/TankstellenWidget.entitlements`
+
+### Step 4 — Pin the widget version to the host
+
+In the `TankstellenWidget` target's build settings, set:
+- `MARKETING_VERSION` → `$(inherited)` (defaults to host)
+- `CURRENT_PROJECT_VERSION` → `$(inherited)` (defaults to host)
+
+The `Info.plist` template already references these variables, so the
+widget version always tracks the host app.
+
+### Step 5 — Add to fastlane / CI build
+
+If you use `fastlane match` and the GitHub Actions iOS workflow, add
+the widget bundle ID to the match table and to the workflow's profile
+fetch step. The TestFlight upload step does NOT need changes — the
+widget extension is bundled inside the host app's IPA automatically
+once the target is added.
+
+## Manual verification (real iPhone)
+
+1. Build + install the host app on a physical iPhone.
+2. Open the app, complete onboarding, and let it load a couple of
+   nearby stations. This writes `nearest_json` to the App Group.
+3. Long-press the iPhone home screen → + → search "Sparkilo" or
+   "Tankstellen" → add the medium / large widget to the home screen.
+4. The widget should render 3 (medium) or 5 (large) rows of nearby
+   stations with prices + distances.
+5. Tap a row → the host app cold-starts (or warm-starts) and lands
+   directly on `/station/<id>` — same flow as Android, driven by the
+   `tankstellenwidget://station?id=<id>` URI.
+
+## Known gaps / future work
+
+- **Cheapest widget variant** — only `NearestStationsWidget` ships
+  here. The Android `StationWidgetRenderer` also supports a Favorites
+  / Cheapest mode; the SwiftUI equivalent can be added alongside
+  `NearestStationsWidget` in `TankstellenWidgetBundle` once a
+  matching `FavoritesProvider` lands.
+- **Predictive widget content** — the `predictive_*` fields the Dart
+  side optionally emits (#1121) are not yet rendered. Add a
+  `PredictiveBadge` view in `NearestStationsWidgetView.swift` once
+  the iOS widget ships.
+- **Configuration UI** — the widget is `StaticConfiguration` today;
+  if you want per-widget vehicle / fuel selection like the Android
+  `WidgetConfigureActivity`, the Swift side needs an `AppIntent` or
+  `IntentConfiguration` (iOS 17+) or `IntentTimelineProvider` (iOS
+  14+).

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<!--
+  App entitlements for the main iOS app target.
+
+  The `com.apple.security.application-groups` entry is REQUIRED for the
+  TankstellenWidget extension to share data (nearest-stations JSON, etc.)
+  with the host app through `UserDefaults(suiteName:)`.
+
+  The group identifier MUST be `group.<bundle-id>` per Apple's App Group
+  naming rules. Match the value to the one in
+  `ios/TankstellenWidget/TankstellenWidget.entitlements` — both targets
+  must declare the SAME group string and both must be code-signed by
+  provisioning profiles that include this App Group capability (set up
+  in the Apple Developer Portal → Identifiers).
+-->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.de.tankstellen.tankstellen</string>
+	</array>
+</dict>
+</plist>

--- a/ios/TankstellenWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/TankstellenWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0xA8",
+          "red" : "0x10"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/TankstellenWidget/Assets.xcassets/Contents.json
+++ b/ios/TankstellenWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/TankstellenWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/ios/TankstellenWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x14",
+          "green" : "0x14",
+          "red" : "0x14"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/TankstellenWidget/Info.plist
+++ b/ios/TankstellenWidget/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<!--
+  Info.plist for the TankstellenWidget WidgetKit extension target.
+
+  Apple-supplied values (CFBundleVersion / CFBundleShortVersionString)
+  are populated automatically by Xcode at build time. We keep them as
+  template variables so the widget version always tracks the host app
+  (avoids "Widget version X but app version Y" confusion in TestFlight).
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Tankstellen</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/TankstellenWidget/NearestStationsEntry.swift
+++ b/ios/TankstellenWidget/NearestStationsEntry.swift
@@ -1,0 +1,58 @@
+// TimelineEntry payload for the Nearest-Stations widget.
+//
+// `rows` is the parsed `nearest_json` array (see `StationRow`). `isStale`
+// reflects the `nearest_is_stale` flag the Dart side sets when the data
+// is older than the freshness budget — the SwiftUI view renders a small
+// "stale" pill when this is true so the user knows the prices may have
+// moved since the last sync.
+
+import Foundation
+import WidgetKit
+
+struct NearestStationsEntry: TimelineEntry {
+    let date: Date
+    let rows: [StationRow]
+    let isStale: Bool
+    let emptyReason: String?
+
+    /// Placeholder used by `placeholder(in:)` and SwiftUI previews when
+    /// the App Group container is empty (e.g. before the host app has
+    /// run once, or while a fresh install is still downloading prices).
+    static let placeholder = NearestStationsEntry(
+        date: Date(),
+        rows: (1...3).map { i in
+            StationRow(
+                id: "placeholder-\(i)",
+                brand: "Sparkilo",
+                name: nil,
+                street: "Loading…",
+                postCode: nil,
+                place: nil,
+                e5: nil,
+                e10: nil,
+                diesel: nil,
+                preferredFuelCode: nil,
+                preferredFuelPrice: nil,
+                distanceKm: Double(i),
+                isOpen: true,
+                currency: "€",
+                priceFormatted: "—"
+            )
+        },
+        isStale: false,
+        emptyReason: nil
+    )
+
+    /// Fallback rendered when the App Group container reports an empty
+    /// `nearest_json`. The view shows `emptyReason` verbatim so the
+    /// user knows why ("no GPS fix", "no nearby stations", etc.) —
+    /// matches the Android empty-state copy.
+    static func empty(reason: String) -> NearestStationsEntry {
+        NearestStationsEntry(
+            date: Date(),
+            rows: [],
+            isStale: false,
+            emptyReason: reason
+        )
+    }
+}

--- a/ios/TankstellenWidget/NearestStationsProvider.swift
+++ b/ios/TankstellenWidget/NearestStationsProvider.swift
@@ -1,0 +1,92 @@
+// TimelineProvider that reads the latest Nearest-Stations payload from
+// the shared App Group container.
+//
+// Refresh cadence: the host app updates the container whenever a new
+// search resolves (typically every few minutes when the app is open).
+// We schedule a `Timeline` reload every 15 minutes from the last entry
+// so the widget refreshes even when the host hasn't run — WidgetKit
+// budgets ~40 reloads per day so 15 minutes is comfortably under the
+// throttle ceiling.
+
+import Foundation
+import WidgetKit
+
+/// App Group identifier — MUST match the one declared in
+/// `Runner.entitlements` and `TankstellenWidget.entitlements`, AND the
+/// `_iosGroupId` constant on the Dart side
+/// (`lib/features/widget/data/home_widget_service.dart`). All three
+/// strings break together; keep them in lock-step.
+let kTankstellenAppGroupId = "group.de.tankstellen.tankstellen"
+
+struct NearestStationsProvider: TimelineProvider {
+    typealias Entry = NearestStationsEntry
+
+    func placeholder(in context: Context) -> Entry {
+        NearestStationsEntry.placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
+        completion(currentEntry())
+    }
+
+    func getTimeline(
+        in context: Context,
+        completion: @escaping (Timeline<Entry>) -> Void
+    ) {
+        let entry = currentEntry()
+        let nextRefresh = Calendar.current.date(
+            byAdding: .minute,
+            value: 15,
+            to: entry.date
+        ) ?? entry.date.addingTimeInterval(15 * 60)
+        completion(
+            Timeline(entries: [entry], policy: .after(nextRefresh))
+        )
+    }
+
+    // MARK: - private
+
+    private func currentEntry() -> Entry {
+        let defaults = UserDefaults(suiteName: kTankstellenAppGroupId)
+        guard let defaults = defaults else {
+            return NearestStationsEntry.empty(
+                reason: "App Group not configured"
+            )
+        }
+        // The Dart side writes the rows as a JSON-encoded string under
+        // the `nearest_json` key (see `HomeWidgetService.updateWidget`).
+        // If the key is missing the host app has never run, never
+        // resolved a location, or never had any nearby results — the
+        // empty-reason copy disambiguates the latter two.
+        guard let raw = defaults.string(forKey: "nearest_json") else {
+            return NearestStationsEntry.empty(
+                reason: defaults.string(forKey: "nearest_empty_reason")
+                    ?? "Open Sparkilo to load nearby prices"
+            )
+        }
+        guard let data = raw.data(using: .utf8) else {
+            return NearestStationsEntry.empty(
+                reason: "Couldn't decode widget data"
+            )
+        }
+        do {
+            let rows = try JSONDecoder().decode([StationRow].self, from: data)
+            if rows.isEmpty {
+                return NearestStationsEntry.empty(
+                    reason: defaults.string(forKey: "nearest_empty_reason")
+                        ?? "No nearby stations"
+                )
+            }
+            return NearestStationsEntry(
+                date: Date(),
+                rows: rows,
+                isStale: defaults.bool(forKey: "nearest_is_stale"),
+                emptyReason: nil
+            )
+        } catch {
+            return NearestStationsEntry.empty(
+                reason: "Couldn't read widget data"
+            )
+        }
+    }
+}

--- a/ios/TankstellenWidget/NearestStationsWidgetView.swift
+++ b/ios/TankstellenWidget/NearestStationsWidgetView.swift
@@ -1,0 +1,121 @@
+// SwiftUI body for the Nearest-Stations widget.
+//
+// Renders one row per station with `widgetURL` set to the
+// `tankstellenwidget://station?id=<id>` deep link so taps follow the
+// same cold-start / warm-click flow Android uses (handled in the
+// Flutter app by `WidgetClickListener` + the router's pending-URI
+// redirect).
+//
+// Visual language deliberately matches the Android renderer: brand /
+// street, price chip, distance pill. Keep both in lock-step so the
+// user sees the same widget on both platforms.
+
+import SwiftUI
+import WidgetKit
+
+struct NearestStationsWidgetView: View {
+    let entry: NearestStationsEntry
+
+    /// `.systemMedium` shows 3 rows, `.systemLarge` shows 5. Configurable
+    /// via the widget family environment so the same body adapts.
+    @Environment(\.widgetFamily) private var family
+
+    private var maxRows: Int {
+        switch family {
+        case .systemLarge: return 5
+        default: return 3
+        }
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color(.systemBackground)
+            VStack(alignment: .leading, spacing: 6) {
+                header
+                if entry.rows.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(Array(entry.rows.prefix(maxRows))) { row in
+                        Link(destination: row.deepLink) {
+                            StationRowView(row: row)
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+        }
+        .widgetURL(
+            // Fallback tap target for the whole widget (system small +
+            // any tap that misses an individual Link). Routes to the
+            // search screen via a sentinel URI the parser ignores —
+            // the app's redirect chain falls through to its normal
+            // landing without trying to open a station detail.
+            URL(string: "tankstellenwidget://station?id=__widget_root__")
+        )
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 6) {
+            Image(systemName: "fuelpump.fill")
+                .foregroundStyle(.tint)
+            Text("Sparkilo")
+                .font(.caption.weight(.semibold))
+            Spacer()
+            if entry.isStale {
+                Text("stale")
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule().fill(Color.orange.opacity(0.18))
+                    )
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(entry.emptyReason ?? "No data yet")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct StationRowView: View {
+    let row: StationRow
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.displayName)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+                if let street = row.street, street != row.displayName {
+                    Text(street)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                if let price = row.priceFormatted, !price.isEmpty {
+                    Text(price)
+                        .font(.callout.weight(.semibold))
+                        .monospacedDigit()
+                }
+                if let distance = row.distanceKm {
+                    Text(String(format: "%.1f km", distance))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+        }
+    }
+}

--- a/ios/TankstellenWidget/StationRow.swift
+++ b/ios/TankstellenWidget/StationRow.swift
@@ -1,0 +1,77 @@
+// Decodable mirror of the Dart-side widget row (see
+// `lib/features/widget/data/home_widget_service.dart` /
+// `nearest_widget_data_builder.dart`).
+//
+// Keep the JSON keys in lock-step with the Dart writer — the Android
+// renderer (`StationWidgetRenderer.kt`) reads the same keys, and any
+// drift between the three readers shows up as missing prices /
+// distance-less rows in production. When a new field lands on Dart,
+// add the same `CodingKey` here and on the Android side.
+
+import Foundation
+
+struct StationRow: Codable, Identifiable, Equatable {
+    let id: String
+    let brand: String?
+    let name: String?
+    let street: String?
+    let postCode: String?
+    let place: String?
+    let e5: Double?
+    let e10: Double?
+    let diesel: Double?
+    let preferredFuelCode: String?
+    let preferredFuelPrice: Double?
+    let distanceKm: Double?
+    let isOpen: Bool?
+    let currency: String?
+    /// Pre-formatted price string (e.g. "1.45⁹ €"). The Dart layer
+    /// formats it because the locale / currency / fractional-cent
+    /// convention varies per country and we don't want to duplicate
+    /// the rules in Swift.
+    let priceFormatted: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case brand
+        case name
+        case street
+        case postCode
+        case place
+        case e5
+        case e10
+        case diesel
+        case preferredFuelCode = "preferred_fuel_code"
+        case preferredFuelPrice = "preferred_fuel_price"
+        case distanceKm = "distance_km"
+        case isOpen
+        case currency
+        case priceFormatted
+    }
+
+    /// Convenience: best non-empty display label for the row. Mirrors
+    /// the Dart `StationDisplay.displayName` ordering — brand wins
+    /// when it isn't a generic "Station" placeholder; otherwise fall
+    /// back to street, then place.
+    var displayName: String {
+        if let brand = brand,
+           !brand.isEmpty,
+           brand.lowercased() != "station",
+           brand.lowercased() != "autoroute" {
+            return brand
+        }
+        if let street = street, !street.isEmpty { return street }
+        if let name = name, !name.isEmpty { return name }
+        return place ?? id
+    }
+
+    /// `widgetURL(_:)` target — exact mirror of the Android
+    /// `tankstellenwidget://station?id=<id>` PendingIntent URI the
+    /// `StationWidgetRenderer` emits. The Flutter app's
+    /// `widgetUriToPath` parses this scheme and routes to
+    /// `/station/<id>` (or `/ev-station/<id>` for OCM-prefixed ids).
+    var deepLink: URL {
+        URL(string: "tankstellenwidget://station?id=\(id)")
+            ?? URL(string: "tankstellenwidget://station")!
+    }
+}

--- a/ios/TankstellenWidget/TankstellenWidget.entitlements
+++ b/ios/TankstellenWidget/TankstellenWidget.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<!--
+  Widget extension entitlements.
+
+  Same App Group identifier as `ios/Runner/Runner.entitlements` — both
+  targets MUST declare the SAME string. Without this entitlement the
+  widget extension cannot read the host app's `nearest_json` /
+  `stations_json` payload via `UserDefaults(suiteName: …)`.
+
+  The Apple Developer Portal App ID for the widget extension's bundle
+  identifier (`de.tankstellen.tankstellen.TankstellenWidget`) must have
+  the "App Groups" capability enabled and include this exact group
+  string. Provisioning profiles must be regenerated AFTER adding the
+  capability.
+-->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.de.tankstellen.tankstellen</string>
+	</array>
+</dict>
+</plist>

--- a/ios/TankstellenWidget/TankstellenWidget.swift
+++ b/ios/TankstellenWidget/TankstellenWidget.swift
@@ -1,0 +1,42 @@
+// Widget extension bundle entry point.
+//
+// Defines the Nearest-Stations widget and registers it with the WidgetKit
+// runtime. Pair widget for the Cheapest / Favourites variant can be added
+// alongside `NearestStationsWidget` inside the `WidgetBundle` body once a
+// dedicated provider lands.
+//
+// Shape mirrors the Android `StationWidgetRenderer`'s NearestStations row
+// — same JSON contract under the shared App Group UserDefaults so a single
+// Dart write path (`HomeWidgetService.updateWidget`) feeds both platforms.
+
+import SwiftUI
+import WidgetKit
+
+@main
+struct TankstellenWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        NearestStationsWidget()
+    }
+}
+
+struct NearestStationsWidget: Widget {
+    let kind: String = "NearestStationsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: NearestStationsProvider()) { entry in
+            NearestStationsWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Sparkilo — Nearest")
+        .description("Closest fuel stations and their current prices.")
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}
+
+#if DEBUG
+struct NearestStationsWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        NearestStationsWidgetView(entry: NearestStationsEntry.placeholder)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+    }
+}
+#endif

--- a/lib/features/widget/data/home_widget_service.dart
+++ b/lib/features/widget/data/home_widget_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' show Platform;
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -25,8 +26,28 @@ import 'predictive_payload.dart';
 /// 2. This service reads cached data -> writes to SharedPreferences via home_widget
 /// 3. Native Android widgets read SharedPreferences -> render UI
 ///
-/// Widget group ID must match the `android:authorities` in AndroidManifest.
-const _widgetGroupId = 'de.tankstellen.fuelprices.widget';
+/// Android: the SharedPreferences file the `home_widget` plugin writes
+/// to. Must match the prefs file that `StationWidgetRenderer.kt` reads
+/// — keep the two literals in lock-step.
+const _androidWidgetGroupId = 'de.tankstellen.fuelprices.widget';
+
+/// iOS: the App Group identifier the WidgetKit extension shares with
+/// the host app. MUST start with `group.` (Apple convention) and
+/// match the entitlements on BOTH targets:
+/// - `ios/Runner/Runner.entitlements`
+/// - `ios/TankstellenWidget/TankstellenWidget.entitlements`
+/// — and `kTankstellenAppGroupId` in
+/// `ios/TankstellenWidget/NearestStationsProvider.swift`. All four
+/// strings break together; keep them in lock-step.
+const _iosWidgetGroupId = 'group.de.tankstellen.tankstellen';
+
+/// Platform-correct widget-data scope. The same `HomeWidget.saveWidgetData`
+/// call goes through this string — Android treats it as the prefs file
+/// name, iOS as an `UserDefaults(suiteName:)` argument backed by the
+/// App Group container. Branching at the source keeps the two
+/// platforms' shared-storage conventions tidy.
+String get _widgetGroupId =>
+    Platform.isIOS ? _iosWidgetGroupId : _androidWidgetGroupId;
 // Single provider class (#713) — the widget toggles between favorites
 // and nearest modes internally. The old NearestWidgetProvider receiver
 // was dropped from the manifest.


### PR DESCRIPTION
## Summary

Adds every file an iOS WidgetKit extension needs to mirror the Android home-screen widget — Swift sources, entitlements, Info.plist, asset catalogs, and the Dart-side platform-correct App Group ID. **Cannot add the Xcode target itself from outside Xcode reliably**, so this PR ships source files alongside a step-by-step Mac-developer guide at \`docs/guides/ios-widget-extension.md\`.

## What ships

\`ios/TankstellenWidget/\` (NEW):
- \`TankstellenWidget.swift\` — \`@main\` WidgetBundle + \`NearestStationsWidget\` configuration.
- \`NearestStationsProvider.swift\` — TimelineProvider reads \`nearest_json\` from \`UserDefaults(suiteName: kTankstellenAppGroupId)\`.
- \`NearestStationsEntry.swift\` — TimelineEntry + placeholder + empty states.
- \`NearestStationsWidgetView.swift\` — SwiftUI layout. Each row emits a \`Link\` to \`tankstellenwidget://station?id=<id>\` — same URI shape Android emits, so the cold-start / warm-click flow wired in #1554 works on both platforms.
- \`StationRow.swift\` — Codable mirror of the Dart-side widget row shape.
- \`Info.plist\`, \`TankstellenWidget.entitlements\`, \`Assets.xcassets/\` (Accent + WidgetBackground).

\`ios/Runner/Runner.entitlements\` (NEW): App Group on the host app target — must match the widget extension.

\`lib/features/widget/data/home_widget_service.dart\`:
- Branches App Group ID by \`Platform.isIOS\`. Android keeps \`de.tankstellen.fuelprices.widget\` (no data migration); iOS uses \`group.de.tankstellen.tankstellen\` (Apple-required \`group.\` prefix).

## What still needs Mac access

- Xcode "Add Target → Widget Extension" UI flow — \`project.pbxproj\` changes for embedded extensions are too fragile to hand-edit.
- Apple Developer Portal: App Group identifier creation + capability toggle on both App IDs + provisioning profile regen.
- Physical-device verification (widget cannot be tested in the simulator).

Marked partial against the iOS lineage (#1295 / #1542). Deep-link plumbing landed in #1554.

## Test plan
- [x] \`flutter analyze\` — clean
- [x] \`flutter test test/features/widget/ test/lint/\` — 123 passing
- [x] Dart \`Platform.isIOS\` branch is no-op on Android (existing prefs file preserved)
- [ ] (Mac-dev) Follow \`docs/guides/ios-widget-extension.md\`: create App Group → add Widget Extension target → wire entitlements → match regen → install on iPhone → verify widget renders + tap deep-links to /station/:id

🤖 Generated with [Claude Code](https://claude.com/claude-code)