### PR TITLE
fix(widget): encode the row deep-link URI + a deterministic refresh (#1961)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
@@ -194,16 +194,18 @@ object StationWidgetRenderer {
             ),
         )
 
-        // Refresh icon (#1801 / #1803) — an Activity PendingIntent that
-        // opens the app; the Flutter side then refreshes the widget on
-        // resume. This used to be a broadcast whose onReceive called
-        // `startActivity`, which Android 10+ blocks from a receiver — so
-        // the refresh button silently did nothing.
+        // Refresh icon (#1801 / #1803 / #1961) — an Activity PendingIntent
+        // that opens the app carrying the `tankstellenwidget://refresh`
+        // marker URI. The Flutter side recognises that URI and runs an
+        // explicit widget rebuild (price re-fetch + re-render) instead of
+        // relying on the resume heartbeat alone — so a tap deterministically
+        // refreshes. A bare launch (uri = null) used to leave the refresh
+        // racing the resume tick.
         views.setOnClickPendingIntent(
             R.id.widget_refresh,
             buildActivity(
                 context,
-                uri = null,
+                uri = Uri.parse("tankstellenwidget://refresh"),
                 requestCode = appWidgetId * 10 + 2,
             ),
         )
@@ -396,7 +398,15 @@ object StationWidgetRenderer {
             "buildRow widgetId=$appWidgetId index=$index id=$stationId brand=${station.optString("brand", "")} profile=${profileId ?: "active"}",
         )
         if (stationId.isNotBlank()) {
-            val uri = Uri.parse("tankstellenwidget://station?id=$stationId")
+            // #1961 — build the URI with Uri.Builder so the station id is
+            // percent-encoded. String-interpolating it raw let an id
+            // containing `&`, `+`, `%`, `#` or a space corrupt the query
+            // — the Flutter parser then opened the wrong station or none.
+            val uri = Uri.Builder()
+                .scheme("tankstellenwidget")
+                .authority("station")
+                .appendQueryParameter("id", stationId)
+                .build()
             row.setOnClickPendingIntent(
                 R.id.station_row_root,
                 buildActivity(

--- a/lib/features/widget/presentation/widget_click_listener.dart
+++ b/lib/features/widget/presentation/widget_click_listener.dart
@@ -8,9 +8,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../app/router.dart';
 import '../../consumption/data/obd2/event_channel_cancel.dart';
+import '../providers/nearest_widget_refresh_provider.dart';
 import 'widget_uri_parser.dart';
 
-export 'widget_uri_parser.dart' show widgetUriToPath;
+export 'widget_uri_parser.dart' show isWidgetRefreshUri, widgetUriToPath;
 
 part 'widget_click_listener.g.dart';
 
@@ -26,9 +27,21 @@ part 'widget_click_listener.g.dart';
 class WidgetLaunchHandler {
   final GoRouter _router;
 
-  WidgetLaunchHandler(this._router);
+  /// Invoked when the launch URI is the [isWidgetRefreshUri] marker —
+  /// rebuilds the home-screen widget instead of navigating (#1961).
+  final VoidCallback _onRefresh;
+
+  WidgetLaunchHandler(this._router, this._onRefresh);
 
   void handle(Uri? uri) {
+    // #1961 — the refresh button launches the app with a `refresh`
+    // marker URI rather than a station route. Rebuild the widget and
+    // stay on whatever screen the user is on; never navigate.
+    if (isWidgetRefreshUri(uri)) {
+      debugPrint('WidgetLaunchHandler.handle uri=$uri outcome=refresh');
+      _onRefresh();
+      return;
+    }
     final path = widgetUriToPath(uri);
     // #753 diagnostic — prints every widget launch so the user can
     // diff what Kotlin bound to the row (see StationWidgetRenderer
@@ -48,7 +61,12 @@ class WidgetLaunchHandler {
 
 @riverpod
 WidgetLaunchHandler widgetLaunchHandler(Ref ref) {
-  return WidgetLaunchHandler(ref.watch(routerProvider));
+  return WidgetLaunchHandler(
+    ref.watch(routerProvider),
+    // Lazily triggered — only a refresh-marker tap reads (and so starts)
+    // the keep-alive refresh provider; an ordinary row tap never does.
+    () => ref.read(nearestWidgetRefreshProvider.notifier).refresh(),
+  );
 }
 
 /// Listens for taps on a home-screen widget row and navigates the app

--- a/lib/features/widget/presentation/widget_click_listener.g.dart
+++ b/lib/features/widget/presentation/widget_click_listener.g.dart
@@ -55,4 +55,4 @@ final class WidgetLaunchHandlerProvider
 }
 
 String _$widgetLaunchHandlerHash() =>
-    r'259f9b333bd7222fdc6f1ca6fafd5841f6314dfb';
+    r'a5f58e4a6884fcb4915435691fbb75ab1fa23082';

--- a/lib/features/widget/presentation/widget_uri_parser.dart
+++ b/lib/features/widget/presentation/widget_uri_parser.dart
@@ -21,3 +21,16 @@ String? widgetUriToPath(Uri? uri) {
   if (id == null || id.isEmpty) return null;
   return id.startsWith('ocm-') ? '/ev-station/$id' : '/station/$id';
 }
+
+/// Whether [uri] is the home-widget **refresh** marker
+/// (`tankstellenwidget://refresh`), set by the widget's refresh button
+/// (`StationWidgetRenderer`, #1961).
+///
+/// It is not a navigation target — the caller treats it as "rebuild the
+/// widget" rather than a route to push. [widgetUriToPath] returns `null`
+/// for it (host is `refresh`, not `station`), so the two helpers are
+/// mutually exclusive.
+bool isWidgetRefreshUri(Uri? uri) =>
+    uri != null &&
+    uri.scheme == 'tankstellenwidget' &&
+    uri.host == 'refresh';

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -53,6 +53,13 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
     unawaited(_tick());
   }
 
+  /// Force an immediate widget rebuild — both variants — outside the
+  /// timer/resume cadence. Driven by the home-widget refresh button
+  /// (#1961): a tap launches the app with the `refresh` marker URI, and
+  /// `WidgetLaunchHandler` calls this so the rebuild is deterministic
+  /// rather than racing the resume heartbeat.
+  Future<void> refresh() => _tick();
+
   Future<void> _tick() async {
     try {
       final storage = ref.read(storageRepositoryProvider);

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -93,7 +93,7 @@ final class NearestWidgetRefreshProvider
 }
 
 String _$nearestWidgetRefreshHash() =>
-    r'8aa9324db9553fcdc28a75963a247ff1654a6851';
+    r'483dcc88e9cb265fbeefc2e990106ad501b93313';
 
 /// Foreground heartbeat that rebuilds the home-screen widget — both the
 /// favorites and the nearest variants — every

--- a/test/features/widget/presentation/widget_click_listener_test.dart
+++ b/test/features/widget/presentation/widget_click_listener_test.dart
@@ -135,6 +135,82 @@ void main() {
     });
   });
 
+  group('isWidgetRefreshUri (#1961 — refresh marker)', () {
+    test('tankstellenwidget://refresh → true', () {
+      expect(
+        isWidgetRefreshUri(Uri.parse('tankstellenwidget://refresh')),
+        isTrue,
+      );
+    });
+
+    test('a station deep-link → false', () {
+      expect(
+        isWidgetRefreshUri(
+          Uri.parse('tankstellenwidget://station?id=abc'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('null / wrong scheme → false', () {
+      expect(isWidgetRefreshUri(null), isFalse);
+      expect(isWidgetRefreshUri(Uri.parse('https://refresh')), isFalse);
+    });
+
+    test('the refresh marker is not also a navigation target', () {
+      // The two parsers must stay mutually exclusive — a refresh tap
+      // must never resolve to a route to push.
+      final refresh = Uri.parse('tankstellenwidget://refresh');
+      expect(isWidgetRefreshUri(refresh), isTrue);
+      expect(widgetUriToPath(refresh), isNull);
+    });
+  });
+
+  group('WidgetLaunchHandler — refresh marker (#1961)', () {
+    GoRouter buildRouter() => GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(path: '/', builder: (_, _) => const Text('home')),
+            GoRoute(
+              path: '/station/:id',
+              builder: (_, state) =>
+                  Text('station ${state.pathParameters['id']}'),
+            ),
+          ],
+        );
+
+    testWidgets('a refresh URI runs onRefresh and does not navigate',
+        (tester) async {
+      final router = buildRouter();
+      var refreshCount = 0;
+      final handler = WidgetLaunchHandler(router, () => refreshCount++);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      expect(find.text('home'), findsOneWidget);
+
+      handler.handle(Uri.parse('tankstellenwidget://refresh'));
+      await tester.pumpAndSettle();
+
+      expect(refreshCount, 1);
+      expect(find.text('home'), findsOneWidget,
+          reason: 'a refresh tap must rebuild the widget, never navigate');
+    });
+
+    testWidgets('a station URI navigates and does NOT run onRefresh',
+        (tester) async {
+      final router = buildRouter();
+      var refreshCount = 0;
+      final handler = WidgetLaunchHandler(router, () => refreshCount++);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      handler.handle(Uri.parse('tankstellenwidget://station?id=abc'));
+      await tester.pumpAndSettle();
+
+      expect(refreshCount, 0);
+      expect(find.text('station abc'), findsOneWidget);
+    });
+  });
+
   group('WidgetLaunchHandler (#587 widget → detail)', () {
     testWidgets(
         'handle() pushes /station/:id onto the real router when called from '


### PR DESCRIPTION
## What

Fixes the two broken home-screen widget interactions in #1961.

### Row tap → station detail

`StationWidgetRenderer` built the deep-link URI by interpolating the
station id raw: `Uri.parse("tankstellenwidget://station?id=$stationId")`.
An id containing `&`, `+`, `%`, `#` or a space corrupted the query, so
the Flutter parser opened the wrong station — or none. Now built with
`Uri.Builder().appendQueryParameter("id", stationId)`, which
percent-encodes the value.

### Refresh button

The refresh icon launched the app with a bare (null) intent and relied
on the resume heartbeat to rebuild the widget — a race the user
perceived as "refresh does nothing". The button now carries a
`tankstellenwidget://refresh` marker URI; `WidgetLaunchHandler`
recognises it (`isWidgetRefreshUri`) and calls
`NearestWidgetRefresh.refresh()` directly — a deterministic price
re-fetch + re-render of both widget variants — instead of navigating.

The refresh provider is read lazily, so an ordinary row tap never spins
up the keep-alive heartbeat.

## Test

- New unit tests for `isWidgetRefreshUri` + `WidgetLaunchHandler`'s
  refresh-vs-navigate branching.
- `flutter analyze`, `test/lint/`, the widget suite, codegen-drift and
  the module-boundary check all pass.

> Note: the Kotlin change can't be compiled locally (no Android SDK);
> `build-android` is the CI gate.

Closes #1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)
