### PR TITLE
ci: drop public APK distribution, add manual Dev APK workflow

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -149,10 +149,16 @@ jobs:
           flutter build appbundle --release --flavor play \
             --build-number=${{ needs.pre-check.outputs.build_number }}
 
-      - name: Build per-ABI APKs (play flavor)
-        run: |
-          flutter build apk --release --flavor play --split-per-abi \
-            --build-number=${{ needs.pre-check.outputs.build_number }}
+      # Per-ABI APKs were dropped from the public nightly release on
+      # purpose — Play App Signing re-signs every Play install with
+      # Google's app-signing key (different from the upload key the
+      # CI keystore uses), so sideloaded APKs from the GitHub release
+      # ALWAYS clashed with Play installs (Android refuses to update
+      # across signing certs). Single-channel distribution via Play
+      # Store / TestFlight is now the canonical path for end-users.
+      # Developers needing a personal APK can trigger `.github/
+      # workflows/dev-apk.yml` from the Actions UI; the artifact lives
+      # on the run, not on the public Releases page.
 
       - name: Clean up decoded keystore
         if: always() && env.ANDROID_KEYSTORE_PATH != ''
@@ -164,9 +170,6 @@ jobs:
           name: android-release
           path: |
             build/app/outputs/bundle/playRelease/app-play-release.aab
-            build/app/outputs/flutter-apk/app-arm64-v8a-play-release.apk
-            build/app/outputs/flutter-apk/app-armeabi-v7a-play-release.apk
-            build/app/outputs/flutter-apk/app-x86_64-play-release.apk
           if-no-files-found: error
           retention-days: 7
 
@@ -368,13 +371,16 @@ jobs:
             echo
             echo "**Android (Play flavor, signed):**"
             echo "- \`app-play-release.aab\` — Play Store bundle"
-            echo "- \`app-arm64-v8a-play-release.apk\` — sideload, modern 64-bit ARM"
-            echo "- \`app-armeabi-v7a-play-release.apk\` — sideload, legacy 32-bit ARM"
-            echo "- \`app-x86_64-play-release.apk\` — sideload, x86_64 emulators"
             echo
             echo "**iOS (App Store distribution, signed):**"
             echo "- \`Runner.ipa\` — distribution build (TestFlight / App Store; not directly sideloadable on consumer devices)"
             echo "- \`*.app.dSYM.zip\` — debug symbols for crash symbolication"
+            echo
+            echo "### 📱 Install / update"
+            echo
+            echo "- **Android users:** install via the [Sparkilo Play Store listing](https://play.google.com/store/apps/details?id=de.tankstellen.fuelprices). Public APKs are intentionally not attached — Play App Signing re-signs every Play install with Google's key, so sideloaded APKs would conflict with Play updates on the same device."
+            echo "- **iOS users:** install via TestFlight."
+            echo "- **Developers needing a local APK:** trigger the [\`Dev APK (arm64)\`](../actions/workflows/dev-apk.yml) workflow from the Actions UI. The APK is signed with the upload key and downloads from the run's Artifacts pane — useful for inspecting a specific commit on your own device. NOT distributable, NOT cross-channel-updatable with Play."
             echo
             echo "_Build number: ${{ needs.pre-check.outputs.build_number }} · Built from \`${{ github.sha }}\`_"
           } >> "$NOTES_FILE"

--- a/.github/workflows/dev-apk.yml
+++ b/.github/workflows/dev-apk.yml
@@ -1,0 +1,121 @@
+name: Dev APK (arm64)
+
+# Manual-only workflow that produces a single arm64-v8a APK for the
+# developer's own device. Triggered from the Actions UI; the APK lands
+# in the run's Artifacts pane (NOT a public release attachment).
+#
+# Background: public Releases dropped APK distribution intentionally
+# because Play App Signing re-signs every Play install with Google's
+# app-signing key, and the GitHub APKs (signed by the upload key) had a
+# different signature, blocking cross-channel updates on user devices.
+# This workflow keeps a tightly-scoped APK path for developers who
+# need to flash a specific commit onto a personal Android — they
+# uninstall + reinstall once, knowing the APK isn't update-compatible
+# with the Play Store version.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to build (defaults to master)'
+        required: false
+        default: 'master'
+        type: string
+
+concurrency:
+  group: dev-apk-${{ github.event.inputs.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+
+      - name: Decode signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ] || [ -z "$ANDROID_KEYSTORE_PASSWORD" ] || [ -z "$ANDROID_KEY_ALIAS" ]; then
+            echo "::error::Missing keystore secrets. Configure ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS in the repo or environment secrets." >&2
+            exit 1
+          fi
+          KEYSTORE_PATH="$RUNNER_TEMP/upload-keystore.jks"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_PATH"
+          {
+            echo "ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH"
+            echo "ANDROID_KEYSTORE_PASSWORD=$ANDROID_KEYSTORE_PASSWORD"
+            echo "ANDROID_KEY_ALIAS=$ANDROID_KEY_ALIAS"
+          } >> "$GITHUB_ENV"
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build arm64-v8a APK (play flavor, release)
+        # `--target-platform android-arm64` keeps the build to the
+        # single ABI the modern Samsung device cares about — smaller
+        # download, faster CI (~5-6 min instead of ~13 for split-per-
+        # abi).
+        run: |
+          flutter build apk --release --flavor play \
+            --target-platform android-arm64
+
+      - name: Clean up decoded keystore
+        if: always() && env.ANDROID_KEYSTORE_PATH != ''
+        run: rm -f "$ANDROID_KEYSTORE_PATH"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-apk-arm64-${{ github.event.inputs.ref }}-${{ github.run_number }}
+          path: build/app/outputs/flutter-apk/app-play-release.apk
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Summary
+        run: |
+          {
+            echo "### Dev APK ready"
+            echo
+            echo "- **Ref built:** \`${{ github.event.inputs.ref }}\`"
+            echo "- **Run #:** ${{ github.run_number }}"
+            echo "- **ABI:** arm64-v8a (modern 64-bit ARM, e.g. Samsung Galaxy S20+)"
+            echo "- **Signed with:** upload key (\`ANDROID_KEYSTORE\` secret)"
+            echo
+            echo "Download from the run's Artifacts pane above."
+            echo
+            echo "**Reminder:** this APK's signing certificate does NOT match"
+            echo "the one Google uses to re-sign Play Store installs. To put"
+            echo "it on a device that has the Play version installed:"
+            echo "1. Uninstall the Play Store version (this loses local data)."
+            echo "2. Install this APK via adb or by tapping it on the device."
+            echo "3. Future Play Store updates will be blocked until you"
+            echo "   uninstall this APK and reinstall from Play."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Play App Signing re-signs every Play Store install with Google's app-signing key, which never matches the upload key the CI keystore uses. Sideloaded APKs from the GitHub nightly therefore had a different signature from Play installs, and Android blocked cross-channel updates in either direction.

Single-channel distribution via Play Store / TestFlight is now the canonical user path. Developers needing a personal APK get a tightly-scoped manual workflow instead.

## Changes

1. **\`daily-github-release.yml\`** no longer attaches the three \`app-{abi}-play-release.apk\` files. Release publishes the AAB + iOS IPA + dSYMs. Release notes spell out the sign mismatch and point Android end-users at the Play Store listing.
2. **\`dev-apk.yml\`** (new, \`workflow_dispatch\`-only) builds a single arm64-v8a release APK and uploads it as a run artifact (NOT a public release attachment — only repo collaborators can reach it). Run summary warns that installing it requires uninstalling the Play Store version first.

## Test plan
- [x] yaml syntax sanity (analyze workflow on this PR)
- [ ] After merge: trigger \`Dev APK (arm64)\` from the Actions UI → run completes in ~5-6 min → download artifact → install on the 64-bit Samsung
- [ ] Confirm the next \`Daily GitHub Release\` nightly run no longer attaches APKs; only \`app-play-release.aab\` + iOS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)