### PR TITLE
feat(consumption): derive GPS driving-style features from sample stream (#2057)

### DIFF
--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import 'trip_recorder.dart';
+
+/// Driving-style aggregate derived from a stream of [TripSample]s
+/// **without** any OBD2 telemetry — the lean feature set the GPS
+/// calibration matrix (ADR 0010 / #2057 / Epic #2055) is fit against.
+///
+/// Pure transform. No vehicle, no matrix, no I/O. The caller passes
+/// in the trajet's `Iterable<TripSample>`; the static
+/// [GpsDrivingFeatures.from] returns the aggregate (or `null` when
+/// the sample stream is empty / too short to produce a meaningful
+/// figure).
+///
+/// Field names map 1:1 to the matrix design in
+/// `docs/decisions/0010-gps-calibration-matrix.md`. The 4-coefficient
+/// lean model consumes:
+///
+/// - `idleSeconds / totalSeconds` → `idleCost`
+/// - `highSpeedSeconds / totalSeconds` → `highSpeedPenalty`
+/// - `accelEvents / distanceKm` → `accelEventCost`
+/// - the constant term (baseline)
+///
+/// The remaining fields ([brakeEvents], [gradeClimbMeters],
+/// [gradeDescentMeters], [cornerLoadIntegral]) are captured so the
+/// 7-coefficient expansion path doesn't have to revisit the recorder
+/// when it lands.
+class GpsDrivingFeatures {
+  /// Seconds where `speedKmh < 5` — engine running, car stationary.
+  final double idleSeconds;
+
+  /// Seconds where `5 ≤ speedKmh < 50` — urban / start-stop.
+  final double lowSpeedSeconds;
+
+  /// Seconds where `50 ≤ speedKmh < 110` — cruise / extra-urban.
+  final double cruiseSeconds;
+
+  /// Seconds where `speedKmh ≥ 110` — highway, the fuel-cost penalty
+  /// bucket. Plain integration of speed-band time so brief overspeeds
+  /// don't dominate a long cruise leg.
+  final double highSpeedSeconds;
+
+  /// Count of acceleration events: `d(speed)/dt > 2 m/s²` sustained
+  /// for > 1 s. Counted once per event, not per sample.
+  final int accelEvents;
+
+  /// Count of deceleration / brake events: `d(speed)/dt < −2 m/s²`
+  /// sustained for > 1 s. Reserved for the 7-coef expansion.
+  final int brakeEvents;
+
+  /// Peak absolute acceleration in g, sample-to-sample. Provides a
+  /// cap for the harsh-event detector + a quick sanity ceiling for
+  /// the fit (an `accelEventCost × accelEvents/km` term shouldn't
+  /// explode when the user does one hard accel on an otherwise calm
+  /// trajet).
+  final double maxAccelG;
+
+  /// Mean speed = `distanceKm / (totalSeconds / 3600)`. Convenience.
+  final double meanSpeedKmh;
+
+  /// Total trajet distance — sum of great-circle segment lengths
+  /// between consecutive GPS-fix samples (samples lacking lat/lng
+  /// integrate via `speedKmh × dt` for the segment they cover).
+  final double distanceKm;
+
+  /// Total wall-clock duration covered by the samples.
+  final double totalSeconds;
+
+  /// Cumulative altitude climbed (positive deltas summed). Reserved
+  /// for the 7-coef expansion (`gradeClimbCost`).
+  final double gradeClimbMeters;
+
+  /// Cumulative altitude descended (absolute value of negative
+  /// deltas summed). Reserved.
+  final double gradeDescentMeters;
+
+  /// Heading-rate × speed² integral — a proxy for lateral g-load over
+  /// the trajet. Higher = more aggressive cornering. Reserved.
+  final double cornerLoadIntegral;
+
+  const GpsDrivingFeatures({
+    required this.idleSeconds,
+    required this.lowSpeedSeconds,
+    required this.cruiseSeconds,
+    required this.highSpeedSeconds,
+    required this.accelEvents,
+    required this.brakeEvents,
+    required this.maxAccelG,
+    required this.meanSpeedKmh,
+    required this.distanceKm,
+    required this.totalSeconds,
+    required this.gradeClimbMeters,
+    required this.gradeDescentMeters,
+    required this.cornerLoadIntegral,
+  });
+
+  /// Idle share of the trajet (0.0–1.0). Used by the matrix's
+  /// `idleCost` term. Returns 0 when the trajet has zero seconds
+  /// (degenerate empty stream).
+  double get idleShare =>
+      totalSeconds > 0 ? idleSeconds / totalSeconds : 0.0;
+
+  /// High-speed share (0.0–1.0). Used by the matrix's
+  /// `highSpeedPenalty` term.
+  double get highSpeedShare =>
+      totalSeconds > 0 ? highSpeedSeconds / totalSeconds : 0.0;
+
+  /// Acceleration events per km. Used by the matrix's
+  /// `accelEventCost` term. Returns 0 for zero-distance trajets.
+  double get accelEventsPerKm =>
+      distanceKm > 0 ? accelEvents / distanceKm : 0.0;
+
+  /// Derives the feature aggregate from [samples]. Returns `null`
+  /// when the stream is empty or carries fewer than 2 samples (one
+  /// sample = no integration possible).
+  ///
+  /// Speed-band integration uses each sample's `speedKmh` over the
+  /// elapsed time to the next sample (rectangle rule — fine for
+  /// 1 Hz GPS streams).
+  ///
+  /// Distance prefers great-circle math (`_haversineMeters`) when
+  /// both samples carry lat/lng, falling back to `speedKmh × dt`
+  /// for segments where either side is GPS-unfixed.
+  ///
+  /// Acceleration events: rolling window detects `> 2 m/s²` (or
+  /// `< -2 m/s²`) sustained for ≥ 1 s — the same threshold the
+  /// trip recorder's harsh-event detector uses, so the two numbers
+  /// agree on what counts as "an event".
+  static GpsDrivingFeatures? from(Iterable<TripSample> samples) {
+    final list = samples.toList();
+    if (list.length < 2) return null;
+    list.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+    double idle = 0, low = 0, cruise = 0, high = 0;
+    double distM = 0;
+    int accelEvents = 0, brakeEvents = 0;
+    double maxAccelG = 0;
+    double climb = 0, descent = 0;
+    double cornerLoad = 0;
+
+    // Acceleration-event detector state.
+    bool inAccelEvent = false, inBrakeEvent = false;
+    double accelEventDur = 0, brakeEventDur = 0;
+
+    for (var i = 1; i < list.length; i++) {
+      final prev = list[i - 1];
+      final cur = list[i];
+      final dt = cur.timestamp.difference(prev.timestamp).inMilliseconds /
+          1000.0;
+      if (dt <= 0 || dt > 60) continue; // gap — skip
+
+      // Speed-band integration on the leading sample (rectangle rule).
+      final v = prev.speedKmh;
+      if (v < 5) {
+        idle += dt;
+      } else if (v < 50) {
+        low += dt;
+      } else if (v < 110) {
+        cruise += dt;
+      } else {
+        high += dt;
+      }
+
+      // Distance — prefer haversine when both samples have a fix.
+      final pLat = prev.latitude, pLng = prev.longitude;
+      final cLat = cur.latitude, cLng = cur.longitude;
+      if (pLat != null && pLng != null && cLat != null && cLng != null) {
+        distM += _haversineMeters(pLat, pLng, cLat, cLng);
+      } else {
+        // m = (km/h × 1000/3600) × s
+        distM += v / 3.6 * dt;
+      }
+
+      // Acceleration in m/s² (signed). speed in km/h → m/s via /3.6.
+      final accelMps2 = (cur.speedKmh - prev.speedKmh) / 3.6 / dt;
+      final absG = accelMps2.abs() / 9.81;
+      if (absG > maxAccelG) maxAccelG = absG;
+
+      // Sustained > 1 s windowing for accel / brake events.
+      if (accelMps2 > 2.0) {
+        accelEventDur += dt;
+        if (!inAccelEvent && accelEventDur >= 1.0) {
+          accelEvents++;
+          inAccelEvent = true;
+        }
+      } else {
+        accelEventDur = 0;
+        inAccelEvent = false;
+      }
+      if (accelMps2 < -2.0) {
+        brakeEventDur += dt;
+        if (!inBrakeEvent && brakeEventDur >= 1.0) {
+          brakeEvents++;
+          inBrakeEvent = true;
+        }
+      } else {
+        brakeEventDur = 0;
+        inBrakeEvent = false;
+      }
+
+      // Altitude delta.
+      final pAlt = prev.altitudeM, cAlt = cur.altitudeM;
+      if (pAlt != null && cAlt != null) {
+        final dAlt = cAlt - pAlt;
+        if (dAlt > 0) {
+          climb += dAlt;
+        } else {
+          descent += -dAlt;
+        }
+      }
+
+      // Corner-load integral: |Δheading| ≈ atan2(crossTrack) — we don't
+      // have heading directly, so approximate via successive bearings
+      // when 3 GPS-fixed samples are available. For v1 we keep this
+      // term at zero unless extended in #G; the 4-coef lean fit
+      // doesn't read it. Field stays present for the future expansion.
+      cornerLoad += 0;
+    }
+
+    final total = idle + low + cruise + high;
+    if (total <= 0) return null;
+    final distKm = distM / 1000.0;
+    final meanSpeed = distKm / (total / 3600.0);
+
+    return GpsDrivingFeatures(
+      idleSeconds: idle,
+      lowSpeedSeconds: low,
+      cruiseSeconds: cruise,
+      highSpeedSeconds: high,
+      accelEvents: accelEvents,
+      brakeEvents: brakeEvents,
+      maxAccelG: maxAccelG,
+      meanSpeedKmh: meanSpeed,
+      distanceKm: distKm,
+      totalSeconds: total,
+      gradeClimbMeters: climb,
+      gradeDescentMeters: descent,
+      cornerLoadIntegral: cornerLoad,
+    );
+  }
+
+  /// Great-circle distance between two WGS-84 coordinates in metres.
+  /// Standard haversine — accurate enough for trajet legs (sub-metre
+  /// over kilometres, plenty for L/100 km estimates).
+  static double _haversineMeters(
+    double lat1,
+    double lng1,
+    double lat2,
+    double lng2,
+  ) {
+    const earthR = 6371000.0; // metres
+    final dLat = _toRad(lat2 - lat1);
+    final dLng = _toRad(lng2 - lng1);
+    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(_toRad(lat1)) *
+            math.cos(_toRad(lat2)) *
+            math.sin(dLng / 2) *
+            math.sin(dLng / 2);
+    final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+    return earthR * c;
+  }
+
+  static double _toRad(double deg) => deg * math.pi / 180.0;
+}

--- a/test/features/consumption/domain/gps_driving_features_test.dart
+++ b/test/features/consumption/domain/gps_driving_features_test.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+TripSample _s(
+  DateTime t,
+  double speedKmh, {
+  double? lat,
+  double? lng,
+  double? altM,
+}) =>
+    TripSample(
+      timestamp: t,
+      speedKmh: speedKmh,
+      rpm: 0,
+      latitude: lat,
+      longitude: lng,
+      altitudeM: altM,
+    );
+
+Iterable<TripSample> _constantSpeed({
+  required double speedKmh,
+  required int seconds,
+  required DateTime start,
+}) sync* {
+  for (var i = 0; i <= seconds; i++) {
+    yield _s(start.add(Duration(seconds: i)), speedKmh);
+  }
+}
+
+void main() {
+  group('GpsDrivingFeatures.from', () {
+    final t0 = DateTime.utc(2026, 5, 25, 10);
+
+    test('null on empty stream', () {
+      expect(GpsDrivingFeatures.from(const <TripSample>[]), isNull);
+    });
+
+    test('null on single-sample stream', () {
+      expect(GpsDrivingFeatures.from([_s(t0, 50)]), isNull);
+    });
+
+    group('speed-band integration', () {
+      test('all idle (speed < 5) → idleSeconds = totalSeconds', () {
+        final f = GpsDrivingFeatures.from(
+          _constantSpeed(speedKmh: 0, seconds: 60, start: t0),
+        )!;
+        expect(f.totalSeconds, closeTo(60.0, 0.01));
+        expect(f.idleSeconds, closeTo(60.0, 0.01));
+        expect(f.lowSpeedSeconds, 0);
+        expect(f.cruiseSeconds, 0);
+        expect(f.highSpeedSeconds, 0);
+        expect(f.idleShare, closeTo(1.0, 0.001));
+      });
+
+      test('all cruise (50 ≤ speed < 110) → cruiseSeconds = totalSeconds',
+          () {
+        final f = GpsDrivingFeatures.from(
+          _constantSpeed(speedKmh: 80, seconds: 120, start: t0),
+        )!;
+        expect(f.cruiseSeconds, closeTo(120.0, 0.01));
+        expect(f.idleSeconds, 0);
+        expect(f.lowSpeedSeconds, 0);
+        expect(f.highSpeedSeconds, 0);
+      });
+
+      test('all high-speed (≥ 110) → highSpeedSeconds + highSpeedShare = 1',
+          () {
+        final f = GpsDrivingFeatures.from(
+          _constantSpeed(speedKmh: 130, seconds: 30, start: t0),
+        )!;
+        expect(f.highSpeedSeconds, closeTo(30.0, 0.01));
+        expect(f.highSpeedShare, closeTo(1.0, 0.001));
+      });
+
+      test('threshold edges: 5, 50, 110 each go to the upper band', () {
+        // speed = 5 → low; speed = 50 → cruise; speed = 110 → high
+        final f = GpsDrivingFeatures.from([
+          _s(t0, 5),
+          _s(t0.add(const Duration(seconds: 10)), 50),
+          _s(t0.add(const Duration(seconds: 20)), 110),
+          _s(t0.add(const Duration(seconds: 30)), 110),
+        ])!;
+        // Each leading sample is integrated over the next dt (10s):
+        //   leading 5 → low: 10s
+        //   leading 50 → cruise: 10s
+        //   leading 110 → high: 10s
+        expect(f.lowSpeedSeconds, closeTo(10.0, 0.01));
+        expect(f.cruiseSeconds, closeTo(10.0, 0.01));
+        expect(f.highSpeedSeconds, closeTo(10.0, 0.01));
+      });
+    });
+
+    group('accel / brake events', () {
+      test('a sustained > 2 m/s² ramp for ≥ 1s counts once', () {
+        // Speed goes 0 → 36 km/h over 5s → 2 m/s². Sustained, single
+        // event.
+        final samples = <TripSample>[];
+        for (var i = 0; i <= 5; i++) {
+          // 36 km/h = 10 m/s. Linear ramp.
+          samples.add(_s(t0.add(Duration(seconds: i)), i * 36.0 / 5));
+        }
+        // Then 10s of cruise so the integrator has time after the ramp.
+        for (var i = 1; i <= 10; i++) {
+          samples.add(_s(t0.add(Duration(seconds: 5 + i)), 36.0));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.accelEvents, 1);
+        expect(f.brakeEvents, 0);
+        expect(f.maxAccelG, greaterThan(0.1));
+      });
+
+      test('a hard brake (< -2 m/s² for ≥ 1s) counts as brakeEvent', () {
+        // Speed drops 72 → 0 km/h over 5s → -4 m/s².
+        final samples = <TripSample>[];
+        for (var i = 0; i <= 5; i++) {
+          samples.add(_s(t0.add(Duration(seconds: i)), 72.0 - i * 14.4));
+        }
+        for (var i = 1; i <= 5; i++) {
+          samples.add(_s(t0.add(Duration(seconds: 5 + i)), 0.0));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.brakeEvents, 1);
+        expect(f.accelEvents, 0);
+      });
+
+      test('a sub-1s blip is NOT an event (debounce)', () {
+        // 500 ms isolated bump — speed jumps 50 → 70 over 0.5s then
+        // drops back over 0.5s. Both deltas are sustained for less
+        // than the 1s threshold individually.
+        final samples = [
+          _s(t0, 50),
+          _s(t0.add(const Duration(milliseconds: 500)), 70),
+          _s(t0.add(const Duration(milliseconds: 1000)), 50),
+          _s(t0.add(const Duration(milliseconds: 2000)), 50),
+          _s(t0.add(const Duration(milliseconds: 3000)), 50),
+        ];
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.accelEvents, 0);
+        expect(f.brakeEvents, 0);
+      });
+    });
+
+    test('distance via haversine when both samples have GPS fixes', () {
+      // Two points ~1 km apart on the same latitude line at the
+      // equator (latitude 0). 1° of longitude at the equator ≈
+      // 111 km, so 0.009° ≈ 1 km.
+      final samples = [
+        _s(t0, 50, lat: 0, lng: 0),
+        _s(t0.add(const Duration(seconds: 60)), 50, lat: 0, lng: 0.009),
+      ];
+      final f = GpsDrivingFeatures.from(samples)!;
+      // ~1 km expected, give a generous tolerance.
+      expect(f.distanceKm, closeTo(1.0, 0.05));
+    });
+
+    test('distance falls back to speed × dt when GPS is missing', () {
+      // No lat/lng provided — falls back to speedKmh × dt math.
+      // 50 km/h × 60 s = 50 km/h × 60/3600 h = 50/60 km ≈ 0.833 km.
+      final samples = [
+        _s(t0, 50),
+        _s(t0.add(const Duration(seconds: 60)), 50),
+      ];
+      final f = GpsDrivingFeatures.from(samples)!;
+      expect(f.distanceKm, closeTo(50 / 60, 0.01));
+    });
+
+    test('mean speed = distance / total_hours', () {
+      final f = GpsDrivingFeatures.from(
+        _constantSpeed(speedKmh: 60, seconds: 600, start: t0),
+      )!;
+      expect(f.meanSpeedKmh, closeTo(60.0, 0.5));
+    });
+
+    group('altitude (grade) tracking', () {
+      test('climb sums positive deltas, descent sums absolute negatives',
+          () {
+        final samples = [
+          _s(t0, 50, lat: 45, lng: 5, altM: 100),
+          _s(t0.add(const Duration(seconds: 10)), 50, lat: 45, lng: 5.001, altM: 110), // +10
+          _s(t0.add(const Duration(seconds: 20)), 50, lat: 45, lng: 5.002, altM: 105), // -5
+          _s(t0.add(const Duration(seconds: 30)), 50, lat: 45, lng: 5.003, altM: 120), // +15
+        ];
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.gradeClimbMeters, closeTo(25.0, 0.01));
+        expect(f.gradeDescentMeters, closeTo(5.0, 0.01));
+      });
+
+      test('null altitudes leave grade fields at 0', () {
+        final f = GpsDrivingFeatures.from(
+          _constantSpeed(speedKmh: 60, seconds: 60, start: t0),
+        )!;
+        expect(f.gradeClimbMeters, 0);
+        expect(f.gradeDescentMeters, 0);
+      });
+    });
+
+    test('idleShare + highSpeedShare for the matrix coefficients', () {
+      // 30s idle, then 30s cruise — share split should be 0.5/0.0.
+      final samples = [
+        ..._constantSpeed(speedKmh: 0, seconds: 30, start: t0).toList()
+          ..removeLast(),
+        ..._constantSpeed(
+          speedKmh: 80,
+          seconds: 30,
+          start: t0.add(const Duration(seconds: 30)),
+        ),
+      ];
+      final f = GpsDrivingFeatures.from(samples)!;
+      expect(f.idleShare, closeTo(0.5, 0.05));
+      expect(f.highSpeedShare, 0);
+    });
+
+    test('accelEventsPerKm guards against zero-distance', () {
+      // Two stationary samples — distance is 0.
+      final samples = [_s(t0, 0), _s(t0.add(const Duration(seconds: 30)), 0)];
+      final f = GpsDrivingFeatures.from(samples)!;
+      expect(f.distanceKm, 0);
+      expect(f.accelEventsPerKm, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Pure transform `Iterable<TripSample> → GpsDrivingFeatures` — speed-band integration, accel/brake event counting, distance (haversine where GPS-fixed, fallback `speedKmh × dt`), altitude climb/descent.
- Convenience getters (`idleShare`, `highSpeedShare`, `accelEventsPerKm`) produce the GPS calibration matrix's lean-4-coef model inputs directly (per ADR 0010 / #2056).
- Reserved fields (`brakeEvents`, `gradeClimbMeters`, `gradeDescentMeters`, `cornerLoadIntegral`) for the 7-coef expansion path so the recorder doesn't need revisiting.
- 16 unit tests covering all edge cases.

Closes #2057. Parent Epic #2055.

## Test plan
- [x] `flutter analyze` clean on the new files.
- [x] All 16 unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)