### PR TITLE
fix(ci): suppress httplib2 308-as-redirect so Play resumable uploads complete (#2011)

### DIFF
--- a/tools/upload_to_play.py
+++ b/tools/upload_to_play.py
@@ -29,6 +29,20 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload
 
+# #2009 part 2 — httplib2 lists 308 in `REDIRECT_CODES` and follows it
+# as a normal redirect. Google's resumable-upload protocol abuses 308
+# ("Resume Incomplete") to mean "I've received N bytes — please POST
+# the next range to the SAME session URI" and intentionally omits the
+# `Location` header (the session URI is sticky). httplib2's redirect-
+# follow code then raises `RedirectMissingLocation` and the upload
+# dies even though googleapiclient's `next_chunk` is itself designed
+# to recognise a 308 + sticky URI and continue the upload (see
+# googleapiclient/http.py `next_chunk` — it reads `resp["range"]` and
+# loops). Removing 308 from `REDIRECT_CODES` lets the 308 pass
+# through to googleapiclient so it can resume correctly. Affects
+# only our process — the frozenset is class-level, not per-instance.
+httplib2.REDIRECT_CODES = frozenset(httplib2.REDIRECT_CODES - {308})
+
 DEFAULT_PACKAGE = "de.tankstellen.fuelprices"
 DEFAULT_TRACK = "beta"  # 'beta' = open testing, 'internal' = internal, 'alpha' = closed, 'production' = prod
 DEFAULT_AAB = "build/app/outputs/bundle/playRelease/app-play-release.aab"


### PR DESCRIPTION
Closes #2011.

## Why the workflow STILL failed after #1999 + #2009

Run #53 (commit `8ba819d`, master post-#2009) hit:

```
bundles.upload attempt 1/4 failed (RedirectMissingLocation); retrying in 2s
bundles.upload attempt 2/4 failed (RedirectMissingLocation); retrying in 8s
bundles.upload attempt 3/4 failed (RedirectMissingLocation); retrying in 30s
ERROR: bundle upload failed: Redirected but the response is missing a Location: header.
```

All four attempts (1 initial + 3 outer retries) failed with the same
`RedirectMissingLocation`. The retry was firing perfectly — but the
issue isn't transient. It's a **protocol mismatch** between
googleapiclient and httplib2.

## The actual root cause

Google's resumable-upload protocol:

1. Client `POST`s the session start. Server returns `200 OK` with
   the resumable session URI in the `Location` header.
2. Client `PUT`s chunks at that URI. Each chunk gets a response of
   either `308 Resume Incomplete` + `Range: bytes=0-N-1` + **no
   Location** (the session URI is sticky), OR `200/201 OK` when the
   final chunk has been received.

`googleapiclient.http.next_chunk` is designed to read `resp["range"]`
on a 308 and resume from the next byte. But before it gets the
chance:

- `httplib2.REDIRECT_CODES = frozenset({300, 301, 302, 303, 307, 308})`.
- httplib2 sees a 308, treats it as a redirect, looks for `Location`,
  doesn't find one, raises `RedirectMissingLocation`.

The error became visible on master only after #2000 widened the
socket-timeout window so MORE chunks succeed and surface the 308.

## Fix

One line in `tools/upload_to_play.py`, at module-import time:

```python
httplib2.REDIRECT_CODES = frozenset(httplib2.REDIRECT_CODES - {308})
```

Now httplib2 passes 308 responses through as normal data,
googleapiclient sees them and resumes the upload correctly. The five
other redirect codes (300/301/302/303/307) are untouched.

## Verification

Locally:

```text
REDIRECT_CODES after patch: [300, 301, 302, 303, 307]
308 successfully removed; real redirects still preserved.
```

The next Daily Open-Testing Build run is the real validation.

## Combined retry stack now in place

| Layer | What it absorbs |
|---|---|
| httplib2 `timeout=300` socket (#1999) | Slow chunk response read |
| googleapiclient `num_retries=5` (#1983) | HttpError / 5xx within a session |
| `_execute_with_retry` outer × 3 (#2009) | Whole-session failure (dead session URI) |
| `REDIRECT_CODES -= {308}` (this PR) | Protocol mismatch on every chunk PUT |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
