### PR TITLE
feat(vehicle): offline PSA VIN engine-candidate resolver (#1864)

### DIFF
--- a/lib/features/vehicle/domain/psa_vin_engine_resolver.dart
+++ b/lib/features/vehicle/domain/psa_vin_engine_resolver.dart
@@ -1,0 +1,67 @@
+import 'entities/reference_vehicle.dart';
+import 'entities/vin_data.dart';
+
+/// Offline PSA VIN engine-candidate resolver (#1864).
+///
+/// A PSA-group VIN (Peugeot / Citroën / DS / Opel / Vauxhall) encodes
+/// the make in its WMI and the model year in position 10 — both
+/// decodable offline by [VinDecoder]. The **engine**, however, sits in
+/// the VDS (positions 4–9), whose make→engine mapping is PSA-internal
+/// and not a publicly-sourceable dataset. Guessing it would surface
+/// *wrong* engine data — worse than no answer — so this resolver does
+/// not pretend to decode it.
+///
+/// Instead it resolves a **candidate set**: every entry in the
+/// reference catalog whose make matches the VIN's decoded make and
+/// whose generation spans the decoded model year. The UI can present
+/// these for the user to confirm — an honest "one of these" rather
+/// than a fabricated exact answer.
+
+/// PSA-group brand names, lower-cased, as they appear in both the WMI
+/// table and the reference catalog.
+const Set<String> _psaBrands = {
+  'peugeot',
+  'citroen',
+  'citroën',
+  'ds',
+  'ds automobiles',
+  'opel',
+  'vauxhall',
+};
+
+/// Whether [vinData] decoded to a PSA-group make.
+bool isPsaVin(VinData vinData) {
+  final make = vinData.make;
+  return make != null && _psaBrands.contains(make.toLowerCase());
+}
+
+/// Resolve the reference-catalog engine candidates for a PSA VIN.
+///
+/// Returns every [catalog] entry whose make matches [vinData]'s
+/// decoded make and whose `[yearStart, yearEnd]` generation window
+/// spans [vinData]'s model year. When the model year could not be
+/// decoded the year filter is dropped (every make match is a
+/// candidate). Returns an empty list when [vinData] is not a PSA VIN
+/// or nothing matches — never a fabricated engine.
+List<ReferenceVehicle> resolvePsaEngineCandidates({
+  required VinData vinData,
+  required List<ReferenceVehicle> catalog,
+}) {
+  if (!isPsaVin(vinData)) return const [];
+  final make = vinData.make!.toLowerCase();
+  final year = vinData.modelYear;
+  return [
+    for (final v in catalog)
+      if (v.make.toLowerCase() == make && _yearInGeneration(v, year)) v,
+  ];
+}
+
+/// Whether [year] falls within [v]'s generation window. A null [year]
+/// (position 10 undecodable) passes — the candidate is not excluded on
+/// a year we don't know.
+bool _yearInGeneration(ReferenceVehicle v, int? year) {
+  if (year == null) return true;
+  if (year < v.yearStart) return false;
+  final end = v.yearEnd;
+  return end == null || year <= end;
+}

--- a/lib/features/vehicle/providers/psa_vin_engine_candidates_provider.dart
+++ b/lib/features/vehicle/providers/psa_vin_engine_candidates_provider.dart
@@ -1,0 +1,29 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/reference_vehicle_catalog_provider.dart';
+import '../domain/entities/reference_vehicle.dart';
+import '../domain/psa_vin_engine_resolver.dart';
+import 'vin_decoder_provider.dart';
+
+part 'psa_vin_engine_candidates_provider.g.dart';
+
+/// Offline engine-candidate set for a PSA VIN (#1864).
+///
+/// Decodes [vin] via [decodedVinProvider] (offline WMI + position-10
+/// year, no proprietary VDS table) and resolves the reference-catalog
+/// candidates whose make + generation match — see
+/// [resolvePsaEngineCandidates].
+///
+/// Returns an empty list for a non-PSA VIN, an undecodable VIN, or
+/// when nothing in the catalog matches. Keyed by VIN so two callers
+/// asking for the same VIN share one resolution.
+@riverpod
+Future<List<ReferenceVehicle>> psaVinEngineCandidates(
+  Ref ref,
+  String vin,
+) async {
+  final vinData = await ref.watch(decodedVinProvider(vin).future);
+  if (vinData == null) return const [];
+  final catalog = await ref.watch(referenceVehicleCatalogProvider.future);
+  return resolvePsaEngineCandidates(vinData: vinData, catalog: catalog);
+}

--- a/lib/features/vehicle/providers/psa_vin_engine_candidates_provider.g.dart
+++ b/lib/features/vehicle/providers/psa_vin_engine_candidates_provider.g.dart
@@ -1,0 +1,142 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'psa_vin_engine_candidates_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Offline engine-candidate set for a PSA VIN (#1864).
+///
+/// Decodes [vin] via [decodedVinProvider] (offline WMI + position-10
+/// year, no proprietary VDS table) and resolves the reference-catalog
+/// candidates whose make + generation match — see
+/// [resolvePsaEngineCandidates].
+///
+/// Returns an empty list for a non-PSA VIN, an undecodable VIN, or
+/// when nothing in the catalog matches. Keyed by VIN so two callers
+/// asking for the same VIN share one resolution.
+
+@ProviderFor(psaVinEngineCandidates)
+final psaVinEngineCandidatesProvider = PsaVinEngineCandidatesFamily._();
+
+/// Offline engine-candidate set for a PSA VIN (#1864).
+///
+/// Decodes [vin] via [decodedVinProvider] (offline WMI + position-10
+/// year, no proprietary VDS table) and resolves the reference-catalog
+/// candidates whose make + generation match — see
+/// [resolvePsaEngineCandidates].
+///
+/// Returns an empty list for a non-PSA VIN, an undecodable VIN, or
+/// when nothing in the catalog matches. Keyed by VIN so two callers
+/// asking for the same VIN share one resolution.
+
+final class PsaVinEngineCandidatesProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<ReferenceVehicle>>,
+          List<ReferenceVehicle>,
+          FutureOr<List<ReferenceVehicle>>
+        >
+    with
+        $FutureModifier<List<ReferenceVehicle>>,
+        $FutureProvider<List<ReferenceVehicle>> {
+  /// Offline engine-candidate set for a PSA VIN (#1864).
+  ///
+  /// Decodes [vin] via [decodedVinProvider] (offline WMI + position-10
+  /// year, no proprietary VDS table) and resolves the reference-catalog
+  /// candidates whose make + generation match — see
+  /// [resolvePsaEngineCandidates].
+  ///
+  /// Returns an empty list for a non-PSA VIN, an undecodable VIN, or
+  /// when nothing in the catalog matches. Keyed by VIN so two callers
+  /// asking for the same VIN share one resolution.
+  PsaVinEngineCandidatesProvider._({
+    required PsaVinEngineCandidatesFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'psaVinEngineCandidatesProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$psaVinEngineCandidatesHash();
+
+  @override
+  String toString() {
+    return r'psaVinEngineCandidatesProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<List<ReferenceVehicle>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<ReferenceVehicle>> create(Ref ref) {
+    final argument = this.argument as String;
+    return psaVinEngineCandidates(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PsaVinEngineCandidatesProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$psaVinEngineCandidatesHash() =>
+    r'3fdb281d847d10a6a7fa6b70678c5565fe440c69';
+
+/// Offline engine-candidate set for a PSA VIN (#1864).
+///
+/// Decodes [vin] via [decodedVinProvider] (offline WMI + position-10
+/// year, no proprietary VDS table) and resolves the reference-catalog
+/// candidates whose make + generation match — see
+/// [resolvePsaEngineCandidates].
+///
+/// Returns an empty list for a non-PSA VIN, an undecodable VIN, or
+/// when nothing in the catalog matches. Keyed by VIN so two callers
+/// asking for the same VIN share one resolution.
+
+final class PsaVinEngineCandidatesFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<List<ReferenceVehicle>>, String> {
+  PsaVinEngineCandidatesFamily._()
+    : super(
+        retry: null,
+        name: r'psaVinEngineCandidatesProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Offline engine-candidate set for a PSA VIN (#1864).
+  ///
+  /// Decodes [vin] via [decodedVinProvider] (offline WMI + position-10
+  /// year, no proprietary VDS table) and resolves the reference-catalog
+  /// candidates whose make + generation match — see
+  /// [resolvePsaEngineCandidates].
+  ///
+  /// Returns an empty list for a non-PSA VIN, an undecodable VIN, or
+  /// when nothing in the catalog matches. Keyed by VIN so two callers
+  /// asking for the same VIN share one resolution.
+
+  PsaVinEngineCandidatesProvider call(String vin) =>
+      PsaVinEngineCandidatesProvider._(argument: vin, from: this);
+
+  @override
+  String toString() => r'psaVinEngineCandidatesProvider';
+}

--- a/test/features/vehicle/domain/psa_vin_engine_resolver_test.dart
+++ b/test/features/vehicle/domain/psa_vin_engine_resolver_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/vehicle/data/vin_decoder.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/reference_vehicle.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vin_data.dart';
+import 'package:tankstellen/features/vehicle/domain/psa_vin_engine_resolver.dart';
+
+/// Coverage for the offline PSA VIN engine-candidate resolver (#1864).
+///
+/// PSA VINs are decoded offline (`VinDecoder` with the network path
+/// disabled — WMI make + position-10 model year). The resolver then
+/// matches the decoded make + year against a reference catalog; it
+/// never fabricates an engine.
+void main() {
+  final decoder = VinDecoder(allowOnlineLookup: false);
+
+  // Structurally-valid 17-char VINs (no I/O/Q) with real PSA WMI
+  // prefixes and a position-10 year code. Layout: WMI(3) · VDS(6) ·
+  // year(1) · suffix(7). 'K' → 2019, 'L' → 2020, 'N' → 2022.
+  const peugeotVin2019 = 'VF3AAAAAAKAAAAAAA'; // VF3 = Peugeot, France
+  const citroenVin2020 = 'VF7AAAAAALAAAAAAA'; // VF7 = Citroën, France
+  const opelVin2022 = 'W0LAAAAAANAAAAAAA'; // W0L = Opel, Germany
+
+  ReferenceVehicle ref({
+    required String make,
+    required String model,
+    required int yearStart,
+    int? yearEnd,
+    int displacementCc = 1200,
+  }) =>
+      ReferenceVehicle(
+        make: make,
+        model: model,
+        generation: '$model ($yearStart-)',
+        yearStart: yearStart,
+        yearEnd: yearEnd,
+        displacementCc: displacementCc,
+        fuelType: 'petrol',
+        transmission: 'manual',
+      );
+
+  final catalog = [
+    ref(make: 'Peugeot', model: '208', yearStart: 2019), // current gen
+    ref(make: 'Peugeot', model: '308', yearStart: 2013, yearEnd: 2021),
+    ref(make: 'Peugeot', model: '207', yearStart: 2006, yearEnd: 2014),
+    ref(make: 'Citroen', model: 'C3', yearStart: 2016),
+    ref(make: 'Opel', model: 'Corsa', yearStart: 2019),
+    ref(make: 'Renault', model: 'Clio', yearStart: 2019), // non-PSA
+  ];
+
+  group('isPsaVin', () {
+    test('true for PSA-group makes', () async {
+      expect(isPsaVin((await decoder.decode(peugeotVin2019))!), isTrue);
+      expect(isPsaVin((await decoder.decode(citroenVin2020))!), isTrue);
+      expect(isPsaVin((await decoder.decode(opelVin2022))!), isTrue);
+    });
+
+    test('false for a non-PSA make and for a make-less VinData', () {
+      expect(
+        isPsaVin(const VinData(
+          vin: 'x',
+          make: 'Renault',
+          source: VinDataSource.wmiOffline,
+        )),
+        isFalse,
+      );
+      expect(
+        isPsaVin(const VinData(vin: 'x', source: VinDataSource.invalid)),
+        isFalse,
+      );
+    });
+  });
+
+  group('resolvePsaEngineCandidates', () {
+    test('a Peugeot VIN resolves to Peugeot entries spanning the year',
+        () async {
+      final vinData = (await decoder.decode(peugeotVin2019))!;
+      expect(vinData.make, 'Peugeot');
+      expect(vinData.modelYear, 2019);
+
+      final candidates =
+          resolvePsaEngineCandidates(vinData: vinData, catalog: catalog);
+      final models = candidates.map((c) => c.model).toSet();
+
+      // 208 (2019-) and 308 (2013-2021) span 2019; 207 (2006-2014) does
+      // not; nothing from another make.
+      expect(models, {'208', '308'});
+      expect(candidates.every((c) => c.make == 'Peugeot'), isTrue);
+    });
+
+    test('a Citroën VIN resolves only Citroën candidates', () async {
+      final vinData = (await decoder.decode(citroenVin2020))!;
+      final candidates =
+          resolvePsaEngineCandidates(vinData: vinData, catalog: catalog);
+      expect(candidates.map((c) => c.model), ['C3']);
+    });
+
+    test('an Opel VIN resolves only Opel candidates', () async {
+      final vinData = (await decoder.decode(opelVin2022))!;
+      final candidates =
+          resolvePsaEngineCandidates(vinData: vinData, catalog: catalog);
+      expect(candidates.map((c) => c.model), ['Corsa']);
+    });
+
+    test('a non-PSA VIN resolves nothing — no cross-make guessing', () {
+      const renault = VinData(
+        vin: 'VF1AAAAAAKAAAAAAA',
+        make: 'Renault',
+        modelYear: 2019,
+        source: VinDataSource.wmiOffline,
+      );
+      expect(
+        resolvePsaEngineCandidates(vinData: renault, catalog: catalog),
+        isEmpty,
+      );
+    });
+
+    test('the model year filters out non-overlapping generations', () {
+      // A Peugeot VIN from 2010 must not match the 2019- 208.
+      const old = VinData(
+        vin: 'VF3AAAAAAAAAAAAAA',
+        make: 'Peugeot',
+        modelYear: 2010,
+        source: VinDataSource.wmiOffline,
+      );
+      final models = resolvePsaEngineCandidates(vinData: old, catalog: catalog)
+          .map((c) => c.model)
+          .toSet();
+      // 207 (2006-2014) spans 2010; 308 (2013-2021) and 208 (2019-)
+      // do not.
+      expect(models, {'207'});
+    });
+
+    test('an undecodable model year keeps every make match as a candidate',
+        () {
+      const noYear = VinData(
+        vin: 'VF3AAAAAAAAAAAAAA',
+        make: 'Peugeot',
+        source: VinDataSource.wmiOffline,
+      );
+      final models =
+          resolvePsaEngineCandidates(vinData: noYear, catalog: catalog)
+              .map((c) => c.model)
+              .toSet();
+      expect(models, {'208', '308', '207'},
+          reason: 'with no year to filter on, every Peugeot entry is a '
+              'candidate the user can pick from');
+    });
+  });
+}


### PR DESCRIPTION
## What

A PSA-group VIN (Peugeot / Citroën / DS / Opel / Vauxhall) encodes its
**make** (WMI) and **model year** (position 10) offline — but the
**engine** lives in the VDS, whose make→engine mapping is PSA-internal
and not a publicly-sourceable dataset.

#1864's own triage warns that guessing it ships **wrong engine data —
worse than no answer**. With no authoritative VDS table available
(confirmed with the maintainer), this takes the issue's sanctioned
alternative (acceptance item 3): resolve an honest **candidate set**
instead of a fabricated exact decode.

## How

- **`resolvePsaEngineCandidates`** (pure domain) — for an offline-decoded
  `VinData`, returns every reference-catalog entry whose make matches
  and whose generation window spans the decoded model year. Non-PSA VIN
  or no match → empty list, never a guess. Undecodable year → drop the
  year filter (every make match is a candidate).
- **`isPsaVin`** — PSA-group make gate.
- **`psaVinEngineCandidatesProvider`** — wires the offline VIN decode +
  reference catalog through the resolver, keyed by VIN.

## Verification

`flutter analyze` clean; `test/lint/` + `test/features/vehicle/` pass
(692 tests), including 8 new tests against real PSA WMI prefixes
(Peugeot `VF3`, Citroën `VF7`, Opel `W0L`) decoded through the offline
`VinDecoder`, plus the year-filter / non-PSA / no-year edge cases.

Surfacing the candidate set in the VIN-confirm onboarding UI is a
natural follow-up.

Closes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
