### PR TITLE
feat(theme): soften the forest-green contrast into a cohesive identity (#1887)

### DIFF
--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -40,9 +40,9 @@ class ShellBottomBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final barHeight = isLandscape ? 48.0 : 64.0;
-    // Portrait: the centre button rises into a transparent strip above
-    // the coloured bar. Landscape keeps the bar flat — no head-room.
-    final rise = isLandscape ? 0.0 : 20.0;
+    // Portrait: the centre button rises into a bar-coloured cradle (see
+    // _centerButton, #1885). Landscape keeps the bar flat — no head-room.
+    final rise = isLandscape ? 0.0 : 24.0;
 
     final primaryIndex = items.indexWhere((i) => i.isPrimary);
 
@@ -98,8 +98,8 @@ class ShellBottomBar extends StatelessWidget {
           height: barHeight + rise,
           child: Stack(
             children: [
-              // Coloured bar pinned to the bottom; the top `rise` strip
-              // stays transparent so the button appears to float.
+              // Coloured bar pinned to the bottom. The top `rise` strip
+              // is where the centre button's cradle protrudes (#1885).
               Positioned(
                 left: 0,
                 right: 0,
@@ -177,12 +177,43 @@ class ShellBottomBar extends StatelessWidget {
   }
 
   /// The raised, primary-tinted centre button for the core action.
+  ///
+  /// Portrait (#1885): the button is seated in a circular *cradle* in
+  /// the bar's own surface colour. The cradle's lower half overlaps the
+  /// flat bar — same colour, so the seam vanishes — and its upper half
+  /// protrudes into the `rise` strip, so the bar appears to rise up and
+  /// embrace the button rather than the button floating on top of it.
+  /// Landscape has no head-room, so the button stays flat in the bar.
   Widget _centerButton(BuildContext context, int i) {
     final theme = Theme.of(context);
     final selected = i == currentIndex;
     final item = items[i];
     final controller = iconControllers[branchForSlot[i]];
     final diameter = isLandscape ? 40.0 : 56.0;
+
+    final button = Material(
+      color: theme.colorScheme.primary,
+      shape: const CircleBorder(),
+      elevation: 4,
+      shadowColor: Colors.black.withValues(alpha: 0.4),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: () => onTap(i),
+        child: SizedBox(
+          width: diameter,
+          height: diameter,
+          child: Center(
+            child: ShellBounceIcon(
+              controller: controller,
+              selected: selected,
+              icon: selected ? item.filledIcon : item.outlinedIcon,
+              iconSize: isLandscape ? 22.0 : 28.0,
+              color: theme.colorScheme.onPrimary,
+            ),
+          ),
+        ),
+      ),
+    );
 
     return Semantics(
       label: item.label,
@@ -191,29 +222,33 @@ class ShellBottomBar extends StatelessWidget {
       excludeSemantics: true,
       child: Tooltip(
         message: item.label,
-        child: Material(
-          color: theme.colorScheme.primary,
-          shape: const CircleBorder(),
-          elevation: 4,
-          shadowColor: Colors.black.withValues(alpha: 0.4),
-          child: InkWell(
-            customBorder: const CircleBorder(),
-            onTap: () => onTap(i),
-            child: SizedBox(
-              width: diameter,
-              height: diameter,
-              child: Center(
-                child: ShellBounceIcon(
-                  controller: controller,
-                  selected: selected,
-                  icon: selected ? item.filledIcon : item.outlinedIcon,
-                  iconSize: isLandscape ? 22.0 : 28.0,
-                  color: theme.colorScheme.onPrimary,
-                ),
+        child: isLandscape
+            ? button
+            : Stack(
+                alignment: Alignment.center,
+                children: [
+                  // Bar-coloured cradle — blends into the bar where it
+                  // overlaps, protrudes as a soft bump above it.
+                  Container(
+                    width: diameter + 20,
+                    height: diameter + 20,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      boxShadow: [
+                        BoxShadow(
+                          color: theme.brightness == Brightness.dark
+                              ? Colors.black.withValues(alpha: 0.4)
+                              : Colors.black.withValues(alpha: 0.12),
+                          blurRadius: 10,
+                          offset: const Offset(0, 1),
+                        ),
+                      ],
+                    ),
+                  ),
+                  button,
+                ],
               ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -22,17 +22,24 @@ const FlexSchemeColor _forestGreen = FlexSchemeColor(
 class AppTheme {
   AppTheme._();
 
-  /// Default light theme (#1757) — calm forest green. Surfaces are a
-  /// soft green-tinted off-white rather than stark white, and the
-  /// accent is the icon's forest green, for a professional,
-  /// low-contrast feel.
+  /// Default light theme (#1757, retuned #1887) — calm forest green.
+  ///
+  /// #1887 — the previous tuning still read as a generic bright-day
+  /// light theme with a stark dark-green accent. The surface
+  /// green-tint is raised well up (`blendLevel` 14 → 26) so every
+  /// surface — scaffold, cards, chrome — is a deliberate soft
+  /// sage-green-tinted off-white. That carries the brand identity
+  /// across the whole app *and* narrows the jarring gap between the
+  /// forest-green filled surfaces and their background, so the accent
+  /// reads as part of a green family rather than a high-contrast
+  /// stamp on white. The forest-green accent itself is unchanged.
   static ThemeData light() {
     return FlexThemeData.light(
       colors: _forestGreen,
       surfaceMode: FlexSurfaceMode.levelSurfacesLowScaffold,
-      blendLevel: 14,
+      blendLevel: 26,
       subThemesData: const FlexSubThemesData(
-        blendOnLevel: 12,
+        blendOnLevel: 18,
         blendOnColors: false,
         useMaterial3Typography: true,
         useM2StyleDividerInM3: true,
@@ -47,12 +54,16 @@ class AppTheme {
   }
 
   /// Dark theme — the forest-green palette adjusted for a dark surface,
-  /// kept coherent with [light] (#1757).
+  /// kept coherent with [light] (#1757, retuned #1887).
+  ///
+  /// #1887 — the surface green-tint is lifted (`blendLevel` 16 → 22)
+  /// in step with [light], so the dark surfaces carry the same
+  /// deliberate green identity rather than reading as neutral charcoal.
   static ThemeData dark() {
     return FlexThemeData.dark(
       colors: _forestGreen.toDark(28),
       surfaceMode: FlexSurfaceMode.levelSurfacesLowScaffold,
-      blendLevel: 16,
+      blendLevel: 22,
       subThemesData: const FlexSubThemesData(
         blendOnLevel: 20,
         useMaterial3Typography: true,

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -157,6 +157,49 @@ void main() {
       expect(material.shape, isA<CircleBorder>());
       expect(material.elevation, greaterThan(0));
     });
+
+    /// Returns the circular cradle Containers (#1885) — circular boxes
+    /// in the bar's own surface colour.
+    Iterable<Container> cradles(WidgetTester tester) {
+      final ctx = tester.element(find.byType(ShellBottomBar));
+      final barColor = Theme.of(ctx).colorScheme.surfaceContainerHighest;
+      return tester.widgetList<Container>(find.byType(Container)).where((c) {
+        final d = c.decoration;
+        return d is BoxDecoration &&
+            d.shape == BoxShape.circle &&
+            d.color == barColor;
+      });
+    }
+
+    testWidgets('portrait — the button is seated in a bar-coloured cradle',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: controllers(3),
+        isLandscape: false,
+        onTap: (_) {},
+      );
+      expect(cradles(tester), isNotEmpty,
+          reason: '#1885 — the centre button sits in a circular cradle '
+              'in the bar surface colour.');
+    });
+
+    testWidgets('landscape — no cradle (the bar is flat, no head-room)',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: controllers(3),
+        isLandscape: true,
+        onTap: (_) {},
+      );
+      expect(cradles(tester), isEmpty);
+    });
   });
 
   group('ShellBottomBar onTap', () {


### PR DESCRIPTION
## Summary

The #1757 forest-green theme read as a generic bright-day light theme with a stark dark-green accent on near-white surfaces — maintainer feedback: *"the green is good but the contrast is far too intense; it shouldn't look like the bright-day look — it should be a real corporate identity."*

## Change

Raises the surface green-tint in `AppTheme` (`flex_color_scheme`):

- light `blendLevel` **14 → 26**, `blendOnLevel` **12 → 18**
- dark `blendLevel` **16 → 22**

Every surface — scaffold, cards, chrome — becomes a deliberate soft sage-green-tinted off-white instead of bright neutral, so the brand identity carries across the whole app. It also **narrows the green-vs-background gap**: the forest-green filled surfaces (record button, nav cradle, tab indicator) now sit on a green-tinted surface, so the accent reads as part of a green family rather than a high-contrast stamp on white.

The `_forestGreen` accent palette itself is unchanged — "the green is good" — only how strongly it tints the surfaces.

`flutter analyze` clean; `test/lint/` + `test/app/` + `test/core/theme/` green (no colour-pin breakage — those suites use the scheme semantically).

## Note

Theme work is iterative — this is the first considered pass; review the rendered result on-device and I'll refine the blend / accent from there.

Closes #1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
