### PR TITLE
feat(coaching): accelG pipeline + timestamped harsh-event list (#2022, #2029)

### DIFF
--- a/lib/features/consumption/data/exporters/backup/backup_xml_writer.dart
+++ b/lib/features/consumption/data/exporters/backup/backup_xml_writer.dart
@@ -281,6 +281,24 @@ class BackupXmlWriter {
         // older backups (where the tag is missing) default to
         // `gpsPlusObd2` via `TripKind.fromWireName`.
         _writeText(builder, 'Kind', t.summary.kind.wireName);
+        // #2029 — timestamped harsh-event detail. The integer
+        // [HarshBrakes] / [HarshAccelerations] elements above stay
+        // populated as the simple counter view; this list carries the
+        // per-event timestamp + magnitude + speed for post-trip
+        // coaching. Omitted entirely when no events fired so legacy
+        // backups round-trip unchanged.
+        if (t.summary.harshEvents.isNotEmpty) {
+          builder.element('HarshEvents', nest: () {
+            for (final e in t.summary.harshEvents) {
+              builder.element('HarshEvent', nest: () {
+                _writeText(builder, 'Timestamp', _iso(e.timestamp));
+                _writeText(builder, 'Type', e.type.wireName);
+                _writeText(builder, 'MagnitudeG', e.magnitudeG.toString());
+                _writeText(builder, 'SpeedKmh', e.speedKmh.toString());
+              });
+            }
+          });
+        }
       });
 
       builder.element('Samples', nest: () {

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -234,6 +234,12 @@ Map<String, dynamic> _summaryToJson(TripSummary s) => {
       // #2025 — trajet kind. Omitted when gpsPlusObd2 (the historical
       // default) so legacy trips round-trip with zero bytes added.
       if (s.kind != TripKind.gpsPlusObd2) 'kind': s.kind.wireName,
+      // #2029: per-event harsh-brake / harsh-accel detail with
+      // timestamp + magnitude + speed. Compact key 'he'. Omitted when
+      // empty so legacy trips and event-free trips round-trip with
+      // zero bytes added.
+      if (s.harshEvents.isNotEmpty)
+        'he': s.harshEvents.map((e) => e.toJson()).toList(growable: false),
     };
 
 TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -269,6 +275,14 @@ TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
       // #2025: trajet kind. Missing key → gpsPlusObd2 because every
       // recording before this field landed required an OBD2 connection.
       kind: TripKind.fromWireName(j['kind'] as String?),
+      // #2029: per-event harsh-brake / harsh-accel detail. Missing
+      // key → empty list so legacy trips fall back to the bare
+      // [harshBrakes] / [harshAccelerations] integer counters.
+      harshEvents: (j['he'] as List?)
+              ?.map((e) =>
+                  HarshEvent.fromJson((e as Map).cast<String, dynamic>()))
+              .toList(growable: false) ??
+          const [],
     );
 
 /// Hive-backed list of finalised trips (#726).

--- a/lib/features/consumption/domain/harsh_event.dart
+++ b/lib/features/consumption/domain/harsh_event.dart
@@ -1,0 +1,88 @@
+/// Classifies a single harsh-driving event captured by
+/// [HarshEventDetector] (#2029). Replaces the old integer counters
+/// with a typed list so post-trip coaching can say "harsh brake at
+/// 14:23, 0.45 g, while doing 80 km/h" instead of bare "12 events".
+class HarshEvent {
+  /// Wall-clock timestamp the event was detected at — the trailing
+  /// sample of the evaluation interval (since the derivative is
+  /// computed *from* the previous anchor *to* this point).
+  final DateTime timestamp;
+
+  /// Acceleration magnitude in g. Always positive; the sign is encoded
+  /// in [type] (a harsh brake is a negative m/s² internally, surfaced
+  /// here as the positive magnitude).
+  final double magnitudeG;
+
+  /// Speed at the moment of the event in km/h. Surface lets post-trip
+  /// review distinguish "harsh brake while doing 90 km/h on the
+  /// motorway" from "harsh brake while doing 30 km/h in traffic".
+  final double speedKmh;
+
+  /// Whether the event was a brake or an acceleration.
+  final HarshEventType type;
+
+  const HarshEvent({
+    required this.timestamp,
+    required this.magnitudeG,
+    required this.speedKmh,
+    required this.type,
+  });
+
+  /// Compact JSON encoding — short keys (`t`, `m`, `s`, `k`) mirror the
+  /// [TripSample] convention so per-trip JSON stays small even when a
+  /// long trip carries dozens of events.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        't': timestamp.millisecondsSinceEpoch,
+        'm': magnitudeG,
+        's': speedKmh,
+        'k': type.wireName,
+      };
+
+  static HarshEvent fromJson(Map<String, dynamic> j) => HarshEvent(
+        timestamp: DateTime.fromMillisecondsSinceEpoch(
+          (j['t'] as num).toInt(),
+          isUtc: true,
+        ),
+        magnitudeG: (j['m'] as num).toDouble(),
+        speedKmh: (j['s'] as num).toDouble(),
+        type: HarshEventType.fromWireName(j['k'] as String?),
+      );
+}
+
+enum HarshEventType {
+  brake,
+  acceleration;
+
+  String get wireName => switch (this) {
+        HarshEventType.brake => 'brake',
+        HarshEventType.acceleration => 'accel',
+      };
+
+  static HarshEventType fromWireName(String? s) => switch (s) {
+        'accel' => HarshEventType.acceleration,
+        _ => HarshEventType.brake,
+      };
+}
+
+/// Earth gravity constant used to convert m/s² → g. Single source of
+/// truth so [HarshEventDetector] and the future raw-accelerometer
+/// pipeline agree on the unit conversion.
+const double standardGravityMps2 = 9.80665;
+
+/// Pure function: derives instantaneous acceleration in **g** from two
+/// consecutive speed samples (#2022). Returns null when [dtSeconds] is
+/// zero or negative (out-of-order timestamps); the caller decides
+/// whether to suppress the event entirely.
+///
+/// Sign convention: positive = acceleration, negative = braking. The
+/// caller is responsible for taking the magnitude when feeding into a
+/// [HarshEvent], which carries unsigned magnitude + a [HarshEventType].
+double? accelGForInterval({
+  required double prevSpeedKmh,
+  required double currSpeedKmh,
+  required double dtSeconds,
+}) {
+  if (dtSeconds <= 0) return null;
+  final dvMps = (currSpeedKmh - prevSpeedKmh) / 3.6;
+  return (dvMps / dtSeconds) / standardGravityMps2;
+}

--- a/lib/features/consumption/domain/harsh_event_detector.dart
+++ b/lib/features/consumption/domain/harsh_event_detector.dart
@@ -1,4 +1,6 @@
-/// Counts harsh-braking / harsh-acceleration events from a stream of
+import 'harsh_event.dart';
+
+/// Detects harsh-braking / harsh-acceleration events from a stream of
 /// speed samples, decoupled from the sample-feed cadence (#1922).
 ///
 /// Extracted from [TripRecorder]: the recorder is fed a `TripSample`
@@ -15,6 +17,11 @@
 /// Genuine hard braking (a large Δspeed within ~1 s) still trips the
 /// threshold; the staircase no longer does; and the count is
 /// independent of how fast samples are fed.
+///
+/// Since #2029 the detector also records a [HarshEvent] per crossing
+/// — the integer counters stay as cheap getters for legacy consumers,
+/// while [events] gives post-trip coaching the timestamped detail it
+/// needs to surface "harsh brake at 14:23, 0.45 g while doing 80 km/h".
 class HarshEventDetector {
   HarshEventDetector({
     this.brakeThresholdMps2 = 3.5,
@@ -35,8 +42,7 @@ class HarshEventDetector {
   /// sample instead of skipping to a 2 s window.
   static const double _evalIntervalSec = 0.9;
 
-  int _brakes = 0;
-  int _accels = 0;
+  final List<HarshEvent> _events = [];
 
   // The last sample an evaluation was anchored on. Advances only when
   // an evaluation actually fires, so a burst of sub-second samples
@@ -45,10 +51,20 @@ class HarshEventDetector {
   DateTime? _anchorAt;
 
   /// Number of harsh-braking events counted so far.
-  int get brakes => _brakes;
+  int get brakes => _events
+      .where((e) => e.type == HarshEventType.brake)
+      .length;
 
   /// Number of harsh-acceleration events counted so far.
-  int get accelerations => _accels;
+  int get accelerations => _events
+      .where((e) => e.type == HarshEventType.acceleration)
+      .length;
+
+  /// Per-event detail captured since the detector was last reset
+  /// (#2029). Surfaces the timestamped magnitude + speed needed for
+  /// post-trip coaching messages. Caller copies defensively if it
+  /// intends to mutate.
+  List<HarshEvent> get events => List.unmodifiable(_events);
 
   /// Feed one speed sample. Safe to call at any cadence; samples
   /// closer together than [_evalIntervalSec] are folded into the next
@@ -68,9 +84,19 @@ class HarshEventDetector {
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
     final accelMps2 = ((speedKmh - anchorSpeed) / 3.6) / dt;
     if (accelMps2 <= -brakeThresholdMps2) {
-      _brakes++;
+      _events.add(HarshEvent(
+        timestamp: timestamp,
+        magnitudeG: (-accelMps2) / standardGravityMps2,
+        speedKmh: speedKmh,
+        type: HarshEventType.brake,
+      ));
     } else if (accelMps2 >= accelThresholdMps2) {
-      _accels++;
+      _events.add(HarshEvent(
+        timestamp: timestamp,
+        magnitudeG: accelMps2 / standardGravityMps2,
+        speedKmh: speedKmh,
+        type: HarshEventType.acceleration,
+      ));
     }
     _anchorAt = timestamp;
     _anchorSpeedKmh = speedKmh;
@@ -79,8 +105,7 @@ class HarshEventDetector {
   /// Reset the counters and anchor — used before recording a fresh
   /// trip without discarding the detector instance.
   void reset() {
-    _brakes = 0;
-    _accels = 0;
+    _events.clear();
     _anchorSpeedKmh = null;
     _anchorAt = null;
   }

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -296,6 +296,7 @@ class TripRecorder {
       startedAt: _startedAt,
       endedAt: _endedAt,
       coldStartSurcharge: coldStartSurcharge,
+      harshEvents: _harshDetector.events,
     );
   }
 

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -1,3 +1,7 @@
+import 'harsh_event.dart';
+
+export 'harsh_event.dart';
+
 /// Aggregated metrics for a single driving trip (#718).
 ///
 /// Extracted from `trip_recorder.dart` (#1927 — keeps that file under
@@ -85,6 +89,16 @@ class TripSummary {
   /// required an OBD2 connection.
   final TripKind kind;
 
+  /// Timestamped per-event harsh-brake / harsh-accel detail (#2029).
+  /// Replaces the bare [harshBrakes] / [harshAccelerations] counters
+  /// for post-trip coaching ("harsh brake at 14:23, 0.45 g while
+  /// doing 80 km/h"). The counters remain populated alongside the
+  /// list — every legacy consumer keeps working unchanged; new UI
+  /// reads from [harshEvents] directly. Legacy trips deserialise with
+  /// an empty list, in which case rendering falls back to the bare
+  /// counters.
+  final List<HarshEvent> harshEvents;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -102,6 +116,7 @@ class TripSummary {
     this.fuelRateSuspect = false,
     this.volumetricEfficiencyUsed,
     this.kind = TripKind.gpsPlusObd2,
+    this.harshEvents = const [],
   });
 
   /// Returns a copy with the given fields replaced (#1858). Used by the
@@ -126,6 +141,7 @@ class TripSummary {
     bool? fuelRateSuspect,
     double? volumetricEfficiencyUsed,
     TripKind? kind,
+    List<HarshEvent>? harshEvents,
   }) =>
       TripSummary(
         distanceKm: distanceKm ?? this.distanceKm,
@@ -146,6 +162,7 @@ class TripSummary {
         volumetricEfficiencyUsed:
             volumetricEfficiencyUsed ?? this.volumetricEfficiencyUsed,
         kind: kind ?? this.kind,
+        harshEvents: harshEvents ?? this.harshEvents,
       );
 }
 

--- a/test/features/consumption/domain/harsh_event_test.dart
+++ b/test/features/consumption/domain/harsh_event_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/harsh_event.dart';
+import 'package:tankstellen/features/consumption/domain/harsh_event_detector.dart';
+
+void main() {
+  group('HarshEvent (#2029)', () {
+    test('JSON round-trip preserves every field', () {
+      final original = HarshEvent(
+        timestamp: DateTime.utc(2026, 5, 24, 14, 30, 5),
+        magnitudeG: 0.42,
+        speedKmh: 87.3,
+        type: HarshEventType.brake,
+      );
+      final json = original.toJson();
+      final round = HarshEvent.fromJson(json);
+      expect(round.timestamp, original.timestamp);
+      expect(round.magnitudeG, closeTo(original.magnitudeG, 1e-9));
+      expect(round.speedKmh, closeTo(original.speedKmh, 1e-9));
+      expect(round.type, original.type);
+    });
+
+    test('HarshEventType.fromWireName defaults to brake for unknown', () {
+      expect(HarshEventType.fromWireName(null), HarshEventType.brake);
+      expect(HarshEventType.fromWireName('xyz'), HarshEventType.brake);
+      expect(
+          HarshEventType.fromWireName('accel'), HarshEventType.acceleration);
+      expect(HarshEventType.fromWireName('brake'), HarshEventType.brake);
+    });
+  });
+
+  group('accelGForInterval (#2022)', () {
+    test('positive g for acceleration', () {
+      // 0 → 30 km/h in 2 s → 8.333 m/s / 2 s = 4.166 m/s² ≈ 0.425 g
+      final g = accelGForInterval(
+        prevSpeedKmh: 0,
+        currSpeedKmh: 30,
+        dtSeconds: 2,
+      );
+      expect(g, isNotNull);
+      expect(g!, closeTo(0.425, 0.01));
+    });
+
+    test('negative g for braking', () {
+      // 80 → 50 km/h in 1.5 s → -8.333 m/s / 1.5 s = -5.555 m/s² ≈ -0.566 g
+      final g = accelGForInterval(
+        prevSpeedKmh: 80,
+        currSpeedKmh: 50,
+        dtSeconds: 1.5,
+      );
+      expect(g, isNotNull);
+      expect(g!, closeTo(-0.566, 0.01));
+    });
+
+    test('null when dtSeconds is zero or negative', () {
+      expect(
+          accelGForInterval(prevSpeedKmh: 0, currSpeedKmh: 30, dtSeconds: 0),
+          isNull);
+      expect(
+          accelGForInterval(prevSpeedKmh: 0, currSpeedKmh: 30, dtSeconds: -1),
+          isNull);
+    });
+  });
+
+  group('HarshEventDetector.events (#2029)', () {
+    test('emits a HarshEvent on threshold crossing with the magnitude in g',
+        () {
+      final detector = HarshEventDetector(
+        brakeThresholdMps2: 3.5,
+        accelThresholdMps2: 3.0,
+      );
+      final t0 = DateTime.utc(2026, 5, 24, 14, 0);
+      detector.onSample(80, t0);
+      // 1 s later: 80 → 60 km/h = -5.56 m/s² → harsh brake
+      detector.onSample(60, t0.add(const Duration(seconds: 1)));
+      expect(detector.events, hasLength(1));
+      expect(detector.events.first.type, HarshEventType.brake);
+      // magnitude ≈ |(-5.56)| / 9.80665 ≈ 0.566 g
+      expect(detector.events.first.magnitudeG, closeTo(0.566, 0.02));
+      expect(detector.events.first.speedKmh, 60);
+    });
+
+    test('reset clears events as well as anchor', () {
+      final detector = HarshEventDetector();
+      final t0 = DateTime.utc(2026, 5, 24);
+      detector.onSample(80, t0);
+      detector.onSample(60, t0.add(const Duration(seconds: 1)));
+      expect(detector.brakes, 1);
+      detector.reset();
+      expect(detector.brakes, 0);
+      expect(detector.events, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #2022 and #2029.

## Summary

Two commits, one per issue.

### #2022: `accelGForInterval` pure pipeline
- Speed-derivative acceleration in g via a single pure function
- Single `standardGravityMps2` constant; matching `HarshEvent` + `HarshEventType` types
- Foundation for the detector's per-event magnitude in #2029

### #2029: timestamped harsh-event list on TripSummary
- HarshEventDetector now records `List<HarshEvent>` with timestamp + magnitude (g) + speed (km/h) + type
- Integer `brakes` / `accelerations` survive as cheap getters over the list — every legacy consumer unchanged
- TripSummary gains `harshEvents` (empty default, so legacy trips deserialise unchanged)
- JSON compact key `'he'`, omitted when empty; backup XML `<HarshEvents>` block, also omitted when empty
- Backup golden fixture regenerated to include the new block

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/consumption/domain/harsh_event_test.dart` — 7/7
- [x] `flutter test test/features/consumption/domain/harsh_event_detector_test.dart` — 11/11 (regression, integer counter contract preserved)
- [x] `flutter test test/features/consumption/data/trip_history_repository_test.dart` — 34/34 (JSON round-trip)
- [x] `flutter test test/features/consumption/data/exporters/backup/` — 5/5 (golden updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)