### PR TITLE
feat(features): hide channel-unavailable features from the feature-management UI (#1675)

### DIFF
--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -41,6 +41,13 @@ class FeatureManagementSection extends ConsumerWidget {
     final manifest = ref.watch(featureManifestProvider);
     final enabled = ref.watch(enabledFeaturesProvider);
 
+    // #1675 — a feature not available in the current build channel
+    // (e.g. a beta-only feature in a production build) never renders in
+    // the feature-management list.
+    final channel = ref.watch(buildChannelProvider);
+    bool availableInChannel(Feature f) =>
+        manifest.entries[f]?.isAvailableIn(channel) ?? false;
+
     // Build groups in manifest declaration order (#1440). A feature with
     // no `requires` (or whose `requires` does not reference an already-
     // seen parent) becomes a new group; otherwise it is appended to the
@@ -73,7 +80,7 @@ class FeatureManagementSection extends ConsumerWidget {
       // trip recording, so it belongs to the Trajets tier just like
       // glideCoach / gpsTripPath.
       Feature.experimentalOemPids,
-    ];
+    ].where(availableInChannel).toList();
 
     // Filter the regular group rendering: drop the Conso "parent" flags
     // (replaced by the segmented control) AND drop the Conso dependents
@@ -81,13 +88,15 @@ class FeatureManagementSection extends ConsumerWidget {
     // priceAlerts, …) flow through unchanged.
     final filteredGroups = <_FeatureGroup>[
       for (final group in groups)
-        if (!consoModeFlags.contains(group.parent))
+        if (!consoModeFlags.contains(group.parent) &&
+            availableInChannel(group.parent))
           _FeatureGroup(
             parent: group.parent,
             children: [
               for (final c in group.children)
                 if (!consoDependents.contains(c) &&
-                    !consoModeFlags.contains(c))
+                    !consoModeFlags.contains(c) &&
+                    availableInChannel(c))
                   c,
             ],
           ),

--- a/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
+++ b/test/features/profile/presentation/screens/profile_screen_feature_mgmt_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/build_channel.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
 import 'package:tankstellen/features/profile/presentation/screens/profile_screen.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/feature_management_section.dart';
 
@@ -20,6 +22,23 @@ import '../../../../mocks/mocks.dart';
 /// dependent switches become disabled-with-tooltip via
 /// `isEffectivelyEnabled`, with their stored state preserved so
 /// re-enabling the parent restores the prior surface.
+/// A copy of the default manifest with [f] flipped to a beta-only
+/// feature — available and default-on in beta, absent in production.
+FeatureManifest _manifestWithBetaOnly(Feature f) {
+  final entries = Map<Feature, FeatureManifestEntry>.from(
+      FeatureManifest.defaultManifest.entries);
+  final orig = entries[f]!;
+  entries[f] = FeatureManifestEntry(
+    feature: f,
+    availableChannels: const {BuildChannel.beta},
+    defaultEnabledChannels: const {BuildChannel.beta},
+    displayName: orig.displayName,
+    description: orig.description,
+    requires: orig.requires,
+  );
+  return FeatureManifest(entries);
+}
+
 void main() {
   group('ProfileScreen — Feature management section (#1373 phase 2)', () {
     late MockHiveStorage mockStorage;
@@ -300,6 +319,42 @@ void main() {
       expect(tooltip.message!, contains('OBD2 trip recording'),
           reason: 'tooltip must point the user at the parent they need '
               'to flip back on to make the child reachable.');
+    });
+
+    testWidgets(
+        '#1675 — a beta-only feature is hidden from the list in a '
+        'production build', (tester) async {
+      await pumpApp(tester, const ProfileScreen(), overrides: [
+        ...baseOverrides,
+        featureManifestProvider
+            .overrideWithValue(_manifestWithBetaOnly(Feature.fuelCalculator)),
+        buildChannelProvider.overrideWithValue(BuildChannel.production),
+      ]);
+      await openSection(tester);
+
+      expect(find.byKey(const Key('featureToggle_fuelCalculator')),
+          findsNothing,
+          reason: 'a beta-only feature must not render in a production '
+              'build');
+      // A channel-available feature still renders.
+      expect(find.byKey(const Key('featureToggle_priceAlerts')),
+          findsOneWidget);
+    });
+
+    testWidgets(
+        '#1675 — the same feature is visible in a beta build',
+        (tester) async {
+      await pumpApp(tester, const ProfileScreen(), overrides: [
+        ...baseOverrides,
+        featureManifestProvider
+            .overrideWithValue(_manifestWithBetaOnly(Feature.fuelCalculator)),
+        buildChannelProvider.overrideWithValue(BuildChannel.beta),
+      ]);
+      await openSection(tester);
+
+      expect(find.byKey(const Key('featureToggle_fuelCalculator')),
+          findsOneWidget,
+          reason: 'a beta-only feature must render in a beta build');
     });
   });
 }


### PR DESCRIPTION
## Summary

The Settings → Feature management list now filters every feature through the current build channel (epic #1670, builds on #1674).

A feature not available in the current channel — e.g. a beta-only feature in a production build — never renders: it is dropped from the regular feature groups (parent + children) and from the Conso card's Trajets-tier dependents.

Production behaviour is unchanged — every current feature is available in both channels, so the full list still renders in a production build.

## Verification

- New widget tests: a beta-only feature is hidden from the list in a production build and visible in a beta build.
- `flutter analyze` clean, `build_runner` shows no drift, the feature-management section tests + 148 profile-widget tests green.

Closes #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)
