### PR TITLE
feat(ux): match the Trajets record button to the fuel-tab FAB style (#1889)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -149,8 +149,14 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 220),
         child: stage == null
-            ? FilledButton.icon(
+            // #1889 — an extended FAB so the record CTA matches the
+            // fuel tab's "Ajouter un plein" (soft light-green tonal
+            // style) instead of a heavy dark-green FilledButton.
+            // `heroTag: null` — it lives inline, so it must not
+            // contend for the screen-level FAB's hero tag.
+            ? FloatingActionButton.extended(
                 key: const Key('trajets_start_recording_button'),
+                heroTag: null,
                 onPressed: _onStartRecording,
                 icon: Icon(
                   isRecordingActive

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -791,8 +791,9 @@ void main() {
 
         expect(find.text('Start recording'), findsOneWidget);
         expect(find.text('Resume recording'), findsNothing);
-        // FilledButton.icon renders the dot when no trip is active.
-        final button = tester.widget<FilledButton>(
+        // #1889 — the CTA is an extended FAB (matching the fuel tab's
+        // "add" button) and is enabled when no trip is active.
+        final button = tester.widget<FloatingActionButton>(
           find.byKey(const Key('trajets_start_recording_button')),
         );
         expect(button.onPressed, isNotNull);


### PR DESCRIPTION
## Summary

The Consommation screen's two tabs had inconsistent CTAs:

- **Carburant** — "Ajouter un plein": a soft light-green `FloatingActionButton.extended`.
- **Trajets** — "Démarrer l'enregistrement": a heavy dark-green `FilledButton.icon`, off-theme against the rest of the screen.

Maintainer wants the Trajets record button to look like "Ajouter un plein".

## Change

`trajets_tab.dart` — the header CTA goes from `FilledButton.icon` → `FloatingActionButton.extended`. Same `_onStartRecording` handler, same record-dot / visibility icon and Start/Resume labels, same `Key('trajets_start_recording_button')`. It now picks up the FAB theme — the light-green tonal style — identical to "Ajouter un plein".

- Stays **inline** in the tab header: it's that tab's primary CTA, and the `AnimatedSwitcher` → `TripStartProgress` start-up sequence needs the inline slot (a FAB-slot FAB can't host the multi-stage progress widget).
- `heroTag: null` so the inline FAB can't collide with the screen-level fuel/charging FAB's hero tag.

## Tests

`trajets_tab_test.dart` — the idle-state assertion updated to `FloatingActionButton`. `flutter analyze` clean; `test/lint/` + `trajets_tab` + `consumption_screen_trajets_tab` suites green.

Closes #1889

🤖 Generated with [Claude Code](https://claude.com/claude-code)
