### PR TITLE
chore(favorites): rename FavoritesFuelTab to FavoritesTab (#1788)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -10,7 +10,7 @@ import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/favorites_provider.dart';
 import '../widgets/alerts_tab.dart';
-import '../widgets/favorites_fuel_tab.dart';
+import '../widgets/favorites_tab.dart';
 
 class FavoritesScreen extends ConsumerStatefulWidget {
   const FavoritesScreen({super.key});
@@ -123,7 +123,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
               children: [
                 RepaintBoundary(
                   key: _shareBoundaryKey,
-                  child: const FavoritesFuelTab(),
+                  child: const FavoritesTab(),
                 ),
                 const AlertsTab(),
               ],

--- a/lib/features/favorites/presentation/widgets/favorites_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_tab.dart
@@ -45,8 +45,8 @@ class _EvRow extends _FavRow {
 /// and EV favorites in a single unified list. Uses the merged
 /// [favoritesProvider] for IDs and loads data from [favoriteStationsProvider]
 /// (fuel) and [evFavoriteStationsProvider] (EV).
-class FavoritesFuelTab extends ConsumerWidget {
-  const FavoritesFuelTab({super.key});
+class FavoritesTab extends ConsumerWidget {
+  const FavoritesTab({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/test/features/favorites/favorites_tab_order_test.dart
+++ b/test/features/favorites/favorites_tab_order_test.dart
@@ -27,7 +27,7 @@ void main() {
     'FavoritesSectionHeader order helper — fuel header appears before EV header',
     (tester) async {
       // Pin the visual ordering by composing the two headers the same way
-      // `FavoritesFuelTab` now does (fuel first, then EV).
+      // `FavoritesTab` now does (fuel first, then EV).
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/test/features/favorites/presentation/widgets/favorites_tab_test.dart
+++ b/test/features/favorites/presentation/widgets/favorites_tab_test.dart
@@ -5,7 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/widgets/service_status_banner.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
-import 'package:tankstellen/features/favorites/presentation/widgets/favorites_fuel_tab.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/favorites_tab.dart';
 import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
 import 'package:tankstellen/features/favorites/providers/favorites_provider.dart';
 import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_card.dart';
@@ -30,7 +30,7 @@ ChargingStation _evStation({String id = 'ev-1', String name = 'Test Charger'}) {
 }
 
 void main() {
-  group('FavoritesFuelTab', () {
+  group('FavoritesTab', () {
     testWidgets('renders empty state when no favorites of any kind',
         (tester) async {
       final test = standardTestOverrides(favoriteIds: []);
@@ -38,7 +38,7 @@ void main() {
 
       await pumpApp(
         tester,
-        const Material(child: FavoritesFuelTab()),
+        const Material(child: FavoritesTab()),
         overrides: test.overrides,
       );
 
@@ -55,7 +55,7 @@ void main() {
 
       await pumpApp(
         tester,
-        const Material(child: FavoritesFuelTab()),
+        const Material(child: FavoritesTab()),
         overrides: [
           ...test.overrides,
           evFavoriteStationsProvider
@@ -81,7 +81,7 @@ void main() {
 
       await pumpApp(
         tester,
-        const Material(child: FavoritesFuelTab()),
+        const Material(child: FavoritesTab()),
         overrides: [
           ...test.overrides,
           favoriteStationsProvider.overrideWith(
@@ -115,7 +115,7 @@ void main() {
 
       await pumpApp(
         tester,
-        const Material(child: FavoritesFuelTab()),
+        const Material(child: FavoritesTab()),
         overrides: [
           ...test.overrides,
           favoriteStationsProvider


### PR DESCRIPTION
## What

Renames `FavoritesFuelTab` → `FavoritesTab` (and `favorites_fuel_tab.dart` → `favorites_tab.dart`).

The widget already renders **both** fuel and EV favorites in one unified list — the "Fuel" in the name was stale and gets more misleading as the list becomes genuinely mixed (epic #1780).

## Changes

- `git mv` the widget file + its test file.
- Rename the class, the doc-comment mention, and the `FavoritesScreen` import + call site.
- **No behaviour change.**

## Verification

- `flutter analyze` — no issues.
- `flutter test test/features/favorites/ test/lint/` — 137 passed.

Closes #1788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
