### PR TITLE
feat(consumption): PiP overlay — context-adaptive primary metric (#2094)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -70,20 +70,67 @@ class TripRecordingPipView extends StatelessWidget {
       return _buildApproachPriceLayout(context, approach!);
     }
 
+    return _buildDefaultLayout(context);
+  }
+
+  /// Default PiP layout (no approach radius hit) — picks the **most
+  /// informative** metric for the big slot based on what the trajet
+  /// has produced so far (#2094). Three branches in priority order:
+  ///
+  /// 1. **OBD2 live fuel rate available** → huge L/100 km (or L/h on
+  ///    idle). Secondary row: distance + elapsed.
+  /// 2. **GPS-only, distance ≥ 0.1 km** → huge **distance**. The
+  ///    GPS-matrix L/100 km estimate is post-trip only (#2080), so
+  ///    nothing live to render in that slot; distance is the most
+  ///    useful real-time number. Secondary row: elapsed.
+  /// 3. **Pre-roll (distance ≈ 0)** → huge **elapsed time**. The user
+  ///    sees the session is recording while the GPS warms up.
+  ///    Secondary row: empty.
+  ///
+  /// The big `~` placeholder that wasted the tile pre-#2094 is gone —
+  /// no branch renders an information-free symbol huge.
+  Widget _buildDefaultLayout(BuildContext context) {
     final l = AppLocalizations.of(context);
     final live = state.live;
     final paused = state.phase == TripRecordingPhase.paused;
     final distance = live?.distanceKmSoFar;
     final elapsed = live?.elapsed;
 
-    // The L/100 km figure: prefer the OBD2-derived instantaneous
-    // consumption when available, else render the GPS-only placeholder.
-    // `formatInstantConsumption` returns "5.8 L/100" or "1.2 L/h"
-    // (idle) — strip the trailing unit so we can render it ourselves
-    // in a smaller font below the figure.
+    // Resolve OBD2-derived live L/100 km (or L/h at idle).
     final raw = (live != null && !paused) ? formatInstantConsumption(live) : null;
-    final figure = raw != null ? _stripUnit(raw) : '~';
-    final unit = raw != null ? _unitOf(raw) : 'L/100 km';
+
+    final String bigFigure;
+    final String bigCaption;
+    final List<String> secondaryRow;
+
+    if (raw != null) {
+      // Branch 1 — OBD2 live consumption is the most informative.
+      bigFigure = _stripUnit(raw);
+      bigCaption = _unitOf(raw);
+      secondaryRow = [
+        if (distance != null) '${distance.toStringAsFixed(1)} km',
+        if (elapsed != null) _fmtElapsed(elapsed),
+      ];
+    } else if (distance != null && distance >= 0.1) {
+      // Branch 2 — GPS-only mid-trajet: distance is the live signal.
+      bigFigure = distance.toStringAsFixed(1);
+      bigCaption = 'km';
+      secondaryRow = [
+        if (elapsed != null) _fmtElapsed(elapsed),
+      ];
+    } else if (elapsed != null) {
+      // Branch 3 — pre-roll: lead with elapsed time so the user
+      // knows the session is recording while GPS warms up.
+      bigFigure = _fmtElapsed(elapsed);
+      bigCaption = l?.tripRecordingPipElapsedCaption ?? 'elapsed';
+      secondaryRow = const <String>[];
+    } else {
+      // No data at all (shouldn't happen during an active recording,
+      // but render a sane fallback rather than crashing).
+      bigFigure = '0:00';
+      bigCaption = l?.tripRecordingPipElapsedCaption ?? 'elapsed';
+      secondaryRow = const <String>[];
+    }
 
     return Material(
       color: backgroundColor,
@@ -97,7 +144,7 @@ class TripRecordingPipView extends StatelessWidget {
               FittedBox(
                 fit: BoxFit.scaleDown,
                 child: Text(
-                  figure,
+                  bigFigure,
                   style: TextStyle(
                     color: foregroundColor,
                     fontWeight: FontWeight.w800,
@@ -109,48 +156,42 @@ class TripRecordingPipView extends StatelessWidget {
               ),
               const SizedBox(height: 2),
               Text(
-                unit,
+                bigCaption,
                 style: TextStyle(
                   color: foregroundColor.withValues(alpha: 0.85),
                   fontWeight: FontWeight.w600,
                   fontSize: 14,
                 ),
               ),
-              const SizedBox(height: 6),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  if (distance != null)
-                    Text(
-                      '${distance.toStringAsFixed(1)} km',
-                      style: TextStyle(
-                        color: foregroundColor.withValues(alpha: 0.9),
-                        fontSize: 12,
-                        fontFeatures: const [FontFeature.tabularFigures()],
-                      ),
-                    ),
-                  if (distance != null && elapsed != null)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 6),
-                      child: Text(
-                        '·',
+              if (secondaryRow.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    for (var i = 0; i < secondaryRow.length; i++) ...[
+                      if (i > 0)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 6),
+                          child: Text(
+                            '·',
+                            style: TextStyle(
+                              color: foregroundColor.withValues(alpha: 0.6),
+                              fontSize: 12,
+                            ),
+                          ),
+                        ),
+                      Text(
+                        secondaryRow[i],
                         style: TextStyle(
-                          color: foregroundColor.withValues(alpha: 0.6),
+                          color: foregroundColor.withValues(alpha: 0.9),
                           fontSize: 12,
+                          fontFeatures: const [FontFeature.tabularFigures()],
                         ),
                       ),
-                    ),
-                  if (elapsed != null)
-                    Text(
-                      _fmtElapsed(elapsed),
-                      style: TextStyle(
-                        color: foregroundColor.withValues(alpha: 0.9),
-                        fontSize: 12,
-                        fontFeatures: const [FontFeature.tabularFigures()],
-                      ),
-                    ),
-                ],
-              ),
+                    ],
+                  ],
+                ),
+              ],
               if (paused) ...[
                 const SizedBox(height: 4),
                 Text(
@@ -273,9 +314,21 @@ class TripRecordingPipView extends StatelessWidget {
     return '';
   }
 
+  /// Format an elapsed [Duration] so it reads as a duration, not a
+  /// clock time (#2094). Pre-#2094 returned `"14:12"` which on a PiP
+  /// tile next to the system clock could be mistaken for 14:12 of
+  /// the day. New shapes:
+  ///
+  /// - Under 1 minute → `"42s"`.
+  /// - Under 1 hour → `"14m 12s"`.
+  /// - 1 hour or more → `"1h 14m"` (seconds drop — at hour-plus
+  ///   scale the second precision is noise).
   static String _fmtElapsed(Duration d) {
-    final m = d.inMinutes;
+    final h = d.inHours;
+    final m = d.inMinutes % 60;
     final s = d.inSeconds % 60;
-    return '${m.toString()}:${s.toString().padLeft(2, '0')}';
+    if (h >= 1) return '${h}h ${m}m';
+    if (d.inMinutes >= 1) return '${m}m ${s}s';
+    return '${s}s';
   }
 }

--- a/lib/l10n/_fragments/pip_elapsed_de.arb
+++ b/lib/l10n/_fragments/pip_elapsed_de.arb
@@ -1,0 +1,6 @@
+{
+  "tripRecordingPipElapsedCaption": "vergangen",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
+  }
+}

--- a/lib/l10n/_fragments/pip_elapsed_en.arb
+++ b/lib/l10n/_fragments/pip_elapsed_en.arb
@@ -1,0 +1,6 @@
+{
+  "tripRecordingPipElapsedCaption": "elapsed",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
+  }
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "изминало",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "uplynulo",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "forløbet",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1978,6 +1978,10 @@
   "onboardingObd2VinReadFailed": "VIN konnte nicht ausgelesen werden — bitte manuell eingeben",
   "onboardingObd2ConnectFailed": "Adapter konnte nicht verbunden werden. Du kannst es erneut versuchen oder überspringen.",
   "onboardingPickUseMode": "Wähle einen Nutzungsmodus, um fortzufahren.",
+  "tripRecordingPipElapsedCaption": "vergangen",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
+  },
   "alertsRadiusFrequencyLabel": "Prüfintervall",
   "alertsRadiusFrequencyDaily": "Einmal täglich",
   "alertsRadiusFrequencyTwiceDaily": "Zweimal täglich",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "παρήλθε",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3373,6 +3373,10 @@
   "@onboardingPickUseMode": {
     "description": "Error shown when the user taps the onboarding wizard's Next button on the first step without choosing a use mode (#1691)."
   },
+  "tripRecordingPipElapsedCaption": "elapsed",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
+  },
   "alertsRadiusFrequencyLabel": "Check frequency",
   "@alertsRadiusFrequencyLabel": {
     "description": "Label of the per-alert frequency dropdown (#1012 phase 1) — chooses how often the background runner re-evaluates this radius alert."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1400,6 +1400,7 @@
   "onboardingObd2VinReadFailed": "⟦Çóúłđñ'ŧ řéáđ ṼÎÑ — éñŧéř ɱáñúáłłý ············⟧",
   "onboardingObd2ConnectFailed": "⟦Çóúłđñ'ŧ çóññéçŧ ŧó ŧĥé áđáƥŧéř. Ýóú çáñ řéŧřý óř šķîƥ. ···················⟧",
   "onboardingPickUseMode": "⟦Ƥîçķ á úšé ɱóđé ŧó çóñŧîñúé. ··········⟧",
+  "tripRecordingPipElapsedCaption": "⟦éłáƥšéđ ···⟧",
   "alertsRadiusFrequencyLabel": "⟦Çĥéçķ ƒřéɋúéñçý ······⟧",
   "alertsRadiusFrequencyDaily": "⟦Óñçé á đáý ····⟧",
   "alertsRadiusFrequencyTwiceDaily": "⟦Ŧŵîçé á đáý ····⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "transcurrido",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "möödunud",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "kulunut",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1923,5 +1923,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "écoulé",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "proteklo",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "eltelt",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "trascorso",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8553,6 +8553,12 @@ abstract class AppLocalizations {
   /// **'Pick a use mode to continue.'**
   String get onboardingPickUseMode;
 
+  /// PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches.
+  ///
+  /// In en, this message translates to:
+  /// **'elapsed'**
+  String get tripRecordingPipElapsedCaption;
+
   /// Label of the per-alert frequency dropdown (#1012 phase 1) — chooses how often the background runner re-evaluates this radius alert.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4794,6 +4794,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Изберете режим на използване за да продължите.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'изминало';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Честота на проверка';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4756,6 +4756,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get onboardingPickUseMode => 'Pro pokračování vyberte režim použití.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'uplynulo';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Frekvence kontroly';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4751,6 +4751,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get onboardingPickUseMode => 'Vælg en brugstilstand for at fortsætte.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'forløbet';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Tjekfrekvens';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4777,6 +4777,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Wähle einen Nutzungsmodus, um fortzufahren.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'vergangen';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Prüfintervall';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4797,6 +4797,9 @@ class AppLocalizationsEl extends AppLocalizations {
       'Επιλέξτε λειτουργία χρήσης για συνέχεια.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'παρήλθε';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Συχνότητα ελέγχου';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4725,6 +4725,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get onboardingPickUseMode => 'Pick a use mode to continue.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'elapsed';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Check frequency';
 
   @override
@@ -10183,6 +10186,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get onboardingPickUseMode =>
       '⟦Ƥîçķ á úšé ɱóđé ŧó çóñŧîñúé. ··········⟧';
+
+  @override
+  String get tripRecordingPipElapsedCaption => '⟦éłáƥšéđ ···⟧';
 
   @override
   String get alertsRadiusFrequencyLabel => '⟦Çĥéçķ ƒřéɋúéñçý ······⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4788,6 +4788,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get onboardingPickUseMode => 'Elige un modo de uso para continuar.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'transcurrido';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Frecuencia de comprobación';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4746,6 +4746,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get onboardingPickUseMode => 'Jätkamiseks vali kasutusrežiim.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'möödunud';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Kontrollimissagedus';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4751,6 +4751,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get onboardingPickUseMode => 'Valitse käyttötapa jatkaaksesi.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'kulunut';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Tarkistustiheys';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4802,6 +4802,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Choisissez un mode d\'utilisation pour continuer.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'écoulé';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Fréquence de vérification';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4769,6 +4769,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get onboardingPickUseMode => 'Odaberite način korištenja za nastavak.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'proteklo';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Učestalost provjere';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4795,6 +4795,9 @@ class AppLocalizationsHu extends AppLocalizations {
       'Válasszon használati módot a folytatáshoz.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'eltelt';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Ellenőrzési gyakoriság';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4780,6 +4780,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Scegli una modalità d\'uso per continuare.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'trascorso';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Frequenza di controllo';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4781,6 +4781,9 @@ class AppLocalizationsLt extends AppLocalizations {
       'Norėdami tęsti, pasirinkite naudojimo režimą.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'praėjo';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Patikrinimo dažnis';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4784,6 +4784,9 @@ class AppLocalizationsLv extends AppLocalizations {
       'Izvēlieties lietošanas veidu, lai turpinātu.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'pagājis';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Pārbaudes biežums';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4751,6 +4751,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get onboardingPickUseMode => 'Velg en bruksmodus for å fortsette.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'forløpt';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Sjekkhyppighet';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4768,6 +4768,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get onboardingPickUseMode => 'Kies een gebruiksmodus om door te gaan.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'verstreken';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Controlefrequentie';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4775,6 +4775,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wybierz tryb użytkowania, aby kontynuować.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'upłynęło';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Częstotliwość sprawdzania';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4787,6 +4787,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get onboardingPickUseMode => 'Escolha um modo de uso para continuar.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'decorrido';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Frequência de verificação';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4787,6 +4787,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Alegeți un mod de utilizare pentru a continua.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'scurs';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Frecvența verificărilor';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4772,6 +4772,9 @@ class AppLocalizationsSk extends AppLocalizations {
       'Pre pokračovanie vyberte režim používania.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'uplynulo';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Frekvencia kontrol';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4757,6 +4757,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get onboardingPickUseMode => 'Za nadaljevanje izberite način uporabe.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'preteklo';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Pogostost preverjanja';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4753,6 +4753,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Välj ett användningsläge för att fortsätta.';
 
   @override
+  String get tripRecordingPipElapsedCaption => 'förflutit';
+
+  @override
   String get alertsRadiusFrequencyLabel => 'Kontrollfrekvens';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "praėjo",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "pagājis",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "forløpt",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "verstreken",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "upłynęło",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "decorrido",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "scurs",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "uplynulo",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "preteklo",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1795,5 +1795,9 @@
         "example": "350"
       }
     }
+  },
+  "tripRecordingPipElapsedCaption": "förflutit",
+  "@tripRecordingPipElapsedCaption": {
+    "description": "PiP overlay caption (#2094) shown under the big elapsed-time figure when the trip has just started and no distance / fuel data is available yet. Lowercase, unitless — pairs visually with 'L/100 km' / 'km' on the other branches."
   }
 }

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -231,13 +231,13 @@ void main() {
       expect(find.byKey(const Key('shell-child')), findsNothing,
           reason: 'PiP must not render the shell — that is what dragged '
               'the button bar into the tile (#1977)');
-      // The compact trip strip is still shown. As of #2068 the PiP
-      // tile renders two "km" strings — the distance row ("4.0 km")
-      // and the unit caption ("L/100 km") under the big L/100 km
-      // figure. Asserting the distance is present is enough proof
-      // the tile didn't collapse to nothing.
+      // The compact trip strip is still shown. With distance=4.0 +
+      // no fuel rate, #2094's context-adaptive primary lands the
+      // layout on the GPS-only branch: "4.0" hero figure with "km"
+      // caption. Finding the distance value is enough proof the
+      // tile didn't collapse to nothing.
       expect(find.textContaining('4.0'), findsOneWidget);
-      expect(find.textContaining('L/100 km'), findsOneWidget);
+      expect(find.text('km'), findsOneWidget);
     });
 
     testWidgets('outside PiP mode the shell child renders as usual',

--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -30,6 +30,11 @@ const _stationE10 = Station(
 TripRecordingState _activeState({
   double distance = 12.4,
   Duration elapsed = const Duration(minutes: 8, seconds: 32),
+  // Default fuel rate keeps tests on the OBD2 branch (#2094 Branch 1)
+  // where the L/100 km marker is rendered — that's the canonical
+  // "default layout" for the legacy tests. Branch-2 (GPS-only) and
+  // Branch-3 (pre-roll) get their own dedicated tests further down.
+  double? fuelRateLPerHour = 4.06,
 }) =>
     TripRecordingState(
       phase: TripRecordingPhase.recording,
@@ -39,6 +44,7 @@ TripRecordingState _activeState({
         speedKmh: 70,
         distanceKmSoFar: distance,
         elapsed: elapsed,
+        fuelRateLPerHour: fuelRateLPerHour,
       ),
     );
 
@@ -190,4 +196,75 @@ void main() {
       expect(find.text('Carrefour Pézenas'), findsNothing);
     });
   });
+  group('TripRecordingPipView (#2094) — context-adaptive primary', () {
+    Widget buildWith({double? fuelRate, double distance = 12.4}) =>
+        _wrap(TripRecordingPipView(
+          state: _activeState(
+            distance: distance,
+            fuelRateLPerHour: fuelRate,
+          ),
+          backgroundColor: Colors.green,
+          foregroundColor: Colors.white,
+        ));
+
+    testWidgets('OBD2 branch — fuel rate live → big L/100 km',
+        (tester) async {
+      await tester.pumpWidget(buildWith(fuelRate: 4.06));
+      // Branch 1 active.
+      expect(find.text('L/100 km'), findsOneWidget);
+      // km / elapsed move to the secondary row, NOT the caption.
+      expect(find.text('km'), findsNothing);
+      expect(find.text('elapsed'), findsNothing);
+    });
+
+    testWidgets('GPS-only branch — distance ≥ 0.1 km → big distance',
+        (tester) async {
+      await tester.pumpWidget(buildWith(fuelRate: null, distance: 4.0));
+      // Branch 2 — distance is the hero figure.
+      expect(find.text('4.0'), findsOneWidget);
+      expect(find.text('km'), findsOneWidget);
+      expect(find.text('L/100 km'), findsNothing);
+      // Pre-#2094 the layout rendered "~" huge; assert that's gone.
+      expect(find.text('~'), findsNothing);
+    });
+
+    testWidgets('pre-roll branch — distance ≈ 0 → big elapsed time',
+        (tester) async {
+      await tester.pumpWidget(buildWith(fuelRate: null, distance: 0.0));
+      // Branch 3 — elapsed time is the hero figure with "elapsed"
+      // caption. Default helper uses 8m 32s elapsed.
+      expect(find.text('elapsed'), findsOneWidget);
+      expect(find.text('8m 32s'), findsOneWidget);
+      expect(find.text('km'), findsNothing);
+      expect(find.text('L/100 km'), findsNothing);
+      expect(find.text('~'), findsNothing);
+    });
+
+    testWidgets('elapsed-time formatter reads as a duration, not a clock',
+        (tester) async {
+      // Hour-plus shape drops seconds.
+      await tester.pumpWidget(_wrap(TripRecordingPipView(
+        state: _activeState(
+          distance: 0.0,
+          fuelRateLPerHour: null,
+          elapsed: const Duration(hours: 1, minutes: 14, seconds: 12),
+        ),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+      )));
+      expect(find.text('1h 14m'), findsOneWidget);
+      // Under-1-minute shape uses seconds only.
+      await tester.pumpWidget(_wrap(TripRecordingPipView(
+        state: _activeState(
+          distance: 0.0,
+          fuelRateLPerHour: null,
+          elapsed: const Duration(seconds: 42),
+        ),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+      )));
+      expect(find.text('42s'), findsOneWidget);
+    });
+  });
+
 }


### PR DESCRIPTION
## Summary
- Big PiP figure picks the most informative metric: **L/100 km** (OBD2 live), **distance** (GPS-only mid-trajet), or **elapsed time** (pre-roll). No branch renders huge `~` anymore.
- Elapsed-time formatter now reads as a duration (`14m 12s` / `1h 14m`), not a clock (`14:12`) — clarifies a PiP tile sitting near the system clock.
- 1 new ARB key (`tripRecordingPipElapsedCaption`) across 23 locales with native translations.
- 4 new widget tests + 1 fixture update on the existing PiP tests.

Closes #2094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)