### PR TITLE
feat(vehicle): VeLearner η_v convergence band in the calibration UI (#1626)

### DIFF
--- a/lib/features/vehicle/data/ve_learner.dart
+++ b/lib/features/vehicle/data/ve_learner.dart
@@ -319,6 +319,21 @@ class VeLearner {
   }
 }
 
+/// The ± half-width of the η_v convergence band for a profile with
+/// [sampleCount] accepted plein-complet reconciliations (#1626).
+///
+/// [VeLearner]'s EWMA blend does not track per-sample variance, so the
+/// band is a sample-count heuristic rather than a true standard error:
+/// with no samples the stored η_v is just the catalog default and can
+/// be off by ~0.10; each accepted tankful tightens the estimate.
+/// Decays as `0.10 / (sampleCount + 1)` and is clamped to `[0.01,
+/// 0.10]` so a long-calibrated profile still reports a small, honest
+/// band rather than implying zero uncertainty.
+double veConvergenceHalfWidth(int sampleCount) {
+  final n = sampleCount < 0 ? 0 : sampleCount;
+  return (0.10 / (n + 1)).clamp(0.01, 0.10).toDouble();
+}
+
 /// Default sample-count heuristic: trip duration in seconds ≈ sample
 /// count, because OBD2 polling hovers near 1 Hz. Falls back to a
 /// 50-sample floor when either timestamp is missing but the trip

--- a/lib/features/vehicle/presentation/widgets/calibration_section.dart
+++ b/lib/features/vehicle/presentation/widgets/calibration_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../l10n/app_localizations.dart';
+import '../../data/ve_learner.dart';
 import '../../domain/entities/reference_vehicle.dart';
 import '../../domain/entities/vehicle_profile.dart';
 
@@ -359,12 +360,17 @@ class _CalibrationSectionState extends State<CalibrationSection> {
   }
 
   String _learnerStatus(AppLocalizations? l) {
-    final eta = _formatDouble(widget.profile.volumetricEfficiency);
     final samples = widget.profile.volumetricEfficiencySamples;
     if (samples == 0) {
       return l?.calibrationLearnerStatusNoSamples ??
           'η_v: 0.85 (default — no plein-complet yet)';
     }
+    // #1626 — show the ± convergence band so the user sees how settled
+    // the learned η_v is. Folded into the `eta` placeholder so the
+    // existing parameterised ARB strings need no signature change.
+    final etaValue = _formatDouble(widget.profile.volumetricEfficiency);
+    final band = _formatDouble(veConvergenceHalfWidth(samples));
+    final eta = '$etaValue ± $band';
     if (samples < 3) {
       return l?.calibrationLearnerStatusLearning(eta, samples) ??
           'η_v: $eta (learning, $samples samples)';

--- a/test/features/vehicle/data/ve_learner_test.dart
+++ b/test/features/vehicle/data/ve_learner_test.dart
@@ -525,6 +525,37 @@ void main() {
       }
     });
   });
+
+  group('veConvergenceHalfWidth (#1626 convergence band)', () {
+    test('an unlearned profile (0 samples) reports the widest band', () {
+      expect(veConvergenceHalfWidth(0), 0.10);
+    });
+
+    test('the band narrows monotonically as samples accumulate', () {
+      var prev = veConvergenceHalfWidth(0);
+      for (var n = 1; n <= 30; n++) {
+        final v = veConvergenceHalfWidth(n);
+        expect(v, lessThanOrEqualTo(prev),
+            reason: 'band at $n samples ($v) must not exceed $n-1 ($prev)');
+        prev = v;
+      }
+    });
+
+    test('decays as 0.10 / (samples + 1)', () {
+      expect(veConvergenceHalfWidth(1), closeTo(0.05, 1e-9));
+      expect(veConvergenceHalfWidth(4), closeTo(0.02, 1e-9));
+    });
+
+    test('a long-calibrated profile keeps a small but non-zero band', () {
+      // Clamped floor — never implies zero uncertainty.
+      expect(veConvergenceHalfWidth(1000), 0.01);
+      expect(veConvergenceHalfWidth(9), closeTo(0.01, 1e-9));
+    });
+
+    test('a negative sample count is treated as zero (defensive)', () {
+      expect(veConvergenceHalfWidth(-5), 0.10);
+    });
+  });
 }
 
 /// In-memory trip history so the learner can exercise the time


### PR DESCRIPTION
## Summary

Epic #1611 — adds the η_v **convergence band** to the calibration UI.

`veConvergenceHalfWidth(sampleCount)` returns the ± half-width: `0.10 / (samples + 1)` clamped to `[0.01, 0.10]`. The EWMA learner tracks no per-sample variance, so it is an honest sample-count heuristic — widest while η_v is the catalog default, narrowing per accepted plein-complet, never zero.

`CalibrationSection` now shows `η_v: 0.88 ± 0.03 (learning, 2 samples)` — the band is folded into the existing `eta` ARB placeholder, so no string-signature change and no translation tail.

**Retroactive recompute (criterion 2) → split to #1858.** A precise rescale of stored trips on an η_v override change needs each `TripSummary` to record the η_v it was integrated with — a schema field that doesn't exist. #1858 adds that provenance field + the recompute and migration test.

## Test plan
- `flutter analyze` + module-boundary check — clean
- `flutter test test/lint/ test/features/vehicle/data/ve_learner_test.dart` + calibration_section suite — 71 pass (incl. 5 new band tests)

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)
