### PR TITLE
fix(widget): make the widget refresh button work — open the app + refresh on resume (#1801, #1803)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/FuelPriceWidgetProvider.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/FuelPriceWidgetProvider.kt
@@ -2,7 +2,6 @@ package de.tankstellen.tankstellen
 
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 
@@ -26,38 +25,28 @@ class FuelPriceWidgetProvider : AppWidgetProvider() {
 
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
-        when (intent.action) {
-            StationWidgetRenderer.ACTION_TOGGLE_MODE -> {
-                val id = intent.getIntExtra(
-                    StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
-                    AppWidgetManager.INVALID_APPWIDGET_ID,
+        // #1801 — the refresh icon is now an Activity PendingIntent
+        // (see StationWidgetRenderer), not a broadcast: a
+        // BroadcastReceiver cannot reliably `startActivity` on
+        // Android 10+, so the old ACTION_REFRESH broadcast silently
+        // no-op'd. Only the mode toggle stays a broadcast — it merely
+        // re-renders, which is allowed from onReceive.
+        if (intent.action == StationWidgetRenderer.ACTION_TOGGLE_MODE) {
+            val id = intent.getIntExtra(
+                StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
+                AppWidgetManager.INVALID_APPWIDGET_ID,
+            )
+            if (id != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                StationWidgetRenderer.toggleMode(
+                    context,
+                    id,
+                    StationWidgetRenderer.MODE_FAVORITES,
                 )
-                if (id != AppWidgetManager.INVALID_APPWIDGET_ID) {
-                    StationWidgetRenderer.toggleMode(
-                        context,
-                        id,
-                        StationWidgetRenderer.MODE_FAVORITES,
-                    )
-                    renderAndCommit(
-                        context,
-                        AppWidgetManager.getInstance(context),
-                        id,
-                    )
-                }
-            }
-            StationWidgetRenderer.ACTION_REFRESH -> {
-                val mgr = AppWidgetManager.getInstance(context)
-                val ids = mgr.getAppWidgetIds(
-                    ComponentName(context, FuelPriceWidgetProvider::class.java),
+                renderAndCommit(
+                    context,
+                    AppWidgetManager.getInstance(context),
+                    id,
                 )
-                for (id in ids) renderAndCommit(context, mgr, id)
-                // Open the app so its Riverpod stack can pull fresh prices.
-                val launchIntent =
-                    context.packageManager.getLaunchIntentForPackage(context.packageName)
-                if (launchIntent != null) {
-                    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    context.startActivity(launchIntent)
-                }
             }
         }
     }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
@@ -51,7 +51,9 @@ object StationWidgetRenderer {
 
     const val ACTION_TOGGLE_MODE = "de.tankstellen.fuelprices.TOGGLE_MODE"
     const val ACTION_OPEN_APP = "de.tankstellen.fuelprices.OPEN_APP"
-    const val ACTION_REFRESH = "de.tankstellen.fuelprices.REFRESH"
+    // #1801 — ACTION_REFRESH removed: the refresh icon is now an
+    // Activity PendingIntent (a broadcast can't reliably startActivity
+    // on Android 10+), so there is no refresh broadcast to name.
 
     const val EXTRA_APP_WIDGET_ID = "appWidgetId"
 
@@ -192,16 +194,17 @@ object StationWidgetRenderer {
             ),
         )
 
-        // Refresh icon — re-renders from cache and opens the app so the
-        // Flutter side can pull fresh prices.
+        // Refresh icon (#1801 / #1803) — an Activity PendingIntent that
+        // opens the app; the Flutter side then refreshes the widget on
+        // resume. This used to be a broadcast whose onReceive called
+        // `startActivity`, which Android 10+ blocks from a receiver — so
+        // the refresh button silently did nothing.
         views.setOnClickPendingIntent(
             R.id.widget_refresh,
-            buildBroadcast(
+            buildActivity(
                 context,
-                providerClass,
-                ACTION_REFRESH,
+                uri = null,
                 requestCode = appWidgetId * 10 + 2,
-                extraAppWidgetId = appWidgetId,
             ),
         )
 

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/services/service_providers.dart';
@@ -10,31 +10,44 @@ import '../data/home_widget_service.dart';
 
 part 'nearest_widget_refresh_provider.g.dart';
 
-/// Foreground heartbeat that rebuilds the nearest home-screen widget every
-/// [kNearestWidgetForegroundInterval].
+/// Foreground heartbeat that rebuilds the home-screen widget — both the
+/// favorites and the nearest variants — every
+/// [kNearestWidgetForegroundInterval], once immediately on app open,
+/// and again whenever the app returns to the foreground (#1803).
 ///
 /// WorkManager enforces a 15-minute floor on periodic tasks, so background
 /// refresh alone can't meet the #609 target of "widget feels fresh". This
 /// provider adds a foreground 2-minute tick that kicks the builder while
-/// the app is running. When the app is backgrounded, the provider is
-/// disposed by the framework; the background task takes over.
+/// the app is running.
+///
+/// #1803 — the resume hook is what makes the widget's refresh button
+/// work: that button opens the app (#1801), and the app reaching the
+/// foreground triggers a tick that rebuilds both widget variants.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
-/// the tick; the provider owns its own Timer and releases it in onDispose.
+/// the tick; the provider owns its Timer + [AppLifecycleListener] and
+/// releases both in onDispose.
 @Riverpod(keepAlive: true)
 class NearestWidgetRefresh extends _$NearestWidgetRefresh {
   Timer? _timer;
+  AppLifecycleListener? _lifecycle;
 
   @override
   void build() {
     ref.onDispose(() {
       _timer?.cancel();
       _timer = null;
+      _lifecycle?.dispose();
+      _lifecycle = null;
     });
     _timer ??= Timer.periodic(
       kNearestWidgetForegroundInterval,
       (_) => _tick(),
     );
+    // #1803 — refresh again whenever the app returns to the foreground,
+    // so the widget's refresh button (which opens the app, #1801) and
+    // any ordinary resume leave the widget up to date.
+    _lifecycle ??= AppLifecycleListener(onResume: () => unawaited(_tick()));
     // Fire one immediate refresh so the widget reflects the current
     // session as soon as the user opens the app (don't wait two minutes).
     unawaited(_tick());
@@ -44,6 +57,18 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
     try {
       final storage = ref.read(storageRepositoryProvider);
       final stationService = ref.read(stationServiceProvider);
+      // #1803 — refresh the favorites variant too. It's a cheap local
+      // read (favorite ids + their stored prices, no network), so
+      // running it on every tick keeps the favorites widget from going
+      // stale between favorites edits.
+      await HomeWidgetService.updateWidget(
+        storage,
+        profileStorage: storage,
+        settingsStorage: storage,
+        pricePredictor: (stationId, fuelType) => ref.read(
+          pricePredictionProvider(stationId, fuelType),
+        ),
+      );
       await HomeWidgetService.updateNearestWidget(
         storage,
         storage,

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -8,45 +8,63 @@ part of 'nearest_widget_refresh_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Foreground heartbeat that rebuilds the nearest home-screen widget every
-/// [kNearestWidgetForegroundInterval].
+/// Foreground heartbeat that rebuilds the home-screen widget — both the
+/// favorites and the nearest variants — every
+/// [kNearestWidgetForegroundInterval], once immediately on app open,
+/// and again whenever the app returns to the foreground (#1803).
 ///
 /// WorkManager enforces a 15-minute floor on periodic tasks, so background
 /// refresh alone can't meet the #609 target of "widget feels fresh". This
 /// provider adds a foreground 2-minute tick that kicks the builder while
-/// the app is running. When the app is backgrounded, the provider is
-/// disposed by the framework; the background task takes over.
+/// the app is running.
+///
+/// #1803 — the resume hook is what makes the widget's refresh button
+/// work: that button opens the app (#1801), and the app reaching the
+/// foreground triggers a tick that rebuilds both widget variants.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
-/// the tick; the provider owns its own Timer and releases it in onDispose.
+/// the tick; the provider owns its Timer + [AppLifecycleListener] and
+/// releases both in onDispose.
 
 @ProviderFor(NearestWidgetRefresh)
 final nearestWidgetRefreshProvider = NearestWidgetRefreshProvider._();
 
-/// Foreground heartbeat that rebuilds the nearest home-screen widget every
-/// [kNearestWidgetForegroundInterval].
+/// Foreground heartbeat that rebuilds the home-screen widget — both the
+/// favorites and the nearest variants — every
+/// [kNearestWidgetForegroundInterval], once immediately on app open,
+/// and again whenever the app returns to the foreground (#1803).
 ///
 /// WorkManager enforces a 15-minute floor on periodic tasks, so background
 /// refresh alone can't meet the #609 target of "widget feels fresh". This
 /// provider adds a foreground 2-minute tick that kicks the builder while
-/// the app is running. When the app is backgrounded, the provider is
-/// disposed by the framework; the background task takes over.
+/// the app is running.
+///
+/// #1803 — the resume hook is what makes the widget's refresh button
+/// work: that button opens the app (#1801), and the app reaching the
+/// foreground triggers a tick that rebuilds both widget variants.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
-/// the tick; the provider owns its own Timer and releases it in onDispose.
+/// the tick; the provider owns its Timer + [AppLifecycleListener] and
+/// releases both in onDispose.
 final class NearestWidgetRefreshProvider
     extends $NotifierProvider<NearestWidgetRefresh, void> {
-  /// Foreground heartbeat that rebuilds the nearest home-screen widget every
-  /// [kNearestWidgetForegroundInterval].
+  /// Foreground heartbeat that rebuilds the home-screen widget — both the
+  /// favorites and the nearest variants — every
+  /// [kNearestWidgetForegroundInterval], once immediately on app open,
+  /// and again whenever the app returns to the foreground (#1803).
   ///
   /// WorkManager enforces a 15-minute floor on periodic tasks, so background
   /// refresh alone can't meet the #609 target of "widget feels fresh". This
   /// provider adds a foreground 2-minute tick that kicks the builder while
-  /// the app is running. When the app is backgrounded, the provider is
-  /// disposed by the framework; the background task takes over.
+  /// the app is running.
+  ///
+  /// #1803 — the resume hook is what makes the widget's refresh button
+  /// work: that button opens the app (#1801), and the app reaching the
+  /// foreground triggers a tick that rebuilds both widget variants.
   ///
   /// Reading the provider once (e.g. from the app's root widget) starts
-  /// the tick; the provider owns its own Timer and releases it in onDispose.
+  /// the tick; the provider owns its Timer + [AppLifecycleListener] and
+  /// releases both in onDispose.
   NearestWidgetRefreshProvider._()
     : super(
         from: null,
@@ -75,19 +93,25 @@ final class NearestWidgetRefreshProvider
 }
 
 String _$nearestWidgetRefreshHash() =>
-    r'a6630c70cbbb2f0bbed3a1b9ca87ceb64d13723c';
+    r'8aa9324db9553fcdc28a75963a247ff1654a6851';
 
-/// Foreground heartbeat that rebuilds the nearest home-screen widget every
-/// [kNearestWidgetForegroundInterval].
+/// Foreground heartbeat that rebuilds the home-screen widget — both the
+/// favorites and the nearest variants — every
+/// [kNearestWidgetForegroundInterval], once immediately on app open,
+/// and again whenever the app returns to the foreground (#1803).
 ///
 /// WorkManager enforces a 15-minute floor on periodic tasks, so background
 /// refresh alone can't meet the #609 target of "widget feels fresh". This
 /// provider adds a foreground 2-minute tick that kicks the builder while
-/// the app is running. When the app is backgrounded, the provider is
-/// disposed by the framework; the background task takes over.
+/// the app is running.
+///
+/// #1803 — the resume hook is what makes the widget's refresh button
+/// work: that button opens the app (#1801), and the app reaching the
+/// foreground triggers a tick that rebuilds both widget variants.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
-/// the tick; the provider owns its own Timer and releases it in onDispose.
+/// the tick; the provider owns its Timer + [AppLifecycleListener] and
+/// releases both in onDispose.
 
 abstract class _$NearestWidgetRefresh extends $Notifier<void> {
   void build();


### PR DESCRIPTION
Closes #1801
Closes #1803

Bundled — both issues are the widget-refresh subsystem; one commit per issue.

## #1801 — refresh button silently did nothing

The refresh icon was a broadcast `PendingIntent` whose `onReceive` handler called `context.startActivity(...)` to open the app. **Android 10+ blocks an Activity start from a `BroadcastReceiver`** — so the button no-op'd.

It is now an Activity `PendingIntent` (`buildActivity` — the mechanism the row taps and chrome tap already use); a launcher-fired Activity start is a foreground launch and is not restricted. The dead `ACTION_REFRESH` broadcast branch + constant are removed.

## #1803 — refresh didn't fetch fresh data

The favorites widget was rebuilt only on a favorites edit / background task / cold start — never on a plain resume. `NearestWidgetRefresh` now:

- refreshes the **favorites** variant on every tick too (a cheap local Hive read — no network), not just the nearest variant;
- owns an `AppLifecycleListener` firing a tick on every foreground resume.

So tapping refresh → the app opens (#1801) → reaching the foreground triggers a tick → both widget variants are rebuilt with the app's latest data.

## Tests

- `flutter analyze` clean; `test/features/widget/` (94) and `test/app/` (224) green.
- The Kotlin change (Activity vs broadcast `PendingIntent`) is compile-checked by `build-android` on master; on-device verification of the refresh tap is a quick follow-up if needed.

_Part of epic #1800._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
