### PR TITLE
fix(i18n): localize the onboarding "pick a use mode" error (#1691)

### DIFF
--- a/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
+++ b/lib/features/setup/presentation/screens/onboarding_wizard_screen.dart
@@ -123,10 +123,10 @@ class _OnboardingWizardScreenState
     // enter the next step with a null `activeAppProfileProvider`.
     if (currentStep == 0 &&
         ref.read(activeAppProfileProvider) == null) {
-      // English-only for now; ARB string to follow in a follow-up.
       SnackBarHelper.showError(
         context,
-        'Pick a use mode to continue.',
+        AppLocalizations.of(context)?.onboardingPickUseMode ??
+            'Pick a use mode to continue.',
       );
       return;
     }

--- a/lib/l10n/_fragments/onboarding_de.arb
+++ b/lib/l10n/_fragments/onboarding_de.arb
@@ -5,5 +5,6 @@
   "onboardingObd2SkipButton": "Später",
   "onboardingObd2ReadingVin": "VIN wird ausgelesen…",
   "onboardingObd2VinReadFailed": "VIN konnte nicht ausgelesen werden — bitte manuell eingeben",
-  "onboardingObd2ConnectFailed": "Adapter konnte nicht verbunden werden. Du kannst es erneut versuchen oder überspringen."
+  "onboardingObd2ConnectFailed": "Adapter konnte nicht verbunden werden. Du kannst es erneut versuchen oder überspringen.",
+  "onboardingPickUseMode": "Wähle einen Nutzungsmodus, um fortzufahren."
 }

--- a/lib/l10n/_fragments/onboarding_en.arb
+++ b/lib/l10n/_fragments/onboarding_en.arb
@@ -23,5 +23,9 @@
   "@onboardingObd2VinReadFailed": {
     "description": "Banner shown on the next manual vehicle step when the OBD2 adapter connected but the VIN could not be read (#816)."
   },
-  "onboardingObd2ConnectFailed": "Couldn't connect to the adapter. You can retry or skip."
+  "onboardingObd2ConnectFailed": "Couldn't connect to the adapter. You can retry or skip.",
+  "onboardingPickUseMode": "Pick a use mode to continue.",
+  "@onboardingPickUseMode": {
+    "description": "Error shown when the user taps the onboarding wizard's Next button on the first step without choosing a use mode (#1691)."
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1826,6 +1826,7 @@
   "onboardingObd2ReadingVin": "VIN wird ausgelesen…",
   "onboardingObd2VinReadFailed": "VIN konnte nicht ausgelesen werden — bitte manuell eingeben",
   "onboardingObd2ConnectFailed": "Adapter konnte nicht verbunden werden. Du kannst es erneut versuchen oder überspringen.",
+  "onboardingPickUseMode": "Wähle einen Nutzungsmodus, um fortzufahren.",
   "alertsRadiusFrequencyLabel": "Prüfintervall",
   "alertsRadiusFrequencyDaily": "Einmal täglich",
   "alertsRadiusFrequencyTwiceDaily": "Zweimal täglich",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3149,6 +3149,10 @@
     "description": "Banner shown on the next manual vehicle step when the OBD2 adapter connected but the VIN could not be read (#816)."
   },
   "onboardingObd2ConnectFailed": "Couldn't connect to the adapter. You can retry or skip.",
+  "onboardingPickUseMode": "Pick a use mode to continue.",
+  "@onboardingPickUseMode": {
+    "description": "Error shown when the user taps the onboarding wizard's Next button on the first step without choosing a use mode (#1691)."
+  },
   "alertsRadiusFrequencyLabel": "Check frequency",
   "@alertsRadiusFrequencyLabel": {
     "description": "Label of the per-alert frequency dropdown (#1012 phase 1) — chooses how often the background runner re-evaluates this radius alert."

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1378,5 +1378,6 @@
   "discardChangesBody": "Vous avez des modifications non enregistrées. Quitter maintenant les supprimera.",
   "discardChangesConfirm": "Abandonner",
   "discardChangesKeepEditing": "Continuer la modification",
-  "tankSyncSectionSubtitle": "Synchronisation cloud entre vos appareils"
+  "tankSyncSectionSubtitle": "Synchronisation cloud entre vos appareils",
+  "onboardingPickUseMode": "Choisissez un mode d'utilisation pour continuer."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8264,6 +8264,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t connect to the adapter. You can retry or skip.'**
   String get onboardingObd2ConnectFailed;
 
+  /// Error shown when the user taps the onboarding wizard's Next button on the first step without choosing a use mode (#1691).
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a use mode to continue.'**
+  String get onboardingPickUseMode;
+
   /// Label of the per-alert frequency dropdown (#1012 phase 1) — chooses how often the background runner re-evaluates this radius alert.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4565,6 +4565,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4565,6 +4565,9 @@ class AppLocalizationsCs extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4563,6 +4563,9 @@ class AppLocalizationsDa extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4605,6 +4605,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Adapter konnte nicht verbunden werden. Du kannst es erneut versuchen oder überspringen.';
 
   @override
+  String get onboardingPickUseMode =>
+      'Wähle einen Nutzungsmodus, um fortzufahren.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Prüfintervall';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4567,6 +4567,9 @@ class AppLocalizationsEl extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4557,6 +4557,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4566,6 +4566,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4560,6 +4560,9 @@ class AppLocalizationsEt extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4563,6 +4563,9 @@ class AppLocalizationsFi extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4611,6 +4611,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Connexion impossible — vérifiez l\'adaptateur ou passez l\'étape';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Fréquence de vérification';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4611,7 +4611,8 @@ class AppLocalizationsFr extends AppLocalizations {
       'Connexion impossible — vérifiez l\'adaptateur ou passez l\'étape';
 
   @override
-  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+  String get onboardingPickUseMode =>
+      'Choisissez un mode d\'utilisation pour continuer.';
 
   @override
   String get alertsRadiusFrequencyLabel => 'Fréquence de vérification';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4562,6 +4562,9 @@ class AppLocalizationsHr extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4567,6 +4567,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4566,6 +4566,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4564,6 +4564,9 @@ class AppLocalizationsLt extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4566,6 +4566,9 @@ class AppLocalizationsLv extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4562,6 +4562,9 @@ class AppLocalizationsNb extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4567,6 +4567,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4565,6 +4565,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4566,6 +4566,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4565,6 +4565,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4566,6 +4566,9 @@ class AppLocalizationsSk extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4560,6 +4560,9 @@ class AppLocalizationsSl extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4564,6 +4564,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Couldn\'t connect to the adapter. You can retry or skip.';
 
   @override
+  String get onboardingPickUseMode => 'Pick a use mode to continue.';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override


### PR DESCRIPTION
Refs #1691 (acceptance bullet 1 of 3)

## Change

The onboarding wizard's first-step guard — `'Pick a use mode to continue.'` — was a hardcoded English string carrying an explicit `// ARB string to follow in a follow-up` TODO, and a violation of the no-hardcoded-user-facing-text hard rule.

Localized via a new `onboardingPickUseMode` key in the `onboarding` ARB fragment (en + de) + `build_arb` / `gen-l10n`.

## Scope

This delivers **bullet 1** of #1691. Bullets 2–3 (demo-mode CTA on the API-key step; GDPR consent-screen rebalance + key-validation progress) are UX-feature / design additions — kept open on #1691 for a focused design-aware pass rather than rushed here. The PR therefore `Refs` (not `Closes`) #1691.

## Tests

`flutter analyze` clean; `no_hardcoded_ui_strings_test` + `test/features/setup/` green (198).

_Part of epic #1689._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
