### PR TITLE
fix(consumption): bake EXIF orientation before pump-display OCR (#1711)

### DIFF
--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
 
 import 'pump_display_parser.dart';
@@ -126,15 +127,45 @@ class ReceiptScanService {
     return image?.path;
   }
 
+  /// Runs ML Kit text recognition on the capture at [path].
+  ///
+  /// #1711 — `InputImage.fromFilePath` does not reliably honour a
+  /// JPEG's EXIF orientation tag, so a phone held in portrait while
+  /// photographing a landscape pump display delivered the image to the
+  /// recognizer rotated 90° — which ML Kit's general recognizer cannot
+  /// read, the dominant cause of the pump-display OCR failures. We OCR
+  /// an EXIF-upright temp copy and delete it immediately; the original
+  /// [path] is untouched for the bad-scan reporting flow.
   Future<String?> _recognise(String path) async {
+    String? uprightTemp;
     try {
-      final inputImage = InputImage.fromFilePath(path);
+      uprightTemp = await _writeUprightCopy(path);
+      final inputImage = InputImage.fromFilePath(uprightTemp ?? path);
       final recognized = await _recognizer.processImage(inputImage);
       final text = recognized.text;
       debugPrint('OCR text (${text.length} chars):\n$text');
       return text;
     } catch (e, st) {
       debugPrint('OCR scan failed: $e\n$st');
+      return null;
+    } finally {
+      if (uprightTemp != null) await _tryDelete(uprightTemp);
+    }
+  }
+
+  /// Decodes the JPEG at [path], bakes its EXIF orientation into the
+  /// pixels, and writes the upright result to a sibling temp file —
+  /// returns that temp path, or null when the image cannot be decoded
+  /// (the caller then OCRs the original unchanged).
+  Future<String?> _writeUprightCopy(String path) async {
+    try {
+      final upright = bakeImageOrientation(await File(path).readAsBytes());
+      if (upright == null) return null;
+      final tempPath = '$path.upright.jpg';
+      await File(tempPath).writeAsBytes(upright);
+      return tempPath;
+    } catch (e, st) {
+      debugPrint('OCR orientation-bake failed: $e\n$st');
       return null;
     }
   }
@@ -155,5 +186,30 @@ class ReceiptScanService {
 
   void dispose() {
     _recognizer.close();
+  }
+}
+
+/// Re-encodes [jpegBytes] with any EXIF orientation baked into the
+/// pixel data (#1711).
+///
+/// A camera capture stores the raw sensor orientation plus an EXIF tag
+/// describing how to rotate it for display. ML Kit's
+/// `InputImage.fromFilePath` does not reliably apply that tag, so a
+/// sideways capture reaches the recognizer rotated and OCR fails. This
+/// applies the rotation to the pixels and clears the tag, so the
+/// recognizer always sees an upright image.
+///
+/// Returns the upright JPEG bytes, or `null` when the input cannot be
+/// decoded as a JPEG — the caller then OCRs the original unchanged.
+Uint8List? bakeImageOrientation(Uint8List jpegBytes) {
+  try {
+    final decoded = img.decodeJpg(jpegBytes);
+    if (decoded == null) return null;
+    final upright = img.bakeOrientation(decoded);
+    return img.encodeJpg(upright, quality: 90);
+  } catch (e, st) {
+    // A malformed / non-JPEG file is not fatal — OCR the original.
+    debugPrint('bakeImageOrientation: decode failed: $e\n$st');
+    return null;
   }
 }

--- a/test/features/consumption/data/receipt_scan_service_test.dart
+++ b/test/features/consumption/data/receipt_scan_service_test.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:image/image.dart' as img;
 import 'package:image_picker/image_picker.dart';
 import 'package:tankstellen/features/consumption/data/pump_display_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
@@ -311,6 +313,43 @@ void main() {
       expect(outcome.parse.totalCost, 20);
       expect(outcome.ocrText, 'hello');
       expect(outcome.imagePath, '/tmp/x.jpg');
+    });
+  });
+
+  group('bakeImageOrientation (#1711)', () {
+    test('rotates an EXIF-orientation-6 image upright — dimensions swap',
+        () {
+      // An 80×40 landscape image tagged orientation 6 ("rotate 90° CW")
+      // displays as 40×80. Baking the rotation into the pixels must
+      // produce a 40×80 upright image — the fix for the sideways
+      // pump-display photos that ML Kit could not read.
+      final src = img.Image(width: 80, height: 40);
+      img.fill(src, color: img.ColorRgb8(40, 80, 120));
+      src.exif.imageIfd['Orientation'] = 6;
+      final tagged = Uint8List.fromList(img.encodeJpg(src));
+
+      final baked = bakeImageOrientation(tagged);
+      expect(baked, isNotNull);
+      final out = img.decodeJpg(baked!)!;
+      expect(out.width, 40);
+      expect(out.height, 80);
+    });
+
+    test('leaves an already-upright image unchanged in dimensions', () {
+      final src = img.Image(width: 100, height: 60);
+      img.fill(src, color: img.ColorRgb8(10, 20, 30));
+      final upright = Uint8List.fromList(img.encodeJpg(src));
+
+      final baked = bakeImageOrientation(upright);
+      expect(baked, isNotNull);
+      final out = img.decodeJpg(baked!)!;
+      expect(out.width, 100);
+      expect(out.height, 60);
+    });
+
+    test('returns null for non-JPEG / garbage bytes', () {
+      final garbage = Uint8List.fromList(List.generate(64, (i) => i % 256));
+      expect(bakeImageOrientation(garbage), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes **#1711** — a real French fuel-pump photo where the OCR read neither the litres nor the price.

## Root cause
OCR-stage, not parse-stage. `InputImage.fromFilePath` does not reliably honour a JPEG's EXIF orientation tag, so a phone held in portrait photographing a landscape pump display handed ML Kit a 90°-rotated image — which its general recognizer cannot read. (Confirmed against the #1714 failure corpus: orientation is the dominant cause.)

## Fix
`ReceiptScanService._recognise` decodes the capture, bakes the EXIF rotation into the pixels (`bakeImageOrientation`, via the `image` package), and OCRs an upright temp copy — deleted as soon as recognition returns. The original photo is untouched for the bad-scan reporting flow; a decode failure is non-fatal (falls back to the original bytes).

The secondary corpus causes — 7-segment font, glare, wide framing, low contrast — are split to **#1860** (capture-guide reticle + contrast preprocessing).

## Test plan
- `flutter analyze` + module-boundary check — clean
- `flutter test test/lint/ test/features/consumption/data/` — 1501 pass, incl. 3 new `bakeImageOrientation` tests (orientation-6 dimension swap, upright no-op, garbage → null)

Closes #1711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
