### PR TITLE
fix(obd2): one-shot retry on the connect / init handshake (#1916)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -118,12 +118,50 @@ class Obd2Service implements Obd2RawCommandPort {
     String? vehicleFallbackKey,
     this.breadcrumbCollector,
   }) {
+    // #1916 — the supported-PIDs prime + discovery run during connect,
+    // when the BLE link is least settled. Wrap their `_send` callback
+    // with the same one-shot retry the init handshake now uses, so a
+    // single lost write at trip-start doesn't reach the user as a
+    // connect failure. After prime returns, the resolver only serves
+    // the cached set (no further `_send`), so no live-polling call
+    // sites pick up the wrapper.
     _pids = SupportedPidsResolver(
-      send: _send,
+      send: (cmd) => _withConnectRetry(cmd, _send),
       isConnected: () => _transport.isConnected,
       cache: pidsCache,
       vehicleFallbackKey: vehicleFallbackKey,
     );
+  }
+
+  /// #1916 — settle delay between the first connect-time send and its
+  /// single retry. Matches the polling-loop value
+  /// [TripRecordingController._transportRetryDelay] so the same
+  /// transient-blip window is absorbed in both phases. Exposed as
+  /// `@visibleForTesting` so the connect-retry unit test runs in
+  /// milliseconds instead of waiting a real 150 ms per case.
+  @visibleForTesting
+  static Duration connectRetryDelay = const Duration(milliseconds: 150);
+
+  /// One-shot retry around a connect-time send. The init sequence,
+  /// the `ATI` firmware probe, and the supported-PIDs prime all route
+  /// through this — Bluetooth links hiccup briefly in the first few
+  /// seconds of a fresh link (a lost write, an RF collision); the
+  /// retry absorbs that common transient case so it never propagates
+  /// up to `connect()` returning `false`. The same pattern lives in
+  /// the polling loop as `TripRecordingController._runTransport`
+  /// (#1904) — here we extend it to the connect / init phase the
+  /// polling-loop guard doesn't cover.
+  Future<String> _withConnectRetry(
+    String command,
+    Future<String> Function(String) inner,
+  ) async {
+    try {
+      return await inner(command);
+    } catch (e, st) {
+      debugPrint('OBD2 connect-time send retry after $e\n$st');
+      await Future<void>.delayed(connectRetryDelay);
+      return inner(command);
+    }
   }
 
   /// AT command that asks the ELM327 to identify itself. Returns a
@@ -209,8 +247,14 @@ class Obd2Service implements Obd2RawCommandPort {
       for (var i = 0; i < sequence.length; i++) {
         // #1925 — time each handshake command for the opt-in OBD2
         // debug log (a no-op when debug logging is off).
+        // #1916 — route through [_withConnectRetry] so a single
+        // transient BLE blip during the init sequence is absorbed
+        // rather than failing the whole connect attempt.
         final sw = Stopwatch()..start();
-        final response = await _transport.sendCommand(sequence[i]);
+        final response = await _withConnectRetry(
+          sequence[i],
+          _transport.sendCommand,
+        );
         sw.stop();
         Obd2DebugSessionRecorder.recordHandshakeCommand(
           sequence[i],
@@ -231,8 +275,14 @@ class Obd2Service implements Obd2RawCommandPort {
       // [Obd2AdapterCapability.standardOnly] default and let the
       // connect succeed. No call site branches on `capability` yet.
       try {
+        // #1916 — same retry guard as the init sequence; the ATI probe
+        // is the first command after the init burst and a hiccup here
+        // would skip firmware-tier detection entirely.
         final atiSw = Stopwatch()..start();
-        final raw = await _transport.sendCommand(_atiCommand);
+        final raw = await _withConnectRetry(
+          _atiCommand,
+          _transport.sendCommand,
+        );
         atiSw.stop();
         Obd2DebugSessionRecorder.recordHandshakeCommand(
           _atiCommand,

--- a/test/features/consumption/data/obd2/obd2_service_connect_retry_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_connect_retry_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// Transport that throws on a configurable subset of commands and
+/// returns canned responses on the rest. Used to drive the connect-
+/// time retry: the first attempt at the targeted command(s) throws,
+/// the retry attempt succeeds (#1916).
+class _FlakyTransport implements Obd2Transport {
+  _FlakyTransport({
+    required this.responses,
+    this.throwOnceFor = const <String>{},
+  });
+
+  final Map<String, String> responses;
+
+  /// Commands (trimmed) that should throw on their FIRST encounter.
+  /// On the retry attempt they succeed and serve `responses`.
+  final Set<String> throwOnceFor;
+
+  final Map<String, int> attempts = <String, int>{};
+  final List<String> log = <String>[];
+
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    final n = (attempts[cmd] ?? 0) + 1;
+    attempts[cmd] = n;
+    log.add(cmd);
+    if (n == 1 && throwOnceFor.contains(cmd)) {
+      throw StateError('simulated transient BLE blip on $cmd');
+    }
+    return responses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+}
+
+void main() {
+  // Pin the retry settle to near-zero so the suite runs in
+  // milliseconds — we're verifying the retry happens, not the
+  // wall-clock spacing.
+  setUp(() {
+    Obd2Service.connectRetryDelay = const Duration(milliseconds: 1);
+  });
+  tearDown(() {
+    Obd2Service.connectRetryDelay = const Duration(milliseconds: 150);
+  });
+
+  group('Obd2Service.connect() one-shot retry (#1916)', () {
+    test(
+        'a single transient blip on an init-sequence command is absorbed '
+        '— connect still returns true', () async {
+      final transport = _FlakyTransport(
+        responses: const {
+          // Init sequence — values are not asserted; the service just
+          // needs SOMETHING coming back that isn\'t a thrown exception.
+          'ATZ': 'ELM327 v1.5>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATS0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          'ATAT1': 'OK>',
+          'ATI': 'ELM327 v1.5>',
+        },
+        // Make the FIRST attempt at ATE0 throw — the second attempt
+        // (the retry) serves the canned `OK>`.
+        throwOnceFor: const {'ATE0'},
+      );
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect();
+
+      expect(ok, isTrue,
+          reason: 'a single transient blip during the init handshake '
+              'must be absorbed by the connect-time retry (#1916)');
+      expect(transport.attempts['ATE0'], 2,
+          reason: 'the failing command must be retried exactly once');
+    });
+
+    test(
+        'a single transient blip on the ATI firmware probe does not '
+        'fail the connect (ATI failures are already non-fatal, but the '
+        'retry should still recover so the firmware string is captured)',
+        () async {
+      final transport = _FlakyTransport(
+        responses: const {
+          'ATZ': 'OK>',
+          'ATE0': 'OK>',
+          'ATL0': 'OK>',
+          'ATS0': 'OK>',
+          'ATH0': 'OK>',
+          'ATSP0': 'OK>',
+          'ATAT1': 'OK>',
+          'ATI': 'ELM327 v2.2>',
+        },
+        throwOnceFor: const {'ATI'},
+      );
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect();
+
+      expect(ok, isTrue);
+      expect(transport.attempts['ATI'], 2,
+          reason: 'ATI must be retried so the firmware tier detection '
+              'can still complete after a transient blip');
+      expect(service.adapterFirmware, 'ELM327 v2.2',
+          reason: 'the retried ATI response is the one we should record');
+    });
+
+    test(
+        'two consecutive transients on the same init command → no third '
+        'attempt, connect returns false (one-shot retry, not a loop)',
+        () async {
+      var atE0Calls = 0;
+      final transport = _AlwaysFailsAtE0(onAttempt: () => atE0Calls++);
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect();
+
+      expect(ok, isFalse,
+          reason: 'a hard failure (not a transient blip) must still '
+              'bubble up — the retry is bounded, not unlimited');
+      expect(atE0Calls, 2,
+          reason: 'ATE0 must be attempted exactly twice — once + one '
+              'retry — before the connect bails');
+    });
+  });
+}
+
+/// Transport that always throws on `ATE0` — used to prove the retry
+/// is **bounded** (one extra attempt, never two).
+class _AlwaysFailsAtE0 implements Obd2Transport {
+  _AlwaysFailsAtE0({required this.onAttempt});
+  final void Function() onAttempt;
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+  @override
+  Future<void> connect() async => _connected = true;
+  @override
+  Future<void> disconnect() async => _connected = false;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    if (cmd == 'ATE0') {
+      onAttempt();
+      throw StateError('hard ATE0 failure');
+    }
+    return 'OK>';
+  }
+}


### PR DESCRIPTION
Closes #1916.

Mirror the polling-loop retry (`TripRecordingController._runTransport`
from #1904) into the OBD2 connect phase: a single transient BLE blip
during the init sequence, the ATI firmware probe, or the
supported-PIDs prime is absorbed by a 150 ms-spaced retry instead of
failing the whole connect attempt.

## Why this matters

A fresh BLE link is least settled in the first seconds — exactly when
`Obd2Service.connect()` runs the ELM init burst, the `ATI` probe, and
`_pids.prime()`. A lost write here makes connect return `false` and
the user sees "the connection with the adapter interrupts when
starting." The auto-reconnect path runs the same `connect()`, so the
"reconnect often doesn't work" complaint was the same root cause.

## Implementation

- `_withConnectRetry(cmd, inner)` in `Obd2Service` — one retry after
  `connectRetryDelay` (150 ms, `@visibleForTesting`, matches the
  polling-loop value).
- Init sequence loop and the ATI probe route through it.
- The supported-PIDs resolver is now constructed with
  `send: (cmd) => _withConnectRetry(cmd, _send)`. The resolver only
  calls `_send` during prime / discovery (both of which run during
  connect), so live polling is unaffected and the polling-loop retry
  is not stacked on top.

## Verification

- `flutter analyze` — clean.
- `flutter test test/features/consumption/data/obd2/ test/lint/ test/l10n/`
  — 1033 tests green, including 3 new cases in
  `obd2_service_connect_retry_test.dart`:
  1. transient blip on an init command → absorbed, attempted twice.
  2. transient blip on ATI → absorbed, firmware still captured.
  3. hard always-throwing failure → exactly two attempts, no loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
