### PR TITLE
fix(ux): microcopy — de-jargon the demo banner + describe the TankSync section (#1696)

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -93,10 +93,14 @@ class ProfileScreen extends ConsumerWidget {
           // mode, etc.) is preserved; re-enabling the feature surfaces
           // the section with the prior configuration intact.
           if (tankSyncOn) ...[
-            const _FoldableSection(
+            _FoldableSection(
               icon: Icons.cloud_outlined,
-              title: 'TankSync',
-              child: TankSyncSection(),
+              title: 'TankSync', // i18n-ignore: brand name
+              // #1696 — a localized descriptive subtitle so the
+              // brand-named section isn't an unexplained label.
+              subtitle: l?.tankSyncSectionSubtitle ??
+                  'Cloud sync across your devices',
+              child: const TankSyncSection(),
             ),
             const SizedBox(height: 8),
           ],
@@ -231,17 +235,23 @@ class ProfileScreen extends ConsumerWidget {
 class _FoldableSection extends StatelessWidget {
   final IconData icon;
   final String title;
+
+  /// Optional one-line description shown under [title] (#1696) — e.g.
+  /// explaining a brand-named section like "TankSync".
+  final String? subtitle;
   final Widget child;
 
   const _FoldableSection({
     required this.icon,
     required this.title,
+    this.subtitle,
     required this.child,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final subtitleText = subtitle;
     return Card(
       margin: EdgeInsets.zero,
       child: ExpansionTile(
@@ -249,6 +259,14 @@ class _FoldableSection extends StatelessWidget {
         title: Text(title,
             style: theme.textTheme.titleSmall
                 ?.copyWith(fontWeight: FontWeight.bold)),
+        subtitle: subtitleText == null
+            ? null
+            : Text(
+                subtitleText,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
         initiallyExpanded: false,
         shape: const Border(),
         collapsedShape: const Border(),

--- a/lib/features/search/presentation/widgets/demo_mode_banner.dart
+++ b/lib/features/search/presentation/widgets/demo_mode_banner.dart
@@ -17,16 +17,28 @@ class DemoModeBanner extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
 
     if (country.requiresApiKey && !storage.hasApiKey()) {
+      // #1696 — jargon-free copy: the banner names neither "API key"
+      // nor any technical term; the user just learns prices are sample
+      // data and that Settings is where live prices are turned on.
       return MaterialBanner(
+        // #1696 — `forceActionsBelow` keeps the action on its own row.
+        // In the default single-row layout the action button takes its
+        // intrinsic width and the content `Expanded` gets whatever is
+        // left; in a narrow pane (e.g. the wide-screen two-pane search
+        // layout) that leftover collapses to a few pixels and the
+        // content text wraps one glyph per line — an 800+ dp tall
+        // banner. Dropping the action below gives the content the full
+        // banner width at every size.
+        forceActionsBelow: true,
         content: Text(
           '${country.flag} ${country.name} — '
-          '${l10n?.demoModeBanner ?? 'Demo mode. Configure API key in settings for live prices.'}',
+          '${l10n?.demoModeBanner ?? 'Demo mode — showing sample prices.'}',
         ),
         leading: const Icon(Icons.science_outlined),
         actions: [
           TextButton(
             onPressed: () => context.go('/profile'),
-            child: Text(l10n?.apiKeySetup ?? 'Setup'),
+            child: Text(l10n?.demoModeBannerAction ?? 'Get live prices'),
           ),
         ],
       );

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -198,7 +198,8 @@
   "refreshPrices": "Preise aktualisieren",
   "station": "Tankstelle",
   "locationDenied": "Standortfreigabe abgelehnt. Sie können per PLZ suchen.",
-  "demoModeBanner": "Demo-Modus. API-Schlüssel in den Einstellungen eingeben.",
+  "demoModeBanner": "Demo-Modus – Beispielpreise werden angezeigt.",
+  "demoModeBannerAction": "Live-Preise aktivieren",
   "sortDistance": "Entfernung",
   "sortOpen24h": "24h",
   "sortRating": "Bewertung",
@@ -1249,5 +1250,6 @@
   "discardChangesTitle": "Änderungen verwerfen?",
   "discardChangesBody": "Du hast nicht gespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.",
   "discardChangesConfirm": "Verwerfen",
-  "discardChangesKeepEditing": "Weiter bearbeiten"
+  "discardChangesKeepEditing": "Weiter bearbeiten",
+  "tankSyncSectionSubtitle": "Cloud-Synchronisierung über deine Geräte hinweg"
 }

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -211,7 +211,14 @@
   "refreshPrices": "Refresh prices",
   "station": "Station",
   "locationDenied": "Location permission denied. You can search by postal code.",
-  "demoModeBanner": "Demo mode. Configure API key in settings for live prices.",
+  "demoModeBanner": "Demo mode — showing sample prices.",
+  "@demoModeBanner": {
+    "description": "Demo-mode banner content shown for API-key countries with no key configured. Jargon-free per #1696 — names neither 'API key' nor any technical term."
+  },
+  "demoModeBannerAction": "Get live prices",
+  "@demoModeBannerAction": {
+    "description": "Action button on the demo-mode banner — opens Settings where live prices can be set up. Jargon-free wording (#1696)."
+  },
   "sortDistance": "Distance",
   "sortOpen24h": "24h",
   "sortRating": "Rating",
@@ -1515,5 +1522,9 @@
   "discardChangesKeepEditing": "Keep editing",
   "@discardChangesKeepEditing": {
     "description": "Dismiss action on the unsaved-changes dialog — stays on the form (#1693)."
+  },
+  "tankSyncSectionSubtitle": "Cloud sync across your devices",
+  "@tankSyncSectionSubtitle": {
+    "description": "Subtitle under the 'TankSync' settings section header — explains what the (brand-named) feature does so it isn't an unexplained label (#1696)."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -198,7 +198,8 @@
   "refreshPrices": "Preise aktualisieren",
   "station": "Tankstelle",
   "locationDenied": "Standortfreigabe abgelehnt. Sie können per PLZ suchen.",
-  "demoModeBanner": "Demo-Modus. API-Schlüssel in den Einstellungen eingeben.",
+  "demoModeBanner": "Demo-Modus – Beispielpreise werden angezeigt.",
+  "demoModeBannerAction": "Live-Preise aktivieren",
   "sortDistance": "Entfernung",
   "sortOpen24h": "24h",
   "sortRating": "Bewertung",
@@ -1250,6 +1251,7 @@
   "discardChangesBody": "Du hast nicht gespeicherte Änderungen. Wenn du jetzt gehst, gehen sie verloren.",
   "discardChangesConfirm": "Verwerfen",
   "discardChangesKeepEditing": "Weiter bearbeiten",
+  "tankSyncSectionSubtitle": "Cloud-Synchronisierung über deine Geräte hinweg",
   "achievementSmoothDriver": "Ruhige Serie",
   "@achievementSmoothDriver": {
     "description": "Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5)."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -211,7 +211,14 @@
   "refreshPrices": "Refresh prices",
   "station": "Station",
   "locationDenied": "Location permission denied. You can search by postal code.",
-  "demoModeBanner": "Demo mode. Configure API key in settings for live prices.",
+  "demoModeBanner": "Demo mode — showing sample prices.",
+  "@demoModeBanner": {
+    "description": "Demo-mode banner content shown for API-key countries with no key configured. Jargon-free per #1696 — names neither 'API key' nor any technical term."
+  },
+  "demoModeBannerAction": "Get live prices",
+  "@demoModeBannerAction": {
+    "description": "Action button on the demo-mode banner — opens Settings where live prices can be set up. Jargon-free wording (#1696)."
+  },
   "sortDistance": "Distance",
   "sortOpen24h": "24h",
   "sortRating": "Rating",
@@ -1517,6 +1524,10 @@
   "discardChangesKeepEditing": "Keep editing",
   "@discardChangesKeepEditing": {
     "description": "Dismiss action on the unsaved-changes dialog — stays on the form (#1693)."
+  },
+  "tankSyncSectionSubtitle": "Cloud sync across your devices",
+  "@tankSyncSectionSubtitle": {
+    "description": "Subtitle under the 'TankSync' settings section header — explains what the (brand-named) feature does so it isn't an unexplained label (#1696)."
   },
   "achievementSmoothDriver": "Smooth streak",
   "@achievementSmoothDriver": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -234,7 +234,8 @@
   "refreshPrices": "Actualiser les prix",
   "station": "Station",
   "locationDenied": "Autorisation de localisation refusée. Vous pouvez chercher par code postal.",
-  "demoModeBanner": "Mode démo. Configurez la clé API dans les paramètres.",
+  "demoModeBanner": "Mode démo – prix d'exemple affichés.",
+  "demoModeBannerAction": "Activer les prix réels",
   "sortDistance": "Distance",
   "cheap": "bon marché",
   "expensive": "cher",
@@ -1370,5 +1371,6 @@
   "discardChangesTitle": "Abandonner les modifications ?",
   "discardChangesBody": "Vous avez des modifications non enregistrées. Quitter maintenant les supprimera.",
   "discardChangesConfirm": "Abandonner",
-  "discardChangesKeepEditing": "Continuer la modification"
+  "discardChangesKeepEditing": "Continuer la modification",
+  "tankSyncSectionSubtitle": "Synchronisation cloud entre vos appareils"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1118,11 +1118,17 @@ abstract class AppLocalizations {
   /// **'Location permission denied. You can search by postal code.'**
   String get locationDenied;
 
-  /// No description provided for @demoModeBanner.
+  /// Demo-mode banner content shown for API-key countries with no key configured. Jargon-free per #1696 — names neither 'API key' nor any technical term.
   ///
   /// In en, this message translates to:
-  /// **'Demo mode. Configure API key in settings for live prices.'**
+  /// **'Demo mode — showing sample prices.'**
   String get demoModeBanner;
+
+  /// Action button on the demo-mode banner — opens Settings where live prices can be set up. Jargon-free wording (#1696).
+  ///
+  /// In en, this message translates to:
+  /// **'Get live prices'**
+  String get demoModeBannerAction;
 
   /// No description provided for @sortDistance.
   ///
@@ -5989,6 +5995,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Keep editing'**
   String get discardChangesKeepEditing;
+
+  /// Subtitle under the 'TankSync' settings section header — explains what the (brand-named) feature does so it isn't an unexplained label (#1696).
+  ///
+  /// In en, this message translates to:
+  /// **'Cloud sync across your devices'**
+  String get tankSyncSectionSubtitle;
 
   /// Title of the smoothDriver badge — five consecutive trips with driving-score >= 80 (#1041 phase 5).
   ///

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -533,6 +533,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get demoModeBanner => 'Демо режим. Настройте API ключа в настройките.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Разстояние';
 
   @override
@@ -3208,6 +3211,9 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -533,6 +533,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get demoModeBanner => 'Demo režim. Nastavte klíč API v nastavení.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Vzdálenost';
 
   @override
@@ -3208,6 +3211,9 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -534,6 +534,9 @@ class AppLocalizationsDa extends AppLocalizations {
       'Demo-tilstand. Konfigurer API-nøgle i indstillinger.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Afstand';
 
   @override
@@ -3206,6 +3209,9 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -531,8 +531,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Standortfreigabe abgelehnt. Sie können per PLZ suchen.';
 
   @override
-  String get demoModeBanner =>
-      'Demo-Modus. API-Schlüssel in den Einstellungen eingeben.';
+  String get demoModeBanner => 'Demo-Modus – Beispielpreise werden angezeigt.';
+
+  @override
+  String get demoModeBannerAction => 'Live-Preise aktivieren';
 
   @override
   String get sortDistance => 'Entfernung';
@@ -3233,6 +3235,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Weiter bearbeiten';
+
+  @override
+  String get tankSyncSectionSubtitle =>
+      'Cloud-Synchronisierung über deine Geräte hinweg';
 
   @override
   String get achievementSmoothDriver => 'Ruhige Serie';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -533,6 +533,9 @@ class AppLocalizationsEl extends AppLocalizations {
       'Λειτουργία επίδειξης. Ρυθμίστε το κλειδί API στις ρυθμίσεις.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Απόσταση';
 
   @override
@@ -3210,6 +3213,9 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -527,8 +527,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Location permission denied. You can search by postal code.';
 
   @override
-  String get demoModeBanner =>
-      'Demo mode. Configure API key in settings for live prices.';
+  String get demoModeBanner => 'Demo mode — showing sample prices.';
+
+  @override
+  String get demoModeBannerAction => 'Get live prices';
 
   @override
   String get sortDistance => 'Distance';
@@ -3201,6 +3203,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -534,6 +534,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get demoModeBanner => 'Modo demo. Configure la clave API en ajustes.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Distancia';
 
   @override
@@ -3209,6 +3212,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -532,6 +532,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get demoModeBanner => 'Demorežiim. Seadistage API võti seadetes.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Kaugus';
 
   @override
@@ -3203,6 +3206,9 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -533,6 +533,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get demoModeBanner => 'Demotila. Määritä API-avain asetuksissa.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Etäisyys';
 
   @override
@@ -3206,6 +3209,9 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -531,8 +531,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Autorisation de localisation refusée. Vous pouvez chercher par code postal.';
 
   @override
-  String get demoModeBanner =>
-      'Mode démo. Configurez la clé API dans les paramètres.';
+  String get demoModeBanner => 'Mode démo – prix d\'exemple affichés.';
+
+  @override
+  String get demoModeBannerAction => 'Activer les prix réels';
 
   @override
   String get sortDistance => 'Distance';
@@ -3232,6 +3234,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Continuer la modification';
+
+  @override
+  String get tankSyncSectionSubtitle =>
+      'Synchronisation cloud entre vos appareils';
 
   @override
   String get achievementSmoothDriver => 'Série souple';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -533,6 +533,9 @@ class AppLocalizationsHr extends AppLocalizations {
       'Demo način. Konfigurirajte API ključ u postavkama.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Udaljenost';
 
   @override
@@ -3205,6 +3208,9 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -535,6 +535,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'Demó mód. Állítsa be az API-kulcsot a beállításokban.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Távolság';
 
   @override
@@ -3210,6 +3213,9 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -535,6 +535,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Modalità demo. Configura la chiave API nelle impostazioni.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Distanza';
 
   @override
@@ -3209,6 +3212,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -534,6 +534,9 @@ class AppLocalizationsLt extends AppLocalizations {
       'Demo režimas. Nustatykite API raktą nustatymuose.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Atstumas';
 
   @override
@@ -3207,6 +3210,9 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -534,6 +534,9 @@ class AppLocalizationsLv extends AppLocalizations {
       'Demo režīms. Konfigurējiet API atslēgu iestatījumos.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Attālums';
 
   @override
@@ -3209,6 +3212,9 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -534,6 +534,9 @@ class AppLocalizationsNb extends AppLocalizations {
       'Demomodus. Konfigurer API-nøkkel i innstillinger.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Avstand';
 
   @override
@@ -3205,6 +3208,9 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -535,6 +535,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Demomodus. Configureer API-sleutel in instellingen.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Afstand';
 
   @override
@@ -3210,6 +3213,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -534,6 +534,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Tryb demo. Skonfiguruj klucz API w ustawieniach.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Odległość';
 
   @override
@@ -3208,6 +3211,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -535,6 +535,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Modo de demonstração. Configure a chave API nas definições.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Distância';
 
   @override
@@ -3209,6 +3212,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -533,6 +533,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get demoModeBanner => 'Mod demo. Configurați cheia API în setări.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Distanță';
 
   @override
@@ -3208,6 +3211,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -533,6 +533,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get demoModeBanner => 'Demo režim. Nastavte kľúč API v nastaveniach.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Vzdialenosť';
 
   @override
@@ -3209,6 +3212,9 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -533,6 +533,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get demoModeBanner => 'Demo način. Nastavite API ključ v nastavitvah.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Razdalja';
 
   @override
@@ -3203,6 +3206,9 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -534,6 +534,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Demoläge. Konfigurera API-nyckel i inställningar.';
 
   @override
+  String get demoModeBannerAction => 'Get live prices';
+
+  @override
   String get sortDistance => 'Avstånd';
 
   @override
@@ -3207,6 +3210,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get discardChangesKeepEditing => 'Keep editing';
+
+  @override
+  String get tankSyncSectionSubtitle => 'Cloud sync across your devices';
 
   @override
   String get achievementSmoothDriver => 'Smooth streak';

--- a/test/features/search/presentation/widgets/demo_mode_banner_test.dart
+++ b/test/features/search/presentation/widgets/demo_mode_banner_test.dart
@@ -127,8 +127,31 @@ void main() {
           ],
         );
 
-        // The demo banner should have a TextButton (API key setup label)
+        // The demo banner should have a TextButton (the call-to-action).
         expect(find.byType(TextButton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'demo banner copy is jargon-free — no "API key" wording (#1696)',
+      (tester) async {
+        final storage = mockHiveStorageOverride();
+        when(() => storage.mock.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const DemoModeBanner(country: Countries.germany),
+          overrides: [
+            storage.override,
+            activeCountryOverride(Countries.germany),
+          ],
+        );
+
+        // #1696 — neither the banner content nor its action exposes the
+        // "API key" jargon to a casual user.
+        expect(find.textContaining('API key'), findsNothing);
+        expect(find.textContaining('API-Schlüssel'), findsNothing);
+        expect(find.text('Get live prices'), findsOneWidget);
       },
     );
   });


### PR DESCRIPTION
## What

Closes #1696 — child of epic #1689 (UX audit, dimension 7: Content & Microcopy).

- **Demo-mode banner** exposed "API key" jargon — in both the banner copy *and* its action button — to casual users who never asked for one. The copy is now **"Demo mode — showing sample prices."** and the action reads **"Get live prices"** (it still opens Settings, where the technical setup lives — the jargon stays only on that dedicated screen).
- **TankSync settings section** rendered the bare brand literal `'TankSync'` with no explanation. `_FoldableSection` gains an optional `subtitle`; the section now shows a localized **"Cloud sync across your devices"** descriptor, and the brand title carries an `// i18n-ignore`.

`demoModeBanner` reworded; new `demoModeBannerAction` + `tankSyncSectionSubtitle` strings (en/de/fr).

## Scope of finding 1

The third finding — auditing the pervasive `?? 'English literal'` fallbacks — is, per **this issue's own wording** ("coordinated with epic #1657"), owned by the i18n epic #1657, whose children #1660-#1663 are the per-surface localization sweeps. It is not re-done here.

## Tests

The demo banner copy is jargon-free (no "API key" / "API-Schlüssel"; action reads "Get live prices"). Whole-repo `flutter analyze`, module-boundary, l10n-completeness and hardcoded-string guards green; 208 search/profile/lint tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
