### PR TITLE
fix(error): log the swallowed exceptions in the three silent catch blocks (#1682)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -768,7 +768,11 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       final avg = stats.avgConsumptionL100km;
       if (avg == null) return null;
       return '${avg.toStringAsFixed(1)} L/100 km';
-    } catch (_) {
+    } catch (e, st) {
+      // A malformed fill-up set must not crash the summary card —
+      // but log the cause rather than hiding it silently (#1682).
+      debugPrint(
+          'TripRecordingScreen: consumption summary calc failed: $e\n$st');
       return null;
     }
   }

--- a/lib/features/map/data/retry_network_tile_provider.dart
+++ b/lib/features/map/data/retry_network_tile_provider.dart
@@ -248,7 +248,12 @@ class RetryingTileHttpClient extends http.BaseClient {
       final when = HttpDate.parse(raw);
       final diff = when.difference(DateTime.now());
       return diff.isNegative ? Duration.zero : diff;
-    } catch (_) {
+    } catch (e, st) {
+      // Malformed Retry-After header — fall back to exponential
+      // backoff. Log so a persistently-bad upstream header is visible
+      // rather than silently discarded (#1682).
+      debugPrint(
+          'RetryingTileHttpClient: unparseable Retry-After "$raw": $e\n$st');
       return null;
     }
   }

--- a/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
+++ b/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
@@ -299,10 +299,20 @@ class VinAdapterPairAutoPopulator {
     } finally {
       try {
         await service?.disconnect();
-      } catch (_) {
-        // Disconnect failures aren't actionable here. The next pair
-        // attempt re-runs the connect path which handles a stuck
-        // transport.
+      } catch (e, st) {
+        // Disconnect failures aren't actionable here — the next pair
+        // attempt re-runs the connect path, which handles a stuck
+        // transport — but log so a recurring field failure isn't
+        // invisible (#1682). Routed through errorLogger to match the
+        // rest of this file rather than a raw debugPrint.
+        await errorLogger.log(
+          ErrorLayer.background,
+          e,
+          st,
+          context: const {
+            'op': 'vinAdapterPairAutoPopulator.disconnect',
+          },
+        );
       }
     }
   }


### PR DESCRIPTION
Closes #1682.

- **F7** — the three `catch (_)` blocks the #1678 audit flagged now log
  their error via `debugPrint` (behaviour unchanged — non-fatal no-op):
  OBD2 disconnect, unparseable `Retry-After` header, consumption-summary
  calc.
- **F8** — verified against source: the `.value!` sites in
  `search_screen` / `map_screen` are all `.hasValue`-guarded and there
  are no unguarded `.requireValue` calls — the audit finding was stale,
  nothing to change.

`flutter analyze` (whole repo) clean; logging-only, no behaviour change.

Closes #1682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
