### PR TITLE
fix(consumption): GPS-only vs OBD2 trajet stripes — visibly distinct again (#2108)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trajet_row.dart
+++ b/lib/features/consumption/presentation/widgets/trajet_row.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
-import '../../domain/trip_recorder.dart' show TripKind;
+import 'trajet_stripe_colors.dart';
 
 /// One row in the Trajets list (#889). Shows date/time + chips for
 /// distance, duration, and average consumption. Extracted from
@@ -49,13 +49,13 @@ class TrajetRow extends StatelessWidget {
         ? const EdgeInsets.symmetric(horizontal: 10, vertical: 4)
         : const EdgeInsets.symmetric(horizontal: 12, vertical: 8);
 
-    // #2059 — 4dp left-edge stripe carries the trip kind at a glance.
-    // Green = OBD2-instrumented (real L/100 km from fuel rate),
-    // blue = GPS-only (estimated). Hybrid coverage is added in a
-    // follow-up once `obd2CoverageRatio` lands in #J of Epic #2065.
-    final stripeColor = s.kind == TripKind.gpsPlusObd2
-        ? theme.colorScheme.primary
-        : theme.colorScheme.tertiary;
+    // #2059 + #2108 — 4dp left-edge stripe carries the trip kind at
+    // a glance. Green = OBD2-instrumented (real L/100 km from fuel
+    // rate), blue = GPS-only (estimated). The colour binding lives
+    // in `TrajetStripeColors` so a future theme rework doesn't
+    // silently collapse the two hues onto the same olive/brown like
+    // the Eco theme's `primary` / `tertiary` did pre-#2108.
+    final stripeColor = TrajetStripeColors.forKind(s.kind, theme.brightness);
 
     return Card(
       key: ValueKey('trajet-${entry.id}'),

--- a/lib/features/consumption/presentation/widgets/trajet_stripe_colors.dart
+++ b/lib/features/consumption/presentation/widgets/trajet_stripe_colors.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../domain/trip_recorder.dart' show TripKind;
+
+/// Resolves the left-edge stripe colour for a trajet card (#2108
+/// refinement of #2059).
+///
+/// The original #2059 bound the stripe to `Theme.colorScheme.primary`
+/// (OBD2) vs `Theme.colorScheme.tertiary` (GPS-only). After the
+/// forest-green Eco theme landed in #1757, both tokens collapsed
+/// onto similar olive/brownish hues — making the two trip kinds
+/// visually indistinguishable on the trajets list.
+///
+/// This module decouples the stripe colour from the generic theme
+/// tokens. The semantic role is "trajet kind", not "tertiary
+/// content"; other `tertiary` consumers can move independently.
+///
+/// The two colours are tuned to:
+/// - read as visibly distinct at 4 dp width on both light and dark
+///   surfaces;
+/// - harmonise with the Eco theme's primary forest green (OBD2 uses
+///   a slightly brighter shade so it lifts off the surface);
+/// - keep the GPS-only/hybrid family on a calm muted blue that
+///   contrasts cleanly against the green without screaming.
+///
+/// Pinned by `test/features/consumption/presentation/widgets/trajet_stripe_colors_test.dart`
+/// — any future theme rework that touches these tokens must update
+/// that test too so the visual-distinction guarantee survives.
+class TrajetStripeColors {
+  TrajetStripeColors._();
+
+  /// OBD2-instrumented trajet — `TripKind.gpsPlusObd2`. Forest green
+  /// that lifts off both light and dark surfaces.
+  static const Color obd2Light = Color(0xFF2E7D32); // Material green 800
+  static const Color obd2Dark = Color(0xFF66BB6A); // Material green 400
+
+  /// GPS-only / hybrid trajet — `TripKind.gpsOnly` (and any kind that
+  /// isn't fully OBD2-instrumented). Muted slate blue.
+  static const Color gpsOnlyLight = Color(0xFF3A6EA5);
+  static const Color gpsOnlyDark = Color(0xFF7BAEDF);
+
+  /// Pick the stripe colour for the trip kind at the current theme
+  /// brightness. Anything other than `gpsPlusObd2` (including hybrid
+  /// partial-coverage trips) gets the GPS-only blue.
+  static Color forKind(TripKind kind, Brightness brightness) {
+    final isObd2 = kind == TripKind.gpsPlusObd2;
+    if (brightness == Brightness.dark) {
+      return isObd2 ? obd2Dark : gpsOnlyDark;
+    }
+    return isObd2 ? obd2Light : gpsOnlyLight;
+  }
+}

--- a/test/features/consumption/presentation/widgets/trajet_stripe_colors_test.dart
+++ b/test/features/consumption/presentation/widgets/trajet_stripe_colors_test.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Pins the trajet-stripe colour binding so a future theme rework
+// can't silently collapse the two hues onto the same olive/brown —
+// the regression that prompted #2108.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart'
+    show TripKind;
+import 'package:tankstellen/features/consumption/presentation/widgets/trajet_stripe_colors.dart';
+
+void main() {
+  group('TrajetStripeColors (#2108)', () {
+    test('OBD2 light + dark are visibly distinct from GPS-only light + dark',
+        () {
+      // Pin the exact values so a future "let me tweak the green a bit"
+      // doesn't accidentally converge them again.
+      expect(TrajetStripeColors.obd2Light, const Color(0xFF2E7D32));
+      expect(TrajetStripeColors.obd2Dark, const Color(0xFF66BB6A));
+      expect(TrajetStripeColors.gpsOnlyLight, const Color(0xFF3A6EA5));
+      expect(TrajetStripeColors.gpsOnlyDark, const Color(0xFF7BAEDF));
+    });
+
+    test('forKind routes gpsPlusObd2 → green and any other kind → blue', () {
+      // Light brightness.
+      expect(
+        TrajetStripeColors.forKind(TripKind.gpsPlusObd2, Brightness.light),
+        TrajetStripeColors.obd2Light,
+      );
+      expect(
+        TrajetStripeColors.forKind(TripKind.gpsOnly, Brightness.light),
+        TrajetStripeColors.gpsOnlyLight,
+      );
+
+      // Dark brightness.
+      expect(
+        TrajetStripeColors.forKind(TripKind.gpsPlusObd2, Brightness.dark),
+        TrajetStripeColors.obd2Dark,
+      );
+      expect(
+        TrajetStripeColors.forKind(TripKind.gpsOnly, Brightness.dark),
+        TrajetStripeColors.gpsOnlyDark,
+      );
+    });
+
+    test(
+        'green family and blue family have meaningfully different hues — RGB '
+        'distance > 100 at both brightnesses', () {
+      // Cheap proxy for "visibly distinct" — Manhattan distance in
+      // RGB space. The pre-#2108 bug had both stripes resolving to
+      // shades of the same forest green where the Manhattan distance
+      // was ~20–40. Anything > 100 is comfortably distinguishable at
+      // 4 dp width on a phone screen.
+      int dist(Color a, Color b) =>
+          ((a.r * 255 - b.r * 255).abs() +
+                  (a.g * 255 - b.g * 255).abs() +
+                  (a.b * 255 - b.b * 255).abs())
+              .round();
+      expect(
+        dist(TrajetStripeColors.obd2Light, TrajetStripeColors.gpsOnlyLight),
+        greaterThan(100),
+        reason: 'OBD2 light + GPS-only light must be visibly distinct.',
+      );
+      expect(
+        dist(TrajetStripeColors.obd2Dark, TrajetStripeColors.gpsOnlyDark),
+        greaterThan(100),
+        reason: 'OBD2 dark + GPS-only dark must be visibly distinct.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
The 4 dp left-edge stripe on trajet cards no longer reads as the same olive/brown for both `TripKind.gpsPlusObd2` and `TripKind.gpsOnly`. Decoupled from `Theme.colorScheme.primary` / `colorScheme.tertiary` (which collapsed onto similar forest-green/olive in the Eco theme) to explicit semantic tokens:
- OBD2 → forest green (`#2E7D32` light / `#66BB6A` dark)
- GPS-only / hybrid → muted slate blue (`#3A6EA5` light / `#7BAEDF` dark)

## Test plan
- [x] `flutter analyze` clean on the touched files.
- [x] `TrajetStripeColors` unit tests pin exact RGB + Manhattan distance > 100.
- [x] `trajets_tab` widget tests still pass.
- [ ] Manual: open Trips on an Eco-theme build, scroll list, confirm OBD2 (with L/100 km) and GPS-only rows are visibly different.

Closes #2108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
