### PR TITLE
test(l10n): add a translation-coverage regression gate (#1699)

### DIFF
--- a/test/l10n/localization_completeness_test.dart
+++ b/test/l10n/localization_completeness_test.dart
@@ -222,6 +222,56 @@ void main() {
               'English for French users (#1439)');
     });
 
+    // #1699 — all 22 partial locales were brought to 100% coverage of
+    // the app_en.arb template (en/de/fr were already complete). This
+    // gate keeps it that way: it emits the untranslated-messages report
+    // to the CI log and FAILS if any locale regresses, so a new
+    // app_en.arb key added without a translation in every
+    // app_<locale>.arb is caught before merge rather than silently
+    // falling back to English in production.
+    test('every locale ARB is fully translated — no coverage '
+        'regressions (#1699)', () {
+      final missingReport = <String, List<String>>{};
+
+      for (final file in arbFiles) {
+        if (file.path.contains('app_en.arb')) continue;
+
+        final locale = _extractLocale(file.path);
+        final arb =
+            jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+        final localeKeys =
+            arb.keys.where((k) => !k.startsWith('@')).toSet();
+
+        final missing = referenceKeys.difference(localeKeys);
+        if (missing.isNotEmpty) {
+          missingReport[locale] = missing.toList()..sort();
+        }
+      }
+
+      // Untranslated-messages report — always emitted to the CI log.
+      if (missingReport.isEmpty) {
+        // ignore: avoid_print
+        print('Translation coverage: all ${arbFiles.length - 1} locales '
+            'at 100% of ${referenceKeys.length} app_en.arb keys.');
+      } else {
+        final buffer = StringBuffer(
+            'Translation coverage regression — locales below 100%:\n');
+        for (final entry in missingReport.entries) {
+          buffer.writeln('  ${entry.key}: ${entry.value.length} '
+              'untranslated — ${entry.value.join(", ")}');
+        }
+        // ignore: avoid_print
+        print(buffer.toString());
+      }
+
+      expect(missingReport, isEmpty,
+          reason: 'Every locale ARB must contain every app_en.arb key. '
+              'All offered locales reached 100% coverage in #1699; a key '
+              'added to app_en.arb must be translated into every '
+              'app_<locale>.arb in the same change. See the printed '
+              'report above for the untranslated keys.');
+    });
+
     test('no locale has extra keys not in app_en.arb', () {
       final extraReport = <String, List<String>>{};
 


### PR DESCRIPTION
## What

Adds a CI gate that locks in the locale translation coverage just
completed under #1699. Addresses the issue's second acceptance item —
"CI emits an untranslated-messages report and fails on regressions."

## Why

All 22 previously-partial locales were brought to 100% of the
1528-key `app_en.arb` template (PRs #1831–#1835). Before this,
`localization_completeness_test` only hard-failed for German and a
handful of French namespaces — every other locale was print-only
("missing translations fall back to English"), which was correct
while those locales were incomplete but now lets coverage silently
rot: a new `app_en.arb` key could merge with 22 locales falling back
to English and nothing would flag it.

## How

A new test in `test/l10n/localization_completeness_test.dart`:

- Emits the untranslated-messages report to the CI log every run
  (`Translation coverage: all 22 locales at 100% of 1528 keys.` when
  clean; a per-locale breakdown when not).
- **Fails** if any `app_<locale>.arb` is missing any `app_en.arb` key.

So adding a user-facing string now requires translating it into every
locale in the same change — caught by the pre-push `flutter test
test/l10n/` gate, never reaching production as an English fallback.

Test-only change — no new required check, no human step, `gh pr merge
--auto` unaffected.

## Verification

- `flutter test test/l10n/` — all 5 tests pass; new gate prints
  `all 22 locales at 100%`.
- Regression check: removing one key from `app_sv.arb` made the gate
  fail with `sv: 1 untranslated — searchCriteriaTitle`, then restored.
- `flutter analyze` — no issues.

Part of #1699 (the pseudo-localization acceptance item remains open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
