### PR TITLE
feat(obd2): exportable connection/recording diagnostic log (#1920)

### DIFF
--- a/lib/features/consumption/data/obd2/auto_record_trace_log.dart
+++ b/lib/features/consumption/data/obd2/auto_record_trace_log.dart
@@ -87,6 +87,41 @@ enum AutoRecordEventKind {
   /// count.
   obd2SpeedReadFailed,
 
+  /// `Obd2Service.connect()` entered — the ELM327 init handshake is
+  /// about to start. Mac carries the adapter id (#1920).
+  connectStarted,
+
+  /// `Obd2Service.connect()` is about to return `true` — the init
+  /// sequence completed. Detail carries the firmware string when the
+  /// adapter reported one (#1920).
+  connectSucceeded,
+
+  /// `Obd2Service.connect()` threw before it could return — the
+  /// handshake failed. Detail carries the error message (#1920).
+  connectFailed,
+
+  /// A recording session's drop detector flagged a connection drop —
+  /// the scheduler is about to stop. Detail carries the
+  /// [TripDropReason] (#1920).
+  dropDetected,
+
+  /// A transport-error drop entered the #1904 invisible reconnect
+  /// window — the controller still reports `recording` while the
+  /// scanner probes for the adapter (#1920).
+  silentReconnectStarted,
+
+  /// The adapter came back inside the #1904 silent reconnect window —
+  /// polling resumed without the user ever seeing a pause (#1920).
+  silentReconnectSucceeded,
+
+  /// The silent reconnect window elapsed without the adapter coming
+  /// back; the drop escalated to the visible pause banner (#1920).
+  dropEscalatedToVisible,
+
+  /// The adapter came back after the drop went visible — the
+  /// pause-with-grace state was cleared and polling resumed (#1920).
+  reconnectSucceeded,
+
   /// Generic catch — detail carries a free-form message. Used
   /// sparingly so the enum stays the contract.
   error,

--- a/lib/features/consumption/data/obd2/obd2_diagnostic_report.dart
+++ b/lib/features/consumption/data/obd2/obd2_diagnostic_report.dart
@@ -1,0 +1,88 @@
+import 'auto_record_trace_log.dart';
+
+/// Formats a list of [AutoRecordEvent]s into a plain-text OBD2
+/// connection/recording diagnostic report (#1920).
+///
+/// The report is meant to be handed to the OS share sheet so a user
+/// can send the trace of a failed recording session to a developer.
+/// It is deliberately:
+///
+///  * **plain text** — readable in any mail / chat client, no parsing
+///    tooling required;
+///  * **PII-safe** — the BLE MAC address is redacted to its last four
+///    characters (a full MAC is a stable hardware identifier). No VIN,
+///    no GPS coordinates are ever in the trace ring, so nothing else
+///    needs scrubbing here.
+///
+/// Output shape:
+///
+/// ```text
+/// OBD2 diagnostic log — generated 2024-01-15 09:30:00
+/// [09:30:01.123] connectStarted  ··········EE:FF
+/// [09:30:03.456] connectSucceeded  ··········EE:FF  ELM327 v1.5
+/// ```
+///
+/// One header line (the generated-at timestamp) followed by one line
+/// per event: `[HH:mm:ss.SSS] <kind>  <mac?>  <detail?>`. An empty
+/// event list produces a clear "no events recorded" line so the
+/// recipient can tell an empty trace apart from a truncated paste.
+String formatObd2DiagnosticReport(
+  List<AutoRecordEvent> events, {
+  DateTime? generatedAt,
+}) {
+  final DateTime stamp = generatedAt ?? DateTime.now();
+  final StringBuffer buffer = StringBuffer()
+    ..writeln('OBD2 diagnostic log — generated ${_formatStamp(stamp)}');
+
+  if (events.isEmpty) {
+    buffer.writeln('(no events recorded)');
+    return buffer.toString();
+  }
+
+  for (final AutoRecordEvent event in events) {
+    final List<String> parts = <String>[
+      '[${_formatEventTime(event.timestamp)}]',
+      event.kind.name,
+      if (event.mac != null) _redactMac(event.mac!),
+      if (event.detail != null) event.detail!,
+    ];
+    buffer.writeln(parts.join('  '));
+  }
+  return buffer.toString();
+}
+
+/// `YYYY-MM-DD HH:mm:ss` header timestamp.
+String _formatStamp(DateTime ts) {
+  final String y = ts.year.toString().padLeft(4, '0');
+  final String mo = ts.month.toString().padLeft(2, '0');
+  final String d = ts.day.toString().padLeft(2, '0');
+  return '$y-$mo-$d ${_formatClock(ts)}';
+}
+
+/// `HH:mm:ss.SSS` per-event timestamp.
+String _formatEventTime(DateTime ts) {
+  final String ms = ts.millisecond.toString().padLeft(3, '0');
+  return '${_formatClock(ts)}.$ms';
+}
+
+/// `HH:mm:ss` clock fragment shared by both formats.
+String _formatClock(DateTime ts) {
+  final String h = ts.hour.toString().padLeft(2, '0');
+  final String m = ts.minute.toString().padLeft(2, '0');
+  final String s = ts.second.toString().padLeft(2, '0');
+  return '$h:$m:$s';
+}
+
+/// Redact a BLE MAC / remote-id to its last four characters — a full
+/// MAC is a stable hardware identifier (PII). Everything before the
+/// final four characters is replaced with the middle-dot `·` so the
+/// length is still visible without leaking the address.
+///
+/// `AA:BB:CC:DD:EE:FF` → `···············E:FF`. A string of four
+/// characters or fewer is returned unchanged (there is nothing to
+/// hide).
+String _redactMac(String mac) {
+  if (mac.length <= 4) return mac;
+  final String visible = mac.substring(mac.length - 4);
+  return '${'·' * (mac.length - 4)}$visible';
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import 'adapter_capability.dart';
+import 'auto_record_trace_log.dart';
 import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 import 'fuel_rate_estimator.dart' as estimator;
@@ -182,6 +183,12 @@ class Obd2Service implements Obd2RawCommandPort {
   Future<bool> connect({
     Elm327Adapter adapter = const GenericElm327Adapter(),
   }) async {
+    // #1920 — trace the connect attempt so a failed recording session
+    // can be analysed from the exportable OBD2 diagnostic log.
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.connectStarted,
+      mac: adapterMac,
+    );
     try {
       _adapter = adapter;
       await _transport.connect();
@@ -238,9 +245,23 @@ class Obd2Service implements Obd2RawCommandPort {
 
       await _pids.prime();
 
+      // #1920 — record the successful handshake with the firmware
+      // string when the adapter reported one.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.connectSucceeded,
+        mac: adapterMac,
+        detail: adapterFirmware,
+      );
       return true;
     } catch (e, st) {
       debugPrint('OBD2 connect failed: $e\n$st');
+      // #1920 — record the failure so the diagnostic log shows the
+      // connect attempt that never produced a session.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.connectFailed,
+        mac: adapterMac,
+        detail: e.toString(),
+      );
       return false;
     }
   }

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -11,6 +11,7 @@ import '../../domain/services/gear_inference.dart';
 import '../../domain/trip_recorder.dart';
 import '../trip_history_repository.dart';
 import 'adapter_reconnect_scanner.dart';
+import 'auto_record_trace_log.dart';
 import 'elm327_protocol.dart';
 import 'live_sample_snapshot.dart';
 import 'obd2_breadcrumb_collector.dart';
@@ -969,6 +970,13 @@ class TripRecordingController {
     TripDropReason reason = TripDropReason.transportError,
   }) {
     if (_pausedDueToDrop || _silentlyReconnecting) return;
+    // #1920 — trace every detected drop so a failed recording session
+    // can be analysed from the exportable OBD2 diagnostic log.
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.dropDetected,
+      mac: _pinnedAdapterMac,
+      detail: reason.name,
+    );
     _scheduler?.stop();
     _dropDetector.clearErrorWindow();
     _persistPausedSnapshot();
@@ -976,6 +984,11 @@ class TripRecordingController {
         _silentReconnectWindow > Duration.zero) {
       _silentlyReconnecting = true;
       _dropReason = reason;
+      // #1920 — record entry into the #1904 invisible reconnect window.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.silentReconnectStarted,
+        mac: _pinnedAdapterMac,
+      );
       _startReconnectScanner();
       _silentReconnectTimer?.cancel();
       _silentReconnectTimer =
@@ -1007,6 +1020,12 @@ class TripRecordingController {
     _silentReconnectTimer = null;
     if (!_silentlyReconnecting || _pausedDueToDrop || _stopped) return;
     _silentlyReconnecting = false;
+    // #1920 — record the escalation: the silent window elapsed without
+    // the adapter coming back, so the drop is now visible to the user.
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.dropEscalatedToVisible,
+      mac: _pinnedAdapterMac,
+    );
     _enterVisibleDrop(_dropReason ?? TripDropReason.transportError);
   }
 
@@ -1057,6 +1076,12 @@ class TripRecordingController {
       _dropReason = null;
       _dropDetector.reset();
       _clearPausedTripRow();
+      // #1920 — record the silent-path recovery: the adapter came back
+      // inside the #1904 window and the user never saw a pause.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.silentReconnectSucceeded,
+        mac: _pinnedAdapterMac,
+      );
       // Respect a user pause that landed during the silent window.
       if (!_paused && !_stopped) _scheduler?.start();
       _emitState();
@@ -1064,7 +1089,15 @@ class TripRecordingController {
     }
     // Reconnected after the drop went visible — the ordinary resume()
     // path cancels the grace timer and clears the paused-trips row.
-    if (_pausedDueToDrop) resume();
+    if (_pausedDueToDrop) {
+      // #1920 — record the visible-path recovery: the adapter came back
+      // after the pause banner had already been shown.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.reconnectSucceeded,
+        mac: _pinnedAdapterMac,
+      );
+      resume();
+    }
   }
 
   Future<void> _stopReconnectScanner() async {

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -1,13 +1,32 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../data/obd2/auto_record_trace_log.dart';
 import '../../data/obd2/obd2_breadcrumb_collector.dart';
+import '../../data/obd2/obd2_diagnostic_report.dart';
 import '../../providers/obd2_breadcrumb_provider.dart';
 import 'broken_map_widgets.dart';
+
+/// Hook for the share-sheet handoff of the OBD2 diagnostic log
+/// (#1920). Production uses `SharePlus.instance.share`; tests
+/// substitute a fake via [debugObd2DiagnosticShareSinkOverride] to
+/// assert the outgoing report text without launching the OS share
+/// sheet. Mirrors the seam pattern in `full_backup_exporter.dart`.
+typedef Obd2DiagnosticShareSink = Future<void> Function(ShareParams params);
+
+/// Test-only override for the share sink used by the OBD2 diagnostic
+/// share button. When set, the button hands the formatted report to
+/// this sink instead of the real `share_plus` plugin.
+@visibleForTesting
+Obd2DiagnosticShareSink? debugObd2DiagnosticShareSinkOverride;
+
+Future<void> _defaultObd2DiagnosticShareSink(ShareParams params) =>
+    SharePlus.instance.share(params);
 
 /// In-app overlay that renders the most recent fuel-rate breadcrumbs
 /// captured by [Obd2BreadcrumbsNotifier] (#1395). Sibling to the map
@@ -28,6 +47,25 @@ import 'broken_map_widgets.dart';
 /// production builds where the flag is off.
 class Obd2BreadcrumbOverlay extends ConsumerWidget {
   const Obd2BreadcrumbOverlay({super.key});
+
+  /// Format the process-wide OBD2 trace ring into a plain-text report
+  /// and hand it to the OS share sheet (#1920). Best-effort — a share
+  /// failure is logged and swallowed so the developer-only overlay
+  /// never crashes the recording screen.
+  Future<void> _shareDiagnosticLog() async {
+    final String report = formatObd2DiagnosticReport(
+      AutoRecordTraceLog.snapshot(),
+    );
+    final ShareParams params = ShareParams(text: report);
+    final Obd2DiagnosticShareSink sink =
+        debugObd2DiagnosticShareSinkOverride ??
+            _defaultObd2DiagnosticShareSink;
+    try {
+      await sink(params);
+    } catch (e, st) {
+      debugPrint('Obd2BreadcrumbOverlay share diagnostic log failed: $e\n$st');
+    }
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -113,6 +151,24 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
                         child: Text(
                           l10n?.obd2DebugOverlayClearButton ?? 'Clear',
                         ),
+                      ),
+                      // #1920 — export the OBD2 connect/drop/reconnect
+                      // trace as plain text so a developer can analyse
+                      // a failed recording session. The trace ring is
+                      // process-wide, not tied to the fuel-rate
+                      // breadcrumbs above.
+                      IconButton(
+                        onPressed: () => _shareDiagnosticLog(),
+                        icon: const Icon(Icons.share, size: 18),
+                        color: Colors.white,
+                        tooltip: l10n?.obd2DiagnosticShareLabel ??
+                            'Share diagnostic log',
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        constraints: const BoxConstraints(
+                          minWidth: 32,
+                          minHeight: 32,
+                        ),
+                        visualDensity: VisualDensity.compact,
                       ),
                       TextButton(
                         onPressed: () {

--- a/lib/l10n/_fragments/obd2_diagnostic_overlay_de.arb
+++ b/lib/l10n/_fragments/obd2_diagnostic_overlay_de.arb
@@ -3,5 +3,6 @@
   "obd2DebugOverlayDisabledSnack": "OBD2-Diagnose-Overlay deaktiviert",
   "obd2DebugOverlayClearButton": "Leeren",
   "obd2DebugOverlayCloseButton": "Schließen",
-  "obd2DebugOverlayTitle": "OBD2-Spuren"
+  "obd2DebugOverlayTitle": "OBD2-Spuren",
+  "obd2DiagnosticShareLabel": "Diagnoseprotokoll teilen"
 }

--- a/lib/l10n/_fragments/obd2_diagnostic_overlay_en.arb
+++ b/lib/l10n/_fragments/obd2_diagnostic_overlay_en.arb
@@ -18,5 +18,9 @@
   "obd2DebugOverlayTitle": "OBD2 breadcrumbs",
   "@obd2DebugOverlayTitle": {
     "description": "Title shown at the top of the in-app OBD2 fuel-rate diagnostic overlay panel (#1395)."
+  },
+  "obd2DiagnosticShareLabel": "Share diagnostic log",
+  "@obd2DiagnosticShareLabel": {
+    "description": "Label and tooltip for the button on the in-app OBD2 diagnostic overlay that exports the OBD2 connect/drop/reconnect trace as plain text to the OS share sheet, so a developer can analyse a failed recording session (#1920)."
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Изчисти",
   "obd2DebugOverlayCloseButton": "Затвори",
   "obd2DebugOverlayTitle": "OBD2 следи",
+  "obd2DiagnosticShareLabel": "Споделяне на диагностичния дневник",
   "obd2PickerPinnedFallback": "Не може да се достигне до '{adapterName}' — изберете друг адаптер",
   "onboardingObd2StepTitle": "Свържете OBD2 адаптера",
   "onboardingObd2StepBody": "Включете OBD2 адаптера в порта на автомобила и включете запалването. Ще прочетем VIN и ще попълним данните за двигателя вместо вас.",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Vymazat",
   "obd2DebugOverlayCloseButton": "Zavřít",
   "obd2DebugOverlayTitle": "Stopy OBD2",
+  "obd2DiagnosticShareLabel": "Sdílet diagnostický protokol",
   "obd2PickerPinnedFallback": "Nelze se připojit k '{adapterName}' — vyberte jiný adaptér",
   "onboardingObd2StepTitle": "Připojit adaptér OBD2",
   "onboardingObd2StepBody": "Zapojte adaptér OBD2 do portu auta a zapněte zapalování. Přečteme VIN a vyplníme podrobnosti o motoru za vás.",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Ryd",
   "obd2DebugOverlayCloseButton": "Luk",
   "obd2DebugOverlayTitle": "OBD2-brødkrummer",
+  "obd2DiagnosticShareLabel": "Del diagnostiklog",
   "obd2PickerPinnedFallback": "Kunne ikke nå '{adapterName}' — vælg en anden adapter",
   "onboardingObd2StepTitle": "Tilslut din OBD2-adapter",
   "onboardingObd2StepBody": "Sæt din OBD2-adapter i bilens port og tænd tændingen. Vi aflæser VIN'en og udfylder motoroplysninger for dig.",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1850,6 +1850,7 @@
   "obd2DebugOverlayClearButton": "Leeren",
   "obd2DebugOverlayCloseButton": "Schließen",
   "obd2DebugOverlayTitle": "OBD2-Spuren",
+  "obd2DiagnosticShareLabel": "Diagnoseprotokoll teilen",
   "obd2PickerPinnedFallback": "Konnte '{adapterName}' nicht erreichen — wähle einen anderen Adapter",
   "@obd2PickerPinnedFallback": {
     "description": "Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Εκκαθάριση",
   "obd2DebugOverlayCloseButton": "Κλείσιμο",
   "obd2DebugOverlayTitle": "Ίχνη OBD2",
+  "obd2DiagnosticShareLabel": "Κοινοποίηση διαγνωστικού αρχείου",
   "obd2PickerPinnedFallback": "Δεν ήταν δυνατή η επαφή με '{adapterName}' — επιλέξτε άλλον προσαρμογέα",
   "onboardingObd2StepTitle": "Σύνδεση προσαρμογέα OBD2",
   "onboardingObd2StepBody": "Συνδέστε τον προσαρμογέα OBD2 στη θύρα του αυτοκινήτου και ανάψτε τη μίζα. Θα διαβάσουμε το VIN και θα συμπληρώσουμε τα στοιχεία κινητήρα για εσάς.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3209,6 +3209,10 @@
   "@obd2DebugOverlayTitle": {
     "description": "Title shown at the top of the in-app OBD2 fuel-rate diagnostic overlay panel (#1395)."
   },
+  "obd2DiagnosticShareLabel": "Share diagnostic log",
+  "@obd2DiagnosticShareLabel": {
+    "description": "Label and tooltip for the button on the in-app OBD2 diagnostic overlay that exports the OBD2 connect/drop/reconnect trace as plain text to the OS share sheet, so a developer can analyse a failed recording session (#1920)."
+  },
   "obd2PickerPinnedFallback": "Couldn't reach '{adapterName}' — pick another adapter",
   "@obd2PickerPinnedFallback": {
     "description": "Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "⟦Çłéář ··⟧",
   "obd2DebugOverlayCloseButton": "⟦Çłóšé ··⟧",
   "obd2DebugOverlayTitle": "⟦ÓƁĐ2 ƀřéáđçřúɱƀš ······⟧",
+  "obd2DiagnosticShareLabel": "⟦Šĥářé đîáǧñóšŧîç łóǧ ········⟧",
   "obd2PickerPinnedFallback": "⟦Çóúłđñ'ŧ řéáçĥ '{adapterName}' — ƥîçķ áñóŧĥéř áđáƥŧéř ··············⟧",
   "onboardingObd2StepTitle": "⟦Çóññéçŧ ýóúř ÓƁĐ2 áđáƥŧéř ·········⟧",
   "onboardingObd2StepBody": "⟦Ƥłúǧ ýóúř ÓƁĐ2 áđáƥŧéř îñŧó ŧĥé çář'š ƥóřŧ áñđ ŧúřñ ŧĥé îǧñîŧîóñ óñ. Ŵé'łł řéáđ ŧĥé ṼÎÑ áñđ ƒîłł îñ éñǧîñé đéŧáîłš ƒóř ýóú. ···········································⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Borrar",
   "obd2DebugOverlayCloseButton": "Cerrar",
   "obd2DebugOverlayTitle": "Rastro de OBD2",
+  "obd2DiagnosticShareLabel": "Compartir registro de diagnóstico",
   "obd2PickerPinnedFallback": "No se pudo contactar con «{adapterName}»: elige otro adaptador",
   "onboardingObd2StepTitle": "Conecta tu adaptador OBD2",
   "onboardingObd2StepBody": "Conecta tu adaptador OBD2 al puerto del coche y enciende el contacto. Leeremos el VIN y rellenaremos por ti los detalles del motor.",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Tühjenda",
   "obd2DebugOverlayCloseButton": "Sulge",
   "obd2DebugOverlayTitle": "OBD2 leivaraasud",
+  "obd2DiagnosticShareLabel": "Jaga diagnostikalogi",
   "obd2PickerPinnedFallback": "Ei suutnud jõuda '{adapterName}' — vali teine adapter",
   "onboardingObd2StepTitle": "Ühenda oma OBD2 adapter",
   "onboardingObd2StepBody": "Ühenda oma OBD2 adapter auto porti ja lülita süütevool sisse. Loeme VIN-koodi ja täidame mootori andmed sinu eest.",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Tyhjennä",
   "obd2DebugOverlayCloseButton": "Sulje",
   "obd2DebugOverlayTitle": "OBD2-jäljet",
+  "obd2DiagnosticShareLabel": "Jaa diagnostiikkaloki",
   "obd2PickerPinnedFallback": "Ei voitu tavoittaa '{adapterName}' — valitse toinen sovitin",
   "onboardingObd2StepTitle": "Yhdistä OBD2-sovitin",
   "onboardingObd2StepBody": "Kytke OBD2-sovitin auton porttiin ja käynnistä sytytin. Luemme VIN-koodin ja täytämme moottorin tiedot puolestasi.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1162,6 +1162,7 @@
   "obd2DebugOverlayClearButton": "Effacer",
   "obd2DebugOverlayCloseButton": "Fermer",
   "obd2DebugOverlayTitle": "Traces OBD2",
+  "obd2DiagnosticShareLabel": "Partager le journal de diagnostic",
   "brokenMapChipVerifying": "Vérification du capteur MAP…",
   "brokenMapChipDisclaimer": "Lectures MAP suspectes",
   "brokenMapSnackbarUnreliable": "Le capteur MAP donne des valeurs incorrectes — la consommation affichée peut être 50 à 80 % trop basse. Essayez un autre adaptateur.",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Očisti",
   "obd2DebugOverlayCloseButton": "Zatvori",
   "obd2DebugOverlayTitle": "OBD2 trag",
+  "obd2DiagnosticShareLabel": "Podijeli dijagnostički zapisnik",
   "obd2PickerPinnedFallback": "Nije moguće dosegnuti '{adapterName}' — odaberite drugi adapter",
   "onboardingObd2StepTitle": "Spojite vaš OBD2 adapter",
   "onboardingObd2StepBody": "Priključite OBD2 adapter u priključak automobila i uključite paljenje. Pročitat ćemo VIN i popuniti detalje motora za vas.",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Törlés",
   "obd2DebugOverlayCloseButton": "Bezárás",
   "obd2DebugOverlayTitle": "OBD2 morzsakód-nyomvonal",
+  "obd2DiagnosticShareLabel": "Diagnosztikai napló megosztása",
   "obd2PickerPinnedFallback": "Nem sikerült elérni a(z) '{adapterName}'-t — válasszon másik adaptert",
   "onboardingObd2StepTitle": "OBD2-adapter csatlakoztatása",
   "onboardingObd2StepBody": "Dugja be az OBD2-adaptert az autó portjába, és kapcsolja be a gyújtást. Beolvassuk a VIN-t, és kitöltjük a motoradatokat.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Azzera",
   "obd2DebugOverlayCloseButton": "Chiudi",
   "obd2DebugOverlayTitle": "Breadcrumb OBD2",
+  "obd2DiagnosticShareLabel": "Condividi il registro diagnostico",
   "obd2PickerPinnedFallback": "Impossibile raggiungere '{adapterName}' — scegli un altro adattatore",
   "onboardingObd2StepTitle": "Connetti il tuo adattatore OBD2",
   "onboardingObd2StepBody": "Collega il tuo adattatore OBD2 alla porta dell'auto e accendi il quadro. Leggeremo il VIN e inseriremo i dettagli del motore per te.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8373,6 +8373,12 @@ abstract class AppLocalizations {
   /// **'OBD2 breadcrumbs'**
   String get obd2DebugOverlayTitle;
 
+  /// Label and tooltip for the button on the in-app OBD2 diagnostic overlay that exports the OBD2 connect/drop/reconnect trace as plain text to the OS share sheet, so a developer can analyse a failed recording session (#1920).
+  ///
+  /// In en, this message translates to:
+  /// **'Share diagnostic log'**
+  String get obd2DiagnosticShareLabel;
+
   /// Snackbar shown after the OBD2 picker falls back from a silent pinned-MAC connect to the manual sheet (#1188). The placeholder is the display name of the previously paired adapter so the user knows which one was unreachable.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4685,6 +4685,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 следи';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Споделяне на диагностичния дневник';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Не може да се достигне до \'$adapterName\' — изберете друг адаптер';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4651,6 +4651,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Stopy OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Sdílet diagnostický protokol';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nelze se připojit k \'$adapterName\' — vyberte jiný adaptér';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4646,6 +4646,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2-brødkrummer';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Del diagnostiklog';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Kunne ikke nå \'$adapterName\' — vælg en anden adapter';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4670,6 +4670,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2-Spuren';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Diagnoseprotokoll teilen';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Konnte \'$adapterName\' nicht erreichen — wähle einen anderen Adapter';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4688,6 +4688,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Ίχνη OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Κοινοποίηση διαγνωστικού αρχείου';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Δεν ήταν δυνατή η επαφή με \'$adapterName\' — επιλέξτε άλλον προσαρμογέα';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4620,6 +4620,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 breadcrumbs';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Share diagnostic log';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Couldn\'t reach \'$adapterName\' — pick another adapter';
   }
@@ -9993,6 +9996,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get obd2DebugOverlayTitle => '⟦ÓƁĐ2 ƀřéáđçřúɱƀš ······⟧';
+
+  @override
+  String get obd2DiagnosticShareLabel => '⟦Šĥářé đîáǧñóšŧîç łóǧ ········⟧';
 
   @override
   String obd2PickerPinnedFallback(String adapterName) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4683,6 +4683,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Rastro de OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Compartir registro de diagnóstico';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'No se pudo contactar con «$adapterName»: elige otro adaptador';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4640,6 +4640,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 leivaraasud';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Jaga diagnostikalogi';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Ei suutnud jõuda \'$adapterName\' — vali teine adapter';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4646,6 +4646,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2-jäljet';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Jaa diagnostiikkaloki';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Ei voitu tavoittaa \'$adapterName\' — valitse toinen sovitin';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4693,6 +4693,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Traces OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Partager le journal de diagnostic';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Impossible de joindre \'$adapterName\' — choisissez un autre adaptateur';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4662,6 +4662,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 trag';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Podijeli dijagnostički zapisnik';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nije moguće dosegnuti \'$adapterName\' — odaberite drugi adapter';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4687,6 +4687,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 morzsakód-nyomvonal';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Diagnosztikai napló megosztása';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nem sikerült elérni a(z) \'$adapterName\'-t — válasszon másik adaptert';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4672,6 +4672,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Breadcrumb OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Condividi il registro diagnostico';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Impossibile raggiungere \'$adapterName\' — scegli un altro adattatore';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4675,6 +4675,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 sekos žurnalai';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Bendrinti diagnostikos žurnalą';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nepavyko pasiekti \"$adapterName\" — pasirinkite kitą adapterį';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4676,6 +4676,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 izsekošanas pēdas';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Kopīgot diagnostikas žurnālu';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nevarēja sasniegt \'$adapterName\' — izvēlieties citu adapteru';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4646,6 +4646,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2-brødkrummer';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Del diagnoselogg';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Kunne ikke nå \'$adapterName\' – velg en annen adapter';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4662,6 +4662,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2-breadcrumbs';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Diagnoselogboek delen';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Kon \'$adapterName\' niet bereiken — kies een andere adapter';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4668,6 +4668,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Breadcrumbs OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Udostępnij dziennik diagnostyczny';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nie można było dotrzeć do \'$adapterName\' — wybierz inny adapter';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4682,6 +4682,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Breadcrumbs OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Partilhar registo de diagnóstico';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Não foi possível alcançar \'$adapterName\' — escolha outro adaptador';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4680,6 +4680,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Traseu OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Partajează jurnalul de diagnosticare';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nu s-a putut accesa \'$adapterName\' — alegeți alt adaptor';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4666,6 +4666,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2 záznamy';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Zdieľať diagnostický denník';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Nepodarilo sa dosiahnuť \'$adapterName\' — vyberte iný adaptér';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4652,6 +4652,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'Sledilne točke OBD2';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Deli diagnostični dnevnik';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Ni bilo mogoče doseči \'$adapterName\' — izberite drug adapter';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4646,6 +4646,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get obd2DebugOverlayTitle => 'OBD2-brödsmulor';
 
   @override
+  String get obd2DiagnosticShareLabel => 'Dela diagnostiklogg';
+
+  @override
   String obd2PickerPinnedFallback(String adapterName) {
     return 'Kunde inte nå \'$adapterName\' – välj en annan adapter';
   }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Išvalyti",
   "obd2DebugOverlayCloseButton": "Uždaryti",
   "obd2DebugOverlayTitle": "OBD2 sekos žurnalai",
+  "obd2DiagnosticShareLabel": "Bendrinti diagnostikos žurnalą",
   "obd2PickerPinnedFallback": "Nepavyko pasiekti \"{adapterName}\" — pasirinkite kitą adapterį",
   "onboardingObd2StepTitle": "Prijunkite savo OBD2 adapterį",
   "onboardingObd2StepBody": "Įkiškite OBD2 adapterį į automobilio lizdą ir įjunkite uždegimą. Nuskaitysime VIN ir užpildysime variklio detales už jus.",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Notīrīt",
   "obd2DebugOverlayCloseButton": "Aizvērt",
   "obd2DebugOverlayTitle": "OBD2 izsekošanas pēdas",
+  "obd2DiagnosticShareLabel": "Kopīgot diagnostikas žurnālu",
   "obd2PickerPinnedFallback": "Nevarēja sasniegt '{adapterName}' — izvēlieties citu adapteru",
   "onboardingObd2StepTitle": "Savienojiet savu OBD2 adapteru",
   "onboardingObd2StepBody": "Pievienojiet OBD2 adapteru automašīnas portam un ieslēdziet aizdedzi. Mēs nolasīsim VIN un aizpildīsim dzinēja datus jūsu vietā.",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Tøm",
   "obd2DebugOverlayCloseButton": "Lukk",
   "obd2DebugOverlayTitle": "OBD2-brødkrummer",
+  "obd2DiagnosticShareLabel": "Del diagnoselogg",
   "obd2PickerPinnedFallback": "Kunne ikke nå '{adapterName}' – velg en annen adapter",
   "onboardingObd2StepTitle": "Koble til OBD2-adapteren din",
   "onboardingObd2StepBody": "Sett OBD2-adapteren i bilens port og slå på tenningen. Vi leser VIN-nummeret og fyller inn motordetaljer for deg.",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Wissen",
   "obd2DebugOverlayCloseButton": "Sluiten",
   "obd2DebugOverlayTitle": "OBD2-breadcrumbs",
+  "obd2DiagnosticShareLabel": "Diagnoselogboek delen",
   "obd2PickerPinnedFallback": "Kon '{adapterName}' niet bereiken — kies een andere adapter",
   "onboardingObd2StepTitle": "Verbind je OBD2-adapter",
   "onboardingObd2StepBody": "Sluit je OBD2-adapter aan op de poort van de auto en zet het contact aan. We lezen het VIN en vullen de motorgegevens voor je in.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Wyczyść",
   "obd2DebugOverlayCloseButton": "Zamknij",
   "obd2DebugOverlayTitle": "Breadcrumbs OBD2",
+  "obd2DiagnosticShareLabel": "Udostępnij dziennik diagnostyczny",
   "obd2PickerPinnedFallback": "Nie można było dotrzeć do '{adapterName}' — wybierz inny adapter",
   "onboardingObd2StepTitle": "Podłącz adapter OBD2",
   "onboardingObd2StepBody": "Podłącz adapter OBD2 do portu diagnostycznego samochodu i włącz zapłon. Odczytamy VIN i uzupełnimy dane silnika.",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Limpar",
   "obd2DebugOverlayCloseButton": "Fechar",
   "obd2DebugOverlayTitle": "Breadcrumbs OBD2",
+  "obd2DiagnosticShareLabel": "Partilhar registo de diagnóstico",
   "obd2PickerPinnedFallback": "Não foi possível alcançar '{adapterName}' — escolha outro adaptador",
   "onboardingObd2StepTitle": "Ligue o seu adaptador OBD2",
   "onboardingObd2StepBody": "Ligue o adaptador OBD2 à porta do carro e ligue o contacto. Vamos ler o VIN e preencher os detalhes do motor por si.",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Ștergeți",
   "obd2DebugOverlayCloseButton": "Închideți",
   "obd2DebugOverlayTitle": "Traseu OBD2",
+  "obd2DiagnosticShareLabel": "Partajează jurnalul de diagnosticare",
   "obd2PickerPinnedFallback": "Nu s-a putut accesa '{adapterName}' — alegeți alt adaptor",
   "onboardingObd2StepTitle": "Conectați adaptorul OBD2",
   "onboardingObd2StepBody": "Introduceți adaptorul OBD2 în portul mașinii și porniți contactul. Vom citi VIN-ul și vom completa detaliile motorului pentru dvs.",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Vymazať",
   "obd2DebugOverlayCloseButton": "Zavrieť",
   "obd2DebugOverlayTitle": "OBD2 záznamy",
+  "obd2DiagnosticShareLabel": "Zdieľať diagnostický denník",
   "obd2PickerPinnedFallback": "Nepodarilo sa dosiahnuť '{adapterName}' — vyberte iný adaptér",
   "onboardingObd2StepTitle": "Pripojiť OBD2 adaptér",
   "onboardingObd2StepBody": "Zapojte OBD2 adaptér do portu auta a zapnite zapaľovanie. Prečítame VIN a vyplníme detaily motora za vás.",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Počisti",
   "obd2DebugOverlayCloseButton": "Zapri",
   "obd2DebugOverlayTitle": "Sledilne točke OBD2",
+  "obd2DiagnosticShareLabel": "Deli diagnostični dnevnik",
   "obd2PickerPinnedFallback": "Ni bilo mogoče doseči '{adapterName}' — izberite drug adapter",
   "onboardingObd2StepTitle": "Povežite adapter OBD2",
   "onboardingObd2StepBody": "Priključite adapter OBD2 v vrata avtomobila in vklopite vžig. Prebrali bomo VIN in izpolnili podrobnosti motorja za vas.",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1370,6 +1370,7 @@
   "obd2DebugOverlayClearButton": "Rensa",
   "obd2DebugOverlayCloseButton": "Stäng",
   "obd2DebugOverlayTitle": "OBD2-brödsmulor",
+  "obd2DiagnosticShareLabel": "Dela diagnostiklogg",
   "obd2PickerPinnedFallback": "Kunde inte nå '{adapterName}' – välj en annan adapter",
   "onboardingObd2StepTitle": "Anslut din OBD2-adapter",
   "onboardingObd2StepBody": "Koppla din OBD2-adapter till bilens port och slå på tändningen. Vi läser VIN och fyller i motordetaljer åt dig.",

--- a/test/features/consumption/data/obd2/auto_record_trace_log_test.dart
+++ b/test/features/consumption/data/obd2/auto_record_trace_log_test.dart
@@ -128,4 +128,23 @@ void main() {
     expect(crumb.detail, contains('mac=AA:BB:CC:DD:EE:FF'));
     expect(crumb.detail, contains('speed=12.3 kmh'));
   });
+
+  test('#1920 OBD2 connect/drop/reconnect event kinds exist', () {
+    // The exportable diagnostic log (#1920) depends on these eight
+    // kinds being present in the enum — guard against an accidental
+    // rename or removal.
+    const List<AutoRecordEventKind> kinds = <AutoRecordEventKind>[
+      AutoRecordEventKind.connectStarted,
+      AutoRecordEventKind.connectSucceeded,
+      AutoRecordEventKind.connectFailed,
+      AutoRecordEventKind.dropDetected,
+      AutoRecordEventKind.silentReconnectStarted,
+      AutoRecordEventKind.silentReconnectSucceeded,
+      AutoRecordEventKind.dropEscalatedToVisible,
+      AutoRecordEventKind.reconnectSucceeded,
+    ];
+    for (final AutoRecordEventKind kind in kinds) {
+      expect(AutoRecordEventKind.values, contains(kind));
+    }
+  });
 }

--- a/test/features/consumption/data/obd2/obd2_diagnostic_report_test.dart
+++ b/test/features/consumption/data/obd2/obd2_diagnostic_report_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_diagnostic_report.dart';
+
+/// Coverage for [formatObd2DiagnosticReport] — the pure plain-text
+/// formatter behind the exportable OBD2 diagnostic log (#1920).
+///
+/// Asserts the report shape (header + one line per event), the
+/// per-event timestamp format, MAC redaction (PII), and the empty
+/// list case.
+void main() {
+  final DateTime generatedAt = DateTime.utc(2024, 1, 15, 9, 30, 0);
+
+  test('empty event list produces a clear "no events" line', () {
+    final String report = formatObd2DiagnosticReport(
+      const <AutoRecordEvent>[],
+      generatedAt: generatedAt,
+    );
+    expect(report, contains('2024-01-15 09:30:00'));
+    expect(report.toLowerCase(), contains('no events'));
+  });
+
+  test('header carries the generated-at timestamp', () {
+    final String report = formatObd2DiagnosticReport(
+      <AutoRecordEvent>[
+        AutoRecordEvent(
+          timestamp: DateTime.utc(2024, 1, 15, 9, 30, 1, 123),
+          kind: AutoRecordEventKind.connectStarted,
+        ),
+      ],
+      generatedAt: generatedAt,
+    );
+    final List<String> lines = report.trimRight().split('\n');
+    expect(lines.first, contains('2024-01-15 09:30:00'));
+  });
+
+  test('one line per event in the kind/mac/detail shape', () {
+    final String report = formatObd2DiagnosticReport(
+      <AutoRecordEvent>[
+        AutoRecordEvent(
+          timestamp: DateTime.utc(2024, 1, 15, 9, 30, 1, 123),
+          kind: AutoRecordEventKind.connectStarted,
+          mac: 'AA:BB:CC:DD:EE:FF',
+        ),
+        AutoRecordEvent(
+          timestamp: DateTime.utc(2024, 1, 15, 9, 30, 3, 456),
+          kind: AutoRecordEventKind.connectSucceeded,
+          mac: 'AA:BB:CC:DD:EE:FF',
+          detail: 'ELM327 v1.5',
+        ),
+      ],
+      generatedAt: generatedAt,
+    );
+    final List<String> lines = report.trimRight().split('\n');
+    // header + 2 event lines.
+    expect(lines, hasLength(3));
+    expect(lines[1], startsWith('[09:30:01.123]'));
+    expect(lines[1], contains('connectStarted'));
+    expect(lines[2], startsWith('[09:30:03.456]'));
+    expect(lines[2], contains('connectSucceeded'));
+    expect(lines[2], contains('ELM327 v1.5'),
+        reason: 'the firmware detail must survive into the report');
+  });
+
+  test('MAC is redacted to its last four characters', () {
+    final String report = formatObd2DiagnosticReport(
+      <AutoRecordEvent>[
+        AutoRecordEvent(
+          timestamp: DateTime.utc(2024, 1, 15, 9, 30, 1),
+          kind: AutoRecordEventKind.connectStarted,
+          mac: 'AA:BB:CC:DD:EE:FF',
+        ),
+      ],
+      generatedAt: generatedAt,
+    );
+    // The full MAC is PII and must never appear verbatim.
+    expect(report, isNot(contains('AA:BB:CC:DD:EE:FF')));
+    // Only the trailing four characters survive, the rest masked.
+    expect(report, contains('E:FF'));
+    expect(report, isNot(contains('AA:BB')));
+    expect(report, contains('·'),
+        reason: 'redacted characters are shown as the middle dot');
+  });
+
+  test('events without mac or detail render the bare kind', () {
+    final String report = formatObd2DiagnosticReport(
+      <AutoRecordEvent>[
+        AutoRecordEvent(
+          timestamp: DateTime.utc(2024, 1, 15, 9, 30, 5),
+          kind: AutoRecordEventKind.dropEscalatedToVisible,
+        ),
+      ],
+      generatedAt: generatedAt,
+    );
+    final List<String> lines = report.trimRight().split('\n');
+    expect(lines[1], '[09:30:05.000]  dropEscalatedToVisible');
+  });
+}

--- a/test/features/consumption/presentation/widgets/obd2_breadcrumb_overlay_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_breadcrumb_overlay_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:tankstellen/core/providers/app_state_provider.dart';
+import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_breadcrumb_collector.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart';
 import 'package:tankstellen/features/consumption/providers/obd2_breadcrumb_provider.dart';
@@ -138,6 +140,52 @@ void main() {
       // provider must report `false`.
       expect(container.read(obd2DebugOverlayProvider), isFalse);
     });
+
+    testWidgets(
+      '#1920 share button hands the formatted diagnostic log to the sink',
+      (tester) async {
+        AutoRecordTraceLog.clear();
+        AutoRecordTraceLog.add(
+          AutoRecordEventKind.connectStarted,
+          mac: 'AA:BB:CC:DD:EE:FF',
+        );
+        AutoRecordTraceLog.add(
+          AutoRecordEventKind.connectFailed,
+          mac: 'AA:BB:CC:DD:EE:FF',
+          detail: 'TimeoutException',
+        );
+
+        ShareParams? captured;
+        debugObd2DiagnosticShareSinkOverride = (params) async {
+          captured = params;
+        };
+        addTearDown(() {
+          debugObd2DiagnosticShareSinkOverride = null;
+          AutoRecordTraceLog.clear();
+        });
+
+        await pumpApp(
+          tester,
+          const Stack(children: [Obd2BreadcrumbOverlay()]),
+          overrides: [
+            obd2DebugOverlayProvider.overrideWith(() => _FixedOverlay(true)),
+          ],
+        );
+
+        await tester.tap(find.byIcon(Icons.share));
+        await tester.pump();
+
+        expect(captured, isNotNull,
+            reason: 'the share button must invoke the sink');
+        final String text = captured!.text ?? '';
+        expect(text, contains('OBD2 diagnostic log'));
+        expect(text, contains('connectStarted'));
+        expect(text, contains('connectFailed'));
+        expect(text, contains('TimeoutException'));
+        // The full MAC is PII and must be redacted in the shared text.
+        expect(text, isNot(contains('AA:BB:CC:DD:EE:FF')));
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## What

When the adapter "connects badly / doesn't record," there was no way to hand a developer the data to diagnose it. This adds an **exportable OBD2 session trace**.

- **`AutoRecordTraceLog`** (the existing 100-event ring) gains 8 connection-path event kinds: `connectStarted/Succeeded/Failed`, `dropDetected`, `silentReconnectStarted/Succeeded`, `dropEscalatedToVisible`, `reconnectSucceeded`.
- **`Obd2Service.connect()`** logs the handshake outcome + firmware; **`TripRecordingController`** logs every drop, the silent-reconnect window, escalation, and reconnect.
- **`formatObd2DiagnosticReport`** renders the ring as plain text — one line per event, **BLE MAC redacted** to its last 4 chars (PII), explicit `(no events recorded)` for an empty trace.
- The **OBD2 breadcrumb overlay** gains a **Share** button → the report goes to the OS share sheet (`share_plus`), with a `@visibleForTesting` sink override.

So you can reproduce a failed recording, hit Share in the OBD2 debug overlay (5-tap the recording-screen title to open it), and send me the log — the trace shows exactly where connect / poll / reconnect went wrong.

## Verification

`flutter analyze` clean; `test/features/consumption/data/obd2/` + the overlay test + `test/l10n/` + `test/lint/` pass (1001 tests), incl. new tests for the formatter (shape, MAC redaction, empty list) and the share action. `obd2DiagnosticShareLabel` added across all 24 locales.

Closes #1920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
