### PR TITLE
feat(alerts): navigation entry to the orphaned /alerts route (#1701)

### DIFF
--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -9,7 +9,6 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../alerts/data/models/price_alert.dart';
 import '../../../alerts/providers/alert_provider.dart';
 
 /// Tab showing the user's price alerts with swipe-to-delete and toggle support.
@@ -32,7 +31,7 @@ class AlertsTab extends StatelessWidget {
               subtitle: l10n?.noPriceAlertsHint ??
                   'Create an alert from a station\'s detail page.',
             )
-          : _priceAlertsList(context, ref, l10n, alerts);
+          : _priceAlertsList(context, ref, l10n);
       return Column(
         children: [
           const _RadiusAlertsEntry(),
@@ -46,8 +45,11 @@ class AlertsTab extends StatelessWidget {
     BuildContext context,
     WidgetRef ref,
     AppLocalizations? l10n,
-    List<PriceAlert> alerts,
   ) {
+    // Re-read here (cheap, idempotent) so the helper carries no
+    // explicit alert-model type — keeping favorites/presentation off a
+    // direct import of the alerts feature's data layer.
+    final alerts = ref.watch(alertProvider);
     return Column(
         children: [
           HelpBanner(

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -9,6 +9,7 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../alerts/data/models/price_alert.dart';
 import '../../../alerts/providers/alert_provider.dart';
 
 /// Tab showing the user's price alerts with swipe-to-delete and toggle support.
@@ -21,15 +22,33 @@ class AlertsTab extends StatelessWidget {
 
     return Consumer(builder: (context, ref, _) {
       final alerts = ref.watch(alertProvider);
-      if (alerts.isEmpty) {
-        return EmptyState(
-          icon: Icons.notifications_off_outlined,
-          title: l10n?.noPriceAlerts ?? 'No price alerts',
-          subtitle: l10n?.noPriceAlertsHint ??
-              'Create an alert from a station\'s detail page.',
-        );
-      }
+      // The radius-alerts + statistics entry is always shown — it is
+      // the only navigation path to the `/alerts` screen (#1701), so it
+      // must be reachable whether or not the user has price alerts.
+      final body = alerts.isEmpty
+          ? EmptyState(
+              icon: Icons.notifications_off_outlined,
+              title: l10n?.noPriceAlerts ?? 'No price alerts',
+              subtitle: l10n?.noPriceAlertsHint ??
+                  'Create an alert from a station\'s detail page.',
+            )
+          : _priceAlertsList(context, ref, l10n, alerts);
       return Column(
+        children: [
+          const _RadiusAlertsEntry(),
+          Expanded(child: body),
+        ],
+      );
+    });
+  }
+
+  Widget _priceAlertsList(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations? l10n,
+    List<PriceAlert> alerts,
+  ) {
+    return Column(
         children: [
           HelpBanner(
             storageKey: StorageKeys.helpBannerAlerts,
@@ -99,6 +118,62 @@ class AlertsTab extends StatelessWidget {
           ),
         ],
       );
-    });
+  }
+}
+
+/// Tappable entry on the Alerts tab that opens the radius-alerts +
+/// statistics screen at `/alerts` (#1701).
+///
+/// `/alerts` (`AlertsScreen` — radius alerts + `AlertStatisticsCard`)
+/// had no `context.go`/`push` anywhere, so the whole radius-alerts
+/// feature was unreachable. This entry is the navigation path; it sits
+/// above the price-alert list and shows in the empty state too, so it
+/// is always reachable.
+class _RadiusAlertsEntry extends StatelessWidget {
+  const _RadiusAlertsEntry();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      child: InkWell(
+        key: const Key('radiusAlertsEntry'),
+        onTap: () => context.push('/alerts'),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Icon(Icons.radar, color: theme.colorScheme.primary),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n?.radiusAlertsEntryTitle ??
+                          'Radius alerts & statistics',
+                      style: theme.textTheme.titleSmall,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      l10n?.radiusAlertsEntrySubtitle ??
+                          'Get notified when prices drop near you',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(Icons.chevron_right,
+                  color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1237,5 +1237,7 @@
   "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
   "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
-  "fillUpSavedSnackbar": "Tankvorgang gespeichert"
+  "fillUpSavedSnackbar": "Tankvorgang gespeichert",
+  "radiusAlertsEntryTitle": "Umkreis-Alarme & Statistik",
+  "radiusAlertsEntrySubtitle": "Werde benachrichtigt, wenn die Preise in deiner Nähe fallen"
 }

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1462,5 +1462,13 @@
   "fillUpSavedSnackbar": "Fill-up saved",
   "@fillUpSavedSnackbar": {
     "description": "Success snackbar confirming a fill-up was saved, shown after the Add fill-up screen pops back to the consumption list (#1692)."
+  },
+  "radiusAlertsEntryTitle": "Radius alerts & statistics",
+  "@radiusAlertsEntryTitle": {
+    "description": "Title of the navigation entry on the favorites Alerts tab that opens the radius-alerts + statistics screen (#1701)."
+  },
+  "radiusAlertsEntrySubtitle": "Get notified when prices drop near you",
+  "@radiusAlertsEntrySubtitle": {
+    "description": "Subtitle of the radius-alerts navigation entry on the favorites Alerts tab — explains what radius alerts do (#1701)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1238,6 +1238,8 @@
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
   "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
   "fillUpSavedSnackbar": "Tankvorgang gespeichert",
+  "radiusAlertsEntryTitle": "Umkreis-Alarme & Statistik",
+  "radiusAlertsEntrySubtitle": "Werde benachrichtigt, wenn die Preise in deiner Nähe fallen",
   "achievementSmoothDriver": "Ruhige Serie",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1465,6 +1465,14 @@
   "@fillUpSavedSnackbar": {
     "description": "Success snackbar confirming a fill-up was saved, shown after the Add fill-up screen pops back to the consumption list (#1692)."
   },
+  "radiusAlertsEntryTitle": "Radius alerts & statistics",
+  "@radiusAlertsEntryTitle": {
+    "description": "Title of the navigation entry on the favorites Alerts tab that opens the radius-alerts + statistics screen (#1701)."
+  },
+  "radiusAlertsEntrySubtitle": "Get notified when prices drop near you",
+  "@radiusAlertsEntrySubtitle": {
+    "description": "Subtitle of the radius-alerts navigation entry on the favorites Alerts tab — explains what radius alerts do (#1701)."
+  },
   "achievementSmoothDriver": "Smooth streak",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5918,6 +5918,18 @@ abstract class AppLocalizations {
   /// **'Fill-up saved'**
   String get fillUpSavedSnackbar;
 
+  /// Title of the navigation entry on the favorites Alerts tab that opens the radius-alerts + statistics screen (#1701).
+  ///
+  /// In en, this message translates to:
+  /// **'Radius alerts & statistics'**
+  String get radiusAlertsEntryTitle;
+
+  /// Subtitle of the radius-alerts navigation entry on the favorites Alerts tab — explains what radius alerts do (#1701).
+  ///
+  /// In en, this message translates to:
+  /// **'Get notified when prices drop near you'**
+  String get radiusAlertsEntrySubtitle;
+
   /// Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3168,6 +3168,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3168,6 +3168,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3166,6 +3166,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3193,6 +3193,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Tankvorgang gespeichert';
 
   @override
+  String get radiusAlertsEntryTitle => 'Umkreis-Alarme & Statistik';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Werde benachrichtigt, wenn die Preise in deiner Nähe fallen';
+
+  @override
   String get achievementSmoothDriver => 'Ruhige Serie';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3170,6 +3170,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3161,6 +3161,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3169,6 +3169,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3163,6 +3163,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3166,6 +3166,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3192,6 +3192,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Série souple';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3165,6 +3165,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3170,6 +3170,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3169,6 +3169,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3167,6 +3167,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3169,6 +3169,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3165,6 +3165,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3170,6 +3170,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3168,6 +3168,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3169,6 +3169,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3168,6 +3168,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3169,6 +3169,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3163,6 +3163,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3167,6 +3167,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fillUpSavedSnackbar => 'Fill-up saved';
 
   @override
+  String get radiusAlertsEntryTitle => 'Radius alerts & statistics';
+
+  @override
+  String get radiusAlertsEntrySubtitle =>
+      'Get notified when prices drop near you';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/test/features/favorites/presentation/widgets/alerts_tab_test.dart
+++ b/test/features/favorites/presentation/widgets/alerts_tab_test.dart
@@ -234,6 +234,58 @@ void main() {
       expect(landedOn, '/station/shell-42');
       expect(find.text('station shell-42'), findsOneWidget);
     });
+
+    // #1701 — the radius-alerts + statistics screen at `/alerts` had no
+    // navigation entry point anywhere. This entry is it.
+    testWidgets(
+        'the radius-alerts entry is reachable (empty state) and routes '
+        'to /alerts', (tester) async {
+      final mockStorageOverride = mockStorageRepositoryOverride();
+      when(() => mockStorageOverride.mock.getSetting(any())).thenReturn(null);
+
+      String? landedOn;
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(body: AlertsTab()),
+          ),
+          GoRoute(
+            path: '/alerts',
+            builder: (_, _) {
+              landedOn = '/alerts';
+              return const Scaffold(body: Text('alerts screen'));
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Object>[
+            mockStorageOverride.override,
+            // Zero price alerts → empty state; the entry must still show.
+            alertProvider.overrideWith(() => _RecordingAlerts(const [])),
+          ].cast(),
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('radiusAlertsEntry')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('radiusAlertsEntry')));
+      await tester.pumpAndSettle();
+
+      expect(landedOn, '/alerts');
+      expect(find.text('alerts screen'), findsOneWidget);
+    });
   });
 }
 


### PR DESCRIPTION
Child of epic #1700 (orphan feature #1). The `/alerts` route renders
`AlertsScreen` (radius alerts + `AlertStatisticsCard`) but nothing
navigated to it — the whole radius-alerts feature was unreachable.

## Change
- `AlertsTab` (favorites → Alerts) shows a `_RadiusAlertsEntry` card
  above the price-alert list — a tappable row that pushes `/alerts`.
  It renders in the empty state too, so the feature is always
  reachable.
- New ARB keys `radiusAlertsEntryTitle` / `radiusAlertsEntrySubtitle`
  (en + de).
- A widget test drives the entry through a real `GoRouter` and asserts
  it routes to `/alerts` from the empty state.

## Acceptance
- [x] A navigation entry point routes users to `/alerts`.
- [x] Feature management — no gate added; the basic price-alert
  surfaces are ungated, so the entry keeps parity ("if appropriate").
- [x] Reachability covered by a test.

Whole-repo `flutter analyze` clean; favorites + alerts + lint + l10n
suites pass locally (343 tests).

Closes #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
