### PR TITLE
chore(consumption): compact the tank-level + consumption-stats cards (#1953)

### DIFF
--- a/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
@@ -51,9 +51,9 @@ class ConsumptionStatsCard extends StatelessWidget {
     final showCorrectionHint = stats.correctionShare > 0.05;
 
     return Card(
-      margin: const EdgeInsets.all(16),
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -82,7 +82,7 @@ class ConsumptionStatsCard extends StatelessWidget {
               style: theme.textTheme.titleMedium
                   ?.copyWith(fontWeight: FontWeight.bold),
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 8),
             Row(
               children: [
                 Expanded(
@@ -160,7 +160,7 @@ class _OpenWindowBanner extends StatelessWidget {
     final theme = Theme.of(context);
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
@@ -202,7 +202,7 @@ class _CorrectionShareHint extends StatelessWidget {
     final orange = DarkModeColors.warning(context);
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         color: orange.withValues(alpha: 0.10),
         borderRadius: BorderRadius.circular(8),

--- a/lib/features/consumption/presentation/widgets/tank_level_card.dart
+++ b/lib/features/consumption/presentation/widgets/tank_level_card.dart
@@ -61,9 +61,9 @@ class _EmptyTankLevelCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Card(
-      margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      margin: const EdgeInsets.fromLTRB(12, 6, 12, 6),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -112,12 +112,12 @@ class _PopulatedTankLevelCard extends ConsumerWidget {
     final rangeKm = estimate.rangeKm;
 
     return Card(
-      margin: const EdgeInsets.fromLTRB(12, 8, 12, 8),
+      margin: const EdgeInsets.fromLTRB(12, 6, 12, 6),
       child: InkWell(
         onTap: () => _openDetailSheet(context, ref),
         borderRadius: BorderRadius.circular(12),
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [


### PR DESCRIPTION
The first two cards on the Carburant screen (tank level + consumption
stats) were taller than needed — generous 16 dp paddings/margins left
the content sparse and pushed the fill-up list down.

Density pass (layout only, no behaviour change):
- `TankLevelCard` — margin 8→6 dp vertical, padding 16→12 dp vertical.
- `ConsumptionStatsCard` — margin 16→8 dp vertical, padding 16→12 dp,
  post-title gap 12→8 dp, stat-tile vertical padding 8→6 dp.

`flutter analyze`, `test/lint/`, the tank-card + stats-card tests pass.

Closes #1953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
