### PR TITLE
fix(trip): guard start() against a re-entrant double-start (#1932)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -68,6 +68,15 @@ part 'trip_recording_provider.g.dart';
 class TripRecording extends _$TripRecording {
   Obd2Service? _service;
   TripRecordingController? _controller;
+
+  // #1932 — re-entrancy guard for [start]. `state` is only marked
+  // active by the last line of `start()`, but `start()` has `await`s
+  // before that, so a second start racing in the window between would
+  // pass the `state.isActive` guard and orphan a controller. This flag
+  // is set synchronously at the top of `start()` — before any await —
+  // so the second call is rejected.
+  bool _startInProgress = false;
+
   StreamSubscription<TripLiveReading>? _liveSub;
   StreamSubscription<TripRecordingControllerState>? _stateSub;
 
@@ -234,7 +243,9 @@ class TripRecording extends _$TripRecording {
     Obd2Service? service,
     bool automatic = false,
   }) async {
-    if (state.isActive) return StartTripOutcome.alreadyActive;
+    if (state.isActive || _startInProgress) {
+      return StartTripOutcome.alreadyActive;
+    }
     final activeVehicle = _tryReadActiveVehicle();
     final resolvedVehicleId = vehicleId ?? activeVehicle?.id;
     final resolvedMac = adapterMac ?? activeVehicle?.obd2AdapterMac;
@@ -271,7 +282,25 @@ class TripRecording extends _$TripRecording {
   /// call sites are unchanged. The hands-free [AutoTripCoordinator]
   /// path passes `automatic: true`.
   Future<void> start(Obd2Service service, {bool automatic = false}) async {
-    if (state.isActive) return;
+    // #1932 — synchronous re-entrancy guard. Both the check and the
+    // flag set run before `start()`'s first `await`, so a second start
+    // racing into the window (e.g. the AutoTripCoordinator and a manual
+    // UI start firing together) is rejected instead of orphaning a
+    // second controller. Cleared in a `finally` so a throwing start
+    // never locks recording out permanently.
+    if (state.isActive || _startInProgress) return;
+    _startInProgress = true;
+    try {
+      await _startInternal(service, automatic: automatic);
+    } finally {
+      _startInProgress = false;
+    }
+  }
+
+  Future<void> _startInternal(
+    Obd2Service service, {
+    bool automatic = false,
+  }) async {
     _lastTripStartedAt ??= DateTime.now();
     _service = service;
     // #1312 — snapshot adapter identity NOW. The service is

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'c03c80bc7979afb9ed8bb76c73d45f48bee80e86';
+String _$tripRecordingHash() => r'1aeb92ae04c1285be3c4790d7f6c7dc509f77ae3';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/providers/trip_recording_start_reentrancy_test.dart
+++ b/test/features/consumption/providers/trip_recording_start_reentrancy_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+/// Regression tests for #1932 — `TripRecording.start` must reject a
+/// second start that races into the window before `state` is marked
+/// active. Without the `_startInProgress` guard the second call passes
+/// the `state.isActive` check and orphans a `TripRecordingController`.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('trip_reentry_test_');
+    Hive.init(tmpDir.path);
+    await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  test('a start racing into the window does not replace the controller',
+      () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final svc1 = Obd2Service(FakeObd2Transport(_elmOk()));
+    final svc2 = Obd2Service(FakeObd2Transport(_elmOk()));
+    await svc1.connect();
+    await svc2.connect();
+    final notifier = container.read(tripRecordingProvider.notifier);
+
+    // Fire the first start without awaiting it — its controller is
+    // built synchronously before the first `await`.
+    final f1 = notifier.start(svc1);
+    final controllerAfterFirst = notifier.debugController;
+    expect(controllerAfterFirst, isNotNull);
+
+    // The second start races into the pre-`isActive` window.
+    final f2 = notifier.start(svc2);
+    await Future.wait([f1, f2]);
+
+    expect(notifier.debugController, same(controllerAfterFirst),
+        reason: 'the second start must be rejected by the re-entrancy '
+            'guard, not overwrite _controller with a second one');
+    expect(container.read(tripRecordingProvider).phase,
+        TripRecordingPhase.recording);
+    await notifier.stop();
+  });
+
+  test('startTrip is rejected while a start is in progress', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final svc1 = Obd2Service(FakeObd2Transport(_elmOk()));
+    final svc2 = Obd2Service(FakeObd2Transport(_elmOk()));
+    await svc1.connect();
+    await svc2.connect();
+    final notifier = container.read(tripRecordingProvider.notifier);
+
+    // start() sets `_startInProgress` synchronously before its first
+    // await, so a startTrip() call made before awaiting it sees it.
+    final startFuture = notifier.start(svc1);
+    final outcome = await notifier.startTrip(service: svc2);
+    expect(outcome, StartTripOutcome.alreadyActive);
+    await startFuture;
+    await notifier.stop();
+  });
+
+  test('the guard clears after a start completes — a later start works',
+      () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final svc1 = Obd2Service(FakeObd2Transport(_elmOk()));
+    final svc2 = Obd2Service(FakeObd2Transport(_elmOk()));
+    await svc1.connect();
+    await svc2.connect();
+    final notifier = container.read(tripRecordingProvider.notifier);
+
+    await notifier.start(svc1);
+    await notifier.stop();
+    // A fresh start must not be blocked by a stuck `_startInProgress`.
+    await notifier.start(svc2);
+    expect(container.read(tripRecordingProvider).phase,
+        TripRecordingPhase.recording);
+    await notifier.stop();
+  });
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };


### PR DESCRIPTION
## Problem (confirmed by reading the code)

`TripRecording.start` guards a double-start with
`if (state.isActive) return` at its first line — but `state` is only
marked active by the **last** line of `start()` (line 409), and
`start()` has two `await`s before that (the first at line 341). Any
second `start()` / `startTrip()` running in that window passes the
guard, builds a **second `TripRecordingController`** and overwrites
`_controller`.

The first controller is then **orphaned**: `stop()` only tears down
`_controller`, so it keeps running — timers, BLE polling, and its
live-stream listener still firing `_maybeFlushActiveSnapshot()` after
the other trip's `stop()` ran `_clearActiveSnapshot()`. A leaked
controller re-writing the active-trip snapshot is the most likely root
cause of **#1928** (one drive saved twice — the snapshot gets recovered
and finalised on next launch).

Reachable when two start paths race — e.g. the hands-free
`AutoTripCoordinator` and a manual UI start, or a double-tapped button.

## Fix

A synchronous `_startInProgress` re-entrancy flag: set at the top of
`start()` **before the first `await`**, checked alongside
`state.isActive` in both `start()` and `startTrip()`, cleared in a
`finally` (so a throwing start never locks recording out). Dart runs
synchronously up to the first `await`, so the flag is set before any
second call can interleave — the guard is airtight. The start body is
extracted to `_startInternal` so the guard wraps it without
re-indenting 130 lines.

## Tests

`trip_recording_start_reentrancy_test.dart` (new): a start racing into
the window does not replace the controller; `startTrip()` returns
`alreadyActive` while a start is in progress; the flag clears after a
start completes so a later start still works.

`flutter analyze`, `test/lint/`, the integration journey and all
consumption-provider tests (243) pass; codegen regenerated.

Closes #1932 — the confirmed root cause traced in the #1928
investigation. Once a #1925 debug log confirms no duplicates recur,
#1928 can be closed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
