### PR TITLE
feat(features): enforce the build-channel gate in FeatureFlags (#1674)

### DIFF
--- a/lib/features/feature_management/application/feature_flags_provider.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/logging/error_logger.dart';
 import '../data/feature_flags_repository.dart';
+import '../domain/build_channel.dart';
 import '../domain/feature.dart';
 import '../domain/feature_dependency_graph.dart';
 import '../domain/feature_manifest.dart';
@@ -29,6 +30,20 @@ FeatureFlagsRepository? featureFlagsRepository(Ref ref) {
 /// to inject a synthetic manifest (e.g. for cycle-rejection coverage).
 @Riverpod(keepAlive: true)
 FeatureManifest featureManifest(Ref ref) => FeatureManifest.defaultManifest;
+
+/// The build channel this app instance is running as (#1674).
+///
+/// Resolved from the compile-time `--dart-define=CHANNEL`, baked by
+/// CI / fastlane. Any value other than `beta` — including an absent
+/// define (a local `flutter run`) — resolves to
+/// [BuildChannel.production]: production is the safe default so a
+/// mis-configured build never accidentally exposes beta-only features.
+/// Overridable in tests via `ProviderContainer.overrides`.
+@Riverpod(keepAlive: true)
+BuildChannel buildChannel(Ref ref) {
+  const raw = String.fromEnvironment('CHANNEL');
+  return raw == 'beta' ? BuildChannel.beta : BuildChannel.production;
+}
 
 /// Central feature-flag store (#1373 phase 1).
 ///
@@ -61,12 +76,19 @@ class FeatureFlags extends _$FeatureFlags {
   FutureOr<Set<Feature>> build() async {
     final manifest = ref.watch(featureManifestProvider);
     assertNoCycles(manifest);
+    final channel = ref.watch(buildChannelProvider);
     final repo = ref.watch(featureFlagsRepositoryProvider);
     if (repo == null) {
-      return manifest.defaultEnabledSet();
+      return manifest.defaultEnabledSet(channel);
     }
     try {
-      return await repo.loadEnabled();
+      // First launch resolves to the channel's opt-in/opt-out defaults;
+      // a populated box returns its persisted set (#1674).
+      final loaded = await repo.loadEnabled(channel);
+      // #1674 — force-off any persisted feature that is not available
+      // in this build channel (e.g. a beta-only feature in a
+      // production build).
+      return _availableInChannel(loaded, manifest, channel);
     } catch (e, st) {
       // #1681 — a Hive read failure must not be silent. Log it through
       // the central pipeline, then fall back to manifest defaults so
@@ -77,19 +99,39 @@ class FeatureFlags extends _$FeatureFlags {
         st,
         context: {'op': 'FeatureFlags.loadEnabled'},
       );
-      return manifest.defaultEnabledSet();
+      return manifest.defaultEnabledSet(channel);
     }
   }
+
+  /// Drops every feature not available in [channel] — the channel gate
+  /// applied to a persisted set (#1674).
+  static Set<Feature> _availableInChannel(
+    Set<Feature> features,
+    FeatureManifest manifest,
+    BuildChannel channel,
+  ) =>
+      features
+          .where((f) => manifest.entries[f]?.isAvailableIn(channel) ?? false)
+          .toSet();
 
   /// Enables [feature], throwing [StateError] when a prerequisite is
   /// disabled. The error message names the missing prerequisites so the
   /// Phase 2 UI can surface a tooltip without a second lookup.
   Future<void> enable(Feature feature) async {
     final manifest = ref.read(featureManifestProvider);
+    final channel = ref.read(buildChannelProvider);
     // Await the in-flight (or resolved) build so a flip during the
     // initial Hive load operates on the persisted set, not stale state.
     final current = await future;
     if (current.contains(feature)) return;
+    // #1674 — a feature not available in this build channel can never
+    // be enabled, regardless of its prerequisites.
+    if (!manifest.entryFor(feature).isAvailableIn(channel)) {
+      throw StateError(
+        'Cannot enable ${feature.name}: not available in the '
+        '${channel.name} build channel',
+      );
+    }
     if (!canEnable(feature, manifest, current)) {
       final entry = manifest.entryFor(feature);
       final missing = entry.requires
@@ -155,5 +197,7 @@ class FeatureFlags extends _$FeatureFlags {
 @Riverpod(keepAlive: true)
 Set<Feature> enabledFeatures(Ref ref) {
   return ref.watch(featureFlagsProvider).asData?.value ??
-      ref.watch(featureManifestProvider).defaultEnabledSet();
+      ref
+          .watch(featureManifestProvider)
+          .defaultEnabledSet(ref.watch(buildChannelProvider));
 }

--- a/lib/features/feature_management/application/feature_flags_provider.g.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.g.dart
@@ -126,6 +126,73 @@ final class FeatureManifestProvider
 
 String _$featureManifestHash() => r'7b67cbf211fcf268808f6c329950be1d4ba91881';
 
+/// The build channel this app instance is running as (#1674).
+///
+/// Resolved from the compile-time `--dart-define=CHANNEL`, baked by
+/// CI / fastlane. Any value other than `beta` — including an absent
+/// define (a local `flutter run`) — resolves to
+/// [BuildChannel.production]: production is the safe default so a
+/// mis-configured build never accidentally exposes beta-only features.
+/// Overridable in tests via `ProviderContainer.overrides`.
+
+@ProviderFor(buildChannel)
+final buildChannelProvider = BuildChannelProvider._();
+
+/// The build channel this app instance is running as (#1674).
+///
+/// Resolved from the compile-time `--dart-define=CHANNEL`, baked by
+/// CI / fastlane. Any value other than `beta` — including an absent
+/// define (a local `flutter run`) — resolves to
+/// [BuildChannel.production]: production is the safe default so a
+/// mis-configured build never accidentally exposes beta-only features.
+/// Overridable in tests via `ProviderContainer.overrides`.
+
+final class BuildChannelProvider
+    extends $FunctionalProvider<BuildChannel, BuildChannel, BuildChannel>
+    with $Provider<BuildChannel> {
+  /// The build channel this app instance is running as (#1674).
+  ///
+  /// Resolved from the compile-time `--dart-define=CHANNEL`, baked by
+  /// CI / fastlane. Any value other than `beta` — including an absent
+  /// define (a local `flutter run`) — resolves to
+  /// [BuildChannel.production]: production is the safe default so a
+  /// mis-configured build never accidentally exposes beta-only features.
+  /// Overridable in tests via `ProviderContainer.overrides`.
+  BuildChannelProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'buildChannelProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$buildChannelHash();
+
+  @$internal
+  @override
+  $ProviderElement<BuildChannel> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  BuildChannel create(Ref ref) {
+    return buildChannel(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BuildChannel value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BuildChannel>(value),
+    );
+  }
+}
+
+String _$buildChannelHash() => r'19d064de2926f0eb9ef2781dd22f3b5801cbb0b0';
+
 /// Central feature-flag store (#1373 phase 1).
 ///
 /// State is the set of currently-enabled features. The provider validates
@@ -226,7 +293,7 @@ final class FeatureFlagsProvider
   FeatureFlags create() => FeatureFlags();
 }
 
-String _$featureFlagsHash() => r'10bea65d477d5590e5d8737bedcfa91b7d61920e';
+String _$featureFlagsHash() => r'20bfb70113817172c44594d26d28ec033be230c2';
 
 /// Central feature-flag store (#1373 phase 1).
 ///
@@ -349,4 +416,4 @@ final class EnabledFeaturesProvider
   }
 }
 
-String _$enabledFeaturesHash() => r'2e79e8e31e5bd3a1f94ce3e095d1b76c3ed0b306';
+String _$enabledFeaturesHash() => r'3e7e23a57bfd783ee094a9291b9a6f081f1515a8';

--- a/lib/features/feature_management/data/feature_flags_repository.dart
+++ b/lib/features/feature_management/data/feature_flags_repository.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
+import '../domain/build_channel.dart';
 import '../domain/feature.dart';
 import '../domain/feature_manifest.dart';
 
@@ -37,13 +38,16 @@ class FeatureFlagsRepository {
 
   /// Returns the currently-enabled feature set.
   ///
-  /// First launch (empty box) → manifest defaults. Subsequent launches
-  /// → exactly the set persisted by [saveEnabled]. Unknown enum names
-  /// (e.g. a feature removed in a later version) are skipped silently
-  /// so a downgrade-then-upgrade does not crash.
-  Future<Set<Feature>> loadEnabled() async {
+  /// First launch (empty box) → the manifest defaults for [channel]
+  /// (#1674). Subsequent launches → exactly the set persisted by
+  /// [saveEnabled]. Unknown enum names (e.g. a feature removed in a
+  /// later version) are skipped silently so a downgrade-then-upgrade
+  /// does not crash.
+  Future<Set<Feature>> loadEnabled([
+    BuildChannel channel = BuildChannel.production,
+  ]) async {
     if (_box.isEmpty) {
-      return _manifest.defaultEnabledSet();
+      return _manifest.defaultEnabledSet(channel);
     }
     final result = <Feature>{};
     final byName = {for (final f in Feature.values) f.name: f};

--- a/test/features/feature_management/feature_flags_channel_gate_test.dart
+++ b/test/features/feature_management/feature_flags_channel_gate_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/domain/build_channel.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
+
+/// Build-channel enforcement in `FeatureFlags` (#1674, epic #1670).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // A synthetic manifest: one feature available everywhere, one
+  // beta-only feature that does not exist in production at all.
+  const everywhere = Feature.priceAlerts;
+  const betaOnly = Feature.gamification;
+  const manifest = FeatureManifest({
+    everywhere: FeatureManifestEntry.allChannels(
+      feature: everywhere,
+      defaultOn: true,
+      displayName: 'everywhere',
+      description: 'available in every channel',
+    ),
+    betaOnly: FeatureManifestEntry(
+      feature: betaOnly,
+      availableChannels: {BuildChannel.beta},
+      defaultEnabledChannels: {BuildChannel.beta},
+      displayName: 'beta-only',
+      description: 'available in beta only',
+    ),
+  });
+
+  ProviderContainer containerFor(
+    BuildChannel channel, {
+    FeatureFlagsRepository? repository,
+  }) {
+    final c = ProviderContainer(overrides: [
+      featureManifestProvider.overrideWithValue(manifest),
+      buildChannelProvider.overrideWithValue(channel),
+      featureFlagsRepositoryProvider.overrideWithValue(repository),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  test('buildChannelProvider defaults to production', () {
+    final c = ProviderContainer();
+    addTearDown(c.dispose);
+    expect(c.read(buildChannelProvider), BuildChannel.production);
+  });
+
+  group('default set resolves per channel', () {
+    test('a beta-only feature is force-off in a production build', () async {
+      final c = containerFor(BuildChannel.production);
+      await c.read(featureFlagsProvider.future);
+      final enabled = c.read(enabledFeaturesProvider);
+      expect(enabled, contains(everywhere));
+      expect(enabled, isNot(contains(betaOnly)));
+    });
+
+    test('a beta-only feature is default-on in a beta build', () async {
+      final c = containerFor(BuildChannel.beta);
+      await c.read(featureFlagsProvider.future);
+      final enabled = c.read(enabledFeaturesProvider);
+      expect(enabled, containsAll(<Feature>{everywhere, betaOnly}));
+    });
+  });
+
+  group('enable() honours the channel gate', () {
+    test('enabling a channel-unavailable feature throws', () async {
+      final c = containerFor(BuildChannel.production);
+      await c.read(featureFlagsProvider.future);
+      expect(
+        () => c.read(featureFlagsProvider.notifier).enable(betaOnly),
+        throwsStateError,
+      );
+    });
+
+    test('enabling an available feature succeeds in its channel', () async {
+      final c = containerFor(BuildChannel.beta);
+      await c.read(featureFlagsProvider.future);
+      await c.read(featureFlagsProvider.notifier).enable(betaOnly);
+      expect(c.read(featureFlagsProvider).asData?.value, contains(betaOnly));
+    });
+  });
+
+  group('persisted channel-unavailable features are force-off on load', () {
+    late Directory tmpDir;
+    late Box<dynamic> box;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('ff_channel_test_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<dynamic>(
+        'ff_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    test('a persisted beta-only feature is dropped in a production build',
+        () async {
+      // Box persists the beta-only feature as enabled.
+      await box.put(betaOnly.name, true);
+      final c = containerFor(
+        BuildChannel.production,
+        repository: FeatureFlagsRepository(box: box, manifest: manifest),
+      );
+      final state = await c.read(featureFlagsProvider.future);
+      expect(state, isNot(contains(betaOnly)));
+    });
+  });
+}

--- a/test/features/feature_management/feature_flags_provider_test.dart
+++ b/test/features/feature_management/feature_flags_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/data/feature_flags_repository.dart';
+import 'package:tankstellen/features/feature_management/domain/build_channel.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_dependency_graph.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
@@ -18,7 +19,9 @@ class _ThrowingRepo extends FeatureFlagsRepository {
   _ThrowingRepo(Box<dynamic> box) : super(box: box);
 
   @override
-  Future<Set<Feature>> loadEnabled() async =>
+  Future<Set<Feature>> loadEnabled([
+    BuildChannel channel = BuildChannel.production,
+  ]) async =>
       throw StateError('simulated Hive read failure');
 }
 


### PR DESCRIPTION
## Summary

Wires the live channel resolver and channel enforcement on top of the #1673 model (epic #1670).

- New **`buildChannelProvider`** resolves the channel from the compile-time `--dart-define=CHANNEL`. Anything other than `beta` — including an absent define (local `flutter run`) — is `production`, the safe default.
- **`FeatureFlags.build()`** resolves first-launch defaults per the current channel and force-offs any persisted feature not available in it — a beta-only feature can never be active in a production build.
- **`FeatureFlags.enable()`** rejects a feature not available in the current channel with a `StateError`, regardless of its prerequisites.
- `FeatureFlagsRepository.loadEnabled([channel])` and the `enabledFeatures` derived provider are now channel-aware.

Production behaviour is unchanged — every current feature is available in both channels, so `defaultEnabledSet(production) == defaultEnabledSet(beta)` today.

## Verification

- New `feature_flags_channel_gate_test.dart`: beta-only features force-off in production, default-on in beta, `enable()` rejected off-channel, and a persisted off-channel feature dropped on load.
- `flutter analyze` clean, `build_runner` regenerated, 147 feature-management tests + 562 app/profile tests green.

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
