### PR TITLE
fix(map): cure grey-tile cold start when the first search lands late

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'4a52244a18887a7c25a95defff23ff715326b35e';
+String _$tripRecordingHash() => r'b243709e449fdce6426a8af435d6c56c0647e677';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -211,14 +211,19 @@ class _StationMapLayersState extends State<StationMapLayers> {
   Timer? _coldStartCloseTimer;
 
   /// How long to keep firing tile-resets on programmatic
-  /// size/camera changes after init. Three seconds covers the worst
+  /// size/camera changes after init. Twelve seconds covers the worst
   /// observed cold-start sequence (offstage IndexedStack pre-mount
   /// → onstage promotion → LayoutBuilder gate clears → FlutterMap
   /// internal LayoutBuilder lays out → `fitCamera` post-frame
-  /// callback fires → camera settles). Shorter windows missed the
-  /// late `fitCamera` on slow devices; longer windows risk
-  /// interfering with the user's first deliberate zoom.
-  static const Duration _coldStartResetWindow = Duration(seconds: 3);
+  /// callback fires → camera settles). Originally 3 s but the user's
+  /// 2026-05-24 report showed a slow-network cold open where the
+  /// first search result + `fitCamera` arrived ~5-8 s after mount
+  /// — past the old window — leaving the grey-tile bug uncovered
+  /// until they tapped Refresh. Twelve seconds gives a healthy
+  /// margin for GPS resolution + first network round-trip on cellular
+  /// while still bounded enough that the user's first deliberate
+  /// zoom (10+ s in) is unaffected.
+  static const Duration _coldStartResetWindow = Duration(seconds: 12);
 
   /// #1774 — the marker list and the price range are memoised here and
   /// recomputed only when `stations` / `selectedFuel` /
@@ -256,10 +261,29 @@ class _StationMapLayersState extends State<StationMapLayers> {
     // references until the underlying value changes, so identity
     // comparison is enough to skip the recompute on an unrelated
     // `MapScreen` rebuild.
-    if (!identical(oldWidget.stations, widget.stations) ||
+    final stationsChanged = !identical(oldWidget.stations, widget.stations);
+    if (stationsChanged ||
         oldWidget.selectedFuel != widget.selectedFuel ||
         !identical(oldWidget.selectedStationIds, widget.selectedStationIds)) {
       _recomputeMarkers();
+    }
+    // Tap-the-refresh-button cure (#2025 follow-up). When stations
+    // transition from empty → populated (the first successful search
+    // after a cold open) OR when the camera-anchoring centre changes,
+    // force a TileLayer reset. This catches the case where the user
+    // opens Carte before a search has landed: the initial map renders
+    // with a bootstrap camera and TileLayer captured a degenerate
+    // viewport, the 3-second cold-start window closed silently, and
+    // the user sees a grey background until they tap Refresh. The
+    // reset stream is broadcast + cheap (a no-op when tiles are
+    // already loaded for the visible range), so re-firing it on the
+    // search-results-arrived transition is the safest cure.
+    final wasEmpty = oldWidget.stations.isEmpty;
+    final centerChanged = widget.center != oldWidget.center;
+    if ((wasEmpty && widget.stations.isNotEmpty) || centerChanged) {
+      if (!_resetController.isClosed) {
+        _resetController.add(null);
+      }
     }
   }
 

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -347,8 +347,9 @@ void main() {
         final sub = reset.listen(emissions.add);
         addTearDown(sub.cancel);
 
-        // Burn past the 3-second cold-start window.
-        await tester.pump(const Duration(seconds: 4));
+        // Burn past the 12-second cold-start window (extended from
+        // 3 s in the #2025 follow-up to cover slow-network cold opens).
+        await tester.pump(const Duration(seconds: 13));
         final baseline = emissions.length;
 
         // Programmatic move AFTER the window — must not re-emit on


### PR DESCRIPTION
Two-part fix for the "map stays grey until I tap Refresh" report:

1. **Cold-start reset window 3 s → 12 s** so a slow first search (cellular cold open with GPS resolution) still hits TileLayer with a reset on `fitCamera`.
2. **Reset on stations-just-arrived / center-changed** in `didUpdateWidget` so even a search that lands past the 12 s window kicks TileLayer once.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/map/` — 124/124 (steady-state assertion bumped from 4 s to 13 s)
- [ ] Manual: airplane mode on, cold open Carte → tiles arrive without a Refresh tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)