### PR TITLE
feat(ux): seat the nav-bar centre button in a cradle (#1885)

### DIFF
--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -40,9 +40,9 @@ class ShellBottomBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final barHeight = isLandscape ? 48.0 : 64.0;
-    // Portrait: the centre button rises into a transparent strip above
-    // the coloured bar. Landscape keeps the bar flat — no head-room.
-    final rise = isLandscape ? 0.0 : 20.0;
+    // Portrait: the centre button rises into a bar-coloured cradle (see
+    // _centerButton, #1885). Landscape keeps the bar flat — no head-room.
+    final rise = isLandscape ? 0.0 : 24.0;
 
     final primaryIndex = items.indexWhere((i) => i.isPrimary);
 
@@ -98,8 +98,8 @@ class ShellBottomBar extends StatelessWidget {
           height: barHeight + rise,
           child: Stack(
             children: [
-              // Coloured bar pinned to the bottom; the top `rise` strip
-              // stays transparent so the button appears to float.
+              // Coloured bar pinned to the bottom. The top `rise` strip
+              // is where the centre button's cradle protrudes (#1885).
               Positioned(
                 left: 0,
                 right: 0,
@@ -177,12 +177,43 @@ class ShellBottomBar extends StatelessWidget {
   }
 
   /// The raised, primary-tinted centre button for the core action.
+  ///
+  /// Portrait (#1885): the button is seated in a circular *cradle* in
+  /// the bar's own surface colour. The cradle's lower half overlaps the
+  /// flat bar — same colour, so the seam vanishes — and its upper half
+  /// protrudes into the `rise` strip, so the bar appears to rise up and
+  /// embrace the button rather than the button floating on top of it.
+  /// Landscape has no head-room, so the button stays flat in the bar.
   Widget _centerButton(BuildContext context, int i) {
     final theme = Theme.of(context);
     final selected = i == currentIndex;
     final item = items[i];
     final controller = iconControllers[branchForSlot[i]];
     final diameter = isLandscape ? 40.0 : 56.0;
+
+    final button = Material(
+      color: theme.colorScheme.primary,
+      shape: const CircleBorder(),
+      elevation: 4,
+      shadowColor: Colors.black.withValues(alpha: 0.4),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: () => onTap(i),
+        child: SizedBox(
+          width: diameter,
+          height: diameter,
+          child: Center(
+            child: ShellBounceIcon(
+              controller: controller,
+              selected: selected,
+              icon: selected ? item.filledIcon : item.outlinedIcon,
+              iconSize: isLandscape ? 22.0 : 28.0,
+              color: theme.colorScheme.onPrimary,
+            ),
+          ),
+        ),
+      ),
+    );
 
     return Semantics(
       label: item.label,
@@ -191,29 +222,33 @@ class ShellBottomBar extends StatelessWidget {
       excludeSemantics: true,
       child: Tooltip(
         message: item.label,
-        child: Material(
-          color: theme.colorScheme.primary,
-          shape: const CircleBorder(),
-          elevation: 4,
-          shadowColor: Colors.black.withValues(alpha: 0.4),
-          child: InkWell(
-            customBorder: const CircleBorder(),
-            onTap: () => onTap(i),
-            child: SizedBox(
-              width: diameter,
-              height: diameter,
-              child: Center(
-                child: ShellBounceIcon(
-                  controller: controller,
-                  selected: selected,
-                  icon: selected ? item.filledIcon : item.outlinedIcon,
-                  iconSize: isLandscape ? 22.0 : 28.0,
-                  color: theme.colorScheme.onPrimary,
-                ),
+        child: isLandscape
+            ? button
+            : Stack(
+                alignment: Alignment.center,
+                children: [
+                  // Bar-coloured cradle — blends into the bar where it
+                  // overlaps, protrudes as a soft bump above it.
+                  Container(
+                    width: diameter + 20,
+                    height: diameter + 20,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      boxShadow: [
+                        BoxShadow(
+                          color: theme.brightness == Brightness.dark
+                              ? Colors.black.withValues(alpha: 0.4)
+                              : Colors.black.withValues(alpha: 0.12),
+                          blurRadius: 10,
+                          offset: const Offset(0, 1),
+                        ),
+                      ],
+                    ),
+                  ),
+                  button,
+                ],
               ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -157,6 +157,49 @@ void main() {
       expect(material.shape, isA<CircleBorder>());
       expect(material.elevation, greaterThan(0));
     });
+
+    /// Returns the circular cradle Containers (#1885) — circular boxes
+    /// in the bar's own surface colour.
+    Iterable<Container> cradles(WidgetTester tester) {
+      final ctx = tester.element(find.byType(ShellBottomBar));
+      final barColor = Theme.of(ctx).colorScheme.surfaceContainerHighest;
+      return tester.widgetList<Container>(find.byType(Container)).where((c) {
+        final d = c.decoration;
+        return d is BoxDecoration &&
+            d.shape == BoxShape.circle &&
+            d.color == barColor;
+      });
+    }
+
+    testWidgets('portrait — the button is seated in a bar-coloured cradle',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: controllers(3),
+        isLandscape: false,
+        onTap: (_) {},
+      );
+      expect(cradles(tester), isNotEmpty,
+          reason: '#1885 — the centre button sits in a circular cradle '
+              'in the bar surface colour.');
+    });
+
+    testWidgets('landscape — no cradle (the bar is flat, no head-room)',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: controllers(3),
+        isLandscape: true,
+        onTap: (_) {},
+      );
+      expect(cradles(tester), isEmpty);
+    });
   });
 
   group('ShellBottomBar onTap', () {


### PR DESCRIPTION
## Summary

#1874's raised centre button floated in a plain transparent gap above a flat bar — it read as "pasted on top". This seats it in a **cradle** for a cleaner integration, matching the reference design.

## Change

`ShellBottomBar._centerButton` now draws, behind the raised Search button, a circular **cradle** in the bar's own surface colour (`surfaceContainerHighest`) with a soft ambient shadow:

- The cradle's **lower half overlaps the flat bar** — same colour, so the seam vanishes.
- Its **upper half protrudes** into the `rise` strip — the bar appears to rise up and embrace the button.
- The cradle colour follows the bar, so it's correct in light **and** dark themes.

Landscape is unchanged (no head-room → button stays flat). Side tabs, tap targets, and the swipe gesture are untouched.

## Tests

`shell_bottom_bar_test.dart` — two new tests: portrait has a circular bar-coloured cradle behind the button; landscape has none. `flutter analyze` clean; `test/app/` + `test/lint/` green.

Closes #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)
