### PR TITLE
feat(feature-management): v2 phase 1 — D365FO-style class-per-feature compatibility layer

### DIFF
--- a/docs/design/feature-management-v2.md
+++ b/docs/design/feature-management-v2.md
@@ -1,0 +1,303 @@
+# Feature Management v2 — Design
+
+D365FO-inspired declarative feature system. Phase 1 (this design doc
++ the matching code) ships the compatibility layer alongside the
+existing `Feature` enum so we can adopt the new API incrementally
+without breaking anything.
+
+## Goals (recap of the asks from product)
+
+1. **Class-per-feature** — each feature is a single declarative
+   object, the way D365FO does it. Settings tile, dependencies,
+   parameter UI, persistence id, ARB keys all anchored to one
+   declaration site.
+2. **Presentation hierarchy separate from activation DAG** — the
+   Settings tree-view nesting (parent) can diverge from "which
+   feature must be on for this one to surface" (requires).
+3. **Active-surface ↔ parameter-surface coupling** — when a feature
+   is enabled, both its main-screen surface AND its Settings
+   parameter block appear; when disabled, both disappear. Coupled by
+   construction, not by every site checking the same flag.
+4. **Beta / production maturity** — features can ship beta-flagged,
+   render a badge in Settings, and graduate to production with a
+   one-line const flip.
+5. **Multi-language labels** — preserved via the existing ARB pipeline
+   (`_base_{en,de}.arb` fragments).
+6. **Wizard can flip features in bulk** — preset profile bundles
+   continue to work; presets never auto-enable beta features.
+7. **No performance impact** — per-widget reads are O(1) map
+   lookups, not requires-DAG walks.
+8. **Existing code enriches without rewrite** — Phase 1 is purely
+   additive. Existing call sites work unchanged.
+
+## Core types
+
+```dart
+class FeatureClass {
+  final String id;                                    // stable Hive key
+  final FeatureClass? parent;                         // presentation tree
+  final Set<FeatureClass> requires;                   // activation DAG
+  final bool defaultEnabled;
+  final FeatureMaturity maturity;                     // beta | production
+  final String displayKey;                            // ARB lookup
+  final String displayName;                           // English fallback
+  final String descriptionKey;
+  final String description;
+  final List<ParameterBinding> parameterBuilders;     // Settings UI bindings
+}
+
+enum FeatureMaturity { beta, production }
+
+enum SettingsSection { profile, location, tankSync, theme,
+                       consumption, storage, search, about }
+
+class ParameterBinding {
+  final SettingsSection section;
+  final WidgetBuilder builder;
+  final int order;
+}
+```
+
+Late-binding caveat: `parent` and `requires` are stored as `Function()`
+returns rather than direct references. Lets two consts in the same
+library reference each other without Dart's const evaluator
+complaining about forward references.
+
+## How a feature is declared
+
+One const per feature, in the feature's own module file:
+
+```dart
+// lib/features/consumption/feature_trajets.dart
+import '../feature_management/v2/feature_class.dart';
+import 'feature_obd2.dart';
+
+const kFeatureTrajets = FeatureClass(
+  id: 'trajets',
+  parent: _consumption,                  // Settings tree parent
+  requires: _obd2,                       // activation dependency
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'feature_trajets_name',
+  displayName: 'Trajets',
+  descriptionKey: 'feature_trajets_description',
+  description: 'Trip recording + history.',
+  parameterBuilders: [
+    ParameterBinding(
+      section: SettingsSection.consumption,
+      builder: (_) => const TrajetsParameterBlock(),
+      order: 20,
+    ),
+  ],
+);
+
+FeatureClass _consumption() => kFeatureConsumption;
+Set<FeatureClass> _obd2() => {kFeatureObd2TripRecording};
+```
+
+Then register in `feature_registry.dart`:
+
+```dart
+const featureRegistry = <FeatureClass>[
+  // … existing …
+  kFeatureTrajets,
+];
+```
+
+That's the full surface area for adding a feature. Settings tile,
+parameter UI placement, dependency cascade, profile-bundle eligibility,
+ARB-localized labels, persistence — all live on this one declaration.
+
+## How code refers to a feature
+
+### Active surface — wrap the widget
+
+```dart
+FeatureGate(
+  feature: kFeatureTrajets,
+  child: const TrajetsTab(),
+)
+```
+
+`FeatureGate` reads `effectiveFeatureFlagsProvider.select((m) =>
+m[feature.id])` so it rebuilds only when *this* feature's effective
+state flips.
+
+### Parameter surface — registered automatically
+
+The Settings screen iterates the registry. For each section it
+renders all `ParameterBinding`s whose feature is effectively enabled,
+sorted by `order`. No call site needed; the binding declared on the
+`FeatureClass` does the routing.
+
+This is the coupling primitive: the **same** `featureGate` check
+drives both the active surface (manual call) and the parameter
+surface (automatic via registry iteration). They appear and disappear
+together by construction.
+
+### Reading state imperatively
+
+```dart
+final m = ref.watch(effectiveFeatureFlagsProvider);
+if (m.isOnV2(kFeatureTrajets)) { … }
+```
+
+Or the v1-enum compatibility extension:
+
+```dart
+if (m.isOn(Feature.trajets)) { … }
+```
+
+Both lookups read the same map.
+
+## Performance contract
+
+`effectiveFeatureFlagsProvider` is `keepAlive: true`. It rebuilds
+**only** when `featureFlagsProvider` (the underlying Hive-backed
+enabled set) changes — i.e. when the user toggles a flag. Per-widget
+reads are a single `Map<String, bool>` lookup. No requires-DAG walk
+at read time.
+
+For a 1000-widget screen reading 5 distinct flags after a single user
+toggle, the cost is:
+- One DAG walk over the 20-entry registry (O(N²) worst case, ~400
+  comparisons) when the flag set changes.
+- One `Map.select` rebuild per dependent widget (Riverpod's select
+  pre-filters; widgets read the same value short-circuit).
+
+Compared to today's per-call `isEffectivelyEnabled` walk: 5 walks ×
+1000 widgets = 5000 walks per rebuild. The cache eliminates that.
+
+## Maturity lifecycle
+
+A feature lands as:
+
+```dart
+const kFeatureNew = FeatureClass(
+  …,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.beta,
+);
+```
+
+Settings tile renders a "BETA" badge. The profile bundles never
+auto-enable beta features (`app_profile_provider` filters by
+maturity before applying). Existing users see the tile in Settings
+but it's off until they opt in.
+
+Promotion:
+
+```dart
+const kFeatureNew = FeatureClass(
+  …,
+  defaultEnabled: true,            // or keep false if user opt-in stays preferred
+  maturity: FeatureMaturity.production,
+);
+```
+
+Existing users with an explicit preference (toggled it on or off
+during beta) keep their preference — the legacy-toggle migration
+preserves user state across upgrades. Fresh installs after promotion
+pick up the new default.
+
+No code at call sites changes during promotion. No data migration.
+
+## Bridge to v1 (Phase 1 — what this PR ships)
+
+Every v1 `Feature` enum value gets a paired `FeatureClass` const in
+`known_features.dart`, with `id` matching the enum's `.name`. The
+`featureFlagsProvider` notifier from v1 stays the source of the
+enabled set; `effectiveFeatureFlagsProvider` projects that set into
+the v2 id-keyed map.
+
+Existing code (`flags.contains(Feature.x)`, `isEffectivelyEnabled(Feature.x, manifest, enabled)`)
+continues to work unchanged. New code can pick either API.
+
+Per-feature defaults + dependency edges in v2 mirror the v1 manifest.
+The `defaultEnabled mirrors the v1 manifest for every bridged feature`
+test in `feature_registry_test.dart` guards the bridge so drift
+fails CI loudly.
+
+## Migration plan
+
+### Phase 1 — compatibility layer (this PR)
+- Land `FeatureClass`, `featureRegistry`, `effectiveFeatureFlagsProvider`,
+  `FeatureGate`, `FeatureGateBuilder` next to the existing v1 system.
+- Bridge every v1 enum value to a v2 const.
+- 26 tests; whole-repo analyze clean.
+
+### Phase 2 — incremental adoption (small follow-up PRs)
+- New features added post-Phase-1 declared as `FeatureClass` directly.
+- Existing features migrated one at a time as they're touched:
+  - Swap `if (flags.contains(Feature.x))` for `FeatureGate(feature: kFeatureX, …)` or `m.isOnV2(kFeatureX)`.
+  - Move parameter UI into `ParameterBinding` registration.
+  - Add BETA badge if appropriate.
+- Settings screen rewritten to iterate `featureRegistry` instead of
+  hand-coding switches.
+- ETA: one feature per ~30 min PR. 20 features → ~10 hours of work
+  spread across whoever is touching each area.
+
+### Phase 3 — legacy cleanup (one PR after Phase 2 finishes)
+- Drop `Feature` enum.
+- Drop `FeatureManifest` + `FeatureManifestEntry` map.
+- Drop hand-coded `_featureLabel` / `_featureDescription` /
+  `_blockedEnableMessage` switches in `feature_management_section.dart`
+  (registry-driven now).
+- Drop the `EffectiveFeatureFlagsCompat.isOn` v1-enum extension.
+
+The phases are independent — Phase 1 can sit on master indefinitely
+without Phase 2 starting.
+
+## Known gating gaps (carried over from `feature-flags.md`)
+
+The audit during Phase 1 surfaced four features whose Settings tile
+toggles do not actually gate their user-facing surface:
+
+| Feature | What still needs gating |
+| --- | --- |
+| `consumptionAnalytics` | analytics card renders regardless |
+| `priceAlerts` | alerts pipeline runs regardless |
+| `priceHistory` | chart renders + snapshots get written regardless |
+| `evCharging` | OCM fetch runs regardless |
+
+These are NOT introduced by FM v2 — they're pre-existing gaps in v1.
+The migration to v2 makes them easy to fix: wrap the relevant widget
+in `FeatureGate(feature: kFeatureX, …)`. Tracked as Phase 2 work,
+one PR per fix.
+
+## Risks + alternatives considered
+
+### Risk: const-class forward references
+**Mitigation**: late-binding `parent: Function()` and
+`requires: Function()` pattern; registry tests assert
+the closure resolves to a registered FeatureClass at boot.
+
+### Alternative: codegen registry (build_runner step that scans
+files and emits a `featureRegistry` constant)
+**Why rejected**: another build step in an already-slow pipeline
+(riverpod_generator + freezed + json_serializable). Manual append-one-
+line registration is fine for 20 features and gets us a clean import
+graph (`feature_registry.dart` imports every feature module — easy to
+audit).
+
+### Alternative: collapse `parent` and `requires` into one field
+**Why rejected**: explicit user requirement — the Settings tree
+("Trajets is under Conso") can diverge from the activation cascade
+("Trajets requires obd2TripRecording, which is at the top level").
+Splitting the axes is what makes the model expressive enough.
+
+### Alternative: D365's `IFeatureMetadata` interface
+**Why rejected**: Dart doesn't have C#-style reflection. A const
+class with declarative fields gets us the same readability with
+better runtime characteristics (no reflection cost, no IL emitter).
+
+## Open follow-ups (post Phase 1)
+
+- `releasedIn: 'v5.3'` field for changelog / "what's new" generation.
+- Wizard UI for beta features — preset bundles exclude betas, but
+  Settings could grow a "show preview features" filter.
+- Auto-generated `feature_management_section.dart` driven by registry
+  (Phase 2 will pick this up incrementally).
+- Per-FeatureClass `onEnable` / `onDisable` lifecycle hooks for
+  features that need to initialize / tear down services (e.g.
+  starting background scanners).

--- a/lib/app/current_shell_branch_provider.g.dart
+++ b/lib/app/current_shell_branch_provider.g.dart
@@ -9,38 +9,47 @@ part of 'current_shell_branch_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 /// Exposes the currently-visible bottom-nav branch (0 = Search, 1 = Map,
-/// 2 = Favorites, 3 = Settings). Updated by [ShellScreen] on every
-/// `goBranch` so observers can react to tab visibility changes without
-/// reaching into the shell's private state (#696).
+/// 2 = Favorites, 3 = Consumption, 4 = Settings). Updated by [ShellScreen]
+/// on every `goBranch` so observers can react to tab visibility changes
+/// without reaching into the shell's private state (#696).
 ///
-/// MapScreen listens to this to trigger a tile-viewport recompute every
-/// time the Map tab becomes visible — the IndexedStack pre-mounts every
-/// branch with degenerate constraints, so without this hook the map
-/// stays blank until the user manually pans or zooms.
+/// MapScreen listens to this to trigger a full FlutterMap + TileLayer
+/// teardown every time the Map tab becomes visible — the IndexedStack
+/// pre-mounts every branch with degenerate constraints, so without this
+/// hook the map stays gray until the user manually pans or zooms (#473,
+/// #498, #709). The [RetryNetworkTileProvider] (#757) does NOT subsume
+/// this — it retries failed HTTP requests, but the offstage-mount bug
+/// is a fetch that's never issued in the first place.
 
 @ProviderFor(CurrentShellBranch)
 final currentShellBranchProvider = CurrentShellBranchProvider._();
 
 /// Exposes the currently-visible bottom-nav branch (0 = Search, 1 = Map,
-/// 2 = Favorites, 3 = Settings). Updated by [ShellScreen] on every
-/// `goBranch` so observers can react to tab visibility changes without
-/// reaching into the shell's private state (#696).
+/// 2 = Favorites, 3 = Consumption, 4 = Settings). Updated by [ShellScreen]
+/// on every `goBranch` so observers can react to tab visibility changes
+/// without reaching into the shell's private state (#696).
 ///
-/// MapScreen listens to this to trigger a tile-viewport recompute every
-/// time the Map tab becomes visible — the IndexedStack pre-mounts every
-/// branch with degenerate constraints, so without this hook the map
-/// stays blank until the user manually pans or zooms.
+/// MapScreen listens to this to trigger a full FlutterMap + TileLayer
+/// teardown every time the Map tab becomes visible — the IndexedStack
+/// pre-mounts every branch with degenerate constraints, so without this
+/// hook the map stays gray until the user manually pans or zooms (#473,
+/// #498, #709). The [RetryNetworkTileProvider] (#757) does NOT subsume
+/// this — it retries failed HTTP requests, but the offstage-mount bug
+/// is a fetch that's never issued in the first place.
 final class CurrentShellBranchProvider
     extends $NotifierProvider<CurrentShellBranch, int> {
   /// Exposes the currently-visible bottom-nav branch (0 = Search, 1 = Map,
-  /// 2 = Favorites, 3 = Settings). Updated by [ShellScreen] on every
-  /// `goBranch` so observers can react to tab visibility changes without
-  /// reaching into the shell's private state (#696).
+  /// 2 = Favorites, 3 = Consumption, 4 = Settings). Updated by [ShellScreen]
+  /// on every `goBranch` so observers can react to tab visibility changes
+  /// without reaching into the shell's private state (#696).
   ///
-  /// MapScreen listens to this to trigger a tile-viewport recompute every
-  /// time the Map tab becomes visible — the IndexedStack pre-mounts every
-  /// branch with degenerate constraints, so without this hook the map
-  /// stays blank until the user manually pans or zooms.
+  /// MapScreen listens to this to trigger a full FlutterMap + TileLayer
+  /// teardown every time the Map tab becomes visible — the IndexedStack
+  /// pre-mounts every branch with degenerate constraints, so without this
+  /// hook the map stays gray until the user manually pans or zooms (#473,
+  /// #498, #709). The [RetryNetworkTileProvider] (#757) does NOT subsume
+  /// this — it retries failed HTTP requests, but the offstage-mount bug
+  /// is a fetch that's never issued in the first place.
   CurrentShellBranchProvider._()
     : super(
         from: null,
@@ -72,14 +81,17 @@ String _$currentShellBranchHash() =>
     r'092b87f79222ed19d229e3b41c8b58a575e6bcba';
 
 /// Exposes the currently-visible bottom-nav branch (0 = Search, 1 = Map,
-/// 2 = Favorites, 3 = Settings). Updated by [ShellScreen] on every
-/// `goBranch` so observers can react to tab visibility changes without
-/// reaching into the shell's private state (#696).
+/// 2 = Favorites, 3 = Consumption, 4 = Settings). Updated by [ShellScreen]
+/// on every `goBranch` so observers can react to tab visibility changes
+/// without reaching into the shell's private state (#696).
 ///
-/// MapScreen listens to this to trigger a tile-viewport recompute every
-/// time the Map tab becomes visible — the IndexedStack pre-mounts every
-/// branch with degenerate constraints, so without this hook the map
-/// stays blank until the user manually pans or zooms.
+/// MapScreen listens to this to trigger a full FlutterMap + TileLayer
+/// teardown every time the Map tab becomes visible — the IndexedStack
+/// pre-mounts every branch with degenerate constraints, so without this
+/// hook the map stays gray until the user manually pans or zooms (#473,
+/// #498, #709). The [RetryNetworkTileProvider] (#757) does NOT subsume
+/// this — it retries failed HTTP requests, but the offstage-mount bug
+/// is a fetch that's never issued in the first place.
 
 abstract class _$CurrentShellBranch extends $Notifier<int> {
   int build();

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'43a9ec25f4935dd0fb3a7b8958b026028f6c3e7a';
+String _$routerHash() => r'5ee8eef70ae6c1deb192ba730b4852f9cda95e61';

--- a/lib/core/feedback/auto_record_badge_provider.g.dart
+++ b/lib/core/feedback/auto_record_badge_provider.g.dart
@@ -140,7 +140,7 @@ final class AutoRecordBadgeCountProvider
 }
 
 String _$autoRecordBadgeCountHash() =>
-    r'c5a24468db696e7f608480933646d490dcb5e09f';
+    r'39468b537fc93b32e48f2fbb4a8a9273a9621fc3';
 
 /// Reactive counter mirroring [AutoRecordBadgeService.count] for UI
 /// consumers (#1004 phase 6). The service writes to

--- a/lib/core/feedback/github_issue_reporter_provider.g.dart
+++ b/lib/core/feedback/github_issue_reporter_provider.g.dart
@@ -127,4 +127,4 @@ final class GithubIssueReporterProvider
 }
 
 String _$githubIssueReporterHash() =>
-    r'ac9ca8e61618130edef9ccc0ff13a7a6b6d26070';
+    r'55d88b6ebb5b6f1d836e8d22ce6cfbde84a9c3fc';

--- a/lib/core/location/movement_detection_provider.g.dart
+++ b/lib/core/location/movement_detection_provider.g.dart
@@ -59,7 +59,7 @@ final class MovementDetectionProvider
   }
 }
 
-String _$movementDetectionHash() => r'7b2830093b581101f9d647c7d6616c33e99490b6';
+String _$movementDetectionHash() => r'a9e97d7a37313d4aae713844f74626da331ca9f7';
 
 /// Provides movement detection state for driving mode.
 ///

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'5e4b05167e93e50daff104b9216da4426205ae22';
+String _$syncStateHash() => r'12677f978504c463808800d60c38a6144145e85b';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/features/alerts/providers/radius_alerts_provider.g.dart
+++ b/lib/features/alerts/providers/radius_alerts_provider.g.dart
@@ -171,7 +171,7 @@ final class RadiusAlertsProvider
   RadiusAlerts create() => RadiusAlerts();
 }
 
-String _$radiusAlertsHash() => r'f061e4846f0e417feb7f40ebe3e52057c8a1f227';
+String _$radiusAlertsHash() => r'1b71584521179ee158ecc1f5f21a6dca2e13d210';
 
 /// Radius-watchlist state (#578 phase 1).
 ///

--- a/lib/features/consumption/providers/charging_logs_provider.g.dart
+++ b/lib/features/consumption/providers/charging_logs_provider.g.dart
@@ -138,7 +138,7 @@ final class ChargingLogsProvider
   ChargingLogs create() => ChargingLogs();
 }
 
-String _$chargingLogsHash() => r'1c58203d45fa592b745b097bcf4d225d7a471f9e';
+String _$chargingLogsHash() => r'b3a633eb5293f6a6ac0325f6cd618ee781b9a4ef';
 
 /// Charging-log list state (#582 phase 1).
 ///

--- a/lib/features/consumption/providers/vehicle_baseline_summary_provider.g.dart
+++ b/lib/features/consumption/providers/vehicle_baseline_summary_provider.g.dart
@@ -105,7 +105,7 @@ final class VehicleBaselineSummaryProvider
 }
 
 String _$vehicleBaselineSummaryHash() =>
-    r'cb3b2b43b2b14ffe20fabbf51f841a1944324889';
+    r'2e87740356bc1caee1dd1af30aab390a5649dfbd';
 
 /// Sample count per [DrivingSituation] for a vehicle (#779).
 ///

--- a/lib/features/ev/providers/ev_providers.g.dart
+++ b/lib/features/ev/providers/ev_providers.g.dart
@@ -333,7 +333,7 @@ final class EvStationsProvider
   }
 }
 
-String _$evStationsHash() => r'0afe64b089a8c1e725069db89d3b1deb0137ae0e';
+String _$evStationsHash() => r'20faa6c0b080550b2b762d0918358b22182e7353';
 
 /// Fetches charging stations for the given [viewport] and writes them
 /// through the local repository cache. Applies the current

--- a/lib/features/feature_management/v2/effective_feature_flags_provider.dart
+++ b/lib/features/feature_management/v2/effective_feature_flags_provider.dart
@@ -1,0 +1,79 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../application/feature_flags_provider.dart';
+import '../domain/feature.dart' as v1;
+import 'feature_class.dart';
+import 'feature_registry.dart';
+
+part 'effective_feature_flags_provider.g.dart';
+
+/// Map from `FeatureClass.id` → `isEffectivelyEnabled` boolean.
+///
+/// Computed once whenever the underlying [featureFlagsProvider] flag
+/// set changes (i.e. only when the user toggles in Settings — rare).
+/// Widgets read individual flags via `select((m) => m[id])` so they
+/// rebuild only when *their* flag flips, not on unrelated toggles.
+///
+/// This is the cache that solves the "must not impact performance"
+/// requirement: per-widget reads are a single map lookup, not a
+/// requires-DAG walk.
+///
+/// Bridges to the v1 system: the input flag set is `Set<v1.Feature>`,
+/// and we translate via `Feature.x.name == FeatureClass.id`. Phase 2
+/// migrations don't break this bridge — as long as the IDs match the
+/// enum names, both APIs read the same persistence record.
+@Riverpod(keepAlive: true)
+Map<String, bool> effectiveFeatureFlags(Ref ref) {
+  final v1Enabled = ref.watch(featureFlagsProvider);
+  final enabledIds = v1Enabled.map((f) => f.name).toSet();
+  return {
+    for (final fc in featureRegistry)
+      fc.id: _isEffectivelyEnabledV2(fc, enabledIds),
+  };
+}
+
+/// True when `feature` is in [enabledIds] AND every feature reachable
+/// via `requires` from it is also in [enabledIds]. Pure function so
+/// it can be reused outside the provider (tests, future migrations).
+///
+/// Acyclic per `assertNoCycles()` — visited tracking is belt-and-
+/// braces in case a future const slips a cycle in.
+bool _isEffectivelyEnabledV2(
+  FeatureClass feature,
+  Set<String> enabledIds,
+) {
+  if (!enabledIds.contains(feature.id)) return false;
+  final visited = <FeatureClass>{feature};
+  bool walk(FeatureClass node) {
+    for (final req in node.requires) {
+      if (!enabledIds.contains(req.id)) return false;
+      if (visited.add(req) && !walk(req)) return false;
+    }
+    return true;
+  }
+
+  return walk(feature);
+}
+
+/// Test-friendly export of the v2 effective-enabled walk. Used by
+/// unit tests; production code should `ref.watch` the provider
+/// instead so it benefits from the cache.
+bool isEffectivelyEnabledV2({
+  required FeatureClass feature,
+  required Set<String> enabledIds,
+}) =>
+    _isEffectivelyEnabledV2(feature, enabledIds);
+
+/// Convenience: same shape as the v1 enum-keyed helper. Maps a v1
+/// [v1.Feature] to its v2 FeatureClass and asks the cached provider.
+/// Lets call sites migrate the data type at their own pace without
+/// rewriting the lookup pattern.
+extension EffectiveFeatureFlagsCompat on Map<String, bool> {
+  /// Returns the effective-enabled state for a v1 enum feature.
+  /// Falls back to `false` for ids the registry doesn't know about
+  /// (i.e. v1 enum values that were never given a v2 FeatureClass).
+  bool isOn(v1.Feature legacy) => this[legacy.name] ?? false;
+
+  /// Returns the effective-enabled state for a v2 FeatureClass.
+  bool isOnV2(FeatureClass fc) => this[fc.id] ?? false;
+}

--- a/lib/features/feature_management/v2/effective_feature_flags_provider.g.dart
+++ b/lib/features/feature_management/v2/effective_feature_flags_provider.g.dart
@@ -1,0 +1,104 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'effective_feature_flags_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Map from `FeatureClass.id` → `isEffectivelyEnabled` boolean.
+///
+/// Computed once whenever the underlying [featureFlagsProvider] flag
+/// set changes (i.e. only when the user toggles in Settings — rare).
+/// Widgets read individual flags via `select((m) => m[id])` so they
+/// rebuild only when *their* flag flips, not on unrelated toggles.
+///
+/// This is the cache that solves the "must not impact performance"
+/// requirement: per-widget reads are a single map lookup, not a
+/// requires-DAG walk.
+///
+/// Bridges to the v1 system: the input flag set is `Set<v1.Feature>`,
+/// and we translate via `Feature.x.name == FeatureClass.id`. Phase 2
+/// migrations don't break this bridge — as long as the IDs match the
+/// enum names, both APIs read the same persistence record.
+
+@ProviderFor(effectiveFeatureFlags)
+final effectiveFeatureFlagsProvider = EffectiveFeatureFlagsProvider._();
+
+/// Map from `FeatureClass.id` → `isEffectivelyEnabled` boolean.
+///
+/// Computed once whenever the underlying [featureFlagsProvider] flag
+/// set changes (i.e. only when the user toggles in Settings — rare).
+/// Widgets read individual flags via `select((m) => m[id])` so they
+/// rebuild only when *their* flag flips, not on unrelated toggles.
+///
+/// This is the cache that solves the "must not impact performance"
+/// requirement: per-widget reads are a single map lookup, not a
+/// requires-DAG walk.
+///
+/// Bridges to the v1 system: the input flag set is `Set<v1.Feature>`,
+/// and we translate via `Feature.x.name == FeatureClass.id`. Phase 2
+/// migrations don't break this bridge — as long as the IDs match the
+/// enum names, both APIs read the same persistence record.
+
+final class EffectiveFeatureFlagsProvider
+    extends
+        $FunctionalProvider<
+          Map<String, bool>,
+          Map<String, bool>,
+          Map<String, bool>
+        >
+    with $Provider<Map<String, bool>> {
+  /// Map from `FeatureClass.id` → `isEffectivelyEnabled` boolean.
+  ///
+  /// Computed once whenever the underlying [featureFlagsProvider] flag
+  /// set changes (i.e. only when the user toggles in Settings — rare).
+  /// Widgets read individual flags via `select((m) => m[id])` so they
+  /// rebuild only when *their* flag flips, not on unrelated toggles.
+  ///
+  /// This is the cache that solves the "must not impact performance"
+  /// requirement: per-widget reads are a single map lookup, not a
+  /// requires-DAG walk.
+  ///
+  /// Bridges to the v1 system: the input flag set is `Set<v1.Feature>`,
+  /// and we translate via `Feature.x.name == FeatureClass.id`. Phase 2
+  /// migrations don't break this bridge — as long as the IDs match the
+  /// enum names, both APIs read the same persistence record.
+  EffectiveFeatureFlagsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'effectiveFeatureFlagsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$effectiveFeatureFlagsHash();
+
+  @$internal
+  @override
+  $ProviderElement<Map<String, bool>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  Map<String, bool> create(Ref ref) {
+    return effectiveFeatureFlags(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Map<String, bool> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Map<String, bool>>(value),
+    );
+  }
+}
+
+String _$effectiveFeatureFlagsHash() =>
+    r'7180d6aeadf1f63093df51532fc4f61cd3f2eb46';

--- a/lib/features/feature_management/v2/feature_class.dart
+++ b/lib/features/feature_management/v2/feature_class.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/widgets.dart';
+
+/// Maturity stage of a [FeatureClass].
+///
+/// Drives a "BETA" badge on the Settings tile and informs the preset
+/// profile bundles — beta features are never auto-enabled by a wizard
+/// preset; the user must opt in deliberately.
+///
+/// Graduating a feature is a code change: bump the const from
+/// `FeatureMaturity.beta` to `FeatureMaturity.production`, possibly
+/// flip `defaultEnabled` to `true`. The existing legacy-toggle
+/// migration system preserves explicit user preferences, so promotion
+/// never silently changes the state of users who already toggled.
+enum FeatureMaturity {
+  /// Engineering preview. Settings tile shows a "BETA" badge.
+  /// Excluded from every preset profile bundle by default.
+  beta,
+
+  /// Production-ready. Preset bundles may include it.
+  production,
+}
+
+/// Identifier of a top-level Settings section a [FeatureClass] can
+/// register parameter UI into.
+///
+/// Kept as a closed enum (not a free-form string) so a typo at the
+/// declaration site is a compile error rather than a silently-misfiled
+/// tile. Add a new value whenever a new top-level Settings section
+/// lands.
+enum SettingsSection {
+  /// Settings → Profile (user account, currency, language).
+  profile,
+
+  /// Settings → Location (GPS, postal code).
+  location,
+
+  /// Settings → TankSync (cross-device sync).
+  tankSync,
+
+  /// Settings → Theme (light / dark / system).
+  theme,
+
+  /// Settings → Consumption (the largest section — vehicles, fuel
+  /// logs, OBD2, calibration, eco-coach, etc.).
+  consumption,
+
+  /// Settings → Storage & cache.
+  storage,
+
+  /// Settings → Search & map (visibility filters, unified results,
+  /// route planning).
+  search,
+
+  /// Settings → About / diagnostics (telemetry consent, feedback PAT,
+  /// version info).
+  about,
+}
+
+/// Registration of a parameter / configuration UI block that a
+/// [FeatureClass] contributes to a [SettingsSection].
+///
+/// The Settings screen iterates the [FeatureRegistry] for each
+/// section, sorts the bindings by [order], and renders [builder] only
+/// when the feature is effectively enabled. This is what couples the
+/// "active surface" (whatever the feature renders on its main screen,
+/// e.g. the Trajets tab inside the Conso screen) with the "parameter
+/// surface" (the Trajets options inside Settings → Consumption): both
+/// disappear when the feature toggles off, by construction.
+@immutable
+class ParameterBinding {
+  final SettingsSection section;
+  final WidgetBuilder builder;
+
+  /// Sort key within the section. Lower values render first. Stable
+  /// integers (10, 20, 30 …) leave gaps for future inserts.
+  final int order;
+
+  const ParameterBinding({
+    required this.section,
+    required this.builder,
+    required this.order,
+  });
+}
+
+/// Declarative description of a single application feature.
+///
+/// One `const FeatureClass` instance per feature, declared in the
+/// feature's own module file (or in `known_features.dart` for the
+/// legacy enum migration). The instance is the single source of
+/// truth for:
+/// - persistence id (stable across feature renames)
+/// - presentation hierarchy ([parent]) — where the tile appears
+///   inside the Settings tree
+/// - activation dependencies ([requires]) — which other features
+///   must be on for this one to be effectively enabled
+/// - default state at first install
+/// - maturity (beta / production)
+/// - localized labels via [displayKey] / [descriptionKey] ARB lookup
+/// - optional parameter UI bindings into Settings sections
+///
+/// `parent` vs `requires` deliberately split:
+/// - `parent` is presentation-only. The Settings UI nests the tile
+///   under its parent in the tree view. Two siblings under the same
+///   parent render under the same group header.
+/// - `requires` is activation-only. A feature with an unmet require
+///   is *effectively disabled* even when its own bit is on, per
+///   `isEffectivelyEnabled`. Disabling a parent cascades: children
+///   stay stored-enabled but stop surfacing until the parent comes
+///   back. Restoring the parent restores the children's prior state
+///   without forcing the user to re-toggle.
+///
+/// They often point at the same feature (a child feature lives both
+/// in its parent's Settings group AND requires the parent to be on),
+/// but the two axes can diverge — e.g. a feature can be presented in
+/// one section but require something declared in another.
+@immutable
+class FeatureClass {
+  /// Stable persistence key. MUST match the existing enum value name
+  /// for any feature that's migrating from the v1 `Feature` enum, so
+  /// the Hive-backed flag set reads the same record. For new
+  /// features, use camelCase matching the const name (drop `kFeature`
+  /// prefix).
+  final String id;
+
+  /// Presentation parent — the feature this one nests under in the
+  /// Settings tree view. `null` for top-level features.
+  ///
+  /// Late-bound via getter (rather than a direct `FeatureClass?`
+  /// field) so two features can declare each other in the same const
+  /// graph without Dart's const evaluator complaining about forward
+  /// references.
+  final FeatureClass? Function() _parent;
+  FeatureClass? get parent => _parent();
+
+  /// Activation prerequisites — features that must be on for this
+  /// one to be effectively enabled.
+  ///
+  /// Same late-binding rationale as [parent].
+  final Set<FeatureClass> Function() _requires;
+  Set<FeatureClass> get requires => _requires();
+
+  /// Initial state on a fresh install. The legacy-toggle migration
+  /// preserves explicit user preferences across upgrades.
+  final bool defaultEnabled;
+
+  /// Maturity stage. `beta` features render a "BETA" badge in
+  /// Settings and are excluded from every preset profile bundle.
+  final FeatureMaturity maturity;
+
+  /// ARB key for the user-facing display name.
+  ///
+  /// Convention: `feature_<id>_name`. The Settings tile uses
+  /// `AppLocalizations` to resolve at render time; English fallback
+  /// is the [displayName] field below.
+  final String displayKey;
+
+  /// English-fallback display name. Used when an ARB lookup misses
+  /// (test fixtures, locale that hasn't been translated yet).
+  final String displayName;
+
+  /// ARB key for the user-facing description.
+  ///
+  /// Convention: `feature_<id>_description`. Same fallback pattern as
+  /// [displayKey] → [description].
+  final String descriptionKey;
+
+  /// English-fallback description.
+  final String description;
+
+  /// Parameter UI bindings for this feature. Empty when the feature
+  /// has no per-feature configuration (a pure on/off toggle).
+  final List<ParameterBinding> parameterBuilders;
+
+  const FeatureClass({
+    required this.id,
+    required FeatureClass? Function() parent,
+    required Set<FeatureClass> Function() requires,
+    required this.defaultEnabled,
+    required this.maturity,
+    required this.displayKey,
+    required this.displayName,
+    required this.descriptionKey,
+    required this.description,
+    this.parameterBuilders = const [],
+  })  : _parent = parent,
+        _requires = requires;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is FeatureClass && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'FeatureClass(id: $id)';
+}

--- a/lib/features/feature_management/v2/feature_gate.dart
+++ b/lib/features/feature_management/v2/feature_gate.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'effective_feature_flags_provider.dart';
+import 'feature_class.dart';
+
+/// Renders [child] iff [feature] is effectively enabled.
+///
+/// The primitive that couples a feature's "active surface"
+/// (whatever it renders on its main screen, e.g. the Trajets tab
+/// inside the Conso screen) with its "parameter surface" (the
+/// Trajets options inside Settings → Consumption). Both wrap their
+/// respective widgets in `FeatureGate(feature: kFeatureTrajets, …)`;
+/// the same `effectiveFeatureFlagsProvider` lookup drives both, so
+/// the two surfaces appear and disappear together by construction.
+///
+/// Reads `effectiveFeatureFlagsProvider` via `select` so this widget
+/// only rebuilds when *this* feature's effective-enabled state
+/// changes — toggling an unrelated feature won't churn the subtree.
+class FeatureGate extends ConsumerWidget {
+  final FeatureClass feature;
+  final Widget child;
+
+  /// Optional fallback rendered when [feature] is off. Defaults to
+  /// [SizedBox.shrink] — the gate disappears entirely. Pass a
+  /// non-null fallback when the slot must keep its space in a row /
+  /// column (e.g. a disabled-state placeholder).
+  final Widget? fallback;
+
+  const FeatureGate({
+    super.key,
+    required this.feature,
+    required this.child,
+    this.fallback,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = ref.watch(
+      effectiveFeatureFlagsProvider.select(
+        (m) => m[feature.id] ?? false,
+      ),
+    );
+    if (enabled) return child;
+    return fallback ?? const SizedBox.shrink();
+  }
+}
+
+/// Builder variant — useful when the gated subtree is expensive to
+/// construct and you don't want to allocate it on disabled rebuilds.
+/// Mirrors Riverpod's `Consumer.builder` shape.
+class FeatureGateBuilder extends ConsumerWidget {
+  final FeatureClass feature;
+  final WidgetBuilder builder;
+  final Widget? fallback;
+
+  const FeatureGateBuilder({
+    super.key,
+    required this.feature,
+    required this.builder,
+    this.fallback,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = ref.watch(
+      effectiveFeatureFlagsProvider.select(
+        (m) => m[feature.id] ?? false,
+      ),
+    );
+    if (enabled) return builder(context);
+    return fallback ?? const SizedBox.shrink();
+  }
+}

--- a/lib/features/feature_management/v2/feature_registry.dart
+++ b/lib/features/feature_management/v2/feature_registry.dart
@@ -1,0 +1,101 @@
+import 'feature_class.dart';
+import 'known_features.dart';
+
+/// Central registry of every [FeatureClass] the app ships.
+///
+/// Phase 1 (compatibility layer): the entries below mirror the
+/// existing `Feature` enum values 1:1 via `known_features.dart`.
+/// Phase 2 onward: each new feature lives in its own module file
+/// (`lib/features/<area>/feature.dart`) and is appended to this list.
+///
+/// Adding a feature = one new file + one line here. The Settings
+/// screen, profile bundles, and FeatureGate primitives all read from
+/// this list, so no other file needs to know about the addition.
+const List<FeatureClass> featureRegistry = <FeatureClass>[
+  // Top-level (no parent in either presentation or activation)
+  kFeatureObd2TripRecording,
+  kFeatureTankSync,
+  kFeatureUnifiedSearchResults,
+  kFeaturePriceAlerts,
+  kFeaturePriceHistory,
+  kFeatureRoutePlanning,
+  kFeatureEvCharging,
+  kFeatureShowFuel,
+  kFeatureShowElectric,
+  kFeatureManualConsumption,
+  kFeatureLoyaltyCards,
+
+  // Children of obd2TripRecording
+  kFeatureGamification,
+  kFeatureHapticEcoCoach,
+  kFeatureConsumptionAnalytics,
+  kFeatureGlideCoach,
+  kFeatureGpsTripPath,
+  kFeatureAutoRecord,
+  kFeatureShowConsumptionTab,
+
+  // Child of tankSync
+  kFeatureBaselineSync,
+
+  // Child of priceHistory
+  kFeatureTflitePricePrediction,
+];
+
+/// O(1)-after-init lookup of a [FeatureClass] by its [FeatureClass.id].
+///
+/// Returns `null` for unknown ids — callers should treat that as
+/// "feature was deleted in a recent app version" and fall back to
+/// "disabled".
+FeatureClass? featureById(String id) => _idIndex[id];
+
+final Map<String, FeatureClass> _idIndex = {
+  for (final fc in featureRegistry) fc.id: fc,
+};
+
+/// Throws [StateError] when the registry contains a cycle reachable
+/// via `requires` edges. Acyclic is the activation contract — see
+/// `feature_dependency_graph.dart` (v1) for the same invariant on the
+/// legacy manifest. Run at app boot once so a bad const literal
+/// crashes loudly in dev / CI instead of silently looping in
+/// `isEffectivelyEnabled` at runtime.
+void assertNoCycles() {
+  // White-grey-black DFS; grey set is the in-progress stack.
+  final black = <FeatureClass>{};
+  final grey = <FeatureClass>{};
+  void visit(FeatureClass node) {
+    if (black.contains(node)) return;
+    if (grey.contains(node)) {
+      throw StateError(
+        'FeatureRegistry: cycle detected through ${node.id}. '
+        'Check the `requires:` edges in known_features.dart / any '
+        'feature module file.',
+      );
+    }
+    grey.add(node);
+    for (final r in node.requires) {
+      visit(r);
+    }
+    grey.remove(node);
+    black.add(node);
+  }
+
+  for (final f in featureRegistry) {
+    visit(f);
+  }
+}
+
+/// Throws [StateError] when two registry entries share an `id`.
+/// Duplicate ids would silently merge persistence state across two
+/// FeatureClass declarations — instant data corruption.
+void assertUniqueIds() {
+  final seen = <String>{};
+  for (final f in featureRegistry) {
+    if (!seen.add(f.id)) {
+      throw StateError(
+        'FeatureRegistry: duplicate id "${f.id}". Every FeatureClass '
+        'must declare a unique id — the id is the Hive persistence '
+        'key and conflicts silently merge state.',
+      );
+    }
+  }
+}

--- a/lib/features/feature_management/v2/known_features.dart
+++ b/lib/features/feature_management/v2/known_features.dart
@@ -1,0 +1,318 @@
+/// Bridge layer: every value of the legacy `Feature` enum gets a
+/// paired `FeatureClass` const here.
+///
+/// The `id` of each const **MUST** match the enum value's `.name` so
+/// the persisted feature-flags Hive box reads identically whether
+/// code looks up by the old enum or the new class — no migration
+/// required. The legacy v1 manifest in
+/// `lib/features/feature_management/domain/feature_manifest.dart` is
+/// the source of `defaultEnabled` + dependency edges; this file
+/// transcribes that into the v2 model.
+///
+/// Phase 1 (this file) only mirrors the existing 20 features. New
+/// features post-phase-1 should be declared in their own module file
+/// (`lib/features/<area>/feature.dart`) and added to
+/// `feature_registry.dart`'s import list. Old features migrate one
+/// per PR over time — see `docs/design/feature-management-v2.md` for
+/// the multi-phase plan.
+///
+/// Presentation hierarchy (`parent:`) is set per-feature based on
+/// where the existing Settings UI groups the tile, even when it
+/// differs from the `requires:` activation edge. See the inline
+/// comments for each non-trivial choice.
+library;
+
+import 'feature_class.dart';
+
+// ----------------------------------------------------------------------------
+// Top-level (no parent in either presentation or activation)
+// ----------------------------------------------------------------------------
+
+const kFeatureObd2TripRecording = FeatureClass(
+  id: 'obd2TripRecording',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_obd2TripRecording',
+  displayName: 'OBD2 trip recording',
+  descriptionKey: 'featureDescription_obd2TripRecording',
+  description: 'Capture trips automatically over OBD2.',
+);
+
+const kFeatureTankSync = FeatureClass(
+  id: 'tankSync',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_tankSync',
+  displayName: 'TankSync',
+  descriptionKey: 'featureDescription_tankSync',
+  description: 'Cross-device sync via Supabase.',
+);
+
+const kFeatureUnifiedSearchResults = FeatureClass(
+  id: 'unifiedSearchResults',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_unifiedSearchResults',
+  displayName: 'Unified search results',
+  descriptionKey: 'featureDescription_unifiedSearchResults',
+  description: 'Single result list combining fuel and EV stations.',
+);
+
+const kFeaturePriceAlerts = FeatureClass(
+  id: 'priceAlerts',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_priceAlerts',
+  displayName: 'Price alerts',
+  descriptionKey: 'featureDescription_priceAlerts',
+  description: 'Threshold-based price-drop notifications.',
+);
+
+const kFeaturePriceHistory = FeatureClass(
+  id: 'priceHistory',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_priceHistory',
+  displayName: 'Price history',
+  descriptionKey: 'featureDescription_priceHistory',
+  description: '30-day price charts on station details.',
+);
+
+const kFeatureRoutePlanning = FeatureClass(
+  id: 'routePlanning',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_routePlanning',
+  displayName: 'Route planning',
+  descriptionKey: 'featureDescription_routePlanning',
+  description: 'Cheapest stop along your route.',
+);
+
+const kFeatureEvCharging = FeatureClass(
+  id: 'evCharging',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_evCharging',
+  displayName: 'EV charging',
+  descriptionKey: 'featureDescription_evCharging',
+  description: 'Charging stations via OpenChargeMap.',
+);
+
+const kFeatureShowFuel = FeatureClass(
+  id: 'showFuel',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_showFuel',
+  displayName: 'Show fuel stations',
+  descriptionKey: 'featureDescription_showFuel',
+  description: 'Display petrol/diesel station results in search and on the '
+      'map.',
+);
+
+const kFeatureShowElectric = FeatureClass(
+  id: 'showElectric',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_showElectric',
+  displayName: 'Show charging stations',
+  descriptionKey: 'featureDescription_showElectric',
+  description: 'Display EV charging stations in search and on the map.',
+);
+
+const kFeatureManualConsumption = FeatureClass(
+  id: 'manualConsumption',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_manualConsumption',
+  displayName: 'Manual consumption logging',
+  descriptionKey: 'featureDescription_manualConsumption',
+  description: 'Track fuel fill-ups and EV charging sessions by hand (no OBD2 '
+      'adapter required).',
+);
+
+const kFeatureLoyaltyCards = FeatureClass(
+  id: 'loyaltyCards',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_loyaltyCards',
+  displayName: 'Loyalty cards',
+  descriptionKey: 'featureDescription_loyaltyCards',
+  description: 'Fuel-club / loyalty program cards with per-litre discounts in '
+      'price comparisons.',
+);
+
+// ----------------------------------------------------------------------------
+// Children of obd2TripRecording
+// ----------------------------------------------------------------------------
+
+const kFeatureGamification = FeatureClass(
+  id: 'gamification',
+  parent: _obd2,
+  requires: _obd2Set,
+  // v1 manifest defaults gamification on — every vehicle with OBD2
+  // trip recording gets badges + scores out of the box. Keep this in
+  // lockstep with `feature_manifest.dart` while Phase 1 is the
+  // active bridge.
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_gamification',
+  displayName: 'Gamification',
+  descriptionKey: 'featureDescription_gamification',
+  description: 'Driving scores and earned badges.',
+);
+
+const kFeatureHapticEcoCoach = FeatureClass(
+  id: 'hapticEcoCoach',
+  parent: _obd2,
+  requires: _obd2Set,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_hapticEcoCoach',
+  displayName: 'Haptic eco-coach',
+  descriptionKey: 'featureDescription_hapticEcoCoach',
+  description: 'Real-time haptic feedback during a trip.',
+);
+
+const kFeatureConsumptionAnalytics = FeatureClass(
+  id: 'consumptionAnalytics',
+  parent: _obd2,
+  requires: _obd2Set,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_consumptionAnalytics',
+  displayName: 'Consumption analytics',
+  descriptionKey: 'featureDescription_consumptionAnalytics',
+  description: 'Fill-up and trip analysis tab.',
+);
+
+const kFeatureGlideCoach = FeatureClass(
+  id: 'glideCoach',
+  parent: _obd2,
+  requires: _obd2Set,
+  defaultEnabled: false,
+  // Glide-coach is reserved for a future hypermiling guide; no
+  // runtime implementation yet (see docs/guides/feature-flags.md
+  // "Known gating gaps"). Stays beta until the surface lands.
+  maturity: FeatureMaturity.beta,
+  displayKey: 'featureLabel_glideCoach',
+  displayName: 'Glide-coach',
+  descriptionKey: 'featureDescription_glideCoach',
+  description: 'Hypermiling guidance using OSM traffic signals.',
+);
+
+const kFeatureGpsTripPath = FeatureClass(
+  id: 'gpsTripPath',
+  parent: _obd2,
+  requires: _obd2Set,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_gpsTripPath',
+  displayName: 'GPS trip path',
+  descriptionKey: 'featureDescription_gpsTripPath',
+  description: 'Persist GPS path samples alongside each trip.',
+);
+
+const kFeatureAutoRecord = FeatureClass(
+  id: 'autoRecord',
+  parent: _obd2,
+  requires: _obd2Set,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_autoRecord',
+  displayName: 'Auto-record',
+  descriptionKey: 'featureDescription_autoRecord',
+  description: 'Automatically start a trip when the OBD2 adapter connects to '
+      'a moving vehicle.',
+);
+
+const kFeatureShowConsumptionTab = FeatureClass(
+  id: 'showConsumptionTab',
+  parent: _obd2,
+  requires: _obd2Set,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_showConsumptionTab',
+  displayName: 'Consumption tab',
+  descriptionKey: 'featureDescription_showConsumptionTab',
+  description: 'Show the consumption analytics tab in the bottom navigation.',
+);
+
+// ----------------------------------------------------------------------------
+// Child of tankSync
+// ----------------------------------------------------------------------------
+
+const kFeatureBaselineSync = FeatureClass(
+  id: 'baselineSync',
+  parent: _tankSync,
+  requires: _tankSyncSet,
+  defaultEnabled: false,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_baselineSync',
+  displayName: 'Baseline sync',
+  descriptionKey: 'featureDescription_baselineSync',
+  description: 'Sync driving baselines via TankSync.',
+);
+
+// ----------------------------------------------------------------------------
+// Child of priceHistory
+// ----------------------------------------------------------------------------
+
+const kFeatureTflitePricePrediction = FeatureClass(
+  id: 'tflitePricePrediction',
+  parent: _priceHistory,
+  requires: _priceHistorySet,
+  defaultEnabled: false,
+  // Compile-time gate (`kTflitePredictorEnabled` const) stays false
+  // until a trained `.tflite` artifact ships under `assets/models/`.
+  // Beta reflects the artifact-pending state.
+  maturity: FeatureMaturity.beta,
+  displayKey: 'featureLabel_tflitePricePrediction',
+  displayName: 'TFLite price prediction',
+  descriptionKey: 'featureDescription_tflitePricePrediction',
+  description: 'On-device price forecast model — inference runs locally; '
+      'features and predictions never leave the device.',
+);
+
+// ----------------------------------------------------------------------------
+// Late-binding helpers
+//
+// Top-level + leaf parents/requires are declared as functions so Dart's
+// const evaluator can resolve forward references inside the same library.
+// The functions are lazy; resolution happens when `parent` or `requires`
+// is read at runtime, by which point every const in this file is fully
+// initialised.
+// ----------------------------------------------------------------------------
+
+FeatureClass? _none() => null;
+Set<FeatureClass> _empty() => const {};
+
+FeatureClass _obd2() => kFeatureObd2TripRecording;
+Set<FeatureClass> _obd2Set() => {kFeatureObd2TripRecording};
+
+FeatureClass _tankSync() => kFeatureTankSync;
+Set<FeatureClass> _tankSyncSet() => {kFeatureTankSync};
+
+FeatureClass _priceHistory() => kFeaturePriceHistory;
+Set<FeatureClass> _priceHistorySet() => {kFeaturePriceHistory};

--- a/lib/features/glide_coach/providers/glide_coach_evaluator_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_evaluator_provider.g.dart
@@ -131,4 +131,4 @@ final class GlideCoachEvaluatorProvider
 }
 
 String _$glideCoachEvaluatorHash() =>
-    r'ef913767ef8e86320dc9ffc4b4beadfb6cfa69a6';
+    r'e77d3eafbc0e1793f0e46d91190f16a08f24f140';

--- a/lib/features/itinerary/providers/itinerary_provider.g.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.g.dart
@@ -53,7 +53,7 @@ final class ItineraryNotifierProvider
   }
 }
 
-String _$itineraryNotifierHash() => r'ef67aedfd8c7c110edda45d6b84505b175fd249f';
+String _$itineraryNotifierHash() => r'924654b33108fe778016b7761ee8167bf11436f3';
 
 /// Manages saved itineraries with local-first strategy:
 /// - Save locally first, then sync to DB

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'23a677ec2692a63c3b087e4a9d9927b28f0d0afa';
+String _$routeSearchStateHash() => r'468f8a946f41fa90813d0af191949f306b6c5a1a';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/providers/ev_search_provider.g.dart
+++ b/lib/features/search/providers/ev_search_provider.g.dart
@@ -65,7 +65,7 @@ final class EVSearchStateProvider
   }
 }
 
-String _$eVSearchStateHash() => r'b09eeb0ead926b23a5e29b8906387d180563a910';
+String _$eVSearchStateHash() => r'173762539fdc8835ac3621044e7be22fa6870e95';
 
 /// Manages EV charging station search, parallel to [SearchState] for fuel.
 ///

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -95,7 +95,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'18b410ecf78dd8b652cac24a5f1e7c235658c0a1';
+String _$searchStateHash() => r'0483c8643d393b8aea57622443673eafa39de7e6';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///

--- a/lib/features/station_detail/providers/station_detail_provider.g.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.g.dart
@@ -66,7 +66,7 @@ final class StationDetailProvider
   }
 }
 
-String _$stationDetailHash() => r'cbd0ae2b040766276865f786a554a09b862023af';
+String _$stationDetailHash() => r'84d8bc8b2d2e887bed2286c3d86d1e9004e76f6b';
 
 final class StationDetailFamily extends $Family
     with

--- a/lib/features/sync/providers/ntfy_setup_provider.g.dart
+++ b/lib/features/sync/providers/ntfy_setup_provider.g.dart
@@ -42,7 +42,7 @@ final class NtfySetupControllerProvider
 }
 
 String _$ntfySetupControllerHash() =>
-    r'a0c123f876898293f522695074da65c414899839';
+    r'99814f0d70f950e6349e1fcdb78efc61cb62ff80';
 
 abstract class _$NtfySetupController extends $Notifier<NtfySetupState> {
   NtfySetupState build();

--- a/lib/features/vehicle/data/reference_vehicle_catalog_provider.g.dart
+++ b/lib/features/vehicle/data/reference_vehicle_catalog_provider.g.dart
@@ -164,7 +164,7 @@ final class ReferenceVehicleByMakeModelProvider
 }
 
 String _$referenceVehicleByMakeModelHash() =>
-    r'2c75c00a69ad7b06018564b820a81312818503cb';
+    r'3cc49ef9ebd4f6369ae640188033040230aca157';
 
 /// Returns the best catalog match for [make], [model], and [year], or
 /// `null` if no entry covers the trio (#950 phase 1).

--- a/lib/features/widget/providers/pending_widget_uri_provider.g.dart
+++ b/lib/features/widget/providers/pending_widget_uri_provider.g.dart
@@ -101,7 +101,7 @@ final class PendingWidgetUriProvider
   }
 }
 
-String _$pendingWidgetUriHash() => r'c59e2978fe9e947372c3282738f813b78a4fd6d3';
+String _$pendingWidgetUriHash() => r'c6f9435f44a1ab9dcf183bc4be69410215c4ce9e';
 
 /// One-shot stash for the URI a home-screen widget tap delivered to the
 /// app on cold start.

--- a/test/features/feature_management/v2/effective_feature_flags_provider_test.dart
+++ b/test/features/feature_management/v2/effective_feature_flags_provider_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart'
+    as v1;
+import 'package:tankstellen/features/feature_management/v2/effective_feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/v2/known_features.dart';
+
+/// Coverage for the v2 cached `effectiveFeatureFlagsProvider` and the
+/// pure-function `isEffectivelyEnabledV2` it wraps.
+///
+/// Drives behaviour through a `_TestFeatureFlags` notifier override so
+/// the tests stay in-memory (no Hive). Mirrors the test pattern in
+/// `auto_record_orchestrator_test.dart`.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags(this._initial);
+  final Set<v1.Feature> _initial;
+
+  @override
+  Set<v1.Feature> build() => {..._initial};
+}
+
+void main() {
+  group('isEffectivelyEnabledV2', () {
+    test('returns false when the feature itself is disabled', () {
+      expect(
+        isEffectivelyEnabledV2(
+          feature: kFeatureGamification,
+          enabledIds: const {},
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when a required parent is disabled (single edge)',
+        () {
+      // gamification requires obd2TripRecording. Enable only
+      // gamification → effective false because the require is unmet.
+      expect(
+        isEffectivelyEnabledV2(
+          feature: kFeatureGamification,
+          enabledIds: const {'gamification'},
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns true when feature + all transitive requires are on', () {
+      expect(
+        isEffectivelyEnabledV2(
+          feature: kFeatureGamification,
+          enabledIds: const {'gamification', 'obd2TripRecording'},
+        ),
+        isTrue,
+      );
+    });
+
+    test('walks multi-step require chains (priceHistory → tflite)', () {
+      // tflitePricePrediction requires priceHistory.
+      expect(
+        isEffectivelyEnabledV2(
+          feature: kFeatureTflitePricePrediction,
+          enabledIds: const {'tflitePricePrediction', 'priceHistory'},
+        ),
+        isTrue,
+      );
+      expect(
+        isEffectivelyEnabledV2(
+          feature: kFeatureTflitePricePrediction,
+          enabledIds: const {'tflitePricePrediction'},
+        ),
+        isFalse,
+      );
+    });
+
+    test('parent presentation (kFeatureGamification.parent) does NOT '
+        'affect activation when separate from requires', () {
+      // gamification.parent == kFeatureObd2TripRecording AND
+      // gamification.requires == {kFeatureObd2TripRecording}. Today
+      // they coincide; the test pins that the activation walk reads
+      // ONLY requires, not parent. A future feature whose parent ≠
+      // requires must still activate purely off requires.
+      expect(
+        isEffectivelyEnabledV2(
+          feature: kFeatureGamification,
+          enabledIds: const {'gamification', 'obd2TripRecording'},
+        ),
+        isTrue);
+    });
+  });
+
+  group('effectiveFeatureFlagsProvider', () {
+    ProviderContainer makeContainer(Set<v1.Feature> initial) {
+      final c = ProviderContainer(overrides: [
+        featureFlagsProvider.overrideWith(() => _TestFeatureFlags(initial)),
+      ]);
+      addTearDown(c.dispose);
+      return c;
+    }
+
+    test('returns an entry for every FeatureClass in the registry', () {
+      final c = makeContainer({});
+      final m = c.read(effectiveFeatureFlagsProvider);
+      // Every registered feature has a key; nothing is missing.
+      for (final id in [
+        'obd2TripRecording',
+        'gamification',
+        'tankSync',
+        'baselineSync',
+        'priceHistory',
+        'tflitePricePrediction',
+        'showFuel',
+        'manualConsumption',
+        'loyaltyCards',
+      ]) {
+        expect(m.containsKey(id), isTrue,
+            reason: 'missing entry for $id in the effective map');
+      }
+    });
+
+    test('cascade: disabling obd2TripRecording flips every OBD2 child '
+        'effectively off', () {
+      // Enable all OBD2 children but NOT the parent → every child
+      // should be effectively off via the requires cascade.
+      final c = makeContainer({
+        v1.Feature.gamification,
+        v1.Feature.hapticEcoCoach,
+        v1.Feature.consumptionAnalytics,
+        v1.Feature.gpsTripPath,
+        v1.Feature.autoRecord,
+        v1.Feature.showConsumptionTab,
+        // obd2TripRecording intentionally absent
+      });
+      final m = c.read(effectiveFeatureFlagsProvider);
+      expect(m.isOn(v1.Feature.gamification), isFalse);
+      expect(m.isOn(v1.Feature.hapticEcoCoach), isFalse);
+      expect(m.isOn(v1.Feature.consumptionAnalytics), isFalse);
+      expect(m.isOn(v1.Feature.gpsTripPath), isFalse);
+      expect(m.isOn(v1.Feature.autoRecord), isFalse);
+      expect(m.isOn(v1.Feature.showConsumptionTab), isFalse);
+    });
+
+    test('flipping the parent on restores every still-enabled child', () {
+      final c = makeContainer({
+        v1.Feature.gamification,
+        v1.Feature.obd2TripRecording,
+        v1.Feature.autoRecord,
+      });
+      final m = c.read(effectiveFeatureFlagsProvider);
+      expect(m.isOn(v1.Feature.gamification), isTrue);
+      expect(m.isOn(v1.Feature.autoRecord), isTrue);
+      // hapticEcoCoach not in the set → effectively off
+      expect(m.isOn(v1.Feature.hapticEcoCoach), isFalse);
+    });
+
+    test('isOn / isOnV2 lookups agree (extension methods are mirrors)', () {
+      final c = makeContainer({
+        v1.Feature.priceHistory,
+        v1.Feature.tflitePricePrediction,
+      });
+      final m = c.read(effectiveFeatureFlagsProvider);
+      expect(
+        m.isOn(v1.Feature.tflitePricePrediction),
+        m.isOnV2(kFeatureTflitePricePrediction),
+      );
+    });
+
+    test('isOn returns false for v1 features not yet bridged into v2', () {
+      // Sanity check — if a future v1 enum value lands without a v2
+      // FeatureClass mirror, the extension returns false rather than
+      // throwing. Today every v1 enum has a mirror, so we can't
+      // actually exercise that branch — but the test pins the
+      // contract.
+      final c = makeContainer({});
+      final m = c.read(effectiveFeatureFlagsProvider);
+      // Empty map lookup → null → ?? false → false
+      expect(<String, bool>{}.isOn(v1.Feature.gamification), isFalse);
+      expect(m.isOn(v1.Feature.gamification), isFalse);
+    });
+  });
+}

--- a/test/features/feature_management/v2/feature_gate_test.dart
+++ b/test/features/feature_management/v2/feature_gate_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart'
+    as v1;
+import 'package:tankstellen/features/feature_management/v2/feature_gate.dart';
+import 'package:tankstellen/features/feature_management/v2/known_features.dart';
+
+/// Widget-level coverage for FeatureGate / FeatureGateBuilder. Pumps a
+/// minimal MaterialApp around the gate so the effective-flags
+/// provider has a Riverpod scope to read from.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags(this._initial);
+  final Set<v1.Feature> _initial;
+
+  @override
+  Set<v1.Feature> build() => {..._initial};
+}
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester,
+    Set<v1.Feature> enabled,
+    Widget child,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          featureFlagsProvider.overrideWith(() => _TestFeatureFlags(enabled)),
+        ],
+        child: MaterialApp(home: Scaffold(body: child)),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('FeatureGate', () {
+    testWidgets('renders child when feature is effectively enabled',
+        (tester) async {
+      await pump(
+        tester,
+        {v1.Feature.priceHistory},
+        const FeatureGate(
+          feature: kFeaturePriceHistory,
+          child: Text('GATED-CONTENT'),
+        ),
+      );
+      expect(find.text('GATED-CONTENT'), findsOneWidget);
+    });
+
+    testWidgets('renders fallback (SizedBox.shrink by default) when off',
+        (tester) async {
+      await pump(
+        tester,
+        const <v1.Feature>{},
+        const FeatureGate(
+          feature: kFeaturePriceHistory,
+          child: Text('GATED-CONTENT'),
+        ),
+      );
+      expect(find.text('GATED-CONTENT'), findsNothing);
+    });
+
+    testWidgets('renders custom fallback when provided', (tester) async {
+      await pump(
+        tester,
+        const <v1.Feature>{},
+        const FeatureGate(
+          feature: kFeaturePriceHistory,
+          fallback: Text('FALLBACK'),
+          child: Text('GATED-CONTENT'),
+        ),
+      );
+      expect(find.text('GATED-CONTENT'), findsNothing);
+      expect(find.text('FALLBACK'), findsOneWidget);
+    });
+
+    testWidgets('respects requires cascade — child off when parent off',
+        (tester) async {
+      // Enable gamification but not its required parent
+      // (obd2TripRecording). The gate should hide the child.
+      await pump(
+        tester,
+        {v1.Feature.gamification},
+        const FeatureGate(
+          feature: kFeatureGamification,
+          child: Text('GAMIFICATION-UI'),
+        ),
+      );
+      expect(find.text('GAMIFICATION-UI'), findsNothing);
+    });
+
+    testWidgets('renders child when both child + required parent are on',
+        (tester) async {
+      await pump(
+        tester,
+        {v1.Feature.gamification, v1.Feature.obd2TripRecording},
+        const FeatureGate(
+          feature: kFeatureGamification,
+          child: Text('GAMIFICATION-UI'),
+        ),
+      );
+      expect(find.text('GAMIFICATION-UI'), findsOneWidget);
+    });
+  });
+
+  group('FeatureGateBuilder', () {
+    testWidgets('only invokes builder when feature is enabled',
+        (tester) async {
+      var builderCalls = 0;
+      await pump(
+        tester,
+        const <v1.Feature>{},
+        FeatureGateBuilder(
+          feature: kFeaturePriceHistory,
+          builder: (_) {
+            builderCalls++;
+            return const Text('EXPENSIVE');
+          },
+        ),
+      );
+      expect(builderCalls, 0,
+          reason: 'builder must not run when feature is off — that is the '
+              'reason to use FeatureGateBuilder over FeatureGate');
+      expect(find.text('EXPENSIVE'), findsNothing);
+    });
+
+    testWidgets('invokes builder when feature is enabled', (tester) async {
+      var builderCalls = 0;
+      await pump(
+        tester,
+        {v1.Feature.priceHistory},
+        FeatureGateBuilder(
+          feature: kFeaturePriceHistory,
+          builder: (_) {
+            builderCalls++;
+            return const Text('EXPENSIVE');
+          },
+        ),
+      );
+      expect(builderCalls, 1);
+      expect(find.text('EXPENSIVE'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/feature_management/v2/feature_registry_test.dart
+++ b/test/features/feature_management/v2/feature_registry_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart'
+    as v1;
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+import 'package:tankstellen/features/feature_management/v2/feature_registry.dart';
+import 'package:tankstellen/features/feature_management/v2/known_features.dart';
+
+/// Bridge-layer invariants for the v2 FeatureRegistry.
+///
+/// Pure functions, no Hive, no Riverpod — these tests guarantee that
+/// the bridge keeps the v1 enum's persistence + manifest contract
+/// intact while letting the v2 system see every feature.
+void main() {
+  group('featureRegistry', () {
+    test('every v1 Feature enum value has a matching FeatureClass with '
+        'identical id', () {
+      final registryIds = featureRegistry.map((fc) => fc.id).toSet();
+      for (final v in v1.Feature.values) {
+        expect(registryIds, contains(v.name),
+            reason: 'v1.Feature.${v.name} has no FeatureClass with id '
+                '"${v.name}". Either add it to known_features.dart + '
+                'feature_registry.dart, or remove the enum value.');
+      }
+    });
+
+    test('every FeatureClass id is unique', () {
+      // Bake the assertion into the test runner so a duplicate id
+      // breaks CI loudly rather than silently merging persistence
+      // state at runtime.
+      expect(assertUniqueIds, returnsNormally);
+    });
+
+    test('every FeatureClass `requires` edge points at a registered feature',
+        () {
+      final registryIds = featureRegistry.map((fc) => fc.id).toSet();
+      for (final fc in featureRegistry) {
+        for (final req in fc.requires) {
+          expect(registryIds, contains(req.id),
+              reason: '${fc.id}.requires references ${req.id} which is '
+                  'not in featureRegistry. Add it to the list.');
+        }
+      }
+    });
+
+    test('the requires graph has no cycles', () {
+      expect(assertNoCycles, returnsNormally);
+    });
+
+    test('every FeatureClass `parent` edge points at a registered feature',
+        () {
+      final registry = featureRegistry.toSet();
+      for (final fc in featureRegistry) {
+        final p = fc.parent;
+        if (p == null) continue;
+        expect(registry, contains(p),
+            reason: '${fc.id}.parent points at ${p.id} which is not in '
+                'featureRegistry.');
+      }
+    });
+
+    test(
+      'defaultEnabled mirrors the v1 manifest for every bridged feature',
+      () {
+        // The v1 manifest is still the source of truth for the
+        // existing 20 features during Phase 1. Drift between v1 and
+        // v2 defaults would corrupt first-install state.
+        const manifest = FeatureManifest.defaultManifest;
+        for (final v in v1.Feature.values) {
+          final fc = featureById(v.name);
+          expect(fc, isNotNull,
+              reason: 'no FeatureClass for v1 ${v.name}');
+          final v1Default = manifest.entryFor(v).defaultEnabled;
+          expect(fc!.defaultEnabled, v1Default,
+              reason: 'defaultEnabled drift on ${v.name}: v1 manifest '
+                  'says $v1Default, v2 FeatureClass says '
+                  '${fc.defaultEnabled}. They MUST agree during Phase 1.');
+        }
+      },
+    );
+
+    test('featureById lookups round-trip every id', () {
+      for (final fc in featureRegistry) {
+        expect(featureById(fc.id), same(fc));
+      }
+    });
+
+    test('featureById returns null for unknown ids', () {
+      expect(featureById('not-a-real-feature'), isNull);
+    });
+  });
+
+  group('FeatureClass equality + hashing', () {
+    test('two const FeatureClass instances with the same id are equal', () {
+      // Sanity check the `==` override — needed because the cached
+      // effective-flags provider relies on stable hashing for
+      // Set<FeatureClass> membership tests.
+      expect(kFeatureObd2TripRecording, equals(kFeatureObd2TripRecording));
+      expect(kFeatureObd2TripRecording.hashCode,
+          kFeatureObd2TripRecording.hashCode);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Phase 1 of the D365FO-inspired feature-management system. Adds the new declarative layer alongside the existing \`Feature\` enum without changing any existing call site. New features post-this-PR can be declared as \`FeatureClass\` const + one registry line, with Settings tile, parameter UI, dependency cascade, and persistence-id all anchored to one declaration.

See [\`docs/design/feature-management-v2.md\`](../tree/feat/feature-management-v2-phase1/docs/design/feature-management-v2.md) for the full design + 3-phase migration plan.

## What ships

\`lib/features/feature_management/v2/\`:
- **\`feature_class.dart\`** — \`FeatureClass\` const class + \`FeatureMaturity\` (beta / production) + \`SettingsSection\` + \`ParameterBinding\`.
- **\`known_features.dart\`** — bridge: every v1 \`Feature\` enum value gets a paired \`kFeatureX\` const. IDs match \`Feature.x.name\` so persistence reads identically.
- **\`feature_registry.dart\`** — central list + \`featureById\` lookup + cycle / unique-id invariants.
- **\`effective_feature_flags_provider.dart\`** — cached \`keepAlive\` provider that projects the v1 enabled-set into an id→bool map. Per-widget reads are O(1) map lookups (solves the performance ask).
- **\`feature_gate.dart\`** — \`FeatureGate\` + \`FeatureGateBuilder\`. **The primitive that couples active surface ↔ parameter surface**: both wrap the same gate, appear and disappear together by construction.

26 unit tests cover registry invariants, effective-flag walks, FeatureGate behavior, and v1-default-mirror to fail CI loudly on drift.

## What does NOT change yet

- The v1 \`Feature\` enum + \`FeatureManifest\` are untouched.
- Existing \`if (flags.contains(Feature.x))\` call sites work unchanged.
- The Settings screen still hand-codes its tile switches.

Phase 2 (incremental per-feature migration, one PR per feature) is a separate stream — design doc lays out the plan.

## Asks from product covered

| Ask | How |
| --- | --- |
| Class-per-feature | \`FeatureClass\` const declaration |
| Presentation hierarchy ≠ activation DAG | Separate \`parent\` vs \`requires\` fields |
| Active surface ↔ parameter surface coupling | \`FeatureGate\` primitive + \`ParameterBinding\` registration |
| Beta / production maturity | \`FeatureMaturity\` enum + (Phase 2) Settings tile badge |
| Multi-language labels | \`displayKey\` / \`descriptionKey\` ARB lookup, English fallback baked in |
| Wizard bulk check / uncheck | Same \`featureFlagsProvider\` notifier; preset bundles continue to work |
| No performance impact | Cached \`Map<String, bool>\` provider, rebuilt only on toggle |
| Existing code enriches without rewrite | Phase 1 is purely additive; v1 enum keeps working |

## Test plan
- [x] \`flutter analyze\` — clean
- [x] \`flutter test test/features/feature_management/v2/\` — 26 / 26
- [x] \`flutter test test/lint/\` — 141 passing (no v2 file trips any lint rule)
- [ ] Manual smoke: existing app behavior unchanged (this PR adds files only — no call site touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)