### PR TITLE
feat: wizard Medium = GPS-only trajets + download-only file exports (#2025 follow-up)

### DIFF
--- a/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
@@ -120,20 +120,14 @@ class FullBackupExporter {
     final file = File(filePath);
     await file.writeAsBytes(bytes, flush: true);
 
-    final params = ShareParams(
-      files: [XFile(filePath, mimeType: 'application/zip')],
-      subject: fileName,
-      text: fileName,
-    );
-    final sink = debugBackupShareSinkOverride ?? _defaultShareSink;
-    await sink(params);
-
-    // #2014 — also drop the same zip into the device's public
-    // Downloads folder (MediaStore on Android Q+, Files-app-visible
-    // Documents/Downloads on iOS) so the user can find it via any
-    // file manager after the share sheet closes. The share-sheet
-    // hand-off above is the primary surface; this save step is
-    // best-effort — a failure here must not mask the successful share.
+    // 2026-05-24 follow-up — file exports go straight to the device's
+    // public Downloads folder via PublicFileExporter (MediaStore on
+    // Android Q+, Files-app-visible Documents/Downloads on iOS). The
+    // OS share sheet is no longer offered: the user explicitly asked
+    // for "files only download, do not suggest sharing." The tempDir
+    // copy above is kept because some test fakes assert on
+    // `result.filePath`; the production caller now only reads
+    // `result.savedPath` and surfaces a "Saved to Downloads" snackbar.
     String? savedPath;
     try {
       savedPath = await PublicFileExporter.saveBytesToDownloads(
@@ -145,6 +139,20 @@ class FullBackupExporter {
       debugPrint('FullBackupExporter: save-to-downloads failed: $e\n$st');
     }
 
+    // Keep the share-sink shape so existing test fakes (and any
+    // future surface that wants to re-enable a share fallback) can
+    // still hand the file off. Production wires the no-op default
+    // below.
+    final sink = debugBackupShareSinkOverride;
+    if (sink != null) {
+      final params = ShareParams(
+        files: [XFile(filePath, mimeType: 'application/zip')],
+        subject: fileName,
+        text: fileName,
+      );
+      await sink(params);
+    }
+
     return FullBackupExportResult(
       filePath: filePath,
       byteSize: bytes.length,
@@ -153,5 +161,3 @@ class FullBackupExporter {
   }
 }
 
-Future<void> _defaultShareSink(ShareParams params) =>
-    SharePlus.instance.share(params);

--- a/lib/features/consumption/presentation/screens/trajets_map_screen.dart
+++ b/lib/features/consumption/presentation/screens/trajets_map_screen.dart
@@ -6,8 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:share_plus/share_plus.dart';
 
+import '../../../../core/sharing/public_file_exporter.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -127,23 +127,23 @@ class TrajetsMapScreen extends ConsumerWidget {
         await override(bytes: bytes, fileName: fileName);
         return;
       }
-      await SharePlus.instance.share(
-        ShareParams(
-          files: [
-            XFile.fromData(
-              bytes,
-              mimeType: 'application/gpx+xml',
-              name: fileName,
-            ),
-          ],
-          subject: fileName,
-        ),
+      // 2026-05-24 follow-up — file exports go straight to the device's
+      // public Downloads folder via PublicFileExporter. No share sheet
+      // / chooser; a single confirmation snackbar points the user at
+      // the Downloads folder.
+      await PublicFileExporter.saveBytesToDownloads(
+        bytes: bytes,
+        fileName: fileName,
+        mimeType: 'application/gpx+xml',
       );
+      if (messenger == null) return;
+      final ok = l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
+      messenger.showSnackBar(SnackBar(content: Text(ok)));
     } catch (e, st) {
-      debugPrint('TrajetsMapScreen share GPX: $e\n$st');
+      debugPrint('TrajetsMapScreen save GPX: $e\n$st');
       if (messenger == null) return;
       final errorMsg =
-          l?.trajetsMapShareError ?? "Couldn't share the GPX file";
+          l?.trajetsMapShareError ?? "Couldn't save the GPX file";
       messenger
           .showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
     }

--- a/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
@@ -2,25 +2,33 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:share_plus/share_plus.dart';
 
+import '../../../../core/sharing/public_file_exporter.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/exporters/gpx_exporter.dart';
 import '../../data/trip_history_repository.dart';
 
-/// Test-only override for the GPX share sink (#2032).
+/// Test-only override for the GPX save sink (#2032). Originally named
+/// `*ShareOverride` when this path used the OS share sheet; preserved
+/// for test compatibility after the action became download-only in
+/// the 2026-05-24 follow-up (user request: "for files only download
+/// and do not suggest sharing").
 @visibleForTesting
 Future<void> Function({
   required Uint8List bytes,
   required String fileName,
 })? debugTripDetailGpxShareOverride;
 
-/// Export the trip's persisted GPS samples as a GPX 1.1 file and hand
-/// it to the OS share sheet (#2032). Extracted from
-/// `trip_detail_screen.dart` to keep that file under the 400-line
-/// guard. Best-effort: a share failure surfaces a snackbar, never
-/// throws.
+/// Export the trip's persisted GPS samples as a GPX 1.1 file and save
+/// it to the device's public Downloads folder (#2032 + 2026-05-24
+/// follow-up). The file lands where the user can find it via the
+/// system file manager — no share sheet, no chooser; a single
+/// confirmation snackbar reports success.
+///
+/// Best-effort: a save failure surfaces an error snackbar, never
+/// throws. Empty-GPS trips short-circuit with the same "no GPS
+/// samples" message the share path used.
 Future<void> shareTripGpx(
   BuildContext context,
   AppLocalizations? l,
@@ -42,23 +50,19 @@ Future<void> shareTripGpx(
       await override(bytes: bytes, fileName: fileName);
       return;
     }
-    await SharePlus.instance.share(
-      ShareParams(
-        files: [
-          XFile.fromData(
-            bytes,
-            mimeType: 'application/gpx+xml',
-            name: fileName,
-          ),
-        ],
-        subject: fileName,
-      ),
+    await PublicFileExporter.saveBytesToDownloads(
+      bytes: bytes,
+      fileName: fileName,
+      mimeType: 'application/gpx+xml',
     );
-  } catch (e, st) {
-    debugPrint('TripDetailScreen share GPX: $e\n$st');
     if (messenger == null) return;
-    final errorMsg =
-        l?.trajetDetailShareError ?? "Couldn't share the GPX file";
+    final ok =
+        l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
+    messenger.showSnackBar(SnackBar(content: Text(ok)));
+  } catch (e, st) {
+    debugPrint('TripDetailScreen save GPX: $e\n$st');
+    if (messenger == null) return;
+    final errorMsg = l?.trajetDetailShareError ?? "Couldn't save the GPX file";
     messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));
   }
 }

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -28,8 +28,6 @@ typedef Obd2DiagnosticShareSink = Future<void> Function(ShareParams params);
 @visibleForTesting
 Obd2DiagnosticShareSink? debugObd2DiagnosticShareSinkOverride;
 
-Future<void> _defaultObd2DiagnosticShareSink(ShareParams params) =>
-    SharePlus.instance.share(params);
 
 /// In-app overlay that renders the most recent fuel-rate breadcrumbs
 /// captured by [Obd2BreadcrumbsNotifier] (#1395). Sibling to the map
@@ -65,14 +63,17 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     final String report = formatObd2DiagnosticReport(
       AutoRecordTraceLog.snapshot(),
     );
-    final ShareParams params = ShareParams(text: report);
-    final Obd2DiagnosticShareSink sink =
-        debugObd2DiagnosticShareSinkOverride ??
-            _defaultObd2DiagnosticShareSink;
-    try {
-      await sink(params);
-    } catch (e, st) {
-      debugPrint('Obd2BreadcrumbOverlay share diagnostic log failed: $e\n$st');
+    // 2026-05-24 follow-up — file exports go straight to Downloads,
+    // no share sheet. The test seam (`debugObd2DiagnosticShareSinkOverride`)
+    // is preserved so the widget tests can still observe the outgoing
+    // payload via a `ShareParams(text: ...)` wrapper.
+    final sink = debugObd2DiagnosticShareSinkOverride;
+    if (sink != null) {
+      try {
+        await sink(ShareParams(text: report));
+      } catch (e, st) {
+        debugPrint('Obd2BreadcrumbOverlay diagnostic log sink: $e\n$st');
+      }
     }
     await _alsoSaveToDownloads(
       text: report,
@@ -96,14 +97,15 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
         ? '<!-- No OBD2 debug session recorded. Enable "OBD2 debug '
             'logging" in Settings, then reproduce the issue. -->'
         : formatObd2DebugSessionXml(session);
-    final ShareParams params = ShareParams(text: payload);
-    final Obd2DiagnosticShareSink sink =
-        debugObd2DiagnosticShareSinkOverride ??
-            _defaultObd2DiagnosticShareSink;
-    try {
-      await sink(params);
-    } catch (e, st) {
-      debugPrint('Obd2BreadcrumbOverlay share session XML failed: $e\n$st');
+    // Same download-only policy as `_shareDiagnosticLog` — see note
+    // there.
+    final sink = debugObd2DiagnosticShareSinkOverride;
+    if (sink != null) {
+      try {
+        await sink(ShareParams(text: payload));
+      } catch (e, st) {
+        debugPrint('Obd2BreadcrumbOverlay session XML sink: $e\n$st');
+      }
     }
     await _alsoSaveToDownloads(
       text: payload,

--- a/lib/features/feature_management/domain/app_profile.dart
+++ b/lib/features/feature_management/domain/app_profile.dart
@@ -57,20 +57,23 @@ enum AppProfile {
 ///   `requires:` edge; both go in together so the requires graph stays
 ///   satisfied)
 ///
-/// **Medium** — Basic + manual fill-up logging
+/// **Medium** — Basic + manual fill-up logging + GPS-only trajets
 /// - All Basic features
 /// - `manualConsumption` — fuel fill-ups + EV charging logged by hand
+/// - `obd2TripRecording` + `consumptionAnalytics` + `showConsumptionTab`
+///   — trajet recording feature surfaces, but the user is NOT required
+///   to pair an OBD2 dongle: the absent `obd2Optional` flag means the
+///   #2025 GPS-only path kicks in on Start
+/// - `gpsTripPath` — GPS samples persisted so the post-trip map +
+///   GPX export work for GPS-only trajets
 ///
-/// Trajets / OBD2 stay off on Medium; the Trajets tab self-hides via
-/// the `obd2TripRecording` gate (#conso-coherence).
-///
-/// **Full** — Medium + OBD2 + ergonomics
+/// **Full** — Medium + OBD2 required + ergonomics
 /// - All Medium features
-/// - OBD2 stack: `obd2TripRecording`, `autoRecord`,
-///   `consumptionAnalytics`, `gamification`, `showConsumptionTab`,
-///   `loyaltyCards`
-/// - Ergonomics opt-ins: `hapticEcoCoach`, `glideCoach`, `gpsTripPath`
-///   (all three `requires: {obd2TripRecording}` per the manifest)
+/// - `obd2Optional` — OBD2 is required to start a trip (no GPS-only
+///   fallback). Full users are expected to have an adapter paired.
+/// - OBD2 ergonomics: `autoRecord`, `gamification`, `loyaltyCards`,
+///   `hapticEcoCoach`, `glideCoach` (the last two
+///   `requires: {obd2TripRecording}` per the manifest)
 ///
 /// Off in **every** preset (user opts in individually):
 /// - `tflitePricePrediction` (model artifact still off-band; #1543)
@@ -100,6 +103,15 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     // leaving Medium users no path to configure a vehicle for the
     // manual fill-up flow they just opted into.
     Feature.showConsumptionTab,
+    // #2025 — Medium users get trajet recording but in the GPS-only
+    // path: `obd2TripRecording` surfaces the Trajets tab + recording
+    // CTA, `gpsTripPath` persists GPS samples for the post-trip map
+    // and GPX export, and the deliberate ABSENCE of `obd2Optional`
+    // tells `_onStartRecording` to skip the adapter picker and call
+    // `startGpsOnly()` instead.
+    Feature.obd2TripRecording,
+    Feature.consumptionAnalytics,
+    Feature.gpsTripPath,
   },
   AppProfile.full: {
     Feature.showFuel,
@@ -120,6 +132,11 @@ const Map<AppProfile, Set<Feature>> appProfileBundles = {
     Feature.hapticEcoCoach,
     Feature.glideCoach,
     Feature.gpsTripPath,
+    // #2025 — Full users require an OBD2 dongle. Including
+    // `obd2Optional` in the preset preserves the historical default
+    // (Start → adapter picker → OBD2-driven recording) for users who
+    // pick Full from the wizard.
+    Feature.obd2Optional,
   },
   // The custom sentinel has no bundle — the user's flag set is
   // whatever they last persisted, and re-selecting `custom` from the

--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -230,23 +230,41 @@ class _PrivacyDashboardScreenState
   }
 
   Future<void> _shareErrorLogAsFile(String json) async {
-    final tempDirProvider =
-        debugPrivacyTempDirectoryOverride ?? getTemporaryDirectory;
-    final tempDir = await tempDirProvider();
-    final filePath = '${tempDir.path}/tankstellen-error-log.json';
-    final file = File(filePath);
-    await file.writeAsString(json, flush: true);
-
-    final params = ShareParams(
-      files: [XFile(filePath, mimeType: 'application/json')],
-      subject: 'tankstellen-error-log.json',
-    );
-    final sink = debugPrivacyShareSinkOverride ?? _defaultShareSink;
-    await sink(params);
+    // 2026-05-24 follow-up — file exports go straight to the device's
+    // public Downloads folder. The test seam is preserved so widget
+    // tests can still observe the outgoing ShareParams payload, but
+    // production runs only the PublicFileExporter save.
+    final sink = debugPrivacyShareSinkOverride;
+    if (sink != null) {
+      final tempDirProvider =
+          debugPrivacyTempDirectoryOverride ?? getTemporaryDirectory;
+      final tempDir = await tempDirProvider();
+      final filePath = '${tempDir.path}/tankstellen-error-log.json';
+      final file = File(filePath);
+      await file.writeAsString(json, flush: true);
+      final params = ShareParams(
+        files: [XFile(filePath, mimeType: 'application/json')],
+        subject: 'tankstellen-error-log.json',
+      );
+      await sink(params);
+      return;
+    }
+    try {
+      await PublicFileExporter.saveTextToDownloads(
+        text: json,
+        fileName: 'tankstellen-error-log.json',
+        mimeType: 'application/json',
+      );
+      if (!mounted) return;
+      final l = AppLocalizations.of(context);
+      SnackBarHelper.showSuccess(
+        context,
+        l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
+      );
+    } on Object catch (e, st) {
+      debugPrint('privacy: error-log save-to-downloads failed: $e\n$st');
+    }
   }
-
-  static Future<void> _defaultShareSink(ShareParams params) =>
-      SharePlus.instance.share(params);
 
   Future<void> _exportDataCsv() async {
     // Grab localizations pre-await — see `_exportData` for the same

--- a/test/features/feature_management/app_profile_provider_test.dart
+++ b/test/features/feature_management/app_profile_provider_test.dart
@@ -100,7 +100,9 @@ void main() {
       expect(profileRepo.load(), AppProfile.basic);
     });
 
-    test('medium enables manualConsumption on top of basic', () async {
+    test(
+        'medium enables manualConsumption + GPS-only trajets on top of basic',
+        () async {
       final c = makeContainer();
       await pumpLoad(c);
       await c
@@ -109,7 +111,11 @@ void main() {
       final flags = c.read(enabledFeaturesProvider);
       expect(flags, contains(Feature.manualConsumption));
       expect(flags, contains(Feature.priceAlerts));
-      expect(flags, isNot(contains(Feature.obd2TripRecording)));
+      // #2025 — Medium now surfaces Trajets via obd2TripRecording, but
+      // *without* obd2Optional so the start path uses GPS-only.
+      expect(flags, contains(Feature.obd2TripRecording));
+      expect(flags, contains(Feature.gpsTripPath));
+      expect(flags, isNot(contains(Feature.obd2Optional)));
     });
 
     test(
@@ -132,7 +138,11 @@ void main() {
       final flags = c.read(enabledFeaturesProvider);
       expect(flags, appProfileBundles[AppProfile.medium]);
       expect(flags, contains(Feature.showConsumptionTab));
-      expect(flags, isNot(contains(Feature.obd2TripRecording)));
+      // #2025 — Medium DOES now contain obd2TripRecording (it's just
+      // routed through the GPS-only start path via the absent
+      // obd2Optional flag). The atomic bundle apply still succeeds
+      // because each Feature's prerequisites are written together.
+      expect(flags, contains(Feature.obd2TripRecording));
     });
 
     test('full enables OBD2 stack and loyalty', () async {

--- a/test/features/feature_management/app_profile_test.dart
+++ b/test/features/feature_management/app_profile_test.dart
@@ -44,11 +44,19 @@ void main() {
       // can't reach the vehicle-add affordance).
       expect(medium, contains(Feature.manualConsumption));
       expect(medium, contains(Feature.showConsumptionTab));
-      // Medium STILL excludes the OBD2 stack — that is the Full tier.
-      expect(medium, isNot(contains(Feature.obd2TripRecording)));
+      // #2025 — Medium now includes the trajet recording surface but
+      // routes through the GPS-only path. The presence of
+      // `obd2TripRecording` enables the Trajets tab + Start CTA; the
+      // ABSENCE of `obd2Optional` tells the start flow to call
+      // `startGpsOnly()` instead of the adapter picker.
+      expect(medium, contains(Feature.obd2TripRecording));
+      expect(medium, contains(Feature.consumptionAnalytics));
+      expect(medium, contains(Feature.gpsTripPath));
+      expect(medium, isNot(contains(Feature.obd2Optional)));
+      // Auto-record / gamification / loyalty stay Full-tier — they
+      // assume a paired OBD2 dongle.
       expect(medium, isNot(contains(Feature.autoRecord)));
       expect(medium, isNot(contains(Feature.gamification)));
-      expect(medium, isNot(contains(Feature.consumptionAnalytics)));
       expect(medium, isNot(contains(Feature.loyaltyCards)));
     });
 
@@ -70,6 +78,9 @@ void main() {
       expect(full, contains(Feature.hapticEcoCoach));
       expect(full, contains(Feature.glideCoach));
       expect(full, contains(Feature.gpsTripPath));
+      // #2025 — Full requires an OBD2 dongle to start a trip
+      // (`obd2Optional` ON ⇒ adapter picker, no GPS-only fallback).
+      expect(full, contains(Feature.obd2Optional));
       // Full does NOT mean "every flag on" — `tflitePricePrediction`
       // stays off until the user opts in (off-band model artifact).
       expect(full, isNot(contains(Feature.tflitePricePrediction)));
@@ -154,14 +165,20 @@ void main() {
       );
     });
 
-    test('medium ⇒ ConsoMode.fuel (manual fill-ups, no Trajets)', () {
+    test(
+        'medium ⇒ ConsoMode.fuelAndTrips (manual fill-ups + GPS-only trajets)',
+        () {
+      // #2025 — Medium now exposes the Trajets tab too; the trip-start
+      // path uses the GPS-only branch (no OBD2 required). ConsoMode
+      // still flips to fuelAndTrips because `obd2TripRecording` is in
+      // the bundle — that's the surface gate, not the data-source gate.
       expect(
         consoModeFromFlags(appProfileBundles[AppProfile.medium]!),
-        ConsoMode.fuel,
+        ConsoMode.fuelAndTrips,
       );
     });
 
-    test('full ⇒ ConsoMode.fuelAndTrips (full Conso + OBD2)', () {
+    test('full ⇒ ConsoMode.fuelAndTrips (full Conso + OBD2 required)', () {
       expect(
         consoModeFromFlags(appProfileBundles[AppProfile.full]!),
         ConsoMode.fuelAndTrips,


### PR DESCRIPTION
Two parallel changes, one commit each.

## 1. App Profile presets

- **Medium** now exposes the Trajets tab + recording via `obd2TripRecording` + `consumptionAnalytics` + `gpsTripPath`. Crucially omits `obd2Optional` — that absence tells `_onStartRecording` to call `startGpsOnly()` (PR #2042). Medium users record GPS-only trajets without ever pairing a dongle.
- **Full** adds `obd2Optional` (OBD2 required) on top of the existing OBD2 stack.

## 2. Download-only file exports

User request: "for files only download and do not suggest sharing." Removes the OS share sheet hand-off from every file-export path:

| Surface | What now happens |
|---|---|
| Trip GPX (`trip_detail_gpx_share`) | Saves directly to Downloads |
| Trajets-map aggregate GPX | Saves directly to Downloads |
| Full backup ZIP | Saves directly to Downloads |
| OBD2 debug XML / log | Saves directly to Downloads |
| Privacy error log | Saves directly to Downloads |

Each surface keeps its `debug*ShareSinkOverride` test seam so widget tests still observe payloads. Image/text shares (carbon dashboard, station detail) are untouched — the user's "files" scope was explicit.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/feature_management/` — 149/149
- [x] `flutter test test/features/consumption/{data,presentation/widgets,presentation/screens}/` — all green
- [x] `flutter test test/lint/` — baselines unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)