### PR TITLE
feat(catalog): make→model→generation picker drill-down at catalog scale (#1643)

### DIFF
--- a/lib/features/vehicle/presentation/widgets/reference_vehicle_picker.dart
+++ b/lib/features/vehicle/presentation/widgets/reference_vehicle_picker.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,28 +9,25 @@ import '../../domain/entities/reference_vehicle.dart';
 
 /// Modal bottom sheet that lets the user pre-fill an empty
 /// [EditVehicleScreen] form by picking from the bundled reference
-/// catalog (#1372 phase 3).
+/// catalog (#1372 phase 3; rebuilt for scale in #1643).
 ///
-/// The catalog ships ~50 popular EU passenger cars compiled from the
-/// 2015-2024 new-car registration tables. Each entry carries the engine
-/// quirks the OBD-II layer needs (volumetric efficiency, odometer PID
-/// strategy) so users don't have to discover them by hand. Phase 1
-/// (#1380) shipped the abstraction docs; phase 2 (#1398) grew the
-/// catalog from 31 to 51 entries; this phase exposes a UI affordance.
+/// The catalog grew to ~250 entries (epic #1640), so a flat scrolling
+/// list no longer scales. The picker now offers a **make → model →
+/// generation drill-down**: the user taps a make to see its models,
+/// a model to see its generations, and a generation to select it.
+/// Any catalog entry is therefore reachable in three taps regardless
+/// of catalog size.
+///
+/// A debounced type-ahead search sits above the drill-down: while the
+/// search box is non-empty it overrides the drill-down with a flat
+/// `make + model + generation` substring match across the whole
+/// catalog; clearing it returns to the drill-down at its current level.
 ///
 /// UX:
-/// - Opens via the static [show] helper which routes through
-///   [showModalBottomSheet] with `isScrollControlled: true` so the sheet
-///   can grow to ~85 % of the viewport.
-/// - A search field at the top filters entries by `make + model +
-///   generation` substring, case-insensitive. Empty search shows the
-///   full catalog.
-/// - Each list tile renders `make + model` as the primary line and
-///   `generation · yearStart–yearEnd · displacementCc cc fuelType`
-///   as the subtitle. Tap → [Navigator.pop] with the selected entry
-///   as the result.
-/// - A Cancel button at the bottom dismisses the sheet with a `null`
-///   result. Drag-to-dismiss and scrim-tap also dismiss with `null`.
+/// - Opens via [show] through [showModalBottomSheet] with
+///   `isScrollControlled: true` so the sheet can grow to ~85 % height.
+/// - Tap a generation → [Navigator.pop] with the selected entry.
+/// - Cancel / drag-to-dismiss / scrim-tap dismiss with a `null` result.
 ///
 /// The picker MUST NOT be shown while editing an existing vehicle —
 /// callers gate visibility on "create mode" so the user's tweaks are
@@ -56,6 +55,20 @@ class _ReferenceVehiclePickerState
     extends ConsumerState<ReferenceVehiclePicker> {
   final TextEditingController _searchController = TextEditingController();
 
+  /// Debounce window for the type-ahead. The catalog is ~250 entries —
+  /// trivially filterable — but debouncing still avoids rebuilding the
+  /// list on every keystroke when the user types fast on a long query.
+  static const _debounce = Duration(milliseconds: 250);
+  Timer? _debounceTimer;
+
+  /// The committed (post-debounce) search query.
+  String _query = '';
+
+  /// Drill-down cursor. Both null → make list; make set → model list;
+  /// both set → generation list.
+  String? _make;
+  String? _model;
+
   @override
   void initState() {
     super.initState();
@@ -64,26 +77,41 @@ class _ReferenceVehiclePickerState
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
     _searchController.removeListener(_onSearchChanged);
     _searchController.dispose();
     super.dispose();
   }
 
   void _onSearchChanged() {
-    if (mounted) setState(() {});
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_debounce, () {
+      if (!mounted) return;
+      setState(() => _query = _searchController.text.trim().toLowerCase());
+    });
   }
 
-  /// Case-insensitive substring filter on `make + model + generation`.
-  ///
-  /// 51 entries → trivial to filter on every keystroke. We deliberately
-  /// don't debounce.
-  List<ReferenceVehicle> _filter(List<ReferenceVehicle> all, String query) {
-    final trimmed = query.trim().toLowerCase();
-    if (trimmed.isEmpty) return all;
+  /// Steps one level back up the drill-down. Returns false when already
+  /// at the root (the caller then has nothing to pop).
+  bool _drillUp() {
+    if (_model != null) {
+      setState(() => _model = null);
+      return true;
+    }
+    if (_make != null) {
+      setState(() => _make = null);
+      return true;
+    }
+    return false;
+  }
+
+  /// Flat substring match across the whole catalog — used while the
+  /// search box is non-empty.
+  List<ReferenceVehicle> _search(List<ReferenceVehicle> all) {
+    if (_query.isEmpty) return const [];
     return all.where((v) {
-      final haystack =
-          '${v.make} ${v.model} ${v.generation}'.toLowerCase();
-      return haystack.contains(trimmed);
+      final haystack = '${v.make} ${v.model} ${v.generation}'.toLowerCase();
+      return haystack.contains(_query);
     }).toList(growable: false);
   }
 
@@ -93,6 +121,7 @@ class _ReferenceVehiclePickerState
     final theme = Theme.of(context);
     final catalogAsync = ref.watch(referenceVehicleCatalogProvider);
     final maxHeight = MediaQuery.of(context).size.height * 0.85;
+    final searching = _query.isNotEmpty;
 
     return SafeArea(
       top: false,
@@ -104,33 +133,35 @@ class _ReferenceVehiclePickerState
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Title row.
+              // Title row — a back button appears once the user has
+              // drilled into a make (and is not searching).
               Row(
                 children: [
-                  Icon(
-                    Icons.directions_car_outlined,
-                    color: theme.colorScheme.primary,
-                  ),
+                  if (!searching && _make != null)
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      tooltip: l?.tooltipBack ?? 'Back',
+                      onPressed: _drillUp,
+                    )
+                  else
+                    Icon(Icons.directions_car_outlined,
+                        color: theme.colorScheme.primary),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      l?.pickerButtonLabel ?? 'Pick from catalog',
-                      style: theme.textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
+                      _breadcrumb(l),
+                      style: theme.textTheme.titleLarge
+                          ?.copyWith(fontWeight: FontWeight.w600),
                     ),
                   ),
                 ],
               ),
               const SizedBox(height: 8),
-              // Search field.
               TextField(
                 controller: _searchController,
-                autofocus: false,
                 decoration: InputDecoration(
                   prefixIcon: const Icon(Icons.search),
-                  hintText:
-                      l?.pickerSearchHint ?? 'Search make or model',
+                  hintText: l?.pickerSearchHint ?? 'Search make or model',
                   suffixIcon: _searchController.text.isEmpty
                       ? null
                       : IconButton(
@@ -143,7 +174,6 @@ class _ReferenceVehiclePickerState
                 ),
               ),
               const SizedBox(height: 12),
-              // Body — loading / error / list.
               Flexible(
                 child: catalogAsync.when(
                   loading: () => Center(
@@ -161,40 +191,16 @@ class _ReferenceVehiclePickerState
                     padding: const EdgeInsets.all(16),
                     child: Text(
                       'Error: $error',
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.error,
-                      ),
+                      style: theme.textTheme.bodyMedium
+                          ?.copyWith(color: theme.colorScheme.error),
                     ),
                   ),
-                  data: (catalog) {
-                    final filtered = _filter(catalog, _searchController.text);
-                    if (filtered.isEmpty) {
-                      return Center(
-                        child: Padding(
-                          padding: const EdgeInsets.all(24),
-                          child: Text(
-                            l?.pickerEmptyResults ?? 'No matches',
-                            style: theme.textTheme.bodyMedium,
-                          ),
-                        ),
-                      );
-                    }
-                    return ListView.builder(
-                      shrinkWrap: true,
-                      itemCount: filtered.length,
-                      itemBuilder: (context, i) {
-                        final entry = filtered[i];
-                        return _ReferenceVehicleTile(
-                          entry: entry,
-                          onTap: () => Navigator.of(context).pop(entry),
-                        );
-                      },
-                    );
-                  },
+                  data: (catalog) => searching
+                      ? _buildSearchResults(catalog, l, theme)
+                      : _buildDrillDown(catalog, l, theme),
                 ),
               ),
               const SizedBox(height: 8),
-              // Cancel row.
               Align(
                 alignment: Alignment.centerLeft,
                 child: TextButton(
@@ -208,27 +214,149 @@ class _ReferenceVehiclePickerState
       ),
     );
   }
+
+  /// Title text — plain label at the root, else the drill-down path.
+  String _breadcrumb(AppLocalizations? l) {
+    if (_make == null) return l?.pickerButtonLabel ?? 'Pick from catalog';
+    if (_model == null) return _make!;
+    return '$_make · $_model';
+  }
+
+  Widget _emptyState(AppLocalizations? l, ThemeData theme) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(l?.pickerEmptyResults ?? 'No matches',
+              style: theme.textTheme.bodyMedium),
+        ),
+      );
+
+  Widget _buildSearchResults(
+      List<ReferenceVehicle> catalog, AppLocalizations? l, ThemeData theme) {
+    final results = _search(catalog);
+    if (results.isEmpty) return _emptyState(l, theme);
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: results.length,
+      itemBuilder: (context, i) => _GenerationTile(
+        entry: results[i],
+        showModel: true,
+        onTap: () => Navigator.of(context).pop(results[i]),
+      ),
+    );
+  }
+
+  Widget _buildDrillDown(
+      List<ReferenceVehicle> catalog, AppLocalizations? l, ThemeData theme) {
+    // Level 3 — generations of the selected make + model.
+    if (_make != null && _model != null) {
+      final generations = catalog
+          .where((v) => v.make == _make && v.model == _model)
+          .toList()
+        ..sort((a, b) => b.yearStart.compareTo(a.yearStart));
+      if (generations.isEmpty) return _emptyState(l, theme);
+      return ListView.builder(
+        shrinkWrap: true,
+        itemCount: generations.length,
+        itemBuilder: (context, i) => _GenerationTile(
+          entry: generations[i],
+          showModel: false,
+          onTap: () => Navigator.of(context).pop(generations[i]),
+        ),
+      );
+    }
+
+    // Level 2 — models of the selected make.
+    if (_make != null) {
+      final models = <String, int>{};
+      for (final v in catalog) {
+        if (v.make == _make) {
+          models[v.model] = (models[v.model] ?? 0) + 1;
+        }
+      }
+      final sorted = models.keys.toList()..sort();
+      return ListView.builder(
+        shrinkWrap: true,
+        itemCount: sorted.length,
+        itemBuilder: (context, i) => _GroupTile(
+          label: sorted[i],
+          count: models[sorted[i]]!,
+          onTap: () => setState(() => _model = sorted[i]),
+        ),
+      );
+    }
+
+    // Level 1 — makes.
+    final makes = <String, int>{};
+    for (final v in catalog) {
+      makes[v.make] = (makes[v.make] ?? 0) + 1;
+    }
+    final sorted = makes.keys.toList()..sort();
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: sorted.length,
+      itemBuilder: (context, i) => _GroupTile(
+        label: sorted[i],
+        count: makes[sorted[i]]!,
+        onTap: () => setState(() => _make = sorted[i]),
+      ),
+    );
+  }
 }
 
-/// One row in the [ReferenceVehiclePicker] list.
-///
-/// Title is `make model`; subtitle packs generation + production
-/// window + displacement + fuelType into a single line.
-class _ReferenceVehicleTile extends StatelessWidget {
-  final ReferenceVehicle entry;
+/// A drill-down group row (a make or a model) with its entry count and
+/// a trailing chevron.
+class _GroupTile extends StatelessWidget {
+  final String label;
+  final int count;
   final VoidCallback onTap;
 
-  const _ReferenceVehicleTile({required this.entry, required this.onTap});
+  const _GroupTile(
+      {required this.label, required this.count, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
-    final yearEnd = entry.yearEnd?.toString() ?? '';
-    final yearRange = '${entry.yearStart}–$yearEnd';
-    final subtitle =
-        '${entry.generation} · $yearRange · ${entry.displacementCc}cc ${entry.fuelType}';
     return ListTile(
-      title: Text('${entry.make} ${entry.model}'),
-      subtitle: Text(subtitle),
+      title: Text(label),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('$count',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  )),
+          const SizedBox(width: 4),
+          const Icon(Icons.chevron_right),
+        ],
+      ),
+      onTap: onTap,
+      dense: true,
+    );
+  }
+}
+
+/// A selectable leaf row — one catalog generation.
+///
+/// In the drill-down the make + model are already in the breadcrumb so
+/// only the generation shows; in flat search results [showModel] adds
+/// the `make model` line so the row is self-describing.
+class _GenerationTile extends StatelessWidget {
+  final ReferenceVehicle entry;
+  final bool showModel;
+  final VoidCallback onTap;
+
+  const _GenerationTile(
+      {required this.entry, required this.showModel, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final yearRange = '${entry.yearStart}–${entry.yearEnd?.toString() ?? ''}';
+    final spec =
+        '$yearRange · ${entry.displacementCc}cc ${entry.fuelType}';
+    return ListTile(
+      title: Text(showModel
+          ? '${entry.make} ${entry.model} · ${entry.generation}'
+          : entry.generation),
+      subtitle: Text(spec),
       onTap: onTap,
       dense: true,
     );

--- a/test/features/vehicle/presentation/widgets/reference_vehicle_picker_test.dart
+++ b/test/features/vehicle/presentation/widgets/reference_vehicle_picker_test.dart
@@ -8,15 +8,10 @@ import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.d
 import 'package:tankstellen/features/vehicle/presentation/widgets/reference_vehicle_picker.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
-/// Widget tests for [ReferenceVehiclePicker] (#1372 phase 3).
-///
-/// We override the catalog provider with a hand-built fixture so each
-/// case drives the sheet through a known catalog rather than the
-/// 50-entry shipping JSON. Loading and empty-results branches are
-/// covered explicitly.
+/// Widget tests for [ReferenceVehiclePicker] — rebuilt for the
+/// make → model → generation drill-down (#1643) and exercised against
+/// a 250-entry fixture for the catalog-at-scale acceptance (#1647).
 void main() {
-  // Test fixture — three known entries spanning two makes so the
-  // case-insensitive substring filter has something to chew on.
   const e1 = ReferenceVehicle(
     make: 'Peugeot',
     model: '208',
@@ -46,31 +41,49 @@ void main() {
     transmission: 'manual',
   );
 
-  /// Pump the picker sheet behind a launcher button so the modal
-  /// router lifecycle is exercised faithfully (mirrors how callers use
-  /// the static `show()` helper from the edit-vehicle screen).
+  /// Builds a large synthetic catalog: [makes] × [modelsPerMake] ×
+  /// [gensPerModel] entries — used for the catalog-at-scale tests.
+  List<ReferenceVehicle> bigCatalog({
+    int makes = 25,
+    int modelsPerMake = 5,
+    int gensPerModel = 2,
+  }) {
+    final out = <ReferenceVehicle>[];
+    for (var m = 0; m < makes; m++) {
+      for (var md = 0; md < modelsPerMake; md++) {
+        for (var g = 0; g < gensPerModel; g++) {
+          out.add(ReferenceVehicle(
+            make: 'Make${m.toString().padLeft(2, '0')}',
+            model: 'Model$md',
+            generation: 'Gen$g',
+            yearStart: 2000 + g * 6,
+            displacementCc: 1000 + md * 100,
+            fuelType: 'petrol',
+            transmission: 'manual',
+          ));
+        }
+      }
+    }
+    return out;
+  }
+
   Future<ReferenceVehicle?> pumpPickerSheet(
     WidgetTester tester, {
     AsyncValue<List<ReferenceVehicle>>? catalogValue,
+    List<ReferenceVehicle>? catalog,
   }) async {
     ReferenceVehicle? result;
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           referenceVehicleCatalogProvider.overrideWith((ref) {
-            // overrideWith on a Future provider takes a function
-            // returning a Future; collapse the AsyncValue into a
-            // matching resolution. The loading branch returns a
-            // never-completing future so the spinner stays visible
-            // for the test pump.
             final value = catalogValue ??
-                const AsyncValue<List<ReferenceVehicle>>.data(
-                    [e1, e2, e3]);
+                AsyncValue<List<ReferenceVehicle>>.data(
+                    catalog ?? const [e1, e2, e3]);
             return value.when(
               data: (v) => Future<List<ReferenceVehicle>>.value(v),
               loading: () => Completer<List<ReferenceVehicle>>().future,
-              error: (e, _) =>
-                  Future<List<ReferenceVehicle>>.error(e),
+              error: (e, _) => Future<List<ReferenceVehicle>>.error(e),
             );
           }),
         ],
@@ -94,77 +107,45 @@ void main() {
       ),
     );
     await tester.tap(find.text('open'));
-    // Two pumps — one for the modal route push, one to settle the
-    // bottom sheet animation just enough to make widgets findable
-    // without fully draining timers (we may have a never-completing
-    // loading future on the loading-state test).
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
     return result;
   }
 
-  group('ReferenceVehiclePicker', () {
-    testWidgets('renders header + search field + list', (tester) async {
+  group('ReferenceVehiclePicker — drill-down (#1643)', () {
+    testWidgets('root level lists the makes, not individual entries',
+        (tester) async {
       await pumpPickerSheet(tester);
 
-      expect(find.byType(ReferenceVehiclePicker), findsOneWidget);
-      // Title row.
       expect(find.text('Pick from catalog'), findsOneWidget);
-      // Search input.
       expect(find.byType(TextField), findsOneWidget);
-      expect(find.text('Search make or model'), findsOneWidget);
-      // List of tiles.
-      expect(find.byType(ListTile), findsNWidgets(3));
+      // Two makes for the 3-entry fixture (Peugeot ×2, Renault ×1).
+      expect(find.text('Peugeot'), findsOneWidget);
+      expect(find.text('Renault'), findsOneWidget);
+      // The make tile carries its entry count.
+      expect(find.text('2'), findsOneWidget); // Peugeot
     });
 
-    testWidgets('empty search shows the full catalog', (tester) async {
+    testWidgets('tapping a make drills into its models', (tester) async {
       await pumpPickerSheet(tester);
 
-      // All three fixture entries are visible.
-      expect(find.text('Peugeot 208'), findsOneWidget);
-      expect(find.text('Peugeot 3008'), findsOneWidget);
-      expect(find.text('Renault Clio'), findsOneWidget);
+      await tester.tap(find.text('Peugeot'));
+      await tester.pump();
+
+      // Breadcrumb is the make; models are listed.
+      expect(find.text('208'), findsOneWidget);
+      expect(find.text('3008'), findsOneWidget);
+      expect(find.text('Renault'), findsNothing);
     });
 
-    testWidgets(
-        'search is case-insensitive on make + model + generation '
-        '(substring match)', (tester) async {
-      await pumpPickerSheet(tester);
-
-      // Lowercase brand — both Peugeot rows match, Renault filters out.
-      await tester.enterText(find.byType(TextField), 'peugeot');
-      await tester.pump();
-
-      expect(find.text('Peugeot 208'), findsOneWidget);
-      expect(find.text('Peugeot 3008'), findsOneWidget);
-      expect(find.text('Renault Clio'), findsNothing);
-
-      // Substring on a model name narrows further.
-      await tester.enterText(find.byType(TextField), '3008');
-      await tester.pump();
-
-      expect(find.text('Peugeot 208'), findsNothing);
-      expect(find.text('Peugeot 3008'), findsOneWidget);
-      expect(find.text('Renault Clio'), findsNothing);
-
-      // Generation token also matches (substring on the haystack).
-      await tester.enterText(find.byType(TextField), 'V');
-      await tester.pump();
-
-      // 'V' substring matches 'V' (Clio gen) AND 'Peugeot' (the v),
-      // so we just verify Clio is present and it's at least one row.
-      expect(find.text('Renault Clio'), findsOneWidget);
-    });
-
-    testWidgets('tap on a tile pops the sheet with the tapped entry',
+    testWidgets('drilling make → model → generation pops the entry',
         (tester) async {
       ReferenceVehicle? captured;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            referenceVehicleCatalogProvider.overrideWith((ref) {
-              return Future<List<ReferenceVehicle>>.value([e1, e2, e3]);
-            }),
+            referenceVehicleCatalogProvider.overrideWith((ref) =>
+                Future<List<ReferenceVehicle>>.value([e1, e2, e3])),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -189,26 +170,70 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Tap the second row — Peugeot 3008 — and let the navigator pop.
-      await tester.tap(find.text('Peugeot 3008'));
+      await tester.tap(find.text('Peugeot'));
+      await tester.pump();
+      await tester.tap(find.text('3008'));
+      await tester.pump();
+      await tester.tap(find.text('II'));
       await tester.pumpAndSettle();
 
       expect(captured, isNotNull);
       expect(captured!.make, 'Peugeot');
       expect(captured!.model, '3008');
       expect(captured!.yearStart, 2016);
-      // Sheet is gone after pop.
       expect(find.byType(ReferenceVehiclePicker), findsNothing);
     });
 
-    testWidgets('tap on Cancel pops the sheet with null', (tester) async {
-      ReferenceVehicle? captured = e1; // sentinel — must be cleared
+    testWidgets('the back button steps one level up the drill-down',
+        (tester) async {
+      await pumpPickerSheet(tester);
+
+      await tester.tap(find.text('Peugeot'));
+      await tester.pump();
+      expect(find.text('208'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Back'));
+      await tester.pump();
+
+      // Back at the make list.
+      expect(find.text('Peugeot'), findsOneWidget);
+      expect(find.text('Renault'), findsOneWidget);
+    });
+  });
+
+  group('ReferenceVehiclePicker — debounced search (#1643)', () {
+    testWidgets('search overrides the drill-down with flat results once '
+        'the debounce elapses', (tester) async {
+      await pumpPickerSheet(tester);
+
+      await tester.enterText(find.byType(TextField), 'peugeot');
+      // Before the debounce window: still the make list.
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.text('Renault'), findsOneWidget);
+
+      // After the 250 ms debounce: flat filtered results.
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.textContaining('Peugeot 208'), findsOneWidget);
+      expect(find.textContaining('Peugeot 3008'), findsOneWidget);
+      expect(find.textContaining('Renault Clio'), findsNothing);
+    });
+
+    testWidgets('shows the "No matches" empty state', (tester) async {
+      await pumpPickerSheet(tester);
+
+      await tester.enterText(find.byType(TextField), 'xyzzy-no-brand');
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('No matches'), findsOneWidget);
+    });
+
+    testWidgets('Cancel pops the sheet with null', (tester) async {
+      ReferenceVehicle? captured = e1;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            referenceVehicleCatalogProvider.overrideWith((ref) {
-              return Future<List<ReferenceVehicle>>.value([e1, e2, e3]);
-            }),
+            referenceVehicleCatalogProvider.overrideWith((ref) =>
+                Future<List<ReferenceVehicle>>.value([e1, e2, e3])),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -233,40 +258,95 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      // Bottom-row Cancel TextButton (the suffixIcon on the search
-      // field renders an IconButton, not a Cancel-labelled TextButton).
       await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
       await tester.pumpAndSettle();
 
       expect(captured, isNull);
-      expect(find.byType(ReferenceVehiclePicker), findsNothing);
     });
 
-    testWidgets('shows "No matches" empty state when search filters all out',
-        (tester) async {
-      await pumpPickerSheet(tester);
-
-      await tester.enterText(find.byType(TextField), 'xyzzy-no-such-brand');
-      await tester.pump();
-
-      expect(find.text('No matches'), findsOneWidget);
-      expect(find.byType(ListTile), findsNothing);
-    });
-
-    testWidgets('loading state shows a CircularProgressIndicator + label',
-        (tester) async {
+    testWidgets('loading state shows a spinner + label', (tester) async {
       await pumpPickerSheet(
         tester,
         catalogValue: const AsyncValue<List<ReferenceVehicle>>.loading(),
       );
 
-      // Spinner + label visible. We deliberately use pump (not
-      // pumpAndSettle) above because the loading future never
-      // completes — pumpAndSettle would wait forever.
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.text('Loading catalog…'), findsOneWidget);
-      // No tiles while loading.
-      expect(find.byType(ListTile), findsNothing);
+    });
+  });
+
+  group('ReferenceVehiclePicker — catalog at scale (#1647)', () {
+    testWidgets('a 250-entry catalog renders the make list without overflow',
+        (tester) async {
+      final big = bigCatalog(); // 25 × 5 × 2 = 250 entries
+      expect(big.length, 250);
+      await pumpPickerSheet(tester, catalog: big);
+
+      // The 25 makes are grouped — only make tiles render at the root,
+      // never 250 rows. The first make is reachable.
+      expect(find.text('Make00'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('any entry is reachable in three taps regardless of size',
+        (tester) async {
+      ReferenceVehicle? captured;
+      final big = bigCatalog();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            referenceVehicleCatalogProvider.overrideWith(
+                (ref) => Future<List<ReferenceVehicle>>.value(big)),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      captured = await ReferenceVehiclePicker.show(context);
+                    },
+                    child: const Text('open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Tap 1: make. Tap 2: model. Tap 3: generation → selected.
+      await tester.tap(find.text('Make00'));
+      await tester.pump();
+      await tester.tap(find.text('Model0'));
+      await tester.pump();
+      await tester.tap(find.text('Gen0'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.make, 'Make00');
+      expect(captured!.model, 'Model0');
+      expect(captured!.generation, 'Gen0');
+    });
+
+    testWidgets('debounced search stays responsive against 250 entries',
+        (tester) async {
+      await pumpPickerSheet(tester, catalog: bigCatalog());
+
+      await tester.enterText(find.byType(TextField), 'Make07 Model3');
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Exactly the two generations of Make07/Model3 match (the tile
+      // titles read "Make07 Model3 · GenN" — the bare search-field
+      // text is excluded by matching the "· Gen" tile suffix).
+      expect(find.textContaining('Make07 Model3 · Gen'), findsNWidgets(2));
+      expect(tester.takeException(), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Epic **#1640** — finishes the catalog scale-up. With ~250 entries the picker's flat list no longer works.

Resolves **#1643** (drill-down) and **#1647** (picker-at-scale tests).

## What changed
- `ReferenceVehiclePicker` rebuilt as a **make → model → generation drill-down** — grouped lists with entry counts + a back button; any entry reachable in 3 taps at any catalog size.
- Type-ahead search above the drill-down is **debounced (250 ms)**; while non-empty it overrides the drill-down with a flat substring match across the whole catalog.
- The stale "~50 entries" docstring assumption removed.
- Test suite rebuilt for the drill-down + a **250-entry catalog-at-scale** group (root renders only grouped make tiles, 3-tap reachability, debounced search responsiveness).

## Test plan
- `flutter analyze` + module-boundary check — clean
- `flutter test test/lint/ test/features/vehicle/presentation/` — 246 pass, incl. 11 picker tests

Closes #1643
Closes #1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)
