### PR TITLE
feat(obd2): expand the adapter registry to the 20+ best-sellers (#1641)

### DIFF
--- a/docs/guides/obd2-adapters.md
+++ b/docs/guides/obd2-adapters.md
@@ -12,6 +12,26 @@ The registry source of truth is
 `lib/features/consumption/data/obd2/adapter_registry.dart`; the
 catalogue below is curated manually from that file.
 
+## Buying an adapter (#1648 decisions)
+
+The table carries a **Buy** column with a link per adapter. The
+sourcing decisions, recorded here so they don't drift:
+
+- **Plain links, no affiliate program.** The links are ordinary
+  Amazon *search* URLs — not affiliate / tag links — so there is no
+  affiliate-disclosure obligation and no account to maintain.
+- **Search URLs, not product ASINs.** Each link is an Amazon search
+  for the adapter name (`amazon.de/s?k=<name>+OBD2`). Search URLs are
+  stable; a specific product listing's ASIN rots when the seller
+  re-lists, a search does not.
+- **Reference marketplace: amazon.de.** It is the app's home market.
+  The search-by-name query works unchanged on any Amazon marketplace
+  (swap the TLD) and on any other retailer — so countries Amazon does
+  not serve are covered by the same adapter *name*.
+- **Doc-only, not in-app.** The links live in this guide (and the
+  wiki it feeds), not in an in-app registry field — the adapter
+  picker stays a connection tool, not a storefront.
+
 ## Compatibility status
 
 Each adapter row carries one of three states, sourced from the
@@ -30,24 +50,37 @@ Each adapter row carries one of three states, sourced from the
 
 ## Supported adapters
 
-| Display name | Transport | Name matchers | Notes | Compatibility |
+| Display name | Transport | Name matchers | Compatibility | Buy |
 |---|---|---|---|---|
-| vLinker FS (Classic) | Classic BT | `vlinker fs`, `vlinker ms`, `vlink fs`, `vgate fs` | Dominant Amazon-EU model; Classic SPP | ✅ tested |
-| vLinker FD / MC (BLE) | BLE | `vlinker fd`, `vlinker mc`, `vlink fd`, `vlink mc` | Nordic UART FFF0 family | ⚠️ theoretical |
-| OBDLink MX+ | BLE | `obdlink` | Scantool premium adapter; custom 18f0 service | ⚠️ theoretical |
-| Carista OBD2 | BLE | `carista` | Nordic UART FFF0 family | ⚠️ theoretical |
-| Veepeak BLE+ | BLE | `veepeak` | Nordic UART FFF0 family | ⚠️ theoretical |
-| SmartOBD (BLE) | BLE | `smartobd` | Generic ELM327 v1.5 clone | 👤 user-verified |
-| SmartOBD (Classic) | Classic BT | `smartobd` | Same brand, Classic SPP variant | 👤 user-verified |
-| ieGeek Scanner | BLE | `iegeek` | ELM327 v2.1 BLE clone | ⚠️ theoretical |
-| vLinker BM+ (BLE) | BLE | `vlinker bm+`, `vlink bm+` | BLE-only sibling to vLinker BM; the "+" is load-bearing | ⚠️ theoretical |
-| vLinker BM-Android (Classic) | Classic BT | `vlinker bm-android`, `vlink bm-android` | Classic SPP sibling to vLinker BM+ | ✅ tested |
-| Konnwei KW902 | Classic BT | `konnwei`, `kw902` | ELM327 v1.5 Classic clone | ⚠️ theoretical |
-| Vgate iCar Pro | BLE | `vgate`, `icar pro` | Chinese brand; BLE variant (WiFi variant handled by TCP facade) | ⚠️ theoretical |
-| Panlong WiFi | Classic BT (no-op) | `panlong` | WiFi-only adapter; name kept so the UI can label a mis-paired Classic entry | ⚠️ theoretical |
-| BAFX 34t5 | Classic BT | `bafx` | Legacy ELM327 v1.5 adapter, still sold in the US | ⚠️ theoretical |
-| Generic ELM327 (BLE) | BLE | — (matched by FFF0 service UUID) | Catch-all for unfamiliar BLE FFF0 clones | ⚠️ theoretical |
-| Generic ELM327 (Classic) | Classic BT | `obdii`, `obd-ii`, `obd ii`, `obd2`, `elm327` | Catch-all for unfamiliar Classic-SPP clones | ⚠️ theoretical |
+| vLinker FS (Classic) | Classic BT | `vlinker fs`, `vlinker ms`, `vlink fs`, `vgate fs` | ✅ tested | [amazon.de](https://www.amazon.de/s?k=vLinker+FS+OBD2) |
+| vLinker FD / MC (BLE) | BLE | `vlinker fd`, `vlinker mc`, `vlink fd`, `vlink mc` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=vLinker+FD+OBD2) |
+| vLinker BM+ (BLE) | BLE | `vlinker bm+`, `vlink bm+` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=vLinker+BM+OBD2) |
+| vLinker BM-Android (Classic) | Classic BT | `vlinker bm-android`, `vlink bm-android` | ✅ tested | [amazon.de](https://www.amazon.de/s?k=vLinker+BM+OBD2) |
+| OBDLink MX+ | BLE | `obdlink mx` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=OBDLink+MX+) |
+| OBDLink LX | BLE | `obdlink lx` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=OBDLink+LX) |
+| OBDLink CX | BLE | `obdlink cx` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=OBDLink+CX) |
+| Carista OBD2 | BLE | `carista` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Carista+OBD2) |
+| Veepeak BLE+ | BLE | `veepeak` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Veepeak+OBD2) |
+| BlueDriver | BLE | `bluedriver` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=BlueDriver+OBD2) |
+| PLX Kiwi 3 | BLE | `kiwi` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=PLX+Kiwi+3+OBD2) |
+| SmartOBD (BLE) | BLE | `smartobd` | 👤 user-verified | [amazon.de](https://www.amazon.de/s?k=SmartOBD+ELM327) |
+| SmartOBD (Classic) | Classic BT | `smartobd` | 👤 user-verified | [amazon.de](https://www.amazon.de/s?k=SmartOBD+ELM327) |
+| ieGeek Scanner | BLE | `iegeek` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=ieGeek+OBD2) |
+| LELink BLE | BLE | `lelink` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=LELink+OBD2) |
+| Topdon TopScan | BLE | `topscan`, `topdon` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Topdon+TopScan) |
+| ANCEL BD310 | BLE | `ancel`, `bd310` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=ANCEL+BD310) |
+| Tonwon Pro BLE | BLE | `tonwon` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Tonwon+Pro+OBD2) |
+| NEXAS NexLink | BLE | `nexas`, `nexlink` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=NEXAS+NexLink+OBD2) |
+| Konnwei KW902 | Classic BT | `konnwei`, `kw902` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Konnwei+KW902) |
+| Vgate iCar Pro | BLE | `vgate`, `icar pro` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Vgate+iCar+Pro) |
+| BAFX 34t5 | Classic BT | `bafx` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=BAFX+OBD2) |
+| Panlong WiFi | Classic BT (no-op) | `panlong` | ⚠️ theoretical | [amazon.de](https://www.amazon.de/s?k=Panlong+WiFi+OBD2) |
+| Generic ELM327 (BLE) | BLE | — (matched by FFF0 service UUID) | ⚠️ theoretical | — |
+| Generic ELM327 (Classic) | Classic BT | `obdii`, `obd-ii`, `obd ii`, `obd2`, `elm327` | ⚠️ theoretical | — |
+
+The Notes for each profile (chip family, transport quirks) live in
+the `adapter_registry.dart` source comments — the doc keeps the table
+scannable; the registry file is the long-form reference.
 
 ## How to add a new adapter
 

--- a/lib/features/consumption/data/obd2/adapter_registry.dart
+++ b/lib/features/consumption/data/obd2/adapter_registry.dart
@@ -243,15 +243,36 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
     nameMatchers: ['vlinker fd', 'vlinker mc', 'vlink fd', 'vlink mc'],
   ),
-  // OBDLink MX+ — Scantool's premium adapter, uses a custom service
-  // UUID pair. Name always starts with "OBDLink".
+  // OBDLink MX+ — Scantool's premium STN-chip adapter, custom service
+  // UUID pair. The matcher is the model-specific "obdlink mx" so the
+  // LX / CX siblings below get their own profiles (#1641).
   Obd2AdapterProfile(
     id: 'obdlink-mx',
     displayName: 'OBDLink MX+',
     serviceUuid: '000018f0-0000-1000-8000-00805f9b34fb',
     writeCharUuid: '00002af1-0000-1000-8000-00805f9b34fb',
     notifyCharUuid: '00002af0-0000-1000-8000-00805f9b34fb',
-    nameMatchers: ['obdlink'],
+    nameMatchers: ['obdlink mx'],
+  ),
+  // OBDLink LX — Scantool's mid-range STN-chip BLE adapter (#1641).
+  // Same custom 18F0 service family as the MX+.
+  Obd2AdapterProfile(
+    id: 'obdlink-lx',
+    displayName: 'OBDLink LX',
+    serviceUuid: '000018f0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '00002af1-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '00002af0-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['obdlink lx'],
+  ),
+  // OBDLink CX — Scantool's newest STN-chip BLE adapter, CAN-FD
+  // capable, popular with BMW owners (#1641).
+  Obd2AdapterProfile(
+    id: 'obdlink-cx',
+    displayName: 'OBDLink CX',
+    serviceUuid: '000018f0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '00002af1-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '00002af0-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['obdlink cx'],
   ),
   // Carista OBD2 — Nordic UART like vLinker but advertises as
   // "Carista" so it gets its own named profile.
@@ -379,6 +400,76 @@ const List<Obd2AdapterProfile> _defaultProfiles = [
     displayName: 'BAFX 34t5',
     transport: BluetoothTransport.classic,
     nameMatchers: ['bafx'],
+  ),
+  // BlueDriver (Lemur Vehicle Monitors) — premium BLE scan tool, a
+  // long-running Amazon best-seller (#1641). Rides the Nordic-UART
+  // FFF0 family; theoretical until verified on a real device.
+  Obd2AdapterProfile(
+    id: 'bluedriver',
+    displayName: 'BlueDriver',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['bluedriver'],
+  ),
+  // PLX Kiwi 3 — long-lived premium BLE ELM327-compatible adapter
+  // (#1641). Advertises as "Kiwi".
+  Obd2AdapterProfile(
+    id: 'kiwi-3',
+    displayName: 'PLX Kiwi 3',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['kiwi'],
+  ),
+  // LELink / LELink2 — popular low-cost BLE ELM327 clone, common on
+  // Amazon and iOS-friendly (#1641). Nordic-UART FFF0 family.
+  Obd2AdapterProfile(
+    id: 'lelink',
+    displayName: 'LELink BLE',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['lelink'],
+  ),
+  // Topdon TopScan — recent best-selling BLE OBD2 adapter (#1641).
+  // Advertises as "TopScan" / "Topdon".
+  Obd2AdapterProfile(
+    id: 'topdon-topscan',
+    displayName: 'Topdon TopScan',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['topscan', 'topdon'],
+  ),
+  // ANCEL BD310 — dual-mode (app + standalone display) BLE adapter,
+  // a steady Amazon best-seller (#1641). Nordic-UART FFF0 family.
+  Obd2AdapterProfile(
+    id: 'ancel-bd310',
+    displayName: 'ANCEL BD310',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['ancel', 'bd310'],
+  ),
+  // Tonwon Pro — widely-sold low-cost BLE ELM327 clone (#1641).
+  Obd2AdapterProfile(
+    id: 'tonwon',
+    displayName: 'Tonwon Pro BLE',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['tonwon'],
+  ),
+  // NEXAS NexLink — popular BLE OBD2 adapter sold across Amazon EU
+  // (#1641). Nordic-UART FFF0 family.
+  Obd2AdapterProfile(
+    id: 'nexas-nexlink',
+    displayName: 'NEXAS NexLink',
+    serviceUuid: '0000fff0-0000-1000-8000-00805f9b34fb',
+    writeCharUuid: '0000fff2-0000-1000-8000-00805f9b34fb',
+    notifyCharUuid: '0000fff1-0000-1000-8000-00805f9b34fb',
+    nameMatchers: ['nexas', 'nexlink'],
   ),
   // Generic ELM327 BLE fallback. Matches any clone that advertises
   // the FFF0 service but has an unfamiliar name (plenty on Amazon).

--- a/test/features/consumption/data/obd2/adapter_registry_test.dart
+++ b/test/features/consumption/data/obd2/adapter_registry_test.dart
@@ -385,6 +385,96 @@ void main() {
           unorderedEquals(['vlinker-fs-classic', 'vlinker-bm-android-classic']));
     });
   });
+
+  group('catalog integrity (#1651)', () {
+    test('the registry ships at least 20 named adapter profiles', () {
+      // Epic #1641 grew the registry to the 20+ best-selling adapters.
+      // "Named" excludes the two generic-fallback profiles.
+      final named = registry.profiles
+          .where((p) => p.nameMatchers.isNotEmpty)
+          .toList();
+      expect(named.length, greaterThanOrEqualTo(20),
+          reason: 'registry must list >= 20 named adapters (#1641)');
+    });
+
+    test('profile ids are unique', () {
+      final ids = registry.profiles.map((p) => p.id).toList();
+      expect(ids.toSet().length, ids.length,
+          reason: 'every Obd2AdapterProfile.id must be unique');
+    });
+
+    test('no name matcher is ambiguous across profiles', () {
+      // A matcher owned by two profiles of the SAME transport makes
+      // `resolve` order-dependent and ambiguous. Sharing is allowed
+      // only for a BLE+Classic pair of the same adapter (e.g. SmartOBD
+      // ships both transports under one advertised name).
+      final owners = <String, List<Obd2AdapterProfile>>{};
+      for (final p in registry.profiles) {
+        for (final m in p.nameMatchers) {
+          owners.putIfAbsent(m, () => []).add(p);
+        }
+      }
+      final ambiguous = owners.entries.where((e) {
+        final transports = e.value.map((p) => p.transport).toSet();
+        // OK when each sharing profile has a distinct transport.
+        return transports.length != e.value.length;
+      }).toList();
+      expect(ambiguous, isEmpty,
+          reason: 'same-transport profiles share a matcher: '
+              '${ambiguous.map((e) => "${e.key} -> "
+                  "${e.value.map((p) => p.id)}").join(", ")}');
+    });
+
+    test('every generic (matcher-less) profile has a unique service UUID',
+        () {
+      // Matcher-less profiles resolve purely on the advertised service
+      // UUID; two of them sharing a UUID would be a non-deterministic
+      // fallback. Named profiles legitimately share the FFF0 family.
+      final genericUuids = registry.profiles
+          .where((p) => p.nameMatchers.isEmpty && p.serviceUuid.isNotEmpty)
+          .map((p) => p.serviceUuid.toLowerCase())
+          .toList();
+      expect(genericUuids.toSet().length, genericUuids.length,
+          reason: 'matcher-less fallback profiles must not share a '
+              'service UUID');
+    });
+
+    test('every profile carries a valid compatibility enum value', () {
+      for (final p in registry.profiles) {
+        expect(Obd2AdapterCompatibility.values, contains(p.compatibility),
+            reason: '${p.id} has an invalid compatibility value');
+      }
+    });
+
+    test('every BLE profile defines all three GATT UUIDs', () {
+      for (final p in registry.profiles
+          .where((p) => p.transport == BluetoothTransport.ble)) {
+        expect(p.serviceUuid, isNotEmpty, reason: '${p.id} serviceUuid');
+        expect(p.writeCharUuid, isNotEmpty, reason: '${p.id} writeCharUuid');
+        expect(p.notifyCharUuid, isNotEmpty,
+            reason: '${p.id} notifyCharUuid');
+      }
+    });
+
+    test('the #1641 best-seller additions resolve by name', () {
+      expect(
+          registry.resolve(_candidate(name: 'BlueDriver', services: []))?.id,
+          'bluedriver');
+      expect(
+          registry.resolve(_candidate(name: 'OBDLink LX', services: []))?.id,
+          'obdlink-lx');
+      expect(
+          registry.resolve(_candidate(name: 'OBDLink CX', services: []))?.id,
+          'obdlink-cx');
+      expect(
+          registry.resolve(_candidate(name: 'TopScan', services: []))?.id,
+          'topdon-topscan');
+      // The tightened MX matcher still catches the MX+.
+      expect(
+          registry.resolve(_candidate(name: 'OBDLink MX+', services: []))?.id,
+          'obdlink-mx');
+    });
+  });
 }
 
 Obd2AdapterCandidate _candidate({


### PR DESCRIPTION
## Summary

Epic **#1641** — grows the OBD2 adapter registry to the best-selling adapters. Resolves **#1648**, **#1649**, **#1650**, **#1651**.

## #1648 — sourcing decisions
Plain Amazon **search** links (no affiliate program — no disclosure obligation; search URLs don't rot like product ASINs); **amazon.de** reference marketplace (the name query works on any marketplace/retailer); links **doc-only**, not an in-app field. Recorded in `obd2-adapters.md`.

## #1649 — registry expansion
9 new `Obd2AdapterProfile` entries — OBDLink LX/CX, BlueDriver, PLX Kiwi 3, LELink, Topdon TopScan, ANCEL BD310, Tonwon Pro, NEXAS NexLink — for **20+ named adapters**. Each has name matchers + GATT UUIDs, `theoretical` compatibility. `obdlink-mx`'s matcher tightened `obdlink` → `obdlink mx` so LX/CX resolve distinctly.

## #1650 — guide refresh
`docs/guides/obd2-adapters.md` rebuilt: 20+ adapters, per-adapter Amazon buy-link column, the #1648 decisions. The GitHub-wiki `User-*-Consumption-OBD2.md` pages mirror this doc (doc is source of truth; wiki sync is a manual publish step).

## #1651 — integrity tests
≥20 named profiles, unique ids, no same-transport matcher collisions, generic profiles have unique service UUIDs, valid compatibility enums, BLE profiles define all 3 GATT UUIDs, new adapters resolve by name.

## Test plan
- `flutter analyze` + module-boundary check — clean
- `flutter test test/lint/ test/features/consumption/data/obd2/` — 962 pass (44 registry tests incl. the new #1651 group)

Closes #1648
Closes #1649
Closes #1650
Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
