### PR TITLE
fix(search): scope results to the search type — no EV/fuel mixing (#1866)

### DIFF
--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -130,14 +130,16 @@ class SearchState extends _$SearchState {
           );
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
-      // EV search runs concurrently with the fuel fetch — see
-      // finalizeUnifiedResult for the merge.
-      final evFuture = beginEvSearch(
-        ref,
-        lat: position.latitude,
-        lng: position.longitude,
-        radiusKm: resolved.radiusKm,
-      );
+      // #1866 — EV runs concurrently ONLY for an EV-intent search; a
+      // fuel search stays fuel-only (evFuture null → fuel-only feed).
+      final evFuture = isEvSearch(resolved.fuelType)
+          ? beginEvSearch(
+              ref,
+              lat: position.latitude,
+              lng: position.longitude,
+              radiusKm: resolved.radiusKm,
+            )
+          : null;
 
       // Reverse-geocode for a postal code (Prix-Carburants + co).
       final addr = await tryReverseGeocode(
@@ -197,12 +199,15 @@ class SearchState extends _$SearchState {
       if (!ref.mounted) return;
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
-      final evFuture = beginEvSearch(
-        ref,
-        lat: coordsResult.data.lat,
-        lng: coordsResult.data.lng,
-        radiusKm: resolved.radiusKm,
-      );
+      // #1866 — EV merges only for an EV-intent search.
+      final evFuture = isEvSearch(resolved.fuelType)
+          ? beginEvSearch(
+              ref,
+              lat: coordsResult.data.lat,
+              lng: coordsResult.data.lng,
+              radiusKm: resolved.radiusKm,
+            )
+          : null;
 
       final cityName = await tryReverseGeocode(
         geocoding, coordsResult.data.lat, coordsResult.data.lng,
@@ -270,12 +275,15 @@ class SearchState extends _$SearchState {
       }
 
       final resolved = resolveFuelAndRadius(ref, fuelType, radiusKm);
-      final evFuture = beginEvSearch(
-        ref,
-        lat: lat,
-        lng: lng,
-        radiusKm: resolved.radiusKm,
-      );
+      // #1866 — EV merges only for an EV-intent search.
+      final evFuture = isEvSearch(resolved.fuelType)
+          ? beginEvSearch(
+              ref,
+              lat: lat,
+              lng: lng,
+              radiusKm: resolved.radiusKm,
+            )
+          : null;
 
       final params = SearchParams(
         lat: lat,

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -95,7 +95,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'3bce5186b862e574dbd6741610e239b736f7a783';
+String _$searchStateHash() => r'354af7ae78668d3b2e400afc4df4f62900aa1223';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///

--- a/lib/features/search/providers/search_provider_orchestration.dart
+++ b/lib/features/search/providers/search_provider_orchestration.dart
@@ -46,6 +46,16 @@ Future<void> autoUpdatePositionIfEnabled(Ref ref) async {
   );
 }
 
+/// True when [fuelType] denotes an EV charging search (#1866).
+///
+/// EV charging stations may only appear in the result feed when the
+/// user explicitly searched for them — `FuelType.electric` is that
+/// signal. Every other fuel type — including the `all` wildcard, which
+/// means "all *fuels*" — is a fuel search and must not merge EV
+/// results in. `SearchNotifier` gates [beginEvSearch] on this so a
+/// fuel search returns fuel stations only, and vice versa.
+bool isEvSearch(FuelType fuelType) => fuelType == FuelType.electric;
+
 /// Reverse-geocodes [lat], [lng] to a human-readable address. Returns
 /// `null` on failure (network error, no result) — every caller treats
 /// reverse geocoding as a non-fatal optional step. Errors are logged
@@ -112,14 +122,17 @@ Future<void> beginEvSearch(
       .searchNearby(lat: lat, lng: lng, radiusKm: radiusKm);
 }
 
-/// Awaits the concurrently-started [evFuture] and merges its outcome
-/// with [fuelResult] into the unified [SearchResultItem] feed (#1781 /
-/// #1782).
+/// Builds the final [SearchResultItem] feed so it always matches the
+/// search intent (#1866): a search is either a fuel search or an EV
+/// search, never both, so the two kinds are never mixed in one feed.
 ///
-/// When [evFuture] is `null` (unified search disabled) the fuel result
-/// is wrapped on its own. Partial-failure-tolerant: an EV-side error is
-/// folded into the merged result's `errors` while the fuel results
-/// still render — see [mergeFuelAndEvResults].
+///   * [evFuture] is `null` — a fuel search. [fuelResult] is wrapped on
+///     its own; no EV rows.
+///   * [evFuture] is non-null — an EV search. It is awaited and the EV
+///     outcome is returned alone; the [fuelResult] the caller still
+///     fetched is discarded so no fuel row leaks into an EV feed. An
+///     EV-side error becomes an empty result carrying that error so the
+///     freshness banner can still report the OpenChargeMap outage.
 Future<AsyncValue<ServiceResult<List<SearchResultItem>>>>
     finalizeUnifiedResult(
   Ref ref,
@@ -132,9 +145,28 @@ Future<AsyncValue<ServiceResult<List<SearchResultItem>>>>
   await evFuture;
   return AsyncValue.data(
     ref.read(eVSearchStateProvider).when(
-          data: (ev) => mergeFuelAndEvResults(fuel: fuelResult, ev: ev),
-          loading: () => mergeFuelAndEvResults(fuel: fuelResult),
-          error: (e, _) => mergeFuelAndEvResults(fuel: fuelResult, evError: e),
+          data: wrapEvResultAsSearchItems,
+          loading: _emptyEvSearchResult,
+          error: (e, _) => _emptyEvSearchResult(evError: e),
         ),
   );
 }
+
+/// An empty EV [SearchResultItem] feed, optionally carrying [evError]
+/// so an EV search that failed still surfaces the OpenChargeMap outage
+/// in the freshness / fallback banner (#1866).
+ServiceResult<List<SearchResultItem>> _emptyEvSearchResult({Object? evError}) =>
+    ServiceResult<List<SearchResultItem>>(
+      data: const [],
+      source: ServiceSource.openChargeMapApi,
+      fetchedAt: DateTime.now(),
+      errors: evError == null
+          ? const []
+          : [
+              ServiceError(
+                source: ServiceSource.openChargeMapApi,
+                message: evError.toString(),
+                occurredAt: DateTime.now(),
+              ),
+            ],
+    );

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -796,7 +796,7 @@ void main() {
     });
   });
 
-  group('EV dispatch — unified fuel + EV search', () {
+  group('EV dispatch — results match the search intent (#1866)', () {
     void stubFuel() {
       when(() => mockStationService.searchStations(any(),
               cancelToken: any(named: 'cancelToken')))
@@ -807,9 +807,11 @@ void main() {
               ));
     }
 
-    test('fetches fuel AND EV and merges both kinds into one list',
+    test('a fuel search returns fuel stations only — no EV rows leak in',
         () async {
       stubFuel();
+      // The EV fake WOULD return a charging station — the fuel search
+      // must still not surface it.
       final container = createContainerUnified(_OneStationEVSearchState());
 
       await container.read(searchStateProvider.notifier).searchByCoordinates(
@@ -819,17 +821,12 @@ void main() {
             radiusKm: 7.0,
           );
 
-      // Fuel service WAS called (not short-circuited by EV dispatch).
-      verify(() => mockStationService.searchStations(
-            any(),
-            cancelToken: any(named: 'cancelToken'),
-          )).called(1);
       final items = container.read(searchStateProvider).value!.data;
       expect(items.whereType<FuelStationResult>(), hasLength(1));
-      expect(items.whereType<EVStationResult>(), hasLength(1));
+      expect(items.whereType<EVStationResult>(), isEmpty);
     });
 
-    test('electric fuel type is no longer EV-exclusive under unified search',
+    test('an EV search returns EV stations only — no fuel rows leak in',
         () async {
       stubFuel();
       final container = createContainerUnified(_OneStationEVSearchState());
@@ -842,12 +839,11 @@ void main() {
           );
 
       final items = container.read(searchStateProvider).value!.data;
-      // Electric selected, yet fuel stations still appear alongside EV.
-      expect(items.whereType<FuelStationResult>(), hasLength(1));
       expect(items.whereType<EVStationResult>(), hasLength(1));
+      expect(items.whereType<FuelStationResult>(), isEmpty);
     });
 
-    test('EV failure is tolerated — fuel results survive, error recorded',
+    test('an EV search whose EV fetch fails records the OpenChargeMap error',
         () async {
       stubFuel();
       final container = createContainerUnified(_FailingEVSearchState());
@@ -855,13 +851,13 @@ void main() {
       await container.read(searchStateProvider.notifier).searchByCoordinates(
             lat: 52.52,
             lng: 13.41,
-            fuelType: FuelType.e10,
+            fuelType: FuelType.electric,
             radiusKm: 7.0,
           );
 
       final result = container.read(searchStateProvider).value!;
-      expect(result.data.whereType<FuelStationResult>(), hasLength(1));
-      expect(result.data.whereType<EVStationResult>(), isEmpty);
+      // EV search failed → empty feed; no fuel rows leak in to mask it.
+      expect(result.data, isEmpty);
       expect(
         result.errors.where((e) => e.source == ServiceSource.openChargeMapApi),
         hasLength(1),


### PR DESCRIPTION
## Summary

A fuel search showed EV charging stations and an EV search showed fuel
stations — the result feed never matched what the user searched for.

Root cause: every `SearchNotifier` entry point ran `beginEvSearch`
unconditionally and `finalizeUnifiedResult` always merged both kinds.

## Fix

A search is now either a fuel search **or** an EV search, never both:

- `isEvSearch(FuelType)` — `FuelType.electric` is the only EV signal;
  the `all` wildcard means "all *fuels*" and stays a fuel search.
- `searchByGps` / `searchByZipCode` / `searchByCoordinates` only start
  `beginEvSearch` for an EV-intent search; a fuel search passes a null
  `evFuture` and stays fuel-only.
- `finalizeUnifiedResult` returns the EV outcome alone for an EV search
  — the concurrently-fetched fuel result is discarded so no fuel row
  leaks into an EV feed. An EV-side failure becomes an empty feed
  carrying the OpenChargeMap error for the freshness banner.

## Tests

The EV-dispatch group now asserts the result kind always matches the
search type: a fuel search → fuel rows only; an EV search → EV rows
only; a failed EV search → empty feed + recorded OpenChargeMap error.

`flutter analyze` clean; `test/lint/` + `test/features/search/` — 774
passing.

Closes #1866

🤖 Generated with [Claude Code](https://claude.com/claude-code)
