### PR TITLE
chore(station-detail): compact the station-detail screen (#1989)

### DIFF
--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -22,7 +22,7 @@ import '../widgets/wait_time_section.dart';
 /// Detail screen for a single fuel station.
 ///
 /// #1539 — the data state uses a `CustomScrollView` + `SliverAppBar`
-/// (pinned, `expandedHeight: 220`) so the rich status-row + brand-header
+/// (pinned, `expandedHeight: 196`) so the rich status-row + brand-header
 /// block collapses out of view on scroll, leaving a 1-row compact bar
 /// (back arrow + station name + cheapest-price chip + actions). Loading
 /// and error states keep a plain fixed `AppBar` since there is no scroll
@@ -100,7 +100,7 @@ class _StationDetailPlain extends StatelessWidget {
 }
 
 /// Loaded state — `CustomScrollView` + `SliverAppBar(pinned: true,
-/// expandedHeight: 220)`. Status row and brand header live inside the
+/// expandedHeight: 196)`. Status row and brand header live inside the
 /// `flexibleSpace.background`, so they fade out as the bar collapses
 /// to its compact form on scroll past the prices card.
 class _StationDetailLoaded extends StatelessWidget {
@@ -128,7 +128,9 @@ class _StationDetailLoaded extends StatelessWidget {
         slivers: [
           SliverAppBar(
             pinned: true,
-            expandedHeight: 220,
+            // #1989 — trimmed from 220: the status row + brand header
+            // do not fill that much, leaving dead space below the name.
+            expandedHeight: 196,
             leading: IconButton(
               icon: const Icon(Icons.arrow_back),
               onPressed: () => context.pop(),
@@ -177,7 +179,7 @@ class _StationDetailLoaded extends StatelessWidget {
                         serviceResult: serviceResult,
                         stationId: stationId,
                       ),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: 8),
                       StationBrandHeader(station: station),
                     ],
                   ),
@@ -193,17 +195,17 @@ class _StationDetailLoaded extends StatelessWidget {
             sliver: SliverList(
               delegate: SliverChildListDelegate.fixed([
                 StationPricesSection(station: station),
-                const SizedBox(height: 12),
+                const SizedBox(height: 8),
                 // #1119 phase 2 — community wait-time hint + "Track my wait"
                 // toggle. Hidden entirely when consent is OFF; renders the
                 // toggle alone when consent is ON but the aggregate row is
                 // still sparse (< 5 samples server-side).
                 WaitTimeSection(stationId: stationId),
-                const SizedBox(height: 12),
+                const SizedBox(height: 8),
                 StationInfoSection(station: station, detail: detail),
-                const SizedBox(height: 12),
+                const SizedBox(height: 8),
                 StationRatingSection(stationId: stationId),
-                const SizedBox(height: 12),
+                const SizedBox(height: 8),
                 // #1957 — the price-history chart is a tall,
                 // detail-on-demand block; show it in a foldable that is
                 // collapsed by default so it does not dominate the page.

--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -48,6 +48,7 @@ class StationInfoSection extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         ListTile(
+          dense: true,
           leading: const Icon(Icons.location_on),
           title: Text(
             '${station.street}${station.houseNumber != null ? ' ${station.houseNumber}' : ''}',
@@ -62,7 +63,7 @@ class StationInfoSection extends StatelessWidget {
             tooltip: l10n?.navigate ?? 'Navigate',
           ),
         ),
-        const SizedBox(height: 24),
+        const SizedBox(height: 12),
 
         // Opening times
         SectionHeader(
@@ -94,7 +95,7 @@ class StationInfoSection extends StatelessWidget {
             leading: Icon(Icons.schedule),
             title: Text('—'),
           ),
-        const SizedBox(height: 24),
+        const SizedBox(height: 12),
 
         // Location info
         if (station.department != null || station.region != null) ...[
@@ -113,7 +114,7 @@ class StationInfoSection extends StatelessWidget {
                 ? Text(l10n?.highway ?? 'Highway')
                 : Text(l10n?.localStation ?? 'Local station'),
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: 12),
         ],
 
         // Amenities (icon chips) — at the bottom
@@ -124,7 +125,7 @@ class StationInfoSection extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           AmenityChips(amenities: station.amenities, maxVisible: 8),
-          const SizedBox(height: 24),
+          const SizedBox(height: 12),
         ],
 
         // Payment methods (inferred from brand — no API data available)
@@ -137,7 +138,7 @@ class StationInfoSection extends StatelessWidget {
           PaymentMethodChips(brand: station.brand, maxVisible: 8),
           const SizedBox(height: 8),
           PayWithAppButton(brand: station.brand),
-          const SizedBox(height: 24),
+          const SizedBox(height: 12),
         ],
 
         // Services (raw text from API) — at the bottom, collapsed by


### PR DESCRIPTION
## What

Layout-density pass on the station-detail screen — no field or
behaviour change, sibling of the search-form compaction (#1962).

- `station_detail_screen.dart`: `SliverAppBar.expandedHeight` 220 → 196
  (the status row + brand header left visible dead space below the
  station name); SliverList section gaps + the header's internal gap
  go 12 → 8 dp.
- `station_info_section.dart`: the sub-section gaps between Address /
  Opening hours / Zone / Amenities / Payment methods drop 24 → 12 dp;
  the Address `ListTile` becomes `dense` to match its siblings.

## Test

`flutter analyze`, `test/lint/`, the station-detail suite (96 tests),
codegen-drift all pass.

Closes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
