### PR TITLE
fix(ui): halve the tank-level figure + swap the Carte/Favoris nav order (#1914)

### DIFF
--- a/lib/app/shell/shell_destinations.dart
+++ b/lib/app/shell/shell_destinations.dart
@@ -38,9 +38,9 @@ class ShellDestinations {
 /// other destinations flank it. Consumption is now **two** separate
 /// destinations, Carburant and Trajets (#1901):
 ///
-///   * Conso off:            `Map · [Search] · Favorites`
-///   * Fuel-only mode:       `Map · Favorites · [Search] · Carburant`
-///   * Fuel + Trips mode:    `Map · Favorites · [Search] · Carburant · Trajets`
+///   * Conso off:            `Favorites · [Search] · Map`
+///   * Fuel-only mode:       `Favorites · Map · [Search] · Carburant`
+///   * Fuel + Trips mode:    `Favorites · Map · [Search] · Carburant · Trajets`
 ///
 /// Settings is **not** a tab — it lives in the top-right app bar
 /// (`SettingsAppBarAction`), reached via router branch 4 (`/profile`).
@@ -89,18 +89,18 @@ ShellDestinations resolveShellDestinations({
 
   if (!showConsumption) {
     return ShellDestinations(
-      items: [map, search, favorites],
-      branchForSlot: const [1, 0, 2],
+      items: [favorites, search, map],
+      branchForSlot: const [2, 0, 1],
     );
   }
   if (!showTrajets) {
     return ShellDestinations(
-      items: [map, favorites, search, carburant],
-      branchForSlot: const [1, 2, 0, 3],
+      items: [favorites, map, search, carburant],
+      branchForSlot: const [2, 1, 0, 3],
     );
   }
   return ShellDestinations(
-    items: [map, favorites, search, carburant, trajets],
-    branchForSlot: const [1, 2, 0, 3, kTrajetsBranchIndex],
+    items: [favorites, map, search, carburant, trajets],
+    branchForSlot: const [2, 1, 0, 3, kTrajetsBranchIndex],
   );
 }

--- a/lib/features/consumption/presentation/widgets/tank_level_card.dart
+++ b/lib/features/consumption/presentation/widgets/tank_level_card.dart
@@ -129,7 +129,10 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
               Text(
                 l?.tankLevelLitersFormat(litresText) ?? '$litresText L',
                 key: const Key('tank_level_big_number'),
-                style: theme.textTheme.displayMedium?.copyWith(
+                // #1914 — was `displayMedium` (~45 sp), which dominated
+                // the card; `titleLarge` (~22 sp) roughly halves it
+                // while the w600 weight keeps it the card's focal point.
+                style: theme.textTheme.titleLarge?.copyWith(
                   color: lowFuel ? theme.colorScheme.error : null,
                   fontWeight: FontWeight.w600,
                   fontFeatures: const [FontFeature.tabularFigures()],

--- a/test/app/shell/shell_destinations_test.dart
+++ b/test/app/shell/shell_destinations_test.dart
@@ -28,9 +28,9 @@ void main() {
         );
 
         expect(result.items, hasLength(3));
-        expect(result.branchForSlot, [1, 0, 2]);
+        expect(result.branchForSlot, [2, 0, 1]);
         expect(result.items.map((i) => i.label).toList(),
-            ['Map', 'Search', 'Favorites']);
+            ['Favorites', 'Search', 'Map']);
 
         // No fuel-station / route icon in the visible items list.
         for (final item in result.items) {
@@ -41,7 +41,7 @@ void main() {
     );
 
     test(
-      'fuel-only mode → Map · Favorites · [Search] · Carburant '
+      'fuel-only mode → Favorites · Map · [Search] · Carburant '
       '(#1901: Trajets hidden)',
       () {
         final result = resolveShellDestinations(
@@ -53,9 +53,9 @@ void main() {
         expect(result.items, hasLength(4));
         // Visual slots map back to router branches Search=0, Map=1,
         // Favorites=2, Carburant=3.
-        expect(result.branchForSlot, [1, 2, 0, 3]);
+        expect(result.branchForSlot, [2, 1, 0, 3]);
         expect(result.items.map((i) => i.label).toList(),
-            ['Map', 'Favorites', 'Search', 'Fuel']);
+            ['Favorites', 'Map', 'Search', 'Fuel']);
 
         // Carburant item carries the fuel-station icon.
         expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
@@ -69,7 +69,7 @@ void main() {
     );
 
     test(
-      'fuel + trips mode → Map · Favorites · [Search] · Carburant · Trajets '
+      'fuel + trips mode → Favorites · Map · [Search] · Carburant · Trajets '
       '(#1901)',
       () {
         final result = resolveShellDestinations(
@@ -80,9 +80,9 @@ void main() {
 
         expect(result.items, hasLength(5));
         // Search=0, Map=1, Favorites=2, Carburant=3, Trajets=5.
-        expect(result.branchForSlot, [1, 2, 0, 3, kTrajetsBranchIndex]);
+        expect(result.branchForSlot, [2, 1, 0, 3, kTrajetsBranchIndex]);
         expect(result.items.map((i) => i.label).toList(),
-            ['Map', 'Favorites', 'Search', 'Fuel', 'Trips']);
+            ['Favorites', 'Map', 'Search', 'Fuel', 'Trips']);
 
         // Carburant carries the fuel-station icon, Trajets the route icon.
         expect(result.items[3].outlinedIcon, Icons.local_gas_station_outlined);
@@ -140,7 +140,7 @@ void main() {
         showTrajets: true,
       );
       expect(result.items.map((i) => i.label).toList(),
-          ['Map', 'Favorites', 'Search', 'Fuel', 'Trips']);
+          ['Favorites', 'Map', 'Search', 'Fuel', 'Trips']);
     });
 
     test('the Carburant slot routes to kConsumptionBranchIndex', () {


### PR DESCRIPTION
## What

Two screenshot-driven tweaks.

- **Tank-level figure** — the `{litres} L` hero number rendered in
  `displayMedium` (~45 sp) and dominated the screen. Dropped to
  `titleLarge` (~22 sp) — roughly half — keeping the w600 weight so
  it's still the card's focal point.
- **Nav-bar order** — the bottom bar's left pair is swapped from
  `Carte · Favoris` to `Favoris · Carte`, in all three layouts. Only
  the visual `items` order + `branchForSlot` change; router branch
  indices are untouched.

## Verification

`flutter analyze` clean; `test/app/` + `test/lint/` + the tank-level
widget tests pass — `shell_destinations_test` updated for the new
order.

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
