### PR TITLE
feat(consumption): activate GPS trip-path recording by default (#1981)

### DIFF
--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -44,22 +44,36 @@ class TripGpsStreamController {
   /// Open a Geolocator position stream and route every fix through
   /// [TripRecordingController.updateGpsFix] (#1374 phase 1).
   ///
-  /// No-op when [Feature.gpsTripPath] is disabled — that's the
-  /// default for every existing user, so this method must NEVER pull
-  /// on the Geolocator plugin in that case (zero battery cost). When
-  /// the flag is on we open the stream at [LocationAccuracy.high]
-  /// because the eventual heatmap (Phase 3) wants ~10 m precision.
+  /// No-op when [Feature.gpsTripPath] is disabled — the user can still
+  /// turn it off from Feature management, and the flag-off path never
+  /// touches the Geolocator plugin (zero battery cost). When the flag
+  /// is on we open the stream at [LocationAccuracy.high] because the
+  /// eventual heatmap (Phase 3) wants ~10 m precision.
+  ///
+  /// #1981 — before opening the stream we ensure foreground location
+  /// permission: `getPositionStream` does not prompt, so without a
+  /// grant it just errors. A denial is non-fatal — `start` returns and
+  /// the recorder finalises on the virtual odometer.
   ///
   /// Stream errors are logged and swallowed: a permission revoke
   /// mid-trip, a temporary loss of fix, or the OS killing the
   /// position service must NOT derail the OBD2 trip recording. The
   /// controller's per-tick latch simply stops being refreshed and
   /// subsequent samples carry `latitude: null, longitude: null`.
-  void start(TripRecordingController ctl) {
+  Future<void> start(TripRecordingController ctl) async {
     final flags = _ref.read(featureFlagsProvider.notifier);
     if (!flags.isEnabled(Feature.gpsTripPath)) return;
     final geolocator = _ref.read(geolocatorWrapperProvider);
     try {
+      // #1981 — request foreground location permission up front.
+      var permission = await geolocator.checkPermission();
+      if (permission == LocationPermission.denied) {
+        permission = await geolocator.requestPermission();
+      }
+      if (permission != LocationPermission.whileInUse &&
+          permission != LocationPermission.always) {
+        return;
+      }
       _gpsSub = geolocator
           .getPositionStream(
         locationSettings: const LocationSettings(

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -370,11 +370,12 @@ class TripRecording extends _$TripRecording {
     await _baselines.load();
 
     await ctl.start();
-    // #1374 phase 1 — opt-in GPS sampling. Only when the user has
-    // explicitly turned the feature on do we open a Geolocator
-    // position stream; the flag-off path skips the plugin entirely so
-    // a default-config user pays no battery cost.
-    _gps.start(ctl);
+    // #1374 / #1981 — GPS trip-path sampling. Default-on for trip
+    // recorders (#1981) so consumption uses true road distance; the
+    // controller requests location permission and no-ops cleanly if
+    // the flag is off or permission is denied. Fire-and-forget — the
+    // permission round-trip must not block trip-start.
+    unawaited(_gps.start(ctl));
     // #1615 — opt-in experimental OEM-PID exact-fuel-level poll. A
     // no-op (no timer, no registry resolution) when the flag is off or
     // the adapter is not OEM-PID-capable, so a default-config user pays

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'1aeb92ae04c1285be3c4790d7f6c7dc509f77ae3';
+String _$tripRecordingHash() => r'4a52244a18887a7c25a95defff23ff715326b35e';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/feature_management/domain/feature_manifest.dart
+++ b/lib/features/feature_management/domain/feature_manifest.dart
@@ -117,7 +117,9 @@ class FeatureManifest {
   /// - `consumptionAnalytics`: false (no trips → no tab)
   /// - `baselineSync`: false (off until TankSync is enabled)
   /// - `priceAlerts`, `priceHistory`, `routePlanning`, `evCharging`: true
-  /// - `glideCoach`, `gpsTripPath`: false (future features, opt-in)
+  /// - `glideCoach`: false (future feature, opt-in)
+  /// - `gpsTripPath`: true (#1981 — a GPS track is true road distance,
+  ///   which makes the consumption figure accurate; #1979)
   /// - `showFuel`, `showElectric`: true (#1373 phase 3c — both
   ///   surfaces visible by default; mirrors the historical
   ///   `UserProfile.showFuel` / `showElectric` defaults so existing
@@ -201,7 +203,12 @@ class FeatureManifest {
     ),
     Feature.gpsTripPath: FeatureManifestEntry.allChannels(
       feature: Feature.gpsTripPath,
-      defaultOn: false,
+      // #1981 — default-on: the GPS track is true road distance, which
+      // makes the consumption figure accurate (the OBD speed sensor
+      // over-reads — #1979). `requires: obd2TripRecording` scopes it to
+      // users who actually record trips; it is foreground-only and can
+      // still be turned off from Feature management.
+      defaultOn: true,
       requires: {Feature.obd2TripRecording},
       displayName: 'GPS trip path',
       description: 'Persist GPS path samples alongside each trip.',

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -102,6 +102,10 @@ void main() {
 
       final notifier = container.read(tripRecordingProvider.notifier);
       await notifier.start(service);
+      // #1981 — `_gps.start` is now async (it awaits a location-
+      // permission check before opening the stream) and the provider
+      // fires it without awaiting; drain so the subscription is wired.
+      await Future<void>.delayed(Duration.zero);
 
       // The provider must have asked Geolocator for a stream exactly once.
       expect(fakeGeo.positionStreamCallCount, 1,
@@ -167,6 +171,9 @@ void main() {
 
       final notifier = container.read(tripRecordingProvider.notifier);
       await notifier.start(service);
+      // #1981 — drain the async permission check so `_gps.start` has
+      // opened the stream before the first fix is pushed.
+      await Future<void>.delayed(Duration.zero);
       // First push a real fix so we know the wiring works…
       fakeGeo.emit(_pos(50.0, 4.0));
       await Future<void>.delayed(Duration.zero);
@@ -180,6 +187,40 @@ void main() {
       fakeGeo.emitError(Exception('permission revoked'));
       await Future<void>.delayed(Duration.zero);
       // The trip is still active — no phase regression.
+      expect(container.read(tripRecordingProvider).isActive, isTrue);
+
+      await notifier.stop();
+    });
+
+    test(
+        'flag ON but location permission denied — no stream opens, the '
+        'trip still records (#1981)', () async {
+      final fakeGeo = _RecordingGeolocator()
+        ..permission = LocationPermission.denied;
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gpsTripPath);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fakeGeo.positionStreamCallCount, 0,
+          reason: 'a denied location permission must not open a stream');
+      // The trip records regardless — GPS distance just falls back to
+      // the virtual odometer.
       expect(container.read(tripRecordingProvider).isActive, isTrue);
 
       await notifier.stop();
@@ -226,6 +267,17 @@ class _RecordingGeolocator extends GeolocatorWrapper {
   // subscribed (a single shared controller would conflate the two).
   StreamController<Position>? _controller;
   int activeListeners = 0;
+
+  /// Permission the fake hands back from [checkPermission] /
+  /// [requestPermission] (#1981). Granted by default so the flag-on
+  /// tests open a stream; a test flips it to assert the denied path.
+  LocationPermission permission = LocationPermission.whileInUse;
+
+  @override
+  Future<LocationPermission> checkPermission() async => permission;
+
+  @override
+  Future<LocationPermission> requestPermission() async => permission;
 
   @override
   Stream<Position> getPositionStream({LocationSettings? locationSettings}) {

--- a/test/features/feature_management/feature_manifest_completeness_test.dart
+++ b/test/features/feature_management/feature_manifest_completeness_test.dart
@@ -52,4 +52,17 @@ void main() {
       }
     });
   });
+
+  group('#1981 — GPS trip path default-on', () {
+    test('gpsTripPath ships default-on so trip consumption uses the '
+        'accurate GPS-track distance', () {
+      final entry = manifest.entries[Feature.gpsTripPath];
+      expect(entry, isNotNull);
+      expect(entry!.defaultEnabledIn(BuildChannel.production), isTrue,
+          reason: 'a GPS track gives true road distance (#1979/#1981); '
+              'without it the speed-sensor virtual odometer over-reads');
+      expect(entry.requires, contains(Feature.obd2TripRecording),
+          reason: 'GPS trip path only matters once trips are recorded');
+    });
+  });
 }


### PR DESCRIPTION
## What

Makes the GPS-track distance source (#1979) actually take effect, so
trip consumption is computed from true road distance.

- `Feature.gpsTripPath` → **`defaultOn: true`**. It still `requires:
  obd2TripRecording`, so it only engages for users who record trips,
  and can still be disabled from Feature management. Mirrors
  `autoRecord` (default-on, not bundled).
- `TripGpsStreamController.start` is now async: it checks — and
  requests, if needed — foreground location permission before opening
  the position stream (`getPositionStream` does not prompt; without a
  grant it just errors). A denial returns cleanly and the recorder
  finalises on the `virtual` odometer, exactly as before. The provider
  fires `start` without awaiting, so the permission round-trip never
  blocks trip-start.

Result: a recorded trip captures a GPS track and reports
`distanceSource: gps` with accurate consumption, instead of the
low-biased speed-sensor odometer.

## Notes

- Foreground location only — recorded during an active trip; the
  screen-off `BackgroundLocationConsent` path is untouched.

## Test

- New manifest test pins `gpsTripPath` default-on.
- New GPS-gating test: a denied permission opens no stream and the
  trip still records. Existing flag-on/error tests updated for the now
  fire-and-forget async `start`.
- `flutter analyze`, `test/lint/`, the feature-management + consumption
  suites, codegen-drift and the module-boundary check all pass.

Closes #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)
