### PR TITLE
fix(ci): exclude network + flaky tags with one flag so neither leaks into PR runs (#1910)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,15 +227,13 @@ jobs:
             # the 4 matrix runners.
             mapfile -t TESTS < affected_tests.txt
             flutter test "${TESTS[@]}" \
-              --exclude-tags=network \
-              --exclude-tags=flaky \
+              --exclude-tags=network,flaky \
               --total-shards=4 \
               --shard-index=${{ matrix.shard }}
           else
             # Empty selector output ⇒ paranoia: run full suite.
             flutter test \
-              --exclude-tags=network \
-              --exclude-tags=flaky \
+              --exclude-tags=network,flaky \
               --total-shards=4 \
               --shard-index=${{ matrix.shard }}
           fi
@@ -244,8 +242,7 @@ jobs:
         run: |
           flutter test \
             --coverage \
-            --exclude-tags=network \
-            --exclude-tags=flaky \
+            --exclude-tags=network,flaky \
             --total-shards=4 \
             --shard-index=${{ matrix.shard }}
       - name: Upload shard coverage


### PR DESCRIPTION
## Bug

The `test` job passed `--exclude-tags=network --exclude-tags=flaky` as **two separate flags**. `flutter test` doesn't accumulate a repeated `--exclude-tags` — the last wins — so only `flaky` was excluded and **every `network`-tagged test ran on every PR**. They passed silently while the live third-party APIs were up, and flaked a PR the moment one 5xx'd.

PR #1909 — which touches no shared code — failed `test (1)` on `api_connectivity_test.dart` ("Spain — MITECO API") with a live `503`. That file is `@Tags(['network'])` and should never run on a PR.

## Fix

All three `flutter test` invocations in the `test` job now use the single-flag comma form `--exclude-tags=network,flaky` — the same form `nightly-flaky.yml` already uses for `--tags`. `network` + `flaky` tests are now genuinely excluded from PR / master runs; `nightly-flaky` still runs them.

This PR's own CI run already exercises the fix (a `pull_request` run uses the head branch's workflow), so it validates itself.

Closes #1910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
