### PR TITLE
ci(android): skip signing on Dependabot triggers, fall back to debug build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,15 @@ jobs:
       # file, then export the three env vars gradle's resolveReleaseSigning()
       # helper reads. The keystore file is written to a runner-local path
       # outside the checkout so it never ends up in an artifact.
+      #
+      # Dependabot-triggered runs cannot read repository secrets per
+      # GitHub's "no secrets to bot actors" policy. On those PRs we skip
+      # signing entirely and fall back to a debug build below — still
+      # validates that the deps Dependabot bumped actually compile + link,
+      # without the keystore-decode step exiting non-zero. Regular PRs
+      # and pushes to master use the existing signed-release path.
       - name: Decode signing keystore
+        if: github.actor != 'dependabot[bot]'
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -171,17 +179,28 @@ jobs:
           echo "ANDROID_KEYSTORE_PASSWORD=$ANDROID_KEYSTORE_PASSWORD" >> "$GITHUB_ENV"
           echo "ANDROID_KEY_ALIAS=$ANDROID_KEY_ALIAS" >> "$GITHUB_ENV"
       - name: Build APK (split per ABI)
+        if: github.actor != 'dependabot[bot]'
         run: flutter build apk --release --split-per-abi --flavor play
       - name: Build App Bundle
+        if: github.actor != 'dependabot[bot]'
         run: flutter build appbundle --release --flavor play
+      # Dependabot smoke build — unsigned debug APK. Confirms the bumped
+      # dependencies still compile + link end-to-end without needing the
+      # release keystore. Branch protection is satisfied because the job
+      # as a whole still completes successfully.
+      - name: Build APK (debug, Dependabot smoke)
+        if: github.actor == 'dependabot[bot]'
+        run: flutter build apk --debug --flavor play
       - name: Clean up decoded keystore
         if: always()
         run: rm -f "$RUNNER_TEMP/tankstellen-release.jks"
       - uses: actions/upload-artifact@v7
+        if: github.actor != 'dependabot[bot]'
         with:
           name: android-apk
           path: build/app/outputs/flutter-apk/app-*-play-release.apk
       - uses: actions/upload-artifact@v7
+        if: github.actor != 'dependabot[bot]'
         with:
           name: android-aab
           path: build/app/outputs/bundle/playRelease/app-play-release.aab


### PR DESCRIPTION
## Problem

GitHub's "no secrets for bot actors" policy means Dependabot-opened PRs cannot read \`ANDROID_KEYSTORE_BASE64\` / \`_PASSWORD\` / \`KEY_ALIAS\`. The existing keystore-decode step exits non-zero on those runs, which tanks the \`build-android\` check on every routine dep bump (#1551, #1552, the flutter_blue_plus bumps). Branch protection requires \`build-android\`, so admin-merge was the only way through — exactly what you asked me to stop doing.

## Fix

Gate the signing-related steps on \`github.actor != 'dependabot[bot]'\`. Dependabot runs get a **debug build** of the play flavor instead — still validates that the bumped deps compile + link end-to-end, no signing required, job completes successfully, branch protection happy. Regular PRs and master pushes are unchanged.

Four conditional steps:
- \`Decode signing keystore\` — skipped on Dependabot
- \`Build APK (split per ABI)\` / \`Build App Bundle\` — skipped (need the env from decode)
- The two \`upload-artifact\` steps — skipped (no release artifacts to publish)

Plus one new step:
- \`Build APK (debug, Dependabot smoke)\` — only runs on Dependabot. Unsigned debug APK as the compile-link sanity check.

## Test plan
- [x] Local diff reviewed — 19 lines added, no logic change for non-Dependabot triggers
- [ ] CI green on this PR (non-Dependabot trigger → signing path takes the existing branch)
- [ ] After merge: re-trigger #1551 + #1552 — the \`build-android\` check should now pass via the new debug-smoke path
- [ ] Re-running #1553 will also run through the smoke build (still leave merge of #1553 itself blocked on the FBP v2 device-test discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)