### PR TITLE
refactor(features): convert FeatureFlags to AsyncNotifier — remove I/O from build() (#1681)

### DIFF
--- a/lib/app/routes/consumption_routes.dart
+++ b/lib/app/routes/consumption_routes.dart
@@ -31,7 +31,7 @@ List<RouteBase> get consumptionRoutes => [
         builder: (context, state) => Consumer(
           builder: (context, ref, _) {
             final enabled = ref
-                .watch(featureFlagsProvider)
+                .watch(enabledFeaturesProvider)
                 .contains(Feature.carbonDashboard);
             if (!enabled) {
               WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -181,7 +181,7 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     // gets no Conso tab; Medium / Full do. Replaces the old #893
     // hasVehicle gate which created a catch-22 for Medium users.
     final manifest = ref.watch(featureManifestProvider);
-    final enabledFlags = ref.watch(featureFlagsProvider);
+    final enabledFlags = ref.watch(enabledFeaturesProvider);
     final showConsumption = isConsumptionTabReachable(manifest, enabledFlags);
     final destinations = resolveShellDestinations(
       l10n: l10n,

--- a/lib/core/refuel/unified_search_results_enabled.dart
+++ b/lib/core/refuel/unified_search_results_enabled.dart
@@ -28,7 +28,7 @@ class UnifiedSearchResultsEnabled extends _$UnifiedSearchResultsEnabled {
     // shims and forward-compat (#1447). `Feature.unifiedSearchResults`
     // has no requires today so the helper short-circuits to
     // `state.contains` — identical observable behaviour.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(
       Feature.unifiedSearchResults,

--- a/lib/core/refuel/unified_search_results_enabled.g.dart
+++ b/lib/core/refuel/unified_search_results_enabled.g.dart
@@ -85,7 +85,7 @@ final class UnifiedSearchResultsEnabledProvider
 }
 
 String _$unifiedSearchResultsEnabledHash() =>
-    r'8a3ef4f95d3d5dd8851ab79ae2ef26211e2a1f71';
+    r'b613b6452445f9e0f52991b0e2c3ca0c2b5c0ee4';
 
 /// Feature flag for the #1116 phase-3 unified fuel + EV search results.
 ///

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -170,7 +170,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     // without trip recording enabled, and the empty tab confused
     // Medium users. Reading ConsoMode directly is clearer than
     // walking the dependency graph for obd2TripRecording.
-    final enabledFlags = ref.watch(featureFlagsProvider);
+    final enabledFlags = ref.watch(enabledFeaturesProvider);
     final showTrajets = consoModeFromFlags(enabledFlags) ==
         ConsoMode.fuelAndTrips;
     // Recreate the TabController when the tab-set cardinality
@@ -239,7 +239,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
         ),
         // #1613 — the Carbon dashboard entry point is gated on the
         // central Feature enum so it can be toggled per profile.
-        if (ref.watch(featureFlagsProvider).contains(Feature.carbonDashboard))
+        if (ref.watch(enabledFeaturesProvider).contains(Feature.carbonDashboard))
           IconButton(
             key: const Key('open_carbon_dashboard'),
             tooltip: l?.carbonDashboardTitle ?? 'Carbon dashboard',

--- a/lib/features/consumption/providers/auto_record_orchestrator.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.dart
@@ -83,6 +83,12 @@ class AutoRecordOrchestrator extends _$AutoRecordOrchestrator {
     // list — when the gate goes off the diff sees an empty `wanted`
     // set and tears down every active coordinator; when it flips back
     // on the diff re-arms the eligible vehicles.
+    //
+    // #1681 — watch the `featureFlagsProvider` AsyncNotifier directly
+    // (one dependency hop) rather than the derived `enabledFeatures`
+    // view: a `keepAlive` orchestrator with no external listener
+    // rebuilds reliably on a direct dependency change, and the diff
+    // below reads the resolved set via `enabledFeaturesProvider`.
     ref.watch(featureFlagsProvider);
 
     // ref.listen fires on every change to the vehicle list, including
@@ -163,7 +169,7 @@ class AutoRecordOrchestrator extends _$AutoRecordOrchestrator {
     // value, so the user disabling consumption tracking gets a clean
     // shutdown of the whole hands-free chain.
     final manifest = ref.read(featureManifestProvider);
-    final enabled = ref.read(featureFlagsProvider);
+    final enabled = ref.read(enabledFeaturesProvider);
     final centralEnabled = isEffectivelyEnabled(
       Feature.autoRecord,
       manifest,

--- a/lib/features/consumption/providers/auto_record_orchestrator.g.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.g.dart
@@ -195,7 +195,7 @@ final class AutoRecordOrchestratorProvider
 }
 
 String _$autoRecordOrchestratorHash() =>
-    r'636ec863afef4200091749ef79143d8e367d33a8';
+    r'890904dcb2647ed4493a3ce32e71a534c2070d56';
 
 /// Production wiring for the hands-free auto-record flow (#1004 phase 2b-3).
 ///

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -38,7 +38,7 @@ class DrivingSettingsSection extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final ecoEnabled = ref.watch(hapticEcoCoachEnabledProvider);
-    final flags = ref.watch(featureFlagsProvider);
+    final flags = ref.watch(enabledFeaturesProvider);
     // #1608 — the haptic eco-coach toggle must pre-check the dependency:
     // enabling it while `obd2TripRecording` is off throws a StateError
     // in the central provider. When the parent is off (and the toggle

--- a/lib/features/driving/providers/haptic_eco_coach_provider.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.dart
@@ -31,7 +31,7 @@ class HapticEcoCoachEnabled extends _$HapticEcoCoachEnabled {
     // (the parent) is off, this surfaces as `false` regardless of the
     // stored haptic-coach value. The lifecycle provider re-runs and
     // tears down its subscription on the next frame.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(Feature.hapticEcoCoach, manifest, enabled);
   }

--- a/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
+++ b/lib/features/driving/providers/haptic_eco_coach_provider.g.dart
@@ -78,7 +78,7 @@ final class HapticEcoCoachEnabledProvider
 }
 
 String _$hapticEcoCoachEnabledHash() =>
-    r'b880f6dd2f782b95a5e1450d6a2ca8c3244241e3';
+    r'fc559e030c6448a2d1a8023cc27e9696c90ef420';
 
 /// Persisted opt-in switch for the real-time eco-coaching haptic
 /// (#1122). As of #1373 phase 3a this is a thin shim over

--- a/lib/features/feature_management/application/feature_flags_provider.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/logging/error_logger.dart';
 import '../data/feature_flags_repository.dart';
 import '../domain/feature.dart';
 import '../domain/feature_dependency_graph.dart';
@@ -38,25 +41,44 @@ FeatureManifest featureManifest(Ref ref) => FeatureManifest.defaultManifest;
 /// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
 /// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
 /// through this provider one feature at a time.
+///
+/// ## AsyncNotifier (#1681)
+///
+/// `build` is an `async` `FutureOr<Set<Feature>>` so the Hive read is
+/// awaited inside it — Riverpod owns the loading frame instead of the
+/// old pattern of returning manifest defaults synchronously and then
+/// mutating `state` from a `.then()` callback (which needed an
+/// `invalid_use_of_protected_member` ignore and swallowed read errors).
+/// A failed Hive read is now logged via [errorLogger] and falls back to
+/// the manifest defaults rather than failing silently.
+///
+/// Most consumers want the resolved `Set<Feature>` and have a sensible
+/// answer for the brief pre-load frame; they watch [enabledFeaturesProvider]
+/// (a synchronous derived view) rather than this provider directly.
 @Riverpod(keepAlive: true)
 class FeatureFlags extends _$FeatureFlags {
   @override
-  Set<Feature> build() {
+  FutureOr<Set<Feature>> build() async {
     final manifest = ref.watch(featureManifestProvider);
     assertNoCycles(manifest);
     final repo = ref.watch(featureFlagsRepositoryProvider);
     if (repo == null) {
       return manifest.defaultEnabledSet();
     }
-    // First-frame state: manifest defaults so synchronous reads have a
-    // sensible answer. The async load below replaces it once Hive
-    // returns — the persisted set wins on every subsequent read.
-    final initial = manifest.defaultEnabledSet();
-    repo.loadEnabled().then((persisted) {
-      // ignore: invalid_use_of_protected_member
-      state = persisted;
-    });
-    return initial;
+    try {
+      return await repo.loadEnabled();
+    } catch (e, st) {
+      // #1681 — a Hive read failure must not be silent. Log it through
+      // the central pipeline, then fall back to manifest defaults so
+      // the app stays usable rather than stuck on an error state.
+      await errorLogger.log(
+        ErrorLayer.storage,
+        e,
+        st,
+        context: {'op': 'FeatureFlags.loadEnabled'},
+      );
+      return manifest.defaultEnabledSet();
+    }
   }
 
   /// Enables [feature], throwing [StateError] when a prerequisite is
@@ -64,20 +86,23 @@ class FeatureFlags extends _$FeatureFlags {
   /// Phase 2 UI can surface a tooltip without a second lookup.
   Future<void> enable(Feature feature) async {
     final manifest = ref.read(featureManifestProvider);
-    if (state.contains(feature)) return;
-    if (!canEnable(feature, manifest, state)) {
+    // Await the in-flight (or resolved) build so a flip during the
+    // initial Hive load operates on the persisted set, not stale state.
+    final current = await future;
+    if (current.contains(feature)) return;
+    if (!canEnable(feature, manifest, current)) {
       final entry = manifest.entryFor(feature);
       final missing = entry.requires
-          .where((f) => !state.contains(f))
+          .where((f) => !current.contains(f))
           .map((f) => f.name)
           .join(', ');
       throw StateError(
         'Cannot enable ${feature.name}: requires $missing which is disabled',
       );
     }
-    final next = {...state, feature};
+    final next = {...current, feature};
     await _persist(next);
-    state = next;
+    state = AsyncData(next);
   }
 
   /// Disables [feature]. Always succeeds — children that `requires` this
@@ -89,10 +114,11 @@ class FeatureFlags extends _$FeatureFlags {
   /// Re-enabling [feature] later restores those children to their previous
   /// user-visible state, no manual re-toggling required.
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    final next = {...state}..remove(feature);
+    final current = await future;
+    if (!current.contains(feature)) return;
+    final next = {...current}..remove(feature);
     await _persist(next);
-    state = next;
+    state = AsyncData(next);
   }
 
   /// True when [feature] is currently in the stored enabled set. Does NOT
@@ -100,11 +126,34 @@ class FeatureFlags extends _$FeatureFlags {
   /// for [feature] and the caller wants the user-visible "is this surface
   /// reachable right now" answer, use the pure helper
   /// `isEffectivelyEnabled` from `feature_dependency_graph.dart` (#1447).
-  bool isEnabled(Feature feature) => state.contains(feature);
+  ///
+  /// Returns `false` while the initial Hive load is still in flight —
+  /// the same answer a not-yet-enabled feature gives, so a caller racing
+  /// the first frame degrades safely.
+  bool isEnabled(Feature feature) =>
+      state.asData?.value.contains(feature) ?? false;
 
   Future<void> _persist(Set<Feature> next) async {
     final repo = ref.read(featureFlagsRepositoryProvider);
     if (repo == null) return;
     await repo.saveEnabled(next);
   }
+}
+
+/// Synchronous view of the enabled-feature set (#1681).
+///
+/// [featureFlagsProvider] is an `AsyncNotifier`, so watching it directly
+/// yields an `AsyncValue<Set<Feature>>`. Almost every consumer only
+/// needs the resolved `Set<Feature>` and has a sensible answer for the
+/// brief pre-Hive-load frame: the manifest defaults. This derived
+/// provider encapsulates that — during the load frame (or on an
+/// `AsyncError` fallback) it resolves to `defaultEnabledSet()`, matching
+/// the pre-#1681 synchronous-`build()` behaviour bit-for-bit.
+///
+/// Callers that mutate flags still go through
+/// `featureFlagsProvider.notifier` (`enable` / `disable` / `isEnabled`).
+@Riverpod(keepAlive: true)
+Set<Feature> enabledFeatures(Ref ref) {
+  return ref.watch(featureFlagsProvider).asData?.value ??
+      ref.watch(featureManifestProvider).defaultEnabledSet();
 }

--- a/lib/features/feature_management/application/feature_flags_provider.g.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.g.dart
@@ -137,6 +137,20 @@ String _$featureManifestHash() => r'7b67cbf211fcf268808f6c329950be1d4ba91881';
 /// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
 /// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
 /// through this provider one feature at a time.
+///
+/// ## AsyncNotifier (#1681)
+///
+/// `build` is an `async` `FutureOr<Set<Feature>>` so the Hive read is
+/// awaited inside it — Riverpod owns the loading frame instead of the
+/// old pattern of returning manifest defaults synchronously and then
+/// mutating `state` from a `.then()` callback (which needed an
+/// `invalid_use_of_protected_member` ignore and swallowed read errors).
+/// A failed Hive read is now logged via [errorLogger] and falls back to
+/// the manifest defaults rather than failing silently.
+///
+/// Most consumers want the resolved `Set<Feature>` and have a sensible
+/// answer for the brief pre-load frame; they watch [enabledFeaturesProvider]
+/// (a synchronous derived view) rather than this provider directly.
 
 @ProviderFor(FeatureFlags)
 final featureFlagsProvider = FeatureFlagsProvider._();
@@ -152,8 +166,22 @@ final featureFlagsProvider = FeatureFlagsProvider._();
 /// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
 /// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
 /// through this provider one feature at a time.
+///
+/// ## AsyncNotifier (#1681)
+///
+/// `build` is an `async` `FutureOr<Set<Feature>>` so the Hive read is
+/// awaited inside it — Riverpod owns the loading frame instead of the
+/// old pattern of returning manifest defaults synchronously and then
+/// mutating `state` from a `.then()` callback (which needed an
+/// `invalid_use_of_protected_member` ignore and swallowed read errors).
+/// A failed Hive read is now logged via [errorLogger] and falls back to
+/// the manifest defaults rather than failing silently.
+///
+/// Most consumers want the resolved `Set<Feature>` and have a sensible
+/// answer for the brief pre-load frame; they watch [enabledFeaturesProvider]
+/// (a synchronous derived view) rather than this provider directly.
 final class FeatureFlagsProvider
-    extends $NotifierProvider<FeatureFlags, Set<Feature>> {
+    extends $AsyncNotifierProvider<FeatureFlags, Set<Feature>> {
   /// Central feature-flag store (#1373 phase 1).
   ///
   /// State is the set of currently-enabled features. The provider validates
@@ -165,6 +193,20 @@ final class FeatureFlagsProvider
   /// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
   /// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
   /// through this provider one feature at a time.
+  ///
+  /// ## AsyncNotifier (#1681)
+  ///
+  /// `build` is an `async` `FutureOr<Set<Feature>>` so the Hive read is
+  /// awaited inside it — Riverpod owns the loading frame instead of the
+  /// old pattern of returning manifest defaults synchronously and then
+  /// mutating `state` from a `.then()` callback (which needed an
+  /// `invalid_use_of_protected_member` ignore and swallowed read errors).
+  /// A failed Hive read is now logged via [errorLogger] and falls back to
+  /// the manifest defaults rather than failing silently.
+  ///
+  /// Most consumers want the resolved `Set<Feature>` and have a sensible
+  /// answer for the brief pre-load frame; they watch [enabledFeaturesProvider]
+  /// (a synchronous derived view) rather than this provider directly.
   FeatureFlagsProvider._()
     : super(
         from: null,
@@ -182,17 +224,9 @@ final class FeatureFlagsProvider
   @$internal
   @override
   FeatureFlags create() => FeatureFlags();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(Set<Feature> value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<Set<Feature>>(value),
-    );
-  }
 }
 
-String _$featureFlagsHash() => r'1c1ae2547cc2a9c678e75604243e9984a36e16e4';
+String _$featureFlagsHash() => r'10bea65d477d5590e5d8737bedcfa91b7d61920e';
 
 /// Central feature-flag store (#1373 phase 1).
 ///
@@ -205,21 +239,114 @@ String _$featureFlagsHash() => r'1c1ae2547cc2a9c678e75604243e9984a36e16e4';
 /// toggles — no consumer is migrated yet. Phase 3 of #1373 will route
 /// `autoRecord`, `gamificationEnabled`, `hapticEcoCoachEnabled`, etc.
 /// through this provider one feature at a time.
+///
+/// ## AsyncNotifier (#1681)
+///
+/// `build` is an `async` `FutureOr<Set<Feature>>` so the Hive read is
+/// awaited inside it — Riverpod owns the loading frame instead of the
+/// old pattern of returning manifest defaults synchronously and then
+/// mutating `state` from a `.then()` callback (which needed an
+/// `invalid_use_of_protected_member` ignore and swallowed read errors).
+/// A failed Hive read is now logged via [errorLogger] and falls back to
+/// the manifest defaults rather than failing silently.
+///
+/// Most consumers want the resolved `Set<Feature>` and have a sensible
+/// answer for the brief pre-load frame; they watch [enabledFeaturesProvider]
+/// (a synchronous derived view) rather than this provider directly.
 
-abstract class _$FeatureFlags extends $Notifier<Set<Feature>> {
-  Set<Feature> build();
+abstract class _$FeatureFlags extends $AsyncNotifier<Set<Feature>> {
+  FutureOr<Set<Feature>> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    final ref = this.ref as $Ref<Set<Feature>, Set<Feature>>;
+    final ref = this.ref as $Ref<AsyncValue<Set<Feature>>, Set<Feature>>;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<Set<Feature>, Set<Feature>>,
-              Set<Feature>,
+              AnyNotifier<AsyncValue<Set<Feature>>, Set<Feature>>,
+              AsyncValue<Set<Feature>>,
               Object?,
               Object?
             >;
     element.handleCreate(ref, build);
   }
 }
+
+/// Synchronous view of the enabled-feature set (#1681).
+///
+/// [featureFlagsProvider] is an `AsyncNotifier`, so watching it directly
+/// yields an `AsyncValue<Set<Feature>>`. Almost every consumer only
+/// needs the resolved `Set<Feature>` and has a sensible answer for the
+/// brief pre-Hive-load frame: the manifest defaults. This derived
+/// provider encapsulates that — during the load frame (or on an
+/// `AsyncError` fallback) it resolves to `defaultEnabledSet()`, matching
+/// the pre-#1681 synchronous-`build()` behaviour bit-for-bit.
+///
+/// Callers that mutate flags still go through
+/// `featureFlagsProvider.notifier` (`enable` / `disable` / `isEnabled`).
+
+@ProviderFor(enabledFeatures)
+final enabledFeaturesProvider = EnabledFeaturesProvider._();
+
+/// Synchronous view of the enabled-feature set (#1681).
+///
+/// [featureFlagsProvider] is an `AsyncNotifier`, so watching it directly
+/// yields an `AsyncValue<Set<Feature>>`. Almost every consumer only
+/// needs the resolved `Set<Feature>` and has a sensible answer for the
+/// brief pre-Hive-load frame: the manifest defaults. This derived
+/// provider encapsulates that — during the load frame (or on an
+/// `AsyncError` fallback) it resolves to `defaultEnabledSet()`, matching
+/// the pre-#1681 synchronous-`build()` behaviour bit-for-bit.
+///
+/// Callers that mutate flags still go through
+/// `featureFlagsProvider.notifier` (`enable` / `disable` / `isEnabled`).
+
+final class EnabledFeaturesProvider
+    extends $FunctionalProvider<Set<Feature>, Set<Feature>, Set<Feature>>
+    with $Provider<Set<Feature>> {
+  /// Synchronous view of the enabled-feature set (#1681).
+  ///
+  /// [featureFlagsProvider] is an `AsyncNotifier`, so watching it directly
+  /// yields an `AsyncValue<Set<Feature>>`. Almost every consumer only
+  /// needs the resolved `Set<Feature>` and has a sensible answer for the
+  /// brief pre-Hive-load frame: the manifest defaults. This derived
+  /// provider encapsulates that — during the load frame (or on an
+  /// `AsyncError` fallback) it resolves to `defaultEnabledSet()`, matching
+  /// the pre-#1681 synchronous-`build()` behaviour bit-for-bit.
+  ///
+  /// Callers that mutate flags still go through
+  /// `featureFlagsProvider.notifier` (`enable` / `disable` / `isEnabled`).
+  EnabledFeaturesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'enabledFeaturesProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$enabledFeaturesHash();
+
+  @$internal
+  @override
+  $ProviderElement<Set<Feature>> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Set<Feature> create(Ref ref) {
+    return enabledFeatures(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Set<Feature> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Set<Feature>>(value),
+    );
+  }
+}
+
+String _$enabledFeaturesHash() => r'2e79e8e31e5bd3a1f94ce3e095d1b76c3ed0b306';

--- a/lib/features/feature_management/v2/effective_feature_flags_provider.dart
+++ b/lib/features/feature_management/v2/effective_feature_flags_provider.dart
@@ -24,7 +24,7 @@ part 'effective_feature_flags_provider.g.dart';
 /// enum names, both APIs read the same persistence record.
 @Riverpod(keepAlive: true)
 Map<String, bool> effectiveFeatureFlags(Ref ref) {
-  final v1Enabled = ref.watch(featureFlagsProvider);
+  final v1Enabled = ref.watch(enabledFeaturesProvider);
   final enabledIds = v1Enabled.map((f) => f.name).toSet();
   return {
     for (final fc in featureRegistry)

--- a/lib/features/feature_management/v2/effective_feature_flags_provider.g.dart
+++ b/lib/features/feature_management/v2/effective_feature_flags_provider.g.dart
@@ -101,4 +101,4 @@ final class EffectiveFeatureFlagsProvider
 }
 
 String _$effectiveFeatureFlagsHash() =>
-    r'7180d6aeadf1f63093df51532fc4f61cd3f2eb46';
+    r'06cb2e03fb733b44dea3b5d0ecabf8c8bf73b285';

--- a/lib/features/price_history/providers/price_prediction_provider.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.dart
@@ -162,7 +162,7 @@ double? _maybeModelPredict({
   required FeatureVector latest,
 }) {
   final manifest = ref.watch(featureManifestProvider);
-  final enabled = ref.watch(featureFlagsProvider);
+  final enabled = ref.watch(enabledFeaturesProvider);
   if (!isEffectivelyEnabled(
     Feature.tflitePricePrediction,
     manifest,

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -37,7 +37,7 @@ class ProfileScreen extends ConsumerWidget {
     // not see settings whose UI cannot do anything. Re-enabling the
     // root from the Feature management section restores them.
     final manifest = ref.watch(featureManifestProvider);
-    final enabledFlags = ref.watch(featureFlagsProvider);
+    final enabledFlags = ref.watch(enabledFeaturesProvider);
     final tankSyncOn = isEffectivelyEnabled(
       Feature.tankSync,
       manifest,

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -39,7 +39,7 @@ class FeatureManagementSection extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final manifest = ref.watch(featureManifestProvider);
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
 
     // Build groups in manifest declaration order (#1440). A feature with
     // no `requires` (or whose `requires` does not reference an already-
@@ -253,7 +253,7 @@ class _ConsoFeatureCard extends ConsumerWidget {
     for (final f in delta.toRemove) {
       await notifier.disable(f);
     }
-    final newFlags = ref.read(featureFlagsProvider);
+    final newFlags = ref.read(enabledFeaturesProvider);
     await ref
         .read(activeAppProfileProvider.notifier)
         .reconcileWithFlags(newFlags);
@@ -661,7 +661,7 @@ Future<void> _toggleAndReconcile(
   } else {
     await notifier.disable(feature);
   }
-  final newFlags = ref.read(featureFlagsProvider);
+  final newFlags = ref.read(enabledFeaturesProvider);
   await ref
       .read(activeAppProfileProvider.notifier)
       .reconcileWithFlags(newFlags);

--- a/lib/features/profile/providers/gamification_enabled_provider.dart
+++ b/lib/features/profile/providers/gamification_enabled_provider.dart
@@ -41,7 +41,7 @@ class GamificationEnabled extends _$GamificationEnabled {
     // of the stored value. Disabling the parent (`obd2TripRecording`)
     // therefore hides the gamification UI without touching the user's
     // gamification preference; re-enabling the parent restores it.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(Feature.gamification, manifest, enabled);
   }

--- a/lib/features/profile/providers/gamification_enabled_provider.g.dart
+++ b/lib/features/profile/providers/gamification_enabled_provider.g.dart
@@ -120,7 +120,7 @@ final class GamificationEnabledProvider
 }
 
 String _$gamificationEnabledHash() =>
-    r'7b107298eae3d49674cc71a66fcfb0e975e29b5b';
+    r'b7733b1037907f37e124a2c74107ecbe14ac720f';
 
 /// Master gate for gamification surfaces (#1194).
 ///

--- a/lib/features/profile/providers/show_consumption_tab_enabled_provider.dart
+++ b/lib/features/profile/providers/show_consumption_tab_enabled_provider.dart
@@ -39,7 +39,7 @@ class ShowConsumptionTabEnabled extends _$ShowConsumptionTabEnabled {
     // bottom-nav regardless of the stored `showConsumptionTab` value.
     // The user's tab-visibility preference is preserved so re-enabling
     // trip recording restores the prior layout.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(Feature.showConsumptionTab, manifest, enabled);
   }

--- a/lib/features/profile/providers/show_consumption_tab_enabled_provider.g.dart
+++ b/lib/features/profile/providers/show_consumption_tab_enabled_provider.g.dart
@@ -114,7 +114,7 @@ final class ShowConsumptionTabEnabledProvider
 }
 
 String _$showConsumptionTabEnabledHash() =>
-    r'ee0e997da35419922ab33b0101f0350d4365a285';
+    r'7f4e06a34794e6349e6b9e15c3ca1592ef6af4dd';
 
 /// Visibility gate for the consumption analytics tab in the bottom
 /// navigation (#1373 phase 3c).

--- a/lib/features/profile/providers/show_electric_enabled_provider.dart
+++ b/lib/features/profile/providers/show_electric_enabled_provider.dart
@@ -37,7 +37,7 @@ class ShowElectricEnabled extends _$ShowElectricEnabled {
     // shims and forward-compat (#1447). `Feature.showElectric` has no
     // requires today so the helper short-circuits to `state.contains` —
     // identical observable behaviour to the prior `.contains` call.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(Feature.showElectric, manifest, enabled);
   }

--- a/lib/features/profile/providers/show_electric_enabled_provider.g.dart
+++ b/lib/features/profile/providers/show_electric_enabled_provider.g.dart
@@ -111,7 +111,7 @@ final class ShowElectricEnabledProvider
 }
 
 String _$showElectricEnabledHash() =>
-    r'fd3eb59c1114c377a436862b2a1ed7b1e77091d4';
+    r'6b4bea61579545dc7d5f45bbd6ca34a57d554e80';
 
 /// Visibility gate for EV charging-station results in search and on
 /// the map (#1373 phase 3c).

--- a/lib/features/profile/providers/show_fuel_enabled_provider.dart
+++ b/lib/features/profile/providers/show_fuel_enabled_provider.dart
@@ -36,7 +36,7 @@ class ShowFuelEnabled extends _$ShowFuelEnabled {
     // shims and forward-compat (#1447). `Feature.showFuel` has no
     // requires today so the helper short-circuits to `state.contains` —
     // identical observable behaviour to the prior `.contains` call.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(Feature.showFuel, manifest, enabled);
   }

--- a/lib/features/profile/providers/show_fuel_enabled_provider.g.dart
+++ b/lib/features/profile/providers/show_fuel_enabled_provider.g.dart
@@ -107,7 +107,7 @@ final class ShowFuelEnabledProvider
   }
 }
 
-String _$showFuelEnabledHash() => r'21cc73828648685c439dda8634ce9caa511f4de7';
+String _$showFuelEnabledHash() => r'5cabee1dd34c2c7bf4a0b3998fb1481d9cf3c9a1';
 
 /// Visibility gate for fuel-station results in search and on the map
 /// (#1373 phase 3c).

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -144,7 +144,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     // so the body never renders the route input. The stored mode value
     // is preserved (re-enabling the feature restores the prior choice).
     final manifest = ref.watch(featureManifestProvider);
-    final enabledFlags = ref.watch(featureFlagsProvider);
+    final enabledFlags = ref.watch(enabledFeaturesProvider);
     final routePlanningOn = isEffectivelyEnabled(
       Feature.routePlanning,
       manifest,

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -100,7 +100,7 @@ class SearchResultsList extends ConsumerWidget {
               // point anywhere in lib/; this affordance makes it
               // reachable when Feature.fuelCalculator is enabled.
               if (ref
-                  .watch(featureFlagsProvider)
+                  .watch(enabledFeaturesProvider)
                   .contains(Feature.fuelCalculator)) ...[
                 Semantics(
                   label: l10n?.fuelCostCalculator ?? 'Fuel Cost Calculator',

--- a/lib/features/sync/providers/baseline_sync_enabled_provider.dart
+++ b/lib/features/sync/providers/baseline_sync_enabled_provider.dart
@@ -33,7 +33,7 @@ class BaselineSyncEnabled extends _$BaselineSyncEnabled {
     // parent) is off, this surfaces as `false` regardless of the stored
     // value. The trip-flush hook reads this via `ref.read` at flush
     // time and skips the upload when the parent is gone.
-    final enabled = ref.watch(featureFlagsProvider);
+    final enabled = ref.watch(enabledFeaturesProvider);
     final manifest = ref.watch(featureManifestProvider);
     return isEffectivelyEnabled(Feature.baselineSync, manifest, enabled);
   }

--- a/lib/features/sync/providers/baseline_sync_enabled_provider.g.dart
+++ b/lib/features/sync/providers/baseline_sync_enabled_provider.g.dart
@@ -99,7 +99,7 @@ final class BaselineSyncEnabledProvider
 }
 
 String _$baselineSyncEnabledHash() =>
-    r'8a46849953aa43c536e5200e65e9d1064af762bf';
+    r'd2a8d202603c3a20adecd5bc02d33079ef8c2f12';
 
 /// Persisted opt-in switch for per-vehicle driving-baseline sync via
 /// TankSync (#780). As of #1373 phase 3e this is a thin shim over

--- a/test/core/refuel/unified_search_results_enabled_test.dart
+++ b/test/core/refuel/unified_search_results_enabled_test.dart
@@ -64,7 +64,7 @@ void main() {
   /// observe the persisted set rather than the manifest-default
   /// placeholder.
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -115,7 +115,7 @@ void main() {
           .set(true);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.unifiedSearchResults),
         reason:
             'set(true) must route through featureFlagsProvider.enable so '
@@ -147,7 +147,7 @@ void main() {
           .set(false);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.unifiedSearchResults)),
       );
       expect(container.read(unifiedSearchResultsEnabledProvider), isFalse);
@@ -172,7 +172,7 @@ void main() {
             'state stay in sync.',
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.unifiedSearchResults),
       );
 
@@ -187,7 +187,7 @@ void main() {
             'verifies both branches of the toggle delegate to set().',
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.unifiedSearchResults)),
       );
     });
@@ -259,7 +259,7 @@ void main() {
               'than crashing on a developer mistake.',
         );
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           isNot(contains(Feature.unifiedSearchResults)),
         );
       },
@@ -282,14 +282,14 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }
 

--- a/test/features/consumption/providers/auto_record_orchestrator_test.dart
+++ b/test/features/consumption/providers/auto_record_orchestrator_test.dart
@@ -640,13 +640,13 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
@@ -75,7 +76,7 @@ void main() {
 
       // Central state must have flipped on.
       expect(
-        fakeFlags.state,
+        fakeFlags.state.requireValue,
         contains(Feature.hapticEcoCoach),
         reason:
             'Tapping the toggle must enable hapticEcoCoach in the central '
@@ -260,14 +261,14 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }
 

--- a/test/features/driving/providers/haptic_eco_coach_provider_test.dart
+++ b/test/features/driving/providers/haptic_eco_coach_provider_test.dart
@@ -63,7 +63,7 @@ void main() {
   /// observe the persisted set rather than the manifest-default
   /// placeholder.
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -119,7 +119,7 @@ void main() {
           .set(true);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.hapticEcoCoach),
         reason:
             'set(true) must route through featureFlagsProvider.enable so '
@@ -153,7 +153,7 @@ void main() {
           .set(false);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.hapticEcoCoach)),
       );
       expect(container.read(hapticEcoCoachEnabledProvider), isFalse);
@@ -178,7 +178,7 @@ void main() {
 
       // The violating enable did not take effect — state is unchanged.
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.hapticEcoCoach)),
       );
       expect(container.read(hapticEcoCoachEnabledProvider), isFalse);

--- a/test/features/feature_management/app_profile_provider_test.dart
+++ b/test/features/feature_management/app_profile_provider_test.dart
@@ -53,7 +53,7 @@ void main() {
   }
 
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -94,7 +94,7 @@ void main() {
       final c = makeContainer();
       await pumpLoad(c);
       await c.read(activeAppProfileProvider.notifier).select(AppProfile.basic);
-      final flags = c.read(featureFlagsProvider);
+      final flags = c.read(enabledFeaturesProvider);
       expect(flags, appProfileBundles[AppProfile.basic]);
       expect(c.read(activeAppProfileProvider), AppProfile.basic);
       expect(profileRepo.load(), AppProfile.basic);
@@ -106,7 +106,7 @@ void main() {
       await c
           .read(activeAppProfileProvider.notifier)
           .select(AppProfile.medium);
-      final flags = c.read(featureFlagsProvider);
+      final flags = c.read(enabledFeaturesProvider);
       expect(flags, contains(Feature.manualConsumption));
       expect(flags, contains(Feature.priceAlerts));
       expect(flags, isNot(contains(Feature.obd2TripRecording)));
@@ -116,7 +116,7 @@ void main() {
       final c = makeContainer();
       await pumpLoad(c);
       await c.read(activeAppProfileProvider.notifier).select(AppProfile.full);
-      final flags = c.read(featureFlagsProvider);
+      final flags = c.read(enabledFeaturesProvider);
       expect(flags, contains(Feature.obd2TripRecording));
       expect(flags, contains(Feature.gamification));
       expect(flags, contains(Feature.loyaltyCards));
@@ -132,14 +132,14 @@ void main() {
       await pumpLoad(c);
       await c.read(activeAppProfileProvider.notifier).select(AppProfile.full);
       await c.read(activeAppProfileProvider.notifier).select(AppProfile.basic);
-      final flags = c.read(featureFlagsProvider);
+      final flags = c.read(enabledFeaturesProvider);
       expect(flags, isNot(contains(Feature.obd2TripRecording)));
       expect(flags, isNot(contains(Feature.gamification)));
       expect(flags, isNot(contains(Feature.loyaltyCards)));
       expect(flags, isNot(contains(Feature.manualConsumption)));
       // Re-applying basic should be a no-op.
       await c.read(activeAppProfileProvider.notifier).select(AppProfile.basic);
-      final flagsAgain = c.read(featureFlagsProvider);
+      final flagsAgain = c.read(enabledFeaturesProvider);
       expect(flagsAgain, flags);
     });
 
@@ -147,11 +147,11 @@ void main() {
       final c = makeContainer();
       await pumpLoad(c);
       await c.read(activeAppProfileProvider.notifier).select(AppProfile.full);
-      final beforeCustom = Set<Feature>.from(c.read(featureFlagsProvider));
+      final beforeCustom = Set<Feature>.from(c.read(enabledFeaturesProvider));
       await c
           .read(activeAppProfileProvider.notifier)
           .select(AppProfile.custom);
-      final afterCustom = c.read(featureFlagsProvider);
+      final afterCustom = c.read(enabledFeaturesProvider);
       expect(afterCustom, beforeCustom);
       expect(c.read(activeAppProfileProvider), AppProfile.custom);
     });

--- a/test/features/feature_management/feature_flags_provider_test.dart
+++ b/test/features/feature_management/feature_flags_provider_test.dart
@@ -3,11 +3,41 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_dependency_graph.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+/// A [FeatureFlagsRepository] whose [loadEnabled] always throws — used to
+/// exercise the #1681 AsyncNotifier error path (the Hive read failing).
+class _ThrowingRepo extends FeatureFlagsRepository {
+  _ThrowingRepo(Box<dynamic> box) : super(box: box);
+
+  @override
+  Future<Set<Feature>> loadEnabled() async =>
+      throw StateError('simulated Hive read failure');
+}
+
+/// Minimal [TraceRecorder] fake — captures whatever [errorLogger] routes
+/// to it so the test can assert the failure was surfaced, not swallowed.
+class _FakeTraceRecorder implements TraceRecorder {
+  Object? capturedError;
+  int recordCount = 0;
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    capturedError = error;
+    recordCount++;
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -31,9 +61,12 @@ void main() {
     tmpDir.deleteSync(recursive: true);
   });
 
-  ProviderContainer makeContainer({FeatureManifest? manifest}) {
+  ProviderContainer makeContainer({
+    FeatureManifest? manifest,
+    FeatureFlagsRepository? repository,
+  }) {
     final c = ProviderContainer(overrides: [
-      featureFlagsRepositoryProvider.overrideWithValue(repo),
+      featureFlagsRepositoryProvider.overrideWithValue(repository ?? repo),
       if (manifest != null)
         featureManifestProvider.overrideWithValue(manifest),
     ]);
@@ -41,21 +74,18 @@ void main() {
     return c;
   }
 
-  /// Drains the post-build async load so reads observe the persisted set
-  /// rather than the synchronous manifest-default placeholder.
+  /// Awaits the AsyncNotifier `build()` so reads observe the persisted
+  /// set rather than the synchronous manifest-default placeholder
+  /// [enabledFeaturesProvider] returns during the load frame (#1681).
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
-    // Two microtask drains — one for repo.loadEnabled().then, one for the
-    // setter. A single delay covers both in practice.
-    await Future<void>.delayed(Duration.zero);
-    await Future<void>.delayed(Duration.zero);
+    await c.read(featureFlagsProvider.future);
   }
 
   group('FeatureFlags initial state', () {
     test('matches defaultManifest defaults on an empty box', () async {
       final c = makeContainer();
       await pumpLoad(c);
-      final state = c.read(featureFlagsProvider);
+      final state = c.read(enabledFeaturesProvider);
       expect(state, FeatureManifest.defaultManifest.defaultEnabledSet());
       // Sanity-check a few that should default true / false respectively.
       expect(state, contains(Feature.gamification));
@@ -99,7 +129,7 @@ void main() {
           .read(featureFlagsProvider.notifier)
           .enable(Feature.gamification);
 
-      final state = c.read(featureFlagsProvider);
+      final state = c.read(enabledFeaturesProvider);
       expect(state, contains(Feature.obd2TripRecording));
       expect(state, contains(Feature.gamification));
     });
@@ -113,7 +143,7 @@ void main() {
       await c
           .read(featureFlagsProvider.notifier)
           .enable(Feature.obd2TripRecording);
-      expect(c.read(featureFlagsProvider), contains(Feature.gamification));
+      expect(c.read(enabledFeaturesProvider), contains(Feature.gamification));
 
       // Cascading-disable: parent comes off, child stays in storage so the
       // user's preference is preserved, but the user-visible "is this
@@ -122,7 +152,7 @@ void main() {
           .read(featureFlagsProvider.notifier)
           .disable(Feature.obd2TripRecording);
 
-      final state = c.read(featureFlagsProvider);
+      final state = c.read(enabledFeaturesProvider);
       expect(state, isNot(contains(Feature.obd2TripRecording)));
       expect(
         state,
@@ -152,7 +182,7 @@ void main() {
         isEffectivelyEnabled(
           Feature.gamification,
           FeatureManifest.defaultManifest,
-          c.read(featureFlagsProvider),
+          c.read(enabledFeaturesProvider),
         ),
         isTrue,
       );
@@ -174,12 +204,12 @@ void main() {
       final c1 = makeContainer();
       await pumpLoad(c1);
       await c1.read(featureFlagsProvider.notifier).enable(Feature.tankSync);
-      expect(c1.read(featureFlagsProvider), contains(Feature.tankSync));
+      expect(c1.read(enabledFeaturesProvider), contains(Feature.tankSync));
 
       // Fresh container, same Hive box → persisted set wins over defaults.
       final c2 = makeContainer();
       await pumpLoad(c2);
-      final state = c2.read(featureFlagsProvider);
+      final state = c2.read(enabledFeaturesProvider);
       expect(state, contains(Feature.tankSync));
       // Things on by default that were never touched stay on.
       expect(state, contains(Feature.priceAlerts));
@@ -195,7 +225,8 @@ void main() {
 
       final c2 = makeContainer();
       await pumpLoad(c2);
-      expect(c2.read(featureFlagsProvider), isNot(contains(Feature.priceAlerts)));
+      expect(c2.read(enabledFeaturesProvider),
+          isNot(contains(Feature.priceAlerts)));
     });
   });
 
@@ -218,16 +249,42 @@ void main() {
         ),
       });
       final c = makeContainer(manifest: cyclic);
-      // Riverpod wraps build-time throws inside ProviderException; the
-      // contract we care about is that the StateError surfaces (matched
-      // by message), not the wrapper class.
-      expect(
-        () => c.read(featureFlagsProvider),
+      // `assertNoCycles` throws inside the async `build()`, so the
+      // failure surfaces as a rejected `future` rather than a
+      // synchronous throw. The contract we care about is that the
+      // StateError naming the cycle surfaces (matched by message).
+      await expectLater(
+        c.read(featureFlagsProvider.future),
         throwsA(predicate(
           (e) => e.toString().contains('Feature dependency cycle'),
           'wraps a StateError naming the cycle',
         )),
       );
+    });
+  });
+
+  group('FeatureFlags Hive-read failure (#1681)', () {
+    test('a failed loadEnabled is logged and falls back to manifest defaults',
+        () async {
+      final recorder = _FakeTraceRecorder();
+      errorLogger.testRecorderOverride = recorder;
+      addTearDown(errorLogger.resetForTest);
+
+      final c = makeContainer(repository: _ThrowingRepo(box));
+
+      // build() catches the throwing loadEnabled, logs it, and resolves
+      // to the manifest defaults — the future completes, never rejects.
+      final state = await c.read(featureFlagsProvider.future);
+      expect(state, FeatureManifest.defaultManifest.defaultEnabledSet());
+      expect(c.read(enabledFeaturesProvider),
+          FeatureManifest.defaultManifest.defaultEnabledSet());
+
+      // The failure was surfaced through the central error pipeline,
+      // tagged as a storage-layer error — not silently swallowed.
+      expect(recorder.recordCount, greaterThan(0));
+      final captured = recorder.capturedError;
+      expect(captured, isA<ContextualError>());
+      expect((captured! as ContextualError).layer, ErrorLayer.storage);
     });
   });
 }

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -143,7 +143,7 @@ void main() {
       // tankSync defaults to false in the manifest; toggling it on is
       // unblocked because it has no prerequisites.
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.tankSync)),
       );
       // Post-#1440 the section renders grouped cards which can push
@@ -163,7 +163,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.tankSync),
       );
     });
@@ -184,11 +184,11 @@ void main() {
           .disable(Feature.gamification);
       // Sanity: we are now in the state we want to test against.
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.gamification)),
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.obd2TripRecording)),
       );
 
@@ -240,7 +240,7 @@ void main() {
           .read(featureFlagsProvider.notifier)
           .enable(Feature.obd2TripRecording);
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         containsAll(<Feature>[
           Feature.obd2TripRecording,
           Feature.gamification,
@@ -271,11 +271,11 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.obd2TripRecording)),
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.gamification),
         reason: 'Stored child state must survive parent-disable so the '
             'user does not lose their preference.',

--- a/test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart
+++ b/test/features/profile/presentation/widgets/feature_management_section_grouping_test.dart
@@ -183,11 +183,11 @@ void main() {
           .read(featureFlagsProvider.notifier)
           .disable(Feature.gamification);
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.gamification)),
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.obd2TripRecording)),
       );
 
@@ -320,7 +320,7 @@ void main() {
       await tester.tap(find.text('Fuel'));
       await tester.pumpAndSettle();
 
-      final flags = container.read(featureFlagsProvider);
+      final flags = container.read(enabledFeaturesProvider);
       expect(flags, contains(Feature.showConsumptionTab));
       expect(flags, contains(Feature.manualConsumption));
       expect(flags, isNot(contains(Feature.obd2TripRecording)));
@@ -357,7 +357,7 @@ void main() {
       await tester.tap(find.text('Off'));
       await tester.pumpAndSettle();
 
-      final flags = container.read(featureFlagsProvider);
+      final flags = container.read(enabledFeaturesProvider);
       expect(flags, isNot(contains(Feature.showConsumptionTab)));
       expect(flags, isNot(contains(Feature.manualConsumption)));
       expect(flags, isNot(contains(Feature.obd2TripRecording)));

--- a/test/features/profile/presentation/widgets/gamification_settings_tile_test.dart
+++ b/test/features/profile/presentation/widgets/gamification_settings_tile_test.dart
@@ -125,7 +125,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(
-      fakeFlags.state,
+      fakeFlags.state.requireValue,
       contains(Feature.gamification),
       reason:
           'Tapping the toggle must enable gamification in the central '
@@ -208,14 +208,14 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }
 

--- a/test/features/profile/providers/gamification_enabled_provider_test.dart
+++ b/test/features/profile/providers/gamification_enabled_provider_test.dart
@@ -66,7 +66,7 @@ void main() {
   /// observe the persisted set rather than the manifest-default
   /// placeholder.
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -163,7 +163,7 @@ void main() {
           .set(true);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.gamification),
         reason:
             'set(true) must route through featureFlagsProvider.enable so '
@@ -198,7 +198,7 @@ void main() {
           .set(false);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.gamification)),
       );
       expect(container.read(gamificationEnabledProvider), isFalse);
@@ -237,7 +237,7 @@ void main() {
             'than crashing on a developer mistake.',
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.gamification)),
       );
     });
@@ -337,14 +337,14 @@ class _BuildCountingFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }
 
@@ -363,13 +363,13 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }

--- a/test/features/profile/providers/show_consumption_tab_enabled_provider_test.dart
+++ b/test/features/profile/providers/show_consumption_tab_enabled_provider_test.dart
@@ -50,7 +50,7 @@ void main() {
   }
 
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -114,11 +114,11 @@ void main() {
             .set(true);
 
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           contains(Feature.showConsumptionTab),
         );
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           contains(Feature.obd2TripRecording),
           reason:
               'The prerequisite must remain enabled — set(true) only '
@@ -163,7 +163,7 @@ void main() {
               'The shim swallows so the widget tree stays standing.',
         );
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           isNot(contains(Feature.showConsumptionTab)),
         );
       },
@@ -186,11 +186,11 @@ void main() {
           .set(false);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.showConsumptionTab)),
       );
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.obd2TripRecording),
         reason:
             'set(false) on the dependent must NOT disturb the '
@@ -240,7 +240,7 @@ void main() {
 
         expect(container.read(showConsumptionTabEnabledProvider), isFalse);
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           contains(Feature.showConsumptionTab),
           reason:
               'Stored child state must survive parent-disable so '

--- a/test/features/profile/providers/show_electric_enabled_provider_test.dart
+++ b/test/features/profile/providers/show_electric_enabled_provider_test.dart
@@ -43,7 +43,7 @@ void main() {
   }
 
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -81,7 +81,7 @@ void main() {
       await container.read(showElectricEnabledProvider.notifier).set(true);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.showElectric),
       );
       expect(container.read(showElectricEnabledProvider), isTrue);
@@ -96,7 +96,7 @@ void main() {
       await container.read(showElectricEnabledProvider.notifier).set(false);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.showElectric)),
       );
       expect(container.read(showElectricEnabledProvider), isFalse);

--- a/test/features/profile/providers/show_fuel_enabled_provider_test.dart
+++ b/test/features/profile/providers/show_fuel_enabled_provider_test.dart
@@ -51,7 +51,7 @@ void main() {
   }
 
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -99,7 +99,7 @@ void main() {
       await container.read(showFuelEnabledProvider.notifier).set(true);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         contains(Feature.showFuel),
         reason:
             'set(true) must route through featureFlagsProvider.enable so '
@@ -120,7 +120,7 @@ void main() {
       await container.read(showFuelEnabledProvider.notifier).set(false);
 
       expect(
-        container.read(featureFlagsProvider),
+        container.read(enabledFeaturesProvider),
         isNot(contains(Feature.showFuel)),
       );
       expect(container.read(showFuelEnabledProvider), isFalse);

--- a/test/features/sync/providers/baseline_sync_enabled_provider_test.dart
+++ b/test/features/sync/providers/baseline_sync_enabled_provider_test.dart
@@ -66,7 +66,7 @@ void main() {
   /// observe the persisted set rather than the manifest-default
   /// placeholder.
   Future<void> pumpLoad(ProviderContainer c) async {
-    c.read(featureFlagsProvider);
+    c.read(enabledFeaturesProvider);
     await Future<void>.delayed(Duration.zero);
     await Future<void>.delayed(Duration.zero);
   }
@@ -122,7 +122,7 @@ void main() {
       container.read(baselineSyncEnabledProvider);
       await container.read(baselineSyncEnabledProvider.notifier).set(true);
 
-      final after = container.read(featureFlagsProvider);
+      final after = container.read(enabledFeaturesProvider);
       expect(
         after,
         contains(Feature.baselineSync),
@@ -163,7 +163,7 @@ void main() {
       container.read(baselineSyncEnabledProvider);
       await container.read(baselineSyncEnabledProvider.notifier).set(false);
 
-      final after = container.read(featureFlagsProvider);
+      final after = container.read(enabledFeaturesProvider);
       expect(
         after,
         isNot(contains(Feature.baselineSync)),
@@ -205,7 +205,7 @@ void main() {
               'than crashing on a developer mistake.',
         );
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           isNot(contains(Feature.baselineSync)),
         );
       },
@@ -278,7 +278,7 @@ void main() {
               'standing rather than crashing on a developer mistake.',
         );
         expect(
-          container.read(featureFlagsProvider),
+          container.read(enabledFeaturesProvider),
           isNot(contains(Feature.baselineSync)),
         );
       },
@@ -302,14 +302,14 @@ class _TestFeatureFlags extends FeatureFlags {
 
   @override
   Future<void> enable(Feature feature) async {
-    if (state.contains(feature)) return;
-    state = {...state, feature};
+    final current = state.value ?? const <Feature>{}; if (current.contains(feature)) return;
+    state = AsyncData({...current, feature});
   }
 
   @override
   Future<void> disable(Feature feature) async {
-    if (!state.contains(feature)) return;
-    state = {...state}..remove(feature);
+    final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
+    state = AsyncData({...current}..remove(feature));
   }
 }
 


### PR DESCRIPTION
## What

Closes #1681 — child of epic #1678 (full-codebase audit).

`FeatureFlags.build()` returned manifest defaults synchronously, then fired `repo.loadEnabled().then((p) => state = p)` with an `// ignore: invalid_use_of_protected_member` — async I/O plus a `state =` mutation inside a synchronous `build()`, with **no error handling** on the Hive read.

## How

- **`FeatureFlags` is now an `AsyncNotifier`** — `build()` returns `FutureOr<Set<Feature>>` and `await`s `repo.loadEnabled()`. A failed Hive read is logged through `errorLogger` (storage layer) and falls back to the manifest defaults — *handled, not silent*. The protected-member ignore and the `.then()` mutation are gone.
- **New `enabledFeaturesProvider`** — a synchronous `Set<Feature>` view (`featureFlagsProvider.asData?.value ?? manifest defaults`). Every value-read call site moved to it; the brief pre-load frame resolves to manifest defaults, exactly the pre-#1681 first-frame behaviour. `.notifier` call sites are unchanged.
- `enable`/`disable` await `future` before mutating and publish via `state = AsyncData(next)`; `isEnabled` reads `state.asData?.value`.
- `auto_record_orchestrator` watches `featureFlagsProvider` directly (one dependency hop) so the `keepAlive`, no-external-listener provider still rebuilds reliably on a flag flip.

## Design note

Test doubles return the set **synchronously** (`Set<Feature> build()` — a valid covariant override of `FutureOr<Set<Feature>>`), so the AsyncNotifier resolves straight to `AsyncData` with no loading frame and the existing suites keep their behaviour bit-for-bit.

## Acceptance

1. ✅ `FeatureFlags` is an `AsyncNotifier` returning `FutureOr<Set<Feature>>`.
2. ✅ Hive-read failure handled — logged via `errorLogger`, falls back to manifest defaults (new throwing-repo test).
3. ✅ The `invalid_use_of_protected_member` suppression is removed.

## Tests

Whole-repo `flutter analyze` clean; module-boundary check passes. Verified: feature-management, all feature-flag shim providers, sync/driving/profile/search/price-prediction/consumption surfaces, the auto-record orchestrator, and the shell. New `feature_flags_provider_test` coverage for the Hive-read-failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
