### PR TITLE
ci: epic #1578 + #1591 follow-ups — drop PR coverage, flaky tag, build cache, test selector, nightly full + flaky workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,11 @@ jobs:
   # for the test phase drops from ~30 min to ~7-8 min; total billed
   # minutes go up ~4× (acceptable trade — same quality).
   #
-  # Coverage threshold + startup-budget enforcement moved to the
-  # downstream `coverage-merge` job so the shards stay single-purpose
-  # and we don't enforce a threshold on incomplete data.
+  # #1582 — `--coverage` is dropped on PR runs (it doubles per-shard
+  # wall clock for a report no one reviews mid-PR). Master pushes and
+  # the weekly schedule still produce coverage so the lcov artefact
+  # and threshold check stay current. Startup-budget enforcement
+  # moved to its own job so PRs still get that gate.
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -81,7 +83,15 @@ jobs:
       # APIs (Argentina, Italy MIMIT, etc.) that intermittently time out
       # and cannot block PRs. Run them on demand with
       # `flutter test --tags=network` from a workstation.
-      - name: Run test shard ${{ matrix.shard }} of 4
+      - name: Run test shard ${{ matrix.shard }} of 4 (PR — no coverage)
+        if: github.event_name == 'pull_request'
+        run: |
+          flutter test \
+            --exclude-tags=network \
+            --total-shards=4 \
+            --shard-index=${{ matrix.shard }}
+      - name: Run test shard ${{ matrix.shard }} of 4 (master/nightly — with coverage)
+        if: github.event_name != 'pull_request'
         run: |
           flutter test \
             --coverage \
@@ -89,6 +99,7 @@ jobs:
             --total-shards=4 \
             --shard-index=${{ matrix.shard }}
       - name: Upload shard coverage
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-shard-${{ matrix.shard }}
@@ -98,9 +109,10 @@ jobs:
 
   # Aggregates the 4 shard coverage reports into one merged lcov.info
   # and enforces the project-wide threshold over the unified view.
-  # Also runs the startup-budget structural check here so the matrix
-  # shards stay single-purpose.
+  # #1582 — Only runs on master push + the weekly schedule. PRs skip
+  # this job; coverage is regenerated when a PR's commits land on master.
   coverage-merge:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [test]
     steps:
@@ -135,6 +147,27 @@ jobs:
           echo "Merged ${#ARGS[@]} shard lcov files into coverage/lcov.info"
       - name: Check coverage threshold
         run: bash scripts/check_coverage.sh
+
+  # #1582 — Startup-budget gate split out of coverage-merge so PRs
+  # still enforce it. Cheap: runs only the test/core/perf/ subset.
+  startup-budget:
+    runs-on: ubuntu-latest
+    needs: [analyze]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
       - name: Check startup time budget
         run: bash scripts/check_startup_budget.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,18 @@ jobs:
       - name: Compute affected tests (PR only)
         if: github.event_name == 'pull_request'
         run: |
+          # `dart run` emits `Running build hooks...` progress text to stdout
+          # (with `\r` overwrites). Naively redirecting `> affected_tests.txt`
+          # captures that prefix and concatenates it with the first real test
+          # path, so the shard then tries to load a bogus path like
+          # `.../Running build hooks...test/foo_test.dart` and every shard fails
+          # at suite-load time. Filter the stream to lines that look like test
+          # files so the selector output stays clean even if dart prepends
+          # noise. Empty output still triggers the full-suite fallback below.
           dart run tool/test_selector.dart \
             --base origin/${{ github.base_ref }} \
+            2>/dev/null \
+            | grep -E '^test/.*_test\.dart$' \
             > affected_tests.txt || true
           if [ -s affected_tests.txt ]; then
             echo "Selector produced $(wc -l < affected_tests.txt) test files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,23 @@ jobs:
   # the weekly schedule still produce coverage so the lcov artefact
   # and threshold check stay current. Startup-budget enforcement
   # moved to its own job so PRs still get that gate.
+  #
+  # #1584 — `--exclude-tags=flaky` (plus the existing `network`
+  # exclusion) on PR + master + scheduled runs. The flaky tag covers
+  # plugin tests (share_plus, etc.) whose channel timing is unreliable
+  # in the headless test environment. The nightly flaky-suite workflow
+  # re-runs those with the tag so a real regression still surfaces.
+  #
+  # #1585 — Cache the `build/` directory keyed on pubspec + lib hash
+  # so re-runs of the same branch skip the build_runner regen step
+  # and avoid recompiling Dart sources untouched since the last run.
+  #
+  # #1594 — On `pull_request` events a `dart run tool/test_selector.dart`
+  # pre-step writes the affected-test list to `affected_tests.txt`. The
+  # shard then either runs ONLY those tests (sharded across the matrix)
+  # or, if the selector emits an empty list (or fails), falls back to
+  # the full suite as a paranoia net. Master pushes + the weekly cron
+  # ignore the selector entirely.
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -66,6 +83,10 @@ jobs:
         shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v6
+        with:
+          # #1594 — selector needs `git diff master...HEAD` to work.
+          # Shallow clone (default) has no master tip locally.
+          fetch-depth: 0
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
@@ -77,25 +98,65 @@ jobs:
             .dart_tool
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: ${{ runner.os }}-pub-
+      # #1585 — Cache compiled artefacts. Same-branch reruns and rebase
+      # rounds reuse build_runner output keyed on the source state.
+      - uses: actions/cache@v5
+        with:
+          path: build/
+          key: ${{ runner.os }}-build-${{ hashFiles('pubspec.lock', 'lib/**/*.dart') }}
+          restore-keys: ${{ runner.os }}-build-
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      # Excludes the `network` tag — those tests hit real third-party
-      # APIs (Argentina, Italy MIMIT, etc.) that intermittently time out
-      # and cannot block PRs. Run them on demand with
-      # `flutter test --tags=network` from a workstation.
-      - name: Run test shard ${{ matrix.shard }} of 4 (PR — no coverage)
+      # #1594 — Compute the affected-test list once per shard. Fast
+      # (pure Dart, file-walk) and per-shard so the selector cost is
+      # parallelised. Empty output triggers a full-suite fallback in
+      # the run step.
+      - name: Compute affected tests (PR only)
         if: github.event_name == 'pull_request'
         run: |
-          flutter test \
-            --exclude-tags=network \
-            --total-shards=4 \
-            --shard-index=${{ matrix.shard }}
-      - name: Run test shard ${{ matrix.shard }} of 4 (master/nightly — with coverage)
+          dart run tool/test_selector.dart \
+            --base origin/${{ github.base_ref }} \
+            > affected_tests.txt || true
+          if [ -s affected_tests.txt ]; then
+            echo "Selector produced $(wc -l < affected_tests.txt) test files"
+            head -20 affected_tests.txt
+          else
+            echo "Selector emitted empty list — shard will fall back to full suite"
+          fi
+      # Excludes the `network` + `flaky` tags — those tests hit real
+      # third-party APIs (Argentina, Italy MIMIT) or platform plugins
+      # (share_plus) that intermittently fail and cannot block PRs.
+      # The nightly-flaky workflow re-runs both buckets.
+      - name: Run test shard ${{ matrix.shard }} of 4 (PR — affected only, no coverage)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          if [ -s affected_tests.txt ]; then
+            # Read into a bash array so flutter test receives all
+            # files in a single invocation; sharding then splits
+            # this stable, sorted list deterministically across
+            # the 4 matrix runners.
+            mapfile -t TESTS < affected_tests.txt
+            flutter test "${TESTS[@]}" \
+              --exclude-tags=network \
+              --exclude-tags=flaky \
+              --total-shards=4 \
+              --shard-index=${{ matrix.shard }}
+          else
+            # Empty selector output ⇒ paranoia: run full suite.
+            flutter test \
+              --exclude-tags=network \
+              --exclude-tags=flaky \
+              --total-shards=4 \
+              --shard-index=${{ matrix.shard }}
+          fi
+      - name: Run test shard ${{ matrix.shard }} of 4 (master/nightly — full suite + coverage)
         if: github.event_name != 'pull_request'
         run: |
           flutter test \
             --coverage \
             --exclude-tags=network \
+            --exclude-tags=flaky \
             --total-shards=4 \
             --shard-index=${{ matrix.shard }}
       - name: Upload shard coverage
@@ -249,6 +310,12 @@ jobs:
             .dart_tool
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: ${{ runner.os }}-pub-
+      # #1585 — Cache compiled Flutter artefacts for same-branch reruns.
+      - uses: actions/cache@v5
+        with:
+          path: build/
+          key: ${{ runner.os }}-build-android-${{ hashFiles('pubspec.lock', 'lib/**/*.dart', 'android/**') }}
+          restore-keys: ${{ runner.os }}-build-android-
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       # #48 — Decode the release keystore from a GitHub secret into a temp

--- a/.github/workflows/nightly-flaky.yml
+++ b/.github/workflows/nightly-flaky.yml
@@ -1,0 +1,57 @@
+name: Nightly Flaky + Network Suite
+
+# Companion to #1584. The `flaky` + `network` buckets are excluded from
+# PR + master CI because their failures are intermittent and would
+# block merges. This workflow re-runs them once a day so a real
+# regression in a tagged test still surfaces within ~24 h.
+#
+# Tag scope:
+#   - `network` — live-API tests (Italy MIMIT, Argentina, etc).
+#   - `flaky`   — platform-plugin tests whose channel timing is
+#                 unreliable in headless runners (share_plus, etc).
+
+on:
+  schedule:
+    # 05:00 UTC = 07:00 Europe/Paris (CEST) / 06:00 (CET).
+    # Runs an hour after the nightly-full suite so failures don't
+    # collide with the full-suite comment on #1591.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-flaky
+  cancel-in-progress: false
+
+jobs:
+  flaky-suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Run flaky + network suites
+        # Includes both tags so we cover everything the PR/master path
+        # excludes. Single invocation — comma-separated tags is the
+        # `flutter test --tags=` syntax.
+        run: flutter test --tags=flaky,network
+      - name: Surface failure on tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment 1584 --body \
+            "Nightly flaky+network run failed on $(date -u +%F): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/nightly-full.yml
+++ b/.github/workflows/nightly-full.yml
@@ -1,0 +1,51 @@
+name: Nightly Full Test Suite
+
+# Paranoia net for #1591's path-affected test selector — if the selector
+# ever misses a transitively-affected test, this workflow catches it
+# within a day by running the full suite (no selector, no exclude-tags
+# except `network` because the live-API tests can't run reliably from
+# GitHub-hosted runners).
+#
+# Failure surfaces by reopening / commenting on the tracking issue
+# (#1591) so the user sees it without having to check Actions UI.
+
+on:
+  schedule:
+    # 04:00 UTC = 06:00 Europe/Paris (CEST) / 05:00 (CET).
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-full
+  cancel-in-progress: false
+
+jobs:
+  full-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Run full test suite (selector bypassed)
+        run: flutter test --coverage --exclude-tags=network
+      - name: Surface failure on tracking issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment 1591 --body \
+            "Nightly full-suite run failed on $(date -u +%F): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -9,3 +9,11 @@ tags:
       Tests that hit real third-party APIs over the network. Intermittent
       upstream timeouts mean these cannot block PRs. Run on demand with
       `flutter test --tags=network`.
+  flaky:
+    description: >
+      Tests that have observably flaked in CI without a related code
+      change — usually because they exercise a platform plugin
+      (share_plus, etc.) whose channel timing is unreliable in the
+      headless test environment. Excluded from PR + master runs; the
+      nightly flaky-suite workflow re-runs them so genuine regressions
+      still surface within a day.

--- a/test/core/sharing/widget_share_renderer_test.dart
+++ b/test/core/sharing/widget_share_renderer_test.dart
@@ -1,3 +1,11 @@
+// #1584 — Tagged `flaky` because share_plus's platform channel
+// occasionally returns null or doesn't call back in the headless
+// test environment, so the captured ShareParams arrives late or not
+// at all. The nightly flaky-suite re-runs this file with the tag so
+// a real regression still surfaces within a day.
+@Tags(['flaky'])
+library;
+
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/test/features/favorites/presentation/screens/favorites_screen_share_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_share_test.dart
@@ -1,3 +1,11 @@
+// #1584 — Tagged `flaky` because share_plus's platform channel
+// occasionally returns null or doesn't call back in the headless
+// test environment, so the captured ShareParams arrives late or not
+// at all. The nightly flaky-suite re-runs this file with the tag so
+// a real regression still surfaces within a day.
+@Tags(['flaky'])
+library;
+
 import 'dart:io';
 
 import 'package:flutter/material.dart';


### PR DESCRIPTION
Bundles every remaining child of #1578 and #1591 into one PR so we
don't pay 5× sequential CI on the same workflow file.

## What's in here

### Closes #1582 — \`--coverage\` off on PR runs
- PR shards run \`flutter test --exclude-tags=network --exclude-tags=flaky --total-shards=4 --shard-index=N\` (no coverage). Master push + the weekly cron keep \`--coverage\`.
- \`coverage-merge\` gated to \`github.event_name != 'pull_request'\`.
- New \`startup-budget\` job runs the structural startup-instrumentation gate on every event so the gate doesn't get lost when coverage-merge is skipped.

### Closes #1584 — \`flaky\` tag + nightly flaky-suite
- Declare \`flaky\` tag in \`dart_test.yaml\`.
- Tag \`test/core/sharing/widget_share_renderer_test.dart\` + \`test/features/favorites/presentation/screens/favorites_screen_share_test.dart\` with \`@Tags(['flaky'])\`. share_plus's platform channel is unreliable in headless test runs.
- \`--exclude-tags=flaky\` on every PR + master + cron run.
- \`nightly-flaky.yml\` re-runs both buckets so a real regression still surfaces.

### Closes #1585 — \`build/\` cache between runs
- \`actions/cache\` keyed on pubspec.lock + lib/**/*.dart (test job) and pubspec.lock + lib/** + android/** (build-android job).

### Closes #1594 — test-selector wired into matrix
- \`fetch-depth: 0\` on the test job (selector needs full git history).
- New step on \`pull_request\` events: \`dart run tool/test_selector.dart --base origin/<base_ref>\` writes \`affected_tests.txt\`.
- The test step branches: PR with non-empty selector output runs ONLY those tests (sharded); empty output triggers a full-suite fallback. Master + cron always run the full suite.

### Closes #1595 — nightly full-test workflow
- \`nightly-full.yml\`: 04:00 UTC daily, runs every test (selector bypassed, \`--exclude-tags=network\` only). Failure comments on #1591.
- \`nightly-flaky.yml\`: 05:00 UTC daily, runs \`--tags=flaky,network\`. Failure comments on #1584.

## Test plan
- [x] Local: \`flutter test test/ci/ci_workflow_test.dart test/tool/test_selector_test.dart\` — 28/28 pass.
- [x] Local: selector emits a stable sorted list against master.
- [ ] CI green on this PR.
- [ ] After merge, \`nightly-full.yml\` and \`nightly-flaky.yml\` show up under Actions.

Closes #1582.
Closes #1584.
Closes #1585.
Closes #1594.
Closes #1595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)