### PR TITLE
fix(obd2): use ATAT1 (recommended adaptive timing) not ATAT2 — recording regression (#1918)

### DIFF
--- a/lib/features/consumption/data/obd2/elm327_commands.dart
+++ b/lib/features/consumption/data/obd2/elm327_commands.dart
@@ -104,15 +104,16 @@ class Elm327Commands {
   /// Turn off headers in responses.
   static const headersOffCommand = 'ATH0\r';
 
-  /// Enable aggressive adaptive timing (#1904). `ATAT2` lets the
-  /// ELM327 shorten its per-request timeout when the ECU is answering
-  /// quickly and *extend* it when a slow ECU needs more time — a fixed
-  /// timeout either wastes time or cuts a slow reply short, and the
-  /// latter shows up as a dropped read. Adaptive timing measurably
-  /// cuts spurious mid-trip drops.
-  static const adaptiveTimingCommand = 'ATAT2\r';
+  /// Enable adaptive timing (#1904, mode corrected in #1918). `ATAT1`
+  /// is the ELM327's **default and documented-recommended** adaptive
+  /// mode: it sets each request's timeout from the vehicle's actual
+  /// response times and re-learns as bus load changes. `ATAT2` (the
+  /// more *aggressive* variant #1904 originally shipped) cut ECU
+  /// replies short on some adapters — a recording regression — so the
+  /// init sequence pins the recommended `ATAT1` explicitly.
+  static const adaptiveTimingCommand = 'ATAT1\r';
 
-  /// Standard initialization sequence for a new connection. `ATAT2` is
+  /// Standard initialization sequence for a new connection. `ATAT1` is
   /// sent last, after the protocol is selected, so the adaptive-timing
   /// algorithm is in effect for the very first OBD request.
   static const initCommands = [

--- a/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
@@ -59,7 +59,7 @@ void main() {
         'ATL0\r',
         'ATH0\r',
         'ATSP0\r',
-        'ATAT2\r', // #1904 — aggressive adaptive timing
+        'ATAT1\r', // #1904 — adaptive timing (ATAT1, #1918)
       ]);
     });
 
@@ -159,7 +159,7 @@ void main() {
         // #1401 phase 1: connect appends a firmware-version probe
         // (`ATI`) after the init sequence — same interCommandDelay
         // applies, so it slots into the gap-bound assertions below.
-        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATAT2', 'ATI']);
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATAT1', 'ATI']);
 
         // Gap before ATE0 reflects the 400 ms postResetDelay.
         final firstGap = transport.commands[1].at - transport.commands[0].at;

--- a/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
@@ -64,7 +64,7 @@ void main() {
         'ATL0\r',
         'ATH0\r',
         'ATSP0\r',
-        'ATAT2\r', // #1904 — aggressive adaptive timing
+        'ATAT1\r', // #1904 — adaptive timing (ATAT1, #1918)
       ]);
     });
 
@@ -114,7 +114,7 @@ void main() {
         // #1401 phase 1: the connect path now appends an `ATI`
         // firmware-version probe after the init sequence. Subject to
         // the same interCommandDelay as the rest of the loop.
-        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATAT2', 'ATI']);
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATAT1', 'ATI']);
 
         // Gap between cmd[0] (ATZ) and cmd[1] (ATE0) reflects the
         // 200 ms postResetDelay. Generous lower bound (180 ms) avoids

--- a/test/features/consumption/data/obd2/elm327_adapter_test.dart
+++ b/test/features/consumption/data/obd2/elm327_adapter_test.dart
@@ -67,7 +67,7 @@ void main() {
         'ATL0\r',
         'ATH0\r',
         'ATSP0\r',
-        'ATAT2\r', // #1904 — aggressive adaptive timing
+        'ATAT1\r', // #1904 — adaptive timing (ATAT1, #1918)
       ]);
     });
 
@@ -104,14 +104,14 @@ void main() {
           'ATL0': 'OK>',
           'ATH0': 'OK>',
           'ATSP0': 'OK>',
-          'ATAT2': 'OK>',
+          'ATAT1': 'OK>',
         });
         final service = Obd2Service(transport);
 
         final connected = await service.connect();
 
         expect(connected, isTrue);
-        // Captured commands match the init list (#1904 added ATAT2),
+        // Captured commands match the init list (#1904 added ATAT1),
         // followed by the #1401 phase 1 firmware-version probe.
         final sent = transport.commands.map((c) => c.command).toList();
         expect(sent, [
@@ -120,7 +120,7 @@ void main() {
           'ATL0',
           'ATH0',
           'ATSP0',
-          'ATAT2',
+          'ATAT1',
           'ATI',
         ]);
 

--- a/test/features/consumption/data/obd2/elm327_commands_test.dart
+++ b/test/features/consumption/data/obd2/elm327_commands_test.dart
@@ -207,16 +207,16 @@ void main() {
 
     test('initCommands contains the AT init commands in expected order',
         () {
-      // #1904 — ATAT2 (aggressive adaptive timing) is sent last, after
+      // #1904 — ATAT1 (adaptive timing (ATAT1, #1918)) is sent last, after
       // the protocol is selected.
-      expect(Elm327Commands.adaptiveTimingCommand, 'ATAT2\r');
+      expect(Elm327Commands.adaptiveTimingCommand, 'ATAT1\r');
       expect(Elm327Commands.initCommands, <String>[
         'ATZ\r',
         'ATE0\r',
         'ATL0\r',
         'ATH0\r',
         'ATSP0\r',
-        'ATAT2\r',
+        'ATAT1\r',
       ]);
     });
 

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -708,14 +708,14 @@ void main() {
             'ATL0': 'OK>',
             'ATH0': 'OK>',
             'ATSP0': 'OK>',
-            'ATAT2': 'OK>',
+            'ATAT1': 'OK>',
             'ATI': 'ELM327 v1.5>',
           },
           sent,
         );
         final service = Obd2Service(transport);
         await service.connect();
-        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATAT2', 'ATI']);
+        expect(sent, ['ATZ', 'ATE0', 'ATL0', 'ATH0', 'ATSP0', 'ATAT1', 'ATI']);
       },
     );
 

--- a/test/features/consumption/data/obd2/trip_recording_controller_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_test.dart
@@ -467,7 +467,7 @@ void main() {
         'ATL0': 'OK>',
         'ATH0': 'OK>',
         'ATSP0': 'OK>',
-        'ATAT2': 'OK>',
+        'ATAT1': 'OK>',
         '015E': 'NO DATA>',
         '0110': 'NO DATA>',
         '010B': '41 0B 50>', // MAP 80 kPa
@@ -514,7 +514,7 @@ void main() {
         'ATL0': 'OK>',
         'ATH0': 'OK>',
         'ATSP0': 'OK>',
-        'ATAT2': 'OK>',
+        'ATAT1': 'OK>',
         '015E': '41 5E 00 64>', // PID 5E direct fuel rate = 5.0 L/h
         '010C': '41 0C 0E A6>', // RPM ~937
         '010D': '41 0D 32>', // 50 km/h


### PR DESCRIPTION
## Regression

User: *"All adapters connect badly and aren't recording anymore."*

#1904 added **`ATAT2`** to every adapter's ELM327 init sequence. Web research on ELM327 timing is unambiguous:

- **`ATAT1` is the ELM327 default *and* the documented-recommended** adaptive-timing mode — it derives each request's timeout from the vehicle's actual response times and re-learns as bus load changes.
- `ATAT2` is the *more aggressive* variant. Forcing it on every adapter cut ECU replies short on some adapters → failed PID reads → "not recording." The **all-adapters** scope matches a global init-command change.

## Fix

`adaptiveTimingCommand` → **`ATAT1`** (the recommended mode, pinned explicitly). Init-sequence tests updated across the adapter suite.

Sources: ELM327 datasheet (elmelectronics.com) + the ELM327 AT-command reference — both list `ATAT1` as default/recommended.

## Verification

`flutter analyze` clean; `test/features/consumption/data/obd2/` + `test/lint/` pass (954 obd2 tests). **Runtime confirmation needs an on-device build** — this restores the recommended timing mode that the pre-#1904 builds effectively used (adapter default).

Closes #1918

🤖 Generated with [Claude Code](https://claude.com/claude-code)
