### PR TITLE
feat(widget): in-app home-screen widget help section (#1806)

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -13,6 +13,7 @@ import '../../../feature_management/domain/consumption_tab_visibility.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../../feature_management/domain/feature_dependency_graph.dart';
 import '../../../sync/presentation/widgets/ntfy_setup.dart';
+import '../../../widget/presentation/widget_help_section.dart';
 import '../widgets/about_section.dart';
 import '../widgets/api_key_section.dart';
 import '../widgets/feature_management_section.dart';
@@ -168,6 +169,17 @@ class ProfileScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 8),
           ],
+
+          // #1806 — home-screen widget help. The Android widget's
+          // per-widget config is OS-mediated (long-press → Reconfigure)
+          // and can't be launched from the app, so this section is the
+          // in-app discoverable surface for it.
+          _FoldableSection(
+            icon: Icons.widgets_outlined,
+            title: l?.widgetHelpSectionTitle ?? 'Home-screen widget',
+            child: const WidgetHelpSection(),
+          ),
+          const SizedBox(height: 8),
 
           // Storage & Cache
           _FoldableSection(

--- a/lib/features/widget/presentation/widget_help_section.dart
+++ b/lib/features/widget/presentation/widget_help_section.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+
+/// In-app help for the home-screen widget (#1806).
+///
+/// The Android widget's per-widget configuration is OS-mediated
+/// (long-press → Reconfigure) and cannot be launched from inside the
+/// app, so the discoverable surface is this explanatory section in
+/// Settings: how to add the widget, how its taps behave, and how to
+/// reach the reconfigure gesture.
+class WidgetHelpSection extends StatelessWidget {
+  const WidgetHelpSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final lines = <String>[
+      l?.widgetHelpIntro ??
+          'Add the SparKilo widget to your home screen to see fuel and '
+              'charging prices at a glance.',
+      l?.widgetHelpAdd ??
+          "Add it from your launcher's widget picker — long-press an "
+              'empty area of the home screen, choose Widgets, and find '
+              'SparKilo.',
+      l?.widgetHelpTap ??
+          'Tap a station in the widget to open it in the app. Tap the '
+              'refresh icon to update prices.',
+      l?.widgetHelpConfigure ??
+          'On Android, long-press the widget and choose Reconfigure to '
+              'change the profile, colour, and content.',
+    ];
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (final line in lines) ...[
+            Text(line, style: theme.textTheme.bodySmall),
+            const SizedBox(height: 8),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/_fragments/widget_help_de.arb
+++ b/lib/l10n/_fragments/widget_help_de.arb
@@ -1,0 +1,7 @@
+{
+  "widgetHelpSectionTitle": "Homescreen-Widget",
+  "widgetHelpIntro": "Füge das SparKilo-Widget zu deinem Startbildschirm hinzu, um Sprit- und Ladepreise auf einen Blick zu sehen.",
+  "widgetHelpAdd": "Füge es über die Widget-Auswahl deines Launchers hinzu — halte einen leeren Bereich des Startbildschirms gedrückt, wähle „Widgets“ und suche SparKilo.",
+  "widgetHelpTap": "Tippe im Widget auf eine Station, um sie in der App zu öffnen. Tippe auf das Aktualisieren-Symbol, um die Preise zu aktualisieren.",
+  "widgetHelpConfigure": "Halte das Widget unter Android gedrückt und wähle „Neu konfigurieren“, um Profil, Farbe und Inhalt zu ändern."
+}

--- a/lib/l10n/_fragments/widget_help_en.arb
+++ b/lib/l10n/_fragments/widget_help_en.arb
@@ -1,0 +1,22 @@
+{
+  "widgetHelpSectionTitle": "Home-screen widget",
+  "@widgetHelpSectionTitle": {
+    "description": "Title of the home-screen widget help section in Settings (#1806)."
+  },
+  "widgetHelpIntro": "Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.",
+  "@widgetHelpIntro": {
+    "description": "Intro line of the home-screen widget help section in Settings (#1806)."
+  },
+  "widgetHelpAdd": "Add it from your launcher's widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.",
+  "@widgetHelpAdd": {
+    "description": "Help line explaining how to add the home-screen widget (#1806)."
+  },
+  "widgetHelpTap": "Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.",
+  "@widgetHelpTap": {
+    "description": "Help line explaining the home-screen widget's tap and refresh behaviour (#1806)."
+  },
+  "widgetHelpConfigure": "On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.",
+  "@widgetHelpConfigure": {
+    "description": "Help line explaining how to reconfigure the Android home-screen widget (#1806)."
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2005,6 +2005,11 @@
   "waitTimeTrackStart": "Meine Wartezeit verfolgen",
   "waitTimeTrackEnd": "Ich gehe gerade",
   "waitTimeElapsedShort": "Bisher {minutes} Min",
+  "widgetHelpSectionTitle": "Homescreen-Widget",
+  "widgetHelpIntro": "Füge das SparKilo-Widget zu deinem Startbildschirm hinzu, um Sprit- und Ladepreise auf einen Blick zu sehen.",
+  "widgetHelpAdd": "Füge es über die Widget-Auswahl deines Launchers hinzu — halte einen leeren Bereich des Startbildschirms gedrückt, wähle „Widgets“ und suche SparKilo.",
+  "widgetHelpTap": "Tippe im Widget auf eine Station, um sie in der App zu öffnen. Tippe auf das Aktualisieren-Symbol, um die Preise zu aktualisieren.",
+  "widgetHelpConfigure": "Halte das Widget unter Android gedrückt und wähle „Neu konfigurieren“, um Profil, Farbe und Inhalt zu ändern.",
   "widgetVariantDefault": "Nur aktueller Preis",
   "widgetVariantPredictive": "Prognose: bester Tankzeitpunkt",
   "widgetPredictiveNowPrefix": "jetzt"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3899,6 +3899,26 @@
       }
     }
   },
+  "widgetHelpSectionTitle": "Home-screen widget",
+  "@widgetHelpSectionTitle": {
+    "description": "Title of the home-screen widget help section in Settings (#1806)."
+  },
+  "widgetHelpIntro": "Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.",
+  "@widgetHelpIntro": {
+    "description": "Intro line of the home-screen widget help section in Settings (#1806)."
+  },
+  "widgetHelpAdd": "Add it from your launcher's widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.",
+  "@widgetHelpAdd": {
+    "description": "Help line explaining how to add the home-screen widget (#1806)."
+  },
+  "widgetHelpTap": "Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.",
+  "@widgetHelpTap": {
+    "description": "Help line explaining the home-screen widget's tap and refresh behaviour (#1806)."
+  },
+  "widgetHelpConfigure": "On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.",
+  "@widgetHelpConfigure": {
+    "description": "Help line explaining how to reconfigure the Android home-screen widget (#1806)."
+  },
   "widgetVariantDefault": "Current price only",
   "@widgetVariantDefault": {
     "description": "Label for the default home-widget content variant — shows just the current pump price (#1121)."

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9266,6 +9266,36 @@ abstract class AppLocalizations {
   /// **'{minutes} min so far'**
   String waitTimeElapsedShort(int minutes);
 
+  /// Title of the home-screen widget help section in Settings (#1806).
+  ///
+  /// In en, this message translates to:
+  /// **'Home-screen widget'**
+  String get widgetHelpSectionTitle;
+
+  /// Intro line of the home-screen widget help section in Settings (#1806).
+  ///
+  /// In en, this message translates to:
+  /// **'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.'**
+  String get widgetHelpIntro;
+
+  /// Help line explaining how to add the home-screen widget (#1806).
+  ///
+  /// In en, this message translates to:
+  /// **'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.'**
+  String get widgetHelpAdd;
+
+  /// Help line explaining the home-screen widget's tap and refresh behaviour (#1806).
+  ///
+  /// In en, this message translates to:
+  /// **'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.'**
+  String get widgetHelpTap;
+
+  /// Help line explaining how to reconfigure the Android home-screen widget (#1806).
+  ///
+  /// In en, this message translates to:
+  /// **'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.'**
+  String get widgetHelpConfigure;
+
   /// Label for the default home-widget content variant — shows just the current pump price (#1121).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -5132,6 +5132,25 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -5132,6 +5132,25 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -5130,6 +5130,25 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5176,6 +5176,25 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Homescreen-Widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Füge das SparKilo-Widget zu deinem Startbildschirm hinzu, um Sprit- und Ladepreise auf einen Blick zu sehen.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Füge es über die Widget-Auswahl deines Launchers hinzu — halte einen leeren Bereich des Startbildschirms gedrückt, wähle „Widgets“ und suche SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tippe im Widget auf eine Station, um sie in der App zu öffnen. Tippe auf das Aktualisieren-Symbol, um die Preise zu aktualisieren.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'Halte das Widget unter Android gedrückt und wähle „Neu konfigurieren“, um Profil, Farbe und Inhalt zu ändern.';
+
+  @override
   String get widgetVariantDefault => 'Nur aktueller Preis';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -5134,6 +5134,25 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5124,6 +5124,25 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5133,6 +5133,25 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -5127,6 +5127,25 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -5130,6 +5130,25 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5184,6 +5184,25 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -5129,6 +5129,25 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -5134,6 +5134,25 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -5133,6 +5133,25 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -5131,6 +5131,25 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -5133,6 +5133,25 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -5129,6 +5129,25 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -5134,6 +5134,25 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -5132,6 +5132,25 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -5133,6 +5133,25 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5132,6 +5132,25 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -5133,6 +5133,25 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -5127,6 +5127,25 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -5131,6 +5131,25 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get widgetHelpSectionTitle => 'Home-screen widget';
+
+  @override
+  String get widgetHelpIntro =>
+      'Add the SparKilo widget to your home screen to see fuel and charging prices at a glance.';
+
+  @override
+  String get widgetHelpAdd =>
+      'Add it from your launcher\'s widget picker — long-press an empty area of the home screen, choose Widgets, and find SparKilo.';
+
+  @override
+  String get widgetHelpTap =>
+      'Tap a station in the widget to open it in the app. Tap the refresh icon to update prices.';
+
+  @override
+  String get widgetHelpConfigure =>
+      'On Android, long-press the widget and choose Reconfigure to change the profile, colour, and content.';
+
+  @override
   String get widgetVariantDefault => 'Current price only';
 
   @override

--- a/test/features/widget/presentation/widget_help_section_test.dart
+++ b/test/features/widget/presentation/widget_help_section_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/widget/presentation/widget_help_section.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+import '../../../helpers/pump_app.dart';
+
+void main() {
+  testWidgets('WidgetHelpSection renders the home-screen widget help (#1806)',
+      (tester) async {
+    await pumpApp(tester, const WidgetHelpSection());
+
+    final l = AppLocalizations.of(
+      tester.element(find.byType(WidgetHelpSection)),
+    )!;
+    expect(find.text(l.widgetHelpIntro), findsOneWidget);
+    expect(find.text(l.widgetHelpAdd), findsOneWidget);
+    expect(find.text(l.widgetHelpTap), findsOneWidget);
+    expect(find.text(l.widgetHelpConfigure), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #1806

## Problem

The Android home-screen widget's per-widget configuration is OS-mediated (long-press → Reconfigure) and can't be launched from inside the app — so the widget had **no discoverable in-app surface at all**. Users don't know it exists, how taps behave, or that it's configurable.

## Fix

A new **"Home-screen widget"** foldable section on the Settings screen (`WidgetHelpSection`) explains:

- how to add the widget from the launcher's widget picker;
- that tapping a station opens it in the app, and the refresh icon updates prices;
- how to reach the Android reconfigure gesture (long-press → Reconfigure) for profile / colour / content.

All copy is localized — new `widget_help` ARB fragment (en + de), merged via `build_arb` + `gen-l10n`.

## Tests

- New `widget_help_section_test.dart` — the section renders all four localized help lines.
- `flutter analyze` + module-boundary check clean; `test/features/profile/` + `test/features/widget/` (440) + `no_hardcoded_ui_strings` + `test/l10n/` green.

_Completes epic #1800 — #1807 was closed as already-covered, #1802/#1805 closed with documented findings._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
