### PR TITLE
feat(consumption): pump-start/pump-end bracket detector from the fuel-level delta (#1619)

### DIFF
--- a/lib/features/consumption/domain/services/pump_bracket_detector.dart
+++ b/lib/features/consumption/domain/services/pump_bracket_detector.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/foundation.dart';
+
+/// The fuel-level bracket of a detected pump operation (#1619).
+///
+/// [startL] is the litres-in-tank just before the fill began; [endL]
+/// the litres once the fill settled. [deltaL] is the dispensed volume —
+/// what the verified-by-adapter badge cross-checks against the
+/// user-typed litres.
+@immutable
+class PumpBracket {
+  /// Litres in the tank immediately before the pump operation.
+  final double startL;
+
+  /// Litres in the tank immediately after the pump operation.
+  final double endL;
+
+  const PumpBracket({required this.startL, required this.endL});
+
+  /// Dispensed volume — `endL - startL`. Always ≥ 0 by construction
+  /// ([PumpBracketDetector] only completes a bracket on a net rise).
+  double get deltaL => endL - startL;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PumpBracket &&
+      other.startL == startL &&
+      other.endL == endL;
+
+  @override
+  int get hashCode => Object.hash(startL, endL);
+
+  @override
+  String toString() => 'PumpBracket($startL L → $endL L, Δ$deltaL L)';
+}
+
+/// Brackets a pump operation from a stream of fuel-level readings by
+/// its fuel-level *delta* — not by when the user opened or saved the
+/// fill-up form (#1619, deferred from #1434).
+///
+/// ## Why
+///
+/// The MVP snapshots the tank level at form-open and form-submit. That
+/// mis-captures the fill whenever the form lifecycle and the actual
+/// pump operation don't line up:
+///   * the user opens the form *before* fuelling → the "before" read
+///     is already correct but a naive "after" read at submit can be
+///     stale if they drove off first;
+///   * the user opens the form *after* fuelling → the "before" read is
+///     already the post-fill level.
+///
+/// Feeding every fuel-level reading through [observe] instead lets the
+/// detector find the pump operation itself: a sharp net rise in tank
+/// litres, bracketed by the stable level just before it and the peak
+/// once it settles. The verified-by-adapter badge then reflects the
+/// real fill regardless of form timing.
+///
+/// ## State machine
+///
+/// `beforeFill` → (a step-up rise) → `filling` → (level settles back
+/// below the peak, or enough rise has accumulated) → `complete`.
+///
+/// A rise that never reaches [riseThresholdL] total is treated as
+/// sensor noise / a slosh artefact and discarded — the detector
+/// returns to `beforeFill`. The FIRST genuine fill wins; later rises
+/// are ignored so a multi-stop journey doesn't overwrite the bracket.
+///
+/// The detector is pure and synchronous — it holds no streams and no
+/// timers. The caller drives it: one [observe] call per fuel-level
+/// reading, in chronological order.
+class PumpBracketDetector {
+  /// Minimum net rise (litres) for a bracket to count as a real fill.
+  /// Below this the rise is discarded as noise. A genuine fill-up adds
+  /// far more; the floor only rejects coarse-PID jitter.
+  final double riseThresholdL;
+
+  /// Minimum single-reading step-up (litres) that opens the `filling`
+  /// phase. Filters the ±1 % jitter of a coarse `0x2F` percentage read.
+  final double minStepL;
+
+  /// How far below the running peak a reading must fall before the
+  /// fill is considered settled (the car is being driven away).
+  /// Tolerates a single noisy dip mid-fill.
+  final double settleToleranceL;
+
+  PumpBracketDetector({
+    this.riseThresholdL = 2.0,
+    this.minStepL = 1.0,
+    this.settleToleranceL = 1.0,
+  });
+
+  _Phase _phase = _Phase.beforeFill;
+
+  /// Running pre-fill level — the latest reading seen while no fill is
+  /// in progress. Tracks down as the car is driven; becomes the
+  /// bracket's [PumpBracket.startL] when a rise begins.
+  double? _baseLevelL;
+
+  /// Tank level captured the moment the current fill's rise started.
+  double _startLevelL = 0;
+
+  /// Highest level seen during the current fill.
+  double _peakLevelL = 0;
+
+  PumpBracket? _completed;
+
+  /// Feed one fuel-level reading (litres). Readings must arrive in
+  /// chronological order. A negative reading is ignored defensively —
+  /// a corrupt decode must never derail the bracket.
+  void observe(double fuelLevelL) {
+    if (fuelLevelL < 0) return;
+
+    switch (_phase) {
+      case _Phase.beforeFill:
+        final base = _baseLevelL;
+        if (base != null && fuelLevelL > base + minStepL) {
+          // A step-up — the pump operation has started.
+          _phase = _Phase.filling;
+          _startLevelL = base;
+          _peakLevelL = fuelLevelL;
+        } else {
+          // Still pre-fill: track the level (it drifts down while
+          // driving). Never let `_baseLevelL` rise here — a gentle
+          // creep up without a clear step is treated as noise.
+          if (base == null || fuelLevelL < base) {
+            _baseLevelL = fuelLevelL;
+          }
+        }
+      case _Phase.filling:
+        if (fuelLevelL >= _peakLevelL) {
+          _peakLevelL = fuelLevelL;
+        } else if (fuelLevelL < _peakLevelL - settleToleranceL) {
+          // The level has fallen clear of the peak — the fill is over
+          // and the car is being driven away.
+          _finalizeOrDiscard(nextBaseL: fuelLevelL);
+        }
+      case _Phase.complete:
+        // First genuine fill wins — ignore everything after.
+        break;
+    }
+  }
+
+  /// The detected pump bracket, or null when no genuine fill has been
+  /// observed yet.
+  ///
+  /// Returns a result in two cases:
+  ///   * `complete` — the fill settled (a decline past the peak was
+  ///     seen); the finalized bracket.
+  ///   * `filling` with the net rise already past [riseThresholdL] —
+  ///     a *provisional* bracket, so a user who saves the form the
+  ///     instant they finish fuelling (before any decline) still gets
+  ///     the real fill bracketed.
+  PumpBracket? get bracket {
+    if (_completed != null) return _completed;
+    if (_phase == _Phase.filling &&
+        _peakLevelL - _startLevelL >= riseThresholdL) {
+      return PumpBracket(startL: _startLevelL, endL: _peakLevelL);
+    }
+    return null;
+  }
+
+  /// True once a genuine pump operation has been bracketed.
+  bool get hasBracket => bracket != null;
+
+  void _finalizeOrDiscard({required double nextBaseL}) {
+    if (_peakLevelL - _startLevelL >= riseThresholdL) {
+      _completed = PumpBracket(startL: _startLevelL, endL: _peakLevelL);
+      _phase = _Phase.complete;
+    } else {
+      // The rise never reached the threshold — sensor noise, not a
+      // fill. Reset and keep watching.
+      _phase = _Phase.beforeFill;
+      _baseLevelL = nextBaseL;
+    }
+  }
+}
+
+enum _Phase { beforeFill, filling, complete }

--- a/test/features/consumption/domain/services/pump_bracket_detector_test.dart
+++ b/test/features/consumption/domain/services/pump_bracket_detector_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/pump_bracket_detector.dart';
+
+/// Unit tests for [PumpBracketDetector] (#1619).
+///
+/// The detector brackets a pump operation by its fuel-level delta
+/// rather than the fill-up form lifecycle. These tests pin the three
+/// acceptance scenarios — normal, open-before-fuelling, save-after-
+/// driving — plus the noise / threshold guards.
+
+void main() {
+  /// Feed a chronological list of fuel-level readings into a fresh
+  /// detector and return it for inspection.
+  PumpBracketDetector detect(List<double> readings,
+      {double riseThresholdL = 2.0}) {
+    final d = PumpBracketDetector(riseThresholdL: riseThresholdL);
+    for (final r in readings) {
+      d.observe(r);
+    }
+    return d;
+  }
+
+  group('PumpBracketDetector — normal case (#1619)', () {
+    test('brackets the fill between the pre-fill level and the peak', () {
+      // Driving in (level declines) → fill → driving away (declines).
+      final d = detect([42, 40, 38, 55, 54, 50, 45]);
+
+      expect(d.hasBracket, isTrue);
+      expect(d.bracket, const PumpBracket(startL: 38, endL: 55));
+      expect(d.bracket!.deltaL, 17);
+    });
+
+    test('a fill seen as one jump across an engine-off gap is bracketed', () {
+      // OBD2 disconnects while the engine is off during fuelling, so
+      // the fill shows up as a single reading-to-reading jump.
+      final d = detect([30, 62, 60]);
+
+      expect(d.bracket, const PumpBracket(startL: 30, endL: 62));
+    });
+  });
+
+  group('PumpBracketDetector — open-before-fuelling (#1619)', () {
+    test('a fill after a run of stable pre-fuel readings is still caught', () {
+      // The form (and detector) opened well before the user fuelled —
+      // a stretch of flat readings, then the pump operation.
+      final d = detect([40, 40, 40, 40, 56, 54]);
+
+      expect(d.bracket, const PumpBracket(startL: 40, endL: 56));
+    });
+  });
+
+  group('PumpBracketDetector — save-after-driving (#1619)', () {
+    test('a long post-fill decline does not contaminate the bracket', () {
+      // Fill 38 → 55, then the user drives a while before saving the
+      // form: the level falls steadily. The bracket must stay the
+      // fill, not stretch to the post-drive level.
+      final d = detect([38, 55, 50, 44, 38, 32]);
+
+      expect(d.bracket, const PumpBracket(startL: 38, endL: 55));
+    });
+
+    test('the first genuine fill wins — a later fill never overwrites it', () {
+      // Two fills in one detector lifetime (a multi-stop journey).
+      final d = detect([
+        40, 58, // fill 1: 40 → 58
+        52, 46, // drive away
+        70, 68, // fill 2: should be ignored
+      ]);
+
+      expect(d.bracket, const PumpBracket(startL: 40, endL: 58));
+    });
+  });
+
+  group('PumpBracketDetector — provisional bracket', () {
+    test('a fill with no decline yet still exposes a provisional bracket', () {
+      // The user saves the form the instant they finish fuelling — no
+      // post-fill decline has been observed.
+      final d = detect([38, 55]);
+
+      expect(d.hasBracket, isTrue);
+      expect(d.bracket, const PumpBracket(startL: 38, endL: 55));
+    });
+
+    test('the provisional bracket tracks the peak as the fill climbs', () {
+      // Fuelling observed gradually (engine-on slow trickle).
+      final d = detect([40, 43, 47, 52]);
+
+      expect(d.bracket, const PumpBracket(startL: 40, endL: 52));
+    });
+  });
+
+  group('PumpBracketDetector — noise + threshold guards', () {
+    test('coarse-PID jitter with no real fill yields no bracket', () {
+      final d = detect([40, 40.4, 39.8, 40.2, 39.9, 40.1]);
+
+      expect(d.hasBracket, isFalse);
+      expect(d.bracket, isNull);
+    });
+
+    test('a sub-threshold rise is discarded as noise', () {
+      // A 1.5 L bump never reaches the 2 L floor — not a fill.
+      final d = detect([40, 41.5, 39]);
+
+      expect(d.hasBracket, isFalse);
+    });
+
+    test('a real fill after a discarded sub-threshold bump is still caught',
+        () {
+      // The detector must reset cleanly after a noise blip.
+      final d = detect([40, 41.5, 39, 60, 58]);
+
+      expect(d.bracket, const PumpBracket(startL: 39, endL: 60));
+    });
+
+    test('an empty reading stream yields no bracket', () {
+      expect(detect(const []).bracket, isNull);
+    });
+
+    test('a negative reading is ignored defensively', () {
+      // A corrupt decode must not derail the bracket.
+      final d = detect([38, -1, 55]);
+
+      expect(d.bracket, const PumpBracket(startL: 38, endL: 55));
+    });
+
+    test('riseThresholdL is configurable', () {
+      // With a 10 L floor, a 5 L top-up no longer counts as a fill.
+      final d = detect([40, 45, 41], riseThresholdL: 10);
+      expect(d.hasBracket, isFalse);
+    });
+  });
+
+  group('PumpBracket', () {
+    test('deltaL is endL - startL', () {
+      const b = PumpBracket(startL: 12.5, endL: 48.0);
+      expect(b.deltaL, 35.5);
+    });
+
+    test('value equality', () {
+      expect(
+        const PumpBracket(startL: 10, endL: 40),
+        const PumpBracket(startL: 10, endL: 40),
+      );
+      expect(
+        const PumpBracket(startL: 10, endL: 40),
+        isNot(const PumpBracket(startL: 10, endL: 41)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Closes #1619 — child of epic #1609 (deferred from #1434).

The MVP snapshots the tank level at fill-up **form-open** and **form-submit**. That mis-captures the fill whenever the form lifecycle and the actual pump operation don't line up — the user opens the form *before* fuelling, or saves long *after* driving away — which makes the verified-by-adapter badge untrustworthy.

## How

Adds `PumpBracketDetector` — a pure, synchronous state machine that brackets a pump operation by its fuel-level **delta** instead of the form lifecycle. Fed one reading per `observe()` call, it detects the sharp net rise of a fill and brackets it between the stable pre-fill level and the settled peak, exposing a `PumpBracket` (`startL` / `endL` / `deltaL`).

- State machine: `beforeFill` → (a step-up) → `filling` → (settles below the peak, or enough rise accumulates) → `complete`.
- A rise below `riseThresholdL` is discarded as coarse-PID noise; the **first** genuine fill wins so a multi-stop journey can't overwrite it.
- `bracket` also returns a *provisional* result mid-`filling`, so a user who saves the form the instant they finish fuelling still gets the real fill bracketed.

## Tests

The three acceptance scenarios — **normal**, **open-before-fuelling**, **save-after-driving** — plus the noise/threshold guards, the provisional bracket, first-fill-wins, and the defensive negative-read guard. 15 tests, all green; whole-repo `flutter analyze` clean.

## Scope

Pure domain logic, no schema change (the triage's "small state machine"). Feeding the detector the live OBD2 fuel-level samples and consuming `bracket` in the fill-up form is the natural follow-up wiring phase — the same producer-then-consumer split epic #1609 already uses (`OemPidRegistry` → #1615, `psaFuelLevelProvider` → #1616).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
