### PR TITLE
perf(startup): defer cache eviction, profile migration + deep-feature Hive boxes past first frame (#1768, #1794)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -97,6 +97,19 @@ class AppInitializer {
     final container = ProviderContainer();
 
     final storage = HiveStorage();
+
+    // #1794 / #1768 — post-first-frame storage work. `initDeferred()`
+    // opens the deep-feature Hive boxes; it is idempotent + cached, so
+    // the post-frame readers below (`_runTripsSyncMerge`, the trip
+    // recovery passes) await the same opens. Cache eviction and the
+    // country/language profile migration each walk an entire box and
+    // are not needed for the first frame, so they run here too.
+    _deferPostFirstFrame(() async {
+      unawaited(HiveBoxes.initDeferred());
+      await CacheManager(storage).evictExpired();
+      await ProfileRepository(storage).migrateProfileCountryLanguage();
+    });
+
     // #795 phase 1 — defer Supabase/TankSync warm-up and community-config
     // asset read until after the first frame. Neither is required for the
     // landing UI and both touch relatively slow I/O (asset bundle decode +
@@ -301,19 +314,17 @@ class AppInitializer {
       return true;
     }());
 
-    // Evict stale cache entries on startup.
-    final storage = HiveStorage();
-    final cacheManager = CacheManager(storage);
-    await cacheManager.evictExpired();
-
-    // Migrate existing profiles to include country/language.
-    final profileRepo = ProfileRepository(storage);
-    await profileRepo.migrateProfileCountryLanguage();
-
     // Safety net: guarantee a default profile always exists (#555).
     // The onboarding wizard calls ensureDefaultProfile() at completion,
     // but if the wizard was ever skipped (e.g., by the #521 hasApiKey
-    // regression), the app would run without any profile.
+    // regression), the app would run without any profile. This stays on
+    // the critical path — the first route depends on a profile existing.
+    //
+    // #1768 — cache eviction and the country/language profile migration
+    // used to run here too; both walk an entire Hive box and neither
+    // result is needed to paint the first frame, so they are deferred
+    // past it (see `run()`'s post-first-frame block).
+    final profileRepo = ProfileRepository(HiveStorage());
     await profileRepo.ensureDefaultProfile();
   }
 
@@ -465,6 +476,9 @@ class AppInitializer {
   /// unchanged on error so a transient network blip never costs the
   /// user their local history view.
   static Future<void> _runTripsSyncMerge() async {
+    // #1794 — `obd2TripHistory` is a deferred box; wait for the
+    // post-first-frame opens before reading it.
+    await HiveBoxes.initDeferred();
     if (TankSyncClient.client == null) return;
     if (!Hive.isBoxOpen(HiveBoxes.obd2TripHistory)) return;
     try {
@@ -537,6 +551,9 @@ class AppInitializer {
   static Future<void> _runActiveTripRecovery(
     ProviderContainer container,
   ) async {
+    // #1794 — the active-trip + trip-history boxes are deferred; wait
+    // for the post-first-frame opens before reading them.
+    await HiveBoxes.initDeferred();
     if (!Hive.isBoxOpen(HiveBoxes.obd2ActiveTrip)) return;
     final activeRepo = ActiveTripRepository(
       box: Hive.box<String>(HiveBoxes.obd2ActiveTrip),
@@ -623,6 +640,9 @@ class AppInitializer {
   static Future<void> _runPausedTripRecovery(
     ProviderContainer container,
   ) async {
+    // #1794 — the paused-trip + trip-history boxes are deferred; wait
+    // for the post-first-frame opens before reading them.
+    await HiveBoxes.initDeferred();
     if (!Hive.isBoxOpen(HiveBoxes.obd2PausedTrips)) return;
     if (!Hive.isBoxOpen(HiveBoxes.obd2TripHistory)) return;
     final pausedRepo = PausedTripRepository(
@@ -772,6 +792,9 @@ class AppInitializer {
     // optimisation; trips still save without it).
     _deferPostFirstFrame(() async {
       try {
+        // #1794 — the aggregator hook reads `obd2TripHistory`, a
+        // deferred box; wait for the post-first-frame opens first.
+        await HiveBoxes.initDeferred();
         final wired = wireAggregatorIntoTripHistory(container);
         if (!wired) {
           debugPrint(

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -150,15 +150,33 @@ class HiveBoxes {
         'Hive migration: $boxName migrated to encrypted (${entries.length} entries)');
   }
 
-  /// Initialize all Hive boxes for the main isolate.
+  /// Boxes only read by deep OBD2 / trip / badge / snapshot / glide
+  /// features — none is needed to paint the landing search screen, so
+  /// [initDeferred] opens them *after* the first frame (#1794).
+  static const _deferredBoxes = {
+    obd2Baselines,
+    obd2TripHistory,
+    achievements,
+    obd2SupportedPids,
+    serviceReminders,
+    obd2PausedTrips,
+    obd2ActiveTrip,
+    priceSnapshots,
+    trafficSignalsCache,
+  };
+
+  static Future<void>? _deferredInit;
+
+  /// Initialize the Hive boxes required to paint the first frame.
   ///
-  /// #1764 — every box opens on the cold-start critical path before the
-  /// first frame. No box depends on another being open, so the two
-  /// phases below run their disk I/O concurrently via [Future.wait]
-  /// rather than awaiting ~30 `openBox` calls one at a time: the
-  /// encrypted-box migration probe is one parallel batch, and the real
-  /// opens are another. Every box is still open before `init()` returns,
-  /// so there is no "box not open" risk for any reader.
+  /// #1764 — the encrypted-box migration probe and the box opens each
+  /// run their disk I/O concurrently via [Future.wait] rather than
+  /// awaiting ~30 `openBox` calls one at a time.
+  ///
+  /// #1794 — only the boxes the landing screen needs open here. The
+  /// nine deep-feature boxes in [_deferredBoxes] move to [initDeferred],
+  /// which the app-initializer kicks after the first frame. Every box
+  /// `init()` opens is still open before it returns.
   static Future<void> init() async {
     await Hive.initFlutter();
     final cipher = await _loadCipher();
@@ -177,10 +195,9 @@ class HiveBoxes {
       }
     }));
 
-    // Phase 2 — open every box in one parallel batch. The 6 encrypted
-    // boxes and the unencrypted domain boxes have no inter-box ordering
-    // dependency, so a single Future.wait collapses what used to be ~18
-    // sequential awaits into one I/O-bound wait.
+    // Phase 2 — open the first-frame-critical boxes in one parallel
+    // batch: the 6 encrypted domain boxes plus the three unencrypted
+    // boxes the landing path / background isolate need immediately.
     await Future.wait<Box<dynamic>>([
       Hive.openBox(settings, encryptionCipher: cipher),
       Hive.openBox(profiles, encryptionCipher: cipher),
@@ -188,44 +205,25 @@ class HiveBoxes {
       Hive.openBox(cache, encryptionCipher: cipher),
       Hive.openBox(priceHistory, encryptionCipher: cipher),
       Hive.openBox(alerts, encryptionCipher: cipher),
-      // #769 — OBD2 baselines are unencrypted JSON strings; low
-      // sensitivity and opened once at startup like the other boxes.
-      Hive.openBox<String>(obd2Baselines),
-      // #726 — OBD2 trip history: rolling log of finalised trips.
-      Hive.openBox<String>(obd2TripHistory),
-      // #781 — gamification badges: one entry per earned badge.
-      Hive.openBox<String>(achievements),
-      // #811 — supported-PID bitmap cache (per VIN, or make:model:year
-      // fallback). Values are JSON-encoded `List<int>` of PID indices,
-      // mirroring the storage idiom used by the other OBD2 boxes so
-      // we don't need a custom adapter.
-      Hive.openBox<String>(obd2SupportedPids),
-      // #584 — odometer-based service reminders: one entry per reminder.
-      Hive.openBox<String>(serviceReminders),
-      // #797 — partial OBD2 trips paused by a BT drop. Same string-typed
-      // JSON pattern as [obd2TripHistory] so one box adapter covers both.
-      Hive.openBox<String>(obd2PausedTrips),
-      // #1303 — write-through snapshot of the currently-recording trip.
-      // Single-entry box; the provider rewrites on a 5-second debounce
-      // and the recovery service reads it on next cold start.
-      Hive.openBox<String>(obd2ActiveTrip),
-      // #579 — rolling price snapshots for the velocity detector.
-      Hive.openBox<String>(priceSnapshots),
-      // #1105 — isolate error spool: background-isolate errors written
-      // here while Riverpod is unavailable, drained by the foreground
-      // initialiser into TraceRecorder. Unencrypted so the BG isolate
-      // can write before consent / keychain unlock.
+      // #1105 — isolate error spool: the background isolate writes here
+      // before Riverpod is available, so it must be open immediately.
       Hive.openBox<String>(isolateErrorSpool),
-      // #1125 — glide-coach OSM traffic-signal cache (phase 1).
-      Hive.openBox<String>(trafficSignalsCache),
-      // #1373 — central feature-flag set (phase 1).
+      // #1373 — central feature-flag set: read during the first build.
       Hive.openBox<dynamic>(featureFlags),
-      // #1517 — active "use mode" profile (Basic / Medium / Full /
-      // Custom). Tiny box, always one entry; opened next to feature_flags
-      // since the two systems collaborate at startup.
+      // #1517 — active "use mode" profile: gates the first route.
       Hive.openBox<dynamic>(appProfile),
     ]);
   }
+
+  /// Opens the deep-feature boxes ([_deferredBoxes]) that the landing
+  /// screen does not need (#1794).
+  ///
+  /// Idempotent — the result is cached, so every post-first-frame
+  /// reader of a deferred box can `await HiveBoxes.initDeferred()` to
+  /// be sure its box is open without re-running the opens.
+  static Future<void> initDeferred() => _deferredInit ??= Future.wait(
+        _deferredBoxes.map((name) => Hive.openBox<String>(name)),
+      );
 
   /// Initialize Hive in a background isolate with proper encryption.
   static Future<void> initInIsolate() async {

--- a/test/core/storage/hive_boxes_test.dart
+++ b/test/core/storage/hive_boxes_test.dart
@@ -235,6 +235,60 @@ void main() {
       });
     });
 
+    group('deferred-box opening (#1794)', () {
+      test('init() opens only first-frame-critical boxes; the deep-feature '
+          'boxes move to initDeferred()', () {
+        final source =
+            File('lib/core/storage/hive_boxes.dart').readAsStringSync();
+
+        expect(
+          source.contains('static Future<void> initDeferred()'),
+          isTrue,
+          reason: 'initDeferred() must exist to open the deferred boxes '
+              'after the first frame (#1794)',
+        );
+
+        final initMatch = RegExp(
+          r'static Future<void> init\(\) async \{(.*?)\n  \}',
+          dotAll: true,
+        ).firstMatch(source);
+        expect(initMatch, isNotNull);
+        final initBody = initMatch!.group(1)!;
+
+        // The deep-feature boxes must NOT open in init() — they are
+        // deferred past the first frame.
+        for (final box in [
+          'obd2TripHistory',
+          'obd2ActiveTrip',
+          'obd2PausedTrips',
+          'priceSnapshots',
+          'serviceReminders',
+          'trafficSignalsCache',
+        ]) {
+          expect(
+            initBody.contains(box),
+            isFalse,
+            reason: '$box is a deep-feature box — it must open in '
+                'initDeferred(), not on the first-frame critical path',
+          );
+        }
+
+        // First-frame-critical boxes stay in init().
+        for (final box in [
+          'settings',
+          'featureFlags',
+          'appProfile',
+          'isolateErrorSpool',
+        ]) {
+          expect(
+            initBody.contains(box),
+            isTrue,
+            reason: '$box is first-frame-critical and must stay in init()',
+          );
+        }
+      });
+    });
+
     group('toStringDynamicMap', () {
       test('returns null for null input', () {
         expect(HiveBoxes.toStringDynamicMap(null), isNull);


### PR DESCRIPTION
Closes #1768
Closes #1794

Bundle A of the epic #1678 cold-start residue — two `app_initializer.dart` / `hive_boxes.dart` deferral changes, one commit per issue.

## #1794 — defer the deep-feature Hive boxes

After #1764 all ~18 Hive boxes opened in `init()` before the first frame. Nine — `obd2Baselines`, `obd2TripHistory`, `achievements`, `obd2SupportedPids`, `serviceReminders`, `obd2PausedTrips`, `obd2ActiveTrip`, `priceSnapshots`, `trafficSignalsCache` — are read only by deep OBD2 / trip / badge features, not the landing screen.

`init()` now opens only the first-frame-critical boxes; the nine move to a new idempotent, cached `HiveBoxes.initDeferred()`.

**Reader audit:** every post-first-frame reader of a deferred box — `_runTripsSyncMerge`, `_runActiveTripRecovery`, `_runPausedTripRecovery`, and the vehicle-aggregator wiring — now `await HiveBoxes.initDeferred()` before touching its box, so a deferred box is always open by the time its reader runs (the existing `Hive.isBoxOpen` guards remain as belt-and-suspenders).

## #1768 — defer cache eviction + profile migration

`_initStorage` awaited `CacheManager.evictExpired()` (walks the whole `cache` box) and `migrateProfileCountryLanguage()` (walks every profile) before `runApp`. Both move to the post-first-frame block; `ensureDefaultProfile()` stays critical (the first route needs a profile).

## Tests

- New `hive_boxes_test.dart` guard: `init()` opens only the critical boxes, the deep-feature boxes moved to `initDeferred()`.
- Whole-repo `flutter analyze` clean; `test/core/storage/` + `test/app/` green (433). The `startup-budget` CI gate measures the cold-start win.

_Part of epic #1678._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
