### PR TITLE
feat(consumption): RoadGradeCalculator — smoothed GPS altitude to road grade (#1941)

### DIFF
--- a/lib/features/consumption/domain/road_grade_calculator.dart
+++ b/lib/features/consumption/domain/road_grade_calculator.dart
@@ -1,0 +1,127 @@
+/// A road grade (slope) estimate with a confidence flag (#1941).
+class RoadGrade {
+  /// Signed grade as a rise/run fraction — positive uphill, negative
+  /// downhill. `0.05` is a 5 % climb.
+  final double gradeFraction;
+
+  /// Whether the estimate is trustworthy enough to feed into the fuel
+  /// model. False until a full distance window of reasonably dense
+  /// altitude samples has accumulated; callers treat a non-confident
+  /// grade as flat road (0).
+  final bool confident;
+
+  const RoadGrade({required this.gradeFraction, required this.confident});
+
+  /// The neutral "flat road / don't know" value.
+  static const RoadGrade flat = RoadGrade(gradeFraction: 0, confident: false);
+}
+
+/// Computes a smoothed road grade from a stream of GPS altitude +
+/// distance samples (#1941, epic #1935 child B).
+///
+/// Phone GPS altitude is noisy — ±10–30 m per fix — so differencing it
+/// sample-to-sample yields meaningless grades. This calculator instead:
+///
+///  * **exponentially smooths** altitude before using it, which damps
+///    the per-fix random error;
+///  * measures grade over a distance **window** ([windowMeters]), where
+///    the residual-noise-to-window ratio is small (a ±3 m residual over
+///    a 150 m window is a 2 % grade error);
+///  * reports a **confidence** — the grade is only [RoadGrade.confident]
+///    once a full window of reasonably dense samples exists. A stretch
+///    with no GPS altitude thins the window out and drops confidence.
+///
+/// Pure logic — no Flutter / plugin dependency, fully unit-testable.
+/// The caller (#1942) feeds it the trip's running distance + the GPS
+/// altitude latched on each [TripSample] (#1940), and applies the grade
+/// to the speed-density fuel estimate only when it is confident.
+class RoadGradeCalculator {
+  RoadGradeCalculator({
+    this.windowMeters = 150.0,
+    this.smoothingFactor = 0.2,
+    this.minSamplesInWindow = 5,
+  })  : assert(windowMeters > 0),
+        assert(smoothingFactor > 0 && smoothingFactor <= 1),
+        assert(minSamplesInWindow >= 2);
+
+  /// Distance (metres) the grade is measured over. Longer = less
+  /// noise-sensitive but slower to react to a real slope change.
+  final double windowMeters;
+
+  /// Exponential-smoothing factor for altitude (0..1]. Lower is
+  /// smoother (more noise rejection, more lag).
+  final double smoothingFactor;
+
+  /// Minimum smoothed samples that must fall inside the window for the
+  /// grade to be [RoadGrade.confident] — guards against a sparse
+  /// window left by a GPS-altitude dropout.
+  final int minSamplesInWindow;
+
+  final List<_GradePoint> _points = <_GradePoint>[];
+  double? _smoothedAltitudeM;
+
+  /// Feed one sample. [cumulativeDistanceKm] is the trip's total
+  /// distance so far (monotonically non-decreasing); [altitudeM] is the
+  /// GPS altitude in metres, or null when no fix is available — a null
+  /// adds no point, so a run of nulls thins the window and lowers
+  /// confidence.
+  void addSample({
+    required double cumulativeDistanceKm,
+    double? altitudeM,
+  }) {
+    if (altitudeM == null) return;
+    final distanceM = cumulativeDistanceKm * 1000.0;
+    final previous = _smoothedAltitudeM;
+    final smoothed = previous == null
+        ? altitudeM
+        : smoothingFactor * altitudeM + (1 - smoothingFactor) * previous;
+    _smoothedAltitudeM = smoothed;
+    _points.add(_GradePoint(distanceM, smoothed));
+    // Keep memory bounded — nothing past 2x the window is ever read.
+    final cutoff = distanceM - windowMeters * 2;
+    _points.removeWhere((p) => p.distanceM < cutoff);
+  }
+
+  /// The current grade estimate over the trailing [windowMeters].
+  RoadGrade get current {
+    if (_points.length < 2) return RoadGrade.flat;
+    final latest = _points.last;
+
+    // The anchor is the newest point at least a full window behind the
+    // latest one — so `latest - anchor` spans ~windowMeters.
+    _GradePoint? anchor;
+    var samplesInWindow = 1; // the latest point itself
+    for (final p in _points) {
+      final back = latest.distanceM - p.distanceM;
+      if (back >= windowMeters) {
+        anchor = p;
+      } else if (back > 0) {
+        samplesInWindow++;
+      }
+    }
+    if (anchor == null) return RoadGrade.flat;
+
+    final run = latest.distanceM - anchor.distanceM;
+    if (run <= 0) return RoadGrade.flat;
+    final rise = latest.smoothedAltitudeM - anchor.smoothedAltitudeM;
+
+    return RoadGrade(
+      gradeFraction: rise / run,
+      // A full window AND enough samples in it — a GPS-altitude
+      // dropout leaves the window sparse and is not trusted.
+      confident: samplesInWindow >= minSamplesInWindow,
+    );
+  }
+
+  /// Drop all accumulated state — call before recording a fresh trip.
+  void reset() {
+    _points.clear();
+    _smoothedAltitudeM = null;
+  }
+}
+
+class _GradePoint {
+  final double distanceM;
+  final double smoothedAltitudeM;
+  const _GradePoint(this.distanceM, this.smoothedAltitudeM);
+}

--- a/test/features/consumption/domain/road_grade_calculator_test.dart
+++ b/test/features/consumption/domain/road_grade_calculator_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/road_grade_calculator.dart';
+
+/// Unit tests for [RoadGradeCalculator] (#1941, epic #1935 child B).
+void main() {
+  group('RoadGradeCalculator (#1941)', () {
+    test('a flat road yields grade ~0 and is confident once the window '
+        'fills', () {
+      final calc = RoadGradeCalculator();
+      // 30 samples, 20 m apart, constant 100 m altitude.
+      for (var i = 0; i < 30; i++) {
+        calc.addSample(cumulativeDistanceKm: i * 0.02, altitudeM: 100);
+      }
+      final g = calc.current;
+      expect(g.gradeFraction, closeTo(0.0, 1e-9));
+      expect(g.confident, isTrue);
+    });
+
+    test('a steady 5% climb yields grade ~0.05', () {
+      final calc = RoadGradeCalculator();
+      // 60 samples 20 m apart; +5 m per 100 m. Enough samples for the
+      // exponential smoothing to converge — once converged its constant
+      // lag cancels in the windowed difference, so the grade is exact.
+      for (var i = 0; i < 60; i++) {
+        final distM = i * 20.0;
+        calc.addSample(
+          cumulativeDistanceKm: distM / 1000.0,
+          altitudeM: 100 + 0.05 * distM,
+        );
+      }
+      final g = calc.current;
+      expect(g.gradeFraction, closeTo(0.05, 0.002));
+      expect(g.confident, isTrue);
+    });
+
+    test('a steady 4% descent yields a negative grade', () {
+      final calc = RoadGradeCalculator();
+      for (var i = 0; i < 60; i++) {
+        final distM = i * 20.0;
+        calc.addSample(
+          cumulativeDistanceKm: distM / 1000.0,
+          altitudeM: 500 - 0.04 * distM,
+        );
+      }
+      expect(calc.current.gradeFraction, closeTo(-0.04, 0.002));
+    });
+
+    test('noisy altitude on a flat road still reads ~flat — smoothing '
+        'works', () {
+      final calc = RoadGradeCalculator();
+      // Flat 100 m road, but every fix is ±12 m off (alternating) —
+      // raw differencing of adjacent fixes would give a ~120% grade.
+      for (var i = 0; i < 40; i++) {
+        final noise = (i.isEven ? 12.0 : -12.0);
+        calc.addSample(
+          cumulativeDistanceKm: i * 0.02,
+          altitudeM: 100 + noise,
+        );
+      }
+      final g = calc.current;
+      expect(g.gradeFraction.abs(), lessThan(0.04),
+          reason: 'exponential smoothing must damp the ±12 m noise to a '
+              'near-flat grade');
+      expect(g.confident, isTrue);
+    });
+
+    test('too little distance — not confident', () {
+      final calc = RoadGradeCalculator();
+      // Three samples spanning only 40 m — far short of the 150 m
+      // window, so no anchor exists yet.
+      calc.addSample(cumulativeDistanceKm: 0.00, altitudeM: 100);
+      calc.addSample(cumulativeDistanceKm: 0.02, altitudeM: 101);
+      calc.addSample(cumulativeDistanceKm: 0.04, altitudeM: 102);
+      final g = calc.current;
+      expect(g.confident, isFalse);
+      expect(g.gradeFraction, 0.0);
+    });
+
+    test('a GPS-altitude dropout leaves the window too sparse to trust',
+        () {
+      final calc = RoadGradeCalculator();
+      // Samples every 20 m across 300 m, but altitude only every 60 m
+      // (a dropout nulls the rest). The window then holds too few
+      // points to be confident, even though it is distance-full.
+      for (var i = 0; i <= 15; i++) {
+        final distM = i * 20.0;
+        calc.addSample(
+          cumulativeDistanceKm: distM / 1000.0,
+          altitudeM: (distM % 60 == 0) ? 100.0 : null,
+        );
+      }
+      expect(calc.current.confident, isFalse);
+    });
+
+    test('reset clears all accumulated state', () {
+      final calc = RoadGradeCalculator();
+      for (var i = 0; i < 30; i++) {
+        calc.addSample(cumulativeDistanceKm: i * 0.02, altitudeM: 100);
+      }
+      expect(calc.current.confident, isTrue);
+
+      calc.reset();
+      expect(calc.current.confident, isFalse);
+      expect(calc.current.gradeFraction, 0.0);
+    });
+
+    test('RoadGrade.flat is the neutral value', () {
+      expect(RoadGrade.flat.gradeFraction, 0.0);
+      expect(RoadGrade.flat.confident, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Epic #1935 — child B of 3

A pure-domain calculator turning the GPS altitude stream (child A,
#1940) into a road grade the speed-density fuel model (child C, #1942)
will use.

## How it handles noisy GPS altitude

Phone GPS altitude is ±10–30 m per fix — differencing it
sample-to-sample is meaningless. `RoadGradeCalculator`:

- **exponentially smooths** altitude (`smoothingFactor`, default 0.2)
  before use, damping the per-fix random error;
- measures grade as **rise / run over a distance window**
  (`windowMeters`, default 150 m), where the residual-noise-to-window
  ratio is small;
- reports a **confidence** — `RoadGrade.confident` is false until a
  full window of reasonably dense samples exists; a GPS-altitude
  dropout that thins the window (`minSamplesInWindow`) drops it back
  to non-confident. Callers treat a non-confident grade as flat.

`RoadGrade` carries a signed `gradeFraction` (+uphill / −downhill).

## Tests

8 cases: flat → ~0; steady 5 % climb → 0.05; 4 % descent → negative;
**±12 m noisy flat road still reads ~flat** (smoothing works — raw
differencing would give >100 %); too little distance → not confident;
a GPS-altitude dropout → window too sparse → not confident; reset.

`flutter analyze`, `test/lint/` green. No integration yet — child C
(#1942) wires this into the fuel estimate.

Closes #1941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
