### PR TITLE
refactor(ui): theme SnackBarHelper + status icons (#1683 + #1692 cluster)

### DIFF
--- a/lib/core/widgets/snackbar_helper.dart
+++ b/lib/core/widgets/snackbar_helper.dart
@@ -1,7 +1,14 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/app_localizations.dart';
+
 /// Centralized SnackBar utility to eliminate duplicate
 /// ScaffoldMessenger.of(context).showSnackBar calls.
+///
+/// Success and error snackbars are themed via [ColorScheme] (never
+/// hard-coded colours, so dark mode stays harmonious) and carry a
+/// leading icon — so the success/error distinction is conveyed by more
+/// than colour alone (#1683 / #1692, accessibility).
 ///
 /// Usage:
 /// ```dart
@@ -14,46 +21,92 @@ class SnackBarHelper {
   SnackBarHelper._();
 
   /// Show a simple informational snackbar.
-  static void show(BuildContext context, String message, {Duration duration = const Duration(seconds: 3)}) {
+  static void show(BuildContext context, String message,
+      {Duration duration = const Duration(seconds: 3)}) {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message), duration: duration),
     );
   }
 
-  /// Show a success snackbar (green background).
-  static void showSuccess(BuildContext context, String message, {Duration duration = const Duration(seconds: 3)}) {
+  /// Show a success snackbar — themed (`tertiaryContainer`) with a
+  /// check icon so success is not signalled by colour alone.
+  static void showSuccess(BuildContext context, String message,
+      {Duration duration = const Duration(seconds: 3)}) {
     if (!context.mounted) return;
+    final scheme = Theme.of(context).colorScheme;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(message),
-        backgroundColor: Colors.green,
+        content: _IconatedContent(
+          icon: Icons.check_circle_outline,
+          message: message,
+          foreground: scheme.onTertiaryContainer,
+        ),
+        backgroundColor: scheme.tertiaryContainer,
         duration: duration,
       ),
     );
   }
 
-  /// Show a snackbar with an undo action.
-  static void showWithUndo(BuildContext context, String message, {required VoidCallback onUndo, String undoLabel = 'Undo'}) {
+  /// Show a snackbar with an undo action. [undoLabel] defaults to the
+  /// localized "Undo" string — never a hard-coded literal.
+  static void showWithUndo(BuildContext context, String message,
+      {required VoidCallback onUndo, String? undoLabel}) {
     if (!context.mounted) return;
+    final label =
+        undoLabel ?? AppLocalizations.of(context)?.undo ?? 'Undo';
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),
         duration: const Duration(seconds: 4),
-        action: SnackBarAction(label: undoLabel, onPressed: onUndo),
+        action: SnackBarAction(label: label, onPressed: onUndo),
       ),
     );
   }
 
-  /// Show an error snackbar (red background).
+  /// Show an error snackbar — themed (`errorContainer`) with an error
+  /// icon so the failure is not signalled by colour alone.
   static void showError(BuildContext context, String message) {
     if (!context.mounted) return;
+    final scheme = Theme.of(context).colorScheme;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(message),
-        backgroundColor: Theme.of(context).colorScheme.error,
+        content: _IconatedContent(
+          icon: Icons.error_outline,
+          message: message,
+          foreground: scheme.onErrorContainer,
+        ),
+        backgroundColor: scheme.errorContainer,
         duration: const Duration(seconds: 5),
       ),
+    );
+  }
+}
+
+/// SnackBar content row: a leading status icon plus the message. The
+/// icon gives success/error a non-colour signal; the message [Text] is
+/// what the screen reader announces when the SnackBar appears.
+class _IconatedContent extends StatelessWidget {
+  const _IconatedContent({
+    required this.icon,
+    required this.message,
+    required this.foreground,
+  });
+
+  final IconData icon;
+  final String message;
+  final Color foreground;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, color: foreground, size: 20),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(message, style: TextStyle(color: foreground)),
+        ),
+      ],
     );
   }
 }

--- a/test/core/widgets/snackbar_helper_test.dart
+++ b/test/core/widgets/snackbar_helper_test.dart
@@ -37,7 +37,8 @@ void main() {
       expect(find.text('Short message'), findsOneWidget);
     });
 
-    testWidgets('showSuccess() displays green snackbar', (tester) async {
+    testWidgets('showSuccess() displays a themed snackbar with a check icon',
+        (tester) async {
       await pumpApp(tester, Builder(
         builder: (context) => ElevatedButton(
           onPressed: () => SnackBarHelper.showSuccess(context, 'Success!'),
@@ -50,12 +51,17 @@ void main() {
 
       expect(find.text('Success!'), findsOneWidget);
 
-      // Verify green background
+      // #1683/#1692 — themed via colorScheme (never hard-coded green, so
+      // dark mode stays harmonious) and carries a check icon so success
+      // is signalled by more than colour alone.
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
-      expect(snackBar.backgroundColor, Colors.green);
+      expect(snackBar.backgroundColor, isNotNull);
+      expect(snackBar.backgroundColor, isNot(Colors.green));
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
     });
 
-    testWidgets('showError() displays red snackbar', (tester) async {
+    testWidgets('showError() displays a themed snackbar with an error icon',
+        (tester) async {
       await pumpApp(tester, Builder(
         builder: (context) => ElevatedButton(
           onPressed: () => SnackBarHelper.showError(context, 'Error occurred'),
@@ -68,11 +74,11 @@ void main() {
 
       expect(find.text('Error occurred'), findsOneWidget);
 
-      // Verify error color background
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
       expect(snackBar.backgroundColor, isNotNull);
-      // Theme.of(context).colorScheme.error — just verify it's not null/green
       expect(snackBar.backgroundColor, isNot(Colors.green));
+      // #1692 — error is signalled by an icon, not colour alone.
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
     });
 
     testWidgets('showError() has 5-second duration', (tester) async {


### PR DESCRIPTION
Shared foundation of the #1709 SnackBar cluster (#1683 + #1692, same
files — bundled per the loop-efficiency practice).

- `showSuccess` drops hard-coded `Colors.green` → `colorScheme`
  (`tertiaryContainer`); dark mode stays harmonious.
- `showError` → `colorScheme.errorContainer`.
- Both gain a leading status icon — success/error no longer signalled
  by colour alone (accessibility).
- `showWithUndo` default label comes from the `undo` ARB key, not a
  hard-coded literal.

`flutter analyze` (whole repo) clean; snackbar_helper + no_hardcoded
lint tests pass.

Part of #1683, #1692 — the remaining call-site sweeps (route the 39
raw SnackBars; localize `e.toString()` snackbars; fill-up save
confirmation) continue on those issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
