### PR TITLE
fix(profile): stop feature-toggle & use-mode changes crashing with a disposed-ref StateError (#1808)

### DIFF
--- a/lib/features/feature_management/application/app_profile_provider.dart
+++ b/lib/features/feature_management/application/app_profile_provider.dart
@@ -106,5 +106,16 @@ class ActiveAppProfile extends _$ActiveAppProfile {
       await repo.save(detected);
     }
   }
+
+  /// Reconciles the active profile against the *current* resolved
+  /// feature-flag set.
+  ///
+  /// #1808 — reads [enabledFeaturesProvider] through this notifier's
+  /// own [Ref] (a provider ref, valid for the provider's whole
+  /// lifetime), so a caller in a widget doesn't have to carry the flag
+  /// set across an `await` with a `WidgetRef` that may already belong
+  /// to an unmounted element.
+  Future<void> reconcile() =>
+      reconcileWithFlags(ref.read(enabledFeaturesProvider));
 }
 

--- a/lib/features/feature_management/application/app_profile_provider.g.dart
+++ b/lib/features/feature_management/application/app_profile_provider.g.dart
@@ -160,7 +160,7 @@ final class ActiveAppProfileProvider
   }
 }
 
-String _$activeAppProfileHash() => r'11f62d6de9c9c8af25320cc6e3f2279bf98a6a84';
+String _$activeAppProfileHash() => r'12488e4871dca36942cbe08f555511c2606c05be';
 
 /// Active "use mode" profile (#1517).
 ///

--- a/lib/features/profile/presentation/widgets/feature_management_section.dart
+++ b/lib/features/profile/presentation/widgets/feature_management_section.dart
@@ -255,17 +255,19 @@ class _ConsoFeatureCard extends ConsumerWidget {
 
   Future<void> _applyConsoMode(WidgetRef ref, ConsoMode next) async {
     final delta = consoModeFlagDelta(next);
+    // #1808 — capture both notifiers before the awaits. The widget's
+    // `ref` must not be touched after an `await`: the user can leave
+    // this screen mid-apply, which unmounts the element and makes any
+    // later `ref.read` throw a disposed-ref StateError.
     final notifier = ref.read(featureFlagsProvider.notifier);
+    final profile = ref.read(activeAppProfileProvider.notifier);
     for (final f in delta.toAdd) {
       await notifier.enable(f);
     }
     for (final f in delta.toRemove) {
       await notifier.disable(f);
     }
-    final newFlags = ref.read(enabledFeaturesProvider);
-    await ref
-        .read(activeAppProfileProvider.notifier)
-        .reconcileWithFlags(newFlags);
+    await profile.reconcile();
   }
 }
 
@@ -678,13 +680,13 @@ Future<void> _toggleAndReconcile(
   Feature feature,
   bool next,
 ) async {
+  // #1808 — capture the profile notifier before the await. The widget
+  // `ref` is unsafe to use once the user has left the screen mid-apply.
+  final profile = ref.read(activeAppProfileProvider.notifier);
   if (next) {
     await notifier.enable(feature);
   } else {
     await notifier.disable(feature);
   }
-  final newFlags = ref.read(enabledFeaturesProvider);
-  await ref
-      .read(activeAppProfileProvider.notifier)
-      .reconcileWithFlags(newFlags);
+  await profile.reconcile();
 }

--- a/test/features/feature_management/app_profile_provider_test.dart
+++ b/test/features/feature_management/app_profile_provider_test.dart
@@ -214,4 +214,36 @@ void main() {
       expect(c.read(activeAppProfileProvider), AppProfile.basic);
     });
   });
+
+  group('reconcile() — #1808', () {
+    test('reconciles against the current flag set without an explicit arg',
+        () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      await c
+          .read(activeAppProfileProvider.notifier)
+          .select(AppProfile.medium);
+      expect(c.read(activeAppProfileProvider), AppProfile.medium);
+
+      // User flips an off-bundle flag directly on the FeatureFlags
+      // notifier — `enabledFeaturesProvider` now diverges from the preset.
+      await c
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.unifiedSearchResults);
+
+      // reconcile() reads `enabledFeaturesProvider` through the
+      // notifier's own ref — no flag set passed in — and detects it.
+      await c.read(activeAppProfileProvider.notifier).reconcile();
+      expect(c.read(activeAppProfileProvider), AppProfile.custom);
+    });
+
+    test('is a no-op when the flag set still matches the active preset',
+        () async {
+      final c = makeContainer();
+      await pumpLoad(c);
+      await c.read(activeAppProfileProvider.notifier).select(AppProfile.basic);
+      await c.read(activeAppProfileProvider.notifier).reconcile();
+      expect(c.read(activeAppProfileProvider), AppProfile.basic);
+    });
+  });
 }


### PR DESCRIPTION
Closes #1808

## Crash

```
StateError: Using "ref" when a widget is about to or has been unmounted is unsafe.
  ConsumerStatefulElement.read
  _ConsoFeatureCard._applyConsoMode (feature_management_section.dart)
```
Multiple production occurrences (Android, app 5.0.0).

## Root cause

`_applyConsoMode` and `_toggleAndReconcile` used the widget `WidgetRef` **after** `await`ing `FeatureFlags.enable`/`disable` — they then called `ref.read(enabledFeaturesProvider)` and `ref.read(activeAppProfileProvider.notifier)`. Leaving the screen while those awaits were in flight unmounts the `ConsumerWidget`'s element, so the post-`await` `ref.read` throws.

## Fix

- Both functions capture the `featureFlagsProvider` / `activeAppProfileProvider` notifiers **before** the first `await` (notifier objects outlive the widget — both providers are `keepAlive`).
- New `ActiveAppProfile.reconcile()` — reconciles against the current `enabledFeaturesProvider` read through the **notifier's own `Ref`** (a provider ref, valid for the provider's whole lifetime). Widget callers no longer carry the flag set across an async gap.
- No widget `ref` is touched after an `await` in either function.

## Tests

- New `reconcile()` tests in `app_profile_provider_test.dart`: reconciles against the current flag set with no explicit arg; no-op when the set still matches the preset.
- Whole-repo `flutter analyze` clean; `test/features/feature_management/` + `test/features/profile/` green (497 tests).

## Note

The sibling crash in the same trace batch — `Cannot enable showConsumptionTab: requires obd2TripRecording` — was already fixed by #1765; those traces predate that build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
