### PR TITLE
fix(ci): raise Play upload socket timeout + halve chunk size (#1999)

### DIFF
--- a/.github/workflows/daily-beta.yml
+++ b/.github/workflows/daily-beta.yml
@@ -103,7 +103,12 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python deps
-        run: pip install --quiet google-api-python-client google-auth
+        # #1999 — `google-auth-httplib2` is a transitive dep of
+        # `google-api-python-client`, but make it explicit so a future
+        # constraint change in the upstream wheel can't silently
+        # break the long-timeout `AuthorizedHttp` wiring in
+        # `tools/upload_to_play.py`.
+        run: pip install --quiet google-api-python-client google-auth google-auth-httplib2
 
       - name: Decode service-account key
         env:

--- a/tools/upload_to_play.py
+++ b/tools/upload_to_play.py
@@ -21,7 +21,9 @@ import sys
 from datetime import date
 from pathlib import Path
 
+import httplib2
 from google.oauth2 import service_account
+from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload
@@ -39,8 +41,20 @@ SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
 # `num_retries` makes googleapiclient retry those with exponential
 # backoff. `UPLOAD_CHUNK_BYTES` splits the resumable AAB upload into
 # smaller, individually-retryable requests (must be a 256 KB multiple).
+#
+# #1999 — #1983's retries don't help when the failure mode is a *slow*
+# chunk (server still processing the previous one, the PUT response
+# read stalls past httplib2's default ~60 s socket timeout). Two
+# follow-ups:
+#   1. Drop the chunk size from 8 MiB to 4 MiB — a retry replays half
+#      as much data, and the per-chunk wall-clock shrinks so a slow
+#      server is less likely to push us past the read timeout.
+#   2. Wrap the credentialed client in an [AuthorizedHttp] backed by
+#      an [httplib2.Http] with a 300 s (5 min) socket timeout, well
+#      above the worst slow-chunk window observed in CI (~65 s).
 MAX_API_RETRIES = 5
-UPLOAD_CHUNK_BYTES = 8 * 1024 * 1024
+UPLOAD_CHUNK_BYTES = 4 * 1024 * 1024
+HTTP_SOCKET_TIMEOUT_S = 300
 
 
 def load_release_notes(
@@ -105,7 +119,13 @@ def main() -> int:
 
     print(f"Authenticating as service account from {key}")
     creds = service_account.Credentials.from_service_account_file(str(key), scopes=SCOPES)
-    service = build("androidpublisher", "v3", credentials=creds, cache_discovery=False)
+    # #1999 — route the API client through an httplib2.Http with a
+    # 5-minute socket timeout so the chunked AAB upload doesn't die on
+    # one slow-server response read. The default httplib2 timeout
+    # (~60 s) was the trigger for the Daily Open-Testing Build failures
+    # logged on 2026-05-19 / 2026-05-20.
+    authed_http = AuthorizedHttp(creds, http=httplib2.Http(timeout=HTTP_SOCKET_TIMEOUT_S))
+    service = build("androidpublisher", "v3", http=authed_http, cache_discovery=False)
     edits = service.edits()
 
     print(f"Opening edit for {args.package}")


### PR DESCRIPTION
Closes #1999.

## Why the build "fails so often"

Looking at the last 20 Daily Open-Testing Build runs (5 failures,
25 %):

- **2 failures** → this issue's chronic `next_chunk` SSL `TimeoutError`
  in `tools/upload_to_play.py` during the chunked AAB upload (run #50
  today + the 2026-05-19 12:31 UTC run).
- **1 failure** → Gradle `:app:checkPlayReleaseAarMetadata` "4 issues
  found" (2026-05-19 18:10 UTC). One-off, unrelated.
- **1 failure** → `:tflite_flutter:compileReleaseKotlin` JVM-target
  mismatch (2026-05-18 18:10 UTC). One-off, unrelated.
- **1 failure** → other build error (unrelated).

So **~half the recurring failures are the upload timeout**, and that's
what this PR fixes. The Gradle / tflite cases are separate, one-off
dependency-bump fallout.

## Why #1983's retries didn't help

#1983 added `num_retries=5` + an 8 MiB resumable chunksize — fine
against `HttpError` / 5xx / short connection drops. The actual
failure mode is a *slow* chunk: the server is still processing the
previous PUT and the response read stalls past httplib2's default
~60 s socket timeout. The retry doesn't help when every retry attempt
hits the same window.

## Fix

1. **300 s per-request socket timeout.** Build the Android Publisher
   service through `AuthorizedHttp(creds, http=httplib2.Http(timeout=300))`
   so the chunked PUT response read has 5 minutes of headroom — well
   above the worst slow-chunk wall-clock observed in CI (~65 s).
2. **4 MiB chunk size** (down from 8 MiB) — a retry replays half as
   much data; per-chunk wall-clock shrinks.
3. **Explicit `google-auth-httplib2` install** in `daily-beta.yml` —
   it's a transitive dep, but making it explicit so a future upstream
   constraint can't silently break the long-timeout wiring.

`MAX_API_RETRIES` stays at 5.

## Verification

- `python3 tools/upload_to_play.py --help` runs cleanly with the new
  imports.
- `ast.parse` confirms the script parses.
- The next Daily Open-Testing Build run will exercise the real fix —
  no in-CI test can stand in for a 132 MB Play upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
