### PR TITLE
feat(trajets): fold trip-detail charts into one collapsible section (#1895)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -220,24 +220,44 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
           GpsDiagnosticsCard(
             diagnostics: widget.entry.gpsSampleDiagnostics,
           ),
-        _ChartSection(
-          title: l?.trajetDetailChartSpeed ?? 'Speed (km/h)',
-          chart: TripDetailSpeedChart(samples: widget.samples),
-        ),
-        _ChartSection(
-          title: l?.trajetDetailChartFuelRate ?? 'Fuel rate (L/h)',
-          chart: TripDetailFuelRateChart(samples: widget.samples),
-        ),
-        if (hasRpmSamples)
-          _ChartSection(
-            title: l?.trajetDetailChartRpm ?? 'RPM',
-            chart: TripDetailRpmChart(samples: widget.samples),
+        // #1895 — the per-trip telemetry charts are folded into one
+        // collapsible section, collapsed by default, so the summary
+        // and insight cards above stay the focus on open. maintainState
+        // keeps the chart widgets in the tree while collapsed — the
+        // Share-to-PNG boundary and the widget tests both rely on every
+        // section being present regardless of fold state.
+        Card(
+          margin: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+          clipBehavior: Clip.antiAlias,
+          child: ExpansionTile(
+            title: Text(l?.trajetDetailChartsSection ?? 'Charts'),
+            initiallyExpanded: false,
+            maintainState: true,
+            shape: const Border(),
+            collapsedShape: const Border(),
+            childrenPadding: const EdgeInsets.only(bottom: 4),
+            children: [
+              _ChartSection(
+                title: l?.trajetDetailChartSpeed ?? 'Speed (km/h)',
+                chart: TripDetailSpeedChart(samples: widget.samples),
+              ),
+              _ChartSection(
+                title: l?.trajetDetailChartFuelRate ?? 'Fuel rate (L/h)',
+                chart: TripDetailFuelRateChart(samples: widget.samples),
+              ),
+              if (hasRpmSamples)
+                _ChartSection(
+                  title: l?.trajetDetailChartRpm ?? 'RPM',
+                  chart: TripDetailRpmChart(samples: widget.samples),
+                ),
+              if (hasEngineLoadSamples)
+                _ChartSection(
+                  title: l?.trajetDetailChartEngineLoad ?? 'Engine load (%)',
+                  chart: TripDetailEngineLoadChart(samples: widget.samples),
+                ),
+            ],
           ),
-        if (hasEngineLoadSamples)
-          _ChartSection(
-            title: l?.trajetDetailChartEngineLoad ?? 'Engine load (%)',
-            chart: TripDetailEngineLoadChart(samples: widget.samples),
-          ),
+        ),
       ],
     );
 

--- a/lib/l10n/_fragments/trajets_de.arb
+++ b/lib/l10n/_fragments/trajets_de.arb
@@ -26,6 +26,7 @@
   "trajetDetailChartFuelRate": "Kraftstoffrate (L/h)",
   "trajetDetailChartRpm": "Drehzahl",
   "trajetDetailChartEngineLoad": "Motorlast (%)",
+  "trajetDetailChartsSection": "Diagramme",
   "trajetsRowColdStartChip": "Kaltstart",
   "trajetsRowColdStartTooltip": "Der Motor erreichte während dieser Fahrt nicht die Betriebstemperatur — der Verbrauch war höher als üblich.",
   "trajetDetailChartEmpty": "Keine Messwerte",

--- a/lib/l10n/_fragments/trajets_en.arb
+++ b/lib/l10n/_fragments/trajets_en.arb
@@ -125,6 +125,10 @@
   "@trajetDetailChartEngineLoad": {
     "description": "Section title above the engine-load-over-time chart on the Trip detail screen (#1262 phase 3). Hidden when no sample carries an engineLoadPercent value (cars without OBD2 PID 0x04)."
   },
+  "trajetDetailChartsSection": "Charts",
+  "@trajetDetailChartsSection": {
+    "description": "Header of the collapsible section that groups all per-trip telemetry charts on the Trip detail screen (#1895). Collapsed by default — the trip summary and insight cards stay visible above it."
+  },
   "trajetsRowColdStartChip": "Cold start",
   "@trajetsRowColdStartChip": {
     "description": "Compact chip label rendered on the trip-history row when the trip's coldStartSurcharge flag is true (#1262 phase 3). Tells the user the engine never reached operating temperature, which raised fuel consumption."

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Горивен поток (л/ч)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Натоварване на двигателя (%)",
+  "trajetDetailChartsSection": "Графики",
   "trajetsRowColdStartChip": "Студен старт",
   "trajetsRowColdStartTooltip": "Двигателят не достигна работна температура по време на пътуването — разходът на гориво е бил по-висок от обичайното.",
   "trajetDetailChartEmpty": "Не са записани проби",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Průtok paliva (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Zatížení motoru (%)",
+  "trajetDetailChartsSection": "Grafy",
   "trajetsRowColdStartChip": "Studený start",
   "trajetsRowColdStartTooltip": "Motor nedosáhl provozní teploty během této cesty — spotřeba paliva byla vyšší než obvykle.",
   "trajetDetailChartEmpty": "Žádné vzorky nezaznamenány",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Brændstofrate (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Motorbelastning (%)",
+  "trajetDetailChartsSection": "Diagrammer",
   "trajetsRowColdStartChip": "Koldstart",
   "trajetsRowColdStartTooltip": "Motoren nåede ikke driftstemperatur under denne tur — brændstofforbruget var højere end normalt.",
   "trajetDetailChartEmpty": "Ingen prøver registreret",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1962,6 +1962,7 @@
   "trajetDetailChartFuelRate": "Kraftstoffrate (L/h)",
   "trajetDetailChartRpm": "Drehzahl",
   "trajetDetailChartEngineLoad": "Motorlast (%)",
+  "trajetDetailChartsSection": "Diagramme",
   "trajetsRowColdStartChip": "Kaltstart",
   "trajetsRowColdStartTooltip": "Der Motor erreichte während dieser Fahrt nicht die Betriebstemperatur — der Verbrauch war höher als üblich.",
   "trajetDetailChartEmpty": "Keine Messwerte",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Ροή καυσίμου (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Φόρτωση κινητήρα (%)",
+  "trajetDetailChartsSection": "Γραφήματα",
   "trajetsRowColdStartChip": "Ψυχρή εκκίνηση",
   "trajetsRowColdStartTooltip": "Ο κινητήρας δεν έφτασε σε θερμοκρασία λειτουργίας κατά τη διάρκεια αυτού του ταξιδιού — η κατανάλωση καυσίμου ήταν υψηλότερη από το συνηθισμένο.",
   "trajetDetailChartEmpty": "Δεν καταγράφηκαν δείγματα",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3681,6 +3681,10 @@
   "@trajetDetailChartEngineLoad": {
     "description": "Section title above the engine-load-over-time chart on the Trip detail screen (#1262 phase 3). Hidden when no sample carries an engineLoadPercent value (cars without OBD2 PID 0x04)."
   },
+  "trajetDetailChartsSection": "Charts",
+  "@trajetDetailChartsSection": {
+    "description": "Header of the collapsible section that groups all per-trip telemetry charts on the Trip detail screen (#1895). Collapsed by default — the trip summary and insight cards stay visible above it."
+  },
   "trajetsRowColdStartChip": "Cold start",
   "@trajetsRowColdStartChip": {
     "description": "Compact chip label rendered on the trip-history row when the trip's coldStartSurcharge flag is true (#1262 phase 3). Tells the user the engine never reached operating temperature, which raised fuel consumption."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "⟦Ƒúéł řáŧé (Ł/ĥ) ·····⟧",
   "trajetDetailChartRpm": "⟦ŘƤṀ ·⟧",
   "trajetDetailChartEngineLoad": "⟦Éñǧîñé łóáđ (%) ·····⟧",
+  "trajetDetailChartsSection": "⟦Çĥářŧš ···⟧",
   "trajetsRowColdStartChip": "⟦Çółđ šŧářŧ ····⟧",
   "trajetsRowColdStartTooltip": "⟦Éñǧîñé đîđñ'ŧ řéáçĥ óƥéřáŧîñǧ ŧéɱƥéřáŧúřé đúřîñǧ ŧĥîš ŧřîƥ — ƒúéł çóñšúɱƥŧîóñ ŵáš ĥîǧĥéř ŧĥáñ úšúáł. ·····································⟧",
   "trajetDetailChartEmpty": "⟦Ñó šáɱƥłéš řéçóřđéđ ········⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Caudal de combustible (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Carga del motor (%)",
+  "trajetDetailChartsSection": "Gráficos",
   "trajetsRowColdStartChip": "Arranque en frío",
   "trajetsRowColdStartTooltip": "El motor no alcanzó la temperatura de funcionamiento durante este viaje: el consumo de combustible fue mayor de lo habitual.",
   "trajetDetailChartEmpty": "No se han registrado muestras",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Kütusemäär (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Mootori koormus (%)",
+  "trajetDetailChartsSection": "Graafikud",
   "trajetsRowColdStartChip": "Külmkäivitus",
   "trajetsRowColdStartTooltip": "Mootor ei jõudnud selle reisi jooksul töötemperatuurini — kütusekulu oli tavalisest kõrgem.",
   "trajetDetailChartEmpty": "Näidiseid pole salvestatud",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Polttoaineen kulutus (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Moottorin kuorma (%)",
+  "trajetDetailChartsSection": "Kaaviot",
   "trajetsRowColdStartChip": "Kylmäkäynnistys",
   "trajetsRowColdStartTooltip": "Moottori ei saavuttanut käyntölämpöä tällä matkalla — polttoaineen kulutus oli tavallista suurempi.",
   "trajetDetailChartEmpty": "Ei tallennettuja näytteitä",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1782,6 +1782,7 @@
   "trajetDetailChartFuelRate": "Débit de carburant (L/h)",
   "trajetDetailChartRpm": "Régime (tr/min)",
   "trajetDetailChartEngineLoad": "Charge moteur (%)",
+  "trajetDetailChartsSection": "Graphiques",
   "trajetsRowColdStartChip": "Démarrage à froid",
   "trajetsRowColdStartTooltip": "Le moteur n'a pas atteint sa température de fonctionnement pendant ce trajet — la consommation a été plus élevée que d'habitude.",
   "trajetDetailChartEmpty": "Aucun échantillon enregistré",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Protok goriva (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Opterećenje motora (%)",
+  "trajetDetailChartsSection": "Grafikoni",
   "trajetsRowColdStartChip": "Hladan start",
   "trajetsRowColdStartTooltip": "Motor nije dostigao radnu temperaturu za vrijeme ove vožnje — potrošnja goriva bila je viša od uobičajene.",
   "trajetDetailChartEmpty": "Nema snimljenih uzoraka",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Üzemanyag-arány (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Motorterhelés (%)",
+  "trajetDetailChartsSection": "Diagramok",
   "trajetsRowColdStartChip": "Hidegindítás",
   "trajetsRowColdStartTooltip": "A motor nem érte el az üzemi hőmérsékletet ezen az úton — az üzemanyag-fogyasztás magasabb volt a szokásosnál.",
   "trajetDetailChartEmpty": "Nincsenek rögzített minták",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Flusso carburante (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Carico motore (%)",
+  "trajetDetailChartsSection": "Grafici",
   "trajetsRowColdStartChip": "Avviamento a freddo",
   "trajetsRowColdStartTooltip": "Il motore non ha raggiunto la temperatura di esercizio durante questo percorso — il consumo di carburante era più alto del solito.",
   "trajetDetailChartEmpty": "Nessun campione registrato",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8979,6 +8979,12 @@ abstract class AppLocalizations {
   /// **'Engine load (%)'**
   String get trajetDetailChartEngineLoad;
 
+  /// Header of the collapsible section that groups all per-trip telemetry charts on the Trip detail screen (#1895). Collapsed by default — the trip summary and insight cards stay visible above it.
+  ///
+  /// In en, this message translates to:
+  /// **'Charts'**
+  String get trajetDetailChartsSection;
+
   /// Compact chip label rendered on the trip-history row when the trip's coldStartSurcharge flag is true (#1262 phase 3). Tells the user the engine never reached operating temperature, which raised fuel consumption.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -5027,6 +5027,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Натоварване на двигателя (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Графики';
+
+  @override
   String get trajetsRowColdStartChip => 'Студен старт';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4990,6 +4990,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Zatížení motoru (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafy';
+
+  @override
   String get trajetsRowColdStartChip => 'Studený start';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4985,6 +4985,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Motorbelastning (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagrammer';
+
+  @override
   String get trajetsRowColdStartChip => 'Koldstart';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -5012,6 +5012,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Motorlast (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagramme';
+
+  @override
   String get trajetsRowColdStartChip => 'Kaltstart';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -5030,6 +5030,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Φόρτωση κινητήρα (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Γραφήματα';
+
+  @override
   String get trajetsRowColdStartChip => 'Ψυχρή εκκίνηση';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4958,6 +4958,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Engine load (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Charts';
+
+  @override
   String get trajetsRowColdStartChip => 'Cold start';
 
   @override
@@ -10332,6 +10335,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get trajetDetailChartEngineLoad => '⟦Éñǧîñé łóáđ (%) ·····⟧';
+
+  @override
+  String get trajetDetailChartsSection => '⟦Çĥářŧš ···⟧';
 
   @override
   String get trajetsRowColdStartChip => '⟦Çółđ šŧářŧ ····⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -5024,6 +5024,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Carga del motor (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Gráficos';
+
+  @override
   String get trajetsRowColdStartChip => 'Arranque en frío';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4977,6 +4977,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Mootori koormus (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Graafikud';
+
+  @override
   String get trajetsRowColdStartChip => 'Külmkäivitus';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4987,6 +4987,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Moottorin kuorma (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Kaaviot';
+
+  @override
   String get trajetsRowColdStartChip => 'Kylmäkäynnistys';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -5038,6 +5038,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Charge moteur (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Graphiques';
+
+  @override
   String get trajetsRowColdStartChip => 'Démarrage à froid';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -5001,6 +5001,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Opterećenje motora (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafikoni';
+
+  @override
   String get trajetsRowColdStartChip => 'Hladan start';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -5028,6 +5028,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Motorterhelés (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagramok';
+
+  @override
   String get trajetsRowColdStartChip => 'Hidegindítás';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -5012,6 +5012,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Carico motore (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafici';
+
+  @override
   String get trajetsRowColdStartChip => 'Avviamento a freddo';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -5016,6 +5016,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Variklio apkrova (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagramos';
+
+  @override
   String get trajetsRowColdStartChip => 'Šaltasis paleidimas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -5017,6 +5017,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Dzinēja slodze (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagrammas';
+
+  @override
   String get trajetsRowColdStartChip => 'Aukstais starts';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4983,6 +4983,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Motorbelastning (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagrammer';
+
+  @override
   String get trajetsRowColdStartChip => 'Kaldstart';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -5002,6 +5002,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Motorbelasting (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafieken';
+
+  @override
   String get trajetsRowColdStartChip => 'Koude start';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -5008,6 +5008,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Obciążenie silnika (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Wykresy';
+
+  @override
   String get trajetsRowColdStartChip => 'Zimny start';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -5022,6 +5022,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Carga do motor (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Gráficos';
+
+  @override
   String get trajetsRowColdStartChip => 'Arranque a frio';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -5021,6 +5021,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Sarcină motor (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafice';
+
+  @override
   String get trajetsRowColdStartChip => 'Pornire la rece';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -5006,6 +5006,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Zaťaženie motora (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafy';
+
+  @override
   String get trajetsRowColdStartChip => 'Studený štart';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4990,6 +4990,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Obremenitev motorja (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Grafikoni';
+
+  @override
   String get trajetsRowColdStartChip => 'Hladen zagon';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4986,6 +4986,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get trajetDetailChartEngineLoad => 'Motorbelastning (%)';
 
   @override
+  String get trajetDetailChartsSection => 'Diagram';
+
+  @override
   String get trajetsRowColdStartChip => 'Kallstart';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Kuro norma (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Variklio apkrova (%)",
+  "trajetDetailChartsSection": "Diagramos",
   "trajetsRowColdStartChip": "Šaltasis paleidimas",
   "trajetsRowColdStartTooltip": "Variklis nepasiekė darbinės temperatūros šios kelionės metu — kuro suvartojimas buvo didesnis nei įprastai.",
   "trajetDetailChartEmpty": "Nėra įrašytų mėginių",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Degvielas patēriņš (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Dzinēja slodze (%)",
+  "trajetDetailChartsSection": "Diagrammas",
   "trajetsRowColdStartChip": "Aukstais starts",
   "trajetsRowColdStartTooltip": "Dzinējs šī brauciena laikā nesasniedza darba temperatūru — degvielas patēriņš bija augstāks nekā parasti.",
   "trajetDetailChartEmpty": "Nav ierakstītu paraugu",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Drivstoffrate (L/t)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Motorbelastning (%)",
+  "trajetDetailChartsSection": "Diagrammer",
   "trajetsRowColdStartChip": "Kaldstart",
   "trajetsRowColdStartTooltip": "Motoren nådde ikke driftstemperatur under denne turen – drivstofforbruket var høyere enn vanlig.",
   "trajetDetailChartEmpty": "Ingen prøver registrert",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Brandstofverbruik (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Motorbelasting (%)",
+  "trajetDetailChartsSection": "Grafieken",
   "trajetsRowColdStartChip": "Koude start",
   "trajetsRowColdStartTooltip": "Motor bereikte de bedrijfstemperatuur niet tijdens deze rit — brandstofverbruik was hoger dan normaal.",
   "trajetDetailChartEmpty": "Geen steekproeven geregistreerd",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Przepływ paliwa (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Obciążenie silnika (%)",
+  "trajetDetailChartsSection": "Wykresy",
   "trajetsRowColdStartChip": "Zimny start",
   "trajetsRowColdStartTooltip": "Silnik nie osiągnął temperatury roboczej podczas tej trasy — zużycie paliwa było wyższe niż zwykle.",
   "trajetDetailChartEmpty": "Brak zarejestrowanych próbek",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Caudal de combustível (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Carga do motor (%)",
+  "trajetDetailChartsSection": "Gráficos",
   "trajetsRowColdStartChip": "Arranque a frio",
   "trajetsRowColdStartTooltip": "O motor não atingiu a temperatura de funcionamento durante esta viagem — o consumo de combustível foi superior ao normal.",
   "trajetDetailChartEmpty": "Sem amostras gravadas",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Debit combustibil (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Sarcină motor (%)",
+  "trajetDetailChartsSection": "Grafice",
   "trajetsRowColdStartChip": "Pornire la rece",
   "trajetsRowColdStartTooltip": "Motorul nu a atins temperatura de funcționare în această călătorie — consumul a fost mai mare decât de obicei.",
   "trajetDetailChartEmpty": "Niciun eșantion înregistrat",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Prietok paliva (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Zaťaženie motora (%)",
+  "trajetDetailChartsSection": "Grafy",
   "trajetsRowColdStartChip": "Studený štart",
   "trajetsRowColdStartTooltip": "Motor nedosiahol prevádzkovú teplotu počas tejto jazdy — spotreba paliva bola vyššia ako zvyčajne.",
   "trajetDetailChartEmpty": "Žiadne zaznamenané vzorky",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Pretok goriva (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Obremenitev motorja (%)",
+  "trajetDetailChartsSection": "Grafikoni",
   "trajetsRowColdStartChip": "Hladen zagon",
   "trajetsRowColdStartTooltip": "Motor med to vožnjo ni dosegel obratovalne temperature — poraba goriva je bila višja kot običajno.",
   "trajetDetailChartEmpty": "Ni zabeleženih vzorcev",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1471,6 +1471,7 @@
   "trajetDetailChartFuelRate": "Bränsleflöde (L/h)",
   "trajetDetailChartRpm": "RPM",
   "trajetDetailChartEngineLoad": "Motorbelastning (%)",
+  "trajetDetailChartsSection": "Diagram",
   "trajetsRowColdStartChip": "Kallstart",
   "trajetsRowColdStartTooltip": "Motorn nådde inte driftstemperatur under den här resan – bränsleförbrukningen var högre än normalt.",
   "trajetDetailChartEmpty": "Inga prover inspelade",

--- a/test/features/consumption/presentation/widgets/trip_detail_body_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_detail_body_test.dart
@@ -104,6 +104,11 @@ void main() {
   });
 
   group('TripDetailBody — always-mounted sections', () {
+    // #1895 — the per-trip charts now live inside a collapsible
+    // [ExpansionTile] that is collapsed by default, so their widgets
+    // are offstage on first frame. `maintainState: true` keeps them in
+    // the tree regardless of fold state, so `skipOffstage: false`
+    // asserts on mounting (the share-to-PNG boundary relies on this).
     testWidgets('mounts the summary card and the speed + fuel-rate charts',
         (tester) async {
       await _pump(
@@ -117,8 +122,10 @@ void main() {
       );
 
       expect(find.byType(TripSummaryCard), findsOneWidget);
-      expect(find.byType(TripDetailSpeedChart), findsOneWidget);
-      expect(find.byType(TripDetailFuelRateChart), findsOneWidget);
+      expect(find.byType(TripDetailSpeedChart, skipOffstage: false),
+          findsOneWidget);
+      expect(find.byType(TripDetailFuelRateChart, skipOffstage: false),
+          findsOneWidget);
     });
 
     testWidgets('renders the localized speed and fuel-rate section titles',
@@ -134,8 +141,53 @@ void main() {
       );
 
       // English locale (pumpApp default) — section titles come from ARB.
-      expect(find.text('Speed (km/h)'), findsOneWidget);
-      expect(find.text('Fuel rate (L/h)'), findsOneWidget);
+      expect(find.text('Speed (km/h)', skipOffstage: false), findsOneWidget);
+      expect(
+          find.text('Fuel rate (L/h)', skipOffstage: false), findsOneWidget);
+    });
+  });
+
+  // #1895 — the charts are grouped under one [ExpansionTile], collapsed
+  // by default so the trip summary + insight cards stay the focus.
+  group('TripDetailBody — charts fold (#1895)', () {
+    testWidgets('charts are collapsed (offstage) by default', (tester) async {
+      await _pump(
+        tester,
+        TripDetailBody(
+          entry: _entry(),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+      );
+
+      // The collapsible section header is on screen...
+      expect(find.text('Charts'), findsOneWidget);
+      // ...but the charts themselves are folded away (offstage).
+      expect(find.byType(TripDetailSpeedChart), findsNothing);
+      expect(find.byType(TripDetailSpeedChart, skipOffstage: false),
+          findsOneWidget);
+    });
+
+    testWidgets('tapping the section header reveals the charts',
+        (tester) async {
+      await _pump(
+        tester,
+        TripDetailBody(
+          entry: _entry(),
+          vehicle: _vehicle,
+          samples: const [],
+          isEv: false,
+        ),
+      );
+
+      await tester.ensureVisible(find.text('Charts'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Charts'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TripDetailSpeedChart), findsOneWidget);
+      expect(find.byType(TripDetailFuelRateChart), findsOneWidget);
     });
   });
 
@@ -156,8 +208,11 @@ void main() {
         ),
       );
 
-      expect(find.byType(TripDetailRpmChart), findsOneWidget);
-      expect(find.text('RPM'), findsOneWidget);
+      // #1895 — charts live in a collapsed ExpansionTile; assert on
+      // mounting with skipOffstage so the gating logic is what's tested.
+      expect(find.byType(TripDetailRpmChart, skipOffstage: false),
+          findsOneWidget);
+      expect(find.text('RPM', skipOffstage: false), findsOneWidget);
     });
 
     testWidgets('hides the RPM chart when every sample has null rpm',
@@ -218,8 +273,12 @@ void main() {
         ),
       );
 
-      expect(find.byType(TripDetailEngineLoadChart), findsOneWidget);
-      expect(find.text('Engine load (%)'), findsOneWidget);
+      // #1895 — charts live in a collapsed ExpansionTile; assert on
+      // mounting with skipOffstage so the gating logic is what's tested.
+      expect(find.byType(TripDetailEngineLoadChart, skipOffstage: false),
+          findsOneWidget);
+      expect(
+          find.text('Engine load (%)', skipOffstage: false), findsOneWidget);
     });
 
     testWidgets(
@@ -277,6 +336,15 @@ void main() {
         ),
       );
 
+      // #1895 — expand the collapsible charts section so the chart
+      // widgets are laid out and `getTopLeft` returns real positions.
+      // ensureVisible first: with insight cards present the section
+      // header can sit below the 600-px test-surface fold.
+      await tester.ensureVisible(find.text('Charts'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Charts'));
+      await tester.pumpAndSettle();
+
       final summaryY =
           tester.getTopLeft(find.byType(TripSummaryCard)).dy;
       final speedY =
@@ -309,8 +377,10 @@ void main() {
       );
 
       expect(find.byType(TripSummaryCard), findsOneWidget);
-      expect(find.byType(TripDetailSpeedChart), findsOneWidget);
-      expect(find.byType(TripDetailFuelRateChart), findsOneWidget);
+      expect(find.byType(TripDetailSpeedChart, skipOffstage: false),
+          findsOneWidget);
+      expect(find.byType(TripDetailFuelRateChart, skipOffstage: false),
+          findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## What

The trip-detail screen rendered the four per-trip telemetry charts
(speed, fuel rate, RPM, engine load) as always-expanded sections. That
pushed the trip summary and driving-insight cards — the information a
user actually scans first — far above the fold.

This groups all four charts under **one `ExpansionTile`, collapsed by
default**. The summary and insight cards stay the focus; the charts are
one tap away when wanted.

## Notes

- `maintainState: true` keeps the chart widgets mounted while collapsed,
  so the Share-to-PNG `RepaintBoundary` and the widget tests that assert
  on chart presence/absence still see every section regardless of fold
  state.
- Widget tests updated: mounting assertions now use `skipOffstage:
  false`; position/ordering checks expand the section first. New tests
  cover the collapsed-by-default state and the tap-to-expand behaviour.
- Adds the `trajetDetailChartsSection` ARB key across all 24 locales.

Closes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)
