### PR TITLE
test(consumption): real-trip life-cycle transition coverage for PiP context-adaptive primary (#2094 follow-up)

### DIFF
--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -265,6 +265,71 @@ void main() {
       )));
       expect(find.text('42s'), findsOneWidget);
     });
-  });
 
+    testWidgets(
+        'real-trip life-cycle — pre-roll → GPS-only → OBD2 adapts the '
+        'primary slot one transition at a time', (tester) async {
+      // Walks the widget through the natural sequence a real trip
+      // produces: start parked (pre-roll, 0 km, no fuel rate), drive a
+      // bit on GPS only (distance > 0.1 km, still no fuel rate),
+      // adapter finally connects mid-trip (fuel rate becomes
+      // available). The big-slot caption must adapt at each step
+      // without any branch ever rendering the `~` placeholder huge
+      // that #2094 set out to kill.
+      Future<void> pumpAt({
+        double distance = 0,
+        double? fuelRate,
+        Duration elapsed = const Duration(seconds: 42),
+      }) async {
+        await tester.pumpWidget(_wrap(TripRecordingPipView(
+          state: _activeState(
+            distance: distance,
+            fuelRateLPerHour: fuelRate,
+            elapsed: elapsed,
+          ),
+          backgroundColor: Colors.green,
+          foregroundColor: Colors.white,
+        )));
+        await tester.pump();
+      }
+
+      // T = 0 — engine on, GPS still warming up, no fuel rate.
+      // Branch 3: elapsed time is the hero.
+      await pumpAt(distance: 0, fuelRate: null);
+      expect(find.text('elapsed'), findsOneWidget);
+      expect(find.text('km'), findsNothing);
+      expect(find.text('L/100 km'), findsNothing);
+      expect(find.text('~'), findsNothing,
+          reason:
+              'the `~` placeholder pre-#2094 wasted the whole tile — '
+              'no branch should render it');
+
+      // T = 30 s — moved 0.5 km on GPS, still no OBD2 adapter.
+      // Branch 2: distance is the hero.
+      await pumpAt(
+        distance: 0.5,
+        fuelRate: null,
+        elapsed: const Duration(seconds: 30),
+      );
+      expect(find.text('0.5'), findsOneWidget);
+      expect(find.text('km'), findsOneWidget);
+      expect(find.text('elapsed'), findsNothing);
+      expect(find.text('L/100 km'), findsNothing);
+      expect(find.text('~'), findsNothing);
+
+      // T = 5 min — adapter connected, fuel-rate sample landed.
+      // Branch 1: L/100 km takes the hero slot.
+      await pumpAt(
+        distance: 4.0,
+        fuelRate: 4.06,
+        elapsed: const Duration(minutes: 5),
+      );
+      expect(find.text('L/100 km'), findsOneWidget);
+      // Distance + elapsed move to the secondary row — they're
+      // still findable, just no longer the hero caption.
+      expect(find.textContaining('4.0'), findsOneWidget);
+      expect(find.text('elapsed'), findsNothing);
+      expect(find.text('~'), findsNothing);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Re-creates the feature branch for #2094 — original PR #2095 auto-merged but its CI was stuck `Queued` against the GitHub Actions auth-incident on 2026-05-26, never exercising any test.
- Adds **one** transition test (`real-trip life-cycle — pre-roll → GPS-only → OBD2 adapts the primary slot one transition at a time`) that walks the widget through the natural state sequence a real trip produces.
- No production code change — the feature is already complete on master (commit `5efbf0bf`).

## Why one more test
The original PR shipped three separate tests, each pinning one of the three primary-slot branches. None of them asserted the **transition between branches** — the actual user experience. This test pumps the widget through:

| T | State | Hero caption |
| --- | --- | --- |
| 0 | engine on, GPS warming up, no fuel rate | `elapsed` |
| 30 s | 0.5 km on GPS, no OBD2 yet | `km` |
| 5 min | 4.0 km, fuel-rate live | `L/100 km` |

Each assertion also explicitly checks `find.text('~')` returns nothing — proves the bug #2094 fixed (a `~` placeholder rendered huge during pre-roll) stays fixed across the entire trip life-cycle, not just at static snapshots.

## Test plan
- [x] `flutter test test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart` — 11/11 pass locally
- [x] `flutter analyze` on the test file — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)