### PR TITLE
fix(search): re-entry guard + decouple town selection from search (#2136, #2137)

### DIFF
--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -46,43 +46,24 @@ class SearchCriteriaScreen extends ConsumerStatefulWidget {
 }
 
 class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
-  /// Drives [RouteInputWidgetState.resolveAndSearch] when the central FAB
-  /// fires a route search (#2131). The inline submit button is gone;
-  /// the text controllers still live inside [RouteInput].
+  // #2131 / #2137 — GlobalKeys drive the inline inputs' submit from the FAB.
   final GlobalKey<RouteInputWidgetState> _routeInputKey =
       GlobalKey<RouteInputWidgetState>();
-
-  /// Drives [LocationInputWidgetState.submit] when the central FAB fires
-  /// a nearby search (#2137 — city/ZIP/GPS selection only updates the
-  /// criteria; the FAB submits).
   final GlobalKey<LocationInputWidgetState> _locationInputKey =
       GlobalKey<LocationInputWidgetState>();
 
-  /// Last action registered on the shell FAB, kept so we can `clearIf`
-  /// in `dispose` without stomping on a sibling screen that registered
-  /// after us.
   SearchFabAction? _registeredFabAction;
-
-  /// FAB notifier captured in initState so `dispose` can clear without
-  /// touching `ref` (Riverpod forbids ref usage after `deactivate`).
   SearchFabActionController? _fabNotifier;
 
-  /// Re-entry guard against rapid FAB / Enter / suggestion taps that
-  /// each call `Navigator.of(context).pop()` (#2136). The second pop
-  /// runs while the first pop's close animation is still inverting and
-  /// `lastWhere(isPresentPredicate)` finds no present route, crashing
-  /// with `StateError: No element`. Once a search has fired, the modal
-  /// is on its way out — additional taps are no-ops.
+  // #2136 — re-entry guard: double-tap pop races crash with "No element".
   bool _searchFired = false;
 
   @override
   void initState() {
     super.initState();
     _fabNotifier = ref.read(searchFabActionControllerProvider.notifier);
-    // Push the initial FAB action after first build so the shell sees
-    // it before the user can tap. didChangeDependencies isn't enough —
-    // the route input controllers (and their text-presence flags)
-    // only stabilise on the first frame.
+    // Defer to post-frame: the input widgets' state (and their text
+    // controllers) only stabilises after the first build.
     WidgetsBinding.instance.addPostFrameCallback((_) => _updateFabAction());
   }
 
@@ -91,11 +72,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final action = _registeredFabAction;
     final notifier = _fabNotifier;
     if (action != null && notifier != null) {
-      // Defer outside the dispose lifecycle — Riverpod forbids
-      // provider mutation inside build/initState/dispose. A
-      // post-frame callback runs after the current frame finishes
-      // but stays bound to this test's scheduler, so it doesn't leak
-      // across pumps the way Future.microtask does.
+      // Riverpod forbids mutation in dispose; defer via post-frame.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         try {
           notifier.clearIf(action);
@@ -107,9 +84,6 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     super.dispose();
   }
 
-  /// Pushes a fresh [SearchFabAction] reflecting the current mode +
-  /// route-input enabled state. Idempotent — invoked on every mode or
-  /// route-input change via `ref.listen` in [build].
   void _updateFabAction() {
     if (!mounted) return;
     final l10n = AppLocalizations.of(context);
@@ -131,9 +105,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       onTap = () => _routeInputKey.currentState?.resolveAndSearch();
     } else {
       enabled = true;
-      // #2137 — dispatch through LocationInput.submit so the FAB
-      // honours the user's current selection (city → coords, ZIP →
-      // by-postcode, empty → GPS) instead of always doing GPS.
+      // #2137 — LocationInput.submit dispatches to city/ZIP/GPS.
       onTap = () {
         final loc = _locationInputKey.currentState;
         if (loc != null) {

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -30,7 +30,7 @@ import '../../providers/search_screen_ui_provider.dart';
 import '../widgets/amenity_filter_wrap.dart';
 import '../widgets/brand_filter_chips.dart';
 import '../widgets/fuel_type_selector.dart';
-import '../widgets/location_input.dart';
+import '../widgets/location_input.dart' show LocationInput, LocationInputWidgetState;
 import '../widgets/search_mode_toggle.dart';
 import '../widgets/search_radius_slider.dart';
 
@@ -52,6 +52,12 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   final GlobalKey<RouteInputWidgetState> _routeInputKey =
       GlobalKey<RouteInputWidgetState>();
 
+  /// Drives [LocationInputWidgetState.submit] when the central FAB fires
+  /// a nearby search (#2137 — city/ZIP/GPS selection only updates the
+  /// criteria; the FAB submits).
+  final GlobalKey<LocationInputWidgetState> _locationInputKey =
+      GlobalKey<LocationInputWidgetState>();
+
   /// Last action registered on the shell FAB, kept so we can `clearIf`
   /// in `dispose` without stomping on a sibling screen that registered
   /// after us.
@@ -60,6 +66,14 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   /// FAB notifier captured in initState so `dispose` can clear without
   /// touching `ref` (Riverpod forbids ref usage after `deactivate`).
   SearchFabActionController? _fabNotifier;
+
+  /// Re-entry guard against rapid FAB / Enter / suggestion taps that
+  /// each call `Navigator.of(context).pop()` (#2136). The second pop
+  /// runs while the first pop's close animation is still inverting and
+  /// `lastWhere(isPresentPredicate)` finds no present route, crashing
+  /// with `StateError: No element`. Once a search has fired, the modal
+  /// is on its way out — additional taps are no-ops.
+  bool _searchFired = false;
 
   @override
   void initState() {
@@ -117,7 +131,17 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       onTap = () => _routeInputKey.currentState?.resolveAndSearch();
     } else {
       enabled = true;
-      onTap = () => unawaited(_performGpsSearch());
+      // #2137 — dispatch through LocationInput.submit so the FAB
+      // honours the user's current selection (city → coords, ZIP →
+      // by-postcode, empty → GPS) instead of always doing GPS.
+      onTap = () {
+        final loc = _locationInputKey.currentState;
+        if (loc != null) {
+          loc.submit();
+        } else {
+          unawaited(_performGpsSearch());
+        }
+      };
     }
 
     final action = SearchFabAction(
@@ -131,6 +155,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   }
 
   Future<void> _performGpsSearch() async {
+    if (_searchFired) return;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
     final settings = ref.read(settingsStorageProvider);
@@ -149,16 +174,20 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       }
       await LocationConsentDialog.recordConsent(settings);
     }
+    if (_searchFired || !mounted) return;
+    _searchFired = true;
 
     // SearchState dispatches to EV or fuel service internally based on fuelType.
     unawaited(ref.read(searchStateProvider.notifier).searchByGps(
           fuelType: fuelType,
           radiusKm: radius,
         ));
-    if (mounted) Navigator.of(context).pop();
+    Navigator.of(context).pop();
   }
 
   void _performZipSearch(String zip) {
+    if (_searchFired || !mounted) return;
+    _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
     ref.read(searchStateProvider.notifier).searchByZipCode(
@@ -170,6 +199,8 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   }
 
   void _performCitySearch(ResolvedLocation city) {
+    if (_searchFired || !mounted) return;
+    _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     final radius = ref.read(searchRadiusProvider);
     ref.read(searchStateProvider.notifier).searchByCoordinates(
@@ -184,6 +215,8 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   }
 
   void _performRouteSearch(List<RouteWaypoint> waypoints) {
+    if (_searchFired || !mounted) return;
+    _searchFired = true;
     final fuelType = ref.read(selectedFuelTypeProvider);
     // #1602 — the route search corridor is the user's detour budget.
     final detourBudgetKm =
@@ -314,6 +347,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
               // the fold on a stock S23 at 1x text scale.
               if (mode == SearchMode.nearby) ...[
                 LocationInput(
+                  key: _locationInputKey,
                   onGpsSearch: _performGpsSearch,
                   onZipSearch: _performZipSearch,
                   onCitySearch: _performCitySearch,

--- a/lib/features/search/presentation/widgets/location_input.dart
+++ b/lib/features/search/presentation/widgets/location_input.dart
@@ -28,10 +28,13 @@ class LocationInput extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<LocationInput> createState() => _LocationInputState();
+  ConsumerState<LocationInput> createState() => LocationInputWidgetState();
 }
 
-class _LocationInputState extends ConsumerState<LocationInput> {
+/// Public State so the parent criteria screen can drive [submit] via a
+/// `GlobalKey` (#2137 — central FAB owns the search trigger; tapping a
+/// city suggestion only updates the criteria's selectedCity).
+class LocationInputWidgetState extends ConsumerState<LocationInput> {
   final _controller = TextEditingController();
   final _focusNode = FocusNode();
   Timer? _debounce;
@@ -85,7 +88,11 @@ class _LocationInputState extends ConsumerState<LocationInput> {
     }
   }
 
-  void _submit() {
+  /// Dispatches the current criteria to the appropriate search callback.
+  /// Public so the criteria-screen FAB can fire it via `GlobalKey`
+  /// without the suggestion-tap or Enter-key paths having to call it
+  /// themselves (#2137).
+  void submit() {
     final country = ref.read(activeCountryProvider);
     final uiState = ref.read(locationInputControllerProvider);
     final text = _controller.text.trim();
@@ -189,9 +196,10 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                         constraints: const BoxConstraints(
                             minWidth: 32, minHeight: 32),
                         onPressed: () {
+                          // #2137 — switch the criteria to GPS mode but
+                          // don't fire the search; the FAB owns that.
                           _controller.clear();
                           _onChanged('');
-                          widget.onGpsSearch();
                         },
                       ),
                     ],
@@ -200,7 +208,9 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                       const BoxConstraints(minWidth: 36, minHeight: 36),
                 ),
                 onChanged: _onChanged,
-                onSubmitted: (_) => _submit(),
+                // #2137 — Enter is not a search trigger any more; the
+                // central FAB owns that. Tapping Done just unfocuses.
+                onSubmitted: (_) => _focusNode.unfocus(),
               );
             },
           ),
@@ -238,7 +248,8 @@ class _LocationInputState extends ConsumerState<LocationInput> {
                     ref
                         .read(locationInputControllerProvider.notifier)
                         .selectCity(city);
-                    widget.onCitySearch(city);
+                    // #2137 — selection updates the criteria; the
+                    // central FAB triggers the actual search.
                   },
                 );
               },

--- a/test/features/search/presentation/widgets/location_input_test.dart
+++ b/test/features/search/presentation/widgets/location_input_test.dart
@@ -163,6 +163,60 @@ void main() {
     });
   });
 
+  group('LocationInput #2137 — selection does not auto-trigger search', () {
+    testWidgets('GPS icon tap does NOT fire onGpsSearch (FAB owns search)',
+        (tester) async {
+      var gpsCalls = 0;
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        LocationInput(
+          onGpsSearch: () => gpsCalls++,
+          onZipSearch: (_) {},
+          onCitySearch: (_) {},
+        ),
+        overrides: test.overrides,
+      );
+
+      // Tap the suffix GPS icon. It clears + switches mode but must
+      // not fire onGpsSearch — the central FAB does that.
+      await tester.tap(find.byIcon(Icons.my_location).first);
+      await tester.pumpAndSettle();
+
+      expect(gpsCalls, 0,
+          reason: '#2137 — GPS icon must not auto-fire onGpsSearch.');
+    });
+
+    testWidgets('Enter key on the field does NOT fire any callback',
+        (tester) async {
+      var gps = 0;
+      var zip = 0;
+      var city = 0;
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        LocationInput(
+          onGpsSearch: () => gps++,
+          onZipSearch: (_) => zip++,
+          onCitySearch: (_) => city++,
+        ),
+        overrides: test.overrides,
+      );
+
+      await tester.enterText(find.byType(TextField), '34540');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(gps, 0, reason: '#2137 — Enter must not fire onGpsSearch.');
+      expect(zip, 0, reason: '#2137 — Enter must not fire onZipSearch.');
+      expect(city, 0, reason: '#2137 — Enter must not fire onCitySearch.');
+    });
+  });
+
   group('LocationInput accessibility', () {
     testWidgets('TextField is not wrapped in nested Semantics(textField: true)',
         (tester) async {


### PR DESCRIPTION
## Summary

- **#2136 (close)** — `_performGpsSearch` and friends now bail out via a `_searchFired` re-entry guard so rapid double-taps on the criteria FAB no longer crash with `Navigator pop: No element` (9 traces in a single 2026-05-28 session).
- **#2137 (close)** — tapping a city suggestion / pressing Enter / hitting the GPS icon now only updates the criteria; the central FAB is the sole search trigger (consistent with #2131). `LocationInputWidgetState.submit()` becomes public and is invoked by the FAB via a `GlobalKey`, mirroring the route-input pattern.

## Test plan

- [x] `flutter test test/features/search test/features/route_search test/app/shell` — 921 pass, 0 fail.
- [x] `flutter analyze lib/features/search lib/features/route_search` — no issues.
- [ ] Manual: open criteria, double-tap the FAB rapidly → one search fires, modal closes once, no crash.
- [ ] Manual: type a city, pick a suggestion → no search; tap the FAB → search uses the picked city.
- [ ] Manual: clear field, tap GPS icon → no search; tap the FAB → GPS search fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)