### PR TITLE
fix(obd2): freeze integration during the silent-reconnect window (#1912)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -1183,7 +1183,12 @@ class TripRecordingController {
   /// a [TripLiveReading], integrates any new fuel/distance since the
   /// last emit, and pushes to [live].
   void _emit() {
-    if (_paused || _pausedDueToDrop) return; // don't flood while paused
+    // Don't emit/integrate while paused, while a drop is on the pause
+    // banner, OR during the #1904 silent-reconnect window (#1912): the
+    // scheduler is stopped then, so the snapshot is stale — feeding it
+    // to the recorder would integrate phantom distance/fuel from a
+    // frozen speed over real elapsed time.
+    if (_paused || _pausedDueToDrop || _silentlyReconnecting) return;
     if (_liveController.isClosed) return;
 
     final snap = _liveSampleSnapshot;

--- a/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
@@ -442,6 +442,64 @@ void main() {
             reason: 'the retrying path makes exactly 2 attempts before '
                 'giving up — one try + one retry');
       });
+
+      test(
+          'the silent-reconnect window emits nothing — no phantom '
+          'integration from a stale snapshot (#1912)', () async {
+        // Speed + RPM PIDs so live telemetry actually flows before the
+        // drop. The default scheduler is used (no override) so it
+        // really polls; a short pollInterval keeps the emit timer
+        // ticking inside the test window.
+        final transport = FakeObd2Transport({
+          ...initResponses(),
+          '010D': '41 0D 32>', // 50 km/h
+          '010C': '41 0C 0E A6>', // ~937 rpm
+        });
+        await transport.connect();
+        final ctl = TripRecordingController(
+          service: Obd2Service(transport),
+          pollInterval: const Duration(milliseconds: 40),
+          vehicleId: 'car-1912',
+          pausedRepo: pausedRepo,
+          historyRepo: historyRepo,
+          pinnedAdapterMac: 'AA:BB',
+          // A scanner that never auto-reconnects, so the trip stays in
+          // the silent window for the whole test.
+          reconnectScannerFactory: (mac, onReconnect) => _ObservableScanner(
+            pinnedMac: mac,
+            onReconnect: onReconnect,
+            onStart: () {},
+            onStop: () {},
+          ),
+        );
+
+        final readings = <Object>[];
+        final sub = ctl.live.listen(readings.add);
+        await ctl.start();
+        // Live telemetry flows normally before the drop.
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        expect(readings, isNotEmpty,
+            reason: 'the emit timer must produce readings while the '
+                'trip is genuinely recording');
+
+        // Transport drop → enters the invisible reconnect window.
+        ctl.debugTriggerDrop();
+        expect(ctl.debugSilentlyReconnecting, isTrue);
+        final countAtDrop = readings.length;
+
+        // Several emit-timer ticks elapse while still inside the
+        // silent window (the scanner never reconnects here).
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(readings.length, countAtDrop,
+            reason: '#1912 — _emit must be gated during the silent '
+                'reconnect window: the scheduler is stopped, so emitting '
+                'the stale snapshot would integrate phantom distance / '
+                'fuel from a frozen speed over real elapsed time');
+
+        await sub.cancel();
+        await ctl.stop();
+      });
     });
   });
 }


### PR DESCRIPTION
## Bug

Found in a correctness audit of #1904's silent in-presence reconnect.

`TripRecordingController._emit` guarded only `_paused || _pausedDueToDrop`
— **not `_silentlyReconnecting`**. During the silent-reconnect window the
scheduler is stopped (no fresh telemetry) but the emit timer keeps
ticking, so every tick built a `TripSample` from the **stale** snapshot
with a fresh timestamp and fed the recorder — integrating **phantom
distance + fuel** from a frozen speed over real elapsed time, and feeding
the #1858 η_v-provenance accumulators stale ticks.

In-presence drops — the case the feature targets — all pass through this
window, so every blip silently fabricated up to ~6 s of trip data. The
visible-drop path was never affected (`_pausedDueToDrop` already
short-circuits `_emit`).

## Fix

`_emit` now also short-circuits on `_silentlyReconnecting` — the window
freezes integration exactly like a pause; on reconnect the recorder
integrates one interval across the gap (the existing pause/resume
behaviour).

## Verification

`flutter analyze` clean; `test/features/consumption/data/obd2/` +
`test/lint/` pass (984 tests), including a new test: while
`_silentlyReconnecting`, the emit timer keeps ticking but no
`TripLiveReading` is emitted and nothing is integrated.

Closes #1912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
