### PR TITLE
fix(ci): regen ntfy_setup_provider.g.dart + flip nightly-flaky to OR (#2003)

### DIFF
--- a/.github/workflows/nightly-flaky.yml
+++ b/.github/workflows/nightly-flaky.yml
@@ -44,10 +44,16 @@ jobs:
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
       - name: Run flaky + network suites
-        # Includes both tags so we cover everything the PR/master path
-        # excludes. Single invocation — comma-separated tags is the
-        # `flutter test --tags=` syntax.
-        run: flutter test --tags=flaky,network
+        # #2003 — the comma form `--tags=flaky,network` is parsed by
+        # `package:test` (which `flutter test --tags=` delegates to) as
+        # the Boolean expression `flaky && network`. Zero tests carry
+        # both tags (`flaky` is on 2 share-plus widget tests; `network`
+        # is on 8 live-API tests; intersection is empty), so the runner
+        # exited 79 with "No tests match" on every nightly run. The
+        # intent — per this workflow's own header comment — is OR: "we
+        # cover everything the PR/master path excludes". Use the
+        # explicit Boolean form so the selector matches both buckets.
+        run: flutter test --tags 'flaky || network'
       - name: Surface failure on tracking issue
         if: failure()
         env:

--- a/lib/features/sync/providers/ntfy_setup_provider.g.dart
+++ b/lib/features/sync/providers/ntfy_setup_provider.g.dart
@@ -42,7 +42,7 @@ final class NtfySetupControllerProvider
 }
 
 String _$ntfySetupControllerHash() =>
-    r'99814f0d70f950e6349e1fcdb78efc61cb62ff80';
+    r'1d3822ca811b1f08af75438b0fabb6b067156bed';
 
 abstract class _$NtfySetupController extends $Notifier<NtfySetupState> {
   NtfySetupState build();


### PR DESCRIPTION
Closes #2003.

## Two failures on master after PR #2002 merged

1. **`codegen-drift` job failed on commit `3ed57cc`.** Changing
   `NtfySetupController.sendTestNotification` from `Future<bool>` to
   `Future<NtfyPostResult>` (#2002) updated the @riverpod generator's
   output, but I shipped the stale `.g.dart`. Master has been in a
   codegen-drift state since the #2002 merge.
2. **`Nightly Flaky + Network Suite` has been silently dead since
   filing.** Run #5 (today) and every prior nightly run exited 79
   with "No tests match the requested tag selectors: include 'flaky
   && network'". The workflow invokes
   `flutter test --tags=flaky,network`. `package:test` parses the
   comma form as **AND**, and no test in the repo carries both tags
   (`flaky` is on 2 share-plus widget tests; `network` is on 8
   live-API tests; intersection is empty). The intent — per the
   workflow's own header comment — is OR.

## Fix

- Ran `dart run build_runner build --delete-conflicting-outputs`;
  committed the regenerated `lib/features/sync/providers/ntfy_setup_provider.g.dart`.
- Flipped `--tags=flaky,network` → `--tags 'flaky || network'` in
  `.github/workflows/nightly-flaky.yml`.

## Verification

- `flutter analyze` — clean.
- `git diff --exit-code -- '*.g.dart' '*.freezed.dart'` — clean
  after the regen.
- The next nightly-flaky run will actually exercise the flaky +
  network buckets and produce a real outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
