### PR TITLE
fix(ux): navigation & IA — tab-removal notice, swipe hint, localized 404 (#1690)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../core/data/storage_repository.dart';
+import '../l10n/app_localizations.dart';
 import '../core/telemetry/integrations/navigation_trace_observer.dart';
 import '../core/storage/storage_keys.dart';
 import '../core/storage/storage_providers.dart';
@@ -70,27 +71,35 @@ GoRouter router(Ref ref) {
   return GoRouter(
     initialLocation: '/consent',
     observers: [NavigationTraceObserver()],
-    errorBuilder: (context, state) => Scaffold(
-      appBar: AppBar(title: const Text('Page not found')),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.error_outline, size: 64, color: Colors.grey),
-            const SizedBox(height: 16),
-            Text(
-              '"${state.matchedLocation}" not found.',
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            FilledButton(
-              onPressed: () => context.go('/'),
-              child: const Text('Home'),
-            ),
-          ],
+    errorBuilder: (context, state) {
+      // #1690 — the 404 / page-not-found screen is localized so it
+      // doesn't render in English for non-English users.
+      final l = AppLocalizations.of(context);
+      return Scaffold(
+        appBar: AppBar(
+          title: Text(l?.notFoundTitle ?? 'Page not found'),
         ),
-      ),
-    ),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 64, color: Colors.grey),
+              const SizedBox(height: 16),
+              Text(
+                l?.notFoundBody(state.matchedLocation) ??
+                    '"${state.matchedLocation}" not found.',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () => context.go('/'),
+                child: Text(l?.notFoundHomeButton ?? 'Home'),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
     redirect: (context, state) {
       // Read live from storage each redirect — not cached at provider creation
       final hasConsent = storage.getSetting(StorageKeys.gdprConsentGiven) == true;

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'5ee8eef70ae6c1deb192ba730b4852f9cda95e61';
+String _$routerHash() => r'6e6ecef9669fccff3069e83ee4f2c64a0771194e';

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../core/storage/storage_providers.dart';
 import '../core/utils/frame_callbacks.dart';
 import '../features/feature_management/application/feature_flags_provider.dart';
 import '../features/feature_management/domain/consumption_tab_visibility.dart';
@@ -70,6 +71,9 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(currentShellBranchProvider.notifier).set(_currentIndex);
+      // #1690 — one-time first-run hint that the tabs can be swiped
+      // between (the gesture is otherwise undiscoverable).
+      _maybeShowSwipeHint();
     });
 
     _iconControllers = List.generate(
@@ -156,6 +160,32 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     }
   }
 
+  /// SettingsStorage key for the one-time swipe-between-tabs hint.
+  static const String _swipeHintStorageKey = 'shell_swipe_hint_shown';
+
+  /// #1690 — surface a one-time hint that the tabs respond to a
+  /// horizontal swipe (an otherwise undiscoverable gesture). Shown once
+  /// ever, gated on a [SettingsStorage] flag; best-effort so a missing
+  /// settings box in a widget test simply skips the hint.
+  Future<void> _maybeShowSwipeHint() async {
+    try {
+      final settings = ref.read(settingsStorageProvider);
+      if (settings.getSetting(_swipeHintStorageKey) == true) return;
+      await settings.putSetting(_swipeHintStorageKey, true);
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(
+          l10n?.swipeBetweenTabsHint ??
+              'Tip: swipe left or right to switch between tabs.',
+        ),
+        duration: const Duration(seconds: 5),
+      ));
+    } catch (e, st) {
+      debugPrint('ShellScreen: swipe hint skipped: $e\n$st');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // Keep in sync with go_router's actual index (e.g. deep link or redirect)
@@ -197,9 +227,16 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     // the nav bar and leaving `_currentIndex` pointing at it would
     // leave no item highlighted.
     if (!showConsumption && _currentIndex == kConsumptionBranchIndex) {
+      // #1690 — the tab vanishing + the selection jumping is silent
+      // and confusing; tell the user a profile change hid the tab.
+      final tabHiddenNotice = l10n?.consumptionTabHiddenNotice ??
+          'The Consumption tab was hidden by your profile settings.';
       safePostFrame(() {
         if (!mounted) return;
         if (_currentIndex != kConsumptionBranchIndex) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(tabHiddenNotice)),
+        );
         _goToPage(0);
       });
     }

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1239,5 +1239,10 @@
   "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
   "fillUpSavedSnackbar": "Tankvorgang gespeichert",
   "radiusAlertsEntryTitle": "Umkreis-Alarme & Statistik",
-  "radiusAlertsEntrySubtitle": "Werde benachrichtigt, wenn die Preise in deiner Nähe fallen"
+  "radiusAlertsEntrySubtitle": "Werde benachrichtigt, wenn die Preise in deiner Nähe fallen",
+  "notFoundTitle": "Seite nicht gefunden",
+  "notFoundBody": "„{location}“ nicht gefunden.",
+  "notFoundHomeButton": "Startseite",
+  "consumptionTabHiddenNotice": "Der Verbrauch-Tab wurde durch deine Profileinstellungen ausgeblendet.",
+  "swipeBetweenTabsHint": "Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln."
 }

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1470,5 +1470,30 @@
   "radiusAlertsEntrySubtitle": "Get notified when prices drop near you",
   "@radiusAlertsEntrySubtitle": {
     "description": "Subtitle of the radius-alerts navigation entry on the favorites Alerts tab — explains what radius alerts do (#1701)."
+  },
+  "notFoundTitle": "Page not found",
+  "@notFoundTitle": {
+    "description": "AppBar title of the go_router 404 / error screen shown when a route cannot be matched (#1690)."
+  },
+  "notFoundBody": "\"{location}\" not found.",
+  "@notFoundBody": {
+    "description": "Body of the 404 / page-not-found screen, naming the unmatched route location (#1690).",
+    "placeholders": {
+      "location": {
+        "type": "String"
+      }
+    }
+  },
+  "notFoundHomeButton": "Home",
+  "@notFoundHomeButton": {
+    "description": "Button on the 404 screen that returns the user to the home route (#1690)."
+  },
+  "consumptionTabHiddenNotice": "The Consumption tab was hidden by your profile settings.",
+  "@consumptionTabHiddenNotice": {
+    "description": "SnackBar shown when a profile change removes the Consumption tab at runtime and the bottom-nav selection jumps to Search — explains why the tab vanished (#1690)."
+  },
+  "swipeBetweenTabsHint": "Tip: swipe left or right to switch between tabs.",
+  "@swipeBetweenTabsHint": {
+    "description": "One-time first-run SnackBar hint that the bottom-nav tabs respond to a horizontal swipe gesture (#1690)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1240,6 +1240,11 @@
   "fillUpSavedSnackbar": "Tankvorgang gespeichert",
   "radiusAlertsEntryTitle": "Umkreis-Alarme & Statistik",
   "radiusAlertsEntrySubtitle": "Werde benachrichtigt, wenn die Preise in deiner Nähe fallen",
+  "notFoundTitle": "Seite nicht gefunden",
+  "notFoundBody": "„{location}“ nicht gefunden.",
+  "notFoundHomeButton": "Startseite",
+  "consumptionTabHiddenNotice": "Der Verbrauch-Tab wurde durch deine Profileinstellungen ausgeblendet.",
+  "swipeBetweenTabsHint": "Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln.",
   "achievementSmoothDriver": "Ruhige Serie",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1473,6 +1473,31 @@
   "@radiusAlertsEntrySubtitle": {
     "description": "Subtitle of the radius-alerts navigation entry on the favorites Alerts tab — explains what radius alerts do (#1701)."
   },
+  "notFoundTitle": "Page not found",
+  "@notFoundTitle": {
+    "description": "AppBar title of the go_router 404 / error screen shown when a route cannot be matched (#1690)."
+  },
+  "notFoundBody": "\"{location}\" not found.",
+  "@notFoundBody": {
+    "description": "Body of the 404 / page-not-found screen, naming the unmatched route location (#1690).",
+    "placeholders": {
+      "location": {
+        "type": "String"
+      }
+    }
+  },
+  "notFoundHomeButton": "Home",
+  "@notFoundHomeButton": {
+    "description": "Button on the 404 screen that returns the user to the home route (#1690)."
+  },
+  "consumptionTabHiddenNotice": "The Consumption tab was hidden by your profile settings.",
+  "@consumptionTabHiddenNotice": {
+    "description": "SnackBar shown when a profile change removes the Consumption tab at runtime and the bottom-nav selection jumps to Search — explains why the tab vanished (#1690)."
+  },
+  "swipeBetweenTabsHint": "Tip: swipe left or right to switch between tabs.",
+  "@swipeBetweenTabsHint": {
+    "description": "One-time first-run SnackBar hint that the bottom-nav tabs respond to a horizontal swipe gesture (#1690)."
+  },
   "achievementSmoothDriver": "Smooth streak",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1361,5 +1361,10 @@
   "consoModeFuelAndTripsDescription": "Ajoute l'enregistrement OBD2 automatique des trajets. Nécessite un adaptateur appairé.",
   "consoSubsectionVehicles": "Mes véhicules",
   "consoSubsectionTrajets": "Trajets (OBD2)",
-  "consoSubsectionToggles": "Conduite"
+  "consoSubsectionToggles": "Conduite",
+  "notFoundTitle": "Page introuvable",
+  "notFoundBody": "« {location} » introuvable.",
+  "notFoundHomeButton": "Accueil",
+  "consumptionTabHiddenNotice": "L'onglet Consommation a été masqué par les réglages de votre profil.",
+  "swipeBetweenTabsHint": "Astuce : balayez vers la gauche ou la droite pour changer d'onglet."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5930,6 +5930,36 @@ abstract class AppLocalizations {
   /// **'Get notified when prices drop near you'**
   String get radiusAlertsEntrySubtitle;
 
+  /// AppBar title of the go_router 404 / error screen shown when a route cannot be matched (#1690).
+  ///
+  /// In en, this message translates to:
+  /// **'Page not found'**
+  String get notFoundTitle;
+
+  /// Body of the 404 / page-not-found screen, naming the unmatched route location (#1690).
+  ///
+  /// In en, this message translates to:
+  /// **'\"{location}\" not found.'**
+  String notFoundBody(String location);
+
+  /// Button on the 404 screen that returns the user to the home route (#1690).
+  ///
+  /// In en, this message translates to:
+  /// **'Home'**
+  String get notFoundHomeButton;
+
+  /// SnackBar shown when a profile change removes the Consumption tab at runtime and the bottom-nav selection jumps to Search — explains why the tab vanished (#1690).
+  ///
+  /// In en, this message translates to:
+  /// **'The Consumption tab was hidden by your profile settings.'**
+  String get consumptionTabHiddenNotice;
+
+  /// One-time first-run SnackBar hint that the bottom-nav tabs respond to a horizontal swipe gesture (#1690).
+  ///
+  /// In en, this message translates to:
+  /// **'Tip: swipe left or right to switch between tabs.'**
+  String get swipeBetweenTabsHint;
+
   /// Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3175,6 +3175,25 @@ class AppLocalizationsBg extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3175,6 +3175,25 @@ class AppLocalizationsCs extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3173,6 +3173,25 @@ class AppLocalizationsDa extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3200,6 +3200,25 @@ class AppLocalizationsDe extends AppLocalizations {
       'Werde benachrichtigt, wenn die Preise in deiner Nähe fallen';
 
   @override
+  String get notFoundTitle => 'Seite nicht gefunden';
+
+  @override
+  String notFoundBody(String location) {
+    return '„$location“ nicht gefunden.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Startseite';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'Der Verbrauch-Tab wurde durch deine Profileinstellungen ausgeblendet.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln.';
+
+  @override
   String get achievementSmoothDriver => 'Ruhige Serie';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3177,6 +3177,25 @@ class AppLocalizationsEl extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3168,6 +3168,25 @@ class AppLocalizationsEn extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3176,6 +3176,25 @@ class AppLocalizationsEs extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3170,6 +3170,25 @@ class AppLocalizationsEt extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3173,6 +3173,25 @@ class AppLocalizationsFi extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3199,6 +3199,25 @@ class AppLocalizationsFr extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page introuvable';
+
+  @override
+  String notFoundBody(String location) {
+    return '« $location » introuvable.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Accueil';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'L\'onglet Consommation a été masqué par les réglages de votre profil.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Astuce : balayez vers la gauche ou la droite pour changer d\'onglet.';
+
+  @override
   String get achievementSmoothDriver => 'Série souple';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3172,6 +3172,25 @@ class AppLocalizationsHr extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3177,6 +3177,25 @@ class AppLocalizationsHu extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3176,6 +3176,25 @@ class AppLocalizationsIt extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3174,6 +3174,25 @@ class AppLocalizationsLt extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3176,6 +3176,25 @@ class AppLocalizationsLv extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3172,6 +3172,25 @@ class AppLocalizationsNb extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3177,6 +3177,25 @@ class AppLocalizationsNl extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3175,6 +3175,25 @@ class AppLocalizationsPl extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3176,6 +3176,25 @@ class AppLocalizationsPt extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3175,6 +3175,25 @@ class AppLocalizationsRo extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3176,6 +3176,25 @@ class AppLocalizationsSk extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3170,6 +3170,25 @@ class AppLocalizationsSl extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3174,6 +3174,25 @@ class AppLocalizationsSv extends AppLocalizations {
       'Get notified when prices drop near you';
 
   @override
+  String get notFoundTitle => 'Page not found';
+
+  @override
+  String notFoundBody(String location) {
+    return '\"$location\" not found.';
+  }
+
+  @override
+  String get notFoundHomeButton => 'Home';
+
+  @override
+  String get consumptionTabHiddenNotice =>
+      'The Consumption tab was hidden by your profile settings.';
+
+  @override
+  String get swipeBetweenTabsHint =>
+      'Tip: swipe left or right to switch between tabs.';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override


### PR DESCRIPTION
## What

Closes #1690 — child of epic #1689 (UX audit, dimension 1: Navigation & IA).

Three navigation findings:

- **Tab-removal notice** — switching the profile to Basic silently dropped the Consumption tab and snapped the bottom-nav selection to Search with no explanation (`shell_screen.dart`). A SnackBar now fires when the snap happens, telling the user the tab was hidden by their profile settings.
- **Swipe hint** — horizontal-swipe tab switching was an undiscoverable hidden gesture. A **one-time first-run SnackBar** now surfaces it, gated on a `SettingsStorage` flag (`shell_swipe_hint_shown`) and wrapped best-effort so a missing settings box never derails the shell.
- **Localized 404** — the go_router `errorBuilder` rendered hardcoded English. It now resolves through `AppLocalizations`; `notFound*` strings added en / de / fr.

## Tests

Verified by the existing `test/app/` suite (**219 tests** — router build, shell build, the Conso-tab snap branch, navigation) plus whole-repo `flutter analyze`, module-boundary, l10n-completeness and hardcoded-string guards — all green.

The 404 `errorBuilder` is not given a dedicated widget test: the app's top-level `redirect` resolves an unmatched route *before* the `errorBuilder`, so it is not reliably reachable via `go()` in a test harness. The change itself is a pure literal-to-ARB swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
