### PR TITLE
fix(profile): apply preset use-mode bundles atomically — fixes Medium-select crash (#1765)

### DIFF
--- a/lib/features/feature_management/application/app_profile_provider.dart
+++ b/lib/features/feature_management/application/app_profile_provider.dart
@@ -65,15 +65,17 @@ class ActiveAppProfile extends _$ActiveAppProfile {
   ///
   /// For [AppProfile.custom] this is a flag no-op — the user's set
   /// stays whatever it was last persisted. For the three preset
-  /// profiles, every Feature in [Feature.values] is either enabled (if
-  /// in the bundle) or disabled (if not), so re-selecting the same
-  /// profile is idempotent and switching profiles never leaves
-  /// stale-on flags around.
+  /// profiles the bundle is applied atomically via
+  /// [FeatureFlags.applyBundle]: the enabled set becomes exactly the
+  /// bundle, so re-selecting the same profile is idempotent and
+  /// switching profiles never leaves stale-on flags around.
   ///
-  /// Bundle application respects the dependency graph by walking
-  /// [Feature.values] in declaration order, which matches the
-  /// dependency order today (parents before children) — see the
-  /// declaration order comment on [Feature] for why this isn't fragile.
+  /// A preset bundle is applied as a whole, NOT feature-by-feature
+  /// through the prerequisite-guarded [FeatureFlags.enable] — a preset
+  /// deliberately includes dependents (e.g. `showConsumptionTab` in
+  /// Medium) whose `requires` edge is satisfied at the reachability
+  /// layer rather than the dependency graph; routing those through
+  /// `enable` crashed (#1765).
   Future<void> select(AppProfile profile) async {
     final repo = ref.read(appProfileRepositoryProvider);
     state = profile;
@@ -84,27 +86,7 @@ class ActiveAppProfile extends _$ActiveAppProfile {
     if (profile == AppProfile.custom) return;
 
     final bundle = appProfileBundles[profile] ?? <Feature>{};
-    final flags = ref.read(featureFlagsProvider.notifier);
-    final manifest = ref.read(featureManifestProvider);
-    // Two-pass apply: enable parents before children so the dependency
-    // graph never rejects an enable mid-bundle. We sort by topological
-    // depth — features with no `requires` first, then features whose
-    // requires are already in the bundle.
-    final sorted = _topologicalOrder(bundle, manifest.entries);
-    for (final feature in sorted) {
-      await flags.enable(feature);
-    }
-    // Disable everything not in the bundle. Walk in reverse topological
-    // order so children are disabled before their parents (parents are
-    // safe to disable at any time per the lazy-cascade contract, but
-    // reverse-order keeps the persisted set tidy after each step).
-    final toDisable = Feature.values
-        .where((f) => !bundle.contains(f))
-        .toList()
-        .reversed;
-    for (final feature in toDisable) {
-      await flags.disable(feature);
-    }
+    await ref.read(featureFlagsProvider.notifier).applyBundle(bundle);
   }
 
   /// Recomputes the active profile after an external feature-flag
@@ -126,31 +108,3 @@ class ActiveAppProfile extends _$ActiveAppProfile {
   }
 }
 
-/// Returns [features] in topological order so every feature comes after
-/// the features it `requires`. Used by `select()` to enable parents
-/// before children regardless of declaration order in [Feature].
-///
-/// The manifest's `assertNoCycles` invariant guarantees termination.
-List<Feature> _topologicalOrder(
-  Set<Feature> features,
-  Map<Feature, dynamic> manifestEntries,
-) {
-  final visited = <Feature>{};
-  final result = <Feature>[];
-  void visit(Feature node) {
-    if (visited.contains(node)) return;
-    visited.add(node);
-    final entry = manifestEntries[node];
-    if (entry != null) {
-      for (final required in entry.requires as Set<Feature>) {
-        if (features.contains(required)) visit(required);
-      }
-    }
-    result.add(node);
-  }
-
-  for (final f in features) {
-    visit(f);
-  }
-  return result;
-}

--- a/lib/features/feature_management/application/app_profile_provider.g.dart
+++ b/lib/features/feature_management/application/app_profile_provider.g.dart
@@ -160,7 +160,7 @@ final class ActiveAppProfileProvider
   }
 }
 
-String _$activeAppProfileHash() => r'513e719a332855c999c5c58fe3adf0c7ada4c39b';
+String _$activeAppProfileHash() => r'11f62d6de9c9c8af25320cc6e3f2279bf98a6a84';
 
 /// Active "use mode" profile (#1517).
 ///

--- a/lib/features/feature_management/application/feature_flags_provider.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.dart
@@ -163,6 +163,30 @@ class FeatureFlags extends _$FeatureFlags {
     state = AsyncData(next);
   }
 
+  /// Replaces the entire enabled set with [bundle] — used to apply a
+  /// preset profile bundle atomically (#1517 / #1765).
+  ///
+  /// Unlike [enable], this does NOT run the per-feature prerequisite
+  /// guard: a preset bundle is a complete, intentional set, and a
+  /// preset deliberately includes dependents (e.g. `showConsumptionTab`
+  /// in the Medium bundle) whose manifest `requires` edge is satisfied
+  /// at the reachability layer, not the dependency graph. Routing a
+  /// bundle through [enable] crashed the moment a dependent's
+  /// prerequisite was absent from the bundle (#1765).
+  ///
+  /// Channel-unavailable features are dropped (#1674); the result is
+  /// exactly [bundle] minus those, so no stale-on flags survive a
+  /// profile switch.
+  Future<void> applyBundle(Set<Feature> bundle) async {
+    final manifest = ref.read(featureManifestProvider);
+    final channel = ref.read(buildChannelProvider);
+    // Await the in-flight build so the apply replaces the resolved set.
+    await future;
+    final next = _availableInChannel(bundle, manifest, channel);
+    await _persist(next);
+    state = AsyncData(next);
+  }
+
   /// True when [feature] is currently in the stored enabled set. Does NOT
   /// walk the dependency chain — when the manifest declares prerequisites
   /// for [feature] and the caller wants the user-visible "is this surface

--- a/lib/features/feature_management/application/feature_flags_provider.g.dart
+++ b/lib/features/feature_management/application/feature_flags_provider.g.dart
@@ -293,7 +293,7 @@ final class FeatureFlagsProvider
   FeatureFlags create() => FeatureFlags();
 }
 
-String _$featureFlagsHash() => r'20bfb70113817172c44594d26d28ec033be230c2';
+String _$featureFlagsHash() => r'afce31debe12158b3852c03faaf6e39e62781934';
 
 /// Central feature-flag store (#1373 phase 1).
 ///

--- a/test/features/feature_management/app_profile_provider_test.dart
+++ b/test/features/feature_management/app_profile_provider_test.dart
@@ -112,6 +112,29 @@ void main() {
       expect(flags, isNot(contains(Feature.obd2TripRecording)));
     });
 
+    test(
+        '#1765 — selecting medium after basic does not crash; the Medium '
+        'bundle re-enables showConsumptionTab without its obd2 prerequisite',
+        () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      // Basic excludes showConsumptionTab — after this it is OFF, the
+      // precondition that made the old enable()-per-feature select()
+      // throw `StateError: Cannot enable showConsumptionTab: requires
+      // obd2TripRecording`.
+      await c.read(activeAppProfileProvider.notifier).select(AppProfile.basic);
+      expect(c.read(enabledFeaturesProvider),
+          isNot(contains(Feature.showConsumptionTab)));
+      // Must not throw — the preset bundle is applied atomically.
+      await c
+          .read(activeAppProfileProvider.notifier)
+          .select(AppProfile.medium);
+      final flags = c.read(enabledFeaturesProvider);
+      expect(flags, appProfileBundles[AppProfile.medium]);
+      expect(flags, contains(Feature.showConsumptionTab));
+      expect(flags, isNot(contains(Feature.obd2TripRecording)));
+    });
+
     test('full enables OBD2 stack and loyalty', () async {
       final c = makeContainer();
       await pumpLoad(c);


### PR DESCRIPTION
## Summary

Selecting the **Medium** use-mode crashed with `StateError: Cannot enable showConsumptionTab: requires obd2TripRecording which is disabled` (reported from a 5.0.0+2026051519 device) — whenever `showConsumptionTab` was currently off, e.g. after a prior Basic selection.

**Root cause:** `ActiveAppProfile.select` applied a preset bundle by calling `FeatureFlags.enable()` per feature — the *interactive single-toggle* path, which rejects a feature whose manifest prerequisite is disabled. The Medium bundle deliberately carries `showConsumptionTab` without `obd2TripRecording` (#1568 — Medium is manual-consumption, no OBD2); that `requires` edge is satisfied at the reachability layer (`isConsumptionTabReachable`'s `manual ∨ obd2` OR-logic), not the dependency graph. So `enable(showConsumptionTab)` threw mid-bundle.

The pre-existing test only selected Medium from defaults — where `showConsumptionTab` is default-on, so `enable()` early-returned and never reached the guard. The crash needs it *off* first.

## Fix

- New **`FeatureFlags.applyBundle(Set<Feature>)`** — replaces the enabled set with exactly the bundle (channel-filtered, persisted), *without* the per-feature prerequisite guard, since a preset is a complete, intentional set.
- `select()` now applies bundles via `applyBundle`; the topological-sort + enable/disable loops and the `_topologicalOrder` helper are removed (simpler, and `select`'s "exact bundle, no stale-on flags" intent is now literal).

## Verification

- New regression test: `select(Basic)` → `select(Medium)` completes without throwing and yields exactly the Medium bundle (`showConsumptionTab` on, `obd2TripRecording` off) — the precise crash precondition.
- `flutter analyze` clean, `build_runner` regenerated, 150 feature-management tests green.

Closes #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
