### PR TITLE
fix(ux): visual consistency — semantic colors adapt to dark mode (#1694)

### DIFF
--- a/lib/core/services/widgets/freshness_badge.dart
+++ b/lib/core/services/widgets/freshness_badge.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../theme/dark_mode_colors.dart';
 import '../service_result.dart';
 
 /// Compact badge showing data age and source with color-coded freshness.
@@ -19,7 +20,7 @@ class FreshnessBadge extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     final age = DateTime.now().difference(result.fetchedAt);
 
-    final _BadgeStyle style = _styleForAge(age, result.isStale);
+    final _BadgeStyle style = _styleForAge(context, age, result.isStale);
 
     final String label;
     if (result.isStale) {
@@ -61,25 +62,26 @@ class FreshnessBadge extends StatelessWidget {
     );
   }
 
-  static _BadgeStyle _styleForAge(Duration age, bool isStale) {
+  static _BadgeStyle _styleForAge(
+      BuildContext context, Duration age, bool isStale) {
     if (isStale || age.inMinutes > 15) {
-      return const _BadgeStyle(
+      return _BadgeStyle(
         icon: Icons.warning_amber_rounded,
-        backgroundColor: Colors.red,
-        foregroundColor: Colors.red,
+        backgroundColor: DarkModeColors.error(context),
+        foregroundColor: DarkModeColors.error(context),
       );
     }
     if (age.inMinutes >= 5) {
-      return const _BadgeStyle(
+      return _BadgeStyle(
         icon: Icons.schedule,
-        backgroundColor: Colors.amber,
-        foregroundColor: Colors.amber,
+        backgroundColor: DarkModeColors.warning(context),
+        foregroundColor: DarkModeColors.warning(context),
       );
     }
-    return const _BadgeStyle(
+    return _BadgeStyle(
       icon: Icons.check_circle_outline,
-      backgroundColor: Colors.green,
-      foregroundColor: Colors.green,
+      backgroundColor: DarkModeColors.success(context),
+      foregroundColor: DarkModeColors.success(context),
     );
   }
 }

--- a/lib/core/widgets/password_strength_indicator.dart
+++ b/lib/core/widgets/password_strength_indicator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../theme/dark_mode_colors.dart';
 import '../utils/password_validator.dart';
 
 /// Visual password strength indicator with real-time requirement checklist.
@@ -25,9 +26,9 @@ class PasswordStrengthIndicator extends StatelessWidget {
     final requirements = PasswordValidator.validate(password);
 
     final color = switch (strength) {
-      PasswordStrength.weak => Colors.red,
-      PasswordStrength.fair => Colors.orange,
-      PasswordStrength.strong => Colors.green,
+      PasswordStrength.weak => DarkModeColors.error(context),
+      PasswordStrength.fair => DarkModeColors.warning(context),
+      PasswordStrength.strong => DarkModeColors.success(context),
     };
 
     final label = switch (strength) {
@@ -73,7 +74,7 @@ class PasswordStrengthIndicator extends StatelessWidget {
               Icon(
                 req.met ? Icons.check_circle : Icons.circle_outlined,
                 size: 14,
-                color: req.met ? Colors.green : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                color: req.met ? DarkModeColors.success(context) : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
               ),
               const SizedBox(width: 6),
               Text(

--- a/lib/core/widgets/swipe_to_delete.dart
+++ b/lib/core/widgets/swipe_to_delete.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../theme/dark_mode_colors.dart';
+
 /// Reusable swipe-to-delete wrapper with red background and delete icon.
 ///
 /// Replaces 2 identical Dismissible implementations in AlertsScreen
@@ -24,7 +26,7 @@ class SwipeToDelete extends StatelessWidget {
       background: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
-        color: Colors.red,
+        color: DarkModeColors.error(context),
         child: const Icon(Icons.delete, color: Colors.white),
       ),
       onDismissed: (_) => onDismissed(),

--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -129,7 +130,7 @@ class _AlertListTile extends ConsumerWidget {
       background: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
-        color: Colors.red,
+        color: DarkModeColors.error(context),
         child: const Icon(Icons.delete, color: Colors.white),
       ),
       onDismissed: (_) {
@@ -226,7 +227,7 @@ class _RadiusAlertListTile extends ConsumerWidget {
       background: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
-        color: Colors.red,
+        color: DarkModeColors.error(context),
         child: const Icon(Icons.delete, color: Colors.white),
       ),
       onDismissed: (_) {

--- a/lib/features/alerts/presentation/widgets/alert_statistics_card.dart
+++ b/lib/features/alerts/presentation/widgets/alert_statistics_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/alert_statistics_provider.dart';
 
@@ -29,7 +30,7 @@ class AlertStatisticsCard extends ConsumerWidget {
             _StatColumn(
               icon: Icons.today,
               iconColor: stats.triggeredToday > 0
-                  ? Colors.green
+                  ? DarkModeColors.success(context)
                   : theme.colorScheme.onSurfaceVariant,
               value: stats.triggeredToday.toString(),
               label: l10n?.alertStatsToday ?? 'Today',

--- a/lib/features/carbon/presentation/widgets/trip_length_breakdown_card.dart
+++ b/lib/features/carbon/presentation/widgets/trip_length_breakdown_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/domain/services/trip_length_aggregator.dart';
 
@@ -257,7 +258,7 @@ class _DeltaArrow extends StatelessWidget {
     return Icon(
       worse ? Icons.arrow_upward : Icons.arrow_downward,
       size: 16,
-      color: worse ? theme.colorScheme.error : Colors.green.shade700,
+      color: worse ? theme.colorScheme.error : DarkModeColors.success(context),
     );
   }
 }

--- a/lib/features/consumption/presentation/widgets/broken_map_widgets.dart
+++ b/lib/features/consumption/presentation/widgets/broken_map_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
@@ -202,18 +203,18 @@ class BrokenMapOverlayRow extends ConsumerWidget {
           text = l?.brokenMapOverlayPosterior(pePct, marginPct) ??
               'MAP sensor: $pePct% ± $marginPct%';
         }
-        color = Colors.greenAccent;
+        color = DarkModeColors.success(context);
         break;
       case BrokenMapBand.verifying:
         text = l?.brokenMapOverlayPosterior(pePct, marginPct) ??
             'MAP sensor: $pePct% ± $marginPct%';
-        color = Colors.amber;
+        color = DarkModeColors.warning(context);
         break;
       case BrokenMapBand.warning:
       case BrokenMapBand.hardDisable:
         text = l?.brokenMapOverlayPosterior(pePct, marginPct) ??
             'MAP sensor: $pePct% ± $marginPct%';
-        color = Colors.redAccent;
+        color = DarkModeColors.error(context);
         break;
     }
     return Padding(

--- a/lib/features/consumption/presentation/widgets/charging_tab.dart
+++ b/lib/features/consumption/presentation/widgets/charging_tab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/entities/charging_log.dart';
@@ -63,7 +64,7 @@ class ChargingTab extends ConsumerWidget {
               background: Container(
                 alignment: Alignment.centerRight,
                 padding: const EdgeInsets.only(right: 24),
-                color: Colors.red,
+                color: DarkModeColors.error(context),
                 child: const Icon(Icons.delete, color: Colors.white),
               ),
               onDismissed: (_) {

--- a/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/consumption_stats.dart';
 
@@ -198,7 +199,7 @@ class _CorrectionShareHint extends StatelessWidget {
     final theme = Theme.of(context);
     // Reuse the orange palette established by the correction fill-up
     // card (#1361) so the visual language stays consistent.
-    final orange = Colors.orange.shade700;
+    final orange = DarkModeColors.warning(context);
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),

--- a/lib/features/consumption/presentation/widgets/eco_score_badge.dart
+++ b/lib/features/consumption/presentation/widgets/eco_score_badge.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/eco_score.dart';
 
@@ -21,7 +22,7 @@ class EcoScoreBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
-    final (icon, color) = _styleFor(score.direction, theme);
+    final (icon, color) = _styleFor(context, score.direction, theme);
 
     final deltaText =
         '${score.deltaPercent >= 0 ? '+' : ''}${score.deltaPercent.toStringAsFixed(0)}%';
@@ -63,12 +64,16 @@ class EcoScoreBadge extends StatelessWidget {
     );
   }
 
-  (IconData, Color) _styleFor(EcoScoreDirection dir, ThemeData theme) {
+  (IconData, Color) _styleFor(
+    BuildContext context,
+    EcoScoreDirection dir,
+    ThemeData theme,
+  ) {
     switch (dir) {
       case EcoScoreDirection.improving:
-        return (Icons.arrow_downward, Colors.green.shade700);
+        return (Icons.arrow_downward, DarkModeColors.success(context));
       case EcoScoreDirection.worsening:
-        return (Icons.arrow_upward, Colors.orange.shade800);
+        return (Icons.arrow_upward, DarkModeColors.warning(context));
       case EcoScoreDirection.stable:
         return (Icons.arrow_forward, theme.colorScheme.onSurfaceVariant);
     }

--- a/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/edit_correction_fill_up_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/add_fill_up_validators.dart';
 import '../../domain/entities/fill_up.dart';
@@ -129,7 +130,7 @@ class _EditCorrectionFillUpSheetState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
-    final correctionColor = Colors.orange.shade700;
+    final correctionColor = DarkModeColors.warning(context);
     final dateStr =
         '${_date.year}-${_pad(_date.month)}-${_pad(_date.day)}';
 

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -62,7 +63,7 @@ class FillUpCard extends StatelessWidget {
     // and dark backgrounds. Picked shade 700 for the border + circle
     // background so the contrast vs. white text on the avatar stays
     // readable at smaller sizes.
-    final correctionColor = Colors.orange.shade700;
+    final correctionColor = DarkModeColors.warning(context);
     // #1401 phase 7b — only render the verified-by-adapter chip when
     // both fuel-level captures are present. Either missing → no chip.
     final isVerifiedByAdapter = FillUpVariance.hasAdapterCapture(fillUp);

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/storage/storage_keys.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/help_banner.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -93,7 +94,7 @@ class FuelTab extends ConsumerWidget {
           background: Container(
             alignment: Alignment.centerRight,
             padding: const EdgeInsets.only(right: 24),
-            color: Colors.red,
+            color: DarkModeColors.error(context),
             child: const Icon(Icons.delete, color: Colors.white),
           ),
           onDismissed: (_) {

--- a/lib/features/consumption/presentation/widgets/monthly_insights_card.dart
+++ b/lib/features/consumption/presentation/widgets/monthly_insights_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/services/monthly_insights_aggregator.dart';
 
@@ -223,7 +224,7 @@ class _DeltaArrow extends StatelessWidget {
     final color = switch (sentiment) {
       _Sentiment.neutral => theme.colorScheme.onSurfaceVariant,
       _Sentiment.lowerIsBetter =>
-        up ? theme.colorScheme.error : Colors.green.shade700,
+        up ? theme.colorScheme.error : DarkModeColors.success(context),
     };
     return Icon(
       up ? Icons.arrow_upward : Icons.arrow_downward,

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/providers/app_state_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/obd2/obd2_breadcrumb_collector.dart';
 import '../../providers/obd2_breadcrumb_provider.dart';
@@ -196,14 +197,14 @@ class _BreadcrumbRow extends StatelessWidget {
     }
   }
 
-  Color get _color {
+  Color _color(BuildContext context) {
     switch (crumb.flag) {
       case Obd2BreadcrumbCollector.flagSuspiciousLow:
-        return Colors.amber;
+        return DarkModeColors.warning(context);
       case Obd2BreadcrumbCollector.flag5eVsMafDivergent:
-        return Colors.redAccent;
+        return DarkModeColors.error(context);
       default:
-        return Colors.greenAccent;
+        return DarkModeColors.success(context);
     }
   }
 
@@ -215,7 +216,7 @@ class _BreadcrumbRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = _color;
+    final color = _color(context);
     final secondLine = StringBuffer()
       ..write('AFR=${_formatNum(crumb.afr, decimals: 1)} ')
       ..write('ρ=${_formatNum(crumb.fuelDensityGPerL, decimals: 0)} ')

--- a/lib/features/consumption/presentation/widgets/obd2_status_dot.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_status_dot.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/obd2_connection_state_provider.dart';
 
@@ -24,7 +25,7 @@ class Obd2StatusDot extends ConsumerWidget {
     final snapshot = ref.watch(obd2ConnectionStatusProvider);
     if (!snapshot.hasVisibleIndicator) return const SizedBox.shrink();
     final l = AppLocalizations.of(context);
-    final (color, semanticsLabel) = _styleFor(snapshot, l);
+    final (color, semanticsLabel) = _styleFor(context, snapshot, l);
     return Semantics(
       label: semanticsLabel,
       button: true,
@@ -48,28 +49,29 @@ class Obd2StatusDot extends ConsumerWidget {
   }
 
   (Color, String) _styleFor(
+    BuildContext context,
     Obd2ConnectionSnapshot s,
     AppLocalizations? l,
   ) {
     switch (s.state) {
       case Obd2ConnectionState.connected:
         return (
-          Colors.green.shade600,
+          DarkModeColors.success(context),
           l?.obd2StatusConnected ?? 'OBD2 adapter: connected',
         );
       case Obd2ConnectionState.attempting:
         return (
-          Colors.amber.shade700,
+          DarkModeColors.warning(context),
           l?.obd2StatusAttempting ?? 'OBD2 adapter: connecting',
         );
       case Obd2ConnectionState.unreachable:
         return (
-          Colors.red.shade700,
+          DarkModeColors.error(context),
           l?.obd2StatusUnreachable ?? 'OBD2 adapter: unreachable',
         );
       case Obd2ConnectionState.permissionDenied:
         return (
-          Colors.red.shade700,
+          DarkModeColors.error(context),
           l?.obd2StatusPermissionDenied ??
               'OBD2 adapter: Bluetooth permission needed',
         );

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/cold_start_baselines.dart';
@@ -169,7 +170,8 @@ class TripRecordingBanner extends ConsumerWidget {
     switch (band) {
       case ConsumptionBand.eco:
         return _BannerPalette(
-            background: Colors.green.shade600, foreground: Colors.white);
+            background: DarkModeColors.success(context),
+            foreground: Colors.white);
       case ConsumptionBand.normal:
         return _BannerPalette(
           background: Theme.of(context).colorScheme.primary,
@@ -177,10 +179,12 @@ class TripRecordingBanner extends ConsumerWidget {
         );
       case ConsumptionBand.heavy:
         return _BannerPalette(
-            background: Colors.amber.shade800, foreground: Colors.black);
+            background: DarkModeColors.warning(context),
+            foreground: Colors.black);
       case ConsumptionBand.veryHeavy:
         return _BannerPalette(
-            background: Colors.red.shade700, foreground: Colors.white);
+            background: DarkModeColors.error(context),
+            foreground: Colors.white);
       case ConsumptionBand.transient:
         return _BannerPalette(
             background: Colors.teal.shade400, foreground: Colors.white);

--- a/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -174,11 +175,20 @@ class _ConnectorTile extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     switch (status) {
       case ConnectorStatus.available:
-        return (l10n?.evStatusAvailable ?? 'Available', Colors.green);
+        return (
+          l10n?.evStatusAvailable ?? 'Available',
+          DarkModeColors.success(context)
+        );
       case ConnectorStatus.occupied:
-        return (l10n?.evStatusOccupied ?? 'Occupied', Colors.orange);
+        return (
+          l10n?.evStatusOccupied ?? 'Occupied',
+          DarkModeColors.warning(context)
+        );
       case ConnectorStatus.outOfOrder:
-        return (l10n?.evStatusOutOfOrder ?? 'Out of order', Colors.red);
+        return (
+          l10n?.evStatusOutOfOrder ?? 'Out of order',
+          DarkModeColors.error(context)
+        );
       case ConnectorStatus.unknown:
         return (l10n?.evStatusUnknown ?? 'Unknown', Colors.grey);
     }

--- a/lib/features/ev/presentation/widgets/ev_map_overlay.dart
+++ b/lib/features/ev/presentation/widgets/ev_map_overlay.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/charging_station.dart';
 import '../../providers/ev_providers.dart';
@@ -80,7 +81,7 @@ class EvToggleButton extends ConsumerWidget {
     final shown = ref.watch(evShowOnMapProvider);
     final l10n = AppLocalizations.of(context);
     return Material(
-      color: shown ? Colors.green : Colors.white,
+      color: shown ? DarkModeColors.success(context) : Colors.white,
       shape: const CircleBorder(),
       elevation: 4,
       child: InkWell(

--- a/lib/features/ev/presentation/widgets/ev_marker_widget.dart
+++ b/lib/features/ev/presentation/widgets/ev_marker_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../domain/entities/charging_station.dart';
 
 /// Visual marker representing an EV [ChargingStation] on the flutter_map.
@@ -21,14 +22,14 @@ class EvMarkerWidget extends StatelessWidget {
     this.onTap,
   });
 
-  static Color colorFor(ChargingStation station) {
+  static Color colorFor(BuildContext context, ChargingStation station) {
     if (station.connectors.isEmpty) return Colors.grey;
-    if (station.hasAvailableConnector) return Colors.green;
+    if (station.hasAvailableConnector) return DarkModeColors.success(context);
     final anyKnown = station.connectors.any(
       (c) => c.status != ConnectorStatus.unknown,
     );
     if (!anyKnown) return Colors.grey;
-    return Colors.red;
+    return DarkModeColors.error(context);
   }
 
   /// Build a flutter_map [Marker] for this station.
@@ -46,7 +47,7 @@ class EvMarkerWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = colorFor(station);
+    final color = colorFor(context, station);
     final maxPower = station.maxPowerKw.round();
 
     return GestureDetector(

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/storage/storage_keys.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/empty_state.dart';
@@ -70,7 +71,7 @@ class AlertsTab extends StatelessWidget {
             background: Container(
               alignment: Alignment.centerRight,
               padding: const EdgeInsets.only(right: 24),
-              color: Colors.red,
+              color: DarkModeColors.error(context),
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/entities/charging_station.dart';
 
@@ -79,13 +80,17 @@ class EvFavoriteCard extends StatelessWidget {
                           Icon(
                             Icons.power,
                             size: 14,
-                            color: available > 0 ? Colors.green : Colors.grey,
+                            color: available > 0
+                                ? DarkModeColors.success(context)
+                                : Colors.grey,
                           ),
                           const SizedBox(width: 4),
                           Text(
                             '$available/$total ${l10n?.evStatusAvailable ?? 'available'}',
                             style: theme.textTheme.bodySmall?.copyWith(
-                              color: available > 0 ? Colors.green : null,
+                              color: available > 0
+                                  ? DarkModeColors.success(context)
+                                  : null,
                             ),
                           ),
                         ],

--- a/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/favorite_station_dismissible.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -82,7 +83,7 @@ class FavoriteStationDismissible extends ConsumerWidget {
         child: Container(
           alignment: Alignment.centerRight,
           padding: const EdgeInsets.only(right: 24),
-          color: Colors.red,
+          color: DarkModeColors.error(context),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/features/map/presentation/widgets/route_station_chip.dart
+++ b/lib/features/map/presentation/widgets/route_station_chip.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/utils/unit_formatter.dart';
@@ -113,7 +114,7 @@ class RouteStationChip extends StatelessWidget {
                         fontWeight: FontWeight.w500,
                         color: isSelected
                             ? selectedFg.withValues(alpha: 0.9)
-                            : Colors.green.shade700,
+                            : DarkModeColors.success(context),
                       ),
                     ),
                     Text(

--- a/lib/features/profile/presentation/widgets/api_key_section.dart
+++ b/lib/features/profile/presentation/widgets/api_key_section.dart
@@ -5,6 +5,7 @@ import '../../../../core/constants/app_constants.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/data/storage_repository.dart';
 import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 class ApiKeySection extends ConsumerWidget {
@@ -136,7 +137,9 @@ class ApiKeySection extends ConsumerWidget {
           Icon(
             isConfigured ? Icons.check_circle : Icons.cancel,
             size: 16,
-            color: isConfigured ? Colors.green : Colors.red,
+            color: isConfigured
+                ? DarkModeColors.success(context)
+                : DarkModeColors.error(context),
           ),
           const SizedBox(width: 6),
           Text(subtitle),

--- a/lib/features/profile/presentation/widgets/config_verification_widget.dart
+++ b/lib/features/profile/presentation/widgets/config_verification_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/profile_provider.dart';
 
@@ -208,8 +209,8 @@ class _ConfigRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final statusColor = switch (status) {
-      _Status.ok => Colors.green,
-      _Status.warning => Colors.orange,
+      _Status.ok => DarkModeColors.success(context),
+      _Status.warning => DarkModeColors.warning(context),
       _Status.neutral => theme.colorScheme.onSurfaceVariant,
     };
 

--- a/lib/features/profile/presentation/widgets/feedback_token_section.dart
+++ b/lib/features/profile/presentation/widgets/feedback_token_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../../../../core/feedback/github_issue_reporter_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Settings section for managing the optional GitHub PAT used by the
@@ -85,7 +86,9 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
               Icon(
                 _hasToken ? Icons.check_circle : Icons.cancel_outlined,
                 size: 16,
-                color: _hasToken ? Colors.green : theme.colorScheme.outline,
+                color: _hasToken
+                    ? DarkModeColors.success(context)
+                    : theme.colorScheme.outline,
               ),
               const SizedBox(width: 6),
               Text(

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/country/country_config.dart';
 import '../../../../core/language/language_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';

--- a/lib/features/profile/presentation/widgets/profile_edit_sheet_parts.dart
+++ b/lib/features/profile/presentation/widgets/profile_edit_sheet_parts.dart
@@ -285,7 +285,7 @@ class _SaveDeleteActions extends StatelessWidget {
           OutlinedButton(
             onPressed: onConfirmDelete,
             style: OutlinedButton.styleFrom(
-              foregroundColor: Colors.red,
+              foregroundColor: DarkModeColors.error(context),
             ),
             child: Text(l10n?.delete ?? 'Delete'),
           ),

--- a/lib/features/profile/presentation/widgets/storage_section.dart
+++ b/lib/features/profile/presentation/widgets/storage_section.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../../../../core/cache/cache_manager.dart';
 import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'storage_bar.dart';
@@ -56,7 +57,7 @@ class StorageSection extends ConsumerWidget {
                 StorageSegment(
                   'Price History (${storageMgmt.priceHistoryEntryCount})',
                   stats.priceHistory,
-                  Colors.orange.withValues(alpha: 0.7),
+                  DarkModeColors.warning(context).withValues(alpha: 0.7),
                 ),
               ],
               totalBytes: stats.total,
@@ -95,13 +96,13 @@ class StorageSection extends ConsumerWidget {
               detail:
                   '${storageMgmt.priceHistoryEntryCount} stations tracked',
               bytes: stats.priceHistory,
-              color: Colors.orange.withValues(alpha: 0.7),
+              color: DarkModeColors.warning(context).withValues(alpha: 0.7),
             ),
             StorageDetailRow(
               label: l?.priceAlerts ?? 'Alerts',
               detail: '${storageMgmt.alertCount} configured',
               bytes: stats.alerts,
-              color: Colors.amber.withValues(alpha: 0.7),
+              color: DarkModeColors.warning(context).withValues(alpha: 0.7),
             ),
             StorageDetailRow(
               label: 'Ignored',

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -5,6 +5,7 @@ import '../../../sync/presentation/widgets/qr_share_widget.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/sync/sync_config.dart';
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 
@@ -43,7 +44,7 @@ class TankSyncSection extends ConsumerWidget {
     final consent = ref.watch(gdprConsentProvider);
     return [
       ListTile(
-        leading: const Icon(Icons.cloud_done, color: Colors.green),
+        leading: Icon(Icons.cloud_done, color: DarkModeColors.success(context)),
         title: Text(syncConfig.modeName),
         subtitle: Text(
           syncConfig.hasEmail

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -68,7 +69,9 @@ class AllPricesStationCard extends StatelessWidget {
                     height: 10,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: station.isOpen ? Colors.green : Colors.red,
+                      color: station.isOpen
+                          ? DarkModeColors.success(context)
+                          : DarkModeColors.error(context),
                     ),
                   ),
                   const SizedBox(width: 8),
@@ -89,8 +92,10 @@ class AllPricesStationCard extends StatelessWidget {
                         horizontal: 6, vertical: 2),
                     decoration: BoxDecoration(
                       color: station.isOpen
-                          ? Colors.green.withValues(alpha: 0.12)
-                          : Colors.red.withValues(alpha: 0.12),
+                          ? DarkModeColors.success(context)
+                              .withValues(alpha: 0.12)
+                          : DarkModeColors.error(context)
+                              .withValues(alpha: 0.12),
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Text(
@@ -100,7 +105,9 @@ class AllPricesStationCard extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 10,
                         fontWeight: FontWeight.w600,
-                        color: station.isOpen ? Colors.green : Colors.red,
+                        color: station.isOpen
+                            ? DarkModeColors.success(context)
+                            : DarkModeColors.error(context),
                       ),
                     ),
                   ),

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/geo_utils.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
@@ -211,7 +212,7 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
       secondaryBackground: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
-        color: Colors.orange.shade700,
+        color: DarkModeColors.warning(context),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/search/presentation/widgets/swipeable_station_card.dart
+++ b/lib/features/search/presentation/widgets/swipeable_station_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_tier.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../loyalty/providers/loyalty_provider.dart';
@@ -72,7 +73,7 @@ class SwipeableStationCard extends ConsumerWidget {
       secondaryBackground: Container(
         alignment: Alignment.centerRight,
         padding: const EdgeInsets.only(right: 24),
-        color: Colors.orange.shade700,
+        color: DarkModeColors.warning(context),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/setup/presentation/widgets/api_key_input_section.dart
+++ b/lib/features/setup/presentation/widgets/api_key_input_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/country/country_config.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Setup screen section: optional API key input with format validation and a
@@ -24,12 +25,12 @@ class ApiKeyInputSection extends StatelessWidget {
     required this.l10n,
   });
 
-  Widget? _buildFormatIndicator() {
+  Widget? _buildFormatIndicator(BuildContext context) {
     if (formatValid == null) return null;
     if (formatValid!) {
-      return const Icon(Icons.check_circle, color: Colors.green);
+      return Icon(Icons.check_circle, color: DarkModeColors.success(context));
     }
-    return const Icon(Icons.error_outline, color: Colors.red);
+    return Icon(Icons.error_outline, color: DarkModeColors.error(context));
   }
 
   @override
@@ -73,7 +74,7 @@ class ApiKeyInputSection extends StatelessWidget {
             hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
             prefixIcon: const Icon(Icons.key),
             border: const OutlineInputBorder(),
-            suffixIcon: _buildFormatIndicator(),
+            suffixIcon: _buildFormatIndicator(context),
             errorText: formatValid == false
                 ? (l10n?.apiKeyFormatError ??
                     'Invalid format — expected UUID (8-4-4-4-12)')

--- a/lib/features/setup/presentation/widgets/api_key_step.dart
+++ b/lib/features/setup/presentation/widgets/api_key_step.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/country/country_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/api_key_validator.dart';
 
@@ -64,12 +65,12 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
     });
   }
 
-  Widget? _buildFormatIndicator() {
+  Widget? _buildFormatIndicator(BuildContext context) {
     if (_isFormatValid == null) return null;
     if (_isFormatValid!) {
-      return const Icon(Icons.check_circle, color: Colors.green);
+      return Icon(Icons.check_circle, color: DarkModeColors.success(context));
     }
-    return const Icon(Icons.error_outline, color: Colors.red);
+    return Icon(Icons.error_outline, color: DarkModeColors.error(context));
   }
 
   @override
@@ -131,7 +132,7 @@ class _ApiKeyStepState extends ConsumerState<ApiKeyStep> {
               hintText: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
               prefixIcon: const Icon(Icons.key),
               border: const OutlineInputBorder(),
-              suffixIcon: _buildFormatIndicator(),
+              suffixIcon: _buildFormatIndicator(context),
               errorText: _isFormatValid == false
                   ? (l10n?.apiKeyFormatError ??
                       'Invalid format — expected UUID (8-4-4-4-12)')

--- a/lib/features/setup/presentation/widgets/country_language_step.dart
+++ b/lib/features/setup/presentation/widgets/country_language_step.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/language/language_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'illustrations/globe_illustration.dart';
 
@@ -120,8 +121,8 @@ class CountryLanguageStep extends ConsumerWidget {
                         ),
                         decoration: BoxDecoration(
                           color: country.requiresApiKey
-                              ? Colors.orange.shade100
-                              : Colors.green.shade100,
+                              ? DarkModeColors.warningSurface(context)
+                              : DarkModeColors.successSurface(context),
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Text(
@@ -132,8 +133,8 @@ class CountryLanguageStep extends ConsumerWidget {
                             fontSize: 11,
                             fontWeight: FontWeight.w600,
                             color: country.requiresApiKey
-                                ? Colors.orange.shade800
-                                : Colors.green.shade800,
+                                ? DarkModeColors.warning(context)
+                                : DarkModeColors.success(context),
                           ),
                         ),
                       ),

--- a/lib/features/setup/presentation/widgets/country_status_badge.dart
+++ b/lib/features/setup/presentation/widgets/country_status_badge.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/country/country_config.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 
 /// Small pill that labels a country with either "API key required" (orange)
 /// or "Free — no key needed" (green). Used inside the country picker on
@@ -22,8 +23,9 @@ class CountryStatusBadge extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         decoration: BoxDecoration(
-          color:
-              requiresKey ? Colors.orange.shade100 : Colors.green.shade100,
+          color: requiresKey
+              ? DarkModeColors.warningSurface(context)
+              : DarkModeColors.successSurface(context),
           borderRadius: BorderRadius.circular(12),
         ),
         child: Text(
@@ -31,8 +33,9 @@ class CountryStatusBadge extends StatelessWidget {
           style: TextStyle(
             fontSize: 11,
             fontWeight: FontWeight.w600,
-            color:
-                requiresKey ? Colors.orange.shade800 : Colors.green.shade800,
+            color: requiresKey
+                ? DarkModeColors.warning(context)
+                : DarkModeColors.success(context),
           ),
         ),
       ),

--- a/lib/features/sync/presentation/screens/data_transparency_screen.dart
+++ b/lib/features/sync/presentation/screens/data_transparency_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/sync/sync_provider.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/sync/trips_sync.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -85,7 +86,9 @@ class DataTransparencyScreen extends ConsumerWidget {
             child: Text(AppLocalizations.of(context)?.cancel ?? 'Cancel'),
           ),
           FilledButton(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            style: FilledButton.styleFrom(
+              backgroundColor: DarkModeColors.error(context),
+            ),
             onPressed: () => Navigator.pop(context, true),
             child: Text(AppLocalizations.of(context)?.deleteEverything ?? 'Delete everything'),
           ),
@@ -124,7 +127,9 @@ class DataTransparencyScreen extends ConsumerWidget {
           ),
           FilledButton(
             key: const Key('forget_all_synced_trips_confirm'),
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            style: FilledButton.styleFrom(
+              backgroundColor: DarkModeColors.error(context),
+            ),
             onPressed: () => Navigator.pop(context, true),
             child: Text(
               l?.forgetAllSyncedTripsConfirmAction ?? 'Forget all',

--- a/lib/features/sync/presentation/widgets/anon_key_field.dart
+++ b/lib/features/sync/presentation/widgets/anon_key_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Text field for entering a Supabase anon key with:
@@ -34,20 +35,20 @@ class AnonKeyField extends StatelessWidget {
     final isJwtFormat = controller.text.split('.').length == 3;
 
     String? helperText;
-    Color helperColor = Colors.orange;
+    Color helperColor = DarkModeColors.warning(context);
     if (keyLen > 0) {
       if (isTooLong) {
         helperText = l?.anonKeyTooLong(keyLen) ??
             'Key is too long ($keyLen chars) — check for extra text';
-        helperColor = Colors.red;
+        helperColor = DarkModeColors.error(context);
       } else if (isComplete && isJwtFormat) {
         helperText = l?.anonKeyLooksCorrect(keyLen) ??
             'Key looks correct ($keyLen chars)';
-        helperColor = Colors.green;
+        helperColor = DarkModeColors.success(context);
       } else if (!isJwtFormat && keyLen > 10) {
         helperText = l?.anonKeyShouldBeJwt ??
             'Key should be a JWT (header.payload.signature)';
-        helperColor = Colors.red;
+        helperColor = DarkModeColors.error(context);
       } else {
         helperText = l?.anonKeyMayBeTruncated(keyLen) ??
             'Key may be truncated ($keyLen of ~208 expected chars)';
@@ -69,7 +70,12 @@ class AnonKeyField extends StatelessWidget {
                 padding: const EdgeInsets.only(right: 4),
                 child: Text(
                   '$keyLen',
-                  style: TextStyle(fontSize: 11, color: isComplete ? Colors.green : Colors.orange),
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: isComplete
+                        ? DarkModeColors.success(context)
+                        : DarkModeColors.warning(context),
+                  ),
                 ),
               ),
             IconButton(

--- a/lib/features/sync/presentation/widgets/data_transparency_cards.dart
+++ b/lib/features/sync/presentation/widgets/data_transparency_cards.dart
@@ -153,7 +153,9 @@ class DataActionButtons extends StatelessWidget {
           const SizedBox(height: 8),
         ] else ...[
           FilledButton.icon(
-            style: FilledButton.styleFrom(backgroundColor: Colors.red),
+            style: FilledButton.styleFrom(
+              backgroundColor: DarkModeColors.error(context),
+            ),
             onPressed: onDeleteAll,
             icon: const Icon(Icons.delete_forever),
             label: Text(l?.deleteAllServerData ?? 'Delete all server data'),
@@ -167,7 +169,9 @@ class DataActionButtons extends StatelessWidget {
           // above it.
           OutlinedButton.icon(
             key: const Key('forget_all_synced_trips_button'),
-            style: OutlinedButton.styleFrom(foregroundColor: Colors.red),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: DarkModeColors.error(context),
+            ),
             onPressed: onForgetAllTrips,
             icon: const Icon(Icons.history_toggle_off),
             label: Text(

--- a/lib/features/sync/presentation/widgets/link_device_import_card.dart
+++ b/lib/features/sync/presentation/widgets/link_device_import_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../providers/link_device_provider.dart';
 
@@ -102,7 +103,9 @@ class LinkDeviceImportCard extends ConsumerWidget {
               Text(
                 uiState.result!,
                 style: theme.textTheme.bodyMedium?.copyWith(
-                  color: uiState.isError ? Colors.red : Colors.green,
+                  color: uiState.isError
+                      ? DarkModeColors.error(context)
+                      : DarkModeColors.success(context),
                 ),
               ),
             ],

--- a/lib/features/sync/presentation/widgets/sync_credentials_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_credentials_step.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/sync/sync_config.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Credentials input step for private/join-existing sync modes.
@@ -104,7 +105,9 @@ class SyncCredentialsStep extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsets.only(right: 4),
                     child: Text('$keyLen', style: TextStyle(fontSize: 10,
-                      color: keyLen >= 200 ? Colors.green : Colors.orange)),
+                      color: keyLen >= 200
+                          ? DarkModeColors.success(context)
+                          : DarkModeColors.warning(context))),
                   ),
                 IconButton(
                   icon: Icon(showKey ? Icons.visibility_off : Icons.visibility, size: 18),

--- a/lib/features/sync/presentation/widgets/sync_done_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_done_step.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Final step of the TankSync setup wizard — confirms a successful
@@ -20,8 +21,12 @@ class SyncDoneStep extends StatelessWidget {
           liveRegion: true,
           child: Column(
             children: [
-              const ExcludeSemantics(
-                child: Icon(Icons.check_circle, size: 64, color: Colors.green),
+              ExcludeSemantics(
+                child: Icon(
+                  Icons.check_circle,
+                  size: 64,
+                  color: DarkModeColors.success(context),
+                ),
               ),
               const SizedBox(height: 16),
               Text(

--- a/lib/features/sync/presentation/widgets/sync_mode_step.dart
+++ b/lib/features/sync/presentation/widgets/sync_mode_step.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/sync/sync_config.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'sync_mode_card.dart';
 
@@ -51,7 +52,7 @@ class SyncModeStep extends StatelessWidget {
             subtitle: l10n?.syncModeCommunitySubtitle ??
                 'Share favorites & ratings with all users',
             privacyLabel: l10n?.syncPrivacyShared ?? 'Shared',
-            privacyColor: Colors.green,
+            privacyColor: DarkModeColors.success(context),
             onTap: () => onSelectMode(SyncMode.community),
           ),
         ),
@@ -81,7 +82,7 @@ class SyncModeStep extends StatelessWidget {
             subtitle: l10n?.syncModeGroupSubtitle ??
                 'Family or friends shared database',
             privacyLabel: l10n?.syncPrivacyGroup ?? 'Group',
-            privacyColor: Colors.orange,
+            privacyColor: DarkModeColors.warning(context),
             onTap: () => onSelectMode(SyncMode.joinExisting),
           ),
         ),

--- a/lib/features/sync/presentation/widgets/wizard_auth_step.dart
+++ b/lib/features/sync/presentation/widgets/wizard_auth_step.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/password_strength_indicator.dart';
 import '../../../../l10n/app_localizations.dart';
 import 'wizard_option_card.dart';
@@ -112,14 +113,19 @@ class WizardAuthStep extends StatelessWidget {
         if (testResult != null) ...[
           const SizedBox(height: 12),
           Card(
-            color: testSuccess ? Colors.green.withValues(alpha: 0.1) : Colors.red.withValues(alpha: 0.1),
+            color: testSuccess
+                ? DarkModeColors.success(context).withValues(alpha: 0.1)
+                : DarkModeColors.error(context).withValues(alpha: 0.1),
             child: Padding(
               padding: const EdgeInsets.all(12),
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Icon(testSuccess ? Icons.check_circle : Icons.error,
-                      color: testSuccess ? Colors.green : Colors.red, size: 20),
+                      color: testSuccess
+                          ? DarkModeColors.success(context)
+                          : DarkModeColors.error(context),
+                      size: 20),
                   const SizedBox(width: 8),
                   Expanded(child: Text(testResult!, style: theme.textTheme.bodySmall)),
                 ],

--- a/lib/features/sync/presentation/widgets/wizard_schema_step.dart
+++ b/lib/features/sync/presentation/widgets/wizard_schema_step.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../../../core/sync/schema_verifier.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 
@@ -37,7 +38,9 @@ class WizardSchemaStep extends StatelessWidget {
         Icon(
           allReady ? Icons.check_circle : Icons.warning_amber,
           size: 48,
-          color: allReady ? Colors.green : Colors.orange,
+          color: allReady
+              ? DarkModeColors.success(context)
+              : DarkModeColors.warning(context),
         ),
         const SizedBox(height: 16),
         Text(
@@ -55,7 +58,9 @@ class WizardSchemaStep extends StatelessWidget {
             dense: true,
             leading: Icon(
               schemaStatus![table] == true ? Icons.check_circle : Icons.cancel,
-              color: schemaStatus![table] == true ? Colors.green : Colors.red,
+              color: schemaStatus![table] == true
+                  ? DarkModeColors.success(context)
+                  : DarkModeColors.error(context),
               size: 18,
             ),
             title: Text(table, style: theme.textTheme.bodySmall),
@@ -65,7 +70,9 @@ class WizardSchemaStep extends StatelessWidget {
                   : (l10n?.syncTableStatusMissing ?? 'Missing'),
               style: TextStyle(
                 fontSize: 11,
-                color: schemaStatus![table] == true ? Colors.green : Colors.red,
+                color: schemaStatus![table] == true
+                    ? DarkModeColors.success(context)
+                    : DarkModeColors.error(context),
               ),
             ),
           ),

--- a/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_extras_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../consumption/presentation/widgets/vehicle_adapter_section.dart';
 import '../../../consumption/presentation/widgets/vehicle_baseline_section.dart';
@@ -110,7 +111,7 @@ class _Obd2AdapterCardHighlight extends StatelessWidget {
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
-              color: Colors.amber.withValues(alpha: t),
+              color: DarkModeColors.warning(context).withValues(alpha: t),
               width: 2,
             ),
           ),

--- a/test/features/consumption/presentation/fill_up_card_test.dart
+++ b/test/features/consumption/presentation/fill_up_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/consumption/domain/entities/consumption_stats.dart';
 import 'package:tankstellen/features/consumption/domain/entities/eco_score.dart';
 import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
@@ -145,7 +146,10 @@ void main() {
       final shape = card.shape;
       expect(shape, isA<RoundedRectangleBorder>());
       final border = (shape! as RoundedRectangleBorder).side;
-      expect(border.color, Colors.orange.shade700);
+      expect(
+        border.color,
+        DarkModeColors.warning(tester.element(find.byType(Card))),
+      );
       expect(border.width, 4);
     });
 

--- a/test/features/consumption/presentation/widgets/eco_score_badge_test.dart
+++ b/test/features/consumption/presentation/widgets/eco_score_badge_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/consumption/domain/entities/eco_score.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/eco_score_badge.dart';
 
@@ -58,7 +59,10 @@ void main() {
         ),
       );
       final icon = tester.widget<Icon>(find.byIcon(Icons.arrow_downward));
-      expect(icon.color, Colors.green.shade700);
+      expect(
+        icon.color,
+        DarkModeColors.success(tester.element(find.byType(EcoScoreBadge))),
+      );
     });
 
     testWidgets('worsening → orange up-arrow', (tester) async {
@@ -69,7 +73,10 @@ void main() {
         ),
       );
       final icon = tester.widget<Icon>(find.byIcon(Icons.arrow_upward));
-      expect(icon.color, Colors.orange.shade800);
+      expect(
+        icon.color,
+        DarkModeColors.warning(tester.element(find.byType(EcoScoreBadge))),
+      );
     });
 
     testWidgets('stable → neutral forward-arrow', (tester) async {

--- a/test/features/ev/presentation/ev_marker_widget_test.dart
+++ b/test/features/ev/presentation/ev_marker_widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/ev/presentation/widgets/ev_marker_widget.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
@@ -53,11 +54,26 @@ void main() {
       ],
     );
 
-    test('colorFor returns green for available, red for occupied,'
-        ' grey for unknown', () {
-      expect(EvMarkerWidget.colorFor(availableStation), Colors.green);
-      expect(EvMarkerWidget.colorFor(occupiedStation), Colors.red);
-      expect(EvMarkerWidget.colorFor(unknownStation), Colors.grey);
+    testWidgets('colorFor returns success for available, error for occupied,'
+        ' grey for unknown', (tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            ctx = context;
+            return const SizedBox.shrink();
+          }),
+        ),
+      );
+      expect(
+        EvMarkerWidget.colorFor(ctx, availableStation),
+        DarkModeColors.success(ctx),
+      );
+      expect(
+        EvMarkerWidget.colorFor(ctx, occupiedStation),
+        DarkModeColors.error(ctx),
+      );
+      expect(EvMarkerWidget.colorFor(ctx, unknownStation), Colors.grey);
     });
 
     testWidgets('renders an ev_station icon and responds to tap',

--- a/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
+++ b/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/ev/presentation/widgets/ev_map_overlay.dart';
 import 'package:tankstellen/features/ev/providers/ev_providers.dart';
@@ -101,7 +102,10 @@ void main() {
           matching: find.byType(Material),
         ).first,
       );
-      expect(material.color, Colors.green);
+      expect(
+        material.color,
+        DarkModeColors.success(tester.element(find.byIcon(Icons.ev_station))),
+      );
 
       final icon = tester.widget<Icon>(find.byIcon(Icons.ev_station));
       expect(icon.color, Colors.white);

--- a/test/features/favorites/presentation/widgets/ev_favorite_card_test.dart
+++ b/test/features/favorites/presentation/widgets/ev_favorite_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_card.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
@@ -115,7 +116,10 @@ void main() {
         ),
       );
       final icon = tester.widget<Icon>(find.byIcon(Icons.power));
-      expect(icon.color, Colors.green);
+      expect(
+        icon.color,
+        DarkModeColors.success(tester.element(find.byIcon(Icons.power))),
+      );
     });
 
     testWidgets('availability icon is grey when none available',

--- a/test/features/setup/presentation/widgets/api_key_input_section_test.dart
+++ b/test/features/setup/presentation/widgets/api_key_input_section_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/setup/presentation/widgets/api_key_input_section.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
@@ -73,14 +74,20 @@ void main() {
     testWidgets('shows green check when the format is valid', (tester) async {
       await pumpSection(tester, formatValid: true);
       final icon = tester.widget<Icon>(find.byIcon(Icons.check_circle));
-      expect(icon.color, Colors.green);
+      expect(
+        icon.color,
+        DarkModeColors.success(tester.element(find.byIcon(Icons.check_circle))),
+      );
     });
 
     testWidgets('shows red error icon and error text when format is invalid',
         (tester) async {
       await pumpSection(tester, formatValid: false);
       final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
-      expect(icon.color, Colors.red);
+      expect(
+        icon.color,
+        DarkModeColors.error(tester.element(find.byIcon(Icons.error_outline))),
+      );
       expect(
         find.text('Invalid format — expected UUID (8-4-4-4-12)'),
         findsOneWidget,

--- a/test/features/setup/presentation/widgets/api_key_step_test.dart
+++ b/test/features/setup/presentation/widgets/api_key_step_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/country/country_provider.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/setup/presentation/widgets/api_key_step.dart';
 
 import '../../../../helpers/pump_app.dart';
@@ -136,7 +137,10 @@ void main() {
       // After debounce: green check.
       await tester.pump(const Duration(milliseconds: 600));
       final icon = tester.widget<Icon>(find.byIcon(Icons.check_circle));
-      expect(icon.color, Colors.green);
+      expect(
+        icon.color,
+        DarkModeColors.success(tester.element(find.byIcon(Icons.check_circle))),
+      );
       expect(find.byIcon(Icons.error_outline), findsNothing);
     });
 
@@ -153,7 +157,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 600));
 
       final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
-      expect(icon.color, Colors.red);
+      expect(
+        icon.color,
+        DarkModeColors.error(tester.element(find.byIcon(Icons.error_outline))),
+      );
       expect(
         find.text('Invalid format — expected UUID (8-4-4-4-12)'),
         findsOneWidget,
@@ -175,7 +182,10 @@ void main() {
       // No `tester.pump` for a debounce — initState calls _evaluateFormat
       // directly. pumpApp already did pumpAndSettle.
       final icon = tester.widget<Icon>(find.byIcon(Icons.check_circle));
-      expect(icon.color, Colors.green);
+      expect(
+        icon.color,
+        DarkModeColors.success(tester.element(find.byIcon(Icons.check_circle))),
+      );
     });
 
     testWidgets(
@@ -190,7 +200,10 @@ void main() {
       );
 
       final icon = tester.widget<Icon>(find.byIcon(Icons.error_outline));
-      expect(icon.color, Colors.red);
+      expect(
+        icon.color,
+        DarkModeColors.error(tester.element(find.byIcon(Icons.error_outline))),
+      );
     });
 
     testWidgets(

--- a/test/features/setup/presentation/widgets/country_status_badge_test.dart
+++ b/test/features/setup/presentation/widgets/country_status_badge_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/setup/presentation/widgets/country_status_badge.dart';
 
 const _withKey = CountryConfig(
@@ -56,7 +57,11 @@ void main() {
       await pumpBadge(tester, _withKey);
       final container = tester.widget<Container>(find.byType(Container));
       final decoration = container.decoration as BoxDecoration;
-      expect(decoration.color, Colors.orange.shade100);
+      expect(
+        decoration.color,
+        DarkModeColors.warningSurface(
+            tester.element(find.byType(Container))),
+      );
     });
 
     testWidgets('uses the green palette when no API key is required',
@@ -64,7 +69,11 @@ void main() {
       await pumpBadge(tester, _withoutKey);
       final container = tester.widget<Container>(find.byType(Container));
       final decoration = container.decoration as BoxDecoration;
-      expect(decoration.color, Colors.green.shade100);
+      expect(
+        decoration.color,
+        DarkModeColors.successSurface(
+            tester.element(find.byType(Container))),
+      );
     });
 
     testWidgets('is wrapped in ExcludeSemantics so the pill never reads to '

--- a/test/features/sync/presentation/widgets/sync_done_step_test.dart
+++ b/test/features/sync/presentation/widgets/sync_done_step_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/features/sync/presentation/widgets/sync_done_step.dart';
 
 import '../../../../helpers/pump_app.dart';
@@ -21,7 +22,10 @@ void main() {
     testWidgets('icon is the positive green cue at 64 px', (tester) async {
       await pumpApp(tester, const SyncDoneStep());
       final icon = tester.widget<Icon>(find.byIcon(Icons.check_circle));
-      expect(icon.color, Colors.green);
+      expect(
+        icon.color,
+        DarkModeColors.success(tester.element(find.byIcon(Icons.check_circle))),
+      );
       expect(icon.size, 64);
     });
 


### PR DESCRIPTION
## Summary

Closes **#1694** (epic #1689 — Visual Consistency).

### Criterion 1 — semantic colours → `DarkModeColors` ✅
~96 hardcoded `Colors.red/green/orange/amber` literals across 50 presentation files now use the theme-adaptive `DarkModeColors.error/success/warning` helpers — status colours meet WCAG-AA contrast in dark mode instead of a fixed light hue. Swept via 6 parallel agents over disjoint file sets.

Deliberately **kept**: rating / favourite stars (`Colors.amber` — gold in both themes) and `station_marker`'s `Color.lerp` price gradient (context-less static through `Colors.yellow`). Five colour-pinning widget tests updated to the new values.

### Criterion 2 — Scaffold audit → no change, by design
The four flagged screens (GDPR consent, onboarding wizard, setup, driving mode) are intentionally immersive, app-bar-less flows. `PageScaffold` mandates an `AppBar`; migrating would *add* wrong chrome — a regression. They correctly stay bare `Scaffold`.

### Criterion 3 — disclosure audit → already coherent
The settings fold-vs-navigate split follows a consistent rule (dedicated rich screen → navigate; inline group → fold), both `Card`-wrapped. No change needed.

## Test plan
- `flutter analyze` — clean
- `flutter test test/lint/ test/goldens/` + the touched feature suites — green (the only failures are `@Tags(['network'])` `api_connectivity_test` live-endpoint flakiness, which CI excludes)

Closes #1694.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
