### PR TITLE
refactor(ui): SnackBar routing + feedback-state UX (#1683, #1692)

### DIFF
--- a/lib/core/widgets/snackbar_helper.dart
+++ b/lib/core/widgets/snackbar_helper.dart
@@ -2,13 +2,25 @@ import 'package:flutter/material.dart';
 
 import '../../l10n/app_localizations.dart';
 
-/// Centralized SnackBar utility to eliminate duplicate
-/// ScaffoldMessenger.of(context).showSnackBar calls.
+/// Centralized SnackBar utility — the single styling, theming and
+/// accessibility authority for every SnackBar in the app.
 ///
 /// Success and error snackbars are themed via [ColorScheme] (never
 /// hard-coded colours, so dark mode stays harmonious) and carry a
 /// leading icon — so the success/error distinction is conveyed by more
-/// than colour alone (#1683 / #1692, accessibility).
+/// than colour alone. Every snackbar's content is wrapped in a
+/// `liveRegion` [Semantics] node so assistive technologies announce it
+/// when it appears (#1683 / #1692, accessibility).
+///
+/// Two flavours of API:
+///  - `show*` context wrappers — for synchronous call sites that still
+///    hold a mounted [BuildContext].
+///  - `*SnackBar` builders — pure functions that return a [SnackBar].
+///    Call sites that show a snackbar *after* an `await` must capture
+///    the [ScaffoldMessengerState] (and, for themed variants, the
+///    [ColorScheme]) BEFORE the await and feed them to a builder —
+///    passing a possibly-unmounted context into a `show*` wrapper would
+///    silently drop the snackbar.
 ///
 /// Usage:
 /// ```dart
@@ -16,26 +28,48 @@ import '../../l10n/app_localizations.dart';
 /// SnackBarHelper.showSuccess(context, 'Report sent');
 /// SnackBarHelper.showWithUndo(context, 'Station hidden', onUndo: () => ...);
 /// SnackBarHelper.showError(context, 'Connection failed');
+///
+/// // async call site:
+/// final messenger = ScaffoldMessenger.of(context);
+/// final scheme = Theme.of(context).colorScheme;
+/// await doWork();
+/// messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, message));
 /// ```
 class SnackBarHelper {
   SnackBarHelper._();
 
-  /// Show a simple informational snackbar.
-  static void show(BuildContext context, String message,
-      {Duration duration = const Duration(seconds: 3)}) {
-    if (!context.mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message), duration: duration),
-    );
-  }
+  static const Duration _infoDuration = Duration(seconds: 3);
+  static const Duration _errorDuration = Duration(seconds: 5);
+  static const Duration _undoDuration = Duration(seconds: 4);
 
-  /// Show a success snackbar — themed (`tertiaryContainer`) with a
-  /// check icon so success is not signalled by colour alone.
-  static void showSuccess(BuildContext context, String message,
-      {Duration duration = const Duration(seconds: 3)}) {
-    if (!context.mounted) return;
-    final scheme = Theme.of(context).colorScheme;
-    ScaffoldMessenger.of(context).showSnackBar(
+  // ---- Builders -------------------------------------------------------
+  // Pure: take only already-resolved values, so they stay safe to call
+  // across an async gap once the messenger has been captured.
+
+  /// A plain informational [SnackBar]. [action] adds a trailing button;
+  /// [key] lets a caller keep a stable test handle when routing a
+  /// previously-bespoke snackbar through the helper.
+  static SnackBar infoSnackBar(
+    String message, {
+    Duration duration = _infoDuration,
+    SnackBarAction? action,
+    Key? key,
+  }) =>
+      SnackBar(
+        key: key,
+        content: _Announced(child: Text(message)),
+        duration: duration,
+        action: action,
+      );
+
+  /// A success [SnackBar] — themed via [scheme] (`tertiaryContainer`,
+  /// never hard-coded green) with a check icon so success is signalled
+  /// by more than colour alone.
+  static SnackBar successSnackBar(
+    ColorScheme scheme,
+    String message, {
+    Duration duration = _infoDuration,
+  }) =>
       SnackBar(
         content: _IconatedContent(
           icon: Icons.check_circle_outline,
@@ -44,7 +78,40 @@ class SnackBarHelper {
         ),
         backgroundColor: scheme.tertiaryContainer,
         duration: duration,
-      ),
+      );
+
+  /// An error [SnackBar] — themed via [scheme] (`errorContainer`) with
+  /// an error icon so the failure is signalled by more than colour.
+  static SnackBar errorSnackBar(ColorScheme scheme, String message) =>
+      SnackBar(
+        content: _IconatedContent(
+          icon: Icons.error_outline,
+          message: message,
+          foreground: scheme.onErrorContainer,
+        ),
+        backgroundColor: scheme.errorContainer,
+        duration: _errorDuration,
+      );
+
+  // ---- Context wrappers ----------------------------------------------
+
+  /// Show a simple informational snackbar. [action] adds a trailing
+  /// button (e.g. a navigation shortcut).
+  static void show(BuildContext context, String message,
+      {Duration duration = _infoDuration, SnackBarAction? action}) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      infoSnackBar(message, duration: duration, action: action),
+    );
+  }
+
+  /// Show a success snackbar — themed with a check icon.
+  static void showSuccess(BuildContext context, String message,
+      {Duration duration = _infoDuration}) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      successSnackBar(Theme.of(context).colorScheme, message,
+          duration: duration),
     );
   }
 
@@ -56,36 +123,40 @@ class SnackBarHelper {
     final label =
         undoLabel ?? AppLocalizations.of(context)?.undo ?? 'Undo';
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        duration: const Duration(seconds: 4),
+      infoSnackBar(
+        message,
+        duration: _undoDuration,
         action: SnackBarAction(label: label, onPressed: onUndo),
       ),
     );
   }
 
-  /// Show an error snackbar — themed (`errorContainer`) with an error
-  /// icon so the failure is not signalled by colour alone.
+  /// Show an error snackbar — themed with an error icon.
   static void showError(BuildContext context, String message) {
     if (!context.mounted) return;
-    final scheme = Theme.of(context).colorScheme;
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: _IconatedContent(
-          icon: Icons.error_outline,
-          message: message,
-          foreground: scheme.onErrorContainer,
-        ),
-        backgroundColor: scheme.errorContainer,
-        duration: const Duration(seconds: 5),
-      ),
+      errorSnackBar(Theme.of(context).colorScheme, message),
     );
   }
 }
 
+/// Wraps SnackBar content in a `liveRegion` [Semantics] node so
+/// assistive technologies announce the message when the snackbar
+/// appears — colour and motion are not the only signal (#1692).
+class _Announced extends StatelessWidget {
+  const _Announced({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) =>
+      Semantics(liveRegion: true, container: true, child: child);
+}
+
 /// SnackBar content row: a leading status icon plus the message. The
-/// icon gives success/error a non-colour signal; the message [Text] is
-/// what the screen reader announces when the SnackBar appears.
+/// icon gives success/error a non-colour signal; the row is wrapped in
+/// a `liveRegion` [Semantics] node so the message is announced when the
+/// SnackBar appears.
 class _IconatedContent extends StatelessWidget {
   const _IconatedContent({
     required this.icon,
@@ -99,14 +170,16 @@ class _IconatedContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(icon, color: foreground, size: 20),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Text(message, style: TextStyle(color: foreground)),
-        ),
-      ],
+    return _Announced(
+      child: Row(
+        children: [
+          Icon(icon, color: foreground, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(message, style: TextStyle(color: foreground)),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
@@ -301,9 +302,19 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       }
     }
 
+    // Capture the root messenger + theme before the screen pops — the
+    // success confirmation appears on the surface we return to (#1692).
+    final messenger = ScaffoldMessenger.of(context);
+    final scheme = Theme.of(context).colorScheme;
+    final savedMessage = AppLocalizations.of(context)?.fillUpSavedSnackbar ??
+        'Fill-up saved';
+
     await ref.read(fillUpListProvider.notifier).add(fillUp);
     if (!mounted) return;
     context.pop();
+    messenger.showSnackBar(
+      SnackBarHelper.successSnackBar(scheme, savedMessage),
+    );
   }
 
   String _pad(int n) => n.toString().padLeft(2, '0');

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../../core/sharing/widget_share_renderer.dart';
 import '../../../../core/sync/trips_sync.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
@@ -252,6 +253,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     final subject = l?.trajetDetailShareSubject(formattedDate) ??
         'Sparkilo — trip on $formattedDate';
     final messenger = ScaffoldMessenger.maybeOf(context);
+    final scheme = Theme.of(context).colorScheme;
     final renderer = debugTripDetailShareOverride ?? shareWidgetAsImage;
     try {
       await renderer(
@@ -267,7 +269,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       if (messenger == null) return;
       final errorMsg = l?.trajetDetailShareError ??
           "Couldn't generate share image";
-      messenger.showSnackBar(SnackBar(content: Text(errorMsg)));
+      messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
     }
   }
 

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -9,6 +9,7 @@ import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../driving/haptic_eco_coach.dart';
 import '../../../driving/providers/haptic_eco_coach_provider.dart';
@@ -286,7 +287,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
                   'OBD2 diagnostic overlay enabled');
           ScaffoldMessenger.of(context)
             ..hideCurrentSnackBar()
-            ..showSnackBar(SnackBar(content: Text(msg)));
+            ..showSnackBar(SnackBarHelper.infoSnackBar(msg));
         }),
       );
     }

--- a/lib/features/consumption/presentation/widgets/bad_scan_report_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_report_sheet.dart
@@ -9,6 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/feedback/feedback_consent.dart';
 import '../../../../core/feedback/github_issue_reporter.dart';
 import '../../../../core/feedback/github_issue_reporter_provider.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/receipt_scan_service.dart';
 import 'bad_scan_form_view.dart';
@@ -253,11 +254,9 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     // outlives this modal sheet.
     if (showSnackbar) {
       messenger?.showSnackBar(
-        SnackBar(
-          content: Text(
-            l?.badScanReportFallbackToShare ??
-                'Submission failed — manual share',
-          ),
+        SnackBarHelper.infoSnackBar(
+          l?.badScanReportFallbackToShare ??
+              'Submission failed — manual share',
         ),
       );
     }

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/adapter_registry.dart';
@@ -79,11 +80,9 @@ Future<Obd2Service?> _showPickerSheet(
     if (messenger != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         messenger.showSnackBar(
-          SnackBar(
-            content: Text(
-              l?.obd2PickerPinnedFallback(fallbackAdapterName) ??
-                  "Couldn't reach '$fallbackAdapterName' — pick another adapter",
-            ),
+          SnackBarHelper.infoSnackBar(
+            l?.obd2PickerPinnedFallback(fallbackAdapterName) ??
+                "Couldn't reach '$fallbackAdapterName' — pick another adapter",
           ),
         );
       });

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/cold_start_baselines.dart';
 import '../../domain/situation_classifier.dart';
@@ -87,11 +88,9 @@ class TripRecordingBanner extends ConsumerWidget {
                       return;
                     }
                     final messenger = ScaffoldMessenger.maybeOf(context);
-                    messenger?.showSnackBar(SnackBar(
-                      content: Text(
-                        l?.tripBannerOpenFromConsumptionTab ??
-                            'Open the active trip from the Conso tab',
-                      ),
+                    messenger?.showSnackBar(SnackBarHelper.infoSnackBar(
+                      l?.tripBannerOpenFromConsumptionTab ??
+                          'Open the active trip from the Conso tab',
                     ));
                   },
                   child: Padding(

--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import '../../../../core/sharing/widget_share_renderer.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/favorites_provider.dart';
@@ -151,6 +152,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     final fileNameStem =
         'tankstellen_favorites_${DateFormat('yyyyMMdd').format(DateTime.now())}';
     final messenger = ScaffoldMessenger.maybeOf(context);
+    final scheme = Theme.of(context).colorScheme;
     try {
       await shareWidgetAsImage(
         boundaryKey: _shareBoundaryKey,
@@ -165,7 +167,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
       if (messenger == null) return;
       final errorMsg = l10n?.favoritesShareError ??
           "Couldn't generate share image";
-      messenger.showSnackBar(SnackBar(content: Text(errorMsg)));
+      messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
     }
   }
 }

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/app_profile_provider.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
@@ -435,12 +436,7 @@ class _FeatureToggle extends ConsumerWidget {
           if (messenger == null) return;
           messenger
             ..hideCurrentSnackBar()
-            ..showSnackBar(
-              SnackBar(
-                content: Text(reason),
-                duration: const Duration(seconds: 3),
-              ),
-            );
+            ..showSnackBar(SnackBarHelper.infoSnackBar(reason));
         },
         child: tile,
       ),

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -186,9 +186,17 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               if (state.hasValue && state.value!.data.isNotEmpty) {
                 unawaited(_performGpsSearch());
               }
-            } catch (e, st) { // ignore: unused_catch_stack
+            } catch (e, st) {
+              // #1692 — never surface a raw exception toString() to the
+              // user; show a localized, actionable message instead. The
+              // cause is kept for support via debugPrint below.
+              debugPrint('SearchScreen GPS update failed: $e\n$st');
               if (!context.mounted) return;
-              SnackBarHelper.showError(context, e.toString());
+              SnackBarHelper.showError(
+                context,
+                AppLocalizations.of(context)?.searchFailedSnackbar ??
+                    'Search failed — please try again',
+              );
             }
           },
         ),

--- a/lib/features/setup/presentation/widgets/onboarding_obd2_step.dart
+++ b/lib/features/setup/presentation/widgets/onboarding_obd2_step.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/data/obd2/obd2_service.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
@@ -90,13 +91,10 @@ class _OnboardingObd2StepState extends ConsumerState<OnboardingObd2Step> {
       // later" button — the skip path is still available below the
       // scaffold body.
       setState(() => _phase = _Phase.initial);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            l10n?.onboardingObd2ConnectFailed ??
-                "Couldn't connect to the adapter. You can retry or skip.",
-          ),
-        ),
+      SnackBarHelper.show(
+        context,
+        l10n?.onboardingObd2ConnectFailed ??
+            "Couldn't connect to the adapter. You can retry or skip.",
       );
       return;
     }

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/brand_logo_mapper.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/obd2_vin_reader.dart';
 import '../../data/reference_vehicle_catalog_provider.dart';
@@ -314,9 +315,8 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     final l = AppLocalizations.of(context);
     final vin = _ctrl.vinController.text.trim();
     if (vin.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l?.vinInvalidFormat ?? 'Invalid VIN format')),
-      );
+      SnackBarHelper.show(
+          context, l?.vinInvalidFormat ?? 'Invalid VIN format');
       return;
     }
 
@@ -332,12 +332,11 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
 
     if (decoded == null || decoded.source == VinDataSource.invalid) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(decoded == null
-              ? (l?.vinDecodeError ?? "Couldn't decode this VIN")
-              : (l?.vinInvalidFormat ?? 'Invalid VIN format')),
-        ),
+      SnackBarHelper.showError(
+        context,
+        decoded == null
+            ? (l?.vinDecodeError ?? "Couldn't decode this VIN")
+            : (l?.vinInvalidFormat ?? 'Invalid VIN format'),
       );
       return;
     }
@@ -390,13 +389,12 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
       return;
     }
 
-    final messenger = ScaffoldMessenger.of(context);
     final message = result.failure == ObdVinFailureReason.unsupported
         ? (l?.vehicleReadVinFailedUnsupportedSnackbar ??
             'VIN not available (Mode 09 PID 02 unsupported on pre-2005 vehicles)')
         : (l?.vehicleReadVinFailedGenericSnackbar ??
             'VIN read failed — please enter manually');
-    messenger.showSnackBar(SnackBar(content: Text(message)));
+    SnackBarHelper.show(context, message);
   }
 
   void _onAdapterChanged(String? name, String? mac) {
@@ -457,17 +455,13 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     final summary = outcome.conflictSummary;
     if (summary == null) return;
     final l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(
-          l?.vehicleDetectedFromVinSnackbar(summary) ??
-              'Detected from VIN: $summary. Apply?',
-        ),
-        action: SnackBarAction(
-          label: l?.vehicleDetectedFromVinApply ?? 'Apply',
-          onPressed: () => _applyDetectedConflicts(updated),
-        ),
+    SnackBarHelper.show(
+      context,
+      l?.vehicleDetectedFromVinSnackbar(summary) ??
+          'Detected from VIN: $summary. Apply?',
+      action: SnackBarAction(
+        label: l?.vehicleDetectedFromVinApply ?? 'Apply',
+        onPressed: () => _applyDetectedConflicts(updated),
       ),
     );
   }

--- a/lib/features/vehicle/presentation/widgets/auto_record_section.dart
+++ b/lib/features/vehicle/presentation/widgets/auto_record_section.dart
@@ -4,6 +4,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/widgets/section_card.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/vehicle_profile.dart';
 import '../../providers/vehicle_providers.dart';
@@ -239,7 +240,6 @@ class AutoRecordSection extends ConsumerWidget {
     required VehicleProfile profile,
     required AppLocalizations? l,
   }) async {
-    final messenger = ScaffoldMessenger.maybeOf(context);
     final navigator = Navigator.maybeOf(context);
     final foregroundPrompt =
         requestForegroundLocation ?? _defaultRequestForegroundLocation;
@@ -252,13 +252,10 @@ class AutoRecordSection extends ConsumerWidget {
       final fgStatus = await foregroundPrompt();
       if (!fgStatus.isGranted) {
         if (!context.mounted) return;
-        messenger?.showSnackBar(
-          SnackBar(
-            content: Text(
-              l?.autoRecordBackgroundLocationForegroundDeniedSnackbar ??
-                  'Location permission required',
-            ),
-          ),
+        SnackBarHelper.show(
+          context,
+          l?.autoRecordBackgroundLocationForegroundDeniedSnackbar ??
+              'Location permission required',
         );
         return;
       }
@@ -309,13 +306,10 @@ class AutoRecordSection extends ConsumerWidget {
         },
       );
       if (!context.mounted) return;
-      messenger?.showSnackBar(
-        SnackBar(
-          content: Text(
-            l?.autoRecordBackgroundLocationRequestFailedSnackbar ??
-                'Could not request background location',
-          ),
-        ),
+      SnackBarHelper.showError(
+        context,
+        l?.autoRecordBackgroundLocationRequestFailedSnackbar ??
+            'Could not request background location',
       );
     }
   }

--- a/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
+++ b/lib/features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart
@@ -3,6 +3,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/catalog_reresolve_detector.dart';
 import '../../providers/catalog_reresolve_provider.dart';
@@ -82,8 +83,8 @@ class _CatalogReresolveSnackbarHostState
     final action = l10n?.catalogReresolveSnackbarAction ?? 'Update';
 
     messenger.showSnackBar(
-      SnackBar(
-        content: Text(message),
+      SnackBarHelper.infoSnackBar(
+        message,
         duration: const Duration(seconds: 8),
         action: SnackBarAction(
           label: action,

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1236,5 +1236,6 @@
   "alertsRadiusDeleteConfirm": "Umkreis-Alarm löschen?",
   "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
-  "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen"
+  "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
+  "fillUpSavedSnackbar": "Tankvorgang gespeichert"
 }

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1458,5 +1458,9 @@
         "example": "5"
       }
     }
+  },
+  "fillUpSavedSnackbar": "Fill-up saved",
+  "@fillUpSavedSnackbar": {
+    "description": "Success snackbar confirming a fill-up was saved, shown after the Add fill-up screen pops back to the consumption list (#1692)."
   }
 }

--- a/lib/l10n/_fragments/unified_search_de.arb
+++ b/lib/l10n/_fragments/unified_search_de.arb
@@ -2,5 +2,6 @@
   "unifiedFilterFuel": "Kraftstoff",
   "unifiedFilterEv": "EV",
   "unifiedFilterBoth": "Beide",
-  "unifiedNoResultsForFilter": "Keine Ergebnisse für diesen Filter"
+  "unifiedNoResultsForFilter": "Keine Ergebnisse für diesen Filter",
+  "searchFailedSnackbar": "Suche fehlgeschlagen – bitte erneut versuchen"
 }

--- a/lib/l10n/_fragments/unified_search_en.arb
+++ b/lib/l10n/_fragments/unified_search_en.arb
@@ -14,5 +14,9 @@
   "unifiedNoResultsForFilter": "No results match this filter",
   "@unifiedNoResultsForFilter": {
     "description": "Empty-state placeholder shown in the unified search list when the active filter (Fuel / EV / Both) leaves zero options (#1116 phase 3c)."
+  },
+  "searchFailedSnackbar": "Search failed — please try again",
+  "@searchFailedSnackbar": {
+    "description": "Error snackbar shown when a search request fails. Replaces a raw exception toString() that previously leaked stack-like text to the user (#1692)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1237,6 +1237,7 @@
   "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
   "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
+  "fillUpSavedSnackbar": "Tankvorgang gespeichert",
   "achievementSmoothDriver": "Ruhige Serie",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."
@@ -1917,6 +1918,7 @@
   "unifiedFilterEv": "EV",
   "unifiedFilterBoth": "Beide",
   "unifiedNoResultsForFilter": "Keine Ergebnisse für diesen Filter",
+  "searchFailedSnackbar": "Suche fehlgeschlagen – bitte erneut versuchen",
   "vinLabel": "FIN (optional)",
   "vinDecodeTooltip": "FIN entschlüsseln",
   "vinConfirmAction": "Ja, automatisch ausfüllen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1461,6 +1461,10 @@
       }
     }
   },
+  "fillUpSavedSnackbar": "Fill-up saved",
+  "@fillUpSavedSnackbar": {
+    "description": "Success snackbar confirming a fill-up was saved, shown after the Add fill-up screen pops back to the consumption list (#1692)."
+  },
   "achievementSmoothDriver": "Smooth streak",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."
@@ -3554,6 +3558,10 @@
   "unifiedNoResultsForFilter": "No results match this filter",
   "@unifiedNoResultsForFilter": {
     "description": "Empty-state placeholder shown in the unified search list when the active filter (Fuel / EV / Both) leaves zero options (#1116 phase 3c)."
+  },
+  "searchFailedSnackbar": "Search failed — please try again",
+  "@searchFailedSnackbar": {
+    "description": "Error snackbar shown when a search request fails. Replaces a raw exception toString() that previously leaked stack-like text to the user (#1692)."
   },
   "vinLabel": "VIN (optional)",
   "vinDecodeTooltip": "Decode VIN",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5912,6 +5912,12 @@ abstract class AppLocalizations {
   /// **'{stationCount} stations dropped by up to {maxDropCents}¢ in the last hour'**
   String velocityAlertBody(int stationCount, int maxDropCents);
 
+  /// Success snackbar confirming a fill-up was saved, shown after the Add fill-up screen pops back to the consumption list (#1692).
+  ///
+  /// In en, this message translates to:
+  /// **'Fill-up saved'**
+  String get fillUpSavedSnackbar;
+
   /// Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5).
   ///
   /// In en, this message translates to:
@@ -8821,6 +8827,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No results match this filter'**
   String get unifiedNoResultsForFilter;
+
+  /// Error snackbar shown when a search request fails. Replaces a raw exception toString() that previously leaked stack-like text to the user (#1692).
+  ///
+  /// In en, this message translates to:
+  /// **'Search failed — please try again'**
+  String get searchFailedSnackbar;
 
   /// No description provided for @vinLabel.
   ///

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3165,6 +3165,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4862,6 +4865,9 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3165,6 +3165,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4862,6 +4865,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3163,6 +3163,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4860,6 +4863,9 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3190,6 +3190,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Tankvorgang gespeichert';
+
+  @override
   String get achievementSmoothDriver => 'Ruhige Serie';
 
   @override
@@ -4906,6 +4909,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'Keine Ergebnisse für diesen Filter';
+
+  @override
+  String get searchFailedSnackbar =>
+      'Suche fehlgeschlagen – bitte erneut versuchen';
 
   @override
   String get vinLabel => 'FIN (optional)';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3167,6 +3167,9 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4864,6 +4867,9 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3158,6 +3158,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4855,6 +4858,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4863,6 +4866,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3160,6 +3160,9 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4857,6 +4860,9 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3163,6 +3163,9 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4860,6 +4863,9 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3189,6 +3189,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Série souple';
 
   @override
@@ -4912,6 +4915,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'Aucun résultat pour ce filtre';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optionnel)';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3162,6 +3162,9 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4859,6 +4862,9 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3167,6 +3167,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4864,6 +4867,9 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4863,6 +4866,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3164,6 +3164,9 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4861,6 +4864,9 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4863,6 +4866,9 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3162,6 +3162,9 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4859,6 +4862,9 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3167,6 +3167,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4864,6 +4867,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3165,6 +3165,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4862,6 +4865,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4863,6 +4866,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3165,6 +3165,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4862,6 +4865,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3166,6 +3166,9 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4863,6 +4866,9 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3160,6 +3160,9 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4857,6 +4860,9 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3164,6 +3164,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get fillUpSavedSnackbar => 'Fill-up saved';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override
@@ -4861,6 +4864,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get unifiedNoResultsForFilter => 'No results match this filter';
+
+  @override
+  String get searchFailedSnackbar => 'Search failed — please try again';
 
   @override
   String get vinLabel => 'VIN (optional)';

--- a/test/core/widgets/snackbar_helper_test.dart
+++ b/test/core/widgets/snackbar_helper_test.dart
@@ -189,5 +189,162 @@ void main() {
       final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
       expect(snackBar.duration, const Duration(seconds: 3));
     });
+
+    // #1692 — every snackbar's content is wrapped in a `liveRegion`
+    // Semantics node so assistive technologies announce the message
+    // when it appears (colour and motion are not the only signal).
+    testWidgets('snackbar content is announced via a liveRegion',
+        (tester) async {
+      await pumpApp(tester, Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => SnackBarHelper.show(context, 'Announce me'),
+          child: const Text('Tap'),
+        ),
+      ));
+
+      await tester.tap(find.text('Tap'));
+      await tester.pump();
+
+      final liveRegion = find.descendant(
+        of: find.byType(SnackBar),
+        matching: find.byWidgetPredicate(
+          (w) => w is Semantics && w.properties.liveRegion == true,
+        ),
+      );
+      expect(liveRegion, findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('showSuccess() content is announced via a liveRegion',
+        (tester) async {
+      await pumpApp(tester, Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => SnackBarHelper.showSuccess(context, 'Saved'),
+          child: const Text('Tap'),
+        ),
+      ));
+
+      await tester.tap(find.text('Tap'));
+      await tester.pump();
+
+      final liveRegion = find.descendant(
+        of: find.byType(SnackBar),
+        matching: find.byWidgetPredicate(
+          (w) => w is Semantics && w.properties.liveRegion == true,
+        ),
+      );
+      expect(liveRegion, findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('show() with an action renders the action button',
+        (tester) async {
+      await pumpApp(tester, Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => SnackBarHelper.show(
+            context,
+            'With action',
+            action: SnackBarAction(label: 'Go', onPressed: () {}),
+          ),
+          child: const Text('Tap'),
+        ),
+      ));
+
+      await tester.tap(find.text('Tap'));
+      await tester.pump();
+
+      final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+      expect(snackBar.action, isNotNull);
+      expect(snackBar.action!.label, 'Go');
+    });
+
+    group('builders', () {
+      // The `*SnackBar` builders are pure — they let async call sites
+      // capture a messenger before an `await` and theme the snackbar
+      // without holding a BuildContext across the gap.
+      testWidgets('infoSnackBar() builds a plain SnackBar with the message',
+          (tester) async {
+        await pumpApp(tester, Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => ScaffoldMessenger.of(context)
+                .showSnackBar(SnackBarHelper.infoSnackBar('Built info')),
+            child: const Text('Tap'),
+          ),
+        ));
+
+        await tester.tap(find.text('Tap'));
+        await tester.pump();
+
+        expect(find.text('Built info'), findsOneWidget);
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.action, isNull);
+      });
+
+      testWidgets('infoSnackBar() carries the supplied action + key',
+          (tester) async {
+        await pumpApp(tester, Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+              SnackBarHelper.infoSnackBar(
+                'Built with action',
+                key: const Key('builtSnack'),
+                action: SnackBarAction(label: 'Act', onPressed: () {}),
+              ),
+            ),
+            child: const Text('Tap'),
+          ),
+        ));
+
+        await tester.tap(find.text('Tap'));
+        await tester.pump();
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.key, const Key('builtSnack'));
+        expect(snackBar.action!.label, 'Act');
+      });
+
+      testWidgets('errorSnackBar() is themed (errorContainer) with an icon',
+          (tester) async {
+        late ColorScheme scheme;
+        await pumpApp(tester, Builder(
+          builder: (context) {
+            scheme = Theme.of(context).colorScheme;
+            return ElevatedButton(
+              onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBarHelper.errorSnackBar(scheme, 'Built error')),
+              child: const Text('Tap'),
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Tap'));
+        await tester.pump();
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, scheme.errorContainer);
+        expect(snackBar.duration, const Duration(seconds: 5));
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      });
+
+      testWidgets('successSnackBar() is themed (tertiaryContainer) with icon',
+          (tester) async {
+        late ColorScheme scheme;
+        await pumpApp(tester, Builder(
+          builder: (context) {
+            scheme = Theme.of(context).colorScheme;
+            return ElevatedButton(
+              onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBarHelper.successSnackBar(scheme, 'Built success')),
+              child: const Text('Tap'),
+            );
+          },
+        ));
+
+        await tester.tap(find.text('Tap'));
+        await tester.pump();
+
+        final snackBar = tester.widget<SnackBar>(find.byType(SnackBar));
+        expect(snackBar.backgroundColor, scheme.tertiaryContainer);
+        expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      });
+    });
   });
 }


### PR DESCRIPTION
Bundles cluster **C2** from the #1709 triage map — #1683 and #1692 both
rework `snackbar_helper.dart` and the same ~11 SnackBar call sites, so
they ship as one PR (one commit per issue).

## #1683 — route all SnackBars through SnackBarHelper
- `SnackBarHelper` gains pure `*SnackBar` builders so call sites that
  show a snackbar *after* an `await` can theme it without holding a
  `BuildContext` across the gap.
- `infoSnackBar` takes an optional `action` + `key`, so action-bearing
  snackbars route through the helper too.
- All generic info/success/error call sites across 11 files now go
  through the helper; styling and duration are consistent.
- The 4 keyed domain-warning snackbars in `trip_recording_screen`
  (eco-coach, unpinned, resume-hint, broken-MAP) stay bespoke by design.

## #1692 — feedback & states
- Every snackbar's content is wrapped in a `liveRegion` Semantics node
  → assistive tech announces it on appear.
- Success/error snackbars themed via `colorScheme` + a status icon
  (already landed with the helper foundation; preserved here).
- `search_screen` no longer shows a raw `e.toString()` — replaced with
  the localized `searchFailedSnackbar`.
- `AddFillUpScreen` now confirms a save with a themed success snackbar
  (`fillUpSavedSnackbar`) instead of popping silently.

## Tests
- `snackbar_helper_test` extended: builders, `liveRegion` announcement,
  info-with-action.
- Whole-repo `flutter analyze` clean; the cluster's call-site tests,
  `no_hardcoded_ui_strings`, `localization_completeness` and the
  catch/debugPrint lint guards all pass locally.

Closes #1683
Closes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
