### PR TITLE
fix(widget): resolve EV station deep-links by id without requiring a favorite (#1804)

### DIFF
--- a/lib/app/routes/station_routes.dart
+++ b/lib/app/routes/station_routes.dart
@@ -1,8 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/data/storage_repository.dart';
 import '../../core/storage/storage_providers.dart';
+import '../../features/ev/data/repositories/ev_station_repository.dart';
 import '../../features/ev/domain/entities/charging_station.dart';
+import '../../features/ev/providers/ev_providers.dart';
 import '../../features/price_history/presentation/screens/price_history_screen.dart';
 import '../../features/report/presentation/screens/report_screen.dart';
 import '../../features/search/presentation/screens/ev_station_detail_screen.dart';
@@ -44,11 +48,10 @@ List<RouteBase> stationRoutes(Ref ref) => [
         },
       ),
       // Deep-link friendly EV detail: takes the station id in the
-      // path and hydrates the ChargingStation from storage (#713
-      // widget → station detail flow). Used when the caller has
-      // only the id — e.g. a home-screen widget tap or an external
-      // URL. Falls back to the invalid-id screen when the id is
-      // unknown or the cached JSON is missing.
+      // path and hydrates the ChargingStation by id (#713 widget →
+      // station detail flow). Used when the caller has only the id —
+      // a home-screen widget tap or an external URL. Falls back to the
+      // invalid-id screen only when the id is genuinely unknown.
       GoRoute(
         path: '/ev-station/:id',
         builder: (context, state) {
@@ -56,17 +59,15 @@ List<RouteBase> stationRoutes(Ref ref) => [
           if (!isValidStationId(id)) {
             return invalidIdScreen(context, state.matchedLocation);
           }
-          final storage = ref.watch(storageRepositoryProvider);
-          final raw = storage.getEvFavoriteStationData(id!);
-          if (raw == null) {
+          final station = hydrateEvStationById(
+            id!,
+            ref.watch(storageRepositoryProvider),
+            ref.watch(evStationRepositoryProvider),
+          );
+          if (station == null) {
             return invalidIdScreen(context, state.matchedLocation);
           }
-          try {
-            final station = ChargingStation.fromJson(raw);
-            return EVStationDetailScreen(station: station);
-          } catch (e, st) { // ignore: unused_catch_stack
-            return invalidIdScreen(context, state.matchedLocation);
-          }
+          return EVStationDetailScreen(station: station);
         },
       ),
       GoRoute(
@@ -80,3 +81,28 @@ List<RouteBase> stationRoutes(Ref ref) => [
         },
       ),
     ];
+
+/// Hydrates the [ChargingStation] for an `/ev-station/:id` deep link.
+///
+/// #1804 — checks the EV favorites store first, then falls back to the
+/// recently-fetched EV station cache ([EvStationRepository]), so a
+/// station the user has seen on the map — or that a home-screen widget
+/// surfaced — opens from a deep link even when it is **not** a saved
+/// favorite. Returns `null` only when the id is genuinely unknown to
+/// the device (the caller then shows the invalid-id screen).
+@visibleForTesting
+ChargingStation? hydrateEvStationById(
+  String id,
+  EvFavoriteStorage favorites,
+  EvStationRepository cache,
+) {
+  final raw = favorites.getEvFavoriteStationData(id);
+  if (raw != null) {
+    try {
+      return ChargingStation.fromJson(raw);
+    } catch (e, st) { // ignore: unused_catch_stack
+      // A corrupt favorites payload shouldn't block a valid cache hit.
+    }
+  }
+  return cache.getById(id);
+}

--- a/test/app/routes/station_routes_test.dart
+++ b/test/app/routes/station_routes_test.dart
@@ -1,7 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/app/routes/station_routes.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/ev/data/repositories/ev_station_repository.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+
+import '../../mocks/mocks.dart';
 
 /// `stationRoutes` is parameterised with a riverpod [Ref] so its
 /// `/ev-station/:id` builder can hydrate a [ChargingStation] from the
@@ -119,6 +125,72 @@ void main() {
           reason: '${r.path} should use the canonical `:id` parameter name',
         );
       }
+    });
+  });
+
+  group('hydrateEvStationById (#1804)', () {
+    const station = ChargingStation(
+      id: 'ocm-987654',
+      name: 'IONITY Pézenas',
+      operator: 'IONITY',
+      latitude: 43.4672,
+      longitude: 3.4242,
+      dist: 1.1,
+      address: 'A75 Aire de Pézenas',
+      postCode: '34120',
+      place: 'Pézenas',
+      totalPoints: 6,
+      isOperational: true,
+    );
+
+    test('returns the station from the EV favorites store when present', () {
+      final storage = MockHiveStorage();
+      when(() => storage.getEvFavoriteStationData('ocm-987654'))
+          .thenReturn(station.toJson());
+      when(() => storage.getSetting(StorageKeys.evStationsCache))
+          .thenReturn(null);
+
+      final result = hydrateEvStationById(
+        'ocm-987654',
+        storage,
+        EvStationRepository(storage),
+      );
+      expect(result?.id, 'ocm-987654');
+    });
+
+    test('falls back to the EV station cache for a non-favorite station', () {
+      final storage = MockHiveStorage();
+      // Not a saved favorite...
+      when(() => storage.getEvFavoriteStationData(any())).thenReturn(null);
+      // ...but seen recently on the map → present in the EV station cache.
+      when(() => storage.getSetting(StorageKeys.evStationsCache))
+          .thenReturn([station.toJson()]);
+
+      final result = hydrateEvStationById(
+        'ocm-987654',
+        storage,
+        EvStationRepository(storage),
+      );
+      expect(
+        result?.id,
+        'ocm-987654',
+        reason: 'a widget / external-URL deep link must open an EV station '
+            'the user has seen even when it is not a saved favorite',
+      );
+    });
+
+    test('returns null when the id is unknown to both stores', () {
+      final storage = MockHiveStorage();
+      when(() => storage.getEvFavoriteStationData(any())).thenReturn(null);
+      when(() => storage.getSetting(StorageKeys.evStationsCache))
+          .thenReturn(<dynamic>[]);
+
+      final result = hydrateEvStationById(
+        'ocm-does-not-exist',
+        storage,
+        EvStationRepository(storage),
+      );
+      expect(result, isNull);
     });
   });
 }


### PR DESCRIPTION
Closes #1804

## Problem

The `/ev-station/:id` deep-link route — reached by a home-screen widget tap or an external URL — hydrated the `ChargingStation` **only** from `getEvFavoriteStationData(id)`. An EV station the user had seen on the map but not saved as a favorite fell straight through to the invalid-id screen. So EV deep-links worked *only* for saved favorites — while fuel deep-links (`/station/:id`) were never favorite-restricted.

## Fix

The route hydrates through a new `hydrateEvStationById` helper:

1. EV favorites store (`getEvFavoriteStationData`) — as before.
2. **Fallback:** the recently-fetched EV station cache (`EvStationRepository.getById`, keyed by id).

The invalid-id screen is reached only when the id is genuinely unknown to the device. A corrupt favorites payload no longer blocks a valid cache hit. `EvStationRepository` already persists EV stations by id, so no new storage is introduced — this brings EV deep-linking to parity with fuel.

## Tests

- New `hydrateEvStationById` unit tests in `station_routes_test.dart`: favorite hit, **non-favorite cache fallback**, and unknown-id → null.
- Whole-repo `flutter analyze` clean; `test/app/` + `test/features/ev/` green (353 tests).

_Part of epic #1800. The widget surfacing EV stations into that cache is the widget-data-pipeline half, tracked separately._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
