### PR TITLE
feat(ux): affordance & discoverability — empty-search CTA + OBD2 pairing entry (#1695)

### DIFF
--- a/lib/features/consumption/presentation/widgets/obd2_status_chip.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_status_chip.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../providers/obd2_connection_state_provider.dart';
 import 'obd2_adapter_picker.dart';
 
@@ -12,12 +13,16 @@ import 'obd2_adapter_picker.dart';
 /// "your car is plugged in" without competing with the
 /// [Obd2StatusDot]'s traffic-light semantics in the global shell.
 ///
-/// When the adapter is not connected (attempting, unreachable,
-/// permission denied, idle) the chip renders zero-size — this keeps
-/// the AppBar quiet and lets the status dot remain the authoritative
-/// "something is wrong" signal.
+/// When an adapter IS paired but not currently connected (attempting,
+/// unreachable, permission denied) the chip renders zero-size — the
+/// [Obd2StatusDot] owns that "something is wrong" signal.
 ///
-/// Tapping opens the adapter picker sheet so the user can re-pair
+/// When NO adapter is paired at all (#1695), the chip instead shows a
+/// discoverable "pair an OBD2 adapter" action: there is no status-dot
+/// signal in that case either, so hiding entirely left pairing with no
+/// entry point on the Consumption screen.
+///
+/// Tapping opens the adapter picker sheet so the user can pair / re-pair
 /// on demand.
 class Obd2StatusChip extends ConsumerWidget {
   const Obd2StatusChip({super.key});
@@ -25,25 +30,49 @@ class Obd2StatusChip extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final snapshot = ref.watch(obd2ConnectionStatusProvider);
-    if (snapshot.state != Obd2ConnectionState.connected) {
-      return const SizedBox.shrink();
-    }
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final name = snapshot.adapterName ?? '';
-    final tooltip = l?.obd2ConnectedTooltip(name) ??
-        'OBD2 connected: $name';
+
+    if (snapshot.state == Obd2ConnectionState.connected) {
+      final name = snapshot.adapterName ?? '';
+      final tooltip = l?.obd2ConnectedTooltip(name) ??
+          'OBD2 connected: $name';
+      return IconButton(
+        key: const Key('obd2StatusChip'),
+        tooltip: tooltip,
+        icon: Icon(
+          Icons.bluetooth_connected,
+          size: 16,
+          color: theme.colorScheme.primary,
+        ),
+        // Shrink the hit region to keep the icon visually compact but
+        // leave the real tap target at 48 dp so
+        // androidTapTargetGuideline still passes.
+        constraints: const BoxConstraints(
+          minWidth: 48,
+          minHeight: 48,
+        ),
+        padding: EdgeInsets.zero,
+        onPressed: () => showObd2AdapterPicker(context),
+      );
+    }
+
+    // #1695 — not connected. When no adapter is paired to the active
+    // vehicle, surface a discoverable "pair adapter" entry; when one IS
+    // paired (transient disconnect) stay quiet and let the status dot
+    // carry the signal.
+    final pairedMac = ref.watch(activeVehicleProfileProvider)?.obd2AdapterMac;
+    if (pairedMac != null && pairedMac.isNotEmpty) {
+      return const SizedBox.shrink();
+    }
     return IconButton(
-      key: const Key('obd2StatusChip'),
-      tooltip: tooltip,
+      key: const Key('obd2PairChip'),
+      tooltip: l?.obd2PairChipTooltip ?? 'Pair an OBD2 adapter',
       icon: Icon(
-        Icons.bluetooth_connected,
+        Icons.bluetooth_searching,
         size: 16,
-        color: theme.colorScheme.primary,
+        color: theme.colorScheme.onSurfaceVariant,
       ),
-      // Shrink the hit region to keep the icon visually compact but
-      // leave the real tap target at 48 dp so
-      // androidTapTargetGuideline still passes.
       constraints: const BoxConstraints(
         minWidth: 48,
         minHeight: 48,

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -10,6 +10,7 @@ import '../../../profile/providers/profile_provider.dart';
 import '../../domain/entities/search_mode.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
+import '../screens/search_criteria_screen.dart';
 import 'nearest_shortcut_card.dart';
 import 'route_results_view.dart';
 import 'search_results_list.dart';
@@ -81,6 +82,17 @@ class SearchResultsContent extends ConsumerWidget {
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
                   ),
+                  const SizedBox(height: 16),
+                  // #1695 — the empty state always carries an actionable
+                  // search CTA: without it (e.g. a non-"nearest" landing
+                  // mode, where the shortcut card above is hidden) the
+                  // screen was dead-end centered text.
+                  FilledButton.icon(
+                    key: const Key('emptySearchCta'),
+                    onPressed: () => _openCriteria(context),
+                    icon: const Icon(Icons.search),
+                    label: Text(l10n?.searchCriteriaOpen ?? 'Search'),
+                  ),
                 ],
               ),
             ),
@@ -98,4 +110,15 @@ class SearchResultsContent extends ConsumerWidget {
           ),
     );
   }
+}
+
+/// Open the full search-criteria screen (#1695) — shared by the
+/// empty-state CTA here and the [SearchSummaryBar]'s tune action.
+Future<void> _openCriteria(BuildContext context) async {
+  await Navigator.of(context).push<void>(
+    MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (_) => const SearchCriteriaScreen(),
+    ),
+  );
 }

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1235,6 +1235,7 @@
   "alertsRadiusCancel": "Abbrechen",
   "alertsRadiusDeleteConfirm": "Umkreis-Alarm löschen?",
   "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
+  "obd2PairChipTooltip": "OBD2-Adapter koppeln",
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
   "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
   "fillUpSavedSnackbar": "Tankvorgang gespeichert",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1435,6 +1435,10 @@
       }
     }
   },
+  "obd2PairChipTooltip": "Pair an OBD2 adapter",
+  "@obd2PairChipTooltip": {
+    "description": "Tooltip on the title-bar OBD2 chip when no adapter is paired yet — tapping opens the adapter picker so pairing has a discoverable entry point (#1695)."
+  },
   "velocityAlertTitle": "{fuelLabel} dropped at nearby stations",
   "@velocityAlertTitle": {
     "description": "Title of the price-drop velocity notification (#579). Fired when multiple nearby stations drop within the lookback window.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1235,6 +1235,7 @@
   "alertsRadiusCancel": "Abbrechen",
   "alertsRadiusDeleteConfirm": "Umkreis-Alarm löschen?",
   "obd2ConnectedTooltip": "OBD2 verbunden: {adapterName}",
+  "obd2PairChipTooltip": "OBD2-Adapter koppeln",
   "velocityAlertTitle": "{fuelLabel} an Tankstellen in der Nähe gefallen",
   "velocityAlertBody": "{stationCount} Tankstellen um bis zu {maxDropCents}¢ in der letzten Stunde gefallen",
   "fillUpSavedSnackbar": "Tankvorgang gespeichert",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1437,6 +1437,10 @@
       }
     }
   },
+  "obd2PairChipTooltip": "Pair an OBD2 adapter",
+  "@obd2PairChipTooltip": {
+    "description": "Tooltip on the title-bar OBD2 chip when no adapter is paired yet — tapping opens the adapter picker so pairing has a discoverable entry point (#1695)."
+  },
   "velocityAlertTitle": "{fuelLabel} dropped at nearby stations",
   "@velocityAlertTitle": {
     "description": "Title of the price-drop velocity notification (#579). Fired when multiple nearby stations drop within the lookback window.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5900,6 +5900,12 @@ abstract class AppLocalizations {
   /// **'OBD2 connected: {adapterName}'**
   String obd2ConnectedTooltip(String adapterName);
 
+  /// Tooltip on the title-bar OBD2 chip when no adapter is paired yet — tapping opens the adapter picker so pairing has a discoverable entry point (#1695).
+  ///
+  /// In en, this message translates to:
+  /// **'Pair an OBD2 adapter'**
+  String get obd2PairChipTooltip;
+
   /// Title of the price-drop velocity notification (#579). Fired when multiple nearby stations drop within the lookback window.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3155,6 +3155,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3155,6 +3155,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3153,6 +3153,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3180,6 +3180,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'OBD2-Adapter koppeln';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel an Tankstellen in der Nähe gefallen';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3157,6 +3157,9 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3148,6 +3148,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3156,6 +3156,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3150,6 +3150,9 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3153,6 +3153,9 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3179,6 +3179,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3152,6 +3152,9 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3157,6 +3157,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3156,6 +3156,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3154,6 +3154,9 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3156,6 +3156,9 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3152,6 +3152,9 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3157,6 +3157,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3155,6 +3155,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3156,6 +3156,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3155,6 +3155,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3156,6 +3156,9 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3150,6 +3150,9 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3154,6 +3154,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get obd2PairChipTooltip => 'Pair an OBD2 adapter';
+
+  @override
   String velocityAlertTitle(String fuelLabel) {
     return '$fuelLabel dropped at nearby stations';
   }

--- a/test/features/consumption/presentation/widgets/obd2_status_chip_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_status_chip_test.dart
@@ -3,22 +3,28 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/obd2_status_chip.dart';
 import 'package:tankstellen/features/consumption/providers/obd2_connection_state_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 /// Pumps the chip inside a minimal MaterialApp so AppLocalizations +
-/// theme are available. Accepts an [Obd2ConnectionSnapshot] to drive
-/// the provider — we override the whole notifier class rather than
-/// stubbing a single method so tap-through tests can read state back
-/// without reaching into the internals.
+/// theme are available. [snapshot] drives the connection-state
+/// provider; [pairedAdapterMac] drives the active vehicle's paired
+/// adapter (#1695) — null means "no adapter paired", which is what
+/// flips the not-connected chip from hidden to the pairing affordance.
 Future<void> _pumpChip(
   WidgetTester tester, {
   required Obd2ConnectionSnapshot snapshot,
+  String? pairedAdapterMac,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         obd2ConnectionStatusProvider.overrideWith(
           () => _FakeStatus(snapshot),
+        ),
+        activeVehicleProfileProvider.overrideWith(
+          () => _StubActiveVehicle(pairedAdapterMac),
         ),
       ],
       child: MaterialApp(
@@ -41,6 +47,22 @@ class _FakeStatus extends Obd2ConnectionStatus {
   final Obd2ConnectionSnapshot _initial;
   @override
   Obd2ConnectionSnapshot build() => _initial;
+}
+
+/// Stub active vehicle — carries [_mac] as its paired OBD2 adapter, or
+/// resolves to "no vehicle" when [_mac] is null.
+class _StubActiveVehicle extends ActiveVehicleProfile {
+  _StubActiveVehicle(this._mac);
+  final String? _mac;
+  @override
+  VehicleProfile? build() => _mac == null
+      ? null
+      : VehicleProfile(
+          id: 'v1',
+          name: 'Test Car',
+          type: VehicleType.combustion,
+          obd2AdapterMac: _mac,
+        );
 }
 
 void main() {
@@ -74,38 +96,52 @@ void main() {
       expect(button.tooltip, contains('OBD2 connected'));
     });
 
-    testWidgets('renders SizedBox.shrink when the adapter is NOT '
-        'connected (attempting)', (tester) async {
+    testWidgets('stays hidden when an adapter is paired but the '
+        'connection is attempting', (tester) async {
+      // An adapter IS paired — the transient disconnect is the
+      // Obd2StatusDot's job to surface, so the chip stays quiet.
       await _pumpChip(
         tester,
         snapshot: const Obd2ConnectionSnapshot(
           state: Obd2ConnectionState.attempting,
           adapterName: 'vLinker FS',
         ),
+        pairedAdapterMac: 'AA:BB:CC',
       );
       expect(find.byKey(const Key('obd2StatusChip')), findsNothing);
-      expect(find.byIcon(Icons.bluetooth_connected), findsNothing);
+      expect(find.byKey(const Key('obd2PairChip')), findsNothing);
     });
 
-    testWidgets('renders SizedBox.shrink when the adapter is NOT '
-        'connected (unreachable)', (tester) async {
+    testWidgets('stays hidden when an adapter is paired but the '
+        'connection is unreachable', (tester) async {
       await _pumpChip(
         tester,
         snapshot: const Obd2ConnectionSnapshot(
           state: Obd2ConnectionState.unreachable,
           adapterName: 'vLinker FS',
         ),
+        pairedAdapterMac: 'AA:BB:CC',
       );
       expect(find.byKey(const Key('obd2StatusChip')), findsNothing);
+      expect(find.byKey(const Key('obd2PairChip')), findsNothing);
     });
 
-    testWidgets('renders SizedBox.shrink when the state is idle '
-        '(no adapter paired)', (tester) async {
+    testWidgets('shows a discoverable pairing affordance when NO '
+        'adapter is paired (#1695)', (tester) async {
+      // idle state + no paired adapter — there is no status-dot signal
+      // either, so the chip surfaces a "pair an adapter" entry point.
       await _pumpChip(
         tester,
         snapshot: const Obd2ConnectionSnapshot(),
       );
       expect(find.byKey(const Key('obd2StatusChip')), findsNothing);
+      final pairChip = find.byKey(const Key('obd2PairChip'));
+      expect(pairChip, findsOneWidget);
+      expect(find.byIcon(Icons.bluetooth_searching), findsOneWidget);
+      final button = tester.widget<IconButton>(pairChip);
+      expect(button.tooltip, contains('Pair'));
+      expect(button.onPressed, isNotNull,
+          reason: 'tapping the pair chip must open the adapter picker');
     });
 
     testWidgets('tap opens a modal — proves the adapter-picker '
@@ -117,12 +153,6 @@ void main() {
           adapterName: 'vLinker FS',
         ),
       );
-      // The adapter picker sheet reads obd2ConnectionProvider which
-      // isn't wired here; we only assert the tap fires a modal route.
-      // An uncaught exception inside showModalBottomSheet is swallowed
-      // by tester.takeException — we verify via the observer below
-      // that a new route was pushed OR an exception was raised on
-      // tap. Either way the IconButton's onPressed is wired.
       final button = tester.widget<IconButton>(
         find.byKey(const Key('obd2StatusChip')),
       );
@@ -139,6 +169,18 @@ void main() {
           state: Obd2ConnectionState.connected,
           adapterName: 'vLinker FS',
         ),
+      );
+      await expectLater(
+        tester,
+        meetsGuideline(androidTapTargetGuideline),
+      );
+    });
+
+    testWidgets('the pairing affordance also meets the 48 dp guideline',
+        (tester) async {
+      await _pumpChip(
+        tester,
+        snapshot: const Obd2ConnectionSnapshot(),
       );
       await expectLater(
         tester,

--- a/test/features/search/presentation/widgets/search_results_content_test.dart
+++ b/test/features/search/presentation/widgets/search_results_content_test.dart
@@ -96,6 +96,30 @@ void main() {
     });
 
     testWidgets(
+        '#1695 — empty state always carries a search CTA, even when the '
+        'nearest shortcut is hidden', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        SearchResultsContent(onGpsRetry: noopRetry),
+        overrides: [
+          ...test.overrides,
+          searchStateProvider.overrideWith(() => _EmptySearchState()),
+          activeProfileProvider.overrideWith(
+            () => _FakeActiveProfile(LandingScreen.cheapest),
+          ),
+        ].cast(),
+      );
+
+      // Shortcut card hidden (cheapest landing) — but the empty state
+      // is no longer a dead screen: an actionable search CTA is shown.
+      expect(find.byType(NearestShortcutCard), findsNothing);
+      expect(find.byKey(const Key('emptySearchCta')), findsOneWidget);
+    });
+
+    testWidgets(
         '#494 — shows NearestShortcutCard when landing screen IS nearest',
         (tester) async {
       final test = standardTestOverrides();


### PR DESCRIPTION
## What

Closes #1695 — child of epic #1689 (UX audit, dimension 6: Affordance & Discoverability).

Three findings:

- **Empty search state CTA** — when the landing mode isn't "nearest" the nearest-shortcut card is hidden, leaving the empty state as dead-end centred text. It now always carries a **"Search" CTA button** that opens the criteria screen.
- **Filter/edit-criteria action** — *already satisfied*: `SearchSummaryBar` carries a labelled `tune`-icon "Search" button that opens the criteria screen (`search_screen.dart` calls it the "top-level entry point for editing criteria"). No change needed.
- **OBD2 pairing discoverability** — `Obd2StatusChip` rendered zero-size whenever not connected, so an unpaired user had no entry point. It now distinguishes *"adapter paired, transient disconnect"* (stay hidden — the status dot owns that signal) from *"no adapter paired"* (show a discoverable `bluetooth_searching` button that opens the adapter picker).

## Tests

The empty state shows the CTA even with the shortcut hidden; the chip shows the pairing affordance when no adapter is paired, stays hidden when one is paired but disconnected, and the affordance meets the 48 dp tap-target guideline. Whole-repo `flutter analyze`, module-boundary, l10n-completeness and hardcoded-string guards all green; 337 host-screen tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
