### PR TITLE
fix(ci): pin glance-appwidget to a stable version (#1985)

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -32,6 +32,21 @@ subprojects {
     }
 }
 
+// #1985 — the `home_widget` plugin declares `androidx.glance:
+// glance-appwidget:1.+`, a dynamic version. Gradle resolved it up to
+// `1.3.0-alpha01`, whose transitive `androidx.compose.remote` alphas
+// demand AGP 9.1 / compileSdk 37 — this project is on AGP 8.11 / SDK
+// 36, so `bundlePlayRelease` broke. Pin glance to the current stable
+// line (the plugin was authored against 1.1.x) across every subproject.
+subprojects {
+    configurations.all {
+        resolutionStrategy {
+            force("androidx.glance:glance-appwidget:1.1.1")
+            force("androidx.glance:glance:1.1.1")
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## What

The scheduled **Daily Open-Testing Build** failed at the AAB build:

```
Dependency 'androidx.glance:glance-appwidget:1.3.0-alpha01' requires
  Android Gradle plugin 9.1.0 or higher. This build uses 8.11.1.
Dependency 'androidx.compose.remote:remote-creation-android:1.0.0-alpha11'
  requires ... version 37 ... :app is compiled against android-36.
```

## Cause

The `home_widget` plugin (0.9.1) declares
`androidx.glance:glance-appwidget:1.+` — a **dynamic version**.
`1.3.0-alpha01` was published today and `1.+` resolved up to it; its
transitive `androidx.compose.remote` alphas demand AGP 9.1 /
compileSdk 37. The build was green earlier the same day — a textbook
floating-version surprise. The plugin's `1.+` can't be edited here.

## Fix

`resolutionStrategy.force` on `androidx.glance:glance-appwidget` +
`:glance` to `1.1.1` (the current stable line — `home_widget` 0.9.1 was
authored against glance 1.1.x) for every Android subproject in
`android/build.gradle.kts`.

## Verification

Gradle-config-only — no Dart / test impact. `build-android` CI and the
next Daily Open-Testing Build are the gate.

Closes #1985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
