### PR TITLE
chore(glide-coach): migrate kGlideCoachEnabled onto central feature management (#1824)

### DIFF
--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -8,8 +8,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/location/geolocator_wrapper.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
-import '../../glide_coach/data/traffic_signal_repository.dart';
 import '../../glide_coach/domain/entities/glide_coach_advice.dart';
+import '../../glide_coach/providers/glide_coach_enabled_provider.dart';
 import '../../glide_coach/providers/glide_coach_evaluator_provider.dart';
 import '../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../data/obd2/trip_recording_controller.dart';
@@ -84,9 +84,8 @@ class TripGpsStreamController {
           );
           // #1125 phase 3b — opt-in glide-coach evaluation. The hook is
           // gated by:
-          //   1. The compile-time master flag kGlideCoachEnabled (false
-          //      in production; this branch compiles to a constant
-          //      no-op the optimiser can fully elide).
+          //   1. The central Feature.glideCoach flag (default-off in
+          //      production), read via glideCoachEnabledProvider.
           //   2. The user-facing toggle GlideCoachSettings.enabled.
           //   3. The presence of a recent throttle reading (cars
           //      without PID 0x11 — or a freshly-started trip whose
@@ -117,8 +116,8 @@ class TripGpsStreamController {
   /// Per-GPS-fix glide-coach evaluator hook (#1125 phase 3b).
   ///
   /// Layered gate (in order — each rejects the next):
-  ///   1. Compile-time `kGlideCoachEnabled` master flag. False in
-  ///      production today; the call is a constant-folded no-op.
+  ///   1. The central `Feature.glideCoach` flag (default-off in
+  ///      production), read via `glideCoachEnabledProvider`.
   ///   2. User-facing toggle from `GlideCoachSettings`.
   ///   3. Latest throttle reading from the controller's captured-sample
   ///      buffer (cars without PID 0x11 → null → evaluator returns
@@ -139,9 +138,8 @@ class TripGpsStreamController {
     TripRecordingController ctl,
     Position pos,
   ) async {
-    // Rule 1 — compile-time master flag. The constant gate makes this
-    // path constant-fold to nothing in a flag-false build.
-    if (!kGlideCoachEnabled) return;
+    // Rule 1 — the central Feature.glideCoach flag (#1824).
+    if (!_ref.read(glideCoachEnabledProvider)) return;
     try {
       // Rule 2 — user toggle. Defaults to false; even with the master
       // flag flipped, an opt-in is required.

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -9,7 +9,7 @@ import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/conso_mode.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../../feature_management/domain/feature_dependency_graph.dart';
-import '../../../glide_coach/data/traffic_signal_repository.dart';
+import '../../../glide_coach/providers/glide_coach_enabled_provider.dart';
 import '../../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../../../profile/presentation/widgets/gamification_settings_tile.dart';
 import '../../providers/haptic_eco_coach_provider.dart';
@@ -89,7 +89,8 @@ class DrivingSettingsSection extends ConsumerWidget {
             leadingIcon: Icons.route_outlined,
             padding: const EdgeInsets.fromLTRB(0, 4, 0, 4),
           ),
-          if (kGlideCoachEnabled) const _GlideCoachToggleTile(),
+          if (ref.watch(glideCoachEnabledProvider))
+            const _GlideCoachToggleTile(),
         ],
 
         // 3. Driving sub-section — eco-coach + gamification + fuel-club.
@@ -134,9 +135,9 @@ class DrivingSettingsSection extends ConsumerWidget {
 
 /// Beta opt-in tile for the glide-coach haptic (#1125 phase 3b).
 ///
-/// Rendered only when the compile-time master flag
-/// [`kGlideCoachEnabled`] is true; the call site in
-/// [DrivingSettingsSection] gates visibility via `if (kGlideCoachEnabled)`.
+/// Rendered only when the `Feature.glideCoach` flag is enabled; the
+/// call site in [DrivingSettingsSection] gates visibility via
+/// `if (ref.watch(glideCoachEnabledProvider))`.
 class _GlideCoachToggleTile extends ConsumerWidget {
   const _GlideCoachToggleTile();
 

--- a/lib/features/glide_coach/data/traffic_signal_repository.dart
+++ b/lib/features/glide_coach/data/traffic_signal_repository.dart
@@ -6,10 +6,6 @@ import 'package:hive/hive.dart';
 import '../domain/entities/traffic_signal.dart';
 import 'osm_traffic_signal_client.dart';
 
-/// Master toggle for the glide-coach feature (#1125).
-/// TODO: migrate to central feature management once that system lands.
-const bool kGlideCoachEnabled = false;
-
 /// Default cache TTL for cached Overpass responses (#1125 phase 1).
 ///
 /// Public Overpass infrastructure is shared and the underlying OSM map

--- a/lib/features/glide_coach/providers/glide_coach_enabled_provider.dart
+++ b/lib/features/glide_coach/providers/glide_coach_enabled_provider.dart
@@ -1,0 +1,30 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../feature_management/application/feature_flags_provider.dart';
+import '../../feature_management/domain/feature.dart';
+import '../../feature_management/domain/feature_dependency_graph.dart';
+
+part 'glide_coach_enabled_provider.g.dart';
+
+/// Whether the glide-coach feature is enabled (#1824).
+///
+/// Migrated off the compile-time `kGlideCoachEnabled` const onto the
+/// central feature-flag set keyed by [Feature.glideCoach] — the
+/// `FeatureFlags` system (#1373) the old TODO was waiting on.
+///
+/// The manifest defaults [Feature.glideCoach] off and declares
+/// `obd2TripRecording` as a prerequisite, so production behaviour is
+/// unchanged (off by default) — but the toggle in the Feature
+/// management screen is now the single source of truth instead of a
+/// dead switch shadowed by a build-time constant.
+///
+/// `keepAlive` because consumers (`glideCoachEvaluatorProvider`, the
+/// settings notifier, the trip GPS stream controller) span the app
+/// lifecycle. Reads route through `isEffectivelyEnabled` for symmetry
+/// with the other feature shims (`showFuelEnabledProvider` etc.).
+@Riverpod(keepAlive: true)
+bool glideCoachEnabled(Ref ref) {
+  final enabled = ref.watch(enabledFeaturesProvider);
+  final manifest = ref.watch(featureManifestProvider);
+  return isEffectivelyEnabled(Feature.glideCoach, manifest, enabled);
+}

--- a/lib/features/glide_coach/providers/glide_coach_enabled_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_enabled_provider.g.dart
@@ -1,0 +1,100 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'glide_coach_enabled_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Whether the glide-coach feature is enabled (#1824).
+///
+/// Migrated off the compile-time `kGlideCoachEnabled` const onto the
+/// central feature-flag set keyed by [Feature.glideCoach] — the
+/// `FeatureFlags` system (#1373) the old TODO was waiting on.
+///
+/// The manifest defaults [Feature.glideCoach] off and declares
+/// `obd2TripRecording` as a prerequisite, so production behaviour is
+/// unchanged (off by default) — but the toggle in the Feature
+/// management screen is now the single source of truth instead of a
+/// dead switch shadowed by a build-time constant.
+///
+/// `keepAlive` because consumers (`glideCoachEvaluatorProvider`, the
+/// settings notifier, the trip GPS stream controller) span the app
+/// lifecycle. Reads route through `isEffectivelyEnabled` for symmetry
+/// with the other feature shims (`showFuelEnabledProvider` etc.).
+
+@ProviderFor(glideCoachEnabled)
+final glideCoachEnabledProvider = GlideCoachEnabledProvider._();
+
+/// Whether the glide-coach feature is enabled (#1824).
+///
+/// Migrated off the compile-time `kGlideCoachEnabled` const onto the
+/// central feature-flag set keyed by [Feature.glideCoach] — the
+/// `FeatureFlags` system (#1373) the old TODO was waiting on.
+///
+/// The manifest defaults [Feature.glideCoach] off and declares
+/// `obd2TripRecording` as a prerequisite, so production behaviour is
+/// unchanged (off by default) — but the toggle in the Feature
+/// management screen is now the single source of truth instead of a
+/// dead switch shadowed by a build-time constant.
+///
+/// `keepAlive` because consumers (`glideCoachEvaluatorProvider`, the
+/// settings notifier, the trip GPS stream controller) span the app
+/// lifecycle. Reads route through `isEffectivelyEnabled` for symmetry
+/// with the other feature shims (`showFuelEnabledProvider` etc.).
+
+final class GlideCoachEnabledProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether the glide-coach feature is enabled (#1824).
+  ///
+  /// Migrated off the compile-time `kGlideCoachEnabled` const onto the
+  /// central feature-flag set keyed by [Feature.glideCoach] — the
+  /// `FeatureFlags` system (#1373) the old TODO was waiting on.
+  ///
+  /// The manifest defaults [Feature.glideCoach] off and declares
+  /// `obd2TripRecording` as a prerequisite, so production behaviour is
+  /// unchanged (off by default) — but the toggle in the Feature
+  /// management screen is now the single source of truth instead of a
+  /// dead switch shadowed by a build-time constant.
+  ///
+  /// `keepAlive` because consumers (`glideCoachEvaluatorProvider`, the
+  /// settings notifier, the trip GPS stream controller) span the app
+  /// lifecycle. Reads route through `isEffectivelyEnabled` for symmetry
+  /// with the other feature shims (`showFuelEnabledProvider` etc.).
+  GlideCoachEnabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'glideCoachEnabledProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$glideCoachEnabledHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return glideCoachEnabled(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$glideCoachEnabledHash() => r'7d23e90a8f332109eea7166f350b2b64e503e189';

--- a/lib/features/glide_coach/providers/glide_coach_evaluator_provider.dart
+++ b/lib/features/glide_coach/providers/glide_coach_evaluator_provider.dart
@@ -7,20 +7,21 @@ import '../data/traffic_signal_repository.dart';
 import '../domain/entities/glide_coach_settings.dart';
 import '../domain/services/glide_coach_evaluator.dart';
 import '../domain/services/imminent_signal_detector.dart';
+import 'glide_coach_enabled_provider.dart';
 import 'glide_coach_settings_provider.dart';
 
 part 'glide_coach_evaluator_provider.g.dart';
 
 /// Provider for the glide-coach evaluator (#1125 phase 3b).
 ///
-/// Returns `null` when the compile-time master flag
-/// [`kGlideCoachEnabled`] is `false` — that's production today, and
+/// Returns `null` when [glideCoachEnabledProvider] is `false`
+/// (`Feature.glideCoach`, default-off) — that's production today, and
 /// every consumer (currently only `tripRecordingProvider`) early-outs
 /// on the null. Callers MUST treat null as "feature disabled, do
 /// nothing" rather than constructing their own evaluator; the layered
-/// kill-switch is the whole point.
+/// gate is the whole point.
 ///
-/// When the master flag is true, the provider wires:
+/// When the feature is enabled, the provider wires:
 ///   1. An [OsmTrafficSignalClient] (default Dio).
 ///   2. A [TrafficSignalRepository] backed by the
 ///      `traffic_signals_cache` Hive box (opened at startup by
@@ -38,8 +39,8 @@ part 'glide_coach_evaluator_provider.g.dart';
 /// no-ops on missing infrastructure.
 @Riverpod(keepAlive: true)
 GlideCoachEvaluator? glideCoachEvaluator(Ref ref) {
-  // Master kill-switch. Production today.
-  if (!kGlideCoachEnabled) return null;
+  // Feature gate (#1824) — central Feature.glideCoach, default-off.
+  if (!ref.watch(glideCoachEnabledProvider)) return null;
 
   // Defensive: the Overpass cache box is opened at app startup. A
   // widget test that didn't run the Hive bootstrapper hits this path

--- a/lib/features/glide_coach/providers/glide_coach_evaluator_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_evaluator_provider.g.dart
@@ -10,14 +10,14 @@ part of 'glide_coach_evaluator_provider.dart';
 // ignore_for_file: type=lint, type=warning
 /// Provider for the glide-coach evaluator (#1125 phase 3b).
 ///
-/// Returns `null` when the compile-time master flag
-/// [`kGlideCoachEnabled`] is `false` — that's production today, and
+/// Returns `null` when [glideCoachEnabledProvider] is `false`
+/// (`Feature.glideCoach`, default-off) — that's production today, and
 /// every consumer (currently only `tripRecordingProvider`) early-outs
 /// on the null. Callers MUST treat null as "feature disabled, do
 /// nothing" rather than constructing their own evaluator; the layered
-/// kill-switch is the whole point.
+/// gate is the whole point.
 ///
-/// When the master flag is true, the provider wires:
+/// When the feature is enabled, the provider wires:
 ///   1. An [OsmTrafficSignalClient] (default Dio).
 ///   2. A [TrafficSignalRepository] backed by the
 ///      `traffic_signals_cache` Hive box (opened at startup by
@@ -39,14 +39,14 @@ final glideCoachEvaluatorProvider = GlideCoachEvaluatorProvider._();
 
 /// Provider for the glide-coach evaluator (#1125 phase 3b).
 ///
-/// Returns `null` when the compile-time master flag
-/// [`kGlideCoachEnabled`] is `false` — that's production today, and
+/// Returns `null` when [glideCoachEnabledProvider] is `false`
+/// (`Feature.glideCoach`, default-off) — that's production today, and
 /// every consumer (currently only `tripRecordingProvider`) early-outs
 /// on the null. Callers MUST treat null as "feature disabled, do
 /// nothing" rather than constructing their own evaluator; the layered
-/// kill-switch is the whole point.
+/// gate is the whole point.
 ///
-/// When the master flag is true, the provider wires:
+/// When the feature is enabled, the provider wires:
 ///   1. An [OsmTrafficSignalClient] (default Dio).
 ///   2. A [TrafficSignalRepository] backed by the
 ///      `traffic_signals_cache` Hive box (opened at startup by
@@ -73,14 +73,14 @@ final class GlideCoachEvaluatorProvider
     with $Provider<GlideCoachEvaluator?> {
   /// Provider for the glide-coach evaluator (#1125 phase 3b).
   ///
-  /// Returns `null` when the compile-time master flag
-  /// [`kGlideCoachEnabled`] is `false` — that's production today, and
+  /// Returns `null` when [glideCoachEnabledProvider] is `false`
+  /// (`Feature.glideCoach`, default-off) — that's production today, and
   /// every consumer (currently only `tripRecordingProvider`) early-outs
   /// on the null. Callers MUST treat null as "feature disabled, do
   /// nothing" rather than constructing their own evaluator; the layered
-  /// kill-switch is the whole point.
+  /// gate is the whole point.
   ///
-  /// When the master flag is true, the provider wires:
+  /// When the feature is enabled, the provider wires:
   ///   1. An [OsmTrafficSignalClient] (default Dio).
   ///   2. A [TrafficSignalRepository] backed by the
   ///      `traffic_signals_cache` Hive box (opened at startup by
@@ -131,4 +131,4 @@ final class GlideCoachEvaluatorProvider
 }
 
 String _$glideCoachEvaluatorHash() =>
-    r'e77d3eafbc0e1793f0e46d91190f16a08f24f140';
+    r'd7c577e5e6faf3c9f6a364238734ec2c284bbcc5';

--- a/lib/features/glide_coach/providers/glide_coach_settings_provider.dart
+++ b/lib/features/glide_coach/providers/glide_coach_settings_provider.dart
@@ -2,8 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import '../data/traffic_signal_repository.dart';
 import '../domain/entities/glide_coach_settings.dart';
+import 'glide_coach_enabled_provider.dart';
 
 part 'glide_coach_settings_provider.g.dart';
 
@@ -21,24 +21,21 @@ part 'glide_coach_settings_provider.g.dart';
 /// The feature has TWO independent off-switches that must both be true
 /// before any haptic fires:
 ///
-///   1. The compile-time master flag
-///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
-///      a hard kill-switch baked into the build. False in production
-///      today; flipping requires a code change + ship cycle.
+///   1. The central feature flag [Feature.glideCoach], read via
+///      [glideCoachEnabledProvider] — default-off in the manifest
+///      (#1824 migrated this off the old `kGlideCoachEnabled` const).
 ///   2. The user-facing toggle, surfaced as
 ///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
 ///
-/// This notifier respects the master flag: when `kGlideCoachEnabled`
-/// is false, the resulting `enabled` value is forced to `false` even
-/// if the persisted user toggle is `true`. That guarantees a stale
-/// debug-build write (or a malicious / future schema change) cannot
-/// leak the feature on in production. The user toggle is layered on
-/// top of the master flag — never below it.
+/// This notifier respects the feature flag: when [Feature.glideCoach]
+/// is disabled, the resulting `enabled` value is forced to `false`
+/// even if the persisted user toggle is `true`. The user toggle is
+/// layered on top of the feature flag — never below it.
 ///
-/// `setEnabled(true)` will still WRITE to SharedPreferences when
-/// `kGlideCoachEnabled` is false (the value is preserved across builds
-/// so a future master-flag flip does not silently lose the user's
-/// historical opt-in), but the in-memory state stays gated.
+/// `setEnabled(true)` will still WRITE to SharedPreferences when the
+/// feature is disabled (the value is preserved so a later flag flip
+/// does not silently lose the user's historical opt-in), but the
+/// in-memory state stays gated.
 ///
 /// `setThrottleThreshold` and `setCooldown` are deliberately
 /// out-of-scope for this PR — the only UI surface in phase 3b is the
@@ -61,9 +58,9 @@ class GlideCoachSettingsNotifier extends _$GlideCoachSettingsNotifier {
     try {
       final prefs = await SharedPreferences.getInstance();
       final stored = prefs.getBool(prefsKey) ?? false;
-      // Master-flag wins over the persisted user toggle. See the class
-      // doc for the layered-gate rationale.
-      final effective = kGlideCoachEnabled ? stored : false;
+      // The Feature.glideCoach flag wins over the persisted user
+      // toggle. See the class doc for the layered-gate rationale.
+      final effective = ref.read(glideCoachEnabledProvider) ? stored : false;
       if (effective != state.enabled) {
         state = state.copyWith(enabled: effective);
       }
@@ -75,13 +72,13 @@ class GlideCoachSettingsNotifier extends _$GlideCoachSettingsNotifier {
   /// Flip the user-facing `enabled` toggle.
   ///
   /// Persists the requested value to SharedPreferences unconditionally
-  /// — preserving the user's historical opt-in across master-flag
+  /// — preserving the user's historical opt-in across feature-flag
   /// flips — but the in-memory `enabled` is gated by
-  /// [`kGlideCoachEnabled`]. With the master flag false (production
-  /// today) `state.enabled` stays `false` even after `setEnabled(true)`,
-  /// matching the layered-gate contract documented on the class.
+  /// [glideCoachEnabledProvider]. With [Feature.glideCoach] disabled
+  /// (production today) `state.enabled` stays `false` even after
+  /// `setEnabled(true)`, matching the layered-gate contract on the class.
   Future<void> setEnabled(bool value) async {
-    final effective = kGlideCoachEnabled ? value : false;
+    final effective = ref.read(glideCoachEnabledProvider) ? value : false;
     state = state.copyWith(enabled: effective);
     try {
       final prefs = await SharedPreferences.getInstance();

--- a/lib/features/glide_coach/providers/glide_coach_settings_provider.g.dart
+++ b/lib/features/glide_coach/providers/glide_coach_settings_provider.g.dart
@@ -22,24 +22,21 @@ part of 'glide_coach_settings_provider.dart';
 /// The feature has TWO independent off-switches that must both be true
 /// before any haptic fires:
 ///
-///   1. The compile-time master flag
-///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
-///      a hard kill-switch baked into the build. False in production
-///      today; flipping requires a code change + ship cycle.
+///   1. The central feature flag [Feature.glideCoach], read via
+///      [glideCoachEnabledProvider] — default-off in the manifest
+///      (#1824 migrated this off the old `kGlideCoachEnabled` const).
 ///   2. The user-facing toggle, surfaced as
 ///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
 ///
-/// This notifier respects the master flag: when `kGlideCoachEnabled`
-/// is false, the resulting `enabled` value is forced to `false` even
-/// if the persisted user toggle is `true`. That guarantees a stale
-/// debug-build write (or a malicious / future schema change) cannot
-/// leak the feature on in production. The user toggle is layered on
-/// top of the master flag — never below it.
+/// This notifier respects the feature flag: when [Feature.glideCoach]
+/// is disabled, the resulting `enabled` value is forced to `false`
+/// even if the persisted user toggle is `true`. The user toggle is
+/// layered on top of the feature flag — never below it.
 ///
-/// `setEnabled(true)` will still WRITE to SharedPreferences when
-/// `kGlideCoachEnabled` is false (the value is preserved across builds
-/// so a future master-flag flip does not silently lose the user's
-/// historical opt-in), but the in-memory state stays gated.
+/// `setEnabled(true)` will still WRITE to SharedPreferences when the
+/// feature is disabled (the value is preserved so a later flag flip
+/// does not silently lose the user's historical opt-in), but the
+/// in-memory state stays gated.
 ///
 /// `setThrottleThreshold` and `setCooldown` are deliberately
 /// out-of-scope for this PR — the only UI surface in phase 3b is the
@@ -63,24 +60,21 @@ final glideCoachSettingsProvider = GlideCoachSettingsNotifierProvider._();
 /// The feature has TWO independent off-switches that must both be true
 /// before any haptic fires:
 ///
-///   1. The compile-time master flag
-///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
-///      a hard kill-switch baked into the build. False in production
-///      today; flipping requires a code change + ship cycle.
+///   1. The central feature flag [Feature.glideCoach], read via
+///      [glideCoachEnabledProvider] — default-off in the manifest
+///      (#1824 migrated this off the old `kGlideCoachEnabled` const).
 ///   2. The user-facing toggle, surfaced as
 ///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
 ///
-/// This notifier respects the master flag: when `kGlideCoachEnabled`
-/// is false, the resulting `enabled` value is forced to `false` even
-/// if the persisted user toggle is `true`. That guarantees a stale
-/// debug-build write (or a malicious / future schema change) cannot
-/// leak the feature on in production. The user toggle is layered on
-/// top of the master flag — never below it.
+/// This notifier respects the feature flag: when [Feature.glideCoach]
+/// is disabled, the resulting `enabled` value is forced to `false`
+/// even if the persisted user toggle is `true`. The user toggle is
+/// layered on top of the feature flag — never below it.
 ///
-/// `setEnabled(true)` will still WRITE to SharedPreferences when
-/// `kGlideCoachEnabled` is false (the value is preserved across builds
-/// so a future master-flag flip does not silently lose the user's
-/// historical opt-in), but the in-memory state stays gated.
+/// `setEnabled(true)` will still WRITE to SharedPreferences when the
+/// feature is disabled (the value is preserved so a later flag flip
+/// does not silently lose the user's historical opt-in), but the
+/// in-memory state stays gated.
 ///
 /// `setThrottleThreshold` and `setCooldown` are deliberately
 /// out-of-scope for this PR — the only UI surface in phase 3b is the
@@ -102,24 +96,21 @@ final class GlideCoachSettingsNotifierProvider
   /// The feature has TWO independent off-switches that must both be true
   /// before any haptic fires:
   ///
-  ///   1. The compile-time master flag
-  ///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
-  ///      a hard kill-switch baked into the build. False in production
-  ///      today; flipping requires a code change + ship cycle.
+  ///   1. The central feature flag [Feature.glideCoach], read via
+  ///      [glideCoachEnabledProvider] — default-off in the manifest
+  ///      (#1824 migrated this off the old `kGlideCoachEnabled` const).
   ///   2. The user-facing toggle, surfaced as
   ///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
   ///
-  /// This notifier respects the master flag: when `kGlideCoachEnabled`
-  /// is false, the resulting `enabled` value is forced to `false` even
-  /// if the persisted user toggle is `true`. That guarantees a stale
-  /// debug-build write (or a malicious / future schema change) cannot
-  /// leak the feature on in production. The user toggle is layered on
-  /// top of the master flag — never below it.
+  /// This notifier respects the feature flag: when [Feature.glideCoach]
+  /// is disabled, the resulting `enabled` value is forced to `false`
+  /// even if the persisted user toggle is `true`. The user toggle is
+  /// layered on top of the feature flag — never below it.
   ///
-  /// `setEnabled(true)` will still WRITE to SharedPreferences when
-  /// `kGlideCoachEnabled` is false (the value is preserved across builds
-  /// so a future master-flag flip does not silently lose the user's
-  /// historical opt-in), but the in-memory state stays gated.
+  /// `setEnabled(true)` will still WRITE to SharedPreferences when the
+  /// feature is disabled (the value is preserved so a later flag flip
+  /// does not silently lose the user's historical opt-in), but the
+  /// in-memory state stays gated.
   ///
   /// `setThrottleThreshold` and `setCooldown` are deliberately
   /// out-of-scope for this PR — the only UI surface in phase 3b is the
@@ -153,7 +144,7 @@ final class GlideCoachSettingsNotifierProvider
 }
 
 String _$glideCoachSettingsNotifierHash() =>
-    r'a93f4a424ece7a901a6d7a27ace315304ead39e6';
+    r'047aa18bb08487db2c21a3c8e4e589ce862fa20e';
 
 /// Persisted user toggle for the glide-coach feature (#1125 phase 3b).
 ///
@@ -169,24 +160,21 @@ String _$glideCoachSettingsNotifierHash() =>
 /// The feature has TWO independent off-switches that must both be true
 /// before any haptic fires:
 ///
-///   1. The compile-time master flag
-///      [`kGlideCoachEnabled`](../data/traffic_signal_repository.dart) —
-///      a hard kill-switch baked into the build. False in production
-///      today; flipping requires a code change + ship cycle.
+///   1. The central feature flag [Feature.glideCoach], read via
+///      [glideCoachEnabledProvider] — default-off in the manifest
+///      (#1824 migrated this off the old `kGlideCoachEnabled` const).
 ///   2. The user-facing toggle, surfaced as
 ///      [`GlideCoachSettings.enabled`] and persisted by this notifier.
 ///
-/// This notifier respects the master flag: when `kGlideCoachEnabled`
-/// is false, the resulting `enabled` value is forced to `false` even
-/// if the persisted user toggle is `true`. That guarantees a stale
-/// debug-build write (or a malicious / future schema change) cannot
-/// leak the feature on in production. The user toggle is layered on
-/// top of the master flag — never below it.
+/// This notifier respects the feature flag: when [Feature.glideCoach]
+/// is disabled, the resulting `enabled` value is forced to `false`
+/// even if the persisted user toggle is `true`. The user toggle is
+/// layered on top of the feature flag — never below it.
 ///
-/// `setEnabled(true)` will still WRITE to SharedPreferences when
-/// `kGlideCoachEnabled` is false (the value is preserved across builds
-/// so a future master-flag flip does not silently lose the user's
-/// historical opt-in), but the in-memory state stays gated.
+/// `setEnabled(true)` will still WRITE to SharedPreferences when the
+/// feature is disabled (the value is preserved so a later flag flip
+/// does not silently lose the user's historical opt-in), but the
+/// in-memory state stays gated.
 ///
 /// `setThrottleThreshold` and `setCooldown` are deliberately
 /// out-of-scope for this PR — the only UI surface in phase 3b is the

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -7,7 +7,6 @@ import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_settings_section.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
-import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/gamification_settings_tile.dart';
 
 import '../../../fakes/fake_storage_repository.dart';
@@ -175,8 +174,8 @@ void main() {
   );
 
   testWidgets(
-    'glide-coach beta toggle stays invisible while the master flag '
-    'kGlideCoachEnabled is false (#1125 phase 3b)',
+    'glide-coach beta toggle stays invisible while Feature.glideCoach '
+    'is off by default (#1125 phase 3b / #1824)',
     (tester) async {
       await pumpApp(
         tester,
@@ -188,27 +187,15 @@ void main() {
         ],
       );
 
-      // The compile-time master flag is the user-facing safety: when
-      // it's false (production today), the entire toggle MUST stay
-      // invisible so users cannot accidentally enable a half-baked
-      // feature. Flipping the flag in a future release is the
-      // deliberate gate that makes the toggle appear.
-      expect(
-        kGlideCoachEnabled,
-        isFalse,
-        reason:
-            'This test pins the production contract. When the master '
-            'flag flips to true, replace this with a positive '
-            'findsOneWidget assertion instead of inverting it.',
-      );
+      // `_TestFeatureFlags` starts with no features enabled, so
+      // Feature.glideCoach is off — the toggle MUST stay invisible so
+      // users cannot accidentally enable a half-baked feature.
       expect(
         find.byKey(const Key('glideCoachToggle')),
         findsNothing,
         reason:
-            'kGlideCoachEnabled == false MUST hide the glide-coach '
-            'toggle entirely. Even users who would happily try the '
-            'beta cannot enable a half-baked feature until the master '
-            'flag flips after a driving-test cohort.',
+            'A disabled Feature.glideCoach MUST hide the glide-coach '
+            'toggle entirely.',
       );
     },
   );

--- a/test/features/glide_coach/data/traffic_signal_repository_test.dart
+++ b/test/features/glide_coach/data/traffic_signal_repository_test.dart
@@ -228,10 +228,6 @@ void main() {
       expect(result.single.id, 'fresh');
     });
 
-    test('kGlideCoachEnabled remains false (placeholder feature flag)', () {
-      expect(kGlideCoachEnabled, isFalse);
-    });
-
     test('boxName matches the constant registered in HiveBoxes', () {
       expect(TrafficSignalRepository.boxName, 'traffic_signals_cache');
     });

--- a/test/features/glide_coach/providers/glide_coach_evaluator_provider_test.dart
+++ b/test/features/glide_coach/providers/glide_coach_evaluator_provider_test.dart
@@ -1,26 +1,15 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
 import 'package:tankstellen/features/glide_coach/providers/glide_coach_evaluator_provider.dart';
 
 void main() {
   group('glideCoachEvaluatorProvider (#1125 phase 3b)', () {
     test(
-      'returns null when kGlideCoachEnabled is false (production)',
+      'returns null when Feature.glideCoach is disabled (production default)',
       () {
-        // Asserting the master flag explicitly so a future PR that
-        // flips it to true makes this test fail loudly — the provider's
-        // contract changes (it no longer short-circuits to null) and
-        // the test author should swap to a Hive-backed scenario.
-        expect(
-          kGlideCoachEnabled,
-          isFalse,
-          reason:
-              'This test pins the production contract. When the master '
-              'flag flips, replace this assertion with a Hive setup that '
-              'verifies the evaluator is constructed.',
-        );
-
+        // Feature.glideCoach is default-off in the manifest (#1824), so
+        // a bare container has the feature disabled and the provider
+        // short-circuits to null without touching Hive or Overpass.
         final container = ProviderContainer();
         addTearDown(container.dispose);
 
@@ -28,7 +17,7 @@ void main() {
           container.read(glideCoachEvaluatorProvider),
           isNull,
           reason:
-              'With kGlideCoachEnabled == false the provider MUST return '
+              'With Feature.glideCoach disabled the provider MUST return '
               'null so consumers (trip_recording_provider) can early-out '
               'cleanly without touching Hive or the Overpass client.',
         );

--- a/test/features/glide_coach/providers/glide_coach_settings_provider_test.dart
+++ b/test/features/glide_coach/providers/glide_coach_settings_provider_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:tankstellen/features/glide_coach/data/traffic_signal_repository.dart';
 import 'package:tankstellen/features/glide_coach/domain/entities/glide_coach_settings.dart';
 import 'package:tankstellen/features/glide_coach/providers/glide_coach_settings_provider.dart';
 
@@ -24,7 +23,7 @@ void main() {
     );
 
     test(
-      'master flag wins — kGlideCoachEnabled is false in production so '
+      'feature flag wins — Feature.glideCoach is off by default so '
       'setEnabled(true) MUST keep state.enabled at false',
       () async {
         final container = ProviderContainer();
@@ -35,26 +34,16 @@ void main() {
         );
         await notifier.setEnabled(true);
 
-        // Production today has kGlideCoachEnabled == false. The
-        // layered gate dictates that an opted-in user toggle MUST
-        // still surface as disabled in-memory until the master flag
-        // flips. This is the safety: a stale debug-build write or a
-        // future schema change cannot leak the feature on for users.
-        expect(
-          kGlideCoachEnabled,
-          isFalse,
-          reason:
-              'This test is meaningful only while the master flag is '
-              'false. If kGlideCoachEnabled is flipped to true in a '
-              'future PR, update this test to assert the new contract.',
-        );
+        // Feature.glideCoach is default-off (#1824). The layered gate
+        // dictates that an opted-in user toggle MUST still surface as
+        // disabled in-memory until the feature flag is enabled.
         expect(
           container.read(glideCoachSettingsProvider).enabled,
           isFalse,
           reason:
-              'kGlideCoachEnabled == false MUST gate state.enabled to '
+              'A disabled Feature.glideCoach MUST gate state.enabled to '
               'false even after setEnabled(true). The user toggle is '
-              'layered on top of the master flag, never below it.',
+              'layered on top of the feature flag, never below it.',
         );
       },
     );
@@ -123,17 +112,16 @@ void main() {
         container.read(glideCoachSettingsProvider);
         await Future<void>.delayed(Duration.zero);
 
-        // The persisted value is `true` — but the master flag is
-        // false in production, so the gated state stays false. When
-        // the master flag flips in a future PR, the same persisted
-        // value will surface as enabled without the user having to
-        // toggle again.
+        // The persisted value is `true` — but Feature.glideCoach is
+        // default-off, so the gated state stays false. Enabling the
+        // feature later surfaces the same persisted value as enabled
+        // without the user having to toggle again.
         expect(
           container.read(glideCoachSettingsProvider).enabled,
-          kGlideCoachEnabled,
+          isFalse,
           reason:
-              'Restored state must equal `persisted-true && master-flag` '
-              '— production today is false on both axes once gated.',
+              'Restored state must equal `persisted-true && feature-flag` '
+              '— with Feature.glideCoach off it gates to false.',
         );
       },
     );


### PR DESCRIPTION
## What

`traffic_signal_repository.dart` carried a compile-time
`const kGlideCoachEnabled = false` with a TODO to move onto central
feature management once it landed. `FeatureFlags` (#1373) landed long
ago — this migrates the toggle.

## How

- New `glideCoachEnabledProvider` — a keep-alive shim over the central
  feature-flag set keyed by `Feature.glideCoach` (default-off in the
  manifest, `requires obd2TripRecording`), mirroring
  `showFuelEnabledProvider`.
- The four consumers — `glideCoachEvaluatorProvider`, the settings
  notifier, the trip GPS stream controller, and the driving-settings
  section — now read the central flag.
- The `kGlideCoachEnabled` const + its TODO are removed.

Production behaviour is unchanged (manifest keeps `glideCoach`
default-off), but the Feature-management toggle is now the single
source of truth instead of a dead switch shadowed by a build-time
constant.

## Verification

- `flutter analyze` clean; `check_module_boundaries.sh` passes.
- `glide_coach`, `driving`, `consumption/providers`, `feature_management`
  suites all green — tests that pinned the old const migrated to the
  feature flag.

Closes #1824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
