### PR TITLE
chore(release): obfuscate release builds + retain de-obfuscation symbols (#1777)

### DIFF
--- a/.github/workflows/daily-github-release.yml
+++ b/.github/workflows/daily-github-release.yml
@@ -145,9 +145,13 @@ jobs:
         run: flutter pub get
 
       - name: Build AAB (play flavor)
+        # #1777 — `--obfuscate` strips Dart symbol names from the
+        # release binary; `--split-debug-info` writes the symbol files
+        # needed to de-obfuscate later crash reports (uploaded below).
         run: |
           flutter build appbundle --release --flavor play \
-            --build-number=${{ needs.pre-check.outputs.build_number }}
+            --build-number=${{ needs.pre-check.outputs.build_number }} \
+            --obfuscate --split-debug-info=build/symbols
 
       # Per-ABI APKs were dropped from the public nightly release on
       # purpose — Play App Signing re-signs every Play install with
@@ -172,6 +176,17 @@ jobs:
             build/app/outputs/bundle/playRelease/app-play-release.aab
           if-no-files-found: error
           retention-days: 7
+
+      # #1777 — retain the obfuscation symbol files so an obfuscated
+      # release crash can be de-obfuscated. Kept far longer than the
+      # AAB itself (crash reports arrive over the release's lifetime).
+      - name: Upload obfuscation symbols
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-debug-symbols
+          path: build/symbols
+          if-no-files-found: error
+          retention-days: 90
 
   build-ios:
     needs: pre-check

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -130,6 +130,18 @@ jobs:
         if: always()
         run: rm -f "$ASC_API_KEY_FILEPATH"
 
+      # #1777 — retain the obfuscation symbol files (written by
+      # `flutter build ios --split-debug-info` in the Fastfile) so an
+      # obfuscated iOS release crash can be de-obfuscated later.
+      - name: Upload obfuscation symbols
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-debug-symbols
+          path: build/symbols
+          if-no-files-found: warn
+          retention-days: 90
+
       - name: Summary
         if: always()
         run: |

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -84,7 +84,12 @@ platform :ios do
     # duration of the block so the child process sees the normal Ruby
     # environment where CocoaPods is loadable.
     Bundler.with_unbundled_env do
-      sh("flutter build ios --release --no-codesign")
+      # #1777 — obfuscate the Dart code in the release build and write
+      # the de-obfuscation symbol files. `sh` runs from `ios/`, so the
+      # `../build/symbols` path lands the symbols at the repo-root
+      # `build/symbols` (where the workflow's upload step collects them).
+      sh("flutter build ios --release --no-codesign " \
+         "--obfuscate --split-debug-info=../build/symbols")
     end
 
     build_app(


### PR DESCRIPTION
Closes #1777

Bundle B of the epic #1678 residue collapsed to this single issue — **#1770 was closed as won't-fix**: `check_startup_budget.sh`'s own header comment already states CI runners have no emulator, so a *real* cold-start latency budget can't be measured in CI (a headless `flutter test` has no app launch). The achievable structural enforcement already exists, and an emulator-in-CI gate would be slow + flaky.

## Problem

The Android nightly AAB (`daily-github-release.yml`) and the iOS TestFlight build (`ios/fastlane/Fastfile`) built `--release` with **no `--obfuscate` and no `--split-debug-info`** — Dart symbol names shipped in the release binaries, and no symbol file was retained, so an obfuscated release crash could not be de-obfuscated.

## Fix

- **Android** — `flutter build appbundle` gains `--obfuscate --split-debug-info=build/symbols`; a new step uploads `build/symbols` (90-day retention).
- **iOS** — the Fastfile's `flutter build ios` gains the same flags (`../build/symbols`, since `sh` runs from `ios/`); `ios-testflight.yml` uploads the symbols.

Symbol artifacts get **90-day** retention — far longer than the build itself, since crash reports arrive across a release's whole lifetime.

The iOS symbol upload uses `if-no-files-found: warn` (not `error`): the iOS pipeline is `workflow_dispatch`-only and not yet schedule-validated, so a path mismatch must not hard-fail it.

## Verification

These workflows only run on the nightly schedule / dispatch (not PR CI). YAML validated; the Fastfile passes `ruby -c`. The Android obfuscation is exercised on the next nightly release; the iOS half on the next TestFlight dispatch.

_Part of epic #1678._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
