### PR TITLE
feat(obd2): scale broken-MAP thresholds by induction class + baro (#1623)

### DIFF
--- a/lib/features/consumption/data/obd2/broken_map_belief_updater.dart
+++ b/lib/features/consumption/data/obd2/broken_map_belief_updater.dart
@@ -48,31 +48,119 @@ class BrokenMapBeliefUpdater {
   /// observation.
   static const double _bayesFactorEpsilon = 0.01;
 
+  /// Sea-level reference barometric pressure (kPa). The membership-
+  /// function kPa windows were originally calibrated here; away from
+  /// sea level the windows scale relative to this baseline (#1623).
+  static const double _seaLevelBaroKpa = 101.325;
+
+  /// Resolve the `(low, high)` kPa anchors of a membership function,
+  /// scaled for ambient barometric pressure and induction class
+  /// (#1623). The stock anchors ([lowKpa], [highKpa]) were calibrated
+  /// for a sea-level naturally-aspirated engine.
+  ///
+  /// Two independent corrections:
+  ///
+  ///  - **Barometric** — manifold-pressure deltas scale ~linearly with
+  ///    ambient pressure, so at altitude (lower baro) the window
+  ///    shrinks proportionally. Without this a healthy high-altitude
+  ///    engine reads as "low vacuum / small rev swing" and
+  ///    false-positives. The factor is clamped to `[0.6, 1.1]` so a
+  ///    malformed baro reading cannot invert or explode the window. A
+  ///    null [baroKpa] (signal unavailable) leaves the window stock.
+  ///
+  ///  - **Induction** — forced-induction (turbo / VNT / supercharged)
+  ///    engines have MAP excursions the NA calibration models loosely.
+  ///    Their transition band is widened symmetrically around its
+  ///    midpoint, so a borderline reading scores nearer 0.5 (neutral)
+  ///    and the Bayesian updater needs corroborating observations
+  ///    before the belief moves. Widening never produces a *confident*
+  ///    false reading — it only adds tolerance.
+  static (double, double) scaledMembershipAnchors(
+    double lowKpa,
+    double highKpa, {
+    required double? baroKpa,
+    required InductionType? inductionType,
+  }) {
+    final baroFactor = baroKpa == null
+        ? 1.0
+        : (baroKpa / _seaLevelBaroKpa).clamp(0.6, 1.1);
+    var lo = lowKpa * baroFactor;
+    var hi = highKpa * baroFactor;
+    final widen = _inductionBandWiden(inductionType);
+    if (widen != 1.0) {
+      final mid = (lo + hi) / 2.0;
+      lo = mid - (mid - lo) * widen;
+      hi = mid + (hi - mid) * widen;
+    }
+    return (lo, hi);
+  }
+
+  /// Transition-band widening factor by induction class (#1623). `>1`
+  /// widens the neutral band; `1.0` leaves it stock. Forced-induction
+  /// engines all share the same widen — the NA calibration is equally
+  /// loose for any boosted intake.
+  static double _inductionBandWiden(InductionType? type) {
+    switch (type) {
+      case InductionType.turbocharged:
+      case InductionType.supercharged:
+      case InductionType.vnt:
+        return 1.3;
+      case InductionType.naturallyAspirated:
+      case null:
+        return 1.0;
+    }
+  }
+
   /// Idle-vacuum-missing membership. On a healthy NA petrol engine,
-  /// `baro - map` at idle is typically 30-45 kPa (strong vacuum).
-  /// On a broken MAP that returns atmospheric, the delta is ≤ 5 kPa.
-  ///   - Returns 0.0 when delta ≥ 45 kPa (healthy vacuum).
-  ///   - Returns 1.0 when delta ≤ 15 kPa (no vacuum — likely broken).
+  /// `baro - map` at idle is a strong vacuum; a broken MAP that
+  /// returns atmospheric collapses the delta.
+  ///   - Returns 0.0 at/above the healthy anchor (45 kPa at sea level).
+  ///   - Returns 1.0 at/below the suspicious anchor (15 kPa at sea
+  ///     level).
   ///   - Linear interp in between.
+  ///
+  /// Both anchors are scaled by [scaledMembershipAnchors] for ambient
+  /// barometric pressure and [inductionType] (#1623).
   static double vacuumMissingScore({
     required double baroKpa,
     required double mapKpa,
+    InductionType? inductionType,
   }) {
     final delta = baroKpa - mapKpa;
-    return (1.0 - ((delta - 15.0) / 30.0)).clamp(0.0, 1.0);
+    final (lo, hi) = scaledMembershipAnchors(
+      15.0,
+      45.0,
+      baroKpa: baroKpa,
+      inductionType: inductionType,
+    );
+    return (1.0 - ((delta - lo) / (hi - lo))).clamp(0.0, 1.0);
   }
 
   /// Diesel-rev-delta membership. Diesels run unthrottled so idle MAP
   /// is near baro; the discriminator is how much MAP *changes* under
-  /// a brief rev. Healthy: ≥ 30 kPa swing. Broken: ≤ 8 kPa swing.
-  ///   - Returns 0.0 when |rev - idle| ≥ 30 kPa.
-  ///   - Returns 1.0 when |rev - idle| ≤ 8 kPa.
+  /// a brief rev. Healthy: large swing. Broken: small swing.
+  ///   - Returns 0.0 at/above the healthy anchor (30 kPa at sea level).
+  ///   - Returns 1.0 at/below the suspicious anchor (8 kPa at sea
+  ///     level).
+  ///
+  /// Both anchors are scaled by [scaledMembershipAnchors] for ambient
+  /// barometric pressure and [inductionType] (#1623). [baroKpa] is
+  /// optional — the diesel probe reads it best-effort; a null leaves
+  /// the window at its sea-level width.
   static double revDeltaMissingScore({
     required double mapIdleKpa,
     required double mapRevvedKpa,
+    double? baroKpa,
+    InductionType? inductionType,
   }) {
     final delta = (mapRevvedKpa - mapIdleKpa).abs();
-    return (1.0 - ((delta - 8.0) / 22.0)).clamp(0.0, 1.0);
+    final (lo, hi) = scaledMembershipAnchors(
+      8.0,
+      30.0,
+      baroKpa: baroKpa,
+      inductionType: inductionType,
+    );
+    return (1.0 - ((delta - lo) / (hi - lo))).clamp(0.0, 1.0);
   }
 
   /// Plein-complet ratio severity. Reconciler computes

--- a/lib/features/consumption/data/obd2/broken_map_detector.dart
+++ b/lib/features/consumption/data/obd2/broken_map_detector.dart
@@ -134,6 +134,14 @@ class BrokenMapDetector {
       BrokenMapReason reason;
 
       if (isDiesel) {
+        // #1623 — read ambient baro best-effort BEFORE the rev so the
+        // rev-delta membership window scales for altitude. A failed
+        // read leaves baro null and the window stays sea-level wide;
+        // it never aborts the diesel probe (unlike the petrol path,
+        // where baro is load-bearing).
+        final dieselBaroRaw = await port.sendRaw(_baroCommand);
+        final dieselBaro = _parseBaroPressureKpa(dieselBaroRaw);
+
         // Soft "rev" step — phase 2 placeholder. Wait, then re-read
         // PID 0x0B. A cooperating user blipped the throttle in this
         // window; an uncooperative one didn't and the delta will be
@@ -147,6 +155,8 @@ class BrokenMapDetector {
         observationScore = BrokenMapBeliefUpdater.revDeltaMissingScore(
           mapIdleKpa: mapIdle,
           mapRevvedKpa: mapRev,
+          baroKpa: dieselBaro,
+          inductionType: vehicle?.inductionType,
         );
         reason = BrokenMapReason.revDeltaMissing;
       } else {
@@ -157,6 +167,7 @@ class BrokenMapDetector {
         observationScore = BrokenMapBeliefUpdater.vacuumMissingScore(
           baroKpa: baro,
           mapKpa: mapIdle,
+          inductionType: vehicle?.inductionType,
         );
         reason = BrokenMapReason.idleVacuumMissing;
       }

--- a/test/features/consumption/data/obd2/broken_map_belief_updater_test.dart
+++ b/test/features/consumption/data/obd2/broken_map_belief_updater_test.dart
@@ -11,11 +11,13 @@ import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.d
 /// posterior: see the bottom group for the two issue-#1424 acceptance
 /// tests (5×0.4 → posterior > 0.8; 5×0.9 then 20×0.05 → posterior < 0.4).
 void main() {
-  group('vacuumMissingScore', () {
+  // Anchors at the sea-level reference baro (101.325 kPa) so the
+  // window is exactly 15-45 kPa — these pin the stock calibration.
+  group('vacuumMissingScore (sea-level reference)', () {
     test('returns 0.0 when delta is at the healthy boundary (45 kPa)', () {
       final s = BrokenMapBeliefUpdater.vacuumMissingScore(
-        baroKpa: 100,
-        mapKpa: 55,
+        baroKpa: 101.325,
+        mapKpa: 56.325,
       );
       expect(s, 0.0);
     });
@@ -23,16 +25,16 @@ void main() {
     test('returns 1.0 when delta is at/below the suspicious boundary (15 kPa)',
         () {
       final s = BrokenMapBeliefUpdater.vacuumMissingScore(
-        baroKpa: 100,
-        mapKpa: 90,
+        baroKpa: 101.325,
+        mapKpa: 86.325,
       );
       expect(s, 1.0);
     });
 
     test('linear interp at delta 30 returns 0.5', () {
       final s = BrokenMapBeliefUpdater.vacuumMissingScore(
-        baroKpa: 100,
-        mapKpa: 70,
+        baroKpa: 101.325,
+        mapKpa: 71.325,
       );
       expect(s, closeTo(0.5, 1e-9));
     });
@@ -62,6 +64,131 @@ void main() {
         mapRevvedKpa: 81,
       );
       expect(s, closeTo(0.5, 1e-9));
+    });
+  });
+
+  // #1623 — membership-anchor scaling for barometric pressure +
+  // induction class.
+  group('scaledMembershipAnchors (#1623)', () {
+    test('sea-level NA leaves the stock window untouched', () {
+      final (lo, hi) = BrokenMapBeliefUpdater.scaledMembershipAnchors(
+        15.0,
+        45.0,
+        baroKpa: 101.325,
+        inductionType: InductionType.naturallyAspirated,
+      );
+      expect(lo, closeTo(15.0, 1e-9));
+      expect(hi, closeTo(45.0, 1e-9));
+    });
+
+    test('a null baro leaves the window stock', () {
+      final (lo, hi) = BrokenMapBeliefUpdater.scaledMembershipAnchors(
+        8.0,
+        30.0,
+        baroKpa: null,
+        inductionType: null,
+      );
+      expect(lo, closeTo(8.0, 1e-9));
+      expect(hi, closeTo(30.0, 1e-9));
+    });
+
+    test('high altitude (low baro) shrinks the window proportionally', () {
+      // baro 81.06 kPa ≈ 2000 m → factor 0.8.
+      final (lo, hi) = BrokenMapBeliefUpdater.scaledMembershipAnchors(
+        15.0,
+        45.0,
+        baroKpa: 81.06,
+        inductionType: null,
+      );
+      expect(lo, closeTo(12.0, 1e-3));
+      expect(hi, closeTo(36.0, 1e-3));
+    });
+
+    test('an absurdly low baro is clamped at factor 0.6', () {
+      final (lo, hi) = BrokenMapBeliefUpdater.scaledMembershipAnchors(
+        15.0,
+        45.0,
+        baroKpa: 10.0,
+        inductionType: null,
+      );
+      // 0.6 floor → 15*0.6, 45*0.6; window never inverts.
+      expect(lo, closeTo(9.0, 1e-6));
+      expect(hi, closeTo(27.0, 1e-6));
+      expect(hi, greaterThan(lo));
+    });
+
+    test('forced induction widens the band symmetrically about its midpoint',
+        () {
+      final (lo, hi) = BrokenMapBeliefUpdater.scaledMembershipAnchors(
+        8.0,
+        30.0,
+        baroKpa: 101.325,
+        inductionType: InductionType.turbocharged,
+      );
+      // mid = 19; widen 1.3 → lo = 19 - 11*1.3, hi = 19 + 11*1.3.
+      expect(lo, closeTo(19.0 - 14.3, 1e-6));
+      expect(hi, closeTo(19.0 + 14.3, 1e-6));
+      // Midpoint is preserved — widening adds tolerance, not a shift.
+      expect((lo + hi) / 2, closeTo(19.0, 1e-6));
+    });
+  });
+
+  group('membership functions scale for altitude + induction (#1623)', () {
+    test(
+        'vacuum: the same kPa delta reads healthier at altitude than at '
+        'sea level', () {
+      // Absolute delta of 40 kPa. At sea level that is mid-band; at
+      // altitude the window has shrunk so 40 kPa is clearly healthy.
+      final seaLevel = BrokenMapBeliefUpdater.vacuumMissingScore(
+        baroKpa: 101.325,
+        mapKpa: 61.325, // delta 40
+      );
+      final altitude = BrokenMapBeliefUpdater.vacuumMissingScore(
+        baroKpa: 81.06,
+        mapKpa: 41.06, // delta 40
+      );
+      expect(seaLevel, greaterThan(0.0));
+      expect(altitude, lessThan(seaLevel));
+      expect(altitude, 0.0);
+    });
+
+    test(
+        'rev-delta: a turbo diesel scores a borderline swing nearer neutral '
+        'than a NA diesel would', () {
+      // A 19 kPa swing is exactly mid-band (0.5) for a NA diesel.
+      final na = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 119,
+        baroKpa: 101.325,
+        inductionType: InductionType.naturallyAspirated,
+      );
+      // The same swing on a turbo diesel: the band is wider, but the
+      // midpoint is unchanged, so a mid-band swing still scores ~0.5.
+      final turbo = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 119,
+        baroKpa: 101.325,
+        inductionType: InductionType.turbocharged,
+      );
+      expect(na, closeTo(0.5, 1e-9));
+      expect(turbo, closeTo(0.5, 1e-9));
+
+      // ...but a near-healthy swing (28 kPa) that NA scores as almost
+      // clean, the turbo scores less confidently (nearer neutral) —
+      // the wider band demands a bigger swing for full confidence.
+      final naClean = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 128,
+        baroKpa: 101.325,
+        inductionType: InductionType.naturallyAspirated,
+      );
+      final turboClean = BrokenMapBeliefUpdater.revDeltaMissingScore(
+        mapIdleKpa: 100,
+        mapRevvedKpa: 128,
+        baroKpa: 101.325,
+        inductionType: InductionType.turbocharged,
+      );
+      expect(naClean, lessThan(turboClean));
     });
   });
 


### PR DESCRIPTION
Child of epic #1610. #1424 added induction-class priors to the Bayes
factor, but the membership functions `vacuumMissingScore` /
`revDeltaMissingScore` kept fixed kPa thresholds calibrated for a
sea-level NA engine — high-altitude and forced-induction vehicles fell
outside the windows and false-positived.

## Change
- **`scaledMembershipAnchors`** resolves the `(low, high)` kPa anchors:
  - *Barometric* — anchors scale linearly with ambient pressure vs the
    101.325 kPa sea-level reference; factor clamped to `[0.6, 1.1]`.
  - *Induction* — forced-induction (turbo / VNT / supercharged) engines
    get their transition band widened symmetrically about its midpoint
    — a borderline reading scores nearer 0.5 (neutral), adding
    tolerance without ever producing a confident false reading.
- `vacuumMissingScore` / `revDeltaMissingScore` route through the
  helper; `BrokenMapDetector` passes `vehicle?.inductionType` on both
  paths and reads ambient baro best-effort on the diesel path.

## Acceptance
- [x] Membership thresholds scale with induction class + a barometric
  baseline.
- [x] Tests cover sea-level, high-altitude, and tuned-engine inputs.

Whole-repo `flutter analyze` clean; belief-updater + detector +
vin-populator suites pass locally.

Closes #1623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
