### PR TITLE
ci: add workflow_dispatch hatch for manual CI re-firing (#2128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,16 @@ on:
       - '.gitignore'
   schedule:
     - cron: '0 6 * * 0'
+  # #2128 — manual hatch so maintainers can re-fire CI on the active
+  # ref without an empty-commit nudge. Useful after a `gh pr update-
+  # branch` (which uses GITHUB_TOKEN and so doesn't auto-trigger the
+  # downstream workflow) or to retry a flaky run.
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for the manual run (audit trail)'
+        required: false
+        default: 'manual'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch:` to `.github/workflows/ci.yml`. Maintainers can now re-fire CI on any ref via the Actions UI or `gh workflow run ci.yml --ref <branch>` — no more empty-commit nudges after a `gh pr update-branch` (which uses `GITHUB_TOKEN` and so doesn't auto-trigger downstream workflows).

## Why
On 2026-05-27 the queue cleared via #2127, but every rebased PR needed an empty commit to actually run CI on the new tip because `gh pr update-branch` is a `GITHUB_TOKEN` action — GitHub Actions skips downstream triggers from those by design (anti-loop protection).

## Test plan
- [x] YAML parses (action will validate on push).
- [ ] After this lands, `gh workflow run ci.yml --ref some-pr-branch` fires CI without an empty commit.

Closes #2128 (filed implicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
