### PR TITLE
fix(vehicle): auto-record uses the vehicle's obd2AdapterMac — de-duplicate the adapter (#1949 PR1)

### DIFF
--- a/lib/features/consumption/providers/auto_record_orchestrator.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.dart
@@ -135,7 +135,7 @@ class AutoRecordOrchestrator extends _$AutoRecordOrchestrator {
       final wantedProfile = wanted[entry.key];
       if (wantedProfile == null) {
         toRemove.add(entry.key);
-      } else if (wantedProfile.pairedAdapterMac != entry.value.armedMac) {
+      } else if (wantedProfile.autoRecordAdapterMac != entry.value.armedMac) {
         // MAC changed — drop and let the add loop spin up a fresh
         // coordinator below.
         toRemove.add(entry.key);
@@ -177,13 +177,13 @@ class AutoRecordOrchestrator extends _$AutoRecordOrchestrator {
     );
     if (!centralEnabled) return false;
     if (!p.autoRecord) return false;
-    final mac = p.pairedAdapterMac;
+    final mac = p.autoRecordAdapterMac;
     if (mac == null || mac.isEmpty) return false;
     return true;
   }
 
   _OrchestratorEntry? _buildEntry(VehicleProfile profile) {
-    final mac = profile.pairedAdapterMac;
+    final mac = profile.autoRecordAdapterMac;
     if (mac == null || mac.isEmpty) return null;
 
     final listenerFactory = ref.read(autoRecordListenerFactoryProvider);

--- a/lib/features/consumption/providers/auto_record_orchestrator.g.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator.g.dart
@@ -195,7 +195,7 @@ final class AutoRecordOrchestratorProvider
 }
 
 String _$autoRecordOrchestratorHash() =>
-    r'890904dcb2647ed4493a3ce32e71a534c2070d56';
+    r'27e460dd45025d9519cf09761164d9d10b0173ac';
 
 /// Production wiring for the hands-free auto-record flow (#1004 phase 2b-3).
 ///

--- a/lib/features/vehicle/domain/entities/vehicle_profile.dart
+++ b/lib/features/vehicle/domain/entities/vehicle_profile.dart
@@ -407,3 +407,19 @@ class ConnectorTypeSetConverter
   List<String> toJson(Set<ConnectorType> object) =>
       object.map((c) => c.key).toList();
 }
+
+/// Adapter-MAC resolution for the hands-free auto-record flow (#1949).
+extension VehicleProfileAutoRecordAdapter on VehicleProfile {
+  /// The OBD2 adapter MAC auto-record arms on.
+  ///
+  /// Prefers the vehicle's configured [obd2AdapterMac]; falls back to
+  /// the legacy [pairedAdapterMac] for a vehicle paired before the two
+  /// MACs were consolidated. #1950 (PR 2) drops `pairedAdapterMac` and
+  /// this fallback once a migration has copied any paired-only MAC
+  /// across.
+  String? get autoRecordAdapterMac {
+    final obd2 = obd2AdapterMac;
+    if (obd2 != null && obd2.isNotEmpty) return obd2;
+    return pairedAdapterMac;
+  }
+}

--- a/lib/features/vehicle/presentation/widgets/auto_record_section.dart
+++ b/lib/features/vehicle/presentation/widgets/auto_record_section.dart
@@ -164,15 +164,9 @@ class AutoRecordSection extends ConsumerWidget {
                 profile.copyWith(disconnectSaveDelaySec: v),
               ),
             ),
-            const SizedBox(height: 16),
-            _PairedAdapterRow(
-              mac: profile.pairedAdapterMac,
-              label: l?.autoRecordPairedAdapterLabel ?? 'Paired adapter',
-              empty: l?.autoRecordPairedAdapterNone ??
-                  'No adapter paired. Pair one via the OBD2 onboarding '
-                      'first.',
-              theme: theme,
-            ),
+            // #1949 — the adapter is shown once, on the canonical
+            // "Adaptateur OBD2" card; auto-record uses that same
+            // adapter, so no separate paired-adapter row here.
             const SizedBox(height: 16),
             _BackgroundLocationRow(
               consent: profile.backgroundLocationConsent,
@@ -206,10 +200,10 @@ class AutoRecordSection extends ConsumerWidget {
   /// Map the four real states the auto-record orchestrator gates on
   /// to the banner shown on this card (#1310). Mirrors
   /// `AutoRecordOrchestrator._isAutoRecordReady`: a vehicle is
-  /// "active" only when `pairedAdapterMac` is non-empty AND
+  /// "active" only when its OBD2 adapter MAC is non-empty AND
   /// `backgroundLocationConsent` is true.
   _AutoRecordStatus _statusFor(VehicleProfile profile) {
-    final mac = profile.pairedAdapterMac;
+    final mac = profile.autoRecordAdapterMac;
     if (mac == null || mac.isEmpty) {
       return _AutoRecordStatus.needsPairing;
     }
@@ -641,46 +635,6 @@ class _SaveDelaySlider extends StatelessWidget {
           value: v.toDouble(),
           onChanged: (next) => onChanged(next.round()),
         ),
-      ],
-    );
-  }
-}
-
-class _PairedAdapterRow extends StatelessWidget {
-  final String? mac;
-  final String label;
-  final String empty;
-  final ThemeData theme;
-
-  const _PairedAdapterRow({
-    required this.mac,
-    required this.label,
-    required this.empty,
-    required this.theme,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final macText = mac;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(label, style: theme.textTheme.bodyMedium),
-        const SizedBox(height: 4),
-        if (macText != null && macText.isNotEmpty)
-          Text(
-            macText,
-            style: theme.textTheme.bodySmall?.copyWith(
-              fontFamily: 'monospace',
-            ),
-          )
-        else
-          Text(
-            empty,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
       ],
     );
   }

--- a/lib/features/vehicle/providers/auto_record_config_provider.dart
+++ b/lib/features/vehicle/providers/auto_record_config_provider.dart
@@ -57,7 +57,9 @@ class AutoRecordConfig {
   factory AutoRecordConfig.fromProfile(VehicleProfile profile) {
     return AutoRecordConfig(
       autoRecord: profile.autoRecord,
-      pairedAdapterMac: profile.pairedAdapterMac,
+      // #1949 — auto-record arms on the vehicle's obd2AdapterMac,
+      // falling back to the legacy pairedAdapterMac.
+      pairedAdapterMac: profile.autoRecordAdapterMac,
       movementStartThresholdKmh: profile.movementStartThresholdKmh,
       disconnectSaveDelaySec: profile.disconnectSaveDelaySec,
       backgroundLocationConsent: profile.backgroundLocationConsent,

--- a/test/features/vehicle/presentation/widgets/auto_record_section_test.dart
+++ b/test/features/vehicle/presentation/widgets/auto_record_section_test.dart
@@ -159,34 +159,10 @@ void main() {
       expect(list.savedProfiles.single.name, 'Golf');
     });
 
-    testWidgets('paired adapter MAC renders monospace; missing renders hint',
-        (tester) async {
-      // No paired MAC — empty hint visible.
-      final list = _FakeVehicleProfileList([
-        const VehicleProfile(id: 'v1', name: 'Golf', autoRecord: true),
-      ]);
-      await _pumpSection(tester, vehicleId: 'v1', list: list);
-
-      expect(
-        find.textContaining('No adapter paired'),
-        findsOneWidget,
-      );
-    });
-
-    testWidgets('paired adapter MAC is shown when set', (tester) async {
-      final list = _FakeVehicleProfileList([
-        const VehicleProfile(
-          id: 'v1',
-          name: 'Golf',
-          autoRecord: true,
-          pairedAdapterMac: 'AA:BB:CC:11:22:33',
-        ),
-      ]);
-      await _pumpSection(tester, vehicleId: 'v1', list: list);
-
-      expect(find.text('AA:BB:CC:11:22:33'), findsOneWidget);
-      expect(find.textContaining('No adapter paired'), findsNothing);
-    });
+    // #1949 — the auto-record section no longer renders a separate
+    // paired-adapter row; the adapter is shown once on the canonical
+    // "Adaptateur OBD2" card. The two tests that asserted that row are
+    // removed with it.
 
     testWidgets(
       'background-location request button is hidden when consent is true',


### PR DESCRIPTION
## PR 1 of 2 (epic-validated split)

`VehicleProfile` carries **two** adapter MACs — `obd2AdapterMac` (the
vehicle's configured adapter) and `pairedAdapterMac` (a separate marker
the auto-record flow armed on). They drift apart: a reporting user's
vehicle had `66:1E:…` configured but auto-record armed on a different
`D4:E9:…`, and the edit-vehicle screen showed two adapters for one car.

## This PR — behavioural consolidation

- New `VehicleProfile.autoRecordAdapterMac` getter: the vehicle's
  `obd2AdapterMac`, falling back to the legacy `pairedAdapterMac` for a
  vehicle paired before this change.
- `AutoRecordOrchestrator` (arm gate, re-arm-on-MAC-change,
  `_buildEntry`) and `AutoRecordConfig.fromProfile` now read
  `autoRecordAdapterMac` — auto-record arms on the vehicle's adapter.
- The duplicate "Adaptateur appairé" row is removed from the
  auto-record section of the edit screen (its `_PairedAdapterRow`
  widget deleted); the adapter is shown once on the canonical
  "Adaptateur OBD2" card.

`pairedAdapterMac` stays in the model, now unused. **PR 2 (#1950)**
deletes the field + its persistence with a legacy-JSON migration.

## Tests

The two obsolete `auto_record_section` tests for the removed paired-
adapter row are dropped. `flutter analyze`, `test/lint/`, the
auto-record orchestrator + section suites and all vehicle tests (673)
pass; codegen regenerated.

Closes #1949.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
