### PR TITLE
feat(consumption): GPS-track distance source for accurate L/100km (#1979)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_distance_source.dart
+++ b/lib/features/consumption/data/obd2/trip_distance_source.dart
@@ -17,6 +17,18 @@ const String kDistanceSourceReal = 'real';
 /// the oldest samples first.
 const String kDistanceSourceVirtual = 'virtual';
 
+/// Final trip distance came from haversine-summing the trip's recorded
+/// GPS track (#1979). More accurate than [kDistanceSourceVirtual] — the
+/// OBD speed sensor reads the speedometer, which over-reads true road
+/// distance by a few percent — but ranked below [kDistanceSourceReal]:
+/// the car's own odometer stays the ground truth when it is readable.
+const String kDistanceSourceGps = 'gps';
+
+/// Minimum number of buffered GPS fixes before the track is trusted as
+/// a distance source (#1979). A handful of fixes cannot describe a
+/// route; below this the recorder falls back to the virtual odometer.
+const int kMinGpsFixesForDistanceSource = 10;
+
 /// Upper bound on the speed-sample buffer used by the virtual
 /// odometer (#800). At 5 Hz a 10-hour trip produces ~180 k samples —
 /// the typical driving session is well under 2 hours, so 60 k (~3.3

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -7,6 +7,7 @@ import '../../../../core/storage/hive_boxes.dart';
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../domain/entities/gps_sample_diagnostic.dart';
+import '../../domain/gps_track_distance.dart';
 import '../../domain/services/gear_inference.dart';
 import '../../domain/trip_recorder.dart';
 import '../trip_history_repository.dart';
@@ -31,7 +32,7 @@ import 'virtual_odometer.dart';
 // the #563 controller-split refactor. New callers should import the
 // individual files directly.
 export 'trip_distance_source.dart'
-    show kDistanceSourceReal, kDistanceSourceVirtual;
+    show kDistanceSourceReal, kDistanceSourceVirtual, kDistanceSourceGps;
 export 'trip_live_reading.dart' show TripLiveReading;
 
 /// Public recording state exposed by [TripRecordingController]
@@ -322,6 +323,13 @@ class TripRecordingController {
   /// real odometer.
   final List<VirtualOdometerSample> _speedSamples = <VirtualOdometerSample>[];
 
+  /// Rolling buffer of GPS fixes for the #1979 GPS-distance source.
+  /// Appended by [updateGpsFix] (one entry per Geolocator fix);
+  /// haversine-summed at finalisation when a usable track exists.
+  /// Capped at [kVirtualOdometerSampleCap] — the same generous bound
+  /// the speed buffer uses — so a forgotten recording stays bounded.
+  final List<GpsTrackPoint> _gpsTrack = <GpsTrackPoint>[];
+
   /// Owns the #1040 captured-sample buffer and the #1458 GPS
   /// cadence-diagnostics buffer — both per-trip ring buffers
   /// extracted into a focused collaborator (#1679).
@@ -521,6 +529,17 @@ class TripRecordingController {
       longitude: longitude,
       altitudeM: altitudeM,
     );
+    // #1979 — buffer every real fix for the GPS-distance source. A
+    // null-coord call only clears the per-tick latch; it is not a fix.
+    if (latitude != null && longitude != null) {
+      _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+      if (_gpsTrack.length > kVirtualOdometerSampleCap) {
+        _gpsTrack.removeRange(
+          0,
+          _gpsTrack.length - kVirtualOdometerSampleCap,
+        );
+      }
+    }
   }
 
   /// #1615 — push the most recent exact-litre OEM-PID fuel reading into
@@ -808,16 +827,22 @@ class TripRecordingController {
 
   /// Distance covered by the current trip so far (#800).
   ///
-  /// Prefers the ground truth `odometerLatest - odometerStart` when
-  /// both readings are present AND moved forward by more than a
-  /// noise-floor epsilon (odometer PIDs are quantised to 0.1 km on
-  /// most cars — a 0.09-km delta on a 20-minute trip is a sensor
-  /// artefact, not real distance). When the odometer isn't readable
-  /// (Peugeot 107 class), falls back to the trapezoidal integral of
-  /// buffered speed samples via [VirtualOdometer].
+  /// Resolution order (#800 / #1979):
+  ///   1. the ground-truth `odometerLatest - odometerStart` when both
+  ///      readings are present AND moved forward by more than a
+  ///      noise-floor epsilon (odometer PIDs are quantised to 0.1 km
+  ///      on most cars — a 0.09-km delta is a sensor artefact);
+  ///   2. the haversine-summed GPS track, when a usable one was
+  ///      recorded — true road distance, free of the speed sensor's
+  ///      over-read;
+  ///   3. the trapezoidal integral of buffered speed samples via
+  ///      [VirtualOdometer], when the car exposes no odometer
+  ///      (Peugeot 107 class) and no GPS track was captured.
   double get currentDistanceKm {
     final real = _realOdometerDeltaKm();
     if (real != null) return real;
+    final gps = _gpsTrackDistanceKm();
+    if (gps != null) return gps;
     return VirtualOdometer(
       samples: _speedSamples,
       maxGapSeconds: _integrationGapCapSeconds,
@@ -825,19 +850,21 @@ class TripRecordingController {
   }
 
   /// `'real'` when [currentDistanceKm] came from the car's odometer,
+  /// `'gps'` when it came from the haversine-summed GPS track (#1979),
   /// `'virtual'` when it came from [VirtualOdometer] integration
   /// (#800). Persisted on the finalised [TripSummary] so the fill-up
   /// flow and eco-analytics know whether to treat the km as a ground
   /// truth or as an estimate.
-  String get distanceSource =>
-      _realOdometerDeltaKm() != null
-          ? kDistanceSourceReal
-          : kDistanceSourceVirtual;
+  String get distanceSource {
+    if (_realOdometerDeltaKm() != null) return kDistanceSourceReal;
+    if (_gpsTrackDistanceKm() != null) return kDistanceSourceGps;
+    return kDistanceSourceVirtual;
+  }
 
   /// `odometerLatest - odometerStart` if both are present and the
   /// delta is above a small noise-floor epsilon (0.05 km — half the
   /// 0.1 km quantisation most cars apply to PID A6). Returns null
-  /// otherwise so callers can fall back to the virtual odometer.
+  /// otherwise so callers can fall back to the GPS / virtual odometer.
   double? _realOdometerDeltaKm() {
     final start = _odometerStartKm;
     final latest = _odometerLatestKm;
@@ -845,6 +872,18 @@ class TripRecordingController {
     final delta = latest - start;
     if (delta < 0.05) return null;
     return delta;
+  }
+
+  /// Haversine-summed distance of the buffered GPS track, or null when
+  /// the track is too sparse to trust (#1979): fewer than
+  /// [kMinGpsFixesForDistanceSource] fixes, or a sub-50 m total (a
+  /// parked car's GPS scatter). Callers then fall back to the virtual
+  /// odometer.
+  double? _gpsTrackDistanceKm() {
+    if (_gpsTrack.length < kMinGpsFixesForDistanceSource) return null;
+    final km = GpsTrackDistance.haversineKm(_gpsTrack);
+    if (km < 0.05) return null;
+    return km;
   }
 
   /// Append a speed sample to the virtual-odometer buffer, dropping
@@ -1459,4 +1498,13 @@ class TripRecordingController {
   @visibleForTesting
   List<VirtualOdometerSample> get debugSpeedSamples =>
       List.unmodifiable(_speedSamples);
+
+  /// Exposed for tests: append a GPS fix to the #1979 track buffer
+  /// without a live Geolocator stream, so tests can drive the
+  /// GPS-distance path of [currentDistanceKm] / [distanceSource]
+  /// deterministically.
+  @visibleForTesting
+  void debugAppendGpsFix({required double latitude, required double longitude}) {
+    _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+  }
 }

--- a/lib/features/consumption/domain/gps_track_distance.dart
+++ b/lib/features/consumption/domain/gps_track_distance.dart
@@ -1,0 +1,59 @@
+import 'dart:math' as math;
+
+/// A single GPS fix on a recorded trip's track — latitude / longitude
+/// in decimal degrees (#1979).
+class GpsTrackPoint {
+  final double latitude;
+  final double longitude;
+
+  const GpsTrackPoint(this.latitude, this.longitude);
+}
+
+/// Haversine-summed road distance over a sequence of GPS fixes (#1979).
+///
+/// Used as a distance source for the consumption calculation: the GPS
+/// track is the true road distance, more accurate than the OBD
+/// speed-sensor `virtual` odometer (the speedometer sensor over-reads).
+class GpsTrackDistance {
+  GpsTrackDistance._();
+
+  /// Mean Earth radius (km) — the WGS-84 IUGG mean radius.
+  static const double _earthRadiusKm = 6371.0088;
+
+  /// Total polyline distance, in km, through [track].
+  ///
+  /// Each consecutive pair contributes a great-circle segment. A
+  /// per-segment [jitterFloorKm] floor drops sub-floor hops so a
+  /// stationary car's GPS scatter (typically a few metres of drift
+  /// between fixes) does not accumulate phantom distance. A track with
+  /// fewer than two points has zero length.
+  static double haversineKm(
+    List<GpsTrackPoint> track, {
+    double jitterFloorKm = 0.003,
+  }) {
+    var total = 0.0;
+    for (var i = 1; i < track.length; i++) {
+      final segment = _segmentKm(track[i - 1], track[i]);
+      if (segment >= jitterFloorKm) total += segment;
+    }
+    return total;
+  }
+
+  /// Great-circle distance (km) between two fixes via the haversine
+  /// formula.
+  static double _segmentKm(GpsTrackPoint a, GpsTrackPoint b) {
+    final lat1 = _radians(a.latitude);
+    final lat2 = _radians(b.latitude);
+    final dLat = _radians(b.latitude - a.latitude);
+    final dLon = _radians(b.longitude - a.longitude);
+    final h = math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(lat1) *
+            math.cos(lat2) *
+            math.sin(dLon / 2) *
+            math.sin(dLon / 2);
+    // `min(1.0, …)` guards asin's domain against floating-point drift.
+    return 2 * _earthRadiusKm * math.asin(math.min(1.0, math.sqrt(h)));
+  }
+
+  static double _radians(double degrees) => degrees * math.pi / 180.0;
+}

--- a/test/features/consumption/data/obd2/trip_recording_virtual_odometer_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_virtual_odometer_test.dart
@@ -130,4 +130,69 @@ void main() {
       expect(summary.distanceKm, closeTo(live, 1e-9));
     });
   });
+
+  group('TripRecordingController GPS-distance source (#1979)', () {
+    test(
+        'usable GPS track, no odometer → distanceSource == `gps`, '
+        'distanceKm == haversine of the track', () async {
+      final service = await _connectedService({
+        '01A6': 'NO DATA>',
+        '0131': 'NO DATA>',
+      });
+      final ctl = _buildController(service);
+      await ctl.start();
+
+      // 12 fixes, 0.001 deg latitude apart (~111 m) → 11 legs ~1.223 km.
+      for (var i = 0; i < 12; i++) {
+        ctl.debugAppendGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+
+      final summary = await ctl.stop();
+      expect(summary.distanceSource, 'gps');
+      expect(summary.distanceKm, closeTo(1.223, 0.03));
+    });
+
+    test('a real odometer delta still wins over a GPS track', () async {
+      final service = await _connectedService({
+        '01A6': '41 A6 00 01 6A 2C>', // start = 9271.6 km
+      });
+      final ctl = _buildController(service);
+      await ctl.start();
+      ctl.debugSetOdometerReadings(latestKm: 9274.6); // +3.0 km
+      for (var i = 0; i < 12; i++) {
+        ctl.debugAppendGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+
+      final summary = await ctl.stop();
+      expect(summary.distanceSource, 'real');
+      expect(summary.distanceKm, closeTo(3.0, 0.01));
+    });
+
+    test(
+        'a sparse GPS track (< 10 fixes) is not trusted — falls back to '
+        'the virtual odometer', () async {
+      final service = await _connectedService({
+        '01A6': 'NO DATA>',
+        '0131': 'NO DATA>',
+      });
+      final ctl = _buildController(service);
+      await ctl.start();
+
+      // Only 5 fixes — below kMinGpsFixesForDistanceSource.
+      for (var i = 0; i < 5; i++) {
+        ctl.debugAppendGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+      // Speed samples so the virtual fallback has something to integrate:
+      // 30 km/h for 60 s = 0.5 km, at the #1927 ≤15 s cadence.
+      final t0 = DateTime.utc(2026, 5, 19, 10);
+      for (var s = 0; s <= 60; s += 15) {
+        ctl.debugRecordSpeedSample(
+            speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
+
+      final summary = await ctl.stop();
+      expect(summary.distanceSource, 'virtual');
+      expect(summary.distanceKm, closeTo(0.5, 0.01));
+    });
+  });
 }

--- a/test/features/consumption/domain/gps_track_distance_test.dart
+++ b/test/features/consumption/domain/gps_track_distance_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/gps_track_distance.dart';
+
+void main() {
+  group('GpsTrackDistance.haversineKm (#1979)', () {
+    test('empty and single-point tracks have zero length', () {
+      expect(GpsTrackDistance.haversineKm(const []), 0.0);
+      expect(
+        GpsTrackDistance.haversineKm(const [GpsTrackPoint(45.0, 5.0)]),
+        0.0,
+      );
+    });
+
+    test('a 0.5-degree latitude segment is ~55.6 km', () {
+      final km = GpsTrackDistance.haversineKm(const [
+        GpsTrackPoint(0.0, 0.0),
+        GpsTrackPoint(0.5, 0.0),
+      ]);
+      expect(km, closeTo(55.6, 0.3));
+    });
+
+    test('a multi-segment track sums every leg', () {
+      // 4 fixes 0.001 deg latitude apart (~111 m each) = 3 legs ~334 m.
+      final track = [
+        for (var i = 0; i < 4; i++) GpsTrackPoint(45.0 + i * 0.001, 5.0),
+      ];
+      expect(GpsTrackDistance.haversineKm(track), closeTo(0.3336, 0.01));
+    });
+
+    test('sub-floor jitter between near-identical fixes adds nothing', () {
+      // ~2 m hops (below the 3 m jitter floor) — a parked car's GPS
+      // scatter must not accumulate phantom distance.
+      final jitter = [
+        for (var i = 0; i < 20; i++) GpsTrackPoint(45.0 + i * 0.000018, 5.0),
+      ];
+      expect(GpsTrackDistance.haversineKm(jitter), 0.0);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a GPS-track distance source so the consumption calculation uses
true road distance when a trip recorded a GPS track.

## Why

A backup analysis (2026-05-19) showed every recorded trip falls back to
`virtual` distance — the `VirtualOdometer` integral of the OBD speed
PID. That PID reads the speedometer sensor, which over-reads true road
distance by ~2–5 %. Since `L/100km = fuelLitres ÷ distance × 100`, the
biased distance biases the consumption figure low.

## Changes

- New `GpsTrackDistance` helper — haversine-sums a list of GPS fixes,
  with a per-segment jitter floor so a parked car's GPS scatter does
  not accumulate phantom distance.
- New `kDistanceSourceGps`. `trip_recording_controller` buffers every
  GPS fix from `updateGpsFix` and resolves trip distance in the order
  **real odometer → GPS track → virtual odometer**. The GPS branch
  engages only with a usable track (≥ `kMinGpsFixesForDistanceSource`
  fixes, non-trivial total).

`distanceSource` is a free-form string persisted verbatim by every
consumer (trip history, backup XML, active-trip repo) — none branch on
it, so `gps` flows through transparently.

## Scope notes

- GPS road-gradient in the fuel-rate model is **not** included — that
  was closed not-planned (#1935); measured engine load already reflects
  climbs, so a gradient term double-counts.
- A trip only gets a GPS track when location is enabled for trip
  recording; this PR adds the capability, it does not change consent.

## Test

- `GpsTrackDistance` unit tests (known segment, multi-leg sum, jitter
  floor) + controller tests (GPS track wins over virtual, real
  odometer still wins, sparse track falls back). 1023 consumption/lint
  tests green; `flutter analyze`, codegen-drift, module-boundary all
  pass.

Closes #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
