### PR TITLE
fix(trip): discard 0-sample / 0-km stub trips on save (#1923)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -1091,10 +1091,16 @@ class TripRecording extends _$TripRecording {
     List<TripSample> samples = const [],
     List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
   }) async {
-    // Skip empty trips — the user tapped Stop without any usable
-    // sample, or the service disconnected immediately. No signal, no
-    // history clutter.
-    if (summary.distanceKm < 0.01 && summary.startedAt == null) return;
+    // Skip stub trips so they never clutter history (#1923). A trip is
+    // a stub when the recorder never received a sample (`startedAt`
+    // null — service disconnected immediately) OR it covered no
+    // distance (a false-start: Stop tapped, or the adapter dropped,
+    // before the car moved). The pre-#1923 guard required *both* —
+    // `distanceKm < 0.01 && startedAt == null` — so a 20-second 0 km
+    // false-start that did capture a few idle samples still landed in
+    // history. A real trip always has both a `startedAt` and a
+    // non-zero distance, so this never discards a genuine drive.
+    if (summary.startedAt == null || summary.distanceKm < 0.01) return;
     try {
       final repo = ref.read(tripHistoryRepositoryProvider);
       if (repo == null) return;

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'26135443e66de98aecee873fbaf69ae670d4b41f';
+String _$tripRecordingHash() => r'c03c80bc7979afb9ed8bb76c73d45f48bee80e86';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/providers/trip_recording_gps_diagnostics_persistence_test.dart
+++ b/test/features/consumption/providers/trip_recording_gps_diagnostics_persistence_test.dart
@@ -160,6 +160,12 @@ void main() {
           at: start.add(Duration(seconds: i)),
           fuelRateLPerHour: 5.5,
         );
+        // Feed the virtual odometer so the summary clears the #1923
+        // 0 km stub-discard floor in `_saveToHistory`.
+        ctl.debugRecordSpeedSample(
+          speedKmh: 40 + i.toDouble(),
+          at: start.add(Duration(seconds: i)),
+        );
         ctl.debugCaptureSample(TripSample(
           timestamp: start.add(Duration(seconds: i)),
           speedKmh: 40 + i.toDouble(),

--- a/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
@@ -68,6 +68,12 @@ void main() {
         at: start.add(Duration(seconds: i)),
         fuelRateLPerHour: 6.0,
       );
+      // Feed the virtual odometer so the summary clears the #1923
+      // 0 km stub-discard floor in `_saveToHistory`.
+      ctl.debugRecordSpeedSample(
+        speedKmh: 50 + i.toDouble(),
+        at: start.add(Duration(seconds: i)),
+      );
     }
     await stopper(notifier);
 
@@ -159,6 +165,12 @@ void main() {
           at: start.add(Duration(seconds: i)),
           fuelRateLPerHour: 6.0,
         );
+        // Feed the virtual odometer so the summary clears the #1923
+        // 0 km stub-discard floor in `_saveToHistory`.
+        ctl.debugRecordSpeedSample(
+          speedKmh: 50 + i.toDouble(),
+          at: start.add(Duration(seconds: i)),
+        );
       }
       await notifier.stopAndSaveAutomatic();
 
@@ -191,6 +203,12 @@ void main() {
           rpm: 2000 + i * 10,
           at: start.add(Duration(seconds: i)),
           fuelRateLPerHour: 6.0,
+        );
+        // Feed the virtual odometer so the summary clears the #1923
+        // 0 km stub-discard floor in `_saveToHistory`.
+        ctl.debugRecordSpeedSample(
+          speedKmh: 50 + i.toDouble(),
+          at: start.add(Duration(seconds: i)),
         );
       }
       await notifier.stop();

--- a/test/features/consumption/providers/trip_recording_samples_persistence_test.dart
+++ b/test/features/consumption/providers/trip_recording_samples_persistence_test.dart
@@ -121,14 +121,19 @@ void main() {
           rpm: 1800 + i * 5,
           fuelRateLPerHour: 5.5,
         );
-        // Feed the recorder so the resulting summary has a startedAt
-        // and a non-zero distance — without this _saveToHistory
-        // short-circuits as an "empty" trip.
+        // Feed the recorder so the resulting summary has a startedAt;
+        // feed the virtual odometer so it has a non-zero distance —
+        // without both, `_saveToHistory` discards it as a stub trip
+        // (#1923).
         ctl!.debugInjectSample(
           speedKmh: sample.speedKmh,
           rpm: sample.rpm,
           at: sample.timestamp,
           fuelRateLPerHour: sample.fuelRateLPerHour,
+        );
+        ctl.debugRecordSpeedSample(
+          speedKmh: sample.speedKmh,
+          at: sample.timestamp,
         );
         // Capture the same sample into the per-tick buffer that the
         // chart layer reads back at display time.

--- a/test/features/consumption/providers/trip_recording_stub_discard_test.dart
+++ b/test/features/consumption/providers/trip_recording_stub_discard_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+/// Regression tests for #1923 — `_saveToHistory` must discard stub
+/// trips so they never clutter trip history.
+///
+/// The pre-#1923 guard required *both* `distanceKm < 0.01` AND
+/// `startedAt == null`, so a 0 km false-start that did capture a few
+/// idle samples (`startedAt` set) was still persisted. Real device
+/// backups showed several such stubs — e.g. a 20-second 0 km entry
+/// alongside the real drive.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('trip_stub_test_');
+    Hive.init(tmpDir.path);
+    await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test('a trip that captured samples but covered 0 km is NOT persisted',
+      () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final service = Obd2Service(FakeObd2Transport(_elmOk()));
+    await service.connect();
+    final notifier = container.read(tripRecordingProvider.notifier);
+    await notifier.start(service);
+
+    final ctl = notifier.debugController;
+    expect(ctl, isNotNull);
+    // Six stationary samples — the recorder gets a `startedAt`, but the
+    // integrated distance stays 0. A false-start: recording ran while
+    // the car never moved.
+    final start = DateTime(2026, 5, 18, 8);
+    for (var i = 0; i < 6; i++) {
+      ctl!.debugInjectSample(
+        speedKmh: 0,
+        rpm: 800,
+        at: start.add(Duration(seconds: i)),
+      );
+    }
+    await notifier.stop();
+
+    final repo = container.read(tripHistoryRepositoryProvider);
+    expect(repo, isNotNull);
+    expect(repo!.loadAll(), isEmpty,
+        reason: 'a 0 km stub trip must not be written to history');
+  });
+
+  test('a trip that captured no samples at all is NOT persisted', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final service = Obd2Service(FakeObd2Transport(_elmOk()));
+    await service.connect();
+    final notifier = container.read(tripRecordingProvider.notifier);
+    await notifier.start(service);
+    // Stop immediately — the recorder never received a sample, so the
+    // summary has a null `startedAt`.
+    await notifier.stop();
+
+    final repo = container.read(tripHistoryRepositoryProvider);
+    expect(repo!.loadAll(), isEmpty,
+        reason: 'a 0-sample stub trip must not be written to history');
+  });
+
+  test('a genuine moving trip IS still persisted', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final service = Obd2Service(FakeObd2Transport(_elmOk()));
+    await service.connect();
+    final notifier = container.read(tripRecordingProvider.notifier);
+    await notifier.start(service);
+
+    final ctl = notifier.debugController;
+    final start = DateTime(2026, 5, 18, 9);
+    // 50 km/h for 60 s ≈ 0.83 km — a real drive, well above the
+    // 0.01 km stub threshold. `debugInjectSample` gives the recorder a
+    // `startedAt`; `debugRecordSpeedSample` feeds the virtual odometer
+    // that the finalised summary's `distanceKm` is integrated from.
+    for (var i = 0; i <= 60; i++) {
+      final at = start.add(Duration(seconds: i));
+      ctl!.debugInjectSample(speedKmh: 50, rpm: 2000, at: at);
+      ctl.debugRecordSpeedSample(speedKmh: 50, at: at);
+    }
+    await notifier.stop();
+
+    final repo = container.read(tripHistoryRepositoryProvider);
+    expect(repo!.loadAll(), hasLength(1),
+        reason: 'a genuine moving trip must still be persisted');
+  });
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };


### PR DESCRIPTION
## Problem

`TripRecording._saveToHistory` skipped a trip only when it was **both**
zero-distance **and** never-started:

```dart
if (summary.distanceKm < 0.01 && summary.startedAt == null) return;
```

A false-start — Stop tapped, or the adapter dropped, before the car
moved — has `startedAt` set (the recorder got a few idle samples), so
the `&&` let it through. Real device backups from two different cars
showed several such stub trips cluttering history, e.g. a 20-second
0 km entry next to the real drive.

## Fix

Change the guard to `||` — a trip with no `startedAt` (recorder never
received a sample) **or** no distance (`< 0.01 km`) is a stub and is
not persisted. A genuine drive always has both a `startedAt` and real
distance, so a real trip is never discarded.

## Tests

`trip_recording_stub_discard_test.dart` (new) covers: a 0 km trip that
captured idle samples is not persisted; a 0-sample trip is not
persisted; a genuine moving trip still is.

The summary's `distanceKm` is integrated by the **virtual odometer**,
not the recorder — so the existing save-path tests, which only fed the
recorder via `debugInjectSample`, were producing technically-0 km trips
that survived purely on the old `&&` loophole. Three of them
(`samples_persistence`, `gps_diagnostics_persistence`, `automatic_flag`)
now also feed the virtual odometer via `debugRecordSpeedSample` so
their trips clear the stub floor honestly.

`flutter analyze`, `test/lint/`, the integration journey and all 208
consumption-provider tests pass.

## Scope

Closes #1923 — re-scoped to the **stub-trip** half. The duplicate-trip
defect (a 0-sample summary-only shadow of a real drive) has a distinct,
unconfirmed root cause in the snapshot/recovery path and is split into
#1928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
