### PR TITLE
chore(i18n): precise hard-coded-text detector + classified worklist (#1659)

### DIFF
--- a/docs/guides/ARB_FRAGMENTS.md
+++ b/docs/guides/ARB_FRAGMENTS.md
@@ -110,3 +110,50 @@ too large to review, too disruptive. Existing keys migrate opportunistically:
    being rerun).
 
 CI runs this test like any other unit test.
+
+## HARD RULE #1 — no hard-coded user-facing text
+
+Every string a user can see — `Text`, `Tooltip`, `SnackBar`, `hintText`,
+`labelText`, `helperText`, `semanticLabel`, button labels, dialog text,
+AppBar titles, user-facing error messages — **must** come from
+`AppLocalizations`. Add the key to a fragment (en + de) as above; never
+inline a translatable literal.
+
+### Enforcement — the hard-coded-text detector
+
+`test/lint/no_hardcoded_ui_strings_test.dart` scans every UI sink across
+all of `lib/` and fails when a bare string literal sits directly in one.
+It is precise by construction: the literal must be anchored immediately
+after the sink, so the intentional fallback pattern
+`Text(l?.key ?? 'fallback')`, string interpolation and enum / data-map
+keys are never flagged.
+
+The test carries a `_baseline` count of pre-existing violations. It may
+only ever **decrease** — the target is **0** (epic #1657). Never raise
+it. The remaining violations are classified, with their target ARB
+fragment, in `docs/guides/i18n-hardcoded-worklist.md`.
+
+### The `// i18n-ignore: <reason>` exemption
+
+A genuinely non-translatable literal may stay inline if it carries an
+inline `// i18n-ignore: <reason>` comment. The reason is mandatory. The
+comment may sit on the sink's opening line or on a wrapped literal line:
+
+```dart
+title: const Text('PayPal'), // i18n-ignore: brand / proper noun
+
+Text(
+  'Sparkilo', // i18n-ignore: brand wordmark / proper noun
+  style: ...,
+)
+```
+
+Only three categories qualify:
+
+- **Brands / proper nouns** — `GitHub`, `PayPal`, `Sparkilo`.
+- **URLs** — never localized.
+- **Language-neutral format masks / standardized acronyms** — `IBAN`,
+  `dd/MM/yyyy`.
+
+Anything a translator would render differently in another language is
+**not** exempt — give it an ARB key.

--- a/lib/features/payment/presentation/scan_payment_dispatcher.dart
+++ b/lib/features/payment/presentation/scan_payment_dispatcher.dart
@@ -178,7 +178,7 @@ class ScanPaymentDispatcher {
       if (epc.iban != null && epc.iban!.isNotEmpty)
         ListTile(
           dense: true,
-          title: const Text('IBAN'),
+          title: const Text('IBAN'), // i18n-ignore: standardised banking acronym (language-neutral)
           subtitle: Text(epc.iban!),
         ),
       if (epc.amountEur != null)

--- a/lib/features/profile/presentation/widgets/about_section.dart
+++ b/lib/features/profile/presentation/widgets/about_section.dart
@@ -57,7 +57,7 @@ class AboutSection extends StatelessWidget {
           const Divider(height: 1),
           ListTile(
             leading: const Icon(Icons.code),
-            title: const Text('GitHub'),
+            title: const Text('GitHub'), // i18n-ignore: brand / proper noun
             subtitle: const Text('fdittgen-png/tankstellen'),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.githubRepoUrl),
@@ -100,7 +100,7 @@ class AboutSection extends StatelessWidget {
           ListTile(
             leading:
                 const Icon(Icons.payment, color: Color(0xFF003087)),
-            title: const Text('PayPal'),
+            title: const Text('PayPal'), // i18n-ignore: brand / proper noun
             subtitle: const Text('paypal.me/FlorianDITTGEN'),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.paypalUrl),
@@ -110,7 +110,7 @@ class AboutSection extends StatelessWidget {
           ListTile(
             leading: const Icon(Icons.account_balance_wallet,
                 color: Color(0xFF0075EB)),
-            title: const Text('Revolut'),
+            title: const Text('Revolut'), // i18n-ignore: brand / proper noun
             subtitle: const Text('revolut.me/floriamcep'),
             onTap: () => launchUrl(
               Uri.parse(AppConstants.revolutUrl),

--- a/lib/features/setup/presentation/widgets/profile_choice_step.dart
+++ b/lib/features/setup/presentation/widgets/profile_choice_step.dart
@@ -36,9 +36,8 @@ class ProfileChoiceStep extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // Brand wordmark stays untranslated — it's a proper noun.
           Text(
-            'Sparkilo',
+            'Sparkilo', // i18n-ignore: brand wordmark / proper noun
             style: theme.textTheme.headlineLarge?.copyWith(
               fontWeight: FontWeight.bold,
               color: const Color(0xFF2E7D32),

--- a/test/lint/no_hardcoded_ui_strings_test.dart
+++ b/test/lint/no_hardcoded_ui_strings_test.dart
@@ -2,66 +2,149 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Guards against hardcoded user-facing strings in presentation code.
+/// Guards HARD RULE #1 — no hard-coded user-facing text.
 ///
-/// Detects `Text('literal')` and `Text("literal")` patterns in widget files
-/// that should use `AppLocalizations.of(context)?.key ?? 'fallback'` instead.
+/// Scans every UI sink across **all of `lib/`** for a bare string
+/// literal that should instead route through `AppLocalizations`:
 ///
-/// A baseline count is maintained so existing violations don't break CI,
-/// but new ones are caught.
+///   * `Text('literal')` / `const Text('literal')`
+///   * the named text parameters `hintText:` `labelText:` `helperText:`
+///     `errorText:` `semanticLabel:` `tooltip:` carrying a `'literal'`
+///
+/// `SnackBar` content and `AppBar` titles are `Text(...)` widgets, so
+/// the `Text(` sink already covers them.
+///
+/// ## What is NOT flagged (precision)
+///
+/// The literal must sit *immediately* after the sink (modulo `const`
+/// and whitespace). That single anchor rules out the bulk of false
+/// positives for free:
+///
+///   * the intentional fallback pattern `Text(l?.key ?? 'fallback')` —
+///     an expression precedes the literal, so it never matches;
+///   * string interpolation `Text('$count items')` — a `$` inside the
+///     literal disqualifies it;
+///   * enum / data-map keys (`'0104': pidName`, OBD2 PID tables) — a
+///     map key is `'k':`, never `sink('k')` or `param: 'k'`.
+///
+/// A literal is only treated as user-facing text when it *looks* like
+/// prose — it contains whitespace, or it is a capitalised word of four
+/// or more letters. Short lowercase tokens (route names, keys, asset
+/// ids) are skipped.
+///
+/// ## Exemptions — `// i18n-ignore: <reason>`
+///
+/// A genuinely non-translatable literal (brand / proper noun, URL,
+/// language-neutral format mask) may carry an inline
+/// `// i18n-ignore: <reason>` comment on the **same line**; the
+/// detector then skips that line. Every exemption MUST state a reason.
+/// The mechanism is documented in `docs/guides/ARB_FRAGMENTS.md`.
+///
+/// ## Baseline
+///
+/// [_baseline] is the count of pre-existing violations. Per CLAUDE.md
+/// it may only ever **decrease** — the target is **0** (epic #1657).
+/// Never raise it. The classified worklist of the remaining
+/// violations lives in `docs/guides/i18n-hardcoded-worklist.md`.
 void main() {
-  test('hardcoded Text() count does not increase', () {
-    final featuresDir = Directory('lib/features');
-    expect(featuresDir.existsSync(), isTrue);
+  // The UI sinks. Group 1 of each match is the quoted literal.
+  // A literal may not contain `$` (interpolation) or a newline.
+  const quoted = r"""('[^'$\n]*'|"[^"$\n]*")""";
+  final sinks = <RegExp>[
+    // Text('literal') / Text(const 'literal') — quote anchored right
+    // after `Text(`, so `Text(l?.x ?? '...')` cannot match.
+    RegExp('Text\\(\\s*(?:const\\s+)?$quoted\\s*[,)]'),
+    // Named UI-text parameters.
+    RegExp(
+      '\\b(?:hintText|labelText|helperText|errorText|semanticLabel|tooltip):'
+      '\\s*$quoted',
+    ),
+  ];
 
-    // Matches: Text('literal'), Text("literal"), title: 'literal', etc.
-    // Excludes: patterns with ?? (already using l10n fallback),
-    //           patterns with $ (string interpolation with variables),
-    //           patterns that reference l10n/l/AppLocalizations
-    final hardcodedTextPattern = RegExp(
-      r"""(?:const\s+)?Text\(\s*['"][A-Z][^'"$]*['"]\s*\)"""
-      r"""|(?:const\s+)?Text\(\s*['"][a-z][^'"$]{3,}['"]\s*\)""",
-    );
+  /// True when [literal] (quotes stripped) reads like user-facing prose
+  /// rather than an identifier, route name, key or asset id.
+  bool looksLikeProse(String literal) {
+    final text = literal.substring(1, literal.length - 1).trim();
+    if (text.length < 4) return false;
+    // URLs and asset paths are not translatable prose.
+    if (text.startsWith('http') || text.startsWith('assets/')) return false;
+    if (text.contains(RegExp(r'\s'))) return true;
+    // A single capitalised word of 4+ letters (e.g. "Cancel").
+    return RegExp(r'^[A-Z][a-zA-Z]{3,}$').hasMatch(text);
+  }
+
+  test('no new hard-coded user-facing strings (HARD RULE #1)', () {
+    final libDir = Directory('lib');
+    expect(libDir.existsSync(), isTrue);
 
     final violations = <String>[];
 
-    for (final entity in featuresDir.listSync(recursive: true)) {
+    for (final entity in libDir.listSync(recursive: true)) {
       if (entity is! File) continue;
       final path = entity.path.replaceAll(r'\', '/');
       if (!path.endsWith('.dart')) continue;
       if (path.endsWith('.g.dart')) continue;
       if (path.endsWith('.freezed.dart')) continue;
-      if (!path.contains('/presentation/')) continue;
+      // Generated localization output is not source.
+      if (path.contains('/l10n/app_localizations')) continue;
 
-      final lines = entity.readAsLinesSync();
-      for (int i = 0; i < lines.length; i++) {
-        final line = lines[i];
-        // Skip lines that already use l10n pattern
-        if (line.contains('??') || line.contains('l10n') || line.contains('AppLocalizations')) continue;
-        // Skip comments
-        if (line.trimLeft().startsWith('//')) continue;
+      final source = entity.readAsStringSync();
+      final lineStarts = <int>[0];
+      for (var i = 0; i < source.length; i++) {
+        if (source[i] == '\n') lineStarts.add(i + 1);
+      }
+      int lineOf(int offset) {
+        var lo = 0, hi = lineStarts.length - 1;
+        while (lo < hi) {
+          final mid = (lo + hi + 1) >> 1;
+          if (lineStarts[mid] <= offset) {
+            lo = mid;
+          } else {
+            hi = mid - 1;
+          }
+        }
+        return lo;
+      }
 
-        for (final match in hardcodedTextPattern.allMatches(line)) {
-          final text = match.group(0)!;
-          // Skip very short strings (likely identifiers, not UI text)
-          if (text.length < 12) continue;
-          violations.add('$path:${i + 1}: $text');
+      for (final sink in sinks) {
+        for (final match in sink.allMatches(source)) {
+          final literal = match.group(1)!;
+          if (!looksLikeProse(literal)) continue;
+          final firstLine = lineOf(match.start);
+          final lastLine = lineOf(match.end);
+          final spanEnd = lastLine + 1 < lineStarts.length
+              ? lineStarts[lastLine + 1]
+              : source.length;
+          // Inline exemption — the `// i18n-ignore:` comment may sit on
+          // the sink's opening line or on a wrapped literal line.
+          final span = source.substring(lineStarts[firstLine], spanEnd);
+          if (span.contains('// i18n-ignore:')) continue;
+          violations.add('$path:${firstLine + 1}: $literal');
         }
       }
     }
 
-    // Baseline: number of known hardcoded strings as of 2026-04-12.
-    // This number should only go DOWN over time as strings are localized.
-    // If this test fails, you added a new hardcoded string — use l10n instead.
-    const baseline = 120;
+    violations.sort();
+
+    // Baseline as of 2026-05-16 (#1659). Only ever decreases; target 0.
+    // See docs/guides/i18n-hardcoded-worklist.md for the classified
+    // remediation worklist.
+    const baseline = _baseline;
 
     expect(
       violations.length,
       lessThanOrEqualTo(baseline),
-      reason: 'Hardcoded user-facing strings increased! '
-          'Found ${violations.length} (baseline: $baseline).\n'
-          'New violations:\n${violations.take(20).join('\n')}\n'
-          'Use AppLocalizations.of(context)?.key ?? \'fallback\' instead.',
+      reason: 'Hard-coded user-facing strings increased to '
+          '${violations.length} (baseline: $baseline).\n'
+          'Route the new string through AppLocalizations, or — for a '
+          'brand / URL / format mask — add an inline '
+          '`// i18n-ignore: <reason>` comment.\n'
+          'Current violations:\n${violations.join('\n')}',
     );
   });
 }
+
+/// Pre-existing hard-coded-string count. Set by #1659; only decreases.
+/// The 11 remaining are all translatable UI text — see
+/// `docs/guides/i18n-hardcoded-worklist.md` for their feature mapping.
+const _baseline = 11;


### PR DESCRIPTION
## Summary

Resolves **#1659** (epic #1657 — i18n hard-coded-text elimination).

Replaces the crude `Text('literal')`-only baseline-120 lint with a
**precise multi-sink detector** over all of `lib/`, and produces the
classified remediation worklist that #1660–#1664 depend on.

## What changed

- **Detector rewrite** (`test/lint/no_hardcoded_ui_strings_test.dart`)
  — scans `Text(...)` + `hintText` / `labelText` / `helperText` /
  `errorText` / `semanticLabel` / `tooltip`. The literal is anchored to
  its sink, so `Text(l?.k ?? 'fallback')`, interpolation and enum /
  data-map keys are **never** flagged. A prose heuristic skips short
  lowercase tokens (routes, keys, asset ids).
- **`// i18n-ignore: <reason>` exemption** — supported (on the sink
  line or a wrapped literal line) and documented.
- **Classification** — the precise scan finds **16** genuine candidates
  (not ~86): 5 brand/acronym exemptions, 11 translatable, 0 exception
  messages (separate audit — #1663), 0 false positives.
- **5 exemptions applied** — GitHub, PayPal, Revolut, IBAN, Sparkilo.
- **Baseline 120 → 11**, classified by feature cluster in the new
  `docs/guides/i18n-hardcoded-worklist.md`.
- **Docs** — HARD RULE #1 + the exemption mechanism added to
  `docs/guides/ARB_FRAGMENTS.md`.

## Acceptance (#1659)

- [x] Precise detector over all UI sinks across `lib/`, low false positives
- [x] `// i18n-ignore: <reason>` mechanism supported + documented
- [x] 16 candidates classified into a worklist
- [x] Rule documented in `docs/guides/ARB_FRAGMENTS.md`

## Test plan

- `flutter test test/lint/` — all pass; detector green at baseline 11
- `flutter analyze` — clean
- module-boundary check — pass

Closes #1659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
