### PR TITLE
test(fix): un-flake obd2_speed_stream counter-reset assertion (#1598)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,7 +330,7 @@ packages:
     source: hosted
     version: "2.1.2"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,6 +103,7 @@ dev_dependencies:
 
   # Testing
   mocktail: ^1.0.5
+  fake_async: ^1.3.3
   yaml: ^3.1.3
   flutter_launcher_icons: ^0.14.4
   # Required only by the FeedbackTokenSection widget test, which uses

--- a/test/features/consumption/data/obd2/obd2_speed_stream_test.dart
+++ b/test/features/consumption/data/obd2/obd2_speed_stream_test.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
@@ -162,39 +163,47 @@ void main() {
         reason: 'the trace entry must carry the configured MAC');
   });
 
-  // Quarantined (#1598) — Stream-timing race intermittently sees an
-  // AutoRecordEvent emitted before the counter-reset microtask. Flaked
-  // 4+ times across May-2026 CI runs without any related code change.
-  // Remove `skip:` after #1598's deterministic-timing fix lands.
-  test('a successful read resets the consecutive-failure counter',
-      skip: 'race condition tracked in #1598', () async {
-    // Pattern: null × 2, 20, null × 2 — with threshold 3 this should
-    // NEVER fire the failure trace because the counter resets at 20.
-    final transport = _FakeTransport(
-      Queue<int?>.of(<int?>[null, null, 20, null, null, null]),
-    );
-    final service = Obd2Service(transport);
-    final stream = Obd2SpeedStream(
-      service,
-      mac: mac,
-      pollPeriod: shortPoll,
-      failureLogThreshold: 3,
-    );
+  // #1598 — Was previously flaky on real wall-clock timers because
+  // `await Future.delayed(shortPoll * 5)` could let one extra
+  // periodic tick slip in, consuming an extra null and crossing the
+  // threshold. `fake_async` advances the clock deterministically so
+  // the tick count is exactly what the test intends.
+  test('a successful read resets the consecutive-failure counter', () {
+    // Pattern: null × 2, 20, null × 2 — threshold 3.
+    //   Reset works:   counter 1, 2, (20→0), 1, 2 → max 2 < 3 → 0 failures.
+    //   Reset broken:  counter 1, 2, (stays at 2), 3→FIRE, 4 → 1 failure.
+    // 0 vs 1 failure cleanly distinguishes the reset behaviour without
+    // depending on how many ticks the polling timer manages to fire.
+    fakeAsync((async) {
+      final transport = _FakeTransport(
+        Queue<int?>.of(<int?>[null, null, 20, null, null]),
+      );
+      final service = Obd2Service(transport);
+      final stream = Obd2SpeedStream(
+        service,
+        mac: mac,
+        pollPeriod: shortPoll,
+        failureLogThreshold: 3,
+      );
 
-    final received = <double>[];
-    final sub = stream.stream.listen(received.add);
-    // Drive enough ticks to consume the queue but stop before the
-    // post-success null run alone reaches threshold.
-    await Future<void>.delayed(shortPoll * 5);
-    await sub.cancel();
+      final received = <double>[];
+      final sub = stream.stream.listen(received.add);
+      // Immediate tick fires at t=0; periodic ticks fire at
+      // t=5, 10, 15, 20 ms — total 5 ticks consume the whole queue.
+      // Elapsing 4×shortPoll lands on the 4th periodic boundary
+      // inclusively, so the 5th read completes before cancel.
+      async.elapse(shortPoll * 4);
+      sub.cancel();
+      async.flushMicrotasks();
 
-    expect(received, [20.0]);
-    final failures = AutoRecordTraceLog.snapshot()
-        .where((e) => e.kind == AutoRecordEventKind.obd2SpeedReadFailed)
-        .toList();
-    expect(failures, isEmpty,
-        reason: 'a successful read in the middle of a null run must reset '
-            'the counter so the threshold is never crossed');
+      expect(received, [20.0]);
+      final failures = AutoRecordTraceLog.snapshot()
+          .where((e) => e.kind == AutoRecordEventKind.obd2SpeedReadFailed)
+          .toList();
+      expect(failures, isEmpty,
+          reason: 'a successful read in the middle of a null run must reset '
+              'the counter so the threshold is never crossed');
+    });
   });
 
   test('a thrown read is logged and counted as a failure', () async {


### PR DESCRIPTION
## Summary
- Replace wall-clock `Future.delayed` with `fake_async.elapse` so the polling-timer tick count is deterministic.
- Tighten the seed from 6 reads to 5 (`[null, null, 20, null, null]`); reset works ⇒ 0 failures, reset broken ⇒ 1 failure. No timing dependency to distinguish them.
- Remove the `skip:` quarantine.

## Test plan
- [x] Local: 10×10 runs all green (`flutter test test/features/consumption/data/obd2/obd2_speed_stream_test.dart`).
- [ ] CI green on this PR.

Closes #1598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)