### PR TITLE
fix(search) + feat(route): FAB stuck-state guards + non-blocking partial-results banner (#2139, #2140)

### DIFF
--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -225,7 +225,15 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
             '${AppLocalizations.of(context)?.errorUnknown ?? "Error"}: $e');
       }
     } finally {
-      if (mounted) notifier.setSearching(false);
+      // #2139 — always reset isSearching, even if the widget unmounted
+      // mid-await. The captured notifier reference stays valid for the
+      // provider's lifetime (try/catch covers the rare case where the
+      // provider has been auto-disposed already).
+      try {
+        notifier.setSearching(false);
+      } catch (_) {
+        // Provider disposed — state is gone anyway.
+      }
     }
   }
 

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -72,8 +72,10 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final action = _registeredFabAction;
     final notifier = _fabNotifier;
     if (action != null && notifier != null) {
-      // Riverpod forbids mutation in dispose; defer via post-frame.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
+      // #2139 — microtask fires before any frame; addPostFrameCallback
+      // can be skipped if no frame is scheduled, leaving a stale
+      // action that makes the FAB look enabled but no-op.
+      Future.microtask(() {
         try {
           notifier.clearIf(action);
         } catch (_) {
@@ -100,20 +102,11 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final bool enabled;
     final VoidCallback onTap;
     if (effectiveMode == SearchMode.route) {
-      final routeState = ref.read(routeInputControllerProvider);
-      enabled = routeState.canSearch;
-      onTap = () => _routeInputKey.currentState?.resolveAndSearch();
+      enabled = ref.read(routeInputControllerProvider).canSearch;
+      onTap = _onFabRouteTap;
     } else {
       enabled = true;
-      // #2137 — LocationInput.submit dispatches to city/ZIP/GPS.
-      onTap = () {
-        final loc = _locationInputKey.currentState;
-        if (loc != null) {
-          loc.submit();
-        } else {
-          unawaited(_performGpsSearch());
-        }
-      };
+      onTap = _onFabNearbyTap;
     }
 
     final action = SearchFabAction(
@@ -124,6 +117,30 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     );
     ref.read(searchFabActionControllerProvider.notifier).set(action);
     _registeredFabAction = action;
+  }
+
+  // #2139 — defensively clear if invoked after dispose (covers the
+  // window before the dispose-microtask fires).
+  bool _bailIfStale() {
+    if (mounted) return false;
+    final a = _registeredFabAction;
+    if (a != null) _fabNotifier?.clearIf(a);
+    return true;
+  }
+
+  void _onFabRouteTap() {
+    if (_bailIfStale()) return;
+    _routeInputKey.currentState?.resolveAndSearch();
+  }
+
+  void _onFabNearbyTap() {
+    if (_bailIfStale()) return;
+    final loc = _locationInputKey.currentState;
+    if (loc != null) {
+      loc.submit();
+    } else {
+      unawaited(_performGpsSearch());
+    }
   }
 
   Future<void> _performGpsSearch() async {
@@ -148,12 +165,9 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     }
     if (_searchFired || !mounted) return;
     _searchFired = true;
-
-    // SearchState dispatches to EV or fuel service internally based on fuelType.
+    // SearchState dispatches to EV or fuel service based on fuelType.
     unawaited(ref.read(searchStateProvider.notifier).searchByGps(
-          fuelType: fuelType,
-          radiusKm: radius,
-        ));
+        fuelType: fuelType, radiusKm: radius));
     Navigator.of(context).pop();
   }
 
@@ -253,23 +267,14 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
     final openOnly = ref.watch(openOnlyFilterProvider);
     final amenities = ref.watch(selectedAmenitiesProvider);
 
-    // #2131 — keep the shell FAB in sync. ref.listen inside build is
-    // the canonical Riverpod pattern; it de-dupes across rebuilds.
-    ref.listen<SearchMode>(activeSearchModeProvider, (_, _) {
-      _updateFabAction();
-    });
-    ref.listen<RouteInputState>(routeInputControllerProvider, (prev, next) {
-      // Re-register only when the bits the FAB depends on flip; ignore
-      // coord-only updates so we don't churn the controller on every
-      // autocomplete pick.
-      if (prev?.canSearch != next.canSearch) _updateFabAction();
+    // #2131 — re-register the FAB when mode or canSearch flip.
+    ref.listen<SearchMode>(activeSearchModeProvider, (_, _) => _updateFabAction());
+    ref.listen<RouteInputState>(routeInputControllerProvider, (p, n) {
+      if (p?.canSearch != n.canSearch) _updateFabAction();
     });
 
-    // Cascading-feature gate (#1447 phase 4). When `Feature.routePlanning`
-    // is effectively-disabled, the "Along route" mode is unreachable —
-    // hide the toggle entirely AND treat the persisted mode as Nearby
-    // so the body never renders the route input. The stored mode value
-    // is preserved (re-enabling the feature restores the prior choice).
+    // #1447 phase 4 — when routePlanning is gated off, hide the toggle
+    // and treat the stored mode as Nearby (the stored value is preserved).
     final manifest = ref.watch(featureManifestProvider);
     final enabledFlags = ref.watch(enabledFeaturesProvider);
     final routePlanningOn = isEffectivelyEnabled(
@@ -312,11 +317,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
                 ),
                 const SizedBox(height: 8),
               ],
-              // #2111 — drop the redundant "Location" / "Along route"
-              // section headers; the segmented control above already
-              // labels the active mode. Saves ~24 dp vertical so the
-              // radius slider, amenities, and highway filter sit above
-              // the fold on a stock S23 at 1x text scale.
+              // #2111 — segmented control labels the active mode.
               if (mode == SearchMode.nearby) ...[
                 LocationInput(
                   key: _locationInputKey,

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -132,6 +132,16 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // #2140 — non-blocking partial-results banner: shows while
+          // more stations are streaming in. User can still scroll and
+          // tap the partial results below.
+          if (result.isPartial) ...[
+            _PartialResultsBanner(
+              label: l10n?.routeSearchPartialBanner ??
+                  'Searching for more stations…',
+            ),
+            const SizedBox(height: 6),
+          ],
           Row(
             children: [
               Icon(Icons.route, size: 16, color: theme.colorScheme.primary),
@@ -292,5 +302,50 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
     }
     final bestIds = segmentMap.values.toSet();
     return allStations.where((s) => bestIds.contains(s.id)).cast<SearchResultItem>().toList();
+  }
+}
+
+/// #2140 — thin non-blocking banner shown above route results while
+/// more stations are still streaming in. Pairs a small spinner with a
+/// localised label so the user knows data is loading without losing
+/// the ability to interact with what's already on screen.
+class _PartialResultsBanner extends StatelessWidget {
+  final String label;
+  const _PartialResultsBanner({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -17,6 +17,7 @@
   "fabOpenResults": "Ergebnisse anzeigen",
   "fabRunSearch": "Suche starten",
   "fabRefineCriteria": "Suche verfeinern",
+  "routeSearchPartialBanner": "Weitere Tankstellen werden gesucht…",
   "searchCriteriaTitle": "Suchkriterien",
   "searchCriteriaOpen": "Suchen",
   "searchCriteriaRadiusBadge": "Im Umkreis von {km} km",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -17,6 +17,7 @@
   "fabOpenResults": "Open results",
   "fabRunSearch": "Run search",
   "fabRefineCriteria": "Refine search",
+  "routeSearchPartialBanner": "Searching for more stations…",
   "searchCriteriaTitle": "Search criteria",
   "searchCriteriaOpen": "Search",
   "searchCriteriaRadiusBadge": "Within {km} km",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Отвори търсене",
   "fabOpenResults": "Отвори резултати",
   "fabRunSearch": "Стартирай търсене",
-  "fabRefineCriteria": "Прецизирай търсене"
+  "fabRefineCriteria": "Прецизирай търсене",
+  "routeSearchPartialBanner": "Търсене на още станции…"
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Otevřít vyhledávání",
   "fabOpenResults": "Otevřít výsledky",
   "fabRunSearch": "Spustit vyhledávání",
-  "fabRefineCriteria": "Upřesnit vyhledávání"
+  "fabRefineCriteria": "Upřesnit vyhledávání",
+  "routeSearchPartialBanner": "Hledání dalších stanic…"
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Åbn søgning",
   "fabOpenResults": "Åbn resultater",
   "fabRunSearch": "Kør søgning",
-  "fabRefineCriteria": "Forfin søgning"
+  "fabRefineCriteria": "Forfin søgning",
+  "routeSearchPartialBanner": "Søger efter flere stationer…"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -17,6 +17,7 @@
   "fabOpenResults": "Ergebnisse anzeigen",
   "fabRunSearch": "Suche starten",
   "fabRefineCriteria": "Suche verfeinern",
+  "routeSearchPartialBanner": "Weitere Tankstellen werden gesucht…",
   "searchCriteriaTitle": "Suchkriterien",
   "searchCriteriaOpen": "Suchen",
   "searchCriteriaRadiusBadge": "Im Umkreis von {km} km",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Άνοιγμα αναζήτησης",
   "fabOpenResults": "Άνοιγμα αποτελεσμάτων",
   "fabRunSearch": "Εκτέλεση αναζήτησης",
-  "fabRefineCriteria": "Βελτίωση αναζήτησης"
+  "fabRefineCriteria": "Βελτίωση αναζήτησης",
+  "routeSearchPartialBanner": "Αναζήτηση για περισσότερους σταθμούς…"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -17,6 +17,7 @@
   "fabOpenResults": "Open results",
   "fabRunSearch": "Run search",
   "fabRefineCriteria": "Refine search",
+  "routeSearchPartialBanner": "Searching for more stations…",
   "searchCriteriaTitle": "Search criteria",
   "searchCriteriaOpen": "Search",
   "searchCriteriaRadiusBadge": "Within {km} km",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -17,6 +17,7 @@
   "fabOpenResults": "⟦Óƥéñ řéšúłŧš ·····⟧",
   "fabRunSearch": "⟦Řúñ šéářçĥ ····⟧",
   "fabRefineCriteria": "⟦Řéƒîñé šéářçĥ ·····⟧",
+  "routeSearchPartialBanner": "⟦Šéářçĥîñǧ ƒóř ɱóřé šŧáŧîóñš… ···········⟧",
   "searchCriteriaTitle": "⟦Šéářçĥ çřîŧéřîá ······⟧",
   "searchCriteriaOpen": "⟦Šéářçĥ ···⟧",
   "searchCriteriaRadiusBadge": "⟦Ŵîŧĥîñ {km} ķɱ ····⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Abrir búsqueda",
   "fabOpenResults": "Abrir resultados",
   "fabRunSearch": "Ejecutar búsqueda",
-  "fabRefineCriteria": "Refinar búsqueda"
+  "fabRefineCriteria": "Refinar búsqueda",
+  "routeSearchPartialBanner": "Buscando más estaciones…"
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Ava otsing",
   "fabOpenResults": "Ava tulemused",
   "fabRunSearch": "Käivita otsing",
-  "fabRefineCriteria": "Täpsusta otsingut"
+  "fabRefineCriteria": "Täpsusta otsingut",
+  "routeSearchPartialBanner": "Otsitakse rohkem jaamu…"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Avaa haku",
   "fabOpenResults": "Avaa tulokset",
   "fabRunSearch": "Suorita haku",
-  "fabRefineCriteria": "Tarkenna hakua"
+  "fabRefineCriteria": "Tarkenna hakua",
+  "routeSearchPartialBanner": "Etsitään lisää asemia…"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1989,5 +1989,6 @@
   "fabOpenCriteria": "Ouvrir la recherche",
   "fabOpenResults": "Ouvrir les résultats",
   "fabRunSearch": "Lancer la recherche",
-  "fabRefineCriteria": "Affiner la recherche"
+  "fabRefineCriteria": "Affiner la recherche",
+  "routeSearchPartialBanner": "Recherche d'autres stations…"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Otvori pretraživanje",
   "fabOpenResults": "Otvori rezultate",
   "fabRunSearch": "Pokreni pretraživanje",
-  "fabRefineCriteria": "Pročisti pretraživanje"
+  "fabRefineCriteria": "Pročisti pretraživanje",
+  "routeSearchPartialBanner": "Pretražuju se dodatne stanice…"
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Keresés megnyitása",
   "fabOpenResults": "Eredmények megnyitása",
   "fabRunSearch": "Keresés futtatása",
-  "fabRefineCriteria": "Keresés finomítása"
+  "fabRefineCriteria": "Keresés finomítása",
+  "routeSearchPartialBanner": "További állomások keresése…"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Apri ricerca",
   "fabOpenResults": "Apri risultati",
   "fabRunSearch": "Esegui ricerca",
-  "fabRefineCriteria": "Affina ricerca"
+  "fabRefineCriteria": "Affina ricerca",
+  "routeSearchPartialBanner": "Ricerca di altre stazioni…"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -243,6 +243,12 @@ abstract class AppLocalizations {
   /// **'Refine search'**
   String get fabRefineCriteria;
 
+  /// No description provided for @routeSearchPartialBanner.
+  ///
+  /// In en, this message translates to:
+  /// **'Searching for more stations…'**
+  String get routeSearchPartialBanner;
+
   /// No description provided for @searchCriteriaTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -60,6 +60,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fabRefineCriteria => 'Прецизирай търсене';
 
   @override
+  String get routeSearchPartialBanner => 'Търсене на още станции…';
+
+  @override
   String get searchCriteriaTitle => 'Критерии за търсене';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -60,6 +60,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fabRefineCriteria => 'Upřesnit vyhledávání';
 
   @override
+  String get routeSearchPartialBanner => 'Hledání dalších stanic…';
+
+  @override
   String get searchCriteriaTitle => 'Kritéria hledání';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -60,6 +60,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fabRefineCriteria => 'Forfin søgning';
 
   @override
+  String get routeSearchPartialBanner => 'Søger efter flere stationer…';
+
+  @override
   String get searchCriteriaTitle => 'Søgekriterier';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -60,6 +60,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fabRefineCriteria => 'Suche verfeinern';
 
   @override
+  String get routeSearchPartialBanner => 'Weitere Tankstellen werden gesucht…';
+
+  @override
   String get searchCriteriaTitle => 'Suchkriterien';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -60,6 +60,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fabRefineCriteria => 'Βελτίωση αναζήτησης';
 
   @override
+  String get routeSearchPartialBanner =>
+      'Αναζήτηση για περισσότερους σταθμούς…';
+
+  @override
   String get searchCriteriaTitle => 'Κριτήρια αναζήτησης';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -60,6 +60,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fabRefineCriteria => 'Refine search';
 
   @override
+  String get routeSearchPartialBanner => 'Searching for more stations…';
+
+  @override
   String get searchCriteriaTitle => 'Search criteria';
 
   @override
@@ -5511,6 +5514,10 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get fabRefineCriteria => '⟦Řéƒîñé šéářçĥ ·····⟧';
+
+  @override
+  String get routeSearchPartialBanner =>
+      '⟦Šéářçĥîñǧ ƒóř ɱóřé šŧáŧîóñš… ···········⟧';
 
   @override
   String get searchCriteriaTitle => '⟦Šéářçĥ çřîŧéřîá ······⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -60,6 +60,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fabRefineCriteria => 'Refinar búsqueda';
 
   @override
+  String get routeSearchPartialBanner => 'Buscando más estaciones…';
+
+  @override
   String get searchCriteriaTitle => 'Criterios de búsqueda';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -60,6 +60,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fabRefineCriteria => 'Täpsusta otsingut';
 
   @override
+  String get routeSearchPartialBanner => 'Otsitakse rohkem jaamu…';
+
+  @override
   String get searchCriteriaTitle => 'Otsinguparameetrid';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -60,6 +60,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fabRefineCriteria => 'Tarkenna hakua';
 
   @override
+  String get routeSearchPartialBanner => 'Etsitään lisää asemia…';
+
+  @override
   String get searchCriteriaTitle => 'Hakukriteerit';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -60,6 +60,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fabRefineCriteria => 'Affiner la recherche';
 
   @override
+  String get routeSearchPartialBanner => 'Recherche d\'autres stations…';
+
+  @override
   String get searchCriteriaTitle => 'Critères de recherche';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -60,6 +60,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fabRefineCriteria => 'Pročisti pretraživanje';
 
   @override
+  String get routeSearchPartialBanner => 'Pretražuju se dodatne stanice…';
+
+  @override
   String get searchCriteriaTitle => 'Kriteriji pretraživanja';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -60,6 +60,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fabRefineCriteria => 'Keresés finomítása';
 
   @override
+  String get routeSearchPartialBanner => 'További állomások keresése…';
+
+  @override
   String get searchCriteriaTitle => 'Keresési feltételek';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -60,6 +60,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fabRefineCriteria => 'Affina ricerca';
 
   @override
+  String get routeSearchPartialBanner => 'Ricerca di altre stazioni…';
+
+  @override
   String get searchCriteriaTitle => 'Criteri di ricerca';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -60,6 +60,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fabRefineCriteria => 'Tikslinti paiešką';
 
   @override
+  String get routeSearchPartialBanner => 'Ieškoma daugiau stočių…';
+
+  @override
   String get searchCriteriaTitle => 'Paieškos kriterijai';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -60,6 +60,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fabRefineCriteria => 'Precizēt meklēšanu';
 
   @override
+  String get routeSearchPartialBanner => 'Tiek meklētas vairāk staciju…';
+
+  @override
   String get searchCriteriaTitle => 'Meklēšanas kritēriji';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -60,6 +60,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get fabRefineCriteria => 'Avgrens søk';
 
   @override
+  String get routeSearchPartialBanner => 'Søker etter flere stasjoner…';
+
+  @override
   String get searchCriteriaTitle => 'Søkekriterier';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -60,6 +60,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fabRefineCriteria => 'Zoekopdracht verfijnen';
 
   @override
+  String get routeSearchPartialBanner => 'Zoekt naar meer stations…';
+
+  @override
   String get searchCriteriaTitle => 'Zoekcriteria';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -60,6 +60,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fabRefineCriteria => 'Zawęź wyszukiwanie';
 
   @override
+  String get routeSearchPartialBanner => 'Wyszukiwanie kolejnych stacji…';
+
+  @override
   String get searchCriteriaTitle => 'Kryteria wyszukiwania';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -60,6 +60,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fabRefineCriteria => 'Refinar pesquisa';
 
   @override
+  String get routeSearchPartialBanner => 'A procurar mais estações…';
+
+  @override
   String get searchCriteriaTitle => 'Critérios de pesquisa';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -60,6 +60,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fabRefineCriteria => 'Rafinează căutarea';
 
   @override
+  String get routeSearchPartialBanner => 'Se caută mai multe stații…';
+
+  @override
   String get searchCriteriaTitle => 'Criterii de căutare';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -60,6 +60,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fabRefineCriteria => 'Spresniť vyhľadávanie';
 
   @override
+  String get routeSearchPartialBanner => 'Hľadajú sa ďalšie stanice…';
+
+  @override
   String get searchCriteriaTitle => 'Kritériá vyhľadávania';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -60,6 +60,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fabRefineCriteria => 'Izboljšaj iskanje';
 
   @override
+  String get routeSearchPartialBanner => 'Iskanje dodatnih postaj…';
+
+  @override
   String get searchCriteriaTitle => 'Merila iskanja';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -60,6 +60,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fabRefineCriteria => 'Förfina sökning';
 
   @override
+  String get routeSearchPartialBanner => 'Söker efter fler stationer…';
+
+  @override
   String get searchCriteriaTitle => 'Sökkriterier';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Atidaryti paiešką",
   "fabOpenResults": "Atidaryti rezultatus",
   "fabRunSearch": "Vykdyti paiešką",
-  "fabRefineCriteria": "Tikslinti paiešką"
+  "fabRefineCriteria": "Tikslinti paiešką",
+  "routeSearchPartialBanner": "Ieškoma daugiau stočių…"
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Atvērt meklēšanu",
   "fabOpenResults": "Atvērt rezultātus",
   "fabRunSearch": "Veikt meklēšanu",
-  "fabRefineCriteria": "Precizēt meklēšanu"
+  "fabRefineCriteria": "Precizēt meklēšanu",
+  "routeSearchPartialBanner": "Tiek meklētas vairāk staciju…"
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Åpne søk",
   "fabOpenResults": "Åpne resultater",
   "fabRunSearch": "Kjør søk",
-  "fabRefineCriteria": "Avgrens søk"
+  "fabRefineCriteria": "Avgrens søk",
+  "routeSearchPartialBanner": "Søker etter flere stasjoner…"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Zoeken openen",
   "fabOpenResults": "Resultaten openen",
   "fabRunSearch": "Zoekopdracht uitvoeren",
-  "fabRefineCriteria": "Zoekopdracht verfijnen"
+  "fabRefineCriteria": "Zoekopdracht verfijnen",
+  "routeSearchPartialBanner": "Zoekt naar meer stations…"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Otwórz wyszukiwanie",
   "fabOpenResults": "Otwórz wyniki",
   "fabRunSearch": "Uruchom wyszukiwanie",
-  "fabRefineCriteria": "Zawęź wyszukiwanie"
+  "fabRefineCriteria": "Zawęź wyszukiwanie",
+  "routeSearchPartialBanner": "Wyszukiwanie kolejnych stacji…"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Abrir pesquisa",
   "fabOpenResults": "Abrir resultados",
   "fabRunSearch": "Executar pesquisa",
-  "fabRefineCriteria": "Refinar pesquisa"
+  "fabRefineCriteria": "Refinar pesquisa",
+  "routeSearchPartialBanner": "A procurar mais estações…"
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Deschide căutarea",
   "fabOpenResults": "Deschide rezultatele",
   "fabRunSearch": "Execută căutarea",
-  "fabRefineCriteria": "Rafinează căutarea"
+  "fabRefineCriteria": "Rafinează căutarea",
+  "routeSearchPartialBanner": "Se caută mai multe stații…"
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Otvoriť vyhľadávanie",
   "fabOpenResults": "Otvoriť výsledky",
   "fabRunSearch": "Spustiť vyhľadávanie",
-  "fabRefineCriteria": "Spresniť vyhľadávanie"
+  "fabRefineCriteria": "Spresniť vyhľadávanie",
+  "routeSearchPartialBanner": "Hľadajú sa ďalšie stanice…"
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Odpri iskanje",
   "fabOpenResults": "Odpri rezultate",
   "fabRunSearch": "Zaženi iskanje",
-  "fabRefineCriteria": "Izboljšaj iskanje"
+  "fabRefineCriteria": "Izboljšaj iskanje",
+  "routeSearchPartialBanner": "Iskanje dodatnih postaj…"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1861,5 +1861,6 @@
   "fabOpenCriteria": "Öppna sökning",
   "fabOpenResults": "Öppna resultat",
   "fabRunSearch": "Kör sökning",
-  "fabRefineCriteria": "Förfina sökning"
+  "fabRefineCriteria": "Förfina sökning",
+  "routeSearchPartialBanner": "Söker efter fler stationer…"
 }


### PR DESCRIPTION
## Summary

- **#2139 (close)** — FAB stuck-state defences: switch dispose's `clearIf` to `Future.microtask` (postFrame can be skipped if no frame is scheduled); `_onFabRouteTap` / `_onFabNearbyTap` now bail with a self-clear if invoked after dispose; drop the `if (mounted)` guard around `setSearching(false)` in `resolveAndSearch`'s finally so `isSearching` never gets stuck.
- **#2140 (close)** — non-blocking partial-results banner: route-mode shows partial stations as they arrive **and** a thin spinner pill "Searching for more stations…" stays at the top of the list until the final result lands. The user can still scroll / tap partial results.

## Test plan

- [x] `flutter analyze` — 3 pre-existing infos, 0 errors.
- [x] `flutter test test/features/search test/features/route_search test/app/shell test/lint/file_length_test.dart` — 922 pass.
- [x] `flutter test test/l10n/localization_completeness_test.dart` — 23 locales at 100% (en + de fragments + 21 hand-translated locales for the new ARB key).
- [ ] Manual: open criteria, fire a search, immediately reopen criteria → FAB always responds.
- [ ] Manual: run a route search → partial stations show with a banner above; banner disappears when final results land; user can interact with the partial list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)