### PR TITLE
chore(ci): regenerate trip_recording_provider.g.dart after #2047

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'b243709e449fdce6426a8af435d6c56c0647e677';
+String _$tripRecordingHash() => r'354b9aebf5774b713e94fa9f4d63f10822b44b22';
 
 /// App-wide owner of the trip recording (#726).
 ///


### PR DESCRIPTION
## Summary
- PR #2047 added a `debugAppendObd2SampleToGpsOnly` test-seam to `trip_recording_provider.dart` but the codegen rerun was skipped before squash-merge, so the committed `.g.dart` hash drifted on master.
- `dart run build_runner build --delete-conflicting-outputs` only updated the generated content hash — no public-API change.
- Closes the CI red on master (run #2763 — `codegen-drift` job).

## Test plan
- [x] `dart run build_runner build --delete-conflicting-outputs` produced exactly one diff (`trip_recording_provider.g.dart`)
- [ ] `codegen-drift` job goes green on master after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)