### PR TITLE
feat(trip-recording): extend Sample (hAccuracy/bearing/accelG) + TripKind enum (#2019, #2025)

### DIFF
--- a/lib/features/consumption/data/exporters/backup/backup_xml_writer.dart
+++ b/lib/features/consumption/data/exporters/backup/backup_xml_writer.dart
@@ -277,6 +277,10 @@ class BackupXmlWriter {
           'SecondsBelowOptimalGear',
           t.summary.secondsBelowOptimalGear,
         );
+        // #2025 — trajet kind. Emitted on every trip; legacy reads of
+        // older backups (where the tag is missing) default to
+        // `gpsPlusObd2` via `TripKind.fromWireName`.
+        _writeText(builder, 'Kind', t.summary.kind.wireName);
       });
 
       builder.element('Samples', nest: () {
@@ -297,6 +301,15 @@ class BackupXmlWriter {
               s.engineLoadPercent,
             );
             _writeOptionalNumber(builder, 'CoolantTempC', s.coolantTempC);
+            // #2019 — GPS + derived-accel fields. Older backups omit
+            // these tags; the reader treats missing tags as null so
+            // legacy backups round-trip unchanged.
+            _writeOptionalNumber(builder, 'Latitude', s.latitude);
+            _writeOptionalNumber(builder, 'Longitude', s.longitude);
+            _writeOptionalNumber(builder, 'AltitudeM', s.altitudeM);
+            _writeOptionalNumber(builder, 'HAccuracyM', s.hAccuracyM);
+            _writeOptionalNumber(builder, 'BearingDeg', s.bearingDeg);
+            _writeOptionalNumber(builder, 'AccelG', s.accelG);
           });
         }
       });

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -175,6 +175,9 @@ Map<String, dynamic> _sampleToJson(TripSample s) => {
       if (s.latitude != null) 'la': s.latitude,
       if (s.longitude != null) 'lo': s.longitude,
       if (s.altitudeM != null) 'al': s.altitudeM,
+      if (s.hAccuracyM != null) 'ha': s.hAccuracyM,
+      if (s.bearingDeg != null) 'be': s.bearingDeg,
+      if (s.accelG != null) 'ag': s.accelG,
     };
 
 TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -187,14 +190,12 @@ TripSample _sampleFromJson(Map<String, dynamic> j) => TripSample(
       throttlePercent: (j['th'] as num?)?.toDouble(),
       engineLoadPercent: (j['el'] as num?)?.toDouble(),
       coolantTempC: (j['ct'] as num?)?.toDouble(),
-      // #1374 phase 1: GPS fix per sample. Legacy trips written before
-      // this PR carry no key → null on both, which is the right answer
-      // for "we don't know where this sample was taken".
       latitude: (j['la'] as num?)?.toDouble(),
       longitude: (j['lo'] as num?)?.toDouble(),
-      // #1935 child A: GPS altitude per sample. Legacy trips carry no
-      // 'al' key → null.
       altitudeM: (j['al'] as num?)?.toDouble(),
+      hAccuracyM: (j['ha'] as num?)?.toDouble(),
+      bearingDeg: (j['be'] as num?)?.toDouble(),
+      accelG: (j['ag'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _summaryToJson(TripSummary s) => {
@@ -230,6 +231,9 @@ Map<String, dynamic> _summaryToJson(TripSummary s) => {
       // / MAF fuel) carry no value, so parsimony saves bytes.
       if (s.volumetricEfficiencyUsed != null)
         'veUsed': s.volumetricEfficiencyUsed,
+      // #2025 — trajet kind. Omitted when gpsPlusObd2 (the historical
+      // default) so legacy trips round-trip with zero bytes added.
+      if (s.kind != TripKind.gpsPlusObd2) 'kind': s.kind.wireName,
     };
 
 TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -262,6 +266,9 @@ TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
       // fuel was not 100% speed-density carry no key → null, which
       // correctly reads as "not recalculable".
       volumetricEfficiencyUsed: (j['veUsed'] as num?)?.toDouble(),
+      // #2025: trajet kind. Missing key → gpsPlusObd2 because every
+      // recording before this field landed required an OBD2 connection.
+      kind: TripKind.fromWireName(j['kind'] as String?),
     );
 
 /// Hive-backed list of finalised trips (#726).

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -55,6 +55,27 @@ class TripSample {
   /// calculator (#1941) can derive the trip's slope.
   final double? altitudeM;
 
+  /// Reported horizontal accuracy of the GPS fix in metres (#2019).
+  /// Lets downstream filters reject jittery fixes from urban-canyon
+  /// readings before they feed the speed-derivative accel pipeline
+  /// (#2022) or the post-trip map polyline. Null with the same
+  /// semantics as [latitude] — no fix means no accuracy.
+  final double? hAccuracyM;
+
+  /// Bearing in degrees from true north (#2019). Populated when the
+  /// platform supplies it; null otherwise. The trip-detail map can
+  /// render directional arrowheads off this, and the gear-inference
+  /// heuristic (#2023) uses bearing-stability to gate "is this
+  /// straight-line cruise" decisions.
+  final double? bearingDeg;
+
+  /// Acceleration magnitude in g (#2019). Populated by the
+  /// speed-derivative low-pass pipeline (#2022) when no real
+  /// accelerometer feed is wired up; future hardware integrations may
+  /// overwrite this from raw sensor data. Null on legacy samples and
+  /// when the speed series is too short to differentiate.
+  final double? accelG;
+
   const TripSample({
     required this.timestamp,
     required this.speedKmh,
@@ -66,6 +87,9 @@ class TripSample {
     this.latitude,
     this.longitude,
     this.altitudeM,
+    this.hAccuracyM,
+    this.bearingDeg,
+    this.accelG,
   });
 }
 

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -77,6 +77,14 @@ class TripSummary {
   /// recalculable" and such trips are left untouched by a recompute.
   final double? volumetricEfficiencyUsed;
 
+  /// Kind of trajet — whether the recorder collected OBD2 telemetry
+  /// alongside GPS, or GPS only (#2025). Trips upgrade in-place from
+  /// `gpsOnly` to `gpsPlusObd2` the moment an OBD2 adapter starts
+  /// supplying samples mid-recording. Legacy trips deserialise as
+  /// `gpsPlusObd2` because every recording before this field landed
+  /// required an OBD2 connection.
+  final TripKind kind;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -93,6 +101,7 @@ class TripSummary {
     this.secondsBelowOptimalGear,
     this.fuelRateSuspect = false,
     this.volumetricEfficiencyUsed,
+    this.kind = TripKind.gpsPlusObd2,
   });
 
   /// Returns a copy with the given fields replaced (#1858). Used by the
@@ -116,6 +125,7 @@ class TripSummary {
     double? secondsBelowOptimalGear,
     bool? fuelRateSuspect,
     double? volumetricEfficiencyUsed,
+    TripKind? kind,
   }) =>
       TripSummary(
         distanceKm: distanceKm ?? this.distanceKm,
@@ -135,5 +145,39 @@ class TripSummary {
         fuelRateSuspect: fuelRateSuspect ?? this.fuelRateSuspect,
         volumetricEfficiencyUsed:
             volumetricEfficiencyUsed ?? this.volumetricEfficiencyUsed,
+        kind: kind ?? this.kind,
       );
+}
+
+/// Distinguishes a trajet recorded with OBD2 telemetry from one
+/// recorded with GPS alone (#2025). Drives the confidence-tier label
+/// on the calibration UI (#2027) and the recording-screen layout
+/// (#2026) — gpsOnly trips have no instantaneous L/100 km, so they
+/// fall back to a "vs your average %" indicator.
+enum TripKind {
+  /// GPS samples were recorded but no OBD2 adapter contributed any
+  /// telemetry. Used for users who haven't paired a dongle, or whose
+  /// dongle disconnected before any sample landed.
+  gpsOnly,
+
+  /// At least one sample carried OBD2 telemetry (RPM > 0 or a fuel
+  /// rate reading). This is the historical default for every trip
+  /// recorded before #2025 landed.
+  gpsPlusObd2;
+
+  /// Stable string used in JSON / backup XML. Avoids `name` because
+  /// future-Dart enum rename safety relies on the string being chosen
+  /// deliberately rather than tracking the declaration.
+  String get wireName => switch (this) {
+        TripKind.gpsOnly => 'gpsOnly',
+        TripKind.gpsPlusObd2 => 'gpsPlusObd2',
+      };
+
+  /// Parses [s] back to a [TripKind]. Returns [gpsPlusObd2] for
+  /// unknown / null inputs so legacy backups + JSON without the key
+  /// land on the historical default.
+  static TripKind fromWireName(String? s) => switch (s) {
+        'gpsOnly' => TripKind.gpsOnly,
+        _ => TripKind.gpsPlusObd2,
+      };
 }

--- a/test/features/consumption/data/exporters/backup/fixtures/sample_backup_v1.xml
+++ b/test/features/consumption/data/exporters/backup/fixtures/sample_backup_v1.xml
@@ -72,6 +72,7 @@
         <FuelLitersConsumed>1.58</FuelLitersConsumed>
         <DistanceSource>real</DistanceSource>
         <ColdStartSurcharge>false</ColdStartSurcharge>
+        <Kind>gpsPlusObd2</Kind>
       </Summary>
       <Samples>
         <Sample>

--- a/test/features/consumption/domain/trip_kind_test.dart
+++ b/test/features/consumption/domain/trip_kind_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/trip_summary.dart';
+
+void main() {
+  group('TripKind (#2025)', () {
+    test('wireName round-trips through fromWireName', () {
+      for (final k in TripKind.values) {
+        expect(TripKind.fromWireName(k.wireName), k);
+      }
+    });
+
+    test('fromWireName defaults to gpsPlusObd2 for null / unknown', () {
+      expect(TripKind.fromWireName(null), TripKind.gpsPlusObd2);
+      expect(TripKind.fromWireName('garbage'), TripKind.gpsPlusObd2);
+      expect(TripKind.fromWireName(''), TripKind.gpsPlusObd2);
+    });
+
+    test('TripSummary defaults kind to gpsPlusObd2 — preserves legacy trips',
+        () {
+      const summary = TripSummary(
+        distanceKm: 1.0,
+        maxRpm: 1000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+      );
+      expect(summary.kind, TripKind.gpsPlusObd2);
+    });
+
+    test('copyWith preserves and overrides kind correctly', () {
+      const original = TripSummary(
+        distanceKm: 1.0,
+        maxRpm: 1000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        kind: TripKind.gpsOnly,
+      );
+      expect(original.copyWith().kind, TripKind.gpsOnly);
+      expect(
+          original.copyWith(kind: TripKind.gpsPlusObd2).kind,
+          TripKind.gpsPlusObd2);
+    });
+  });
+}


### PR DESCRIPTION
Closes #2019 and #2025.

## Summary

Pure model additions — two commits, one per issue.

### #2019: 3 new fields on TripSample
- `hAccuracyM` — GPS horizontal accuracy (m)
- `bearingDeg` — heading from true north (°)
- `accelG` — derived acceleration magnitude (g), populated by the upcoming speed-derivative pipeline in #2022

All nullable; JSON / backup XML omit when null. Legacy data deserialises unchanged.

### #2025: TripKind enum on TripSummary
- `enum TripKind { gpsOnly, gpsPlusObd2 }`
- Defaults to `gpsPlusObd2` (preserves every existing trip — recording without OBD2 wasn't possible before)
- Wire format uses stable `wireName` for rename safety
- Foundation for #2024 (feature flag), #2026 (recording-screen redesign), #2027 (confidence-tier badge)

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/consumption/domain/trip_kind_test.dart` — 4/4
- [x] `flutter test test/features/consumption/data/trip_history_repository_test.dart` — 34/34
- [x] `flutter test test/features/consumption/data/exporters/backup/` — 5/5 (golden fixture regenerated with the new `<Kind>` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)