### PR TITLE
perf(ui): add RepaintBoundary around station-card rows and map markers (#1772)

### DIFF
--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -55,7 +55,11 @@ class StationMarkerBuilder {
       point: LatLng(station.lat, station.lng),
       width: kStationMarkerWidth,
       height: kStationMarkerHeight,
-      child: Semantics(
+      // #1772 — isolate each marker's raster so an animation or rebuild
+      // on one marker (e.g. the selected-station pastel swap) does not
+      // repaint the entire marker layer.
+      child: RepaintBoundary(
+        child: Semantics(
         label: semanticLabel,
         button: true,
         child: GestureDetector(
@@ -101,6 +105,7 @@ class StationMarkerBuilder {
             ),
           ),
         ),
+      ),
       ),
       ),
     );

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -169,37 +169,44 @@ class SearchResultsList extends ConsumerWidget {
                   return StaggeredFadeIn(
                     key: ValueKey('stagger-${item.id}'),
                     index: index,
-                    // #1771 — the favorite and rating providers are
-                    // watched inside this per-row Consumer, not in the
-                    // parent build. A favorite toggle or rating change
-                    // on one station now rebuilds only that row —
-                    // previously it rebuilt the whole list and re-ran
-                    // the filter/sort pipeline in the parent build.
-                    child: Consumer(
-                      builder: (context, ref, _) {
-                        final isFav =
-                            ref.watch(isFavoriteProvider(item.id));
-                        return switch (item) {
-                          FuelStationResult(:final station) =>
-                            _buildFuelCard(
-                              context: context,
-                              ref: ref,
-                              station: station,
-                              isFavorite: isFav,
-                              allPrices: allPrices,
-                              cheapestMap: cheapestMap,
-                              fuelType: fuelType,
-                              priceRange: priceRange,
-                              profileFuel: profileFuel,
-                            ),
-                          EVStationResult() => EVStationCard(
-                              key: ValueKey('ev-${item.id}'),
-                              result: item,
-                              onTap: () => context.push('/ev-station',
-                                  extra: item.station),
-                            ),
-                        };
-                      },
+                    // #1772 — a RepaintBoundary isolates the card's
+                    // raster from the StaggeredFadeIn opacity tween, so
+                    // the per-row fade-in (and any in-card animation)
+                    // composites a cached layer instead of repainting
+                    // the card on every frame.
+                    child: RepaintBoundary(
+                      // #1771 — the favorite and rating providers are
+                      // watched inside this per-row Consumer, not in
+                      // the parent build. A favorite toggle or rating
+                      // change on one station now rebuilds only that
+                      // row — previously it rebuilt the whole list and
+                      // re-ran the filter/sort pipeline in the parent.
+                      child: Consumer(
+                        builder: (context, ref, _) {
+                          final isFav =
+                              ref.watch(isFavoriteProvider(item.id));
+                          return switch (item) {
+                            FuelStationResult(:final station) =>
+                              _buildFuelCard(
+                                context: context,
+                                ref: ref,
+                                station: station,
+                                isFavorite: isFav,
+                                allPrices: allPrices,
+                                cheapestMap: cheapestMap,
+                                fuelType: fuelType,
+                                priceRange: priceRange,
+                                profileFuel: profileFuel,
+                              ),
+                            EVStationResult() => EVStationCard(
+                                key: ValueKey('ev-${item.id}'),
+                                result: item,
+                                onTap: () => context.push('/ev-station',
+                                    extra: item.station),
+                              ),
+                          };
+                        },
+                      ),
                     ),
                   );
                 },

--- a/test/features/map/presentation/widgets/station_marker_test.dart
+++ b/test/features/map/presentation/widgets/station_marker_test.dart
@@ -64,7 +64,10 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: ((marker.child as Semantics).child as GestureDetector).child,
+          // #1772 — the marker child is wrapped in a RepaintBoundary.
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
         ),
       );
 
@@ -100,7 +103,10 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: ((marker.child as Semantics).child as GestureDetector).child,
+          // #1772 — the marker child is wrapped in a RepaintBoundary.
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
         ),
       );
 
@@ -121,7 +127,10 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: ((marker.child as Semantics).child as GestureDetector).child,
+          // #1772 — the marker child is wrapped in a RepaintBoundary.
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
         ),
       );
 
@@ -143,7 +152,10 @@ void main() {
         SizedBox(
           width: marker.width,
           height: marker.height,
-          child: ((marker.child as Semantics).child as GestureDetector).child,
+          // #1772 — the marker child is wrapped in a RepaintBoundary.
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
         ),
       );
 


### PR DESCRIPTION
Closes #1772

## Problem

An animation or rebuild inside one widget repaints every other widget sharing its paint layer. Two hot surfaces had no paint isolation:

- **Search-results rows** — `StaggeredFadeIn` runs an `AnimatedOpacity` tween per row. With no boundary between the tween and the card, the card repainted on *every* fade frame.
- **Map markers** — `StationMarkerBuilder.build` produced a `Marker` whose child had no boundary, so a rebuild on one marker (e.g. the selected-station pastel swap) repainted the whole marker layer.

## Fix

Wrap the results-row card and the marker child in `RepaintBoundary`:

- The results-row boundary sits *inside* `StaggeredFadeIn`, so the fade composites a cached raster layer instead of repainting the card each frame. (This is distinct from the framework's implicit per-row boundary, which sits *above* `StaggeredFadeIn` and so does not isolate the card from the opacity tween.)
- The marker boundary scopes each marker's raster independently.

No visual or behavioural change — `RepaintBoundary` only scopes the raster cache.

## Tests

- `station_marker_test.dart` updated to unwrap the new `RepaintBoundary` when reaching into the marker subtree.
- Whole-repo `flutter analyze` clean; `test/features/map/`, `test/features/search/`, `test/goldens/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
