### PR TITLE
refactor(sync): integrate the guided create-database wizard into SyncSetupScreen + surface ntfy setup (#1703)

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -12,6 +12,7 @@ import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/consumption_tab_visibility.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../../feature_management/domain/feature_dependency_graph.dart';
+import '../../../sync/presentation/widgets/ntfy_setup.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
 import '../widgets/feature_management_section.dart';
@@ -100,7 +101,16 @@ class ProfileScreen extends ConsumerWidget {
               // brand-named section isn't an unexplained label.
               subtitle: l?.tankSyncSectionSubtitle ??
                   'Cloud sync across your devices',
-              child: const TankSyncSection(),
+              // #1703 — the ntfy.sh push-setup card sits directly below
+              // the sync status/actions; it self-handles the not-yet-
+              // connected state with a "Connect TankSync first" hint.
+              child: const Column(
+                children: [
+                  TankSyncSection(),
+                  SizedBox(height: 8),
+                  NtfySetupCard(),
+                ],
+              ),
             ),
             const SizedBox(height: 8),
           ],

--- a/lib/features/sync/presentation/screens/sync_setup_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_setup_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/sync/sync_config.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../data/auth_error_mapper.dart';
 import '../../providers/sync_setup_provider.dart';
+import '../widgets/anon_key_field.dart';
 import '../widgets/auth_form_widget.dart';
 import '../widgets/qr_scanner_screen.dart';
 import '../widgets/sync_credentials_step.dart';
@@ -15,6 +16,7 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../widgets/sync_done_step.dart';
 import '../widgets/sync_mode_step.dart';
+import '../widgets/wizard_create_new.dart';
 
 /// Clean 3-step sync setup: Mode -> Credentials (if needed) -> Auth -> Done.
 ///
@@ -169,6 +171,30 @@ class _SyncSetupScreenState extends ConsumerState<SyncSetupScreen> {
               builder: (context, _) {
                 final canContinue = _urlController.text.trim().isNotEmpty &&
                     _keyController.text.trim().isNotEmpty;
+                // #1703 — private mode walks the user through creating
+                // their own Supabase database with the guided wizard
+                // flow instead of a bare credentials form. The guide's
+                // final step still collects the URL + key, so an
+                // experienced user can skip ahead and paste existing
+                // credentials.
+                if (setup.selectedMode == SyncMode.private) {
+                  return WizardCreateNew(
+                    currentStep: setup.createDbStep,
+                    urlController: _urlController,
+                    keyController: _keyController,
+                    keyField: AnonKeyField(
+                      controller: _keyController,
+                      showKey: setup.showKey,
+                      onToggleVisibility: ctrl.toggleKeyVisibility,
+                      onChanged: ctrl.touch,
+                    ),
+                    onBack: ctrl.prevCreateDbStep,
+                    onNext: ctrl.nextCreateDbStep,
+                    onContinue: canContinue
+                        ? () => ctrl.goToStep(SyncSetupStep.auth)
+                        : null,
+                  );
+                }
                 return SyncCredentialsStep(
                   selectedMode: setup.selectedMode,
                   urlController: _urlController,

--- a/lib/features/sync/providers/sync_setup_provider.dart
+++ b/lib/features/sync/providers/sync_setup_provider.dart
@@ -16,12 +16,18 @@ class SyncSetupState {
   final String? error;
   final bool showKey;
 
+  /// Sub-step (0-2) of the guided "create your own database" flow shown
+  /// in the credentials step for [SyncMode.private] (#1703). Ignored for
+  /// every other mode. Reset to 0 each time a mode is (re)selected.
+  final int createDbStep;
+
   const SyncSetupState({
     this.step = SyncSetupStep.mode,
     this.selectedMode = SyncMode.none,
     this.isLoading = false,
     this.error,
     this.showKey = false,
+    this.createDbStep = 0,
   });
 
   SyncSetupState copyWith({
@@ -31,6 +37,7 @@ class SyncSetupState {
     String? error,
     bool clearError = false,
     bool? showKey,
+    int? createDbStep,
   }) {
     return SyncSetupState(
       step: step ?? this.step,
@@ -38,6 +45,7 @@ class SyncSetupState {
       isLoading: isLoading ?? this.isLoading,
       error: clearError ? null : (error ?? this.error),
       showKey: showKey ?? this.showKey,
+      createDbStep: createDbStep ?? this.createDbStep,
     );
   }
 }
@@ -55,8 +63,20 @@ class SyncSetupController extends _$SyncSetupController {
       step: mode == SyncMode.community
           ? SyncSetupStep.auth
           : SyncSetupStep.credentials,
+      // Restart the guided create-database flow whenever a mode is picked.
+      createDbStep: 0,
     );
   }
+
+  /// Advances the guided create-database flow (#1703) one sub-step.
+  void nextCreateDbStep() =>
+      state = state.copyWith(createDbStep: state.createDbStep + 1);
+
+  /// Steps the guided create-database flow (#1703) back one sub-step,
+  /// clamped at 0.
+  void prevCreateDbStep() => state = state.copyWith(
+        createDbStep: state.createDbStep > 0 ? state.createDbStep - 1 : 0,
+      );
 
   void toggleKeyVisibility() =>
       state = state.copyWith(showKey: !state.showKey);

--- a/lib/features/sync/providers/sync_setup_provider.g.dart
+++ b/lib/features/sync/providers/sync_setup_provider.g.dart
@@ -42,7 +42,7 @@ final class SyncSetupControllerProvider
 }
 
 String _$syncSetupControllerHash() =>
-    r'abedbdcdb726fa9b7577c621f83ca81de0c43243';
+    r'5f20220cacde7f29db9b1de4a88ac486fe23eb0d';
 
 abstract class _$SyncSetupController extends $Notifier<SyncSetupState> {
   SyncSetupState build();

--- a/test/features/sync/presentation/screens/sync_setup_screen_private_wizard_test.dart
+++ b/test/features/sync/presentation/screens/sync_setup_screen_private_wizard_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/sync/presentation/screens/sync_setup_screen.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/anon_key_field.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/sync_mode_card.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/wizard_create_new.dart';
+import 'package:tankstellen/features/sync/presentation/widgets/sync_credentials_step.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// #1703 — the private ("Base privée") sync mode walks the user through
+/// the guided create-database wizard flow; "join a group" keeps the
+/// plain credentials form.
+void main() {
+  group('SyncSetupScreen — credentials step', () {
+    testWidgets('private mode renders the guided WizardCreateNew flow',
+        (tester) async {
+      await pumpApp(tester, const SyncSetupScreen());
+
+      // Pick the "Private Database" mode card.
+      await tester.tap(
+        find.widgetWithIcon(SyncModeCard, Icons.lock_outline),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WizardCreateNew), findsOneWidget);
+      expect(find.byType(SyncCredentialsStep), findsNothing);
+      // The guided flow shows a step progress bar — the bare form never
+      // does.
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('join-a-group mode keeps the plain credentials form',
+        (tester) async {
+      await pumpApp(tester, const SyncSetupScreen());
+
+      await tester.tap(
+        find.widgetWithIcon(SyncModeCard, Icons.group_outlined),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SyncCredentialsStep), findsOneWidget);
+      expect(find.byType(WizardCreateNew), findsNothing);
+    });
+
+    testWidgets('the guided flow advances through its sub-steps',
+        (tester) async {
+      await pumpApp(tester, const SyncSetupScreen());
+
+      await tester.tap(
+        find.widgetWithIcon(SyncModeCard, Icons.lock_outline),
+      );
+      await tester.pumpAndSettle();
+
+      // Step 1 — the create-Supabase-project guide opens with an
+      // external-link action button and no credentials fields yet.
+      expect(find.byIcon(Icons.open_in_new), findsOneWidget);
+      expect(find.byType(AnonKeyField), findsNothing);
+
+      // The single FilledButton is the wizard's Next/Continue control;
+      // advancing twice reaches the credentials sub-step.
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(FilledButton));
+      await tester.pumpAndSettle();
+
+      // The credentials sub-step surfaces the URL field + the anon-key
+      // field.
+      expect(find.byType(AnonKeyField), findsOneWidget);
+      expect(find.byType(TextField), findsNWidgets(2));
+    });
+  });
+}

--- a/test/features/sync/providers/sync_setup_provider_test.dart
+++ b/test/features/sync/providers/sync_setup_provider_test.dart
@@ -63,4 +63,38 @@ void main() {
     expect(s.error, 'nope');
     expect(s.isLoading, isFalse);
   });
+
+  group('createDbStep — guided create-database flow (#1703)', () {
+    test('defaults to 0', () {
+      final c = makeContainer();
+      expect(c.read(syncSetupControllerProvider).createDbStep, 0);
+    });
+
+    test('nextCreateDbStep advances, prevCreateDbStep goes back', () {
+      final c = makeContainer();
+      final ctrl = c.read(syncSetupControllerProvider.notifier);
+      ctrl.nextCreateDbStep();
+      ctrl.nextCreateDbStep();
+      expect(c.read(syncSetupControllerProvider).createDbStep, 2);
+      ctrl.prevCreateDbStep();
+      expect(c.read(syncSetupControllerProvider).createDbStep, 1);
+    });
+
+    test('prevCreateDbStep clamps at 0', () {
+      final c = makeContainer();
+      final ctrl = c.read(syncSetupControllerProvider.notifier);
+      ctrl.prevCreateDbStep();
+      expect(c.read(syncSetupControllerProvider).createDbStep, 0);
+    });
+
+    test('selectMode resets the guided step to 0', () {
+      final c = makeContainer();
+      final ctrl = c.read(syncSetupControllerProvider.notifier);
+      ctrl.nextCreateDbStep();
+      ctrl.nextCreateDbStep();
+      expect(c.read(syncSetupControllerProvider).createDbStep, 2);
+      ctrl.selectMode(SyncMode.private);
+      expect(c.read(syncSetupControllerProvider).createDbStep, 0);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

`SyncWizardScreen`'s guided create-database flow and the `NtfySetupCard` were both unreachable. Per the maintainer decision on #1703 — *keep both screens, integrate the wizard's guidance into the live flow* — this:

- **Folds the guided flow into `SyncSetupScreen`.** The private ("Base privée") credentials step now renders `WizardCreateNew` — the step-by-step "create your own Supabase project" guide (create project → enable anonymous sign-ins → copy credentials) — instead of a bare URL/key form. "Join a group" keeps the plain QR/credentials form. An experienced user with an existing database can skip ahead and paste credentials on the final sub-step.
- **Surfaces `NtfySetupCard`** in Settings → TankSync, directly below the sync status/actions. The card self-handles the not-yet-connected state with a "Connect TankSync first" hint.

A `createDbStep` field + `nextCreateDbStep`/`prevCreateDbStep` controller methods track the guided sub-step; it resets to 0 on every mode (re)selection.

`SyncWizardScreen` itself is retained per the "keep both" decision.

## Verification

- Provider tests cover `createDbStep` default, advance/clamp, and the reset-on-`selectMode`.
- Widget tests: private mode renders the guided `WizardCreateNew` flow, join-a-group keeps the plain `SyncCredentialsStep`, and the guided flow advances to its credentials sub-step.
- `flutter analyze` clean, module-boundary check passes, `build_runner` regenerated, 367 tests green across the sync + profile-screen suites and the no-hardcoded-strings guard.

Closes #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
