### PR TITLE
fix(services): retry transient errors once before falling through (#1954, #1955)

### DIFF
--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -118,9 +118,16 @@ class StationServiceChain implements StationService {
       }
     }
 
-    // Step 2: API call
+    // Step 2: API call. Wrapped with one transient-error retry so a
+    // single 5xx burst or connect-timeout doesn't immediately fall
+    // through to stale cache (or, when there is no stale cache, throw
+    // `ServiceChainExhaustedException` straight to the user). The
+    // affected sources right now are the MITECO endpoint (#1954 — 503s
+    // under load) and the Argentina CKAN bulk-download (#1955 — slow
+    // first-byte triggering Dio's connect timeout). Both recover on a
+    // second attempt within a second.
     try {
-      final result = await apiCall();
+      final result = await _callWithTransientRetry(apiCall);
       await _cache.put(
         cacheKey,
         serialize(result.data),
@@ -153,6 +160,59 @@ class StationServiceChain implements StationService {
 
     // Step 4: Nothing worked
     throw ServiceChainExhaustedException(errors: errors);
+  }
+
+  /// Delay between the first and second attempt of [_callWithTransientRetry].
+  /// 500 ms keeps the user-visible latency tight (most browsers stall ≥1 s
+  /// before a user even notices), and is long enough for an overloaded
+  /// upstream to clear a 503 burst. Exposed as `@visibleForTesting` so the
+  /// retry test can run without sleeping a real half-second.
+  @visibleForTesting
+  static Duration transientRetryDelay = const Duration(milliseconds: 500);
+
+  /// Wraps a single [apiCall] with one retry on transient remote errors —
+  /// 5xx responses (`ApiException.statusCode in 500..599`) and Dio
+  /// connect/receive/send timeouts (the `ApiException.message` is stamped
+  /// `${e.type.name}:` by [StationServiceHelpers.throwApiException], so we
+  /// match on that prefix). One retry only — the goal is to absorb a
+  /// transient blip, not to mask sustained outages from the chain's
+  /// fall-through to stale cache or to the user-visible error dialog.
+  ///
+  /// Returns the second attempt's result on success; rethrows the second
+  /// attempt's exception on failure so the caller observes the same
+  /// `on Exception` semantics as a plain `await apiCall()`. Non-transient
+  /// errors (4xx, parse failures, anything else) skip the retry — those
+  /// are not going to fix themselves in 500 ms.
+  Future<ServiceResult<T>> _callWithTransientRetry<T>(
+    Future<ServiceResult<T>> Function() apiCall,
+  ) async {
+    try {
+      return await apiCall();
+    } on ApiException catch (e) {
+      if (!_isTransient(e)) rethrow;
+      // Single retry — log to the dev console so debug builds surface the
+      // recovered call (production has no listener attached).
+      debugPrint(
+        'StationServiceChain: retrying after transient error '
+        '(status=${e.statusCode}, message=${e.message})',
+      );
+      await Future<void>.delayed(transientRetryDelay);
+      return apiCall();
+    }
+  }
+
+  /// `true` when [e] is the kind of error a 500 ms retry could plausibly
+  /// recover from — a server-side 5xx burst or a Dio-layer connect /
+  /// receive / send timeout. 4xx ("bad request", "not found") and parse
+  /// errors are not transient.
+  static bool _isTransient(ApiException e) {
+    final code = e.statusCode;
+    if (code != null && code >= 500 && code < 600) return true;
+    final msg = e.message;
+    return msg.startsWith('connectionTimeout') ||
+        msg.startsWith('receiveTimeout') ||
+        msg.startsWith('sendTimeout') ||
+        msg.startsWith('connectionError');
   }
 
   @override

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -188,13 +188,17 @@ class StationServiceChain implements StationService {
   ) async {
     try {
       return await apiCall();
-    } on ApiException catch (e) {
+    } on ApiException catch (e, st) {
       if (!_isTransient(e)) rethrow;
-      // Single retry — log to the dev console so debug builds surface the
-      // recovered call (production has no listener attached).
+      // Single retry — log to the dev console so debug builds surface
+      // the recovered call (production has no listener attached). The
+      // stack trace is included to satisfy the
+      // `catch_block_stacktrace_coverage` lint (#1103) and to help a
+      // future bug report identify which upstream code path triggered
+      // the retry without re-running under a debugger.
       debugPrint(
         'StationServiceChain: retrying after transient error '
-        '(status=${e.statusCode}, message=${e.message})',
+        '(status=${e.statusCode}, message=${e.message})\n$st',
       );
       await Future<void>.delayed(transientRetryDelay);
       return apiCall();

--- a/test/core/services/station_service_chain_transient_retry_test.dart
+++ b/test/core/services/station_service_chain_transient_retry_test.dart
@@ -1,0 +1,230 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Fake upstream that hands the caller a scripted sequence of outcomes —
+/// throw on the first N calls, then return [stations]. Used to verify
+/// that the chain retries transient errors exactly once and recovers
+/// when the retry succeeds (#1954, #1955).
+class _ScriptedService implements StationService {
+  _ScriptedService({
+    required this.script,
+    this.stations = const [],
+  });
+
+  /// Each entry is either an [Object] (thrown on that call) or `null`
+  /// (succeed and return [stations]). Consumed front-to-back.
+  final List<Object?> script;
+  final List<Station> stations;
+
+  int callCount = 0;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    final i = callCount++;
+    final step = i < script.length ? script[i] : null;
+    if (step != null) {
+      throw step;
+    }
+    return ServiceResult(
+      data: stations,
+      source: ServiceSource.tankerkoenigApi,
+      fetchedAt: DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String id, {
+    CancelToken? cancelToken,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids, {
+    CancelToken? cancelToken,
+  }) =>
+      throw UnimplementedError();
+}
+
+/// Trivial in-memory [CacheStrategy] — every key is a miss until [put]
+/// stores something. The chain's stale-cache fallback never fires in
+/// these tests because we only assert the retry / no-retry semantics
+/// against a cold cache, which is the worst case the user reports the
+/// "ServiceChainExhaustedException" snackbar from.
+class _MemCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+
+  @override
+  Future<void> put(
+    String key,
+    Map<String, dynamic> data, {
+    required Duration ttl,
+    required ServiceSource source,
+  }) async {
+    _store[key] = CacheEntry(
+      payload: data,
+      storedAt: DateTime.now(),
+      originalSource: source,
+      ttl: ttl,
+    );
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) => _store[key];
+}
+
+SearchParams _params() => const SearchParams(
+      lat: 48.85,
+      lng: 2.35,
+      radiusKm: 5,
+      fuelType: FuelType.e5,
+    );
+
+void main() {
+  // Pin the retry delay near-zero so the test runs in milliseconds.
+  // We're verifying the retry happens, not the wall-clock spacing.
+  setUp(() {
+    StationServiceChain.transientRetryDelay =
+        const Duration(milliseconds: 1);
+  });
+
+  tearDown(() {
+    StationServiceChain.transientRetryDelay =
+        const Duration(milliseconds: 500);
+  });
+
+  group('StationServiceChain transient-error retry (#1954, #1955)', () {
+    test('5xx on the first attempt → retries once and returns the '
+        'second attempt\'s data', () async {
+      final fake = _ScriptedService(
+        script: [
+          const ApiException(message: 'badResponse: 503', statusCode: 503),
+          null,
+        ],
+        stations: const [
+          Station(
+            id: 's1',
+            name: 'Test',
+            brand: 'Brand',
+            street: 'Rue X',
+            postCode: '75001',
+            place: 'Paris',
+            lat: 48.85,
+            lng: 2.35,
+            isOpen: true,
+          ),
+        ],
+      );
+      final chain = StationServiceChain(fake, _MemCache(), countryCode: 'es');
+
+      final result = await chain.searchStations(_params());
+
+      expect(fake.callCount, 2,
+          reason: 'one retry on transient 503 must hit the upstream twice');
+      expect(result.data, hasLength(1));
+    });
+
+    test('connectionTimeout on the first attempt → retries once and '
+        'recovers', () async {
+      final fake = _ScriptedService(
+        script: [
+          const ApiException(
+            message: 'connectionTimeout: took longer than 20s (path: /x)',
+          ),
+          null,
+        ],
+        stations: const [
+          Station(
+            id: 's2',
+            name: 'AR test',
+            brand: 'B',
+            street: '',
+            postCode: '',
+            place: '',
+            lat: 0,
+            lng: 0,
+            isOpen: true,
+          ),
+        ],
+      );
+      final chain = StationServiceChain(fake, _MemCache(), countryCode: 'ar');
+
+      await chain.searchStations(_params());
+
+      expect(fake.callCount, 2,
+          reason: 'a Dio connectionTimeout must be classed as transient');
+    });
+
+    test('two consecutive transients → no third attempt, the chain '
+        'gives up and throws ServiceChainExhaustedException',
+        () async {
+      final fake = _ScriptedService(
+        script: [
+          const ApiException(message: 'badResponse: 503', statusCode: 503),
+          const ApiException(message: 'badResponse: 503', statusCode: 503),
+        ],
+      );
+      final chain = StationServiceChain(fake, _MemCache(), countryCode: 'es');
+
+      await expectLater(
+        chain.searchStations(_params()),
+        throwsA(isA<ServiceChainExhaustedException>()),
+      );
+      expect(fake.callCount, 2,
+          reason: 'one retry only — the chain must not pile on a third '
+              'attempt and stretch the user-visible latency');
+    });
+
+    test('non-transient errors (4xx, parse) skip the retry — exactly '
+        'one upstream call before the chain gives up', () async {
+      final fake = _ScriptedService(
+        script: [
+          const ApiException(message: 'badResponse: 404', statusCode: 404),
+        ],
+      );
+      final chain = StationServiceChain(fake, _MemCache(), countryCode: 'es');
+
+      await expectLater(
+        chain.searchStations(_params()),
+        throwsA(isA<ServiceChainExhaustedException>()),
+      );
+      expect(fake.callCount, 1,
+          reason: 'a 404 is not transient — retrying it just wastes '
+              'a request and adds latency');
+    });
+
+    test('receiveTimeout and sendTimeout messages are also classed '
+        'as transient', () async {
+      for (final msg in const [
+        'receiveTimeout: server stalled (path: /foo)',
+        'sendTimeout: write stalled (path: /foo)',
+        'connectionError: socket reset (path: /foo)',
+      ]) {
+        final fake = _ScriptedService(
+          script: [ApiException(message: msg), null],
+        );
+        final chain =
+            StationServiceChain(fake, _MemCache(), countryCode: 'es');
+        await chain.searchStations(_params());
+        expect(fake.callCount, 2,
+            reason: 'Dio "$msg" must be treated as a recoverable '
+                'transient blip and trigger the one-shot retry');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #1954.
Closes #1955.

Both bug reports trace to the same root: `StationServiceChain._executeChain`
calls the upstream once, then on the first transient blip falls
through to stale cache, and when no stale cache exists throws
`ServiceChainExhaustedException` straight into the user's face.

- #1954 — MITECO 503 burst.
- #1955 — Argentina CKAN connect timeout (slow first-byte on the
  bulk-download URL).

## Fix

Wrap the API call in `_callWithTransientRetry`: one retry, 500 ms
delay, only for errors a 500 ms wait could plausibly recover from:

- 5xx responses (`ApiException.statusCode in 500..599`).
- Dio connect / receive / send timeouts and connection errors —
  detected on the `ApiException.message` prefix stamped by
  `StationServiceHelpers.throwApiException`
  (`connectionTimeout:`, `receiveTimeout:`, `sendTimeout:`,
  `connectionError:`).

4xx and parse errors skip the retry — those don't fix themselves in
500 ms, so retrying just adds user-visible latency.

The retry delay is exposed via `@visibleForTesting transientRetryDelay`
so the new test runs in milliseconds rather than waiting a real
half-second per case.

## Verification

- `flutter analyze` — clean.
- `flutter test test/core/services/station_service_chain_transient_retry_test.dart`
  — 5 new cases, green: 5xx recovers, connectionTimeout recovers,
  two-consecutive-transients gives up after exactly one retry,
  non-transient 404 skips the retry, every Dio-timeout variant is
  classed as transient.
- `flutter test test/core/services/impl/ test/core/services/station_service_chain_test.dart`
  — adjacent suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
