### PR TITLE
refactor(ui): M3 surface tiers + adaptive switches — finish #2117

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -153,7 +153,8 @@ class _AlertListTile extends ConsumerWidget {
         subtitle: Text(
           '${alert.fuelType.displayName} ≤ ${PriceFormatter.formatPrice(alert.targetPrice)}',
         ),
-        trailing: Switch(
+        // #2117 — platform-adaptive switch glyph.
+        trailing: Switch.adaptive(
           value: alert.isActive,
           onChanged: (_) {
             ref.read(alertProvider.notifier).toggleAlert(alert.id);
@@ -255,7 +256,8 @@ class _RadiusAlertListTile extends ConsumerWidget {
           '${PriceFormatter.formatPrice(alert.threshold)} '
           '· ${alert.radiusKm.round()} km',
         ),
-        trailing: Switch(
+        // #2117 — platform-adaptive switch glyph.
+        trailing: Switch.adaptive(
           value: alert.enabled,
           onChanged: (_) {
             ref.read(radiusAlertsProvider.notifier).toggle(alert.id);

--- a/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
@@ -210,7 +210,10 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
             right: 16,
             bottom: 24,
             child: Card(
-              color: theme.colorScheme.surface.withValues(alpha: 0.9),
+              // #2117 — hint card should lift subtly off the map backdrop;
+              // surfaceContainerLow is the M3 tier for cards on `surface`.
+              color: theme.colorScheme.surfaceContainerLow
+                  .withValues(alpha: 0.9),
               child: Padding(
                 padding: const EdgeInsets.all(12),
                 child: Text(

--- a/lib/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_pinned_save_bar.dart
@@ -24,7 +24,10 @@ class FillUpPinnedSaveBar extends StatelessWidget {
     final theme = Theme.of(context);
     return Material(
       elevation: 8,
-      color: theme.colorScheme.surface,
+      // #2117 — pinned save bars sit visibly above scroll content;
+      // surfaceContainerHighest is the M3 tier for chrome surfaces
+      // that need to lift off `surface`.
+      color: theme.colorScheme.surfaceContainerHighest,
       child: SafeArea(
         top: false,
         child: Padding(

--- a/lib/features/driving/presentation/widgets/driving_bottom_bar.dart
+++ b/lib/features/driving/presentation/widgets/driving_bottom_bar.dart
@@ -33,7 +33,12 @@ class DrivingBottomBar extends StatelessWidget {
         bottom: 12 + bottomPadding,
       ),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.95),
+        // #2117 — in-car bottom bar needs higher contrast for at-a-glance
+        // legibility. surfaceContainerHighest lifts it cleanly off the map.
+        color: Theme.of(context)
+            .colorScheme
+            .surfaceContainerHighest
+            .withValues(alpha: 0.95),
         boxShadow: [
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.3),

--- a/lib/features/favorites/presentation/widgets/alerts_tab.dart
+++ b/lib/features/favorites/presentation/widgets/alerts_tab.dart
@@ -102,6 +102,10 @@ class AlertsTab extends StatelessWidget {
                     ? FuelColors.forType(alert.fuelType)
                     : Colors.grey,
               ),
+              // #2117 \u2014 Switch.adaptive gets the platform-correct
+              // toggle glyph on iOS without changing the ListTile's
+              // tap-to-detail navigation semantics (a full SwitchListTile
+              // would collide with onTap).
               title: Text(alert.stationName),
               subtitle: Text(
                 '${alert.fuelType.displayName} \u2264 ${PriceFormatter.formatPrice(alert.targetPrice)}',
@@ -110,7 +114,7 @@ class AlertsTab extends StatelessWidget {
                         ? FuelColors.forType(alert.fuelType)
                         : Colors.grey),
               ),
-              trailing: Switch(
+              trailing: Switch.adaptive(
                 value: alert.isActive,
                 onChanged: (_) =>
                     ref.read(alertProvider.notifier).toggleAlert(alert.id),

--- a/lib/features/search/presentation/widgets/search_summary_bar.dart
+++ b/lib/features/search/presentation/widgets/search_summary_bar.dart
@@ -105,7 +105,10 @@ class _SummaryChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
+        // #2117 — chip sits on the summary bar's `surfaceContainerHighest`
+        // surface; surfaceContainerLow is the M3 inversion that reads as
+        // a recessed pill rather than fighting the bar.
+        color: theme.colorScheme.surfaceContainerLow,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: theme.colorScheme.outlineVariant),
       ),

--- a/lib/features/vehicle/presentation/widgets/vehicle_save_bar.dart
+++ b/lib/features/vehicle/presentation/widgets/vehicle_save_bar.dart
@@ -19,7 +19,10 @@ class VehicleSaveBar extends StatelessWidget {
     final theme = Theme.of(context);
     return Material(
       elevation: 8,
-      color: theme.colorScheme.surface,
+      // #2117 — pinned save bars sit visibly above scroll content;
+      // surfaceContainerHighest is the M3 tier for chrome surfaces
+      // that need to lift off `surface`.
+      color: theme.colorScheme.surfaceContainerHighest,
       child: SafeArea(
         top: false,
         child: Padding(


### PR DESCRIPTION
## Summary

Picks up the remaining audit items from #2117 after items 1 + 3 landed in #2134.

**Item 2 — M3 surface tiers** (5 files): pinned save bars + driving bottom bar move to `surfaceContainerHighest` (chrome lifts off `surface`); the map-picker hint card + the search-summary-bar chip move to `surfaceContainerLow` (recessed pills on a raised bar).

**Item 4 — adaptive switches** (3 ListTile+Switch sites): `Switch.adaptive` so iOS gets the platform-native toggle. Full `SwitchListTile` would collide with the existing `onTap` navigation semantics, so we keep the ListTile shape.

Closes #2117.

## Test plan

- [x] `flutter analyze` — 3 pre-existing infos, 0 errors.
- [x] Targeted tests on every touched widget (alerts_tab, alerts_screen, radius_alert_map_picker, search_summary_bar, driving_bottom_bar, fill_up_pinned_save_bar, vehicle_save_bar) — 30 pass.
- [ ] Manual: confirm pinned save bars visibly lift off scroll content.
- [ ] Manual: on iOS, the radius/price alert toggles render with the Cupertino-style switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)