### PR TITLE
perf(search): decode Tankerkoenig stations in a single pass (#1775)

### DIFF
--- a/lib/features/station_services/germany/tankerkoenig_station_service.dart
+++ b/lib/features/station_services/germany/tankerkoenig_station_service.dart
@@ -68,15 +68,22 @@ class TankerkoenigStationService with StationServiceHelpers implements StationSe
       _checkOk(response.data);
 
       final stationsJson = response.data['stations'] as List<dynamic>? ?? [];
-      final stations = stationsJson
-          .map((j) => Station.fromJson(Map<String, dynamic>.from(j as Map)))
-          // #753 — scope ids with the `de-` country prefix so a German
-          // UUID can never collide with another country's numeric id
-          // (FR `12345`, AT `12345`, ES `IDEESS`, IT registry id).
-          // [_stripCountryPrefix] strips the prefix before any call back
-          // out to Tankerkönig.
-          .map((s) => s.copyWith(id: _withCountryPrefix(s.id)))
-          .toList();
+      // #1775 — apply the `de-` country prefix to the id *inside* the
+      // decoded map, so each entry decodes to its final `Station` in a
+      // single `fromJson` — no second `.map` + per-station `copyWith`
+      // shell. (A `compute()` isolate, as the Argentina CSV service
+      // uses, is not worth it here: isolate spawn + result
+      // serialisation would cost more than parsing ~100 small JSON
+      // objects on the UI isolate.)
+      final stations = stationsJson.map((j) {
+        final map = Map<String, dynamic>.from(j as Map);
+        // #753 — scope ids with the `de-` country prefix so a German
+        // UUID can never collide with another country's numeric id
+        // (FR `12345`, AT `12345`, ES `IDEESS`, IT registry id). The
+        // prefix is stripped before any call back out to Tankerkönig.
+        map['id'] = _withCountryPrefix(map['id'] as String);
+        return Station.fromJson(map);
+      }).toList();
 
       return ServiceResult(
         data: stations,


### PR DESCRIPTION
Closes #1775

## Problem

`TankerkoenigStationService.searchStations` mapped the API payload through `Station.fromJson` and then a **second** `.map` of `.copyWith(id: _withCountryPrefix(...))` — every result decoded to a `Station` only to be immediately replaced by a `copyWith` shell, synchronously on the UI isolate right as the results list mounts.

## Fix

The `de-` country prefix (#753) is now applied to the `id` **inside the decoded JSON map**, before `Station.fromJson` — so each entry decodes straight to its final `Station` in one pass, no per-station `copyWith` shell.

`compute()` (the Argentina CSV service's pattern, cited in the issue as the alternative) was considered and **rejected**: isolate spawn + result serialisation would cost more than parsing ~100 small JSON objects — `compute` earns its keep on a large CSV string, not a short JSON list.

## Tests

Behaviour-preserving — ids stay `de-`-prefixed. `flutter analyze` clean; `test/features/station_services/` (769) and `test/features/search/` (766) green.

_Part of epic #1678._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
