### PR TITLE
feat(consumption): contrast-preprocess pump-display captures for OCR (#1860)

### DIFF
--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -105,7 +105,10 @@ class ReceiptScanService {
   Future<PumpDisplayScanOutcome?> scanPumpDisplay() async {
     final capture = await _capture();
     if (capture == null) return null;
-    final text = await _recognise(capture);
+    // #1860 — the pump path runs an extra grayscale + contrast pass so
+    // ML Kit can read 7-segment LCDs and sky-washed displays. Scoped
+    // here so the prose-receipt OCR is not affected.
+    final text = await _recognise(capture, enhanceContrast: true);
     if (text == null) {
       await _tryDelete(capture);
       return null;
@@ -136,10 +139,14 @@ class ReceiptScanService {
   /// read, the dominant cause of the pump-display OCR failures. We OCR
   /// an EXIF-upright temp copy and delete it immediately; the original
   /// [path] is untouched for the bad-scan reporting flow.
-  Future<String?> _recognise(String path) async {
+  ///
+  /// #1860 — when [enhanceContrast] is set (the pump-display path) the
+  /// temp copy also gets a grayscale + histogram-normalise + contrast
+  /// pass so 7-segment LCDs and washed-out displays become readable.
+  Future<String?> _recognise(String path, {bool enhanceContrast = false}) async {
     String? uprightTemp;
     try {
-      uprightTemp = await _writeUprightCopy(path);
+      uprightTemp = await _writeUprightCopy(path, enhanceContrast: enhanceContrast);
       final inputImage = InputImage.fromFilePath(uprightTemp ?? path);
       final recognized = await _recognizer.processImage(inputImage);
       final text = recognized.text;
@@ -157,9 +164,19 @@ class ReceiptScanService {
   /// pixels, and writes the upright result to a sibling temp file —
   /// returns that temp path, or null when the image cannot be decoded
   /// (the caller then OCRs the original unchanged).
-  Future<String?> _writeUprightCopy(String path) async {
+  ///
+  /// #1860 — with [enhanceContrast] the temp copy is additionally run
+  /// through [preprocessPumpDisplayForOcr] (grayscale + normalise +
+  /// contrast); otherwise it is the plain [bakeImageOrientation] path.
+  Future<String?> _writeUprightCopy(
+    String path, {
+    bool enhanceContrast = false,
+  }) async {
     try {
-      final upright = bakeImageOrientation(await File(path).readAsBytes());
+      final bytes = await File(path).readAsBytes();
+      final upright = enhanceContrast
+          ? preprocessPumpDisplayForOcr(bytes)
+          : bakeImageOrientation(bytes);
       if (upright == null) return null;
       final tempPath = '$path.upright.jpg';
       await File(tempPath).writeAsBytes(upright);
@@ -210,6 +227,42 @@ Uint8List? bakeImageOrientation(Uint8List jpegBytes) {
   } catch (e, st) {
     // A malformed / non-JPEG file is not fatal — OCR the original.
     debugPrint('bakeImageOrientation: decode failed: $e\n$st');
+    return null;
+  }
+}
+
+/// Re-encodes a pump-display capture for OCR (#1860).
+///
+/// Bakes EXIF orientation (exactly as [bakeImageOrientation] does) and
+/// then applies a three-step enhancement pass:
+///
+///   1. **grayscale** — colour carries no signal on a monochrome LCD
+///      and only adds noise for the recognizer.
+///   2. **histogram normalise** — stretches the tonal range to the
+///      full 0–255 span, the fix for sky-washed / grey-on-grey
+///      displays whose digits and background sit a few levels apart.
+///   3. **contrast boost** — crisps the 7-segment edges so ML Kit's
+///      general recognizer stops dropping/misreading segment digits.
+///
+/// Scoped to the pump-display path only — [scanReceipt]'s prose-receipt
+/// OCR keeps the plain [bakeImageOrientation] path, since this much
+/// contrast would crush faint thermal-receipt print and regress
+/// full-page recognition (#1860 acceptance).
+///
+/// Returns the processed JPEG bytes, or `null` when the input cannot be
+/// decoded as a JPEG — the caller then OCRs the original unchanged.
+Uint8List? preprocessPumpDisplayForOcr(Uint8List jpegBytes) {
+  try {
+    final decoded = img.decodeJpg(jpegBytes);
+    if (decoded == null) return null;
+    final upright = img.bakeOrientation(decoded);
+    final gray = img.grayscale(upright);
+    final normalized = img.normalize(gray, min: 0, max: 255);
+    final boosted = img.contrast(normalized, contrast: 140);
+    return img.encodeJpg(boosted, quality: 90);
+  } catch (e, st) {
+    // A malformed / non-JPEG file is not fatal — OCR the original.
+    debugPrint('preprocessPumpDisplayForOcr: decode failed: $e\n$st');
     return null;
   }
 }

--- a/test/features/consumption/data/receipt_scan_service_test.dart
+++ b/test/features/consumption/data/receipt_scan_service_test.dart
@@ -352,4 +352,64 @@ void main() {
       expect(bakeImageOrientation(garbage), isNull);
     });
   });
+
+  group('preprocessPumpDisplayForOcr (#1860)', () {
+    /// Scans every pixel and returns the min/max red-channel value —
+    /// on a grayscale image r == g == b, so this is the tonal range.
+    ({int min, int max}) luminanceSpan(img.Image im) {
+      var lo = 255;
+      var hi = 0;
+      for (final p in im) {
+        final v = p.r.round();
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+      }
+      return (min: lo, max: hi);
+    }
+
+    test('stretches a low-contrast capture toward the full tonal range',
+        () {
+      // A washed-out display: every pixel sits in a narrow 100–140
+      // grey band. After preprocessing the band must span far more of
+      // the 0–255 range so the digits separate from the background.
+      final src = img.Image(width: 40, height: 40);
+      for (final p in src) {
+        final shade = p.y < 20 ? 100 : 140;
+        p.setRgb(shade, shade, shade);
+      }
+      final before = luminanceSpan(src);
+      expect(before.max - before.min, lessThan(60),
+          reason: 'fixture must start as a genuinely low-contrast image.');
+
+      final out = preprocessPumpDisplayForOcr(
+          Uint8List.fromList(img.encodeJpg(src)));
+      expect(out, isNotNull);
+      final after = luminanceSpan(img.decodeJpg(out!)!);
+      expect(after.max - after.min, greaterThan(150),
+          reason: 'normalise + contrast must widen the tonal range so a '
+              'washed-out 7-segment LCD becomes legible.');
+    });
+
+    test('bakes EXIF orientation upright — dimensions swap, like #1711',
+        () {
+      // An 80×40 image tagged orientation 6 displays as 40×80; the
+      // pump path must apply the same orientation bake the plain path
+      // does before it enhances contrast.
+      final src = img.Image(width: 80, height: 40);
+      img.fill(src, color: img.ColorRgb8(60, 60, 60));
+      src.exif.imageIfd['Orientation'] = 6;
+
+      final out = preprocessPumpDisplayForOcr(
+          Uint8List.fromList(img.encodeJpg(src)));
+      expect(out, isNotNull);
+      final decoded = img.decodeJpg(out!)!;
+      expect(decoded.width, 40);
+      expect(decoded.height, 80);
+    });
+
+    test('returns null for non-JPEG / garbage bytes', () {
+      final garbage = Uint8List.fromList(List.generate(64, (i) => i % 256));
+      expect(preprocessPumpDisplayForOcr(garbage), isNull);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

7-segment LCDs and sky-washed pump displays defeated ML Kit's general
text recognizer even on an EXIF-upright image. #1711 fixed orientation;
the #1714 corpus analysis flagged low contrast as the next failure
cause.

`preprocessPumpDisplayForOcr` adds, on top of the orientation bake:

1. **grayscale** — colour carries no signal on a monochrome LCD.
2. **histogram normalise** — stretches the tonal range to 0–255, the
   fix for grey-on-grey / sky-washed displays.
3. **contrast boost** — crisps the 7-segment edges.

It is wired only into `scanPumpDisplay` via a new `enhanceContrast`
flag; `scanReceipt`'s prose-receipt OCR keeps the plain
`bakeImageOrientation` path so faint thermal-receipt print is not
crushed (#1860 acceptance: scoped to the pump path).

## Scope

#1860 bundled three items that are not one task:

- **Framing reticle** → split to **#1868** — `image_picker` delegates
  to the native camera, so a reticle overlay needs a custom in-app
  camera screen.
- **Contrast preprocessing** → this PR.
- **Multi-rotation OCR fallback** (optional) → dropped as redundant
  with the #1711 EXIF bake.

## Tests

`preprocessPumpDisplayForOcr` is covered for the tonal-range stretch
(low-contrast fixture widens to >150 span), the EXIF-orientation bake,
and the non-JPEG null fallback. `flutter analyze` clean; `test/lint/`
green; `receipt_scan_service_test.dart` — 15 passing.

Closes #1860

🤖 Generated with [Claude Code](https://claude.com/claude-code)
