### PR TITLE
fix(obd2): probe the first reconnect fast, within the grace window (#1991)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
+++ b/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
@@ -40,7 +40,10 @@ typedef AdapterConnectAttempt = Future<bool> Function(String mac);
 ///
 /// Lifetime:
 ///   - Constructed by the controller when `_handleDrop` fires.
-///   - [start] schedules the first timer at [initialBackoff].
+///   - [start] schedules the first probe after a short `firstProbeDelay`
+///     (#1991) — a fresh drop is usually a transient BLE blip, so the
+///     first reconnect must land inside the controller's silent-
+///     reconnect grace window rather than after the full backoff.
 ///   - [stop] cancels the timer cleanly; safe to call more than
 ///     once.
 ///   - The scanner does not own the controller; the caller decides
@@ -51,6 +54,14 @@ class AdapterReconnectScanner {
   final AdapterConnectAttempt _connect;
   final VoidCallback _onReconnect;
   final Duration _maxBackoff;
+
+  /// Delay before the FIRST probe after a drop (#1991). A fresh drop is
+  /// most often a transient BLE blip; probing near-immediately — rather
+  /// than after the full [_currentBackoff] — lets the reconnect land
+  /// inside the controller's 6 s silent-reconnect grace window, so the
+  /// user never sees the "connection lost" banner. Only the first
+  /// attempt is fast; subsequent misses use exponential backoff.
+  final Duration _firstProbeDelay;
 
   Duration _currentBackoff;
   Timer? _timer;
@@ -64,11 +75,13 @@ class AdapterReconnectScanner {
     required VoidCallback onReconnect,
     Duration initialBackoff = const Duration(seconds: 5),
     Duration maxBackoff = const Duration(seconds: 60),
+    Duration firstProbeDelay = const Duration(seconds: 1),
   })  : _pinnedMac = pinnedMac,
         _probe = probe,
         _connect = connect,
         _onReconnect = onReconnect,
         _maxBackoff = maxBackoff,
+        _firstProbeDelay = firstProbeDelay,
         _currentBackoff = initialBackoff;
 
   /// `true` while the scanner is active (a probe timer is scheduled
@@ -93,7 +106,10 @@ class AdapterReconnectScanner {
   Future<void> start() async {
     if (_scanning) return;
     _scanning = true;
-    _scheduleNext();
+    // #1991 — first probe fast (a transient drop recovers quickest with
+    // a near-immediate retry); subsequent misses fall back to the
+    // exponential backoff via `_scheduleNext`.
+    _timer = Timer(_firstProbeDelay, _runCycle);
   }
 
   /// Cancel any pending timer and mark the scanner stopped. Safe to
@@ -121,8 +137,11 @@ class AdapterReconnectScanner {
       final inRange = await _probeSafely();
       if (!_scanning) return; // stop() raced — honour it
       if (!inRange) {
-        _doubleBackoff();
+        // Schedule the next retry at the current backoff, THEN double
+        // it — so the first retry after a fast first probe uses
+        // `initialBackoff`, not `initialBackoff × 2` (#1991).
         _scheduleNext();
+        _doubleBackoff();
         return;
       }
       final ok = await _connectSafely();
@@ -136,10 +155,10 @@ class AdapterReconnectScanner {
         return;
       }
       // Probe said "in range" but connect failed (adapter busy,
-      // dance interrupted). Treat as a miss — double the backoff
-      // so we don't hammer the adapter.
-      _doubleBackoff();
+      // dance interrupted). Treat as a miss — schedule the retry,
+      // then double the backoff so we don't hammer the adapter.
       _scheduleNext();
+      _doubleBackoff();
     } finally {
       _cycleInFlight = false;
     }

--- a/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
+++ b/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
@@ -37,6 +37,7 @@ void main() {
         connect: (_) async => true,
         onReconnect: () {},
         initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
         maxBackoff: _kMax,
       );
       await scanner.start();
@@ -61,6 +62,37 @@ void main() {
       await scanner.stop();
     });
 
+    test('first probe fires at firstProbeDelay, not initialBackoff (#1991)',
+        () async {
+      var probeCalls = 0;
+      final scanner = AdapterReconnectScanner(
+        pinnedMac: 'MAC',
+        probe: (_) async {
+          probeCalls++;
+          return false;
+        },
+        connect: (_) async => false,
+        onReconnect: () {},
+        firstProbeDelay: const Duration(milliseconds: 10),
+        // A deliberately long initialBackoff — if the first probe
+        // waited for it, the assertion below would time out.
+        initialBackoff: const Duration(seconds: 30),
+        maxBackoff: const Duration(seconds: 60),
+      );
+      await scanner.start();
+
+      // The first probe must land within the short firstProbeDelay —
+      // far inside the controller's 6 s silent-reconnect grace window,
+      // not after the 30 s initialBackoff.
+      await _waitFor(() => probeCalls >= 1,
+          timeout: const Duration(milliseconds: 500));
+      expect(probeCalls, 1,
+          reason: 'the first reconnect probe must fire at '
+              'firstProbeDelay, not wait the full initialBackoff (#1991)');
+
+      await scanner.stop();
+    });
+
     test('caps backoff at maxBackoff', () async {
       var probeCalls = 0;
       final scanner = AdapterReconnectScanner(
@@ -72,6 +104,7 @@ void main() {
         connect: (_) async => false,
         onReconnect: () {},
         initialBackoff: _kInitial, // 10 ms
+        firstProbeDelay: _kInitial,
         maxBackoff: _kMax, // 80 ms
       );
       await scanner.start();
@@ -97,6 +130,7 @@ void main() {
         },
         onReconnect: () => reconnectCount++,
         initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
       );
       await scanner.start();
 
@@ -119,6 +153,7 @@ void main() {
         connect: (_) async => false,
         onReconnect: () {},
         initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
       );
       await scanner.start();
       expect(scanner.isScanning, isTrue);
@@ -148,6 +183,7 @@ void main() {
         },
         onReconnect: () => reconnectCount++,
         initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
       );
       await scanner.start();
 
@@ -172,6 +208,7 @@ void main() {
         connect: (_) async => true,
         onReconnect: () {},
         initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
       );
       await scanner.start();
 
@@ -204,6 +241,7 @@ void main() {
         connect: (_) async => false,
         onReconnect: () {},
         initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
       );
       await scanner.start();
       await scanner.start();


### PR DESCRIPTION
## Problem

"OBD2 connection lost — recording paused" appears very often, even for
transient BLE blips the adapter recovers from on its own.

## Analysis (web research + code)

A transport drop starts, in parallel:
- a **6 s silent-reconnect grace** (`silentReconnectWindow`, #1906) —
  reconnect within 6 s → no banner;
- the `AdapterReconnectScanner` — but its **first probe was scheduled a
  full `initialBackoff` (5 s) later**, then exponential backoff.

With a BLE scan + connect (~1–3 s) on top of the 5 s wait, the first
reconnect landed at ~6–8 s — just *past* the 6 s grace — so the banner
fired even though the adapter was reachable the whole time. Transient
ELM327/BLE drops recover fastest with an immediate retry; exponential
backoff is right for *sustained* outages, but the first attempt should
be near-immediate.

## Fix

`AdapterReconnectScanner` schedules the **first** probe after a short
`firstProbeDelay` (1 s — enough for the OS BLE stack to free the dead
GATT), then falls back to exponential backoff for retries. The first
reconnect now lands inside the 6 s grace window, so a transient drop
recovers silently; sustained outages still back off to the ceiling.

## Test

New test: with a 30 s `initialBackoff`, the first probe still fires at
the short `firstProbeDelay`. `flutter analyze`, `test/lint/`, the OBD2
suite (1020 tests), codegen-drift all pass.

> Note: real-world drop-rate verification still belongs on the #1925
> OBD2 debug log — this fixes a clear timing gap, not adapter hardware.

Closes #1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)
