### PR TITLE
feat(trip-recording): derive TripKind from samples — mid-trip upgrade (#2025)

### DIFF
--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -197,4 +197,31 @@ enum TripKind {
         'gpsOnly' => TripKind.gpsOnly,
         _ => TripKind.gpsPlusObd2,
       };
+
+  /// Derives the kind from the actual sample data — the mid-trip
+  /// upgrade rule baked into #2025's acceptance: a trip that started
+  /// in GPS-only mode but later received OBD2 telemetry should be
+  /// classified as `gpsPlusObd2`.
+  ///
+  /// Heuristic: any sample with `rpm > 0` OR `fuelRateLPerHour != null`
+  /// is an OBD2 sample (GPS-only samples carry `rpm: 0` and a null
+  /// fuel rate by construction). One such sample flips the whole
+  /// trip — that's the "subsequent samples carry OBD2 fields" clause
+  /// from the issue.
+  ///
+  /// Returns [gpsPlusObd2] for an empty iterable so the historical
+  /// default holds when called against legacy data that doesn't
+  /// thread its samples through.
+  static TripKind fromSamples(Iterable<dynamic> samples) {
+    var sawAny = false;
+    for (final s in samples) {
+      sawAny = true;
+      final rpm = (s as dynamic).rpm as num? ?? 0;
+      final fuelRate =
+          (s as dynamic).fuelRateLPerHour as double?;
+      if (rpm > 0 || fuelRate != null) return TripKind.gpsPlusObd2;
+    }
+    if (!sawAny) return TripKind.gpsPlusObd2;
+    return TripKind.gpsOnly;
+  }
 }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -1317,10 +1317,14 @@ class TripRecording extends _$TripRecording {
       state = const TripRecordingState();
       return const StoppedTripResult.empty();
     }
-    final summary = recorder.buildSummary().copyWith(
-          kind: TripKind.gpsOnly,
-        );
     final samples = List<TripSample>.unmodifiable(_gpsOnlySamples);
+    // #2025 — derive `kind` from the actual sample stream rather than
+    // hardcoding `gpsOnly`. If [_upgradeGpsOnlyToObd2] (or any future
+    // mid-trip path) injected OBD2 samples into the buffer, the
+    // resulting kind correctly flips to `gpsPlusObd2`.
+    final summary = recorder.buildSummary().copyWith(
+          kind: TripKind.fromSamples(samples),
+        );
     await _saveToHistory(
       summary,
       samples: samples,
@@ -1336,6 +1340,25 @@ class TripRecording extends _$TripRecording {
       odometerStartKm: null,
       odometerLatestKm: null,
     );
+  }
+
+  /// #2025 — mid-trip upgrade hook. Appends an externally-built
+  /// [TripSample] (carrying OBD2 telemetry) to the in-progress
+  /// GPS-only buffer + recorder so the final [TripSummary.kind] flips
+  /// to `gpsPlusObd2` via [TripKind.fromSamples].
+  ///
+  /// No-op when no GPS-only trip is active. Future UX surface
+  /// (banner: "OBD2 detected — attach to current trip?") drives
+  /// this; until then the API lives here so the acceptance scenario
+  /// is testable + the data layer supports it the moment any
+  /// caller starts producing OBD2-flavoured samples.
+  @visibleForTesting
+  void debugAppendObd2SampleToGpsOnly(TripSample sample) {
+    if (!_gpsOnlyMode) return;
+    final recorder = _gpsOnlyRecorder;
+    if (recorder == null) return;
+    _gpsOnlySamples.add(sample);
+    recorder.onSample(sample);
   }
 }
 

--- a/test/features/consumption/domain/trip_kind_from_samples_test.dart
+++ b/test/features/consumption/domain/trip_kind_from_samples_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/domain/trip_summary.dart';
+
+TripSample _gpsOnlySample(DateTime t, double speedKmh) => TripSample(
+      timestamp: t,
+      speedKmh: speedKmh,
+      rpm: 0,
+    );
+
+TripSample _obd2Sample(
+  DateTime t, {
+  double speedKmh = 50,
+  double rpm = 2000,
+  double? fuelRateLPerHour,
+}) =>
+    TripSample(
+      timestamp: t,
+      speedKmh: speedKmh,
+      rpm: rpm,
+      fuelRateLPerHour: fuelRateLPerHour,
+    );
+
+void main() {
+  group('TripKind.fromSamples (#2025 mid-trip upgrade)', () {
+    final t0 = DateTime.utc(2026, 5, 25, 10);
+
+    test('empty samples → gpsPlusObd2 (preserves the historical default)',
+        () {
+      expect(TripKind.fromSamples(const <TripSample>[]),
+          TripKind.gpsPlusObd2);
+    });
+
+    test('all GPS-only samples (rpm=0, fuelRate=null) → gpsOnly', () {
+      final samples = [
+        for (int i = 0; i < 5; i++)
+          _gpsOnlySample(t0.add(Duration(seconds: i)), 50.0 + i),
+      ];
+      expect(TripKind.fromSamples(samples), TripKind.gpsOnly);
+    });
+
+    test('any sample with rpm > 0 flips the trip to gpsPlusObd2', () {
+      final samples = [
+        _gpsOnlySample(t0, 50),
+        _gpsOnlySample(t0.add(const Duration(seconds: 1)), 52),
+        // mid-trip OBD2 sample
+        _obd2Sample(t0.add(const Duration(seconds: 2)), rpm: 1800),
+        _gpsOnlySample(t0.add(const Duration(seconds: 3)), 55),
+      ];
+      expect(TripKind.fromSamples(samples), TripKind.gpsPlusObd2);
+    });
+
+    test('any sample with non-null fuelRate flips to gpsPlusObd2', () {
+      final samples = [
+        _gpsOnlySample(t0, 50),
+        // OBD2 reports speed + fuel rate but rpm == 0 (idle case)
+        _obd2Sample(
+          t0.add(const Duration(seconds: 1)),
+          rpm: 0,
+          fuelRateLPerHour: 0.6,
+        ),
+      ];
+      expect(TripKind.fromSamples(samples), TripKind.gpsPlusObd2);
+    });
+
+    test('all OBD2 samples → gpsPlusObd2', () {
+      final samples = [
+        for (int i = 0; i < 5; i++)
+          _obd2Sample(t0.add(Duration(seconds: i))),
+      ];
+      expect(TripKind.fromSamples(samples), TripKind.gpsPlusObd2);
+    });
+
+    test('iterable input — works with sequences that are not Lists', () {
+      Iterable<TripSample> gen() sync* {
+        yield _gpsOnlySample(t0, 50);
+        yield _obd2Sample(t0.add(const Duration(seconds: 1)));
+      }
+
+      expect(TripKind.fromSamples(gen()), TripKind.gpsPlusObd2);
+    });
+  });
+}


### PR DESCRIPTION
PR #2042 closed #2025 but hardcoded `kind: TripKind.gpsOnly` in the GPS-only stop path. This satisfies the issue's third acceptance scenario (OBD2 connects mid-trip) by deriving the kind from the actual sample stream.

## Changes

- `TripKind.fromSamples(Iterable<TripSample>)` — any sample with `rpm > 0` OR a non-null `fuelRateLPerHour` flips the trip to `gpsPlusObd2`. Empty iterable → `gpsPlusObd2` (preserves the historical default).
- `_stopGpsOnly` uses it. Same trip, same data, correct classification.
- `debugAppendObd2SampleToGpsOnly` test seam ready for the future mid-trip-upgrade UX (banner: "OBD2 detected — attach to current trip?").

## Acceptance scenarios

| Scenario | Sample data | Derived kind |
|---|---|---|
| No OBD2 | all rpm=0, fuelRate=null | gpsOnly ✅ |
| OBD2 from start | all rpm>0 + fuelRate | gpsPlusObd2 ✅ |
| OBD2 mid-trip | GPS-only then OBD2 samples | gpsPlusObd2 ✅ |
| Legacy | empty iterable | gpsPlusObd2 ✅ |

## Test plan

- [x] `flutter analyze` clean
- [x] 6 new TripKind.fromSamples tests
- [x] 538/538 existing consumption + trip-history tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)