### PR TITLE
fix(ci): normalise all Android subprojects to JVM 17 (#1936)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -19,6 +19,19 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// #1936 — force every subproject's Java compilation to JVM 17 so it
+// matches the app module and the Kotlin tasks. Newer Gradle hard-fails
+// on a Java/Kotlin JVM-target mismatch; the `tflite_flutter` plugin
+// ships Java at 11 / Kotlin at 17 and its own build.gradle can't be
+// edited, so we normalise it here. Core-Gradle types only — no
+// AGP/KGP imports.
+subprojects {
+    tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = JavaVersion.VERSION_17.toString()
+        targetCompatibility = JavaVersion.VERSION_17.toString()
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## What

Adds a `subprojects { }` block to `android/build.gradle.kts` that
forces every subproject's `JavaCompile` task to JVM 17.

## Why

`build-android` broke when newer Gradle began **hard-failing** on a
Java/Kotlin JVM-target mismatch instead of warning. The `tflite_flutter`
plugin ships Java at JVM 11 / Kotlin at JVM 17; the app module uses 17
for both. Pinning `flutter-version` (#1938) stopped the floating-stable
surprise, but the underlying plugin inconsistency is still there and
would re-break on any future toolchain bump — this is the durable fix
#1936 asked for.

The block uses only core-Gradle types (`JavaCompile`, `JavaVersion`) —
no AGP/KGP imports. It's the standard remedy for "Inconsistent
JVM-target compatibility" with a third-party plugin whose own
`build.gradle` can't be edited.

## Verification

Gradle-only change — no Dart / lib / test impact. `build-android` in CI
is the gate (no Android SDK on the dev machine).

Closes #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)
