### PR TITLE
fix(trip): don't integrate distance/fuel across a connection-dropout gap (#1927)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -353,6 +353,13 @@ class TripRecordingController {
   /// and [_recordSpeedSample] tear-offs.
   late final LiveSampleSnapshot _liveSampleSnapshot;
 
+  /// Maximum Δt (seconds) between samples that the distance / fuel
+  /// integrators bridge (#1927). A longer gap is a connection dropout
+  /// or pause — integrating across it fabricates distance and fuel, so
+  /// `TripRecorder` and `VirtualOdometer` skip it. 15 s is far above
+  /// the ~250 ms poll cadence and the 6 s silent-reconnect window.
+  static const double _integrationGapCapSeconds = 15.0;
+
   TripRecordingController({
     required Obd2Service service,
     TripRecorder? recorder,
@@ -378,7 +385,9 @@ class TripRecordingController {
     )? reconnectScannerFactory,
     Obd2BreadcrumbRecorder? breadcrumbCollector,
   })  : _service = service,
-        _recorder = recorder ?? TripRecorder(),
+        _recorder = recorder ??
+            TripRecorder(
+                maxIntegrationGapSeconds: _integrationGapCapSeconds),
         _pollInterval = pollInterval,
         _now = now ?? DateTime.now,
         _vehicle = vehicle,
@@ -802,7 +811,10 @@ class TripRecordingController {
   double get currentDistanceKm {
     final real = _realOdometerDeltaKm();
     if (real != null) return real;
-    return VirtualOdometer(samples: _speedSamples).integrateKm();
+    return VirtualOdometer(
+      samples: _speedSamples,
+      maxGapSeconds: _integrationGapCapSeconds,
+    ).integrateKm();
   }
 
   /// `'real'` when [currentDistanceKm] came from the car's odometer,

--- a/lib/features/consumption/data/obd2/virtual_odometer.dart
+++ b/lib/features/consumption/data/obd2/virtual_odometer.dart
@@ -41,7 +41,20 @@ class VirtualOdometer {
   /// poisoning the total.
   final List<VirtualOdometerSample> samples;
 
-  const VirtualOdometer({required this.samples});
+  /// Maximum gap (seconds) between two adjacent samples that is still
+  /// integrated (#1927). A gap longer than this is a connection
+  /// dropout or a pause, not a measurement interval — bridging it with
+  /// `avgSpeed × dt` fabricates distance (a 20-minute hole added ~10 km
+  /// in a real backup). Pairs beyond this gap are skipped, so the
+  /// estimate honestly under-counts the lost stretch instead of
+  /// guessing it. Defaults to [double.infinity] — the pure integrator
+  /// caps nothing; the trip-recording path opts into a finite value.
+  final double maxGapSeconds;
+
+  const VirtualOdometer({
+    required this.samples,
+    this.maxGapSeconds = double.infinity,
+  });
 
   /// Trapezoidal integration of speed × dt over the captured
   /// [samples]. For each adjacent pair `(t_i, v_i)`, `(t_{i+1},
@@ -58,6 +71,8 @@ class VirtualOdometer {
   ///     a buffered tick out of order, and dropping the bad pair is
   ///     less damaging than negating a chunk of real distance.
   ///   - Samples with the same timestamp → skipped as above.
+  ///   - A gap longer than [maxGapSeconds] → the pair is skipped
+  ///     (#1927): a multi-minute dropout is not a measurement interval.
   double integrateKm() {
     if (samples.length < 2) return 0.0;
     var distanceKm = 0.0;
@@ -67,6 +82,7 @@ class VirtualOdometer {
       final dtSeconds = curr.timestamp.difference(prev.timestamp).inMicroseconds
           / Duration.microsecondsPerSecond;
       if (dtSeconds <= 0) continue; // skip non-monotonic pair
+      if (dtSeconds > maxGapSeconds) continue; // #1927 — skip a dropout gap
       final v1 = prev.speedKmh < 0 ? 0.0 : prev.speedKmh;
       final v2 = curr.speedKmh < 0 ? 0.0 : curr.speedKmh;
       final avgKmh = (v1 + v2) / 2.0;

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -1,6 +1,12 @@
 import 'dart:math' as math;
 
 import 'harsh_event_detector.dart';
+import 'trip_summary.dart';
+
+// TripSummary lives in its own file (#1927 — keeps this file under the
+// 400-line guard) but is re-exported so importers of `trip_recorder.dart`
+// still see it as one unit.
+export 'trip_summary.dart';
 
 /// One OBD2 sample tick — captured by the polling loop and fed into
 /// [TripRecorder] for metric accumulation.
@@ -55,142 +61,6 @@ class TripSample {
   });
 }
 
-/// Aggregated metrics for a single driving trip (#718).
-class TripSummary {
-  final double distanceKm;
-  final double maxRpm;
-  final double highRpmSeconds;
-  final double idleSeconds;
-  final int harshBrakes;
-  final int harshAccelerations;
-  /// Average fuel consumption in L/100 km. Null when the trip carried
-  /// no fuel-rate samples (cars without PID 5E / MAF).
-  final double? avgLPer100Km;
-  /// Estimated fuel burned during the trip, in litres. Null when the
-  /// trip carried no fuel-rate samples. This is what the "save as
-  /// fill-up" flow pre-fills into the liters field (#726).
-  final double? fuelLitersConsumed;
-  final DateTime? startedAt;
-  final DateTime? endedAt;
-
-  /// Provenance flag for [distanceKm] (#800). Either `'real'` — the
-  /// value came from the car's odometer (`odometerLatest -
-  /// odometerStart`) — or `'virtual'` — the value is the trapezoidal
-  /// integration of speed samples from [VirtualOdometer]. UI /
-  /// analytics use this to decide whether to trust the km figure as a
-  /// ground truth (fuel-reconciliation denominator) or flag it as an
-  /// estimate. Defaults to `'virtual'` because the recorder
-  /// integrates speed even when an odometer is available — legacy
-  /// trips before this flag landed keep that honest label.
-  final String distanceSource;
-
-  /// Whether this trip likely paid a cold-start fuel surcharge
-  /// (#1262 phase 2). Flipped true when the coolant temperature
-  /// telemetry suggests the engine was warming up for a meaningful
-  /// portion of the trip — short trips that never reached operating
-  /// temperature, trips where the coolant max stayed below 70 °C, or
-  /// trips that only crossed 70 °C in the second half. Cars without
-  /// PID 0x05 produce no coolant samples, so the flag stays false to
-  /// avoid false positives on absent data. UI surfaces (Phase 3)
-  /// render a chip on the trip card based on this bit.
-  final bool coldStartSurcharge;
-
-  /// Seconds during the trip the engine was in a lower gear than
-  /// optimal — heuristic: in-gear-N when N+1 would let RPM drop below
-  /// `optimalRpmCeiling` (≈ 2200 RPM). Computed from
-  /// `gear_inference.dart` outputs at trip end. Null = no inference
-  /// (no centroids, EV, insufficient samples).
-  final double? secondsBelowOptimalGear;
-
-  /// Whether the fuel-rate samples that produced [fuelLitersConsumed]
-  /// / [avgLPer100Km] tripped the cross-check sanity bounds at a
-  /// meaningful rate during the trip (#1395). Set true at trip end
-  /// when the breadcrumb collector reports
-  /// `suspiciousSampleCount / totalSampleCount > 0.3` — i.e. more
-  /// than 30 % of samples were either implausibly low (RPM > 1500
-  /// AND L/h < 0.3) or showed > 50 % divergence between PID 5E and
-  /// the MAF-derived rate. Stays false when no samples or no flagged
-  /// samples were recorded; UI surfaces (#1395 phase 4) render a chip
-  /// on the trip summary card based on this bit.
-  final bool fuelRateSuspect;
-
-  /// Fuel-weighted mean volumetric efficiency (η_v) the trip's fuel was
-  /// integrated with (#1858), or null when the trip is **not**
-  /// η_v-recalculable.
-  ///
-  /// Speed-density fuel scales linearly with η_v, so a stored trip can
-  /// be retroactively recomputed for a corrected η_v by
-  /// `fuelLitersConsumed × (newVe / volumetricEfficiencyUsed)` — but
-  /// only when *every* litre was speed-density-derived. This field is
-  /// non-null exactly then: it carries the fuel-weighted mean of the
-  /// per-tick η_v actually applied. It is null when any fuel came from
-  /// PID 5E or the MAF branch (neither uses η_v — rescaling would
-  /// corrupt that portion), when the trip burned no fuel, and for
-  /// legacy trips recorded before #1858. A null value means "not
-  /// recalculable" and such trips are left untouched by a recompute.
-  final double? volumetricEfficiencyUsed;
-
-  const TripSummary({
-    required this.distanceKm,
-    required this.maxRpm,
-    required this.highRpmSeconds,
-    required this.idleSeconds,
-    required this.harshBrakes,
-    required this.harshAccelerations,
-    this.avgLPer100Km,
-    this.fuelLitersConsumed,
-    this.startedAt,
-    this.endedAt,
-    this.distanceSource = 'virtual',
-    this.coldStartSurcharge = false,
-    this.secondsBelowOptimalGear,
-    this.fuelRateSuspect = false,
-    this.volumetricEfficiencyUsed,
-  });
-
-  /// Returns a copy with the given fields replaced (#1858). Used by the
-  /// retroactive η_v recompute to rescale `fuelLitersConsumed` /
-  /// `avgLPer100Km` and re-stamp `volumetricEfficiencyUsed`. A passed
-  /// null keeps the existing value — the recompute never needs to
-  /// *clear* a field, so the simple form is sufficient.
-  TripSummary copyWith({
-    double? distanceKm,
-    double? maxRpm,
-    double? highRpmSeconds,
-    double? idleSeconds,
-    int? harshBrakes,
-    int? harshAccelerations,
-    double? avgLPer100Km,
-    double? fuelLitersConsumed,
-    DateTime? startedAt,
-    DateTime? endedAt,
-    String? distanceSource,
-    bool? coldStartSurcharge,
-    double? secondsBelowOptimalGear,
-    bool? fuelRateSuspect,
-    double? volumetricEfficiencyUsed,
-  }) =>
-      TripSummary(
-        distanceKm: distanceKm ?? this.distanceKm,
-        maxRpm: maxRpm ?? this.maxRpm,
-        highRpmSeconds: highRpmSeconds ?? this.highRpmSeconds,
-        idleSeconds: idleSeconds ?? this.idleSeconds,
-        harshBrakes: harshBrakes ?? this.harshBrakes,
-        harshAccelerations: harshAccelerations ?? this.harshAccelerations,
-        avgLPer100Km: avgLPer100Km ?? this.avgLPer100Km,
-        fuelLitersConsumed: fuelLitersConsumed ?? this.fuelLitersConsumed,
-        startedAt: startedAt ?? this.startedAt,
-        endedAt: endedAt ?? this.endedAt,
-        distanceSource: distanceSource ?? this.distanceSource,
-        coldStartSurcharge: coldStartSurcharge ?? this.coldStartSurcharge,
-        secondsBelowOptimalGear:
-            secondsBelowOptimalGear ?? this.secondsBelowOptimalGear,
-        fuelRateSuspect: fuelRateSuspect ?? this.fuelRateSuspect,
-        volumetricEfficiencyUsed:
-            volumetricEfficiencyUsed ?? this.volumetricEfficiencyUsed,
-      );
-}
-
 /// Pure-logic accumulator that turns a stream of OBD2 [TripSample]s
 /// into a [TripSummary]. The Bluetooth polling loop feeds samples in
 /// via [onSample] at whatever cadence it can sustain (~1-2 Hz); the
@@ -203,6 +73,15 @@ class TripSummary {
 class TripRecorder {
   /// RPM value above which the recorder clocks "high-RPM" time.
   final double highRpmThreshold;
+
+  /// Maximum Δt (seconds) between two samples that is still integrated
+  /// (#1927). A gap longer than this is a connection dropout or a
+  /// pause, not a measurement interval — integrating `avgSpeed × dt`
+  /// or `avgFuelRate × dt` across it fabricates distance and fuel.
+  /// Intervals beyond this gap are skipped entirely. Defaults to
+  /// [double.infinity] (no cap); the trip-recording path opts into a
+  /// finite value.
+  final double maxIntegrationGapSeconds;
 
   /// Detects harsh braking / acceleration from the speed stream. Kept
   /// in its own class (#1922) so the speed derivative is re-sampled at
@@ -237,6 +116,7 @@ class TripRecorder {
 
   TripRecorder({
     this.highRpmThreshold = 3500,
+    this.maxIntegrationGapSeconds = double.infinity,
     double harshBrakeThresholdMps2 = 3.5,
     double harshAccelThresholdMps2 = 3.0,
   }) : _harshDetector = HarshEventDetector(
@@ -284,6 +164,17 @@ class TripRecorder {
         / Duration.microsecondsPerSecond;
     if (dt <= 0) {
       // Out-of-order or duplicate timestamp — skip.
+      _previous = sample;
+      return;
+    }
+    if (dt > maxIntegrationGapSeconds) {
+      // #1927 — a gap far longer than the poll cadence is a connection
+      // dropout or a pause, not a measurement interval. Integrating
+      // distance / fuel / idle / high-RPM time across it would
+      // fabricate a chunk of metric (a 20-minute hole added ~10 km of
+      // phantom distance in a real backup). Skip every dt-based
+      // accumulator; the trip honestly under-counts the lost stretch.
+      // `_previous` still advances so the next interval integrates.
       _previous = sample;
       return;
     }

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -1,0 +1,139 @@
+/// Aggregated metrics for a single driving trip (#718).
+///
+/// Extracted from `trip_recorder.dart` (#1927 — keeps that file under
+/// the 400-line guard); re-exported from there so existing importers
+/// are unaffected.
+class TripSummary {
+  final double distanceKm;
+  final double maxRpm;
+  final double highRpmSeconds;
+  final double idleSeconds;
+  final int harshBrakes;
+  final int harshAccelerations;
+  /// Average fuel consumption in L/100 km. Null when the trip carried
+  /// no fuel-rate samples (cars without PID 5E / MAF).
+  final double? avgLPer100Km;
+  /// Estimated fuel burned during the trip, in litres. Null when the
+  /// trip carried no fuel-rate samples. This is what the "save as
+  /// fill-up" flow pre-fills into the liters field (#726).
+  final double? fuelLitersConsumed;
+  final DateTime? startedAt;
+  final DateTime? endedAt;
+
+  /// Provenance flag for [distanceKm] (#800). Either `'real'` — the
+  /// value came from the car's odometer (`odometerLatest -
+  /// odometerStart`) — or `'virtual'` — the value is the trapezoidal
+  /// integration of speed samples from [VirtualOdometer]. UI /
+  /// analytics use this to decide whether to trust the km figure as a
+  /// ground truth (fuel-reconciliation denominator) or flag it as an
+  /// estimate. Defaults to `'virtual'` because the recorder
+  /// integrates speed even when an odometer is available — legacy
+  /// trips before this flag landed keep that honest label.
+  final String distanceSource;
+
+  /// Whether this trip likely paid a cold-start fuel surcharge
+  /// (#1262 phase 2). Flipped true when the coolant temperature
+  /// telemetry suggests the engine was warming up for a meaningful
+  /// portion of the trip — short trips that never reached operating
+  /// temperature, trips where the coolant max stayed below 70 °C, or
+  /// trips that only crossed 70 °C in the second half. Cars without
+  /// PID 0x05 produce no coolant samples, so the flag stays false to
+  /// avoid false positives on absent data. UI surfaces (Phase 3)
+  /// render a chip on the trip card based on this bit.
+  final bool coldStartSurcharge;
+
+  /// Seconds during the trip the engine was in a lower gear than
+  /// optimal — heuristic: in-gear-N when N+1 would let RPM drop below
+  /// `optimalRpmCeiling` (≈ 2200 RPM). Computed from
+  /// `gear_inference.dart` outputs at trip end. Null = no inference
+  /// (no centroids, EV, insufficient samples).
+  final double? secondsBelowOptimalGear;
+
+  /// Whether the fuel-rate samples that produced [fuelLitersConsumed]
+  /// / [avgLPer100Km] tripped the cross-check sanity bounds at a
+  /// meaningful rate during the trip (#1395). Set true at trip end
+  /// when the breadcrumb collector reports
+  /// `suspiciousSampleCount / totalSampleCount > 0.3` — i.e. more
+  /// than 30 % of samples were either implausibly low (RPM > 1500
+  /// AND L/h < 0.3) or showed > 50 % divergence between PID 5E and
+  /// the MAF-derived rate. Stays false when no samples or no flagged
+  /// samples were recorded; UI surfaces (#1395 phase 4) render a chip
+  /// on the trip summary card based on this bit.
+  final bool fuelRateSuspect;
+
+  /// Fuel-weighted mean volumetric efficiency (η_v) the trip's fuel was
+  /// integrated with (#1858), or null when the trip is **not**
+  /// η_v-recalculable.
+  ///
+  /// Speed-density fuel scales linearly with η_v, so a stored trip can
+  /// be retroactively recomputed for a corrected η_v by
+  /// `fuelLitersConsumed × (newVe / volumetricEfficiencyUsed)` — but
+  /// only when *every* litre was speed-density-derived. This field is
+  /// non-null exactly then: it carries the fuel-weighted mean of the
+  /// per-tick η_v actually applied. It is null when any fuel came from
+  /// PID 5E or the MAF branch (neither uses η_v — rescaling would
+  /// corrupt that portion), when the trip burned no fuel, and for
+  /// legacy trips recorded before #1858. A null value means "not
+  /// recalculable" and such trips are left untouched by a recompute.
+  final double? volumetricEfficiencyUsed;
+
+  const TripSummary({
+    required this.distanceKm,
+    required this.maxRpm,
+    required this.highRpmSeconds,
+    required this.idleSeconds,
+    required this.harshBrakes,
+    required this.harshAccelerations,
+    this.avgLPer100Km,
+    this.fuelLitersConsumed,
+    this.startedAt,
+    this.endedAt,
+    this.distanceSource = 'virtual',
+    this.coldStartSurcharge = false,
+    this.secondsBelowOptimalGear,
+    this.fuelRateSuspect = false,
+    this.volumetricEfficiencyUsed,
+  });
+
+  /// Returns a copy with the given fields replaced (#1858). Used by the
+  /// retroactive η_v recompute to rescale `fuelLitersConsumed` /
+  /// `avgLPer100Km` and re-stamp `volumetricEfficiencyUsed`. A passed
+  /// null keeps the existing value — the recompute never needs to
+  /// *clear* a field, so the simple form is sufficient.
+  TripSummary copyWith({
+    double? distanceKm,
+    double? maxRpm,
+    double? highRpmSeconds,
+    double? idleSeconds,
+    int? harshBrakes,
+    int? harshAccelerations,
+    double? avgLPer100Km,
+    double? fuelLitersConsumed,
+    DateTime? startedAt,
+    DateTime? endedAt,
+    String? distanceSource,
+    bool? coldStartSurcharge,
+    double? secondsBelowOptimalGear,
+    bool? fuelRateSuspect,
+    double? volumetricEfficiencyUsed,
+  }) =>
+      TripSummary(
+        distanceKm: distanceKm ?? this.distanceKm,
+        maxRpm: maxRpm ?? this.maxRpm,
+        highRpmSeconds: highRpmSeconds ?? this.highRpmSeconds,
+        idleSeconds: idleSeconds ?? this.idleSeconds,
+        harshBrakes: harshBrakes ?? this.harshBrakes,
+        harshAccelerations: harshAccelerations ?? this.harshAccelerations,
+        avgLPer100Km: avgLPer100Km ?? this.avgLPer100Km,
+        fuelLitersConsumed: fuelLitersConsumed ?? this.fuelLitersConsumed,
+        startedAt: startedAt ?? this.startedAt,
+        endedAt: endedAt ?? this.endedAt,
+        distanceSource: distanceSource ?? this.distanceSource,
+        coldStartSurcharge: coldStartSurcharge ?? this.coldStartSurcharge,
+        secondsBelowOptimalGear:
+            secondsBelowOptimalGear ?? this.secondsBelowOptimalGear,
+        fuelRateSuspect: fuelRateSuspect ?? this.fuelRateSuspect,
+        volumetricEfficiencyUsed:
+            volumetricEfficiencyUsed ?? this.volumetricEfficiencyUsed,
+      );
+}

--- a/test/features/consumption/data/obd2/trip_recording_virtual_odometer_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_virtual_odometer_test.dart
@@ -59,19 +59,17 @@ void main() {
       final ctl = _buildController(service);
       await ctl.start();
 
-      // Pre-populate the virtual-odometer buffer: 0→60 km/h ramp over
-      // 30 s, then cruise at 60 km/h for 270 s = 4.5 km cruise +
-      // 0.25 km ramp = 4.75 km total.
+      // Pre-populate the virtual-odometer buffer at the ≤15 s cadence
+      // the #1927 gap cap requires: 0→60 km/h ramp over 30 s = 0.25 km,
+      // then cruise at 60 km/h for 270 s = 4.5 km → 4.75 km total.
       final t0 = DateTime.utc(2026, 4, 22, 11);
       ctl.debugRecordSpeedSample(speedKmh: 0, at: t0);
       ctl.debugRecordSpeedSample(
-        speedKmh: 60,
-        at: t0.add(const Duration(seconds: 30)),
-      );
-      ctl.debugRecordSpeedSample(
-        speedKmh: 60,
-        at: t0.add(const Duration(seconds: 300)),
-      );
+          speedKmh: 30, at: t0.add(const Duration(seconds: 15)));
+      for (var s = 30; s <= 300; s += 15) {
+        ctl.debugRecordSpeedSample(
+            speedKmh: 60, at: t0.add(Duration(seconds: s)));
+      }
 
       final summary = await ctl.stop();
       final expected = VirtualOdometer(samples: ctl.debugSpeedSamples)
@@ -92,13 +90,13 @@ void main() {
       await ctl.start();
       // Odometer never moved (car was idling / reading quantised away).
       ctl.debugSetOdometerReadings(latestKm: 9271.6);
-      // But some speed samples were recorded.
+      // But some speed samples were recorded — 30 km/h for 60 s =
+      // 0.5 km, at the ≤15 s cadence the #1927 gap cap requires.
       final t0 = DateTime.utc(2026, 4, 22, 12);
-      ctl.debugRecordSpeedSample(speedKmh: 30, at: t0);
-      ctl.debugRecordSpeedSample(
-        speedKmh: 30,
-        at: t0.add(const Duration(seconds: 60)),
-      );
+      for (var s = 0; s <= 60; s += 15) {
+        ctl.debugRecordSpeedSample(
+            speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
 
       final summary = await ctl.stop();
       // 0 km real delta → null → virtual. 0.5 km from samples
@@ -118,12 +116,13 @@ void main() {
       final ctl = _buildController(service);
       await ctl.start();
 
+      // 0→60 km/h ramp over 60 s = 0.5 km, at the ≤15 s cadence the
+      // #1927 gap cap requires.
       final t0 = DateTime.utc(2026, 4, 22, 13);
-      ctl.debugRecordSpeedSample(speedKmh: 0, at: t0);
-      ctl.debugRecordSpeedSample(
-        speedKmh: 60,
-        at: t0.add(const Duration(seconds: 60)),
-      );
+      for (var s = 0; s <= 60; s += 15) {
+        ctl.debugRecordSpeedSample(
+            speedKmh: s.toDouble(), at: t0.add(Duration(seconds: s)));
+      }
       final live = ctl.currentDistanceKm;
       expect(live, closeTo(0.5, 0.01));
 

--- a/test/features/consumption/data/obd2/virtual_odometer_test.dart
+++ b/test/features/consumption/data/obd2/virtual_odometer_test.dart
@@ -109,5 +109,70 @@ void main() {
       ]);
       expect(odo.integrateKm(), closeTo(0.0, 0.001));
     });
+
+    group('maxGapSeconds dropout cap (#1927)', () {
+      test('a gap longer than maxGapSeconds is not integrated', () {
+        final odo = VirtualOdometer(
+          maxGapSeconds: 15,
+          samples: [
+            VirtualOdometerSample(timestamp: _t0, speedKmh: 60),
+            // 20-minute dropout — must NOT add 60 km/h × 20 min = 20 km.
+            VirtualOdometerSample(
+                timestamp: _t0.add(const Duration(minutes: 20)),
+                speedKmh: 60),
+          ],
+        );
+        expect(odo.integrateKm(), 0.0);
+      });
+
+      test('a pair within the cap is still integrated', () {
+        final odo = VirtualOdometer(
+          maxGapSeconds: 15,
+          samples: [
+            VirtualOdometerSample(timestamp: _t0, speedKmh: 60),
+            VirtualOdometerSample(
+                timestamp: _t0.add(const Duration(seconds: 10)),
+                speedKmh: 60),
+          ],
+        );
+        expect(odo.integrateKm(), closeTo(60 * 10 / 3600, 1e-9));
+      });
+
+      test(
+          'only the dropout pair is skipped — surrounding distance '
+          'survives', () {
+        final odo = VirtualOdometer(
+          maxGapSeconds: 15,
+          samples: [
+            VirtualOdometerSample(timestamp: _t0, speedKmh: 60),
+            VirtualOdometerSample(
+                timestamp: _t0.add(const Duration(seconds: 10)),
+                speedKmh: 60),
+            // 20-minute dropout in the middle of the drive.
+            VirtualOdometerSample(
+                timestamp:
+                    _t0.add(const Duration(minutes: 20, seconds: 10)),
+                speedKmh: 60),
+            VirtualOdometerSample(
+                timestamp:
+                    _t0.add(const Duration(minutes: 20, seconds: 20)),
+                speedKmh: 60),
+          ],
+        );
+        // The two valid 10-s intervals integrate; the dropout is skipped.
+        expect(odo.integrateKm(), closeTo(2 * 60 * 10 / 3600, 1e-9));
+      });
+
+      test('the default (no cap) integrates any gap — unchanged behaviour',
+          () {
+        final odo = VirtualOdometer(samples: [
+          VirtualOdometerSample(timestamp: _t0, speedKmh: 60),
+          VirtualOdometerSample(
+              timestamp: _t0.add(const Duration(minutes: 20)),
+              speedKmh: 60),
+        ]);
+        expect(odo.integrateKm(), closeTo(60 * 20 / 60, 1e-9));
+      });
+    });
   });
 }

--- a/test/features/consumption/domain/trip_recorder_test.dart
+++ b/test/features/consumption/domain/trip_recorder_test.dart
@@ -419,5 +419,87 @@ void main() {
       ));
       expect(strict.buildSummary().harshBrakes, 1);
     });
+
+    group('maxIntegrationGapSeconds dropout cap (#1927)', () {
+      test('distance and fuel are not integrated across an abnormal gap',
+          () {
+        final r = TripRecorder(maxIntegrationGapSeconds: 15);
+        final start = DateTime.utc(2026);
+        r.onSample(TripSample(
+            timestamp: start, speedKmh: 60, rpm: 2000, fuelRateLPerHour: 6));
+        // A 20-minute connection dropout — not 20 minutes of driving.
+        r.onSample(TripSample(
+          timestamp: start.add(const Duration(minutes: 20)),
+          speedKmh: 60,
+          rpm: 2000,
+          fuelRateLPerHour: 6,
+        ));
+        final s = r.buildSummary();
+        expect(s.distanceKm, 0,
+            reason: 'no distance may be fabricated across the gap');
+        expect(s.fuelLitersConsumed ?? 0, 0,
+            reason: 'no fuel may be fabricated across the gap');
+      });
+
+      test('a long gap does not inflate idle time', () {
+        final r = TripRecorder(maxIntegrationGapSeconds: 15);
+        final start = DateTime.utc(2026);
+        // Stationary, engine on — would clock as "idle" if integrated.
+        r.onSample(TripSample(timestamp: start, speedKmh: 0, rpm: 800));
+        r.onSample(TripSample(
+          timestamp: start.add(const Duration(minutes: 20)),
+          speedKmh: 0,
+          rpm: 800,
+        ));
+        expect(r.buildSummary().idleSeconds, 0);
+      });
+
+      test('intervals within the cap still integrate normally', () {
+        final r = TripRecorder(maxIntegrationGapSeconds: 15);
+        final start = DateTime.utc(2026);
+        r.onSample(TripSample(timestamp: start, speedKmh: 60, rpm: 2000));
+        r.onSample(TripSample(
+          timestamp: start.add(const Duration(seconds: 10)),
+          speedKmh: 60,
+          rpm: 2000,
+        ));
+        expect(r.buildSummary().distanceKm, closeTo(60 * 10 / 3600, 1e-6));
+      });
+
+      test('only the dropout interval is skipped — the rest integrates',
+          () {
+        final r = TripRecorder(maxIntegrationGapSeconds: 15);
+        final start = DateTime.utc(2026);
+        r.onSample(TripSample(timestamp: start, speedKmh: 60, rpm: 2000));
+        r.onSample(TripSample(
+            timestamp: start.add(const Duration(seconds: 10)),
+            speedKmh: 60,
+            rpm: 2000));
+        // 20-minute dropout, then driving resumes.
+        r.onSample(TripSample(
+            timestamp: start.add(const Duration(minutes: 20, seconds: 10)),
+            speedKmh: 60,
+            rpm: 2000));
+        r.onSample(TripSample(
+            timestamp: start.add(const Duration(minutes: 20, seconds: 20)),
+            speedKmh: 60,
+            rpm: 2000));
+        expect(r.buildSummary().distanceKm,
+            closeTo(2 * 60 * 10 / 3600, 1e-6));
+      });
+
+      test('the default (no cap) integrates any gap — unchanged behaviour',
+          () {
+        final r = TripRecorder();
+        final start = DateTime.utc(2026);
+        r.onSample(TripSample(timestamp: start, speedKmh: 60, rpm: 2000));
+        r.onSample(TripSample(
+          timestamp: start.add(const Duration(minutes: 20)),
+          speedKmh: 60,
+          rpm: 2000,
+        ));
+        expect(r.buildSummary().distanceKm, closeTo(60 * 20 / 60, 1e-6));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Problem

A real device backup showed trips with **8–20 minute holes** mid-
recording. The trip summary integrated straight *across* the hole:
both `TripRecorder` and `VirtualOdometer` bridge two adjacent samples
with `avgSpeed × Δt`, so a 20-minute gap fabricated **~10 km of
phantom distance** (and matching fuel) — one 23-minute drive reported
just 7.63 km because the integration was a mix of real data and a
bogus bridge.

## Fix

Both integrators gain a `maxGap` cap. An interval longer than the cap
is a connection dropout or a pause — not a measurement interval — and
is **skipped entirely**, so the trip honestly under-counts the lost
stretch rather than inventing a value for it.

- `TripRecorder.maxIntegrationGapSeconds` gates distance / fuel /
  idle / high-RPM accumulation.
- `VirtualOdometer.maxGapSeconds` gates the distance the finalised
  summary actually uses (`currentDistanceKm`).
- Both default to `double.infinity` — **no cap** — so the pure
  integrators and every existing test are unchanged.
  `TripRecordingController` opts both into a **15 s** cap: far above
  the ~250 ms poll cadence and the 6 s silent-reconnect window, far
  below a multi-minute hole.

`TripSummary` is extracted to `trip_summary.dart` (re-exported from
`trip_recorder.dart`, so no import site changes) to keep that file
under the 400-line guard.

## Tests

New cases on `VirtualOdometer` and `TripRecorder` (a long gap is not
integrated; intervals within the cap still are; only the dropout pair
is skipped; the no-cap default is unchanged) and updated controller↔
odometer wiring tests to the realistic ≤15 s cadence. `flutter
analyze`, `test/lint/`, the integration journey and the full
consumption suite (2807 tests) pass.

Closes #1927 — the "exclude the gap from the integration" branch of
the acceptance. Whether a long outage should also auto-end the trip is
a behavioural question the #1930 debug log will inform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
