### PR TITLE
feat(map): add a Share action to the Carte screen (#1959)

### DIFF
--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../app/current_shell_branch_provider.dart';
 import '../../../../app/shell/settings_app_bar_action.dart';
+import '../../../../core/sharing/widget_share_renderer.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/presentation/widgets/ev_filter_chips.dart';
@@ -74,6 +75,26 @@ class _MapScreenState extends ConsumerState<MapScreen>
   /// When the app last entered a non-resumed state. Compared against the
   /// resume timestamp to decide whether to refresh.
   DateTime? _pausedAt;
+
+  /// Boundary around the map body — `shareWidgetAsImage` renders the
+  /// widget under this key to a PNG for the Share action (#1959).
+  final GlobalKey _shareBoundaryKey =
+      GlobalKey(debugLabel: 'map_share_boundary');
+
+  /// Render the current map view to an image and hand it to the OS
+  /// share sheet (#1959). Best-effort — a share failure is logged and
+  /// swallowed so the action never crashes the map screen.
+  Future<void> _onShare(AppLocalizations? l10n) async {
+    try {
+      await shareWidgetAsImage(
+        boundaryKey: _shareBoundaryKey,
+        subject: l10n?.map ?? 'Map',
+        fileNameStem: 'tankstellen_map',
+      );
+    } catch (e, st) {
+      debugPrint('MapScreen share image: $e\n$st');
+    }
+  }
 
   @override
   void initState() {
@@ -164,14 +185,22 @@ class _MapScreenState extends ConsumerState<MapScreen>
           tooltip: l10n?.refreshPrices ?? 'Refresh prices',
         ),
         const EvToggleButton(),
+        IconButton(
+          icon: const Icon(Icons.share),
+          onPressed: () => _onShare(l10n),
+          tooltip: l10n?.favoritesShareAction ?? 'Share',
+        ),
         const SettingsAppBarAction(),
       ],
       bodyPadding: EdgeInsets.zero,
-      body: Column(
-        children: [
-          if (isVisibleBranch && showEv) const EvFilterChips(),
-          Expanded(child: body),
-        ],
+      body: RepaintBoundary(
+        key: _shareBoundaryKey,
+        child: Column(
+          children: [
+            if (isVisibleBranch && showEv) const EvFilterChips(),
+            Expanded(child: body),
+          ],
+        ),
       ),
     );
   }

--- a/test/features/map/presentation/screens/map_screen_test.dart
+++ b/test/features/map/presentation/screens/map_screen_test.dart
@@ -115,6 +115,22 @@ void main() {
     );
 
     testWidgets(
+      'exposes the share action in the app bar (#1959)',
+      (tester) async {
+        final test = standardTestOverrides();
+        when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+        await pumpApp(
+          tester,
+          const MapScreen(),
+          overrides: [...test.overrides, userPositionNullOverride()],
+        );
+
+        expect(find.byIcon(Icons.share), findsOneWidget);
+      },
+    );
+
+    testWidgets(
       'a long-gap app resume while Carte is visible does not throw',
       (tester) async {
         final test = standardTestOverrides();


### PR DESCRIPTION
## What

Adds a Share action to the Carte/map screen, matching the one on the
fuel-station favorites screen.

- Wraps the map body in a `RepaintBoundary`.
- Adds a Share `IconButton` to the app bar, between the EV toggle and
  Settings actions.
- Tapping it renders the current map view to a PNG via
  `shareWidgetAsImage` and hands it to the OS share sheet.
- Best-effort: a share failure is logged and swallowed so the action
  never crashes the map screen.

## i18n

No new ARB key — reuses the existing `favoritesShareAction` string for
the tooltip and the localized `map` string as the share subject.

## Test

- New widget test asserting the share icon is exposed in the app bar.
- `flutter analyze`, the map-screen suite and `test/lint/` all green.

Closes #1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
