### PR TITLE
fix(ci): layered outer retry around every Play edit call (#2009)

### DIFF
--- a/tools/upload_to_play.py
+++ b/tools/upload_to_play.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from datetime import date
 from pathlib import Path
 
@@ -52,9 +53,69 @@ SCOPES = ["https://www.googleapis.com/auth/androidpublisher"]
 #   2. Wrap the credentialed client in an [AuthorizedHttp] backed by
 #      an [httplib2.Http] with a 300 s (5 min) socket timeout, well
 #      above the worst slow-chunk window observed in CI (~65 s).
+#
+# #2009 — #1999 still leaves one failure mode uncovered. The Play
+# upload server occasionally returns HTTP 308 ("Resume Incomplete")
+# WITHOUT a `Location` header, and httplib2 misreads that as a
+# malformed redirect and raises `RedirectMissingLocation` straight
+# out of `next_chunk`. The googleapiclient inner `num_retries` DOES
+# catch it (it's a `httplib2.HttpLib2Error` subclass) but every
+# retry hits the same server window with the same response. The fix:
+# wrap each Android-Publisher .execute() through `_execute_with_retry`,
+# which catches both `HttpError` AND `httplib2.HttpLib2Error` and
+# retries the WHOLE edit call (3 attempts, 2 s / 8 s / 30 s backoff)
+# so each outer attempt starts a fresh resumable session — that's
+# what actually clears the flaky 308.
 MAX_API_RETRIES = 5
 UPLOAD_CHUNK_BYTES = 4 * 1024 * 1024
 HTTP_SOCKET_TIMEOUT_S = 300
+OUTER_RETRY_BACKOFFS_S = (2, 8, 30)
+
+
+def _execute_with_retry(call_factory, *, label: str):
+    """Run a Google API request through layered retry (#2009).
+
+    `call_factory` is a zero-arg callable that builds a fresh request
+    object each invocation. We don't reuse the same request across
+    outer retries — a `MediaFileUpload` becomes useless after a
+    failed resumable session because its internal byte-offset state
+    is stale. Building fresh each attempt keeps the retry idempotent.
+
+    Catches:
+        - `googleapiclient.errors.HttpError` (real HTTP-level errors
+          surfaced after the inner `num_retries=MAX_API_RETRIES` gave
+          up).
+        - `httplib2.error.HttpLib2Error` (covers `RedirectMissingLocation`
+          and the parse-level errors httplib2 raises when the
+          upstream returns a malformed response — exactly the 308-
+          without-Location case from #2009).
+        - `TimeoutError` (the per-chunk socket read timed out even
+          past the 300 s `HTTP_SOCKET_TIMEOUT_S` ceiling).
+
+    Returns the result of the successful `.execute(...)` call.
+    Re-raises the last exception when all attempts fail.
+    """
+    last_error: Exception | None = None
+    attempts = len(OUTER_RETRY_BACKOFFS_S) + 1
+    for attempt in range(attempts):
+        try:
+            request = call_factory()
+            return request.execute(num_retries=MAX_API_RETRIES)
+        except (HttpError, httplib2.HttpLib2Error, TimeoutError) as e:
+            last_error = e
+            if attempt == attempts - 1:
+                break
+            delay = OUTER_RETRY_BACKOFFS_S[attempt]
+            print(
+                f"  {label} attempt {attempt + 1}/{attempts} failed "
+                f"({type(e).__name__}); retrying in {delay}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+    # Re-raise so the per-step `except` blocks in main() can map to
+    # the right exit code. The original traceback is preserved.
+    assert last_error is not None
+    raise last_error
 
 
 def load_release_notes(
@@ -128,31 +189,48 @@ def main() -> int:
     service = build("androidpublisher", "v3", http=authed_http, cache_discovery=False)
     edits = service.edits()
 
+    # All Android-Publisher edit calls below route through
+    # `_execute_with_retry` so each layered failure mode has the same
+    # 3-attempt safety net (#2009). The same `except` mapping each
+    # step had before stays — only the call itself is wrapped.
     print(f"Opening edit for {args.package}")
     try:
-        edit = edits.insert(packageName=args.package, body={}).execute(
-            num_retries=MAX_API_RETRIES,
+        edit = _execute_with_retry(
+            lambda: edits.insert(packageName=args.package, body={}),
+            label="edits.insert",
         )
-    except HttpError as e:
+    except (HttpError, httplib2.HttpLib2Error, TimeoutError) as e:
         print(f"ERROR: edits.insert failed: {e}", file=sys.stderr)
         return 3
     edit_id = edit["id"]
     print(f"  edit id: {edit_id}")
 
     print(f"Uploading {aab} ({aab.stat().st_size / 1_000_000:.2f} MB)")
-    media = MediaFileUpload(
-        str(aab),
-        mimetype="application/octet-stream",
-        resumable=True,
-        chunksize=UPLOAD_CHUNK_BYTES,
-    )
-    try:
-        bundle = edits.bundles().upload(
+    # #2009 — build a FRESH MediaFileUpload inside each outer retry.
+    # A `MediaFileUpload` carries internal resumable-session state
+    # (byte-offset, session URI) that becomes stale after a failed
+    # session; reusing it across outer retries would resend a chunk
+    # to a dead URI. The lambda below is re-evaluated on every
+    # outer attempt so each one starts a clean resumable session.
+    def _build_upload_request():
+        media = MediaFileUpload(
+            str(aab),
+            mimetype="application/octet-stream",
+            resumable=True,
+            chunksize=UPLOAD_CHUNK_BYTES,
+        )
+        return edits.bundles().upload(
             packageName=args.package,
             editId=edit_id,
             media_body=media,
-        ).execute(num_retries=MAX_API_RETRIES)
-    except HttpError as e:
+        )
+
+    try:
+        bundle = _execute_with_retry(
+            _build_upload_request,
+            label="bundles.upload",
+        )
+    except (HttpError, httplib2.HttpLib2Error, TimeoutError) as e:
         print(f"ERROR: bundle upload failed: {e}", file=sys.stderr)
         return 4
     version_code = bundle["versionCode"]
@@ -163,42 +241,51 @@ def main() -> int:
 
     print(f"Assigning to track '{args.track}'")
     try:
-        edits.tracks().update(
-            packageName=args.package,
-            editId=edit_id,
-            track=args.track,
-            body={
-                "track": args.track,
-                "releases": [{
-                    "name": f"{version_code}",
-                    "versionCodes": [str(version_code)],
-                    "status": "completed",
-                    "releaseNotes": release_notes,
-                }],
-            },
-        ).execute(num_retries=MAX_API_RETRIES)
-    except HttpError as e:
+        _execute_with_retry(
+            lambda: edits.tracks().update(
+                packageName=args.package,
+                editId=edit_id,
+                track=args.track,
+                body={
+                    "track": args.track,
+                    "releases": [{
+                        "name": f"{version_code}",
+                        "versionCodes": [str(version_code)],
+                        "status": "completed",
+                        "releaseNotes": release_notes,
+                    }],
+                },
+            ),
+            label="tracks.update",
+        )
+    except (HttpError, httplib2.HttpLib2Error, TimeoutError) as e:
         print(f"ERROR: track update failed: {e}", file=sys.stderr)
         return 5
 
     if args.dry_run:
         print("Dry-run: validating edit (no commit)")
         try:
-            edits.validate(packageName=args.package, editId=edit_id).execute(
-                num_retries=MAX_API_RETRIES,
+            _execute_with_retry(
+                lambda: edits.validate(
+                    packageName=args.package, editId=edit_id,
+                ),
+                label="edits.validate",
             )
             print("Validation OK — edit will NOT be committed (dry-run).")
-        except HttpError as e:
+        except (HttpError, httplib2.HttpLib2Error, TimeoutError) as e:
             print(f"ERROR: validation failed: {e}", file=sys.stderr)
             return 6
         return 0
 
     print("Committing edit")
     try:
-        edits.commit(packageName=args.package, editId=edit_id).execute(
-            num_retries=MAX_API_RETRIES,
+        _execute_with_retry(
+            lambda: edits.commit(
+                packageName=args.package, editId=edit_id,
+            ),
+            label="edits.commit",
         )
-    except HttpError as e:
+    except (HttpError, httplib2.HttpLib2Error, TimeoutError) as e:
         print(f"ERROR: edits.commit failed: {e}", file=sys.stderr)
         return 7
 


### PR DESCRIPTION
Closes #2009.

## Why the workflow still failed twice after #1999/#2000

Two Daily Open-Testing Build failures today (09:53 and 10:46 UTC),
both on master post-#1999, both with the SAME new traceback:

```
httplib2.error.RedirectMissingLocation:
  Redirected but the response is missing a Location: header.
  at googleapiclient/http.py:1084 next_chunk
```

This is the Play upload server occasionally responding to a chunk
PUT with HTTP 308 ("Resume Incomplete") **without** a `Location`
header — and httplib2 misreads that as a malformed redirect.

The catch list inside `next_chunk` already covers it
(`httplib2.HttpLib2Error` is the parent of `RedirectMissingLocation`),
so `num_retries=5` is firing — but every inner retry hits the same
Google response in the same short window. The retries don't start a
fresh resumable session; they just resend the same chunk PUT to the
same dead session URI.

## The layered fix

Wrap every Android-Publisher `.execute(...)` call in
`_execute_with_retry`, which retries the WHOLE edit call:

- **Outer**: 3 attempts, 2 s / 8 s / 30 s backoff. Each outer attempt
  builds a **fresh** request object via a factory lambda — critical
  for the resumable upload because a stale `MediaFileUpload` carries
  dead session URI state and would just re-fail.
- **Inner**: the existing `num_retries=5` (~exponential backoff
  inside `googleapiclient`) catches transient `HttpError` /
  `httplib2.HttpLib2Error` / socket reads within a single attempt.
- **Catch list**: `HttpError`, `httplib2.HttpLib2Error`,
  `TimeoutError`.

Wired into all 5 Android-Publisher call sites: `edits.insert`,
`bundles.upload`, `tracks.update`, `edits.validate` (dry-run path),
`edits.commit`.

## Verification

Six-case offline smoke test against the helper (run as a Python
inline script — no pytest infra in this repo for `tools/`):

| Case | Outcome |
|---|---|
| immediate success | 1 attempt, returns the value |
| recovers on 3rd attempt | factory called 3 times, last call returns |
| exhausted at 4 attempts | re-raises the LAST error |
| factory rebuilds the request each attempt | fresh resumable session every outer try |
| `HttpError` is also retried | covers 5xx / Google-API surface |
| non-transient `ValueError` bubbles immediately | no false retry on caller bugs |

The next Daily Open-Testing Build run is the real validation — no
in-CI test can stand in for a 132 MB Play upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
