### PR TITLE
perf(search): rebuild only the affected row on favorite/rating change (#1771)

### DIFF
--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -162,26 +162,6 @@ class SearchResultsList extends ConsumerWidget {
                 itemCount: sorted.length,
                 itemBuilder: (context, index) {
                   final item = sorted[index];
-                  final isFav = ref.watch(isFavoriteProvider(item.id));
-
-                  final card = switch (item) {
-                    FuelStationResult(:final station) => _buildFuelCard(
-                      context: context,
-                      ref: ref,
-                      station: station,
-                      isFavorite: isFav,
-                      allPrices: allPrices,
-                      cheapestMap: cheapestMap,
-                      fuelType: fuelType,
-                      priceRange: priceRange,
-                      profileFuel: profileFuel,
-                    ),
-                    EVStationResult() => EVStationCard(
-                      key: ValueKey('ev-${item.id}'),
-                      result: item,
-                      onTap: () => context.push('/ev-station', extra: item.station),
-                    ),
-                  };
                   // #595 — cap stagger so a 50-result search finishes
                   // fading in well under a second. Index key keeps the
                   // animation bound to the slot, so rebuilds (refresh,
@@ -189,7 +169,38 @@ class SearchResultsList extends ConsumerWidget {
                   return StaggeredFadeIn(
                     key: ValueKey('stagger-${item.id}'),
                     index: index,
-                    child: card,
+                    // #1771 — the favorite and rating providers are
+                    // watched inside this per-row Consumer, not in the
+                    // parent build. A favorite toggle or rating change
+                    // on one station now rebuilds only that row —
+                    // previously it rebuilt the whole list and re-ran
+                    // the filter/sort pipeline in the parent build.
+                    child: Consumer(
+                      builder: (context, ref, _) {
+                        final isFav =
+                            ref.watch(isFavoriteProvider(item.id));
+                        return switch (item) {
+                          FuelStationResult(:final station) =>
+                            _buildFuelCard(
+                              context: context,
+                              ref: ref,
+                              station: station,
+                              isFavorite: isFav,
+                              allPrices: allPrices,
+                              cheapestMap: cheapestMap,
+                              fuelType: fuelType,
+                              priceRange: priceRange,
+                              profileFuel: profileFuel,
+                            ),
+                          EVStationResult() => EVStationCard(
+                              key: ValueKey('ev-${item.id}'),
+                              result: item,
+                              onTap: () => context.push('/ev-station',
+                                  extra: item.station),
+                            ),
+                        };
+                      },
+                    ),
                   );
                 },
               );

--- a/test/features/search/presentation/widgets/search_results_list_row_scope_test.dart
+++ b/test/features/search/presentation/widgets/search_results_list_row_scope_test.dart
@@ -1,0 +1,85 @@
+// Regression test for #1771 — each row of [SearchResultsList] watches
+// its favorite/rating providers inside its own per-row `Consumer`, so a
+// favorite toggle or rating change rebuilds only that row instead of
+// the whole list (which would also re-run the filter/sort pipeline in
+// the parent build).
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_list.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+const _stationA = Station(
+  id: 's1',
+  name: 'Total A',
+  brand: 'TOTAL',
+  street: '1 rue A',
+  postCode: '34120',
+  place: 'Pézenas',
+  lat: 43.45,
+  lng: 3.42,
+  isOpen: true,
+);
+const _stationB = Station(
+  id: 's2',
+  name: 'Esso B',
+  brand: 'ESSO',
+  street: '2 rue B',
+  postCode: '34120',
+  place: 'Pézenas',
+  lat: 43.46,
+  lng: 3.43,
+  isOpen: true,
+);
+
+Future<void> _pumpList(WidgetTester tester) async {
+  final test = standardTestOverrides();
+  when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+  when(() => test.mockStorage.getApiKey()).thenReturn(null);
+  when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+  when(() => test.mockStorage.getRatings()).thenReturn(<String, int>{});
+
+  await pumpApp(
+    tester,
+    SearchResultsList(
+      result: ServiceResult<List<SearchResultItem>>(
+        data: const [
+          FuelStationResult(_stationA),
+          FuelStationResult(_stationB),
+        ],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime(2026, 4, 14),
+      ),
+      onRefresh: () {},
+    ),
+    overrides: test.overrides,
+  );
+}
+
+void main() {
+  group('SearchResultsList per-row provider scope (#1771)', () {
+    testWidgets('each results row sits under its own Consumer',
+        (tester) async {
+      await _pumpList(tester);
+
+      for (final id in ['s1', 's2']) {
+        expect(
+          find.ancestor(
+            of: find.byKey(ValueKey('station-$id')),
+            matching: find.byType(Consumer),
+          ),
+          findsOneWidget,
+          reason: 'station-$id must be wrapped in a per-row Consumer so a '
+              'favorite/rating change rebuilds only that row (#1771)',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #1771

## Problem

`SearchResultsList` called `ref.watch(isFavoriteProvider(item.id))` and `ref.watch(stationRatingProvider(station.id))` **inside** the `ListView.builder` `itemBuilder`. That closure runs in the parent `ConsumerWidget`'s `build`, so the watches registered on the *parent* element — toggling a favorite or changing a rating on **any one station** rebuilt the whole list and re-ran the filter/sort pipeline (`filteredSortedSearchResultsProvider`) in the parent build.

## Fix

Each row's card is now wrapped in a per-row `Consumer`. The favorite and rating providers are watched on that per-row element, so a favorite/rating change rebuilds **only the affected row**.

`StaggeredFadeIn` stays *outside* the `Consumer`, so the row's animation controller is no longer rebuilt on a favorite toggle either.

No visual or behavioural change — the same widgets render; only rebuild scope changes.

## Tests

- New `search_results_list_row_scope_test.dart` pins that each results row sits under its own `Consumer`.
- Whole-repo `flutter analyze` clean; `test/features/search/` + `test/goldens/` all green (787 tests).

## Note

Sibling issue **#1778** (`prototypeItem`) was closed as won't-fix — `prototypeItem` forces a *uniform* extent, which the mixed fuel/EV/all-prices card list cannot satisfy. #1772 (per-row `RepaintBoundary`) remains the open scrolling-perf companion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
