### PR TITLE
docs(obd2): document the iOS BLE-only adapter decision (#1542 phase 8)

### DIFF
--- a/docs/guides/ios-auto-record.md
+++ b/docs/guides/ios-auto-record.md
@@ -319,12 +319,16 @@ shippable:
       forward the option (verified by reading the FBP changelog).
       Major-version migration; budget a half-day for breaking-API
       cleanup in `lib/features/consumption/data/obd2/`.
-- [ ] **MFi adapter decision.** Are we adding an External Accessory
-      / classic-BT path for vLinker FS / OBDLink MX+, or restricting
-      iOS users to BLE adapters only? Document the decision in
-      docs/guides/obd2-adapters.md once it lands.
+- [x] **MFi adapter decision.** Resolved (#1542 phase 8): iOS is
+      BLE-only — Classic-BT ELM327 adapters are not MFi-certified, so
+      an External Accessory path is not buildable for them. No
+      classic-BT path is added; the decision + rationale is documented
+      under "Platform support — iOS vs Android" in
+      docs/guides/obd2-adapters.md.
 - [ ] **On-device verification spike.** Real iPhone + real BLE ELM327.
       Acceptance script in "Phase 5 — Device-test acceptance" above.
-- [ ] **Localise the onboarding copy** (block above) into the 23
-      locales the app already supports. ARB pass; no Dart needed
-      until the screen widget is wired.
+- [x] **Localise the onboarding copy** (block above) — done. The
+      `OnboardingIosStandbyStep` widget is wired into the onboarding
+      wizard and the `iosAutoRecordOnboarding*` ARB keys are present
+      across all supported locales (guarded by
+      `test/l10n/localization_completeness_test.dart`).

--- a/docs/guides/obd2-adapters.md
+++ b/docs/guides/obd2-adapters.md
@@ -48,6 +48,31 @@ Each adapter row carries one of three states, sourced from the
   GATT profile / SPP transport is correct, but if you have one and
   it works (or doesn't), please open an issue so we can promote it.
 
+## Platform support — iOS vs Android (#1542 phase 8)
+
+**iOS supports BLE adapters only.** The `Transport` column in the
+table below distinguishes `BLE` from `Classic BT`:
+
+- **BLE** adapters work on **both Android and iOS**.
+- **Classic BT** (Bluetooth SPP) adapters work on **Android only**.
+
+This is an Apple platform constraint, not a project limitation. iOS
+does not let a third-party app open a Classic-Bluetooth SPP
+connection to an arbitrary device — the accessory must be
+MFi-certified and the app must talk to it through the External
+Accessory framework under Apple's Made-for-iPhone programme. ELM327
+Classic-BT adapters (vLinker FS, the BM-Android variant, BAFX,
+Konnwei, the generic SPP clones) are not MFi-certified, so **no
+amount of app-side work can reach them on iOS** — an External
+Accessory path is not buildable for these adapters.
+
+**Decision (#1542 phase 8):** iOS ships BLE-only adapter support;
+no External Accessory / classic-BT path is added. `flutter_blue_plus`
+on iOS surfaces only BLE peripherals, so the in-app adapter picker
+already shows the right subset with no platform branch. iOS users
+should buy a **BLE** adapter — e.g. vLinker FD/MC, OBDLink
+MX+/LX/CX, Veepeak BLE+, or any generic FFF0 ELM327 BLE clone.
+
 ## Supported adapters
 
 | Display name | Transport | Name matchers | Compatibility | Buy |


### PR DESCRIPTION
## Summary

#1542 phase 8 asked: add an External Accessory / classic-BT path for iOS, or restrict iOS to BLE adapters?

**Decision: iOS is BLE-only.** This isn't a project choice — iOS only lets a third-party app reach a Classic-Bluetooth SPP device via the External Accessory framework, and only when the device is MFi-certified. ELM327 classic-BT clones are not MFi-certified, so an External Accessory path is **not buildable** for them. `flutter_blue_plus` already surfaces only BLE peripherals on iOS, so the adapter picker shows the correct subset with no platform branch.

## Changes (docs-only)

- `obd2-adapters.md` — new "Platform support — iOS vs Android" section: BLE works on both platforms, Classic BT is Android-only, with the rationale.
- `ios-auto-record.md` — ticks the two now-resolved checklist items: the MFi decision (this PR) and the onboarding-copy localisation (`OnboardingIosStandbyStep` is wired into the wizard and its ARB keys are present across all locales, guarded by `localization_completeness_test`).

Part of #1542 (phase 8). Phases 3 / 5 / 7 and the App Store Connect tasks remain hardware- / Mac-gated per the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
