### PR TITLE
feat(ux): tighten the Trajets tab for better space efficiency (#1893)

### DIFF
--- a/lib/features/consumption/presentation/widgets/monthly_insights_card.dart
+++ b/lib/features/consumption/presentation/widgets/monthly_insights_card.dart
@@ -94,9 +94,10 @@ class MonthlyInsightsCard extends StatelessWidget {
 
     return Card(
       key: const ValueKey('monthly_insights_card'),
-      margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      // #1893 — tighter margin/padding for Trajets-tab space efficiency.
+      margin: const EdgeInsets.fromLTRB(12, 6, 12, 6),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -115,14 +116,14 @@ class MonthlyInsightsCard extends StatelessWidget {
                 ),
               ),
             ],
-            const SizedBox(height: 12),
+            const SizedBox(height: 8),
             tripsRow,
-            const SizedBox(height: 8),
+            const SizedBox(height: 6),
             driveTimeRow,
-            const SizedBox(height: 8),
+            const SizedBox(height: 6),
             distanceRow,
             if (consumptionRow != null) ...[
-              const SizedBox(height: 8),
+              const SizedBox(height: 6),
               consumptionRow,
             ],
           ],

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -145,7 +145,7 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
     // than starting a new one.
     final isRecordingActive = ref.watch(tripRecordingProvider).isActive;
     final header = Padding(
-      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
       child: AnimatedSwitcher(
         duration: const Duration(milliseconds: 220),
         child: stage == null
@@ -284,14 +284,14 @@ class _TrajetRow extends StatelessWidget {
 
     return Card(
       key: ValueKey('trajet-${entry.id}'),
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
       child: InkWell(
         onTap: onTap,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           child: Row(
             children: [
-              const Icon(Icons.route, size: 28),
+              const Icon(Icons.route, size: 24),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(


### PR DESCRIPTION
## Summary

The Trajets tab was loosely spaced — only ~3 trip rows fit alongside the comparison card. Layout-only tightening:

- **`_TrajetRow`** — inner padding 12 → 8 vertical, route icon 28 → 24, card margin 4 → 3 vertical.
- **`MonthlyInsightsCard`** — padding top 16 → 12, inter-row gaps 12/8 → 8/6, margin 8 → 6 vertical.
- **Trajets header** — record-button padding top 12 → 8.

No structural change; nothing clips, tap targets stay adequate. The fuel tab and other screens are untouched.

`flutter analyze` clean; `trajets_tab` + `monthly_insights` + `test/lint/` (incl. the 400-line file-length guard) green.

Closes #1893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
