### PR TITLE
chore(deps): document the held-back dependency pins (#1684)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,9 @@ dependencies:
   # Maps & Location
   flutter_map: ^8.3.0
   flutter_map_marker_cluster: ^8.2.2
+  # Pinned to 0.x — latlong2 0.10.x is a breaking API bump used
+  # pervasively by the map + routing layer. Bump under its own
+  # migration pass, not as routine drift (#1684).
   latlong2: ^0.9.1
   geolocator: ^14.0.2
   geocoding: ^4.0.0
@@ -49,6 +52,9 @@ dependencies:
   # Utilities
   collection: ^1.19.0
   meta: ^1.17.0
+  # Pinned to 6.x — xml 7.x is a major bump; the 17 country
+  # station-service parsers depend on the 6.x API. Bump under its own
+  # pass (#1684).
   xml: ^6.6.1
   path_provider: ^2.1.5
   uuid: ^4.5.1
@@ -66,11 +72,19 @@ dependencies:
   shared_preferences: ^2.5.5
   url_launcher: ^6.3.1
   http: ^1.3.0
+  # Pinned to 12.x — share_plus 13.x is a major bump; deferred to its
+  # own migration pass (#1684).
   share_plus: ^12.0.2
+  # Pinned to 1.x — flutter_blue_plus 2.x is a major BLE-API rewrite,
+  # and BLE is core to OBD2 trip recording. The 2.x upgrade is tracked
+  # separately as part of #1542; do NOT bump it as routine drift.
   flutter_blue_plus: ^1.35.5
   async: ^2.11.0
   permission_handler: ^12.0.0+1
   flutter_secure_storage: ^10.2.0
+  # Pinned to 8.x — package_info_plus 9.x/10.x are major bumps; the app
+  # only reads the version string, so the upgrade is low-value and
+  # deferred to its own pass (#1684).
   package_info_plus: ^8.3.1
   sentry_flutter: ^9.20.0
   home_widget: ^0.9.1


### PR DESCRIPTION
Closes #1684. The #1678 audit flagged five direct deps a major behind
with no recorded reason. Evaluated each — none resolves within current
constraints (`flutter pub outdated` confirmed) — and documented the
pins in `pubspec.yaml`, matching the existing `connectivity_plus`
convention:

- `flutter_blue_plus` 2.x — major BLE-API rewrite, core to OBD2; the
  upgrade is tracked separately in #1542.
- `latlong2` / `share_plus` / `xml` / `package_info_plus` — major
  breaking bumps deferred to their own verification passes.

Comment-only change — `flutter pub get` + whole-repo `flutter analyze`
clean, no version change.

Closes #1684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
