### PR TITLE
fix(ci): downgrade the Android JVM-target check to a warning (#1936)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,12 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 android.useAndroidX=true
 org.gradle.parallel=true
 org.gradle.caching=true
+
+# #1936 — the `tflite_flutter` plugin compiles its Java at JVM 11 but
+# its Kotlin at JVM 17. Newer Gradle (Flutter 3.44+) hard-fails the
+# release build on that mismatch; the plugin's own build.gradle can't
+# be edited, and a root `subprojects { JavaCompile }` override is
+# re-applied by AGP. Downgrade the (benign) JVM-target check back to a
+# warning — the documented Kotlin-Gradle escape hatch. Version-
+# independent: fixes both ci.yml and the Daily Open-Testing Build.
+kotlin.jvm.target.validation.mode=warning


### PR DESCRIPTION
## What

Adds `kotlin.jvm.target.validation.mode=warning` to
`android/gradle.properties`.

## Why

`#1968`'s `subprojects { JavaCompile → 17 }` block did **not** fix the
release build: AGP re-applies the `tflite_flutter` plugin's own Java-11
`compileOptions` after our `configureEach`, so `compileReleaseJavaWithJavac`
stays at 11 while `compileReleaseKotlin` is 17 — the same task-level
override that sank PR #1937.

`ci.yml`'s `build-android` only stays green because #1938 pinned it to
Flutter 3.41.9 (older Gradle — warns). The unpinned
`daily-github-release.yml` picks up Flutter 3.44 / newer Gradle and
**hard-fails** — `Daily GitHub Release #20` failed on exactly this.

`kotlin.jvm.target.validation.mode=warning` is the documented
Kotlin-Gradle escape hatch: it downgrades the conservative
Java/Kotlin JVM-target consistency check back to a warning. The mixed
Java-11 / Kotlin-17 bytecode from a third-party plugin is benign in the
packaged APK. Version-independent — fixes both the Daily Open-Testing
Build and ci.yml regardless of the Flutter toolchain.

## Verification

Gradle-config-only — no Dart / lib / test impact. `build-android` in CI
is the gate; the Daily Open-Testing Build is the ultimate confirmation.

Closes #1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)
