### PR TITLE
chore(driving): remove hapticEcoCoach StateError swallow + gate its toggle (#1608)

### DIFF
--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -8,6 +8,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/conso_mode.dart';
 import '../../../feature_management/domain/feature.dart';
+import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../../../glide_coach/data/traffic_signal_repository.dart';
 import '../../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../../../profile/presentation/widgets/gamification_settings_tile.dart';
@@ -38,6 +39,17 @@ class DrivingSettingsSection extends ConsumerWidget {
     final theme = Theme.of(context);
     final ecoEnabled = ref.watch(hapticEcoCoachEnabledProvider);
     final flags = ref.watch(featureFlagsProvider);
+    // #1608 — the haptic eco-coach toggle must pre-check the dependency:
+    // enabling it while `obd2TripRecording` is off throws a StateError
+    // in the central provider. When the parent is off (and the toggle
+    // isn't already on) the switch is disabled rather than letting the
+    // tap fail.
+    final canToggleEco = ecoEnabled ||
+        canEnable(
+          Feature.hapticEcoCoach,
+          ref.watch(featureManifestProvider),
+          flags,
+        );
     // #1517 / #1520 — gate the Loyalty tile by the new
     // [Feature.loyaltyCards] flag. Default-off; only the
     // `AppProfile.full` preset turns it on, so Basic + Medium users
@@ -108,8 +120,10 @@ class DrivingSettingsSection extends ConsumerWidget {
                     'during cruise',
             style: theme.textTheme.bodySmall,
           ),
-          onChanged: (v) =>
-              ref.read(hapticEcoCoachEnabledProvider.notifier).set(v),
+          onChanged: canToggleEco
+              ? (v) =>
+                  ref.read(hapticEcoCoachEnabledProvider.notifier).set(v)
+              : null,
           contentPadding: EdgeInsets.zero,
         ),
         const GamificationSettingsTile(),

--- a/lib/features/driving/providers/haptic_eco_coach_provider.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.dart
@@ -41,33 +41,19 @@ class HapticEcoCoachEnabled extends _$HapticEcoCoachEnabled {
   /// while a trip is recording starts the coach immediately, and a
   /// `set(false)` cancels its subscription on the next frame.
   ///
-  /// A [StateError] from a dependency-violation is intentionally
-  /// swallowed and the toggle stays at its prior state — see the
-  /// catch block below for why.
+  /// Enabling `hapticEcoCoach` while its `obd2TripRecording` parent is
+  /// off is a dependency violation — `featureFlagsProvider.enable`
+  /// throws a [StateError] for it, and this setter lets that surface
+  /// (#1608). Callers MUST pre-check [canEnable] first; the only call
+  /// site, the driving-settings toggle, disables itself when the parent
+  /// is off. A swallow used to hide this (`TODO(1373)`) — removed once
+  /// the single call site was audited for pre-check coverage.
   Future<void> set(bool value) async {
     final notifier = ref.read(featureFlagsProvider.notifier);
-    try {
-      if (value) {
-        await notifier.enable(Feature.hapticEcoCoach);
-      } else {
-        await notifier.disable(Feature.hapticEcoCoach);
-      }
-      // The central provider throws a StateError specifically for
-      // dependency-violation; we want to swallow ONLY that — see the
-      // body comment for why. The lint deliberately discourages
-      // catching Error subclasses, but the central API's contract
-      // documents this exact StateError as the dependency-violation
-      // signal, so the catch is intentional and narrow.
-      // ignore: avoid_catching_errors
-    } on StateError {
-      // TODO(1373): Phase 2's settings UI already pre-checks
-      // `canEnable` / `blockingDisable` before invoking this setter, so
-      // a dependency-violation here is a defensive-only catch — the UI
-      // path can't currently reach it. We swallow rather than rethrow
-      // so a programmatic caller (e.g. a test or a future call site)
-      // sees the toggle stay at its prior state instead of crashing
-      // the widget tree. Remove once every call site has been audited
-      // for `canEnable` pre-check coverage.
+    if (value) {
+      await notifier.enable(Feature.hapticEcoCoach);
+    } else {
+      await notifier.disable(Feature.hapticEcoCoach);
     }
   }
 }

--- a/test/features/driving/providers/haptic_eco_coach_provider_test.dart
+++ b/test/features/driving/providers/haptic_eco_coach_provider_test.dart
@@ -21,10 +21,10 @@ import 'package:tankstellen/features/feature_management/domain/feature.dart';
 ///      [Feature.hapticEcoCoach].
 ///   2. `set(true)` enables `hapticEcoCoach` in the central provider.
 ///   3. `set(false)` disables it.
-///   4. A dependency-violation is swallowed and the toggle stays at
-///      its prior state — the central provider throws StateError when
-///      `obd2TripRecording` is missing; the shim's catch must surface
-///      that as "no-op" rather than a thrown error.
+///   4. A dependency-violation surfaces (#1608): enabling
+///      `hapticEcoCoach` while `obd2TripRecording` is missing throws
+///      the central provider's StateError — the shim no longer
+///      swallows it, so a mis-gated call site fails loudly.
 ///
 /// Migration concerns (the legacy `hapticEcoCoachEnabled` Hive key
 /// → central state promotion) are covered in
@@ -159,33 +159,29 @@ void main() {
       expect(container.read(hapticEcoCoachEnabledProvider), isFalse);
     });
 
-    test('set(true) is a no-op when prerequisite is missing — does NOT throw',
-        () async {
-      // Prerequisite obd2TripRecording is OFF. Calling enable on the
-      // central provider would throw StateError; the shim must swallow
-      // it and leave the toggle at its prior state.
+    test('set(true) surfaces a StateError when the prerequisite is missing '
+        '(#1608)', () async {
+      // Prerequisite obd2TripRecording is OFF — enabling hapticEcoCoach
+      // is a dependency violation. Since #1608 the shim no longer
+      // swallows it: the central provider's StateError surfaces so a
+      // mis-gated call site fails loudly instead of silently no-op'ing.
+      // The only real call site, the driving-settings toggle, disables
+      // itself when the parent is off (canEnable pre-check), so the UI
+      // path can never reach this — only a programmatic caller can.
       final container = makeContainer();
       await pumpLoad(container);
 
-      // No throw expected.
-      await container
-          .read(hapticEcoCoachEnabledProvider.notifier)
-          .set(true);
-
-      expect(
-        container.read(hapticEcoCoachEnabledProvider),
-        isFalse,
-        reason:
-            'Dependency-violation must be silent at the shim layer — the '
-            'Phase 2 settings UI pre-checks `canEnable`, so reaching this '
-            'path means a programmatic / test caller bypassed the guard. '
-            'The shim swallows so the widget tree stays standing rather '
-            'than crashing on a developer mistake.',
+      await expectLater(
+        container.read(hapticEcoCoachEnabledProvider.notifier).set(true),
+        throwsStateError,
       );
+
+      // The violating enable did not take effect — state is unchanged.
       expect(
         container.read(featureFlagsProvider),
         isNot(contains(Feature.hapticEcoCoach)),
       );
+      expect(container.read(hapticEcoCoachEnabledProvider), isFalse);
     });
   });
 


### PR DESCRIPTION
Closes #1608. Removes the `TODO(1373)` defensive `StateError` swallow in
`HapticEcoCoachEnabled.set()` after auditing its single call site.

- `set()` has one call site (`driving_settings_section.dart` eco-coach
  toggle); it did not pre-check the dependency.
- The toggle now disables itself via a `canEnable` pre-check when
  `obd2TripRecording` (the parent) is off — the UI can't reach a
  violating `set(true)`.
- The swallow + `avoid_catching_errors` ignore are gone; a real
  dependency violation surfaces. The provider test now asserts the
  violating `set(true)` throws `StateError`.

`flutter analyze` clean; driving provider + section tests pass.

Closes #1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)