### PR TITLE
feat(refuel): parse ChargingStation.usageCost into a structured EV price (#1785)

### DIFF
--- a/lib/features/ev/domain/entities/ev_price.dart
+++ b/lib/features/ev/domain/entities/ev_price.dart
@@ -1,0 +1,165 @@
+/// A structured EV charging price parsed from the free-form
+/// `ChargingStation.usageCost` string (#1785).
+///
+/// OpenChargeMap's `UsageCost` field has no schema — it carries
+/// anything from `"0.49 EUR/kWh"` to `"Free"` to `"Ask operator"`.
+/// [EvPrice.parse] turns the common shapes into a typed value so the
+/// UI can render a consistent price and later features (favorites
+/// merge, sorting) can reason about it; anything it cannot classify
+/// degrades to [EvPriceKind.unknown] and the caller falls back to the
+/// raw string.
+library;
+
+/// What kind of EV charging tariff [EvPrice] describes.
+enum EvPriceKind {
+  /// Energy-metered — a price per kilowatt-hour.
+  perKwh,
+
+  /// A flat fee per charging session.
+  perSession,
+
+  /// Charging is free of charge.
+  free,
+
+  /// The `usageCost` string could not be classified — callers should
+  /// fall back to showing the raw string.
+  unknown,
+}
+
+/// A parsed EV charging price. Immutable value type.
+class EvPrice {
+  /// The tariff kind.
+  final EvPriceKind kind;
+
+  /// The numeric amount for [EvPriceKind.perKwh] / [EvPriceKind.perSession];
+  /// `null` for [EvPriceKind.free] and [EvPriceKind.unknown].
+  final double? amount;
+
+  /// ISO-ish currency token detected in the source string (`EUR`, `GBP`,
+  /// `USD`, …); `null` when no currency could be identified.
+  final String? currency;
+
+  /// The original, untouched `usageCost` string (empty when the source
+  /// was null/blank) — callers render this for the `unknown` kind.
+  final String raw;
+
+  const EvPrice({
+    required this.kind,
+    required this.raw,
+    this.amount,
+    this.currency,
+  });
+
+  /// True when the price carries a numeric amount worth rendering.
+  bool get hasAmount => amount != null;
+
+  /// A render-ready price label for the structured kinds (`perKwh` /
+  /// `perSession`), or `null` for [EvPriceKind.free] /
+  /// [EvPriceKind.unknown] — for which the caller shows [raw] instead.
+  ///
+  /// [perKwhUnit] / [perSessionUnit] are the localised unit suffixes
+  /// (`AppLocalizations.refuelUnitPerKwh` / `refuelUnitPerSession`,
+  /// e.g. `"/kWh"`). The amount is shown without a trailing `.0`.
+  String? label({
+    required String perKwhUnit,
+    required String perSessionUnit,
+  }) {
+    final value = amount;
+    if (value == null) return null;
+    final n = value == value.roundToDouble()
+        ? value.toStringAsFixed(0)
+        : value.toString();
+    final money = currency == null ? n : '$n $currency';
+    switch (kind) {
+      case EvPriceKind.perKwh:
+        return '$money$perKwhUnit';
+      case EvPriceKind.perSession:
+        return '$money$perSessionUnit';
+      case EvPriceKind.free:
+      case EvPriceKind.unknown:
+        return null;
+    }
+  }
+
+  static final _amount = RegExp(r'(\d+(?:[.,]\d+)?)');
+  static const _freeWords = <String>[
+    'free', 'gratis', 'gratuit', 'kostenlos', 'gratuito', 'gratuita',
+    'bezpłatn', 'ingyenes', 'nemokama', 'zdarma', 'besplatno',
+  ];
+  static const _currencyTokens = <String, String>{
+    '€': 'EUR', 'eur': 'EUR',
+    '£': 'GBP', 'gbp': 'GBP',
+    r'$': 'USD', 'usd': 'USD',
+    'chf': 'CHF', 'kr': 'SEK', 'zł': 'PLN', 'pln': 'PLN',
+  };
+
+  /// Parses a free-form `usageCost` string into a typed [EvPrice].
+  ///
+  /// Classification order matters: a string like `"Free parking,
+  /// 0.79 EUR/kWh"` is a per-kWh tariff, not free — so a structured
+  /// per-kWh / per-session price is detected *before* the free-words
+  /// check. Decimal commas (`0,49`) are normalised to dots.
+  factory EvPrice.parse(String? usageCost) {
+    final raw = usageCost?.trim() ?? '';
+    if (raw.isEmpty) return const EvPrice(kind: EvPriceKind.unknown, raw: '');
+
+    final low = raw.toLowerCase();
+    final currency = _detectCurrency(low);
+    final amountMatch = _amount.firstMatch(raw);
+    final amount = amountMatch == null
+        ? null
+        : double.tryParse(amountMatch.group(1)!.replaceAll(',', '.'));
+
+    final perKwh = low.contains('kwh') || low.contains('kw/h') ||
+        low.contains('/kw');
+    final perSession = low.contains('session') ||
+        low.contains('charge') ||
+        low.contains('flat') ||
+        low.contains('par recharge');
+
+    if (amount != null && amount > 0 && perKwh) {
+      return EvPrice(
+        kind: EvPriceKind.perKwh,
+        amount: amount,
+        currency: currency,
+        raw: raw,
+      );
+    }
+    if (amount != null && amount > 0 && perSession) {
+      return EvPrice(
+        kind: EvPriceKind.perSession,
+        amount: amount,
+        currency: currency,
+        raw: raw,
+      );
+    }
+    // No structured price — a "free" wording (or a bare 0) means free.
+    final saysFree = _freeWords.any(low.contains);
+    if (saysFree || (amount == 0 && !perKwh && !perSession)) {
+      return EvPrice(kind: EvPriceKind.free, raw: raw);
+    }
+    return EvPrice(kind: EvPriceKind.unknown, raw: raw);
+  }
+
+  static String? _detectCurrency(String lower) {
+    for (final entry in _currencyTokens.entries) {
+      if (lower.contains(entry.key)) return entry.value;
+    }
+    return null;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is EvPrice &&
+      other.kind == kind &&
+      other.amount == amount &&
+      other.currency == currency &&
+      other.raw == raw;
+
+  @override
+  int get hashCode => Object.hash(kind, amount, currency, raw);
+
+  @override
+  String toString() =>
+      'EvPrice($kind, amount: $amount, currency: $currency, raw: "$raw")';
+}

--- a/lib/features/search/presentation/widgets/ev_station_card.dart
+++ b/lib/features/search/presentation/widgets/ev_station_card.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../ev/domain/entities/ev_price.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_result_item.dart';
 import 'ev_connector_chips.dart';
@@ -20,9 +22,19 @@ class EVStationCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final station = result.station;
     final maxPower = result.maxPowerKW;
     final connectors = result.connectorTypes;
+
+    // #1785 — show a structured per-kWh / per-session price; free and
+    // unclassifiable `usageCost` strings degrade to the raw value.
+    final evPrice = EvPrice.parse(station.usageCost);
+    final priceLabel = evPrice.label(
+          perKwhUnit: l10n?.refuelUnitPerKwh ?? '/kWh',
+          perSessionUnit: l10n?.refuelUnitPerSession ?? '/session',
+        ) ??
+        station.usageCost;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
@@ -103,11 +115,11 @@ class EVStationCard extends StatelessWidget {
                           PriceFormatter.formatDistance(station.dist),
                           style: theme.textTheme.bodySmall,
                         ),
-                        if (station.usageCost != null) ...[
+                        if (priceLabel != null && priceLabel.isNotEmpty) ...[
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
-                              station.usageCost!,
+                              priceLabel,
                               style: theme.textTheme.bodySmall?.copyWith(
                                 color: const Color(0xFF009688),
                                 fontWeight: FontWeight.w600,

--- a/test/features/ev/domain/entities/ev_price_test.dart
+++ b/test/features/ev/domain/entities/ev_price_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/ev/domain/entities/ev_price.dart';
+
+/// Pins `EvPrice.parse` (#1785) — the heuristic parser that turns
+/// OpenChargeMap's free-form `usageCost` string into a typed price.
+void main() {
+  group('EvPrice.parse — per-kWh tariffs', () {
+    test('"0.49 EUR/kWh" → perKwh 0.49 EUR', () {
+      final p = EvPrice.parse('0.49 EUR/kWh');
+      expect(p.kind, EvPriceKind.perKwh);
+      expect(p.amount, 0.49);
+      expect(p.currency, 'EUR');
+    });
+
+    test('decimal comma is normalised — "€0,50/kWh"', () {
+      final p = EvPrice.parse('€0,50/kWh');
+      expect(p.kind, EvPriceKind.perKwh);
+      expect(p.amount, 0.50);
+      expect(p.currency, 'EUR');
+    });
+
+    test('"0.45 EUR per kWh" (spaced unit) → perKwh', () {
+      expect(EvPrice.parse('0.45 EUR per kWh').kind, EvPriceKind.perKwh);
+    });
+
+    test('a non-EUR currency is detected — "0.30 GBP/kWh"', () {
+      expect(EvPrice.parse('0.30 GBP/kWh').currency, 'GBP');
+    });
+  });
+
+  group('EvPrice.parse — per-session tariffs', () {
+    test('"5 EUR/session" → perSession 5 EUR', () {
+      final p = EvPrice.parse('5 EUR/session');
+      expect(p.kind, EvPriceKind.perSession);
+      expect(p.amount, 5);
+      expect(p.currency, 'EUR');
+    });
+
+    test('"3.50 EUR flat charge fee" → perSession', () {
+      expect(EvPrice.parse('3.50 EUR flat charge fee').kind,
+          EvPriceKind.perSession);
+    });
+  });
+
+  group('EvPrice.parse — free', () {
+    test('"Free" → free', () {
+      expect(EvPrice.parse('Free').kind, EvPriceKind.free);
+    });
+
+    test('localised free words — Gratis / Kostenlos / Gratuit', () {
+      expect(EvPrice.parse('Gratis').kind, EvPriceKind.free);
+      expect(EvPrice.parse('Kostenlos').kind, EvPriceKind.free);
+      expect(EvPrice.parse('Gratuit').kind, EvPriceKind.free);
+    });
+
+    test('a bare "0" with no unit → free', () {
+      expect(EvPrice.parse('0').kind, EvPriceKind.free);
+    });
+
+    test('a per-kWh price beats a stray "free" word — '
+        '"Free parking, 0.79 EUR/kWh"', () {
+      final p = EvPrice.parse('Free parking, 0.79 EUR/kWh');
+      expect(p.kind, EvPriceKind.perKwh);
+      expect(p.amount, 0.79);
+    });
+  });
+
+  group('EvPrice.parse — unknown / degrade to raw', () {
+    test('unclassifiable text → unknown, raw preserved', () {
+      final p = EvPrice.parse('Ask the operator');
+      expect(p.kind, EvPriceKind.unknown);
+      expect(p.raw, 'Ask the operator');
+    });
+
+    test('null → unknown with empty raw', () {
+      final p = EvPrice.parse(null);
+      expect(p.kind, EvPriceKind.unknown);
+      expect(p.raw, '');
+    });
+
+    test('blank string → unknown', () {
+      expect(EvPrice.parse('   ').kind, EvPriceKind.unknown);
+    });
+  });
+
+  group('EvPrice.label', () {
+    test('per-kWh renders amount + currency + unit', () {
+      final label = EvPrice.parse('0.49 EUR/kWh')
+          .label(perKwhUnit: '/kWh', perSessionUnit: '/session');
+      expect(label, '0.49 EUR/kWh');
+    });
+
+    test('an integer amount drops the trailing .0', () {
+      final label = EvPrice.parse('5 EUR/session')
+          .label(perKwhUnit: '/kWh', perSessionUnit: '/session');
+      expect(label, '5 EUR/session');
+    });
+
+    test('free and unknown have no structured label (caller shows raw)',
+        () {
+      const units = (perKwhUnit: '/kWh', perSessionUnit: '/session');
+      expect(
+        EvPrice.parse('Free')
+            .label(perKwhUnit: units.perKwhUnit, perSessionUnit: units.perSessionUnit),
+        isNull,
+      );
+      expect(
+        EvPrice.parse('Ask operator')
+            .label(perKwhUnit: units.perKwhUnit, perSessionUnit: units.perSessionUnit),
+        isNull,
+      );
+    });
+
+    test('a missing currency still renders amount + unit', () {
+      final label = EvPrice.parse('0.55/kWh')
+          .label(perKwhUnit: '/kWh', perSessionUnit: '/session');
+      expect(label, '0.55/kWh');
+    });
+  });
+}


### PR DESCRIPTION
## What

EV charging cards showed OpenChargeMap's free-form `usageCost` string
verbatim. This parses it into a typed `EvPrice` and renders a
consistent price. Child of epic #1780.

## How

- **`EvPrice`** (`features/ev/domain/entities/ev_price.dart`) — typed
  value + `EvPrice.parse` heuristic classifier: `perKwh`,
  `perSession`, `free`, `unknown`.
  - tolerates decimal commas (`0,49` → `0.49`);
  - detects currency (EUR / GBP / USD / CHF / …);
  - a structured per-kWh / per-session price is detected **before**
    the free-words check, so `"Free parking, 0.79 EUR/kWh"` is a
    per-kWh tariff, not free.
- **`EVStationCard`** renders the structured price for per-kWh /
  per-session tariffs (amount + currency + the localised
  `refuelUnitPerKwh` / `refuelUnitPerSession` suffix). `free` and
  `unknown` degrade to the raw string — no behaviour regression and
  **no new ARB keys**.

## Verification

- 17 new unit tests cover the common `usageCost` shapes + label
  rendering — all pass.
- `flutter test test/features/ev/ test/features/search/presentation/widgets/`
  — 459 pass.
- `flutter analyze` clean; `check_module_boundaries.sh` passes;
  `build_runner` — no drift.

Part of epic #1780. Closes #1785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
