### PR TITLE
feat(obd2): enrich the debug log so a data gap is self-diagnosing (#1930)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_debug_session.dart
+++ b/lib/features/consumption/data/obd2/obd2_debug_session.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/foundation.dart';
 
-import 'auto_record_trace_log.dart';
+// The recorder lives in its own file (#1930 — keeps each under the
+// 400-line guard) but is re-exported so importers of this file still
+// see `Obd2DebugSessionRecorder` as one unit.
+export 'obd2_debug_session_recorder.dart';
 
 /// Kinds of event captured in an [Obd2DebugSession] (#1925).
 ///
-/// Most are mapped from [AutoRecordEventKind] as it is recorded — see
-/// [Obd2DebugSessionRecorder.ingest]. [handshakeCommand] and [dataGap]
+/// Most are mapped from `AutoRecordEventKind` as it is recorded — see
+/// `Obd2DebugSessionRecorder.ingest`. [handshakeCommand] and [dataGap]
 /// carry detail the lightweight trace ring does not, so they are fed
 /// in directly by the connect path and the poll loop.
 enum Obd2SessionEventKind {
@@ -35,6 +38,18 @@ enum Obd2SessionEventKind {
 
   /// A reconnect attempt did not bring the adapter back in time.
   reconnectFailed,
+
+  /// The disconnect-save debounce timer was scheduled — the auto-record
+  /// flow is waiting to either reconnect or save the trip (#1930).
+  disconnectTimerStarted,
+
+  /// A reconnect within the debounce window cancelled the pending
+  /// save — the trip carries on (#1930).
+  disconnectTimerCancelled,
+
+  /// The disconnect-save debounce timer fired — the trip is about to
+  /// be saved because the adapter never came back (#1930).
+  disconnectTimerFired,
 
   /// The session was finalised — the session footer.
   sessionEnded,
@@ -67,6 +82,23 @@ class Obd2SessionEvent {
   /// only.
   final int? gapMs;
 
+  /// Vehicle speed (km/h) at the last reading **before** a gap —
+  /// [Obd2SessionEventKind.dataGap] only. A non-zero value means the
+  /// car was moving when data stopped (the link died mid-drive); zero
+  /// with [preGapRpm] zero means the engine was idle/off (#1930).
+  final double? preGapSpeedKmh;
+
+  /// Engine RPM at the last reading **before** a gap — dataGap only.
+  final double? preGapRpm;
+
+  /// Vehicle speed (km/h) at the first reading **after** a gap —
+  /// dataGap only; null when data never resumed (a trailing gap).
+  final double? postGapSpeedKmh;
+
+  /// Engine RPM at the first reading **after** a gap — dataGap only;
+  /// null when data never resumed.
+  final double? postGapRpm;
+
   const Obd2SessionEvent({
     required this.timestamp,
     required this.kind,
@@ -75,6 +107,10 @@ class Obd2SessionEvent {
     this.response,
     this.latencyMs,
     this.gapMs,
+    this.preGapSpeedKmh,
+    this.preGapRpm,
+    this.postGapSpeedKmh,
+    this.postGapRpm,
   });
 }
 
@@ -160,6 +196,9 @@ class Obd2DebugSession {
         case Obd2SessionEventKind.sessionStarted:
         case Obd2SessionEventKind.dropDetected:
         case Obd2SessionEventKind.reconnectFailed:
+        case Obd2SessionEventKind.disconnectTimerStarted:
+        case Obd2SessionEventKind.disconnectTimerCancelled:
+        case Obd2SessionEventKind.disconnectTimerFired:
         case Obd2SessionEventKind.sessionEnded:
           break;
       }
@@ -178,170 +217,5 @@ class Obd2DebugSession {
               ? 'failed'
               : 'unknown',
     );
-  }
-}
-
-/// Process-wide recorder for [Obd2DebugSession]s (#1925).
-///
-/// Off by default — every method is a cheap no-op until [enabled] is
-/// flipped on (the user opts in via the OBD2 debug-logging checkbox in
-/// settings; `Obd2DebugSessionLogging` keeps [enabled] in sync with the
-/// persisted flag). When on, it captures one session per OBD2
-/// connection so a failed recording can be exported as XML and analysed.
-///
-/// Most events are mirrored from [AutoRecordTraceLog]: [ingest] is
-/// called from `AutoRecordTraceLog.add`, so the connect / drop /
-/// reconnect transitions need no extra instrumentation. The connect
-/// path adds per-command handshake timing via [recordHandshakeCommand];
-/// the poll loop pings [recordData] so silence is detected as a gap.
-///
-/// Static, like [AutoRecordTraceLog] — the OBD2 stack is single-isolate
-/// so no synchronisation is needed.
-class Obd2DebugSessionRecorder {
-  Obd2DebugSessionRecorder._();
-
-  /// Master switch. False ⇒ every method returns immediately; the
-  /// feature has zero cost when the user has not opted in.
-  static bool enabled = false;
-
-  /// A run of silence at least this long (ms) between successful data
-  /// pings is recorded as an [Obd2SessionEventKind.dataGap]. The poll
-  /// loop nominally delivers a sample every ~250 ms.
-  static const int dataGapThresholdMs = 3000;
-
-  static Obd2DebugSession? _current;
-  static Obd2DebugSession? _last;
-  static DateTime? _lastDataAt;
-
-  /// The session currently being recorded, if any.
-  static Obd2DebugSession? get currentSession => _current;
-
-  /// The most relevant session for export — the live one if a
-  /// connection is in progress, otherwise the last finished one.
-  static Obd2DebugSession? get latestSession => _current ?? _last;
-
-  /// Map a trace-ring event onto the session log. Called by
-  /// `AutoRecordTraceLog.add`; a no-op when the feature is off.
-  static void ingest(
-    AutoRecordEventKind kind, {
-    String? mac,
-    String? detail,
-    required DateTime timestamp,
-  }) {
-    if (!enabled) return;
-    switch (kind) {
-      case AutoRecordEventKind.connectStarted:
-        _begin(mac, timestamp);
-      case AutoRecordEventKind.connectSucceeded:
-        _add(timestamp, Obd2SessionEventKind.connectionEstablished,
-            detail: detail);
-      case AutoRecordEventKind.connectFailed:
-        _add(timestamp, Obd2SessionEventKind.connectionFailed,
-            detail: detail);
-        _finalize(timestamp);
-      case AutoRecordEventKind.dropDetected:
-        _add(timestamp, Obd2SessionEventKind.dropDetected, detail: detail);
-      case AutoRecordEventKind.silentReconnectStarted:
-        _add(timestamp, Obd2SessionEventKind.reconnectStarted,
-            detail: detail);
-      case AutoRecordEventKind.silentReconnectSucceeded:
-      case AutoRecordEventKind.reconnectSucceeded:
-        _add(timestamp, Obd2SessionEventKind.reconnectSucceeded,
-            detail: detail);
-      case AutoRecordEventKind.dropEscalatedToVisible:
-        _add(timestamp, Obd2SessionEventKind.reconnectFailed,
-            detail: detail ?? 'silent reconnect window elapsed');
-      // Coordinator / threshold / trip-lifecycle events are not part
-      // of the OBD2 link picture this log is meant to debug.
-      default:
-        break;
-    }
-  }
-
-  /// Record one ELM327 init/handshake command and its reply. Called
-  /// per command by `Obd2Service.connect`.
-  static void recordHandshakeCommand(
-    String command,
-    String response,
-    int latencyMs, {
-    DateTime? clock,
-  }) {
-    if (!enabled || _current == null) return;
-    final ts = clock ?? DateTime.now();
-    _current!.events.add(Obd2SessionEvent(
-      timestamp: ts,
-      kind: Obd2SessionEventKind.handshakeCommand,
-      command: command.trim(),
-      response: response.trim(),
-      latencyMs: latencyMs,
-    ));
-  }
-
-  /// Ping that data was successfully received. When the gap since the
-  /// previous ping exceeds [dataGapThresholdMs] a [dataGap] event is
-  /// recorded so stretches of silence are visible in the export.
-  static void recordData(DateTime timestamp) {
-    if (!enabled || _current == null) return;
-    final last = _lastDataAt;
-    if (last != null) {
-      final gapMs = timestamp.difference(last).inMilliseconds;
-      if (gapMs >= dataGapThresholdMs) {
-        _current!.events.add(Obd2SessionEvent(
-          timestamp: timestamp,
-          kind: Obd2SessionEventKind.dataGap,
-          gapMs: gapMs,
-        ));
-      }
-    }
-    _lastDataAt = timestamp;
-  }
-
-  /// Finalise the current session (e.g. when recording stops). Safe to
-  /// call when there is no open session.
-  static void endSession({DateTime? clock}) {
-    if (!enabled) return;
-    _finalize(clock ?? DateTime.now());
-  }
-
-  static void _begin(String? mac, DateTime ts) {
-    _finalize(ts);
-    _current = Obd2DebugSession(startedAt: ts, adapterMac: mac)
-      ..events.add(Obd2SessionEvent(
-        timestamp: ts,
-        kind: Obd2SessionEventKind.sessionStarted,
-        detail: mac == null ? null : 'adapter $mac',
-      ));
-    _lastDataAt = null;
-  }
-
-  static void _add(
-    DateTime ts,
-    Obd2SessionEventKind kind, {
-    String? detail,
-  }) {
-    final cur = _current;
-    if (cur == null) return;
-    cur.events.add(Obd2SessionEvent(timestamp: ts, kind: kind, detail: detail));
-  }
-
-  static void _finalize(DateTime ts) {
-    final cur = _current;
-    if (cur == null) return;
-    cur.endedAt = ts;
-    cur.events.add(Obd2SessionEvent(
-      timestamp: ts,
-      kind: Obd2SessionEventKind.sessionEnded,
-    ));
-    _last = cur;
-    _current = null;
-    _lastDataAt = null;
-  }
-
-  /// Test reset — drops the current and last session.
-  @visibleForTesting
-  static void reset() {
-    _current = null;
-    _last = null;
-    _lastDataAt = null;
   }
 }

--- a/lib/features/consumption/data/obd2/obd2_debug_session_recorder.dart
+++ b/lib/features/consumption/data/obd2/obd2_debug_session_recorder.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/foundation.dart';
+
+import 'auto_record_trace_log.dart';
+import 'obd2_debug_session.dart';
+
+/// Process-wide recorder for [Obd2DebugSession]s (#1925).
+///
+/// Off by default — every method is a cheap no-op until [enabled] is
+/// flipped on (the user opts in via the OBD2 debug-logging checkbox in
+/// settings; `Obd2DebugSessionLogging` keeps [enabled] in sync with the
+/// persisted flag). When on, it captures one session per OBD2
+/// connection so a failed recording can be exported as XML and analysed.
+///
+/// Most events are mirrored from [AutoRecordTraceLog]: [ingest] is
+/// called from `AutoRecordTraceLog.add`, so the connect / drop /
+/// reconnect transitions need no extra instrumentation. The connect
+/// path adds per-command handshake timing via [recordHandshakeCommand];
+/// the poll loop pings [recordData] so silence is detected as a gap.
+///
+/// Static, like [AutoRecordTraceLog] — the OBD2 stack is single-isolate
+/// so no synchronisation is needed.
+class Obd2DebugSessionRecorder {
+  Obd2DebugSessionRecorder._();
+
+  /// Master switch. False ⇒ every method returns immediately; the
+  /// feature has zero cost when the user has not opted in.
+  static bool enabled = false;
+
+  /// A run of silence at least this long (ms) between successful data
+  /// pings is recorded as an [Obd2SessionEventKind.dataGap]. The poll
+  /// loop nominally delivers a sample every ~250 ms.
+  static const int dataGapThresholdMs = 3000;
+
+  static Obd2DebugSession? _current;
+  static Obd2DebugSession? _last;
+  static DateTime? _lastDataAt;
+
+  // Vehicle state at the most recent [recordData] ping — stamped onto
+  // the *pre-gap* side of the next [dataGap] event so a gap shows what
+  // the car was doing when data stopped (#1930).
+  static double? _lastSpeedKmh;
+  static double? _lastRpm;
+
+  /// The session currently being recorded, if any.
+  static Obd2DebugSession? get currentSession => _current;
+
+  /// The most relevant session for export — the live one if a
+  /// connection is in progress, otherwise the last finished one.
+  static Obd2DebugSession? get latestSession => _current ?? _last;
+
+  /// Map a trace-ring event onto the session log. Called by
+  /// `AutoRecordTraceLog.add`; a no-op when the feature is off.
+  static void ingest(
+    AutoRecordEventKind kind, {
+    String? mac,
+    String? detail,
+    required DateTime timestamp,
+  }) {
+    if (!enabled) return;
+    switch (kind) {
+      case AutoRecordEventKind.connectStarted:
+        _begin(mac, timestamp);
+      case AutoRecordEventKind.connectSucceeded:
+        _add(timestamp, Obd2SessionEventKind.connectionEstablished,
+            detail: detail);
+      case AutoRecordEventKind.connectFailed:
+        _add(timestamp, Obd2SessionEventKind.connectionFailed,
+            detail: detail);
+        _finalize(timestamp);
+      case AutoRecordEventKind.dropDetected:
+        _add(timestamp, Obd2SessionEventKind.dropDetected, detail: detail);
+      case AutoRecordEventKind.silentReconnectStarted:
+        _add(timestamp, Obd2SessionEventKind.reconnectStarted,
+            detail: detail);
+      case AutoRecordEventKind.silentReconnectSucceeded:
+      case AutoRecordEventKind.reconnectSucceeded:
+        _add(timestamp, Obd2SessionEventKind.reconnectSucceeded,
+            detail: detail);
+      case AutoRecordEventKind.dropEscalatedToVisible:
+        _add(timestamp, Obd2SessionEventKind.reconnectFailed,
+            detail: detail ?? 'silent reconnect window elapsed');
+      case AutoRecordEventKind.disconnectTimerStarted:
+        _add(timestamp, Obd2SessionEventKind.disconnectTimerStarted,
+            detail: detail);
+      case AutoRecordEventKind.disconnectTimerCancelled:
+        _add(timestamp, Obd2SessionEventKind.disconnectTimerCancelled,
+            detail: detail);
+      case AutoRecordEventKind.disconnectTimerFired:
+        _add(timestamp, Obd2SessionEventKind.disconnectTimerFired,
+            detail: detail);
+      // Coordinator / threshold / trip-lifecycle events are not part
+      // of the OBD2 link picture this log is meant to debug.
+      default:
+        break;
+    }
+  }
+
+  /// Record one ELM327 init/handshake command and its reply. Called
+  /// per command by `Obd2Service.connect`.
+  static void recordHandshakeCommand(
+    String command,
+    String response,
+    int latencyMs, {
+    DateTime? clock,
+  }) {
+    if (!enabled || _current == null) return;
+    final ts = clock ?? DateTime.now();
+    _current!.events.add(Obd2SessionEvent(
+      timestamp: ts,
+      kind: Obd2SessionEventKind.handshakeCommand,
+      command: command.trim(),
+      response: response.trim(),
+      latencyMs: latencyMs,
+    ));
+  }
+
+  /// Ping that data was successfully received, with the vehicle state
+  /// ([speedKmh] / [rpm]) at that moment. When the gap since the
+  /// previous ping exceeds [dataGapThresholdMs] a [dataGap] event is
+  /// recorded — stamped with the pre-gap state (carried from the last
+  /// ping) and the post-gap state (this ping) so the export shows what
+  /// the car was doing when data stopped and resumed (#1930).
+  static void recordData(DateTime timestamp, {double? speedKmh, double? rpm}) {
+    if (!enabled || _current == null) return;
+    final last = _lastDataAt;
+    if (last != null) {
+      final gapMs = timestamp.difference(last).inMilliseconds;
+      if (gapMs >= dataGapThresholdMs) {
+        _current!.events.add(Obd2SessionEvent(
+          timestamp: timestamp,
+          kind: Obd2SessionEventKind.dataGap,
+          gapMs: gapMs,
+          preGapSpeedKmh: _lastSpeedKmh,
+          preGapRpm: _lastRpm,
+          postGapSpeedKmh: speedKmh,
+          postGapRpm: rpm,
+        ));
+      }
+    }
+    _lastDataAt = timestamp;
+    _lastSpeedKmh = speedKmh;
+    _lastRpm = rpm;
+  }
+
+  /// Finalise the current session (e.g. when recording stops). Safe to
+  /// call when there is no open session.
+  static void endSession({DateTime? clock}) {
+    if (!enabled) return;
+    _finalize(clock ?? DateTime.now());
+  }
+
+  static void _begin(String? mac, DateTime ts) {
+    _finalize(ts);
+    _current = Obd2DebugSession(startedAt: ts, adapterMac: mac)
+      ..events.add(Obd2SessionEvent(
+        timestamp: ts,
+        kind: Obd2SessionEventKind.sessionStarted,
+        detail: mac == null ? null : 'adapter $mac',
+      ));
+    _lastDataAt = null;
+    _lastSpeedKmh = null;
+    _lastRpm = null;
+  }
+
+  static void _add(
+    DateTime ts,
+    Obd2SessionEventKind kind, {
+    String? detail,
+  }) {
+    final cur = _current;
+    if (cur == null) return;
+    cur.events.add(Obd2SessionEvent(timestamp: ts, kind: kind, detail: detail));
+  }
+
+  static void _finalize(DateTime ts) {
+    final cur = _current;
+    if (cur == null) return;
+    // Trailing data gap (#1930) — the session ended while data was
+    // still silent, so no resuming ping ever emitted a dataGap. Record
+    // it now (post-gap state null — data never came back) so a
+    // recording that simply stopped receiving data is not invisible.
+    final last = _lastDataAt;
+    if (last != null) {
+      final gapMs = ts.difference(last).inMilliseconds;
+      if (gapMs >= dataGapThresholdMs) {
+        cur.events.add(Obd2SessionEvent(
+          timestamp: ts,
+          kind: Obd2SessionEventKind.dataGap,
+          gapMs: gapMs,
+          preGapSpeedKmh: _lastSpeedKmh,
+          preGapRpm: _lastRpm,
+        ));
+      }
+    }
+    cur.endedAt = ts;
+    cur.events.add(Obd2SessionEvent(
+      timestamp: ts,
+      kind: Obd2SessionEventKind.sessionEnded,
+    ));
+    _last = cur;
+    _current = null;
+    _lastDataAt = null;
+    _lastSpeedKmh = null;
+    _lastRpm = null;
+  }
+
+  /// Test reset — drops the current and last session.
+  @visibleForTesting
+  static void reset() {
+    _current = null;
+    _last = null;
+    _lastDataAt = null;
+    _lastSpeedKmh = null;
+    _lastRpm = null;
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_debug_session_xml.dart
+++ b/lib/features/consumption/data/obd2/obd2_debug_session_xml.dart
@@ -79,6 +79,21 @@ String formatObd2DebugSessionXml(Obd2DebugSession session) {
           }
           final gapMs = e.gapMs;
           if (gapMs != null) builder.attribute('gapMs', '$gapMs');
+          // Vehicle state around a data gap (#1930) — non-zero pre-gap
+          // speed/rpm means the car was driving when data stopped (the
+          // link died); zero means the engine was idle/off.
+          final preSpeed = e.preGapSpeedKmh;
+          if (preSpeed != null) {
+            builder.attribute('preGapSpeedKmh', _num(preSpeed));
+          }
+          final preRpm = e.preGapRpm;
+          if (preRpm != null) builder.attribute('preGapRpm', _num(preRpm));
+          final postSpeed = e.postGapSpeedKmh;
+          if (postSpeed != null) {
+            builder.attribute('postGapSpeedKmh', _num(postSpeed));
+          }
+          final postRpm = e.postGapRpm;
+          if (postRpm != null) builder.attribute('postGapRpm', _num(postRpm));
           final detail = e.detail;
           if (detail != null) builder.attribute('detail', detail);
         });
@@ -87,6 +102,11 @@ String formatObd2DebugSessionXml(Obd2DebugSession session) {
   });
   return builder.buildDocument().toXmlString(pretty: true);
 }
+
+/// Format a double for an XML attribute — drops a redundant `.0` so
+/// `95.0` serialises as `95`, keeping the export readable.
+String _num(double v) =>
+    v == v.roundToDouble() ? '${v.toInt()}' : v.toString();
 
 /// Redact a BLE MAC to its last four characters — a full MAC is a
 /// stable hardware identifier (PII). Everything before the final four

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -1275,7 +1275,9 @@ class TripRecordingController {
       _lastSampleAt = nowTs;
       // #1925 — ping the opt-in debug recorder so a stretch of silence
       // surfaces as a data-gap event in the exported session log.
-      Obd2DebugSessionRecorder.recordData(nowTs);
+      // #1930 — pass the vehicle state so a gap records what the car
+      // was doing when data stopped (driving vs engine-off).
+      Obd2DebugSessionRecorder.recordData(nowTs, speedKmh: speedKmh, rpm: rpm);
       _sampleBuffer.maybeCapture(sample);
     }
     if (fuelRate != null) {

--- a/test/features/consumption/data/obd2/obd2_debug_session_test.dart
+++ b/test/features/consumption/data/obd2/obd2_debug_session_test.dart
@@ -94,6 +94,59 @@ void main() {
       expect(gaps.single.gapMs, 10000);
     });
 
+    test('a data gap records vehicle state before and after the silence',
+        () {
+      Obd2DebugSessionRecorder.ingest(AutoRecordEventKind.connectStarted,
+          timestamp: at(0));
+      Obd2DebugSessionRecorder.recordData(at(1), speedKmh: 95, rpm: 2200);
+      // 12 s later data resumes with the car stopped — the link died
+      // mid-drive (pre-gap moving, post-gap stationary).
+      Obd2DebugSessionRecorder.recordData(at(13), speedKmh: 0, rpm: 0);
+      final gap = Obd2DebugSessionRecorder.currentSession!.events
+          .firstWhere((e) => e.kind == Obd2SessionEventKind.dataGap);
+      expect(gap.preGapSpeedKmh, 95);
+      expect(gap.preGapRpm, 2200);
+      expect(gap.postGapSpeedKmh, 0);
+      expect(gap.postGapRpm, 0);
+    });
+
+    test('a session that ends while data is silent records a trailing gap',
+        () {
+      Obd2DebugSessionRecorder.ingest(AutoRecordEventKind.connectStarted,
+          timestamp: at(0));
+      Obd2DebugSessionRecorder.recordData(at(1), speedKmh: 80, rpm: 2000);
+      // No further data — the session ends 30 s later.
+      Obd2DebugSessionRecorder.endSession(clock: at(31));
+      final gaps = Obd2DebugSessionRecorder.latestSession!.events
+          .where((e) => e.kind == Obd2SessionEventKind.dataGap)
+          .toList();
+      expect(gaps, hasLength(1));
+      expect(gaps.single.gapMs, 30000);
+      expect(gaps.single.preGapSpeedKmh, 80);
+      expect(gaps.single.postGapSpeedKmh, isNull,
+          reason: 'data never resumed — post-gap state is unknown');
+    });
+
+    test('disconnect-save timer transitions are mapped into the session',
+        () {
+      Obd2DebugSessionRecorder.ingest(AutoRecordEventKind.connectStarted,
+          timestamp: at(0));
+      Obd2DebugSessionRecorder.ingest(
+          AutoRecordEventKind.disconnectTimerStarted,
+          timestamp: at(5));
+      Obd2DebugSessionRecorder.ingest(
+          AutoRecordEventKind.disconnectTimerFired,
+          timestamp: at(65));
+      final kinds = Obd2DebugSessionRecorder.currentSession!.events
+          .map((e) => e.kind);
+      expect(
+          kinds,
+          containsAll(<Obd2SessionEventKind>[
+            Obd2SessionEventKind.disconnectTimerStarted,
+            Obd2SessionEventKind.disconnectTimerFired,
+          ]));
+    });
+
     test('drop and silent-reconnect transitions are mapped', () {
       Obd2DebugSessionRecorder.ingest(AutoRecordEventKind.connectStarted,
           timestamp: at(0));
@@ -164,10 +217,11 @@ void main() {
           timestamp: at(1));
       Obd2DebugSessionRecorder.recordData(at(2));
       Obd2DebugSessionRecorder.recordData(at(20)); // 18 s gap
-      Obd2DebugSessionRecorder.endSession(clock: at(30));
+      // End at the last data point so no trailing gap is added (#1930).
+      Obd2DebugSessionRecorder.endSession(clock: at(20));
 
       final s = Obd2DebugSessionRecorder.latestSession!.summary;
-      expect(s.duration, const Duration(seconds: 30));
+      expect(s.duration, const Duration(seconds: 20));
       expect(s.handshakeCommands, 2);
       expect(s.handshakeLatencyMs, 130);
       expect(s.dataGaps, 1);

--- a/test/features/consumption/data/obd2/obd2_debug_session_xml_test.dart
+++ b/test/features/consumption/data/obd2/obd2_debug_session_xml_test.dart
@@ -35,6 +35,10 @@ void main() {
         timestamp: at(30),
         kind: Obd2SessionEventKind.dataGap,
         gapMs: 9500,
+        preGapSpeedKmh: 95,
+        preGapRpm: 2200,
+        postGapSpeedKmh: 0,
+        postGapRpm: 0,
       ))
       ..add(Obd2SessionEvent(
         timestamp: at(90),
@@ -89,6 +93,20 @@ void main() {
     final gap =
         events.firstWhere((e) => e.getAttribute('kind') == 'dataGap');
     expect(gap.getAttribute('gapMs'), '9500');
+  });
+
+  test('a data gap serialises the pre/post-gap vehicle state (#1930)', () {
+    final doc = XmlDocument.parse(formatObd2DebugSessionXml(buildSession()));
+    final gap = doc.rootElement
+        .getElement('Events')!
+        .findElements('Event')
+        .firstWhere((e) => e.getAttribute('kind') == 'dataGap');
+    // Pre-gap moving, post-gap stopped — the link died mid-drive. A
+    // whole .0 is dropped so the export reads cleanly.
+    expect(gap.getAttribute('preGapSpeedKmh'), '95');
+    expect(gap.getAttribute('preGapRpm'), '2200');
+    expect(gap.getAttribute('postGapSpeedKmh'), '0');
+    expect(gap.getAttribute('postGapRpm'), '0');
   });
 
   test('an in-progress session (no endedAt) still serialises', () {


### PR DESCRIPTION
## What

The opt-in OBD2 debug log (#1925/#1926) recorded *that* a data gap
happened, but not enough to explain it. For a multi-minute mid-trip gap
(#1927) the decisive question — **did the OBD link genuinely die, or
should the recording have ended (engine off / car parked)?** — still
couldn't be answered from the XML alone. This makes a gap self-diagnosing.

## How

- **Vehicle state around every `dataGap`.** Events now carry
  `preGapSpeedKmh` / `preGapRpm` (what the car was doing when data
  stopped) and `postGapSpeedKmh` / `postGapRpm` (when it resumed).
  Non-zero pre-gap speed ⇒ the link died mid-drive (adapter/BLE
  reliability); zero ⇒ the engine was idle/off ⇒ the recording arguably
  should have ended. `recordData` gains optional `speedKmh` / `rpm`,
  passed by the poll loop from the live snapshot.
- **Trailing gap on session end.** A session that ends while data is
  still silent now emits a final `dataGap` (post-gap state null) —
  previously invisible because no resuming sample triggered it.
- **Disconnect-save timer events.** `disconnectTimerStarted` /
  `Cancelled` / `Fired` are mapped from `AutoRecordTraceLog` into the
  session, so the log shows whether the auto-save logic ran and fired.
- `formatObd2DebugSessionXml` serialises all of the above.

`Obd2DebugSessionRecorder` is split into its own file (both it and the
model would otherwise exceed the 400-line guard); the model file
re-exports it, so **no import site changes**.

## Tests

New cases: a `dataGap` records pre/post-gap speed + RPM; a session
ending mid-silence yields a trailing gap; `disconnectTimer*` events are
mapped; the XML serialises the new attributes. `flutter analyze`,
`test/lint/`, the controller suite and the integration journey pass.

Closes #1930. Directly unblocks #1927 — a single exported XML over a
mid-trip hole now shows whether the car was moving when data stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
