### PR TITLE
feat(ux): forms — locale dates, numeric keyboard, inline validation, discard guard (#1693)

### DIFF
--- a/lib/core/widgets/discard_changes_dialog.dart
+++ b/lib/core/widgets/discard_changes_dialog.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+
+/// Confirm dialog shown when the user tries to leave a form that has
+/// unsaved changes (#1693 — Forms & Input UX).
+///
+/// Returns `true` when the user chooses to discard and leave, `false`
+/// when they dismiss the dialog or choose to keep editing. Callers
+/// pair this with a `PopScope` (`canPop: !isDirty`) so the system back
+/// gesture and an explicit close button both route through it.
+Future<bool> showDiscardChangesDialog(BuildContext context) async {
+  final l = AppLocalizations.of(context);
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(l?.discardChangesTitle ?? 'Discard changes?'),
+      content: Text(
+        l?.discardChangesBody ??
+            'You have unsaved changes. Leaving now will discard them.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: Text(l?.discardChangesKeepEditing ?? 'Keep editing'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: Text(l?.discardChangesConfirm ?? 'Discard'),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/widgets/discard_changes_dialog.dart';
 
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -317,13 +320,34 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     );
   }
 
-  String _pad(int n) => n.toString().padLeft(2, '0');
+  /// #1693 — true once the user has entered any fill-up data (typed or
+  /// receipt-scanned). The form's controllers all start empty, so any
+  /// non-empty field means there is unsaved data the discard guard
+  /// should protect.
+  bool get _isDirty =>
+      _litersCtrl.text.isNotEmpty ||
+      _costCtrl.text.isNotEmpty ||
+      _odoCtrl.text.isNotEmpty ||
+      _notesCtrl.text.isNotEmpty;
+
+  /// #1693 — discard guard for a blocked pop (system back / the
+  /// leading button via `Navigator.maybePop`). Confirms with the user
+  /// before discarding the unsaved fill-up.
+  Future<void> _onPopInvoked(bool didPop, Object? result) async {
+    if (didPop) return;
+    final discard = await showDiscardChangesDialog(context);
+    if (discard && mounted) {
+      Navigator.of(context).pop();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final dateStr =
-        '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
+    // #1693 — locale-aware date instead of a raw YYYY-MM-DD string.
+    final dateStr = DateFormat.yMMMd(
+      Localizations.localeOf(context).toString(),
+    ).format(_date);
     // Tolerate providers in error state during widget tests without
     // a real Hive storage — the selector simply hides itself (#694).
     List<VehicleProfile> vehicles;
@@ -341,16 +365,24 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       return const FillUpNoVehicleCta();
     }
 
-    return PageScaffold(
+    // #1693 — guard unsaved fill-up data. `canPop` blocks the system
+    // back gesture and `Navigator.maybePop` (the leading button)
+    // whenever the form is dirty; the save path uses an imperative
+    // `context.pop()` which is unaffected.
+    return PopScope(
+      canPop: !_isDirty,
+      onPopInvokedWithResult: _onPopInvoked,
+      child: PageScaffold(
       title: l?.addFillUp ?? 'Add fill-up',
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         tooltip: l?.tooltipBack ?? 'Back',
-        onPressed: () => context.pop(),
+        onPressed: () => Navigator.maybePop(context),
       ),
       bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
+        autovalidateMode: AutovalidateMode.onUserInteraction,
         child: ListView(
           padding: EdgeInsets.fromLTRB(
             16,
@@ -395,6 +427,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
         ),
       ),
       bottomNavigationBar: FillUpPinnedSaveBar(onSave: _save),
+      ),
     );
   }
 }

--- a/lib/features/setup/presentation/widgets/preferences_step.dart
+++ b/lib/features/setup/presentation/widgets/preferences_step.dart
@@ -65,7 +65,10 @@ class _PreferencesStepState extends ConsumerState<PreferencesStep> {
               prefixIcon: const Icon(Icons.home),
               border: const OutlineInputBorder(),
             ),
-            keyboardType: TextInputType.text,
+            // #1693 — postal codes in every supported country are
+            // numeric; show the number pad rather than the text
+            // keyboard.
+            keyboardType: TextInputType.number,
             onChanged: (value) => notifier.setHomeZipCode(
                 value.trim().isEmpty ? null : value.trim()),
           ),

--- a/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
+++ b/lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/brand_logo_mapper.dart';
+import '../../../../core/widgets/discard_changes_dialog.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -128,6 +129,10 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     );
     if (widget.vehicleId != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadExisting());
+    } else {
+      // #1693 — new-vehicle path has no async load; the construction
+      // defaults are the discard-guard baseline.
+      _ctrl.snapshotBaseline();
     }
   }
 
@@ -151,6 +156,8 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
     final existing = list.where((v) => v.id == widget.vehicleId).firstOrNull;
     if (existing == null) return false;
     final snap = _ctrl.load(existing);
+    // #1693 — the freshly-loaded profile is the discard-guard baseline.
+    _ctrl.snapshotBaseline();
     setState(() {
       _existingId = snap.id;
       _type = snap.type;
@@ -572,7 +579,14 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
       });
     }
 
-    return PageScaffold(
+    // #1693 — guard unsaved vehicle edits. `canPop` blocks the system
+    // back gesture and the AppBar back button (both route through
+    // `Navigator.maybePop`); the imperative `pop()` in the save path
+    // is unaffected.
+    return PopScope(
+      canPop: !_ctrl.isDirty,
+      onPopInvokedWithResult: _onPopInvoked,
+      child: PageScaffold(
       title: isEdit
           ? (l?.vehicleEditTitle ?? 'Edit vehicle')
           : (l?.vehicleAddTitle ?? 'Add vehicle'),
@@ -586,6 +600,7 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
       bodyPadding: EdgeInsets.zero,
       body: Form(
         key: _formKey,
+        autovalidateMode: AutovalidateMode.onUserInteraction,
         child: ListView(
           controller: _scrollController,
           padding: EdgeInsets.fromLTRB(16, 16, 16,
@@ -777,6 +792,17 @@ class _EditVehicleScreenState extends ConsumerState<EditVehicleScreen>
       // Pinned bottom Save (#751 §3) — always in the tree regardless
       // of scroll, which tests and TalkBack rely on.
       bottomNavigationBar: VehicleSaveBar(onSave: _save),
+      ),
     );
+  }
+
+  /// #1693 — discard guard for a blocked pop (system back / AppBar
+  /// back button). Confirms before discarding unsaved vehicle edits.
+  Future<void> _onPopInvoked(bool didPop, Object? result) async {
+    if (didPop) return;
+    final discard = await showDiscardChangesDialog(context);
+    if (discard && mounted) {
+      Navigator.of(context).pop();
+    }
   }
 }

--- a/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_form_controllers.dart
@@ -223,6 +223,38 @@ class VehicleFormControllers {
     );
   }
 
+  // #1693 — unsaved-changes tracking for the discard guard.
+  Map<String, String> _baseline = const {};
+
+  Map<String, String> _currentValues() => {
+        'name': nameController.text,
+        'battery': batteryController.text,
+        'maxKw': maxChargingKwController.text,
+        'tank': tankController.text,
+        'fuel': fuelTypeController.text,
+        'minSoc': minSocController.text,
+        'maxSoc': maxSocController.text,
+        'vin': vinController.text,
+      };
+
+  /// Capture the current controller values as the "clean" baseline.
+  /// The screen calls this once the form is populated — after [load]
+  /// for an existing vehicle, or right after construction for a new
+  /// one — so [isDirty] can tell whether the user has edited anything.
+  void snapshotBaseline() => _baseline = _currentValues();
+
+  /// True when any text field differs from the captured baseline.
+  /// Returns false until [snapshotBaseline] has run, so the guard
+  /// never fires spuriously in the pre-load frame.
+  bool get isDirty {
+    if (_baseline.isEmpty) return false;
+    final current = _currentValues();
+    for (final entry in current.entries) {
+      if (_baseline[entry.key] != entry.value) return true;
+    }
+    return false;
+  }
+
   void dispose() {
     nameController.dispose();
     batteryController.dispose();

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1245,5 +1245,9 @@
   "notFoundBody": "„{location}“ nicht gefunden.",
   "notFoundHomeButton": "Startseite",
   "consumptionTabHiddenNotice": "Der Verbrauch-Tab wurde durch deine Profileinstellungen ausgeblendet.",
-  "swipeBetweenTabsHint": "Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln."
+  "swipeBetweenTabsHint": "Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln.",
+  "discardChangesTitle": "Änderungen verwerfen?",
+  "discardChangesBody": "Du hast nicht gespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.",
+  "discardChangesConfirm": "Verwerfen",
+  "discardChangesKeepEditing": "Weiter bearbeiten"
 }

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1499,5 +1499,21 @@
   "swipeBetweenTabsHint": "Tip: swipe left or right to switch between tabs.",
   "@swipeBetweenTabsHint": {
     "description": "One-time first-run SnackBar hint that the bottom-nav tabs respond to a horizontal swipe gesture (#1690)."
+  },
+  "discardChangesTitle": "Discard changes?",
+  "@discardChangesTitle": {
+    "description": "Title of the confirm dialog shown when the user leaves a form (fill-up, vehicle edit) with unsaved changes (#1693)."
+  },
+  "discardChangesBody": "You have unsaved changes. Leaving now will discard them.",
+  "@discardChangesBody": {
+    "description": "Body of the unsaved-changes confirm dialog (#1693)."
+  },
+  "discardChangesConfirm": "Discard",
+  "@discardChangesConfirm": {
+    "description": "Confirm action on the unsaved-changes dialog — leaves the form and discards the edits (#1693)."
+  },
+  "discardChangesKeepEditing": "Keep editing",
+  "@discardChangesKeepEditing": {
+    "description": "Dismiss action on the unsaved-changes dialog — stays on the form (#1693)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1246,6 +1246,10 @@
   "notFoundHomeButton": "Startseite",
   "consumptionTabHiddenNotice": "Der Verbrauch-Tab wurde durch deine Profileinstellungen ausgeblendet.",
   "swipeBetweenTabsHint": "Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln.",
+  "discardChangesTitle": "Änderungen verwerfen?",
+  "discardChangesBody": "Du hast nicht gespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.",
+  "discardChangesConfirm": "Verwerfen",
+  "discardChangesKeepEditing": "Weiter bearbeiten",
   "achievementSmoothDriver": "Ruhige Serie",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1502,6 +1502,22 @@
   "@swipeBetweenTabsHint": {
     "description": "One-time first-run SnackBar hint that the bottom-nav tabs respond to a horizontal swipe gesture (#1690)."
   },
+  "discardChangesTitle": "Discard changes?",
+  "@discardChangesTitle": {
+    "description": "Title of the confirm dialog shown when the user leaves a form (fill-up, vehicle edit) with unsaved changes (#1693)."
+  },
+  "discardChangesBody": "You have unsaved changes. Leaving now will discard them.",
+  "@discardChangesBody": {
+    "description": "Body of the unsaved-changes confirm dialog (#1693)."
+  },
+  "discardChangesConfirm": "Discard",
+  "@discardChangesConfirm": {
+    "description": "Confirm action on the unsaved-changes dialog — leaves the form and discards the edits (#1693)."
+  },
+  "discardChangesKeepEditing": "Keep editing",
+  "@discardChangesKeepEditing": {
+    "description": "Dismiss action on the unsaved-changes dialog — stays on the form (#1693)."
+  },
   "achievementSmoothDriver": "Smooth streak",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1366,5 +1366,9 @@
   "notFoundBody": "« {location} » introuvable.",
   "notFoundHomeButton": "Accueil",
   "consumptionTabHiddenNotice": "L'onglet Consommation a été masqué par les réglages de votre profil.",
-  "swipeBetweenTabsHint": "Astuce : balayez vers la gauche ou la droite pour changer d'onglet."
+  "swipeBetweenTabsHint": "Astuce : balayez vers la gauche ou la droite pour changer d'onglet.",
+  "discardChangesTitle": "Abandonner les modifications ?",
+  "discardChangesBody": "Vous avez des modifications non enregistrées. Quitter maintenant les supprimera.",
+  "discardChangesConfirm": "Abandonner",
+  "discardChangesKeepEditing": "Continuer la modification"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5966,6 +5966,30 @@ abstract class AppLocalizations {
   /// **'Tip: swipe left or right to switch between tabs.'**
   String get swipeBetweenTabsHint;
 
+  /// Title of the confirm dialog shown when the user leaves a form (fill-up, vehicle edit) with unsaved changes (#1693).
+  ///
+  /// In en, this message translates to:
+  /// **'Discard changes?'**
+  String get discardChangesTitle;
+
+  /// Body of the unsaved-changes confirm dialog (#1693).
+  ///
+  /// In en, this message translates to:
+  /// **'You have unsaved changes. Leaving now will discard them.'**
+  String get discardChangesBody;
+
+  /// Confirm action on the unsaved-changes dialog — leaves the form and discards the edits (#1693).
+  ///
+  /// In en, this message translates to:
+  /// **'Discard'**
+  String get discardChangesConfirm;
+
+  /// Dismiss action on the unsaved-changes dialog — stays on the form (#1693).
+  ///
+  /// In en, this message translates to:
+  /// **'Keep editing'**
+  String get discardChangesKeepEditing;
+
   /// Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3197,6 +3197,19 @@ class AppLocalizationsBg extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3197,6 +3197,19 @@ class AppLocalizationsCs extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3195,6 +3195,19 @@ class AppLocalizationsDa extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3222,6 +3222,19 @@ class AppLocalizationsDe extends AppLocalizations {
       'Tipp: Wische nach links oder rechts, um zwischen den Tabs zu wechseln.';
 
   @override
+  String get discardChangesTitle => 'Änderungen verwerfen?';
+
+  @override
+  String get discardChangesBody =>
+      'Du hast nicht gespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.';
+
+  @override
+  String get discardChangesConfirm => 'Verwerfen';
+
+  @override
+  String get discardChangesKeepEditing => 'Weiter bearbeiten';
+
+  @override
   String get achievementSmoothDriver => 'Ruhige Serie';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3199,6 +3199,19 @@ class AppLocalizationsEl extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3190,6 +3190,19 @@ class AppLocalizationsEn extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3198,6 +3198,19 @@ class AppLocalizationsEs extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3192,6 +3192,19 @@ class AppLocalizationsEt extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3195,6 +3195,19 @@ class AppLocalizationsFi extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3221,6 +3221,19 @@ class AppLocalizationsFr extends AppLocalizations {
       'Astuce : balayez vers la gauche ou la droite pour changer d\'onglet.';
 
   @override
+  String get discardChangesTitle => 'Abandonner les modifications ?';
+
+  @override
+  String get discardChangesBody =>
+      'Vous avez des modifications non enregistrées. Quitter maintenant les supprimera.';
+
+  @override
+  String get discardChangesConfirm => 'Abandonner';
+
+  @override
+  String get discardChangesKeepEditing => 'Continuer la modification';
+
+  @override
   String get achievementSmoothDriver => 'Série souple';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3194,6 +3194,19 @@ class AppLocalizationsHr extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3199,6 +3199,19 @@ class AppLocalizationsHu extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3198,6 +3198,19 @@ class AppLocalizationsIt extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3196,6 +3196,19 @@ class AppLocalizationsLt extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3198,6 +3198,19 @@ class AppLocalizationsLv extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3194,6 +3194,19 @@ class AppLocalizationsNb extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3199,6 +3199,19 @@ class AppLocalizationsNl extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3197,6 +3197,19 @@ class AppLocalizationsPl extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3198,6 +3198,19 @@ class AppLocalizationsPt extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3197,6 +3197,19 @@ class AppLocalizationsRo extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3198,6 +3198,19 @@ class AppLocalizationsSk extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3192,6 +3192,19 @@ class AppLocalizationsSl extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3196,6 +3196,19 @@ class AppLocalizationsSv extends AppLocalizations {
       'Tip: swipe left or right to switch between tabs.';
 
   @override
+  String get discardChangesTitle => 'Discard changes?';
+
+  @override
+  String get discardChangesBody =>
+      'You have unsaved changes. Leaving now will discard them.';
+
+  @override
+  String get discardChangesConfirm => 'Discard';
+
+  @override
+  String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
   String get achievementSmoothDriver => 'Smooth streak';
 
   @override

--- a/test/core/widgets/discard_changes_dialog_test.dart
+++ b/test/core/widgets/discard_changes_dialog_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/discard_changes_dialog.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// Tests for [showDiscardChangesDialog] (#1693) — the unsaved-changes
+/// confirm dialog shared by the fill-up and vehicle-edit forms.
+
+void main() {
+  /// Pumps a button that opens the dialog; [resultSink] captures the
+  /// dialog's resolved outcome.
+  Future<void> pumpOpener(
+    WidgetTester tester,
+    void Function(bool) resultSink,
+  ) async {
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              resultSink(await showDiscardChangesDialog(context));
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders the title, body and both actions', (tester) async {
+    await pumpOpener(tester, (_) {});
+
+    expect(find.text('Discard changes?'), findsOneWidget);
+    expect(find.textContaining('unsaved changes'), findsOneWidget);
+    expect(find.text('Discard'), findsOneWidget);
+    expect(find.text('Keep editing'), findsOneWidget);
+  });
+
+  testWidgets('tapping Discard resolves true', (tester) async {
+    bool? result;
+    await pumpOpener(tester, (r) => result = r);
+
+    await tester.tap(find.text('Discard'));
+    await tester.pumpAndSettle();
+
+    expect(result, isTrue);
+    expect(find.text('Discard changes?'), findsNothing);
+  });
+
+  testWidgets('tapping Keep editing resolves false', (tester) async {
+    bool? result;
+    await pumpOpener(tester, (r) => result = r);
+
+    await tester.tap(find.text('Keep editing'));
+    await tester.pumpAndSettle();
+
+    expect(result, isFalse);
+    expect(find.text('Discard changes?'), findsNothing);
+  });
+
+  testWidgets('dismissing the dialog (barrier tap) resolves false',
+      (tester) async {
+    bool? result;
+    await pumpOpener(tester, (r) => result = r);
+
+    // Tap outside the dialog to dismiss it.
+    await tester.tapAt(const Offset(20, 20));
+    await tester.pumpAndSettle();
+
+    expect(result, isFalse,
+        reason: 'a dismissed dialog must be treated as "keep editing"');
+  });
+}

--- a/test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart
+++ b/test/features/vehicle/presentation/widgets/vehicle_form_controllers_test.dart
@@ -543,6 +543,60 @@ void main() {
     });
   });
 
+  group('VehicleFormControllers — isDirty discard-guard tracking (#1693)', () {
+    test('isDirty is false before a baseline is captured', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+      // No snapshotBaseline() yet — the guard must not fire spuriously
+      // in the pre-load frame.
+      c.nameController.text = 'edited';
+      expect(c.isDirty, isFalse);
+    });
+
+    test('isDirty is false right after snapshotBaseline', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+      c.nameController.text = 'My Car';
+      c.tankController.text = '50';
+      c.snapshotBaseline();
+      expect(c.isDirty, isFalse);
+    });
+
+    test('isDirty turns true when a text field changes after the baseline',
+        () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+      c.nameController.text = 'My Car';
+      c.snapshotBaseline();
+      c.nameController.text = 'My Car (renamed)';
+      expect(c.isDirty, isTrue);
+    });
+
+    test('editing then reverting a field clears isDirty again', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+      c.vinController.text = 'VF3AAAA';
+      c.snapshotBaseline();
+      c.vinController.text = 'VF3AAAB';
+      expect(c.isDirty, isTrue);
+      c.vinController.text = 'VF3AAAA';
+      expect(c.isDirty, isFalse,
+          reason: 'reverting to the baseline value is no longer dirty');
+    });
+
+    test('a fresh snapshotBaseline re-bases the dirty check', () {
+      final c = VehicleFormControllers();
+      addTearDown(c.dispose);
+      c.tankController.text = '50';
+      c.snapshotBaseline();
+      c.tankController.text = '60';
+      expect(c.isDirty, isTrue);
+      // e.g. a VIN-decode reload re-snapshots — 60 is now the baseline.
+      c.snapshotBaseline();
+      expect(c.isDirty, isFalse);
+    });
+  });
+
   group('VehicleFormSnapshot', () {
     test('exposes constructor-supplied fields verbatim', () {
       final snapshot = VehicleFormSnapshot(


### PR DESCRIPTION
## What

Closes #1693 — child of epic #1689 (UX audit, dimension 4: Forms & Input).

Four findings:

- **Locale-aware date** — the add-fill-up screen rendered the date as a raw `YYYY-MM-DD` string. It now uses `DateFormat.yMMMd` keyed off the device locale.
- **Numeric keyboard** — every *named* numeric field (liters, cost, odometer, tank/battery capacity, SoC) already set `keyboardType`; the one real gap was the onboarding home-postal field, switched from the text keyboard to the number pad.
- **Inline validation** — the fill-up and vehicle-edit `Form`s now set `autovalidateMode: onUserInteraction`, so errors surface as the user types rather than only on Save.
- **Discard guard** — both form screens wrap in a `PopScope` that, when the form is dirty, intercepts the system back gesture and the back button (`Navigator.maybePop`) and confirms via a new shared `showDiscardChangesDialog` before discarding. The imperative save-path `pop()` is unaffected. Add-fill-up tracks dirty via its initially-empty controllers; `VehicleFormControllers` gains a `snapshotBaseline` / `isDirty` pair re-based after the profile load.

## Tests

The discard dialog's outcomes (discard / keep-editing / dismiss); `VehicleFormControllers.isDirty` across baseline / edit / revert / re-snapshot. Whole-repo `flutter analyze`, module-boundary, l10n-completeness and hardcoded-string guards green; **356** add-fill-up / vehicle-edit / setup screen tests pass (regression coverage of the date, autovalidate and `PopScope` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
