### PR TITLE
perf(search): drive the results-list fade-in from one shared controller (#1773)

### DIFF
--- a/lib/core/widgets/staggered_fade_in.dart
+++ b/lib/core/widgets/staggered_fade_in.dart
@@ -1,81 +1,95 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
-/// Fades a child in from `opacity: 0` to `opacity: 1` after a small
-/// per-index delay — `index * stepMs`, capped at `maxStaggered`
-/// positions so that long result lists don't make the user wait.
+/// Per-index start-delay step. 50 ms matches the #595 spec.
+const int _kStepMs = 50;
+
+/// Fade duration of a single card.
+const int _kFadeMs = 220;
+
+/// Upper bound on the stagger multiplier — a row at index `>= this` is
+/// clamped so the last card in a long search fades in no later than
+/// `_kMaxStaggered * _kStepMs` after the list mounts.
+const int _kMaxStaggered = 10;
+
+/// Fades a child in from `opacity: 0` to `opacity: 1` as one slice of a
+/// shared fade timeline, offset by a small per-index delay.
 ///
 /// Added in #595 so the shimmer → results transition feels like a
-/// cascade rather than a flash. Uses [AnimatedOpacity] + a one-shot
-/// [Timer] rather than an AnimationController so the widget stays
-/// lightweight inside `ListView.builder`.
+/// cascade rather than a flash.
+///
+/// #1773 — every row used to own an [AnimatedOpacity] (its own ticker)
+/// plus a one-shot `Timer`; a 50-result search spun up dozens of
+/// tickers and timers. Now the whole list shares ONE
+/// [AnimationController] ([timelineDuration] long) created by the host;
+/// each row is a stateless [Interval] slice of it rendered through a
+/// [FadeTransition] — one ticker for the list, none per row, no timers.
 class StaggeredFadeIn extends StatefulWidget {
-  /// Position within the visible list. Capped internally at
-  /// [maxStaggered] so item 1000 doesn't wait 50 s to appear.
+  /// The list-wide fade timeline. The host creates a single
+  /// [AnimationController] of [timelineDuration], `forward()`s it, and
+  /// passes it to every row.
+  final AnimationController controller;
+
+  /// Position within the visible list; clamped at [_kMaxStaggered].
   final int index;
-
-  /// Per-index delay. 50 ms matches the #595 spec.
-  final int stepMs;
-
-  /// Fade duration per card.
-  final Duration duration;
-
-  /// Upper bound on the stagger multiplier. Index `>= maxStaggered` is
-  /// clamped so the last card in a 50-result search fades in no later
-  /// than `maxStaggered * stepMs` after the list mounts.
-  final int maxStaggered;
 
   final Widget child;
 
   const StaggeredFadeIn({
     super.key,
+    required this.controller,
     required this.index,
     required this.child,
-    this.stepMs = 50,
-    this.duration = const Duration(milliseconds: 220),
-    this.maxStaggered = 10,
   });
+
+  /// Total length of the shared timeline — the last staggered start
+  /// offset plus one card's fade. Use this as the controller duration.
+  static Duration get timelineDuration =>
+      const Duration(milliseconds: _kMaxStaggered * _kStepMs + _kFadeMs);
 
   @override
   State<StaggeredFadeIn> createState() => _StaggeredFadeInState();
 }
 
 class _StaggeredFadeInState extends State<StaggeredFadeIn> {
-  double _opacity = 0.0;
-  Timer? _timer;
+  late CurvedAnimation _opacity;
 
   @override
   void initState() {
     super.initState();
-    final stagger = widget.index.clamp(0, widget.maxStaggered);
-    final delay = Duration(milliseconds: stagger * widget.stepMs);
-    if (delay == Duration.zero) {
-      // Next microtask so the first frame still registers opacity=0
-      // and AnimatedOpacity lerps to 1.0 rather than snapping.
-      scheduleMicrotask(() {
-        if (mounted) setState(() => _opacity = 1.0);
-      });
-    } else {
-      _timer = Timer(delay, () {
-        if (mounted) setState(() => _opacity = 1.0);
-      });
+    _opacity = _buildOpacity();
+  }
+
+  @override
+  void didUpdateWidget(StaggeredFadeIn oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller ||
+        oldWidget.index != widget.index) {
+      _opacity.dispose();
+      _opacity = _buildOpacity();
     }
+  }
+
+  /// The row's opacity is its [Interval] of the shared timeline: it
+  /// starts at `clampedIndex * step` and finishes one fade later.
+  CurvedAnimation _buildOpacity() {
+    final total = (_kMaxStaggered * _kStepMs + _kFadeMs).toDouble();
+    final clamped = widget.index.clamp(0, _kMaxStaggered);
+    final begin = (clamped * _kStepMs) / total;
+    final end = (clamped * _kStepMs + _kFadeMs) / total;
+    return CurvedAnimation(
+      parent: widget.controller,
+      curve: Interval(begin, end, curve: Curves.easeInOut),
+    );
   }
 
   @override
   void dispose() {
-    _timer?.cancel();
+    _opacity.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedOpacity(
-      opacity: _opacity,
-      duration: widget.duration,
-      curve: Curves.easeInOut,
-      child: widget.child,
-    );
+    return FadeTransition(opacity: _opacity, child: widget.child);
   }
 }

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -39,7 +39,7 @@ part 'search_results_list_parts.dart';
 /// Accepts a unified [List<SearchResultItem>] that may contain both
 /// [FuelStationResult] and [EVStationResult]. Fuel-specific features
 /// (price sorting, brand filtering, cheapest flags) apply only to fuel items.
-class SearchResultsList extends ConsumerWidget {
+class SearchResultsList extends ConsumerStatefulWidget {
   final ServiceResult<List<SearchResultItem>> result;
   final VoidCallback onRefresh;
 
@@ -50,7 +50,45 @@ class SearchResultsList extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SearchResultsList> createState() => _SearchResultsListState();
+}
+
+/// #1773 — the whole results list shares ONE fade timeline. Every row
+/// used to own an `AnimatedOpacity` (its own ticker) plus a one-shot
+/// `Timer`; this state hosts the single [AnimationController] the rows
+/// slice into via their per-index `Interval`.
+class _SearchResultsListState extends ConsumerState<SearchResultsList>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _fadeController;
+
+  @override
+  void initState() {
+    super.initState();
+    _fadeController = AnimationController(
+      vsync: this,
+      duration: StaggeredFadeIn.timelineDuration,
+    )..forward();
+  }
+
+  @override
+  void didUpdateWidget(SearchResultsList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A fresh search → replay the staggered cascade from the top.
+    if (!identical(oldWidget.result, widget.result)) {
+      _fadeController.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _fadeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final result = widget.result;
+    final onRefresh = widget.onRefresh;
     final l10n = AppLocalizations.of(context);
     final ignoredIds = ref.watch(ignoredStationsProvider);
     final sortMode = ref.watch(selectedSortModeProvider);
@@ -168,6 +206,7 @@ class SearchResultsList extends ConsumerWidget {
                   // filter changes) don't re-trigger it.
                   return StaggeredFadeIn(
                     key: ValueKey('stagger-${item.id}'),
+                    controller: _fadeController,
                     index: index,
                     // #1772 — a RepaintBoundary isolates the card's
                     // raster from the StaggeredFadeIn opacity tween, so

--- a/test/core/widgets/staggered_fade_in_test.dart
+++ b/test/core/widgets/staggered_fade_in_test.dart
@@ -3,94 +3,110 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/widgets/staggered_fade_in.dart';
 
 void main() {
-  group('StaggeredFadeIn', () {
-    testWidgets('first card (index 0) fades in immediately', (tester) async {
-      await tester.pumpWidget(const MaterialApp(
-        home: Scaffold(
-          body: StaggeredFadeIn(
-            index: 0,
-            child: Text('card-0'),
-          ),
-        ),
-      ));
-
-      // First frame: opacity target is 0, widget is invisible.
-      final first = tester
-          .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
-          .opacity;
-      expect(first, 0.0);
-
-      // Microtask elapses → opacity target flips to 1.0, AnimatedOpacity
-      // starts lerping immediately (no Timer delay for index 0).
-      await tester.pump();
-      final target = tester
-          .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
-          .opacity;
-      expect(target, 1.0);
-    });
-
-    testWidgets('cards beyond maxStaggered clamp to the cap delay',
+  group('StaggeredFadeIn (#1773 — shared timeline)', () {
+    testWidgets('renders a FadeTransition, not a per-row AnimatedOpacity',
         (tester) async {
-      // index = 1000, step = 50 ms, cap = 10 → effective delay = 500 ms.
-      await tester.pumpWidget(const MaterialApp(
+      final controller = AnimationController(
+        vsync: const TestVSync(),
+        duration: StaggeredFadeIn.timelineDuration,
+      );
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: StaggeredFadeIn(
-            index: 1000,
-            child: Text('card-clamped'),
+            controller: controller,
+            index: 0,
+            child: const Text('card'),
           ),
         ),
       ));
 
-      // At 499 ms the Timer has not fired yet → target still 0.
-      await tester.pump(const Duration(milliseconds: 499));
+      // Scope to the StaggeredFadeIn subtree — MaterialApp's own route
+      // transitions also use FadeTransition.
       expect(
-        tester
-            .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
-            .opacity,
-        0.0,
+        find.descendant(
+          of: find.byType(StaggeredFadeIn),
+          matching: find.byType(FadeTransition),
+        ),
+        findsOneWidget,
       );
-
-      // At 501 ms the Timer has fired → target now 1.0.
-      await tester.pump(const Duration(milliseconds: 2));
       expect(
-        tester
-            .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
-            .opacity,
-        1.0,
+        find.descendant(
+          of: find.byType(StaggeredFadeIn),
+          matching: find.byType(AnimatedOpacity),
+        ),
+        findsNothing,
       );
-
-      await tester.pumpAndSettle();
     });
 
-    testWidgets('staggers index=3 to kick in around 150 ms', (tester) async {
-      await tester.pumpWidget(const MaterialApp(
+    testWidgets('the index-0 row leads the timeline; a clamped row trails it',
+        (tester) async {
+      final controller = AnimationController(
+        vsync: const TestVSync(),
+        duration: StaggeredFadeIn.timelineDuration,
+      );
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MaterialApp(
         home: Scaffold(
-          body: StaggeredFadeIn(
-            index: 3,
-            child: Text('card-3'),
+          body: Column(
+            children: [
+              StaggeredFadeIn(
+                controller: controller,
+                index: 0,
+                child: const Text('lead'),
+              ),
+              // index >> maxStaggered → clamped to the cap delay.
+              StaggeredFadeIn(
+                controller: controller,
+                index: 1000,
+                child: const Text('trail'),
+              ),
+            ],
           ),
         ),
       ));
 
-      // At 100 ms the Timer (150 ms) has not fired.
-      await tester.pump(const Duration(milliseconds: 100));
-      expect(
-        tester
-            .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
-            .opacity,
-        0.0,
-      );
+      double opacityOf(String text) => tester
+          .widget<FadeTransition>(
+            find.descendant(
+              of: find.ancestor(
+                of: find.text(text),
+                matching: find.byType(StaggeredFadeIn),
+              ),
+              matching: find.byType(FadeTransition),
+            ),
+          )
+          .opacity
+          .value;
 
-      // At 160 ms the Timer has fired.
-      await tester.pump(const Duration(milliseconds: 60));
-      expect(
-        tester
-            .widget<AnimatedOpacity>(find.byType(AnimatedOpacity))
-            .opacity,
-        1.0,
-      );
+      // Timeline at 0 → nothing has faded in yet.
+      expect(opacityOf('lead'), 0.0);
+      expect(opacityOf('trail'), 0.0);
 
-      await tester.pumpAndSettle();
+      // Just past the index-0 interval (~0.31 of the timeline) the lead
+      // row is fully in, while the clamped row has not started.
+      controller.value = 0.35;
+      await tester.pump();
+      expect(opacityOf('lead'), 1.0,
+          reason: 'index 0 finishes its fade in the first slice');
+      expect(opacityOf('trail'), 0.0,
+          reason: 'a clamped row only starts near the end of the timeline');
+
+      // Timeline complete → every row fully visible.
+      controller.value = 1.0;
+      await tester.pump();
+      expect(opacityOf('lead'), 1.0);
+      expect(opacityOf('trail'), 1.0);
+    });
+
+    test('timelineDuration is the last start offset plus one fade', () {
+      // maxStaggered (10) * stepMs (50) + fadeMs (220) = 720 ms.
+      expect(
+        StaggeredFadeIn.timelineDuration,
+        const Duration(milliseconds: 720),
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #1773

## Problem

Every results row was wrapped in a `StaggeredFadeIn` that owned an `AnimatedOpacity` — an `ImplicitlyAnimatedWidget` with its **own internal `AnimationController`/`Ticker`** — plus a one-shot `Timer` for the per-index delay. A 50-result search spun up dozens of tickers and timers just for the shimmer → results cascade.

## Fix

`SearchResultsList` now hosts **one** `AnimationController` (`StaggeredFadeIn.timelineDuration` long, re-run from 0 on a fresh search). `StaggeredFadeIn` is now a stateless slice of that timeline — a `FadeTransition` whose opacity is an `Interval`-curved `CurvedAnimation` derived from the row's clamped index.

> One ticker for the whole list, none per row, **no timers**.

`SearchResultsList` becomes a `ConsumerStatefulWidget` to own the controller lifecycle. The staggered cascade is visually preserved; a new search replays it from the top.

## Tests

- `staggered_fade_in_test.dart` rewritten for the shared-controller API: the `Interval` timeline math (index-0 leads, a clamped row trails), `timelineDuration` (720 ms), and the `FadeTransition`-not-`AnimatedOpacity` contract.
- Whole-repo `flutter analyze` clean; `test/features/search/`, `test/goldens/`, `test/core/widgets/` all green (930 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
