### PR TITLE
fix(widget): cold-start widget tap now opens the station for already-setup users

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -118,6 +118,22 @@ GoRouter router(Ref ref) {
       final isSetupAllowedChild = state.matchedLocation == '/vehicles' ||
           state.matchedLocation == '/vehicles/edit';
 
+      // Cold-start widget tap on an existing fully-setup user lands the
+      // router at the configured `landingScreen` (typically '/'). The
+      // stashed widget URI must be consumed BEFORE the consent/setup
+      // gates run their default behaviour, otherwise an existing user
+      // whose redirect never falls into the consent/setup branches
+      // never gets the URI applied (the original 2026-05-24 report).
+      // Consuming up-front is safe: the consent/setup gates below
+      // return their own override paths if the user actually needs to
+      // be sent to onboarding, and the pending URI is then re-honoured
+      // by the consent/setup branches once the user lands past those
+      // walls.
+      if (hasConsent && isReady && !isConsent && !isSetup) {
+        final widgetPath = _consumePendingWidgetPath(ref);
+        if (widgetPath != null) return widgetPath;
+      }
+
       // Step 1: GDPR consent must be given before anything else
       if (!hasConsent && !isConsent) return '/consent';
       if (hasConsent && isConsent) {

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -48,4 +48,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'ca4157d3a8eff7baf498bf7c0c213ae04cf1393d';
+String _$routerHash() => r'd6e2d76e6c2c48513399b7f4b8a90a57697efb24';


### PR DESCRIPTION
User report 2026-05-24: tapping a station row in the home-screen widget didn't open that station in the app.

## Root cause

The redirect chain in `router.dart` only consumed the stashed widget URI inside its consent + setup gates. An existing user past both starts at '/', never hits either branch, and the URI was orphaned → user lands on the configured landing screen instead of the requested station detail.

## Fix

Hoist `_consumePendingWidgetPath` to run **before** the consent/setup gates when the user is past both. The original consent/setup branches still re-honour the URI (the stash is single-shot, so the second consume becomes a no-op).

## Test plan

- [x] `flutter analyze` clean
- [x] Existing #753 e2e tests pass (`widget_tap_e2e_test.dart`, 3/3)
- [x] Full widget + router sweep — 333/333 green
- [ ] Manual: long-press a station row in the widget → confirm app opens to that station detail (not the landing screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)