### PR TITLE
fix(ux): wizard / Conso coherence — always-on Conso, Trajets gate, use-mode under Conso

### DIFF
--- a/lib/app/shell/shell_destinations.dart
+++ b/lib/app/shell/shell_destinations.dart
@@ -13,8 +13,9 @@ const int kConsumptionBranchIndex = 3;
 ///
 /// [items] is the list the bottom-bar / rail should iterate over.
 /// [branchForSlot] maps each visible slot back to its router-branch
-/// index — when Conso is hidden (#893), Settings still routes to
-/// branch 4 even though it sits at display-slot 3.
+/// index. The list is kept stable across renders so destinations
+/// don't reorder — every slot index always points at the same
+/// router branch.
 class ShellDestinations {
   final List<ShellNavItem> items;
   final List<int> branchForSlot;
@@ -25,18 +26,26 @@ class ShellDestinations {
   });
 }
 
-/// Build the canonical 5-item nav list, then strip the Conso slot
-/// when no vehicle is configured. Pure function — no Flutter state,
-/// no Riverpod — the shell decides _when_ to call it (every build)
-/// and what `hasVehicle` evaluates to.
+/// Build the canonical 5-item nav list.
+///
+/// History: #893 hid the Conso slot when no vehicle was configured.
+/// That created a catch-22 for the Medium use-mode profile (#1517) —
+/// the user couldn't reach the consumption screen to add their first
+/// fill-up + vehicle because the tab was hidden until a vehicle
+/// existed. The gate was removed so the Conso tab is always visible;
+/// the empty-state inside the consumption screen owns the "no vehicle
+/// yet" affordance now.
+///
+/// Pure function — no Flutter state, no Riverpod — kept lean so the
+/// shell can re-resolve on every build without paying provider-read
+/// overhead.
 ShellDestinations resolveShellDestinations({
   required AppLocalizations? l10n,
-  required bool hasVehicle,
 }) {
   // Kept in router-branch order so the index handed to
-  // `navigationShell.goBranch()` still lines up: Search=0, Map=1,
+  // `navigationShell.goBranch()` lines up directly: Search=0, Map=1,
   // Favorites=2, Consumption=3, Settings=4.
-  final allDestinations = <ShellNavItem>[
+  final destinations = <ShellNavItem>[
     ShellNavItem(
       Icons.search_outlined,
       Icons.search,
@@ -60,18 +69,8 @@ ShellDestinations resolveShellDestinations({
     ),
   ];
 
-  // Visible items + the router-branch index each one maps to. When
-  // Conso is hidden, Settings still routes to branch 4 even though
-  // it renders at display-slot 3.
-  final visibleDestinations = <ShellNavItem>[];
-  final branchForSlot = <int>[];
-  for (var i = 0; i < allDestinations.length; i++) {
-    if (i == kConsumptionBranchIndex && !hasVehicle) continue;
-    visibleDestinations.add(allDestinations[i]);
-    branchForSlot.add(i);
-  }
   return ShellDestinations(
-    items: visibleDestinations,
-    branchForSlot: branchForSlot,
+    items: destinations,
+    branchForSlot: List<int>.generate(destinations.length, (i) => i),
   );
 }

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../core/utils/frame_callbacks.dart';
 import '../features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart';
-import '../features/vehicle/providers/vehicle_providers.dart';
 import '../l10n/app_localizations.dart';
 import 'current_shell_branch_provider.dart';
 import 'responsive_search_layout.dart';
@@ -173,41 +172,17 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     final isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
 
-    // #893 — Conso tab is only visible once the user has configured at
-    // least one vehicle. A fresh install (no vehicles) shows the 4
-    // canonical destinations (Search, Map, Favorites, Settings); the
-    // Conso branch still exists in the router (deep links to
-    // `/consumption-tab` and `/consumption/...` remain functional),
-    // only the bottom-nav item is conditional. `ref.watch` makes this
-    // reactive — removing the last vehicle from Settings instantly
-    // collapses the tab to 4, and adding the first vehicle grows it
-    // back to 5.
-    final hasVehicle = ref.watch(vehicleProfileListProvider).isNotEmpty;
-
-    // #778 contract preserved: the bottom-nav Consumption slot is
-    // gated SOLELY on `hasVehicle`. Profile-tier gating (Basic
-    // skips the vehicle wizard step → no vehicle added → no
-    // Consumption slot) happens implicitly via the wizard. Stricter
-    // gating belongs in the Settings → Consumption section
-    // (`isConsumptionTabReachable`), not in the nav bar — see
-    // `shell_consumption_tab_test.dart`.
-    final destinations =
-        resolveShellDestinations(l10n: l10n, hasVehicle: hasVehicle);
+    // Conso tab is always visible — the empty-state inside the
+    // consumption screen owns the "no vehicle yet" affordance so the
+    // Medium use-mode profile (#1517) can reach the consumption flow
+    // without first configuring a vehicle. The #893 vehicle gate that
+    // used to live here created a catch-22 for Medium users (vehicle
+    // configured FROM the conso screen, conso hidden UNTIL a vehicle
+    // exists).
+    final destinations = resolveShellDestinations(l10n: l10n);
     final visibleDestinations = destinations.items;
     final branchForSlot = destinations.branchForSlot;
     _branchForSlot = branchForSlot;
-
-    // If the user was on the Conso tab and just deleted their last
-    // vehicle, snap the selection to Search (branch 0) — the Conso
-    // slot has disappeared from the nav bar and leaving
-    // `_currentIndex` pointing at it would leave no item highlighted.
-    if (!hasVehicle && _currentIndex == kConsumptionBranchIndex) {
-      safePostFrame(() {
-        if (!mounted) return;
-        if (_currentIndex != kConsumptionBranchIndex) return;
-        _goToPage(0);
-      });
-    }
 
     // Display-slot the animated nav bar should highlight. `-1` when
     // the active branch has no visible slot (transient, resolved by

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -8,6 +8,9 @@ import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../feature_management/application/feature_flags_provider.dart';
+import '../../../feature_management/domain/feature.dart';
+import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/exporters/backup/full_backup_exporter.dart';
@@ -71,10 +74,11 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
   }
 
   void _ensureTabController({
+    required bool showTrajets,
     required bool showCharging,
     int? preferredIndex,
   }) {
-    final newLength = showCharging ? 3 : 2;
+    final newLength = 1 + (showTrajets ? 1 : 0) + (showCharging ? 1 : 0);
     final previous = _tabController;
     if (previous != null && previous.length == newLength) {
       return;
@@ -82,16 +86,11 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
 
     // Clamp the previous index into the new controller's range so we
     // don't strand the user on a now-missing tab. When the Charging
-    // tab vanishes while the user is on it, fall back to Trajets
-    // (index 1) rather than Fuel — it's the closest neighbour in the
+    // tab vanishes while the user is on it, fall back to Trajets when
+    // it's visible or Fuel otherwise — closest neighbour in the
     // mental model of "what I was just looking at".
     final oldIndex = preferredIndex ?? previous?.index ?? 0;
-    final int initialIndex;
-    if (!showCharging && oldIndex >= newLength) {
-      initialIndex = 1; // Trajets
-    } else {
-      initialIndex = oldIndex.clamp(0, newLength - 1);
-    }
+    final initialIndex = oldIndex.clamp(0, newLength - 1);
 
     final controller = TabController(
       length: newLength,
@@ -164,12 +163,28 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     final stats = ref.watch(consumptionStatsProvider);
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
     final showCharging = _shouldShowCharging(activeVehicle);
+    // Trajets tab is gated on the OBD2 trip-recording feature — users
+    // who haven't enabled OBD2 capture have no trips to render and the
+    // empty tab was confusing. The flag is read via the manifest's
+    // effective-enabled walk so a disabled prerequisite (e.g.
+    // priceHistory, future deps) cascades through.
+    final manifest = ref.watch(featureManifestProvider);
+    final enabledFlags = ref.watch(featureFlagsProvider);
+    final showTrajets = isEffectivelyEnabled(
+      Feature.obd2TripRecording,
+      manifest,
+      enabledFlags,
+    );
     // Recreate the TabController when the tab-set cardinality
-    // changes (#892). Doing this in build — rather than in initState
-    // — lets us react to live vehicle switches without a ref.listen
-    // round-trip, and keeps the controller's length always consistent
-    // with the rendered Tab list (length mismatch throws at runtime).
-    _ensureTabController(showCharging: showCharging);
+    // changes (#892, #conso-coherence). Doing this in build — rather
+    // than in initState — lets us react to live vehicle switches /
+    // feature-flag toggles without a ref.listen round-trip, and
+    // keeps the controller's length always consistent with the
+    // rendered Tab list (length mismatch throws at runtime).
+    _ensureTabController(
+      showTrajets: showTrajets,
+      showCharging: showCharging,
+    );
     final tabController = _tabController!;
     final l = AppLocalizations.of(context);
 
@@ -195,15 +210,20 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
       ref.read(lastVeLearnResultProvider.notifier).set(null);
     });
 
-    // #889 — tabs are 0 Fuel, 1 Trajets, and (ICE vehicles excepted
-    // per #892) 2 Charging. The FAB rebinds per-tab: Fuel ->
-    // pick-station sheet, Trajets hides the FAB (the "Start
-    // recording" CTA lives inside the tab header), Charging -> Add
-    // charging log sheet.
+    // Tab indices shift based on which optional tabs are present:
+    //   Fuel is always slot 0.
+    //   Trajets sits at slot 1 when `showTrajets` is true.
+    //   Charging sits at the next slot after that (slot 1 when
+    //   Trajets is hidden; slot 2 when Trajets is shown).
+    // The FAB rebinds per-tab: Fuel → pick-station sheet, Trajets
+    // hides the FAB (the "Start recording" CTA lives in the tab
+    // header), Charging → Add charging log sheet.
+    final trajetsIndex = showTrajets ? 1 : -1;
+    final chargingIndex = showCharging ? (showTrajets ? 2 : 1) : -1;
     final tabIndex = tabController.index;
     final isFuelTab = tabIndex == 0;
-    final isTrajetsTab = tabIndex == 1;
-    final isChargingTab = showCharging && tabIndex == 2;
+    final isTrajetsTab = trajetsIndex >= 0 && tabIndex == trajetsIndex;
+    final isChargingTab = chargingIndex >= 0 && tabIndex == chargingIndex;
 
     return PageScaffold(
       title: l?.consumptionLogTitle ?? 'Fuel consumption',
@@ -265,10 +285,15 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
                 label: l?.consumptionTabFuel ?? 'Fuel',
                 icon: Icons.local_gas_station_outlined,
               ),
-              TabSwitcherEntry(
-                label: l?.trajetsTabLabel ?? 'Trips',
-                icon: Icons.route_outlined,
-              ),
+              // Trajets tab is hidden when `Feature.obd2TripRecording`
+              // is off — users who haven't enabled OBD2 capture have
+              // no trips to render and the empty tab confused Medium
+              // use-mode users.
+              if (showTrajets)
+                TabSwitcherEntry(
+                  label: l?.trajetsTabLabel ?? 'Trips',
+                  icon: Icons.route_outlined,
+                ),
               // #892 — Charging tab is hidden when the active vehicle
               // is a pure combustion engine. Hybrid and EV profiles
               // still see it; the no-vehicle case keeps the tab (a
@@ -285,7 +310,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
               controller: tabController,
               children: [
                 FuelTab(fillUps: fillUps, stats: stats, l: l),
-                TrajetsTab(vehicleId: activeVehicle?.id),
+                if (showTrajets) TrajetsTab(vehicleId: activeVehicle?.id),
                 // Charging view is only mounted when the active vehicle
                 // can actually charge — hiding it for ICE profiles (#892)
                 // removes a dead-end tap for combustion-only users without

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -62,17 +62,10 @@ class ProfileScreen extends ConsumerWidget {
         physics: const AlwaysScrollableScrollPhysics(),
         padding: EdgeInsets.zero,
         children: [
-          // Use mode (#1517 / #1519) — first thing on the Settings
-          // screen because it gates which other sections (Consumption,
-          // Loyalty, Vehicles, Achievements) are visible at all.
-          const SectionHeader(
-            leadingIcon: Icons.tune,
-            title: 'Use mode',
-            padding: EdgeInsets.zero,
-          ),
-          const SizedBox(height: 4),
-          const UseModeSection(),
-          const SizedBox(height: 16),
+          // Use mode (#1517 / #1519) used to sit at the top of the
+          // Settings screen; it now lives INSIDE the Consumption
+          // _FoldableSection below so the use-mode chooser is grouped
+          // with the consumption-tier-dependent toggles it gates.
 
           // Profiles — primary user-data section.
           SectionHeader(
@@ -161,7 +154,20 @@ class ProfileScreen extends ConsumerWidget {
             _FoldableSection(
               icon: Icons.local_gas_station_outlined,
               title: l?.navConsumption ?? 'Consumption',
-              child: const DrivingSettingsSection(),
+              child: const Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Use mode chooser anchors the Consumption section
+                  // because the profile (Basic / Medium / Full / Custom)
+                  // is what determines which downstream toggles are
+                  // visible at all. Moved here from the top of the
+                  // Settings screen so users discover the chooser at
+                  // the same time as the toggles it gates.
+                  UseModeSection(),
+                  SizedBox(height: 8),
+                  DrivingSettingsSection(),
+                ],
+              ),
             ),
             const SizedBox(height: 8),
           ],

--- a/test/app/shell/shell_destinations_test.dart
+++ b/test/app/shell/shell_destinations_test.dart
@@ -3,49 +3,34 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/app/shell/shell_destinations.dart';
 
 /// Pure-function tests for the destination-resolution helper extracted
-/// from `shell_screen.dart` during the #563 refactor. Verifies that:
-/// - The 5-item canonical order (Search, Map, Favorites, Conso,
-///   Settings) is preserved when a vehicle is configured.
-/// - The Conso slot is dropped (not stubbed, not reordered) when no
-///   vehicle is configured (#893) — and the remaining slots still map
-///   to their original router-branch indices so Settings still routes
-///   to branch 4.
+/// from `shell_screen.dart` during the #563 refactor.
+///
+/// History note: #893 originally dropped the Conso slot when no
+/// vehicle was configured. That gate was removed (#conso-coherence)
+/// because the Medium use-mode profile (#1517) needs the Conso tab
+/// reachable BEFORE a vehicle exists — the vehicle-add affordance
+/// lives inside the consumption screen, so hiding the tab created a
+/// catch-22. Conso is now always present; the empty-state inside the
+/// consumption screen owns the no-vehicle / no-fill-up affordances.
 void main() {
   group('resolveShellDestinations', () {
-    test('returns 5 destinations and identity slot mapping when vehicle '
-        'is configured', () {
-      final result =
-          resolveShellDestinations(l10n: null, hasVehicle: true);
+    test(
+      'always returns 5 destinations with identity slot mapping',
+      () {
+        final result = resolveShellDestinations(l10n: null);
 
-      expect(result.items, hasLength(5));
-      expect(result.branchForSlot, [0, 1, 2, 3, 4]);
+        expect(result.items, hasLength(5));
+        expect(result.branchForSlot, [0, 1, 2, 3, 4]);
 
-      // The Conso item carries the fuel-station icon — sanity-check
-      // ordering hasn't drifted.
-      expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
-      expect(result.items[3].filledIcon, Icons.local_gas_station);
-    });
-
-    test('drops the Conso slot when no vehicle is configured (#893)', () {
-      final result =
-          resolveShellDestinations(l10n: null, hasVehicle: false);
-
-      expect(result.items, hasLength(4));
-      // The Conso slot (router-branch 3) is gone, but branchForSlot
-      // still preserves the original branch indices so Settings (now
-      // at display-slot 3) routes to branch 4.
-      expect(result.branchForSlot, [0, 1, 2, 4]);
-
-      // No fuel-station icon should appear in the visible items list.
-      for (final item in result.items) {
-        expect(item.outlinedIcon, isNot(Icons.local_gas_station_outlined));
-        expect(item.filledIcon, isNot(Icons.local_gas_station));
-      }
-    });
+        // The Conso item carries the fuel-station icon — sanity-check
+        // ordering hasn't drifted.
+        expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
+        expect(result.items[3].filledIcon, Icons.local_gas_station);
+      },
+    );
 
     test('falls back to English labels when l10n is null', () {
-      final result =
-          resolveShellDestinations(l10n: null, hasVehicle: true);
+      final result = resolveShellDestinations(l10n: null);
 
       expect(result.items.map((i) => i.label).toList(), [
         'Search',
@@ -57,21 +42,16 @@ void main() {
     });
 
     test('Settings always sits at the rightmost visible slot', () {
-      final withConso =
-          resolveShellDestinations(l10n: null, hasVehicle: true);
-      final withoutConso =
-          resolveShellDestinations(l10n: null, hasVehicle: false);
+      final result = resolveShellDestinations(l10n: null);
 
-      expect(withConso.items.last.label, 'Settings');
-      expect(withoutConso.items.last.label, 'Settings');
+      expect(result.items.last.label, 'Settings');
     });
 
     test('kConsumptionBranchIndex matches the position of the Conso '
         'router branch in the canonical destination list', () {
       // If router.dart ever reorders branches, this test fires before
-      // the gating logic silently goes wrong.
-      final result =
-          resolveShellDestinations(l10n: null, hasVehicle: true);
+      // the routing logic silently goes wrong.
+      final result = resolveShellDestinations(l10n: null);
       expect(
         result.items[kConsumptionBranchIndex].outlinedIcon,
         Icons.local_gas_station_outlined,

--- a/test/app/shell_nav_vehicle_gating_test.dart
+++ b/test/app/shell_nav_vehicle_gating_test.dart
@@ -7,27 +7,20 @@ import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dar
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
-/// #893 — the Conso bottom-nav tab is only visible once the user has
-/// configured at least one vehicle. Fresh installs see 4 tabs; adding
-/// a vehicle grows the nav to 5; deleting the last vehicle collapses
-/// it back to 4 (and if Conso was the active tab, selection snaps
-/// to Search).
+/// The Conso bottom-nav tab used to be hidden when no vehicle was
+/// configured (#893). That gate was removed in #conso-coherence —
+/// the Medium use-mode profile needs to reach the consumption screen
+/// to configure its first vehicle / log its first manual fill-up, and
+/// the original gate created a catch-22 (vehicle added FROM the
+/// consumption screen, conso hidden UNTIL a vehicle existed).
+///
+/// These tests lock in the new always-visible behaviour so a future
+/// refactor that accidentally re-introduces vehicle-based hiding
+/// trips here first.
 
 class _EmptyVehicleList extends VehicleProfileList {
   @override
   List<VehicleProfile> build() => const [];
-}
-
-class _MutableVehicleList extends VehicleProfileList {
-  final List<VehicleProfile> initial;
-  _MutableVehicleList(this.initial);
-
-  @override
-  List<VehicleProfile> build() => List<VehicleProfile>.from(initial);
-
-  void setAll(List<VehicleProfile> next) {
-    state = List<VehicleProfile>.from(next);
-  }
 }
 
 class _OneVehicleList extends VehicleProfileList {
@@ -105,121 +98,48 @@ Future<void> _pumpShell(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('ShellScreen bottom-nav vehicle gating (#893)', () {
+  group('ShellScreen — Conso always-visible contract', () {
     testWidgets(
-        'fresh install with zero vehicles renders exactly 4 tabs, no '
-        'Consumption label or icon', (tester) async {
-      await _pumpShell(
-        tester,
-        overrides: [
-          vehicleProfileListProvider.overrideWith(() => _EmptyVehicleList()),
-        ],
-      );
+      'fresh install with zero vehicles still renders all 5 tabs '
+      '(including Consumption) — Medium use-mode needs the tab '
+      'reachable to add its first manual fill-up',
+      (tester) async {
+        await _pumpShell(
+          tester,
+          overrides: [
+            vehicleProfileListProvider.overrideWith(() => _EmptyVehicleList()),
+          ],
+        );
 
-      // The four canonical destinations remain; Consumption is gone.
-      expect(find.text('Search'), findsOneWidget);
-      expect(find.text('Map'), findsOneWidget);
-      expect(find.text('Favorites'), findsOneWidget);
-      expect(find.text('Settings'), findsOneWidget);
-      expect(find.text('Consumption'), findsNothing);
-
-      // The fuel-station icons (outlined / filled) only belong to the
-      // Consumption nav item — neither should be in the tree.
-      expect(find.byIcon(Icons.local_gas_station), findsNothing);
-      expect(find.byIcon(Icons.local_gas_station_outlined), findsNothing);
-
-      // Double-check by counting Semantics buttons the nav exposes.
-      expect(find.bySemanticsLabel('Search'), findsOneWidget);
-      expect(find.bySemanticsLabel('Map'), findsOneWidget);
-      expect(find.bySemanticsLabel('Favorites'), findsOneWidget);
-      expect(find.bySemanticsLabel('Settings'), findsOneWidget);
-      expect(find.bySemanticsLabel('Consumption'), findsNothing);
-    });
-
-    testWidgets('one vehicle configured renders 5 tabs including Consumption',
-        (tester) async {
-      await _pumpShell(
-        tester,
-        overrides: [
-          vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
-        ],
-      );
-
-      expect(find.text('Search'), findsOneWidget);
-      expect(find.text('Map'), findsOneWidget);
-      expect(find.text('Favorites'), findsOneWidget);
-      expect(find.text('Consumption'), findsOneWidget);
-      expect(find.text('Settings'), findsOneWidget);
-      // The Consumption icon should now be visible in the nav bar.
-      expect(
-        find.byIcon(Icons.local_gas_station_outlined),
-        findsOneWidget,
-      );
-    });
+        expect(find.text('Search'), findsOneWidget);
+        expect(find.text('Map'), findsOneWidget);
+        expect(find.text('Favorites'), findsOneWidget);
+        expect(find.text('Consumption'), findsOneWidget);
+        expect(find.text('Settings'), findsOneWidget);
+        expect(find.byIcon(Icons.local_gas_station_outlined),
+            findsOneWidget);
+      },
+    );
 
     testWidgets(
-        'Settings still routes to its branch when Conso is hidden — '
-        'tapping it on a 4-tab nav shows SettingsBody, not the '
-        'ConsumptionBody that sits at the same display slot',
-        (tester) async {
-      await _pumpShell(
-        tester,
-        overrides: [
-          vehicleProfileListProvider.overrideWith(() => _EmptyVehicleList()),
-        ],
-      );
+      'one vehicle configured renders the same 5 tabs — vehicle '
+      'count is no longer an input to the bottom-nav layout',
+      (tester) async {
+        await _pumpShell(
+          tester,
+          overrides: [
+            vehicleProfileListProvider.overrideWith(() => _OneVehicleList()),
+          ],
+        );
 
-      await tester.tap(find.text('Settings'));
-      await tester.pump(const Duration(seconds: 1));
-
-      expect(find.text('SettingsBody'), findsOneWidget);
-      expect(find.text('ConsumptionBody'), findsNothing);
-    });
-
-    testWidgets(
-        'deleting the last vehicle while Conso is selected snaps the '
-        'nav back to 4 tabs and selection to Search', (tester) async {
-      final vehicles = _MutableVehicleList(const [
-        VehicleProfile(
-          id: 'car-1',
-          name: 'Daily Driver',
-          type: VehicleType.combustion,
-        ),
-      ]);
-
-      await _pumpShell(
-        tester,
-        overrides: [
-          vehicleProfileListProvider.overrideWith(() => vehicles),
-        ],
-        initialLocation: '/consumption-tab',
-      );
-
-      // Start with 5 tabs and Conso showing.
-      expect(find.text('Consumption'), findsOneWidget);
-      expect(find.text('ConsumptionBody'), findsOneWidget);
-
-      // User deletes their last vehicle in Settings.
-      vehicles.setAll(const []);
-      await tester.pump();
-      await tester.pump(const Duration(seconds: 1));
-
-      // Conso tab is gone from the bottom nav.
-      expect(find.text('Consumption'), findsNothing);
-      expect(find.byIcon(Icons.local_gas_station), findsNothing);
-      expect(find.byIcon(Icons.local_gas_station_outlined), findsNothing);
-
-      // Remaining tabs are still 4.
-      expect(find.text('Search'), findsOneWidget);
-      expect(find.text('Map'), findsOneWidget);
-      expect(find.text('Favorites'), findsOneWidget);
-      expect(find.text('Settings'), findsOneWidget);
-
-      // Selection snapped to Search — SearchBody is what the user now
-      // sees. The Conso branch is hidden; we don't want a stranded
-      // "nothing highlighted" state.
-      expect(find.text('SearchBody'), findsOneWidget);
-      expect(find.text('ConsumptionBody'), findsNothing);
-    });
+        expect(find.text('Search'), findsOneWidget);
+        expect(find.text('Map'), findsOneWidget);
+        expect(find.text('Favorites'), findsOneWidget);
+        expect(find.text('Consumption'), findsOneWidget);
+        expect(find.text('Settings'), findsOneWidget);
+        expect(find.byIcon(Icons.local_gas_station_outlined),
+            findsOneWidget);
+      },
+    );
   });
 }

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -6,10 +6,21 @@ import 'package:tankstellen/features/consumption/presentation/screens/consumptio
 import 'package:tankstellen/features/consumption/providers/charging_logs_provider.dart';
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+
+/// Enables `Feature.obd2TripRecording` so the Trajets tab renders —
+/// this test file's expected tab counts (2 vs 3) assume Trajets is
+/// always present, which is the case once OBD2 trip recording is on
+/// (#conso-coherence gated Trajets on the feature flag).
+class _ObdEnabledFlags extends FeatureFlags {
+  @override
+  Set<Feature> build() => <Feature>{Feature.obd2TripRecording};
+}
 
 /// #892 — the Charging tab on [ConsumptionScreen] is hidden for ICE
 /// vehicles (combustion) and visible for hybrid / EV profiles. The
@@ -115,6 +126,7 @@ Future<_MutableActiveVehicle> _pumpScreen(
       activeVehicleProfileProvider.overrideWith(() => activeNotifier),
       vehicleProfileListProvider
           .overrideWith(() => _FixedVehicleProfileList(vehicles)),
+      featureFlagsProvider.overrideWith(() => _ObdEnabledFlags()),
     ],
   );
 

--- a/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
@@ -6,10 +6,19 @@ import 'package:tankstellen/features/consumption/presentation/screens/consumptio
 import 'package:tankstellen/features/consumption/providers/charging_logs_provider.dart';
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+
+/// Enables `Feature.obd2TripRecording` — Trajets tab is gated on it
+/// (#conso-coherence) and this test asserts all three icons render.
+class _ObdEnabledFlags extends FeatureFlags {
+  @override
+  Set<Feature> build() => <Feature>{Feature.obd2TripRecording};
+}
 
 /// #1163 — counterpart to `favorites_screen_tab_icons_test.dart`.
 /// Lock that the Conso sub-tabs keep their icon-above-label rendering.
@@ -97,6 +106,7 @@ void main() {
               .overrideWith(() => _FixedActiveVehicle(_evVehicle)),
           vehicleProfileListProvider
               .overrideWith(() => _FixedVehicleProfileList(const [_evVehicle])),
+          featureFlagsProvider.overrideWith(() => _ObdEnabledFlags()),
         ],
       );
 

--- a/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
@@ -9,10 +9,20 @@ import 'package:tankstellen/features/consumption/providers/charging_logs_provide
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
+
+/// Tests that need the Trajets tab visible (default-off feature flag)
+/// override featureFlagsProvider with this notifier — Trajets is gated
+/// on `Feature.obd2TripRecording` per #conso-coherence.
+class _TrajetsEnabledFlags extends FeatureFlags {
+  @override
+  Set<Feature> build() => <Feature>{Feature.obd2TripRecording};
+}
 
 /// #889 — the ConsumptionScreen grows a Trajets tab between Fuel and
 /// Charging, and each row taps through to `/trip/:id`. These tests
@@ -135,6 +145,10 @@ Future<void> _pumpScreen(
           .overrideWith(() => _FixedVehicleProfileList(vehicles)),
       tripHistoryListProvider
           .overrideWith(() => _FixedTripHistoryList(trips)),
+      // Trajets tab is gated on obd2TripRecording (#conso-coherence).
+      // This whole test file asserts Trajets behaviour, so enable the
+      // flag for every test in here.
+      featureFlagsProvider.overrideWith(() => _TrajetsEnabledFlags()),
     ],
   );
 }
@@ -276,5 +290,64 @@ void main() {
       expect(_lastTripIdVisited, equals('2026-04-22T09:00:00.000Z'));
       expect(find.text('TripDetailStub'), findsOneWidget);
     });
+  });
+
+  group('ConsumptionScreen Trajets tab gating (#conso-coherence)', () {
+    const vehicle = VehicleProfile(
+      id: 'v1',
+      name: 'Test vehicle',
+      type: VehicleType.hybrid,
+    );
+
+    /// Pumps the screen WITHOUT enabling Feature.obd2TripRecording so
+    /// the Trajets tab should be hidden. Mirrors `_pumpScreen` above
+    /// except for the missing featureFlagsProvider override.
+    Future<void> pumpWithoutObd(WidgetTester tester) async {
+      final router = GoRouter(
+        initialLocation: '/consumption',
+        routes: [
+          GoRoute(
+            path: '/consumption',
+            builder: (_, _) => const ConsumptionScreen(),
+          ),
+          GoRoute(
+            path: '/trip/:id',
+            builder: (_, _) => const Scaffold(body: Text('TripDetailStub')),
+          ),
+        ],
+      );
+
+      await pumpApp(
+        tester,
+        MaterialApp.router(routerConfig: router),
+        overrides: [
+          fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
+          chargingLogsProvider
+              .overrideWith(() => _FixedChargingLogs(const [])),
+          activeVehicleProfileProvider
+              .overrideWith(() => _FixedActiveVehicle(vehicle)),
+          vehicleProfileListProvider
+              .overrideWith(() => _FixedVehicleProfileList(const [vehicle])),
+          tripHistoryListProvider
+              .overrideWith(() => _FixedTripHistoryList(const [])),
+          // No featureFlagsProvider override → defaults are used →
+          // obd2TripRecording is `false` per the manifest.
+        ],
+      );
+    }
+
+    testWidgets(
+      'Trajets tab is hidden when Feature.obd2TripRecording is off — '
+      'Fuel + Charging only',
+      (tester) async {
+        await pumpWithoutObd(tester);
+        expect(find.text('Fuel'), findsOneWidget);
+        expect(find.text('Trips'), findsNothing,
+            reason: 'Trajets tab must hide when obd2TripRecording is '
+                'off — Medium use-mode users have no trips to render');
+        // Hybrid vehicle still shows Charging.
+        expect(find.text('Charging'), findsOneWidget);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Three coupled bugs in the Use-mode + Consumption tab UX surfaced by the Medium profile (#1517):

### 1. Conso shell tab no longer hidden when no vehicle is configured

The #893 vehicle gate created a catch-22 for Medium use-mode: the consumption screen is the entry point for adding the first vehicle / first manual fill-up, but the Conso bottom-nav tab was hidden until a vehicle existed. Removed the gate; empty-state inside the consumption screen owns the "no vehicle yet" affordance now.

### 2. Trajets tab gated on \`Feature.obd2TripRecording\`

Medium use-mode users have no trips to render. The Trajets tab is now hidden when the flag is off — Fuel + (Charging when applicable) remain. Tab indices are computed dynamically (Fuel=0, Trajets=1 when shown, Charging=1 or 2 depending on Trajets visibility) so the FAB rebind logic stays correct.

### 3. Use-mode chooser moved into the Consumption section

The chooser (Basic / Medium / Full + Custom) moved from top-of-Settings into the Consumption \`_FoldableSection\` — grouped with the toggles it gates.

## Test plan
- [x] \`flutter analyze\` — clean
- [x] \`flutter test test/features/consumption/ test/features/profile/ test/features/feature_management/ test/app/ test/lint/\` — 3263 passing
- [x] New test: Trajets hidden when \`Feature.obd2TripRecording\` is off
- [x] Rewrote #893 vehicle-gating tests to lock in the always-visible Conso contract
- [ ] Manual smoke: complete Medium-profile onboarding (no vehicle, no OBD2) → Conso tab visible → tab has Fuel only (no Trajets) → Settings → Consumption section opens to show the Use-mode chooser at the top → can pick Full to upgrade → Trajets tab appears
- [ ] Manual smoke: existing user with vehicle + obd2TripRecording=true → no regression, tabs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)