### PR TITLE
ci: build_runner dedup + codegen-drift gate (#1730)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,47 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: ${{ runner.os }}-pub-
       - run: flutter pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      # #1730 — no `build_runner build` here. The .g.dart / .freezed.dart
+      # outputs are committed and kept honest by the `codegen-drift` job
+      # below, so `analyze` trusts the checked-in generated files instead
+      # of paying a redundant codegen pass.
       - run: flutter analyze --no-fatal-infos
       - name: Check feature-module boundaries
         run: bash scripts/check_module_boundaries.sh
+
+  # #1730 — committed-codegen guard. Every `.g.dart` / `.freezed.dart`
+  # is committed to the repo, so the `analyze`, `test` and
+  # `startup-budget` jobs trust the checked-in files instead of
+  # regenerating them (which previously cost ~6 redundant build_runner
+  # passes per CI run). This job is what keeps that trust honest: it
+  # regenerates from a clean checkout and fails if the committed output
+  # is stale — i.e. someone edited a `@riverpod` / `@freezed` class but
+  # forgot to run build_runner. Before this gate the staleness was
+  # invisible: every other job regenerated over the top of the stale
+  # files, so CI went green and the drift rotted in the repo.
+  codegen-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - run: flutter pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - name: Fail if committed codegen is stale
+        run: |
+          if ! git diff --exit-code -- '*.g.dart' '*.freezed.dart'; then
+            echo "::error::Committed generated files are stale. Run 'dart run build_runner build --delete-conflicting-outputs' locally and commit the result." >&2
+            exit 1
+          fi
 
   # #1581 — Test job sharded 4× across parallel runners. Each shard
   # runs `flutter test --total-shards=4 --shard-index=N` so every
@@ -64,8 +101,8 @@ jobs:
   # re-runs those with the tag so a real regression still surfaces.
   #
   # #1585 — Cache the `build/` directory keyed on pubspec + lib hash
-  # so re-runs of the same branch skip the build_runner regen step
-  # and avoid recompiling Dart sources untouched since the last run.
+  # so re-runs of the same branch avoid recompiling Dart sources
+  # untouched since the last run.
   #
   # #1594 — On `pull_request` events a `dart run tool/test_selector.dart`
   # pre-step writes the affected-test list to `affected_tests.txt`. The
@@ -99,14 +136,15 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: ${{ runner.os }}-pub-
       # #1585 — Cache compiled artefacts. Same-branch reruns and rebase
-      # rounds reuse build_runner output keyed on the source state.
+      # rounds reuse the compiled Dart output keyed on the source state.
       - uses: actions/cache@v5
         with:
           path: build/
           key: ${{ runner.os }}-build-${{ hashFiles('pubspec.lock', 'lib/**/*.dart') }}
           restore-keys: ${{ runner.os }}-build-
       - run: flutter pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      # #1730 — no `build_runner build` here. Committed generated files
+      # are trusted; the `codegen-drift` job gates their freshness.
       # #1594 — Compute the affected-test list once per shard. Fast
       # (pure Dart, file-walk) and per-shard so the selector cost is
       # parallelised. Empty output triggers a full-suite fallback in
@@ -238,7 +276,8 @@ jobs:
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: ${{ runner.os }}-pub-
       - run: flutter pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
+      # #1730 — no `build_runner build` here. Committed generated files
+      # are trusted; the `codegen-drift` job gates their freshness.
       - name: Check startup time budget
         run: bash scripts/check_startup_budget.sh
 

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'16bebf9ed271271bf11c44c34bb0532aa2c7d70b';
+String _$tripRecordingHash() => r'61fa68af94e570dacfc4e1186f5022bc06d84f5e';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
@@ -78,7 +78,7 @@ final class HapticEcoCoachEnabledProvider
 }
 
 String _$hapticEcoCoachEnabledHash() =>
-    r'214a752dd25d2684c2be3498245ef528386c0a1b';
+    r'b880f6dd2f782b95a5e1450d6a2ca8c3244241e3';
 
 /// Persisted opt-in switch for the real-time eco-coaching haptic
 /// (#1122). As of #1373 phase 3a this is a thin shim over


### PR DESCRIPTION
## What

Closes #1730. `ci.yml` ran `dart run build_runner build` in **every**
job — `analyze`, the 4 `test` shards, and `startup-budget` —
regenerating the committed `.g.dart` / `.freezed.dart` on top of
themselves ~6 times per CI run. The output is byte-identical to what
is already committed, so those passes were pure waste; worse, they
**masked drift** — a `@riverpod`/`@freezed` edit committed without
regenerating went green because every job regenerated over the stale
file.

## Changes

- **New `codegen-drift` job** — clean checkout → `flutter pub get` →
  `build_runner build` → `git diff --exit-code` over `*.g.dart` /
  `*.freezed.dart`. Fails CI when the committed codegen is stale.
- **`analyze`, `test`, `startup-budget`** no longer run `build_runner`
  — they trust the committed (now drift-gated) generated files.
- **`build-android`** keeps `build_runner` — a release build wants a
  from-clean codegen pass. (`build-ios` is commented out; nightly
  workflows are out of scope per the issue.)

`startup-budget` is also dropped here (in addition to the `analyze` +
`test` named in the issue): it is a non-release check job in the same
class as `analyze`, so leaving its redundant pass would defeat the
"share once" goal.

## Prerequisite — drift fix

Running the gate locally on `master` surfaced **real drift** in two
committed `.g.dart` files (stale Riverpod `_$xHash()` source-hash —
hot-reload marker only, no runtime impact). The first commit
regenerates them so the repo starts drift-free; the gate then passes.
Verified locally: `build_runner build` → `git diff` is empty.

## Acceptance

- [x] A `codegen-drift` job fails CI when committed generated files
      are stale.
- [x] `analyze` + `test` jobs no longer run `build_runner build`.
- [x] A full CI run is measurably faster — 6 redundant codegen passes
      removed (1 `analyze` + 4 `test` shards + 1 `startup-budget`),
      replaced by 1 `codegen-drift` pass.

## Maintainer follow-up

Add `codegen-drift` to the branch-protection **required status checks**
so a stale-codegen failure blocks merge (the job runs regardless; this
just makes it gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
