### PR TITLE
fix(ci): unstick master codegen-drift on favorites_provider.g.dart

### DIFF
--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'6fdce4be24c33af318308cc9f777ca10b600042c';
+String _$favoritesHash() => r'8f711e5e6206fee3cde0428d1474e740263f1d84';
 
 /// Manages the user's list of favorite station IDs.
 ///


### PR DESCRIPTION
## Summary
Master's `favorites_provider.g.dart` carries a stale hash that's been blocking every rebased PR's `codegen-drift` check. A clean `build_runner clean && build_runner build --delete-conflicting-outputs` produces the matching `8f711e5e...` hash.

Unblocks #2121, #2123, #2124, #2126.

## Why this happened
`favorites_provider.dart` got a `#2114` comment added without a clean regen. Incremental `build_runner` on the local machine that pushed the merge kept the prior hash; CI's clean build produces a different one.

## Test plan
- [x] `dart pub get && dart run build_runner clean && dart run build_runner build --delete-conflicting-outputs` on master → only this single hash flips.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
