### PR TITLE
fix(map): route every TileLayer through SparkiloTileLayer — kill the recurring grey-map at the root (#2096)

### DIFF
--- a/lib/core/services/impl/flutter_map_provider.dart
+++ b/lib/core/services/impl/flutter_map_provider.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../features/map/data/sparkilo_tile_layer.dart';
 import '../../constants/app_constants.dart';
 import '../map_provider.dart';
 
@@ -50,12 +51,13 @@ class FlutterMapProvider implements MapProvider {
   @override
   Widget buildTileLayer() {
     final config = tileConfig;
-    return TileLayer(
+    // #2096 — was a raw TileLayer with the default
+    // `NetworkTileProvider`. Routed through the hardened wrapper
+    // for retry + cancellation resilience across every map surface
+    // that uses this service.
+    return SparkiloTileLayer(
       urlTemplate: config.urlTemplate,
       userAgentPackageName: config.userAgent ?? '',
-      // #757 — evict failed tiles once off-screen, retry on next pan.
-      evictErrorTileStrategy:
-          EvictErrorTileStrategy.notVisibleRespectMargin,
     );
   }
 

--- a/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
@@ -10,6 +10,7 @@ import '../../../../core/constants/app_constants.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';
+import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Full-screen map-picker for choosing the center of a [RadiusAlert]
@@ -182,13 +183,9 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
               ),
             ),
             children: [
-              TileLayer(
-                urlTemplate: AppConstants.osmTileUrl,
-                userAgentPackageName: AppConstants.osmUserAgent,
-                // #757 — evict failed tiles once off-screen.
-                evictErrorTileStrategy:
-                    EvictErrorTileStrategy.notVisibleRespectMargin,
-              ),
+              // #2096 — was a raw TileLayer; routed through the
+              // hardened wrapper for retry + cancellation resilience.
+              const SparkiloTileLayer(),
               const RichAttributionWidget(
                 attributions: [
                   TextSourceAttribution('OpenStreetMap contributors'),

--- a/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
@@ -6,7 +6,6 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../../../core/constants/app_constants.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/user_position_provider.dart';
 import '../../../../core/widgets/page_scaffold.dart';

--- a/lib/features/consumption/presentation/screens/trajets_map_screen.dart
+++ b/lib/features/consumption/presentation/screens/trajets_map_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/sharing/public_file_exporter.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/exporters/gpx_exporter.dart';
 import '../../data/trip_history_repository.dart';
 import '../../providers/trip_history_provider.dart';
@@ -235,12 +236,10 @@ class _MapState extends State<_Map> {
         ),
       ),
       children: [
-        TileLayer(
-          urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-          userAgentPackageName: 'de.tankstellen.tankstellen',
-          evictErrorTileStrategy:
-              EvictErrorTileStrategy.notVisibleRespectMargin,
-        ),
+        // #2096 — was a raw TileLayer with the default
+        // `NetworkTileProvider`. Routed through the hardened
+        // wrapper.
+        const SparkiloTileLayer(),
         PolylineLayer(
           polylines: [
             for (final t in widget.tracks)

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/driving_insights_analyzer.dart';
 import 'trip_detail_charts.dart';
 
@@ -327,14 +328,12 @@ class _TripPathMapState extends State<_TripPathMap> {
         ),
       ),
       children: [
-        TileLayer(
-          urlTemplate: AppConstants.osmTileUrl,
-          userAgentPackageName: AppConstants.osmUserAgent,
-          maxNativeZoom: 19,
-          maxZoom: 19,
-          evictErrorTileStrategy:
-              EvictErrorTileStrategy.notVisibleRespectMargin,
-        ),
+        // #2096 — was a raw TileLayer with the default
+        // `NetworkTileProvider`, which silently produced grey on
+        // every OSM transient + every rebuild abort. Routed
+        // through the hardened wrapper for retry + cancellation
+        // resilience.
+        const SparkiloTileLayer(),
         PolylineLayer(polylines: polylines),
         MarkerLayer(
           markers: [

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../../../core/constants/app_constants.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -4,7 +4,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
-import '../../../../core/constants/app_constants.dart';
 import '../../../../core/utils/price_utils.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../../search/domain/entities/fuel_type.dart';

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/utils/price_utils.dart';
+import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import 'driving_marker_builder.dart';
@@ -43,15 +44,9 @@ class DrivingMapView extends StatelessWidget {
           initialZoom: 12,
         ),
         children: [
-          TileLayer(
-            urlTemplate: AppConstants.osmTileUrl,
-            userAgentPackageName: AppConstants.osmUserAgent,
-            // #757 — evict failed tiles once off-screen so the next
-            // pan retries cleanly. See station_map_layers.dart for
-            // the full rationale.
-            evictErrorTileStrategy:
-                EvictErrorTileStrategy.notVisibleRespectMargin,
-          ),
+          // #2096 — was a raw TileLayer; routed through the
+          // hardened wrapper.
+          const SparkiloTileLayer(),
         ],
       );
     }
@@ -85,13 +80,9 @@ class DrivingMapView extends StatelessWidget {
         onTap: (_, _) => onInteraction(),
       ),
       children: [
-        TileLayer(
-          urlTemplate: AppConstants.osmTileUrl,
-          userAgentPackageName: AppConstants.osmUserAgent,
-          // #757 — evict failed tiles off-screen so the next pan retries.
-          evictErrorTileStrategy:
-              EvictErrorTileStrategy.notVisibleRespectMargin,
-        ),
+        // #2096 — was a raw TileLayer; routed through the hardened
+        // wrapper.
+        const SparkiloTileLayer(),
         MarkerLayer(markers: markers),
         const RichAttributionWidget(
           attributions: [

--- a/lib/features/map/data/retry_network_tile_provider.dart
+++ b/lib/features/map/data/retry_network_tile_provider.dart
@@ -133,11 +133,27 @@ class RetryingTileHttpClient extends http.BaseClient {
       try {
         final response = await _inner.send(fresh);
         if (_isRetryable(response.statusCode)) {
+          // #2098 — drain the prior retained response's stream before
+          // overwriting it. http.StreamedResponse keeps its socket
+          // alive until the body stream is drained or cancelled;
+          // abandoning it to retain a fresh response leaks the
+          // socket. On fast-pan + transient outage that compounds
+          // into OS socket-pool exhaustion. The drain is fire-and-
+          // forget — errors during drain are not actionable here
+          // (the socket gets reclaimed by the runtime eventually
+          // either way), so swallow them.
+          if (lastResponse != null) {
+            unawaited(lastResponse.stream.drain<void>().catchError((_) {}));
+          }
           lastResponse = response;
           _logAttempt(request.url, attempt, 'HTTP ${response.statusCode}');
         } else {
           // Success (2xx/3xx) or permanent failure (4xx except 429).
-          // Hand it back to flutter_map unchanged.
+          // Drain any prior retained retryable response before
+          // returning — same socket-leak rationale (#2098).
+          if (lastResponse != null) {
+            unawaited(lastResponse.stream.drain<void>().catchError((_) {}));
+          }
           return response;
         }
       } on SocketException catch (e, s) {

--- a/lib/features/map/data/sparkilo_tile_layer.dart
+++ b/lib/features/map/data/sparkilo_tile_layer.dart
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import '../../../core/constants/app_constants.dart';
+import 'retry_network_tile_provider.dart';
+
+/// Drop-in `TileLayer` wrapper that wires every OSM tile fetch
+/// through [RetryNetworkTileProvider] with the hardened config —
+/// the only legitimate way to instantiate a TileLayer in this
+/// codebase (#2096).
+///
+/// ## Why this widget exists
+///
+/// `RetryNetworkTileProvider` + `evictErrorTileStrategy:
+/// notVisibleRespectMargin` + `abortObsoleteRequests: false`
+/// together cover the four documented grey-tile pathologies:
+///
+/// 1. OSM transient HTTP 429 / 5xx — provider retries 3× with
+///    jittered backoff.
+/// 2. flutter_map's rebuild-abort race — provider declines to
+///    re-fire on cancellations, and `abortObsoleteRequests: false`
+///    keeps in-flight fetches alive across rebuilds.
+/// 3. The error-tile cache trap — `notVisibleRespectMargin` evicts
+///    failed tiles once off-screen so the next pan retries cleanly.
+/// 4. The cold-start camera-settled race — the optional [reset]
+///    stream lets a parent fire a tile reset when its layout
+///    settles (used by `station_map_layers.dart`).
+///
+/// Prior to this widget, 6 of 7 TileLayer call sites in `lib/`
+/// instantiated `TileLayer` directly with the **default**
+/// `NetworkTileProvider`. The trip-detail, trajets, driving, and
+/// alert-radius maps all rendered grey when the user hit a
+/// transient OSM glitch. Every "fix" since #757 patched the main
+/// map in isolation. The recurring-bug protocol called for an
+/// architectural solution — every map surface goes through the
+/// same hardened path.
+///
+/// ## Lifecycle (#1234 invariant — DO NOT regress)
+///
+/// The retry provider OWNS an [http.Client] that must live for the
+/// entire visible lifetime of the TileLayer. Recreating it on
+/// every build churns clients and produces a different cold-start
+/// race. This widget holds the provider in [State] (created in
+/// `initState`, disposed in `dispose`) so the http.Client identity
+/// is stable across parent rebuilds.
+///
+/// ## Usage
+///
+/// Drop-in replacement for the raw `TileLayer` constructor — a
+/// single line in place of the prior 4-line setup with
+/// `urlTemplate`, `userAgentPackageName`, and
+/// `evictErrorTileStrategy`. See `station_map_layers.dart` for the
+/// reference inline setup the wrapper consolidates.
+///
+/// Custom OSM endpoints (e.g. self-hosted) override [urlTemplate].
+/// Routes that need to force a tile reset on layout-settle pass a
+/// broadcast stream via [reset]; most callers leave it null.
+class SparkiloTileLayer extends StatefulWidget {
+  /// OSM tile-URL template. Defaults to [AppConstants.osmTileUrl].
+  final String? urlTemplate;
+
+  /// User-Agent header per OSM tile-usage policy. Defaults to
+  /// [AppConstants.osmUserAgent].
+  final String? userAgentPackageName;
+
+  /// Highest zoom level with real tiles (OSM caps at 19). Cameras
+  /// that overzoom past this still render — flutter_map upsamples
+  /// from the deepest available level — but going past 19 starts
+  /// to look pixelated.
+  final int maxNativeZoom;
+
+  /// Hard cap on the camera zoom. Aligned with [maxNativeZoom] so
+  /// a programmatic over-zoom doesn't park the user on a grey
+  /// viewport with no tiles to draw.
+  final double maxZoom;
+
+  /// Broadcast stream that, when emitted, makes the underlying
+  /// [TileLayer] drop all current tile images and re-fetch the
+  /// visible range. Used by `station_map_layers.dart` to defeat
+  /// the cold-start race when the camera settles after the first
+  /// frame. Most callers can leave this null.
+  final Stream<void>? reset;
+
+  const SparkiloTileLayer({
+    super.key,
+    this.urlTemplate,
+    this.userAgentPackageName,
+    this.maxNativeZoom = 19,
+    this.maxZoom = 19,
+    this.reset,
+  });
+
+  @override
+  State<SparkiloTileLayer> createState() => _SparkiloTileLayerState();
+}
+
+class _SparkiloTileLayerState extends State<SparkiloTileLayer> {
+  late final RetryNetworkTileProvider _tileProvider;
+
+  @override
+  void initState() {
+    super.initState();
+    // `abortObsoleteRequests: false` is critical — flutter_map's
+    // default (true) aborts in-flight tile HTTP requests when the
+    // widget rebuilds. Combined with the provider's
+    // cancellation-aware retry logic, false keeps fetches alive
+    // through the rebuild churn.
+    _tileProvider = RetryNetworkTileProvider(abortObsoleteRequests: false);
+  }
+
+  @override
+  void dispose() {
+    _tileProvider.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TileLayer(
+      urlTemplate: widget.urlTemplate ?? AppConstants.osmTileUrl,
+      userAgentPackageName:
+          widget.userAgentPackageName ?? AppConstants.osmUserAgent,
+      maxNativeZoom: widget.maxNativeZoom,
+      maxZoom: widget.maxZoom,
+      tileProvider: _tileProvider,
+      reset: widget.reset,
+      evictErrorTileStrategy:
+          EvictErrorTileStrategy.notVisibleRespectMargin,
+      errorTileCallback: (tile, error, stackTrace) {
+        // Same as `station_map_layers.dart` — visible in device
+        // logs but not in production user UI. Mode B (silent
+        // exhaustion + tap-to-retry) is a follow-up per #2096.
+        if (kDebugMode) {
+          debugPrint(
+              'SparkiloTileLayer: tile error at (z:${tile.coordinates.z} '
+              'x:${tile.coordinates.x} y:${tile.coordinates.y}): $error');
+        }
+      },
+    );
+  }
+}

--- a/test/features/map/data/retry_network_tile_provider_test.dart
+++ b/test/features/map/data/retry_network_tile_provider_test.dart
@@ -164,7 +164,15 @@ void main() {
 
     test('all 3 attempts return 503 → final 503 response surfaces',
         () async {
-      final inner = _FakeClient(responses: List.filled(3, _resp(503)));
+      // Each `_resp(503)` is a fresh response with its own
+      // single-event stream — necessary because #2098's drain
+      // logic consumes each retryable response's stream before
+      // moving on. The prior `List.filled(3, _resp(503))` form
+      // reused one response 3 times and worked only because the
+      // drain wasn't yet wired.
+      final inner = _FakeClient(
+        responses: [_resp(503), _resp(503), _resp(503)],
+      );
       final client = RetryingTileHttpClient(
         inner: inner,
         sleep: (_) async {},
@@ -388,6 +396,93 @@ void main() {
       // Success — no retry.
       expect(RetryingTileHttpClient.isRetryableStatusCode(200), isFalse);
       expect(RetryingTileHttpClient.isRetryableStatusCode(301), isFalse);
+    });
+
+    group('socket-leak prevention (#2098)', () {
+      test(
+          'retryable responses on attempts 1 + 2 get their streams drained '
+          'before the next attempt — only the final attempt\'s body stays '
+          'intact for the caller', () async {
+        // Build three responses, each backed by a controller we
+        // can introspect. After the retry call:
+        //   - controllers 0 + 1 (the 503s that get superseded)
+        //     must have been listened to (= drained).
+        //   - controller 2 (the final 503 the caller receives)
+        //     must NOT have been drained by us — the caller
+        //     reads it.
+        final controllers = [
+          StreamController<List<int>>(),
+          StreamController<List<int>>(),
+          StreamController<List<int>>(),
+        ];
+        // Seed each stream with a small body + close immediately so
+        // `drain` actually completes (stream.value gives a single
+        // event; we want the same semantics).
+        for (final c in controllers) {
+          unawaited(c.addStream(Stream.value(<int>[0x00])).then((_) => c.close()));
+        }
+        final responses = [
+          for (final c in controllers)
+            http.StreamedResponse(c.stream, 503),
+        ];
+        final inner = _FakeClient(responses: responses);
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          random: math.Random(0),
+          sleep: (_) async {},
+        );
+
+        // `client.send` returns the raw StreamedResponse without
+        // BaseClient.get's body-buffering — lets the test inspect
+        // the final response's stream intact.
+        final response = await client.send(
+            http.Request('GET', Uri.parse('https://tile/leak.png')));
+        // Exhausted all 3 attempts → returns the final 503.
+        expect(response.statusCode, 503);
+        expect(inner.sentCount, 3);
+
+        // The first two controllers' streams must have been
+        // listened to (drained). A drained stream's controller
+        // reports `isClosed == true` once the drain has consumed
+        // the data + the seed `close()` lands.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(controllers[0].isClosed, isTrue,
+            reason: 'attempt-1 503 stream should be drained + closed');
+        expect(controllers[1].isClosed, isTrue,
+            reason: 'attempt-2 503 stream should be drained + closed');
+        // The final response's body should still be readable —
+        // proof we didn't drain it ourselves.
+        final body = await response.stream.bytesToString();
+        expect(body.codeUnits, [0x00]);
+      });
+
+      test(
+          'a fresh success after retries drains the prior retained 503 '
+          'before returning', () async {
+        // 503 → 200. The 503 must be drained by the client BEFORE
+        // the 200 is handed back to the caller.
+        final firstCtl = StreamController<List<int>>();
+        unawaited(firstCtl.addStream(Stream.value(<int>[0xFF]))
+            .then((_) => firstCtl.close()));
+        final inner = _FakeClient(responses: [
+          http.StreamedResponse(firstCtl.stream, 503),
+          _resp(200, body: 'ok'),
+        ]);
+        final client = RetryingTileHttpClient(
+          inner: inner,
+          random: math.Random(0),
+          sleep: (_) async {},
+        );
+
+        final response = await client.send(
+            http.Request('GET', Uri.parse('https://tile/leak.png')));
+        expect(response.statusCode, 200);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(firstCtl.isClosed, isTrue,
+            reason: '503 stream drained before returning the 200');
+      });
     });
   });
 }

--- a/test/features/map/tile_layer_consistency_test.dart
+++ b/test/features/map/tile_layer_consistency_test.dart
@@ -52,10 +52,15 @@ void main() {
         final rel = entity.path;
         if (allowlist.contains(rel)) continue;
         final text = entity.readAsStringSync();
-        // Look for the constructor call specifically. `TileLayer.` /
-        // `MapTileLayer` / `_TileLayer` etc. are false positives we
-        // accept — the bug is the parameterless raw constructor.
-        final regex = RegExp(r'\bTileLayer\s*\(');
+        // Look for the constructor call specifically. `MapTileLayer`
+        // / `_TileLayer` etc. are false positives we accept — the
+        // bug is the raw constructor.
+        // #2098 — also match `TileLayer.new(` (Dart 2.15+
+        // constructor tear-off form). Without the `\.new?` branch a
+        // developer using modern Dart syntax could reintroduce the
+        // unhardened default `NetworkTileProvider` without the lint
+        // firing.
+        final regex = RegExp(r'\bTileLayer(\.new)?\s*\(');
         if (regex.hasMatch(text)) {
           offenders.add(rel);
         }
@@ -76,6 +81,27 @@ void main() {
             'follow-up that folds it into the wrapper.\n\n'
             'Offenders:\n${offenders.map((p) => '  $p').join('\n')}',
       );
+    },
+  );
+
+  test(
+    '.new constructor tear-off does not bypass the consistency lint (#2098)',
+    () {
+      // Sanity check: the regex used above must match BOTH the
+      // plain-constructor form `TileLayer(` AND the Dart 2.15+
+      // tear-off form `TileLayer.new(`. Without `.new` matching,
+      // a developer using modern Dart syntax could reintroduce the
+      // unhardened default `NetworkTileProvider` without the test
+      // firing.
+      final regex = RegExp(r'\bTileLayer(\.new)?\s*\(');
+      // Plain form — must match.
+      expect(regex.hasMatch('TileLayer(urlTemplate: x)'), isTrue);
+      // Tear-off form — must match.
+      expect(regex.hasMatch('TileLayer.new(urlTemplate: x)'), isTrue);
+      // False positives we explicitly DON'T want to catch.
+      expect(regex.hasMatch('SparkiloTileLayer(urlTemplate: x)'), isFalse);
+      expect(regex.hasMatch('_TileLayer(urlTemplate: x)'), isFalse);
+      expect(regex.hasMatch('buildTileLayer(urlTemplate: x)'), isFalse);
     },
   );
 }

--- a/test/features/map/tile_layer_consistency_test.dart
+++ b/test/features/map/tile_layer_consistency_test.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Lint-style guard (#2096) — fails when any new `TileLayer(`
+/// constructor call lands in `lib/` outside the allowlisted call
+/// sites that go through `SparkiloTileLayer` or own its lifecycle.
+///
+/// Background: the grey-map bug came back five times (#757 → #1234
+/// → #1316 → #1991 → #2044) because each "fix" patched the main map
+/// in isolation while 6 other TileLayer call sites kept using the
+/// default `NetworkTileProvider`. The default provider has no
+/// retry on transient HTTP errors, no cancellation handling on
+/// flutter_map's viewport-abort, and no cold-start reset hook —
+/// any of which produces a permanently-grey tile.
+///
+/// This test makes the architectural rule mechanical: every new
+/// `TileLayer(` either belongs in `SparkiloTileLayer`'s build
+/// method (the wrapper itself), in `StationMapLayers`' inline
+/// setup (the main map needs cold-start event-stream wiring and
+/// owns its own provider in state), or it's a regression.
+void main() {
+  test(
+    'every TileLayer in lib/ goes through SparkiloTileLayer or is allowlisted (#2096)',
+    () {
+      // Allowlisted files — these own their own retry-provider
+      // lifecycle and the inline TileLayer is intentional.
+      const allowlist = <String>{
+        // The hardened wrapper itself — the ONE place a raw
+        // TileLayer is allowed.
+        'lib/features/map/data/sparkilo_tile_layer.dart',
+        // The main map. Holds the provider in state + wires the
+        // cold-start event-stream reset. A future cleanup can fold
+        // this into SparkiloTileLayer with an optional cold-start
+        // hook; until then the inline setup is allowlisted with
+        // its existing rationale documented in the file.
+        'lib/features/map/presentation/widgets/station_map_layers.dart',
+      };
+
+      final offenders = <String>[];
+      final lib = Directory('lib');
+      for (final entity in lib.listSync(recursive: true)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart')) continue;
+        if (entity.path.endsWith('.g.dart') ||
+            entity.path.endsWith('.freezed.dart')) {
+          continue;
+        }
+        final rel = entity.path;
+        if (allowlist.contains(rel)) continue;
+        final text = entity.readAsStringSync();
+        // Look for the constructor call specifically. `TileLayer.` /
+        // `MapTileLayer` / `_TileLayer` etc. are false positives we
+        // accept — the bug is the parameterless raw constructor.
+        final regex = RegExp(r'\bTileLayer\s*\(');
+        if (regex.hasMatch(text)) {
+          offenders.add(rel);
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason:
+            'Found `TileLayer(` outside the allowlist. The grey-map bug '
+            'regresses every time a new map surface ships with the '
+            'default `NetworkTileProvider`. Replace with '
+            '`SparkiloTileLayer(...)` from '
+            '`lib/features/map/data/sparkilo_tile_layer.dart` — or, if '
+            'this site genuinely needs its own provider lifecycle '
+            '(cold-start hook, etc.), add it to the allowlist in this '
+            'test with a short rationale and a TODO link to the '
+            'follow-up that folds it into the wrapper.\n\n'
+            'Offenders:\n${offenders.map((p) => '  $p').join('\n')}',
+      );
+    },
+  );
+}

--- a/test/features/map/tile_layer_eviction_strategy_test.dart
+++ b/test/features/map/tile_layer_eviction_strategy_test.dart
@@ -28,14 +28,17 @@ void main() {
       // char (space / newline / `[` / `,` / `(`). Avoids the
       // `buildTileLayer(` false positive in the MapProvider
       // abstraction.
-      final tokenRe = RegExp(r'(?<![A-Za-z0-9_])TileLayer\(');
+      // #2098 — also match `TileLayer.new(` so the lint can't be
+      // bypassed with the Dart 2.15+ constructor tear-off form.
+      final tokenRe = RegExp(r'(?<![A-Za-z0-9_])TileLayer(\.new)?\(');
       for (final match in tokenRe.allMatches(text)) {
         final idx = match.start;
         {
         // Find the matching close paren; naive but sufficient for
-        // well-formed Dart. The TileLayer constructor is short and
-        // balanced.
-        final end = _matchingCloseParen(text, idx + 'TileLayer('.length - 1);
+        // well-formed Dart. Account for the optional `.new` suffix
+        // when computing where the opening paren lives.
+        final open = text.indexOf('(', idx);
+        final end = _matchingCloseParen(text, open);
         if (end < 0) {
           offenders.add('${entity.path} near char $idx: '
               'unbalanced TileLayer(...) — cannot verify strategy');


### PR DESCRIPTION
## Summary
Fifth grey-map regression. Root cause: 6 of 7 `TileLayer` call sites in `lib/` used the default `NetworkTileProvider` instead of the hardened `RetryNetworkTileProvider` from #757. Each prior fix only patched the main map.

- New `SparkiloTileLayer` widget at `lib/features/map/data/sparkilo_tile_layer.dart` — holds the retry provider in state, sets `abortObsoleteRequests: false`, `evictErrorTileStrategy: notVisibleRespectMargin`, error-tile logging. One-line drop-in.
- 6 broken call sites updated: trip-path-map (user's screenshot), trajets-on-map, radius alert picker, driving mode (×2), generic flutter_map_provider service.
- New no-regression test `tile_layer_consistency_test.dart` scans `lib/` for raw `TileLayer(` calls outside the allowlist (`sparkilo_tile_layer.dart` + `station_map_layers.dart`).

Closes #2096.
Closes #2098.

## Test plan
- [x] `flutter analyze` clean.
- [x] All 125 `test/features/map/` tests pass.
- [x] Consistency test catches drift if anyone re-introduces a raw `TileLayer(`.
- [ ] Manual: trip-detail screen on flaky network renders tiles, not grey (can't reproduce in widget tests — flutter_map mocks the fetch).

## For challenge by other LLMs
The issue body (#2096) contains the full diagnostic + 5 alternatives considered with rejection reasons. Mode-B (silent retry exhaustion + "tap to retry" UI) is documented as out-of-scope follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
