### PR TITLE
feat(privacy): rename error-log button to 'Save' so it matches actual functionality (#2145)

### DIFF
--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -110,8 +110,11 @@ class _PrivacyDashboardScreenState
                   onPressed: _exportErrorLog,
                   icon: const Icon(Icons.bug_report_outlined),
                   label: Text(
-                    l?.privacyCopyErrorLog(errorLogCount) ??
-                        'Copy error log to clipboard ($errorLogCount)',
+                    // #2145 — label reflects the dominant behaviour
+                    // (save to Downloads); clipboard/share fallbacks
+                    // happen automatically based on payload size.
+                    l?.privacySaveErrorLog(errorLogCount) ??
+                        'Save error log ($errorLogCount)',
                   ),
                 ),
               ),

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -739,6 +739,15 @@
       }
     }
   },
+  "privacySaveErrorLog": "Fehlerprotokoll speichern ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "privacyClearErrorLog": "Fehlerprotokoll löschen",
   "privacyErrorLogCleared": "Fehlerprotokoll gelöscht",
   "privacyDeleteTitle": "Alle Daten löschen?",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -761,6 +761,15 @@
       }
     }
   },
+  "privacySaveErrorLog": "Save error log ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder (and shares / copies as a secondary path). Supersedes privacyCopyErrorLog (#2145). count = number of traces buffered.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "privacyClearErrorLog": "Clear error log",
   "privacyErrorLogCleared": "Error log cleared",
   "privacyDeleteTitle": "Delete all data?",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Отвори резултати",
   "fabRunSearch": "Стартирай търсене",
   "fabRefineCriteria": "Прецизирай търсене",
-  "routeSearchPartialBanner": "Търсене на още станции…"
+  "routeSearchPartialBanner": "Търсене на още станции…",
+  "privacySaveErrorLog": "Запази дневник на грешки ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Otevřít výsledky",
   "fabRunSearch": "Spustit vyhledávání",
   "fabRefineCriteria": "Upřesnit vyhledávání",
-  "routeSearchPartialBanner": "Hledání dalších stanic…"
+  "routeSearchPartialBanner": "Hledání dalších stanic…",
+  "privacySaveErrorLog": "Uložit záznam chyb ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Åbn resultater",
   "fabRunSearch": "Kør søgning",
   "fabRefineCriteria": "Forfin søgning",
-  "routeSearchPartialBanner": "Søger efter flere stationer…"
+  "routeSearchPartialBanner": "Søger efter flere stationer…",
+  "privacySaveErrorLog": "Gem fejllog ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -747,6 +747,15 @@
       }
     }
   },
+  "privacySaveErrorLog": "Fehlerprotokoll speichern ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "privacyClearErrorLog": "Fehlerprotokoll löschen",
   "privacyErrorLogCleared": "Fehlerprotokoll gelöscht",
   "privacyDeleteTitle": "Alle Daten löschen?",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Άνοιγμα αποτελεσμάτων",
   "fabRunSearch": "Εκτέλεση αναζήτησης",
   "fabRefineCriteria": "Βελτίωση αναζήτησης",
-  "routeSearchPartialBanner": "Αναζήτηση για περισσότερους σταθμούς…"
+  "routeSearchPartialBanner": "Αναζήτηση για περισσότερους σταθμούς…",
+  "privacySaveErrorLog": "Αποθήκευση αρχείου σφαλμάτων ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -769,6 +769,15 @@
       }
     }
   },
+  "privacySaveErrorLog": "Save error log ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder (and shares / copies as a secondary path). Supersedes privacyCopyErrorLog (#2145). count = number of traces buffered.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "privacyClearErrorLog": "Clear error log",
   "privacyErrorLogCleared": "Error log cleared",
   "privacyDeleteTitle": "Delete all data?",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -482,6 +482,7 @@
   "savedToDownloadsFolder": "⟦Šáṽéđ ŧó ýóúř Đóŵñłóáđš ƒółđéř ············⟧",
   "privacyDeleteButton": "⟦Đéłéŧé áłł đáŧá ······⟧",
   "privacyCopyErrorLog": "⟦Çóƥý éřřóř łóǧ ŧó çłîƥƀóářđ ({count}) ··········⟧",
+  "privacySaveErrorLog": "⟦Šáṽé éřřóř łóǧ ({count}) ·····⟧",
   "privacyClearErrorLog": "⟦Çłéář éřřóř łóǧ ······⟧",
   "privacyErrorLogCleared": "⟦Éřřóř łóǧ çłéářéđ ·······⟧",
   "privacyDeleteTitle": "⟦Đéłéŧé áłł đáŧá? ······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Abrir resultados",
   "fabRunSearch": "Ejecutar búsqueda",
   "fabRefineCriteria": "Refinar búsqueda",
-  "routeSearchPartialBanner": "Buscando más estaciones…"
+  "routeSearchPartialBanner": "Buscando más estaciones…",
+  "privacySaveErrorLog": "Guardar registro de errores ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Ava tulemused",
   "fabRunSearch": "Käivita otsing",
   "fabRefineCriteria": "Täpsusta otsingut",
-  "routeSearchPartialBanner": "Otsitakse rohkem jaamu…"
+  "routeSearchPartialBanner": "Otsitakse rohkem jaamu…",
+  "privacySaveErrorLog": "Salvesta tõrkelogi ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Avaa tulokset",
   "fabRunSearch": "Suorita haku",
   "fabRefineCriteria": "Tarkenna hakua",
-  "routeSearchPartialBanner": "Etsitään lisää asemia…"
+  "routeSearchPartialBanner": "Etsitään lisää asemia…",
+  "privacySaveErrorLog": "Tallenna virheloki ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1990,5 +1990,14 @@
   "fabOpenResults": "Ouvrir les résultats",
   "fabRunSearch": "Lancer la recherche",
   "fabRefineCriteria": "Affiner la recherche",
-  "routeSearchPartialBanner": "Recherche d'autres stations…"
+  "routeSearchPartialBanner": "Recherche d'autres stations…",
+  "privacySaveErrorLog": "Enregistrer le journal d'erreurs ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Otvori rezultate",
   "fabRunSearch": "Pokreni pretraživanje",
   "fabRefineCriteria": "Pročisti pretraživanje",
-  "routeSearchPartialBanner": "Pretražuju se dodatne stanice…"
+  "routeSearchPartialBanner": "Pretražuju se dodatne stanice…",
+  "privacySaveErrorLog": "Spremi zapisnik pogrešaka ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Eredmények megnyitása",
   "fabRunSearch": "Keresés futtatása",
   "fabRefineCriteria": "Keresés finomítása",
-  "routeSearchPartialBanner": "További állomások keresése…"
+  "routeSearchPartialBanner": "További állomások keresése…",
+  "privacySaveErrorLog": "Hibanapló mentése ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Apri risultati",
   "fabRunSearch": "Esegui ricerca",
   "fabRefineCriteria": "Affina ricerca",
-  "routeSearchPartialBanner": "Ricerca di altre stazioni…"
+  "routeSearchPartialBanner": "Ricerca di altre stazioni…",
+  "privacySaveErrorLog": "Salva il log degli errori ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3033,6 +3033,12 @@ abstract class AppLocalizations {
   /// **'Copy error log to clipboard ({count})'**
   String privacyCopyErrorLog(int count);
 
+  /// Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder (and shares / copies as a secondary path). Supersedes privacyCopyErrorLog (#2145). count = number of traces buffered.
+  ///
+  /// In en, this message translates to:
+  /// **'Save error log ({count})'**
+  String privacySaveErrorLog(int count);
+
   /// No description provided for @privacyClearErrorLog.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1609,6 +1609,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Запази дневник на грешки ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Изчистване на дневника с грешки';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1603,6 +1603,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Uložit záznam chyb ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Vymazat protokol chyb';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1599,6 +1599,11 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Gem fejllog ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Ryd fejllog';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1610,6 +1610,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Fehlerprotokoll speichern ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Fehlerprotokoll löschen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1612,6 +1612,11 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Αποθήκευση αρχείου σφαλμάτων ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Εκκαθάριση αρχείου σφαλμάτων';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1589,6 +1589,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Save error log ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Clear error log';
 
   @override
@@ -7083,6 +7088,11 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String privacyCopyErrorLog(int count) {
     return '⟦Çóƥý éřřóř łóǧ ŧó çłîƥƀóářđ ($count) ··········⟧';
+  }
+
+  @override
+  String privacySaveErrorLog(int count) {
+    return '⟦Šáṽé éřřóř łóǧ ($count) ·····⟧';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1606,6 +1606,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Guardar registro de errores ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Borrar registro de errores';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1595,6 +1595,11 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Salvesta tõrkelogi ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Tühjenda vealogi';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1599,6 +1599,11 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Tallenna virheloki ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Tyhjennä virheloki';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1612,6 +1612,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Enregistrer le journal d\'erreurs ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Effacer le journal d\'erreurs';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1599,6 +1599,11 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Spremi zapisnik pogrešaka ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Očisti zapisnik pogrešaka';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1606,6 +1606,11 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Hibanapló mentése ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Hibanapló törlése';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1605,6 +1605,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Salva il log degli errori ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Cancella registro errori';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1603,6 +1603,11 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Įrašyti klaidų žurnalą ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Išvalyti klaidų žurnalą';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1604,6 +1604,11 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Saglabāt kļūdu žurnālu ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Notīrīt kļūdu žurnālu';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1597,6 +1597,11 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Lagre feillogg ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Tøm feilloggen';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1606,6 +1606,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Foutenlogboek opslaan ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Foutenlogboek wissen';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1604,6 +1604,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Zapisz dziennik błędów ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Wyczyść dziennik błędów';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1608,6 +1608,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Guardar registo de erros ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Limpar registo de erros';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1606,6 +1606,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Salvează jurnalul de erori ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Șterge jurnalul de erori';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1607,6 +1607,11 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Uložiť záznam chýb ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Vymazať protokol chýb';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1599,6 +1599,11 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Shrani dnevnik napak ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Počisti dnevnik napak';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1598,6 +1598,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String privacySaveErrorLog(int count) {
+    return 'Spara felloggen ($count)';
+  }
+
+  @override
   String get privacyClearErrorLog => 'Rensa felloggen';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Atidaryti rezultatus",
   "fabRunSearch": "Vykdyti paiešką",
   "fabRefineCriteria": "Tikslinti paiešką",
-  "routeSearchPartialBanner": "Ieškoma daugiau stočių…"
+  "routeSearchPartialBanner": "Ieškoma daugiau stočių…",
+  "privacySaveErrorLog": "Įrašyti klaidų žurnalą ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Atvērt rezultātus",
   "fabRunSearch": "Veikt meklēšanu",
   "fabRefineCriteria": "Precizēt meklēšanu",
-  "routeSearchPartialBanner": "Tiek meklētas vairāk staciju…"
+  "routeSearchPartialBanner": "Tiek meklētas vairāk staciju…",
+  "privacySaveErrorLog": "Saglabāt kļūdu žurnālu ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Åpne resultater",
   "fabRunSearch": "Kjør søk",
   "fabRefineCriteria": "Avgrens søk",
-  "routeSearchPartialBanner": "Søker etter flere stasjoner…"
+  "routeSearchPartialBanner": "Søker etter flere stasjoner…",
+  "privacySaveErrorLog": "Lagre feillogg ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Resultaten openen",
   "fabRunSearch": "Zoekopdracht uitvoeren",
   "fabRefineCriteria": "Zoekopdracht verfijnen",
-  "routeSearchPartialBanner": "Zoekt naar meer stations…"
+  "routeSearchPartialBanner": "Zoekt naar meer stations…",
+  "privacySaveErrorLog": "Foutenlogboek opslaan ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Otwórz wyniki",
   "fabRunSearch": "Uruchom wyszukiwanie",
   "fabRefineCriteria": "Zawęź wyszukiwanie",
-  "routeSearchPartialBanner": "Wyszukiwanie kolejnych stacji…"
+  "routeSearchPartialBanner": "Wyszukiwanie kolejnych stacji…",
+  "privacySaveErrorLog": "Zapisz dziennik błędów ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Abrir resultados",
   "fabRunSearch": "Executar pesquisa",
   "fabRefineCriteria": "Refinar pesquisa",
-  "routeSearchPartialBanner": "A procurar mais estações…"
+  "routeSearchPartialBanner": "A procurar mais estações…",
+  "privacySaveErrorLog": "Guardar registo de erros ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Deschide rezultatele",
   "fabRunSearch": "Execută căutarea",
   "fabRefineCriteria": "Rafinează căutarea",
-  "routeSearchPartialBanner": "Se caută mai multe stații…"
+  "routeSearchPartialBanner": "Se caută mai multe stații…",
+  "privacySaveErrorLog": "Salvează jurnalul de erori ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Otvoriť výsledky",
   "fabRunSearch": "Spustiť vyhľadávanie",
   "fabRefineCriteria": "Spresniť vyhľadávanie",
-  "routeSearchPartialBanner": "Hľadajú sa ďalšie stanice…"
+  "routeSearchPartialBanner": "Hľadajú sa ďalšie stanice…",
+  "privacySaveErrorLog": "Uložiť záznam chýb ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Odpri rezultate",
   "fabRunSearch": "Zaženi iskanje",
   "fabRefineCriteria": "Izboljšaj iskanje",
-  "routeSearchPartialBanner": "Iskanje dodatnih postaj…"
+  "routeSearchPartialBanner": "Iskanje dodatnih postaj…",
+  "privacySaveErrorLog": "Shrani dnevnik napak ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1862,5 +1862,14 @@
   "fabOpenResults": "Öppna resultat",
   "fabRunSearch": "Kör sökning",
   "fabRefineCriteria": "Förfina sökning",
-  "routeSearchPartialBanner": "Söker efter fler stationer…"
+  "routeSearchPartialBanner": "Söker efter fler stationer…",
+  "privacySaveErrorLog": "Spara felloggen ({count})",
+  "@privacySaveErrorLog": {
+    "description": "Button on the Privacy Dashboard that writes the buffered error traces to the device's Downloads folder. Supersedes privacyCopyErrorLog (#2145).",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -169,8 +169,8 @@ void main() {
     });
 
     testWidgets(
-        'shows the "Copy error log to clipboard" button labelled with the '
-        'current trace count (#476)', (tester) async {
+        'shows the "Save error log" button labelled with the current '
+        'trace count (#476, #2145)', (tester) async {
       await _setTallSurface(tester);
       await pumpApp(
         tester,
@@ -185,14 +185,15 @@ void main() {
         50.0,
       );
 
-      // The new button is keyed for stable lookup; the label includes the
-      // count from the (stubbed) TraceStorage which returns 0.
+      // #2145 — label switched from "Copy error log to clipboard" to
+      // "Save error log" so it reflects the dominant Downloads-write
+      // behaviour. Count comes from the stubbed TraceStorage (0).
       expect(
         find.byKey(const ValueKey('privacy-export-error-log-button')),
         findsOneWidget,
       );
       expect(
-        find.textContaining('Copy error log to clipboard (0)'),
+        find.textContaining('Save error log (0)'),
         findsOneWidget,
       );
     });


### PR DESCRIPTION
## Summary

Renames the Privacy Dashboard's error-log button from "Copy error log to clipboard" to "Save error log" — reflects the dominant Downloads-write behaviour (clipboard / share are secondary fallbacks). New ARB key `privacySaveErrorLog` translated into all 24 locales; the legacy `privacyCopyErrorLog` is left untouched (cleanup later).

## Test plan

- [x] `flutter analyze` — 3 pre-existing infos, 0 errors.
- [x] `flutter test test/features/profile test/l10n test/lint` — 398 pass.
- [x] `flutter test test/l10n/localization_completeness_test.dart` — 23 locales at 100%.
- [ ] Manual: open Privacy Dashboard, confirm button label.

Closes #2145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)