### PR TITLE
fix(search): the 'Independent' sentinel no longer leaks into the search card title (#2061)

### DIFF
--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -3,6 +3,7 @@ import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/station.dart';
 
@@ -35,10 +36,14 @@ class AllPricesStationCard extends StatelessWidget {
     this.profileFuelType,
   });
 
+  /// Defers to the shared [hasRealBrand] helper so the search card and
+  /// the detail screen agree on what counts as a brand (#2061). The
+  /// helper excludes the legacy `'Station'` sentinel and
+  /// `BrandRegistry.independentLabel` (`'Independent'` from #482).
+  /// `'Autoroute'` is a synthetic motorway tag, not a real brand, so
+  /// the card keeps that exclusion on top.
   bool get _hasBrand =>
-      station.brand.isNotEmpty &&
-      station.brand != 'Station' &&
-      station.brand != 'Autoroute';
+      hasRealBrand(station) && station.brand != 'Autoroute';
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -8,6 +8,7 @@ import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/animated_favorite_star.dart';
 import '../../../../core/widgets/animated_price_text.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';
 import '../../domain/entities/brand_registry.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/station.dart';
@@ -65,10 +66,13 @@ class StationCard extends StatelessWidget {
   });
 
   /// True if the station has a real brand name (not empty, not generic "Station")
+  /// Defers to the shared [hasRealBrand] helper so the search card and
+  /// the detail screen agree on what counts as a brand (#2061). The
+  /// helper excludes the legacy `'Station'` sentinel + the
+  /// `BrandRegistry.independentLabel` (`'Independent'` from #482).
+  /// `'Autoroute'` is a synthetic motorway tag, kept excluded here.
   bool get _hasBrand =>
-      station.brand.isNotEmpty &&
-      station.brand != 'Station' &&
-      station.brand != 'Autoroute';
+      hasRealBrand(station) && station.brand != 'Autoroute';
 
   double? get _displayPrice => station.priceFor(selectedFuelType);
 

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -342,6 +342,40 @@ void main() {
       expect(find.text('Rue de la Gare'), findsOneWidget);
     });
 
+    testWidgets(
+        '#2061 — the "Independent" sentinel does not leak into the title',
+        (tester) async {
+      // The French Prix Carburants parser tags brandless stations with
+      // `BrandRegistry.independentLabel` (== "Independent"). Before
+      // #2061 the search card rendered that sentinel as the title;
+      // after, it falls back to the street address (matching the
+      // detail screen).
+      const independentStation = Station(
+        id: 'indep-2061',
+        name: '',
+        brand: 'Independent',
+        street: '26 AVENUE DE VERDUN',
+        postCode: '34120',
+        place: 'Pézenas',
+        lat: 43.46,
+        lng: 3.42,
+        e10: 1.999,
+        isOpen: true,
+      );
+
+      await pumpApp(
+        tester,
+        const AllPricesStationCard(station: independentStation),
+      );
+
+      expect(find.text('Independent'), findsNothing,
+          reason:
+              'The Independent sentinel is an internal classification, '
+              'not a brand to render.');
+      expect(find.text('26 AVENUE DE VERDUN'), findsOneWidget,
+          reason: 'Brandless station falls back to the street as title.');
+    });
+
     group('profile fuel highlight', () {
       testWidgets('profile fuel badge has larger dot', (tester) async {
         await pumpApp(

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -998,5 +998,42 @@ void main() {
         );
       });
     });
+
+    testWidgets(
+        '#2061 — the "Independent" sentinel does not leak into the title',
+        (tester) async {
+      // The French Prix Carburants parser tags brandless stations with
+      // `BrandRegistry.independentLabel` (== "Independent"). Before
+      // #2061 the search card rendered that sentinel as the title;
+      // after, it falls back to the street address (matching the
+      // detail screen).
+      const independentStation = Station(
+        id: 'indep-2061',
+        name: '',
+        brand: 'Independent',
+        street: '26 AVENUE DE VERDUN',
+        postCode: '34120',
+        place: 'Pézenas',
+        lat: 43.46,
+        lng: 3.42,
+        e10: 1.999,
+        isOpen: true,
+      );
+
+      await pumpApp(
+        tester,
+        const StationCard(
+          station: independentStation,
+          selectedFuelType: FuelType.e10,
+        ),
+      );
+
+      expect(find.text('Independent'), findsNothing,
+          reason:
+              'The Independent sentinel is an internal classification, '
+              'not a brand to render.');
+      expect(find.text('26 AVENUE DE VERDUN'), findsOneWidget,
+          reason: 'Brandless station falls back to the street as title.');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- The French Prix Carburants parser tags brandless stations with `BrandRegistry.independentLabel` (`'Independent'` from #482). The detail screen hides that sentinel via `hasRealBrand(station)`; the two search cards had their own incomplete `_hasBrand` getters that missed it, so the sentinel rendered as a station title.
- Both `AllPricesStationCard` and `StationCard` now defer to the shared `hasRealBrand` helper. Title agreement restored between search list and detail screen — both fall back to `station.street` for brandless stations.

## User repro (34120 Pézenas, before this PR)
| Surface | Title | Subtitle |
|---|---|---|
| Search list | "Independent" ❌ | "26 AVENUE DE VERDUN, 34120 Pézenas" |
| Detail screen | "26 AVENUE ..." ✅ | "Station indépendante" (italic) |

After the PR, search list = "26 AVENUE DE VERDUN" / "34120 Pézenas" — matches detail.

## Test plan
- [x] Regression tests on both cards exercise `brand == 'Independent'` → title = street, no "Independent" text.
- [x] All 73 existing card tests still pass locally.

Closes #2061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)