### PR TITLE
fix(favorites): make EV-charger favorites swipeable like fuel stations (#1958)

### DIFF
--- a/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_dismissible.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/utils/navigation_utils.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../ev/domain/entities/charging_station.dart';
+import '../../providers/ev_favorites_provider.dart';
+import 'ev_favorite_card.dart';
+
+/// Wraps an [EvFavoriteCard] in the same swipe-to-act gesture the
+/// fuel-station favorites use (mirrors `FavoriteStationDismissible`,
+/// #1958): swipe right launches navigation, swipe left removes the
+/// favorite — from `evFavoritesProvider` — with an undo snackbar.
+///
+/// Before this, EV-charger favorites were rendered as a bare card and
+/// could not be swiped at all, unlike fuel-station favorites.
+class EvFavoriteDismissible extends ConsumerWidget {
+  final ChargingStation station;
+
+  const EvFavoriteDismissible({super.key, required this.station});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final label = station.name;
+
+    return Dismissible(
+      key: ValueKey('ev-fav-${station.id}'),
+      confirmDismiss: (direction) async {
+        if (direction == DismissDirection.startToEnd) {
+          await NavigationUtils.openInMaps(
+            station.latitude,
+            station.longitude,
+            label: label,
+          );
+          return false;
+        }
+        await ref.read(evFavoritesProvider.notifier).remove(station.id);
+        if (!context.mounted) return true;
+        final l10nSnack = AppLocalizations.of(context);
+        SnackBarHelper.showWithUndo(
+          context,
+          l10nSnack?.removedFromFavoritesName(label) ??
+              '$label removed from favorites',
+          undoLabel: l10nSnack?.undo ?? 'Undo',
+          onUndo: () => ref
+              .read(evFavoritesProvider.notifier)
+              .add(station.id, stationData: station),
+        );
+        return true;
+      },
+      background: Semantics(
+        label: 'Navigate to $label',
+        child: Container(
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.only(left: 24),
+          color: Theme.of(context).colorScheme.primary,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.navigation, color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                l10n?.navigate ?? 'Navigate',
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+        ),
+      ),
+      secondaryBackground: Semantics(
+        label: 'Remove $label from favorites',
+        child: Container(
+          alignment: Alignment.centerRight,
+          padding: const EdgeInsets.only(right: 24),
+          color: DarkModeColors.error(context),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                l10n?.remove ?? 'Remove',
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(width: 8),
+              const Icon(Icons.delete, color: Colors.white, size: 20),
+            ],
+          ),
+        ),
+      ),
+      child: EvFavoriteCard(
+        key: ValueKey(station.id),
+        station: station,
+        onTap: () => context.push('/ev-station', extra: station),
+        onFavoriteTap: () =>
+            ref.read(evFavoritesProvider.notifier).remove(station.id),
+      ),
+    );
+  }
+}

--- a/lib/features/favorites/presentation/widgets/favorites_tab.dart
+++ b/lib/features/favorites/presentation/widgets/favorites_tab.dart
@@ -4,12 +4,11 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/empty_state.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../providers/favorites_provider.dart';
 import '../../providers/merged_favorites_provider.dart';
-import 'ev_favorite_card.dart';
+import 'ev_favorite_dismissible.dart';
 import 'favorite_station_dismissible.dart';
 import 'favorites_loading_view.dart';
 import 'swipe_tutorial_banner.dart';
@@ -76,22 +75,10 @@ class FavoritesTab extends ConsumerWidget {
                     return switch (item) {
                       FuelStationResult(:final station) =>
                         FavoriteStationDismissible(station: station),
-                      EVStationResult(:final station) => EvFavoriteCard(
-                          key: ValueKey('ev-${station.id}'),
-                          station: station,
-                          onTap: () =>
-                              context.push('/ev-station', extra: station),
-                          onFavoriteTap: () {
-                            ref
-                                .read(favoritesProvider.notifier)
-                                .remove(station.id);
-                            SnackBarHelper.show(
-                              context,
-                              l10n?.removedFromFavorites ??
-                                  'Removed from favorites',
-                            );
-                          },
-                        ),
+                      // #1958 — EV favorites now swipe just like
+                      // fuel-station favorites (navigate / remove).
+                      EVStationResult(:final station) =>
+                        EvFavoriteDismissible(station: station),
                     };
                   },
                 ),

--- a/test/features/favorites/presentation/widgets/ev_favorite_dismissible_test.dart
+++ b/test/features/favorites/presentation/widgets/ev_favorite_dismissible_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_card.dart';
+import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_dismissible.dart';
+import 'package:tankstellen/features/favorites/providers/ev_favorites_provider.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Regression tests for #1958 — EV-charger favorites must be swipeable
+/// like fuel-station favorites (`FavoriteStationDismissible`).
+const _ev = ChargingStation(
+  id: 'ev-charger-7',
+  name: 'IECharge Anduze',
+  latitude: 44.05,
+  longitude: 3.99,
+);
+
+/// Test double for [EvFavorites] — records `remove` / `add` so the
+/// swipe-left and undo paths can be asserted without real storage.
+class _RecordingEvFavorites extends EvFavorites {
+  final List<String> removeCalls = <String>[];
+  final List<({String id, ChargingStation? station})> addCalls = [];
+
+  @override
+  List<String> build() => const ['ev-charger-7'];
+
+  @override
+  Future<void> remove(String stationId) async => removeCalls.add(stationId);
+
+  @override
+  Future<void> add(String stationId, {ChargingStation? stationData}) async =>
+      addCalls.add((id: stationId, station: stationData));
+}
+
+void main() {
+  group('EvFavoriteDismissible (#1958)', () {
+    testWidgets('wraps the EV favorite in a swipeable Dismissible',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const EvFavoriteDismissible(station: _ev),
+        overrides: [
+          evFavoritesProvider.overrideWith(_RecordingEvFavorites.new),
+        ],
+      );
+
+      expect(find.byType(Dismissible), findsOneWidget);
+      expect(find.byType(EvFavoriteCard), findsOneWidget);
+    });
+
+    testWidgets(
+        'swipe-left removes the EV favorite and shows the undo snackbar',
+        (tester) async {
+      final recording = _RecordingEvFavorites();
+      await pumpApp(
+        tester,
+        const EvFavoriteDismissible(station: _ev),
+        overrides: [
+          evFavoritesProvider.overrideWith(() => recording),
+        ],
+      );
+
+      await tester.fling(
+        find.byType(Dismissible),
+        const Offset(-500, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      // Removal routed to the EV favorites notifier — not the fuel one.
+      expect(recording.removeCalls, ['ev-charger-7']);
+      expect(
+        find.textContaining('removed from favorites'),
+        findsOneWidget,
+      );
+      expect(find.text('Undo'), findsOneWidget);
+    });
+
+    testWidgets('the undo action re-adds the charger with its station data',
+        (tester) async {
+      final recording = _RecordingEvFavorites();
+      await pumpApp(
+        tester,
+        const EvFavoriteDismissible(station: _ev),
+        overrides: [
+          evFavoritesProvider.overrideWith(() => recording),
+        ],
+      );
+
+      await tester.fling(
+        find.byType(Dismissible),
+        const Offset(-500, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+
+      expect(recording.addCalls, hasLength(1));
+      expect(recording.addCalls.single.id, 'ev-charger-7');
+      expect(recording.addCalls.single.station?.id, 'ev-charger-7');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On the Favoris screen, fuel-station favorites are swipeable
(`FavoriteStationDismissible` — swipe right to navigate, left to
remove with undo). EV-charger favorites were a bare `EvFavoriteCard`
with **no `Dismissible`** — not swipeable at all.

## Fix

- **New `EvFavoriteDismissible`** — mirrors `FavoriteStationDismissible`
  exactly: swipe-right launches navigation, swipe-left removes the
  charger from `evFavoritesProvider` with an undo snackbar, same green
  "Navigate" / red "Remove" backgrounds.
- `favorites_tab.dart` renders EV rows via `EvFavoriteDismissible`.
- Bonus fix: the EV card's favorite-star previously called
  `favoritesProvider.remove` (the **fuel** notifier) — now correctly
  routed to `evFavoritesProvider`.

## Tests

`ev_favorite_dismissible_test.dart` — the swipe wrap, swipe-left
removal + undo snackbar, undo re-add. `flutter analyze`, `test/lint/`
and the favorites suite pass.

Closes #1958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
