### PR TITLE
feat(sharing): save exports to a local Downloads folder (#1993)

### DIFF
--- a/lib/core/sharing/local_file_saver.dart
+++ b/lib/core/sharing/local_file_saver.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Hook for the docs-directory lookup used by [LocalFileSaver]. Tests
+/// substitute a fake (a per-test temp folder) to avoid pulling in the
+/// `path_provider_platform_interface` dev-dep just to stub a single
+/// call — the established pattern matches `debugPrivacyTempDirectoryOverride`
+/// and `debugBackupTempDirectoryOverride` already used by the other
+/// export sites.
+typedef LocalFileSaverDocsProvider = Future<Directory> Function();
+
+/// Test-only override for the docs-directory lookup. When set,
+/// [LocalFileSaver] writes under this directory's `Downloads/` subfolder
+/// instead of the platform's real `getApplicationDocumentsDirectory()`.
+@visibleForTesting
+LocalFileSaverDocsProvider? debugLocalFileSaverDocsOverride;
+
+/// Saves an export to a fixed visible folder under the app's documents
+/// directory — `<docs>/Downloads/` — and returns the absolute path of
+/// the written file (#1993).
+///
+/// Used as an alternative to the OS share sheet by the various export
+/// flows: the user finds the file later via any file manager, without
+/// scrolling through share targets. The Downloads folder is created on
+/// demand and reused across calls; existing files with the same
+/// `fileName` are overwritten.
+class LocalFileSaver {
+  LocalFileSaver._();
+
+  /// Writes [bytes] to `<docs>/Downloads/<fileName>` and returns the
+  /// absolute path. Creates the Downloads folder on first save.
+  static Future<String> saveBytesToDownloads({
+    required Uint8List bytes,
+    required String fileName,
+  }) async {
+    final dir = await _downloadsDir();
+    final file = File('${dir.path}${Platform.pathSeparator}$fileName');
+    await file.writeAsBytes(bytes, flush: true);
+    return file.path;
+  }
+
+  /// Writes [text] (UTF-8) to `<docs>/Downloads/<fileName>` and returns
+  /// the absolute path. Convenience wrapper around [saveBytesToDownloads]
+  /// for the JSON / CSV / XML exports.
+  static Future<String> saveTextToDownloads({
+    required String text,
+    required String fileName,
+  }) async {
+    final dir = await _downloadsDir();
+    final file = File('${dir.path}${Platform.pathSeparator}$fileName');
+    await file.writeAsString(text, flush: true);
+    return file.path;
+  }
+
+  static Future<Directory> _downloadsDir() async {
+    final docsProvider =
+        debugLocalFileSaverDocsOverride ?? getApplicationDocumentsDirectory;
+    final docs = await docsProvider();
+    final dir = Directory(
+      '${docs.path}${Platform.pathSeparator}Downloads',
+    );
+    // `Directory.create(recursive: true)` is a no-op when the path
+    // already exists, so we skip the up-front existence probe — that
+    // avoids the avoid_slow_async_io lint and one syscall on every save.
+    await dir.create(recursive: true);
+    return dir;
+  }
+}

--- a/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../../../../core/constants/app_constants.dart';
+import '../../../../../core/sharing/local_file_saver.dart';
 import '../../../../ev/domain/entities/charging_log.dart';
 import '../../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../domain/entities/fill_up.dart';
@@ -40,18 +41,27 @@ DateTime Function()? debugBackupClockOverride;
 @visibleForTesting
 String? debugBackupAppVersionOverride;
 
-/// Result of a successful export — the bytes written and the absolute
-/// path on disk. Returned for instrumentation / tests; the production
-/// caller hands the path off to the share sheet via the supplied sink
-/// before this value is used.
+/// Result of a successful export — the bytes written, the absolute
+/// temp-file path used for the share sheet, and the on-device Downloads
+/// path the same payload was also written to (#1993). Returned for
+/// instrumentation / tests; the production caller hands [filePath] off
+/// to the share sheet via the supplied sink and surfaces [savedPath]
+/// in a confirmation snackbar so the user can find the file in any
+/// file manager.
 @immutable
 class FullBackupExportResult {
   final String filePath;
   final int byteSize;
 
+  /// Absolute path under `<docs>/Downloads/` where a second copy of the
+  /// zip was written. `null` only if the save-to-Downloads side step
+  /// failed; the temp-file + share-sheet path is unaffected.
+  final String? savedPath;
+
   const FullBackupExportResult({
     required this.filePath,
     required this.byteSize,
+    this.savedPath,
   });
 }
 
@@ -118,9 +128,25 @@ class FullBackupExporter {
     final sink = debugBackupShareSinkOverride ?? _defaultShareSink;
     await sink(params);
 
+    // #1993 — also drop the same zip into the app's Downloads folder
+    // so the user can find it via any file manager after the share
+    // sheet closes. The share-sheet hand-off above is the primary
+    // surface; this save step is best-effort — a failure here must not
+    // mask the successful share.
+    String? savedPath;
+    try {
+      savedPath = await LocalFileSaver.saveBytesToDownloads(
+        bytes: bytes,
+        fileName: fileName,
+      );
+    } on Object catch (e, st) {
+      debugPrint('FullBackupExporter: save-to-downloads failed: $e\n$st');
+    }
+
     return FullBackupExportResult(
       filePath: filePath,
       byteSize: bytes.length,
+      savedPath: savedPath,
     );
   }
 }

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -128,7 +128,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
 
       final exporter =
           ConsumptionScreen.debugExporterOverride ?? FullBackupExporter();
-      await exporter.export(
+      final result = await exporter.export(
         vehicles: vehicles,
         fillUps: fillUps,
         trips: trips,
@@ -136,10 +136,15 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
       );
 
       if (!mounted) return;
-      SnackBarHelper.showSuccess(
-        context,
-        l?.exportBackupReady ?? 'Backup ready — pick a destination',
-      );
+      // #1993 — when the exporter also wrote a copy to Downloads, surface
+      // the saved path so the user can find the file via any file manager
+      // after the share sheet closes. Falls back to the legacy "Backup
+      // ready" snackbar if the save-to-Downloads step bailed.
+      final savedPath = result.savedPath;
+      final message = (savedPath != null)
+          ? (l?.savedToFile(savedPath) ?? 'Saved to $savedPath')
+          : (l?.exportBackupReady ?? 'Backup ready — pick a destination');
+      SnackBarHelper.showSuccess(context, message);
     } catch (e, st) {
       debugPrint('ConsumptionScreen._runBackupExport failed: $e\n$st');
       if (!mounted) return;

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/providers/app_state_provider.dart';
-import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/sharing/local_file_saver.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/obd2/auto_record_trace_log.dart';
 import '../../data/obd2/obd2_breadcrumb_collector.dart';
@@ -13,6 +13,7 @@ import '../../data/obd2/obd2_debug_session_xml.dart';
 import '../../data/obd2/obd2_diagnostic_report.dart';
 import '../../providers/obd2_breadcrumb_provider.dart';
 import 'broken_map_widgets.dart';
+import 'obd2_breadcrumb_row.dart';
 
 /// Hook for the share-sheet handoff of the OBD2 diagnostic log
 /// (#1920). Production uses `SharePlus.instance.share`; tests
@@ -53,8 +54,14 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
   /// Format the process-wide OBD2 trace ring into a plain-text report
   /// and hand it to the OS share sheet (#1920). Best-effort — a share
   /// failure is logged and swallowed so the developer-only overlay
-  /// never crashes the recording screen.
-  Future<void> _shareDiagnosticLog() async {
+  /// never crashes the recording screen. Also drops a copy under
+  /// `<docs>/Downloads/` so the user can grab the file from any file
+  /// manager later (#1993); the saved path is reported through the
+  /// messenger snackbar when [messenger] is supplied.
+  Future<void> _shareDiagnosticLog(
+    ScaffoldMessengerState? messenger,
+    AppLocalizations? l10n,
+  ) async {
     final String report = formatObd2DiagnosticReport(
       AutoRecordTraceLog.snapshot(),
     );
@@ -67,6 +74,12 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     } catch (e, st) {
       debugPrint('Obd2BreadcrumbOverlay share diagnostic log failed: $e\n$st');
     }
+    await _alsoSaveToDownloads(
+      text: report,
+      fileName: 'tankstellen-obd2-diagnostic.txt',
+      messenger: messenger,
+      l10n: l10n,
+    );
   }
 
   /// Export the most recent OBD2 debug session as XML (#1925). Only
@@ -74,7 +87,10 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
   /// logging; otherwise the latest session is null and a short note is
   /// shared so the user understands why. Best-effort, like
   /// [_shareDiagnosticLog].
-  Future<void> _shareSessionXml() async {
+  Future<void> _shareSessionXml(
+    ScaffoldMessengerState? messenger,
+    AppLocalizations? l10n,
+  ) async {
     final Obd2DebugSession? session = Obd2DebugSessionRecorder.latestSession;
     final String payload = session == null
         ? '<!-- No OBD2 debug session recorded. Enable "OBD2 debug '
@@ -88,6 +104,38 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       await sink(params);
     } catch (e, st) {
       debugPrint('Obd2BreadcrumbOverlay share session XML failed: $e\n$st');
+    }
+    await _alsoSaveToDownloads(
+      text: payload,
+      fileName: 'tankstellen-obd2-session.xml',
+      messenger: messenger,
+      l10n: l10n,
+    );
+  }
+
+  /// Write [text] to `<docs>/Downloads/<fileName>` and, when a
+  /// [messenger] is available, surface the resulting path through a
+  /// snackbar (#1993). Best-effort — a write failure is logged but the
+  /// share-sheet hand-off above is already complete, so the user is not
+  /// stranded.
+  Future<void> _alsoSaveToDownloads({
+    required String text,
+    required String fileName,
+    required ScaffoldMessengerState? messenger,
+    required AppLocalizations? l10n,
+  }) async {
+    try {
+      final saved = await LocalFileSaver.saveTextToDownloads(
+        text: text,
+        fileName: fileName,
+      );
+      messenger?.showSnackBar(
+        SnackBar(
+          content: Text(l10n?.savedToFile(saved) ?? 'Saved to $saved'),
+        ),
+      );
+    } on Object catch (e, st) {
+      debugPrint('Obd2BreadcrumbOverlay save-to-downloads failed: $e\n$st');
     }
   }
 
@@ -182,7 +230,10 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
                       // process-wide, not tied to the fuel-rate
                       // breadcrumbs above.
                       IconButton(
-                        onPressed: () => _shareDiagnosticLog(),
+                        onPressed: () => _shareDiagnosticLog(
+                          ScaffoldMessenger.maybeOf(context),
+                          l10n,
+                        ),
                         icon: const Icon(Icons.share, size: 18),
                         color: Colors.white,
                         tooltip: l10n?.obd2DiagnosticShareLabel ??
@@ -198,7 +249,10 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
                       // session (init handshake, data gaps, reconnects)
                       // as XML when the user enabled debug logging.
                       IconButton(
-                        onPressed: () => _shareSessionXml(),
+                        onPressed: () => _shareSessionXml(
+                          ScaffoldMessenger.maybeOf(context),
+                          l10n,
+                        ),
                         icon: const Icon(Icons.bug_report, size: 18),
                         color: Colors.white,
                         tooltip: l10n?.obd2DebugSessionShareLabel ??
@@ -248,7 +302,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
                           // sample. `reverse: true` on the scroll view
                           // keeps the freshest row pinned at bottom.
                           for (final c in crumbs.reversed)
-                            _BreadcrumbRow(crumb: c),
+                            Obd2BreadcrumbRow(crumb: c),
                         ],
                       ),
                     ),
@@ -264,86 +318,3 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
   }
 }
 
-/// One row in the diagnostic overlay: timestamp + branch + L/h on
-/// line 1, AFR/density/displacement/VE on line 2 (smaller). Colour
-/// reflects the sanity flag: green = clean, amber = suspicious-low,
-/// red = 5E-vs-MAF divergent.
-class _BreadcrumbRow extends StatelessWidget {
-  const _BreadcrumbRow({required this.crumb});
-
-  final Obd2Breadcrumb crumb;
-
-  String get _timestamp {
-    final h = crumb.at.hour.toString().padLeft(2, '0');
-    final m = crumb.at.minute.toString().padLeft(2, '0');
-    final s = crumb.at.second.toString().padLeft(2, '0');
-    return '$h:$m:$s';
-  }
-
-  String get _branchTag {
-    switch (crumb.branch) {
-      case Obd2BranchTag.pid5E:
-        return '5E';
-      case Obd2BranchTag.maf:
-        return 'MAF';
-      case Obd2BranchTag.speedDensity:
-        return 'SD';
-      case Obd2BranchTag.none:
-        return '--';
-    }
-  }
-
-  Color _color(BuildContext context) {
-    switch (crumb.flag) {
-      case Obd2BreadcrumbCollector.flagSuspiciousLow:
-        return DarkModeColors.warning(context);
-      case Obd2BreadcrumbCollector.flag5eVsMafDivergent:
-        return DarkModeColors.error(context);
-      default:
-        return DarkModeColors.success(context);
-    }
-  }
-
-  String _formatRate(double? r) =>
-      r == null ? '--' : r.toStringAsFixed(2);
-
-  String _formatNum(double? v, {int decimals = 1}) =>
-      v == null ? '--' : v.toStringAsFixed(decimals);
-
-  @override
-  Widget build(BuildContext context) {
-    final color = _color(context);
-    final secondLine = StringBuffer()
-      ..write('AFR=${_formatNum(crumb.afr, decimals: 1)} ')
-      ..write('ρ=${_formatNum(crumb.fuelDensityGPerL, decimals: 0)} ')
-      ..write('cc=${_formatNum(crumb.engineDisplacementCc, decimals: 0)} ')
-      ..write('η=${_formatNum(crumb.volumetricEfficiency, decimals: 2)}');
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 1),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            '$_timestamp [$_branchTag] ${_formatRate(crumb.fuelRateLPerHour)} L/h',
-            style: TextStyle(
-              color: color,
-              fontSize: 10,
-              fontFamily: 'monospace',
-              height: 1.2,
-            ),
-          ),
-          Text(
-            secondLine.toString(),
-            style: TextStyle(
-              color: color.withValues(alpha: 0.7),
-              fontSize: 9,
-              fontFamily: 'monospace',
-              height: 1.2,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_row.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_row.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/dark_mode_colors.dart';
+import '../../data/obd2/obd2_breadcrumb_collector.dart';
+
+/// One row in the diagnostic overlay: timestamp + branch + L/h on
+/// line 1, AFR/density/displacement/VE on line 2 (smaller). Colour
+/// reflects the sanity flag: green = clean, amber = suspicious-low,
+/// red = 5E-vs-MAF divergent.
+///
+/// Extracted from `obd2_breadcrumb_overlay.dart` (#1993) to keep the
+/// host overlay file under the 400-line guard — the row widget is a
+/// self-contained presentation piece with no dependencies on the
+/// overlay's diagnostic-share / scaffolding helpers.
+class Obd2BreadcrumbRow extends StatelessWidget {
+  const Obd2BreadcrumbRow({super.key, required this.crumb});
+
+  final Obd2Breadcrumb crumb;
+
+  String get _timestamp {
+    final h = crumb.at.hour.toString().padLeft(2, '0');
+    final m = crumb.at.minute.toString().padLeft(2, '0');
+    final s = crumb.at.second.toString().padLeft(2, '0');
+    return '$h:$m:$s';
+  }
+
+  String get _branchTag {
+    switch (crumb.branch) {
+      case Obd2BranchTag.pid5E:
+        return '5E';
+      case Obd2BranchTag.maf:
+        return 'MAF';
+      case Obd2BranchTag.speedDensity:
+        return 'SD';
+      case Obd2BranchTag.none:
+        return '--';
+    }
+  }
+
+  Color _color(BuildContext context) {
+    switch (crumb.flag) {
+      case Obd2BreadcrumbCollector.flagSuspiciousLow:
+        return DarkModeColors.warning(context);
+      case Obd2BreadcrumbCollector.flag5eVsMafDivergent:
+        return DarkModeColors.error(context);
+      default:
+        return DarkModeColors.success(context);
+    }
+  }
+
+  String _formatRate(double? r) =>
+      r == null ? '--' : r.toStringAsFixed(2);
+
+  String _formatNum(double? v, {int decimals = 1}) =>
+      v == null ? '--' : v.toStringAsFixed(decimals);
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _color(context);
+    final secondLine = StringBuffer()
+      ..write('AFR=${_formatNum(crumb.afr, decimals: 1)} ')
+      ..write('ρ=${_formatNum(crumb.fuelDensityGPerL, decimals: 0)} ')
+      ..write('cc=${_formatNum(crumb.engineDisplacementCc, decimals: 0)} ')
+      ..write('η=${_formatNum(crumb.volumetricEfficiency, decimals: 2)}');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$_timestamp [$_branchTag] ${_formatRate(crumb.fuelRateLPerHour)} L/h',
+            style: TextStyle(
+              color: color,
+              fontSize: 10,
+              fontFamily: 'monospace',
+              height: 1.2,
+            ),
+          ),
+          Text(
+            secondLine.toString(),
+            style: TextStyle(
+              color: color.withValues(alpha: 0.7),
+              fontSize: 9,
+              fontFamily: 'monospace',
+              height: 1.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -9,6 +9,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../../../core/sharing/local_file_saver.dart';
 import '../../../../core/telemetry/storage/trace_storage.dart';
 import '../../../../core/export/data_exporter.dart';
 import '../../../../core/storage/storage_providers.dart';
@@ -129,13 +130,18 @@ class _PrivacyDashboardScreenState
   }
 
   Future<void> _exportData() async {
+    // Grab the localizations BEFORE any async gap so the analyzer is
+    // satisfied that we never reach across one to look up `context`.
+    final l = AppLocalizations.of(context);
     final json = ref.read(exportPrivacyDataProvider);
     await Clipboard.setData(ClipboardData(text: json));
-    if (!mounted) return;
-    final l = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l?.privacyExportSuccess ?? 'Data exported to clipboard',
+    // #1993 — also save a copy to the on-device Downloads folder so the
+    // user can find the file later via any file manager. The clipboard
+    // path stays so existing copy-paste workflows are unchanged.
+    await _saveExportToDownloads(
+      text: json,
+      fileName: 'tankstellen-data.json',
+      copySnackbar: l?.privacyExportSuccess ?? 'Data exported to clipboard',
     );
   }
 
@@ -172,18 +178,23 @@ class _PrivacyDashboardScreenState
         return;
       }
       if (!mounted) return;
-      SnackBarHelper.showSuccess(
-        context,
-        'Error log shared ($kb KB, $totalEntries entries)',
+      // #1993 — also drop a copy into Downloads so the user can grab the
+      // file from the file manager without re-running the share flow.
+      await _saveExportToDownloads(
+        text: json,
+        fileName: 'tankstellen-error-log.json',
+        copySnackbar: 'Error log shared ($kb KB, $totalEntries entries)',
       );
       return;
     }
 
     await Clipboard.setData(ClipboardData(text: json));
-    if (!mounted) return;
-    SnackBarHelper.showSuccess(
-      context,
-      _formatCopySnackbar(
+    // #1993 — also persist to Downloads (small-path); snackbar now reports
+    // the saved path. Falls back to the legacy copy snackbar on save failure.
+    await _saveExportToDownloads(
+      text: json,
+      fileName: 'tankstellen-error-log.json',
+      copySnackbar: _formatCopySnackbar(
         parsed: parsed,
         unparsed: unparsed,
         kb: kb,
@@ -238,6 +249,9 @@ class _PrivacyDashboardScreenState
       SharePlus.instance.share(params);
 
   Future<void> _exportDataCsv() async {
+    // Grab localizations pre-await — see `_exportData` for the same
+    // analyser-friendly pattern.
+    final l = AppLocalizations.of(context);
     final storage = ref.read(storageRepositoryProvider);
     final exporter = DataExporter(storage);
     final parts = exporter.exportAllAsCsv();
@@ -247,13 +261,44 @@ class _PrivacyDashboardScreenState
         ..writeln('# $name')
         ..writeln(csv);
     });
-    await Clipboard.setData(ClipboardData(text: buf.toString()));
+    final csvText = buf.toString();
+    await Clipboard.setData(ClipboardData(text: csvText));
+    // #1993 — also save a copy to the Downloads folder for offline retrieval.
+    await _saveExportToDownloads(
+      text: csvText,
+      fileName: 'tankstellen-data.csv',
+      copySnackbar:
+          l?.privacyExportCsvSuccess ?? 'CSV data exported to clipboard',
+    );
+  }
+
+  /// Writes [text] to `<docs>/Downloads/<fileName>` and announces the
+  /// outcome to the user (#1993). When the save succeeds, the snackbar
+  /// shows `savedToFile(path)`; when it fails (no permission, no space),
+  /// it falls back to [copySnackbar] so the user still gets the original
+  /// clipboard/share confirmation.
+  Future<void> _saveExportToDownloads({
+    required String text,
+    required String fileName,
+    required String copySnackbar,
+  }) async {
     if (!mounted) return;
     final l = AppLocalizations.of(context);
-    SnackBarHelper.showSuccess(
-      context,
-      l?.privacyExportCsvSuccess ?? 'CSV data exported to clipboard',
-    );
+    try {
+      final savedPath = await LocalFileSaver.saveTextToDownloads(
+        text: text,
+        fileName: fileName,
+      );
+      if (!mounted) return;
+      SnackBarHelper.showSuccess(
+        context,
+        l?.savedToFile(savedPath) ?? 'Saved to $savedPath',
+      );
+    } on Object catch (e, st) {
+      debugPrint('privacy: save-to-downloads fallback: $e\n$st');
+      if (!mounted) return;
+      SnackBarHelper.showSuccess(context, copySnackbar);
+    }
   }
 
   Future<void> _deleteAllData() async {

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -689,6 +689,7 @@
   "privacyExportSuccess": "Daten in die Zwischenablage exportiert",
   "privacyExportCsvButton": "Alle Daten als CSV exportieren",
   "privacyExportCsvSuccess": "CSV-Daten in die Zwischenablage exportiert",
+  "savedToFile": "Gespeichert unter {path}",
   "privacyDeleteButton": "Alle Daten löschen",
   "privacyCopyErrorLog": "Fehlerprotokoll in Zwischenablage kopieren ({count})",
   "@privacyCopyErrorLog": {

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -708,6 +708,13 @@
   "privacyExportSuccess": "Data exported to clipboard",
   "privacyExportCsvButton": "Export all data as CSV",
   "privacyExportCsvSuccess": "CSV data exported to clipboard",
+  "savedToFile": "Saved to {path}",
+  "@savedToFile": {
+    "description": "Snackbar confirming an export was written to the on-device Downloads folder (#1993). The {path} placeholder is the absolute filesystem path of the saved file.",
+    "placeholders": {
+      "path": { "type": "String" }
+    }
+  },
   "privacyDeleteButton": "Delete all data",
   "privacyCopyErrorLog": "Copy error log to clipboard ({count})",
   "@privacyCopyErrorLog": {

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Данните са експортирани в клипборда",
   "privacyExportCsvButton": "Експортирай всички данни като CSV",
   "privacyExportCsvSuccess": "CSV данните са експортирани в клипборда",
+  "savedToFile": "Запазено в {path}",
   "privacyClearErrorLog": "Изчистване на дневника с грешки",
   "privacyErrorLogCleared": "Дневникът с грешки е изчистен",
   "privacyDeleteButton": "Изтрий всички данни",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Data exportována do schránky",
   "privacyExportCsvButton": "Exportovat všechna data jako CSV",
   "privacyExportCsvSuccess": "Data CSV exportována do schránky",
+  "savedToFile": "Uloženo do {path}",
   "privacyClearErrorLog": "Vymazat protokol chyb",
   "privacyErrorLogCleared": "Protokol chyb byl vymazán",
   "privacyDeleteButton": "Smazat všechna data",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Data eksporteret til udklipsholder",
   "privacyExportCsvButton": "Eksporter alle data som CSV",
   "privacyExportCsvSuccess": "CSV-data eksporteret til udklipsholder",
+  "savedToFile": "Gemt i {path}",
   "privacyClearErrorLog": "Ryd fejllog",
   "privacyErrorLogCleared": "Fejllog ryddet",
   "privacyDeleteButton": "Slet alle data",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -689,6 +689,7 @@
   "privacyExportSuccess": "Daten in die Zwischenablage exportiert",
   "privacyExportCsvButton": "Alle Daten als CSV exportieren",
   "privacyExportCsvSuccess": "CSV-Daten in die Zwischenablage exportiert",
+  "savedToFile": "Gespeichert unter {path}",
   "privacyDeleteButton": "Alle Daten löschen",
   "privacyCopyErrorLog": "Fehlerprotokoll in Zwischenablage kopieren ({count})",
   "@privacyCopyErrorLog": {

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Τα δεδομένα εξήχθησαν στο πρόχειρο",
   "privacyExportCsvButton": "Εξαγωγή όλων των δεδομένων ως CSV",
   "privacyExportCsvSuccess": "Τα δεδομένα CSV εξήχθησαν στο πρόχειρο",
+  "savedToFile": "Αποθηκεύτηκε στο {path}",
   "privacyClearErrorLog": "Εκκαθάριση αρχείου σφαλμάτων",
   "privacyErrorLogCleared": "Το αρχείο σφαλμάτων εκκαθαρίστηκε",
   "privacyDeleteButton": "Διαγραφή όλων των δεδομένων",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -708,6 +708,15 @@
   "privacyExportSuccess": "Data exported to clipboard",
   "privacyExportCsvButton": "Export all data as CSV",
   "privacyExportCsvSuccess": "CSV data exported to clipboard",
+  "savedToFile": "Saved to {path}",
+  "@savedToFile": {
+    "description": "Snackbar confirming an export was written to the on-device Downloads folder (#1993). The {path} placeholder is the absolute filesystem path of the saved file.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
   "privacyDeleteButton": "Delete all data",
   "privacyCopyErrorLog": "Copy error log to clipboard ({count})",
   "@privacyCopyErrorLog": {

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -460,6 +460,7 @@
   "privacyExportSuccess": "⟦Đáŧá éẋƥóřŧéđ ŧó çłîƥƀóářđ ··········⟧",
   "privacyExportCsvButton": "⟦Éẋƥóřŧ áłł đáŧá áš ÇŠṼ ········⟧",
   "privacyExportCsvSuccess": "⟦ÇŠṼ đáŧá éẋƥóřŧéđ ŧó çłîƥƀóářđ ············⟧",
+  "savedToFile": "⟦Šáṽéđ ŧó {path} ···⟧",
   "privacyDeleteButton": "⟦Đéłéŧé áłł đáŧá ······⟧",
   "privacyCopyErrorLog": "⟦Çóƥý éřřóř łóǧ ŧó çłîƥƀóářđ ({count}) ··········⟧",
   "privacyClearErrorLog": "⟦Çłéář éřřóř łóǧ ······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Datos exportados al portapapeles",
   "privacyExportCsvButton": "Exportar todos los datos como CSV",
   "privacyExportCsvSuccess": "Datos CSV exportados al portapapeles",
+  "savedToFile": "Guardado en {path}",
   "privacyClearErrorLog": "Borrar registro de errores",
   "privacyErrorLogCleared": "Registro de errores borrado",
   "privacyDeleteButton": "Eliminar todos los datos",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Andmed eksporditi lõikelauale",
   "privacyExportCsvButton": "Ekspordi kõik andmed CSV-na",
   "privacyExportCsvSuccess": "CSV-andmed eksporditi lõikelauale",
+  "savedToFile": "Salvestatud asukohta {path}",
   "privacyClearErrorLog": "Tühjenda vealogi",
   "privacyErrorLogCleared": "Vealogi tühjendatud",
   "privacyDeleteButton": "Kustuta kõik andmed",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Tiedot viety leikepöydälle",
   "privacyExportCsvButton": "Vie kaikki tiedot CSV-muodossa",
   "privacyExportCsvSuccess": "CSV-tiedot viety leikepöydälle",
+  "savedToFile": "Tallennettu polkuun {path}",
   "privacyClearErrorLog": "Tyhjennä virheloki",
   "privacyErrorLogCleared": "Virheloki tyhjennetty",
   "privacyDeleteButton": "Poista kaikki tiedot",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1536,6 +1536,7 @@
   "privacyViewServerData": "Voir les données du serveur",
   "privacyExportSuccess": "Données exportées dans le presse-papiers",
   "privacyExportCsvSuccess": "Données CSV exportées dans le presse-papiers",
+  "savedToFile": "Enregistré dans {path}",
   "privacyDeleteTitle": "Supprimer toutes les données ?",
   "privacyDeleteBody": "Cela supprimera définitivement :\n\n- Tous les favoris et données de stations\n- Tous les profils de recherche\n- Toutes les alertes de prix\n- Tout l'historique des prix\n- Toutes les données en cache\n- Votre clé API\n- Tous les paramètres de l'application\n\nL'application sera réinitialisée à son état initial. Cette action est irréversible.",
   "privacyDeleteConfirm": "Tout supprimer",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Podaci izvezeni u međuspremnik",
   "privacyExportCsvButton": "Izvezi sve podatke kao CSV",
   "privacyExportCsvSuccess": "CSV podaci izvezeni u međuspremnik",
+  "savedToFile": "Spremljeno u {path}",
   "privacyClearErrorLog": "Očisti zapisnik pogrešaka",
   "privacyErrorLogCleared": "Zapisnik pogrešaka očišćen",
   "privacyDeleteButton": "Obriši sve podatke",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Adatok exportálva a vágólapra",
   "privacyExportCsvButton": "Összes adat exportálása CSV-ként",
   "privacyExportCsvSuccess": "CSV-adatok exportálva a vágólapra",
+  "savedToFile": "Mentve ide: {path}",
   "privacyClearErrorLog": "Hibanapló törlése",
   "privacyErrorLogCleared": "Hibanapló törölve",
   "privacyDeleteButton": "Összes adat törlése",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Dati esportati negli appunti",
   "privacyExportCsvButton": "Esporta tutti i dati come CSV",
   "privacyExportCsvSuccess": "Dati CSV esportati negli appunti",
+  "savedToFile": "Salvato in {path}",
   "privacyClearErrorLog": "Cancella registro errori",
   "privacyErrorLogCleared": "Registro errori cancellato",
   "privacyDeleteButton": "Elimina tutti i dati",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2901,6 +2901,12 @@ abstract class AppLocalizations {
   /// **'CSV data exported to clipboard'**
   String get privacyExportCsvSuccess;
 
+  /// Snackbar confirming an export was written to the on-device Downloads folder (#1993). The {path} placeholder is the absolute filesystem path of the saved file.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to {path}'**
+  String savedToFile(String path);
+
   /// No description provided for @privacyDeleteButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1531,6 +1531,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'CSV данните са експортирани в клипборда';
 
   @override
+  String savedToFile(String path) {
+    return 'Запазено в $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Изтрий всички данни';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1525,6 +1525,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Data CSV exportována do schránky';
 
   @override
+  String savedToFile(String path) {
+    return 'Uloženo do $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Smazat všechna data';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1521,6 +1521,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'CSV-data eksporteret til udklipsholder';
 
   @override
+  String savedToFile(String path) {
+    return 'Gemt i $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Slet alle data';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1532,6 +1532,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'CSV-Daten in die Zwischenablage exportiert';
 
   @override
+  String savedToFile(String path) {
+    return 'Gespeichert unter $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Alle Daten löschen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1533,6 +1533,11 @@ class AppLocalizationsEl extends AppLocalizations {
       'Τα δεδομένα CSV εξήχθησαν στο πρόχειρο';
 
   @override
+  String savedToFile(String path) {
+    return 'Αποθηκεύτηκε στο $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Διαγραφή όλων των δεδομένων';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1511,6 +1511,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV data exported to clipboard';
 
   @override
+  String savedToFile(String path) {
+    return 'Saved to $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Delete all data';
 
   @override
@@ -6816,6 +6821,11 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get privacyExportCsvSuccess =>
       '⟦ÇŠṼ đáŧá éẋƥóřŧéđ ŧó çłîƥƀóářđ ············⟧';
+
+  @override
+  String savedToFile(String path) {
+    return '⟦Šáṽéđ ŧó $path ···⟧';
+  }
 
   @override
   String get privacyDeleteButton => '⟦Đéłéŧé áłł đáŧá ······⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1528,6 +1528,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Datos CSV exportados al portapapeles';
 
   @override
+  String savedToFile(String path) {
+    return 'Guardado en $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Eliminar todos los datos';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1517,6 +1517,11 @@ class AppLocalizationsEt extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV-andmed eksporditi lõikelauale';
 
   @override
+  String savedToFile(String path) {
+    return 'Salvestatud asukohta $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Kustuta kõik andmed';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1521,6 +1521,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV-tiedot viety leikepöydälle';
 
   @override
+  String savedToFile(String path) {
+    return 'Tallennettu polkuun $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Poista kaikki tiedot';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1533,6 +1533,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Données CSV exportées dans le presse-papiers';
 
   @override
+  String savedToFile(String path) {
+    return 'Enregistré dans $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Tout supprimer';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1522,6 +1522,11 @@ class AppLocalizationsHr extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV podaci izvezeni u međuspremnik';
 
   @override
+  String savedToFile(String path) {
+    return 'Spremljeno u $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Obriši sve podatke';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1528,6 +1528,11 @@ class AppLocalizationsHu extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV-adatok exportálva a vágólapra';
 
   @override
+  String savedToFile(String path) {
+    return 'Mentve ide: $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Összes adat törlése';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1527,6 +1527,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Dati CSV esportati negli appunti';
 
   @override
+  String savedToFile(String path) {
+    return 'Salvato in $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Elimina tutti i dati';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1525,6 +1525,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV duomenys eksportuoti į iškarpinę';
 
   @override
+  String savedToFile(String path) {
+    return 'Išsaugota: $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Ištrinti visus duomenis';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1527,6 +1527,11 @@ class AppLocalizationsLv extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV dati eksportēti starpliktuvē';
 
   @override
+  String savedToFile(String path) {
+    return 'Saglabāts mapē $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Dzēst visus datus';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1519,6 +1519,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV-data eksportert til utklippstavle';
 
   @override
+  String savedToFile(String path) {
+    return 'Lagret i $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Slett alle data';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1528,6 +1528,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'CSV-gegevens geëxporteerd naar klembord';
 
   @override
+  String savedToFile(String path) {
+    return 'Opgeslagen in $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Alle gegevens verwijderen';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1527,6 +1527,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Dane CSV wyeksportowane do schowka';
 
   @override
+  String savedToFile(String path) {
+    return 'Zapisano w $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Usuń wszystkie dane';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1530,6 +1530,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Dados CSV exportados para a área de transferência';
 
   @override
+  String savedToFile(String path) {
+    return 'Guardado em $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Eliminar todos os dados';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1528,6 +1528,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Date CSV exportate în clipboard';
 
   @override
+  String savedToFile(String path) {
+    return 'Salvat în $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Ștergeți toate datele';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1529,6 +1529,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Údaje CSV exportované do schránky';
 
   @override
+  String savedToFile(String path) {
+    return 'Uložené do $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Odstrániť všetky údaje';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1521,6 +1521,11 @@ class AppLocalizationsSl extends AppLocalizations {
   String get privacyExportCsvSuccess => 'Podatki CSV izvoženi v odložišče';
 
   @override
+  String savedToFile(String path) {
+    return 'Shranjeno v $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Izbriši vse podatke';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1521,6 +1521,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get privacyExportCsvSuccess => 'CSV-data exporterad till urklipp';
 
   @override
+  String savedToFile(String path) {
+    return 'Sparat i $path';
+  }
+
+  @override
   String get privacyDeleteButton => 'Radera all data';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Duomenys eksportuoti į iškarpinę",
   "privacyExportCsvButton": "Eksportuoti visus duomenis kaip CSV",
   "privacyExportCsvSuccess": "CSV duomenys eksportuoti į iškarpinę",
+  "savedToFile": "Išsaugota: {path}",
   "privacyClearErrorLog": "Išvalyti klaidų žurnalą",
   "privacyErrorLogCleared": "Klaidų žurnalas išvalytas",
   "privacyDeleteButton": "Ištrinti visus duomenis",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Dati eksportēti starpliktuvē",
   "privacyExportCsvButton": "Eksportēt visus datus kā CSV",
   "privacyExportCsvSuccess": "CSV dati eksportēti starpliktuvē",
+  "savedToFile": "Saglabāts mapē {path}",
   "privacyClearErrorLog": "Notīrīt kļūdu žurnālu",
   "privacyErrorLogCleared": "Kļūdu žurnāls notīrīts",
   "privacyDeleteButton": "Dzēst visus datus",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Data eksportert til utklippstavle",
   "privacyExportCsvButton": "Eksporter alle data som CSV",
   "privacyExportCsvSuccess": "CSV-data eksportert til utklippstavle",
+  "savedToFile": "Lagret i {path}",
   "privacyClearErrorLog": "Tøm feilloggen",
   "privacyErrorLogCleared": "Feilloggen tømt",
   "privacyDeleteButton": "Slett alle data",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Gegevens geëxporteerd naar klembord",
   "privacyExportCsvButton": "Alle gegevens exporteren als CSV",
   "privacyExportCsvSuccess": "CSV-gegevens geëxporteerd naar klembord",
+  "savedToFile": "Opgeslagen in {path}",
   "privacyClearErrorLog": "Foutenlogboek wissen",
   "privacyErrorLogCleared": "Foutenlogboek gewist",
   "privacyDeleteButton": "Alle gegevens verwijderen",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Dane wyeksportowane do schowka",
   "privacyExportCsvButton": "Eksportuj wszystkie dane jako CSV",
   "privacyExportCsvSuccess": "Dane CSV wyeksportowane do schowka",
+  "savedToFile": "Zapisano w {path}",
   "privacyClearErrorLog": "Wyczyść dziennik błędów",
   "privacyErrorLogCleared": "Dziennik błędów wyczyszczony",
   "privacyDeleteButton": "Usuń wszystkie dane",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Dados exportados para a área de transferência",
   "privacyExportCsvButton": "Exportar todos os dados como CSV",
   "privacyExportCsvSuccess": "Dados CSV exportados para a área de transferência",
+  "savedToFile": "Guardado em {path}",
   "privacyClearErrorLog": "Limpar registo de erros",
   "privacyErrorLogCleared": "Registo de erros limpo",
   "privacyDeleteButton": "Eliminar todos os dados",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Date exportate în clipboard",
   "privacyExportCsvButton": "Exportați toate datele ca CSV",
   "privacyExportCsvSuccess": "Date CSV exportate în clipboard",
+  "savedToFile": "Salvat în {path}",
   "privacyClearErrorLog": "Șterge jurnalul de erori",
   "privacyErrorLogCleared": "Jurnalul de erori a fost șters",
   "privacyDeleteButton": "Ștergeți toate datele",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Údaje exportované do schránky",
   "privacyExportCsvButton": "Exportovať všetky údaje ako CSV",
   "privacyExportCsvSuccess": "Údaje CSV exportované do schránky",
+  "savedToFile": "Uložené do {path}",
   "privacyClearErrorLog": "Vymazať protokol chýb",
   "privacyErrorLogCleared": "Protokol chýb vymazaný",
   "privacyDeleteButton": "Odstrániť všetky údaje",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Podatki izvoženi v odložišče",
   "privacyExportCsvButton": "Izvozi vse podatke kot CSV",
   "privacyExportCsvSuccess": "Podatki CSV izvoženi v odložišče",
+  "savedToFile": "Shranjeno v {path}",
   "privacyClearErrorLog": "Počisti dnevnik napak",
   "privacyErrorLogCleared": "Dnevnik napak počiščen",
   "privacyDeleteButton": "Izbriši vse podatke",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -474,6 +474,7 @@
   "privacyExportSuccess": "Data exporterad till urklipp",
   "privacyExportCsvButton": "Exportera all data som CSV",
   "privacyExportCsvSuccess": "CSV-data exporterad till urklipp",
+  "savedToFile": "Sparat i {path}",
   "privacyClearErrorLog": "Rensa felloggen",
   "privacyErrorLogCleared": "Felloggen rensad",
   "privacyDeleteButton": "Radera all data",

--- a/test/core/sharing/local_file_saver_test.dart
+++ b/test/core/sharing/local_file_saver_test.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sharing/local_file_saver.dart';
+
+void main() {
+  late Directory tempRoot;
+  late Directory docs;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('local_file_saver_test_');
+    docs = await Directory('${tempRoot.path}/docs').create(recursive: true);
+    debugLocalFileSaverDocsOverride = () async => docs;
+  });
+
+  tearDown(() async {
+    debugLocalFileSaverDocsOverride = null;
+    if (tempRoot.existsSync()) {
+      tempRoot.deleteSync(recursive: true);
+    }
+  });
+
+  group('LocalFileSaver (#1993)', () {
+    test('saveBytesToDownloads writes to <docs>/Downloads/<fileName> '
+        'and returns the absolute path', () async {
+      final bytes = Uint8List.fromList(utf8.encode('hello, world'));
+      final savedPath = await LocalFileSaver.saveBytesToDownloads(
+        bytes: bytes,
+        fileName: 'hello.txt',
+      );
+
+      // Path lands under the Downloads subfolder of the docs dir.
+      expect(savedPath, contains('Downloads'));
+      expect(savedPath, endsWith('hello.txt'));
+      expect(savedPath.startsWith(docs.path), isTrue,
+          reason: 'saved file must live under the docs directory');
+
+      final file = File(savedPath);
+      expect(file.existsSync(), isTrue);
+      expect(await file.readAsBytes(), bytes);
+    });
+
+    test('saveTextToDownloads writes the UTF-8 string', () async {
+      final savedPath = await LocalFileSaver.saveTextToDownloads(
+        text: 'café — données',
+        fileName: 'note.txt',
+      );
+
+      expect(savedPath, endsWith('note.txt'));
+      final file = File(savedPath);
+      expect(await file.readAsString(), 'café — données');
+    });
+
+    test('creates the Downloads folder on first save', () async {
+      final downloads = Directory('${docs.path}/Downloads');
+      expect(downloads.existsSync(), isFalse);
+
+      await LocalFileSaver.saveTextToDownloads(
+        text: 'x',
+        fileName: 'first.txt',
+      );
+
+      expect(downloads.existsSync(), isTrue,
+          reason: 'Downloads folder must be created on demand');
+    });
+
+    test('overwrites an existing file with the same name', () async {
+      await LocalFileSaver.saveTextToDownloads(
+        text: 'v1',
+        fileName: 'pinned.txt',
+      );
+      final secondPath = await LocalFileSaver.saveTextToDownloads(
+        text: 'v2',
+        fileName: 'pinned.txt',
+      );
+
+      expect(await File(secondPath).readAsString(), 'v2',
+          reason: 'a second save with the same filename must overwrite');
+    });
+
+    test('returns a clean absolute path (no double-separators)',
+        () async {
+      // Light sanity check that nothing in the helper accidentally
+      // double-joins the separator or leaves a trailing slash.
+      final saved = await LocalFileSaver.saveTextToDownloads(
+        text: 'ping',
+        fileName: 'integrity.txt',
+      );
+      expect(saved.contains('//'), isFalse);
+      expect(saved.endsWith('/'), isFalse);
+      expect(saved.startsWith(docs.path), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #1993.

Every export now writes a copy to `<docs>/Downloads/<file>` in addition
to the existing share-sheet / clipboard surface, and the snackbar
reports the saved path so the user can find the file via any file
manager — no extra share-sheet hop, no extra dependency.

## Sites wired

- **Privacy dashboard** — error-log export (both the small-clipboard
  path and the large-share path), JSON export, CSV export.
- **Full backup exporter** — the zip; `FullBackupExportResult.savedPath`
  flows to the consumption-screen snackbar.
- **OBD2 breadcrumb overlay** — the plain-text diagnostic log and the
  debug-session XML; the breadcrumb row was extracted to its own file
  so the host overlay stays under the 400-line guard.

## Helper

`lib/core/sharing/local_file_saver.dart` — `saveBytesToDownloads` /
`saveTextToDownloads`. Built on `path_provider`; no new package. Uses a
`debugLocalFileSaverDocsOverride` seam mirroring the existing
`debugBackupTempDirectoryOverride` / `debugPrivacyTempDirectoryOverride`
pattern so tests don't need to stub `PathProviderPlatform`.

## ARB

One new key `savedToFile` ("Saved to {path}") with a `{path}`
placeholder, filled across all 24 locales.

## Verification

- `flutter analyze` — clean.
- `flutter test test/core/sharing/ test/lint/ test/l10n/` — green
  (including the 400-line file guard and the 24-locale completeness
  test).
- `flutter test test/features/profile/ test/features/consumption/data/exporters/backup/ test/features/consumption/presentation/widgets/obd2_breadcrumb_overlay_test.dart test/features/consumption/presentation/screens/consumption_screen_export_test.dart`
  — green. The expected `debugPrint` traces from the save fallback in
  unstubbed test environments are noise — they exercise the `catch`
  branch and the legacy snackbar is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
