### PR TITLE
feat(search): concurrent fuel + EV unified search results (#1781, #1782)

### DIFF
--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -130,15 +130,29 @@ class SearchState extends _$SearchState {
           );
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
-      final ev = await dispatchEvIfNeeded(
-        ref: ref,
-        fuelType: resolved.fuelType,
-        lat: position.latitude,
-        lng: position.longitude,
-        radiusKm: resolved.radiusKm,
-      );
-      if (!ref.mounted) return;
-      if (ev != null) { state = ev; return; }
+      final unified = unifiedSearchEnabled(ref);
+      Future<void>? evFuture;
+      if (unified) {
+        evFuture = beginEvSearch(
+          ref,
+          lat: position.latitude,
+          lng: position.longitude,
+          radiusKm: resolved.radiusKm,
+        );
+      } else {
+        final ev = await dispatchEvIfNeeded(
+          ref: ref,
+          fuelType: resolved.fuelType,
+          lat: position.latitude,
+          lng: position.longitude,
+          radiusKm: resolved.radiusKm,
+        );
+        if (!ref.mounted) return;
+        if (ev != null) {
+          state = ev;
+          return;
+        }
+      }
 
       // Reverse-geocode for a postal code (Prix-Carburants + co).
       final addr = await tryReverseGeocode(
@@ -165,7 +179,9 @@ class SearchState extends _$SearchState {
           .read(stationServiceProvider)
           .searchStations(params, cancelToken: cancelToken);
       if (!ref.mounted) return;
-      state = AsyncValue.data(wrapFuelResultAsSearchItems(result));
+      final finalState = await finalizeUnifiedResult(ref, result, evFuture);
+      if (!ref.mounted) return;
+      state = finalState;
     });
   }
 
@@ -196,15 +212,29 @@ class SearchState extends _$SearchState {
       if (!ref.mounted) return;
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
-      final ev = await dispatchEvIfNeeded(
-        ref: ref,
-        fuelType: resolved.fuelType,
-        lat: coordsResult.data.lat,
-        lng: coordsResult.data.lng,
-        radiusKm: resolved.radiusKm,
-      );
-      if (!ref.mounted) return;
-      if (ev != null) { state = ev; return; }
+      final unified = unifiedSearchEnabled(ref);
+      Future<void>? evFuture;
+      if (unified) {
+        evFuture = beginEvSearch(
+          ref,
+          lat: coordsResult.data.lat,
+          lng: coordsResult.data.lng,
+          radiusKm: resolved.radiusKm,
+        );
+      } else {
+        final ev = await dispatchEvIfNeeded(
+          ref: ref,
+          fuelType: resolved.fuelType,
+          lat: coordsResult.data.lat,
+          lng: coordsResult.data.lng,
+          radiusKm: resolved.radiusKm,
+        );
+        if (!ref.mounted) return;
+        if (ev != null) {
+          state = ev;
+          return;
+        }
+      }
 
       final cityName = await tryReverseGeocode(
         geocoding, coordsResult.data.lat, coordsResult.data.lng,
@@ -232,14 +262,15 @@ class SearchState extends _$SearchState {
       final adjustedStations =
           recalcDistancesFrom(result.data, ref.read(userPositionProvider));
 
-      state = AsyncValue.data(wrapFuelResultAsSearchItems(
-        mergeGeocodingIntoStationResult(
-          stationResult: result,
-          geocodingErrors: coordsResult.errors,
-          geocodingIsStale: coordsResult.isStale,
-          adjustedStations: adjustedStations,
-        ),
-      ));
+      final fuelResult = mergeGeocodingIntoStationResult(
+        stationResult: result,
+        geocodingErrors: coordsResult.errors,
+        geocodingIsStale: coordsResult.isStale,
+        adjustedStations: adjustedStations,
+      );
+      final finalState = await finalizeUnifiedResult(ref, fuelResult, evFuture);
+      if (!ref.mounted) return;
+      state = finalState;
     });
   }
 
@@ -271,15 +302,29 @@ class SearchState extends _$SearchState {
       }
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
-      final ev = await dispatchEvIfNeeded(
-        ref: ref,
-        fuelType: resolved.fuelType,
-        lat: lat,
-        lng: lng,
-        radiusKm: resolved.radiusKm,
-      );
-      if (!ref.mounted) return;
-      if (ev != null) { state = ev; return; }
+      final unified = unifiedSearchEnabled(ref);
+      Future<void>? evFuture;
+      if (unified) {
+        evFuture = beginEvSearch(
+          ref,
+          lat: lat,
+          lng: lng,
+          radiusKm: resolved.radiusKm,
+        );
+      } else {
+        final ev = await dispatchEvIfNeeded(
+          ref: ref,
+          fuelType: resolved.fuelType,
+          lat: lat,
+          lng: lng,
+          radiusKm: resolved.radiusKm,
+        );
+        if (!ref.mounted) return;
+        if (ev != null) {
+          state = ev;
+          return;
+        }
+      }
 
       final params = SearchParams(
         lat: lat,
@@ -296,9 +341,10 @@ class SearchState extends _$SearchState {
       final adjustedStations =
           recalcDistancesFrom(result.data, ref.read(userPositionProvider));
 
-      state = AsyncValue.data(
-        wrapFuelResultAsSearchItems(withStations(result, adjustedStations)),
-      );
+      final fuelResult = withStations(result, adjustedStations);
+      final finalState = await finalizeUnifiedResult(ref, fuelResult, evFuture);
+      if (!ref.mounted) return;
+      state = finalState;
     });
   }
 }

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -95,7 +95,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'0483c8643d393b8aea57622443673eafa39de7e6';
+String _$searchStateHash() => r'70c69ea82bd290d0009be6e9efd43b57e5f3803b';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///

--- a/lib/features/search/providers/search_provider_orchestration.dart
+++ b/lib/features/search/providers/search_provider_orchestration.dart
@@ -5,8 +5,10 @@ import '../../../core/error/exceptions.dart';
 import '../../../core/location/user_position_provider.dart';
 import '../../../core/services/geocoding_chain.dart';
 import '../../../core/services/service_result.dart';
+import '../../../core/refuel/unified_search_results_enabled.dart';
 import '../domain/entities/fuel_type.dart';
 import '../domain/entities/search_result_item.dart';
+import '../domain/entities/station.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../profile/providers/profile_provider.dart';
 import 'ev_search_provider.dart';
@@ -116,4 +118,59 @@ AsyncValue<ServiceResult<List<SearchResultItem>>>? classifySearchError(
     return AsyncValue.error(error, stackTrace);
   }
   return AsyncValue.error(error, stackTrace);
+}
+
+/// Whether the unified fuel + EV search-results path is enabled
+/// (#1781, `Feature.unifiedSearchResults`). When `true`, every search
+/// fetches the fuel station service and the EV charging service
+/// concurrently and merges them into one mixed list; when `false` the
+/// legacy electric-vs-fuel branch ([dispatchEvIfNeeded]) applies and a
+/// search returns one kind only.
+bool unifiedSearchEnabled(Ref ref) =>
+    ref.read(unifiedSearchResultsEnabledProvider);
+
+/// Kicks off the EV charging search for [lat]/[lng]/[radiusKm] without
+/// awaiting it, so it runs concurrently with the fuel fetch (#1781).
+///
+/// The returned future completes once [EVSearchState.searchNearby] has
+/// written its state. `searchNearby` captures its own exceptions into
+/// `AsyncValue.error` (including the keyless `NoEvApiKeyException`), so
+/// this future never throws — the outcome is read back from
+/// [eVSearchStateProvider] by [finalizeUnifiedResult].
+Future<void> beginEvSearch(
+  Ref ref, {
+  required double lat,
+  required double lng,
+  required double radiusKm,
+}) {
+  return ref
+      .read(eVSearchStateProvider.notifier)
+      .searchNearby(lat: lat, lng: lng, radiusKm: radiusKm);
+}
+
+/// Awaits the concurrently-started [evFuture] and merges its outcome
+/// with [fuelResult] into the unified [SearchResultItem] feed (#1781 /
+/// #1782).
+///
+/// When [evFuture] is `null` (unified search disabled) the fuel result
+/// is wrapped on its own. Partial-failure-tolerant: an EV-side error is
+/// folded into the merged result's `errors` while the fuel results
+/// still render — see [mergeFuelAndEvResults].
+Future<AsyncValue<ServiceResult<List<SearchResultItem>>>>
+    finalizeUnifiedResult(
+  Ref ref,
+  ServiceResult<List<Station>> fuelResult,
+  Future<void>? evFuture,
+) async {
+  if (evFuture == null) {
+    return AsyncValue.data(wrapFuelResultAsSearchItems(fuelResult));
+  }
+  await evFuture;
+  return AsyncValue.data(
+    ref.read(eVSearchStateProvider).when(
+          data: (ev) => mergeFuelAndEvResults(fuel: fuelResult, ev: ev),
+          loading: () => mergeFuelAndEvResults(fuel: fuelResult),
+          error: (e, _) => mergeFuelAndEvResults(fuel: fuelResult, evError: e),
+        ),
+  );
 }

--- a/lib/features/search/providers/search_result_helpers.dart
+++ b/lib/features/search/providers/search_result_helpers.dart
@@ -67,6 +67,52 @@ ServiceResult<List<SearchResultItem>> wrapEvResultAsSearchItems(
   );
 }
 
+/// Merges a fuel and an EV [ServiceResult] into one mixed
+/// [SearchResultItem] feed for the unified fuel + EV search results
+/// (#1781 / #1782).
+///
+/// Fuel is the primary feed — its [ServiceResult.source] and
+/// `fetchedAt` are carried through, and fuel results lead the list.
+/// EV is additive and **partial-failure-tolerant**: when the EV side
+/// failed, [ev] is null and [evError] carries the cause (e.g. a
+/// keyless `NoEvApiKeyException`, the default for users without an
+/// OpenChargeMap key). The fuel results still render and the EV
+/// failure is recorded as a [ServiceError] so the status banner can
+/// surface "OpenChargeMap unavailable" without blanking the screen.
+///
+/// `isStale` and the `errors` list are unioned across both sides.
+ServiceResult<List<SearchResultItem>> mergeFuelAndEvResults({
+  required ServiceResult<List<Station>> fuel,
+  ServiceResult<List<ChargingStation>>? ev,
+  Object? evError,
+}) {
+  final items = <SearchResultItem>[
+    ...fuel.data.map((s) => FuelStationResult(s)),
+  ];
+  final errors = <ServiceError>[...fuel.errors];
+  var isStale = fuel.isStale;
+
+  if (ev != null) {
+    items.addAll(ev.data.map((cs) => EVStationResult(cs)));
+    errors.addAll(ev.errors);
+    isStale = isStale || ev.isStale;
+  } else if (evError != null) {
+    errors.add(ServiceError(
+      source: ServiceSource.openChargeMapApi,
+      message: evError.toString(),
+      occurredAt: DateTime.now(),
+    ));
+  }
+
+  return ServiceResult(
+    data: items,
+    source: fuel.source,
+    fetchedAt: fuel.fetchedAt,
+    isStale: isStale,
+    errors: errors,
+  );
+}
+
 /// Returns a copy of [result] with [stations] replacing `result.data`.
 /// Used after distance recalculation where only the station list
 /// changes — every other `ServiceResult` field (source, fetchedAt,

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/location/location_service.dart';
+import 'package:tankstellen/core/refuel/unified_search_results_enabled.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/geocoding_chain.dart';
 import 'package:tankstellen/core/services/service_providers.dart';
@@ -15,6 +16,7 @@ import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/ev_search_provider.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
@@ -74,6 +76,68 @@ class _FakeEVSearchState extends EVSearchState {
   }
 }
 
+/// EV fake that returns one charging station, so unified-search tests
+/// can assert the merged feed carries both kinds.
+class _OneStationEVSearchState extends EVSearchState {
+  @override
+  AsyncValue<ServiceResult<List<ChargingStation>>> build() {
+    return AsyncValue.data(ServiceResult(
+      data: const [],
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime(2024, 1, 1),
+    ));
+  }
+
+  @override
+  Future<void> searchNearby({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    state = AsyncValue.data(ServiceResult(
+      data: const [
+        ChargingStation(
+          id: 'ev-merge-1',
+          name: 'OCM Berlin',
+          latitude: 52.5,
+          longitude: 13.4,
+        ),
+      ],
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime(2024, 1, 1),
+    ));
+  }
+}
+
+/// EV fake whose search always fails — models the keyless
+/// `NoEvApiKeyException` case for unified-search partial-failure tests.
+class _FailingEVSearchState extends EVSearchState {
+  @override
+  AsyncValue<ServiceResult<List<ChargingStation>>> build() {
+    return AsyncValue.data(ServiceResult(
+      data: const [],
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime(2024, 1, 1),
+    ));
+  }
+
+  @override
+  Future<void> searchNearby({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    state = AsyncValue.error(const NoEvApiKeyException(), StackTrace.current);
+  }
+}
+
+/// Forces `Feature.unifiedSearchResults` on without wiring the whole
+/// feature-management stack.
+class _UnifiedOn extends UnifiedSearchResultsEnabled {
+  @override
+  bool build() => true;
+}
+
 void main() {
   late FakeHiveStorage fakeStorage;
   late MockStationService mockStationService;
@@ -116,6 +180,21 @@ void main() {
     ]);
     addTearDown(c.dispose);
     return (c, fakeEv);
+  }
+
+  /// Container for unified-search tests — `Feature.unifiedSearchResults`
+  /// forced on, with a swappable EV fake.
+  ProviderContainer createContainerUnified(EVSearchState evFake) {
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(fakeStorage),
+      stationServiceProvider.overrideWithValue(mockStationService),
+      geocodingChainProvider.overrideWithValue(mockGeocoding),
+      userPositionProvider.overrideWith(() => _NullUserPosition()),
+      eVSearchStateProvider.overrideWith(() => evFake),
+      unifiedSearchResultsEnabledProvider.overrideWith(_UnifiedOn.new),
+    ]);
+    addTearDown(c.dispose);
+    return c;
   }
 
   const testStation = Station(
@@ -857,6 +936,80 @@ void main() {
       // (it stays in initial state because EV dispatch returned early)
       final state = container.read(searchStateProvider);
       expect(state.value!.data, isEmpty);
+    });
+  });
+
+  group('EV dispatch — unified search (Feature.unifiedSearchResults on)',
+      () {
+    void stubFuel() {
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
+    }
+
+    test('fetches fuel AND EV and merges both kinds into one list',
+        () async {
+      stubFuel();
+      final container = createContainerUnified(_OneStationEVSearchState());
+
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 52.52,
+            lng: 13.41,
+            fuelType: FuelType.e10,
+            radiusKm: 7.0,
+          );
+
+      // Fuel service WAS called (not short-circuited by EV dispatch).
+      verify(() => mockStationService.searchStations(
+            any(),
+            cancelToken: any(named: 'cancelToken'),
+          )).called(1);
+      final items = container.read(searchStateProvider).value!.data;
+      expect(items.whereType<FuelStationResult>(), hasLength(1));
+      expect(items.whereType<EVStationResult>(), hasLength(1));
+    });
+
+    test('electric fuel type is no longer EV-exclusive under unified search',
+        () async {
+      stubFuel();
+      final container = createContainerUnified(_OneStationEVSearchState());
+
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 52.52,
+            lng: 13.41,
+            fuelType: FuelType.electric,
+            radiusKm: 7.0,
+          );
+
+      final items = container.read(searchStateProvider).value!.data;
+      // Electric selected, yet fuel stations still appear alongside EV.
+      expect(items.whereType<FuelStationResult>(), hasLength(1));
+      expect(items.whereType<EVStationResult>(), hasLength(1));
+    });
+
+    test('EV failure is tolerated — fuel results survive, error recorded',
+        () async {
+      stubFuel();
+      final container = createContainerUnified(_FailingEVSearchState());
+
+      await container.read(searchStateProvider.notifier).searchByCoordinates(
+            lat: 52.52,
+            lng: 13.41,
+            fuelType: FuelType.e10,
+            radiusKm: 7.0,
+          );
+
+      final result = container.read(searchStateProvider).value!;
+      expect(result.data.whereType<FuelStationResult>(), hasLength(1));
+      expect(result.data.whereType<EVStationResult>(), isEmpty);
+      expect(
+        result.errors.where((e) => e.source == ServiceSource.openChargeMapApi),
+        hasLength(1),
+      );
     });
   });
 

--- a/test/features/search/providers/search_result_helpers_test.dart
+++ b/test/features/search/providers/search_result_helpers_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
@@ -153,6 +154,88 @@ void main() {
         fetchedAt: DateTime(2024, 1, 1),
       ));
       expect(wrapped.data, isEmpty);
+    });
+  });
+
+  group('mergeFuelAndEvResults', () {
+    const ev1 = ChargingStation(
+      id: 'ev-1',
+      name: 'OCM 1',
+      latitude: 52.5,
+      longitude: 13.4,
+    );
+
+    ServiceResult<List<ChargingStation>> evResult(
+      List<ChargingStation> stations, {
+      bool isStale = false,
+      List<ServiceError> errors = const [],
+    }) {
+      return ServiceResult(
+        data: stations,
+        source: ServiceSource.openChargeMapApi,
+        fetchedAt: DateTime(2024, 1, 1, 12),
+        isStale: isStale,
+        errors: errors,
+      );
+    }
+
+    test('both sides succeed — fuel + EV items in one mixed list', () {
+      final merged = mergeFuelAndEvResults(
+        fuel: fuelResult(const [berlinStation]),
+        ev: evResult(const [ev1]),
+      );
+      expect(merged.data, hasLength(2));
+      expect(merged.data.whereType<FuelStationResult>(), hasLength(1));
+      expect(merged.data.whereType<EVStationResult>(), hasLength(1));
+      // Fuel leads the list and owns source / fetchedAt.
+      expect(merged.data.first, isA<FuelStationResult>());
+      expect(merged.source, ServiceSource.tankerkoenigApi);
+    });
+
+    test('EV failure is tolerated — fuel still renders, error recorded', () {
+      final merged = mergeFuelAndEvResults(
+        fuel: fuelResult(const [berlinStation]),
+        evError: const NoEvApiKeyException(),
+      );
+      expect(merged.data, hasLength(1));
+      expect(merged.data.single, isA<FuelStationResult>());
+      expect(merged.errors, hasLength(1));
+      expect(merged.errors.single.source, ServiceSource.openChargeMapApi);
+    });
+
+    test('no EV outcome at all → fuel-only feed, no synthetic error', () {
+      final merged =
+          mergeFuelAndEvResults(fuel: fuelResult(const [berlinStation]));
+      expect(merged.data, hasLength(1));
+      expect(merged.errors, isEmpty);
+    });
+
+    test('errors and staleness are unioned across both sides', () {
+      final fuelErr = ServiceError(
+        source: ServiceSource.tankerkoenigApi,
+        message: 'fuel hiccup',
+        occurredAt: DateTime(2024, 1, 1),
+      );
+      final evErr = ServiceError(
+        source: ServiceSource.openChargeMapApi,
+        message: 'ev hiccup',
+        occurredAt: DateTime(2024, 1, 1),
+      );
+      final merged = mergeFuelAndEvResults(
+        fuel: fuelResult(const [berlinStation],
+            isStale: true, errors: [fuelErr]),
+        ev: evResult(const [ev1], errors: [evErr]),
+      );
+      expect(merged.errors, containsAll(<ServiceError>[fuelErr, evErr]));
+      expect(merged.isStale, isTrue);
+    });
+
+    test('a stale EV side propagates isStale even when fuel is fresh', () {
+      final merged = mergeFuelAndEvResults(
+        fuel: fuelResult(const [berlinStation]),
+        ev: evResult(const [ev1], isStale: true),
+      );
+      expect(merged.isStale, isTrue);
     });
   });
 


### PR DESCRIPTION
## What

Foundation of the EV/fuel unification epic #1780 (Path A). Behind
`Feature.unifiedSearchResults`, a search now fetches **both** the fuel
station service and the EV charging service **concurrently** and merges
them into one mixed `List<SearchResultItem>`.

Closes #1781 and #1782 — they ship together because they are
inseparable: a concurrent fetch without partial-failure handling would
let the EV side (which throws `NoEvApiKeyException` for every user
without an OpenChargeMap key — the default) abort the *whole* search
and blank the fuel results too.

## How

- **#1782 — `mergeFuelAndEvResults`** (`search_result_helpers.dart`):
  combines the fuel + EV `ServiceResult`s. Fuel leads; EV is additive
  and partial-failure-tolerant — an EV error is folded into the merged
  `errors` list as a `ServiceError`, the fuel results still render.
- **#1781 — concurrent fetch** (`search_provider_orchestration.dart` +
  `search_provider.dart`): `beginEvSearch` starts the EV search without
  awaiting it; the fuel fetch runs alongside; `finalizeUnifiedResult`
  awaits the EV future and merges. All three entry points
  (`searchByGps` / `searchByZipCode` / `searchByCoordinates`) are
  wired. Flag off → the legacy electric-vs-fuel path is untouched.

## Verification

- `flutter test test/features/search/` — all pass, incl. 5 new
  `mergeFuelAndEvResults` unit tests + 3 new unified-mode notifier
  tests (concurrent fetch + merge, electric no longer EV-exclusive,
  EV-failure tolerance). The 771 legacy-path tests still pass.
- `test/features/map/` — 123 pass (blast radius).
- `flutter analyze` clean; `check_module_boundaries.sh` passes;
  `build_runner` regenerated `search_provider.g.dart`.

Part of epic #1780. Next: #1783 (kind-aware sort), #1784 (EV filters),
#1785 (usageCost) build on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
