### PR TITLE
fix(ci): force JVM 17 for plugin subprojects to fix build-android (#1936)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -19,6 +19,20 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// #1936 — force every plugin subproject's Java compilation to JVM 17,
+// matching the app module (android/app/build.gradle.kts) and the
+// Kotlin tasks. The newer Gradle bundled with Flutter `stable` hard-
+// fails on a JVM-target mismatch; the `tflite_flutter` plugin ships
+// Java targeting 11 while its Kotlin targets 17. Aligning Java up to
+// 17 makes every subproject internally consistent. Uses only core-
+// Gradle types so the root script needs no AGP/KGP classpath.
+subprojects {
+    tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = JavaVersion.VERSION_17.toString()
+        targetCompatibility = JavaVersion.VERSION_17.toString()
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## Problem

`master` CI is red — `build-android` fails:

```
Execution failed for task ':tflite_flutter:compileReleaseKotlin'.
> Inconsistent JVM-target compatibility detected for tasks
  'compileReleaseJavaWithJavac' (11) and 'compileReleaseKotlin' (17).
```

The `tflite_flutter` plugin compiles its **Java at JVM 11** but its
**Kotlin at JVM 17**. The newer Gradle that the current Flutter
`stable` bundles (CI installs it unpinned via `subosito/flutter-action`,
`channel: stable`) **hard-fails** on that mismatch where older Gradle
only warned. Environmental — it surfaced on PR #1933's merge purely by
timing; #1933 is pure Dart.

## Fix

`android/build.gradle.kts` gains a `subprojects` block forcing every
subproject's Java compilation to JVM 17 — matching the app module and
the Kotlin tasks, so each plugin is internally consistent:

```kotlin
subprojects {
    tasks.withType<JavaCompile>().configureEach {
        sourceCompatibility = JavaVersion.VERSION_17.toString()
        targetCompatibility = JavaVersion.VERSION_17.toString()
    }
}
```

Core-Gradle types only — no AGP/KGP classpath needed in the root
script. Standard remedy for "Inconsistent JVM-target compatibility"
with a third-party plugin whose own `build.gradle` can't be edited.

Verified by `build-android` on this PR (no Android SDK on the dev
machine — CI is the gate). Closes #1936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
