### PR TITLE
fix(obd2): serialise sendCommand on the shared transport (#1972)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -28,6 +28,14 @@ class BluetoothObd2Transport implements Obd2Transport {
   Completer<String>? _pending;
   bool _connected = false;
 
+  /// Tail of the command queue. Every [sendCommand] chains onto this so
+  /// overlapping callers — e.g. the VIN reader racing the auto-record
+  /// PID poller, both sharing one transport — serialise instead of
+  /// colliding on the half-duplex ELM327 link (#1972). The tail tracks
+  /// completion of each command (success *or* error) so one failed
+  /// command never stalls the queue behind it.
+  Future<void> _queueTail = Future<void>.value();
+
   BluetoothObd2Transport(
     this._channel, {
     Duration readTimeout = const Duration(seconds: 5),
@@ -58,7 +66,27 @@ class BluetoothObd2Transport implements Obd2Transport {
     if (!_connected) {
       throw StateError('BluetoothObd2Transport not connected');
     }
-    return _sendRaw(command);
+    // #1972 — serialise every caller onto a single queue. The ELM327 is
+    // half-duplex; without this a second consumer's command collided
+    // with one already in flight and threw a concurrent-sendCommand
+    // StateError.
+    final completer = Completer<String>();
+    _queueTail = _queueTail.then((_) async {
+      // The transport may have been torn down while this command waited
+      // its turn — fail it cleanly rather than writing to a closed link.
+      if (!_connected) {
+        completer.completeError(
+          StateError('BluetoothObd2Transport not connected'),
+        );
+        return;
+      }
+      try {
+        completer.complete(await _sendRaw(command));
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    });
+    return completer.future;
   }
 
   @override
@@ -73,8 +101,9 @@ class BluetoothObd2Transport implements Obd2Transport {
 
   Future<String> _sendRaw(String command) async {
     // One in-flight command at a time — the ELM327 is half-duplex.
-    // Queuing is handled by Future chaining at the service layer;
-    // reject overlapping writes here explicitly.
+    // [sendCommand] serialises every caller onto `_queueTail`, so this
+    // guard is now a defensive invariant: tripping it means a code path
+    // reached `_sendRaw` while another command was unfinished.
     if (_pending != null) {
       throw StateError(
         'BluetoothObd2Transport: concurrent sendCommand is not allowed',

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
@@ -83,6 +83,37 @@ void main() {
       expect(reply.trim(), '41 0D 3C');
     });
 
+    test(
+        'overlapping sendCommand calls serialise instead of colliding (#1972)',
+        () async {
+      final channel = _ScriptedChannel();
+      channel.scriptResponse('ATZ\r', 'ELM327>');
+      channel.scriptResponse('ATE0\r', 'OK>');
+      channel.scriptResponse('ATL0\r', 'OK>');
+      channel.scriptResponse('ATH0\r', 'OK>');
+      channel.scriptResponse('ATSP0\r', 'OK>');
+      channel.scriptResponse('010C\r', '41 0C 1A F8 >');
+      channel.scriptResponse('010D\r', '41 0D 3C >');
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // Fire both WITHOUT awaiting the first — a VIN read racing the
+      // auto-record PID poller on the shared transport. Pre-#1972 the
+      // second call threw a concurrent-sendCommand StateError.
+      final f1 = transport.sendCommand('010C\r');
+      final f2 = transport.sendCommand('010D\r');
+      final results = await Future.wait([f1, f2]);
+
+      expect(results[0], contains('41 0C 1A F8'));
+      expect(results[1], contains('41 0D 3C'));
+      // The second command must be written only after the first's
+      // round-trip — the queue preserves order on the half-duplex link.
+      expect(
+        channel.writesAsStrings.sublist(channel.writesAsStrings.length - 2),
+        ['010C\r', '010D\r'],
+      );
+    });
+
     test('disconnect closes the channel and flips isConnected to false',
         () async {
       final channel = _ScriptedChannel();


### PR DESCRIPTION
## What

`BluetoothObd2Transport._sendRaw` rejects an overlapping write while a
command is in flight — the ELM327 is half-duplex. The "queuing handled
at the service layer" comment only held for a *single* consumer; when
two consumers shared one transport (the VIN reader racing the
auto-record PID poller — seen in a user error log) the second command
threw `concurrent sendCommand is not allowed`.

`sendCommand` now chains every caller onto a single `_queueTail` future,
so concurrent commands queue instead of colliding. The tail tracks each
command's completion (success *or* error) so one failed command never
stalls the queue; a command whose turn arrives after the transport
closed fails cleanly with a not-connected error. `_sendRaw`'s
concurrency check is kept as a defensive invariant.

## Test

- New test fires two `sendCommand` calls without awaiting the first (a
  VIN-read / poller race) and asserts both resolve and the writes stay
  ordered — pre-fix the second threw.
- `flutter analyze`, `test/lint/`, the OBD2 + vehicle suites
  (1251 tests) all pass.

Closes #1972

🤖 Generated with [Claude Code](https://claude.com/claude-code)
