### PR TITLE
feat(consumption): gate Trajets sub-tab on ConsoMode.fuelAndTrips (Task 4 of #1570)

### DIFF
--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -9,8 +9,7 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
-import '../../../feature_management/domain/feature.dart';
-import '../../../feature_management/domain/feature_dependency_graph.dart';
+import '../../../feature_management/domain/conso_mode.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/exporters/backup/full_backup_exporter.dart';
@@ -163,18 +162,16 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     final stats = ref.watch(consumptionStatsProvider);
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
     final showCharging = _shouldShowCharging(activeVehicle);
-    // Trajets tab is gated on the OBD2 trip-recording feature — users
-    // who haven't enabled OBD2 capture have no trips to render and the
-    // empty tab was confusing. The flag is read via the manifest's
-    // effective-enabled walk so a disabled prerequisite (e.g.
-    // priceHistory, future deps) cascades through.
-    final manifest = ref.watch(featureManifestProvider);
+    // #1573 — Trajets sub-tab is visible only in the Trajets-tier
+    // ConsoMode (fuel + trips). The Fuel-only mode (manual fill-up
+    // tier, the Medium use-mode) renders the Conso screen with just
+    // the Fuel sub-tab; OBD2-driven trip history has nothing to show
+    // without trip recording enabled, and the empty tab confused
+    // Medium users. Reading ConsoMode directly is clearer than
+    // walking the dependency graph for obd2TripRecording.
     final enabledFlags = ref.watch(featureFlagsProvider);
-    final showTrajets = isEffectivelyEnabled(
-      Feature.obd2TripRecording,
-      manifest,
-      enabledFlags,
-    );
+    final showTrajets = consoModeFromFlags(enabledFlags) ==
+        ConsoMode.fuelAndTrips;
     // Recreate the TabController when the tab-set cardinality
     // changes (#892, #conso-coherence). Doing this in build — rather
     // than in initState — lets us react to live vehicle switches /

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -13,13 +13,17 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Enables `Feature.obd2TripRecording` so the Trajets tab renders —
-/// this test file's expected tab counts (2 vs 3) assume Trajets is
-/// always present, which is the case once OBD2 trip recording is on
-/// (#conso-coherence gated Trajets on the feature flag).
+/// Enables the full Trajets surface so this test file's expected tab
+/// counts (2 vs 3 tabs) hold. Per #1573 the gate is `consoMode ==
+/// fuelAndTrips`, which requires BOTH `showConsumptionTab` and
+/// `obd2TripRecording` — seeding only the latter resolves to
+/// `ConsoMode.off` and hides Trajets.
 class _ObdEnabledFlags extends FeatureFlags {
   @override
-  Set<Feature> build() => <Feature>{Feature.obd2TripRecording};
+  Set<Feature> build() => <Feature>{
+        Feature.showConsumptionTab,
+        Feature.obd2TripRecording,
+      };
 }
 
 /// #892 — the Charging tab on [ConsumptionScreen] is hidden for ICE

--- a/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
@@ -13,11 +13,15 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Enables `Feature.obd2TripRecording` — Trajets tab is gated on it
-/// (#conso-coherence) and this test asserts all three icons render.
+/// Enables the full Trajets surface so all three tab icons render.
+/// Per #1573 the gate is `consoMode == fuelAndTrips`, requires both
+/// `showConsumptionTab` and `obd2TripRecording`.
 class _ObdEnabledFlags extends FeatureFlags {
   @override
-  Set<Feature> build() => <Feature>{Feature.obd2TripRecording};
+  Set<Feature> build() => <Feature>{
+        Feature.showConsumptionTab,
+        Feature.obd2TripRecording,
+      };
 }
 
 /// #1163 — counterpart to `favorites_screen_tab_icons_test.dart`.

--- a/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
@@ -16,12 +16,17 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Tests that need the Trajets tab visible (default-off feature flag)
-/// override featureFlagsProvider with this notifier — Trajets is gated
-/// on `Feature.obd2TripRecording` per #conso-coherence.
+/// Tests that need the Trajets tab visible override featureFlagsProvider
+/// with this notifier. Per #1573, the gate is now `consoMode ==
+/// fuelAndTrips`, which requires BOTH the Conso surface flag and the
+/// OBD2-trip-recording flag — `obd2TripRecording` alone would resolve
+/// to `ConsoMode.off` because the parent surface is gated separately.
 class _TrajetsEnabledFlags extends FeatureFlags {
   @override
-  Set<Feature> build() => <Feature>{Feature.obd2TripRecording};
+  Set<Feature> build() => <Feature>{
+        Feature.showConsumptionTab,
+        Feature.obd2TripRecording,
+      };
 }
 
 /// #889 — the ConsumptionScreen grows a Trajets tab between Fuel and
@@ -350,4 +355,89 @@ void main() {
       },
     );
   });
+
+  group('ConsumptionScreen Trajets tab gated on ConsoMode (#1573)', () {
+    const vehicle = VehicleProfile(
+      id: 'v1',
+      name: 'Test vehicle',
+      type: VehicleType.hybrid,
+    );
+
+    Future<void> pumpWithFlags(
+      WidgetTester tester,
+      Set<Feature> flags,
+    ) async {
+      final router = GoRouter(
+        initialLocation: '/consumption',
+        routes: [
+          GoRoute(
+            path: '/consumption',
+            builder: (_, _) => const ConsumptionScreen(),
+          ),
+        ],
+      );
+      await pumpApp(
+        tester,
+        MaterialApp.router(routerConfig: router),
+        overrides: [
+          fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
+          chargingLogsProvider
+              .overrideWith(() => _FixedChargingLogs(const [])),
+          activeVehicleProfileProvider
+              .overrideWith(() => _FixedActiveVehicle(vehicle)),
+          vehicleProfileListProvider
+              .overrideWith(() => _FixedVehicleProfileList(const [vehicle])),
+          tripHistoryListProvider
+              .overrideWith(() => _FixedTripHistoryList(const [])),
+          featureFlagsProvider.overrideWith(
+            () => _StaticFeatureFlags(flags),
+          ),
+        ],
+      );
+    }
+
+    testWidgets(
+      'ConsoMode.fuel (Medium tier — showConsumptionTab + manualConsumption, '
+      'NO obd2TripRecording) → Trajets sub-tab absent',
+      (tester) async {
+        await pumpWithFlags(tester, <Feature>{
+          Feature.showConsumptionTab,
+          Feature.manualConsumption,
+        });
+        expect(find.text('Fuel'), findsOneWidget);
+        expect(find.text('Trips'), findsNothing,
+            reason: 'In Carburant (Medium) mode the screen renders only '
+                'the fuel-log surface — no OBD2 trip history yet.');
+        expect(find.text('Charging'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'ConsoMode.fuelAndTrips (Full tier — all three flags) → Trajets '
+      'sub-tab present',
+      (tester) async {
+        await pumpWithFlags(tester, <Feature>{
+          Feature.showConsumptionTab,
+          Feature.manualConsumption,
+          Feature.obd2TripRecording,
+        });
+        expect(find.text('Fuel'), findsOneWidget);
+        expect(find.text('Trips'), findsOneWidget,
+            reason: 'In Carburant + Trajets (Full) mode the OBD2 trip '
+                'sub-tab must render alongside Fuel + Charging.');
+        expect(find.text('Charging'), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// Locks featureFlagsProvider to an exact flag set so each #1573
+/// regression test can pin the precise ConsoMode it's exercising
+/// without leaning on manifest defaults.
+class _StaticFeatureFlags extends FeatureFlags {
+  final Set<Feature> _value;
+  _StaticFeatureFlags(this._value);
+
+  @override
+  Set<Feature> build() => _value;
 }


### PR DESCRIPTION
Closes #1573. Refs #1570 (parent epic).

## Summary
`ConsumptionScreen` now reads `consoModeFromFlags()` directly to decide whether the Trajets sub-tab renders, replacing the indirect `isEffectivelyEnabled(Feature.obd2TripRecording, ...)` dependency-graph walk.

Same behaviour for the canonical profiles:
- **Medium** (`ConsoMode.fuel` — showConsumptionTab + manualConsumption only) → Fuel + Charging tabs only, no Trajets.
- **Full** (`ConsoMode.fuelAndTrips` — all three flags) → Fuel + Trajets + Charging.

Tightens the gate slightly for orphan flag combos: `{obd2TripRecording}` alone with `showConsumptionTab` off used to leak Trajets via deep link. Now the parent surface flag is required.

## Test plan
- [x] `flutter analyze` clean
- [x] `consumption_screen_trajets_tab_test.dart` — all 7 cases pass (4 pre-existing + 1 updated `_TrajetsEnabledFlags` + 2 new ConsoMode-pinned regressions).
- [ ] Manual: switch use-mode chooser from Carburant + Trajets → Carburant; observe the Trajets sub-tab vanish on the Conso bottom-nav screen.

## Triage
Simple task within Epic #1570 — 1 source file + 1 test file, narrow blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)