### PR TITLE
chore(ci): skip the pubspec-only audit jobs on PRs that do not touch dependencies (#1810)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # #1810 — paths gate. Detects whether a PR touches the dependency set
+  # (`pubspec.yaml` / `pubspec.lock`) so the pubspec-only audit jobs
+  # below (security-scan / license-audit / dependency-check) can skip
+  # when it doesn't. Uses `git diff` against the PR base — same pattern
+  # as the `test` job's affected-test selector — so no new third-party
+  # action is introduced. Non-PR events (master push, weekly schedule)
+  # always resolve to `true` so the audits keep running there.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      deps: ${{ steps.filter.outputs.deps }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        name: Detect dependency-set changes
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+               | grep -qE '^pubspec\.(yaml|lock)$'; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deps=false" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
     runs-on: ubuntu-latest
     steps:
@@ -281,7 +310,16 @@ jobs:
       - name: Check startup time budget
         run: bash scripts/check_startup_budget.sh
 
+  # #1810 — security-scan / license-audit / dependency-check are pure
+  # functions of `pubspec.*`. They skip on PRs that don't touch the
+  # dependency set; master push + the weekly schedule always run them,
+  # so a newly-disclosed CVE against an unchanged lockfile still
+  # surfaces within a week. A job-level `if:` skip reports a `skipped`
+  # check conclusion, which branch protection counts as a pass — so
+  # `gh pr merge --auto` is unaffected even if these are required.
   security-scan:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.deps == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -297,6 +335,8 @@ jobs:
             --lockfile=pubspec.lock
 
   license-audit:
+    needs: [changes]  # #1810 — see security-scan
+    if: ${{ needs.changes.outputs.deps == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -316,6 +356,8 @@ jobs:
         run: bash scripts/license_audit.sh
 
   dependency-check:
+    needs: [changes]  # #1810 — see security-scan
+    if: ${{ needs.changes.outputs.deps == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #1810

## Problem

`security-scan` (OSV), `license-audit` and `dependency-check` are **pure functions of the dependency set** — they scan `pubspec.yaml` / `pubspec.lock` and nothing else. They re-ran on every PR regardless. This session's 7 merged PRs (#1792, #1764, #1771, #1772, #1773, #1769, #1808) touched no `pubspec` — yet all three jobs ran on each: **21 job-runs whose result was a foregone-conclusion pass**, each paying a checkout + Flutter setup + `flutter pub get` + the scan.

## Fix

A new `changes` job computes whether the PR touches `pubspec.*` via `git diff` against the base — the same approach the `test` job already uses for its affected-test selector, so **no new third-party action** is introduced. The three audit jobs gain:

```yaml
needs: [changes]
if: needs.changes.outputs.deps == 'true' || github.event_name != 'pull_request'
```

- Dependency-touching PR → they run.
- PR that doesn't touch `pubspec` → they **skip**.
- Master push + the weekly `schedule` cron → they **always** run, so a newly-disclosed CVE against an unchanged lockfile still surfaces within a week.

## Autonomy / safety

A job-level `if:` skip reports a `skipped` check conclusion, which branch protection counts as a pass — so `gh pr merge --auto` is unaffected even if these are required checks. Job *names* are unchanged (gated individually, not merged into one job — renaming a required check *would* break auto-merge).

**This PR demonstrates the change:** it touches only `ci.yml`, so the three jobs should report `skipped` on this very run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
