### PR TITLE
fix(country): show country-switch dialogs via the root navigator (#1971)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../core/data/storage_repository.dart';
+import '../core/navigation/root_navigator_key.dart';
 import '../l10n/app_localizations.dart';
 import '../core/telemetry/integrations/navigation_trace_observer.dart';
 import '../core/storage/storage_keys.dart';
@@ -69,6 +70,10 @@ GoRouter router(Ref ref) {
   final storage = ref.watch(storageRepositoryProvider);
 
   return GoRouter(
+    // #1971 — an explicit root navigator key so widgets above the
+    // navigator (e.g. `CountrySwitchListener` in the MaterialApp
+    // builder) can reach a navigator-bearing context for `showDialog`.
+    navigatorKey: rootNavigatorKey,
     initialLocation: '/consent',
     observers: [NavigationTraceObserver()],
     errorBuilder: (context, state) {

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'6e6ecef9669fccff3069e83ee4f2c64a0771194e';
+String _$routerHash() => r'ca4157d3a8eff7baf498bf7c0c213ae04cf1393d';

--- a/lib/core/country/country_switch_listener.dart
+++ b/lib/core/country/country_switch_listener.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/profile/providers/profile_provider.dart';
+import '../navigation/root_navigator_key.dart';
 import '../widgets/snackbar_helper.dart';
 import '../../l10n/app_localizations.dart';
 import 'country_config.dart';
@@ -73,13 +74,25 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
 
   Future<void> _handleSuggest(CountrySwitchEvent event) async {
     final profile = event.matchingProfile!;
-    final l = AppLocalizations.of(context);
+    // #1971 — mark the cooldown up-front. `CountrySwitchListener` lives
+    // above the navigator (MaterialApp `builder:`), so its own context
+    // has no Navigator; show the dialog against the navigator's overlay
+    // context instead. If that is unavailable, skip without crashing.
+    _markDismissed(event.detectedCountryCode);
+    // Capture the notifier before the await — the user can leave the
+    // screen while the dialog is open, which would make a post-await
+    // `ref` use throw a disposed-ref error.
+    final profileNotifier = ref.read(activeProfileProvider.notifier);
+    final dialogContext = rootNavigatorKey.currentState?.overlay?.context;
+    if (dialogContext == null) return;
+
+    final l = AppLocalizations.of(dialogContext);
     final countryConfig = Countries.byCode(event.detectedCountryCode);
     final countryName = countryConfig?.name ?? event.detectedCountryCode;
     final countryFlag = countryConfig?.flag ?? '';
 
     final confirmed = await showDialog<bool>(
-      context: context,
+      context: dialogContext,
       barrierDismissible: true,
       builder: (ctx) => AlertDialog(
         icon: Text(countryFlag, style: const TextStyle(fontSize: 48)),
@@ -102,19 +115,26 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
     );
 
     if (confirmed == true) {
-      await ref.read(activeProfileProvider.notifier).switchProfile(profile.id);
+      await profileNotifier.switchProfile(profile.id);
     }
-    _markDismissed(event.detectedCountryCode);
   }
 
   Future<void> _handleNoProfile(CountrySwitchEvent event) async {
-    final l = AppLocalizations.of(context);
+    // #1971 — mark the cooldown first so a missing navigator context
+    // can never let the event re-fire and spam the crash, then show the
+    // dialog against the navigator's overlay context (this listener's
+    // own context sits above the navigator and has none).
+    _markDismissed(event.detectedCountryCode);
+    final dialogContext = rootNavigatorKey.currentState?.overlay?.context;
+    if (dialogContext == null) return;
+
+    final l = AppLocalizations.of(dialogContext);
     final countryConfig = Countries.byCode(event.detectedCountryCode);
     final countryName = countryConfig?.name ?? event.detectedCountryCode;
     final countryFlag = countryConfig?.flag ?? '';
 
     await showDialog<void>(
-      context: context,
+      context: dialogContext,
       barrierDismissible: true,
       builder: (ctx) => AlertDialog(
         icon: Text(countryFlag, style: const TextStyle(fontSize: 48)),
@@ -131,6 +151,5 @@ class _CountrySwitchListenerState extends ConsumerState<CountrySwitchListener> {
         ],
       ),
     );
-    _markDismissed(event.detectedCountryCode);
   }
 }

--- a/lib/core/navigation/root_navigator_key.dart
+++ b/lib/core/navigation/root_navigator_key.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/widgets.dart';
+
+/// The root [Navigator]'s key, handed to the app's `GoRouter`
+/// (`routerProvider`).
+///
+/// Code mounted **above** the navigator in the widget tree — e.g.
+/// `CountrySwitchListener`, which lives in `MaterialApp.router`'s
+/// `builder:` callback — has no `Navigator` ancestor in its own
+/// `BuildContext`, so `showDialog` there throws (#1971).
+///
+/// Such code reaches a navigator-bearing context via
+/// `rootNavigatorKey.currentState?.overlay?.context`: the overlay sits
+/// *below* the navigator, so `Navigator.of` resolves correctly.
+final GlobalKey<NavigatorState> rootNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'appRootNavigator');

--- a/test/core/country/country_switch_listener_test.dart
+++ b/test/core/country/country_switch_listener_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_switch_event.dart';
 import 'package:tankstellen/core/country/country_switch_listener.dart';
+import 'package:tankstellen/core/navigation/root_navigator_key.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
@@ -93,15 +94,20 @@ Future<
   await tester.pumpWidget(
     UncontrolledProviderScope(
       container: container,
-      child: const MaterialApp(
+      // #1971 — mount `CountrySwitchListener` in the `builder:`, i.e.
+      // ABOVE the navigator, exactly as production does in
+      // `MaterialApp.router`'s builder. With the pre-fix code the
+      // listener's own context had no Navigator and `showDialog`
+      // crashed; the fix routes dialogs through `rootNavigatorKey`.
+      child: MaterialApp(
+        navigatorKey: rootNavigatorKey,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        locale: Locale('en'),
-        home: Scaffold(
-          body: CountrySwitchListener(
-            child: Text('child-content'),
-          ),
+        locale: const Locale('en'),
+        builder: (context, child) => CountrySwitchListener(
+          child: child ?? const SizedBox.shrink(),
         ),
+        home: const Scaffold(body: Text('child-content')),
       ),
     ),
   );


### PR DESCRIPTION
## What

Fixes the dominant crash in a user-submitted error log — **31 of 39
traces**:

```
_TypeError: Null check operator used on a null value
  Navigator.of → showDialog → _CountrySwitchListenerState._handleNoProfile
```

## Root cause

`CountrySwitchListener` lives in `MaterialApp.router`'s `builder:`
callback — **above** the navigator go_router builds. `_handleNoProfile`
/ `_handleSuggest` passed that builder context to `showDialog`, whose
`Navigator.of` finds no navigator ancestor and the `!` throws.

It crashed 31× because `_markDismissed` (the 10-minute cooldown) ran
*after* `showDialog` — the throw skipped it, so the event re-fired and
re-crashed indefinitely.

## Fix

- The root `GoRouter` gets an explicit `navigatorKey` — a new
  `core/navigation/root_navigator_key.dart` global key.
- `CountrySwitchListener` shows dialogs against the navigator's overlay
  context (`rootNavigatorKey.currentState?.overlay?.context`), which
  *does* have a `Navigator` ancestor; skips gracefully if unavailable.
- The cooldown is marked *before* the dialog so a failure can never
  spam, and the profile notifier is captured before the `await` so
  leaving the screen mid-dialog can't throw a disposed-ref error.

## Test

The widget test now mounts the listener in the `builder:` (above the
navigator) — a faithful repro that crashed pre-fix. `flutter analyze`,
`test/lint/`, the country + router suites, codegen-drift and the
module-boundary check all pass.

Closes #1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
