### PR TITLE
feat(features): gate the Carbon dashboard + refresh the Feature×Parameter map (epic #1613)

### DIFF
--- a/docs/feature-concepts/FEATURE_PARAMETER_MAP.md
+++ b/docs/feature-concepts/FEATURE_PARAMETER_MAP.md
@@ -56,6 +56,8 @@ The audit was run on 2026-05-14 against
 | `manualConsumption` | Conso card (set by Fuel / Fuel+Trips) | *Conso* tab → Fuel + Charging logs | Vehicle list + fill-up sheet inside Conso settings | No |
 | `loyaltyCards` | Settings → *Fuel club cards* section | Per-station discount application | `loyalty_settings_screen.dart` (card management) | No |
 | `tflitePricePrediction` | Feature management toggle (compile-time gated) | Station detail → prediction chip | None yet — model artifact off-band (#1543) | **Tracked in #1543** |
+| `fuelCalculator` | Feature management toggle | Search results header → calculator affordance → `/calculator` | View-only; `calculator_screen.dart` (inputs are in-screen, not settings) | No (#1613 — was orphan; entry point added) |
+| `carbonDashboard` | Feature management toggle | Conso tab → AppBar eco action → `/carbon` | View-only; `carbon_dashboard_screen.dart` aggregates trip data | No (#1613 — brought under the Feature enum) |
 
 ## Cross-references
 

--- a/lib/app/routes/consumption_routes.dart
+++ b/lib/app/routes/consumption_routes.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../features/carbon/presentation/screens/carbon_dashboard_screen.dart';
@@ -6,6 +8,8 @@ import '../../features/consumption/presentation/screens/consumption_screen.dart'
 import '../../features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart';
 import '../../features/consumption/presentation/screens/trip_detail_screen.dart';
 import '../../features/consumption/presentation/screens/trip_recording_screen.dart';
+import '../../features/feature_management/application/feature_flags_provider.dart';
+import '../../features/feature_management/domain/feature.dart';
 import '../../features/search/domain/entities/fuel_type.dart';
 import 'invalid_id_screen.dart';
 
@@ -20,7 +24,24 @@ List<RouteBase> get consumptionRoutes => [
       ),
       GoRoute(
         path: '/carbon',
-        builder: (context, state) => const CarbonDashboardScreen(),
+        // #1613 — the Carbon dashboard is gated on Feature.carbonDashboard.
+        // Guarding the route (not just the entry-point button) means a
+        // deep link or restored navigation stack cannot reach the
+        // dashboard when the feature is disabled.
+        builder: (context, state) => Consumer(
+          builder: (context, ref, _) {
+            final enabled = ref
+                .watch(featureFlagsProvider)
+                .contains(Feature.carbonDashboard);
+            if (!enabled) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (context.mounted) context.go('/consumption-tab');
+              });
+              return const SizedBox.shrink();
+            }
+            return const CarbonDashboardScreen();
+          },
+        ),
       ),
       GoRoute(
         path: '/consumption/pick-station',

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -10,6 +10,7 @@ import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/conso_mode.dart';
+import '../../../feature_management/domain/feature.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/exporters/backup/full_backup_exporter.dart';
@@ -236,12 +237,15 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
           icon: const Icon(Icons.download_outlined),
           onPressed: () => unawaited(_runBackupExport()),
         ),
-        IconButton(
-          key: const Key('open_carbon_dashboard'),
-          tooltip: l?.carbonDashboardTitle ?? 'Carbon dashboard',
-          icon: const Icon(Icons.eco_outlined),
-          onPressed: () => context.push('/carbon'),
-        ),
+        // #1613 — the Carbon dashboard entry point is gated on the
+        // central Feature enum so it can be toggled per profile.
+        if (ref.watch(featureFlagsProvider).contains(Feature.carbonDashboard))
+          IconButton(
+            key: const Key('open_carbon_dashboard'),
+            tooltip: l?.carbonDashboardTitle ?? 'Carbon dashboard',
+            icon: const Icon(Icons.eco_outlined),
+            onPressed: () => context.push('/carbon'),
+          ),
       ],
       floatingActionButton: isTrajetsTab
           // Trajets tab hides the global FAB — the "Start recording"

--- a/lib/features/feature_management/domain/feature.dart
+++ b/lib/features/feature_management/domain/feature.dart
@@ -105,4 +105,10 @@ enum Feature {
   /// and are tested; this flag gates the navigation entry point that
   /// makes its `/calculator` route reachable. Default-on.
   fuelCalculator,
+
+  /// The Carbon dashboard (#1613). Gates the Consumption-tab AppBar eco
+  /// action and the `/carbon` route. Default-on — the dashboard already
+  /// shipped reachable, so the flag preserves current behaviour while
+  /// bringing it under central feature management.
+  carbonDashboard,
 }

--- a/lib/features/feature_management/domain/feature_manifest.dart
+++ b/lib/features/feature_management/domain/feature_manifest.dart
@@ -274,5 +274,15 @@ class FeatureManifest {
       displayName: 'Fuel calculator',
       description: 'Reachable fuel-cost calculator from the search results.',
     ),
+    Feature.carbonDashboard: FeatureManifestEntry(
+      feature: Feature.carbonDashboard,
+      // Default-on (#1613): the Carbon dashboard already shipped live
+      // and reachable — default-on preserves current behaviour while
+      // bringing it under central feature management. No prerequisites.
+      defaultEnabled: true,
+      displayName: 'Carbon dashboard',
+      description: 'CO2 footprint dashboard reachable from the Consumption '
+          'tab.',
+    ),
   });
 }

--- a/lib/features/feature_management/v2/feature_registry.dart
+++ b/lib/features/feature_management/v2/feature_registry.dart
@@ -25,6 +25,7 @@ const List<FeatureClass> featureRegistry = <FeatureClass>[
   kFeatureManualConsumption,
   kFeatureLoyaltyCards,
   kFeatureFuelCalculator,
+  kFeatureCarbonDashboard,
 
   // Children of obd2TripRecording
   kFeatureGamification,

--- a/lib/features/feature_management/v2/known_features.dart
+++ b/lib/features/feature_management/v2/known_features.dart
@@ -175,6 +175,18 @@ const kFeatureFuelCalculator = FeatureClass(
   description: 'Reachable fuel-cost calculator from the search results.',
 );
 
+const kFeatureCarbonDashboard = FeatureClass(
+  id: 'carbonDashboard',
+  parent: _none,
+  requires: _empty,
+  defaultEnabled: true,
+  maturity: FeatureMaturity.production,
+  displayKey: 'featureLabel_carbonDashboard',
+  displayName: 'Carbon dashboard',
+  descriptionKey: 'featureDescription_carbonDashboard',
+  description: 'CO2 footprint dashboard reachable from the Consumption tab.',
+);
+
 // ----------------------------------------------------------------------------
 // Children of obd2TripRecording
 // ----------------------------------------------------------------------------

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -507,6 +507,8 @@ String _featureLabel(AppLocalizations? l, Feature f) {
           'TFLite price prediction';
     case Feature.fuelCalculator:
       return l?.featureLabel_fuelCalculator ?? 'Fuel calculator';
+    case Feature.carbonDashboard:
+      return l?.featureLabel_carbonDashboard ?? 'Carbon dashboard';
   }
 }
 
@@ -576,6 +578,9 @@ String _featureDescription(AppLocalizations? l, Feature f) {
     case Feature.fuelCalculator:
       return l?.featureDescription_fuelCalculator ??
           'Reachable fuel-cost calculator from the search results.';
+    case Feature.carbonDashboard:
+      return l?.featureDescription_carbonDashboard ??
+          'CO2 footprint dashboard reachable from the Consumption tab.';
   }
 }
 
@@ -623,6 +628,7 @@ String _blockedEnableMessage(AppLocalizations? l, Feature f) {
     case Feature.manualConsumption:
     case Feature.loyaltyCards:
     case Feature.fuelCalculator:
+    case Feature.carbonDashboard:
       return 'Prerequisites not met';
   }
 }

--- a/lib/l10n/_fragments/feature_management_de.arb
+++ b/lib/l10n/_fragments/feature_management_de.arb
@@ -49,5 +49,7 @@
   "featureDescription_tflitePricePrediction": "On-Device Preisprognose – die Inferenz läuft lokal; Merkmale und Vorhersagen verlassen das Gerät nie.",
   "featureBlockedEnable_tflitePricePrediction": "Aktiviere zuerst den Preisverlauf",
   "featureLabel_fuelCalculator": "Tankkostenrechner",
-  "featureDescription_fuelCalculator": "Erreichbarer Tankkostenrechner aus den Suchergebnissen."
+  "featureDescription_fuelCalculator": "Erreichbarer Tankkostenrechner aus den Suchergebnissen.",
+  "featureLabel_carbonDashboard": "CO2-Dashboard",
+  "featureDescription_carbonDashboard": "CO2-Bilanz-Dashboard, erreichbar über den Verbrauch-Tab."
 }

--- a/lib/l10n/_fragments/feature_management_en.arb
+++ b/lib/l10n/_fragments/feature_management_en.arb
@@ -202,5 +202,13 @@
   "featureDescription_fuelCalculator": "Reachable fuel-cost calculator from the search results.",
   "@featureDescription_fuelCalculator": {
     "description": "Settings toggle description for the fuel-cost Calculator feature (#1613)."
+  },
+  "featureLabel_carbonDashboard": "Carbon dashboard",
+  "@featureLabel_carbonDashboard": {
+    "description": "Settings toggle label for the Carbon dashboard feature (#1613)."
+  },
+  "featureDescription_carbonDashboard": "CO2 footprint dashboard reachable from the Consumption tab.",
+  "@featureDescription_carbonDashboard": {
+    "description": "Settings toggle description for the Carbon dashboard feature (#1613)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1557,6 +1557,8 @@
   "featureBlockedEnable_tflitePricePrediction": "Aktiviere zuerst den Preisverlauf",
   "featureLabel_fuelCalculator": "Tankkostenrechner",
   "featureDescription_fuelCalculator": "Erreichbarer Tankkostenrechner aus den Suchergebnissen.",
+  "featureLabel_carbonDashboard": "CO2-Dashboard",
+  "featureDescription_carbonDashboard": "CO2-Bilanz-Dashboard, erreichbar über den Verbrauch-Tab.",
   "feedbackConsentTitle": "Bericht an GitHub senden?",
   "feedbackConsentBody": "Damit wird ein öffentliches Ticket in unserem GitHub-Repository mit deinem Foto und dem OCR-Text erstellt. Es werden keine personenbezogenen Daten (Standort, Konto-ID) gesendet. Fortfahren?",
   "feedbackConsentContinue": "Fortfahren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2340,6 +2340,14 @@
   "@featureDescription_fuelCalculator": {
     "description": "Settings toggle description for the fuel-cost Calculator feature (#1613)."
   },
+  "featureLabel_carbonDashboard": "Carbon dashboard",
+  "@featureLabel_carbonDashboard": {
+    "description": "Settings toggle label for the Carbon dashboard feature (#1613)."
+  },
+  "featureDescription_carbonDashboard": "CO2 footprint dashboard reachable from the Consumption tab.",
+  "@featureDescription_carbonDashboard": {
+    "description": "Settings toggle description for the Carbon dashboard feature (#1613)."
+  },
   "feedbackConsentTitle": "Send report to GitHub?",
   "@feedbackConsentTitle": {
     "description": "Title of the one-time consent dialog before we file a public GitHub issue from a bad-scan report (#952 phase 3)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1208,6 +1208,8 @@
   "featureDescription_tflitePricePrediction": "Modèle de prévision de prix sur l'appareil — l'inférence s'exécute localement ; les caractéristiques et les prédictions ne quittent jamais l'appareil.",
   "featureLabel_fuelCalculator": "Calculateur de coût de carburant",
   "featureDescription_fuelCalculator": "Calculateur de coût de carburant accessible depuis les résultats de recherche.",
+  "featureLabel_carbonDashboard": "Tableau de bord carbone",
+  "featureDescription_carbonDashboard": "Tableau de bord de l'empreinte CO2 accessible depuis l'onglet Consommation.",
   "featureBlockedEnable_tflitePricePrediction": "Activez d'abord l'historique des prix",
   "tripPathCardTitle": "Trace du trajet",
   "tripPathCardSubtitle": "Itinéraire enregistré par GPS",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7046,6 +7046,18 @@ abstract class AppLocalizations {
   /// **'Reachable fuel-cost calculator from the search results.'**
   String get featureDescription_fuelCalculator;
 
+  /// Settings toggle label for the Carbon dashboard feature (#1613).
+  ///
+  /// In en, this message translates to:
+  /// **'Carbon dashboard'**
+  String get featureLabel_carbonDashboard;
+
+  /// Settings toggle description for the Carbon dashboard feature (#1613).
+  ///
+  /// In en, this message translates to:
+  /// **'CO2 footprint dashboard reachable from the Consumption tab.'**
+  String get featureDescription_carbonDashboard;
+
   /// Title of the one-time consent dialog before we file a public GitHub issue from a bad-scan report (#952 phase 3).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3848,6 +3848,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3848,6 +3848,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3846,6 +3846,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3883,6 +3883,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Erreichbarer Tankkostenrechner aus den Suchergebnissen.';
 
   @override
+  String get featureLabel_carbonDashboard => 'CO2-Dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2-Bilanz-Dashboard, erreichbar über den Verbrauch-Tab.';
+
+  @override
   String get feedbackConsentTitle => 'Bericht an GitHub senden?';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3850,6 +3850,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3841,6 +3841,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3849,6 +3849,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3846,6 +3846,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3879,11 +3879,18 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activez d\'abord l\'historique des prix';
 
   @override
-  String get featureLabel_fuelCalculator => 'Fuel calculator';
+  String get featureLabel_fuelCalculator => 'Calculateur de coût de carburant';
 
   @override
   String get featureDescription_fuelCalculator =>
-      'Reachable fuel-cost calculator from the search results.';
+      'Calculateur de coût de carburant accessible depuis les résultats de recherche.';
+
+  @override
+  String get featureLabel_carbonDashboard => 'Tableau de bord carbone';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'Tableau de bord de l\'empreinte CO2 accessible depuis l\'onglet Consommation.';
 
   @override
   String get feedbackConsentTitle => 'Envoyer le rapport à GitHub ?';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3845,6 +3845,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3850,6 +3850,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3849,6 +3849,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3847,6 +3847,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3849,6 +3849,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3845,6 +3845,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3850,6 +3850,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3848,6 +3848,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3849,6 +3849,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3848,6 +3848,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3849,6 +3849,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3843,6 +3843,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3847,6 +3847,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Reachable fuel-cost calculator from the search results.';
 
   @override
+  String get featureLabel_carbonDashboard => 'Carbon dashboard';
+
+  @override
+  String get featureDescription_carbonDashboard =>
+      'CO2 footprint dashboard reachable from the Consumption tab.';
+
+  @override
   String get feedbackConsentTitle => 'Send report to GitHub?';
 
   @override

--- a/test/features/feature_management/carbon_dashboard_gate_test.dart
+++ b/test/features/feature_management/carbon_dashboard_gate_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+/// Pins the `Feature.carbonDashboard` gate (epic #1613, child #1637).
+///
+/// The Carbon dashboard already shipped live and reachable; this flag
+/// brings it under central feature management so it can be toggled per
+/// profile. It gates the Consumption-tab AppBar eco action and the
+/// `/carbon` route. Default-on preserves current behaviour.
+void main() {
+  const manifest = FeatureManifest.defaultManifest;
+
+  group('Feature.carbonDashboard manifest entry', () {
+    test('the default manifest declares an entry for carbonDashboard', () {
+      final entry = manifest.entries[Feature.carbonDashboard];
+      expect(entry, isNotNull);
+      expect(entry!.feature, Feature.carbonDashboard);
+    });
+
+    test('is default-enabled — preserves the dashboard being reachable', () {
+      expect(
+        manifest.entries[Feature.carbonDashboard]!.defaultEnabled,
+        isTrue,
+      );
+      expect(
+        manifest.defaultEnabledSet(),
+        contains(Feature.carbonDashboard),
+      );
+    });
+
+    test('has no prerequisites — it depends on nothing', () {
+      expect(manifest.entries[Feature.carbonDashboard]!.requires, isEmpty);
+    });
+  });
+}

--- a/test/features/feature_management/feature_manifest_completeness_test.dart
+++ b/test/features/feature_management/feature_manifest_completeness_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+/// Feature-manifest completeness invariants (epic #1613, child #1639).
+///
+/// Adding a value to the `Feature` enum without a matching
+/// `FeatureManifestEntry` would let the feature exist with no
+/// default-enabled state, display name or dependency edges — a silent
+/// gap. This test makes that gap a CI failure, and pins the #1613 gates
+/// (`fuelCalculator`, `carbonDashboard`) and their dependency edges.
+void main() {
+  const manifest = FeatureManifest.defaultManifest;
+
+  test('every Feature enum value has a default-manifest entry', () {
+    final missing = Feature.values
+        .where((f) => manifest.entries[f] == null)
+        .toList();
+    expect(missing, isEmpty,
+        reason: 'every Feature must have a FeatureManifestEntry — add one '
+            'to FeatureManifest.defaultManifest for: $missing');
+  });
+
+  test('every manifest entry is keyed by its own feature', () {
+    for (final entry in manifest.entries.entries) {
+      expect(entry.value.feature, entry.key,
+          reason: 'manifest map key ${entry.key} must match entry.feature');
+    }
+  });
+
+  test('every requires-edge points at a feature that exists in the manifest',
+      () {
+    for (final entry in manifest.entries.values) {
+      for (final dep in entry.requires) {
+        expect(manifest.entries[dep], isNotNull,
+            reason: '${entry.feature} requires $dep, which has no manifest '
+                'entry');
+      }
+    }
+  });
+
+  group('#1613 gates', () {
+    test('fuelCalculator and carbonDashboard are present and default-on', () {
+      for (final f in [Feature.fuelCalculator, Feature.carbonDashboard]) {
+        final entry = manifest.entries[f];
+        expect(entry, isNotNull, reason: '$f must be in the manifest');
+        expect(entry!.defaultEnabled, isTrue,
+            reason: '$f ships default-on so the surface stays reachable');
+        expect(entry.requires, isEmpty,
+            reason: '$f has no prerequisites');
+      }
+    });
+  });
+}

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -109,12 +109,12 @@ void main() {
           );
         }
       }
-      expect(Feature.values.length, 21,
+      expect(Feature.values.length, 22,
           reason: '#1373 phase 1 shipped 13 features; phase 3d added '
               'autoRecord (14); phase 3c bundled showFuel + showElectric + '
               'showConsumptionTab (17); #1517 added manualConsumption + '
               'loyaltyCards (19); #1543 added tflitePricePrediction (20); '
-              '#1613 added fuelCalculator (21). '
+              '#1613 added fuelCalculator (21) + carbonDashboard (22). '
               'Update the test if a new feature was added or removed.');
     });
 


### PR DESCRIPTION
Epic #1613, part 2 — #1637 + #1639.

- **#1637** — `Feature.carbonDashboard`: the Carbon dashboard's
  Consumption-tab eco action **and** its `/carbon` route are now gated
  on the central Feature enum (default-on; the route guard bounces a
  deep link back when the feature is off).
- **#1639** — `FEATURE_PARAMETER_MAP.md` gains the `fuelCalculator` +
  `carbonDashboard` rows; `feature_manifest_completeness_test.dart`
  pins the invariants (every Feature has a manifest entry, self-keyed,
  resolvable requires-edges) that would have caught the #1636 cascade.

Full `Feature`-enum cascade applied: enum, manifest, v2 known-features /
registry, the 3 feature_management_section switches, ARB (en/de/fr),
feature-count test 21 → 22.

`flutter analyze` clean; feature-management + localization tests pass.

#1638 (gate Payment-QR + Community Report) is intentionally not in this
PR — it carries an open product decision.

Closes #1637, #1639. Part of epic #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)