### PR TITLE
fix(consumption): reopen the active trip via routerProvider (#1987)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
+import '../../../../app/router.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
-import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/cold_start_baselines.dart';
 import '../../domain/situation_classifier.dart';
@@ -85,25 +84,16 @@ class TripRecordingBanner extends ConsumerWidget {
                 bottom: false,
                 child: InkWell(
                   key: const Key('tripRecordingBanner'),
-                  onTap: () {
-                    // #1322 — TripRecordingBanner is wrapped via
-                    // MaterialApp.builder, so its context can sit
-                    // ABOVE the Router/Navigator subtree on certain
-                    // modal paths (e.g. /privacy-dashboard). In those
-                    // cases GoRouter.of throws "No GoRouter found in
-                    // context". Use maybeOf + a ScaffoldMessenger
-                    // fallback so the banner never crashes.
-                    final router = GoRouter.maybeOf(context);
-                    if (router != null) {
-                      router.push('/trip-recording');
-                      return;
-                    }
-                    final messenger = ScaffoldMessenger.maybeOf(context);
-                    messenger?.showSnackBar(SnackBarHelper.infoSnackBar(
-                      l?.tripBannerOpenFromConsumptionTab ??
-                          'Open the active trip from the Conso tab',
-                    ));
-                  },
+                  // #1987 — TripRecordingBanner is wrapped via
+                  // MaterialApp.builder, so its context sits ABOVE the
+                  // Router/Navigator subtree and `GoRouter.of(context)`
+                  // fails. Navigate through the router instance from
+                  // `routerProvider` instead — always resolvable, no
+                  // context lookup — so the banner reliably reopens the
+                  // active recording (the old context-lookup fell back
+                  // to a snackbar naming the long-removed "Conso" tab).
+                  onTap: () =>
+                      ref.read(routerProvider).push('/trip-recording'),
                   child: Padding(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12, vertical: 6),

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
 import 'package:tankstellen/features/consumption/domain/cold_start_baselines.dart';
 import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
+import 'package:tankstellen/app/router.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_banner.dart';
 import 'package:tankstellen/features/consumption/providers/pip_mode_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
@@ -148,95 +149,17 @@ void main() {
     });
   });
 
-  // #1322 — TripRecordingBanner sits inside MaterialApp.builder, so
-  // its build context can be ABOVE the Router/Navigator subtree on
-  // certain modal paths (e.g. /privacy-dashboard). GoRouter.of throws
-  // "No GoRouter found in context" there. Verify the banner now uses
-  // GoRouter.maybeOf and falls back to a snackbar instead of crashing.
-  group('TripRecordingBanner GoRouter fallback (#1322)', () {
+  // #1987 — TripRecordingBanner sits inside MaterialApp.builder, above
+  // the Router/Navigator subtree, so `GoRouter.of(context)` cannot
+  // resolve. It now navigates through the `routerProvider` instance;
+  // verify the tap reliably opens /trip-recording.
+  group('TripRecordingBanner tap → /trip-recording (#1987)', () {
     testWidgets(
-        'tap with no GoRouter ancestor does not throw — '
-        'falls back gracefully on /privacy-dashboard-style modal paths',
+        'tapping the recording banner pushes /trip-recording via '
+        'routerProvider — no dependence on a context-resolvable GoRouter',
         (tester) async {
-      // Plain MaterialApp (no .router constructor) means the InheritedWidget
-      // lookup for GoRouter will return null, mirroring the production
-      // crash on /privacy-dashboard.
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            tripRecordingProvider.overrideWith(
-              () => _FakeTripRecording(_activeState(
-                band: ConsumptionBand.normal,
-                distance: 1.0,
-              )),
-            ),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: TripRecordingBanner(child: SizedBox()),
-            ),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      // Sanity: banner is mounted.
-      expect(find.byKey(const Key('tripRecordingBanner')), findsOneWidget);
-
-      // Tapping must not throw — the production trace was a hard crash.
-      await tester.tap(find.byKey(const Key('tripRecordingBanner')));
-      await tester.pump();
-
-      expect(tester.takeException(), isNull);
-    });
-
-    testWidgets(
-        'tap with no GoRouter ancestor surfaces snackbar pointing '
-        'the user at the consumption tab — silent no-op would be worse',
-        (tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            tripRecordingProvider.overrideWith(
-              () => _FakeTripRecording(_activeState(
-                band: ConsumptionBand.normal,
-                distance: 1.0,
-              )),
-            ),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: TripRecordingBanner(child: SizedBox()),
-            ),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      await tester.tap(find.byKey(const Key('tripRecordingBanner')));
-      // SnackBar uses a slide animation — pump a few frames to let it
-      // mount, but don't pumpAndSettle (the banner shows no spinner
-      // here, but the SnackBar dismissal timer could otherwise dangle).
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
-
-      expect(
-        find.text('Open the active trip from the Conso tab'),
-        findsOneWidget,
-      );
-      expect(tester.takeException(), isNull);
-    });
-
-    testWidgets(
-        'tap with GoRouter ancestor pushes /trip-recording — '
-        'regression for the happy path',
-        (tester) async {
-      final pushedLocations = <String>[];
-      final router = GoRouter(
+      final pushed = <String>[];
+      final testRouter = GoRouter(
         initialLocation: '/',
         routes: [
           GoRoute(
@@ -248,7 +171,7 @@ void main() {
           GoRoute(
             path: '/trip-recording',
             builder: (_, _) {
-              pushedLocations.add('/trip-recording');
+              pushed.add('/trip-recording');
               return const Scaffold(body: Text('trip-recording-screen'));
             },
           ),
@@ -264,11 +187,12 @@ void main() {
                 distance: 1.0,
               )),
             ),
+            routerProvider.overrideWith((ref) => testRouter),
           ],
           child: MaterialApp.router(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            routerConfig: router,
+            routerConfig: testRouter,
           ),
         ),
       );
@@ -277,13 +201,10 @@ void main() {
       expect(find.byKey(const Key('tripRecordingBanner')), findsOneWidget);
 
       await tester.tap(find.byKey(const Key('tripRecordingBanner')));
-      // GoRouter push triggers a route transition animation. Pump a
-      // bounded number of frames rather than pumpAndSettle (in case
-      // any descendant shows a continuous indicator on transition).
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(pushedLocations, contains('/trip-recording'));
+      expect(pushed, contains('/trip-recording'));
       expect(find.text('trip-recording-screen'), findsOneWidget);
       expect(tester.takeException(), isNull);
     });


### PR DESCRIPTION
## What

With a trip recording, tapping the "Ralenti / recording" banner did
nothing useful — it showed the snackbar **"Open the active trip from
the Conso tab"**. The Conso tab was removed (#1905 split it into
Carburant + Trajets), so there was **no way back** to the
`/trip-recording` screen.

## Cause

`TripRecordingBanner` is mounted in `MaterialApp.router`'s `builder:` —
above the navigator. The old `onTap` used `GoRouter.maybeOf(context)`,
got `null` from that context, and fell through to the stale snackbar.

## Fix

Navigate through the router instance:
`ref.read(routerProvider).push('/trip-recording')` — no context
lookup, always resolvable (the banner is a `ConsumerWidget`; this is
what `WidgetClickListener` already does). The `GoRouter.maybeOf` +
snackbar fallback is removed.

## Test

The obsolete `#1322` GoRouter-fallback group is replaced with a
`#1987` test: overriding `routerProvider`, a banner tap pushes
`/trip-recording`.

`flutter analyze`, `test/lint/`, the consumption suite, codegen-drift
all pass.

Closes #1987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
