### PR TITLE
feat(consumption): retroactive η_v recompute on a manual override change (#1858)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -36,6 +36,7 @@ import '../features/consumption/data/obd2/paused_trip_repository.dart';
 import '../features/consumption/data/trip_history_repository.dart';
 import '../features/consumption/providers/auto_record_orchestrator.dart';
 import '../features/consumption/providers/trip_recording_provider.dart';
+import '../features/consumption/providers/trip_ve_recompute_provider.dart';
 import '../features/feature_management/application/legacy_toggle_migration_provider.dart';
 import '../features/profile/data/repositories/profile_repository.dart';
 import '../features/vehicle/data/reference_vehicle_catalog_provider.dart';
@@ -185,6 +186,20 @@ class AppInitializer {
       } catch (e, st) {
         debugPrint(
             'AppInitializer: legacyToggleMigration kick-off failed: $e\n$st');
+      }
+    });
+
+    // #1858 — instantiate the keep-alive η_v recompute listener so it
+    // is watching vehicle-profile edits before the user can reach the
+    // Edit-vehicle screen. Reading the provider triggers its `build`,
+    // which wires the `ref.listen`; deferred because no η_v edit can
+    // happen until well after first frame.
+    _deferPostFirstFrame(() async {
+      try {
+        container.read(tripVeRecomputeListenerProvider);
+      } catch (e, st) {
+        debugPrint(
+            'AppInitializer: η_v recompute listener kick-off failed: $e\n$st');
       }
     });
 

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -81,6 +81,22 @@ class TripHistoryEntry {
     this.gpsSampleDiagnostics = const [],
   });
 
+  /// Returns a copy with the given fields replaced (#1858). The
+  /// retroactive η_v recompute uses it to swap in a rescaled [summary]
+  /// while leaving the id / vehicle / samples / adapter identity
+  /// untouched.
+  TripHistoryEntry copyWith({TripSummary? summary}) => TripHistoryEntry(
+        id: id,
+        vehicleId: vehicleId,
+        summary: summary ?? this.summary,
+        automatic: automatic,
+        samples: samples,
+        adapterMac: adapterMac,
+        adapterName: adapterName,
+        adapterFirmware: adapterFirmware,
+        gpsSampleDiagnostics: gpsSampleDiagnostics,
+      );
+
   Map<String, dynamic> toJson() => {
         'id': id,
         'vehicleId': vehicleId,

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -145,6 +145,48 @@ class TripSummary {
     this.fuelRateSuspect = false,
     this.volumetricEfficiencyUsed,
   });
+
+  /// Returns a copy with the given fields replaced (#1858). Used by the
+  /// retroactive η_v recompute to rescale `fuelLitersConsumed` /
+  /// `avgLPer100Km` and re-stamp `volumetricEfficiencyUsed`. A passed
+  /// null keeps the existing value — the recompute never needs to
+  /// *clear* a field, so the simple form is sufficient.
+  TripSummary copyWith({
+    double? distanceKm,
+    double? maxRpm,
+    double? highRpmSeconds,
+    double? idleSeconds,
+    int? harshBrakes,
+    int? harshAccelerations,
+    double? avgLPer100Km,
+    double? fuelLitersConsumed,
+    DateTime? startedAt,
+    DateTime? endedAt,
+    String? distanceSource,
+    bool? coldStartSurcharge,
+    double? secondsBelowOptimalGear,
+    bool? fuelRateSuspect,
+    double? volumetricEfficiencyUsed,
+  }) =>
+      TripSummary(
+        distanceKm: distanceKm ?? this.distanceKm,
+        maxRpm: maxRpm ?? this.maxRpm,
+        highRpmSeconds: highRpmSeconds ?? this.highRpmSeconds,
+        idleSeconds: idleSeconds ?? this.idleSeconds,
+        harshBrakes: harshBrakes ?? this.harshBrakes,
+        harshAccelerations: harshAccelerations ?? this.harshAccelerations,
+        avgLPer100Km: avgLPer100Km ?? this.avgLPer100Km,
+        fuelLitersConsumed: fuelLitersConsumed ?? this.fuelLitersConsumed,
+        startedAt: startedAt ?? this.startedAt,
+        endedAt: endedAt ?? this.endedAt,
+        distanceSource: distanceSource ?? this.distanceSource,
+        coldStartSurcharge: coldStartSurcharge ?? this.coldStartSurcharge,
+        secondsBelowOptimalGear:
+            secondsBelowOptimalGear ?? this.secondsBelowOptimalGear,
+        fuelRateSuspect: fuelRateSuspect ?? this.fuelRateSuspect,
+        volumetricEfficiencyUsed:
+            volumetricEfficiencyUsed ?? this.volumetricEfficiencyUsed,
+      );
 }
 
 /// Pure-logic accumulator that turns a stream of OBD2 [TripSample]s

--- a/lib/features/consumption/domain/trip_ve_recompute.dart
+++ b/lib/features/consumption/domain/trip_ve_recompute.dart
@@ -1,0 +1,49 @@
+// Retroactive volumetric-efficiency (η_v) recompute (#1858).
+//
+// When a vehicle's η_v is corrected, every stored trip that recorded
+// the η_v its fuel was integrated with (`TripSummary.volumetricEfficiencyUsed`,
+// #1858 part A) can be recomputed: speed-density fuel scales linearly
+// with η_v, so the corrected figure is
+// `fuelLitersConsumed × (newVe / volumetricEfficiencyUsed)`, and
+// `avgLPer100Km` rescales by the same factor.
+//
+// A trip with a null `volumetricEfficiencyUsed` is not recalculable —
+// a legacy trip, or one whose fuel came (even partly) from PID 5E or
+// the MAF branch, neither of which uses η_v — and is returned
+// untouched. Returning the same instance in that case lets callers
+// cheaply detect "nothing changed" with `identical`.
+
+import '../data/trip_history_repository.dart';
+
+/// Recompute one trip for a corrected [newVe].
+///
+/// Returns [entry] unchanged (the identical instance) when it carries
+/// no η_v provenance, when [newVe] already matches the stamped value,
+/// or when either η_v is non-positive (defensive — a stamped value is
+/// always a real 0.6–0.95-ish efficiency).
+TripHistoryEntry recomputeTripForVe(TripHistoryEntry entry, double newVe) {
+  final used = entry.summary.volumetricEfficiencyUsed;
+  if (used == null || used <= 0 || newVe <= 0 || used == newVe) {
+    return entry;
+  }
+  final factor = newVe / used;
+  final s = entry.summary;
+  return entry.copyWith(
+    summary: s.copyWith(
+      fuelLitersConsumed:
+          s.fuelLitersConsumed == null ? null : s.fuelLitersConsumed! * factor,
+      avgLPer100Km:
+          s.avgLPer100Km == null ? null : s.avgLPer100Km! * factor,
+      // Re-stamp so a later η_v change rescales from the new basis.
+      volumetricEfficiencyUsed: newVe,
+    ),
+  );
+}
+
+/// Recompute every trip in [trips] for [newVe]. Order is preserved;
+/// not-recalculable trips pass through untouched (same instance).
+List<TripHistoryEntry> recomputeTripsForVe(
+  List<TripHistoryEntry> trips,
+  double newVe,
+) =>
+    [for (final t in trips) recomputeTripForVe(t, newVe)];

--- a/lib/features/consumption/providers/trip_ve_recompute_provider.dart
+++ b/lib/features/consumption/providers/trip_ve_recompute_provider.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../vehicle/providers/vehicle_providers.dart';
+import '../domain/trip_ve_recompute.dart';
+import 'trip_history_provider.dart';
+
+part 'trip_ve_recompute_provider.g.dart';
+
+/// #1858 — retroactive η_v recompute trigger.
+///
+/// A keep-alive listener that watches [vehicleProfileListProvider] and,
+/// whenever a vehicle's effective η_v changes via a manual profile
+/// save, rescales that vehicle's η_v-recalculable trips in the
+/// trip-history box (see [recomputeTripForVe]).
+///
+/// Scoped to **manual** edits by construction: the VeLearner writes
+/// the vehicle-profile *repository* directly, not the
+/// [VehicleProfileList] notifier, so its converging per-fill-up
+/// micro-adjustments never reach this provider — only a deliberate
+/// edit through the notifier does, which is the intended trigger.
+///
+/// Instantiated once at startup (`app_initializer`) so the listener is
+/// live for the whole session; it holds no state of its own.
+@Riverpod(keepAlive: true)
+class TripVeRecomputeListener extends _$TripVeRecomputeListener {
+  @override
+  void build() {
+    ref.listen<List<VehicleProfile>>(
+      vehicleProfileListProvider,
+      _onVehiclesChanged,
+    );
+  }
+
+  void _onVehiclesChanged(
+    List<VehicleProfile>? previous,
+    List<VehicleProfile> next,
+  ) {
+    // First emission has nothing to diff against.
+    if (previous == null) return;
+    final before = {for (final v in previous) v.id: _effectiveVe(v)};
+    for (final vehicle in next) {
+      final oldVe = before[vehicle.id];
+      final newVe = _effectiveVe(vehicle);
+      // Unchanged η_v (or a newly-added vehicle) → nothing to rescale.
+      if (oldVe == null || oldVe == newVe) continue;
+      unawaited(_recomputeVehicleTrips(vehicle.id, newVe));
+    }
+  }
+
+  /// The η_v a trip should now be recomputed against: the manual
+  /// override when the user has set one, otherwise the learned /
+  /// default value.
+  double _effectiveVe(VehicleProfile v) =>
+      v.manualVolumetricEfficiencyOverride ?? v.volumetricEfficiency;
+
+  /// Rescale every η_v-recalculable trip of [vehicleId] to [newVe] and
+  /// write the changed entries back. Best-effort — a recompute failure
+  /// must never derail the vehicle save that triggered it.
+  Future<void> _recomputeVehicleTrips(String vehicleId, double newVe) async {
+    try {
+      final repo = ref.read(tripHistoryRepositoryProvider);
+      if (repo == null) return;
+      var changed = false;
+      for (final trip in repo.loadAll()) {
+        if (trip.vehicleId != vehicleId) continue;
+        final updated = recomputeTripForVe(trip, newVe);
+        // `recomputeTripForVe` returns the same instance when the trip
+        // is not recalculable / already at newVe.
+        if (identical(updated, trip)) continue;
+        await repo.save(updated);
+        changed = true;
+      }
+      if (changed) {
+        // Refresh the in-memory list so any open trip-history UI
+        // re-reads the rescaled figures.
+        ref.read(tripHistoryListProvider.notifier).refresh();
+      }
+    } catch (e, st) {
+      debugPrint('TripVeRecomputeListener: recompute failed: $e\n$st');
+    }
+  }
+}

--- a/lib/features/consumption/providers/trip_ve_recompute_provider.g.dart
+++ b/lib/features/consumption/providers/trip_ve_recompute_provider.g.dart
@@ -1,0 +1,124 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trip_ve_recompute_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// #1858 — retroactive η_v recompute trigger.
+///
+/// A keep-alive listener that watches [vehicleProfileListProvider] and,
+/// whenever a vehicle's effective η_v changes via a manual profile
+/// save, rescales that vehicle's η_v-recalculable trips in the
+/// trip-history box (see [recomputeTripForVe]).
+///
+/// Scoped to **manual** edits by construction: the VeLearner writes
+/// the vehicle-profile *repository* directly, not the
+/// [VehicleProfileList] notifier, so its converging per-fill-up
+/// micro-adjustments never reach this provider — only a deliberate
+/// edit through the notifier does, which is the intended trigger.
+///
+/// Instantiated once at startup (`app_initializer`) so the listener is
+/// live for the whole session; it holds no state of its own.
+
+@ProviderFor(TripVeRecomputeListener)
+final tripVeRecomputeListenerProvider = TripVeRecomputeListenerProvider._();
+
+/// #1858 — retroactive η_v recompute trigger.
+///
+/// A keep-alive listener that watches [vehicleProfileListProvider] and,
+/// whenever a vehicle's effective η_v changes via a manual profile
+/// save, rescales that vehicle's η_v-recalculable trips in the
+/// trip-history box (see [recomputeTripForVe]).
+///
+/// Scoped to **manual** edits by construction: the VeLearner writes
+/// the vehicle-profile *repository* directly, not the
+/// [VehicleProfileList] notifier, so its converging per-fill-up
+/// micro-adjustments never reach this provider — only a deliberate
+/// edit through the notifier does, which is the intended trigger.
+///
+/// Instantiated once at startup (`app_initializer`) so the listener is
+/// live for the whole session; it holds no state of its own.
+final class TripVeRecomputeListenerProvider
+    extends $NotifierProvider<TripVeRecomputeListener, void> {
+  /// #1858 — retroactive η_v recompute trigger.
+  ///
+  /// A keep-alive listener that watches [vehicleProfileListProvider] and,
+  /// whenever a vehicle's effective η_v changes via a manual profile
+  /// save, rescales that vehicle's η_v-recalculable trips in the
+  /// trip-history box (see [recomputeTripForVe]).
+  ///
+  /// Scoped to **manual** edits by construction: the VeLearner writes
+  /// the vehicle-profile *repository* directly, not the
+  /// [VehicleProfileList] notifier, so its converging per-fill-up
+  /// micro-adjustments never reach this provider — only a deliberate
+  /// edit through the notifier does, which is the intended trigger.
+  ///
+  /// Instantiated once at startup (`app_initializer`) so the listener is
+  /// live for the whole session; it holds no state of its own.
+  TripVeRecomputeListenerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'tripVeRecomputeListenerProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$tripVeRecomputeListenerHash();
+
+  @$internal
+  @override
+  TripVeRecomputeListener create() => TripVeRecomputeListener();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(void value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<void>(value),
+    );
+  }
+}
+
+String _$tripVeRecomputeListenerHash() =>
+    r'ba830cbe85de90ec79bc3f33f89937ffdf6ab258';
+
+/// #1858 — retroactive η_v recompute trigger.
+///
+/// A keep-alive listener that watches [vehicleProfileListProvider] and,
+/// whenever a vehicle's effective η_v changes via a manual profile
+/// save, rescales that vehicle's η_v-recalculable trips in the
+/// trip-history box (see [recomputeTripForVe]).
+///
+/// Scoped to **manual** edits by construction: the VeLearner writes
+/// the vehicle-profile *repository* directly, not the
+/// [VehicleProfileList] notifier, so its converging per-fill-up
+/// micro-adjustments never reach this provider — only a deliberate
+/// edit through the notifier does, which is the intended trigger.
+///
+/// Instantiated once at startup (`app_initializer`) so the listener is
+/// live for the whole session; it holds no state of its own.
+
+abstract class _$TripVeRecomputeListener extends $Notifier<void> {
+  void build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<void, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<void, void>,
+              void,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/consumption/domain/trip_ve_recompute_test.dart
+++ b/test/features/consumption/domain/trip_ve_recompute_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/domain/trip_ve_recompute.dart';
+
+/// Unit coverage for the retroactive η_v recompute (#1858).
+void main() {
+  TripHistoryEntry entry({
+    required String id,
+    double? veUsed,
+    double? fuel,
+    double? avg,
+    String vehicleId = 'veh-1',
+  }) =>
+      TripHistoryEntry(
+        id: id,
+        vehicleId: vehicleId,
+        summary: TripSummary(
+          distanceKm: 100,
+          maxRpm: 3000,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+          fuelLitersConsumed: fuel,
+          avgLPer100Km: avg,
+          volumetricEfficiencyUsed: veUsed,
+        ),
+      );
+
+  group('recomputeTripForVe', () {
+    test('rescales a recalculable trip and re-stamps the η_v', () {
+      // η_v 0.80 → 0.90: speed-density fuel scales ×(0.90/0.80) = 1.125.
+      final t = entry(id: 't1', veUsed: 0.80, fuel: 4.0, avg: 8.0);
+      final r = recomputeTripForVe(t, 0.90);
+
+      expect(r.summary.fuelLitersConsumed, closeTo(4.5, 1e-9));
+      expect(r.summary.avgLPer100Km, closeTo(9.0, 1e-9));
+      expect(r.summary.volumetricEfficiencyUsed, 0.90,
+          reason: 're-stamped so a later η_v change rescales from the '
+              'new basis');
+    });
+
+    test('leaves a not-recalculable trip (null volumetricEfficiencyUsed) '
+        'untouched — returns the identical instance', () {
+      final t = entry(id: 't2', veUsed: null, fuel: 3.0, avg: 6.0);
+      final r = recomputeTripForVe(t, 0.90);
+
+      expect(identical(r, t), isTrue,
+          reason: 'a legacy / PID-5E / MAF trip carries no η_v provenance '
+              'and must not be rescaled');
+    });
+
+    test('is a no-op when newVe already matches the stamped η_v', () {
+      final t = entry(id: 't3', veUsed: 0.85, fuel: 3.0);
+      expect(identical(recomputeTripForVe(t, 0.85), t), isTrue);
+    });
+
+    test('preserves id and vehicleId while rescaling the summary', () {
+      final t = entry(id: 't4', veUsed: 0.80, fuel: 4.0, vehicleId: 'veh-x');
+      final r = recomputeTripForVe(t, 0.88);
+      expect(r.id, 't4');
+      expect(r.vehicleId, 'veh-x');
+      expect(r.summary.fuelLitersConsumed, closeTo(4.0 * 0.88 / 0.80, 1e-9));
+    });
+  });
+
+  group('recomputeTripsForVe', () {
+    test('rescales recalculable trips and passes the rest through', () {
+      final trips = [
+        entry(id: 'a', veUsed: 0.80, fuel: 4.0, avg: 8.0),
+        entry(id: 'b', veUsed: null, fuel: 5.0, avg: 10.0),
+      ];
+      final out = recomputeTripsForVe(trips, 0.90);
+
+      expect(out[0].summary.fuelLitersConsumed, closeTo(4.5, 1e-9));
+      expect(identical(out[1], trips[1]), isTrue,
+          reason: 'the not-recalculable trip is untouched');
+      expect(out, hasLength(2));
+    });
+  });
+}

--- a/test/features/consumption/providers/trip_ve_recompute_provider_test.dart
+++ b/test/features/consumption/providers/trip_ve_recompute_provider_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_ve_recompute_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+/// Coverage for the #1858 retroactive η_v recompute trigger — the
+/// keep-alive listener that rescales a vehicle's trips when its η_v is
+/// edited.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('ve_recompute_');
+    Hive.init(tmpDir.path);
+    await HiveStorage.initForTest();
+    await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  TripHistoryEntry trip({
+    required String id,
+    double? veUsed,
+    required double fuel,
+  }) =>
+      TripHistoryEntry(
+        id: id,
+        vehicleId: 'v1',
+        summary: TripSummary(
+          distanceKm: 100,
+          maxRpm: 3000,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+          fuelLitersConsumed: fuel,
+          avgLPer100Km: fuel,
+          volumetricEfficiencyUsed: veUsed,
+        ),
+      );
+
+  test(
+    'a manual η_v override change rescales the vehicle\'s recalculable '
+    'trips and leaves not-recalculable ones untouched',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Seed the vehicle at η_v 0.80.
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(
+              id: 'v1',
+              name: 'Test car',
+              volumetricEfficiency: 0.80,
+            ),
+          );
+
+      // Seed two trips: one η_v-recalculable, one not.
+      final tripRepo = container.read(tripHistoryRepositoryProvider)!;
+      await tripRepo.save(trip(id: 'recalc', veUsed: 0.80, fuel: 4.0));
+      await tripRepo.save(trip(id: 'legacy', veUsed: null, fuel: 5.0));
+
+      // Arm the listener AFTER seeding, so the seed itself is not a
+      // change it reacts to — only the η_v edit below is.
+      container.read(tripVeRecomputeListenerProvider);
+
+      // The user corrects η_v to 0.90 via a manual override.
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(
+              id: 'v1',
+              name: 'Test car',
+              volumetricEfficiency: 0.80,
+              manualVolumetricEfficiencyOverride: 0.90,
+            ),
+          );
+      // Let the fire-and-forget recompute complete.
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      final trips = {for (final t in tripRepo.loadAll()) t.id: t};
+      // Recalculable trip rescaled ×(0.90/0.80) = 1.125 and re-stamped.
+      expect(trips['recalc']!.summary.fuelLitersConsumed, closeTo(4.5, 1e-6));
+      expect(trips['recalc']!.summary.volumetricEfficiencyUsed, 0.90);
+      // Not-recalculable trip untouched.
+      expect(trips['legacy']!.summary.fuelLitersConsumed, 5.0);
+      expect(trips['legacy']!.summary.volumetricEfficiencyUsed, isNull);
+    },
+  );
+
+  test(
+    'a vehicle save that does not change η_v leaves trips untouched',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(
+              id: 'v1',
+              name: 'Test car',
+              volumetricEfficiency: 0.80,
+            ),
+          );
+      final tripRepo = container.read(tripHistoryRepositoryProvider)!;
+      await tripRepo.save(trip(id: 'recalc', veUsed: 0.80, fuel: 4.0));
+
+      container.read(tripVeRecomputeListenerProvider);
+
+      // A rename — η_v is unchanged.
+      await container.read(vehicleProfileListProvider.notifier).save(
+            const VehicleProfile(
+              id: 'v1',
+              name: 'Renamed car',
+              volumetricEfficiency: 0.80,
+            ),
+          );
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      final recalc = tripRepo.loadAll().single;
+      expect(recalc.summary.fuelLitersConsumed, 4.0,
+          reason: 'no η_v change → no recompute');
+      expect(recalc.summary.volumetricEfficiencyUsed, 0.80);
+    },
+  );
+}


### PR DESCRIPTION
## What

**Completes #1858.** Part A (PR #1907) recorded each trip's η_v
provenance (`TripSummary.volumetricEfficiencyUsed`); this PR is the
retroactive recompute that provenance enables.

When a vehicle's effective η_v changes via a **manual** profile edit,
every stored trip of that vehicle carrying a non-null
`volumetricEfficiencyUsed` is rescaled — speed-density fuel scales
linearly with η_v, so `fuelLitersConsumed` / `avgLPer100Km` are
multiplied by `newVe / volumetricEfficiencyUsed` and the trip is
re-stamped. Trips with null provenance (legacy / PID-5E / MAF) are left
untouched — "not recalculable".

## How

- `recomputeTripForVe` / `recomputeTripsForVe` — pure recompute logic.
- `copyWith` added to `TripSummary` + `TripHistoryEntry`.
- **`TripVeRecomputeListener`** — a keep-alive provider watching
  `vehicleProfileListProvider`; rescales a vehicle's trips on an
  effective-η_v change. **Scoped to manual edits by construction:** the
  VeLearner writes the profile *repository* directly, never the
  notifier, so its converging per-fill-up micro-adjustments never
  trigger a history-wide rescale.
- Wired into `app_initializer` so the listener is live for the session.

## Verification

`flutter analyze` clean; `test/app/app_initializer*` + all of
`test/features/consumption/` + `test/lint/` pass (2768 tests),
including new coverage for the recompute math, the null-provenance
skip, and the manual-η_v-change-vs-rename trigger.

Closes #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
