### PR TITLE
feat(consumption): capture GPS altitude on trip samples (#1940)

### DIFF
--- a/lib/features/consumption/data/obd2/active_trip_repository.dart
+++ b/lib/features/consumption/data/obd2/active_trip_repository.dart
@@ -207,6 +207,7 @@ Map<String, dynamic> _sampleToJson(TripSample s) => {
       // samples deserialise identically when the user finishes it.
       if (s.latitude != null) 'la': s.latitude,
       if (s.longitude != null) 'lo': s.longitude,
+      if (s.altitudeM != null) 'al': s.altitudeM,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -223,6 +224,8 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       // this PR carry no GPS keys → null on both fields.
       latitude: (j['la'] as num?)?.toDouble(),
       longitude: (j['lo'] as num?)?.toDouble(),
+      // #1935 child A — GPS altitude mirror key.
+      altitudeM: (j['al'] as num?)?.toDouble(),
     );
 
 /// Hive-backed singleton store for the live, in-progress trip

--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -69,6 +69,10 @@ class LiveSampleSnapshot {
   double? _latestLatitude;
   double? _latestLongitude;
 
+  // #1935 child A — most recent GPS altitude (metres), pushed in
+  // alongside the lat/lon fix. Feeds the road-grade calculator (#1941).
+  double? _latestAltitudeM;
+
   // #1615 — most recent exact-litre OEM-PID fuel reading, pushed in by
   // the provider layer (`TripOemFuelLevelController`) when the
   // `experimentalOemPids` flag is on and an OEM-capable adapter
@@ -87,13 +91,16 @@ class LiveSampleSnapshot {
   double? get latestFuelLevelPercent => _latestFuelLevelPercent;
   double? get latestLatitude => _latestLatitude;
   double? get latestLongitude => _latestLongitude;
+  double? get latestAltitudeM => _latestAltitudeM;
   double? get latestOemFuelLevelLitres => _latestOemFuelLevelLitres;
 
   /// Push the most recent GPS fix into the per-tick snapshot
-  /// (#1374 phase 1). Pass `null` for either coord to clear the latch.
-  void updateGpsFix({double? latitude, double? longitude}) {
+  /// (#1374 phase 1; altitude added #1935 child A). Pass `null` for a
+  /// field to clear that latch.
+  void updateGpsFix({double? latitude, double? longitude, double? altitudeM}) {
     _latestLatitude = latitude;
     _latestLongitude = longitude;
+    _latestAltitudeM = altitudeM;
   }
 
   /// Push the most recent exact-litre OEM-PID fuel reading into the

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -515,10 +515,11 @@ class TripRecordingController {
   /// only lives at the provider seam, which keeps unit-testing the
   /// controller cheap (no Geolocator mocks required) and lets the
   /// flag-off path skip the plugin entirely.
-  void updateGpsFix({double? latitude, double? longitude}) {
+  void updateGpsFix({double? latitude, double? longitude, double? altitudeM}) {
     _liveSampleSnapshot.updateGpsFix(
       latitude: latitude,
       longitude: longitude,
+      altitudeM: altitudeM,
     );
   }
 
@@ -579,6 +580,12 @@ class TripRecordingController {
   /// [debugLatestLatitude].
   @visibleForTesting
   double? get debugLatestLongitude => _liveSampleSnapshot.latestLongitude;
+
+  /// Read-only snapshot of the most recent GPS altitude (metres) pushed
+  /// in via [updateGpsFix] (#1935 child A). Same caveats as
+  /// [debugLatestLatitude].
+  @visibleForTesting
+  double? get debugLatestAltitudeM => _liveSampleSnapshot.latestAltitudeM;
 
   /// Start polling. Reads the odometer and VIN ONCE to pin trip
   /// identity; subsequent ticks are scheduled per-PID by
@@ -1277,11 +1284,13 @@ class TripRecordingController {
         engineLoadPercent: engineLoadPercent,
         coolantTempC: coolantTempC,
         // #1374 phase 1 — stamp the most recent GPS fix when the
-        // provider has pushed one in. Both fields stay null when the
+        // provider has pushed one in. The fields stay null when the
         // feature flag is off (no Geolocator subscription was ever
-        // started) or before the first fix lands.
+        // started) or before the first fix lands. Altitude added in
+        // #1935 child A for the road-grade calculator.
         latitude: snap.latestLatitude,
         longitude: snap.latestLongitude,
+        altitudeM: snap.latestAltitudeM,
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -174,6 +174,7 @@ Map<String, dynamic> _sampleToJson(TripSample s) => {
       if (s.coolantTempC != null) 'ct': s.coolantTempC,
       if (s.latitude != null) 'la': s.latitude,
       if (s.longitude != null) 'lo': s.longitude,
+      if (s.altitudeM != null) 'al': s.altitudeM,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -191,6 +192,9 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       // for "we don't know where this sample was taken".
       latitude: (j['la'] as num?)?.toDouble(),
       longitude: (j['lo'] as num?)?.toDouble(),
+      // #1935 child A: GPS altitude per sample. Legacy trips carry no
+      // 'al' key → null.
+      altitudeM: (j['al'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _summaryToJson(TripSummary s) => {

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -48,6 +48,13 @@ class TripSample {
   /// — a half-set fix is meaningless on a map.
   final double? longitude;
 
+  /// GPS altitude in metres (#1935 child A — epic #1935). Same
+  /// null-semantics as [latitude]/[longitude]: null when the
+  /// `Feature.gpsTripPath` flag is off, before the first fix, or when
+  /// the platform reports no altitude. Captured so the road-grade
+  /// calculator (#1941) can derive the trip's slope.
+  final double? altitudeM;
+
   const TripSample({
     required this.timestamp,
     required this.speedKmh,
@@ -58,6 +65,7 @@ class TripSample {
     this.coolantTempC,
     this.latitude,
     this.longitude,
+    this.altitudeM,
   });
 }
 

--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -71,6 +71,8 @@ class TripGpsStreamController {
           ctl.updateGpsFix(
             latitude: pos.latitude,
             longitude: pos.longitude,
+            // #1935 child A — altitude feeds the road-grade calculator.
+            altitudeM: pos.altitude,
           );
           // #1458 phase 2 — record one cadence-diagnostic per fix so the
           // user can see, post-trip, whether the OS kept delivering

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -263,6 +263,52 @@ void main() {
       expect(loaded.first.samples.first.fuelRateLPerHour, 4.2);
     });
 
+    test('sample with GPS altitude round-trips through save / loadAll '
+        '(#1935 child A)', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 5, 18);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: start.add(const Duration(seconds: 5)),
+            speedKmh: 60,
+            rpm: 2000,
+            latitude: 45.1,
+            longitude: 6.2,
+            altitudeM: 318.4,
+          ),
+        ],
+      ));
+
+      final sample = repo.loadAll().first.samples.first;
+      expect(sample.altitudeM, 318.4);
+      // The sibling GPS fields still round-trip alongside it.
+      expect(sample.latitude, 45.1);
+      expect(sample.longitude, 6.2);
+    });
+
+    test('a legacy sample with no altitude key deserialises altitudeM '
+        'null (#1935 child A)', () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 5, 18, 1);
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: null,
+        summary: mkSummary(startedAt: start),
+        samples: [
+          TripSample(
+            timestamp: start.add(const Duration(seconds: 5)),
+            speedKmh: 60,
+            rpm: 2000,
+          ),
+        ],
+      ));
+      expect(repo.loadAll().first.samples.first.altitudeM, isNull);
+    });
+
     test(
         'sample with null throttle does NOT include the "th" key in stored '
         'JSON — matches the parsimony rule the "f" key already follows',

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -111,20 +111,23 @@ void main() {
       expect(fakeGeo.lastAccuracy, LocationAccuracy.high);
 
       // Push a fix down the fake stream and let the listener run.
-      fakeGeo.emit(_pos(43.4567, 3.5821));
+      fakeGeo.emit(_pos(43.4567, 3.5821, altitude: 112.0));
       await Future<void>.delayed(Duration.zero);
 
       final ctl = notifier.debugController;
       expect(ctl, isNotNull);
       expect(ctl!.debugLatestLatitude, closeTo(43.4567, 1e-9));
       expect(ctl.debugLatestLongitude, closeTo(3.5821, 1e-9));
+      // #1935 child A — altitude rides the same fix into the latch.
+      expect(ctl.debugLatestAltitudeM, closeTo(112.0, 1e-9));
 
       // A second fix overwrites the first — the latch is "most-recent
       // wins", which matches the heatmap's per-tick semantics.
-      fakeGeo.emit(_pos(43.4600, 3.5900));
+      fakeGeo.emit(_pos(43.4600, 3.5900, altitude: 137.5));
       await Future<void>.delayed(Duration.zero);
       expect(ctl.debugLatestLatitude, closeTo(43.4600, 1e-9));
       expect(ctl.debugLatestLongitude, closeTo(3.5900, 1e-9));
+      expect(ctl.debugLatestAltitudeM, closeTo(137.5, 1e-9));
 
       await notifier.stop();
       // After stop, the subscription must be cancelled. Pushing more
@@ -193,12 +196,12 @@ Map<String, String> _elmOk() => const {
       '01A6': '41 A6 00 01 6A 2C>',
     };
 
-Position _pos(double lat, double lng) => Position(
+Position _pos(double lat, double lng, {double altitude = 0}) => Position(
       latitude: lat,
       longitude: lng,
       timestamp: DateTime.now(),
       accuracy: 5,
-      altitude: 0,
+      altitude: altitude,
       altitudeAccuracy: 0,
       heading: 0,
       headingAccuracy: 0,


### PR DESCRIPTION
## Epic #1935 — child A of 3

Factoring road gradient into the consumption calculation. This first
child captures the elevation signal the grade calculator (child B,
#1941) needs.

## Changes

- **`TripSample.altitudeM`** — GPS altitude in metres, same
  null-semantics as `latitude`/`longitude` (#1374): null when the
  `gpsTripPath` flag is off, before the first fix, or when the
  platform reports no altitude.
- **`LiveSampleSnapshot.updateGpsFix`** + **`TripRecordingController`**
  thread `altitudeM` alongside the lat/lon latch; `_emit` stamps it on
  every `TripSample`. New `debugLatestAltitudeM` test seam.
- **`TripGpsStreamController`** passes `position.altitude` from the
  Geolocator fix.
- Altitude round-trips through the `TripHistoryEntry` and active-trip-
  snapshot sample JSON under the compact `al` key; legacy samples with
  no key deserialise `altitudeM: null`.

No behaviour change beyond capture — child B consumes the value.

## Tests

`debugLatestAltitudeM` reflects a pushed fix; the GPS provider test
asserts altitude rides the same fix into the latch; new
history-repository round-trip tests (with altitude, and the legacy
no-key → null case). `flutter analyze`, `test/lint/` and the full
consumption-obd2 suite (985) pass.

Closes #1940.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
