### PR TITLE
feat(trip-recording): GPS-only trajet recording closes OBD2-optional loop (#2025)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -6,6 +6,8 @@ import '../../../../app/responsive_search_layout.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../feature_management/application/feature_flags_provider.dart';
+import '../../../feature_management/domain/feature.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/obd2_connection_errors.dart';
 import '../../data/trip_history_repository.dart';
@@ -58,6 +60,27 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
     setState(() => _startStage = TripStartStage.connectingAdapter);
     try {
       final notifier = ref.read(tripRecordingProvider.notifier);
+      // #2025 — when the user has disabled "Require OBD2 for trip
+      // recording" in feature management, bypass the adapter picker
+      // and start a GPS-only trajet immediately. The recording screen
+      // displays distance + speed from Geolocator; engine fields stay
+      // null and the persisted trip carries `kind: TripKind.gpsOnly`.
+      final flags = ref.read(enabledFeaturesProvider);
+      final obd2Required = flags.contains(Feature.obd2Optional);
+      if (!obd2Required) {
+        final outcome = await notifier.startGpsOnly();
+        if (!mounted) return;
+        await Navigator.of(context).push<TripSaveResult?>(
+          MaterialPageRoute(
+            builder: (_) => const TripRecordingScreen(),
+          ),
+        );
+        // `outcome` is informational here — the recording screen
+        // handles both the freshly-started and already-active cases
+        // the same way (its build reads from the provider).
+        if (outcome == StartTripOutcome.alreadyActive) return;
+        return;
+      }
       final outcome = await notifier.startTrip();
       if (!mounted) return;
       if (outcome == StartTripOutcome.alreadyActive) {

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/location/geolocator_wrapper.dart';
 
 import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
@@ -90,6 +93,17 @@ class TripRecording extends _$TripRecording {
   String? _adapterMac;
   String? _adapterName;
   String? _adapterFirmware;
+
+  // #2025 — GPS-only recording mode. When `_gpsOnlyMode` is true the
+  // notifier is running a parallel pipeline that taps Geolocator
+  // directly, feeds a pure [TripRecorder], and persists with
+  // `kind: TripKind.gpsOnly` on stop. No `_controller` / `_service` is
+  // created in this mode — the OBD2 polling loop simply isn't started.
+  bool _gpsOnlyMode = false;
+  TripRecorder? _gpsOnlyRecorder;
+  StreamSubscription<Position>? _gpsOnlySub;
+  final List<TripSample> _gpsOnlySamples = [];
+  DateTime? _gpsOnlyStartedAt;
 
   // #1458 phase 2 — most recent app lifecycle state observed by the
   // wiring layer's [WidgetsBindingObserver]. Read by the GPS stream
@@ -558,6 +572,11 @@ class TripRecording extends _$TripRecording {
   /// wrapper below) so the launcher-icon badge increments only when
   /// the coordinator was the one that decided to save.
   Future<StoppedTripResult> stop({bool automatic = false}) async {
+    // #2025 — GPS-only mode runs its own teardown that bypasses the
+    // OBD2 controller / service entirely.
+    if (_gpsOnlyMode) {
+      return _stopGpsOnly(automatic: automatic);
+    }
     final ctl = _controller;
     final svc = _service;
     if (ctl == null || svc == null) {
@@ -1192,6 +1211,131 @@ class TripRecording extends _$TripRecording {
     } catch (e, st) {
       debugPrint('TripRecording._saveToHistory: $e\n$st');
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // #2025 — GPS-only recording path. Lets users record a trajet without
+  // an OBD2 dongle: samples come from Geolocator, the TripRecorder
+  // accumulator runs the same harsh-event / distance / idle integration
+  // it does for OBD2 trips, and the persisted summary carries
+  // `kind: TripKind.gpsOnly` so downstream surfaces (confidence-tier
+  // badge, recording-screen redesign) can adapt.
+  // ---------------------------------------------------------------------------
+
+  /// Start a GPS-only trajet recording (#2025). Skips the OBD2 service
+  /// + adapter picker entirely; instead opens a Geolocator stream and
+  /// feeds a pure [TripRecorder] with synthetic samples (speed from
+  /// `Position.speed`, all engine fields null, lat/lon/altitude/bearing
+  /// from the fix).
+  ///
+  /// Returns:
+  ///  - [StartTripOutcome.started] when the stream was opened. Caller
+  ///    pushes the recording screen.
+  ///  - [StartTripOutcome.alreadyActive] when a trip is already
+  ///    running (OBD2 or GPS-only).
+  Future<StartTripOutcome> startGpsOnly() async {
+    if (state.isActive || _startInProgress) {
+      return StartTripOutcome.alreadyActive;
+    }
+    _startInProgress = true;
+    try {
+      _gpsOnlyMode = true;
+      _gpsOnlyRecorder = TripRecorder(maxIntegrationGapSeconds: 30);
+      _gpsOnlySamples.clear();
+      _gpsOnlyStartedAt = DateTime.now();
+      _lastTripStartedAt = DateTime.now();
+      _lastTripVehicleId = _tryReadActiveVehicle()?.id;
+      // Subscribe to the position stream at high accuracy — the
+      // post-trip map polyline + confidence-tier UX both want ~10 m
+      // precision. Permission failure is non-fatal: the stream errors
+      // and we log; the user sees an unmoving recording until they
+      // grant permission or stop.
+      final geo = ref.read(geolocatorWrapperProvider);
+      _gpsOnlySub = geo
+          .getPositionStream(
+            locationSettings: const LocationSettings(
+              accuracy: LocationAccuracy.high,
+            ),
+          )
+          .listen(
+            _onGpsOnlyPosition,
+            onError: (Object e, StackTrace st) {
+              debugPrint('TripRecording.startGpsOnly: stream error: $e\n$st');
+            },
+          );
+      // Seed the state so the recording screen renders immediately
+      // (the first GPS fix can be 1-3 s away on a cold start).
+      state = state.copyWith(
+        phase: TripRecordingPhase.recording,
+        live: const TripLiveReading(
+          elapsed: Duration.zero,
+          distanceKmSoFar: 0,
+        ),
+      );
+      return StartTripOutcome.started;
+    } finally {
+      _startInProgress = false;
+    }
+  }
+
+  void _onGpsOnlyPosition(Position p) {
+    final recorder = _gpsOnlyRecorder;
+    final startedAt = _gpsOnlyStartedAt;
+    if (recorder == null || startedAt == null || !_gpsOnlyMode) return;
+    // Geolocator can report a stale fix in the first emit before the
+    // GPS warms up — guard against speed = NaN / negative.
+    final speedMps = p.speed.isFinite && p.speed >= 0 ? p.speed : 0.0;
+    final sample = TripSample(
+      timestamp: p.timestamp,
+      speedKmh: speedMps * 3.6,
+      rpm: 0,
+      latitude: p.latitude.isFinite ? p.latitude : null,
+      longitude: p.longitude.isFinite ? p.longitude : null,
+      altitudeM: p.altitude.isFinite ? p.altitude : null,
+      hAccuracyM: p.accuracy.isFinite ? p.accuracy : null,
+      bearingDeg: p.heading.isFinite ? p.heading : null,
+    );
+    _gpsOnlySamples.add(sample);
+    recorder.onSample(sample);
+    final summary = recorder.buildSummary();
+    state = state.copyWith(
+      phase: TripRecordingPhase.recording,
+      live: TripLiveReading(
+        speedKmh: sample.speedKmh,
+        distanceKmSoFar: summary.distanceKm,
+        elapsed: DateTime.now().difference(startedAt),
+      ),
+    );
+  }
+
+  Future<StoppedTripResult> _stopGpsOnly({bool automatic = false}) async {
+    final recorder = _gpsOnlyRecorder;
+    await _gpsOnlySub?.cancel();
+    _gpsOnlySub = null;
+    if (recorder == null) {
+      _gpsOnlyMode = false;
+      state = const TripRecordingState();
+      return const StoppedTripResult.empty();
+    }
+    final summary = recorder.buildSummary().copyWith(
+          kind: TripKind.gpsOnly,
+        );
+    final samples = List<TripSample>.unmodifiable(_gpsOnlySamples);
+    await _saveToHistory(
+      summary,
+      samples: samples,
+      automatic: automatic,
+    );
+    _gpsOnlyMode = false;
+    _gpsOnlyRecorder = null;
+    _gpsOnlySamples.clear();
+    _gpsOnlyStartedAt = null;
+    state = const TripRecordingState();
+    return StoppedTripResult(
+      summary: summary,
+      odometerStartKm: null,
+      odometerLatestKm: null,
+    );
   }
 }
 


### PR DESCRIPTION
Closes #2025. Final piece of the OBD2-optional Epic #2015.

## Summary

`TripRecording` notifier gains a parallel `startGpsOnly()` path that records a trajet without an OBD2 dongle:

- Opens a Geolocator position stream at high accuracy
- Each position becomes a `TripSample` (speedKmh from `Position.speed`, engine fields null, lat/lon/altitude/bearing from the fix)
- Pure `TripRecorder` accumulates samples for distance + harsh events
- `stop()` branches on `_gpsOnlyMode`; GPS-only teardown persists with `kind: TripKind.gpsOnly`

`TrajetsTab._onStartRecording` reads `Feature.obd2Optional`: when OFF (= OBD2 not required), the adapter picker is bypassed and GPS-only kicks in.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/consumption/providers/` — 212/212 green (no regressions on existing OBD2 path)
- [x] `flutter test test/lint/no_hardcoded_ui_strings_test.dart` — baseline unchanged
- [x] `flutter test test/lint/file_length_test.dart` — no new offenders
- [ ] Manual: in feature management toggle "Require OBD2 for trip recording" OFF → tap Start in Trajets → confirm recording starts without OBD2 picker
- [ ] Manual: drive ~1 km → tap Stop → confirm trip persists with kind=gpsOnly + GPS polyline visible in detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)