### PR TITLE
docs(uk,consumption): annotate the #1704 / #1705 decision context

### DIFF
--- a/lib/features/consumption/providers/psa_fuel_level_provider.dart
+++ b/lib/features/consumption/providers/psa_fuel_level_provider.dart
@@ -53,6 +53,18 @@ part 'psa_fuel_level_provider.g.dart';
 /// Tests override this with a service backed by a fake transport so
 /// they can exercise the gate + decoder pipe without touching real
 /// Bluetooth.
+///
+/// ### Completion path (#1705, investigated 2026-05-16)
+///
+/// The decoder ([PsaFuelLevelCanDecoder]) is complete — this seam is
+/// the only gap. To wire it: have `Obd2ConnectionService` (already a
+/// provider — `obd2Connection`) hold and expose its active
+/// `Obd2Service?` (it constructs one per connection in `connect()`),
+/// then point this provider at that instead of `null`. No hardware is
+/// needed for the wiring — only validating the decoder's big-endian
+/// `0x0E6` assumption against a real PSA trace is hardware-blocked.
+/// This is the same `Obd2Service`-ownership problem as epic #1665. The
+/// keep / remove decision is tracked by #1705.
 @riverpod
 Obd2Service? psaFuelLevelObd2Service(Ref ref) => null;
 

--- a/lib/features/station_services/uk/uk_fuel_finder_service.dart
+++ b/lib/features/station_services/uk/uk_fuel_finder_service.dart
@@ -35,6 +35,24 @@ import 'uk_fuel_finder_token_manager.dart';
 /// Keeping the gate inline (not in a central config) deliberately
 /// minimises the blast radius of this dormant code path.
 ///
+/// ### Scheme status — verified 2026-05-16 (#1704)
+///
+/// The Fuel Finder statutory scheme is now **live and enforced**: since
+/// 2 Feb 2026 every UK forecourt must report price changes to the
+/// central database within 30 minutes, and from 1 May 2026 the CMA can
+/// fine non-compliant sites. The legacy voluntary per-retailer scheme
+/// that [UkStationService] consumes has had its GOV.UK guidance page
+/// withdrawn and may be decommissioned as the statutory scheme matures
+/// — so this service is a forward port, not dead code.
+///
+/// API access still requires OAuth2 client-credentials registration at
+/// `developer.fuel-finder.service.gov.uk`; there is no unauthenticated
+/// public JSON feed (a twice-daily CSV download exists as an
+/// alternative). The exact token + data endpoint paths defined below
+/// are best-effort guesses pending that registration — verify them
+/// once credentials exist. The keep / register decision is tracked by
+/// #1704.
+///
 /// ### File split (#563)
 ///
 /// OAuth2 lifecycle lives in


### PR DESCRIPTION
## Summary

Captures the investigation results for two open decision issues directly in the code, so the context survives next to the dormant code rather than only in issue comments. **Both issues stay open** — these are doc-only comment additions, not the decisions themselves.

- **#1704** — `uk_fuel_finder_service.dart`: records that the Fuel Finder statutory scheme is now live and enforced (CMA fines from 1 May 2026), that the voluntary per-retailer scheme `UkStationService` uses has had its GOV.UK guidance withdrawn, and that the scaffold's endpoint paths are unverified pending OAuth2 registration.
- **#1705** — `psa_fuel_level_provider.dart`: records that `PsaFuelLevelCanDecoder` is complete and the only gap is the `psaFuelLevelObd2Service` seam — with the concrete wiring path to close it and a note that only the big-endian `0x0E6` validation is hardware-blocked.

Comment-only changes; `flutter analyze` clean. No behaviour change.

Re #1704, re #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)
