### PR TITLE
feat(search): EV results — favourite star + drop the vestigial kind filter (#1896)

### DIFF
--- a/lib/features/search/presentation/widgets/ev_station_card.dart
+++ b/lib/features/search/presentation/widgets/ev_station_card.dart
@@ -13,10 +13,18 @@ class EVStationCard extends StatelessWidget {
   final EVStationResult result;
   final VoidCallback? onTap;
 
+  /// Whether this charging station is favourited (#1896). When
+  /// [onFavoriteTap] is non-null the card renders a favourite star,
+  /// matching the fuel result cards.
+  final bool isFavorite;
+  final VoidCallback? onFavoriteTap;
+
   const EVStationCard({
     super.key,
     required this.result,
     this.onTap,
+    this.isFavorite = false,
+    this.onFavoriteTap,
   });
 
   @override
@@ -152,6 +160,17 @@ class EVStationCard extends StatelessWidget {
                   EvConnectorChips(connectors: connectors),
                 ],
               ),
+              // #1896 — favourite star, matching the fuel result cards.
+              if (onFavoriteTap != null)
+                IconButton(
+                  icon: Icon(
+                    isFavorite ? Icons.star : Icons.star_border,
+                  ),
+                  color: isFavorite ? DarkModeColors.warning(context) : null,
+                  tooltip: l10n?.favorites ?? 'Favorites',
+                  visualDensity: VisualDensity.compact,
+                  onPressed: onFavoriteTap,
+                ),
             ],
           ),
         ),

--- a/lib/features/search/presentation/widgets/mixed_results_filter_chips.dart
+++ b/lib/features/search/presentation/widgets/mixed_results_filter_chips.dart
@@ -8,14 +8,17 @@ import '../../domain/entities/search_result_item.dart';
 import '../../providers/mixed_results_filter_provider.dart';
 import '../../providers/search_provider.dart';
 
-/// Filter chips for the unified fuel + EV results list (#1784):
-/// a Fuel / EV / Both kind selector, and — when EV rows are in the
-/// list — EV connector-type and minimum-power filters.
+/// EV connector-type and minimum-power filter chips for the search
+/// results list (#1784).
 ///
-/// The EV filter row is hidden when there are no EV results, or when
-/// the user has narrowed the list to Fuel-only, so it never shows
-/// filters that cannot affect anything. Only connector types actually
-/// present in the result set get a chip.
+/// Renders nothing unless the result set contains EV rows with at
+/// least one connector type — so it never shows filters that cannot
+/// affect anything. Only connector types actually present in the
+/// result set get a chip.
+///
+/// #1896 — the old Fuel / EV / Both *kind* selector is gone: since
+/// #1866 a search is strictly fuel **or** EV, so the result set is
+/// always single-kind and a kind selector could never do anything.
 class MixedResultsFilterChips extends ConsumerWidget {
   const MixedResultsFilterChips({super.key});
 
@@ -25,7 +28,6 @@ class MixedResultsFilterChips extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final kind = ref.watch(resultKindFilterProvider);
     final connectorFilter = ref.watch(evConnectorFilterProvider);
     final minPower = ref.watch(evMinPowerFilterProvider);
 
@@ -33,89 +35,48 @@ class MixedResultsFilterChips extends ConsumerWidget {
     // so the offered chips stay stable as the user toggles filters.
     final rawItems =
         ref.watch(searchStateProvider).value?.data ?? const <SearchResultItem>[];
-    // No EV rows at all (a fuel-only search) → the kind selector and
-    // EV filters have nothing to act on; render nothing.
-    if (!rawItems.any((i) => i is EVStationResult)) {
-      return const SizedBox.shrink();
-    }
 
     final availableConnectors = <ConnectorType>{
       for (final item in rawItems)
         if (item is EVStationResult)
           ...item.station.connectors.map((c) => c.type),
     };
+    // No EV rows / no connectors → nothing to filter.
+    if (availableConnectors.isEmpty) {
+      return const SizedBox.shrink();
+    }
 
-    final showEvFilters =
-        kind != ResultKind.fuel && availableConnectors.isNotEmpty;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-          child: Row(
-            children: [
-              _chip(
-                label: l10n?.unifiedFilterBoth ?? 'Both',
-                selected: kind == ResultKind.both,
-                onSelected: () => ref
-                    .read(resultKindFilterProvider.notifier)
-                    .set(ResultKind.both),
-              ),
-              const SizedBox(width: 6),
-              _chip(
-                label: l10n?.unifiedFilterFuel ?? 'Fuel',
-                selected: kind == ResultKind.fuel,
-                onSelected: () => ref
-                    .read(resultKindFilterProvider.notifier)
-                    .set(ResultKind.fuel),
-              ),
-              const SizedBox(width: 6),
-              _chip(
-                label: l10n?.unifiedFilterEv ?? 'EV',
-                selected: kind == ResultKind.ev,
-                onSelected: () => ref
-                    .read(resultKindFilterProvider.notifier)
-                    .set(ResultKind.ev),
-              ),
-            ],
-          ),
-        ),
-        if (showEvFilters)
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.fromLTRB(12, 0, 12, 4),
-            child: Row(
-              children: [
-                for (final preset in _powerPresets) ...[
-                  _chip(
-                    label: preset == 0
-                        ? (l10n?.evPowerAny ?? 'Any')
-                        : (l10n?.evPowerKw(preset.round()) ??
-                            '${preset.round()} kW+'),
-                    selected: minPower == preset,
-                    onSelected: () => ref
-                        .read(evMinPowerFilterProvider.notifier)
-                        .set(preset),
-                  ),
-                  const SizedBox(width: 6),
-                ],
-                for (final type in ConnectorType.values)
-                  if (availableConnectors.contains(type)) ...[
-                    _chip(
-                      label: _connectorLabel(type, l10n),
-                      selected: connectorFilter.contains(type),
-                      onSelected: () => ref
-                          .read(evConnectorFilterProvider.notifier)
-                          .toggle(type),
-                    ),
-                    const SizedBox(width: 6),
-                  ],
-              ],
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Row(
+        children: [
+          for (final preset in _powerPresets) ...[
+            _chip(
+              label: preset == 0
+                  ? (l10n?.evPowerAny ?? 'Any')
+                  : (l10n?.evPowerKw(preset.round()) ??
+                      '${preset.round()} kW+'),
+              selected: minPower == preset,
+              onSelected: () => ref
+                  .read(evMinPowerFilterProvider.notifier)
+                  .set(preset),
             ),
-          ),
-      ],
+            const SizedBox(width: 6),
+          ],
+          for (final type in ConnectorType.values)
+            if (availableConnectors.contains(type)) ...[
+              _chip(
+                label: _connectorLabel(type, l10n),
+                selected: connectorFilter.contains(type),
+                onSelected: () => ref
+                    .read(evConnectorFilterProvider.notifier)
+                    .toggle(type),
+              ),
+              const SizedBox(width: 6),
+            ],
+        ],
+      ),
     );
   }
 

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -244,6 +244,11 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                             EVStationResult() => EVStationCard(
                                 key: ValueKey('ev-${item.id}'),
                                 result: item,
+                                isFavorite: isFav,
+                                onFavoriteTap: () => ref
+                                    .read(favoritesProvider.notifier)
+                                    .toggle(item.id,
+                                        rawJson: item.station.toJson()),
                                 onTap: () => context.push('/ev-station',
                                     extra: item.station),
                               ),

--- a/test/features/search/presentation/widgets/ev_station_card_test.dart
+++ b/test/features/search/presentation/widgets/ev_station_card_test.dart
@@ -129,5 +129,46 @@ void main() {
 
       expect(find.text('--'), findsOneWidget);
     });
+
+    group('favourite star (#1896)', () {
+      testWidgets('no star when onFavoriteTap is null', (tester) async {
+        await pumpApp(
+          tester,
+          const EVStationCard(result: EVStationResult(testStation)),
+        );
+        expect(find.byIcon(Icons.star), findsNothing);
+        expect(find.byIcon(Icons.star_border), findsNothing);
+      });
+
+      testWidgets('outlined star when not favourited; tap fires the callback',
+          (tester) async {
+        var tapped = 0;
+        await pumpApp(
+          tester,
+          EVStationCard(
+            result: const EVStationResult(testStation),
+            onFavoriteTap: () => tapped++,
+          ),
+        );
+        expect(find.byIcon(Icons.star_border), findsOneWidget);
+        expect(find.byIcon(Icons.star), findsNothing);
+
+        await tester.tap(find.byIcon(Icons.star_border));
+        expect(tapped, 1);
+      });
+
+      testWidgets('filled star when favourited', (tester) async {
+        await pumpApp(
+          tester,
+          EVStationCard(
+            result: const EVStationResult(testStation),
+            isFavorite: true,
+            onFavoriteTap: () {},
+          ),
+        );
+        expect(find.byIcon(Icons.star), findsOneWidget);
+        expect(find.byIcon(Icons.star_border), findsNothing);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Two fixes on the EV search-results screen.

### Favourite star

`EVStationCard` had no favourite affordance — fuel cards have one, EV cards didn't. Adds `isFavorite` + `onFavoriteTap` and renders the star (outlined → filled when favourited), matching the fuel cards. `search_results_list` wires it through `favoritesProvider` / `isFavoriteProvider` on the EV station id — the favourites store already hydrates EV stations (#1804).

### Kind filter removed

`MixedResultsFilterChips` still rendered a **Fuel / EV / Both** result-kind selector. Since #1866 a search is strictly fuel **or** EV, so the result set is always single-kind — the selector could never do anything; on an EV search it was pure noise. The kind-selector row is gone; the EV connector-type and minimum-power filter chips stay. `resultKindFilterProvider` is left in place (it has a consumer in the filter pipeline and sits inert at its `both` default).

## Tests

`ev_station_card_test.dart` — three new tests: no star without `onFavoriteTap`, outlined star + tap callback, filled star when favourited. `flutter analyze` clean; full `test/features/search/` suite (739) + `test/lint/` green.

Closes #1896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
