### PR TITLE
refactor(nav): split Conso into Carburant + Trajets bottom-bar destinations (#1901)

### DIFF
--- a/lib/app/routes/shell_branches.dart
+++ b/lib/app/routes/shell_branches.dart
@@ -7,8 +7,15 @@ import '../../features/profile/presentation/screens/profile_screen.dart';
 import '../../features/search/presentation/screens/search_screen.dart';
 
 /// Branches of the bottom-nav `StatefulShellRoute.indexedStack`. Each branch
-/// owns the top-level route for one tab — Search, Map, Favorites, Consumption
-/// (#778), Profile.
+/// owns the top-level route for one tab — Search, Map, Favorites, Carburant
+/// (#778), Profile, Trajets (#1901).
+///
+/// #1901 — Carburant and Trajets are separate destinations. Carburant
+/// keeps branch index 3 / path `/consumption-tab`; Trajets is appended
+/// as branch 5 so Profile stays at branch 4 (deep links + the Settings
+/// app-bar action depend on that index). Branch order is therefore not
+/// the visual order — `ShellDestinations.branchForSlot` maps visible
+/// slots back to branch indices.
 List<StatefulShellBranch> get shellBranches => [
       StatefulShellBranch(
         routes: [
@@ -34,17 +41,16 @@ List<StatefulShellBranch> get shellBranches => [
           ),
         ],
       ),
-      // Consumption is the 4th tab (#778) — sits between
-      // Favorites and Settings so the "behind-the-wheel savings"
-      // workflow has a first-class entry point. Path stays
-      // `/consumption-tab` to avoid colliding with the existing
-      // `/consumption` deep link (which still pushes on top of
-      // the current branch from station detail etc.).
+      // Carburant — branch 3 (#778). Path stays `/consumption-tab` to
+      // avoid colliding with the `/consumption` deep link (which still
+      // pushes on top of the current branch from station detail etc.).
       StatefulShellBranch(
         routes: [
           GoRoute(
             path: '/consumption-tab',
-            builder: (_, _) => const ConsumptionScreen(),
+            builder: (_, _) => const ConsumptionScreen(
+              section: ConsumptionSection.fuel,
+            ),
           ),
         ],
       ),
@@ -53,6 +59,19 @@ List<StatefulShellBranch> get shellBranches => [
           GoRoute(
             path: '/profile',
             builder: (context, state) => const ProfileScreen(),
+          ),
+        ],
+      ),
+      // Trajets — branch 5 (#1901). Appended after Profile so Profile
+      // keeps branch index 4. Renders the same [ConsumptionScreen] in
+      // its Trajets section.
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            path: '/trajets-tab',
+            builder: (_, _) => const ConsumptionScreen(
+              section: ConsumptionSection.trajets,
+            ),
           ),
         ],
       ),

--- a/lib/app/shell/shell_destinations.dart
+++ b/lib/app/shell/shell_destinations.dart
@@ -3,18 +3,23 @@ import 'package:flutter/material.dart';
 import '../../l10n/app_localizations.dart';
 import 'shell_nav_item.dart';
 
-/// Index of the Consumption branch in the StatefulShellRoute (see
-/// `router.dart`). Public so the shell's "snap selection back to
-/// Search when the consumption features are disabled" branch can refer
-/// to the hidden tab by name rather than a naked `3`.
+/// Router-branch index of the **Carburant** destination in the
+/// StatefulShellRoute (see `shell_branches.dart`). Public so the
+/// shell's "snap selection back to Search when consumption is
+/// disabled" branch can refer to it by name rather than a naked `3`.
 const int kConsumptionBranchIndex = 3;
+
+/// Router-branch index of the **Trajets** destination (#1901). Trajets
+/// is appended after Profile so Profile keeps index 4 — see
+/// `shell_branches.dart`.
+const int kTrajetsBranchIndex = 5;
 
 /// Resolved nav destinations for the current shell render.
 ///
 /// [items] is the list the bottom-bar / rail iterates over, **in
-/// visual order** — Search sits in the centre slot (#1874). [branchForSlot]
-/// maps each visible slot back to its router-branch index, so a tap on
-/// slot N routes to `branchForSlot[N]`.
+/// visual order** — Search sits in the centre slot (#1874).
+/// [branchForSlot] maps each visible slot back to its router-branch
+/// index, so a tap on slot N routes to `branchForSlot[N]`.
 class ShellDestinations {
   final List<ShellNavItem> items;
   final List<int> branchForSlot;
@@ -25,28 +30,28 @@ class ShellDestinations {
   });
 }
 
-/// Build the visible nav destinations, hiding the Conso slot when
-/// [showConsumption] is false.
+/// Build the visible nav destinations.
 ///
-/// ## Layout (#1874)
+/// ## Layout (#1874 / #1901)
 ///
 /// Search — the app's core action — is the centre, raised button; the
-/// other destinations flank it:
+/// other destinations flank it. Consumption is now **two** separate
+/// destinations, Carburant and Trajets (#1901):
 ///
-///   * Conso shown:  `Map · Favorites · [Search] · Consumption`
-///   * Conso hidden: `Map · [Search] · Favorites`
+///   * Conso off:            `Map · [Search] · Favorites`
+///   * Fuel-only mode:       `Map · Favorites · [Search] · Carburant`
+///   * Fuel + Trips mode:    `Map · Favorites · [Search] · Carburant · Trajets`
 ///
 /// Settings is **not** a tab — it lives in the top-right app bar
 /// (`SettingsAppBarAction`), reached via router branch 4 (`/profile`).
 ///
 /// ## Conso gate
 ///
-/// The #893 gate hid Conso "when no vehicle is configured", a catch-22
-/// for the Medium use-mode profile (#1517) — the consumption screen is
-/// where users add their first vehicle. The gate is now driven by
-/// `isConsumptionTabReachable(manifest, enabledFlags)`: true when the
-/// user has either `manualConsumption` OR `obd2TripRecording`
-/// effectively enabled (Medium / Full profiles, not Basic).
+/// [showConsumption] gates the whole consumption surface (true for the
+/// Medium / Full use-mode profiles, false for Basic — see
+/// `isConsumptionTabReachable`). [showTrajets] additionally gates the
+/// Trajets destination: it appears only in the fuel-and-trips ConsoMode
+/// (Full profile). Fuel-only mode shows Carburant alone.
 ///
 /// Pure function — no Flutter state, no Riverpod — kept lean so the
 /// shell can re-resolve on every build without paying provider-read
@@ -54,10 +59,11 @@ class ShellDestinations {
 ShellDestinations resolveShellDestinations({
   required AppLocalizations? l10n,
   required bool showConsumption,
+  required bool showTrajets,
 }) {
-  // Branch indices in `router.dart`: Search=0, Map=1, Favorites=2,
-  // Consumption=3, Settings=4. The visual slot order below differs so
-  // Search lands in the centre.
+  // Branch indices in `shell_branches.dart`: Search=0, Map=1,
+  // Favorites=2, Carburant=3, Settings=4, Trajets=5. The visual slot
+  // order below differs so Search lands in the centre.
   final search = ShellNavItem(
     Icons.search_outlined,
     Icons.search,
@@ -70,20 +76,31 @@ ShellDestinations resolveShellDestinations({
     Icons.star,
     l10n?.favorites ?? 'Favorites',
   );
-  final consumption = ShellNavItem(
+  final carburant = ShellNavItem(
     Icons.local_gas_station_outlined,
     Icons.local_gas_station,
-    l10n?.navConsumption ?? 'Consumption',
+    l10n?.consumptionTabFuel ?? 'Fuel',
+  );
+  final trajets = ShellNavItem(
+    Icons.route_outlined,
+    Icons.route,
+    l10n?.trajetsTabLabel ?? 'Trips',
   );
 
-  if (showConsumption) {
+  if (!showConsumption) {
     return ShellDestinations(
-      items: [map, favorites, search, consumption],
+      items: [map, search, favorites],
+      branchForSlot: const [1, 0, 2],
+    );
+  }
+  if (!showTrajets) {
+    return ShellDestinations(
+      items: [map, favorites, search, carburant],
       branchForSlot: const [1, 2, 0, 3],
     );
   }
   return ShellDestinations(
-    items: [map, search, favorites],
-    branchForSlot: const [1, 0, 2],
+    items: [map, favorites, search, carburant, trajets],
+    branchForSlot: const [1, 2, 0, 3, kTrajetsBranchIndex],
   );
 }

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../core/storage/storage_providers.dart';
 import '../core/utils/frame_callbacks.dart';
 import '../features/feature_management/application/feature_flags_provider.dart';
+import '../features/feature_management/domain/conso_mode.dart';
 import '../features/feature_management/domain/consumption_tab_visibility.dart';
 import '../features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host.dart';
 import '../l10n/app_localizations.dart';
@@ -53,10 +54,11 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
   /// otherwise stop on the hidden Conso branch, #893).
   List<int> _branchForSlot = const [0, 1, 2, 3, 4];
 
-  /// Upper bound on destination count — the router always registers 5
-  /// branches (see StatefulShellRoute in router.dart), the UI decides
-  /// how many are visible.
-  static const _pageCount = 5;
+  /// Upper bound on destination count — the router registers 6
+  /// branches (#1901: Search, Map, Favorites, Carburant, Profile,
+  /// Trajets — see `shell_branches.dart`); the UI decides how many
+  /// are visible.
+  static const _pageCount = 6;
 
   @override
   void initState() {
@@ -213,31 +215,53 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     final manifest = ref.watch(featureManifestProvider);
     final enabledFlags = ref.watch(enabledFeaturesProvider);
     final showConsumption = isConsumptionTabReachable(manifest, enabledFlags);
+    // #1901 — Trajets is its own destination, shown only in the
+    // fuel-and-trips ConsoMode (the Full use-mode profile). Fuel-only
+    // mode shows Carburant alone.
+    final showTrajets =
+        consoModeFromFlags(enabledFlags) == ConsoMode.fuelAndTrips;
     final destinations = resolveShellDestinations(
       l10n: l10n,
       showConsumption: showConsumption,
+      showTrajets: showTrajets,
     );
     final visibleDestinations = destinations.items;
     final branchForSlot = destinations.branchForSlot;
     _branchForSlot = branchForSlot;
 
-    // If the user was on the Conso tab and just disabled the gating
-    // features (e.g. switched profile from Full to Basic), snap the
-    // selection to Search (branch 0) — the Conso slot is gone from
-    // the nav bar and leaving `_currentIndex` pointing at it would
-    // leave no item highlighted.
-    if (!showConsumption && _currentIndex == kConsumptionBranchIndex) {
+    // If the user was on a consumption destination and just disabled
+    // the gating features (e.g. switched profile from Full to Basic),
+    // snap the selection to Search (branch 0) — the Carburant/Trajets
+    // slots are gone and leaving `_currentIndex` on one would leave no
+    // item highlighted.
+    final onConsumptionBranch = _currentIndex == kConsumptionBranchIndex ||
+        _currentIndex == kTrajetsBranchIndex;
+    if (!showConsumption && onConsumptionBranch) {
       // #1690 — the tab vanishing + the selection jumping is silent
       // and confusing; tell the user a profile change hid the tab.
       final tabHiddenNotice = l10n?.consumptionTabHiddenNotice ??
           'The Consumption tab was hidden by your profile settings.';
       safePostFrame(() {
         if (!mounted) return;
-        if (_currentIndex != kConsumptionBranchIndex) return;
+        if (_currentIndex != kConsumptionBranchIndex &&
+            _currentIndex != kTrajetsBranchIndex) {
+          return;
+        }
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(tabHiddenNotice)),
         );
         _goToPage(0);
+      });
+    } else if (showConsumption &&
+        !showTrajets &&
+        _currentIndex == kTrajetsBranchIndex) {
+      // #1901 — the Trajets slot vanished (switched to fuel-only mode)
+      // while the user was on it; fall back to Carburant rather than
+      // strand the selection on a now-hidden branch.
+      safePostFrame(() {
+        if (!mounted) return;
+        if (_currentIndex != kTrajetsBranchIndex) return;
+        _goToPage(kConsumptionBranchIndex);
       });
     }
 

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -10,7 +10,6 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/tab_switcher.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
-import '../../../feature_management/domain/conso_mode.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
@@ -24,20 +23,32 @@ import '../widgets/obd2_status_chip.dart';
 import '../widgets/trajets_tab.dart';
 import 'add_charging_log_screen.dart';
 
-/// Lists all logged fill-ups and charging sessions.
+/// Which slice of the consumption feature a [ConsumptionScreen] renders.
 ///
-/// Three-tab scaffold (#582 phase 2 + #889):
-///   * **Fuel** — existing fill-up list with its CSV export + stats card.
-///   * **Trajets** — OBD2 trip history, with a per-tab "Start
-///     recording" CTA.
-///   * **Charging** — EV charging logs backed by [chargingLogsProvider]
-///     with monthly cost-trend and efficiency charts.
+/// #1901 — Carburant and Trajets are now separate bottom-bar
+/// destinations (each its own router branch) rather than two tabs of a
+/// single screen, so the screen is parameterised by section instead of
+/// hosting an in-screen tab bar.
+enum ConsumptionSection { fuel, trajets }
+
+/// Lists logged fill-ups (and EV charging sessions) or OBD2 trips,
+/// depending on [section].
 ///
-/// The FAB rebinds to the active tab so the user always sees the
-/// most obvious "log what I just did" action for the list they're
-/// looking at — no hidden overflow menu entries.
+/// - **[ConsumptionSection.fuel]** — the fill-up list with its CSV
+///   export + stats card. For a vehicle that can charge (hybrid / EV)
+///   a compact Fuel / Charging switcher is shown so the user picks
+///   either energy form; a pure-combustion vehicle just sees fuel.
+/// - **[ConsumptionSection.trajets]** — OBD2 trip history, with its
+///   own "Start recording" CTA in the tab header.
 class ConsumptionScreen extends ConsumerStatefulWidget {
-  const ConsumptionScreen({super.key});
+  /// Which section to render. Defaults to [ConsumptionSection.fuel] so
+  /// the bare `/consumption-tab` route keeps its historical behaviour.
+  final ConsumptionSection section;
+
+  const ConsumptionScreen({
+    super.key,
+    this.section = ConsumptionSection.fuel,
+  });
 
   /// Test-only override for the backup exporter wired into the AppBar
   /// download button (#1317). Lets widget tests assert the export
@@ -55,15 +66,13 @@ class ConsumptionScreen extends ConsumerStatefulWidget {
 
 class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     with TickerProviderStateMixin {
-  // Lazily created in the first `build`. Recreated whenever the
-  // active vehicle's powertrain flips the Charging tab on/off (#892):
-  // TabController requires its `length` to match the TabBar's `tabs`
-  // length exactly, so we tear down the old controller and instantiate
-  // a fresh one with the new length (clamping the selected index so
-  // the user doesn't land on a missing tab).
+  // Fuel / Charging sub-switcher controller, lazily created in `build`.
+  // Only relevant for [ConsumptionSection.fuel] on a vehicle that can
+  // charge; null otherwise. Recreated when the Charging slot appears /
+  // disappears (a TabController's `length` must match its tab count).
   TabController? _tabController;
 
-  /// Whether the Charging tab should appear for the given vehicle.
+  /// Whether the Charging slot should appear for the given vehicle.
   ///
   /// - ICE (`VehicleType.combustion`) → false
   /// - Hybrid / EV → true
@@ -74,38 +83,22 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     return vehicle.isEv;
   }
 
-  void _ensureTabController({
-    required bool showTrajets,
-    required bool showCharging,
-    int? preferredIndex,
-  }) {
-    final newLength = 1 + (showTrajets ? 1 : 0) + (showCharging ? 1 : 0);
-    final previous = _tabController;
-    if (previous != null && previous.length == newLength) {
+  /// Ensure a 2-tab (Fuel / Charging) controller exists, or tear it
+  /// down when charging is not applicable.
+  void _ensureFuelChargingController({required bool showCharging}) {
+    if (!showCharging) {
+      _tabController?.dispose();
+      _tabController = null;
       return;
     }
-
-    // Clamp the previous index into the new controller's range so we
-    // don't strand the user on a now-missing tab. When the Charging
-    // tab vanishes while the user is on it, fall back to Trajets when
-    // it's visible or Fuel otherwise — closest neighbour in the
-    // mental model of "what I was just looking at".
-    final oldIndex = preferredIndex ?? previous?.index ?? 0;
-    final initialIndex = oldIndex.clamp(0, newLength - 1);
-
-    final controller = TabController(
-      length: newLength,
-      vsync: this,
-      initialIndex: initialIndex,
-    );
+    if (_tabController != null && _tabController!.length == 2) return;
+    final controller = TabController(length: 2, vsync: this);
     controller.addListener(() {
-      // The FAB label changes when the tab changes, so trigger a
-      // rebuild on every tab transition (indexIsChanging covers the
-      // animated swipe case too).
+      // The FAB label changes with the sub-tab, so rebuild on change.
       if (!mounted) return;
       setState(() {});
     });
-    previous?.dispose();
+    _tabController?.dispose();
     _tabController = controller;
   }
 
@@ -157,80 +150,11 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final fillUps = ref.watch(fillUpListProvider);
-    final chargingLogsAsync = ref.watch(chargingLogsProvider);
-    final stats = ref.watch(consumptionStatsProvider);
-    final activeVehicle = ref.watch(activeVehicleProfileProvider);
-    final showCharging = _shouldShowCharging(activeVehicle);
-    // #1573 — Trajets sub-tab is visible only in the Trajets-tier
-    // ConsoMode (fuel + trips). The Fuel-only mode (manual fill-up
-    // tier, the Medium use-mode) renders the Conso screen with just
-    // the Fuel sub-tab; OBD2-driven trip history has nothing to show
-    // without trip recording enabled, and the empty tab confused
-    // Medium users. Reading ConsoMode directly is clearer than
-    // walking the dependency graph for obd2TripRecording.
-    final enabledFlags = ref.watch(enabledFeaturesProvider);
-    final showTrajets = consoModeFromFlags(enabledFlags) ==
-        ConsoMode.fuelAndTrips;
-    // Recreate the TabController when the tab-set cardinality
-    // changes (#892, #conso-coherence). Doing this in build — rather
-    // than in initState — lets us react to live vehicle switches /
-    // feature-flag toggles without a ref.listen round-trip, and
-    // keeps the controller's length always consistent with the
-    // rendered Tab list (length mismatch throws at runtime).
-    _ensureTabController(
-      showTrajets: showTrajets,
-      showCharging: showCharging,
-    );
-    final tabController = _tabController!;
-    final l = AppLocalizations.of(context);
-
-    // #815 — surface the η_v calibration outcome as a one-shot
-    // snackbar when the fill-up save path learns a new value for the
-    // active vehicle. Listening here (rather than in the fill-up
-    // screen) keeps the snackbar visible after the fill-up form
-    // pops, which is the screen the user actually sees.
-    ref.listen(lastVeLearnResultProvider, (previous, next) {
-      if (next == null) return;
-      final vehicles = ref.read(vehicleProfileListProvider);
-      final vehicle = vehicles
-          .where((v) => v.id == next.vehicleId)
-          .firstOrNull;
-      final name = vehicle?.name ?? '';
-      final percent = next.accuracyImprovementPct.round().toString();
-      final msg = l?.veCalibratedTitle(name, percent) ??
-          'Consumption calibration updated for $name — '
-              'accuracy improved by $percent%';
-      SnackBarHelper.showSuccess(context, msg);
-      // Clear so a rebuild doesn't re-fire the snackbar on the next
-      // unrelated rebuild (e.g. the user deleting a fill-up).
-      ref.read(lastVeLearnResultProvider.notifier).set(null);
-    });
-
-    // Tab indices shift based on which optional tabs are present:
-    //   Fuel is always slot 0.
-    //   Trajets sits at slot 1 when `showTrajets` is true.
-    //   Charging sits at the next slot after that (slot 1 when
-    //   Trajets is hidden; slot 2 when Trajets is shown).
-    // The FAB rebinds per-tab: Fuel → pick-station sheet, Trajets
-    // hides the FAB (the "Start recording" CTA lives in the tab
-    // header), Charging → Add charging log sheet.
-    final trajetsIndex = showTrajets ? 1 : -1;
-    final chargingIndex = showCharging ? (showTrajets ? 2 : 1) : -1;
-    final tabIndex = tabController.index;
-    final isFuelTab = tabIndex == 0;
-    final isTrajetsTab = trajetsIndex >= 0 && tabIndex == trajetsIndex;
-    final isChargingTab = chargingIndex >= 0 && tabIndex == chargingIndex;
-
-    return PageScaffold(
-      title: l?.consumptionLogTitle ?? 'Fuel consumption',
-      bodyPadding: EdgeInsets.zero,
-      actions: [
-        // #797 phase 3 — title-bar chip announcing "OBD2 connected"
-        // when the pinned adapter is currently linked. Hides
-        // itself otherwise so unpaired users see no chrome.
+  /// AppBar actions shared by both sections (#1901): the OBD2 status
+  /// chip, the backup export button, the gated Carbon dashboard entry
+  /// point, and the Settings action.
+  List<Widget> _appBarActions(AppLocalizations? l) => [
+        // #797 phase 3 — title-bar chip announcing "OBD2 connected".
         const Obd2StatusChip(),
         IconButton(
           key: const Key('export_backup'),
@@ -240,7 +164,9 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
         ),
         // #1613 — the Carbon dashboard entry point is gated on the
         // central Feature enum so it can be toggled per profile.
-        if (ref.watch(enabledFeaturesProvider).contains(Feature.carbonDashboard))
+        if (ref
+            .watch(enabledFeaturesProvider)
+            .contains(Feature.carbonDashboard))
           IconButton(
             key: const Key('open_carbon_dashboard'),
             tooltip: l?.carbonDashboardTitle ?? 'Carbon dashboard',
@@ -248,78 +174,106 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
             onPressed: () => context.push('/carbon'),
           ),
         const SettingsAppBarAction(),
-      ],
-      floatingActionButton: isTrajetsTab
-          // Trajets tab hides the global FAB — the "Start recording"
-          // CTA lives inside the tab header, mirroring the fuel-tab
-          // add-fill-up and charging-tab log-charging patterns but
-          // scoped to the list the user is looking at.
-          ? null
-          : FloatingActionButton.extended(
-              key: Key(isFuelTab ? 'fab_add_fillup' : 'fab_add_charging'),
-              onPressed: () async {
-                if (isFuelTab) {
-                  await context.push('/consumption/pick-station');
-                } else if (isChargingTab) {
-                  await Navigator.of(context).push<bool?>(
-                    MaterialPageRoute(
-                      builder: (_) => const AddChargingLogScreen(),
-                    ),
-                  );
-                }
-              },
-              icon: const Icon(Icons.add),
-              label: Text(
-                isFuelTab
-                    ? (l?.addFillUp ?? 'Add fill-up')
-                    : (l?.addChargingLog ?? 'Log charging'),
-              ),
-            ),
-      // #1441 — TabSwitcher lives inside the body so the AppBar height
-      // matches the other top-level tabs (Recherche, Carte, Favoris,
-      // Paramètres). Keeping the switcher in `bottom:` made the AppBar
-      // visually taller than its siblings.
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+
+    // #815 — surface the η_v calibration outcome as a one-shot
+    // snackbar when the fill-up save path learns a new value for the
+    // active vehicle. Listening here keeps the snackbar visible after
+    // the fill-up form pops, which is the screen the user sees.
+    ref.listen(lastVeLearnResultProvider, (previous, next) {
+      if (next == null) return;
+      final vehicles = ref.read(vehicleProfileListProvider);
+      final vehicle =
+          vehicles.where((v) => v.id == next.vehicleId).firstOrNull;
+      final name = vehicle?.name ?? '';
+      final percent = next.accuracyImprovementPct.round().toString();
+      final msg = l?.veCalibratedTitle(name, percent) ??
+          'Consumption calibration updated for $name — '
+              'accuracy improved by $percent%';
+      SnackBarHelper.showSuccess(context, msg);
+      // Clear so a rebuild doesn't re-fire the snackbar.
+      ref.read(lastVeLearnResultProvider.notifier).set(null);
+    });
+
+    return switch (widget.section) {
+      ConsumptionSection.trajets => _buildTrajets(context, l),
+      ConsumptionSection.fuel => _buildFuel(context, l),
+    };
+  }
+
+  /// #1901 — the Trajets destination: OBD2 trip history. No FAB (the
+  /// "Start recording" CTA lives in the tab header) and no in-screen
+  /// tab bar.
+  Widget _buildTrajets(BuildContext context, AppLocalizations? l) {
+    final activeVehicle = ref.watch(activeVehicleProfileProvider);
+    return PageScaffold(
+      title: l?.trajetsTabLabel ?? 'Trips',
+      bodyPadding: EdgeInsets.zero,
+      actions: _appBarActions(l),
+      body: TrajetsTab(vehicleId: activeVehicle?.id),
+    );
+  }
+
+  /// #1901 — the Carburant destination: the fill-up list, plus a Fuel /
+  /// Charging switcher for a vehicle that can charge.
+  Widget _buildFuel(BuildContext context, AppLocalizations? l) {
+    final fillUps = ref.watch(fillUpListProvider);
+    final chargingLogsAsync = ref.watch(chargingLogsProvider);
+    final stats = ref.watch(consumptionStatsProvider);
+    final activeVehicle = ref.watch(activeVehicleProfileProvider);
+    final showCharging = _shouldShowCharging(activeVehicle);
+    _ensureFuelChargingController(showCharging: showCharging);
+
+    final fuelView = FuelTab(fillUps: fillUps, stats: stats, l: l);
+
+    // Pure-combustion vehicle: no Charging slot — render fuel directly,
+    // no switcher, and the add-fill-up FAB.
+    if (!showCharging) {
+      return PageScaffold(
+        title: l?.consumptionTabFuel ?? 'Fuel',
+        bodyPadding: EdgeInsets.zero,
+        actions: _appBarActions(l),
+        floatingActionButton: _addFillUpFab(context, l),
+        body: fuelView,
+      );
+    }
+
+    // Hybrid / EV: a compact Fuel / Charging switcher — the user picks
+    // which energy form to view (#1901).
+    final controller = _tabController!;
+    final isCharging = controller.index == 1;
+    return PageScaffold(
+      title: l?.consumptionTabFuel ?? 'Fuel',
+      bodyPadding: EdgeInsets.zero,
+      actions: _appBarActions(l),
+      floatingActionButton: isCharging
+          ? _addChargingFab(context, l)
+          : _addFillUpFab(context, l),
       body: Column(
         children: [
           TabSwitcher(
-            controller: tabController,
+            controller: controller,
             tabs: [
               TabSwitcherEntry(
                 label: l?.consumptionTabFuel ?? 'Fuel',
                 icon: Icons.local_gas_station_outlined,
               ),
-              // Trajets tab is hidden when `Feature.obd2TripRecording`
-              // is off — users who haven't enabled OBD2 capture have
-              // no trips to render and the empty tab confused Medium
-              // use-mode users.
-              if (showTrajets)
-                TabSwitcherEntry(
-                  label: l?.trajetsTabLabel ?? 'Trips',
-                  icon: Icons.route_outlined,
-                ),
-              // #892 — Charging tab is hidden when the active vehicle
-              // is a pure combustion engine. Hybrid and EV profiles
-              // still see it; the no-vehicle case keeps the tab (a
-              // dedicated onboarding story covers that path).
-              if (showCharging)
-                TabSwitcherEntry(
-                  label: l?.consumptionTabCharging ?? 'Charging',
-                  icon: Icons.ev_station_outlined,
-                ),
+              TabSwitcherEntry(
+                label: l?.consumptionTabCharging ?? 'Charging',
+                icon: Icons.ev_station_outlined,
+              ),
             ],
           ),
           Expanded(
             child: TabBarView(
-              controller: tabController,
+              controller: controller,
               children: [
-                FuelTab(fillUps: fillUps, stats: stats, l: l),
-                if (showTrajets) TrajetsTab(vehicleId: activeVehicle?.id),
-                // Charging view is only mounted when the active vehicle
-                // can actually charge — hiding it for ICE profiles (#892)
-                // removes a dead-end tap for combustion-only users without
-                // touching `chargingLogsProvider`, so flipping back to a
-                // hybrid/EV restores the logs exactly.
-                if (showCharging) ChargingTab(async: chargingLogsAsync, l: l),
+                fuelView,
+                ChargingTab(async: chargingLogsAsync, l: l),
               ],
             ),
           ),
@@ -327,4 +281,26 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
       ),
     );
   }
+
+  Widget _addFillUpFab(BuildContext context, AppLocalizations? l) =>
+      FloatingActionButton.extended(
+        key: const Key('fab_add_fillup'),
+        onPressed: () => unawaited(context.push('/consumption/pick-station')),
+        icon: const Icon(Icons.add),
+        label: Text(l?.addFillUp ?? 'Add fill-up'),
+      );
+
+  Widget _addChargingFab(BuildContext context, AppLocalizations? l) =>
+      FloatingActionButton.extended(
+        key: const Key('fab_add_charging'),
+        onPressed: () async {
+          await Navigator.of(context).push<bool?>(
+            MaterialPageRoute(
+              builder: (_) => const AddChargingLogScreen(),
+            ),
+          );
+        },
+        icon: const Icon(Icons.add),
+        label: Text(l?.addChargingLog ?? 'Log charging'),
+      );
 }

--- a/test/app/routes/shell_branches_test.dart
+++ b/test/app/routes/shell_branches_test.dart
@@ -4,10 +4,12 @@ import 'package:tankstellen/app/routes/shell_branches.dart';
 
 void main() {
   group('shellBranches', () {
-    test('returns exactly 5 branches', () {
+    test('returns exactly 6 branches', () {
+      // #1901 — Carburant and Trajets are now separate destinations,
+      // so the router registers 6 branches (Trajets appended last).
       // Guards against accidental reorder/insert — the bottom-nav
       // depends on this length matching the destinations list.
-      expect(shellBranches.length, 5);
+      expect(shellBranches.length, 6);
     });
 
     test('branch 0 route path is "/"', () {
@@ -39,6 +41,14 @@ void main() {
     test('branch 4 route path is "/profile"', () {
       final route = shellBranches[4].routes.single as GoRoute;
       expect(route.path, '/profile');
+    });
+
+    test('branch 5 route path is "/trajets-tab" (#1901)', () {
+      // #1901 — Trajets is its own destination, appended after Profile
+      // so Profile keeps branch index 4. Path stays distinct from the
+      // `/consumption-tab` Carburant branch.
+      final route = shellBranches[5].routes.single as GoRoute;
+      expect(route.path, '/trajets-tab');
     });
 
     test('every branch has exactly one route', () {

--- a/test/app/shell/shell_destinations_test.dart
+++ b/test/app/shell/shell_destinations_test.dart
@@ -8,54 +8,103 @@ import 'package:tankstellen/app/shell/shell_destinations.dart';
 /// - #893 hid the Conso slot when no vehicle was configured.
 /// - #conso-coherence re-introduced a gate driven by
 ///   `isConsumptionTabReachable` — true for Medium + Full profiles.
-/// - #1874 (these tests) — Settings left the bottom bar for the
-///   top-right app bar, and Search became the centre, raised slot:
-///   `Map · Favorites · [Search] · Consumption`.
+/// - #1874 — Settings left the bottom bar for the top-right app bar,
+///   and Search became the centre, raised slot.
+/// - #1901 (these tests) — Consumption split into two destinations,
+///   Carburant and Trajets. `resolveShellDestinations` now takes a
+///   `showTrajets` flag covering three visibility states:
+///     conso off:           `Map · [Search] · Favorites`
+///     fuel-only:           `Map · Favorites · [Search] · Carburant`
+///     fuel + trips:        `Map · Favorites · [Search] · Carburant · Trajets`
 void main() {
   group('resolveShellDestinations', () {
     test(
-      'showConsumption: true → Map · Favorites · [Search] · Consumption',
+      'conso off → Map · [Search] · Favorites (Carburant + Trajets dropped)',
       () {
-        final result =
-            resolveShellDestinations(l10n: null, showConsumption: true);
-
-        expect(result.items, hasLength(4));
-        // Visual slots map back to router branches Search=0, Map=1,
-        // Favorites=2, Consumption=3.
-        expect(result.branchForSlot, [1, 2, 0, 3]);
-        expect(result.items.map((i) => i.label).toList(),
-            ['Map', 'Favorites', 'Search', 'Consumption']);
-
-        // Conso item carries the fuel-station icon.
-        expect(result.items[3].outlinedIcon,
-            Icons.local_gas_station_outlined);
-        expect(result.items[3].filledIcon, Icons.local_gas_station);
-      },
-    );
-
-    test(
-      'showConsumption: false → Map · [Search] · Favorites (Conso dropped)',
-      () {
-        final result =
-            resolveShellDestinations(l10n: null, showConsumption: false);
+        final result = resolveShellDestinations(
+          l10n: null,
+          showConsumption: false,
+          showTrajets: false,
+        );
 
         expect(result.items, hasLength(3));
         expect(result.branchForSlot, [1, 0, 2]);
         expect(result.items.map((i) => i.label).toList(),
             ['Map', 'Search', 'Favorites']);
 
-        // No fuel-station icon in the visible items list.
+        // No fuel-station / route icon in the visible items list.
         for (final item in result.items) {
-          expect(item.outlinedIcon,
-              isNot(Icons.local_gas_station_outlined));
+          expect(item.outlinedIcon, isNot(Icons.local_gas_station_outlined));
+          expect(item.outlinedIcon, isNot(Icons.route_outlined));
         }
       },
     );
 
-    test('Search is the only primary (raised, centre) item', () {
-      for (final showConso in [true, false]) {
+    test(
+      'fuel-only mode → Map · Favorites · [Search] · Carburant '
+      '(#1901: Trajets hidden)',
+      () {
         final result = resolveShellDestinations(
-            l10n: null, showConsumption: showConso);
+          l10n: null,
+          showConsumption: true,
+          showTrajets: false,
+        );
+
+        expect(result.items, hasLength(4));
+        // Visual slots map back to router branches Search=0, Map=1,
+        // Favorites=2, Carburant=3.
+        expect(result.branchForSlot, [1, 2, 0, 3]);
+        expect(result.items.map((i) => i.label).toList(),
+            ['Map', 'Favorites', 'Search', 'Fuel']);
+
+        // Carburant item carries the fuel-station icon.
+        expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
+        expect(result.items[3].filledIcon, Icons.local_gas_station);
+
+        // No Trajets destination in fuel-only mode.
+        for (final item in result.items) {
+          expect(item.outlinedIcon, isNot(Icons.route_outlined));
+        }
+      },
+    );
+
+    test(
+      'fuel + trips mode → Map · Favorites · [Search] · Carburant · Trajets '
+      '(#1901)',
+      () {
+        final result = resolveShellDestinations(
+          l10n: null,
+          showConsumption: true,
+          showTrajets: true,
+        );
+
+        expect(result.items, hasLength(5));
+        // Search=0, Map=1, Favorites=2, Carburant=3, Trajets=5.
+        expect(result.branchForSlot, [1, 2, 0, 3, kTrajetsBranchIndex]);
+        expect(result.items.map((i) => i.label).toList(),
+            ['Map', 'Favorites', 'Search', 'Fuel', 'Trips']);
+
+        // Carburant carries the fuel-station icon, Trajets the route icon.
+        expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
+        expect(result.items[3].filledIcon, Icons.local_gas_station);
+        expect(result.items[4].outlinedIcon, Icons.route_outlined);
+        expect(result.items[4].filledIcon, Icons.route);
+      },
+    );
+
+    test('Search is the only primary (raised, centre) item', () {
+      // #1901 — fuel + trips mode has an even item count (5 is odd, so
+      // the centre is well-defined); cover all three visibility states.
+      for (final state in const [
+        (false, false),
+        (true, false),
+        (true, true),
+      ]) {
+        final result = resolveShellDestinations(
+          l10n: null,
+          showConsumption: state.$1,
+          showTrajets: state.$2,
+        );
         final primaries = result.items.where((i) => i.isPrimary).toList();
         expect(primaries, hasLength(1));
         expect(primaries.single.label, 'Search');
@@ -66,9 +115,16 @@ void main() {
     });
 
     test('Settings is never a bottom-bar destination (#1874)', () {
-      for (final showConso in [true, false]) {
+      for (final state in const [
+        (false, false),
+        (true, false),
+        (true, true),
+      ]) {
         final result = resolveShellDestinations(
-            l10n: null, showConsumption: showConso);
+          l10n: null,
+          showConsumption: state.$1,
+          showTrajets: state.$2,
+        );
         expect(result.items.map((i) => i.label), isNot(contains('Settings')));
         expect(result.items.map((i) => i.outlinedIcon),
             isNot(contains(Icons.settings_outlined)));
@@ -78,19 +134,37 @@ void main() {
     });
 
     test('falls back to English labels when l10n is null', () {
-      final result =
-          resolveShellDestinations(l10n: null, showConsumption: true);
+      final result = resolveShellDestinations(
+        l10n: null,
+        showConsumption: true,
+        showTrajets: true,
+      );
       expect(result.items.map((i) => i.label).toList(),
-          ['Map', 'Favorites', 'Search', 'Consumption']);
+          ['Map', 'Favorites', 'Search', 'Fuel', 'Trips']);
     });
 
-    test('the Conso slot routes to kConsumptionBranchIndex', () {
-      final result =
-          resolveShellDestinations(l10n: null, showConsumption: true);
+    test('the Carburant slot routes to kConsumptionBranchIndex', () {
+      final result = resolveShellDestinations(
+        l10n: null,
+        showConsumption: true,
+        showTrajets: false,
+      );
       final consoSlot = result.items
           .indexWhere((i) => i.outlinedIcon == Icons.local_gas_station_outlined);
       expect(consoSlot, isNonNegative);
       expect(result.branchForSlot[consoSlot], kConsumptionBranchIndex);
+    });
+
+    test('the Trajets slot routes to kTrajetsBranchIndex (#1901)', () {
+      final result = resolveShellDestinations(
+        l10n: null,
+        showConsumption: true,
+        showTrajets: true,
+      );
+      final trajetsSlot =
+          result.items.indexWhere((i) => i.outlinedIcon == Icons.route_outlined);
+      expect(trajetsSlot, isNonNegative);
+      expect(result.branchForSlot[trajetsSlot], kTrajetsBranchIndex);
     });
   });
 }

--- a/test/app/shell_nav_vehicle_gating_test.dart
+++ b/test/app/shell_nav_vehicle_gating_test.dart
@@ -83,6 +83,14 @@ Future<void> _pumpShell(
               builder: (_, _) => const Text('SettingsBody'),
             ),
           ]),
+          // #1901 — Trajets is now its own branch (index 5), appended
+          // after Profile. ShellScreen registers 6 branches.
+          StatefulShellBranch(routes: [
+            GoRoute(
+              path: '/trajets-tab',
+              builder: (_, _) => const Text('TrajetsBody'),
+            ),
+          ]),
         ],
       ),
     ],
@@ -135,9 +143,12 @@ void main() {
         expect(find.byIcon(Icons.search), findsOneWidget);
         expect(find.text('Map'), findsOneWidget);
         expect(find.text('Favorites'), findsOneWidget);
-        expect(find.text('Consumption'), findsNothing,
-            reason: 'Basic profile must not surface the Conso tab — '
+        // #1901 — the Carburant destination label is now 'Fuel'.
+        expect(find.text('Fuel'), findsNothing,
+            reason: 'Basic profile must not surface the Carburant tab — '
                 'no consumption features are reachable.');
+        expect(find.text('Trips'), findsNothing,
+            reason: 'Basic profile must not surface the Trajets tab.');
         expect(find.byIcon(Icons.local_gas_station_outlined),
             findsNothing);
       },
@@ -171,7 +182,11 @@ void main() {
         expect(find.byIcon(Icons.search), findsOneWidget);
         expect(find.text('Map'), findsOneWidget);
         expect(find.text('Favorites'), findsOneWidget);
-        expect(find.text('Consumption'), findsOneWidget);
+        // #1901 — Medium profile (manualConsumption, no obd2) is
+        // fuel-only ConsoMode: the Carburant tab shows, Trajets does not.
+        expect(find.text('Fuel'), findsOneWidget);
+        expect(find.text('Trips'), findsNothing,
+            reason: 'Medium profile has no OBD2 trips — Trajets hidden.');
         expect(find.byIcon(Icons.local_gas_station_outlined),
             findsOneWidget);
       },
@@ -204,9 +219,13 @@ void main() {
           },
         );
 
-        expect(find.text('Consumption'), findsOneWidget);
+        // #1901 — Full profile (obd2TripRecording on) is fuel-and-trips
+        // ConsoMode: both Carburant and Trajets destinations show.
+        expect(find.text('Fuel'), findsOneWidget);
+        expect(find.text('Trips'), findsOneWidget);
         expect(find.byIcon(Icons.local_gas_station_outlined),
             findsOneWidget);
+        expect(find.byIcon(Icons.route_outlined), findsOneWidget);
       },
     );
   });

--- a/test/app/shell_screen_responsive_test.dart
+++ b/test/app/shell_screen_responsive_test.dart
@@ -158,6 +158,16 @@ void main() {
                   ),
                 ],
               ),
+              // #1901 — Trajets is its own branch (index 5).
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/trajets-tab',
+                    builder: (context, state) =>
+                        const Center(child: Text('TrajetsScreen')),
+                  ),
+                ],
+              ),
             ],
           ),
         ],
@@ -194,10 +204,13 @@ void main() {
 
       // Bottom nav bar items should be present. Search is the
       // icon-only centre button; Settings moved to the app bar (#1874).
+      // #1901 — Consumption split into Carburant ('Fuel') + Trajets
+      // ('Trips'); the Full profile flags surface both.
       expect(find.byIcon(Icons.search), findsOneWidget);
       expect(find.text('Map'), findsOneWidget);
       expect(find.text('Favorites'), findsOneWidget);
-      expect(find.text('Consumption'), findsOneWidget);
+      expect(find.text('Fuel'), findsOneWidget);
+      expect(find.text('Trips'), findsOneWidget);
 
       // NavigationRail should NOT be present
       expect(find.byType(NavigationRail), findsNothing);

--- a/test/app/shell_screen_test.dart
+++ b/test/app/shell_screen_test.dart
@@ -158,6 +158,16 @@ void main() {
                   ),
                 ],
               ),
+              // #1901 — Trajets is its own branch (index 5).
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/trajets-tab',
+                    builder: (context, state) =>
+                        const Center(child: Text('TrajetsScreen')),
+                  ),
+                ],
+              ),
             ],
           ),
         ],
@@ -315,6 +325,16 @@ void main() {
                   ),
                 ],
               ),
+              // #1901 — Trajets is its own branch (index 5).
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/trajets-tab',
+                    builder: (context, state) =>
+                        const Center(child: Text('TrajetsScreen')),
+                  ),
+                ],
+              ),
             ],
           ),
         ],
@@ -335,10 +355,13 @@ void main() {
 
       // Each bottom-bar nav item carries a Semantics label. Settings
       // is no longer a tab (#1874) — it lives in the app bar.
+      // #1901 — Consumption split into Carburant ('Fuel') and Trajets
+      // ('Trips'); the Full profile flags surface both.
       expect(find.bySemanticsLabel('Search'), findsOneWidget);
       expect(find.bySemanticsLabel('Map'), findsOneWidget);
       expect(find.bySemanticsLabel('Favorites'), findsOneWidget);
-      expect(find.bySemanticsLabel('Consumption'), findsOneWidget);
+      expect(find.bySemanticsLabel('Fuel'), findsOneWidget);
+      expect(find.bySemanticsLabel('Trips'), findsOneWidget);
 
       handle.dispose();
     });

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_tab_test.dart
@@ -79,8 +79,20 @@ void main() {
       // #923 phase 3a — tabs now come from the canonical `TabSwitcher`
       // widget whose `TabSwitcherEntry` contract has no `key:` field,
       // so we assert on the localised label text instead.
-      expect(find.text('Fuel'), findsOneWidget);
-      expect(find.text('Charging'), findsOneWidget);
+      // #1901 — the Fuel section AppBar title is also 'Fuel', so scope
+      // the tab-label assertions to the `Tab` widgets themselves.
+      expect(
+        find.descendant(of: find.byType(Tab), matching: find.text('Fuel')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+            of: find.byType(Tab), matching: find.text('Charging')),
+        findsOneWidget,
+      );
+      // The Fuel/Charging switcher has exactly two entries (#1901 —
+      // Trajets is no longer a tab of this screen).
+      expect(find.byType(Tab), findsNWidgets(2));
     });
 
     testWidgets('Fuel tab shows its empty state with 0 fill-ups',

--- a/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_charging_visibility_test.dart
@@ -13,11 +13,9 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Enables the full Trajets surface so this test file's expected tab
-/// counts (2 vs 3 tabs) hold. Per #1573 the gate is `consoMode ==
-/// fuelAndTrips`, which requires BOTH `showConsumptionTab` and
-/// `obd2TripRecording` — seeding only the latter resolves to
-/// `ConsoMode.off` and hides Trajets.
+/// Enables the consumption surface. #1901 — Trajets is no longer a tab
+/// of this screen, so the Fuel section just needs the Conso surface
+/// flag; the OBD2 flag no longer changes the tab count here.
 class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
@@ -26,17 +24,19 @@ class _ObdEnabledFlags extends FeatureFlags {
       };
 }
 
-/// #892 — the Charging tab on [ConsumptionScreen] is hidden for ICE
-/// vehicles (combustion) and visible for hybrid / EV profiles. The
-/// underlying `chargingLogsProvider` stays untouched, so flipping back
-/// to a hybrid/EV restores the logs unchanged.
+/// #892 / #1901 — the Charging slot on the Fuel section of
+/// [ConsumptionScreen] is hidden for ICE vehicles (combustion) and
+/// visible for hybrid / EV profiles. The underlying
+/// `chargingLogsProvider` stays untouched, so flipping back to a
+/// hybrid/EV restores the logs unchanged.
 ///
-/// These tests map 1:1 to the acceptance criteria on the issue:
-///   1. ICE vehicle → 2 tabs, no "Charging" label
-///   2. EV vehicle → 3 tabs, "Charging" label present
-///   3. Hybrid vehicle → 3 tabs
-///   4. Live switch EV → ICE while on Charging tab → 2 tabs, no
-///      crash, user lands on Trajets (index 1)
+/// #1901 — Trajets is now a separate destination, so the Fuel section
+/// is just Fuel (ICE) or a Fuel / Charging switcher (EV/hybrid):
+///   1. ICE vehicle → no switcher, Fuel only, no "Charging" label
+///   2. EV vehicle → 2-entry Fuel / Charging switcher
+///   3. Hybrid vehicle → 2-entry Fuel / Charging switcher
+///   4. Live switch EV → ICE while on Charging sub-tab → switcher
+///      disappears, no crash, screen falls back to plain Fuel
 
 class _FixedFillUpList extends FillUpList {
   final List<FillUp> _value;
@@ -140,9 +140,17 @@ Future<_MutableActiveVehicle> _pumpScreen(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('ConsumptionScreen Charging tab visibility (#892)', () {
+  group('ConsumptionScreen Charging tab visibility (#892 / #1901)', () {
+    /// Matches a [Tab] whose `text` carries the given label — the Fuel
+    /// section's AppBar title is also 'Fuel', so the bare text finder
+    /// would be ambiguous.
+    Finder tabLabelled(String label) => find.descendant(
+          of: find.byType(Tab),
+          matching: find.text(label),
+        );
+
     testWidgets(
-      'ICE vehicle active → 2 tabs, no "Charging" label [AC1]',
+      'ICE vehicle active → no Fuel/Charging switcher, no "Charging" [AC1]',
       (tester) async {
         await _pumpScreen(
           tester,
@@ -150,27 +158,11 @@ void main() {
           vehicles: const [_iceVehicle],
         );
 
-        // #923 phase 3a — tabs now come from the canonical
-        // `TabSwitcher` widget whose entries carry no per-tab `key:`.
-        // Assert on the localised label instead.
-        expect(
-          find.text('Fuel'),
-          findsOneWidget,
-          reason: 'Fuel tab must always render',
-        );
-        expect(
-          find.text('Trips'),
-          findsOneWidget,
-          reason: 'Trajets tab must render for ICE vehicles',
-        );
-        expect(
-          find.text('Charging'),
-          findsNothing,
-          reason: 'Charging tab must be hidden for combustion vehicles',
-        );
-
-        // Exactly 2 Tab widgets on screen.
-        expect(find.byType(Tab), findsNWidgets(2));
+        // #1901 — a pure-combustion vehicle gets no Fuel/Charging
+        // switcher at all: the Fuel section renders the fill-up list
+        // directly with no `Tab` widgets.
+        expect(find.byType(Tab), findsNothing,
+            reason: 'ICE vehicle has no Fuel/Charging switcher');
 
         // The localised tab labels for Charging must not appear.
         expect(find.text('Charging'), findsNothing);
@@ -181,7 +173,7 @@ void main() {
     );
 
     testWidgets(
-      'EV vehicle active → 3 tabs including Charging [AC2]',
+      'EV vehicle active → 2-entry Fuel / Charging switcher [AC2]',
       (tester) async {
         await _pumpScreen(
           tester,
@@ -189,19 +181,19 @@ void main() {
           vehicles: const [_evVehicle],
         );
 
-        expect(find.text('Fuel'), findsOneWidget);
-        expect(find.text('Trips'), findsOneWidget);
+        expect(tabLabelled('Fuel'), findsOneWidget);
         expect(
-          find.text('Charging'),
+          tabLabelled('Charging'),
           findsOneWidget,
           reason: 'Charging tab must render for EV vehicles',
         );
-        expect(find.byType(Tab), findsNWidgets(3));
+        // #1901 — Trajets is no longer a tab of this screen.
+        expect(find.byType(Tab), findsNWidgets(2));
       },
     );
 
     testWidgets(
-      'Hybrid vehicle active → 3 tabs [AC3]',
+      'Hybrid vehicle active → 2-entry Fuel / Charging switcher [AC3]',
       (tester) async {
         await _pumpScreen(
           tester,
@@ -210,17 +202,17 @@ void main() {
         );
 
         expect(
-          find.text('Charging'),
+          tabLabelled('Charging'),
           findsOneWidget,
           reason: 'Charging tab must render for hybrid vehicles',
         );
-        expect(find.byType(Tab), findsNWidgets(3));
+        expect(find.byType(Tab), findsNWidgets(2));
       },
     );
 
     testWidgets(
-      'Live switch EV → ICE while on Charging tab: '
-      'tab disappears, no crash, user on Trajets [AC4]',
+      'Live switch EV → ICE while on Charging sub-tab: '
+      'switcher disappears, no crash, screen falls back to Fuel [AC4]',
       (tester) async {
         // Start on the EV profile with the Charging tab visible and a
         // couple of logs seeded so the data layer has state we can
@@ -244,13 +236,13 @@ void main() {
         );
 
         // Sanity: Charging tab is there.
-        expect(find.text('Charging'), findsOneWidget);
+        expect(tabLabelled('Charging'), findsOneWidget);
 
         // Tap onto Charging so we're ON the tab that will vanish.
-        await tester.tap(find.text('Charging'));
+        await tester.tap(tabLabelled('Charging'));
         await tester.pumpAndSettle();
 
-        // Flip the active vehicle to ICE — the tab set should shrink.
+        // Flip the active vehicle to ICE — the switcher should vanish.
         activeNotifier.setVehicle(_iceVehicle);
         await tester.pumpAndSettle();
 
@@ -258,32 +250,19 @@ void main() {
         // Binding rethrows on pump if one occurred).
         expect(tester.takeException(), isNull);
 
-        // Charging tab is gone.
+        // #1901 — a combustion vehicle has no Fuel/Charging switcher
+        // at all: the screen falls back to the plain fuel list, the
+        // `Tab` widgets and the TabBar are gone.
         expect(find.text('Charging'), findsNothing);
+        expect(find.byType(Tab), findsNothing);
+        expect(find.byType(TabBar), findsNothing);
 
-        // We now have exactly 2 tabs.
-        expect(find.byType(Tab), findsNWidgets(2));
-
-        // The TabController should have landed on Trajets (index 1)
-        // — the closest neighbour to the old Charging index (2).
-        // Reach in via the TabBar widget's own `controller`.
-        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
-        expect(tabBar.controller, isNotNull);
-        expect(tabBar.controller!.length, equals(2));
-        expect(
-          tabBar.controller!.index,
-          equals(1),
-          reason:
-              'When Charging vanishes under the user, the selection '
-              'should snap to Trajets (index 1), not Fuel.',
-        );
-
-        // Flip back to EV — Charging tab must return and the logs
-        // must still be available from the unchanged provider.
+        // Flip back to EV — the Fuel/Charging switcher must return and
+        // the logs must still be available from the unchanged provider.
         activeNotifier.setVehicle(_evVehicle);
         await tester.pumpAndSettle();
         expect(
-          find.text('Charging'),
+          tabLabelled('Charging'),
           findsOneWidget,
           reason: 'Charging tab must come back when vehicle is EV again',
         );

--- a/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
@@ -13,9 +13,8 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Enables the full Trajets surface so all three tab icons render.
-/// Per #1573 the gate is `consoMode == fuelAndTrips`, requires both
-/// `showConsumptionTab` and `obd2TripRecording`.
+/// Enables the consumption surface. #1901 — the Fuel section's
+/// Fuel/Charging switcher does not depend on the OBD2 flag.
 class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
@@ -28,6 +27,10 @@ class _ObdEnabledFlags extends FeatureFlags {
 /// Lock that the Conso sub-tabs keep their icon-above-label rendering.
 /// If anyone strips an icon from `ConsumptionScreen` to "match" Favoris
 /// the wrong way round, this test fails.
+///
+/// #1901 — the Fuel section of [ConsumptionScreen] renders a 2-entry
+/// Fuel / Charging switcher for an EV/hybrid vehicle (Trajets is now a
+/// separate destination, not a tab here).
 class _FixedFillUpList extends FillUpList {
   final List<FillUp> _value;
   _FixedFillUpList(this._value);
@@ -114,10 +117,11 @@ void main() {
         ],
       );
 
-      // EV profile keeps the Charging tab visible → 3 Tab widgets.
+      // #1901 — EV profile renders the 2-entry Fuel / Charging
+      // switcher (Trajets moved out to its own destination).
       final tabs = tester.widgetList<Tab>(find.byType(Tab)).toList();
-      expect(tabs, hasLength(3),
-          reason: 'EV profile must render Fuel + Trips + Charging');
+      expect(tabs, hasLength(2),
+          reason: 'EV profile must render the Fuel + Charging switcher');
 
       // Every Tab must carry an icon — the visual contract this issue
       // locked across both Conso and Favoris.
@@ -132,7 +136,6 @@ void main() {
       // an EV profile with no logs — the tab assertion above is the
       // strict per-tab guarantee.
       expect(find.byIcon(Icons.local_gas_station_outlined), findsAtLeast(1));
-      expect(find.byIcon(Icons.route_outlined), findsAtLeast(1));
       expect(find.byIcon(Icons.ev_station_outlined), findsAtLeast(1));
     });
   });

--- a/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
@@ -16,23 +16,32 @@ import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import '../../../../helpers/pump_app.dart';
 
-/// Tests that need the Trajets tab visible override featureFlagsProvider
-/// with this notifier. Per #1573, the gate is now `consoMode ==
-/// fuelAndTrips`, which requires BOTH the Conso surface flag and the
-/// OBD2-trip-recording flag — `obd2TripRecording` alone would resolve
-/// to `ConsoMode.off` because the parent surface is gated separately.
-class _TrajetsEnabledFlags extends FeatureFlags {
+/// #889 / #1901 — the Trajets surface (OBD2 trip history).
+///
+/// #1901 — Trajets is no longer a tab of [ConsumptionScreen]; it is
+/// its own bottom-bar destination, reached by pumping the screen with
+/// `section: ConsumptionSection.trajets`. The screen renders
+/// [TrajetsTab] directly — no in-screen tab bar, no FAB.
+///
+/// These tests verify the empty-state CTA, the newest-first sort, and
+/// the navigation target of a row tap. Whether the Trajets destination
+/// is *visible at all* is a shell-level concern gated by `showTrajets`
+/// in `resolveShellDestinations` — see `shell_destinations_test.dart`
+/// and `shell_nav_vehicle_gating_test.dart`; #1901 moved that gate out
+/// of this screen, so the per-flag tab-gating tests that used to live
+/// here were dropped.
+
+/// Enables the consumption surface. The Trajets section renders its
+/// trip list regardless of flags now (#1901) — visibility gating
+/// moved to the shell — but a feature-flag override keeps the pump
+/// path identical to the rest of the suite.
+class _ObdEnabledFlags extends FeatureFlags {
   @override
   Set<Feature> build() => <Feature>{
         Feature.showConsumptionTab,
         Feature.obd2TripRecording,
       };
 }
-
-/// #889 — the ConsumptionScreen grows a Trajets tab between Fuel and
-/// Charging, and each row taps through to `/trip/:id`. These tests
-/// verify tab rendering, the empty-state CTA, the newest-first sort,
-/// and the navigation target of the row tap.
 
 class _FixedFillUpList extends FillUpList {
   final List<FillUp> _value;
@@ -113,12 +122,16 @@ Future<void> _pumpScreen(
   List<VehicleProfile> vehicles = const [],
 }) async {
   _lastTripIdVisited = null;
+  // #1901 — pump the Trajets *section* of ConsumptionScreen directly;
+  // it is its own bottom-bar destination now, not a tab.
   final router = GoRouter(
-    initialLocation: '/consumption',
+    initialLocation: '/trajets-tab',
     routes: [
       GoRoute(
-        path: '/consumption',
-        builder: (_, _) => const ConsumptionScreen(),
+        path: '/trajets-tab',
+        builder: (_, _) => const ConsumptionScreen(
+          section: ConsumptionSection.trajets,
+        ),
       ),
       GoRoute(path: '/consumption/add', builder: (_, _) => const SizedBox()),
       GoRoute(
@@ -150,10 +163,7 @@ Future<void> _pumpScreen(
           .overrideWith(() => _FixedVehicleProfileList(vehicles)),
       tripHistoryListProvider
           .overrideWith(() => _FixedTripHistoryList(trips)),
-      // Trajets tab is gated on obd2TripRecording (#conso-coherence).
-      // This whole test file asserts Trajets behaviour, so enable the
-      // flag for every test in here.
-      featureFlagsProvider.overrideWith(() => _TrajetsEnabledFlags()),
+      featureFlagsProvider.overrideWith(() => _ObdEnabledFlags()),
     ],
   );
 }
@@ -161,25 +171,31 @@ Future<void> _pumpScreen(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('ConsumptionScreen Trajets tab (#889)', () {
+  // #1901 — the `tab row has Fuel, Trajets, and Charging` test was
+  // dropped: its whole point was the in-screen 3-tab ordering, which
+  // no longer exists. Trajets is now a standalone destination and the
+  // Fuel/Charging switcher is covered by the charging-tab tests.
+
+  group('ConsumptionScreen Trajets section (#889 / #1901)', () {
     const vehicle = VehicleProfile(
       id: 'v1',
       name: 'Test vehicle',
       type: VehicleType.hybrid,
     );
 
-    testWidgets('tab row has Fuel, Trajets, and Charging', (tester) async {
+    testWidgets('renders the Trajets section directly — no tab bar, no FAB',
+        (tester) async {
       await _pumpScreen(
         tester,
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      // #923 phase 3a — the canonical `TabSwitcher` has no key-per-tab
-      // contract, so we assert on the localised label text for each
-      // tab entry instead.
-      expect(find.text('Fuel'), findsOneWidget);
-      expect(find.text('Trips'), findsOneWidget);
-      expect(find.text('Charging'), findsOneWidget);
+      // #1901 — the Trajets destination has no in-screen TabSwitcher
+      // and no screen-level FAB (the "Start recording" CTA lives in
+      // the tab header).
+      expect(find.byType(Tab), findsNothing);
+      expect(find.byKey(const Key('fab_add_fillup')), findsNothing);
+      expect(find.byKey(const Key('fab_add_charging')), findsNothing);
     });
 
     testWidgets('Trajets empty state renders CTA + "Start recording" button',
@@ -189,8 +205,6 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      await tester.tap(find.text('Trips'));
-      await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('trajets_empty_state')), findsOneWidget);
       expect(
@@ -239,8 +253,6 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      await tester.tap(find.text('Trips'));
-      await tester.pumpAndSettle();
 
       // Every trip should render a row.
       expect(find.byKey(const ValueKey('trajet-2026-04-20T09:00:00.000Z')),
@@ -281,8 +293,6 @@ void main() {
         activeVehicle: vehicle,
         vehicles: [vehicle],
       );
-      await tester.tap(find.text('Trips'));
-      await tester.pumpAndSettle();
 
       // Sanity — before tap, the detail stub hasn't been visited.
       expect(_lastTripIdVisited, isNull);
@@ -297,147 +307,11 @@ void main() {
     });
   });
 
-  group('ConsumptionScreen Trajets tab gating (#conso-coherence)', () {
-    const vehicle = VehicleProfile(
-      id: 'v1',
-      name: 'Test vehicle',
-      type: VehicleType.hybrid,
-    );
-
-    /// Pumps the screen WITHOUT enabling Feature.obd2TripRecording so
-    /// the Trajets tab should be hidden. Mirrors `_pumpScreen` above
-    /// except for the missing featureFlagsProvider override.
-    Future<void> pumpWithoutObd(WidgetTester tester) async {
-      final router = GoRouter(
-        initialLocation: '/consumption',
-        routes: [
-          GoRoute(
-            path: '/consumption',
-            builder: (_, _) => const ConsumptionScreen(),
-          ),
-          GoRoute(
-            path: '/trip/:id',
-            builder: (_, _) => const Scaffold(body: Text('TripDetailStub')),
-          ),
-        ],
-      );
-
-      await pumpApp(
-        tester,
-        MaterialApp.router(routerConfig: router),
-        overrides: [
-          fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
-          chargingLogsProvider
-              .overrideWith(() => _FixedChargingLogs(const [])),
-          activeVehicleProfileProvider
-              .overrideWith(() => _FixedActiveVehicle(vehicle)),
-          vehicleProfileListProvider
-              .overrideWith(() => _FixedVehicleProfileList(const [vehicle])),
-          tripHistoryListProvider
-              .overrideWith(() => _FixedTripHistoryList(const [])),
-          // No featureFlagsProvider override → defaults are used →
-          // obd2TripRecording is `false` per the manifest.
-        ],
-      );
-    }
-
-    testWidgets(
-      'Trajets tab is hidden when Feature.obd2TripRecording is off — '
-      'Fuel + Charging only',
-      (tester) async {
-        await pumpWithoutObd(tester);
-        expect(find.text('Fuel'), findsOneWidget);
-        expect(find.text('Trips'), findsNothing,
-            reason: 'Trajets tab must hide when obd2TripRecording is '
-                'off — Medium use-mode users have no trips to render');
-        // Hybrid vehicle still shows Charging.
-        expect(find.text('Charging'), findsOneWidget);
-      },
-    );
-  });
-
-  group('ConsumptionScreen Trajets tab gated on ConsoMode (#1573)', () {
-    const vehicle = VehicleProfile(
-      id: 'v1',
-      name: 'Test vehicle',
-      type: VehicleType.hybrid,
-    );
-
-    Future<void> pumpWithFlags(
-      WidgetTester tester,
-      Set<Feature> flags,
-    ) async {
-      final router = GoRouter(
-        initialLocation: '/consumption',
-        routes: [
-          GoRoute(
-            path: '/consumption',
-            builder: (_, _) => const ConsumptionScreen(),
-          ),
-        ],
-      );
-      await pumpApp(
-        tester,
-        MaterialApp.router(routerConfig: router),
-        overrides: [
-          fillUpListProvider.overrideWith(() => _FixedFillUpList(const [])),
-          chargingLogsProvider
-              .overrideWith(() => _FixedChargingLogs(const [])),
-          activeVehicleProfileProvider
-              .overrideWith(() => _FixedActiveVehicle(vehicle)),
-          vehicleProfileListProvider
-              .overrideWith(() => _FixedVehicleProfileList(const [vehicle])),
-          tripHistoryListProvider
-              .overrideWith(() => _FixedTripHistoryList(const [])),
-          featureFlagsProvider.overrideWith(
-            () => _StaticFeatureFlags(flags),
-          ),
-        ],
-      );
-    }
-
-    testWidgets(
-      'ConsoMode.fuel (Medium tier — showConsumptionTab + manualConsumption, '
-      'NO obd2TripRecording) → Trajets sub-tab absent',
-      (tester) async {
-        await pumpWithFlags(tester, <Feature>{
-          Feature.showConsumptionTab,
-          Feature.manualConsumption,
-        });
-        expect(find.text('Fuel'), findsOneWidget);
-        expect(find.text('Trips'), findsNothing,
-            reason: 'In Carburant (Medium) mode the screen renders only '
-                'the fuel-log surface — no OBD2 trip history yet.');
-        expect(find.text('Charging'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'ConsoMode.fuelAndTrips (Full tier — all three flags) → Trajets '
-      'sub-tab present',
-      (tester) async {
-        await pumpWithFlags(tester, <Feature>{
-          Feature.showConsumptionTab,
-          Feature.manualConsumption,
-          Feature.obd2TripRecording,
-        });
-        expect(find.text('Fuel'), findsOneWidget);
-        expect(find.text('Trips'), findsOneWidget,
-            reason: 'In Carburant + Trajets (Full) mode the OBD2 trip '
-                'sub-tab must render alongside Fuel + Charging.');
-        expect(find.text('Charging'), findsOneWidget);
-      },
-    );
-  });
-}
-
-/// Locks featureFlagsProvider to an exact flag set so each #1573
-/// regression test can pin the precise ConsoMode it's exercising
-/// without leaning on manifest defaults.
-class _StaticFeatureFlags extends FeatureFlags {
-  final Set<Feature> _value;
-  _StaticFeatureFlags(this._value);
-
-  @override
-  Set<Feature> build() => _value;
+  // #1901 — the two former gating groups (Trajets tab hidden when
+  // obd2TripRecording is off; Trajets gated on ConsoMode #1573) were
+  // dropped. Trajets is no longer a tab of this screen, so its
+  // visibility is decided by the shell (`resolveShellDestinations`'s
+  // `showTrajets` flag) rather than by ConsumptionScreen. That gate is
+  // covered by `test/app/shell/shell_destinations_test.dart` and
+  // `test/app/shell_nav_vehicle_gating_test.dart`.
 }


### PR DESCRIPTION
## What

The consumption surface was a single **Conso** bottom-bar entry opening
a screen with an in-screen Carburant/Trajets/Charging tab bar. Now
**Carburant** and **Trajets** are two first-class bottom-bar
destinations and the in-screen tab bar is gone:

`Carte · Favoris · [Search] · Carburant · Trajets`

## How

- **`shell_branches.dart`** — Trajets added as router branch 5
  (appended after Profile, so Profile keeps index 4 for deep links).
- **`ConsumptionScreen`** — parameterised by a new `ConsumptionSection`
  enum instead of hosting tabs. The Carburant section keeps a compact
  **Fuel/Charging switcher only for hybrid/EV vehicles** (your "one
  button, choose either or") — a combustion car just sees the fuel
  list, no tab bar.
- **`shell_destinations.dart`** — three states: Conso off, fuel-only
  (Carburant alone), fuel+trips (Carburant + Trajets).
- **`shell_screen.dart`** — 6 branches; snaps selection back when a
  consumption destination is hidden by a profile change.

## Verification

`flutter analyze` clean; the full `test/app/` + `test/features/consumption/`
+ `test/lint/` suites pass (2961 tests). Trajets-visibility gating moved
from a screen-level tab gate to the shell-level `showTrajets` flag, with
coverage moved to the shell tests.

Closes #1901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
