### PR TITLE
fix(map): restore upstream abortObsoleteRequests + bump keepBuffer to kill recurring grey-tile (#2122)

### DIFF
--- a/lib/features/map/data/sparkilo_tile_layer.dart
+++ b/lib/features/map/data/sparkilo_tile_layer.dart
@@ -124,7 +124,11 @@ class _SparkiloTileLayerState extends State<SparkiloTileLayer> {
     // aborts a no-op for the retry loop, so reverting to `true`
     // gives bandwidth back to the tiles the user is actually
     // looking at without compromising transient-failure recovery.
-    _tileProvider = RetryNetworkTileProvider();
+    // Explicit `true` satisfies the #930 lint
+    // (`test/lint/retry_tile_provider_call_site_test.dart`) that
+    // forbids implicit defaults — every call site must be intentional
+    // about this parameter.
+    _tileProvider = RetryNetworkTileProvider(abortObsoleteRequests: true);
   }
 
   @override

--- a/lib/features/map/data/sparkilo_tile_layer.dart
+++ b/lib/features/map/data/sparkilo_tile_layer.dart
@@ -18,17 +18,25 @@ import 'retry_network_tile_provider.dart';
 /// ## Why this widget exists
 ///
 /// `RetryNetworkTileProvider` + `evictErrorTileStrategy:
-/// notVisibleRespectMargin` + `abortObsoleteRequests: false`
+/// notVisibleRespectMargin` + the upstream-default
+/// `abortObsoleteRequests: true` + a wider `keepBuffer` (4)
 /// together cover the four documented grey-tile pathologies:
 ///
 /// 1. OSM transient HTTP 429 / 5xx — provider retries 3× with
 ///    jittered backoff.
-/// 2. flutter_map's rebuild-abort race — provider declines to
-///    re-fire on cancellations, and `abortObsoleteRequests: false`
-///    keeps in-flight fetches alive across rebuilds.
+/// 2. flutter_map's pan-fetch race — `abortObsoleteRequests: true`
+///    (upstream default, restored in #2122) cancels in-flight tile
+///    requests for off-screen coordinates so visible tiles aren't
+///    starved by a backlog. The retry provider's
+///    `_isCancellation` guard makes the cancellations a no-op for
+///    the retry loop.
 /// 3. The error-tile cache trap — `notVisibleRespectMargin` evicts
 ///    failed tiles once off-screen so the next pan retries cleanly.
-/// 4. The cold-start camera-settled race — the optional [reset]
+/// 4. The grey-while-loading symptom — `keepBuffer: 4` keeps the
+///    previous level's painted tiles on screen until the new
+///    fetches resolve, so a slow connection doesn't show grey
+///    squares during the swap.
+/// 5. The cold-start camera-settled race — the optional [reset]
 ///    stream lets a parent fire a tile reset when its layout
 ///    settles (used by `station_map_layers.dart`).
 ///
@@ -106,12 +114,17 @@ class _SparkiloTileLayerState extends State<SparkiloTileLayer> {
   @override
   void initState() {
     super.initState();
-    // `abortObsoleteRequests: false` is critical — flutter_map's
-    // default (true) aborts in-flight tile HTTP requests when the
-    // widget rebuilds. Combined with the provider's
-    // cancellation-aware retry logic, false keeps fetches alive
-    // through the rebuild churn.
-    _tileProvider = RetryNetworkTileProvider(abortObsoleteRequests: false);
+    // #2122 — restored to the upstream default (`true`). The earlier
+    // override to `false` (added in #2097) turned out to amplify the
+    // grey-tile symptom rather than fix it: requests for tiles that
+    // had already panned out of view stayed in the queue, competing
+    // with the visible tiles for bandwidth and producing the user-
+    // reported "loading process gets cut" effect. The retry
+    // provider's `_isCancellation` guard already makes mid-fetch
+    // aborts a no-op for the retry loop, so reverting to `true`
+    // gives bandwidth back to the tiles the user is actually
+    // looking at without compromising transient-failure recovery.
+    _tileProvider = RetryNetworkTileProvider();
   }
 
   @override
@@ -130,6 +143,14 @@ class _SparkiloTileLayerState extends State<SparkiloTileLayer> {
       maxZoom: widget.maxZoom,
       tileProvider: _tileProvider,
       reset: widget.reset,
+      // #2122 — keep the previous level's already-loaded tiles
+      // painted while the new ones fetch. flutter_map's default is
+      // 2; bumping to 4 covers a wider corona around the visible
+      // viewport so a slow connection or a quick pan doesn't expose
+      // a grey ring. `panBuffer` deliberately stays at its default
+      // (1) — the flutter_map docs explicitly warn that raising it
+      // slows the visible tile fetches and adds load to OSM.
+      keepBuffer: 4,
       evictErrorTileStrategy:
           EvictErrorTileStrategy.notVisibleRespectMargin,
       errorTileCallback: (tile, error, stackTrace) {

--- a/test/features/map/data/sparkilo_tile_layer_defaults_test.dart
+++ b/test/features/map/data/sparkilo_tile_layer_defaults_test.dart
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Pins the hardened-tile-loading defaults shipped in #2122 so a
+// future TileLayer rewrite can't silently revert them. The fixes
+// land on the *rendered* TileLayer, so we inspect its widget
+// properties directly.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/map/data/sparkilo_tile_layer.dart';
+
+void main() {
+  testWidgets(
+      'SparkiloTileLayer renders a TileLayer with the #2122 hardened defaults',
+      (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: FlutterMap(
+          options: const MapOptions(
+            initialCenter: LatLng(48, 2),
+            initialZoom: 6,
+          ),
+          children: const [
+            SparkiloTileLayer(),
+          ],
+        ),
+      ),
+    );
+
+    final tile = tester.widget<TileLayer>(find.byType(TileLayer));
+
+    // #2122 — keepBuffer bumped to 4 (flutter_map default is 2) so
+    // the previous level's painted tiles stay on screen while the
+    // new ones fetch. Any future tweak that loosens this back below
+    // 3 must update the comment + this assertion together.
+    expect(tile.keepBuffer, 4,
+        reason:
+            '#2122 — `keepBuffer: 4` is the canonical anti-grey-tile knob.');
+
+    // #2122 — `panBuffer` stays at the flutter_map default. The
+    // upstream docs explicitly warn that raising it slows visible
+    // tile fetches and adds load to OSM.
+    expect(tile.panBuffer, 1,
+        reason: 'panBuffer must stay at flutter_map default; raising it '
+            'slows visible-tile fetches per the upstream docs.');
+
+    // #2122 — error-tile eviction strategy stays at
+    // notVisibleRespectMargin so failed tiles get re-fetched on the
+    // next pan rather than caching grey forever (#757).
+    expect(tile.evictErrorTileStrategy,
+        EvictErrorTileStrategy.notVisibleRespectMargin,
+        reason:
+            'failed-tile eviction must stay tuned per #757 / #2096 / #2122.');
+  });
+}

--- a/test/features/map/data/sparkilo_tile_layer_defaults_test.dart
+++ b/test/features/map/data/sparkilo_tile_layer_defaults_test.dart
@@ -17,14 +17,14 @@ void main() {
       'SparkiloTileLayer renders a TileLayer with the #2122 hardened defaults',
       (tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: FlutterMap(
-          options: const MapOptions(
+          options: MapOptions(
             initialCenter: LatLng(48, 2),
             initialZoom: 6,
           ),
-          children: const [
+          children: [
             SparkiloTileLayer(),
           ],
         ),


### PR DESCRIPTION
## Summary
Restores `abortObsoleteRequests` to the flutter_map upstream default (`true`) and bumps `keepBuffer` from 2 to 4. These two changes — driven by an open-source survey of flutter_map / FMTC / community write-ups — address the user-reported "map background is still grey + loading process gets cut" regression.

## Survey-driven decisions

| Knob | Before | After (#2122) | Why |
|---|---|---|---|
| `abortObsoleteRequests` | `false` (set by #2097) | `true` (upstream default) | #2097's override starved visible-tile requests by keeping off-screen fetches alive. The retry provider's `_isCancellation` guard already short-circuits the retry loop on aborts, so reverting is safe. |
| `keepBuffer` | `2` (default) | `4` | Canonical anti-grey knob — keeps previously-painted tiles on screen during the swap, so a slow connection doesn't expose a grey ring. |
| `panBuffer` | `1` (default) | `1` | Unchanged — upstream docs warn raising it slows visible-tile fetches and adds OSM load. |
| `tileFadeInDuration` | 100 ms (default) | 100 ms | Unchanged — upstream-validated value. |

## Test plan
- [x] `flutter analyze` clean on the touched files.
- [x] New `sparkilo_tile_layer_defaults_test.dart` pins `keepBuffer: 4`, `panBuffer: 1`, and the eviction strategy so a future tweak can't silently revert them.
- [x] 129/129 map tests pass.
- [ ] Manual: open trajets-map screen on a flaky connection — tiles fade in without grey, viewport pans don't cut mid-fetch.

## Out of scope
Issue #1813 upstream describes a paint-loop race (tiles arrive but don't render until manual interaction). If grey tiles persist after this PR lands, that's the next investigation — separate from the fetch-layer fixes here.

Closes #2122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
