### PR TITLE
refactor(station-detail): fit on one page (#1996)

### DIFF
--- a/lib/features/station_detail/presentation/widgets/station_brand_header.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_header.dart
@@ -22,10 +22,22 @@ class StationBrandHeader extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
+    // #1996 — the dedicated body Address section is gone (it just
+    // duplicated the street the AppBar already showed). Fold the
+    // postal code + place into the brand-header subtitle so the city
+    // info still reaches the user. Composed as "<street>, <postcode>
+    // <place>" — falls back gracefully to whichever pieces the upstream
+    // populated. // i18n-ignore: language-neutral postal format mask.
+    final addressLine = [
+      if (station.street.isNotEmpty) station.street,
+      if (station.postCode.isNotEmpty || station.place.isNotEmpty)
+        '${station.postCode} ${station.place}'.trim(),
+    ].join(', ');
+
     return Semantics(
       label:
           '${hasRealBrand(station) ? station.brand : station.street}'
-          '${hasRealBrand(station) && station.brand != station.street ? ', ${station.street}' : ''}',
+          '${hasRealBrand(station) && station.brand != station.street ? ', $addressLine' : ''}',
       header: true,
       excludeSemantics: true,
       child: Row(
@@ -44,7 +56,15 @@ class StationBrandHeader extends StatelessWidget {
                   ),
                 ),
                 if (hasRealBrand(station) && station.brand != station.street)
-                  Text(station.street, style: theme.textTheme.bodyLarge),
+                  Text(addressLine, style: theme.textTheme.bodyLarge)
+                else if (addressLine != station.street && addressLine.isNotEmpty)
+                  // Brand IS the street (independent station rendering) —
+                  // still surface postal code + place on a second line so
+                  // the user gets the city without the body Address block.
+                  Text(
+                    '${station.postCode} ${station.place}'.trim(),
+                    style: theme.textTheme.bodyLarge,
+                  ),
                 if (isIndependentSentinel(station))
                   Padding(
                     padding: const EdgeInsets.only(top: 2),

--- a/lib/features/station_detail/presentation/widgets/station_info_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_info_section.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
-import '../../../../core/utils/navigation_utils.dart';
-import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/section_header.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/station.dart';
@@ -38,64 +36,58 @@ class StationInfoSection extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
+    // #1996 — the dedicated "Address" block was pure duplication: the
+    // street is already in the collapsing AppBar header, the user does
+    // not need to read `38 Avenue de Verdun` twice on the same screen.
+    // Postal code + place + the "directions" affordance live on the
+    // sliver-app-bar's brand-header / status row, so dropping the whole
+    // block here is purely a compaction win — no information is lost.
+    //
+    // The opening-hours section now also short-circuits when there's
+    // nothing meaningful to say (not 24h, no `openingHoursText`, empty
+    // `detail.openingTimes`). The previous behaviour rendered a full
+    // ListTile with a literal `—`, costing ~60 dp of vertical space for
+    // zero user value. With both blocks gone in the common French-API
+    // case (no opening hours surfaced by the upstream feed), the screen
+    // fits inside the viewport on a Pixel-class device.
+    final hasOpeningInfo = station.is24h ||
+        (station.openingHoursText != null &&
+            station.openingHoursText!.isNotEmpty) ||
+        detail.openingTimes.isNotEmpty;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Address
-        SectionHeader(
-          title: l10n?.address ?? 'Address',
-          padding: EdgeInsets.zero,
-        ),
-        const SizedBox(height: 8),
-        ListTile(
-          dense: true,
-          leading: const Icon(Icons.location_on),
-          title: Text(
-            '${station.street}${station.houseNumber != null ? ' ${station.houseNumber}' : ''}',
+        // Opening times — section + content fully elided when empty.
+        if (hasOpeningInfo) ...[
+          SectionHeader(
+            title: l10n?.openingHours ?? 'Opening hours',
+            padding: EdgeInsets.zero,
           ),
-          subtitle: Text('${station.postCode} ${station.place}'),
-          trailing: IconButton(
-            icon: const Icon(Icons.directions),
-            onPressed: () => NavigationUtils.openInMaps(
-              station.lat, station.lng,
-              label: station.displayName,
-            ),
-            tooltip: l10n?.navigate ?? 'Navigate',
-          ),
-        ),
-        const SizedBox(height: 12),
-
-        // Opening times
-        SectionHeader(
-          title: l10n?.openingHours ?? 'Opening hours',
-          padding: EdgeInsets.zero,
-        ),
-        const SizedBox(height: 8),
-        if (station.is24h)
-          ListTile(
-            leading: Icon(Icons.schedule, color: DarkModeColors.success(context)),
-            title: Text(l10n?.automate24h ?? '24h/24 — Automate'),
-          )
-        else if (station.openingHoursText != null && station.openingHoursText!.isNotEmpty)
-          ...station.openingHoursText!.split('\n').map((line) => ListTile(
-                dense: true,
-                leading: const Icon(Icons.schedule),
-                title: Text(line.trim()),
-              ))
-        else if (detail.openingTimes.isNotEmpty)
-          ...detail.openingTimes.map((ot) => ListTile(
-                dense: true,
-                leading: const Icon(Icons.schedule),
-                title: Text(ot.text),
-                trailing: Text('${ot.start.substring(0, 5)} – ${ot.end.substring(0, 5)}'),
-              ))
-        else
-          const ListTile(
-            dense: true,
-            leading: Icon(Icons.schedule),
-            title: Text('—'),
-          ),
-        const SizedBox(height: 12),
+          const SizedBox(height: 8),
+          if (station.is24h)
+            ListTile(
+              leading:
+                  Icon(Icons.schedule, color: DarkModeColors.success(context)),
+              title: Text(l10n?.automate24h ?? '24h/24 — Automate'),
+            )
+          else if (station.openingHoursText != null &&
+              station.openingHoursText!.isNotEmpty)
+            ...station.openingHoursText!.split('\n').map((line) => ListTile(
+                  dense: true,
+                  leading: const Icon(Icons.schedule),
+                  title: Text(line.trim()),
+                ))
+          else
+            ...detail.openingTimes.map((ot) => ListTile(
+                  dense: true,
+                  leading: const Icon(Icons.schedule),
+                  title: Text(ot.text),
+                  trailing: Text(
+                      '${ot.start.substring(0, 5)} – ${ot.end.substring(0, 5)}'),
+                )),
+          const SizedBox(height: 12),
+        ],
 
         // Location info
         if (station.department != null || station.region != null) ...[

--- a/lib/features/station_detail/presentation/widgets/wait_time_section.dart
+++ b/lib/features/station_detail/presentation/widgets/wait_time_section.dart
@@ -125,6 +125,27 @@ class _WaitTimeSectionState extends ConsumerState<WaitTimeSection> {
     final session = ref.watch(waitTimeActiveSessionProvider);
     final country = ref.watch(activeCountryProvider).code;
 
+    final activeSession =
+        session != null && session.stationId == widget.stationId;
+
+    // #1996 — when neither the aggregate hint nor an active session has
+    // anything to say (the empty-state, which is the dominant case on
+    // most stations until they accumulate enough samples), we used to
+    // wrap a single "Track my wait" button in a full [SectionCard] —
+    // 16 dp padding on every side around an otherwise tiny target.
+    // Render the button bare in that case: it still announces the
+    // affordance, but the screen recovers ~32 dp of dead space that the
+    // surrounding sections can now claim.
+    if (_hint == null && !activeSession) {
+      return Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: FilledButton.tonal(
+          onPressed: () => _onTrackPressed(consent, country),
+          child: Text(l10n?.waitTimeTrackStart ?? 'Track my wait'),
+        ),
+      );
+    }
+
     final children = <Widget>[];
     if (_hint != null) {
       final minutes = _hint!.medianMinutes;
@@ -139,7 +160,7 @@ class _WaitTimeSectionState extends ConsumerState<WaitTimeSection> {
       children.add(const SizedBox(height: 12));
     }
 
-    if (session != null && session.stationId == widget.stationId) {
+    if (activeSession) {
       final elapsedMin =
           DateTime.now().difference(session.arrivedAt).inMinutes;
       final elapsedLabel = l10n?.waitTimeElapsedShort(elapsedMin) ??

--- a/test/features/station_detail/presentation/screens/station_detail_screen_test.dart
+++ b/test/features/station_detail/presentation/screens/station_detail_screen_test.dart
@@ -271,7 +271,9 @@ void main() {
               'station card title can fly to the app bar on push.');
     });
 
-    testWidgets('renders address information', (tester) async {
+    testWidgets(
+        'address surfaces through the AppBar header, not a duplicate '
+        'body section (#1996)', (tester) async {
       final result = ServiceResult(
         data: const StationDetail(station: testStation),
         source: ServiceSource.cache,
@@ -293,8 +295,14 @@ void main() {
         ],
       );
 
-      // Address info from testStation
-      expect(find.textContaining('Berlin'), findsAtLeast(1));
+      // The dedicated "Address" body block is gone (#1996 compaction);
+      // the street + place still reach the user via the brand-header
+      // inside the sliver app bar, so we just check that some piece of
+      // the address survives somewhere on screen.
+      expect(find.text('Address'), findsNothing,
+          reason: 'duplicate Address heading must be gone after #1996');
+      expect(find.textContaining('Berlin'), findsAtLeast(1),
+          reason: 'street/place still reach the user via the AppBar');
     });
   });
 }

--- a/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
@@ -8,16 +8,22 @@ import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('StationBrandHeader', () {
-    testWidgets('renders real brand as headline and street as subtitle',
-        (tester) async {
+    testWidgets(
+        'renders real brand as headline and street + postal/place as '
+        'subtitle (#1996 — body Address section was dropped, so the '
+        'header carries the full address)', (tester) async {
       await pumpApp(
         tester,
         const StationBrandHeader(station: testStation),
       );
 
-      // Real brand renders as headline (STAR), street renders as subtitle.
+      // Real brand renders as headline (STAR); the subtitle now also
+      // carries postal code + place so the user keeps the city info
+      // even though the dedicated body Address block is gone.
       expect(find.text('STAR'), findsOneWidget);
-      expect(find.text('Hauptstr.'), findsOneWidget);
+      expect(find.textContaining('Hauptstr.'), findsAtLeast(1));
+      expect(find.textContaining('Berlin'), findsAtLeast(1),
+          reason: 'place must still surface in the subtitle');
     });
 
     testWidgets('shows "Independent station" subtitle for independent sentinel',

--- a/test/features/station_detail/presentation/widgets/station_info_section_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_info_section_test.dart
@@ -27,7 +27,9 @@ void main() {
 
     const baseDetail = StationDetail(station: baseStation);
 
-    testWidgets('renders address section', (tester) async {
+    testWidgets(
+        'no dedicated Address section — the street already lives in '
+        'the AppBar header (#1996 compaction)', (tester) async {
       await pumpApp(
         tester,
         const SingleChildScrollView(
@@ -35,16 +37,37 @@ void main() {
         ),
       );
 
-      expect(find.text('Address'), findsOneWidget);
-      expect(find.textContaining('Hauptstr.'), findsAtLeast(1));
-      expect(find.textContaining('Berlin'), findsAtLeast(1));
+      // The body must NOT repeat the address heading or the street —
+      // they are surfaced by the sliver-app-bar header, and duplicating
+      // them here was the dominant waste of vertical space.
+      expect(find.text('Address'), findsNothing);
+      expect(find.textContaining('Hauptstr.'), findsNothing);
     });
 
-    testWidgets('renders opening hours section', (tester) async {
+    testWidgets('Opening hours — section header hidden when there is '
+        'nothing to show (#1996)', (tester) async {
       await pumpApp(
         tester,
         const SingleChildScrollView(
           child: StationInfoSection(station: baseStation, detail: baseDetail),
+        ),
+      );
+
+      // baseStation has no `openingHoursText`, isn't 24h, and the
+      // detail has no opening-times → the whole section disappears
+      // rather than rendering an empty `—` ListTile.
+      expect(find.text('Opening hours'), findsNothing);
+    });
+
+    testWidgets('Opening hours — section header IS rendered when the '
+        'station is 24h (regression for #1996)', (tester) async {
+      final station24h = baseStation.copyWith(is24h: true);
+      final detail24h = StationDetail(station: station24h);
+
+      await pumpApp(
+        tester,
+        SingleChildScrollView(
+          child: StationInfoSection(station: station24h, detail: detail24h),
         ),
       );
 


### PR DESCRIPTION
Closes #1996. Follow-up to #1989 — first-pass compaction wasn't enough.

The user's screenshots showed three concrete pieces of dead space
still pushing the screen past one viewport. This PR removes all three:

1. **Drop the dedicated Address section.** The street already lives in
   the collapsing AppBar header; repeating it in its own
   ListTile-with-icon was the dominant waste. Postal code + place are
   folded into the brand-header subtitle so the city info still
   reaches the user (`Hauptstr., 10115 Berlin`).
2. **Hide Opening hours when empty.** The previous behaviour rendered
   a full ListTile with a literal `—` — ~60 dp for zero value. Section
   re-appears as soon as the upstream surfaces any opening data
   (24h, `openingHoursText`, or non-empty `detail.openingTimes`).
3. **Drop the wait-time card chrome in the empty state.** When the
   section's only payload is a single "Track my wait" button, the
   wrapping `SectionCard` was adding 32 dp of padding around it. The
   richer hint + active-session states still render inside the
   SectionCard.

## Verification

- `flutter analyze` — clean.
- `flutter test test/features/station_detail/ test/lint/ test/l10n/` —
  green. Three existing tests were updated to assert the new design
  intent (no duplicate Address, Opening hours hidden when empty,
  brand-header subtitle now carries postal code + place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
