### PR TITLE
perf(startup): fetch PackageInfo once + move Sentry.init off the critical path (#1769)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -120,12 +120,12 @@ class AppInitializer {
     // would only delay `runApp`.
     _deferPostFirstFrame(() async {
       try {
-        final packageInfo = await PackageInfo.fromPlatform();
+        final packageInfo = await _resolvePackageInfo();
         AppConstants.setRuntimeVersion(
           '${packageInfo.version}+${packageInfo.buildNumber}',
         );
       } catch (e, st) {
-        debugPrint('PackageInfo.fromPlatform failed (#570): $e\n$st');
+        debugPrint('PackageInfo resolution failed (#570): $e\n$st');
       }
     });
 
@@ -185,24 +185,34 @@ class AppInitializer {
 
     StartupTimer.instance.mark('pre_run_app');
 
+    // #1769 — Sentry no longer wraps `runApp`; the old wrapper forced
+    // both `SentryFlutter.init` and the package-info round-trip it
+    // needs for the release string onto the cold-start critical path.
+    // The app now paints first and Sentry initialises in the first
+    // post-first-frame microtask. Native crash handlers come up a few
+    // hundred ms later — acceptable, since Sentry only needs to be live
+    // before an error is *reported*, not before first paint.
+    // `_installErrorHandlers` is re-run afterwards so the app's
+    // `errorLogger` pipeline stays the authoritative target, matching
+    // today's behaviour where `_launch` overwrote Sentry's own
+    // integration handlers.
     final dsn = resolveSentryDsn(storage);
     final consentGiven = storage
             .getSetting('consent_error_reporting') as bool? ??
         false;
     if (dsn.isNotEmpty && consentGiven) {
-      final packageInfo = await PackageInfo.fromPlatform();
-      final release =
-          'tankstellen@${packageInfo.version}+${packageInfo.buildNumber}';
-      await SentryFlutter.init(
-        (options) {
+      _deferPostFirstFrame(() async {
+        final packageInfo = await _resolvePackageInfo();
+        await SentryFlutter.init((options) {
           options.dsn = dsn;
           options.tracesSampleRate = 0.2;
           options.environment = 'production';
-          options.release = release;
-          // #1109 — strip PII (emails, lat/lng, tokens, user/request blocks,
-          // long breadcrumb payloads) from every event before it leaves the
-          // device. The scrubber is a pure function so it stays unit-tested
-          // and shared with `TraceUploader`.
+          options.release =
+              'tankstellen@${packageInfo.version}+${packageInfo.buildNumber}';
+          // #1109 — strip PII (emails, lat/lng, tokens, user/request
+          // blocks, long breadcrumb payloads) from every event before
+          // it leaves the device. The scrubber is a pure function so it
+          // stays unit-tested and shared with `TraceUploader`.
           options.beforeSend = (event, hint) {
             try {
               return PiiScrubber.scrubSentryEvent(event);
@@ -211,12 +221,12 @@ class AppInitializer {
               return event;
             }
           };
-        },
-        appRunner: () => _launch(container, appBuilder),
-      );
-    } else {
-      _launch(container, appBuilder);
+        });
+        _installErrorHandlers();
+      });
     }
+
+    _launch(container, appBuilder);
   }
 
   /// Resolves the active Sentry DSN at startup. The user-stored
@@ -233,6 +243,15 @@ class AppInitializer {
     const buildDsn = String.fromEnvironment('SENTRY_DSN');
     return buildDsn;
   }
+
+  /// #1769 — reading package info is a platform-channel round-trip.
+  /// Resolve it once, lazily; the same Future is shared by the
+  /// runtime-version cache and the Sentry release string so neither
+  /// path pays a second round-trip.
+  static Future<PackageInfo>? _packageInfoFuture;
+
+  static Future<PackageInfo> _resolvePackageInfo() =>
+      _packageInfoFuture ??= PackageInfo.fromPlatform();
 
   // ---------------------------------------------------------------------------
   // Phase 1 — bootstrap
@@ -637,17 +656,16 @@ class AppInitializer {
   // Phase 5 — runApp
   // ---------------------------------------------------------------------------
 
-  static void _launch(
-    ProviderContainer container,
-    Widget Function(ProviderContainer container) appBuilder,
-  ) {
-    // #1104 — bind the unified errorLogger to this container so every
-    // call to `errorLogger.log(layer, e, st)` from the foreground
-    // isolate routes through TraceRecorder + Sentry. Background-isolate
-    // callsites never reach this path; they fall through to the Hive
-    // ring buffer (IsolateErrorSpool) and are replayed below.
-    errorLogger.bind(container);
-
+  /// Wires the framework + platform error handlers onto the app's
+  /// [errorLogger] pipeline.
+  ///
+  /// Called from [_launch], and again right after the deferred
+  /// `SentryFlutter.init` (#1769): Sentry's `FlutterErrorIntegration`
+  /// and `OnErrorIntegration` chain themselves onto these hooks during
+  /// init, so re-running this keeps the app's `errorLogger` routing
+  /// authoritative — exactly as `_launch` did when it ran inside
+  /// Sentry's old `appRunner`.
+  static void _installErrorHandlers() {
     // Capture Flutter framework errors (build, layout, paint).
     FlutterError.onError = (details) {
       FlutterError.presentError(details);
@@ -666,6 +684,19 @@ class AppInitializer {
       errorLogger.log(ErrorLayer.other, error, stack);
       return true;
     };
+  }
+
+  static void _launch(
+    ProviderContainer container,
+    Widget Function(ProviderContainer container) appBuilder,
+  ) {
+    // #1104 — bind the unified errorLogger to this container so every
+    // call to `errorLogger.log(layer, e, st)` from the foreground
+    // isolate routes through TraceRecorder + Sentry. Background-isolate
+    // callsites never reach this path; they fall through to the Hive
+    // ring buffer (IsolateErrorSpool) and are replayed below.
+    errorLogger.bind(container);
+    _installErrorHandlers();
 
     // #609 — kick the 2-minute nearest-widget heartbeat so the home-screen
     // widget stays fresh while the app is running. The provider is

--- a/test/app/app_initializer_test.dart
+++ b/test/app/app_initializer_test.dart
@@ -127,12 +127,40 @@ void main() {
       expect(body, contains('TimeoutException'));
     });
 
-    test('global error handlers are installed inside _launch', () {
-      final body = _extractMethodBody(initSource, 'static void _launch');
-      expect(body, isNotNull);
-      expect(body, contains('FlutterError.onError'));
-      expect(body, contains('PlatformDispatcher.instance.onError'));
-      expect(body, contains('runApp'));
+    test('global error handlers are installed via _launch', () {
+      final launchBody = _extractMethodBody(initSource, 'static void _launch');
+      expect(launchBody, isNotNull);
+      expect(launchBody, contains('_installErrorHandlers'),
+          reason: '_launch must install the global error handlers');
+      expect(launchBody, contains('runApp'));
+
+      // #1769 — the handler wiring lives in its own helper so it can be
+      // re-asserted after the deferred SentryFlutter.init.
+      final handlersBody =
+          _extractMethodBody(initSource, 'static void _installErrorHandlers');
+      expect(handlersBody, isNotNull,
+          reason: '_installErrorHandlers helper must exist');
+      expect(handlersBody, contains('FlutterError.onError'));
+      expect(handlersBody, contains('PlatformDispatcher.instance.onError'));
+    });
+
+    test('PackageInfo.fromPlatform is invoked at most once (#1769)', () {
+      // A platform-channel round-trip — resolve it once and share the
+      // cached Future between the runtime-version cache and Sentry.
+      final hits = 'PackageInfo.fromPlatform('.allMatches(initSource).length;
+      expect(hits, lessThanOrEqualTo(1),
+          reason: 'PackageInfo.fromPlatform() must be called once and the '
+              'Future reused (#1769)');
+    });
+
+    test('Sentry.init no longer wraps runApp via appRunner (#1769)', () {
+      final runBody = _extractMethodBody(initSource, 'static Future<void> run');
+      expect(runBody, isNotNull);
+      expect(runBody, isNot(contains('appRunner')),
+          reason: 'Sentry.init must not wrap runApp via appRunner — that '
+              'forces it onto the cold-start critical path (#1769)');
+      expect(runBody, contains('SentryFlutter.init'),
+          reason: 'Sentry is still initialised, just off the critical path');
     });
   });
 


### PR DESCRIPTION
Closes #1769

## Problem

`AppInitializer.run` paid two cold-start costs before `runApp`:

- `PackageInfo.fromPlatform()` — a platform-channel round-trip — was awaited on the critical path for the Sentry release string, and fetched a **second** time in the deferred runtime-version block.
- `SentryFlutter.init` ran before the first frame, wrapping `runApp`.

## Fix

**PackageInfo** is now resolved through a single lazily-cached `Future` (`_resolvePackageInfo`), shared by both the runtime-version cache and the Sentry release string — one round-trip, and off the critical path.

**`SentryFlutter.init`** no longer wraps `runApp`. The app paints first; Sentry initialises in the first post-first-frame microtask. Native crash handlers come up a few hundred ms later — fine, since Sentry only needs to be live before an error is *reported*, not before first paint. Async errors stay covered the whole time by the `PlatformDispatcher.onError` handler `_launch` installs.

The framework/platform error-handler wiring is extracted into `_installErrorHandlers`, called from `_launch` **and** re-run right after the deferred `SentryFlutter.init` — Sentry's `FlutterErrorIntegration`/`OnErrorIntegration` chain themselves onto those hooks during init, so re-asserting keeps the app's `errorLogger` pipeline authoritative, matching today's behaviour.

## Tests

- `app_initializer_test.dart`: the `_launch` handler test now verifies the extracted `_installErrorHandlers`; new guards pin `PackageInfo.fromPlatform()` is invoked at most once and that `run()` no longer wraps `runApp` in an app-runner.
- Whole-repo `flutter analyze` clean; `test/app/`, `test/core/perf/`, `test/core/telemetry/`, `test/core/logging/` all green (413 tests). The `startup-budget` CI check gates the cold-start win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
