### PR TITLE
feat(consumption): fill-up L/100 km on every card + trajet kind stripes (#2059, #2060)

### DIFF
--- a/lib/features/consumption/domain/services/eco_score_calculator.dart
+++ b/lib/features/consumption/domain/services/eco_score_calculator.dart
@@ -116,4 +116,43 @@ class EcoScoreCalculator {
     if (deltaPercent >= EcoScore.threshold) return EcoScoreDirection.worsening;
     return EcoScoreDirection.stable;
   }
+
+  /// Returns just the raw L/100 km for [current] (no baseline / no
+  /// comparison-to-rolling-average), or `null` when the math is
+  /// undefined (first-ever fill-up, odometer rollback, no preceding
+  /// same-fuel entry — same fail-conditions as [compute], but only
+  /// the upstream-distance gate, not the baseline-history gate).
+  ///
+  /// Used on partial / auto-corrected entries (#2060) where [compute]
+  /// returns null because there aren't enough preceding same-fuel
+  /// fill-ups to build a rolling baseline, but the per-entry L/100 km
+  /// itself IS meaningful — distance + litres are present, just not
+  /// the comparison data.
+  ///
+  /// Render this as plain text (no trend arrow, no percentage). The
+  /// [EcoScoreBadge] continues to handle the "↓ X L/100 km · -N%"
+  /// shape when [compute] returns non-null.
+  static double? computeLitersPer100Km({
+    required FillUp current,
+    required List<FillUp> history,
+  }) {
+    final sorted = [...history]..sort((a, b) => a.date.compareTo(b.date));
+    final idx = sorted.indexWhere((f) => f.id == current.id);
+    if (idx <= 0) return null; // not found or is the very first entry
+
+    // Find the most recent preceding entry of the SAME fuel type — the
+    // odometer base for distance. Differs from [compute] in that we
+    // don't also need a baseline window; one prior entry is enough.
+    FillUp? referencePrev;
+    for (var i = idx - 1; i >= 0; i--) {
+      if (sorted[i].fuelType == current.fuelType) {
+        referencePrev = sorted[i];
+        break;
+      }
+    }
+    if (referencePrev == null) return null;
+    final distance = current.odometerKm - referencePrev.odometerKm;
+    if (distance <= 0) return null;
+    return current.liters / distance * 100;
+  }
 }

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -34,12 +34,19 @@ import 'eco_score_badge.dart';
 class FillUpCard extends StatelessWidget {
   final FillUp fillUp;
   final EcoScore? ecoScore;
+  /// Raw per-fill-up L/100 km without the comparison-to-baseline
+  /// chip (#2060). Rendered only when [ecoScore] is null AND this
+  /// value is non-null — entries that have enough data to compute
+  /// L/100 km but not enough preceding same-fuel history for a
+  /// rolling baseline. The card stays silent when both are null.
+  final double? rawLPer100Km;
   final VoidCallback? onTap;
 
   const FillUpCard({
     super.key,
     required this.fillUp,
     this.ecoScore,
+    this.rawLPer100Km,
     this.onTap,
   });
 
@@ -139,6 +146,21 @@ class FillUpCard extends StatelessWidget {
             if (ecoScore != null) ...[
               const SizedBox(height: 4),
               EcoScoreBadge(score: ecoScore!),
+            ] else if (rawLPer100Km != null) ...[
+              const SizedBox(height: 4),
+              // #2060 — render the bare L/100 km when there isn't
+              // enough preceding same-fuel history for an EcoScoreBadge
+              // trend chip. Plain text, no arrow, no comparison.
+              Text(
+                l?.ecoScoreConsumption(
+                      rawLPer100Km!.toStringAsFixed(1),
+                    ) ??
+                    '${rawLPer100Km!.toStringAsFixed(1)} L/100 km',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
             ],
           ],
         ),

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -89,6 +89,8 @@ class FuelTab extends ConsumerWidget {
         child: FillUpCard(
           fillUp: fillUp,
           ecoScore: ref.watch(ecoScoreForFillUpProvider(fillUp.id)),
+          rawLPer100Km:
+              ref.watch(litersPer100KmForFillUpProvider(fillUp.id)),
           onTap: fillUp.isCorrection
               ? () => _openCorrectionEditor(context, fillUp)
               : null,

--- a/lib/features/consumption/presentation/widgets/trajet_row.dart
+++ b/lib/features/consumption/presentation/widgets/trajet_row.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
+import '../../domain/trip_recorder.dart' show TripKind;
 
 /// One row in the Trajets list (#889). Shows date/time + chips for
 /// distance, duration, and average consumption. Extracted from
@@ -48,12 +49,26 @@ class TrajetRow extends StatelessWidget {
         ? const EdgeInsets.symmetric(horizontal: 10, vertical: 4)
         : const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
 
+    // #2059 — 4dp left-edge stripe carries the trip kind at a glance.
+    // Green = OBD2-instrumented (real L/100 km from fuel rate),
+    // blue = GPS-only (estimated). Hybrid coverage is added in a
+    // follow-up once `obd2CoverageRatio` lands in #J of Epic #2065.
+    final stripeColor = s.kind == TripKind.gpsPlusObd2
+        ? theme.colorScheme.primary
+        : theme.colorScheme.tertiary;
+
     return Card(
       key: ValueKey('trajet-${entry.id}'),
       margin: cardMargin,
+      clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: Padding(
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border(
+              left: BorderSide(color: stripeColor, width: 4),
+            ),
+          ),
           padding: innerPadding,
           child: Row(
             children: [

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -773,3 +773,23 @@ EcoScore? ecoScoreForFillUp(Ref ref, String fillUpId) {
     history: fillUps,
   );
 }
+
+/// Raw per-fill-up L/100 km, with no baseline / no comparison (#2060).
+///
+/// Returns the per-entry consumption number even when
+/// [ecoScoreForFillUp] is null because there isn't enough history
+/// to build a rolling-average baseline. The card consumes this to
+/// render a plain "X.X L/100 km" line on entries that would otherwise
+/// be blank — the 2026-05-20 entry in the user's screenshot has the
+/// distance + litres to compute a number, just not enough preceding
+/// same-fuel entries for a trend.
+@riverpod
+double? litersPer100KmForFillUp(Ref ref, String fillUpId) {
+  final fillUps = ref.watch(fillUpListProvider);
+  final current = fillUps.where((f) => f.id == fillUpId).firstOrNull;
+  if (current == null) return null;
+  return EcoScoreCalculator.computeLitersPer100Km(
+    current: current,
+    history: fillUps,
+  );
+}

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -670,3 +670,131 @@ final class EcoScoreForFillUpFamily extends $Family
   @override
   String toString() => r'ecoScoreForFillUpProvider';
 }
+
+/// Raw per-fill-up L/100 km, with no baseline / no comparison (#2060).
+///
+/// Returns the per-entry consumption number even when
+/// [ecoScoreForFillUp] is null because there isn't enough history
+/// to build a rolling-average baseline. The card consumes this to
+/// render a plain "X.X L/100 km" line on entries that would otherwise
+/// be blank — the 2026-05-20 entry in the user's screenshot has the
+/// distance + litres to compute a number, just not enough preceding
+/// same-fuel entries for a trend.
+
+@ProviderFor(litersPer100KmForFillUp)
+final litersPer100KmForFillUpProvider = LitersPer100KmForFillUpFamily._();
+
+/// Raw per-fill-up L/100 km, with no baseline / no comparison (#2060).
+///
+/// Returns the per-entry consumption number even when
+/// [ecoScoreForFillUp] is null because there isn't enough history
+/// to build a rolling-average baseline. The card consumes this to
+/// render a plain "X.X L/100 km" line on entries that would otherwise
+/// be blank — the 2026-05-20 entry in the user's screenshot has the
+/// distance + litres to compute a number, just not enough preceding
+/// same-fuel entries for a trend.
+
+final class LitersPer100KmForFillUpProvider
+    extends $FunctionalProvider<double?, double?, double?>
+    with $Provider<double?> {
+  /// Raw per-fill-up L/100 km, with no baseline / no comparison (#2060).
+  ///
+  /// Returns the per-entry consumption number even when
+  /// [ecoScoreForFillUp] is null because there isn't enough history
+  /// to build a rolling-average baseline. The card consumes this to
+  /// render a plain "X.X L/100 km" line on entries that would otherwise
+  /// be blank — the 2026-05-20 entry in the user's screenshot has the
+  /// distance + litres to compute a number, just not enough preceding
+  /// same-fuel entries for a trend.
+  LitersPer100KmForFillUpProvider._({
+    required LitersPer100KmForFillUpFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'litersPer100KmForFillUpProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$litersPer100KmForFillUpHash();
+
+  @override
+  String toString() {
+    return r'litersPer100KmForFillUpProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<double?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  double? create(Ref ref) {
+    final argument = this.argument as String;
+    return litersPer100KmForFillUp(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(double? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<double?>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is LitersPer100KmForFillUpProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$litersPer100KmForFillUpHash() =>
+    r'6f61c26cafb27ca36198380bb9c75ac80b39c9f3';
+
+/// Raw per-fill-up L/100 km, with no baseline / no comparison (#2060).
+///
+/// Returns the per-entry consumption number even when
+/// [ecoScoreForFillUp] is null because there isn't enough history
+/// to build a rolling-average baseline. The card consumes this to
+/// render a plain "X.X L/100 km" line on entries that would otherwise
+/// be blank — the 2026-05-20 entry in the user's screenshot has the
+/// distance + litres to compute a number, just not enough preceding
+/// same-fuel entries for a trend.
+
+final class LitersPer100KmForFillUpFamily extends $Family
+    with $FunctionalFamilyOverride<double?, String> {
+  LitersPer100KmForFillUpFamily._()
+    : super(
+        retry: null,
+        name: r'litersPer100KmForFillUpProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Raw per-fill-up L/100 km, with no baseline / no comparison (#2060).
+  ///
+  /// Returns the per-entry consumption number even when
+  /// [ecoScoreForFillUp] is null because there isn't enough history
+  /// to build a rolling-average baseline. The card consumes this to
+  /// render a plain "X.X L/100 km" line on entries that would otherwise
+  /// be blank — the 2026-05-20 entry in the user's screenshot has the
+  /// distance + litres to compute a number, just not enough preceding
+  /// same-fuel entries for a trend.
+
+  LitersPer100KmForFillUpProvider call(String fillUpId) =>
+      LitersPer100KmForFillUpProvider._(argument: fillUpId, from: this);
+
+  @override
+  String toString() => r'litersPer100KmForFillUpProvider';
+}


### PR DESCRIPTION
## Summary
Two small UX-polish slices bundled (different files, no overlap):

- **#2060** — `FillUpCard` now shows the per-entry L/100 km on entries that have computable distance but lack baseline history (the 2026-05-20 entry in the user's screenshot). When `ecoScore == null && rawLPer100Km != null`, renders a plain "X.X L/100 km" line instead of leaving the slot blank. Trend-chip path unchanged.
- **#2059** — `TrajetRow` now carries a 4dp left-edge stripe: green for OBD2 trajets, blue for GPS-only. Hybrid (mid-trip dropout) falls into the GPS bucket per existing classification; the explicit hybrid stripe waits on `obd2CoverageRatio` (#J in Epic #2065).

## Test plan
- [x] `flutter analyze` clean.
- [x] 645 consumption tests pass locally.
- [x] No new ARB keys — reuses existing `ecoScoreConsumption` formatter.

Closes #2059, #2060. Parent Epic #2055.

🤖 Generated with [Claude Code](https://claude.com/claude-code)