### PR TITLE
fix(ux): responsiveness — scrollable onboarding completion step + wrap-safe country bar (#1698)

### DIFF
--- a/lib/features/search/presentation/widgets/demo_mode_banner.dart
+++ b/lib/features/search/presentation/widgets/demo_mode_banner.dart
@@ -35,7 +35,12 @@ class DemoModeBanner extends ConsumerWidget {
     if (!country.requiresApiKey) {
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+        // #1698 \u2014 let the country / provider label wrap instead of
+        // ellipsis-clipping the provider name under large text scaling.
+        // `start` cross-alignment keeps the flag pinned to the first
+        // line when the label spills onto a second.
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(country.flag, style: const TextStyle(fontSize: 14)),
             const SizedBox(width: 6),
@@ -43,7 +48,6 @@ class DemoModeBanner extends ConsumerWidget {
               child: Text(
                 '${country.name} \u2014 ${country.apiProvider}',
                 style: Theme.of(context).textTheme.labelSmall,
-                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],

--- a/lib/features/setup/presentation/widgets/completion_step.dart
+++ b/lib/features/setup/presentation/widgets/completion_step.dart
@@ -11,31 +11,49 @@ class CompletionStep extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 32),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const ShieldIllustration(size: 160),
-          const SizedBox(height: 24),
-          Text(
-            l10n?.onboardingComplete ?? 'All set!',
-            style: theme.textTheme.headlineMedium?.copyWith(
-              fontWeight: FontWeight.bold,
+    // #1698 — the wizard's PageView is NeverScrollable, so this step
+    // owns its scrolling. The illustration + two texts are centred when
+    // they fit and scroll when large text scaling pushes them past the
+    // viewport: `ConstrainedBox(minHeight)` keeps the centred look in
+    // the common case, the SingleChildScrollView absorbs the overflow.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 32,
+                vertical: 16,
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const ShieldIllustration(size: 160),
+                  const SizedBox(height: 24),
+                  Text(
+                    l10n?.onboardingComplete ?? 'All set!',
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    l10n?.onboardingCompleteHint ??
+                        'You can change these settings anytime in your '
+                            'profile.',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             ),
-            textAlign: TextAlign.center,
           ),
-          const SizedBox(height: 12),
-          Text(
-            l10n?.onboardingCompleteHint ??
-                'You can change these settings anytime in your profile.',
-            style: theme.textTheme.bodyLarge?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/test/features/search/presentation/widgets/demo_mode_banner_test.dart
+++ b/test/features/search/presentation/widgets/demo_mode_banner_test.dart
@@ -55,6 +55,43 @@ void main() {
     );
 
     testWidgets(
+      'country info bar wraps instead of clipping under large text (#1698)',
+      (tester) async {
+        // Narrow viewport + 3x text scaling — the old single-line
+        // ellipsis Row clipped the provider name; it must now wrap.
+        tester.view.physicalSize = const Size(300, 600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final storage = mockHiveStorageOverride();
+
+        await pumpApp(
+          tester,
+          Builder(
+            builder: (context) => MediaQuery(
+              data: MediaQuery.of(context)
+                  .copyWith(textScaler: const TextScaler.linear(3.0)),
+              child: const DemoModeBanner(country: Countries.france),
+            ),
+          ),
+          overrides: [
+            storage.override,
+            activeCountryOverride(Countries.france),
+          ],
+        );
+
+        // The label is still present (not clipped away) and no longer
+        // ellipsis-truncates — it wraps freely instead.
+        final labelFinder = find.textContaining('Prix-Carburants');
+        expect(labelFinder, findsOneWidget);
+        final label = tester.widget<Text>(labelFinder);
+        expect(label.overflow, isNot(TextOverflow.ellipsis));
+        expect(label.maxLines, isNull);
+      },
+    );
+
+    testWidgets(
       'shows nothing when country requires API key and key is configured',
       (tester) async {
         final storage = mockHiveStorageOverride();

--- a/test/features/setup/presentation/widgets/completion_step_test.dart
+++ b/test/features/setup/presentation/widgets/completion_step_test.dart
@@ -28,5 +28,33 @@ void main() {
 
       expect(find.text('Alles bereit!'), findsOneWidget);
     });
+
+    testWidgets('content stays scrollable under large text scaling (#1698)',
+        (tester) async {
+      // A short viewport + 3x text scaling: the shield + headline +
+      // body no longer fit. Before #1698 the centred Column overflowed
+      // (a RenderFlex error fails the test); now the step scrolls.
+      tester.view.physicalSize = const Size(400, 480);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(context)
+                .copyWith(textScaler: const TextScaler.linear(3.0)),
+            child: const CompletionStep(),
+          ),
+        ),
+      );
+
+      // No overflow was thrown, and the step is genuinely scrollable —
+      // the headline is reachable by scrolling.
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+      await tester.scrollUntilVisible(find.text('All set!'), 120);
+      expect(find.text('All set!'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## What

Closes #1698 — child of epic #1689 (UX audit, dimension 9: Responsiveness & Layout).

Two layout findings that broke under large OS text scaling:

- **Onboarding completion step** — the wizard's PageView is `NeverScrollableScrollPhysics`, so each step owns its scrolling. Every step already wrapped its content in a scroll view *except* `CompletionStep`, a centred non-scrolling `Column` that overflowed under 2-3x text. It's now wrapped in `LayoutBuilder` + `SingleChildScrollView` + `ConstrainedBox(minHeight)` — centred when the content fits, scrolls when it doesn't.
- **Demo-mode country info bar** — the country/provider label sat in a single-line `Row` with `TextOverflow.ellipsis`, clipping the provider name under large text. It now wraps freely (`start` cross-alignment keeps the flag on the first line).

## Tests

A 3x-text-scaling case for each: the completion step stays scrollable (a `RenderFlex` overflow would otherwise fail the test) and the country bar's label no longer ellipsis-truncates. Layout-only, no new strings — whole-repo `flutter analyze` clean, 507 setup + search-widget tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
