### PR TITLE
feat(features): add Feature.fuelCalculator + gated Calculator entry point (#1636)

### DIFF
--- a/lib/features/feature_management/domain/feature.dart
+++ b/lib/features/feature_management/domain/feature.dart
@@ -100,4 +100,9 @@ enum Feature {
   /// no-op until a trained `.tflite` artifact is committed and the
   /// const is flipped. Heuristic fallback always covers the gap.
   tflitePricePrediction,
+
+  /// The fuel-cost Calculator (#1613). The screen + logic already exist
+  /// and are tested; this flag gates the navigation entry point that
+  /// makes its `/calculator` route reachable. Default-on.
+  fuelCalculator,
 }

--- a/lib/features/feature_management/domain/feature_manifest.dart
+++ b/lib/features/feature_management/domain/feature_manifest.dart
@@ -265,5 +265,14 @@ class FeatureManifest {
           'On-device price forecast model — inference runs locally; '
               'features and predictions never leave the device.',
     ),
+    Feature.fuelCalculator: FeatureManifestEntry(
+      feature: Feature.fuelCalculator,
+      // Default-on (#1613): the fuel-cost Calculator is a finished,
+      // self-contained, harmless utility — exposing it is the whole
+      // point of the gate. No `requires` edge: it depends on nothing.
+      defaultEnabled: true,
+      displayName: 'Fuel calculator',
+      description: 'Reachable fuel-cost calculator from the search results.',
+    ),
   });
 }

--- a/lib/features/feature_management/v2/feature_registry.dart
+++ b/lib/features/feature_management/v2/feature_registry.dart
@@ -24,6 +24,7 @@ const List<FeatureClass> featureRegistry = <FeatureClass>[
   kFeatureShowElectric,
   kFeatureManualConsumption,
   kFeatureLoyaltyCards,
+  kFeatureFuelCalculator,
 
   // Children of obd2TripRecording
   kFeatureGamification,

--- a/lib/features/feature_management/v2/known_features.dart
+++ b/lib/features/feature_management/v2/known_features.dart
@@ -163,6 +163,18 @@ const kFeatureLoyaltyCards = FeatureClass(
       'price comparisons.',
 );
 
+const kFeatureFuelCalculator = FeatureClass(
+  id: 'fuelCalculator',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_fuelCalculator',
+  displayName: 'Fuel calculator',
+  descriptionKey: 'featureDescription_fuelCalculator',
+  description: 'Reachable fuel-cost calculator from the search results.',
+);
+
 // ----------------------------------------------------------------------------
 // Children of obd2TripRecording
 // ----------------------------------------------------------------------------

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -505,6 +505,8 @@ String _featureLabel(AppLocalizations? l, Feature f) {
     case Feature.tflitePricePrediction:
       return l?.featureLabel_tflitePricePrediction ??
           'TFLite price prediction';
+    case Feature.fuelCalculator:
+      return l?.featureLabel_fuelCalculator ?? 'Fuel calculator';
   }
 }
 
@@ -571,6 +573,9 @@ String _featureDescription(AppLocalizations? l, Feature f) {
       return l?.featureDescription_tflitePricePrediction ??
           'On-device price forecast model — inference runs locally; '
               'features and predictions never leave the device.';
+    case Feature.fuelCalculator:
+      return l?.featureDescription_fuelCalculator ??
+          'Reachable fuel-cost calculator from the search results.';
   }
 }
 
@@ -617,6 +622,7 @@ String _blockedEnableMessage(AppLocalizations? l, Feature f) {
     case Feature.showElectric:
     case Feature.manualConsumption:
     case Feature.loyaltyCards:
+    case Feature.fuelCalculator:
       return 'Prerequisites not met';
   }
 }

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -14,6 +14,8 @@ import '../../../../core/widgets/staggered_fade_in.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../favorites/presentation/widgets/swipe_tutorial_banner.dart';
 import '../../../favorites/providers/favorites_provider.dart';
+import '../../../feature_management/application/feature_flags_provider.dart';
+import '../../../feature_management/domain/feature.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_result_item.dart';
 import '../../domain/entities/station.dart';
@@ -93,6 +95,30 @@ class SearchResultsList extends ConsumerWidget {
                 ),
               ),
               const SizedBox(width: 4),
+              // #1613 — gated entry point for the fuel-cost Calculator.
+              // The /calculator route exists but had no navigation entry
+              // point anywhere in lib/; this affordance makes it
+              // reachable when Feature.fuelCalculator is enabled.
+              if (ref
+                  .watch(featureFlagsProvider)
+                  .contains(Feature.fuelCalculator)) ...[
+                Semantics(
+                  label: l10n?.fuelCostCalculator ?? 'Fuel Cost Calculator',
+                  button: true,
+                  child: InkWell(
+                    onTap: () => context.go('/calculator'),
+                    borderRadius: BorderRadius.circular(12),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 2),
+                      child: Icon(Icons.calculate,
+                          size: 18,
+                          color: Theme.of(context).colorScheme.primary),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 4),
+              ],
               FreshnessBadge(result: result),
             ],
           ),

--- a/lib/l10n/_fragments/feature_management_de.arb
+++ b/lib/l10n/_fragments/feature_management_de.arb
@@ -47,5 +47,7 @@
   "featureBlockedEnable_showConsumptionTab": "Aktiviere zuerst die OBD2-Fahrtaufzeichnung",
   "featureLabel_tflitePricePrediction": "TFLite-Preisvorhersage",
   "featureDescription_tflitePricePrediction": "On-Device Preisprognose – die Inferenz läuft lokal; Merkmale und Vorhersagen verlassen das Gerät nie.",
-  "featureBlockedEnable_tflitePricePrediction": "Aktiviere zuerst den Preisverlauf"
+  "featureBlockedEnable_tflitePricePrediction": "Aktiviere zuerst den Preisverlauf",
+  "featureLabel_fuelCalculator": "Tankkostenrechner",
+  "featureDescription_fuelCalculator": "Erreichbarer Tankkostenrechner aus den Suchergebnissen."
 }

--- a/lib/l10n/_fragments/feature_management_en.arb
+++ b/lib/l10n/_fragments/feature_management_en.arb
@@ -194,5 +194,13 @@
   "featureBlockedEnable_tflitePricePrediction": "Enable price history first",
   "@featureBlockedEnable_tflitePricePrediction": {
     "description": "Tooltip shown on the disabled TFLite-prediction toggle when its prerequisite (priceHistory) is off."
+  },
+  "featureLabel_fuelCalculator": "Fuel calculator",
+  "@featureLabel_fuelCalculator": {
+    "description": "Settings toggle label for the fuel-cost Calculator feature (#1613)."
+  },
+  "featureDescription_fuelCalculator": "Reachable fuel-cost calculator from the search results.",
+  "@featureDescription_fuelCalculator": {
+    "description": "Settings toggle description for the fuel-cost Calculator feature (#1613)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1555,6 +1555,8 @@
   "featureLabel_tflitePricePrediction": "TFLite-Preisvorhersage",
   "featureDescription_tflitePricePrediction": "On-Device Preisprognose – die Inferenz läuft lokal; Merkmale und Vorhersagen verlassen das Gerät nie.",
   "featureBlockedEnable_tflitePricePrediction": "Aktiviere zuerst den Preisverlauf",
+  "featureLabel_fuelCalculator": "Tankkostenrechner",
+  "featureDescription_fuelCalculator": "Erreichbarer Tankkostenrechner aus den Suchergebnissen.",
   "feedbackConsentTitle": "Bericht an GitHub senden?",
   "feedbackConsentBody": "Damit wird ein öffentliches Ticket in unserem GitHub-Repository mit deinem Foto und dem OCR-Text erstellt. Es werden keine personenbezogenen Daten (Standort, Konto-ID) gesendet. Fortfahren?",
   "feedbackConsentContinue": "Fortfahren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2332,6 +2332,14 @@
   "@featureBlockedEnable_tflitePricePrediction": {
     "description": "Tooltip shown on the disabled TFLite-prediction toggle when its prerequisite (priceHistory) is off."
   },
+  "featureLabel_fuelCalculator": "Fuel calculator",
+  "@featureLabel_fuelCalculator": {
+    "description": "Settings toggle label for the fuel-cost Calculator feature (#1613)."
+  },
+  "featureDescription_fuelCalculator": "Reachable fuel-cost calculator from the search results.",
+  "@featureDescription_fuelCalculator": {
+    "description": "Settings toggle description for the fuel-cost Calculator feature (#1613)."
+  },
   "feedbackConsentTitle": "Send report to GitHub?",
   "@feedbackConsentTitle": {
     "description": "Title of the one-time consent dialog before we file a public GitHub issue from a bad-scan report (#952 phase 3)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1206,6 +1206,8 @@
   "featureBlockedEnable_showConsumptionTab": "Activez d'abord l'enregistrement OBD2 des trajets",
   "featureLabel_tflitePricePrediction": "Prédiction de prix TFLite",
   "featureDescription_tflitePricePrediction": "Modèle de prévision de prix sur l'appareil — l'inférence s'exécute localement ; les caractéristiques et les prédictions ne quittent jamais l'appareil.",
+  "featureLabel_fuelCalculator": "Calculateur de coût de carburant",
+  "featureDescription_fuelCalculator": "Calculateur de coût de carburant accessible depuis les résultats de recherche.",
   "featureBlockedEnable_tflitePricePrediction": "Activez d'abord l'historique des prix",
   "tripPathCardTitle": "Trace du trajet",
   "tripPathCardSubtitle": "Itinéraire enregistré par GPS",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7034,6 +7034,18 @@ abstract class AppLocalizations {
   /// **'Enable price history first'**
   String get featureBlockedEnable_tflitePricePrediction;
 
+  /// Settings toggle label for the fuel-cost Calculator feature (#1613).
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel calculator'**
+  String get featureLabel_fuelCalculator;
+
+  /// Settings toggle description for the fuel-cost Calculator feature (#1613).
+  ///
+  /// In en, this message translates to:
+  /// **'Reachable fuel-cost calculator from the search results.'**
+  String get featureDescription_fuelCalculator;
+
   /// Title of the one-time consent dialog before we file a public GitHub issue from a bad-scan report (#952 phase 3).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3839,6 +3839,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3876,6 +3876,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Aktiviere zuerst den Preisverlauf';
 
   @override
+  String get featureLabel_fuelCalculator => 'Tankkostenrechner';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Erreichbarer Tankkostenrechner aus den Suchergebnissen.';
+
+  @override
   String get feedbackConsentTitle => 'Bericht an GitHub senden?';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3834,6 +3834,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3836,6 +3836,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3839,6 +3839,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3879,6 +3879,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activez d\'abord l\'historique des prix';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Envoyer le rapport à GitHub ?';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3838,6 +3838,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3840,6 +3840,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3838,6 +3838,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3842,6 +3842,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3836,6 +3836,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3840,6 +3840,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Enable price history first';
 
   @override
+  String get featureLabel_fuelCalculator => 'Fuel calculator';
+
+  @override
+  String get featureDescription_fuelCalculator =>
+      'Reachable fuel-cost calculator from the search results.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/test/features/feature_management/fuel_calculator_gate_test.dart
+++ b/test/features/feature_management/fuel_calculator_gate_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+/// Pins the `Feature.fuelCalculator` gate (epic #1613, child #1636).
+///
+/// The fuel-cost Calculator screen + `/calculator` route already exist
+/// and are tested; this feature flag gates the navigation entry point
+/// added to the search-results header that finally makes the route
+/// reachable. The manifest contract is what `SearchResultsList` checks.
+void main() {
+  const manifest = FeatureManifest.defaultManifest;
+
+  group('Feature.fuelCalculator manifest entry', () {
+    test('the default manifest declares an entry for fuelCalculator', () {
+      final entry = manifest.entries[Feature.fuelCalculator];
+      expect(entry, isNotNull);
+      expect(entry!.feature, Feature.fuelCalculator);
+    });
+
+    test('is default-enabled — the Calculator must be reachable', () {
+      expect(
+        manifest.entries[Feature.fuelCalculator]!.defaultEnabled,
+        isTrue,
+      );
+      expect(manifest.defaultEnabledSet(), contains(Feature.fuelCalculator));
+    });
+
+    test('has no prerequisites — it depends on nothing', () {
+      expect(manifest.entries[Feature.fuelCalculator]!.requires, isEmpty);
+    });
+  });
+}

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -109,11 +109,12 @@ void main() {
           );
         }
       }
-      expect(Feature.values.length, 20,
+      expect(Feature.values.length, 21,
           reason: '#1373 phase 1 shipped 13 features; phase 3d added '
               'autoRecord (14); phase 3c bundled showFuel + showElectric + '
               'showConsumptionTab (17); #1517 added manualConsumption + '
-              'loyaltyCards (19); #1543 added tflitePricePrediction (20). '
+              'loyaltyCards (19); #1543 added tflitePricePrediction (20); '
+              '#1613 added fuelCalculator (21). '
               'Update the test if a new feature was added or removed.');
     });
 


### PR DESCRIPTION
First child of epic #1613 — brings the orphan fuel-cost Calculator under
feature management and makes it reachable.

- `Feature.fuelCalculator` added to the enum + default manifest
  (default-on, no prerequisites).
- A gated calculator affordance in the search-results header navigates
  to the previously-unreachable `/calculator` route.
- The three exhaustive `Feature` switches in `feature_management_section`
  updated; `featureLabel_fuelCalculator` / `featureDescription_fuelCalculator`
  ARB keys added (en + de) and regenerated.
- `fuel_calculator_gate_test.dart` pins the manifest contract.

`flutter analyze` clean; feature-management + search + profile widget
tests pass (161).

Closes #1636. Part of epic #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)