### PR TITLE
fix(ux): Medium profile shows Conso settings + promote My vehicles to root (#1568)

### DIFF
--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -48,15 +48,10 @@ class DrivingSettingsSection extends ConsumerWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SettingsMenuTile(
-          key: const Key('consoleVehiclesTile'),
-          icon: Icons.directions_car,
-          title: l?.vehiclesMenuTitle ?? 'My vehicles',
-          subtitle: l?.vehiclesMenuSubtitle ??
-              'Battery, connectors, charging preferences',
-          onTap: () => context.push('/vehicles'),
-        ),
-        const SizedBox(height: 8),
+        // #1568 — "My vehicles" tile moved up to Settings root so the
+        // entry-point is discoverable without expanding the Conso
+        // foldable. The fuel-club + eco-coach + gamification toggles
+        // stay clustered here.
         if (loyaltyOn)
           SettingsMenuTile(
             key: const Key('consoleFuelClubCardsTile'),

--- a/lib/features/feature_management/domain/app_profile.dart
+++ b/lib/features/feature_management/domain/app_profile.dart
@@ -97,6 +97,11 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     Feature.tankSync,
     Feature.baselineSync,
     Feature.manualConsumption,
+    // #1568 — without this the `isConsumptionTabReachable` gate
+    // short-circuits to false and the Conso settings section vanishes,
+    // leaving Medium users no path to configure a vehicle for the
+    // manual fill-up flow they just opted into.
+    Feature.showConsumptionTab,
   },
   AppProfile.full: {
     Feature.showFuel,

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -139,18 +139,30 @@ class ProfileScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 8),
 
-          // Consumption-tab settings group: vehicles, fuel club cards,
-          // and the real-time eco-coaching toggle. Section title matches
-          // the bottom-nav "Conso" tab so users can correlate the two
-          // entry points (#1122 follow-up). The standalone "My vehicles"
-          // and "Fuel club cards" tiles were folded INTO this section
-          // so per-vehicle controls cluster under one heading.
-          // #1447 phase 3 — hidden entirely when the root feature
-          // (`obd2TripRecording`) is effectively disabled. Per-vehicle
-          // and eco-coach state stays persisted; re-enabling
-          // consumption restores the section with its previous
-          // configuration.
+          // #1568 — "My vehicles" promoted back to a top-level Settings
+          // entry (it lived inside the Conso foldable since #1242). The
+          // Medium use-mode tier's primary feature is manual fill-up
+          // logging, which is useless without a configured vehicle —
+          // burying the entry-point inside a collapsed foldable made
+          // the configuration unreachable. Top-level placement makes
+          // it discoverable in one tap from Settings root for both
+          // Medium and Full users.
           if (consumptionOn) ...[
+            SettingsMenuTile(
+              key: const Key('settingsRootVehiclesTile'),
+              icon: Icons.directions_car,
+              title: l?.vehiclesMenuTitle ?? 'My vehicles',
+              subtitle: l?.vehiclesMenuSubtitle ??
+                  'Battery, connectors, charging preferences',
+              onTap: () => context.push('/vehicles'),
+            ),
+            const SizedBox(height: 8),
+            // Consumption-tab settings group: fuel club cards, eco-coach,
+            // glide-coach, and gamification. Section title matches the
+            // bottom-nav "Conso" tab so users can correlate the two
+            // entry points (#1122 follow-up). Hidden entirely when
+            // `isConsumptionTabReachable` returns false; per-vehicle
+            // state stays persisted across hide/show.
             _FoldableSection(
               icon: Icons.local_gas_station_outlined,
               title: l?.navConsumption ?? 'Consumption',

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -144,11 +144,15 @@ void main() {
         ],
       );
 
-      // Both moved-in tiles must render with their canonical keys.
+      // #1568 — My vehicles tile was promoted back to Settings root so
+      // Medium-tier users can reach vehicle config without expanding
+      // the Conso foldable. The fuel-club tile remains the only menu
+      // tile inside this section.
       expect(
         find.byKey(const Key('consoleVehiclesTile')),
-        findsOneWidget,
-        reason: 'My vehicles tile is part of the Consumption group.',
+        findsNothing,
+        reason: 'My vehicles tile must NOT be inside DrivingSettingsSection '
+            'after #1568 — it lives at Settings root now.',
       );
       expect(
         find.byKey(const Key('consoleFuelClubCardsTile')),
@@ -156,8 +160,6 @@ void main() {
         reason: 'Fuel club cards tile is part of the Consumption group.',
       );
 
-      // The eco-coach toggle is the third element, after the two
-      // menu tiles.
       final children = <Widget>[
         for (final t in tester
             .widgetList<SettingsMenuTile>(find.byType(SettingsMenuTile)))
@@ -165,10 +167,9 @@ void main() {
       ];
       expect(
         children.length,
-        2,
-        reason: 'Exactly two SettingsMenuTile children: vehicles + fuel '
-            'club. Adding more would risk drift between this section '
-            'and the Conso-tab landing screen.',
+        1,
+        reason: 'Exactly one SettingsMenuTile child: fuel club cards. '
+            'My vehicles was promoted to Settings root in #1568.',
       );
     },
   );

--- a/test/features/feature_management/app_profile_test.dart
+++ b/test/features/feature_management/app_profile_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(basic, isNot(contains(Feature.consumptionAnalytics)));
     });
 
-    test('medium adds manualConsumption to basic, no OBD2 stack', () {
+    test('medium adds manualConsumption + showConsumptionTab to basic, no OBD2 stack', () {
       final basic = appProfileBundles[AppProfile.basic]!;
       final medium = appProfileBundles[AppProfile.medium]!;
       // Medium is a superset of Basic.
@@ -37,8 +37,12 @@ void main() {
         expect(medium, contains(f),
             reason: 'medium must include every basic flag');
       }
-      // Medium adds manualConsumption.
+      // Medium adds manualConsumption + the surface flag for the Conso
+      // settings section (#1568 — without showConsumptionTab the
+      // isConsumptionTabReachable gate short-circuits and Medium users
+      // can't reach the vehicle-add affordance).
       expect(medium, contains(Feature.manualConsumption));
+      expect(medium, contains(Feature.showConsumptionTab));
       // Medium STILL excludes the OBD2 stack — that is the Full tier.
       expect(medium, isNot(contains(Feature.obd2TripRecording)));
       expect(medium, isNot(contains(Feature.autoRecord)));

--- a/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -258,13 +258,10 @@ void main() {
 
       // My vehicles + Fuel club cards must NOT appear at the top
       // level — they were folded into the Consumption section.
-      expect(
-        observedTitles.contains('My vehicles'),
-        isFalse,
-        reason: 'My vehicles tile moved INSIDE the Consumption '
-            'foldable; it must not render as a top-level entry too '
-            '(would be a duplicate).',
-      );
+      // #1568 reversed this for "My vehicles" only: it's now a
+      // top-level Settings entry so Medium-tier users can reach
+      // vehicle config without first expanding the Conso foldable.
+      // Fuel club cards stays inside.
       expect(
         observedTitles.contains('Fuel club cards'),
         isFalse,
@@ -323,38 +320,31 @@ void main() {
             'so users correlate the Settings group with the bottom-nav tab.',
       );
 
-      // Foldable starts collapsed — child tiles should not be in the
-      // tree yet.
+      // #1568 — My vehicles is a top-level Settings entry, visible
+      // even while the Conso foldable is collapsed.
       expect(
-        find.byKey(const Key('consoleVehiclesTile')),
-        findsNothing,
-        reason: 'Consumption foldable must start collapsed; vehicle '
-            'tile should only mount after the user expands it.',
+        find.byKey(const Key('settingsRootVehiclesTile')),
+        findsOneWidget,
+        reason: 'My vehicles tile must be reachable at Settings root '
+            'without expanding the Conso foldable (#1568).',
       );
 
-      // Expand the foldable.
+      // Expand the foldable to verify the remaining toggles still
+      // render inside.
       await tester.tap(consumptionHeader);
       await tester.pumpAndSettle();
 
-      // Now both moved tiles should be present, plus the existing
-      // eco-coaching toggle.
-      expect(
-        find.byKey(const Key('consoleVehiclesTile')),
-        findsOneWidget,
-        reason: 'My vehicles tile must live inside the expanded '
-            'Consumption foldable (was at top level before #1242).',
-      );
       expect(
         find.byKey(const Key('consoleFuelClubCardsTile')),
         findsOneWidget,
-        reason: 'Fuel club cards tile must live inside the expanded '
+        reason: 'Fuel club cards tile lives inside the expanded '
             'Consumption foldable (was at top level before #1242).',
       );
       expect(
         find.byKey(const Key('hapticEcoCoachToggle')),
         findsOneWidget,
         reason: 'The eco-coach haptic toggle remains in the same '
-            'group, now grouped with vehicles + fuel club cards.',
+            'group, alongside the fuel-club tile.',
       );
     });
 


### PR DESCRIPTION
Closes #1568.

## Summary
- `AppProfile.medium` now includes `Feature.showConsumptionTab` — fixes the gate that hid the Conso settings section for Medium users.
- *My vehicles* tile promoted from inside the Conso foldable to Settings root (pre-#1242 placement), gated on `isConsumptionTabReachable`. Fuel-club / eco-coach / glide / gamification stay clustered in the foldable.
- Tests updated to assert the new structure.

## Test plan
- [x] `flutter analyze` clean
- [x] Touched tests pass (`app_profile_test`, `driving_settings_section_test`, `profile_screen_test`)
- [ ] Manual: Settings under Medium profile shows "My vehicles" tile at root + the Conso foldable below it

## Triage
Single task (per #1568) — mechanical 2-file fix, no architectural risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)