### PR TITLE
fix(codegen): regenerate trip_recording_provider.g.dart after #2025

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'4a52244a18887a7c25a95defff23ff715326b35e';
+String _$tripRecordingHash() => r'b243709e449fdce6426a8af435d6c56c0647e677';
 
 /// App-wide owner of the trip recording (#726).
 ///


### PR DESCRIPTION
Master's codegen-drift CI started failing after #2042 merged because the Riverpod `.g.dart` for `TripRecording` wasn't regenerated alongside the new GPS-only fields.

Running `dart run build_runner build --delete-conflicting-outputs` locally produces only one file diff — `trip_recording_provider.g.dart` — committed verbatim here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)