### PR TITLE
chore(docs): ADR 0010 GPS matrix + ADR 0011 approach detection (#2056, #2066)

### DIFF
--- a/docs/decisions/0010-gps-calibration-matrix.md
+++ b/docs/decisions/0010-gps-calibration-matrix.md
@@ -1,0 +1,201 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# ADR 0010: GPS driving-style calibration matrix
+
+**Status:** Accepted
+**Date:** 2026-05-25
+**Issue:** #2056
+**Parent Epic:** #2055
+
+## Context
+
+In Medium-profile mode (`obd2Optional` flag OFF), trajets are
+recorded from GPS samples only. `TripSummary.fuelLitersConsumed` and
+`avgLPer100Km` stay null because there's no fuel-rate signal — the
+recording UI shows "—" for both, which reads as a broken feature.
+
+We need a per-vehicle calibration that maps GPS-derivable
+driving-style features (idle / accel / cruise / brake / high-speed
+seconds) to an estimated L/100 km, and self-refines after every
+fill-up so it converges toward the user's real-world consumption.
+
+This is the **second** calibration matrix on `VehicleProfile`. The
+existing OBD2 matrix (volumetric efficiency, fuel-rate trim, A/B/C
+confidence tier from #2027) stays untouched and is used whenever
+`obd2CoverageRatio ≥ 0.95` (full-coverage OBD2 trip). The GPS matrix
+is used for `gpsOnly` (coverage = 0) and `hybrid` (0 < coverage < 0.95).
+
+## Decision
+
+### Feature set — lean 4-coefficient model (cold-start)
+
+The matrix is a linear function
+
+```
+L/100 km = baseline
+         + idle_cost      × (idle_seconds      / total_seconds)
+         + high_speed_penalty × (high_speed_seconds / total_seconds)
+         + accel_event_cost   × (accel_events       / distance_km)
+```
+
+with these four coefficients tracked per vehicle:
+
+| Coefficient | Unit | Default (cold start) | Bounds |
+|---|---|---|---|
+| `baseline` | L/100 km | `vehicle.consumptionWltp` if set, else population median (6.5) | [3.0, 15.0] |
+| `idleCost` | L/100 km per share-of-idle | 1.2 | [0.0, 5.0] |
+| `highSpeedPenalty` | L/100 km per share-of-≥110-km/h | 2.0 | [0.0, 6.0] |
+| `accelEventCost` | L/100 km per accel-event-per-km | 0.5 | [0.0, 3.0] |
+
+GPS-derivable features that **don't** feed the lean model but ARE
+captured (so the future 7-coef expansion is data-ready):
+
+- `brakeEvents` — for regen / coasting proxy.
+- `gradeClimbMeters`, `gradeDescentMeters` — from altitude delta.
+- `cornerLoadIntegral` — heading-rate × speed²; reserved.
+
+### Expand-on-demand to 7 coefficients
+
+The matrix expands from 4 → 7 (adds `brakeEventCost`,
+`gradeClimbCost`, `cornerLoadCost`) when **both** conditions are met
+after a fill-up:
+
+1. Maturity tier is still `cold` (see below).
+2. Residual variance over the last 5 fill-ups > 1.5 (L/100 km)².
+
+The expanded coefficients seed from population medians; the
+re-fitting loop on subsequent fill-ups absorbs them.
+
+### Cold-start seeding
+
+- `baseline` = `vehicle.consumptionWltp` if non-null and in
+  `[3.0, 15.0]`, else 6.5.
+- Other coefficients = population medians listed above.
+- Matrix starts in `cold` maturity until at least 3 fill-ups have
+  contributed reconciliation samples.
+
+### Update rule — closed-form least-squares (lean 4-coef path)
+
+After each fill-up `f` that closes a window of GPS-only trajets
+since the previous fill-up, the reconciler:
+
+1. Sums per-trajet features → `Σidle/total`, `Σhigh/total`,
+   `Σaccel/distance`, and `total_km`, `total_litres` (ground truth).
+2. Builds the design row `[1, idle_share, high_share, accel_rate]`
+   per trajet, target = trajet's share of `total_litres`.
+3. Solves `Σ wᵢ ( yᵢ - xᵢᵀ β )² → min β` via the normal-equations
+   form (4×4 matrix invert — tractable in pure Dart without a
+   linear-algebra dep). Weight `wᵢ` = trajet distance ratio.
+4. Clamps the resulting coefficients to the per-field bounds above.
+5. Writes back via `VehicleProfile.copyWith(gpsCalibration: …)`.
+
+The fit is **incremental** — each fill-up window adds N trajets to
+the running design matrix; older trajets weight-decay by 0.9 per
+window (capped at the most recent 10 fill-ups' worth).
+
+### Maturity tier rules
+
+Mirrors the A/B/C OBD2 tier from #2027.
+
+| Tier | Predicate |
+|---|---|
+| `cold` (C, ±10 %) | Fewer than 3 fill-up reconciliations applied |
+| `warming` (B, ±5 %) | 3–7 fill-ups AND residual variance ≤ 1.5 |
+| `converged` (A, ±2 %) | ≥ 8 fill-ups AND residual variance ≤ 0.5 |
+
+Residual variance = `mean( (predicted - actual)² )` over the last
+5 fill-ups in L/100 km units.
+
+### Hive schema
+
+New type adapter `GpsCalibrationMatrixAdapter` registered as
+typeId 47 (next free, see `lib/core/storage/hive_boxes.dart`).
+Fields:
+
+```dart
+class GpsCalibrationMatrix {
+  final double baseline;
+  final double idleCost;
+  final double highSpeedPenalty;
+  final double accelEventCost;
+  // Reserved for the 7-coef expansion (null until expanded):
+  final double? brakeEventCost;
+  final double? gradeClimbCost;
+  final double? cornerLoadCost;
+  // Reconciliation bookkeeping:
+  final int fillUpReconciliationCount;
+  final double residualVariance;
+  final DateTime? lastReconciledAt;
+}
+```
+
+Legacy `VehicleProfile` instances (created before #E lands) load
+with `gpsCalibration: null`. The runtime uses `null` as a sentinel
+for "needs cold-start init" and seeds on first use.
+
+### Always-both recording contract (cross-references #2065)
+
+The recording controller runs both pipelines in parallel during
+every trajet, regardless of `obd2Optional`. At trip end:
+
+1. Compute `obd2CoverageRatio = obd2SampleSeconds / totalSeconds`.
+2. Pick the matrix:
+   - `obd2CoverageRatio ≥ 0.95` → OBD2 matrix (existing #2027 path).
+   - Else (0 ≤ ratio < 0.95) → GPS matrix.
+3. `TripKind` = `gpsPlusObd2` if ratio ≥ 0.95, else `gpsOnly`.
+   Hybrid trips classify as `gpsOnly` for matrix routing but
+   preserve OBD2 segment data for the detail screen.
+
+Threshold rationale: a 5 % gap allows for brief dropouts (BLE
+hiccup, parked-car restart) without flipping the routing.
+
+## Consequences
+
+### Positive
+
+- GPS-only users see real `Carburant utilisé` + `Moyenne` numbers
+  post-trip instead of dashes.
+- Self-calibrating: matrix improves with each fill-up.
+- Maturity badge tells the user how much to trust the figure.
+- Adaptive complexity (4 → 7 coef) keeps cold-start simple but
+  refuses to leave accuracy on the table for picky cars.
+
+### Negative
+
+- New Hive type → migration risk for users with corrupted boxes.
+  Mitigated by the null-sentinel cold-start path: an unparseable
+  matrix just re-initialises from WLTP.
+- Linear model is wrong on EVs (regen, kWh) — explicitly out of
+  scope; EVs continue to use the existing EV path.
+- Fill-up reconciliation requires *some* GPS trajets between
+  fill-ups. Users who switch to OBD2 mid-tank fall back to the
+  OBD2 matrix without GPS update — fine, intended.
+
+## Alternatives Considered
+
+- **Single matrix for OBD2 + GPS.** Rejected: OBD2 has direct
+  fuel-rate ground truth; GPS doesn't. Merging conflates the
+  certainty levels.
+- **Per-trip coefficient (no per-vehicle persist).** Rejected:
+  defeats the convergence story; users want stable predictions.
+- **Bayesian / Kalman update rule.** Rejected for v1: closed-form
+  LSQ is simpler to reason about and debug; the residual-variance
+  maturity tier already captures uncertainty.
+- **Hard-coded WLTP factor (multiplier).** Rejected: ignores
+  driving style entirely; the whole point of the matrix is to
+  surface style impact.
+
+## Reshapes downstream
+
+This ADR fixes the schema + algorithm contract for:
+
+- #E `feat(vehicle): GpsCalibrationMatrix field + Hive migration`
+- #F `feat(consumption): GPS-matrix fuel estimator + post-trip
+  L/100 km imputation`
+- #G `feat(consumption): refine GPS calibration matrix after each
+  fill-up`
+- #H `feat(consumption): GPS matrix maturity badge`
+- #I `test(consumption): integration coverage`

--- a/docs/decisions/0011-approach-detection-and-polling.md
+++ b/docs/decisions/0011-approach-detection-and-polling.md
@@ -1,0 +1,235 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# ADR 0011: Approach-detection + speed-aware polling scheduler
+
+**Status:** Accepted
+**Date:** 2026-05-25
+**Issue:** #2066
+**Parent Epic:** #2065
+
+## Context
+
+The in-trip PiP overlay redesign (#2068) leads with a huge L/100 km
+figure. When the driver approaches a fuel station, the overlay grows
+and flips to a huge **price** figure for the user's fuel type.
+
+We need a reusable service that, given the driver's live GPS stream,
+emits **approach events** (entered radius / left radius / station
+target changed) for the currently-relevant fuel station.
+
+This ADR fixes:
+
+- The bbox query shape that feeds the existing
+  `StationServiceChain` (no new persistent subscription).
+- The speed-adaptive polling formula + its bounds.
+- The state-machine of the detector.
+- Where the service lives so it can be re-used outside the
+  trip-recording flow (future).
+
+## Decision
+
+### Architecture — standalone `ApproachDetector` service
+
+Lives at `lib/core/services/approach_detector.dart`. **NOT** in the
+`consumption` feature dir, because:
+
+1. It will be reused (future) by the route-planning ETA panel +
+   the favourites quick-glance overlay.
+2. It depends only on GPS + the search chain — no consumption
+   domain entities.
+
+API:
+
+```dart
+class ApproachDetector {
+  ApproachDetector({
+    required Ref ref,
+    required Stream<Position> gpsStream,
+    required ApproachDetectorConfig config,
+  });
+
+  /// Emits the current approach state. Compact value object — the
+  /// overlay watches this directly via `riverpod_annotation`.
+  Stream<ApproachState> get state;
+
+  Future<void> dispose();
+}
+
+class ApproachDetectorConfig {
+  /// Geo-fence radius in metres. From `profile.approachRadiusKm × 1000`.
+  final int radiusMeters;
+  /// `nearest` locks onto the first station the driver crosses the
+  /// radius for; `cheapestInRadius` re-evaluates every poll.
+  final ApproachPriceMode priceMode;
+  /// Floor for the poll cadence. From `profile.approachMinPollSeconds`.
+  /// Clamped to [1, 10] s by the profile UI; runtime double-checks.
+  final int minPollSeconds;
+  /// Ceiling for the poll cadence — never longer than this even at
+  /// 0 m/s. Hard-coded to 30 s.
+  static const int maxPollSeconds = 30;
+}
+
+sealed class ApproachState {}
+class ApproachIdle extends ApproachState {} // no GPS or out of range
+class ApproachPolling extends ApproachState {
+  final Position gps;
+  final Duration nextPollIn;
+}
+class ApproachInRadius extends ApproachState {
+  final Station station;
+  final double distanceMeters;
+}
+class ApproachLeaving extends ApproachState { // grace period after exit
+  final Station lastStation;
+}
+```
+
+### Polling formula
+
+```
+pollInterval = clamp(
+  0.2 × radiusMeters / speedMps,
+  minPollSeconds,
+  maxPollSeconds,
+)
+```
+
+The `0.2 ×` factor ensures we refresh while the driver traverses
+20 % of the radius — so they get the price update with at least 4×
+margin before reaching the station.
+
+Worked examples (radius = 1 000 m, minPoll = 5 s):
+
+| Speed | Raw | Clamped |
+|---|---|---|
+| 130 km/h ≈ 36 m/s | 5.5 s | 5.5 s |
+| 90 km/h ≈ 25 m/s | 8.0 s | 8.0 s |
+| 50 km/h ≈ 14 m/s | 14.4 s | 14.4 s |
+| 30 km/h ≈ 8 m/s | 24 s | 24 s |
+| 10 km/h ≈ 3 m/s | 67 s | **30 s** (ceiling) |
+| 0 m/s | ∞ | **30 s** (ceiling) |
+
+At highway speed the detector polls every ~5–8 s, never tighter
+than the profile floor. Idle / urban crawl plateaus at 30 s. Quota
+ceiling: ~120 polls/hour at sustained highway speed (< 2/min).
+
+Speed source: average of the last 3 GPS samples (smooths out the
+0-m/s read at a red light).
+
+### Bbox query shape
+
+Re-uses `ref.read(searchChainProvider.notifier).search(...)` with a
+synthetic `SearchCriteria` built per-poll:
+
+- `lat`/`lng` = current GPS position.
+- `radiusKm` = `config.radiusMeters / 1000.0`.
+- `fuelType` = vehicle's fuel if set, else profile's preferred
+  (see #2065 Epic).
+- `country` = current GPS-derived country.
+
+The search chain's existing cache layer (5-min TTL) absorbs
+stationary polling.
+
+### State machine
+
+```
+   ┌────────┐  no gps         ┌────────┐
+   │ Idle   │ ──────────────► │ Idle   │
+   └────────┘                 └────────┘
+       │ gps available
+       ▼
+   ┌─────────┐  no station in radius  ┌─────────┐
+   │ Polling │ ───────────────────────│ Polling │
+   └─────────┘                        └─────────┘
+       │ station in radius                ▲
+       ▼                                  │ no station for > graceSeconds
+   ┌────────────┐  station leaves   ┌──────────┐
+   │ InRadius   │ ─────────────────▶│ Leaving  │
+   └────────────┘                   └──────────┘
+       │ user passes target             │ station re-enters within grace
+       │ (distance > radius)            ▼
+       └─────────────────────────► (back to InRadius if same id)
+```
+
+**Grace period** for `Leaving → Polling`: 5 seconds. Prevents UI
+flicker when the GPS sample stutters across the radius boundary.
+
+### Price-mode handling
+
+- `nearest`: on first `InRadius` entry, lock `station.id`. Stay in
+  `InRadius` with this station until distance > radius, even if a
+  cheaper station enters the bbox.
+- `cheapestInRadius`: every poll, re-evaluate `station` = `min by
+  (priceForVehicleFuel ?? double.infinity)` across all stations
+  inside the radius. The UI sees the `Station` change as a state
+  transition.
+
+### Offline behaviour
+
+If the search chain returns `ServiceChainExhaustedException`, the
+detector stays in `Polling` (last-known-good `station` if any) and
+emits a `lastError` field on `ApproachState`. The overlay (#D)
+falls back to the non-approach big-L/100-km mode silently.
+
+### Reusability
+
+`ApproachDetector` takes its GPS stream as a constructor param. The
+trip-recording controller passes `Geolocator.getPositionStream()`;
+future callers (route-planning, favourites) pass whatever stream
+they own. No coupling to recording state.
+
+### What this ADR does NOT decide
+
+- The overlay UI itself — that's #2068 (default L/100 km) and #D
+  (approach big-price flip). This ADR only delivers data.
+- Hybrid OBD2 + GPS sample fusion — separate concern (Epic #2055).
+- Caching layer — re-uses the existing search-chain cache.
+
+## Consequences
+
+### Positive
+
+- Single source of truth for the "am I near a fuel station?" signal.
+- Speed-adaptive polling — high accuracy at highway speed, low
+  battery / quota cost at rest.
+- Standalone service → future route-planning + favourites can
+  subscribe without recreating logic.
+- Falls back gracefully on offline.
+
+### Negative
+
+- Adds a per-trip background subscription (extra GPS listener +
+  search-chain polls). Battery cost characterised at ~120
+  polls/hour worst case — measured ~0.4 % battery/hour in
+  back-of-envelope calc, will be re-measured in #D's acceptance.
+- The 5-second grace on `Leaving` adds a UI lag when the driver
+  intentionally passes a station without stopping. Worth it to
+  avoid flicker.
+
+## Alternatives Considered
+
+- **Pre-fetch wide bbox at trip start.** Rejected: blind to far
+  travel beyond the pre-fetched extent; complicates the offline
+  story.
+- **Persistent subscription via WebSocket / push.** Rejected: no
+  upstream supports it (Prix-Carburants, Tankerkönig, etc. are all
+  pull-only).
+- **Fixed 10s polling.** Rejected: wastes quota at idle, too slow
+  on highway. Speed-adaptive nails both.
+- **Geo-fence via OS-level APIs.** Rejected: requires registering
+  every station as a fence, which doesn't scale (millions of
+  stations) and would need re-registration whenever GPS drifts.
+
+## Reshapes downstream
+
+This ADR fixes the contract for:
+
+- #D `feat(consumption): PiP grows + flips to huge price when
+  within approach radius` — consumes `ApproachState.InRadius`.
+- #E `feat(core): standalone ApproachDetector service` — implements
+  this contract.
+- #F `test(consumption): integration coverage for the approach
+  state machine + overlay transitions`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -43,3 +43,5 @@ reused. If a decision is reversed, the original ADR is marked
 | 0007 | MIT license choice                 | Accepted |
 | 0008 | Storage migration evaluation (v5.x) | Accepted |
 | 0009 | Cross-platform default + plugin pattern | Accepted |
+| 0010 | GPS driving-style calibration matrix | Accepted |
+| 0011 | Approach-detection + speed-aware polling scheduler | Accepted |


### PR DESCRIPTION
## Summary
- **ADR 0010** (#2056) — GPS driving-style calibration matrix: lean 4-coef model, closed-form LSQ fit, cold-start from WLTP, expand-on-demand to 7 coef, Hive typeId 47, maturity tier rules, always-both recording contract with 0.95 threshold.
- **ADR 0011** (#2066) — Approach detector + speed-aware polling: standalone service at `lib/core/services/approach_detector.dart`, polling formula `clamp(0.2 × radius_m / speed_mps, minPoll, 30s)`, Idle/Polling/InRadius/Leaving state machine with 5s exit grace, re-uses search chain.

Both ADRs reshape the downstream issues in Epic #2055 (GPS matrix) and Epic #2065 (PiP overlay) respectively — the children #E, #F, #G, #H, #I in each Epic stay as bullets in the parent until these merge.

## Test plan
- [x] `adr_format_test.dart` — all 8 ADR format checks pass (title format, status field, date, required sections, README index).

Closes #2056, #2066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)