### PR TITLE
fix(a11y): bottom-nav label scaling, landscape tooltips, tap targets (#1697)

### DIFF
--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -40,7 +40,13 @@ class ShellBottomBar extends StatelessWidget {
     // bar on edge-to-edge devices (same class of bug as #520).
     final barHeight = isLandscape ? 48.0 : 64.0;
 
-    return SafeArea(
+    // #1697 — clamp the bar's text scaling so labels grow with the OS
+    // setting but never past what the fixed-height bar can show. Dense
+    // navigation chrome can't absorb a full 3x scale; Material's own
+    // NavigationBar applies the same kind of bound.
+    return MediaQuery.withClampedTextScaling(
+      maxScaleFactor: 1.3,
+      child: SafeArea(
       top: false,
       child: Container(
         height: barHeight,
@@ -62,56 +68,69 @@ class ShellBottomBar extends StatelessWidget {
             final item = items[i];
             final controller = iconControllers[branchForSlot[i]];
 
+            final inkWell = InkWell(
+              onTap: () => onTap(i),
+              splashColor: theme.colorScheme.primary.withValues(alpha: 0.1),
+              highlightColor: Colors.transparent,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ShellBounceIcon(
+                    controller: controller,
+                    selected: selected,
+                    icon: selected ? item.filledIcon : item.outlinedIcon,
+                    iconSize: iconSize,
+                    color: selected
+                        ? theme.colorScheme.primary
+                        : theme.colorScheme.onSurfaceVariant,
+                  ),
+                  if (!isLandscape) ...[
+                    const SizedBox(height: 2),
+                    // #1697 — themed `labelMedium` instead of a fixed
+                    // 10/11 px font. The bar's text scaling is clamped
+                    // (see `MediaQuery.withClampedTextScaling` below) so
+                    // the label grows with the OS text setting up to a
+                    // bound that still fits the fixed-height bar — the
+                    // same approach Material's own NavigationBar takes.
+                    AnimatedDefaultTextStyle(
+                      duration: const Duration(milliseconds: 200),
+                      style: (theme.textTheme.labelMedium ?? const TextStyle())
+                          .copyWith(
+                        fontWeight:
+                            selected ? FontWeight.w600 : FontWeight.w400,
+                        color: selected
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.onSurfaceVariant,
+                      ),
+                      child: Text(
+                        item.label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            );
+
             return Expanded(
               child: Semantics(
                 label: item.label,
                 button: true,
                 selected: selected,
                 excludeSemantics: true,
-                child: InkWell(
-                  onTap: () => onTap(i),
-                  splashColor:
-                      theme.colorScheme.primary.withValues(alpha: 0.1),
-                  highlightColor: Colors.transparent,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      ShellBounceIcon(
-                        controller: controller,
-                        selected: selected,
-                        icon: selected ? item.filledIcon : item.outlinedIcon,
-                        iconSize: iconSize,
-                        color: selected
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.onSurfaceVariant,
-                      ),
-                      if (!isLandscape) ...[
-                        const SizedBox(height: 2),
-                        AnimatedDefaultTextStyle(
-                          duration: const Duration(milliseconds: 200),
-                          style: TextStyle(
-                            fontSize: selected ? 11 : 10,
-                            fontWeight: selected
-                                ? FontWeight.w600
-                                : FontWeight.w400,
-                            color: selected
-                                ? theme.colorScheme.primary
-                                : theme.colorScheme.onSurfaceVariant,
-                          ),
-                          child: Text(
-                            item.label,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
+                // #1697 — landscape drops the label row to keep the bar
+                // compact, so a Tooltip gives sighted users the
+                // destination name on long-press (screen readers
+                // already get it from the Semantics label above).
+                child: isLandscape
+                    ? Tooltip(message: item.label, child: inkWell)
+                    : inkWell,
               ),
             );
           }),
         ),
+      ),
       ),
     );
   }

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -232,6 +232,151 @@ void main() {
     });
   });
 
+  group('ShellBottomBar accessibility (#1697)', () {
+    testWidgets('portrait labels use the themed labelMedium size, not a '
+        'fixed 10/11 px font', (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: [newController(), newController(), newController()],
+        isLandscape: false,
+        onTap: (_) {},
+      );
+
+      // #1697 — the label font is the themed `labelMedium` size rather
+      // than a hardcoded 10/11. Every slot's AnimatedDefaultTextStyle
+      // carries that size (weight/colour differ for the selected slot).
+      final ctx = tester.element(find.byType(ShellBottomBar));
+      final themed = Theme.of(ctx).textTheme.labelMedium?.fontSize;
+      expect(themed, isNotNull);
+      final styles = tester
+          .widgetList<AnimatedDefaultTextStyle>(
+            find.descendant(
+              of: find.byType(ShellBottomBar),
+              matching: find.byType(AnimatedDefaultTextStyle),
+            ),
+          )
+          .toList();
+      expect(styles, hasLength(items.length));
+      for (final ads in styles) {
+        expect(ads.style.fontSize, themed);
+      }
+    });
+
+    testWidgets('labels survive 3x OS text scaling without overflow',
+        (tester) async {
+      tester.view.physicalSize = const Size(360, 720);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(3.0)),
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.bottomCenter,
+                child: ShellBottomBar(
+                  items: items,
+                  branchForSlot: const [0, 1, 2],
+                  currentIndex: 0,
+                  iconControllers: [
+                    newController(),
+                    newController(),
+                    newController(),
+                  ],
+                  isLandscape: false,
+                  onTap: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // No RenderFlex overflow was thrown, and every label is still
+      // present (FittedBox scaled it to fit rather than clipping it).
+      for (final item in items) {
+        expect(find.text(item.label), findsOneWidget);
+      }
+    });
+
+    testWidgets('landscape slots carry a Tooltip with the destination name',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: [newController(), newController(), newController()],
+        isLandscape: true,
+        onTap: (_) {},
+      );
+
+      // Landscape drops the visible label row, so each slot is wrapped
+      // in a Tooltip carrying the destination name instead.
+      final tooltips =
+          tester.widgetList<Tooltip>(find.byType(Tooltip)).toList();
+      expect(tooltips, hasLength(items.length));
+      expect(
+        tooltips.map((t) => t.message).toSet(),
+        items.map((i) => i.label).toSet(),
+      );
+    });
+
+    testWidgets('meets the Android 48dp tap-target guideline (portrait)',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: [newController(), newController(), newController()],
+        isLandscape: false,
+        onTap: (_) {},
+      );
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+    });
+
+    testWidgets('renders under RTL directionality without overflow',
+        (tester) async {
+      // No shipped locale is RTL today; this is a robustness check so
+      // the bar is safe if an RTL locale is ever added (#1697).
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: Align(
+                alignment: Alignment.bottomCenter,
+                child: ShellBottomBar(
+                  items: items,
+                  branchForSlot: const [0, 1, 2],
+                  currentIndex: 0,
+                  iconControllers: [
+                    newController(),
+                    newController(),
+                    newController(),
+                  ],
+                  isLandscape: false,
+                  onTap: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(InkWell), findsNWidgets(items.length));
+      for (final item in items) {
+        expect(find.text(item.label), findsOneWidget);
+      }
+    });
+  });
+
   group('ShellBottomBar branchForSlot indirection', () {
     testWidgets(
       'non-identity branchForSlot wires the matching iconControllers',


### PR DESCRIPTION
## What

Closes #1697 — child of epic #1689 (UX audit, dimension 8: Accessibility).

Four findings, all on the bottom navigation bar:

- **Label text scaling** — labels used a hardcoded `fontSize: 10/11` and ellipsis-truncated under OS text scaling. They now use the themed `labelMedium` style, and the bar clamps its text scaling to **1.3x** via `MediaQuery.withClampedTextScaling` — labels grow with the OS setting up to what the fixed-height bar can show, the same bound Material's own `NavigationBar` applies.
- **Landscape labels** — landscape drops the visible label row to keep the bar compact; each slot is now wrapped in a `Tooltip` carrying the destination name (screen readers already got it from the existing `Semantics` label).
- **Tap targets** — the bar's `InkWell` slots are ≥48 dp (a `meetsGuideline(androidTapTargetGuideline)` test locks it in); the GDPR consent toggles already use a Material `Switch`, whose default tap target is 48 dp.
- **RTL** — no shipped locale is RTL, so a robustness test verifies the bar renders correctly under `TextDirection.rtl` for the day one is added.

## Note

`FittedBox(scaleDown)` was tried first for the labels but it does not constrain vertical height inside a `Column`, so a 3x-scaled label still overflowed the 64 dp bar — clamping the scale is the correct fix for fixed-height chrome.

## Tests

Themed label size, 3x-scaling no-overflow, landscape tooltips, the 48 dp tap-target guideline, and RTL rendering. Whole-repo `flutter analyze` clean; 219 app/shell tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
