### PR TITLE
chore(build): stop bundling build-time-only source art in the app (#1776)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -139,7 +139,14 @@ flutter:
   generate: true
 
   assets:
-    - assets/
+    # #1776 — `assets/` is deliberately NOT wildcarded. The launcher-icon
+    # source art + Play-Store listing graphics (icon*.png/svg,
+    # feature_graphic.png, play_store_icon_512.png — ~1.4 MB) live in
+    # assets/ but are build-time only: flutter_launcher_icons and the
+    # store-listing tooling read them from the source tree, never via
+    # rootBundle. `tanksync_config.json` is the only runtime-loaded file
+    # at the assets/ root, so it is listed explicitly.
+    - assets/tanksync_config.json
     - assets/models/
     - assets/receipt_overrides/index.json
     - assets/reference_vehicles/vehicles.json


### PR DESCRIPTION
Closes #1776

## Problem

`pubspec.yaml` declared `assets/` as a directory wildcard. The launcher-icon source art + Play-Store listing graphics in `assets/` — `icon.png` (516 KB), `icon_foreground.png` (455 KB), `feature_graphic.png` (399 KB), `play_store_icon_512.png`, the source SVGs — **~1.4 MB** — shipped in every APK/IPA, never loaded at runtime.

## Fix

The `assets/` wildcard is replaced with an explicit runtime-asset list. A `lib/` grep confirmed **`tanksync_config.json` is the only file at the `assets/` root loaded via `rootBundle`** (`community_config.dart`) — so it's listed explicitly; the `models/` / `receipt_overrides/` / `reference_vehicles/` / `schemas/` entries are unchanged.

The art stays in the repo as **source** — `flutter_launcher_icons` (`image_path: assets/icon.png`) and the store-listing tooling read it from the source tree at build time, not via `rootBundle`, so they're unaffected.

## Tests

`flutter analyze` clean; `test/core/` green (2599 passed) — including the `community_config` test that loads the retained `tanksync_config.json`. The one local failure was an unrelated `@Tags(['network'])` test (`api_connectivity_test.dart` — a real Argentina-endpoint `DioException` timeout), which has no connection to an asset-declaration change.

_Part of epic #1678._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
