### PR TITLE
chore(search): remove orphaned mergeFuelAndEvResults helper + tests (#1870)

### DIFF
--- a/lib/features/search/providers/search_result_helpers.dart
+++ b/lib/features/search/providers/search_result_helpers.dart
@@ -67,52 +67,6 @@ ServiceResult<List<SearchResultItem>> wrapEvResultAsSearchItems(
   );
 }
 
-/// Merges a fuel and an EV [ServiceResult] into one mixed
-/// [SearchResultItem] feed for the unified fuel + EV search results
-/// (#1781 / #1782).
-///
-/// Fuel is the primary feed — its [ServiceResult.source] and
-/// `fetchedAt` are carried through, and fuel results lead the list.
-/// EV is additive and **partial-failure-tolerant**: when the EV side
-/// failed, [ev] is null and [evError] carries the cause (e.g. a
-/// keyless `NoEvApiKeyException`, the default for users without an
-/// OpenChargeMap key). The fuel results still render and the EV
-/// failure is recorded as a [ServiceError] so the status banner can
-/// surface "OpenChargeMap unavailable" without blanking the screen.
-///
-/// `isStale` and the `errors` list are unioned across both sides.
-ServiceResult<List<SearchResultItem>> mergeFuelAndEvResults({
-  required ServiceResult<List<Station>> fuel,
-  ServiceResult<List<ChargingStation>>? ev,
-  Object? evError,
-}) {
-  final items = <SearchResultItem>[
-    ...fuel.data.map((s) => FuelStationResult(s)),
-  ];
-  final errors = <ServiceError>[...fuel.errors];
-  var isStale = fuel.isStale;
-
-  if (ev != null) {
-    items.addAll(ev.data.map((cs) => EVStationResult(cs)));
-    errors.addAll(ev.errors);
-    isStale = isStale || ev.isStale;
-  } else if (evError != null) {
-    errors.add(ServiceError(
-      source: ServiceSource.openChargeMapApi,
-      message: evError.toString(),
-      occurredAt: DateTime.now(),
-    ));
-  }
-
-  return ServiceResult(
-    data: items,
-    source: fuel.source,
-    fetchedAt: fuel.fetchedAt,
-    isStale: isStale,
-    errors: errors,
-  );
-}
-
 /// Returns a copy of [result] with [stations] replacing `result.data`.
 /// Used after distance recalculation where only the station list
 /// changes — every other `ServiceResult` field (source, fetchedAt,

--- a/test/features/search/providers/search_result_helpers_test.dart
+++ b/test/features/search/providers/search_result_helpers_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
@@ -154,88 +153,6 @@ void main() {
         fetchedAt: DateTime(2024, 1, 1),
       ));
       expect(wrapped.data, isEmpty);
-    });
-  });
-
-  group('mergeFuelAndEvResults', () {
-    const ev1 = ChargingStation(
-      id: 'ev-1',
-      name: 'OCM 1',
-      latitude: 52.5,
-      longitude: 13.4,
-    );
-
-    ServiceResult<List<ChargingStation>> evResult(
-      List<ChargingStation> stations, {
-      bool isStale = false,
-      List<ServiceError> errors = const [],
-    }) {
-      return ServiceResult(
-        data: stations,
-        source: ServiceSource.openChargeMapApi,
-        fetchedAt: DateTime(2024, 1, 1, 12),
-        isStale: isStale,
-        errors: errors,
-      );
-    }
-
-    test('both sides succeed — fuel + EV items in one mixed list', () {
-      final merged = mergeFuelAndEvResults(
-        fuel: fuelResult(const [berlinStation]),
-        ev: evResult(const [ev1]),
-      );
-      expect(merged.data, hasLength(2));
-      expect(merged.data.whereType<FuelStationResult>(), hasLength(1));
-      expect(merged.data.whereType<EVStationResult>(), hasLength(1));
-      // Fuel leads the list and owns source / fetchedAt.
-      expect(merged.data.first, isA<FuelStationResult>());
-      expect(merged.source, ServiceSource.tankerkoenigApi);
-    });
-
-    test('EV failure is tolerated — fuel still renders, error recorded', () {
-      final merged = mergeFuelAndEvResults(
-        fuel: fuelResult(const [berlinStation]),
-        evError: const NoEvApiKeyException(),
-      );
-      expect(merged.data, hasLength(1));
-      expect(merged.data.single, isA<FuelStationResult>());
-      expect(merged.errors, hasLength(1));
-      expect(merged.errors.single.source, ServiceSource.openChargeMapApi);
-    });
-
-    test('no EV outcome at all → fuel-only feed, no synthetic error', () {
-      final merged =
-          mergeFuelAndEvResults(fuel: fuelResult(const [berlinStation]));
-      expect(merged.data, hasLength(1));
-      expect(merged.errors, isEmpty);
-    });
-
-    test('errors and staleness are unioned across both sides', () {
-      final fuelErr = ServiceError(
-        source: ServiceSource.tankerkoenigApi,
-        message: 'fuel hiccup',
-        occurredAt: DateTime(2024, 1, 1),
-      );
-      final evErr = ServiceError(
-        source: ServiceSource.openChargeMapApi,
-        message: 'ev hiccup',
-        occurredAt: DateTime(2024, 1, 1),
-      );
-      final merged = mergeFuelAndEvResults(
-        fuel: fuelResult(const [berlinStation],
-            isStale: true, errors: [fuelErr]),
-        ev: evResult(const [ev1], errors: [evErr]),
-      );
-      expect(merged.errors, containsAll(<ServiceError>[fuelErr, evErr]));
-      expect(merged.isStale, isTrue);
-    });
-
-    test('a stale EV side propagates isStale even when fuel is fresh', () {
-      final merged = mergeFuelAndEvResults(
-        fuel: fuelResult(const [berlinStation]),
-        ev: evResult(const [ev1], isStale: true),
-      );
-      expect(merged.isStale, isTrue);
     });
   });
 


### PR DESCRIPTION
## Summary

#1866 (PR #1867) made a search strictly fuel **or** EV — `finalizeUnifiedResult` returns one result kind, never a mixed feed. That left `mergeFuelAndEvResults` (`search_result_helpers.dart`) with no production caller.

Verified orphaned: `grep` for `mergeFuelAndEvResults` across `lib/` + `test/` finds only its own definition and its dedicated test group.

## Changes

- Delete `mergeFuelAndEvResults` from `search_result_helpers.dart` (~45 lines).
- Delete the `mergeFuelAndEvResults` test group and the now-unused `core/error/exceptions.dart` import.

The merge *behaviour* is superseded by #1866's "results match the search intent" contract, covered by `search_provider_test.dart`'s EV-dispatch group — **no coverage lost**.

`flutter analyze` clean; `test/lint/` + search provider suites green.

Closes #1870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
