### PR TITLE
fix(ci): correct Play Store package name (#2049)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ concurrency:
 
 env:
   AAB_PATH: app-play-release.aab
-  PACKAGE_NAME: com.dittgen.tankstellen
+  PACKAGE_NAME: de.tankstellen.fuelprices
 
 jobs:
   # --- Job 1: Deploy AAB to Play Store internal track ---

--- a/scripts/deploy_play_store.sh
+++ b/scripts/deploy_play_store.sh
@@ -14,12 +14,12 @@
 #   --dry-run       Validate inputs without uploading
 #   --sa-file PATH  Path to service account JSON file (instead of env var)
 #   --track TRACK   Target track (default: internal)
-#   --package PKG   Package name (default: com.dittgen.tankstellen)
+#   --package PKG   Package name (default: de.tankstellen.fuelprices)
 
 set -euo pipefail
 
 # --- Configuration ---
-DEFAULT_PACKAGE="com.dittgen.tankstellen"
+DEFAULT_PACKAGE="de.tankstellen.fuelprices"
 DEFAULT_TRACK="internal"
 
 # --- Helpers ---

--- a/scripts/promote_play_store.sh
+++ b/scripts/promote_play_store.sh
@@ -12,7 +12,7 @@
 #
 # Usage:
 #   PLAY_STORE_SERVICE_ACCOUNT_JSON='{"..."}' \
-#   PACKAGE_NAME=com.dittgen.tankstellen \
+#   PACKAGE_NAME=de.tankstellen.fuelprices \
 #   TRACK_FROM=internal \
 #   ROLLOUT_PERCENTAGE=5 \
 #   bash scripts/promote_play_store.sh


### PR DESCRIPTION
## Summary
- The Deploy to Play Store workflow (run #2) failed at promote-rollout with `HttpError 404: Package not found: com.dittgen.tankstellen.` — the workflow + scripts carried a stale draft package name never registered with Google Play.
- The real `applicationId` (`android/app/build.gradle.kts:92`) is `de.tankstellen.fuelprices`. Updated three sites: `.github/workflows/deploy.yml` env, `scripts/deploy_play_store.sh` default, and the docstring in `scripts/promote_play_store.sh`.
- No app behaviour change — pure deploy-pipeline configuration.

## Test plan
- [ ] After merge, manual `workflow_dispatch` of `Deploy to Play Store` no longer 404s on the edits endpoint.

Closes #2049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)