### PR TITLE
feat(obd2): wire the PSA passive-CAN fuel-level decoder into the badge (#1616)

### DIFF
--- a/lib/features/consumption/providers/current_obd2_fuel_level_provider.dart
+++ b/lib/features/consumption/providers/current_obd2_fuel_level_provider.dart
@@ -1,6 +1,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../vehicle/providers/vehicle_providers.dart';
+import 'psa_fuel_level_provider.dart';
 import 'trip_recording_provider.dart';
 
 part 'current_obd2_fuel_level_provider.g.dart';
@@ -37,18 +38,35 @@ part 'current_obd2_fuel_level_provider.g.dart';
 ///   * no active vehicle profile, or its [tankCapacityL] is null /
 ///     non-positive (we can't convert).
 ///
-/// OEM-PID native-litres path (#1615): when the `experimentalOemPids`
-/// flag is on and an OEM-capable adapter resolved a manufacturer table,
-/// the trip-recording fuel sampler populates
-/// [TripLiveReading.fuelLevelLitres] with the exact litres read via the
-/// OEM-PID registry. This provider prefers that native source and skips
-/// the percent×capacity conversion entirely. When the field is null
-/// (flag off, incapable adapter, or no table for the VIN) the coarse
-/// percent×capacity path below runs unchanged.
+/// Native-litres precedence (most accurate first):
+///   1. PSA passive-CAN (#1616) — when a `passiveCanCapable` STN-chip
+///      adapter is listening to the instrument-cluster broadcast,
+///      [psaFuelLevelProvider] streams exact litres decoded straight
+///      off the CAN bus. This is the highest-fidelity source; it wins.
+///   2. OEM-PID native litres (#1615) — when the `experimentalOemPids`
+///      flag is on and an OEM-capable adapter resolved a manufacturer
+///      table, the trip-recording fuel sampler populates
+///      [TripLiveReading.fuelLevelLitres] with exact litres read via
+///      the OEM-PID registry.
+///   3. The coarse `percent × tankCapacityL` conversion below.
+///
+/// Each native source is skipped when absent (no passive-CAN stream /
+/// flag off / incapable adapter / no table for the VIN), so the chain
+/// degrades cleanly to the percent path with no behaviour change for
+/// adapters that surface neither.
 @riverpod
 double? currentObd2FuelLevelLitres(Ref ref) {
   final tripState = ref.watch(tripRecordingProvider);
   if (!tripState.isActive) return null;
+
+  // #1616 — prefer the PSA passive-CAN native-litres stream. The
+  // `StreamProvider`'s `.value` is the latest decoded litres, or null
+  // before the first frame / when the stream is empty (no
+  // passiveCan-capable adapter, or the live-service seam is unset in
+  // production). A negative value is treated defensively as "no
+  // reading" and falls through.
+  final canLitres = ref.watch(psaFuelLevelProvider).value;
+  if (canLitres != null && canLitres >= 0) return canLitres;
 
   // #1615 — prefer the exact OEM-PID litres when present. A negative
   // value is treated as "no reading" (defensive) and falls through to

--- a/lib/features/consumption/providers/current_obd2_fuel_level_provider.g.dart
+++ b/lib/features/consumption/providers/current_obd2_fuel_level_provider.g.dart
@@ -40,14 +40,22 @@ part of 'current_obd2_fuel_level_provider.dart';
 ///   * no active vehicle profile, or its [tankCapacityL] is null /
 ///     non-positive (we can't convert).
 ///
-/// OEM-PID native-litres path (#1615): when the `experimentalOemPids`
-/// flag is on and an OEM-capable adapter resolved a manufacturer table,
-/// the trip-recording fuel sampler populates
-/// [TripLiveReading.fuelLevelLitres] with the exact litres read via the
-/// OEM-PID registry. This provider prefers that native source and skips
-/// the percent×capacity conversion entirely. When the field is null
-/// (flag off, incapable adapter, or no table for the VIN) the coarse
-/// percent×capacity path below runs unchanged.
+/// Native-litres precedence (most accurate first):
+///   1. PSA passive-CAN (#1616) — when a `passiveCanCapable` STN-chip
+///      adapter is listening to the instrument-cluster broadcast,
+///      [psaFuelLevelProvider] streams exact litres decoded straight
+///      off the CAN bus. This is the highest-fidelity source; it wins.
+///   2. OEM-PID native litres (#1615) — when the `experimentalOemPids`
+///      flag is on and an OEM-capable adapter resolved a manufacturer
+///      table, the trip-recording fuel sampler populates
+///      [TripLiveReading.fuelLevelLitres] with exact litres read via
+///      the OEM-PID registry.
+///   3. The coarse `percent × tankCapacityL` conversion below.
+///
+/// Each native source is skipped when absent (no passive-CAN stream /
+/// flag off / incapable adapter / no table for the VIN), so the chain
+/// degrades cleanly to the percent path with no behaviour change for
+/// adapters that surface neither.
 
 @ProviderFor(currentObd2FuelLevelLitres)
 final currentObd2FuelLevelLitresProvider =
@@ -85,14 +93,22 @@ final currentObd2FuelLevelLitresProvider =
 ///   * no active vehicle profile, or its [tankCapacityL] is null /
 ///     non-positive (we can't convert).
 ///
-/// OEM-PID native-litres path (#1615): when the `experimentalOemPids`
-/// flag is on and an OEM-capable adapter resolved a manufacturer table,
-/// the trip-recording fuel sampler populates
-/// [TripLiveReading.fuelLevelLitres] with the exact litres read via the
-/// OEM-PID registry. This provider prefers that native source and skips
-/// the percent×capacity conversion entirely. When the field is null
-/// (flag off, incapable adapter, or no table for the VIN) the coarse
-/// percent×capacity path below runs unchanged.
+/// Native-litres precedence (most accurate first):
+///   1. PSA passive-CAN (#1616) — when a `passiveCanCapable` STN-chip
+///      adapter is listening to the instrument-cluster broadcast,
+///      [psaFuelLevelProvider] streams exact litres decoded straight
+///      off the CAN bus. This is the highest-fidelity source; it wins.
+///   2. OEM-PID native litres (#1615) — when the `experimentalOemPids`
+///      flag is on and an OEM-capable adapter resolved a manufacturer
+///      table, the trip-recording fuel sampler populates
+///      [TripLiveReading.fuelLevelLitres] with exact litres read via
+///      the OEM-PID registry.
+///   3. The coarse `percent × tankCapacityL` conversion below.
+///
+/// Each native source is skipped when absent (no passive-CAN stream /
+/// flag off / incapable adapter / no table for the VIN), so the chain
+/// degrades cleanly to the percent path with no behaviour change for
+/// adapters that surface neither.
 
 final class CurrentObd2FuelLevelLitresProvider
     extends $FunctionalProvider<double?, double?, double?>
@@ -129,14 +145,22 @@ final class CurrentObd2FuelLevelLitresProvider
   ///   * no active vehicle profile, or its [tankCapacityL] is null /
   ///     non-positive (we can't convert).
   ///
-  /// OEM-PID native-litres path (#1615): when the `experimentalOemPids`
-  /// flag is on and an OEM-capable adapter resolved a manufacturer table,
-  /// the trip-recording fuel sampler populates
-  /// [TripLiveReading.fuelLevelLitres] with the exact litres read via the
-  /// OEM-PID registry. This provider prefers that native source and skips
-  /// the percent×capacity conversion entirely. When the field is null
-  /// (flag off, incapable adapter, or no table for the VIN) the coarse
-  /// percent×capacity path below runs unchanged.
+  /// Native-litres precedence (most accurate first):
+  ///   1. PSA passive-CAN (#1616) — when a `passiveCanCapable` STN-chip
+  ///      adapter is listening to the instrument-cluster broadcast,
+  ///      [psaFuelLevelProvider] streams exact litres decoded straight
+  ///      off the CAN bus. This is the highest-fidelity source; it wins.
+  ///   2. OEM-PID native litres (#1615) — when the `experimentalOemPids`
+  ///      flag is on and an OEM-capable adapter resolved a manufacturer
+  ///      table, the trip-recording fuel sampler populates
+  ///      [TripLiveReading.fuelLevelLitres] with exact litres read via
+  ///      the OEM-PID registry.
+  ///   3. The coarse `percent × tankCapacityL` conversion below.
+  ///
+  /// Each native source is skipped when absent (no passive-CAN stream /
+  /// flag off / incapable adapter / no table for the VIN), so the chain
+  /// degrades cleanly to the percent path with no behaviour change for
+  /// adapters that surface neither.
   CurrentObd2FuelLevelLitresProvider._()
     : super(
         from: null,
@@ -171,4 +195,4 @@ final class CurrentObd2FuelLevelLitresProvider
 }
 
 String _$currentObd2FuelLevelLitresHash() =>
-    r'993b6f89c0a10892656fcca6866851a0d485418d';
+    r'fec0b6d479dc3aef8c8c5256a58b5fb3e16994fe';

--- a/test/features/consumption/providers/current_obd2_fuel_level_provider_test.dart
+++ b/test/features/consumption/providers/current_obd2_fuel_level_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
 import 'package:tankstellen/features/consumption/providers/current_obd2_fuel_level_provider.dart';
+import 'package:tankstellen/features/consumption/providers/psa_fuel_level_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
@@ -68,12 +69,20 @@ void main() {
   ProviderContainer makeContainer({
     required TripRecordingState tripState,
     VehicleProfile? activeVehicle,
+    Stream<double>? psaCanStream,
   }) {
     final c = ProviderContainer(overrides: [
       tripRecordingProvider
           .overrideWith(() => _ManualTripRecording(tripState)),
       activeVehicleProfileProvider
           .overrideWith(() => _StubActiveVehicle(activeVehicle)),
+      // #1616 — when a test drives the PSA passive-CAN path, override
+      // the stream provider directly with a canned stream. Tests that
+      // omit this exercise the real provider, whose production
+      // `psaFuelLevelObd2Service` seam is null → empty stream → the
+      // passive-CAN branch falls through (the absent-stream fallback).
+      if (psaCanStream != null)
+        psaFuelLevelProvider.overrideWith((ref) => psaCanStream),
     ]);
     addTearDown(c.dispose);
     return c;
@@ -293,6 +302,76 @@ void main() {
       // reading" and the percent×capacity fallback takes over.
       final c = makeContainer(
         tripState: recordingWith(fuelLevelPercent: 50, fuelLevelLitres: -1),
+        activeVehicle: vehicleWithCapacity,
+      );
+
+      expect(
+        c.read(currentObd2FuelLevelLitresProvider),
+        closeTo(25, 0.0001),
+      );
+    });
+  });
+
+  group('currentObd2FuelLevelLitresProvider — PSA passive-CAN (#1616)', () {
+    test('a live passive-CAN stream surfaces its exact decoded litres', () async {
+      // A passiveCan-capable STN-chip adapter decodes litres straight
+      // off the instrument-cluster broadcast — the highest-fidelity
+      // source. 50 % × 50 L would be 25 L; the CAN read wins.
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50),
+        activeVehicle: vehicleWithCapacity,
+        psaCanStream: Stream<double>.value(38.5),
+      );
+      // Drain the stream's first event so the StreamProvider holds a
+      // value before the synchronous badge-provider read.
+      // Keep the autoDispose StreamProvider alive across the await so
+      // it isn't torn down before the canned stream emits.
+      c.listen(psaFuelLevelProvider, (_, _) {});
+      await c.read(psaFuelLevelProvider.future);
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), 38.5);
+    });
+
+    test('passive-CAN litres win over the OEM-PID litres', () async {
+      // Both native sources present — passive-CAN is the more accurate
+      // tier, so it takes precedence over the OEM-PID value.
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50, fuelLevelLitres: 41.5),
+        activeVehicle: vehicleWithCapacity,
+        psaCanStream: Stream<double>.value(39.0),
+      );
+      // Keep the autoDispose StreamProvider alive across the await so
+      // it isn't torn down before the canned stream emits.
+      c.listen(psaFuelLevelProvider, (_, _) {});
+      await c.read(psaFuelLevelProvider.future);
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), 39.0);
+    });
+
+    test('a negative passive-CAN value falls through to the OEM litres',
+        () async {
+      // Defensive: a corrupt/negative CAN decode is "no reading" — the
+      // next source (OEM-PID litres) takes over.
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50, fuelLevelLitres: 41.5),
+        activeVehicle: vehicleWithCapacity,
+        psaCanStream: Stream<double>.value(-1),
+      );
+      // Keep the autoDispose StreamProvider alive across the await so
+      // it isn't torn down before the canned stream emits.
+      c.listen(psaFuelLevelProvider, (_, _) {});
+      await c.read(psaFuelLevelProvider.future);
+
+      expect(c.read(currentObd2FuelLevelLitresProvider), 41.5);
+    });
+
+    test('no passive-CAN stream → the chain falls through unchanged', () {
+      // The default (no override) provider has a null
+      // `psaFuelLevelObd2Service` seam → empty stream → the passive-CAN
+      // branch is skipped and the percent×capacity path runs (#1616
+      // absent-stream fallback). 50 % × 50 L = 25 L.
+      final c = makeContainer(
+        tripState: recordingWith(fuelLevelPercent: 50),
         activeVehicle: vehicleWithCapacity,
       );
 


### PR DESCRIPTION
## What

Closes #1616 — child of epic #1609.

`psaFuelLevelProvider` (#1418) already decodes the PSA instrument-cluster passive-CAN broadcast frame `0x0E6` into a litres-in-tank stream — but **nothing consumed it**. The verified-by-adapter fuel-level badge still ran only the OEM-PID path (#1615) and the coarse `percent × capacity` estimate.

## How

`currentObd2FuelLevelLitres` (the badge's input provider) now watches `psaFuelLevelProvider` and prefers its decoded litres. Precedence chain, most accurate first:

1. **PSA passive-CAN** (`passiveCanCapable` STN-chip adapters) — exact litres straight off the CAN bus.
2. **OEM-PID native litres** (#1615) — exact litres via the OEM-PID registry.
3. **`percent × tankCapacityL`** — the coarse fallback.

Each native source is skipped when absent, so the chain degrades cleanly.

## Safety

In production the `psaFuelLevelObd2Service` seam is still `null` (elevating the live `Obd2Service` into Riverpod is a separate epic), so `psaFuelLevelProvider` emits an empty stream and the badge falls through **exactly as before** — no behaviour change until a `passiveCan`-capable adapter *and* the live-service wiring are both present.

## Tests

A live passive-CAN stream surfacing exact litres; passive-CAN winning over the OEM-PID value; a negative CAN decode falling through; and the absent-stream fallback. Whole-repo `flutter analyze` clean; codegen drift-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
