### PR TITLE
feat(consumption): record per-trip η_v provenance (#1858)

### DIFF
--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -242,6 +242,21 @@ class LiveSampleSnapshot {
     );
   }
 
+  /// #1858 — the branch [deriveFuelRateLPerHour] resolved on its most
+  /// recent call. Lets the controller tell η_v-derived fuel (the
+  /// [Obd2BranchTag.speedDensity] branch) from fuel that does not use
+  /// η_v (PID 5E / MAF) so it can stamp the trip's recompute
+  /// provenance. Null before the first call.
+  Obd2BranchTag? _lastFuelRateBranch;
+  Obd2BranchTag? get lastFuelRateBranch => _lastFuelRateBranch;
+
+  /// #1858 — the volumetric efficiency applied on the most recent
+  /// [deriveFuelRateLPerHour] call. Only meaningful when
+  /// [lastFuelRateBranch] is [Obd2BranchTag.speedDensity]; null
+  /// otherwise (PID 5E / MAF / no rate do not use η_v).
+  double? _lastFuelRateVe;
+  double? get lastFuelRateVe => _lastFuelRateVe;
+
   /// Derive the current fuel rate (L/h) from whatever snapshot
   /// values have landed so far. Mirrors the tier-1/2/3 fallback in
   /// [Obd2Service.readFuelRateLPerHour], but over snapshot values
@@ -254,6 +269,9 @@ class LiveSampleSnapshot {
   /// anything else (including null / unknown) stays on the petrol
   /// defaults the pre-#800 path used.
   double? deriveFuelRateLPerHour() {
+    // #1858 — provenance defaults; each branch below overrides them.
+    _lastFuelRateBranch = Obd2BranchTag.none;
+    _lastFuelRateVe = null;
     final preferredFuel =
         _vehicle?.preferredFuelType?.trim().toLowerCase() ?? '';
     final isDiesel = preferredFuel.contains('diesel');
@@ -328,6 +346,7 @@ class LiveSampleSnapshot {
           );
         }
       }
+      _lastFuelRateBranch = Obd2BranchTag.pid5E;
       return direct;
     }
 
@@ -346,6 +365,7 @@ class LiveSampleSnapshot {
         engineDisplacementCc: displacement.toDouble(),
         volumetricEfficiency: ve,
       );
+      _lastFuelRateBranch = Obd2BranchTag.maf;
       return corrected;
     }
 
@@ -401,6 +421,10 @@ class LiveSampleSnapshot {
       engineDisplacementCc: displacement.toDouble(),
       volumetricEfficiency: ve,
     );
+    // #1858 — the only η_v-derived branch: record the η_v applied so
+    // the controller can stamp the trip's recompute provenance.
+    _lastFuelRateBranch = Obd2BranchTag.speedDensity;
+    _lastFuelRateVe = ve;
     return corrected;
   }
 

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -271,6 +271,19 @@ class TripRecordingController {
   double? _odometerLatestKm;
   double _fuelLitersSoFar = 0;
   bool _fuelRateSeen = false;
+
+  // #1858 — η_v recompute provenance, accumulated per emit tick.
+  // [_veWeightedFuelSum] is Σ(η_v_i × fuelRate_i) and
+  // [_veDerivedFuelRateSum] is Σ(fuelRate_i), both over speed-density
+  // ticks only; [_sawNonVeDerivedFuel] flips true the moment any fuel
+  // is integrated from PID 5E or the MAF branch (neither uses η_v).
+  // At trip end these collapse into [TripSummary.volumetricEfficiencyUsed].
+  // A fresh controller is built per trip, so declaration-time zero is
+  // the only reset needed (the values carry correctly across
+  // pause/resume — that is all one trip).
+  double _veWeightedFuelSum = 0;
+  double _veDerivedFuelRateSum = 0;
+  bool _sawNonVeDerivedFuel = false;
   bool _paused = false;
   bool _pausedDueToDrop = false;
   bool _started = false;
@@ -671,6 +684,15 @@ class TripRecordingController {
         fuelRateSuspect = true;
       }
     }
+    // #1858 — η_v recompute provenance. Non-null ONLY when every litre
+    // of the trip's fuel was speed-density-derived (η_v-scalable) and
+    // some fuel was burned; then it is the fuel-weighted mean of the
+    // per-tick η_v applied. Any PID 5E / MAF fuel — or no fuel — leaves
+    // it null, marking the trip "not recalculable".
+    final double? veUsed =
+        (!_sawNonVeDerivedFuel && _veDerivedFuelRateSum > 0)
+            ? _veWeightedFuelSum / _veDerivedFuelRateSum
+            : null;
     return TripSummary(
       distanceKm: distanceKm,
       maxRpm: base.maxRpm,
@@ -685,6 +707,7 @@ class TripRecordingController {
       distanceSource: source,
       secondsBelowOptimalGear: _computeGearCoachingMetric(),
       fuelRateSuspect: fuelRateSuspect,
+      volumetricEfficiencyUsed: veUsed,
     );
   }
 
@@ -1166,6 +1189,20 @@ class TripRecordingController {
     final snap = _liveSampleSnapshot;
     final nowTs = _now();
     final fuelRate = snap.deriveFuelRateLPerHour();
+    // #1858 — fold this tick into the trip's η_v recompute provenance.
+    // Speed-density fuel is the only η_v-derived branch; PID 5E / MAF
+    // fuel marks the trip non-recalculable.
+    if (fuelRate != null && fuelRate > 0) {
+      final veUsed = snap.lastFuelRateBranch == Obd2BranchTag.speedDensity
+          ? snap.lastFuelRateVe
+          : null;
+      if (veUsed != null && veUsed > 0) {
+        _veWeightedFuelSum += veUsed * fuelRate;
+        _veDerivedFuelRateSum += fuelRate;
+      } else {
+        _sawNonVeDerivedFuel = true;
+      }
+    }
     final speedKmh = snap.latestSpeedKmh;
     final rpm = snap.latestRpm;
     final throttlePercent = snap.latestThrottlePercent;

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -205,6 +205,11 @@ Map<String, dynamic> _summaryToJson(TripSummary s) => {
       // gear-inference data carry no value, so parsimony saves bytes.
       if (s.secondsBelowOptimalGear != null)
         'sblog': s.secondsBelowOptimalGear,
+      // #1858: η_v recompute provenance. Compact key 'veUsed'. Omitted
+      // when null — legacy trips and non-recalculable trips (any PID 5E
+      // / MAF fuel) carry no value, so parsimony saves bytes.
+      if (s.volumetricEfficiencyUsed != null)
+        'veUsed': s.volumetricEfficiencyUsed,
     };
 
 TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -233,6 +238,10 @@ TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
       // #1263 phase 2: gear-inference coaching metric. Legacy trips
       // (and EV / no-inference trips) carry no key → null.
       secondsBelowOptimalGear: (j['sblog'] as num?)?.toDouble(),
+      // #1858: η_v recompute provenance. Legacy trips and trips whose
+      // fuel was not 100% speed-density carry no key → null, which
+      // correctly reads as "not recalculable".
+      volumetricEfficiencyUsed: (j['veUsed'] as num?)?.toDouble(),
     );
 
 /// Hive-backed list of finalised trips (#726).

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -112,6 +112,22 @@ class TripSummary {
   /// on the trip summary card based on this bit.
   final bool fuelRateSuspect;
 
+  /// Fuel-weighted mean volumetric efficiency (η_v) the trip's fuel was
+  /// integrated with (#1858), or null when the trip is **not**
+  /// η_v-recalculable.
+  ///
+  /// Speed-density fuel scales linearly with η_v, so a stored trip can
+  /// be retroactively recomputed for a corrected η_v by
+  /// `fuelLitersConsumed × (newVe / volumetricEfficiencyUsed)` — but
+  /// only when *every* litre was speed-density-derived. This field is
+  /// non-null exactly then: it carries the fuel-weighted mean of the
+  /// per-tick η_v actually applied. It is null when any fuel came from
+  /// PID 5E or the MAF branch (neither uses η_v — rescaling would
+  /// corrupt that portion), when the trip burned no fuel, and for
+  /// legacy trips recorded before #1858. A null value means "not
+  /// recalculable" and such trips are left untouched by a recompute.
+  final double? volumetricEfficiencyUsed;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -127,6 +143,7 @@ class TripSummary {
     this.coldStartSurcharge = false,
     this.secondsBelowOptimalGear,
     this.fuelRateSuspect = false,
+    this.volumetricEfficiencyUsed,
   });
 }
 

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -454,6 +454,98 @@ void main() {
     });
   });
 
+  group('η_v recompute provenance — #1858', () {
+    test(
+        'a speed-density-only trip stamps volumetricEfficiencyUsed with the '
+        'η_v that was applied', () async {
+      // No PID 5E (015E) and no MAF (0110) → the fuel rate can only
+      // come from the speed-density branch (MAP + IAT + RPM), which is
+      // the one branch that uses η_v.
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        'ATAT2': 'OK>',
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 50>', // MAP 80 kPa
+        '010F': '41 0F 41>', // IAT 25 °C
+        '010C': '41 0C 0E A6>', // RPM ~937
+        '010D': '41 0D 32>', // 50 km/h
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(milliseconds: 50),
+        scheduler: PidScheduler(
+          transport: service.sendCommand,
+          tickRate: const Duration(milliseconds: 20),
+        ),
+        vehicle: const VehicleProfile(
+          id: 'sd-car',
+          name: 'Speed-density car',
+          engineDisplacementCc: 1200,
+          volumetricEfficiency: 0.80,
+        ),
+      );
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 800));
+      final summary = await ctl.stop();
+
+      expect(summary.fuelLitersConsumed, isNotNull,
+          reason: 'the speed-density branch must integrate some fuel');
+      expect(summary.volumetricEfficiencyUsed, isNotNull,
+          reason: 'an all-speed-density trip is η_v-recalculable');
+      expect(summary.volumetricEfficiencyUsed, closeTo(0.80, 0.001),
+          reason: 'the stamped η_v is the (flat) value actually applied');
+    });
+
+    test(
+        'a trip whose fuel came from PID 5E leaves volumetricEfficiencyUsed '
+        'null — PID 5E does not use η_v, so the trip is not recalculable',
+        () async {
+      // PID 5E answers directly → the fuel rate never touches η_v.
+      final transport = FakeObd2Transport({
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        'ATAT2': 'OK>',
+        '015E': '41 5E 00 64>', // PID 5E direct fuel rate = 5.0 L/h
+        '010C': '41 0C 0E A6>', // RPM ~937
+        '010D': '41 0D 32>', // 50 km/h
+      });
+      final service = Obd2Service(transport);
+      await service.connect();
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(milliseconds: 50),
+        scheduler: PidScheduler(
+          transport: service.sendCommand,
+          tickRate: const Duration(milliseconds: 20),
+        ),
+        vehicle: const VehicleProfile(
+          id: 'pid5e-car',
+          name: 'PID 5E car',
+          volumetricEfficiency: 0.80,
+        ),
+      );
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 800));
+      final summary = await ctl.stop();
+
+      expect(summary.fuelLitersConsumed, isNotNull,
+          reason: 'PID 5E still integrates fuel');
+      expect(summary.volumetricEfficiencyUsed, isNull,
+          reason: 'PID-5E fuel is not η_v-derived — rescaling it would be '
+              'wrong, so the trip must read as not-recalculable');
+    });
+  });
+
   group('BT drop resilience — #797 phase 1', () {
     late Directory tmpDir;
     late Box<String> pausedBox;

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -847,4 +847,93 @@ void main() {
       expect(s.coolantTempC, 82.0);
     });
   });
+
+  group('TripSummary.volumetricEfficiencyUsed persistence (#1858)', () {
+    test(
+        'summary with volumetricEfficiencyUsed populated round-trips through '
+        'save / loadAll', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 5, 18, 9);
+      final recalculable = TripSummary(
+        distanceKm: 42,
+        maxRpm: 3000,
+        highRpmSeconds: 5,
+        idleSeconds: 30,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: 3.1,
+        avgLPer100Km: 7.4,
+        startedAt: start,
+        endedAt: start.add(const Duration(minutes: 40)),
+        volumetricEfficiencyUsed: 0.88,
+      );
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'veh-recalc',
+        summary: recalculable,
+      ));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.first.summary.volumetricEfficiencyUsed, 0.88,
+          reason: 'the η_v recompute basis must survive Hive round-trip');
+    });
+
+    test(
+        'summary with volumetricEfficiencyUsed null omits the "veUsed" key — '
+        'a not-recalculable / legacy trip carries no provenance', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 5, 18, 9);
+      final notRecalculable = TripSummary(
+        distanceKm: 18,
+        maxRpm: 2600,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: 1.4,
+        startedAt: start,
+        endedAt: start.add(const Duration(minutes: 16)),
+        // volumetricEfficiencyUsed defaults null
+      );
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: notRecalculable,
+      ));
+
+      final raw = box.get(start.toIso8601String())!;
+      final decoded = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      final summaryJson = (decoded['summary'] as Map).cast<String, dynamic>();
+      expect(summaryJson.containsKey('veUsed'), isFalse);
+
+      final loaded = repo.loadAll();
+      expect(loaded.first.summary.volumetricEfficiencyUsed, isNull);
+    });
+
+    test(
+        'a legacy payload without the "veUsed" key deserialises with a null '
+        'volumetricEfficiencyUsed — pre-#1858 trips read as not-recalculable',
+        () {
+      // A pre-#1858 stored summary — no `veUsed` key at all.
+      final legacy = {
+        'id': 'legacy-ve',
+        'vehicleId': 'veh-1',
+        'summary': {
+          'distanceKm': 30.0,
+          'maxRpm': 2800.0,
+          'highRpmSeconds': 0.0,
+          'idleSeconds': 0.0,
+          'harshBrakes': 0,
+          'harshAccelerations': 0,
+          'fuelLitersConsumed': 2.2,
+          'distanceSource': 'virtual',
+        },
+      };
+      final restored = TripHistoryEntry.fromJson(legacy);
+      expect(restored.summary.volumetricEfficiencyUsed, isNull,
+          reason: 'legacy trips have no η_v provenance and must read as '
+              'not-recalculable rather than throwing');
+    });
+  });
 }


### PR DESCRIPTION
## What

A stored trip records `fuelLitersConsumed` but **not the volumetric
efficiency (η_v) it was integrated with** — so #1858's retroactive
recompute had nothing to rescale against. This PR adds that provenance
(the recording foundation; the rescale itself follows).

## How

`TripSummary` gains a nullable `volumetricEfficiencyUsed`. The
trip-recording controller accumulates it per emit tick — the live-sample
snapshot now exposes which branch produced each fuel rate:

- **speed-density** ticks (the only η_v-using branch) are fuel-weighted
  into a mean η_v;
- **PID 5E / MAF** ticks (neither uses η_v) flag the trip.

At trip end the field is set to the fuel-weighted mean η_v **only when
every litre was speed-density-derived**. Any PID-5E / MAF fuel — or no
fuel — leaves it null, which reads as "not recalculable" (rescaling a
non-η_v portion by `newVe/oldVe` would corrupt it). The repository
round-trips the field; legacy trips with no key deserialise as null.

## Scope

This is **part of #1858** — the provenance *recording*. The retroactive
rescale on an η_v-override change (acceptance item 3) is the remaining
half and follows in a focused PR; #1858 stays open until then.

## Verification

`flutter analyze` clean; `test/features/consumption/data/` + `test/lint/`
pass (1543 tests), including new coverage: a speed-density trip stamps
the applied η_v, a PID-5E trip stays null, and the field round-trips /
legacy-deserialises through the repository.

Part of #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
