### PR TITLE
feat(profiles): revised use-mode bundles + feature-flag registry doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ docs/guides/*
 !docs/guides/ios-auto-record.md
 !docs/guides/ios-codesigning.md
 !docs/guides/ios-widget-extension.md
+!docs/guides/feature-flags.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/feature-flags.md
+++ b/docs/guides/feature-flags.md
@@ -1,0 +1,309 @@
+# Feature flags — registry, gating, profile bundles
+
+Single source of truth for every `Feature` enum value the app ships:
+what it does, what it depends on, what user-facing code actually
+respects it, and which preset profile turns it on.
+
+Generated from `lib/features/feature_management/domain/feature.dart`
++ `feature_manifest.dart` + `app_profile.dart` plus a grep audit of
+`lib/`. Keep in sync when adding or removing a flag.
+
+## Profile bundles
+
+The first-run wizard asks the user to pick one of three presets. The
+selector is also visible in Settings → Consumption section, so the
+user can switch later. Picking a preset is **exhaustive** — every
+flag listed below is enabled, every other flag is disabled
+(`applyProfile()` semantics in `app_profile_provider.dart`).
+
+| Flag | Basic | Medium | Full |
+| --- | :-: | :-: | :-: |
+| `showFuel` | ✓ | ✓ | ✓ |
+| `showElectric` | ✓ | ✓ | ✓ |
+| `priceAlerts` | ✓ | ✓ | ✓ |
+| `priceHistory` | ✓ | ✓ | ✓ |
+| `routePlanning` | ✓ | ✓ | ✓ |
+| `evCharging` | ✓ | ✓ | ✓ |
+| `tankSync` | ✓ | ✓ | ✓ |
+| `baselineSync` | ✓ | ✓ | ✓ |
+| `manualConsumption` | — | ✓ | ✓ |
+| `obd2TripRecording` | — | — | ✓ |
+| `autoRecord` | — | — | ✓ |
+| `consumptionAnalytics` | — | — | ✓ |
+| `gamification` | — | — | ✓ |
+| `showConsumptionTab` | — | — | ✓ |
+| `loyaltyCards` | — | — | ✓ |
+| `hapticEcoCoach` | — | — | ✓ |
+| `glideCoach` | — | — | ✓ |
+| `gpsTripPath` | — | — | ✓ |
+| `unifiedSearchResults` | — | — | — |
+| `tflitePricePrediction` | — | — | — |
+
+`Custom` is a sentinel — appears in the Settings selector once the
+user toggles any individual flag away from a preset.
+
+## Requires graph (parent → child)
+
+A flag with a `requires:` parent is *effectively* disabled when the
+parent is off, even if its own bit is on (per
+`isEffectivelyEnabled`). Lazy cascade — children don't lose their
+stored preference, they just stop surfacing until the parent comes
+back on.
+
+```
+priceHistory
+└─ tflitePricePrediction         (default-off, model artifact off-band)
+
+tankSync
+└─ baselineSync                  (driving-baseline cross-device)
+
+obd2TripRecording                (root of the OBD2 family)
+├─ autoRecord                    (master gate for hands-free record)
+├─ gamification                  (scores + badges)
+├─ hapticEcoCoach                (real-time haptic feedback)
+├─ consumptionAnalytics          (fill-up + trip analysis tab)
+├─ glideCoach                    (future hypermiling guide)
+├─ gpsTripPath                   (GPS path persistence per trip)
+└─ showConsumptionTab            (bottom-nav Conso tab)
+```
+
+Eight flags have **no** parent: `obd2TripRecording`, `tankSync`,
+`unifiedSearchResults`, `priceAlerts`, `priceHistory`,
+`routePlanning`, `evCharging`, `showFuel`, `showElectric`,
+`manualConsumption`, `loyaltyCards`.
+
+## Per-flag registry
+
+For each flag below: description, default state from the manifest,
+parent (if any), the Settings tile that owns the toggle, and the
+runtime code path that actually gates the user-facing behavior.
+
+### `obd2TripRecording`
+- **Description**: OBD2-driven trip capture — the foundation for the
+  rest of the consumption / driving family.
+- **Default**: off (requires user opt-in for OBD2 hardware).
+- **Requires**: none.
+- **Settings tile**: Consumption → "OBD2 trip recording".
+- **Runtime gates**: `consumption_screen.dart` — the Trajets tab is
+  hidden when this is effectively off (`#conso-coherence`).
+
+### `gamification`
+- **Description**: Driving scores + earned badges surfaces.
+- **Default**: off.
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "Gamification".
+- **Runtime gates**: `gamificationEnabledProvider` reads
+  `isEffectivelyEnabled(Feature.gamification, …)`. Consumers
+  (BadgeShelf, achievements screen) listen to that provider.
+
+### `hapticEcoCoach`
+- **Description**: Real-time haptic feedback during an active trip.
+- **Default**: off.
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "Haptic eco-coach".
+- **Runtime gates**: `hapticEcoCoachEnabledProvider` →
+  `isEffectivelyEnabled(…)`. The haptic-pulse code in the trip
+  recorder watches that provider.
+
+### `tankSync`
+- **Description**: Cross-device sync via Supabase (favorites, fill-ups,
+  trips, baselines, etc.).
+- **Default**: off.
+- **Requires**: none.
+- **Settings tile**: TankSync section in Settings (visible when this
+  flag is effectively on).
+- **Runtime gates**: `profile_screen.dart` — the TankSync settings
+  section is hidden when off.
+
+### `consumptionAnalytics`
+- **Description**: Fill-up + trip analysis tab.
+- **Default**: off.
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "Consumption analytics".
+- **Runtime gates**: ⚠️ **GAP** — currently only the Settings toggle
+  exists; the analytics card on the Conso screen renders regardless.
+  Tracking: see "Known gating gaps" below.
+
+### `baselineSync`
+- **Description**: Sync driving baselines (η_v calibration) via
+  TankSync.
+- **Default**: off.
+- **Requires**: `tankSync`.
+- **Settings tile**: Consumption → "Baseline sync".
+- **Runtime gates**: `baselineSyncEnabledProvider` →
+  `isEffectivelyEnabled(…)`. The baseline-upload path in
+  `vehicle_baseline_repository` checks the provider before pushing.
+
+### `unifiedSearchResults`
+- **Description**: Single result list combining fuel + EV stations
+  (vs the default separated views).
+- **Default**: off.
+- **Requires**: none.
+- **Settings tile**: Search → "Unified results".
+- **Runtime gates**: `unifiedSearchResultsEnabledProvider` →
+  `isEffectivelyEnabled(…)`. Search screen reads this to choose the
+  list shape.
+
+### `priceAlerts`
+- **Description**: Threshold-based price-drop notifications (radius
+  alerts, station alerts).
+- **Default**: on.
+- **Requires**: none.
+- **Settings tile**: Consumption → "Price alerts".
+- **Runtime gates**: ⚠️ **GAP** — toggle present but the alerts
+  pipeline runs regardless. Background scanner + UI surfaces don't
+  check this flag.
+
+### `priceHistory`
+- **Description**: 30-day price charts on station detail.
+- **Default**: on.
+- **Requires**: none.
+- **Settings tile**: Consumption → "Price history".
+- **Runtime gates**: ⚠️ **GAP** — the price-history chart renders
+  regardless on station detail. The `priceHistoryRepository` still
+  records snapshots whether this is on or off.
+
+### `routePlanning`
+- **Description**: Cheapest stop along the user's planned route.
+- **Default**: on.
+- **Requires**: none (cross-feature dependency via the search
+  criteria UI surfaces is not modelled as a requires edge).
+- **Settings tile**: Consumption → "Route planning".
+- **Runtime gates**: `search_criteria_screen.dart` — the "Along
+  route" search mode chip is hidden when this is off.
+
+### `evCharging`
+- **Description**: EV charging stations via OpenChargeMap (data
+  pipeline, separate from `showElectric` which is the search/map
+  visibility filter).
+- **Default**: on.
+- **Requires**: none.
+- **Settings tile**: Consumption → "EV charging".
+- **Runtime gates**: ⚠️ **GAP** — the OCM fetch path runs whether
+  this is on or off. The `showElectric` flag is what actually hides
+  EV results today; this one is decorative.
+
+### `glideCoach`
+- **Description**: Hypermiling guidance using OSM traffic signals
+  (future, not yet implemented).
+- **Default**: off.
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "Glide coach".
+- **Runtime gates**: none yet — the feature implementation is
+  pending; the flag is reserved.
+
+### `gpsTripPath`
+- **Description**: Persist GPS path samples alongside each trip.
+- **Default**: off.
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "GPS trip path".
+- **Runtime gates**: `trip_recording_provider.dart` — `flags.isEnabled(…)`
+  check at line 870 controls whether GPS samples are appended to the
+  in-flight trip buffer.
+
+### `autoRecord`
+- **Description**: Master gate for hands-free auto-record (overrides
+  the per-vehicle `autoRecord` bool when off).
+- **Default**: on.
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "Auto-record".
+- **Runtime gates**: `auto_record_orchestrator.dart` —
+  `isEffectivelyEnabled(…)` short-circuits coordinator startup when
+  off.
+
+### `showFuel`
+- **Description**: Display fuel stations in search results + on the
+  map.
+- **Default**: on.
+- **Requires**: none.
+- **Settings tile**: Search → "Show fuel stations".
+- **Runtime gates**: `showFuelEnabledProvider` →
+  `isEffectivelyEnabled(…)`. Search + map widgets watch the provider.
+
+### `showElectric`
+- **Description**: Display EV charging stations in search + map.
+- **Default**: on.
+- **Requires**: none.
+- **Settings tile**: Search → "Show charging stations".
+- **Runtime gates**: `showElectricEnabledProvider` →
+  `isEffectivelyEnabled(…)`. Same widget pattern as `showFuel`.
+
+### `showConsumptionTab`
+- **Description**: Consumption tab in the bottom navigation.
+- **Default**: on (with `obd2TripRecording` parent).
+- **Requires**: `obd2TripRecording`.
+- **Settings tile**: Consumption → "Consumption tab".
+- **Runtime gates**: `consumption_tab_visibility.dart` —
+  `isConsumptionTabReachable(manifest, enabled)` ORs this with
+  `manualConsumption` so Medium users still see the tab without OBD2.
+
+### `manualConsumption`
+- **Description**: Manual fuel fill-ups + EV charging logs (no OBD2
+  required).
+- **Default**: off.
+- **Requires**: none.
+- **Settings tile**: Consumption → "Manual consumption logging".
+- **Runtime gates**: `consumption_tab_visibility.dart` — OR'd with
+  OBD2 trip recording to keep the Conso tab reachable for Medium-
+  use-mode users.
+
+### `loyaltyCards`
+- **Description**: Fuel-club / loyalty discount cards with per-litre
+  savings.
+- **Default**: off.
+- **Requires**: none.
+- **Settings tile**: Consumption → "Loyalty cards".
+- **Runtime gates**: `driving_settings_section.dart` — the loyalty
+  section in Settings → Consumption is hidden when off.
+
+### `tflitePricePrediction`
+- **Description**: On-device TFLite price-prediction model.
+- **Default**: off.
+- **Requires**: `priceHistory`.
+- **Settings tile**: Consumption → "TFLite price prediction".
+- **Runtime gates**: `price_prediction_provider.dart` — triple-gated
+  via the manifest flag, the compile-time `kTflitePredictorEnabled`
+  const, and the static confidence band on the inference output.
+
+## Known gating gaps
+
+Four flags have a Settings toggle + Profile-bundle membership but
+their user-facing behavior runs **regardless** of the flag's state.
+The Settings tile is currently decorative for these. Tracking
+follow-ups separately because each one is its own integration
+problem.
+
+| Flag | What's missing |
+| --- | --- |
+| `consumptionAnalytics` | Toggle visible in Settings; the analytics card on the Conso screen renders for any user who reaches the screen. Should gate the stats card / monthly-insights card. |
+| `priceAlerts` | The radius-alerts background scanner + the alerts tab in Favorites surface regardless. Should gate both. |
+| `priceHistory` | The 30-day chart on station detail renders for everyone. `priceHistoryRepository` also records snapshots regardless. Should gate the chart widget + the snapshot writer. |
+| `evCharging` | The OCM fetch pipeline runs whether this is on or off. `showElectric` happens to be the de-facto kill switch today; `evCharging` is currently decorative. |
+
+`glideCoach` is also ungated, but unlike the four above it has **no
+implementation yet** — the flag is reserved for the future
+hypermiling feature. Listed for completeness only.
+
+## Adding a new flag
+
+Checklist when introducing a `Feature.x`:
+
+1. Add the enum value to `feature.dart` with a one-line dartdoc.
+2. Add the `FeatureManifestEntry` to `feature_manifest.dart`
+   (`defaultEnabled`, `requires`, `displayName`, `description`).
+3. Add a Settings tile case to
+   `feature_management_section.dart` (`_featureLabel`,
+   `_featureDescription`, `_blockedEnableMessage`).
+4. Add ARB keys (`featureLabel_<name>`, `featureDescription_<name>`,
+   `featureBlockedEnable_<name>` if it has a parent) to the
+   `_base_{en,de}.arb` fragments.
+5. **Gate it at the user-visible code path** — either an
+   `isEffectivelyEnabled(Feature.<name>, …)` call or a dedicated
+   `<name>EnabledProvider`. Without this, the toggle is decorative
+   (see "Known gating gaps" above).
+6. Update `appProfileBundles` if the flag should land on / off for
+   any preset profile.
+7. Bump the feature-toggle-count test in
+   `profile_screen_feature_mgmt_test.dart`.
+8. Add tests covering the new gate (enabled → behavior on, disabled
+   → behavior off).

--- a/lib/features/feature_management/domain/app_profile.dart
+++ b/lib/features/feature_management/domain/app_profile.dart
@@ -47,19 +47,35 @@ enum AppProfile {
 /// flag — the bundles are exhaustive, not additive, so re-applying the
 /// same profile is idempotent.
 ///
-/// Bundle composition (from #1517 product brief):
-/// - **Basic** — pure search/discovery experience. Includes the
-///   manifest's default-on visibility flags (`showFuel`, `showElectric`,
-///   `priceAlerts`, `priceHistory`, `routePlanning`, `evCharging`). No
-///   consumption, no OBD2, no loyalty.
-/// - **Medium** — Basic + manual fill-up logging
-///   (`manualConsumption`).
-/// - **Full** — Medium + OBD2 stack (`obd2TripRecording`, `autoRecord`,
-///   `consumptionAnalytics`, `gamification`, `showConsumptionTab`) +
-///   `loyaltyCards`. Opt-in extras (`hapticEcoCoach`, `glideCoach`,
-///   `gpsTripPath`, `tankSync`, `baselineSync`, `unifiedSearchResults`)
-///   stay off — Full does NOT mean "every flag on", it means "every
-///   flag on the canonical Full path".
+/// Bundle composition (revised post-#1517):
+///
+/// **Basic** — search / discovery + cross-device sync
+/// - Visibility + discovery: `showFuel`, `showElectric`, `priceAlerts`,
+///   `priceHistory`, `routePlanning`, `evCharging`
+/// - Cross-device sync: `tankSync`, `baselineSync`
+///   (baseline driving-stat sync requires `tankSync` per the manifest
+///   `requires:` edge; both go in together so the requires graph stays
+///   satisfied)
+///
+/// **Medium** — Basic + manual fill-up logging
+/// - All Basic features
+/// - `manualConsumption` — fuel fill-ups + EV charging logged by hand
+///
+/// Trajets / OBD2 stay off on Medium; the Trajets tab self-hides via
+/// the `obd2TripRecording` gate (#conso-coherence).
+///
+/// **Full** — Medium + OBD2 + ergonomics
+/// - All Medium features
+/// - OBD2 stack: `obd2TripRecording`, `autoRecord`,
+///   `consumptionAnalytics`, `gamification`, `showConsumptionTab`,
+///   `loyaltyCards`
+/// - Ergonomics opt-ins: `hapticEcoCoach`, `glideCoach`, `gpsTripPath`
+///   (all three `requires: {obd2TripRecording}` per the manifest)
+///
+/// Off in **every** preset (user opts in individually):
+/// - `unifiedSearchResults` (single fuel + EV list — opinionated UX,
+///   not the default)
+/// - `tflitePricePrediction` (model artifact still off-band; #1543)
 const Map<AppProfile, Set<Feature>> appProfileBundles = {
   AppProfile.basic: {
     Feature.showFuel,
@@ -68,6 +84,8 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     Feature.priceHistory,
     Feature.routePlanning,
     Feature.evCharging,
+    Feature.tankSync,
+    Feature.baselineSync,
   },
   AppProfile.medium: {
     Feature.showFuel,
@@ -76,6 +94,8 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     Feature.priceHistory,
     Feature.routePlanning,
     Feature.evCharging,
+    Feature.tankSync,
+    Feature.baselineSync,
     Feature.manualConsumption,
   },
   AppProfile.full: {
@@ -85,6 +105,8 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     Feature.priceHistory,
     Feature.routePlanning,
     Feature.evCharging,
+    Feature.tankSync,
+    Feature.baselineSync,
     Feature.manualConsumption,
     Feature.loyaltyCards,
     Feature.obd2TripRecording,
@@ -92,6 +114,9 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     Feature.consumptionAnalytics,
     Feature.gamification,
     Feature.showConsumptionTab,
+    Feature.hapticEcoCoach,
+    Feature.glideCoach,
+    Feature.gpsTripPath,
   },
   // The custom sentinel has no bundle — the user's flag set is
   // whatever they last persisted, and re-selecting `custom` from the

--- a/test/features/feature_management/app_profile_provider_test.dart
+++ b/test/features/feature_management/app_profile_provider_test.dart
@@ -165,10 +165,13 @@ void main() {
       await c
           .read(activeAppProfileProvider.notifier)
           .select(AppProfile.medium);
-      // User toggles tankSync — not in any preset bundle.
+      // User toggles a flag that is NOT in any preset bundle —
+      // `unifiedSearchResults` is the canonical off-bundle flag,
+      // kept off by every preset and reserved for explicit user
+      // opt-in.
       final next = {
         ...appProfileBundles[AppProfile.medium]!,
-        Feature.tankSync,
+        Feature.unifiedSearchResults,
       };
       await c
           .read(activeAppProfileProvider.notifier)

--- a/test/features/feature_management/app_profile_test.dart
+++ b/test/features/feature_management/app_profile_test.dart
@@ -7,7 +7,8 @@ import 'package:tankstellen/features/feature_management/domain/feature.dart';
 /// drives both the wizard's first page and the Settings selector.
 void main() {
   group('appProfileBundles', () {
-    test('basic only includes the price/discovery flags', () {
+    test('basic includes the price / discovery flags + sync foundation',
+        () {
       final basic = appProfileBundles[AppProfile.basic]!;
       expect(basic, contains(Feature.showFuel));
       expect(basic, contains(Feature.showElectric));
@@ -15,6 +16,11 @@ void main() {
       expect(basic, contains(Feature.priceHistory));
       expect(basic, contains(Feature.routePlanning));
       expect(basic, contains(Feature.evCharging));
+      // Cross-device sync is part of every preset, including Basic —
+      // users running search-only workflows still benefit from
+      // favorites + price-history sync across phones.
+      expect(basic, contains(Feature.tankSync));
+      expect(basic, contains(Feature.baselineSync));
       // Basic must NOT include the consumption / OBD2 / loyalty stack.
       expect(basic, isNot(contains(Feature.manualConsumption)));
       expect(basic, isNot(contains(Feature.obd2TripRecording)));
@@ -41,27 +47,29 @@ void main() {
       expect(medium, isNot(contains(Feature.loyaltyCards)));
     });
 
-    test('full includes the OBD2 stack and loyalty on top of medium', () {
+    test('full includes the OBD2 stack + loyalty + ergonomic opt-ins '
+        'on top of medium', () {
       final medium = appProfileBundles[AppProfile.medium]!;
       final full = appProfileBundles[AppProfile.full]!;
       for (final f in medium) {
         expect(full, contains(f),
             reason: 'full must include every medium flag');
       }
-      // Full adds OBD2 + loyalty.
+      // Full adds OBD2 + loyalty + ergonomic opt-ins.
       expect(full, contains(Feature.obd2TripRecording));
       expect(full, contains(Feature.autoRecord));
       expect(full, contains(Feature.gamification));
       expect(full, contains(Feature.consumptionAnalytics));
       expect(full, contains(Feature.showConsumptionTab));
       expect(full, contains(Feature.loyaltyCards));
-      // Full does NOT mean "every flag on" — opt-in extras stay off.
-      expect(full, isNot(contains(Feature.hapticEcoCoach)));
-      expect(full, isNot(contains(Feature.glideCoach)));
-      expect(full, isNot(contains(Feature.gpsTripPath)));
-      expect(full, isNot(contains(Feature.tankSync)));
-      expect(full, isNot(contains(Feature.baselineSync)));
+      expect(full, contains(Feature.hapticEcoCoach));
+      expect(full, contains(Feature.glideCoach));
+      expect(full, contains(Feature.gpsTripPath));
+      // Full does NOT mean "every flag on" — `unifiedSearchResults`
+      // and `tflitePricePrediction` stay off until the user opts in
+      // (opinionated UX + off-band model artifact respectively).
       expect(full, isNot(contains(Feature.unifiedSearchResults)));
+      expect(full, isNot(contains(Feature.tflitePricePrediction)));
     });
 
     test('custom has an empty bundle (it is a sentinel, not a preset)', () {
@@ -102,7 +110,10 @@ void main() {
         () {
       final flags = {
         ...appProfileBundles[AppProfile.basic]!,
-        Feature.tankSync, // Not in any preset bundle.
+        // `unifiedSearchResults` is in NO preset bundle (opinionated
+        // UX kept off by default) — adding it to Basic drifts the
+        // user off the canonical Basic flag set.
+        Feature.unifiedSearchResults,
       };
       expect(detectProfileFromFlags(flags), AppProfile.custom);
     });
@@ -120,8 +131,10 @@ void main() {
     test('returns custom for a flag set that is a strict superset of full', () {
       final flags = {
         ...appProfileBundles[AppProfile.full]!,
-        Feature.tankSync,
-        Feature.glideCoach,
+        // Neither of these lands in any preset bundle, so adding them
+        // to Full drifts the user off the canonical Full flag set.
+        Feature.unifiedSearchResults,
+        Feature.tflitePricePrediction,
       };
       expect(detectProfileFromFlags(flags), AppProfile.custom);
     });


### PR DESCRIPTION
## Summary

Revised \`appProfileBundles\` to match the new product spec and added \`docs/guides/feature-flags.md\` — a single-source-of-truth registry covering every \`Feature\` flag (description, default, requires parent, settings tile, runtime gating site).

## Bundle changes

| | Basic | Medium | Full |
| --- | :-: | :-: | :-: |
| Search / discovery (6 flags) | ✓ | ✓ | ✓ |
| **\`tankSync\` + \`baselineSync\` (NEW everywhere)** | ✓ | ✓ | ✓ |
| \`manualConsumption\` | — | ✓ | ✓ |
| OBD2 stack (6 flags) | — | — | ✓ |
| **Ergonomic opt-ins (\`hapticEcoCoach\`, \`glideCoach\`, \`gpsTripPath\`, NEW in Full)** | — | — | ✓ |

Off in every preset (explicit user opt-in only): \`unifiedSearchResults\`, \`tflitePricePrediction\`.

\`requires:\` graph stays satisfied — \`baselineSync\` needs \`tankSync\` (both in every bundle); \`hapticEcoCoach\` / \`glideCoach\` / \`gpsTripPath\` need \`obd2TripRecording\` (all four in Full).

## Audit + docs

While writing the registry doc I grepped every \`Feature.<name>\` use in \`lib/\` to verify each flag actually gates user-facing behavior. **Four flags surfaced as decorative** (toggle in Settings + bundle membership but no runtime gate):
- \`consumptionAnalytics\` — analytics card renders regardless
- \`priceAlerts\` — alerts subsystem runs regardless
- \`priceHistory\` — chart renders + snapshots get recorded regardless
- \`evCharging\` — OCM fetch runs regardless (\`showElectric\` is the de-facto kill switch)

Listed in the doc's "Known gating gaps" section. Each one is its own integration pass — keeping this PR scoped to the bundle revision + docs.

## Test plan
- [x] \`flutter analyze\` — clean
- [x] \`flutter test test/features/feature_management/ test/features/profile/ test/features/consumption/ test/app/ test/lint/\` — 3263 passing
- [x] \`app_profile_test\` + \`app_profile_provider_test\` updated for the new bundle composition
- [ ] Manual smoke: fresh install → pick each preset in the wizard → verify Settings → Consumption section shows the right tiles on / off

🤖 Generated with [Claude Code](https://claude.com/claude-code)