### PR TITLE
refactor(consumption): decompose the OBD2 trip-recording god-classes (#1679)

### DIFF
--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -1,0 +1,420 @@
+import '../../../vehicle/domain/entities/reference_vehicle.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import 'elm327_protocol.dart';
+import 'obd2_breadcrumb_collector.dart';
+import 'obd2_service.dart';
+import 'pid_scheduler.dart';
+
+/// The "clock"-side snapshot extracted from [TripRecordingController]
+/// (#1679): the per-PID latest-value scratch space, the scheduler
+/// subscription wiring that fills it, and the tier-1/2/3 fuel-rate
+/// derivation that reads it.
+///
+/// The controller keeps the emit timer + `_emit` itself — that path
+/// entangles lifecycle flags, the recorder, and the fuel accumulators.
+/// This collaborator is the safe core of the split: it owns the
+/// values, the controller reads them once per emit tick.
+///
+/// Scheduler callbacks push high-priority parse outcomes back through
+/// [_onHighPriorityParse] (the controller's silent-failure observer)
+/// and vehicle-speed samples through [_onSpeedSample] (the controller's
+/// virtual-odometer buffer), so this class carries no drop-detection
+/// or distance state of its own.
+class LiveSampleSnapshot {
+  LiveSampleSnapshot({
+    required Obd2Service service,
+    VehicleProfile? vehicle,
+    ReferenceVehicle? referenceVehicle,
+    Obd2BreadcrumbRecorder? breadcrumbCollector,
+    required void Function(Object? parsedValue) onHighPriorityParse,
+    required void Function(double speedKmh) onSpeedSample,
+  })  : _service = service,
+        _vehicle = vehicle,
+        _referenceVehicle = referenceVehicle,
+        _breadcrumbCollector = breadcrumbCollector,
+        _onHighPriorityParse = onHighPriorityParse,
+        _onSpeedSample = onSpeedSample;
+
+  final Obd2Service _service;
+  final VehicleProfile? _vehicle;
+  final ReferenceVehicle? _referenceVehicle;
+  final Obd2BreadcrumbRecorder? _breadcrumbCollector;
+  final void Function(Object? parsedValue) _onHighPriorityParse;
+  final void Function(double speedKmh) _onSpeedSample;
+
+  // Latest parsed values, keyed by PID command. Written by scheduler
+  // callbacks, read by the controller's `_emit` when assembling a
+  // TripLiveReading. Not a typed struct because most fields are
+  // optional doubles and a freezed class for this scratch space buys
+  // nothing.
+  double? _latestSpeedKmh;
+  double? _latestRpm;
+  double? _latestMaf;
+  double? _latestMapKpa;
+  double? _latestIatCelsius;
+  double? _latestThrottlePercent;
+  double? _latestEngineLoadPercent;
+  double? _latestCoolantTempC;
+  double? _latestFuelLevelPercent;
+  double? _latestStft;
+  double? _latestLtft;
+  double? _latestDirectFuelRate;
+
+  // #1374 phase 1 — most recent GPS fix, pushed in by the provider
+  // when the `Feature.gpsTripPath` flag is enabled. The controller
+  // does NOT subscribe to Geolocator itself — that decision lives at
+  // the provider layer. When the flag is off both fields stay null
+  // and every persisted sample carries `latitude: null,
+  // longitude: null` (matching pre-#1374 behaviour bit-for-bit).
+  double? _latestLatitude;
+  double? _latestLongitude;
+
+  double? get latestSpeedKmh => _latestSpeedKmh;
+  double? get latestRpm => _latestRpm;
+  double? get latestThrottlePercent => _latestThrottlePercent;
+  double? get latestEngineLoadPercent => _latestEngineLoadPercent;
+  double? get latestCoolantTempC => _latestCoolantTempC;
+  double? get latestFuelLevelPercent => _latestFuelLevelPercent;
+  double? get latestLatitude => _latestLatitude;
+  double? get latestLongitude => _latestLongitude;
+
+  /// Push the most recent GPS fix into the per-tick snapshot
+  /// (#1374 phase 1). Pass `null` for either coord to clear the latch.
+  void updateGpsFix({double? latitude, double? longitude}) {
+    _latestLatitude = latitude;
+    _latestLongitude = longitude;
+  }
+
+  /// Wire every priority tier's PID subscriptions onto [scheduler].
+  /// Each callback writes the latest parsed value into this snapshot;
+  /// high-priority callbacks additionally feed the silent-failure
+  /// observer, and the vehicle-speed callback feeds the virtual
+  /// odometer.
+  void subscribeAllTiers(PidScheduler scheduler) {
+    // ---- 5 Hz tier (high priority) --------------------------------
+    // RPM and speed are consumed directly by TripSample → TripRecorder
+    // for distance/idle/harsh-accel accumulation, so they need the
+    // highest refresh we can squeeze out of the adapter.
+    scheduler.subscribe(
+      Elm327Protocol.engineRpmCommand,
+      ScheduledPid(hz: 5.0, priority: PidPriority.high),
+      (r) {
+        final v = Elm327Protocol.parseEngineRpm(r);
+        if (v != null) _latestRpm = v;
+        _onHighPriorityParse(v);
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.vehicleSpeedCommand,
+      ScheduledPid(hz: 5.0, priority: PidPriority.high),
+      (r) {
+        final v = Elm327Protocol.parseVehicleSpeed(r);
+        if (v != null) {
+          _latestSpeedKmh = v.toDouble();
+          _onSpeedSample(v.toDouble());
+        }
+        _onHighPriorityParse(v);
+      },
+    );
+    // MAF and MAP are the two alternate air-mass inputs to the fuel-
+    // rate derivation. Cheap cars (Peugeot 107) only have MAP+IAT;
+    // modern cars expose MAF. We subscribe both and let the snapshot-
+    // based derivation pick whichever landed most recently.
+    if (_service.supportsPid(0x10)) {
+      scheduler.subscribe(
+        Elm327Protocol.mafCommand,
+        ScheduledPid(hz: 5.0, priority: PidPriority.high),
+        (r) {
+          final v = Elm327Protocol.parseMafGramsPerSecond(r);
+          if (v != null) _latestMaf = v;
+          _onHighPriorityParse(v);
+        },
+      );
+    }
+    if (_service.supportsPid(0x0B)) {
+      scheduler.subscribe(
+        Elm327Protocol.intakeManifoldPressureCommand,
+        ScheduledPid(hz: 5.0, priority: PidPriority.high),
+        (r) {
+          final v = Elm327Protocol.parseManifoldPressureKpa(r);
+          if (v != null) _latestMapKpa = v;
+          _onHighPriorityParse(v);
+        },
+      );
+    }
+    scheduler.subscribe(
+      Elm327Protocol.throttlePositionCommand,
+      ScheduledPid(hz: 5.0, priority: PidPriority.high),
+      (r) {
+        final v = Elm327Protocol.parseThrottlePercent(r);
+        if (v != null) _latestThrottlePercent = v;
+        _onHighPriorityParse(v);
+      },
+    );
+    // PID 5E is only present on ~2014+ ECUs. Skip when #811 discovery
+    // already proved the car rejects it, to save the 200 ms round-
+    // trip of a guaranteed NO DATA.
+    if (_service.supportsPid(0x5E)) {
+      scheduler.subscribe(
+        Elm327Protocol.engineFuelRateCommand,
+        ScheduledPid(hz: 5.0, priority: PidPriority.high),
+        (r) {
+          final v = Elm327Protocol.parseFuelRateLPerHour(r);
+          if (v != null) _latestDirectFuelRate = v;
+          _onHighPriorityParse(v);
+        },
+      );
+    }
+
+    // ---- 1 Hz tier (medium priority) ------------------------------
+    scheduler.subscribe(
+      Elm327Protocol.engineLoadCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseEngineLoad(r);
+        if (v != null) _latestEngineLoadPercent = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.intakeAirTempCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseIntakeAirTempCelsius(r);
+        if (v != null) _latestIatCelsius = v;
+      },
+    );
+    // Coolant temp drifts slowly — 1 Hz is more than enough resolution
+    // for the cold-start surcharge heuristic (#1262 phase 2) to detect
+    // whether the trip ever crossed operating temperature.
+    scheduler.subscribe(
+      Elm327Protocol.coolantTempCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseCoolantTempCelsius(r);
+        if (v != null) _latestCoolantTempC = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.shortTermFuelTrimCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseShortTermFuelTrim(r);
+        if (v != null) _latestStft = v;
+      },
+    );
+    scheduler.subscribe(
+      Elm327Protocol.longTermFuelTrimCommand,
+      ScheduledPid(hz: 1.0),
+      (r) {
+        final v = Elm327Protocol.parseLongTermFuelTrim(r);
+        if (v != null) _latestLtft = v;
+      },
+    );
+
+    // ---- 0.1 Hz tier (low priority) -------------------------------
+    scheduler.subscribe(
+      Elm327Protocol.fuelTankLevelCommand,
+      ScheduledPid(hz: 0.1, priority: PidPriority.low),
+      (r) {
+        final v = Elm327Protocol.parseFuelLevelPercent(r);
+        if (v != null) _latestFuelLevelPercent = v;
+      },
+    );
+  }
+
+  /// Derive the current fuel rate (L/h) from whatever snapshot
+  /// values have landed so far. Mirrors the tier-1/2/3 fallback in
+  /// [Obd2Service.readFuelRateLPerHour], but over snapshot values
+  /// instead of live I/O — the scheduler has already done the
+  /// reads. Returns null when not enough inputs have arrived yet
+  /// (e.g. first 200 ms of a trip before MAP/IAT both land).
+  ///
+  /// AFR + density are chosen from the active vehicle's preferred
+  /// fuel type (#800). Diesel profiles get AFR 14.5 / density 832 g/L;
+  /// anything else (including null / unknown) stays on the petrol
+  /// defaults the pre-#800 path used.
+  double? deriveFuelRateLPerHour() {
+    final preferredFuel =
+        _vehicle?.preferredFuelType?.trim().toLowerCase() ?? '';
+    final isDiesel = preferredFuel.contains('diesel');
+    // #1397 — manual overrides take precedence over the inferred /
+    // catalog-resolved values. Mirrors the resolution chain in
+    // [Obd2Service.readFuelRateLPerHour] so the live integrator and the
+    // pull-mode estimator agree on every scalar.
+    final afr = _vehicle?.manualAfrOverride ??
+        (isDiesel ? Obd2Service.dieselAfr : Obd2Service.petrolAfr);
+    final density = _vehicle?.manualFuelDensityGPerLOverride ??
+        (isDiesel
+            ? Obd2Service.dieselDensityGPerL
+            : Obd2Service.petrolDensityGPerL);
+    final displacement = _vehicle?.manualEngineDisplacementCcOverride
+            ?.round() ??
+        _vehicle?.engineDisplacementCc ??
+        1000;
+    // #1422 phase 1 — same precedence as Obd2Service.readFuelRateLPerHour:
+    // manual override → stored profile (when learned or non-default) →
+    // engine-tech helper on the reference catalog row → hard 0.85
+    // fallback. The two paths must agree so the live integrator and
+    // the pull-mode estimator produce identical numbers for the same
+    // tick.
+    final ve = _vehicle?.manualVolumetricEfficiencyOverride ??
+        _resolveControllerProfileVe() ??
+        (_referenceVehicle != null
+            ? defaultVolumetricEfficiency(_referenceVehicle)
+            : 0.85);
+    final collector = _breadcrumbCollector;
+
+    // Step 1: direct PID 5E. Already post-trim, no correction.
+    final direct = _latestDirectFuelRate;
+    if (direct != null) {
+      // #1395 — sanity bound A: implausibly-low at non-idle RPM.
+      // Same threshold as Obd2Service.readFuelRateLPerHour but evaluated
+      // on the controller's most-recent RPM snapshot so this works
+      // even when the trip is being driven by raw scheduler callbacks
+      // rather than the readFuelRate API.
+      String? lowFlag;
+      String? lowDetail;
+      final rpm = _latestRpm;
+      if (direct < 0.3 && rpm != null && rpm > 1500) {
+        lowFlag = Obd2BreadcrumbCollector.flagSuspiciousLow;
+        lowDetail = 'directRate=${direct.toStringAsFixed(2)};'
+            'rpm=${rpm.toStringAsFixed(0)}';
+      }
+      collector?.record(
+        branch: Obd2BranchTag.pid5E,
+        fuelRateLPerHour: direct,
+        pid5ELPerHour: direct,
+        rpm: rpm,
+        afr: afr,
+        fuelDensityGPerL: density,
+        engineDisplacementCc: displacement.toDouble(),
+        volumetricEfficiency: ve,
+        flag: lowFlag,
+        flagDetail: lowDetail,
+      );
+      // Sanity bound B: 5E vs MAF cross-check on the controller's
+      // cached MAF snapshot. Evaluated AFTER the breadcrumb is
+      // pushed so [recordFlag] mutates the same row.
+      final mafSnapshot = _latestMaf;
+      if (mafSnapshot != null) {
+        final mafDerived = mafSnapshot * 3600.0 / (afr * density);
+        if (mafDerived > 0 &&
+            (direct - mafDerived).abs() / mafDerived > 0.5) {
+          collector?.recordFlag(
+            Obd2BreadcrumbCollector.flag5eVsMafDivergent,
+            'direct=${direct.toStringAsFixed(2)};'
+                'mafDerived=${mafDerived.toStringAsFixed(2)};'
+                'maf=${mafSnapshot.toStringAsFixed(2)}',
+          );
+        }
+      }
+      return direct;
+    }
+
+    // Step 2: MAF-based. L/h = MAF × 3600 / (AFR × density).
+    final maf = _latestMaf;
+    if (maf != null) {
+      final raw = maf * 3600.0 / (afr * density);
+      final corrected = _applyTrim(raw);
+      collector?.record(
+        branch: Obd2BranchTag.maf,
+        fuelRateLPerHour: corrected,
+        mafGramsPerSecond: maf,
+        rpm: _latestRpm,
+        afr: afr,
+        fuelDensityGPerL: density,
+        engineDisplacementCc: displacement.toDouble(),
+        volumetricEfficiency: ve,
+      );
+      return corrected;
+    }
+
+    // Step 3: speed-density from MAP+IAT+RPM. Feeds the pre-#810
+    // estimator with the active vehicle's displacement + VE (#812).
+    final mapKpa = _latestMapKpa;
+    final iat = _latestIatCelsius;
+    final rpm = _latestRpm;
+    if (mapKpa == null || iat == null || rpm == null) {
+      collector?.record(
+        branch: Obd2BranchTag.none,
+        mapKpa: mapKpa,
+        iatCelsius: iat,
+        rpm: rpm,
+        afr: afr,
+        fuelDensityGPerL: density,
+        engineDisplacementCc: displacement.toDouble(),
+        volumetricEfficiency: ve,
+      );
+      return null;
+    }
+    final raw = Obd2Service.estimateFuelRateLPerHourFromMap(
+      mapKpa: mapKpa,
+      iatCelsius: iat,
+      rpm: rpm,
+      engineDisplacementCc: displacement,
+      volumetricEfficiency: ve,
+      afr: afr,
+      fuelDensityGPerL: density,
+    );
+    if (raw == null) {
+      collector?.record(
+        branch: Obd2BranchTag.none,
+        mapKpa: mapKpa,
+        iatCelsius: iat,
+        rpm: rpm,
+        afr: afr,
+        fuelDensityGPerL: density,
+        engineDisplacementCc: displacement.toDouble(),
+        volumetricEfficiency: ve,
+      );
+      return null;
+    }
+    final corrected = _applyTrim(raw);
+    collector?.record(
+      branch: Obd2BranchTag.speedDensity,
+      fuelRateLPerHour: corrected,
+      mapKpa: mapKpa,
+      iatCelsius: iat,
+      rpm: rpm,
+      afr: afr,
+      fuelDensityGPerL: density,
+      engineDisplacementCc: displacement.toDouble(),
+      volumetricEfficiency: ve,
+    );
+    return corrected;
+  }
+
+  /// Returns the user profile's η_v that should beat the engine-tech
+  /// helper, or null when the helper should kick in instead (#1422
+  /// phase 1). Mirrors the rules in [_resolveProfileVolumetricEfficiency]
+  /// in `obd2_service.dart` so both the live integrator and the
+  /// pull-mode estimator agree on a per-tick basis.
+  ///
+  /// Profile null → null (caller will use the helper or hard fallback).
+  /// Without a reference catalog row the stored profile value is the
+  /// best we can do, even if it equals the legacy 0.85 default.
+  /// Otherwise: keep the stored value when the VeLearner has logged at
+  /// least one sample OR when the value differs from the legacy 0.85
+  /// default. A cold-start profile sitting on 0.85 with zero samples
+  /// returns null, letting the engine-tech helper provide a closer
+  /// initial guess (e.g. 0.95 for a Dacia dCi VNT diesel).
+  double? _resolveControllerProfileVe() {
+    final v = _vehicle;
+    if (v == null) return null;
+    if (_referenceVehicle == null) return v.volumetricEfficiency;
+    if (v.volumetricEfficiencySamples > 0) return v.volumetricEfficiency;
+    if (v.volumetricEfficiency != 0.85) return v.volumetricEfficiency;
+    return null;
+  }
+
+  /// Apply the STFT + LTFT correction used on the MAF / speed-density
+  /// branches (#813). Returns [raw] unchanged when either trim hasn't
+  /// landed yet — better an uncorrected estimate than one shifted by
+  /// half the real signal.
+  double _applyTrim(double raw) {
+    final stft = _latestStft;
+    final ltft = _latestLtft;
+    if (stft == null || ltft == null) return raw;
+    return Obd2Service.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -12,6 +12,7 @@ import 'obd2_breadcrumb_collector.dart';
 import 'obd2_transport.dart';
 import 'oem_pid_table.dart';
 import 'supported_pids_cache.dart';
+import 'supported_pids_resolver.dart';
 
 // Re-export the pure-math estimator + stoichiometric constants so
 // callers that only need the math (e.g. [TripRecordingController]'s
@@ -43,22 +44,11 @@ export 'fuel_rate_estimator.dart'
 class Obd2Service implements Obd2RawCommandPort {
   final Obd2Transport _transport;
 
-  /// Optional persistent supported-PID cache (#811). When present and
-  /// a VIN (or [vehicleFallbackKey]) resolves to a cached entry,
-  /// [connect] skips the 8 × `01 XX` bitmap scan entirely.
-  final SupportedPidsCache? _pidsCache;
-
-  /// Fallback cache key for when the car doesn't return a VIN (old
-  /// ECUs / incompatible adapters). Typically `'${make}:${model}:${year}'`
-  /// — see [SupportedPidsCache.fallbackKey].
-  final String? _vehicleFallbackKey;
-
-  /// Per-connection cache of the Mode 01 PIDs the car supports,
-  /// populated by [discoverSupportedPids] or reloaded from [_pidsCache]
-  /// during [connect]. `null` means "we haven't asked the car yet,
-  /// so don't trust this cache to reject PIDs" (see [isPidSupported]
-  /// for the exact semantics).
-  Set<int>? _supportedPids;
+  /// Owns the #811 supported-PID concern — the persistent cache, the
+  /// per-connection PID set, and the vehicle-key resolution that
+  /// picks the cache slot. Extracted from this class in #1679; built
+  /// in the constructor body so it can capture the [_send] tear-off.
+  late final SupportedPidsResolver _pids;
 
   /// Stable adapter identifier (BLE remote-id / Classic MAC) for the
   /// device backing this session (#1312). Stamped by
@@ -125,8 +115,14 @@ class Obd2Service implements Obd2RawCommandPort {
     SupportedPidsCache? pidsCache,
     String? vehicleFallbackKey,
     this.breadcrumbCollector,
-  })  : _pidsCache = pidsCache,
-        _vehicleFallbackKey = vehicleFallbackKey;
+  }) {
+    _pids = SupportedPidsResolver(
+      send: _send,
+      isConnected: () => _transport.isConnected,
+      cache: pidsCache,
+      vehicleFallbackKey: vehicleFallbackKey,
+    );
+  }
 
   /// AT command that asks the ELM327 to identify itself. Returns a
   /// version string like `ELM327 v1.5` / `ELM327 v2.2` /
@@ -192,7 +188,7 @@ class Obd2Service implements Obd2RawCommandPort {
 
       // Clear the per-connection supported-PIDs cache. A new session
       // may be a different car / different adapter firmware.
-      _supportedPids = null;
+      _pids.resetForNewConnection();
 
       // Adapter-driven init sequence (#1330). [GenericElm327Adapter]
       // matches the legacy hardcoded behaviour byte-for-byte: the
@@ -240,7 +236,7 @@ class Obd2Service implements Obd2RawCommandPort {
         debugPrint('OBD2 ATI firmware read failed: $e\n$st');
       }
 
-      await _primeSupportedPidsCache();
+      await _pids.prime();
 
       return true;
     } catch (e, st) {
@@ -249,57 +245,8 @@ class Obd2Service implements Obd2RawCommandPort {
     }
   }
 
-  /// Attempt to load the supported-PID set from the persistent cache
-  /// (#811). Silent no-op when no cache was injected. Always swallows
-  /// errors: a broken cache must not break the connect flow — worst
-  /// case we fall back to blind querying, which is exactly what the
-  /// adapter did before this feature landed.
-  Future<void> _primeSupportedPidsCache() async {
-    final cache = _pidsCache;
-    if (cache == null) return;
-    try {
-      final key = await _resolveVehicleCacheKey();
-      if (key == null) {
-        debugPrint(
-            'OBD2 supported-PID cache: no VIN and no fallback key — '
-            'scanning blindly this session');
-        return;
-      }
-      final cached = cache.get(key);
-      if (cached != null) {
-        _supportedPids = cached;
-        debugPrint(
-            'OBD2 supported-PID cache HIT for "$key" '
-            '(${cached.length} PIDs) — skipping scan');
-        return;
-      }
-      debugPrint('OBD2 supported-PID cache MISS for "$key" — scanning');
-      final discovered = await discoverSupportedPids();
-      if (discovered.isNotEmpty) {
-        await cache.put(key, discovered);
-      }
-    } catch (e, st) {
-      debugPrint('OBD2 supported-PID cache prime failed: $e\n$st');
-    }
-  }
-
-  /// Resolve the cache key for the currently-connected vehicle.
-  /// Prefers the VIN; falls back to the static [_vehicleFallbackKey]
-  /// provided at construction time. Returns null when neither is
-  /// available, at which point the cache is skipped this session.
-  Future<String?> _resolveVehicleCacheKey() async {
-    try {
-      final response = await _send(Elm327Protocol.vinCommand);
-      final vin = Elm327Protocol.parseVin(response);
-      if (vin != null && vin.isNotEmpty) return vin;
-    } catch (e, st) {
-      debugPrint('OBD2 VIN read for cache key failed: $e\n$st');
-    }
-    return _vehicleFallbackKey;
-  }
-
   /// Whether [pid] is known to be supported by the connected vehicle
-  /// (#811). Key semantics:
+  /// (#811). Delegates to [SupportedPidsResolver]. Key semantics:
   ///
   ///   - When [discoverSupportedPids] has NOT been called yet
   ///     (cache is null), returns `true` — we don't know enough to
@@ -309,21 +256,20 @@ class Obd2Service implements Obd2RawCommandPort {
   ///     `true`.
   ///   - When the cache IS populated and [pid] is absent, returns
   ///     `false` — callers skip the query.
-  bool isPidSupported(int pid) =>
-      _supportedPids == null || _supportedPids!.contains(pid);
+  bool isPidSupported(int pid) => _pids.isPidSupported(pid);
 
   /// Alias for [isPidSupported] — matches the name used in the #811
   /// issue. Same semantics: `true` when the cache is unpopulated or
   /// [pid] is present, `false` only when we know the car doesn't
   /// implement it.
-  bool supportsPid(int pid) => isPidSupported(pid);
+  bool supportsPid(int pid) => _pids.supportsPid(pid);
 
   /// Direct view of the supported-PID set for tests and diagnostics.
   /// Returns an unmodifiable empty set when discovery hasn't run —
   /// callers that want "is this supported?" should use [supportsPid]
   /// instead to respect the "unknown ⇒ allow" semantics.
   @visibleForTesting
-  Set<int> get debugSupportedPids => Set.unmodifiable(_supportedPids ?? {});
+  Set<int> get debugSupportedPids => _pids.debugSupportedPids;
 
   /// Read the odometer value in km.
   ///
@@ -471,33 +417,7 @@ class Obd2Service implements Obd2RawCommandPort {
   /// [isPidSupported] calls short-circuit queries for PIDs the car
   /// doesn't implement. One walk per trip-recording session is
   /// enough.
-  Future<Set<int>> discoverSupportedPids() async {
-    if (!_transport.isConnected) return const <int>{};
-    final supported = <int>{};
-    for (final command in Elm327Protocol.supportedPidsCommands) {
-      // Derive the 32-PID group base from the command (e.g. "0140\r"
-      // → 0x40). The commands list is in lockstep with the group
-      // bases, so we just hex-parse the middle two chars.
-      final groupBase = int.parse(command.substring(2, 4), radix: 16);
-      try {
-        final response = await _send(command);
-        final bitmap =
-            Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
-        if (bitmap == null) break;
-        supported.addAll(bitmap);
-        // "Bit 32" of the bitmap — i.e. PID (groupBase + 32) — is
-        // conventionally the "are PIDs in the next range supported?"
-        // flag. If it's not in the set we just parsed, stop walking.
-        final nextRangeFlag = groupBase + 32;
-        if (!bitmap.contains(nextRangeFlag)) break;
-      } catch (e, st) {
-        debugPrint('OBD2 discoverSupportedPids failed on $command: $e\n$st');
-        break;
-      }
-    }
-    _supportedPids = supported;
-    return supported;
-  }
+  Future<Set<int>> discoverSupportedPids() => _pids.discoverSupportedPids();
 
   /// Read current engine RPM.
   Future<double?> readRpm() async {

--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/foundation.dart';
+
+import 'elm327_protocol.dart';
+import 'supported_pids_cache.dart';
+
+/// Owns the #811 supported-PID concern, extracted from [Obd2Service]
+/// (#1679): the per-connection set of Mode 01 PIDs the car implements,
+/// the persistent cache that lets [prime] skip the 8 × `01 XX` bitmap
+/// scan, and the vehicle-key resolution that picks the cache slot.
+///
+/// The collaborator talks to the adapter through an injected
+/// [send] closure (the host's `_send`, which applies the active
+/// [Elm327Adapter.preParse] hook) and an [isConnected] predicate, so
+/// it carries no transport dependency of its own.
+class SupportedPidsResolver {
+  SupportedPidsResolver({
+    required Future<String> Function(String command) send,
+    required bool Function() isConnected,
+    SupportedPidsCache? cache,
+    String? vehicleFallbackKey,
+  })  : _send = send,
+        _isConnected = isConnected,
+        _cache = cache,
+        _vehicleFallbackKey = vehicleFallbackKey;
+
+  final Future<String> Function(String command) _send;
+  final bool Function() _isConnected;
+
+  /// Optional persistent supported-PID cache (#811). When present and
+  /// a VIN (or [_vehicleFallbackKey]) resolves to a cached entry,
+  /// [prime] skips the 8 × `01 XX` bitmap scan entirely.
+  final SupportedPidsCache? _cache;
+
+  /// Fallback cache key for when the car doesn't return a VIN (old
+  /// ECUs / incompatible adapters). Typically `'${make}:${model}:${year}'`.
+  final String? _vehicleFallbackKey;
+
+  /// Per-connection cache of the Mode 01 PIDs the car supports,
+  /// populated by [discoverSupportedPids] or reloaded from [_cache]
+  /// during [prime]. `null` means "we haven't asked the car yet, so
+  /// don't trust this cache to reject PIDs" (see [isPidSupported]).
+  Set<int>? _supportedPids;
+
+  /// Clear the per-connection supported-PIDs cache. A new session may
+  /// be a different car / different adapter firmware. Call at the top
+  /// of the host's `connect`.
+  void resetForNewConnection() {
+    _supportedPids = null;
+  }
+
+  /// Attempt to load the supported-PID set from the persistent cache
+  /// (#811). Silent no-op when no cache was injected. Always swallows
+  /// errors: a broken cache must not break the connect flow — worst
+  /// case we fall back to blind querying, which is exactly what the
+  /// adapter did before this feature landed.
+  Future<void> prime() async {
+    final cache = _cache;
+    if (cache == null) return;
+    try {
+      final key = await _resolveVehicleCacheKey();
+      if (key == null) {
+        debugPrint(
+            'OBD2 supported-PID cache: no VIN and no fallback key — '
+            'scanning blindly this session');
+        return;
+      }
+      final cached = cache.get(key);
+      if (cached != null) {
+        _supportedPids = cached;
+        debugPrint(
+            'OBD2 supported-PID cache HIT for "$key" '
+            '(${cached.length} PIDs) — skipping scan');
+        return;
+      }
+      debugPrint('OBD2 supported-PID cache MISS for "$key" — scanning');
+      final discovered = await discoverSupportedPids();
+      if (discovered.isNotEmpty) {
+        await cache.put(key, discovered);
+      }
+    } catch (e, st) {
+      debugPrint('OBD2 supported-PID cache prime failed: $e\n$st');
+    }
+  }
+
+  /// Resolve the cache key for the currently-connected vehicle.
+  /// Prefers the VIN; falls back to the static [_vehicleFallbackKey]
+  /// provided at construction time. Returns null when neither is
+  /// available, at which point the cache is skipped this session.
+  Future<String?> _resolveVehicleCacheKey() async {
+    try {
+      final response = await _send(Elm327Protocol.vinCommand);
+      final vin = Elm327Protocol.parseVin(response);
+      if (vin != null && vin.isNotEmpty) return vin;
+    } catch (e, st) {
+      debugPrint('OBD2 VIN read for cache key failed: $e\n$st');
+    }
+    return _vehicleFallbackKey;
+  }
+
+  /// Ask the adapter which Mode 01 PIDs the vehicle supports (#811).
+  ///
+  /// Walks the standard supported-PIDs chain: `01 00` returns a
+  /// bitmap for PIDs 01–20, and bit-32 of that bitmap is set iff PIDs
+  /// 21–40 are also addressable — querying `01 20` in turn returns
+  /// that range, and so on up to `01 C0`. We stop as soon as a
+  /// bitmap's "next-range supported" flag is clear or the query
+  /// returns NO DATA.
+  ///
+  /// Returns an empty set when the adapter isn't connected or the
+  /// first bitmap can't be read — the caller should fall back to
+  /// blind querying. Also populates the internal per-connection
+  /// cache so subsequent [isPidSupported] calls short-circuit.
+  Future<Set<int>> discoverSupportedPids() async {
+    if (!_isConnected()) return const <int>{};
+    final supported = <int>{};
+    for (final command in Elm327Protocol.supportedPidsCommands) {
+      // Derive the 32-PID group base from the command (e.g. "0140\r"
+      // → 0x40). The commands list is in lockstep with the group
+      // bases, so we just hex-parse the middle two chars.
+      final groupBase = int.parse(command.substring(2, 4), radix: 16);
+      try {
+        final response = await _send(command);
+        final bitmap =
+            Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
+        if (bitmap == null) break;
+        supported.addAll(bitmap);
+        // "Bit 32" of the bitmap — i.e. PID (groupBase + 32) — is
+        // conventionally the "are PIDs in the next range supported?"
+        // flag. If it's not in the set we just parsed, stop walking.
+        final nextRangeFlag = groupBase + 32;
+        if (!bitmap.contains(nextRangeFlag)) break;
+      } catch (e, st) {
+        debugPrint('OBD2 discoverSupportedPids failed on $command: $e\n$st');
+        break;
+      }
+    }
+    _supportedPids = supported;
+    return supported;
+  }
+
+  /// Whether [pid] is known to be supported by the connected vehicle
+  /// (#811). Key semantics:
+  ///
+  ///   - When discovery has NOT run yet (cache is null), returns
+  ///     `true` — we don't know enough to reject the query, so let it
+  ///     go through and surface NO DATA naturally.
+  ///   - When the cache IS populated and [pid] is present → `true`.
+  ///   - When the cache IS populated and [pid] is absent → `false`.
+  bool isPidSupported(int pid) =>
+      _supportedPids == null || _supportedPids!.contains(pid);
+
+  /// Alias for [isPidSupported] — matches the name used in the #811
+  /// issue.
+  bool supportsPid(int pid) => isPidSupported(pid);
+
+  /// Direct view of the supported-PID set for tests and diagnostics.
+  /// Returns an unmodifiable empty set when discovery hasn't run.
+  Set<int> get debugSupportedPids => Set.unmodifiable(_supportedPids ?? {});
+}

--- a/lib/features/consumption/data/obd2/trip_drop_detector.dart
+++ b/lib/features/consumption/data/obd2/trip_drop_detector.dart
@@ -1,0 +1,127 @@
+import 'obd2_connection_errors.dart';
+
+/// Owns the connection-drop *detection* heuristics extracted from
+/// [TripRecordingController] (#1679): the #797 transport-error sliding
+/// window and the #1330 silent-failure null-parse counter.
+///
+/// This collaborator only *detects* — it counts, classifies, and
+/// answers "should the controller drop now?". The *reaction* (pausing
+/// the scheduler, persisting the paused snapshot, the grace timer, the
+/// reconnect scanner) stays on the controller, which is ordering-
+/// sensitive lifecycle that doesn't belong here.
+class TripDropDetector {
+  TripDropDetector({
+    required DateTime Function() now,
+    Duration dropWindow = const Duration(seconds: 5),
+    int dropThreshold = 3,
+    int silentFailureThreshold = 50,
+  })  : _now = now,
+        _dropWindow = dropWindow,
+        _dropThreshold = dropThreshold,
+        _silentFailureThreshold = silentFailureThreshold;
+
+  final DateTime Function() _now;
+
+  /// Sliding window used for the "3 consecutive transport errors"
+  /// heuristic (#797 phase 1).
+  final Duration _dropWindow;
+  final int _dropThreshold;
+
+  /// Threshold for the "adapter connected but every PID parse returns
+  /// null" silent-failure heuristic (#1330 phase 3).
+  final int _silentFailureThreshold;
+
+  /// Consecutive-error bookkeeping for the drop heuristic. First entry
+  /// is the oldest. Reset on a successful transport read.
+  final List<DateTime> _recentErrors = <DateTime>[];
+
+  /// Consecutive-null-parse counter for the silent-failure heuristic
+  /// (#1330 phase 3). Incremented from every high-priority PID parse
+  /// that returns null; reset to zero the moment any high-priority PID
+  /// parses a non-null value. Distinct from [_recentErrors] which
+  /// counts *transport-level* failures — silent-failure is the case
+  /// where the transport is healthy but the ECU never speaks.
+  int _consecutiveNullReads = 0;
+
+  /// Sticky flag so the silent-failure handler only fires once per
+  /// recording session. Cleared by [reset] on stop / resume.
+  bool _silentFailureFired = false;
+
+  /// Current consecutive-null count. Lets the silent-failure tests
+  /// assert "49 nulls did NOT trigger" before the 50th lands.
+  int get consecutiveNullReads => _consecutiveNullReads;
+
+  /// Whether the silent-failure threshold has been crossed for this
+  /// recording session. Cleared by [reset].
+  bool get silentFailureFired => _silentFailureFired;
+
+  /// Record a clean transport read — the only signal strong enough to
+  /// clear the error window. ELM327 NO DATA responses come back via
+  /// the response string, not an exception, so they don't reach here.
+  void registerSuccess() => _recentErrors.clear();
+
+  /// Clear the transport-error window without recording a success.
+  /// Called by the controller's drop handler.
+  void clearErrorWindow() => _recentErrors.clear();
+
+  /// Register a transport [error] and report whether the controller
+  /// should now drop into the paused-due-to-drop state — either
+  /// because a typed disconnect was seen, or because
+  /// [_dropThreshold] errors landed inside [_dropWindow].
+  bool registerTransportError(Object error) {
+    final now = _now();
+    _recentErrors.add(now);
+    // Keep only errors inside the window so the heuristic doesn't
+    // count a ten-minute-old blip.
+    _recentErrors.removeWhere(
+      (ts) => now.difference(ts) > _dropWindow,
+    );
+    return _isTypedDisconnect(error) ||
+        _recentErrors.length >= _dropThreshold;
+  }
+
+  /// Observe a high-priority PID parse outcome and report whether the
+  /// silent-failure threshold was crossed *for the first time* by this
+  /// call. A non-null [parsedValue] resets the counter (we're
+  /// detecting "ECU is dead", not "this PID is unsupported") and
+  /// returns false. A null value increments the counter; the first
+  /// time it reaches [_silentFailureThreshold] this latches
+  /// [silentFailureFired] and returns true. Subsequent nulls return
+  /// false so the controller doesn't re-fire.
+  bool observeHighPriorityParse(Object? parsedValue) {
+    if (parsedValue != null) {
+      _consecutiveNullReads = 0;
+      return false;
+    }
+    if (_silentFailureFired) return false;
+    _consecutiveNullReads++;
+    if (_consecutiveNullReads >= _silentFailureThreshold) {
+      _silentFailureFired = true;
+      return true;
+    }
+    return false;
+  }
+
+  /// Reset the silent-failure latch + counter so a subsequent
+  /// recording (or a manual resume followed by another silent
+  /// stretch) can fire again. Called on stop / resume.
+  void reset() {
+    _consecutiveNullReads = 0;
+    _silentFailureFired = false;
+  }
+
+  bool _isTypedDisconnect(Object error) {
+    if (error is Obd2DisconnectedException) return true;
+    // The live Bluetooth transport throws `StateError('Transport
+    // closed')` once its channel is shut down by the OS / user.
+    // Match by message so the controller works against the real
+    // implementation without reaching into platform-specific
+    // exception types.
+    if (error is StateError) {
+      final msg = error.message.toLowerCase();
+      if (msg.contains('transport closed')) return true;
+      if (msg.contains('not connected')) return true;
+    }
+    return false;
+  }
+}

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -18,6 +18,7 @@ import 'obd2_service.dart';
 import 'paused_trip_repository.dart';
 import 'pid_scheduler.dart';
 import 'trip_distance_source.dart';
+import 'trip_drop_detector.dart';
 import 'trip_live_reading.dart';
 import 'trip_sample_buffer.dart';
 import 'virtual_odometer.dart';
@@ -216,20 +217,13 @@ class TripRecordingController {
   /// (e.g. 100 ms) to exercise the auto-finalise path.
   final Duration _pauseGraceWindow;
 
-  /// Sliding window used for the "3 consecutive transport errors"
-  /// heuristic (#797 phase 1). The counter resets on every successful
-  /// read. Override for tests that want to pin the exact threshold.
-  final Duration _dropWindow;
-  final int _dropThreshold;
-
-  /// Threshold for the "adapter connected but every PID parse returns
-  /// null" silent-failure heuristic (#1330 phase 3). At the 5 Hz fast
-  /// tier 50 consecutive null parses ≈ 10 s — long enough to ride out a
-  /// brief noise burst, short enough that the user gets a notification
-  /// before they've driven a meaningful distance with no data.
-  /// Test-only: tests inject a small value (e.g. 3) so a fake service
-  /// can drive the counter past the threshold without 50 round-trips.
-  final int _silentFailureThreshold;
+  /// Owns the connection-drop *detection* heuristics — the #797
+  /// transport-error sliding window and the #1330 silent-failure
+  /// null-parse counter — extracted into a focused collaborator
+  /// (#1679). The controller keeps the *reaction* ([_handleDrop],
+  /// grace timer, reconnect scanner). Built in the constructor body
+  /// so it can capture the resolved [_now] clock.
+  late final TripDropDetector _dropDetector;
 
   /// Pinned adapter MAC that the auto-reconnect scanner (#797 phase 3)
   /// will search for when a drop flips us into
@@ -273,26 +267,6 @@ class TripRecordingController {
   bool _started = false;
   bool _stopped = false;
   String? _sessionId; // ISO start-ts, stable across pause→resume cycles
-
-  /// Consecutive-error bookkeeping for the drop heuristic. First entry
-  /// is the oldest. Reset on a successful transport read.
-  final List<DateTime> _recentErrors = <DateTime>[];
-
-  /// Consecutive-null-parse counter for the silent-failure heuristic
-  /// (#1330 phase 3). Incremented from every high-priority PID
-  /// callback when the parser returns null; reset to zero the moment
-  /// any high-priority PID parses a non-null value. Distinct from
-  /// [_recentErrors] which counts *transport-level* failures —
-  /// silent-failure is the case where the transport is healthy but
-  /// the ECU never speaks.
-  int _consecutiveNullReads = 0;
-
-  /// Sticky flag so the silent-failure handler only fires once per
-  /// recording session — even if more null parses keep arriving past
-  /// the threshold, we don't want to keep re-entering [_handleDrop].
-  /// Reset on stop()/resume() so a subsequent recording (or a manual
-  /// resume followed by another silent stretch) can fire again.
-  bool _silentFailureFired = false;
 
   /// Reason the most recent [_handleDrop] fired (#1330 phase 3).
   /// Null when no drop has occurred. Read by the provider so the
@@ -398,14 +372,18 @@ class TripRecordingController {
         _pausedRepoOverride = pausedRepo,
         _historyRepoOverride = historyRepo,
         _pauseGraceWindow = pauseGraceWindow,
-        _dropWindow = dropWindow,
-        _dropThreshold = dropThreshold,
-        _silentFailureThreshold = silentFailureThreshold,
         _schedulerTickRate = schedulerTickRate,
         _pinnedAdapterMac = pinnedAdapterMac,
         _automatic = automatic,
         _reconnectScannerFactory = reconnectScannerFactory,
-        _breadcrumbCollector = breadcrumbCollector;
+        _breadcrumbCollector = breadcrumbCollector {
+    _dropDetector = TripDropDetector(
+      now: _now,
+      dropWindow: dropWindow,
+      dropThreshold: dropThreshold,
+      silentFailureThreshold: silentFailureThreshold,
+    );
+  }
 
   /// Optional fuel-rate diagnostic breadcrumb sink (#1395). Wired in
   /// by [tripRecordingProvider] when a recording starts so the
@@ -473,8 +451,7 @@ class TripRecordingController {
       // post-resume stretch of nulls can fire again. Without this,
       // a user who resumes after a silent-failure drop and then hits
       // a fresh silent failure would never get a second snackbar.
-      _silentFailureFired = false;
-      _consecutiveNullReads = 0;
+      _dropDetector.reset();
       // Also tear down the auto-reconnect scanner (#797 phase 3) —
       // either we got here because the scanner fired its callback
       // (in which case it already stopped itself), or the user
@@ -607,8 +584,7 @@ class TripRecordingController {
     _started = false;
     _stopped = true;
     _pausedDueToDrop = false;
-    _silentFailureFired = false;
-    _consecutiveNullReads = 0;
+    _dropDetector.reset();
     _emitState();
     if (!_stateController.isClosed) {
       await _stateController.close();
@@ -848,7 +824,7 @@ class TripRecordingController {
       // A clean read is the only signal strong enough to clear the
       // error window; ELM327 NO DATA responses come back via the
       // response string, not an exception.
-      _recentErrors.clear();
+      _dropDetector.registerSuccess();
       return response;
     } catch (e, st) { // ignore: unused_catch_stack
       _registerTransportError(e);
@@ -856,34 +832,15 @@ class TripRecordingController {
     }
   }
 
+  /// Funnel a transport error through the drop detector and react to
+  /// its verdict (#797 phase 1). The lifecycle guard stays here — the
+  /// detector counts, the controller owns the "are we already
+  /// pausing?" state.
   void _registerTransportError(Object error) {
     if (_pausedDueToDrop || _stopped) return;
-    final now = _now();
-    _recentErrors.add(now);
-    // Keep only errors inside the window so the heuristic doesn't
-    // count a ten-minute-old blip.
-    _recentErrors.removeWhere(
-      (ts) => now.difference(ts) > _dropWindow,
-    );
-    final typedDisconnect = _isTypedDisconnect(error);
-    if (typedDisconnect || _recentErrors.length >= _dropThreshold) {
+    if (_dropDetector.registerTransportError(error)) {
       _handleDrop();
     }
-  }
-
-  bool _isTypedDisconnect(Object error) {
-    if (error is Obd2DisconnectedException) return true;
-    // The live Bluetooth transport throws `StateError('Transport
-    // closed')` once its channel is shut down by the OS / user.
-    // Match by message so the controller works against the real
-    // implementation without reaching into platform-specific
-    // exception types.
-    if (error is StateError) {
-      final msg = error.message.toLowerCase();
-      if (msg.contains('transport closed')) return true;
-      if (msg.contains('not connected')) return true;
-    }
-    return false;
   }
 
   /// Bookkeeping for the silent-failure heuristic (#1330 phase 3).
@@ -903,37 +860,29 @@ class TripRecordingController {
     if (parsedValue != null) {
       // ANY successful high-priority parse clears the window — we're
       // detecting "ECU is dead", not "this one PID is unsupported".
-      _consecutiveNullReads = 0;
+      _dropDetector.observeHighPriorityParse(parsedValue);
       return;
     }
-    if (_silentFailureFired) return;
+    // The transport-error drop already paused us — don't let a stretch
+    // of nulls double-fire into a second drop. The lifecycle guard
+    // stays here; the detector just counts.
     if (_pausedDueToDrop || _stopped) return;
-    _consecutiveNullReads++;
-    if (_consecutiveNullReads >= _silentFailureThreshold) {
+    if (_dropDetector.observeHighPriorityParse(parsedValue)) {
       _onSilentFailure();
     }
   }
 
   /// Silent-failure handler (#1330 phase 3). Fired exactly once per
-  /// recording session when the consecutive-null counter crosses the
-  /// threshold. Drives the same pause-with-grace recovery as
-  /// [_handleDrop] for transport errors, but tags the drop with
-  /// [TripDropReason.silentFailure] so the UI surfaces "OBD2 adapter
-  /// connected but not returning data" instead of "OBD2 connection
-  /// lost".
+  /// recording session when the drop detector's consecutive-null
+  /// counter crosses the threshold. Drives the same pause-with-grace
+  /// recovery as [_handleDrop] for transport errors, but tags the drop
+  /// with [TripDropReason.silentFailure] so the UI surfaces "OBD2
+  /// adapter connected but not returning data" instead of "OBD2
+  /// connection lost".
   void _onSilentFailure() {
-    if (_silentFailureFired) return;
-    if (_pausedDueToDrop || _stopped) {
-      // The transport-error drop already paused us — don't double-fire
-      // and don't override the reason. The user is already seeing the
-      // "connection lost" banner; switching it mid-flight to "not
-      // responding" would be misleading.
-      return;
-    }
-    _silentFailureFired = true;
     debugPrint(
       'TripRecordingController: silent-failure detected — '
-      '$_consecutiveNullReads consecutive null PID parses',
+      '${_dropDetector.consecutiveNullReads} consecutive null PID parses',
     );
     _handleDrop(reason: TripDropReason.silentFailure);
   }
@@ -945,7 +894,7 @@ class TripRecordingController {
     _pausedDueToDrop = true;
     _dropReason = reason;
     _scheduler?.stop();
-    _recentErrors.clear();
+    _dropDetector.clearErrorWindow();
     _persistPausedSnapshot();
     _graceTimer?.cancel();
     _graceTimer = Timer(_pauseGraceWindow, _onGraceWindowElapsed);
@@ -1524,12 +1473,12 @@ class TripRecordingController {
   /// silent-failure tests assert "49 nulls did NOT trigger" before
   /// the 50th lands (#1330 phase 3).
   @visibleForTesting
-  int get debugConsecutiveNullReads => _consecutiveNullReads;
+  int get debugConsecutiveNullReads => _dropDetector.consecutiveNullReads;
 
   /// Exposed for tests: whether the silent-failure handler has fired
   /// for this recording session. Resets on resume() / stop().
   @visibleForTesting
-  bool get debugSilentFailureFired => _silentFailureFired;
+  bool get debugSilentFailureFired => _dropDetector.silentFailureFired;
 
   /// Exposed for tests: synchronously drive the grace-window
   /// finalisation path. Useful with fake-async patterns where

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -19,6 +19,7 @@ import 'paused_trip_repository.dart';
 import 'pid_scheduler.dart';
 import 'trip_distance_source.dart';
 import 'trip_live_reading.dart';
+import 'trip_sample_buffer.dart';
 import 'virtual_odometer.dart';
 
 // Re-export the DTO + distance-source constants so existing callers
@@ -312,52 +313,23 @@ class TripRecordingController {
   /// real odometer.
   final List<VirtualOdometerSample> _speedSamples = <VirtualOdometerSample>[];
 
-  /// Per-tick sample buffer used by the trip-detail charts (#1040).
-  /// Decimated to ~1 Hz inside [_emit] — the user-facing charts don't
-  /// need the 4 Hz emit cadence, and 1 Hz × 8 fields keeps a 39-min
-  /// trip's payload well under 20 KB compressed. Capped at
-  /// [_capturedSampleCap] so a forgotten recording can't eat unbounded
-  /// memory; the cap covers a 33-hour drive at 1 Hz which is more
-  /// than enough headroom.
-  final List<TripSample> _capturedSamples = <TripSample>[];
-
-  /// Timestamp of the most recently *captured* (decimated) sample.
-  /// Distinct from [_lastSampleAt] which tracks the recorder feed at
-  /// the full 4 Hz emit cadence.
-  DateTime? _lastCapturedAt;
-
-  /// Cap on the captured-sample buffer (#1040). 120000 samples = 33 h
-  /// at 1 Hz — comfortably above any plausible single trip — so this
-  /// only kicks in if the user forgets to stop a recording overnight.
-  static const int _capturedSampleCap = 120000;
+  /// Owns the #1040 captured-sample buffer and the #1458 GPS
+  /// cadence-diagnostics buffer — both per-trip ring buffers
+  /// extracted into a focused collaborator (#1679).
+  final TripSampleBuffer _sampleBuffer = TripSampleBuffer();
 
   /// Read-only snapshot of the captured sample buffer (#1040). The
   /// list is unmodifiable so callers can't accidentally mutate the
   /// controller's state — the provider clones it into the persisted
   /// [TripHistoryEntry] at stop time.
-  List<TripSample> get capturedSamples => List.unmodifiable(_capturedSamples);
-
-  /// Per-trip GPS cadence diagnostics buffer (#1458 phase 2). Appended
-  /// to by [recordGpsSampleDiagnostic] every time the provider's
-  /// position-stream listener fires; persisted onto the saved
-  /// [TripHistoryEntry] at stop time. Capped at
-  /// [_gpsSampleDiagnosticCap] so a forgotten recording can't eat
-  /// unbounded memory.
-  final List<GpsSampleDiagnostic> _gpsSampleDiagnostics =
-      <GpsSampleDiagnostic>[];
-
-  /// Cap on the GPS diagnostics buffer (#1458 phase 2). At ~1 Hz GPS
-  /// fix cadence the cap covers ~33 hours — comfortably above any
-  /// plausible single trip and well below the trip-detail JSON
-  /// size budget.
-  static const int _gpsSampleDiagnosticCap = 120000;
+  List<TripSample> get capturedSamples => _sampleBuffer.capturedSamples;
 
   /// Read-only snapshot of the GPS cadence diagnostics buffer
   /// (#1458 phase 2). The list is unmodifiable so callers can't
   /// accidentally mutate the controller's state — the provider clones
   /// it into the persisted [TripHistoryEntry] at stop time.
   List<GpsSampleDiagnostic> get capturedGpsSampleDiagnostics =>
-      List.unmodifiable(_gpsSampleDiagnostics);
+      _sampleBuffer.capturedGpsSampleDiagnostics;
 
   /// Latest parsed values, keyed by PID command. Written by scheduler
   /// callbacks, read by [_emit] when assembling [TripLiveReading]. Not
@@ -561,20 +533,10 @@ class TripRecordingController {
     required DateTime now,
     required String lifecycleState,
   }) {
-    final entry = GpsSampleDiagnostic(
-      timestamp: now,
+    _sampleBuffer.recordGpsSampleDiagnostic(
+      now: now,
       lifecycleState: lifecycleState,
-      index: _gpsSampleDiagnostics.length,
     );
-    _gpsSampleDiagnostics.add(entry);
-    if (_gpsSampleDiagnostics.length > _gpsSampleDiagnosticCap) {
-      // Drop the oldest slice — losing the early stretch is preferable
-      // to letting a forgotten overnight recording eat unbounded memory.
-      _gpsSampleDiagnostics.removeRange(
-        0,
-        _gpsSampleDiagnostics.length - _gpsSampleDiagnosticCap,
-      );
-    }
   }
 
   /// Exposed for tests: append a cadence diagnostic without going
@@ -583,7 +545,7 @@ class TripRecordingController {
   /// needing a real Geolocator stream.
   @visibleForTesting
   void debugCaptureGpsSampleDiagnostic(GpsSampleDiagnostic diagnostic) {
-    _gpsSampleDiagnostics.add(diagnostic);
+    _sampleBuffer.debugCaptureGpsSampleDiagnostic(diagnostic);
   }
 
   /// Read-only snapshot of the most recent GPS latitude pushed in via
@@ -747,11 +709,12 @@ class TripRecordingController {
     // gears. Hybrids DO have a step-ratio transmission on the
     // combustion side, so they fall through to the inference path.
     if (vehicle.type == VehicleType.ev) return null;
-    if (_capturedSamples.isEmpty) return null;
+    final captured = _sampleBuffer.capturedSamples;
+    if (captured.isEmpty) return null;
     final tireC = vehicle.tireCircumferenceMeters;
     if (tireC <= 0) return null;
     final result = inferGears(
-      samples: _capturedSamples,
+      samples: captured,
       tireCircumferenceMeters: tireC,
       priorCentroids: vehicle.gearCentroids,
     );
@@ -761,7 +724,7 @@ class TripRecordingController {
           .map((s) => (timestamp: s.timestamp, gear: s.gear))
           .toList(growable: false),
       optimalRpmCeiling: _optimalRpmCeiling,
-      samples: _capturedSamples,
+      samples: captured,
       centroids: result.centroids,
     );
   }
@@ -1298,7 +1261,7 @@ class TripRecordingController {
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;
-      _maybeCaptureSample(sample);
+      _sampleBuffer.maybeCapture(sample);
     }
     if (fuelRate != null) {
       _fuelRateSeen = true;
@@ -1518,40 +1481,13 @@ class TripRecordingController {
     return Obd2Service.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
   }
 
-  /// Append [sample] to the captured-samples buffer when at least
-  /// 1 second has elapsed since the previous capture. The 4 Hz emit
-  /// loop drops 3 of every 4 candidate samples — the chart layer
-  /// renders at 1 Hz and the storage budget is sized for that
-  /// cadence (#1040).
-  void _maybeCaptureSample(TripSample sample) {
-    final last = _lastCapturedAt;
-    if (last != null) {
-      // Use 950 ms as the gate so a 1 Hz scheduler that's slightly
-      // jittered (998 ms / 1003 ms) still captures every tick. Without
-      // the slack a 998 ms gap would slip through the >=1000 check
-      // and we'd silently halve the captured rate.
-      if (sample.timestamp.difference(last).inMilliseconds < 950) return;
-    }
-    _capturedSamples.add(sample);
-    _lastCapturedAt = sample.timestamp;
-    if (_capturedSamples.length > _capturedSampleCap) {
-      // Drop the oldest slice — losing the early stretch is preferable
-      // to letting a forgotten overnight recording eat unbounded memory.
-      _capturedSamples.removeRange(
-        0,
-        _capturedSamples.length - _capturedSampleCap,
-      );
-    }
-  }
-
   /// Exposed for tests: append a sample to the captured-samples buffer
   /// without going through the scheduler / debounced emit timer
   /// (#1040). Tests use this to populate a deterministic buffer + then
   /// drive [TripRecording.stop] end-to-end.
   @visibleForTesting
   void debugCaptureSample(TripSample sample) {
-    _capturedSamples.add(sample);
-    _lastCapturedAt = sample.timestamp;
+    _sampleBuffer.debugCaptureSample(sample);
   }
 
   /// Exposed for tests: force an emit immediately instead of waiting

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -12,6 +12,7 @@ import '../../domain/trip_recorder.dart';
 import '../trip_history_repository.dart';
 import 'adapter_reconnect_scanner.dart';
 import 'elm327_protocol.dart';
+import 'live_sample_snapshot.dart';
 import 'obd2_breadcrumb_collector.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_service.dart';
@@ -305,38 +306,18 @@ class TripRecordingController {
   List<GpsSampleDiagnostic> get capturedGpsSampleDiagnostics =>
       _sampleBuffer.capturedGpsSampleDiagnostics;
 
-  /// Latest parsed values, keyed by PID command. Written by scheduler
-  /// callbacks, read by [_emit] when assembling [TripLiveReading]. Not
-  /// using a typed struct because most fields are optional doubles
-  /// and adding a freezed class for this scratch space buys nothing.
-  double? _latestSpeedKmh;
-  double? _latestRpm;
-  double? _latestMaf;
-  double? _latestMapKpa;
-  double? _latestIatCelsius;
-  double? _latestThrottlePercent;
-  double? _latestEngineLoadPercent;
-  double? _latestCoolantTempC;
-  double? _latestFuelLevelPercent;
-  double? _latestStft;
-  double? _latestLtft;
-  double? _latestDirectFuelRate;
+  /// VIN read once at [start]. Null on older ECUs / adapters that
+  /// can't answer Mode 09 PID 02.
   String? _vin;
 
-  // #1374 phase 1 — most recent GPS fix, pushed in by the provider
-  // when the `Feature.gpsTripPath` flag is enabled. The controller
-  // does NOT subscribe to Geolocator itself — that decision lives at
-  // the provider layer so the controller stays free of plugin
-  // imports and tests can drive the latch with hand-built doubles.
-  // When the flag is off the provider never calls [updateGpsFix],
-  // both fields stay null, and every persisted sample carries
-  // `latitude: null, longitude: null` (matching pre-#1374 behaviour
-  // bit-for-bit). When the flag is on but no fix has landed yet
-  // (cold-start, indoors, permission revoked), the fields are also
-  // null and the corresponding sample is written with both keys
-  // absent — better than failing the trip.
-  double? _latestLatitude;
-  double? _latestLongitude;
+  /// The "clock"-side snapshot — the per-PID latest-value scratch
+  /// space, the scheduler subscription wiring, and the tier-1/2/3
+  /// fuel-rate derivation — extracted into a focused collaborator
+  /// (#1679). The emit timer + [_emit] stay on the controller; this
+  /// collaborator owns the values that [_emit] reads. Built in the
+  /// constructor body so it can capture the [_observeHighPriorityParse]
+  /// and [_recordSpeedSample] tear-offs.
+  late final LiveSampleSnapshot _liveSampleSnapshot;
 
   TripRecordingController({
     required Obd2Service service,
@@ -382,6 +363,14 @@ class TripRecordingController {
       dropWindow: dropWindow,
       dropThreshold: dropThreshold,
       silentFailureThreshold: silentFailureThreshold,
+    );
+    _liveSampleSnapshot = LiveSampleSnapshot(
+      service: _service,
+      vehicle: _vehicle,
+      referenceVehicle: _referenceVehicle,
+      breadcrumbCollector: _breadcrumbCollector,
+      onHighPriorityParse: _observeHighPriorityParse,
+      onSpeedSample: _recordSpeedSample,
     );
   }
 
@@ -489,8 +478,10 @@ class TripRecordingController {
   /// controller cheap (no Geolocator mocks required) and lets the
   /// flag-off path skip the plugin entirely.
   void updateGpsFix({double? latitude, double? longitude}) {
-    _latestLatitude = latitude;
-    _latestLongitude = longitude;
+    _liveSampleSnapshot.updateGpsFix(
+      latitude: latitude,
+      longitude: longitude,
+    );
   }
 
   /// #1458 phase 2 — append one cadence-diagnostic record at [now]
@@ -530,13 +521,13 @@ class TripRecordingController {
   /// production reads the value through the persisted [TripSample]
   /// fields, not this getter.
   @visibleForTesting
-  double? get debugLatestLatitude => _latestLatitude;
+  double? get debugLatestLatitude => _liveSampleSnapshot.latestLatitude;
 
   /// Read-only snapshot of the most recent GPS longitude pushed in via
   /// [updateGpsFix] (#1374 phase 1). Same caveats as
   /// [debugLatestLatitude].
   @visibleForTesting
-  double? get debugLatestLongitude => _latestLongitude;
+  double? get debugLatestLongitude => _liveSampleSnapshot.latestLongitude;
 
   /// Start polling. Reads the odometer and VIN ONCE to pin trip
   /// identity; subsequent ticks are scheduled per-PID by
@@ -559,7 +550,7 @@ class TripRecordingController {
     _vin = await _readVinOnce();
 
     _scheduler = _schedulerOverride ?? _buildScheduler();
-    _subscribeAllTiers(_scheduler!);
+    _liveSampleSnapshot.subscribeAllTiers(_scheduler!);
     _scheduler!.start();
 
     _emitTimer = Timer.periodic(_pollInterval, (_) => _emit());
@@ -1032,138 +1023,6 @@ class TripRecordingController {
     _stateController.add(currentState);
   }
 
-  void _subscribeAllTiers(PidScheduler scheduler) {
-    // ---- 5 Hz tier (high priority) --------------------------------
-    // RPM and speed are consumed directly by TripSample → TripRecorder
-    // for distance/idle/harsh-accel accumulation, so they need the
-    // highest refresh we can squeeze out of the adapter.
-    scheduler.subscribe(
-      Elm327Protocol.engineRpmCommand,
-      ScheduledPid(hz: 5.0, priority: PidPriority.high),
-      (r) {
-        final v = Elm327Protocol.parseEngineRpm(r);
-        if (v != null) _latestRpm = v;
-        _observeHighPriorityParse(v);
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.vehicleSpeedCommand,
-      ScheduledPid(hz: 5.0, priority: PidPriority.high),
-      (r) {
-        final v = Elm327Protocol.parseVehicleSpeed(r);
-        if (v != null) {
-          _latestSpeedKmh = v.toDouble();
-          _recordSpeedSample(v.toDouble());
-        }
-        _observeHighPriorityParse(v);
-      },
-    );
-    // MAF and MAP are the two alternate air-mass inputs to the fuel-
-    // rate derivation. Cheap cars (Peugeot 107) only have MAP+IAT;
-    // modern cars expose MAF. We subscribe both and let the snapshot-
-    // based derivation pick whichever landed most recently.
-    if (_service.supportsPid(0x10)) {
-      scheduler.subscribe(
-        Elm327Protocol.mafCommand,
-        ScheduledPid(hz: 5.0, priority: PidPriority.high),
-        (r) {
-          final v = Elm327Protocol.parseMafGramsPerSecond(r);
-          if (v != null) _latestMaf = v;
-          _observeHighPriorityParse(v);
-        },
-      );
-    }
-    if (_service.supportsPid(0x0B)) {
-      scheduler.subscribe(
-        Elm327Protocol.intakeManifoldPressureCommand,
-        ScheduledPid(hz: 5.0, priority: PidPriority.high),
-        (r) {
-          final v = Elm327Protocol.parseManifoldPressureKpa(r);
-          if (v != null) _latestMapKpa = v;
-          _observeHighPriorityParse(v);
-        },
-      );
-    }
-    scheduler.subscribe(
-      Elm327Protocol.throttlePositionCommand,
-      ScheduledPid(hz: 5.0, priority: PidPriority.high),
-      (r) {
-        final v = Elm327Protocol.parseThrottlePercent(r);
-        if (v != null) _latestThrottlePercent = v;
-        _observeHighPriorityParse(v);
-      },
-    );
-    // PID 5E is only present on ~2014+ ECUs. Skip when #811 discovery
-    // already proved the car rejects it, to save the 200 ms round-
-    // trip of a guaranteed NO DATA.
-    if (_service.supportsPid(0x5E)) {
-      scheduler.subscribe(
-        Elm327Protocol.engineFuelRateCommand,
-        ScheduledPid(hz: 5.0, priority: PidPriority.high),
-        (r) {
-          final v = Elm327Protocol.parseFuelRateLPerHour(r);
-          if (v != null) _latestDirectFuelRate = v;
-          _observeHighPriorityParse(v);
-        },
-      );
-    }
-
-    // ---- 1 Hz tier (medium priority) ------------------------------
-    scheduler.subscribe(
-      Elm327Protocol.engineLoadCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseEngineLoad(r);
-        if (v != null) _latestEngineLoadPercent = v;
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.intakeAirTempCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseIntakeAirTempCelsius(r);
-        if (v != null) _latestIatCelsius = v;
-      },
-    );
-    // Coolant temp drifts slowly — 1 Hz is more than enough resolution
-    // for the cold-start surcharge heuristic (#1262 phase 2) to detect
-    // whether the trip ever crossed operating temperature.
-    scheduler.subscribe(
-      Elm327Protocol.coolantTempCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseCoolantTempCelsius(r);
-        if (v != null) _latestCoolantTempC = v;
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.shortTermFuelTrimCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseShortTermFuelTrim(r);
-        if (v != null) _latestStft = v;
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.longTermFuelTrimCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseLongTermFuelTrim(r);
-        if (v != null) _latestLtft = v;
-      },
-    );
-
-    // ---- 0.1 Hz tier (low priority) -------------------------------
-    scheduler.subscribe(
-      Elm327Protocol.fuelTankLevelCommand,
-      ScheduledPid(hz: 0.1, priority: PidPriority.low),
-      (r) {
-        final v = Elm327Protocol.parseFuelLevelPercent(r);
-        if (v != null) _latestFuelLevelPercent = v;
-      },
-    );
-  }
-
   /// Read the VIN exactly once at [start]. Wrapped so the one-shot
   /// decision is visible to readers of [start] — if we ever need to
   /// re-read mid-trip (e.g. user hot-swaps cars) this is the place
@@ -1185,28 +1044,34 @@ class TripRecordingController {
     if (_paused || _pausedDueToDrop) return; // don't flood while paused
     if (_liveController.isClosed) return;
 
+    final snap = _liveSampleSnapshot;
     final nowTs = _now();
-    final fuelRate = _deriveFuelRateLPerHour();
+    final fuelRate = snap.deriveFuelRateLPerHour();
+    final speedKmh = snap.latestSpeedKmh;
+    final rpm = snap.latestRpm;
+    final throttlePercent = snap.latestThrottlePercent;
+    final engineLoadPercent = snap.latestEngineLoadPercent;
+    final coolantTempC = snap.latestCoolantTempC;
     // The recorder integrates fuel rate and Δt itself, so we only
     // hand it one TripSample per emit — not per PID callback. At a
     // 250 ms emit cadence that's 4 Hz into the recorder, matching
     // the pre-#814 1 Hz loop's behavior closely enough that the
     // distance/fuelLitersConsumed integration is unchanged.
-    if (_latestSpeedKmh != null || _latestRpm != null) {
+    if (speedKmh != null || rpm != null) {
       final sample = TripSample(
         timestamp: nowTs,
-        speedKmh: _latestSpeedKmh ?? 0,
-        rpm: _latestRpm ?? 0,
+        speedKmh: speedKmh ?? 0,
+        rpm: rpm ?? 0,
         fuelRateLPerHour: fuelRate,
-        throttlePercent: _latestThrottlePercent,
-        engineLoadPercent: _latestEngineLoadPercent,
-        coolantTempC: _latestCoolantTempC,
+        throttlePercent: throttlePercent,
+        engineLoadPercent: engineLoadPercent,
+        coolantTempC: coolantTempC,
         // #1374 phase 1 — stamp the most recent GPS fix when the
         // provider has pushed one in. Both fields stay null when the
         // feature flag is off (no Geolocator subscription was ever
         // started) or before the first fix lands.
-        latitude: _latestLatitude,
-        longitude: _latestLongitude,
+        latitude: snap.latestLatitude,
+        longitude: snap.latestLongitude,
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;
@@ -1218,13 +1083,13 @@ class TripRecordingController {
           (_recorder.buildSummary().fuelLitersConsumed) ?? _fuelLitersSoFar;
     }
     final reading = TripLiveReading(
-      speedKmh: _latestSpeedKmh,
-      rpm: _latestRpm,
+      speedKmh: speedKmh,
+      rpm: rpm,
       fuelRateLPerHour: fuelRate,
-      fuelLevelPercent: _latestFuelLevelPercent,
-      engineLoadPercent: _latestEngineLoadPercent,
-      throttlePercent: _latestThrottlePercent,
-      coolantTempC: _latestCoolantTempC,
+      fuelLevelPercent: snap.latestFuelLevelPercent,
+      engineLoadPercent: engineLoadPercent,
+      throttlePercent: throttlePercent,
+      coolantTempC: coolantTempC,
       distanceKmSoFar: _recorder.buildSummary().distanceKm,
       fuelLitersSoFar: _fuelRateSeen ? _fuelLitersSoFar : null,
       elapsed: nowTs.difference(_startedAt ?? nowTs),
@@ -1232,202 +1097,6 @@ class TripRecordingController {
       odometerNowKm: _odometerLatestKm,
     );
     _liveController.add(reading);
-  }
-
-  /// Derive the current fuel rate (L/h) from whatever snapshot
-  /// values have landed so far. Mirrors the tier-1/2/3 fallback in
-  /// [Obd2Service.readFuelRateLPerHour], but over snapshot values
-  /// instead of live I/O — the scheduler has already done the
-  /// reads. Returns null when not enough inputs have arrived yet
-  /// (e.g. first 200 ms of a trip before MAP/IAT both land).
-  ///
-  /// AFR + density are chosen from the active vehicle's preferred
-  /// fuel type (#800). Diesel profiles get AFR 14.5 / density 832 g/L;
-  /// anything else (including null / unknown) stays on the petrol
-  /// defaults the pre-#800 path used.
-  double? _deriveFuelRateLPerHour() {
-    final preferredFuel =
-        _vehicle?.preferredFuelType?.trim().toLowerCase() ?? '';
-    final isDiesel = preferredFuel.contains('diesel');
-    // #1397 — manual overrides take precedence over the inferred /
-    // catalog-resolved values. Mirrors the resolution chain in
-    // [Obd2Service.readFuelRateLPerHour] so the live integrator and the
-    // pull-mode estimator agree on every scalar.
-    final afr = _vehicle?.manualAfrOverride ??
-        (isDiesel ? Obd2Service.dieselAfr : Obd2Service.petrolAfr);
-    final density = _vehicle?.manualFuelDensityGPerLOverride ??
-        (isDiesel
-            ? Obd2Service.dieselDensityGPerL
-            : Obd2Service.petrolDensityGPerL);
-    final displacement = _vehicle?.manualEngineDisplacementCcOverride
-            ?.round() ??
-        _vehicle?.engineDisplacementCc ??
-        1000;
-    // #1422 phase 1 — same precedence as Obd2Service.readFuelRateLPerHour:
-    // manual override → stored profile (when learned or non-default) →
-    // engine-tech helper on the reference catalog row → hard 0.85
-    // fallback. The two paths must agree so the live integrator and
-    // the pull-mode estimator produce identical numbers for the same
-    // tick.
-    final ve = _vehicle?.manualVolumetricEfficiencyOverride ??
-        _resolveControllerProfileVe() ??
-        (_referenceVehicle != null
-            ? defaultVolumetricEfficiency(_referenceVehicle)
-            : 0.85);
-    final collector = _breadcrumbCollector;
-
-    // Step 1: direct PID 5E. Already post-trim, no correction.
-    final direct = _latestDirectFuelRate;
-    if (direct != null) {
-      // #1395 — sanity bound A: implausibly-low at non-idle RPM.
-      // Same threshold as Obd2Service.readFuelRateLPerHour but evaluated
-      // on the controller's most-recent RPM snapshot so this works
-      // even when the trip is being driven by raw scheduler callbacks
-      // rather than the readFuelRate API.
-      String? lowFlag;
-      String? lowDetail;
-      final rpm = _latestRpm;
-      if (direct < 0.3 && rpm != null && rpm > 1500) {
-        lowFlag = Obd2BreadcrumbCollector.flagSuspiciousLow;
-        lowDetail = 'directRate=${direct.toStringAsFixed(2)};'
-            'rpm=${rpm.toStringAsFixed(0)}';
-      }
-      collector?.record(
-        branch: Obd2BranchTag.pid5E,
-        fuelRateLPerHour: direct,
-        pid5ELPerHour: direct,
-        rpm: rpm,
-        afr: afr,
-        fuelDensityGPerL: density,
-        engineDisplacementCc: displacement.toDouble(),
-        volumetricEfficiency: ve,
-        flag: lowFlag,
-        flagDetail: lowDetail,
-      );
-      // Sanity bound B: 5E vs MAF cross-check on the controller's
-      // cached MAF snapshot. Evaluated AFTER the breadcrumb is
-      // pushed so [recordFlag] mutates the same row.
-      final mafSnapshot = _latestMaf;
-      if (mafSnapshot != null) {
-        final mafDerived = mafSnapshot * 3600.0 / (afr * density);
-        if (mafDerived > 0 &&
-            (direct - mafDerived).abs() / mafDerived > 0.5) {
-          collector?.recordFlag(
-            Obd2BreadcrumbCollector.flag5eVsMafDivergent,
-            'direct=${direct.toStringAsFixed(2)};'
-                'mafDerived=${mafDerived.toStringAsFixed(2)};'
-                'maf=${mafSnapshot.toStringAsFixed(2)}',
-          );
-        }
-      }
-      return direct;
-    }
-
-    // Step 2: MAF-based. L/h = MAF × 3600 / (AFR × density).
-    final maf = _latestMaf;
-    if (maf != null) {
-      final raw = maf * 3600.0 / (afr * density);
-      final corrected = _applyTrim(raw);
-      collector?.record(
-        branch: Obd2BranchTag.maf,
-        fuelRateLPerHour: corrected,
-        mafGramsPerSecond: maf,
-        rpm: _latestRpm,
-        afr: afr,
-        fuelDensityGPerL: density,
-        engineDisplacementCc: displacement.toDouble(),
-        volumetricEfficiency: ve,
-      );
-      return corrected;
-    }
-
-    // Step 3: speed-density from MAP+IAT+RPM. Feeds the pre-#810
-    // estimator with the active vehicle's displacement + VE (#812).
-    final mapKpa = _latestMapKpa;
-    final iat = _latestIatCelsius;
-    final rpm = _latestRpm;
-    if (mapKpa == null || iat == null || rpm == null) {
-      collector?.record(
-        branch: Obd2BranchTag.none,
-        mapKpa: mapKpa,
-        iatCelsius: iat,
-        rpm: rpm,
-        afr: afr,
-        fuelDensityGPerL: density,
-        engineDisplacementCc: displacement.toDouble(),
-        volumetricEfficiency: ve,
-      );
-      return null;
-    }
-    final raw = Obd2Service.estimateFuelRateLPerHourFromMap(
-      mapKpa: mapKpa,
-      iatCelsius: iat,
-      rpm: rpm,
-      engineDisplacementCc: displacement,
-      volumetricEfficiency: ve,
-      afr: afr,
-      fuelDensityGPerL: density,
-    );
-    if (raw == null) {
-      collector?.record(
-        branch: Obd2BranchTag.none,
-        mapKpa: mapKpa,
-        iatCelsius: iat,
-        rpm: rpm,
-        afr: afr,
-        fuelDensityGPerL: density,
-        engineDisplacementCc: displacement.toDouble(),
-        volumetricEfficiency: ve,
-      );
-      return null;
-    }
-    final corrected = _applyTrim(raw);
-    collector?.record(
-      branch: Obd2BranchTag.speedDensity,
-      fuelRateLPerHour: corrected,
-      mapKpa: mapKpa,
-      iatCelsius: iat,
-      rpm: rpm,
-      afr: afr,
-      fuelDensityGPerL: density,
-      engineDisplacementCc: displacement.toDouble(),
-      volumetricEfficiency: ve,
-    );
-    return corrected;
-  }
-
-  /// Returns the user profile's η_v that should beat the engine-tech
-  /// helper, or null when the helper should kick in instead (#1422
-  /// phase 1). Mirrors the rules in [_resolveProfileVolumetricEfficiency]
-  /// in `obd2_service.dart` so both the live integrator and the
-  /// pull-mode estimator agree on a per-tick basis.
-  ///
-  /// Profile null → null (caller will use the helper or hard fallback).
-  /// Without a reference catalog row the stored profile value is the
-  /// best we can do, even if it equals the legacy 0.85 default.
-  /// Otherwise: keep the stored value when the VeLearner has logged at
-  /// least one sample OR when the value differs from the legacy 0.85
-  /// default. A cold-start profile sitting on 0.85 with zero samples
-  /// returns null, letting the engine-tech helper provide a closer
-  /// initial guess (e.g. 0.95 for a Dacia dCi VNT diesel).
-  double? _resolveControllerProfileVe() {
-    final v = _vehicle;
-    if (v == null) return null;
-    if (_referenceVehicle == null) return v.volumetricEfficiency;
-    if (v.volumetricEfficiencySamples > 0) return v.volumetricEfficiency;
-    if (v.volumetricEfficiency != 0.85) return v.volumetricEfficiency;
-    return null;
-  }
-
-  /// Apply the STFT + LTFT correction used on the MAF / speed-density
-  /// branches (#813). Returns [raw] unchanged when either trim hasn't
-  /// landed yet — better an uncorrected estimate than one shifted by
-  /// half the real signal.
-  double _applyTrim(double raw) {
-    final stft = _latestStft;
-    final ltft = _latestLtft;
-    if (stft == null || ltft == null) return raw;
-    return Obd2Service.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
   }
 
   /// Exposed for tests: append a sample to the captured-samples buffer

--- a/lib/features/consumption/data/obd2/trip_sample_buffer.dart
+++ b/lib/features/consumption/data/obd2/trip_sample_buffer.dart
@@ -1,0 +1,116 @@
+import '../../domain/entities/gps_sample_diagnostic.dart';
+import '../../domain/trip_recorder.dart';
+
+/// Owns the two per-trip ring buffers extracted from
+/// [TripRecordingController] (#1679):
+///
+///  * the #1040 captured-sample buffer that feeds the trip-detail
+///    charts, decimated to ~1 Hz;
+///  * the #1458 GPS cadence-diagnostics buffer.
+///
+/// Both are append-only, capped, and exposed as unmodifiable lists.
+/// The controller delegates capture + read here and clones the
+/// snapshots into the persisted [TripHistoryEntry] at stop time.
+class TripSampleBuffer {
+  /// Cap on the captured-sample buffer (#1040). 120000 samples = 33 h
+  /// at 1 Hz — comfortably above any plausible single trip — so this
+  /// only kicks in if the user forgets to stop a recording overnight.
+  static const int _capturedSampleCap = 120000;
+
+  /// Cap on the GPS diagnostics buffer (#1458 phase 2). At ~1 Hz GPS
+  /// fix cadence the cap covers ~33 hours — comfortably above any
+  /// plausible single trip and well below the trip-detail JSON
+  /// size budget.
+  static const int _gpsSampleDiagnosticCap = 120000;
+
+  /// Per-tick sample buffer used by the trip-detail charts (#1040).
+  /// Decimated to ~1 Hz by [maybeCapture] — the user-facing charts
+  /// don't need the 4 Hz emit cadence, and 1 Hz × 8 fields keeps a
+  /// 39-min trip's payload well under 20 KB compressed.
+  final List<TripSample> _capturedSamples = <TripSample>[];
+
+  /// Timestamp of the most recently *captured* (decimated) sample.
+  DateTime? _lastCapturedAt;
+
+  /// Per-trip GPS cadence diagnostics buffer (#1458 phase 2).
+  final List<GpsSampleDiagnostic> _gpsSampleDiagnostics =
+      <GpsSampleDiagnostic>[];
+
+  /// Read-only snapshot of the captured sample buffer (#1040). The
+  /// list is unmodifiable so callers can't accidentally mutate the
+  /// buffer's state.
+  List<TripSample> get capturedSamples => List.unmodifiable(_capturedSamples);
+
+  /// Read-only snapshot of the GPS cadence diagnostics buffer
+  /// (#1458 phase 2). Unmodifiable for the same reason.
+  List<GpsSampleDiagnostic> get capturedGpsSampleDiagnostics =>
+      List.unmodifiable(_gpsSampleDiagnostics);
+
+  /// Append [sample] to the captured-samples buffer when at least
+  /// 1 second has elapsed since the previous capture. The 4 Hz emit
+  /// loop drops 3 of every 4 candidate samples — the chart layer
+  /// renders at 1 Hz and the storage budget is sized for that
+  /// cadence (#1040).
+  void maybeCapture(TripSample sample) {
+    final last = _lastCapturedAt;
+    if (last != null) {
+      // Use 950 ms as the gate so a 1 Hz scheduler that's slightly
+      // jittered (998 ms / 1003 ms) still captures every tick. Without
+      // the slack a 998 ms gap would slip through the >=1000 check
+      // and we'd silently halve the captured rate.
+      if (sample.timestamp.difference(last).inMilliseconds < 950) return;
+    }
+    _capturedSamples.add(sample);
+    _lastCapturedAt = sample.timestamp;
+    if (_capturedSamples.length > _capturedSampleCap) {
+      // Drop the oldest slice — losing the early stretch is preferable
+      // to letting a forgotten overnight recording eat unbounded memory.
+      _capturedSamples.removeRange(
+        0,
+        _capturedSamples.length - _capturedSampleCap,
+      );
+    }
+  }
+
+  /// Append a sample to the captured-samples buffer without the
+  /// 950 ms decimation gate. Used by tests to populate a deterministic
+  /// buffer (#1040).
+  void debugCaptureSample(TripSample sample) {
+    _capturedSamples.add(sample);
+    _lastCapturedAt = sample.timestamp;
+  }
+
+  /// #1458 phase 2 — append one cadence-diagnostic record at [now]
+  /// with the given app [lifecycleState].
+  ///
+  /// The index assigned to the diagnostic is the buffer's length at
+  /// insertion time so it is monotonic per trip and stable across
+  /// process restarts (a forgotten recording that bumps into
+  /// [_gpsSampleDiagnosticCap] drops the OLDEST samples first — the
+  /// `index` field surfaces those gaps).
+  void recordGpsSampleDiagnostic({
+    required DateTime now,
+    required String lifecycleState,
+  }) {
+    final entry = GpsSampleDiagnostic(
+      timestamp: now,
+      lifecycleState: lifecycleState,
+      index: _gpsSampleDiagnostics.length,
+    );
+    _gpsSampleDiagnostics.add(entry);
+    if (_gpsSampleDiagnostics.length > _gpsSampleDiagnosticCap) {
+      // Drop the oldest slice — losing the early stretch is preferable
+      // to letting a forgotten overnight recording eat unbounded memory.
+      _gpsSampleDiagnostics.removeRange(
+        0,
+        _gpsSampleDiagnostics.length - _gpsSampleDiagnosticCap,
+      );
+    }
+  }
+
+  /// Append a cadence diagnostic without going through
+  /// [recordGpsSampleDiagnostic]. Used by tests to pre-seed a buffer.
+  void debugCaptureGpsSampleDiagnostic(GpsSampleDiagnostic diagnostic) {
+    _gpsSampleDiagnostics.add(diagnostic);
+  }
+}

--- a/lib/features/consumption/providers/trip_baseline_recorder.dart
+++ b/lib/features/consumption/providers/trip_baseline_recorder.dart
@@ -1,0 +1,307 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/storage/hive_boxes.dart';
+import '../../../core/sync/baselines_sync.dart';
+import '../../sync/providers/baseline_sync_enabled_provider.dart';
+import '../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../vehicle/domain/fuzzy_classifier.dart';
+import '../../vehicle/providers/calibration_mode_providers.dart';
+import '../../vehicle/providers/vehicle_providers.dart';
+import '../data/baseline_store.dart';
+import '../data/obd2/trip_live_reading.dart';
+import '../domain/cold_start_baselines.dart';
+import '../domain/situation_classifier.dart';
+
+/// Owns the #769 / #780 / #894 baseline-learning concern extracted
+/// from the [TripRecording] notifier (#1679): the per-trip situation
+/// classifier, the learned-baseline [BaselineStore], and the
+/// classify → record → band → delta pipeline that runs on every live
+/// reading.
+///
+/// The notifier hands one live reading in via [recordAndClassify] and
+/// gets `(situation, band, delta)` back to stamp onto its state. The
+/// collaborator reads its Riverpod dependencies through [_ref].
+class TripBaselineRecorder {
+  TripBaselineRecorder(this._ref);
+
+  final Ref _ref;
+
+  SituationClassifier? _classifier;
+  BaselineStore? _store;
+  String? _vehicleId;
+  ConsumptionFuelFamily _fuelFamily = ConsumptionFuelFamily.gasoline;
+
+  /// Vehicle id the current recording's baselines are scoped to.
+  /// Surfaced so the notifier can tag the active-trip snapshot and
+  /// the saved [TripHistoryEntry] with it. Null between trips.
+  String? get vehicleId => _vehicleId;
+
+  /// #769 — resolve the active vehicle + fuel family and load its
+  /// learned baselines from Hive. Falls back silently to cold-start
+  /// defaults when the box isn't open (widget tests) or the active
+  /// vehicle is unavailable.
+  Future<void> load() async {
+    _classifier = SituationClassifier();
+    try {
+      final vehicle = _ref.read(activeVehicleProfileProvider);
+      _vehicleId = vehicle?.id;
+      _fuelFamily = _resolveFuelFamily(vehicle?.preferredFuelType);
+      if (Hive.isBoxOpen(HiveBoxes.obd2Baselines)) {
+        _store = BaselineStore(
+          box: Hive.box<String>(HiveBoxes.obd2Baselines),
+        );
+        if (_vehicleId != null) {
+          await _store!.loadVehicle(_vehicleId!);
+        }
+      }
+    } catch (e, st) {
+      debugPrint('TripRecording.start: baseline setup failed: $e\n$st');
+      _store = null;
+    }
+  }
+
+  /// Classify one live [reading], record it into the learned-baseline
+  /// store, and return the situation, consumption band, and live
+  /// delta-fraction the notifier stamps onto its state.
+  ({DrivingSituation situation, ConsumptionBand band, double? delta})
+      recordAndClassify(TripLiveReading reading) {
+    final situation = _classifyFrom(reading);
+    _recordToStore(reading, situation);
+    final band = _classifyBandFrom(reading, situation);
+    final delta = _computeDelta(reading, situation);
+    return (situation: situation, band: band, delta: delta);
+  }
+
+  /// #769 — flush learned baselines before releasing the service so
+  /// the next trip starts from the updated values, then #780 — fold
+  /// in the server copy. Best-effort: a Hive write failure here
+  /// shouldn't block trip teardown. Resets state for the next trip.
+  Future<void> flushAndSync() async {
+    final store = _store;
+    final vid = _vehicleId;
+    if (store != null && vid != null) {
+      try {
+        await store.flush(vid);
+      } catch (e, st) {
+        debugPrint('TripRecording.stop: baseline flush failed: $e\n$st');
+      }
+      // #780 — fold in the server copy once the local flush lands.
+      await _syncBaselineAfterFlush(vid);
+    }
+    _store = null;
+    _vehicleId = null;
+    _classifier = null;
+  }
+
+  /// Map a [FuelType] apiValue onto a [ConsumptionFuelFamily] for
+  /// the cold-start tables. Everything that isn't diesel maps to
+  /// gasoline — LPG/CNG calorific values are close enough to petrol
+  /// that the cold-start number is within measurement noise.
+  ConsumptionFuelFamily _resolveFuelFamily(String? apiValue) {
+    if (apiValue == null) return ConsumptionFuelFamily.gasoline;
+    if (apiValue.startsWith('diesel')) return ConsumptionFuelFamily.diesel;
+    return ConsumptionFuelFamily.gasoline;
+  }
+
+  void _recordToStore(TripLiveReading r, DrivingSituation situation) {
+    final store = _store;
+    final vid = _vehicleId;
+    if (store == null || vid == null) return;
+    final baseline = coldStartBaseline(_fuelFamily, situation);
+    final live = _liveConsumptionFor(r, baseline);
+    if (live == null) return;
+
+    // #894 wiring (#1426): when the active vehicle has opted into
+    // fuzzy calibration, route this sample through the fuzzy
+    // classifier and record one weighted vote per non-zero
+    // membership bucket. Rule mode keeps the legacy single-bucket
+    // path so users who haven't opted in see no behaviour change.
+    final profile = _tryReadActiveVehicle();
+    if (profile?.calibrationMode == VehicleCalibrationMode.fuzzy) {
+      _recordFuzzy(store, vid, r, live);
+      return;
+    }
+
+    store.record(
+      vehicleId: vid,
+      situation: situation,
+      value: live,
+    );
+  }
+
+  /// Fuzzy path: split [live] across all non-transient buckets the
+  /// classifier flags as members, weighted by membership.
+  ///
+  /// `accel` and `grade` aren't on the OBD2 live stream, so we pass
+  /// 0 — the classifier degrades gracefully (decel and climbing zero
+  /// out, which is the same conservative result the rule path
+  /// produces when those signals are missing). [Situation.fuelCut]
+  /// maps onto a transient and is filtered by [BaselineStore]; we
+  /// drop it pre-call so the bridge stays explicit.
+  void _recordFuzzy(
+    BaselineStore store,
+    String vehicleId,
+    TripLiveReading r,
+    double live,
+  ) {
+    final classifier = _ref.read(fuzzyClassifierProvider);
+    final memberships = classifier.classify(
+      speedKmh: r.speedKmh ?? 0,
+      accel: 0,
+      grade: 0,
+      throttlePct: r.engineLoadPercent ?? 0,
+      rpm: r.rpm ?? 0,
+    );
+    for (final entry in memberships.entries) {
+      if (entry.value <= 0) continue;
+      final ds = _bridgeFuzzySituation(entry.key);
+      if (ds == null) continue;
+      store.recordWeighted(
+        vehicleId: vehicleId,
+        situation: ds,
+        value: live,
+        weight: entry.value,
+      );
+    }
+  }
+
+  /// Bridge between the vehicle layer's [Situation] enum (#894) and
+  /// the consumption layer's [DrivingSituation] enum (#769). Returns
+  /// null for transient buckets the [BaselineStore] doesn't persist.
+  static DrivingSituation? _bridgeFuzzySituation(Situation s) {
+    switch (s) {
+      case Situation.idle:
+        return DrivingSituation.idle;
+      case Situation.stopAndGo:
+        return DrivingSituation.stopAndGo;
+      case Situation.urban:
+        return DrivingSituation.urbanCruise;
+      case Situation.highway:
+        return DrivingSituation.highwayCruise;
+      case Situation.climbing:
+        return DrivingSituation.climbingOrLoaded;
+      case Situation.decel:
+        return DrivingSituation.deceleration;
+      case Situation.fuelCut:
+        return null;
+    }
+  }
+
+  SituationBaseline _baselineFor(DrivingSituation situation) {
+    final store = _store;
+    final vid = _vehicleId;
+    if (store == null || vid == null) {
+      return coldStartBaseline(_fuelFamily, situation);
+    }
+    return store.lookup(
+      vehicleId: vid,
+      situation: situation,
+      fuelFamily: _fuelFamily,
+    );
+  }
+
+  DrivingSituation _classifyFrom(TripLiveReading r) {
+    final cls = _classifier;
+    if (cls == null) return DrivingSituation.idle;
+    return cls.onSample(DrivingSample(
+      timestamp: DateTime.now(),
+      speedKmh: r.speedKmh ?? 0,
+      rpm: r.rpm ?? 0,
+      throttlePercent: r.engineLoadPercent, // close-enough proxy
+      engineLoadPercent: r.engineLoadPercent,
+      fuelRateLPerHour: r.fuelRateLPerHour,
+    ));
+  }
+
+  ConsumptionBand _classifyBandFrom(
+    TripLiveReading r,
+    DrivingSituation situation,
+  ) {
+    final baseline = _baselineFor(situation);
+    final live = _liveConsumptionFor(r, baseline);
+    if (live == null) return ConsumptionBand.normal;
+    return classifyBand(
+      situation: situation,
+      live: live,
+      baseline: baseline,
+    );
+  }
+
+  double? _computeDelta(
+    TripLiveReading r,
+    DrivingSituation situation,
+  ) {
+    final baseline = _baselineFor(situation);
+    if (baseline.value <= 0) return null;
+    final live = _liveConsumptionFor(r, baseline);
+    if (live == null) return null;
+    return (live - baseline.value) / baseline.value;
+  }
+
+  /// Compute the live consumption value in the baseline's unit —
+  /// L/h for idle baselines, L/100 km otherwise. Returns null when
+  /// the car isn't reporting enough data to derive the metric.
+  double? _liveConsumptionFor(
+    TripLiveReading r,
+    SituationBaseline baseline,
+  ) {
+    final fuelRate = r.fuelRateLPerHour;
+    final speed = r.speedKmh;
+    if (fuelRate == null) return null;
+    if (baseline.unit == BaselineUnit.lPerHour) return fuelRate;
+    if (speed == null || speed <= 5) return null; // avoid /0
+    return fuelRate * 100.0 / speed;
+  }
+
+  /// Read the active vehicle profile, swallowing any provider-wiring
+  /// errors that show up in widget tests (where the Riverpod graph
+  /// for the vehicle-active-profile chain isn't always overridden).
+  VehicleProfile? _tryReadActiveVehicle() {
+    try {
+      return _ref.read(activeVehicleProfileProvider);
+    } catch (e, st) {
+      debugPrint('TripRecording: active vehicle unavailable: $e\n$st');
+      return null;
+    }
+  }
+
+  /// #780 — merge local + server baselines for [vehicleId] via the
+  /// sync service. Called after the Hive flush so the payload on
+  /// disk is what actually gets sent, and the merged result (higher
+  /// per-situation sample counts) overwrites disk for the next
+  /// trip. No-op when the Hive box is closed or the sync client
+  /// is offline/unauthenticated — both paths return the input
+  /// payload unchanged.
+  Future<void> _syncBaselineAfterFlush(String vehicleId) async {
+    try {
+      // #780 phase 3 — honour the opt-in setting. Default false so
+      // users who never toggled it in the sync setup screen don't
+      // silently upload driving data. Ungated favourite sync etc.
+      // are unaffected.
+      // #1373 phase 3e — read the central feature flag instead of the
+      // legacy Hive key. ref.read (not watch) — this is a one-shot
+      // gate at flush time, not a reactive dependency.
+      final enabled = _ref.read(baselineSyncEnabledProvider);
+      if (!enabled) return;
+      if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
+      final box = Hive.box<String>(HiveBoxes.obd2Baselines);
+      final key = 'baseline:$vehicleId';
+      final localJson = box.get(key);
+      final merged = await BaselinesSync.merge(
+        vehicleId: vehicleId,
+        localJson: localJson,
+      );
+      if (merged != null && merged != localJson) {
+        await box.put(key, merged);
+        // No in-memory cache refresh needed — _store is nulled out
+        // right after this call and the next trip creates a fresh
+        // BaselineStore whose loadVehicle reads the merged JSON
+        // from disk.
+      }
+    } catch (e, st) {
+      debugPrint('TripRecording.stop: baseline sync failed: $e\n$st');
+    }
+  }
+}

--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/location/geolocator_wrapper.dart';
+import '../../feature_management/application/feature_flags_provider.dart';
+import '../../feature_management/domain/feature.dart';
+import '../../glide_coach/data/traffic_signal_repository.dart';
+import '../../glide_coach/domain/entities/glide_coach_advice.dart';
+import '../../glide_coach/providers/glide_coach_evaluator_provider.dart';
+import '../../glide_coach/providers/glide_coach_settings_provider.dart';
+import '../data/obd2/trip_recording_controller.dart';
+
+/// Owns the #1374 / #1125 / #1458 GPS concern extracted from the
+/// [TripRecording] notifier (#1679): the opt-in Geolocator position
+/// stream, the per-fix cadence-diagnostic recording, and the
+/// per-fix glide-coach evaluation hook.
+///
+/// The notifier delegates [start] / [stop] here. The collaborator
+/// reads its Riverpod dependencies through [_ref] and the host app's
+/// lifecycle state through the injected [_lifecycleState] getter so
+/// the `_lifecycleState` field itself stays the notifier's.
+class TripGpsStreamController {
+  TripGpsStreamController({
+    required Ref ref,
+    required AppLifecycleState Function() lifecycleState,
+  })  : _ref = ref,
+        _lifecycleState = lifecycleState;
+
+  final Ref _ref;
+  final AppLifecycleState Function() _lifecycleState;
+
+  /// #1374 phase 1 — Geolocator position stream feeding the
+  /// controller's per-tick GPS latch. Only created when
+  /// `Feature.gpsTripPath` is enabled at trip-start; the flag-off
+  /// path leaves this null and never touches the plugin, so the
+  /// battery / permission cost is exactly zero for users who haven't
+  /// opted in.
+  StreamSubscription<Position>? _gpsSub;
+
+  /// Open a Geolocator position stream and route every fix through
+  /// [TripRecordingController.updateGpsFix] (#1374 phase 1).
+  ///
+  /// No-op when [Feature.gpsTripPath] is disabled — that's the
+  /// default for every existing user, so this method must NEVER pull
+  /// on the Geolocator plugin in that case (zero battery cost). When
+  /// the flag is on we open the stream at [LocationAccuracy.high]
+  /// because the eventual heatmap (Phase 3) wants ~10 m precision.
+  ///
+  /// Stream errors are logged and swallowed: a permission revoke
+  /// mid-trip, a temporary loss of fix, or the OS killing the
+  /// position service must NOT derail the OBD2 trip recording. The
+  /// controller's per-tick latch simply stops being refreshed and
+  /// subsequent samples carry `latitude: null, longitude: null`.
+  void start(TripRecordingController ctl) {
+    final flags = _ref.read(featureFlagsProvider.notifier);
+    if (!flags.isEnabled(Feature.gpsTripPath)) return;
+    final geolocator = _ref.read(geolocatorWrapperProvider);
+    try {
+      _gpsSub = geolocator
+          .getPositionStream(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+        ),
+      )
+          .listen(
+        (pos) {
+          ctl.updateGpsFix(
+            latitude: pos.latitude,
+            longitude: pos.longitude,
+          );
+          // #1458 phase 2 — record one cadence-diagnostic per fix so the
+          // user can see, post-trip, whether the OS kept delivering
+          // position updates while the phone was asleep / unpinned. The
+          // call is cheap (one allocation + one list append, capped) so
+          // it's safe on the hot path; the in-memory buffer is flushed
+          // onto the persisted [TripHistoryEntry] at trip-stop time.
+          ctl.recordGpsSampleDiagnostic(
+            now: DateTime.now(),
+            lifecycleState: _lifecycleState().name,
+          );
+          // #1125 phase 3b — opt-in glide-coach evaluation. The hook is
+          // gated by:
+          //   1. The compile-time master flag kGlideCoachEnabled (false
+          //      in production; this branch compiles to a constant
+          //      no-op the optimiser can fully elide).
+          //   2. The user-facing toggle GlideCoachSettings.enabled.
+          //   3. The presence of a recent throttle reading (cars
+          //      without PID 0x11 — or a freshly-started trip whose
+          //      first sample hasn't landed — short-circuit to "do
+          //      nothing").
+          // Both flags must be true for the haptic to fire. See the
+          // class doc on `GlideCoachEvaluator` for the 5-rule decision
+          // flow that the evaluator itself runs.
+          unawaited(_maybeFireGlideCoach(ctl, pos));
+        },
+        onError: (Object error) {
+          debugPrint('TripRecording GPS stream error: $error');
+        },
+      );
+    } catch (e, st) {
+      debugPrint('TripRecording GPS subscribe failed: $e\n$st');
+    }
+  }
+
+  /// Tear down the Geolocator subscription if one was opened (flag-on
+  /// path only). Best-effort: a null sub is the common case (flag off)
+  /// and a cancel that throws shouldn't block trip teardown.
+  Future<void> stop() async {
+    await _gpsSub?.cancel();
+    _gpsSub = null;
+  }
+
+  /// Per-GPS-fix glide-coach evaluator hook (#1125 phase 3b).
+  ///
+  /// Layered gate (in order — each rejects the next):
+  ///   1. Compile-time `kGlideCoachEnabled` master flag. False in
+  ///      production today; the call is a constant-folded no-op.
+  ///   2. User-facing toggle from `GlideCoachSettings`.
+  ///   3. Latest throttle reading from the controller's captured-sample
+  ///      buffer (cars without PID 0x11 → null → evaluator returns
+  ///      `hold` per its rule 2; the haptic does not fire).
+  ///   4. Provider returns null (Hive box closed in widget tests, etc.) —
+  ///      treat as feature off.
+  ///
+  /// The evaluator's 5-rule flow then decides between
+  /// `lift` / `hold` / `cooldown`. Only `lift` translates into a
+  /// `HapticFeedback.lightImpact()` call — "subtle" per the issue body
+  /// (#1125), distinct from the medium / heavy intensities used by the
+  /// over-throttle eco-coach (#767).
+  ///
+  /// Errors are caught and logged: a permission revoke mid-trip, an
+  /// Overpass timeout, or a stale Hive box must NOT derail the OBD2
+  /// recording. Best-effort, non-blocking.
+  Future<void> _maybeFireGlideCoach(
+    TripRecordingController ctl,
+    Position pos,
+  ) async {
+    // Rule 1 — compile-time master flag. The constant gate makes this
+    // path constant-fold to nothing in a flag-false build.
+    if (!kGlideCoachEnabled) return;
+    try {
+      // Rule 2 — user toggle. Defaults to false; even with the master
+      // flag flipped, an opt-in is required.
+      final settings = _ref.read(glideCoachSettingsProvider);
+      if (!settings.enabled) return;
+      // Rule 4 — provider returns null when the feature is fully
+      // unavailable (Hive box closed in tests). Resolved AFTER the
+      // user-toggle gate so an off-by-default user pays no Hive read.
+      final evaluator = _ref.read(glideCoachEvaluatorProvider);
+      if (evaluator == null) return;
+      // Rule 3 — pull the latest throttle from the controller's
+      // captured-sample buffer. The buffer accumulates at 1 Hz (#1040);
+      // the GPS listener cadence is set by `LocationAccuracy.high`
+      // (typically also ~1 Hz). Cars without PID 0x11 carry
+      // `throttlePercent == null` on every sample; the evaluator's
+      // rule 2 short-circuits that to `hold` so this getter returning
+      // null is fine.
+      final samples = ctl.capturedSamples;
+      final throttle = samples.isEmpty
+          ? null
+          : samples.last.throttlePercent;
+      final reading = (
+        latitude: pos.latitude,
+        longitude: pos.longitude,
+        headingDegrees: pos.heading,
+      );
+      final advice = await evaluator.evaluate(
+        reading: reading,
+        throttlePercent: throttle,
+      );
+      if (advice == GlideCoachAdvice.lift) {
+        // Subtle on purpose — `lightImpact`, not `mediumImpact`. The
+        // issue body explicitly calls out distraction risk; the haptic
+        // is a hint, not a brake-warning.
+        await HapticFeedback.lightImpact();
+      }
+    } catch (e, st) {
+      debugPrint('TripRecording glide-coach evaluation failed: $e\n$st');
+    }
+  }
+}

--- a/lib/features/consumption/providers/trip_haptic_controller.dart
+++ b/lib/features/consumption/providers/trip_haptic_controller.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/services.dart';
+
+import '../domain/cold_start_baselines.dart';
+import 'haptic_feedback_policy.dart';
+
+/// Owns the #767 band-transition haptic concern, extracted from the
+/// [TripRecording] notifier (#1679).
+///
+/// Fires a short corrective vibration when the live consumption band
+/// crosses *into* heavy territory. Positive improvements (e.g.
+/// normal → eco) stay silent so the haptic is a nudge, not constant
+/// feedback — the policy decision itself lives in the pure
+/// [hapticForBandTransition] function.
+///
+/// The two counters are bumped alongside the real platform call so
+/// tests can assert on haptic intent without hooking the platform
+/// channel; counting here does not short-circuit the device vibration.
+class TripHapticController {
+  int _lightCount = 0;
+  int _mediumCount = 0;
+
+  /// Number of light-impact haptics fired since this controller was
+  /// constructed. Surfaced through [TripRecording.hapticLightCount].
+  int get lightCount => _lightCount;
+
+  /// Number of medium-impact haptics fired since this controller was
+  /// constructed. Surfaced through [TripRecording.hapticMediumCount].
+  int get mediumCount => _mediumCount;
+
+  /// Fire the haptic (if any) for a [previous] → [current] band
+  /// transition. Equal bands and positive transitions are no-ops.
+  void fireForBandTransition(
+    ConsumptionBand previous,
+    ConsumptionBand current,
+  ) {
+    switch (hapticForBandTransition(previous, current)) {
+      case HapticIntensity.light:
+        _lightCount++;
+        HapticFeedback.lightImpact();
+      case HapticIntensity.medium:
+        _mediumCount++;
+        HapticFeedback.mediumImpact();
+      case HapticIntensity.none:
+        break;
+    }
+  }
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -10,17 +10,12 @@ import '../../../core/feedback/auto_record_badge_service.dart';
 import '../../../core/providers/app_state_provider.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/sync/trips_sync.dart';
-import '../../../core/sync/baselines_sync.dart';
 import '../../search/domain/entities/fuel_type.dart';
-import '../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../vehicle/data/reference_vehicle_catalog_provider.dart';
 import '../../vehicle/data/vehicle_profile_catalog_matcher.dart';
 import '../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
-import '../../vehicle/domain/fuzzy_classifier.dart';
-import '../../vehicle/providers/calibration_mode_providers.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
-import '../data/baseline_store.dart';
 import '../data/obd2/active_trip_repository.dart';
 import '../data/obd2/adapter_registry.dart';
 import '../data/obd2/adapter_reconnect_scanner.dart';
@@ -31,8 +26,8 @@ import 'obd2_breadcrumb_provider.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/cold_start_baselines.dart';
 import '../domain/entities/gps_sample_diagnostic.dart';
-import '../domain/situation_classifier.dart';
 import '../domain/trip_recorder.dart';
+import 'trip_baseline_recorder.dart';
 import 'trip_gps_stream_controller.dart';
 import 'trip_haptic_controller.dart';
 import 'trip_history_provider.dart';
@@ -72,10 +67,6 @@ class TripRecording extends _$TripRecording {
   TripRecordingController? _controller;
   StreamSubscription<TripLiveReading>? _liveSub;
   StreamSubscription<TripRecordingControllerState>? _stateSub;
-  SituationClassifier? _classifier;
-  BaselineStore? _store;
-  String? _vehicleId;
-  ConsumptionFuelFamily _fuelFamily = ConsumptionFuelFamily.gasoline;
 
   // #1312 — adapter identity captured at trip-start so it survives
   // into the saved [TripHistoryEntry] even if the [Obd2Service] has
@@ -113,6 +104,12 @@ class TripRecording extends _$TripRecording {
     ref: ref,
     lifecycleState: () => _lifecycleState,
   );
+
+  /// #769 / #780 / #894 baseline-learning concern — the per-trip
+  /// situation classifier, the learned-baseline store, and the
+  /// classify → record → band → delta pipeline — extracted into a
+  /// focused collaborator (#1679). `late` so it can capture [ref].
+  late final TripBaselineRecorder _baselines = TripBaselineRecorder(ref);
 
   /// Tests count haptic fires via these instead of hooking the
   /// platform channel. The production path also still calls
@@ -326,29 +323,11 @@ class TripRecording extends _$TripRecording {
       breadcrumbCollector: breadcrumbs,
     );
     _controller = ctl;
-    _classifier = SituationClassifier();
 
     // #769 — resolve the active vehicle + fuel family and load its
-    // learned baselines from Hive. Falls back silently to cold-start
-    // defaults when the box isn't open (widget tests) or the active
-    // vehicle is unavailable.
-    try {
-      final vehicle = ref.read(activeVehicleProfileProvider);
-      _vehicleId = vehicle?.id;
-      _lastTripVehicleId ??= vehicle?.id;
-      _fuelFamily = _resolveFuelFamily(vehicle?.preferredFuelType);
-      if (Hive.isBoxOpen(HiveBoxes.obd2Baselines)) {
-        _store = BaselineStore(
-          box: Hive.box<String>(HiveBoxes.obd2Baselines),
-        );
-        if (_vehicleId != null) {
-          await _store!.loadVehicle(_vehicleId!);
-        }
-      }
-    } catch (e, st) {
-      debugPrint('TripRecording.start: baseline setup failed: $e\n$st');
-      _store = null;
-    }
+    // learned baselines from Hive (delegated to TripBaselineRecorder).
+    _lastTripVehicleId ??= activeVehicle?.id;
+    await _baselines.load();
 
     await ctl.start();
     // #1374 phase 1 — opt-in GPS sampling. Only when the user has
@@ -364,17 +343,14 @@ class TripRecording extends _$TripRecording {
     // recording UI on next launch.
     _seedActiveSnapshot();
     _liveSub = ctl.live.listen((reading) {
-      final situation = _classifyFrom(reading);
-      _recordToStore(reading, situation);
-      final band = _classifyBandFrom(reading, situation);
-      final delta = _computeDelta(reading, situation);
-      _haptics.fireForBandTransition(state.band, band);
+      final classified = _baselines.recordAndClassify(reading);
+      _haptics.fireForBandTransition(state.band, classified.band);
       state = state.copyWith(
         phase: _phaseFor(ctl),
         live: reading,
-        situation: situation,
-        band: band,
-        liveDeltaFraction: delta,
+        situation: classified.situation,
+        band: classified.band,
+        liveDeltaFraction: classified.delta,
       );
       // #1303 — debounced write-through. Cheap when the gate
       // rejects (a single timestamp comparison + counter bump).
@@ -467,162 +443,6 @@ class TripRecording extends _$TripRecording {
       debugPrint('TripRecording: reference catalog unavailable: $e\n$st');
       return null;
     }
-  }
-
-  ConsumptionFuelFamily _resolveFuelFamily(String? apiValue) {
-    if (apiValue == null) return ConsumptionFuelFamily.gasoline;
-    if (apiValue.startsWith('diesel')) return ConsumptionFuelFamily.diesel;
-    return ConsumptionFuelFamily.gasoline;
-  }
-
-  void _recordToStore(TripLiveReading r, DrivingSituation situation) {
-    final store = _store;
-    final vid = _vehicleId;
-    if (store == null || vid == null) return;
-    final baseline = coldStartBaseline(_fuelFamily, situation);
-    final live = _liveConsumptionFor(r, baseline);
-    if (live == null) return;
-
-    // #894 wiring (#1426): when the active vehicle has opted into
-    // fuzzy calibration, route this sample through the fuzzy
-    // classifier and record one weighted vote per non-zero
-    // membership bucket. Rule mode keeps the legacy single-bucket
-    // path so users who haven't opted in see no behaviour change.
-    final profile = _tryReadActiveVehicle();
-    if (profile?.calibrationMode == VehicleCalibrationMode.fuzzy) {
-      _recordFuzzy(store, vid, r, live);
-      return;
-    }
-
-    store.record(
-      vehicleId: vid,
-      situation: situation,
-      value: live,
-    );
-  }
-
-  /// Fuzzy path: split [live] across all non-transient buckets the
-  /// classifier flags as members, weighted by membership.
-  ///
-  /// `accel` and `grade` aren't on the OBD2 live stream, so we pass
-  /// 0 — the classifier degrades gracefully (decel and climbing zero
-  /// out, which is the same conservative result the rule path
-  /// produces when those signals are missing). [Situation.fuelCut]
-  /// maps onto a transient and is filtered by [BaselineStore]; we
-  /// drop it pre-call so the bridge stays explicit.
-  void _recordFuzzy(
-    BaselineStore store,
-    String vehicleId,
-    TripLiveReading r,
-    double live,
-  ) {
-    final classifier = ref.read(fuzzyClassifierProvider);
-    final memberships = classifier.classify(
-      speedKmh: r.speedKmh ?? 0,
-      accel: 0,
-      grade: 0,
-      throttlePct: r.engineLoadPercent ?? 0,
-      rpm: r.rpm ?? 0,
-    );
-    for (final entry in memberships.entries) {
-      if (entry.value <= 0) continue;
-      final ds = _bridgeFuzzySituation(entry.key);
-      if (ds == null) continue;
-      store.recordWeighted(
-        vehicleId: vehicleId,
-        situation: ds,
-        value: live,
-        weight: entry.value,
-      );
-    }
-  }
-
-  /// Bridge between the vehicle layer's [Situation] enum (#894) and
-  /// the consumption layer's [DrivingSituation] enum (#769). Returns
-  /// null for transient buckets the [BaselineStore] doesn't persist.
-  static DrivingSituation? _bridgeFuzzySituation(Situation s) {
-    switch (s) {
-      case Situation.idle:
-        return DrivingSituation.idle;
-      case Situation.stopAndGo:
-        return DrivingSituation.stopAndGo;
-      case Situation.urban:
-        return DrivingSituation.urbanCruise;
-      case Situation.highway:
-        return DrivingSituation.highwayCruise;
-      case Situation.climbing:
-        return DrivingSituation.climbingOrLoaded;
-      case Situation.decel:
-        return DrivingSituation.deceleration;
-      case Situation.fuelCut:
-        return null;
-    }
-  }
-
-  SituationBaseline _baselineFor(DrivingSituation situation) {
-    final store = _store;
-    final vid = _vehicleId;
-    if (store == null || vid == null) {
-      return coldStartBaseline(_fuelFamily, situation);
-    }
-    return store.lookup(
-      vehicleId: vid,
-      situation: situation,
-      fuelFamily: _fuelFamily,
-    );
-  }
-
-  DrivingSituation _classifyFrom(TripLiveReading r) {
-    final cls = _classifier;
-    if (cls == null) return DrivingSituation.idle;
-    return cls.onSample(DrivingSample(
-      timestamp: DateTime.now(),
-      speedKmh: r.speedKmh ?? 0,
-      rpm: r.rpm ?? 0,
-      throttlePercent: r.engineLoadPercent, // close-enough proxy
-      engineLoadPercent: r.engineLoadPercent,
-      fuelRateLPerHour: r.fuelRateLPerHour,
-    ));
-  }
-
-  ConsumptionBand _classifyBandFrom(
-    TripLiveReading r,
-    DrivingSituation situation,
-  ) {
-    final baseline = _baselineFor(situation);
-    final live = _liveConsumptionFor(r, baseline);
-    if (live == null) return ConsumptionBand.normal;
-    return classifyBand(
-      situation: situation,
-      live: live,
-      baseline: baseline,
-    );
-  }
-
-  double? _computeDelta(
-    TripLiveReading r,
-    DrivingSituation situation,
-  ) {
-    final baseline = _baselineFor(situation);
-    if (baseline.value <= 0) return null;
-    final live = _liveConsumptionFor(r, baseline);
-    if (live == null) return null;
-    return (live - baseline.value) / baseline.value;
-  }
-
-  /// Compute the live consumption value in the baseline's unit —
-  /// L/h for idle baselines, L/100 km otherwise. Returns null when
-  /// the car isn't reporting enough data to derive the metric.
-  double? _liveConsumptionFor(
-    TripLiveReading r,
-    SituationBaseline baseline,
-  ) {
-    final fuelRate = r.fuelRateLPerHour;
-    final speed = r.speedKmh;
-    if (fuelRate == null) return null;
-    if (baseline.unit == BaselineUnit.lPerHour) return fuelRate;
-    if (speed == null || speed <= 5) return null; // avoid /0
-    return fuelRate * 100.0 / speed;
   }
 
   void pause() {
@@ -725,27 +545,10 @@ class TripRecording extends _$TripRecording {
       gpsSampleDiagnostics: capturedGpsDiagnostics,
       automatic: automatic,
     );
-    // #769 — flush learned baselines before releasing the service so
-    // the next trip starts from the updated values. Best-effort: a
-    // Hive write failure here shouldn't block teardown.
-    final store = _store;
-    final vid = _vehicleId;
-    if (store != null && vid != null) {
-      try {
-        await store.flush(vid);
-      } catch (e, st) {
-        debugPrint('TripRecording.stop: baseline flush failed: $e\n$st');
-      }
-      // #780 — fold in the server copy once the local flush lands.
-      // `syncVehicleBaseline` returns the merged JSON; if the merge
-      // changed anything, we rewrite Hive and reload so the next
-      // trip sees the higher-confidence per-situation accumulators.
-      // Entirely best-effort: offline, unauthenticated, or sync
-      // errors all return the local payload unchanged.
-      await _syncBaselineAfterFlush(vid);
-    }
-    _store = null;
-    _vehicleId = null;
+    // #769 / #780 — flush learned baselines + fold in the server copy
+    // before releasing the service so the next trip starts from the
+    // updated values. Delegated to TripBaselineRecorder; best-effort.
+    await _baselines.flushAndSync();
     // #1312 — clear the captured adapter identity once the trip has
     // been persisted; the next [start] call snapshots fresh values
     // from whichever service it receives.
@@ -837,7 +640,7 @@ class TripRecording extends _$TripRecording {
     final startedAt = _lastTripStartedAt ?? DateTime.now();
     _activeSnapshot = ActiveTripSnapshot(
       id: id,
-      vehicleId: _lastTripVehicleId ?? _vehicleId,
+      vehicleId: _lastTripVehicleId ?? _baselines.vehicleId,
       vin: ctl.vin,
       automatic: false, // refined on every flush via _buildSnapshotFor
       phase: 'recording',
@@ -1177,44 +980,6 @@ class TripRecording extends _$TripRecording {
     return true;
   }
 
-  /// #780 — merge local + server baselines for [vehicleId] via the
-  /// sync service. Called after the Hive flush so the payload on
-  /// disk is what actually gets sent, and the merged result (higher
-  /// per-situation sample counts) overwrites disk for the next
-  /// trip. No-op when the Hive box is closed or the sync client
-  /// is offline/unauthenticated — both paths return the input
-  /// payload unchanged.
-  Future<void> _syncBaselineAfterFlush(String vehicleId) async {
-    try {
-      // #780 phase 3 — honour the opt-in setting. Default false so
-      // users who never toggled it in the sync setup screen don't
-      // silently upload driving data. Ungated favourite sync etc.
-      // are unaffected.
-      // #1373 phase 3e — read the central feature flag instead of the
-      // legacy Hive key. ref.read (not watch) — this is a one-shot
-      // gate at flush time, not a reactive dependency.
-      final enabled = ref.read(baselineSyncEnabledProvider);
-      if (!enabled) return;
-      if (!Hive.isBoxOpen(HiveBoxes.obd2Baselines)) return;
-      final box = Hive.box<String>(HiveBoxes.obd2Baselines);
-      final key = 'baseline:$vehicleId';
-      final localJson = box.get(key);
-      final merged = await BaselinesSync.merge(
-        vehicleId: vehicleId,
-        localJson: localJson,
-      );
-      if (merged != null && merged != localJson) {
-        await box.put(key, merged);
-        // No in-memory cache refresh needed — _store is nulled out
-        // right after this call and the next trip creates a fresh
-        // BaselineStore whose loadVehicle reads the merged JSON
-        // from disk.
-      }
-    } catch (e, st) {
-      debugPrint('TripRecording.stop: baseline sync failed: $e\n$st');
-    }
-  }
-
   /// Build the reconnect-scanner factory handed to
   /// [TripRecordingController] (#797 phase 3). The returned closure
   /// is called once per drop with the pinned MAC + an onReconnect
@@ -1295,7 +1060,7 @@ class TripRecording extends _$TripRecording {
           DateTime.now().toIso8601String();
       await repo.save(TripHistoryEntry(
         id: id,
-        vehicleId: _vehicleId,
+        vehicleId: _baselines.vehicleId,
         summary: summary,
         automatic: automatic,
         samples: samples,
@@ -1337,7 +1102,7 @@ class TripRecording extends _$TripRecording {
             (e) => e.id == id,
             orElse: () => TripHistoryEntry(
               id: id,
-              vehicleId: _vehicleId,
+              vehicleId: _baselines.vehicleId,
               summary: summary,
               automatic: automatic,
             ),

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -2,23 +2,15 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
-import '../../../core/location/geolocator_wrapper.dart';
 import '../../../core/providers/app_state_provider.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/sync/trips_sync.dart';
 import '../../../core/sync/baselines_sync.dart';
-import '../../feature_management/application/feature_flags_provider.dart';
-import '../../feature_management/domain/feature.dart';
-import '../../glide_coach/data/traffic_signal_repository.dart';
-import '../../glide_coach/domain/entities/glide_coach_advice.dart';
-import '../../glide_coach/providers/glide_coach_evaluator_provider.dart';
-import '../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../sync/providers/baseline_sync_enabled_provider.dart';
 import '../../vehicle/data/reference_vehicle_catalog_provider.dart';
@@ -41,6 +33,7 @@ import '../domain/cold_start_baselines.dart';
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/situation_classifier.dart';
 import '../domain/trip_recorder.dart';
+import 'trip_gps_stream_controller.dart';
 import 'trip_haptic_controller.dart';
 import 'trip_history_provider.dart';
 import 'trip_recording_phase.dart';
@@ -79,13 +72,6 @@ class TripRecording extends _$TripRecording {
   TripRecordingController? _controller;
   StreamSubscription<TripLiveReading>? _liveSub;
   StreamSubscription<TripRecordingControllerState>? _stateSub;
-  // #1374 phase 1 — Geolocator position stream feeding the
-  // controller's per-tick GPS latch. Only created when
-  // `Feature.gpsTripPath` is enabled at trip-start; the flag-off
-  // path leaves this null and never touches the plugin, so the
-  // battery / permission cost is exactly zero for users who haven't
-  // opted in. Cancelled on stop alongside the live + state subs.
-  StreamSubscription<Position>? _gpsSub;
   SituationClassifier? _classifier;
   BaselineStore? _store;
   String? _vehicleId;
@@ -117,6 +103,16 @@ class TripRecording extends _$TripRecording {
   /// recordings so the test counters accumulate exactly as the
   /// inlined fields did.
   final TripHapticController _haptics = TripHapticController();
+
+  /// #1374 / #1125 / #1458 GPS concern — the opt-in Geolocator
+  /// position stream, the per-fix cadence diagnostics, and the
+  /// glide-coach evaluation hook — extracted into a focused
+  /// collaborator (#1679). `late` so it can capture [ref] and the
+  /// [_lifecycleState] getter.
+  late final TripGpsStreamController _gps = TripGpsStreamController(
+    ref: ref,
+    lifecycleState: () => _lifecycleState,
+  );
 
   /// Tests count haptic fires via these instead of hooking the
   /// platform channel. The production path also still calls
@@ -358,12 +354,8 @@ class TripRecording extends _$TripRecording {
     // #1374 phase 1 — opt-in GPS sampling. Only when the user has
     // explicitly turned the feature on do we open a Geolocator
     // position stream; the flag-off path skips the plugin entirely so
-    // a default-config user pays no battery cost. Errors on the
-    // stream are logged and swallowed (a permission revoke mid-trip
-    // must not derail the recording) — the controller's per-tick
-    // latch simply stops being refreshed and subsequent samples
-    // carry `latitude: null, longitude: null`.
-    _startGpsSubscriptionIfEnabled(ctl);
+    // a default-config user pays no battery cost.
+    _gps.start(ctl);
     // #1303 — seed the active-trip snapshot identity now that the
     // controller knows its session id + odometer reads. The first
     // flush happens off the live-stream debounce below; if the
@@ -721,8 +713,7 @@ class TripRecording extends _$TripRecording {
     // was opened (flag-on path only). Best-effort: a null sub is the
     // common case (flag off) and a cancel that throws shouldn't
     // block trip teardown.
-    await _gpsSub?.cancel();
-    _gpsSub = null;
+    await _gps.stop();
     _controller = null;
     // #726 — persist to the trip history rolling log. Every trip
     // (including discarded ones) is logged; the fill-up flow is a
@@ -833,142 +824,6 @@ class TripRecording extends _$TripRecording {
     } catch (e, st) {
       debugPrint('TripRecording active repo: $e\n$st');
       return null;
-    }
-  }
-
-  /// Open a Geolocator position stream and route every fix through
-  /// [TripRecordingController.updateGpsFix] (#1374 phase 1).
-  ///
-  /// No-op when [Feature.gpsTripPath] is disabled — that's the
-  /// default for every existing user, so this method must NEVER pull
-  /// on the Geolocator plugin in that case (zero battery cost). When
-  /// the flag is on we open the stream at [LocationAccuracy.high]
-  /// because the eventual heatmap (Phase 3) wants ~10 m precision;
-  /// downgrading to medium / low is a Phase 2 follow-up if device
-  /// testing flags battery as an issue.
-  ///
-  /// Stream errors are logged and swallowed: a permission revoke
-  /// mid-trip, a temporary loss of fix, or the OS killing the
-  /// position service must NOT derail the OBD2 trip recording. The
-  /// controller's per-tick latch simply stops being refreshed and
-  /// subsequent samples carry `latitude: null, longitude: null`.
-  void _startGpsSubscriptionIfEnabled(TripRecordingController ctl) {
-    final flags = ref.read(featureFlagsProvider.notifier);
-    if (!flags.isEnabled(Feature.gpsTripPath)) return;
-    final geolocator = ref.read(geolocatorWrapperProvider);
-    try {
-      _gpsSub = geolocator
-          .getPositionStream(
-        locationSettings: const LocationSettings(
-          accuracy: LocationAccuracy.high,
-        ),
-      )
-          .listen(
-        (pos) {
-          ctl.updateGpsFix(
-            latitude: pos.latitude,
-            longitude: pos.longitude,
-          );
-          // #1458 phase 2 — record one cadence-diagnostic per fix so the
-          // user can see, post-trip, whether the OS kept delivering
-          // position updates while the phone was asleep / unpinned. The
-          // call is cheap (one allocation + one list append, capped) so
-          // it's safe on the hot path; the in-memory buffer is flushed
-          // onto the persisted [TripHistoryEntry] at trip-stop time.
-          ctl.recordGpsSampleDiagnostic(
-            now: DateTime.now(),
-            lifecycleState: _lifecycleState.name,
-          );
-          // #1125 phase 3b — opt-in glide-coach evaluation. The hook is
-          // gated by:
-          //   1. The compile-time master flag kGlideCoachEnabled (false
-          //      in production; this branch compiles to a constant
-          //      no-op the optimiser can fully elide).
-          //   2. The user-facing toggle GlideCoachSettings.enabled.
-          //   3. The presence of a recent throttle reading (cars
-          //      without PID 0x11 — or a freshly-started trip whose
-          //      first sample hasn't landed — short-circuit to "do
-          //      nothing").
-          // Both flags must be true for the haptic to fire. See the
-          // class doc on `GlideCoachEvaluator` for the 5-rule decision
-          // flow that the evaluator itself runs.
-          unawaited(_maybeFireGlideCoach(ctl, pos));
-        },
-        onError: (Object error) {
-          debugPrint('TripRecording GPS stream error: $error');
-        },
-      );
-    } catch (e, st) {
-      debugPrint('TripRecording GPS subscribe failed: $e\n$st');
-    }
-  }
-
-  /// Per-GPS-fix glide-coach evaluator hook (#1125 phase 3b).
-  ///
-  /// Layered gate (in order — each rejects the next):
-  ///   1. Compile-time `kGlideCoachEnabled` master flag. False in
-  ///      production today; the call is a constant-folded no-op.
-  ///   2. User-facing toggle from `GlideCoachSettings`.
-  ///   3. Latest throttle reading from the controller's captured-sample
-  ///      buffer (cars without PID 0x11 → null → evaluator returns
-  ///      `hold` per its rule 2; the haptic does not fire).
-  ///   4. Provider returns null (Hive box closed in widget tests, etc.) —
-  ///      treat as feature off.
-  ///
-  /// The evaluator's 5-rule flow then decides between
-  /// `lift` / `hold` / `cooldown`. Only `lift` translates into a
-  /// `HapticFeedback.lightImpact()` call — "subtle" per the issue body
-  /// (#1125), distinct from the medium / heavy intensities used by the
-  /// over-throttle eco-coach (#767).
-  ///
-  /// Errors are caught and logged: a permission revoke mid-trip, an
-  /// Overpass timeout, or a stale Hive box must NOT derail the OBD2
-  /// recording. Best-effort, non-blocking.
-  Future<void> _maybeFireGlideCoach(
-    TripRecordingController ctl,
-    Position pos,
-  ) async {
-    // Rule 1 — compile-time master flag. The constant gate makes this
-    // path constant-fold to nothing in a flag-false build.
-    if (!kGlideCoachEnabled) return;
-    try {
-      // Rule 2 — user toggle. Defaults to false; even with the master
-      // flag flipped, an opt-in is required.
-      final settings = ref.read(glideCoachSettingsProvider);
-      if (!settings.enabled) return;
-      // Rule 4 — provider returns null when the feature is fully
-      // unavailable (Hive box closed in tests). Resolved AFTER the
-      // user-toggle gate so an off-by-default user pays no Hive read.
-      final evaluator = ref.read(glideCoachEvaluatorProvider);
-      if (evaluator == null) return;
-      // Rule 3 — pull the latest throttle from the controller's
-      // captured-sample buffer. The buffer accumulates at 1 Hz (#1040);
-      // the GPS listener cadence is set by `LocationAccuracy.high`
-      // (typically also ~1 Hz). Cars without PID 0x11 carry
-      // `throttlePercent == null` on every sample; the evaluator's
-      // rule 2 short-circuits that to `hold` so this getter returning
-      // null is fine.
-      final samples = ctl.capturedSamples;
-      final throttle = samples.isEmpty
-          ? null
-          : samples.last.throttlePercent;
-      final reading = (
-        latitude: pos.latitude,
-        longitude: pos.longitude,
-        headingDegrees: pos.heading,
-      );
-      final advice = await evaluator.evaluate(
-        reading: reading,
-        throttlePercent: throttle,
-      );
-      if (advice == GlideCoachAdvice.lift) {
-        // Subtle on purpose — `lightImpact`, not `mediumImpact`. The
-        // issue body explicitly calls out distraction risk; the haptic
-        // is a hint, not a brake-warning.
-        await HapticFeedback.lightImpact();
-      }
-    } catch (e, st) {
-      debugPrint('TripRecording glide-coach evaluation failed: $e\n$st');
     }
   }
 

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -41,7 +41,7 @@ import '../domain/cold_start_baselines.dart';
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/situation_classifier.dart';
 import '../domain/trip_recorder.dart';
-import 'haptic_feedback_policy.dart';
+import 'trip_haptic_controller.dart';
 import 'trip_history_provider.dart';
 import 'trip_recording_phase.dart';
 import 'trip_recording_state.dart';
@@ -112,14 +112,20 @@ class TripRecording extends _$TripRecording {
   // certainly foreground.
   AppLifecycleState _lifecycleState = AppLifecycleState.resumed;
 
+  /// #767 band-transition haptics, extracted into a focused
+  /// collaborator (#1679). Constructed once and reused across
+  /// recordings so the test counters accumulate exactly as the
+  /// inlined fields did.
+  final TripHapticController _haptics = TripHapticController();
+
   /// Tests count haptic fires via these instead of hooking the
   /// platform channel. The production path also still calls
   /// [HapticFeedback], so counting here doesn't short-circuit the
   /// real vibration on a device.
   @visibleForTesting
-  int hapticLightCount = 0;
+  int get hapticLightCount => _haptics.lightCount;
   @visibleForTesting
-  int hapticMediumCount = 0;
+  int get hapticMediumCount => _haptics.mediumCount;
 
   /// Exposed for tests: the underlying [TripRecordingController] while
   /// a trip is active. Lets the #1040 sample-persistence test inject a
@@ -370,7 +376,7 @@ class TripRecording extends _$TripRecording {
       _recordToStore(reading, situation);
       final band = _classifyBandFrom(reading, situation);
       final delta = _computeDelta(reading, situation);
-      _fireBandTransitionHaptic(state.band, band);
+      _haptics.fireForBandTransition(state.band, band);
       state = state.copyWith(
         phase: _phaseFor(ctl),
         live: reading,
@@ -427,25 +433,6 @@ class TripRecording extends _$TripRecording {
         return TripRecordingPhase.pausedDueToDrop;
       case TripRecordingControllerState.stopped:
         return TripRecordingPhase.finished;
-    }
-  }
-
-  /// #767 — fire a short haptic when the band crosses *into* heavy
-  /// territory. Positive improvements (normal → eco) stay silent so
-  /// the vibration is a corrective nudge, not constant feedback.
-  void _fireBandTransitionHaptic(
-    ConsumptionBand previous,
-    ConsumptionBand current,
-  ) {
-    switch (hapticForBandTransition(previous, current)) {
-      case HapticIntensity.light:
-        hapticLightCount++;
-        HapticFeedback.lightImpact();
-      case HapticIntensity.medium:
-        hapticMediumCount++;
-        HapticFeedback.mediumImpact();
-      case HapticIntensity.none:
-        break;
     }
   }
 


### PR DESCRIPTION
## What

Closes #1679. Decomposes the three OBD2 trip-recording god-classes
(`obd2_service.dart` 1182 LOC, `trip_recording_controller.dart` 1662,
`trip_recording_provider.dart` 1565) into seven focused collaborators.
**Behaviour unchanged** — every collaborator is reached through a
preserved facade method/getter on the host class, so no guard test
needed editing; that is the proof of behaviour-equivalence.

## Acceptance criteria

- [x] `TripRecording` notifier split into focused collaborators —
  `TripHapticController`, `TripGpsStreamController`, `TripBaselineRecorder`.
- [x] `TripRecordingController` split (clock / sample buffer / reconnect) —
  `LiveSampleSnapshot`, `TripSampleBuffer`, `TripDropDetector`.
- [x] PID-cache priming + vehicle-key resolution extracted from
  `Obd2Service` — `SupportedPidsResolver`.
- [x] Behaviour unchanged; existing OBD2 tests still pass.

## The seven collaborators (one commit each)

| Collaborator | Host | Concern |
|---|---|---|
| `TripHapticController` | `TripRecording` | #767 band-transition haptics |
| `SupportedPidsResolver` | `Obd2Service` | #811 supported-PID cache + VIN/fallback key |
| `TripSampleBuffer` | `TripRecordingController` | #1040 sample + #1458 GPS-diagnostic ring buffers |
| `TripDropDetector` | `TripRecordingController` | #797 transport-error window + #1330 silent-failure counter |
| `LiveSampleSnapshot` | `TripRecordingController` | per-PID snapshot, scheduler wiring, fuel-rate derivation |
| `TripGpsStreamController` | `TripRecording` | #1374/#1125/#1458 GPS stream + glide-coach hook |
| `TripBaselineRecorder` | `TripRecording` | #769/#780/#894 baseline learning |

Scope deliberately narrowed where the plan flagged high risk: the
emit timer + `_emit`, the `_handleDrop` grace/scanner/persistence
machinery, and the lifecycle state machine **stay on the host class**
— they are ordering-sensitive lifecycle. The collaborators own the
well-bounded state and the host keeps the lifecycle reaction.

## Verification

- `flutter analyze` (whole repo) — clean.
- `scripts/check_module_boundaries.sh` — passed.
- Full guard suite: `test/features/consumption/data/obd2/` +
  `test/features/consumption/providers/` — **1099 tests, all pass**,
  none edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
