### PR TITLE
feat(sync): gated trajet-sync to TankSync (#1667, #1668, #1669)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -26,6 +26,7 @@ import '../core/storage/hive_storage.dart';
 import '../core/sync/community_config.dart';
 import '../core/sync/supabase_client.dart';
 import '../core/sync/trips_sync.dart';
+import '../core/sync/trips_sync_enabled_provider.dart';
 import '../core/telemetry/pii_scrubber.dart';
 import '../core/utils/edge_to_edge.dart';
 import '../features/consumption/data/obd2/active_trip_recovery_service.dart';
@@ -124,7 +125,7 @@ class AppInitializer {
       // #1541 — run the trip-summaries merge + details retention pass
       // once TankSync is up. No-ops cleanly when the user is signed
       // out or when the trip-history Hive box isn't open.
-      await _runTripsSyncMerge();
+      await _runTripsSyncMerge(container);
     });
 
     // Cache runtime version so AppConstants.appVersion is accurate (#570).
@@ -475,12 +476,15 @@ class AppInitializer {
   /// missing server row — `TripsSync.merge` returns the input
   /// unchanged on error so a transient network blip never costs the
   /// user their local history view.
-  static Future<void> _runTripsSyncMerge() async {
+  static Future<void> _runTripsSyncMerge(ProviderContainer container) async {
     // #1794 — `obd2TripHistory` is a deferred box; wait for the
     // post-first-frame opens before reading it.
     await HiveBoxes.initDeferred();
     if (TankSyncClient.client == null) return;
     if (!Hive.isBoxOpen(HiveBoxes.obd2TripHistory)) return;
+    // #1665 — gate the launch-time merge on the trajet-sync gate so an
+    // anonymous session no longer downloads / heals trip rows.
+    if (!container.read(tripsSyncEnabledProvider)) return;
     try {
       final repo = TripHistoryRepository(
         box: Hive.box<String>(HiveBoxes.obd2TripHistory),

--- a/lib/core/sync/trips_sync_enabled_provider.dart
+++ b/lib/core/sync/trips_sync_enabled_provider.dart
@@ -1,0 +1,32 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../providers/app_state_provider.dart';
+import 'sync_provider.dart';
+
+part 'trips_sync_enabled_provider.g.dart';
+
+/// Whether recorded trajets sync to TankSync (#1665).
+///
+/// The single source of truth for the trajet-sync gate — `A ∧ B ∧ C`:
+///  - **A** — a non-anonymous (email-backed) TankSync account
+///    (`SyncConfig.hasEmail`);
+///  - **B** — the master `cloudSync` GDPR consent;
+///  - **C** — the `syncTrips` toggle.
+///
+/// Consulted at both trigger points — the `_saveToHistory` upload hook
+/// in `trip_recording_provider` and the app-launch `_runTripsSyncMerge`
+/// — so an anonymous session neither uploads nor merges trip rows.
+/// `TripsSync` stays a pure I/O helper (its `currentUser == null`
+/// early-return is a safety net); the gate lives here, not in the wire
+/// layer.
+///
+/// `cloudSync` and `syncTrips` are checked explicitly rather than
+/// relying on `GdprConsent.save()`'s `effectiveSyncTrips` coupling —
+/// a fresh `build()` reads the raw stored values, so a stale
+/// `syncTrips = true` under `cloudSync = false` must still gate off.
+@riverpod
+bool tripsSyncEnabled(Ref ref) {
+  final syncConfig = ref.watch(syncStateProvider);
+  final consent = ref.watch(gdprConsentProvider);
+  return syncConfig.hasEmail && consent.cloudSync && consent.syncTrips;
+}

--- a/lib/core/sync/trips_sync_enabled_provider.g.dart
+++ b/lib/core/sync/trips_sync_enabled_provider.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trips_sync_enabled_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Whether recorded trajets sync to TankSync (#1665).
+///
+/// The single source of truth for the trajet-sync gate — `A ∧ B ∧ C`:
+///  - **A** — a non-anonymous (email-backed) TankSync account
+///    (`SyncConfig.hasEmail`);
+///  - **B** — the master `cloudSync` GDPR consent;
+///  - **C** — the `syncTrips` toggle.
+///
+/// Consulted at both trigger points — the `_saveToHistory` upload hook
+/// in `trip_recording_provider` and the app-launch `_runTripsSyncMerge`
+/// — so an anonymous session neither uploads nor merges trip rows.
+/// `TripsSync` stays a pure I/O helper (its `currentUser == null`
+/// early-return is a safety net); the gate lives here, not in the wire
+/// layer.
+///
+/// `cloudSync` and `syncTrips` are checked explicitly rather than
+/// relying on `GdprConsent.save()`'s `effectiveSyncTrips` coupling —
+/// a fresh `build()` reads the raw stored values, so a stale
+/// `syncTrips = true` under `cloudSync = false` must still gate off.
+
+@ProviderFor(tripsSyncEnabled)
+final tripsSyncEnabledProvider = TripsSyncEnabledProvider._();
+
+/// Whether recorded trajets sync to TankSync (#1665).
+///
+/// The single source of truth for the trajet-sync gate — `A ∧ B ∧ C`:
+///  - **A** — a non-anonymous (email-backed) TankSync account
+///    (`SyncConfig.hasEmail`);
+///  - **B** — the master `cloudSync` GDPR consent;
+///  - **C** — the `syncTrips` toggle.
+///
+/// Consulted at both trigger points — the `_saveToHistory` upload hook
+/// in `trip_recording_provider` and the app-launch `_runTripsSyncMerge`
+/// — so an anonymous session neither uploads nor merges trip rows.
+/// `TripsSync` stays a pure I/O helper (its `currentUser == null`
+/// early-return is a safety net); the gate lives here, not in the wire
+/// layer.
+///
+/// `cloudSync` and `syncTrips` are checked explicitly rather than
+/// relying on `GdprConsent.save()`'s `effectiveSyncTrips` coupling —
+/// a fresh `build()` reads the raw stored values, so a stale
+/// `syncTrips = true` under `cloudSync = false` must still gate off.
+
+final class TripsSyncEnabledProvider
+    extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether recorded trajets sync to TankSync (#1665).
+  ///
+  /// The single source of truth for the trajet-sync gate — `A ∧ B ∧ C`:
+  ///  - **A** — a non-anonymous (email-backed) TankSync account
+  ///    (`SyncConfig.hasEmail`);
+  ///  - **B** — the master `cloudSync` GDPR consent;
+  ///  - **C** — the `syncTrips` toggle.
+  ///
+  /// Consulted at both trigger points — the `_saveToHistory` upload hook
+  /// in `trip_recording_provider` and the app-launch `_runTripsSyncMerge`
+  /// — so an anonymous session neither uploads nor merges trip rows.
+  /// `TripsSync` stays a pure I/O helper (its `currentUser == null`
+  /// early-return is a safety net); the gate lives here, not in the wire
+  /// layer.
+  ///
+  /// `cloudSync` and `syncTrips` are checked explicitly rather than
+  /// relying on `GdprConsent.save()`'s `effectiveSyncTrips` coupling —
+  /// a fresh `build()` reads the raw stored values, so a stale
+  /// `syncTrips = true` under `cloudSync = false` must still gate off.
+  TripsSyncEnabledProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'tripsSyncEnabledProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$tripsSyncEnabledHash();
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    return tripsSyncEnabled(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$tripsSyncEnabledHash() => r'a97a4800280e788bed5f5255b944b91e6f1d8f0b';

--- a/lib/features/consent/presentation/widgets/consent_settings_section.dart
+++ b/lib/features/consent/presentation/widgets/consent_settings_section.dart
@@ -156,42 +156,14 @@ class _ConsentSettingsSectionState
                 syncTrips: consent.syncTrips,
               ),
         ),
-        // #1479 phase 1 — trip-sync consent. Sits LAST so the
-        // historical 0..4 SwitchListTile indices in older tests stay
-        // stable. Gated on the master Cloud Sync above; the toggle
-        // is disabled (onChanged: null) when cloudSync is off and the
-        // provider's `save()` enforces effective-false when
-        // cloudSync=false so the visible position stays honest.
-        SwitchListTile(
-          key: const Key('consentSyncTripsToggle'),
-          secondary: const Icon(Icons.route_outlined, size: 20),
-          title: Text(l10n?.consentSyncTripsTitle ?? 'Sync trip recordings'),
-          subtitle: Text(
-            consent.cloudSync
-                ? (l10n?.consentSyncTripsSubtitle ??
-                    'Back up OBD2 + GPS trips to TankSync. '
-                        'Cross-device, opt-in.')
-                : (l10n?.consentSyncTripsDisabledHint ??
-                    'Enable Cloud Sync above to back up trips.'),
-            style: theme.textTheme.bodySmall,
-            maxLines: collapsedMaxLines(),
-            overflow: collapsedOverflow(),
-          ),
-          value: consent.syncTrips,
-          onChanged: consent.cloudSync
-              ? (v) => ref.read(gdprConsentProvider.notifier).save(
-                    location: consent.location,
-                    errorReporting: consent.errorReporting,
-                    cloudSync: consent.cloudSync,
-                    communityWaitTime: consent.communityWaitTime,
-                    vinOnlineDecode: consent.vinOnlineDecode,
-                    syncTrips: v,
-                  )
-              : null,
-        ),
-        // #1529 — section-level expand toggle for the 4 collapsed
+        // #1665 — the trajet-sync toggle moved to Settings → TankSync
+        // (`tank_sync_section.dart`); it now also gates on a
+        // non-anonymous account, which only makes sense alongside the
+        // account controls. The `consentSyncTrips` storage key +
+        // `GdprConsent.syncTrips` field still back it.
+        // #1529 — section-level expand toggle for the 3 collapsed
         // subtitles (Cloud Sync, Community Wait Times, VIN online
-        // decode, Sync trip recordings). The first two consents
+        // decode). The first two consents
         // (Location, Error Reporting) keep their full text always
         // because they're the ones a user is most likely to revisit.
         Align(

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -7,9 +7,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
-import '../../../core/providers/app_state_provider.dart';
 import '../../../core/storage/hive_boxes.dart';
 import '../../../core/sync/trips_sync.dart';
+import '../../../core/sync/trips_sync_enabled_provider.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
 import '../../search/domain/entities/fuel_type.dart';
@@ -1130,16 +1130,13 @@ class TripRecording extends _$TripRecording {
           debugPrint('TripRecording auto-record badge increment: $e\n$st');
         }
       }
-      // #1479 phase 2 — opportunistic upload of the freshly saved
-      // summary to TankSync. Gated on the user's opt-in
-      // `consentSyncTrips` consent (which is itself gated on the
-      // master `cloudSync` consent at the toggle layer). Read here
-      // rather than hoisted into the orchestrator so a manual stop
-      // path also benefits — the user opted in once, every trip
-      // they save flows through the same `_saveToHistory`.
+      // #1479 phase 2 / #1665 — opportunistic upload of the freshly
+      // saved summary to TankSync. Gated by `tripsSyncEnabledProvider`
+      // — the single source of truth (non-anonymous account ∧ cloud
+      // sync consent ∧ trips toggle). Read here rather than hoisted
+      // into the orchestrator so a manual stop path also benefits.
       try {
-        final consent = ref.read(gdprConsentProvider);
-        if (consent.syncTrips) {
+        if (ref.read(tripsSyncEnabledProvider)) {
           final entry = repo.loadAll().firstWhere(
             (e) => e.id == id,
             orElse: () => TripHistoryEntry(

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'cf6bf6c5a01028d27f2137303f655bf22e24fd5d';
+String _$tripRecordingHash() => r'26135443e66de98aecee873fbaf69ae670d4b41f';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../sync/presentation/widgets/qr_share_widget.dart';
+import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/sync/sync_config.dart';
 import '../../../../core/sync/sync_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -39,6 +40,7 @@ class TankSyncSection extends ConsumerWidget {
     ThemeData theme,
   ) {
     final l = AppLocalizations.of(context);
+    final consent = ref.watch(gdprConsentProvider);
     return [
       ListTile(
         leading: const Icon(Icons.cloud_done, color: Colors.green),
@@ -63,6 +65,39 @@ class TankSyncSection extends ConsumerWidget {
           subtitle: Text(l?.switchToAnonymousSubtitle ?? 'Keep local data, use new anonymous session'),
           onTap: () => _confirmSwitchToAnonymous(context, ref),
         ),
+      const Divider(indent: 16, endIndent: 16),
+      // #1665 — trajet sync. Recorded trips upload to TankSync only
+      // when a non-anonymous (email) account is configured AND this
+      // toggle is on AND Cloud Sync consent is granted. Disabled with
+      // a hint when the account is anonymous or Cloud Sync is off.
+      SwitchListTile(
+        key: const Key('tripsSyncToggle'),
+        secondary: const Icon(Icons.route_outlined),
+        title: Text(l?.consentSyncTripsTitle ?? 'Sync trip recordings'),
+        subtitle: Text(
+          !consent.cloudSync
+              ? (l?.consentSyncTripsDisabledHint ??
+                  'Enable Cloud Sync to back up trips.')
+              : !syncConfig.hasEmail
+                  ? (l?.consentSyncTripsNeedsEmailHint ??
+                      'Sign in with an email account to sync trips '
+                          'across devices.')
+                  : (l?.consentSyncTripsSubtitle ??
+                      'Back up OBD2 + GPS trips to TankSync. '
+                          'Cross-device, opt-in.'),
+        ),
+        value: consent.syncTrips,
+        onChanged: (consent.cloudSync && syncConfig.hasEmail)
+            ? (v) => ref.read(gdprConsentProvider.notifier).save(
+                  location: consent.location,
+                  errorReporting: consent.errorReporting,
+                  cloudSync: consent.cloudSync,
+                  communityWaitTime: consent.communityWaitTime,
+                  vinOnlineDecode: consent.vinOnlineDecode,
+                  syncTrips: v,
+                )
+            : null,
+      ),
       const Divider(indent: 16, endIndent: 16),
       ListTile(
         leading: const Icon(Icons.visibility_outlined),

--- a/lib/l10n/_fragments/i18n_audit_de.arb
+++ b/lib/l10n/_fragments/i18n_audit_de.arb
@@ -33,6 +33,7 @@
   "consentSyncTripsTitle": "Fahrtaufzeichnungen synchronisieren",
   "consentSyncTripsSubtitle": "OBD2- und GPS-Fahrten in TankSync sichern. Geräteübergreifend, opt-in.",
   "consentSyncTripsDisabledHint": "Cloud-Sync oben aktivieren, um Fahrten zu sichern.",
+  "consentSyncTripsNeedsEmailHint": "Mit einem E-Mail-Konto anmelden, um Fahrten geräteübergreifend zu synchronisieren.",
   "consentHideDetails": "Details ausblenden",
   "consentShowDetails": "Details anzeigen",
   "dialogOk": "OK",

--- a/lib/l10n/_fragments/i18n_audit_en.arb
+++ b/lib/l10n/_fragments/i18n_audit_en.arb
@@ -63,6 +63,7 @@
   "consentSyncTripsTitle": "Sync trip recordings",
   "consentSyncTripsSubtitle": "Back up OBD2 + GPS trips to TankSync. Cross-device, opt-in.",
   "consentSyncTripsDisabledHint": "Enable Cloud Sync above to back up trips.",
+  "consentSyncTripsNeedsEmailHint": "Sign in with an email account to sync trips across devices.",
   "consentHideDetails": "Hide details",
   "consentShowDetails": "Show details",
   "dialogOk": "OK",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Синхронизиране на записи на пътувания",
   "consentSyncTripsSubtitle": "Резервно копие на OBD2 + GPS пътувания в TankSync. Между устройства, по избор.",
   "consentSyncTripsDisabledHint": "Активирайте облачната синхронизация по-горе за резервно копие на пътуванията.",
+  "consentSyncTripsNeedsEmailHint": "Влезте с имейл акаунт, за да синхронизирате пътуванията между устройства.",
   "consentHideDetails": "Скрий подробностите",
   "consentShowDetails": "Покажи подробностите",
   "dialogOk": "OK",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synchronizovat záznamy cest",
   "consentSyncTripsSubtitle": "Zálohovat OBD2 + GPS cesty na TankSync. Mezi zařízeními, volitelné.",
   "consentSyncTripsDisabledHint": "Pro zálohování cest povolte cloudovou synchronizaci výše.",
+  "consentSyncTripsNeedsEmailHint": "Přihlaste se pomocí e-mailového účtu pro synchronizaci jízd mezi zařízeními.",
   "consentHideDetails": "Skrýt podrobnosti",
   "consentShowDetails": "Zobrazit podrobnosti",
   "dialogOk": "OK",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synkroniser turoptagelser",
   "consentSyncTripsSubtitle": "Sikkerhedskopier OBD2 + GPS-ture til TankSync. Tværenhed, opt-in.",
   "consentSyncTripsDisabledHint": "Aktivér Cloud-synkronisering ovenfor for at sikkerhedskopiere ture.",
+  "consentSyncTripsNeedsEmailHint": "Log ind med en e-mailkonto for at synkronisere ture mellem enheder.",
   "consentHideDetails": "Skjul detaljer",
   "consentShowDetails": "Vis detaljer",
   "dialogOk": "OK",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1767,6 +1767,7 @@
   "consentSyncTripsTitle": "Fahrtaufzeichnungen synchronisieren",
   "consentSyncTripsSubtitle": "OBD2- und GPS-Fahrten in TankSync sichern. Geräteübergreifend, opt-in.",
   "consentSyncTripsDisabledHint": "Cloud-Sync oben aktivieren, um Fahrten zu sichern.",
+  "consentSyncTripsNeedsEmailHint": "Mit einem E-Mail-Konto anmelden, um Fahrten geräteübergreifend zu synchronisieren.",
   "consentHideDetails": "Details ausblenden",
   "consentShowDetails": "Details anzeigen",
   "dialogOk": "OK",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Συγχρονισμός καταγεγραμμένων ταξιδιών",
   "consentSyncTripsSubtitle": "Δημιουργία αντιγράφων ταξιδιών OBD2 + GPS στο TankSync. Μεταξύ συσκευών, προαιρετικό.",
   "consentSyncTripsDisabledHint": "Ενεργοποιήστε τον Συγχρονισμό Cloud παραπάνω για δημιουργία αντιγράφων ταξιδιών.",
+  "consentSyncTripsNeedsEmailHint": "Συνδεθείτε με λογαριασμό email για συγχρονισμό διαδρομών μεταξύ συσκευών.",
   "consentHideDetails": "Απόκρυψη λεπτομερειών",
   "consentShowDetails": "Εμφάνιση λεπτομερειών",
   "dialogOk": "ΟΚ",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2937,6 +2937,7 @@
   "consentSyncTripsTitle": "Sync trip recordings",
   "consentSyncTripsSubtitle": "Back up OBD2 + GPS trips to TankSync. Cross-device, opt-in.",
   "consentSyncTripsDisabledHint": "Enable Cloud Sync above to back up trips.",
+  "consentSyncTripsNeedsEmailHint": "Sign in with an email account to sync trips across devices.",
   "consentHideDetails": "Hide details",
   "consentShowDetails": "Show details",
   "dialogOk": "OK",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "⟦Šýñç ŧřîƥ řéçóřđîñǧš ········⟧",
   "consentSyncTripsSubtitle": "⟦Ɓáçķ úƥ ÓƁĐ2 + ǦƤŠ ŧřîƥš ŧó ŦáñķŠýñç. Çřóšš-đéṽîçé, óƥŧ-îñ. ···················⟧",
   "consentSyncTripsDisabledHint": "⟦Éñáƀłé Çłóúđ Šýñç áƀóṽé ŧó ƀáçķ úƥ ŧřîƥš. ···············⟧",
+  "consentSyncTripsNeedsEmailHint": "⟦Šîǧñ îñ ŵîŧĥ áñ éɱáîł áççóúñŧ ŧó šýñç ŧřîƥš áçřóšš đéṽîçéš. ······················⟧",
   "consentHideDetails": "⟦Ĥîđé đéŧáîłš ·····⟧",
   "consentShowDetails": "⟦Šĥóŵ đéŧáîłš ·····⟧",
   "dialogOk": "⟦ÓĶ ·⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sincronizar grabaciones de viajes",
   "consentSyncTripsSubtitle": "Haz una copia de seguridad de los viajes OBD2 + GPS en TankSync. Entre dispositivos, opcional.",
   "consentSyncTripsDisabledHint": "Activa la sincronización en la nube arriba para hacer copias de seguridad de los viajes.",
+  "consentSyncTripsNeedsEmailHint": "Inicia sesión con una cuenta de correo para sincronizar los viajes entre dispositivos.",
   "consentHideDetails": "Ocultar detalles",
   "consentShowDetails": "Mostrar detalles",
   "dialogOk": "Aceptar",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sünkrooni reisi salvestisi",
   "consentSyncTripsSubtitle": "Varunda OBD2 + GPS reisid TankSync'i. Seadmeteülene, vabatahtlik.",
   "consentSyncTripsDisabledHint": "Luba ülal Pilvsünkroonimine reiside varundamiseks.",
+  "consentSyncTripsNeedsEmailHint": "Logige sisse e-posti kontoga, et sõite seadmete vahel sünkroonida.",
   "consentHideDetails": "Peida üksikasjad",
   "consentShowDetails": "Kuva üksikasjad",
   "dialogOk": "OK",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synkronoi matkatallenteet",
   "consentSyncTripsSubtitle": "Varmuuskopioi OBD2- ja GPS-matkat TankSynciin. Laitteiden välinen, valinnainen.",
   "consentSyncTripsDisabledHint": "Ota pilvisynkronointi käyttöön yllä varmuuskopioidaksesi matkat.",
+  "consentSyncTripsNeedsEmailHint": "Kirjaudu sähköpostitilillä, jotta voit synkronoida matkat laitteiden välillä.",
   "consentHideDetails": "Piilota tiedot",
   "consentShowDetails": "Näytä tiedot",
   "dialogOk": "OK",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1389,6 +1389,7 @@
   "consentSyncTripsTitle": "Synchroniser les trajets enregistrés",
   "consentSyncTripsSubtitle": "Sauvegardez les trajets OBD2 + GPS dans TankSync. Multi-appareil, opt-in.",
   "consentSyncTripsDisabledHint": "Activez Cloud Sync ci-dessus pour sauvegarder les trajets.",
+  "consentSyncTripsNeedsEmailHint": "Connecte-toi avec un compte e-mail pour synchroniser les trajets entre appareils.",
   "consentHideDetails": "Masquer les détails",
   "consentShowDetails": "Afficher les détails",
   "dialogOk": "OK",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sinkroniziraj snimanja vožnji",
   "consentSyncTripsSubtitle": "Sigurnosno kopirajte OBD2 + GPS vožnje na TankSync. Između uređaja, po izboru.",
   "consentSyncTripsDisabledHint": "Omogućite Sinkronizaciju u oblaku gore za sigurnosno kopiranje vožnji.",
+  "consentSyncTripsNeedsEmailHint": "Prijavite se s računom e-pošte za sinkronizaciju vožnji među uređajima.",
   "consentHideDetails": "Sakrij pojedinosti",
   "consentShowDetails": "Prikaži pojedinosti",
   "dialogOk": "U redu",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Útfelvételek szinkronizálása",
   "consentSyncTripsSubtitle": "OBD2 + GPS utak mentése TankSync-re. Eszközök között, opcionális.",
   "consentSyncTripsDisabledHint": "Az utak mentéséhez engedélyezze a Felhőszinkronizálást fentebb.",
+  "consentSyncTripsNeedsEmailHint": "Jelentkezz be e-mail-fiókkal az utak eszközök közötti szinkronizálásához.",
   "consentHideDetails": "Részletek elrejtése",
   "consentShowDetails": "Részletek megjelenítése",
   "dialogOk": "OK",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sincronizza registrazioni percorsi",
   "consentSyncTripsSubtitle": "Backup percorsi OBD2 + GPS su TankSync. Multi-dispositivo, opt-in.",
   "consentSyncTripsDisabledHint": "Abilita la sincronizzazione cloud sopra per fare il backup dei percorsi.",
+  "consentSyncTripsNeedsEmailHint": "Accedi con un account e-mail per sincronizzare i viaggi tra dispositivi.",
   "consentHideDetails": "Nascondi dettagli",
   "consentShowDetails": "Mostra dettagli",
   "dialogOk": "OK",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7959,6 +7959,12 @@ abstract class AppLocalizations {
   /// **'Enable Cloud Sync above to back up trips.'**
   String get consentSyncTripsDisabledHint;
 
+  /// No description provided for @consentSyncTripsNeedsEmailHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign in with an email account to sync trips across devices.'**
+  String get consentSyncTripsNeedsEmailHint;
+
   /// No description provided for @consentHideDetails.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4447,6 +4447,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Активирайте облачната синхронизация по-горе за резервно копие на пътуванията.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Влезте с имейл акаунт, за да синхронизирате пътуванията между устройства.';
+
+  @override
   String get consentHideDetails => 'Скрий подробностите';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4415,6 +4415,10 @@ class AppLocalizationsCs extends AppLocalizations {
       'Pro zálohování cest povolte cloudovou synchronizaci výše.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Přihlaste se pomocí e-mailového účtu pro synchronizaci jízd mezi zařízeními.';
+
+  @override
   String get consentHideDetails => 'Skrýt podrobnosti';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4410,6 +4410,10 @@ class AppLocalizationsDa extends AppLocalizations {
       'Aktivér Cloud-synkronisering ovenfor for at sikkerhedskopiere ture.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Log ind med en e-mailkonto for at synkronisere ture mellem enheder.';
+
+  @override
   String get consentHideDetails => 'Skjul detaljer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4432,6 +4432,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Cloud-Sync oben aktivieren, um Fahrten zu sichern.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Mit einem E-Mail-Konto anmelden, um Fahrten geräteübergreifend zu synchronisieren.';
+
+  @override
   String get consentHideDetails => 'Details ausblenden';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4450,6 +4450,10 @@ class AppLocalizationsEl extends AppLocalizations {
       'Ενεργοποιήστε τον Συγχρονισμό Cloud παραπάνω για δημιουργία αντιγράφων ταξιδιών.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Συνδεθείτε με λογαριασμό email για συγχρονισμό διαδρομών μεταξύ συσκευών.';
+
+  @override
   String get consentHideDetails => 'Απόκρυψη λεπτομερειών';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4385,6 +4385,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enable Cloud Sync above to back up trips.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Sign in with an email account to sync trips across devices.';
+
+  @override
   String get consentHideDetails => 'Hide details';
 
   @override
@@ -9654,6 +9658,10 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get consentSyncTripsDisabledHint =>
       '⟦Éñáƀłé Çłóúđ Šýñç áƀóṽé ŧó ƀáçķ úƥ ŧřîƥš. ···············⟧';
+
+  @override
+  String get consentSyncTripsNeedsEmailHint =>
+      '⟦Šîǧñ îñ ŵîŧĥ áñ éɱáîł áççóúñŧ ŧó šýñç ŧřîƥš áçřóšš đéṽîçéš. ······················⟧';
 
   @override
   String get consentHideDetails => '⟦Ĥîđé đéŧáîłš ·····⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4444,6 +4444,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Activa la sincronización en la nube arriba para hacer copias de seguridad de los viajes.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Inicia sesión con una cuenta de correo para sincronizar los viajes entre dispositivos.';
+
+  @override
   String get consentHideDetails => 'Ocultar detalles';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4405,6 +4405,10 @@ class AppLocalizationsEt extends AppLocalizations {
       'Luba ülal Pilvsünkroonimine reiside varundamiseks.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Logige sisse e-posti kontoga, et sõite seadmete vahel sünkroonida.';
+
+  @override
   String get consentHideDetails => 'Peida üksikasjad';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4408,6 +4408,10 @@ class AppLocalizationsFi extends AppLocalizations {
       'Ota pilvisynkronointi käyttöön yllä varmuuskopioidaksesi matkat.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Kirjaudu sähköpostitilillä, jotta voit synkronoida matkat laitteiden välillä.';
+
+  @override
   String get consentHideDetails => 'Piilota tiedot';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4455,6 +4455,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Activez Cloud Sync ci-dessus pour sauvegarder les trajets.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Connecte-toi avec un compte e-mail pour synchroniser les trajets entre appareils.';
+
+  @override
   String get consentHideDetails => 'Masquer les détails';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4424,6 +4424,10 @@ class AppLocalizationsHr extends AppLocalizations {
       'Omogućite Sinkronizaciju u oblaku gore za sigurnosno kopiranje vožnji.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Prijavite se s računom e-pošte za sinkronizaciju vožnji među uređajima.';
+
+  @override
   String get consentHideDetails => 'Sakrij pojedinosti';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4448,6 +4448,10 @@ class AppLocalizationsHu extends AppLocalizations {
       'Az utak mentéséhez engedélyezze a Felhőszinkronizálást fentebb.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Jelentkezz be e-mail-fiókkal az utak eszközök közötti szinkronizálásához.';
+
+  @override
   String get consentHideDetails => 'Részletek elrejtése';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4435,6 +4435,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Abilita la sincronizzazione cloud sopra per fare il backup dei percorsi.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Accedi con un account e-mail per sincronizzare i viaggi tra dispositivi.';
+
+  @override
   String get consentHideDetails => 'Nascondi dettagli';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4435,6 +4435,10 @@ class AppLocalizationsLt extends AppLocalizations {
       'Įjunkite debesų sinchronizavimą aukščiau, kad kurti atsargines kelionių kopijas.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Prisijunkite naudodami el. pašto paskyrą, kad sinchronizuotumėte keliones tarp įrenginių.';
+
+  @override
   String get consentHideDetails => 'Slėpti detales';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4436,6 +4436,10 @@ class AppLocalizationsLv extends AppLocalizations {
       'Iespējojiet Mākoņa sinhronizāciju augstāk, lai dublētu braucienus.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Pierakstieties ar e-pasta kontu, lai sinhronizētu braucienus starp ierīcēm.';
+
+  @override
   String get consentHideDetails => 'Slēpt detaļas';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4409,6 +4409,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Aktiver Skysynkronisering ovenfor for å sikkerhetskopiere turer.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Logg på med en e-postkonto for å synkronisere turer mellom enheter.';
+
+  @override
   String get consentHideDetails => 'Skjul detaljer';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4425,6 +4425,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Schakel hierboven Cloudsync in om ritten te back-uppen.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Meld je aan met een e-mailaccount om ritten tussen apparaten te synchroniseren.';
+
+  @override
   String get consentHideDetails => 'Details verbergen';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4431,6 +4431,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Włącz Synchronizację w chmurze powyżej, aby tworzyć kopię tras.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Zaloguj się przy użyciu konta e-mail, aby synchronizować trasy między urządzeniami.';
+
+  @override
   String get consentHideDetails => 'Ukryj szczegóły';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4444,6 +4444,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Ative a Sincronização na Nuvem acima para fazer cópia de segurança das viagens.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Inicia sessão com uma conta de e-mail para sincronizar as viagens entre dispositivos.';
+
+  @override
   String get consentHideDetails => 'Ocultar detalhes';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4439,6 +4439,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Activați mai întâi Sincronizarea cloud pentru a face backup la călătorii.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Conectează-te cu un cont de e-mail pentru a sincroniza călătoriile între dispozitive.';
+
+  @override
   String get consentHideDetails => 'Ascundeți detaliile';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4431,6 +4431,10 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zapnite synchronizáciu s cloudom vyššie pre zálohovanie jázd.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Prihláste sa pomocou e-mailového účtu na synchronizáciu jázd medzi zariadeniami.';
+
+  @override
   String get consentHideDetails => 'Skryť podrobnosti';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4416,6 +4416,10 @@ class AppLocalizationsSl extends AppLocalizations {
       'Zgoraj omogočite sinhronizacijo v oblaku za varnostno kopiranje voženj.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Prijavite se z e-poštnim računom za sinhronizacijo voženj med napravami.';
+
+  @override
   String get consentHideDetails => 'Skrij podrobnosti';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4411,6 +4411,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Aktivera Molnsynkronisering ovan för att säkerhetskopiera resor.';
 
   @override
+  String get consentSyncTripsNeedsEmailHint =>
+      'Logga in med ett e-postkonto för att synkronisera resor mellan enheter.';
+
+  @override
   String get consentHideDetails => 'Dölj detaljer';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sinchronizuoti kelionių įrašus",
   "consentSyncTripsSubtitle": "Kurti atsargines OBD2 + GPS kelionių kopijas TankSync. Tarpįrengininis, pasirenkamas.",
   "consentSyncTripsDisabledHint": "Įjunkite debesų sinchronizavimą aukščiau, kad kurti atsargines kelionių kopijas.",
+  "consentSyncTripsNeedsEmailHint": "Prisijunkite naudodami el. pašto paskyrą, kad sinchronizuotumėte keliones tarp įrenginių.",
   "consentHideDetails": "Slėpti detales",
   "consentShowDetails": "Rodyti detales",
   "dialogOk": "Gerai",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sinhronizēt braucienu ierakstus",
   "consentSyncTripsSubtitle": "Dublēt OBD2 + GPS braucienus ar TankSync. Starpierīču, pēc izvēles.",
   "consentSyncTripsDisabledHint": "Iespējojiet Mākoņa sinhronizāciju augstāk, lai dublētu braucienus.",
+  "consentSyncTripsNeedsEmailHint": "Pierakstieties ar e-pasta kontu, lai sinhronizētu braucienus starp ierīcēm.",
   "consentHideDetails": "Slēpt detaļas",
   "consentShowDetails": "Rādīt detaļas",
   "dialogOk": "Labi",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synkroniser turopptak",
   "consentSyncTripsSubtitle": "Sikkerhetskopier OBD2 + GPS-turer til TankSync. På tvers av enheter, valgfritt.",
   "consentSyncTripsDisabledHint": "Aktiver Skysynkronisering ovenfor for å sikkerhetskopiere turer.",
+  "consentSyncTripsNeedsEmailHint": "Logg på med en e-postkonto for å synkronisere turer mellom enheter.",
   "consentHideDetails": "Skjul detaljer",
   "consentShowDetails": "Vis detaljer",
   "dialogOk": "OK",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Ritopnames synchroniseren",
   "consentSyncTripsSubtitle": "OBD2 + GPS-ritten back-uppen naar TankSync. Cross-device, opt-in.",
   "consentSyncTripsDisabledHint": "Schakel hierboven Cloudsync in om ritten te back-uppen.",
+  "consentSyncTripsNeedsEmailHint": "Meld je aan met een e-mailaccount om ritten tussen apparaten te synchroniseren.",
   "consentHideDetails": "Details verbergen",
   "consentShowDetails": "Details tonen",
   "dialogOk": "OK",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synchronizuj nagrania tras",
   "consentSyncTripsSubtitle": "Twórz kopię zapasową tras OBD2 + GPS w TankSync. Między urządzeniami, opt-in.",
   "consentSyncTripsDisabledHint": "Włącz Synchronizację w chmurze powyżej, aby tworzyć kopię tras.",
+  "consentSyncTripsNeedsEmailHint": "Zaloguj się przy użyciu konta e-mail, aby synchronizować trasy między urządzeniami.",
   "consentHideDetails": "Ukryj szczegóły",
   "consentShowDetails": "Pokaż szczegóły",
   "dialogOk": "OK",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sincronizar gravações de viagens",
   "consentSyncTripsSubtitle": "Fazer cópia de segurança das viagens OBD2 + GPS no TankSync. Entre dispositivos, opcional.",
   "consentSyncTripsDisabledHint": "Ative a Sincronização na Nuvem acima para fazer cópia de segurança das viagens.",
+  "consentSyncTripsNeedsEmailHint": "Inicia sessão com uma conta de e-mail para sincronizar as viagens entre dispositivos.",
   "consentHideDetails": "Ocultar detalhes",
   "consentShowDetails": "Mostrar detalhes",
   "dialogOk": "OK",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sincronizați înregistrările de călătorii",
   "consentSyncTripsSubtitle": "Faceți backup la călătoriile OBD2 + GPS în TankSync. Cross-device, opt-in.",
   "consentSyncTripsDisabledHint": "Activați mai întâi Sincronizarea cloud pentru a face backup la călătorii.",
+  "consentSyncTripsNeedsEmailHint": "Conectează-te cu un cont de e-mail pentru a sincroniza călătoriile între dispozitive.",
   "consentHideDetails": "Ascundeți detaliile",
   "consentShowDetails": "Afișați detaliile",
   "dialogOk": "OK",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synchronizovať záznamy jázd",
   "consentSyncTripsSubtitle": "Zálohovať OBD2 + GPS jazdy do TankSync. Naprieč zariadeniami, dobrovoľné.",
   "consentSyncTripsDisabledHint": "Zapnite synchronizáciu s cloudom vyššie pre zálohovanie jázd.",
+  "consentSyncTripsNeedsEmailHint": "Prihláste sa pomocou e-mailového účtu na synchronizáciu jázd medzi zariadeniami.",
   "consentHideDetails": "Skryť podrobnosti",
   "consentShowDetails": "Zobraziť podrobnosti",
   "dialogOk": "OK",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Sinhroniziraj posnetke voženj",
   "consentSyncTripsSubtitle": "Varnostno kopiraj OBD2 + GPS vožnje v TankSync. Med napravami, po izbiri.",
   "consentSyncTripsDisabledHint": "Zgoraj omogočite sinhronizacijo v oblaku za varnostno kopiranje voženj.",
+  "consentSyncTripsNeedsEmailHint": "Prijavite se z e-poštnim računom za sinhronizacijo voženj med napravami.",
   "consentHideDetails": "Skrij podrobnosti",
   "consentShowDetails": "Prikaži podrobnosti",
   "dialogOk": "V redu",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1301,6 +1301,7 @@
   "consentSyncTripsTitle": "Synka reseinspelningar",
   "consentSyncTripsSubtitle": "Säkerhetskopiera OBD2- och GPS-resor till TankSync. Mellan enheter, opt-in.",
   "consentSyncTripsDisabledHint": "Aktivera Molnsynkronisering ovan för att säkerhetskopiera resor.",
+  "consentSyncTripsNeedsEmailHint": "Logga in med ett e-postkonto för att synkronisera resor mellan enheter.",
   "consentHideDetails": "Dölj detaljer",
   "consentShowDetails": "Visa detaljer",
   "dialogOk": "OK",

--- a/test/core/sync/trips_sync_enabled_provider_test.dart
+++ b/test/core/sync/trips_sync_enabled_provider_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/core/sync/sync_config.dart';
+import 'package:tankstellen/core/sync/sync_provider.dart';
+import 'package:tankstellen/core/sync/trips_sync_enabled_provider.dart';
+
+import '../../fakes/fake_hive_storage.dart';
+
+/// Pins `tripsSyncEnabledProvider` (#1665) — the trajet-sync gate
+/// `A ∧ B ∧ C`: non-anonymous account ∧ cloudSync consent ∧ syncTrips
+/// toggle.
+class _FakeSyncState extends SyncState {
+  _FakeSyncState(this._config);
+  final SyncConfig _config;
+
+  @override
+  SyncConfig build() => _config;
+}
+
+void main() {
+  ProviderContainer makeContainer({
+    required bool hasEmail,
+    required bool cloudSync,
+    required bool syncTrips,
+  }) {
+    final storage = FakeHiveStorage();
+    storage.putSetting(StorageKeys.consentCloudSync, cloudSync);
+    storage.putSetting(StorageKeys.consentSyncTrips, syncTrips);
+    final c = ProviderContainer(overrides: [
+      hiveStorageProvider.overrideWithValue(storage),
+      syncStateProvider.overrideWith(
+        () => _FakeSyncState(
+          SyncConfig(userEmail: hasEmail ? 'driver@example.com' : null),
+        ),
+      ),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('tripsSyncEnabledProvider — gate A ∧ B ∧ C (#1665)', () {
+    test('enabled only when non-anonymous account AND cloudSync AND '
+        'syncTrips are all true', () {
+      expect(
+        makeContainer(hasEmail: true, cloudSync: true, syncTrips: true)
+            .read(tripsSyncEnabledProvider),
+        isTrue,
+      );
+    });
+
+    test('an anonymous account (no email) gates off — even with both '
+        'consents granted', () {
+      expect(
+        makeContainer(hasEmail: false, cloudSync: true, syncTrips: true)
+            .read(tripsSyncEnabledProvider),
+        isFalse,
+        reason: 'trajet sync requires an email-backed account',
+      );
+    });
+
+    test('cloudSync consent off gates off', () {
+      expect(
+        makeContainer(hasEmail: true, cloudSync: false, syncTrips: true)
+            .read(tripsSyncEnabledProvider),
+        isFalse,
+      );
+    });
+
+    test('syncTrips toggle off gates off', () {
+      expect(
+        makeContainer(hasEmail: true, cloudSync: true, syncTrips: false)
+            .read(tripsSyncEnabledProvider),
+        isFalse,
+      );
+    });
+
+    test('all three off gates off', () {
+      expect(
+        makeContainer(hasEmail: false, cloudSync: false, syncTrips: false)
+            .read(tripsSyncEnabledProvider),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/features/consent/presentation/widgets/consent_settings_section_test.dart
+++ b/test/features/consent/presentation/widgets/consent_settings_section_test.dart
@@ -46,38 +46,14 @@ void main() {
   }
 
   group('ConsentSettingsSection', () {
-    testWidgets('shows six toggle switches', (tester) async {
-      // #1479 phase 1 added the 6th toggle (Sync trip recordings).
+    testWidgets('shows five toggle switches', (tester) async {
+      // #1665 — the 6th toggle (Sync trip recordings) moved to the
+      // TankSync settings section; five consent toggles remain here.
       await tester.pumpWidget(buildWidget());
       await tester.pumpAndSettle();
 
-      expect(find.byType(SwitchListTile), findsNWidgets(6));
+      expect(find.byType(SwitchListTile), findsNWidgets(5));
     });
-
-    testWidgets(
-      '#1479 — sync trip recordings toggle is disabled until Cloud Sync is on',
-      (tester) async {
-        await tester.pumpWidget(buildWidget(cloudSync: false));
-        await tester.pumpAndSettle();
-        final tile = tester.widget<SwitchListTile>(
-            find.byKey(const Key('consentSyncTripsToggle')));
-        expect(tile.onChanged, isNull,
-            reason: 'syncTrips toggle must be disabled while cloudSync is off');
-      },
-    );
-
-    testWidgets(
-      '#1479 — sync trip recordings toggle becomes enabled when Cloud Sync is on',
-      (tester) async {
-        await tester.pumpWidget(buildWidget(cloudSync: true));
-        await tester.pumpAndSettle();
-        final tile = tester.widget<SwitchListTile>(
-            find.byKey(const Key('consentSyncTripsToggle')));
-        expect(tile.onChanged, isNotNull,
-            reason:
-                'syncTrips toggle must be tappable once cloudSync consent is on');
-      },
-    );
 
     testWidgets('shows correct labels', (tester) async {
       await tester.pumpWidget(buildWidget());


### PR DESCRIPTION
## What

Epic #1665 — recorded trajets now sync to TankSync **only** behind a
non-anonymous-account gate. Closes all three children.

## How

- **#1667** — `tripsSyncEnabledProvider`: the single source of truth,
  `A ∧ B ∧ C` = non-anonymous account (`SyncConfig.hasEmail`) ∧
  `cloudSync` consent ∧ `syncTrips` toggle. The "Sync trip recordings"
  toggle moves from the GDPR consent section into Settings → TankSync,
  disabled with a hint when the account is anonymous (new
  `consentSyncTripsNeedsEmailHint`, translated into all 24 locales) or
  Cloud Sync is off.
- **#1668** — both trigger points route through the provider:
  `trip_recording_provider._saveToHistory` (per-trip upload) and
  `app_initializer._runTripsSyncMerge` (app-launch merge). An anonymous
  session now neither uploads nor merges trip rows. `TripsSync` stays a
  pure I/O helper; recording is unchanged (local-first).
- **#1669** — truth-table coverage for the gate.

## Verification

- 5 new `tripsSyncEnabledProvider` tests; `consent_settings_section`
  test updated (6→5 toggles after the relocation).
- `flutter test` — consumption / app / profile / sync / consent /
  l10n / i18n suites all green (3500+ tests).
- `flutter analyze` clean; `check_module_boundaries.sh` passes;
  `build_runner` regenerated; new ARB key present in all 24 locales.

Part of epic #1665. Closes #1667, closes #1668, closes #1669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
