### PR TITLE
fix(a11y): BrandLogo semantic label, 48dp rating-star tap targets, 3x text-scale audit (#1687)

### DIFF
--- a/lib/core/widgets/brand_logo.dart
+++ b/lib/core/widgets/brand_logo.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../l10n/app_localizations.dart';
 import '../utils/brand_logo_mapper.dart';
 
 /// Displays a brand logo for a fuel station, with automatic fallback
@@ -23,11 +24,19 @@ class BrandLogo extends StatelessWidget {
   Widget build(BuildContext context) {
     final url = BrandLogoMapper.logoUrl(brand);
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
 
-    if (url == null) {
-      return _fallbackIcon(theme);
-    }
+    // #1687 — a screen reader previously announced nothing for the
+    // logo on every station card. `image: true` marks it as a
+    // graphic; the label names the brand it depicts.
+    return Semantics(
+      label: l10n?.brandLogoLabel(brand) ?? '$brand logo',
+      image: true,
+      child: url == null ? _fallbackIcon(theme) : _networkLogo(url, theme),
+    );
+  }
 
+  Widget _networkLogo(String url, ThemeData theme) {
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
       child: Image.network(

--- a/lib/core/widgets/star_rating.dart
+++ b/lib/core/widgets/star_rating.dart
@@ -1,4 +1,8 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
 
 /// Interactive 5-star rating widget.
 class StarRating extends StatelessWidget {
@@ -15,19 +19,34 @@ class StarRating extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    // #1687 — each star is an icon-only tappable affordance. The icon
+    // glyph stays at [starSize], but the tap target is padded out to
+    // at least 48 dp (the Material / WCAG minimum) so it is reliably
+    // hittable. Each star also carries a semantic label so a screen
+    // reader announces the rating action instead of silence.
+    final tapTarget = math.max(48.0, starSize);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: List.generate(5, (index) {
         final starNumber = index + 1;
         final isFilled = rating != null && starNumber <= rating!;
-        return GestureDetector(
-          onTap: () => onRatingChanged(starNumber),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 2),
-            child: Icon(
-              isFilled ? Icons.star : Icons.star_border,
-              color: isFilled ? Colors.amber : Colors.grey.shade400,
-              size: starSize,
+        return Semantics(
+          button: true,
+          label: l10n?.ratingStarLabel(starNumber) ?? 'Rate $starNumber stars',
+          child: GestureDetector(
+            onTap: () => onRatingChanged(starNumber),
+            behavior: HitTestBehavior.opaque,
+            child: SizedBox(
+              width: tapTarget,
+              height: tapTarget,
+              child: Center(
+                child: Icon(
+                  isFilled ? Icons.star : Icons.star_border,
+                  color: isFilled ? Colors.amber : Colors.grey.shade400,
+                  size: starSize,
+                ),
+              ),
             ),
           ),
         );

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -613,6 +613,22 @@
       }
     }
   },
+  "brandLogoLabel": "{brand}-Logo",
+  "@brandLogoLabel": {
+    "placeholders": {
+      "brand": {
+        "type": "String"
+      }
+    }
+  },
+  "ratingStarLabel": "{count, plural, =1{1 Stern bewerten} other{Mit {count} Sternen bewerten}}",
+  "@ratingStarLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "passwordStrengthWeak": "Schwach",
   "passwordStrengthFair": "Mittel",
   "passwordStrengthStrong": "Stark",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -632,6 +632,22 @@
       }
     }
   },
+  "brandLogoLabel": "{brand} logo",
+  "@brandLogoLabel": {
+    "placeholders": {
+      "brand": {
+        "type": "String"
+      }
+    }
+  },
+  "ratingStarLabel": "{count, plural, =1{Rate 1 star} other{Rate {count} stars}}",
+  "@ratingStarLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "passwordStrengthWeak": "Weak",
   "passwordStrengthFair": "Fair",
   "passwordStrengthStrong": "Strong",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -613,6 +613,22 @@
       }
     }
   },
+  "brandLogoLabel": "{brand}-Logo",
+  "@brandLogoLabel": {
+    "placeholders": {
+      "brand": {
+        "type": "String"
+      }
+    }
+  },
+  "ratingStarLabel": "{count, plural, =1{1 Stern bewerten} other{Mit {count} Sternen bewerten}}",
+  "@ratingStarLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "passwordStrengthWeak": "Schwach",
   "passwordStrengthFair": "Mittel",
   "passwordStrengthStrong": "Stark",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -632,6 +632,22 @@
       }
     }
   },
+  "brandLogoLabel": "{brand} logo",
+  "@brandLogoLabel": {
+    "placeholders": {
+      "brand": {
+        "type": "String"
+      }
+    }
+  },
+  "ratingStarLabel": "{count, plural, =1{Rate 1 star} other{Rate {count} stars}}",
+  "@ratingStarLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "passwordStrengthWeak": "Weak",
   "passwordStrengthFair": "Fair",
   "passwordStrengthStrong": "Strong",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -499,6 +499,8 @@
   "freshnessAgo": "il y a",
   "freshnessStale": "Périmé",
   "freshnessBadgeSemantics": "Fraîcheur des données : {age}",
+  "brandLogoLabel": "Logo {brand}",
+  "ratingStarLabel": "{count, plural, =1{Noter 1 étoile} other{Noter {count} étoiles}}",
   "alertStatsActive": "Actives",
   "alertStatsToday": "Aujourd'hui",
   "alertStatsThisWeek": "Cette semaine",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2612,6 +2612,18 @@ abstract class AppLocalizations {
   /// **'Data freshness: {age}'**
   String freshnessBadgeSemantics(String age);
 
+  /// No description provided for @brandLogoLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{brand} logo'**
+  String brandLogoLabel(String brand);
+
+  /// No description provided for @ratingStarLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Rate 1 star} other{Rate {count} stars}}'**
+  String ratingStarLabel(int count);
+
   /// No description provided for @passwordStrengthWeak.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1356,6 +1356,22 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1356,6 +1356,22 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1354,6 +1354,22 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1367,6 +1367,22 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand-Logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Mit $count Sternen bewerten',
+      one: '1 Stern bewerten',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Schwach';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1358,6 +1358,22 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1348,6 +1348,22 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1357,6 +1357,22 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1351,6 +1351,22 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1354,6 +1354,22 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1362,6 +1362,22 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return 'Logo $brand';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Noter $count étoiles',
+      one: 'Noter 1 étoile',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1353,6 +1353,22 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1358,6 +1358,22 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1357,6 +1357,22 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1355,6 +1355,22 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1357,6 +1357,22 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1353,6 +1353,22 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1358,6 +1358,22 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1356,6 +1356,22 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1357,6 +1357,22 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1356,6 +1356,22 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1357,6 +1357,22 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1351,6 +1351,22 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1355,6 +1355,22 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String brandLogoLabel(String brand) {
+    return '$brand logo';
+  }
+
+  @override
+  String ratingStarLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Rate $count stars',
+      one: 'Rate 1 star',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get passwordStrengthWeak => 'Weak';
 
   @override

--- a/test/a11y/text_scaling_test.dart
+++ b/test/a11y/text_scaling_test.dart
@@ -10,17 +10,23 @@ import '../fixtures/stations.dart';
 import '../helpers/mock_providers.dart';
 import '../helpers/pump_app.dart';
 
-/// Verifies that key widgets render without overflow at 1.5x and 2.0x
-/// text scaling, covering the accessibility requirement from issue #76.
+/// Verifies that key widgets render without overflow at 1.5x, 2.0x
+/// and 3.0x text scaling, covering the accessibility requirement from
+/// issues #76 and #1687.
 ///
 /// The tests do NOT assert pixel-perfect layout — they verify that
 /// Flutter's layout engine does not report overflow errors when text
 /// is scaled up, which would manifest as yellow/black striped bars
 /// on real devices.
+///
+/// #1687 — the 3.0x rung is the audit lock for the dense station-card
+/// surfaces (status / cheapest / loyalty badges, amenity + payment
+/// chips): hard-coded `fontSize:` values on those micro-labels must
+/// not overflow their rows at the maximum OS text scale.
 void main() {
   // ─── StationCard ─────────────────────────────────────────────
   group('StationCard text scaling', () {
-    for (final scale in [1.5, 2.0]) {
+    for (final scale in [1.5, 2.0, 3.0]) {
       testWidgets('renders without overflow at ${scale}x', (tester) async {
         await pumpScaledApp(
           tester,
@@ -97,7 +103,7 @@ void main() {
 
   // ─── AllPricesStationCard ────────────────────────────────────
   group('AllPricesStationCard text scaling', () {
-    for (final scale in [1.5, 2.0]) {
+    for (final scale in [1.5, 2.0, 3.0]) {
       testWidgets('renders without overflow at ${scale}x', (tester) async {
         await pumpScaledApp(
           tester,
@@ -118,7 +124,7 @@ void main() {
 
   // ─── SortSelector ───────────────────────────────────────────
   group('SortSelector text scaling', () {
-    for (final scale in [1.5, 2.0]) {
+    for (final scale in [1.5, 2.0, 3.0]) {
       testWidgets('renders without overflow at ${scale}x', (tester) async {
         await pumpScaledApp(
           tester,
@@ -137,7 +143,7 @@ void main() {
 
   // ─── UserPositionBar (with position) ─────────────────────────
   group('UserPositionBar text scaling', () {
-    for (final scale in [1.5, 2.0]) {
+    for (final scale in [1.5, 2.0, 3.0]) {
       testWidgets('renders with known position at ${scale}x',
           (tester) async {
         await pumpScaledApp(
@@ -172,7 +178,7 @@ void main() {
 
   // ─── Station list (multiple cards) ───────────────────────────
   group('Station list text scaling', () {
-    for (final scale in [1.5, 2.0]) {
+    for (final scale in [1.5, 2.0, 3.0]) {
       testWidgets('renders multiple station cards at ${scale}x',
           (tester) async {
         await pumpScaledApp(
@@ -196,7 +202,7 @@ void main() {
 
   // ─── FavoritesScreen empty state ──────────────────────────────
   group('Favorites empty state text scaling', () {
-    for (final scale in [1.5, 2.0]) {
+    for (final scale in [1.5, 2.0, 3.0]) {
       testWidgets('renders empty favorites hint at ${scale}x',
           (tester) async {
         // Simulate the empty-favorites UI (icon + two text widgets)
@@ -233,6 +239,12 @@ void main() {
   });
 
   // ─── Settings-style list tiles ────────────────────────────────
+  // #1687 — capped at 2.0x: this group pumps raw Material `ListTile`s
+  // as a fixture, and `ListTile`'s fixed-height slots overflow at 3.0x
+  // as a framework characteristic unrelated to this app's hard-coded
+  // `fontSize:` values. The app's own settings rows use SettingsMenuTile
+  // / _FoldableSection, not raw ListTile. The 3.0x audit rung applies
+  // to the dense station-card surfaces above.
   group('Settings list tile text scaling', () {
     for (final scale in [1.5, 2.0]) {
       testWidgets('renders typical settings tiles at ${scale}x',

--- a/test/core/widgets/brand_logo_test.dart
+++ b/test/core/widgets/brand_logo_test.dart
@@ -53,5 +53,39 @@ void main() {
       expect(renderBox.size.width, 48);
       expect(renderBox.size.height, 48);
     });
+
+    // #1687 — the logo previously carried no Semantics; a screen reader
+    // announced nothing for the brand graphic on every station card.
+    testWidgets('exposes an image semantic label naming the brand',
+        (tester) async {
+      await pumpApp(tester, const BrandLogo(brand: 'Shell'));
+
+      final semantics = tester
+          .widgetList<Semantics>(
+            find.descendant(
+              of: find.byType(BrandLogo),
+              matching: find.byType(Semantics),
+            ),
+          )
+          .first;
+      expect(semantics.properties.label, contains('Shell'));
+      expect(semantics.properties.image, isTrue);
+    });
+
+    testWidgets('fallback-icon path is still labelled', (tester) async {
+      // Unknown brand → fallback icon, but the label must remain.
+      await pumpApp(tester, const BrandLogo(brand: 'UnknownBrand'));
+
+      final semantics = tester
+          .widgetList<Semantics>(
+            find.descendant(
+              of: find.byType(BrandLogo),
+              matching: find.byType(Semantics),
+            ),
+          )
+          .first;
+      expect(semantics.properties.label, contains('UnknownBrand'));
+      expect(semantics.properties.image, isTrue);
+    });
   });
 }

--- a/test/core/widgets/star_rating_test.dart
+++ b/test/core/widgets/star_rating_test.dart
@@ -142,4 +142,53 @@ void main() {
       expect(tappedRating, 1);
     });
   });
+
+  // #1687 — each star is an icon-only tappable affordance; before this
+  // fix the tap target was the bare ~28-32 dp icon glyph and a screen
+  // reader announced nothing.
+  group('StarRating accessibility (#1687)', () {
+    Widget harness() => MaterialApp(
+          home: Scaffold(
+            body: StarRating(rating: 2, onRatingChanged: (_) {}),
+          ),
+        );
+
+    testWidgets('each star has at least a 48dp tap target', (tester) async {
+      await tester.pumpWidget(harness());
+
+      final boxes = tester
+          .widgetList<SizedBox>(
+            find.descendant(
+              of: find.byType(StarRating),
+              matching: find.byType(SizedBox),
+            ),
+          )
+          .where((b) => (b.width ?? 0) >= 48 && (b.height ?? 0) >= 48)
+          .toList();
+      expect(boxes.length, 5);
+    });
+
+    testWidgets('star tap targets meet the Android tap-target guideline',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(harness());
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      handle.dispose();
+    });
+
+    testWidgets('each star exposes a button semantics label', (tester) async {
+      await tester.pumpWidget(harness());
+
+      // Bare harness has no AppLocalizations → the fallback label.
+      for (var n = 1; n <= 5; n++) {
+        final semantics = tester.widgetList<Semantics>(find.byType(Semantics));
+        final star = semantics.where(
+          (s) => s.properties.label == 'Rate $n stars',
+        );
+        expect(star.length, 1, reason: 'star $n missing its semantics label');
+        expect(star.first.properties.button, isTrue);
+      }
+    });
+  });
 }


### PR DESCRIPTION
Closes #1687 — quality-audit findings A1/A2/A3 (epic #1678).

## What

- **BrandLogo** now exposes `Semantics(image: true, label: localized "{brand} logo")` — previously a screen reader announced nothing for the brand graphic on every station card. Network-image and fallback-icon paths both covered.
- **StarRating** stars were icon-only `GestureDetector`s with a ~28-32 dp tap target (below the 48 dp Material/WCAG floor) and no semantics. Each star now has a ≥48 dp tap target and a localized `ratingStarLabel` button semantic ("Rate N stars", ICU-plural). Fixes both call sites (`StationRatingSection`, EV station-detail) via the shared widget.
- **Text-scaling audit**: the a11y text-scaling suite now also asserts **3.0x** (max OS scale) for every real-widget group. All dense station-card `fontSize:` micro-labels (status / cheapest / loyalty badges, amenity + payment chips) survive 3x without overflow. The synthetic raw-`ListTile` group stays at 2.0x — `ListTile`'s fixed-height slots overflow at 3x as a framework characteristic.

New ARB strings `brandLogoLabel` + `ratingStarLabel` (en/de/fr).

## Tests

Brand-logo semantic label (both paths); star tap targets meet `androidTapTargetGuideline` + carry button semantics; text-scaling suite extended to 3.0x. Whole-repo `flutter analyze` + hardcoded-string lint green; no codegen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
