### PR TITLE
feat(favorites): EV card grows a crystal-blue right-side detail column (#2143)

### DIFF
--- a/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
@@ -13,6 +13,12 @@ import '../../../ev/domain/entities/charging_station.dart';
 /// the typed [EvConnector] instead of the previous free-form search
 /// side [Connector].
 class EvFavoriteCard extends StatelessWidget {
+  /// Crystal-blue accent (#2143) — cool, glassy, distinct from the
+  /// muted-teal `FuelTypeElectric` (#3B8079). Pairs the EV card's
+  /// right-side detail column with the fuel cards' price column
+  /// without borrowing their fuel palette.
+  static const Color crystalBlue = Color(0xFF4FC3F7);
+
   final ChargingStation station;
   final VoidCallback? onTap;
   final VoidCallback? onFavoriteTap;
@@ -37,6 +43,10 @@ class EvFavoriteCard extends StatelessWidget {
     final maxPower = connectors.isEmpty
         ? 0.0
         : connectors.map((c) => c.maxPowerKw).reduce((a, b) => a > b ? a : b);
+    final connectorTypes = connectors
+        .map((c) => c.rawType ?? c.type.label)
+        .toSet()
+        .toList();
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -46,6 +56,7 @@ class EvFavoriteCard extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Icon(Icons.ev_station, size: 32, color: theme.colorScheme.primary),
               const SizedBox(width: 12),
@@ -68,75 +79,128 @@ class EvFavoriteCard extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
-                    const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        Icon(Icons.bolt, size: 14,
-                            color: theme.colorScheme.onSurfaceVariant),
-                        const SizedBox(width: 4),
-                        Text(
-                          '${maxPower.round()} kW',
-                          style: theme.textTheme.bodySmall,
-                        ),
-                        const SizedBox(width: 12),
-                        if (total > 0) ...[
-                          Icon(
-                            Icons.power,
-                            size: 14,
-                            color: available > 0
-                                ? DarkModeColors.success(context)
-                                : Colors.grey,
-                          ),
-                          const SizedBox(width: 4),
-                          Text(
-                            '$available/$total ${l10n?.evStatusAvailable ?? 'available'}',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: available > 0
-                                  ? DarkModeColors.success(context)
-                                  : null,
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                    if (connectors.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Wrap(
-                          spacing: 4,
-                          children: connectors
-                              .map((c) => c.rawType ?? c.type.label)
-                              .toSet()
-                              .map((type) => Chip(
-                                    label: Text(type,
-                                        style: const TextStyle(fontSize: 10)),
-                                    materialTapTargetSize:
-                                        MaterialTapTargetSize.shrinkWrap,
-                                    visualDensity: VisualDensity.compact,
-                                    padding: EdgeInsets.zero,
-                                    labelPadding: const EdgeInsets.symmetric(
-                                        horizontal: 6),
-                                  ))
-                              .toList(),
-                        ),
-                      ),
                   ],
                 ),
               ),
-              SizedBox(
-                width: 32,
-                height: 32,
-                child: IconButton(
-                  padding: EdgeInsets.zero,
-                  icon: const Icon(Icons.star, color: Colors.amber, size: 22),
-                  onPressed: onFavoriteTap,
-                  tooltip: l10n?.removeFavorite ?? 'Remove from favorites',
-                ),
+              const SizedBox(width: 8),
+              _EvDetailColumn(
+                maxPowerKw: maxPower,
+                available: available,
+                total: total,
+                connectorTypes: connectorTypes,
+                availableLabel:
+                    l10n?.evStatusAvailable ?? 'available',
+                onFavoriteTap: onFavoriteTap,
+                removeFavoriteTooltip:
+                    l10n?.removeFavorite ?? 'Remove from favorites',
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+/// #2143 — Right-side detail column for [EvFavoriteCard]. Mirrors the
+/// layout of `_StationPriceColumn` (big headline + star, then detail
+/// rows) but swaps the price for the station's max-power kW and uses
+/// the crystal-blue accent.
+class _EvDetailColumn extends StatelessWidget {
+  final double maxPowerKw;
+  final int available;
+  final int total;
+  final List<String> connectorTypes;
+  final String availableLabel;
+  final VoidCallback? onFavoriteTap;
+  final String removeFavoriteTooltip;
+
+  const _EvDetailColumn({
+    required this.maxPowerKw,
+    required this.available,
+    required this.total,
+    required this.connectorTypes,
+    required this.availableLabel,
+    required this.onFavoriteTap,
+    required this.removeFavoriteTooltip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.bolt,
+              size: 16,
+              color: EvFavoriteCard.crystalBlue,
+            ),
+            const SizedBox(width: 2),
+            Text(
+              '${maxPowerKw.round()} kW',
+              style: theme.textTheme.titleLarge!.copyWith(
+                fontWeight: FontWeight.bold,
+                color: EvFavoriteCard.crystalBlue,
+              ),
+            ),
+            const SizedBox(width: 4),
+            SizedBox(
+              width: 32,
+              height: 32,
+              child: IconButton(
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                icon: const Icon(Icons.star, color: Colors.amber, size: 22),
+                onPressed: onFavoriteTap,
+                tooltip: removeFavoriteTooltip,
+              ),
+            ),
+          ],
+        ),
+        if (total > 0)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.power,
+                  size: 12,
+                  color: available > 0
+                      ? DarkModeColors.success(context)
+                      : Colors.grey,
+                ),
+                const SizedBox(width: 3),
+                Text(
+                  '$available/$total $availableLabel',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontSize: 11,
+                    color: available > 0
+                        ? DarkModeColors.success(context)
+                        : null,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        if (connectorTypes.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              connectorTypes.join(' · '),
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontSize: 11,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/test/features/favorites/presentation/widgets/ev_favorite_card_test.dart
+++ b/test/features/favorites/presentation/widgets/ev_favorite_card_test.dart
@@ -144,7 +144,7 @@ void main() {
     });
 
     testWidgets(
-        'deduplicates connector-type chips using rawType when present',
+        '#2143 deduplicates connector-type labels using rawType when present',
         (tester) async {
       await pumpApp(
         tester,
@@ -168,9 +168,10 @@ void main() {
           ]),
         ),
       );
-      // CCS appears on 2 connectors but only as 1 chip
-      expect(find.widgetWithText(Chip, 'CCS'), findsOneWidget);
-      expect(find.widgetWithText(Chip, 'Type 2'), findsOneWidget);
+      // #2143 — chips swapped for a single joined label in the
+      // right-side detail column. CCS appears on 2 connectors but
+      // dedupes to one segment.
+      expect(find.text('CCS · Type 2'), findsOneWidget);
     });
 
     testWidgets('tap on the card invokes onTap', (tester) async {


### PR DESCRIPTION
## Summary

EV favorite card now mirrors the fuel cards' layout: max-power kW as the headline + favorite star, availability + connector types beneath. Crystal blue (`Color(0xFF4FC3F7)`) keeps the EV card visually distinct from the green-themed fuel palette.

## Test plan

- [x] `flutter analyze` — 3 pre-existing infos.
- [x] `flutter test test/features/favorites test/features/ev test/lint/` — passes (1 test updated for the chip → joined-text change).
- [ ] Visual check on the Favoris tab: EV card's right column reads the same vertical rhythm as the fuel cards.

Closes #2143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)