### PR TITLE
ci(android): defer release-signing throw until a release task is actually requested

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -120,16 +120,37 @@ android {
             // back to the debug signing key: that produced artefacts that
             // looked valid in CI but would not upgrade an existing install
             // on user devices.
+            //
+            // The throw is deferred to ACTUAL release tasks only. Without
+            // this guard the exception would fire at config-evaluation
+            // time even for `assemblePlayDebug` (Dependabot CI runs that
+            // legitimately can't read the keystore secrets — GitHub's
+            // bot-actor security policy strips them from PRs).
             signingConfig = if (releaseSigning != null) {
                 signingConfigs.getByName("release")
             } else {
-                throw GradleException(
-                    "No release signing configuration available. " +
-                        "Set ANDROID_KEYSTORE_PATH / ANDROID_KEYSTORE_PASSWORD / " +
-                        "ANDROID_KEY_ALIAS environment variables (CI: use GitHub " +
-                        "Secrets), or create android/key.properties locally. " +
-                        "Release builds never fall back to the debug key — see #48."
-                )
+                val taskNames = gradle.startParameter.taskNames
+                    .map { it.lowercase() }
+                val isReleaseRequested = taskNames.any { name ->
+                    name.contains("release") && !name.contains("debug")
+                }
+                if (isReleaseRequested) {
+                    throw GradleException(
+                        "No release signing configuration available. " +
+                            "Set ANDROID_KEYSTORE_PATH / ANDROID_KEYSTORE_PASSWORD / " +
+                            "ANDROID_KEY_ALIAS environment variables (CI: use GitHub " +
+                            "Secrets), or create android/key.properties locally. " +
+                            "Release builds never fall back to the debug key — see #48."
+                    )
+                }
+                // Debug-only builds (e.g. `assemblePlayDebug`) don't need
+                // a release signing config. Leaving this null lets the
+                // configuration phase complete; any subsequent attempt to
+                // actually assemble a release variant would fail at the
+                // signing task, which is still strictly safer than
+                // silently signing with the debug key (the original #48
+                // failure mode).
+                null
             }
         }
     }


### PR DESCRIPTION
## Problem

The #48 gradle exception ("No release signing configuration available") was firing during ANY gradle configuration pass, including \`assemblePlayDebug\`. That broke the Dependabot smoke-build step added in #1558 — Dependabot PRs run a debug build precisely *because* they can't access the release keystore secrets, but the \`buildTypes\` block evaluated regardless of the requested task and the exception killed the whole gradle config.

Run that uncovered it: https://github.com/fdittgen-png/tankstellen/actions/runs/25729075834 — \`Build APK (debug, Dependabot smoke)\` step failed at the \`No release signing configuration available\` throw.

## Fix

In the \`release { signingConfig = ... }\` else branch, check \`gradle.startParameter.taskNames\` for a release task before throwing. If only debug tasks are requested, leave signingConfig null and let configuration complete.

Actual release builds still throw at config time as before (release task name present → keystore missing → fail loudly), preserving the #48 contract that release builds NEVER silently fall back to the debug key.

## End state

| Trigger | Keystore | Behaviour |
| --- | --- | --- |
| Regular PR / master push | present | release signed normally, no change |
| Dependabot PR | absent | \`signingConfig\` null but config completes → \`assemblePlayDebug\` succeeds |
| Manual release attempt without keystore | absent | still throws (preserves #48) |

## Test plan
- [x] Local diff reviewed — 28 lines added, 7 removed; logic guarded by task-name check
- [ ] CI green on this PR (regular trigger → release path → keystore present → existing happy path)
- [ ] After merge: re-trigger #1551 + #1552 — \`build-android\` should now actually pass the debug-smoke step

🤖 Generated with [Claude Code](https://claude.com/claude-code)