### PR TITLE
fix(ci): pin Flutter to 3.41.9 so build-android stops drifting red (#1936)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -106,6 +112,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -168,6 +180,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -267,6 +285,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -305,6 +329,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -336,6 +366,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -364,6 +400,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - run: flutter pub get
       - name: OSV vulnerability scan
@@ -381,6 +423,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -402,6 +450,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:
@@ -435,6 +489,12 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #1936 — pin Flutter. A floating `channel: stable` picked up
+          # a newer SDK whose bundled Gradle plugin hard-fails on the
+          # tflite_flutter Java(11)/Kotlin(17) JVM-target mismatch.
+          # 3.41.9 is the last build-android-green version (and the
+          # local dev SDK). Bump deliberately, not by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -19,20 +19,6 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
-// #1936 — force every plugin subproject's Java compilation to JVM 17,
-// matching the app module (android/app/build.gradle.kts) and the
-// Kotlin tasks. The newer Gradle bundled with Flutter `stable` hard-
-// fails on a JVM-target mismatch; the `tflite_flutter` plugin ships
-// Java targeting 11 while its Kotlin targets 17. Aligning Java up to
-// 17 makes every subproject internally consistent. Uses only core-
-// Gradle types so the root script needs no AGP/KGP classpath.
-subprojects {
-    tasks.withType<JavaCompile>().configureEach {
-        sourceCompatibility = JavaVersion.VERSION_17.toString()
-        targetCompatibility = JavaVersion.VERSION_17.toString()
-    }
-}
-
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## Why the first fix failed

PR #1937 forced the `JavaCompile` tasks to JVM 17 — but **AGP overrides
task-level `source`/`targetCompatibility`**, so `build-android` still
failed with the identical `tflite_flutter` Java(11)/Kotlin(17) mismatch.

## Real root cause (hard data)

`tflite_flutter` (0.12.1, in `pubspec.lock`), AGP 8.11.1, KGP 2.2.20
and the Gradle wrapper are **all pinned in the repo** — identical
between the last green run (#1931) and the first red one (#1933).

The only thing that floated: the **Flutter SDK**. `ci.yml` installs it
with `subosito/flutter-action`, `channel: stable`, **no version**.
Flutter's own Gradle plugin is `includeBuild`'d straight from the SDK
(`android/settings.gradle.kts`); a newer `stable` released that
afternoon tightened it to **hard-fail** on the JVM-target
inconsistency that older stables only warned about.

## Fix

Pin `flutter-version: "3.41.9"` in every `flutter-action` block —
3.41.9 is the last build-android-green version and the local dev SDK
(which builds Android fine). CI no longer drifts onto an untested
Flutter; a bump is now a deliberate, reviewable one-line change.

Also reverts the ineffective gradle block from #1937.

`build-android` runs on this PR (the `android/build.gradle.kts` revert
makes `changes.code == true`), so the fix is verified here. Closes
#1936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
