### PR TITLE
fix(trip): harsh brake/accel counts inflated ~4x by emit cadence (#1922)

### DIFF
--- a/lib/features/consumption/domain/harsh_event_detector.dart
+++ b/lib/features/consumption/domain/harsh_event_detector.dart
@@ -1,0 +1,87 @@
+/// Counts harsh-braking / harsh-acceleration events from a stream of
+/// speed samples, decoupled from the sample-feed cadence (#1922).
+///
+/// Extracted from [TripRecorder]: the recorder is fed a `TripSample`
+/// every 250 ms, but the OBD speed PID (0x0D, integer km/h) refreshes
+/// only ~1 Hz — so `speedKmh` arrives as a *staircase* of repeated
+/// values. Differentiating that staircase over the 250 ms emit
+/// interval divided a ~1 s speed delta by 0.25 s and inflated every
+/// acceleration ~4x: a real device backup showed 428 "harsh brakes"
+/// on a single 157 km motorway drive.
+///
+/// The fix is to re-sample speed at ~1 Hz before taking the
+/// derivative: the threshold is evaluated only between samples at
+/// least [_evalIntervalSec] apart, so Δt is always a real ~1 s window.
+/// Genuine hard braking (a large Δspeed within ~1 s) still trips the
+/// threshold; the staircase no longer does; and the count is
+/// independent of how fast samples are fed.
+class HarshEventDetector {
+  HarshEventDetector({
+    this.brakeThresholdMps2 = 3.5,
+    this.accelThresholdMps2 = 3.0,
+  });
+
+  /// Deceleration magnitude (m/s², positive number) at or above which
+  /// an interval counts as a harsh brake.
+  final double brakeThresholdMps2;
+
+  /// Acceleration (m/s²) at or above which an interval counts as a
+  /// harsh acceleration.
+  final double accelThresholdMps2;
+
+  /// Minimum spacing (seconds) between two evaluated samples — this is
+  /// what re-samples the speed signal at ~1 Hz. 0.9 rather than 1.0 so
+  /// a nominally-1 Hz feed with minor jitter still evaluates every
+  /// sample instead of skipping to a 2 s window.
+  static const double _evalIntervalSec = 0.9;
+
+  int _brakes = 0;
+  int _accels = 0;
+
+  // The last sample an evaluation was anchored on. Advances only when
+  // an evaluation actually fires, so a burst of sub-second samples
+  // cannot drag the anchor forward and starve the detector.
+  double? _anchorSpeedKmh;
+  DateTime? _anchorAt;
+
+  /// Number of harsh-braking events counted so far.
+  int get brakes => _brakes;
+
+  /// Number of harsh-acceleration events counted so far.
+  int get accelerations => _accels;
+
+  /// Feed one speed sample. Safe to call at any cadence; samples
+  /// closer together than [_evalIntervalSec] are folded into the next
+  /// evaluated window rather than each producing a derivative.
+  void onSample(double speedKmh, DateTime timestamp) {
+    final anchorAt = _anchorAt;
+    final anchorSpeed = _anchorSpeedKmh;
+    if (anchorAt == null || anchorSpeed == null) {
+      _anchorAt = timestamp;
+      _anchorSpeedKmh = speedKmh;
+      return;
+    }
+    final dt = timestamp.difference(anchorAt).inMicroseconds /
+        Duration.microsecondsPerSecond;
+    if (dt < _evalIntervalSec) return;
+
+    // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
+    final accelMps2 = ((speedKmh - anchorSpeed) / 3.6) / dt;
+    if (accelMps2 <= -brakeThresholdMps2) {
+      _brakes++;
+    } else if (accelMps2 >= accelThresholdMps2) {
+      _accels++;
+    }
+    _anchorAt = timestamp;
+    _anchorSpeedKmh = speedKmh;
+  }
+
+  /// Reset the counters and anchor — used before recording a fresh
+  /// trip without discarding the detector instance.
+  void reset() {
+    _brakes = 0;
+    _accels = 0;
+    _anchorSpeedKmh = null;
+    _anchorAt = null;
+  }
+}

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'harsh_event_detector.dart';
+
 /// One OBD2 sample tick — captured by the polling loop and fed into
 /// [TripRecorder] for metric accumulation.
 class TripSample {
@@ -202,20 +204,17 @@ class TripRecorder {
   /// RPM value above which the recorder clocks "high-RPM" time.
   final double highRpmThreshold;
 
-  /// Negative acceleration (m/s²) that triggers a harsh-brake count.
-  /// Stored as a positive number; comparison uses absolute value.
-  final double harshBrakeThresholdMps2;
-
-  /// Positive acceleration (m/s²) that triggers a harsh-accel count.
-  final double harshAccelThresholdMps2;
+  /// Detects harsh braking / acceleration from the speed stream. Kept
+  /// in its own class (#1922) so the speed derivative is re-sampled at
+  /// ~1 Hz — feeding it the raw 250 ms emit cadence used to inflate
+  /// the count ~4x.
+  final HarshEventDetector _harshDetector;
 
   TripSample? _previous;
   double _distanceKm = 0;
   double _maxRpm = 0;
   double _highRpmSeconds = 0;
   double _idleSeconds = 0;
-  int _harshBrakes = 0;
-  int _harshAccels = 0;
   double _fuelLiters = 0;
   bool _hadFuelRate = false;
   DateTime? _startedAt;
@@ -238,9 +237,12 @@ class TripRecorder {
 
   TripRecorder({
     this.highRpmThreshold = 3500,
-    this.harshBrakeThresholdMps2 = 3.5,
-    this.harshAccelThresholdMps2 = 3.0,
-  });
+    double harshBrakeThresholdMps2 = 3.5,
+    double harshAccelThresholdMps2 = 3.0,
+  }) : _harshDetector = HarshEventDetector(
+          brakeThresholdMps2: harshBrakeThresholdMps2,
+          accelThresholdMps2: harshAccelThresholdMps2,
+        );
 
   /// Feed one sample. Safe to call with arbitrary cadence; the
   /// recorder derives Δt internally.
@@ -248,6 +250,12 @@ class TripRecorder {
     _startedAt ??= sample.timestamp;
     _endedAt = sample.timestamp;
     _maxRpm = math.max(_maxRpm, sample.rpm);
+
+    // Harsh brake / accel — delegated to the detector, which
+    // re-samples speed at ~1 Hz so the 250 ms emit cadence cannot
+    // inflate the count (#1922). Fed every sample, including the
+    // first, so its anchor is seeded from trip start.
+    _harshDetector.onSample(sample.speedKmh, sample.timestamp);
 
     // Track coolant samples for the cold-start surcharge heuristic
     // (#1262 phase 2). Cars without PID 0x05 carry coolantTempC ==
@@ -295,16 +303,6 @@ class TripRecorder {
     // Idle time: engine on, car stationary for the whole interval.
     if (previous.speedKmh <= 0.5 && previous.rpm > 0) {
       _idleSeconds += dt;
-    }
-
-    // Harsh brake / accel: derivative of speed across the interval.
-    // Convert km/h → m/s by / 3.6.
-    final dvMps = (sample.speedKmh - previous.speedKmh) / 3.6;
-    final accelMps2 = dvMps / dt;
-    if (accelMps2 <= -harshBrakeThresholdMps2) {
-      _harshBrakes++;
-    } else if (accelMps2 >= harshAccelThresholdMps2) {
-      _harshAccels++;
     }
 
     // Fuel: integrate fuel rate across the interval. Only counts when
@@ -368,8 +366,8 @@ class TripRecorder {
       maxRpm: _maxRpm,
       highRpmSeconds: _highRpmSeconds,
       idleSeconds: _idleSeconds,
-      harshBrakes: _harshBrakes,
-      harshAccelerations: _harshAccels,
+      harshBrakes: _harshDetector.brakes,
+      harshAccelerations: _harshDetector.accelerations,
       avgLPer100Km: avgLPer100Km,
       fuelLitersConsumed: _hadFuelRate ? _fuelLiters : null,
       startedAt: _startedAt,
@@ -386,8 +384,7 @@ class TripRecorder {
     _maxRpm = 0;
     _highRpmSeconds = 0;
     _idleSeconds = 0;
-    _harshBrakes = 0;
-    _harshAccels = 0;
+    _harshDetector.reset();
     _fuelLiters = 0;
     _hadFuelRate = false;
     _startedAt = null;

--- a/test/features/consumption/domain/harsh_event_detector_test.dart
+++ b/test/features/consumption/domain/harsh_event_detector_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/harsh_event_detector.dart';
+
+/// Unit tests for [HarshEventDetector] (#1922).
+///
+/// The detector counts harsh braking / acceleration from a speed
+/// stream. Its whole reason to exist is **cadence independence**: the
+/// trip recorder feeds it every 250 ms, but the OBD speed PID refreshes
+/// only ~1 Hz, so `speedKmh` arrives as a staircase of repeated values.
+/// Differentiating that staircase over the 250 ms emit interval used to
+/// inflate every acceleration ~4x (428 "harsh brakes" on one 157 km
+/// motorway drive in a real backup). The detector re-samples speed at
+/// ~1 Hz before taking the derivative.
+///
+/// Default thresholds: harsh brake ≤ -3.5 m/s², harsh accel ≥ 3.0 m/s².
+void main() {
+  group('HarshEventDetector (#1922)', () {
+    late HarshEventDetector detector;
+    final start = DateTime.utc(2026);
+
+    setUp(() {
+      detector = HarshEventDetector();
+    });
+
+    /// Feed a list of per-second speed values as a staircase at the
+    /// given emit cadence: each value is repeated across every emit
+    /// tick that falls inside its 1-second window.
+    void feedStaircase(
+      HarshEventDetector d,
+      List<double> speedsPerSecond, {
+      required Duration emitInterval,
+    }) {
+      final ticksPerSecond =
+          (const Duration(seconds: 1).inMicroseconds /
+                  emitInterval.inMicroseconds)
+              .round();
+      var tick = 0;
+      for (final speed in speedsPerSecond) {
+        for (var sub = 0; sub < ticksPerSecond; sub++) {
+          d.onSample(speed, start.add(emitInterval * tick));
+          tick++;
+        }
+      }
+    }
+
+    test('no samples yields zero counts', () {
+      expect(detector.brakes, 0);
+      expect(detector.accelerations, 0);
+    });
+
+    test('a single sample only seeds the anchor — no count', () {
+      detector.onSample(50, start);
+      expect(detector.brakes, 0);
+      expect(detector.accelerations, 0);
+    });
+
+    test('counts a harsh brake when Δv/Δt ≤ -3.5 m/s²', () {
+      detector.onSample(80, start);
+      // 80 → 30 km/h in 2 s = -6.94 m/s² → harsh.
+      detector.onSample(30, start.add(const Duration(seconds: 2)));
+      expect(detector.brakes, 1);
+      expect(detector.accelerations, 0);
+    });
+
+    test('counts a harsh accel when Δv/Δt ≥ 3.0 m/s²', () {
+      detector.onSample(0, start);
+      // 0 → 50 km/h in 3 s → +4.63 m/s² → harsh.
+      detector.onSample(50, start.add(const Duration(seconds: 3)));
+      expect(detector.accelerations, 1);
+      expect(detector.brakes, 0);
+    });
+
+    test('a gentle change does not tick either counter', () {
+      detector.onSample(50, start);
+      // 50 → 45 km/h in 3 s → -0.46 m/s² → not harsh.
+      detector.onSample(45, start.add(const Duration(seconds: 3)));
+      expect(detector.brakes, 0);
+      expect(detector.accelerations, 0);
+    });
+
+    test(
+        'a gentle 1.1 m/s² ramp fed as a 4 Hz staircase ticks no harsh '
+        'events', () {
+      // Real motion is +4 km/h per second (1.11 m/s², gentle), but the
+      // speed value is repeated across four 250 ms emit ticks before it
+      // steps. Differentiating over the 250 ms tick would read 4.44 m/s²
+      // at each step and count a harsh accel every second.
+      feedStaircase(
+        detector,
+        <double>[for (var s = 0; s <= 12; s++) (s * 4).toDouble()],
+        emitInterval: const Duration(milliseconds: 250),
+      );
+      expect(detector.accelerations, 0);
+      expect(detector.brakes, 0);
+    });
+
+    test('harsh counts are independent of emit cadence', () {
+      // The same speed profile fed at 1 Hz and at 4 Hz must yield the
+      // same counts — a faster cadence must not manufacture events. The
+      // profile carries genuine harsh accels (0→14, 14→28, 28→40 km/h
+      // in 1 s) and harsh brakes (50→35, 35→20 km/h in 1 s).
+      const profile = <double>[0, 14, 28, 40, 50, 50, 35, 20, 8, 0];
+
+      final atOneHz = HarshEventDetector();
+      feedStaircase(atOneHz, profile,
+          emitInterval: const Duration(seconds: 1));
+
+      final atFourHz = HarshEventDetector();
+      feedStaircase(atFourHz, profile,
+          emitInterval: const Duration(milliseconds: 250));
+
+      expect(atOneHz.accelerations, 3);
+      expect(atOneHz.brakes, 2);
+      expect(atFourHz.accelerations, atOneHz.accelerations);
+      expect(atFourHz.brakes, atOneHz.brakes);
+    });
+
+    test('a genuine hard brake is still counted at 4 Hz staircase cadence',
+        () {
+      // An emergency stop: the 1 Hz speed PID drops ~25 km/h between
+      // refreshes (~6.9 m/s²). Cadence-independent detection must still
+      // register it rather than smoothing it away.
+      feedStaircase(
+        detector,
+        const <double>[90, 90, 65, 40, 15, 0],
+        emitInterval: const Duration(milliseconds: 250),
+      );
+      expect(detector.brakes, greaterThanOrEqualTo(3));
+    });
+
+    test('a long speed plateau before a sharp drop is not under-counted',
+        () {
+      // The car cruises at 90 km/h for 5 s, then brakes hard to 60.
+      // The drop must be measured against the ~1 s window it happened
+      // in, not averaged across the whole 5 s plateau.
+      detector.onSample(90, start);
+      for (var s = 1; s <= 5; s++) {
+        detector.onSample(90, start.add(Duration(seconds: s)));
+      }
+      // 90 → 60 km/h over the next second → -8.3 m/s² → harsh.
+      detector.onSample(60, start.add(const Duration(seconds: 6)));
+      expect(detector.brakes, 1);
+    });
+
+    test('reset clears counts and the anchor', () {
+      detector.onSample(80, start);
+      detector.onSample(20, start.add(const Duration(seconds: 2)));
+      expect(detector.brakes, 1);
+
+      detector.reset();
+      expect(detector.brakes, 0);
+      expect(detector.accelerations, 0);
+
+      // After reset the next sample only re-seeds the anchor.
+      detector.onSample(50, start.add(const Duration(seconds: 10)));
+      expect(detector.brakes, 0);
+    });
+
+    test('custom thresholds are honoured', () {
+      final lenient = HarshEventDetector(
+        brakeThresholdMps2: 10.0,
+        accelThresholdMps2: 10.0,
+      );
+      lenient.onSample(80, start);
+      // -6.94 m/s² — harsh under the default 3.5, not under 10.0.
+      lenient.onSample(30, start.add(const Duration(seconds: 2)));
+      expect(lenient.brakes, 0);
+    });
+  });
+}


### PR DESCRIPTION
## What

Harsh braking / acceleration counts in trip summaries were inflated
~4x. A real device backup (Peugeot, ELM327 v1.5) showed **428 harsh
brakes on one 157 km motorway drive** and **91 on a 13 km city run** —
physically impossible.

## Root cause

`TripRecordingController` feeds the recorder a `TripSample` every
**250 ms** (4 Hz), but the OBD speed PID (0x0D, integer km/h) refreshes
only ~1 Hz — so `speedKmh` arrives as a *staircase* of repeated values.
`trip_recorder.dart` took harsh accel/brake as the speed derivative
over the 250 ms emit interval, dividing a ~1 s speed delta by 0.25 s —
a ~4x inflation of every acceleration. Distance/fuel integration was
unaffected (it integrates avgSpeed×Δt, which is staircase-robust);
only the *derivative* metrics broke.

## Fix

Extract the detection into a new `HarshEventDetector` that re-samples
speed at ~1 Hz before differentiating: the threshold is evaluated only
between samples at least 0.9 s apart, so Δt is always a real ~1 s
window. Genuine hard braking still trips the threshold, the staircase
no longer does, and the count is independent of feed cadence.
Extracting also keeps `trip_recorder.dart` under the 400-line guard.

## Tests

`harsh_event_detector_test.dart` (new) covers the staircase / cadence
cases — the existing `trip_recorder_test.dart` harsh tests fed samples
1–3 s apart, which is why this shipped. New tests assert: a 4 Hz
staircase ticks no harsh events for a gentle ramp; the same profile
fed at 1 Hz vs 4 Hz yields identical counts; a genuine hard brake
still registers at 4 Hz; a long plateau before a sharp drop is not
under-counted.

Found analysing a user-supplied recording backup. Closes #1922.
Sibling issue #1923 (spurious / duplicate stub trips) filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
