### PR TITLE
refactor(profile): route catches through errorLogger (#2146 bundle 1 — lib/features/profile)

### DIFF
--- a/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
+++ b/lib/features/profile/presentation/screens/privacy_dashboard_screen.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -12,6 +13,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/sharing/public_file_exporter.dart';
 import '../../../../core/telemetry/storage/trace_storage.dart';
 import '../../../../core/export/data_exporter.dart';
@@ -167,10 +169,12 @@ class _PrivacyDashboardScreenState
       try {
         await _shareErrorLogAsFile(json);
       } on Object catch (e, st) {
-        // If share sheet wiring fails we still want to give the user
-        // something — fall back to clipboard so the bug report doesn't
-        // get blocked on a platform-channel hiccup.
-        debugPrint('privacy: error-log share fallback to clipboard: $e\n$st');
+        // Share-sheet wiring failed; fall back to clipboard so the bug
+        // report isn't blocked on a platform-channel hiccup. #2146 —
+        // also surface on the exportable log.
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+          'where': 'PrivacyDashboard._exportErrorLog: share fallback',
+        }));
         await Clipboard.setData(ClipboardData(text: json));
         if (!mounted) return;
         SnackBarHelper.showSuccess(
@@ -268,7 +272,10 @@ class _PrivacyDashboardScreenState
         l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
       );
     } on Object catch (e, st) {
-      debugPrint('privacy: error-log save-to-downloads failed: $e\n$st');
+      // #2146 — surface on the log the user is about to export.
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'PrivacyDashboard._shareErrorLogAsFile',
+      }));
     }
   }
 
@@ -320,7 +327,11 @@ class _PrivacyDashboardScreenState
         l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
       );
     } on Object catch (e, st) {
-      debugPrint('privacy: save-to-downloads fallback: $e\n$st');
+      // #2146 — surface on the user-exportable log.
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+        'where': 'PrivacyDashboard._saveExportToDownloads',
+        'fileName': fileName,
+      }));
       if (!mounted) return;
       SnackBarHelper.showSuccess(context, copySnackbar);
     }

--- a/lib/features/profile/presentation/widgets/feedback_token_section.dart
+++ b/lib/features/profile/presentation/widgets/feedback_token_section.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../../../../core/feedback/github_issue_reporter_provider.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
@@ -56,7 +59,11 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
         _loading = false;
       });
     } catch (e, st) {
-      debugPrint('FeedbackTokenSection: secure-storage read failed: $e\n$st');
+      // #2146 — route to errorLogger so secure-storage failures land
+      // in the user-exportable log alongside other catches.
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'FeedbackTokenSection._refresh: secure-storage read',
+      }));
       if (!mounted) return;
       setState(() {
         _hasToken = false;
@@ -135,7 +142,10 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
         value: scrubbed,
       );
     } catch (e, st) {
-      debugPrint('FeedbackTokenSection: secure-storage write failed: $e\n$st');
+      // #2146 — same routing rationale as the read catch above.
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'FeedbackTokenSection._setToken: secure-storage write',
+      }));
       return;
     }
 
@@ -149,7 +159,10 @@ class _FeedbackTokenSectionState extends ConsumerState<FeedbackTokenSection> {
     try {
       await _storage.delete(key: kGithubFeedbackTokenKey);
     } catch (e, st) {
-      debugPrint('FeedbackTokenSection: secure-storage delete failed: $e\n$st');
+      // #2146 — same routing rationale as the read/write catches above.
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'FeedbackTokenSection._clearToken: secure-storage delete',
+      }));
     }
     ref.invalidate(githubIssueReporterProvider);
     await _refresh();

--- a/lib/features/profile/presentation/widgets/location_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/location_section_widget.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -183,7 +186,12 @@ class LocationSectionWidget extends ConsumerWidget {
   Future<void> _updateGps(BuildContext context, WidgetRef ref) async {
     try {
       await ref.read(userPositionProvider.notifier).updateFromGps();
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      // #2146 — record the GPS failure on the exportable log so a user
+      // bug report has the stack trace instead of just a snackbar.
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': 'LocationSection._updateGps: userPosition.updateFromGps',
+      }));
       if (context.mounted) {
         final l10n = AppLocalizations.of(context);
         SnackBarHelper.showError(

--- a/lib/features/profile/presentation/widgets/tank_sync_section.dart
+++ b/lib/features/profile/presentation/widgets/tank_sync_section.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../sync/presentation/widgets/qr_share_widget.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/sync/sync_config.dart';
 import '../../../../core/sync/sync_provider.dart';
@@ -251,7 +254,12 @@ class TankSyncSection extends ConsumerWidget {
         if (context.mounted) {
           SnackBarHelper.show(context, AppLocalizations.of(context)?.switchedToAnonymous ?? 'Switched to anonymous session');
         }
-      } catch (e, st) { // ignore: unused_catch_stack
+      } catch (e, st) {
+        // #2146 — route to errorLogger so the failure lands on the
+        // exportable log (the snackbar is transient).
+        unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {
+          'where': 'TankSyncSection: switchToAnonymous',
+        }));
         if (context.mounted) {
           SnackBarHelper.showError(context, AppLocalizations.of(context)?.failedToSwitch(e.toString()) ?? 'Failed to switch: $e');
         }

--- a/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
+++ b/test/features/profile/presentation/screens/privacy_dashboard_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/telemetry/storage/trace_storage.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
 import 'package:tankstellen/core/sync/sync_config.dart';
@@ -72,6 +73,20 @@ void main() {
     late MockStorageRepository mockStorage;
 
     setUp(() {
+      // #2146 — the privacy-dashboard screen now routes its catches
+      // through errorLogger (so they land on the exportable log). In
+      // tests Hive isn't initialised so the spool's default path
+      // throws — point the override at a no-op recorder so log() is
+      // genuinely silent here.
+      errorLogger.spoolEnqueueOverride = ({
+        required String isolateTaskName,
+        required Object error,
+        StackTrace? stack,
+        Map<String, dynamic>? contextMap,
+        DateTime? timestamp,
+      }) async {};
+      addTearDown(errorLogger.resetForTest);
+
       mockStorage = MockStorageRepository();
 
       when(() => mockStorage.favoriteCount).thenReturn(5);

--- a/test/features/profile/presentation/widgets/location_section_widget_test.dart
+++ b/test/features/profile/presentation/widgets/location_section_widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/providers/app_state_provider.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/data/repositories/profile_repository.dart';
@@ -118,6 +119,20 @@ UserProfile _profile({bool autoUpdate = false}) => UserProfile(
 void main() {
   setUpAll(() {
     registerFallbackValue(_profile());
+  });
+
+  setUp(() {
+    // #2146 — LocationSectionWidget now routes GPS-update catches
+    // through errorLogger. In tests Hive isn't initialised so the
+    // spool's default path throws — silence it via the existing seam.
+    errorLogger.spoolEnqueueOverride = ({
+      required String isolateTaskName,
+      required Object error,
+      StackTrace? stack,
+      Map<String, dynamic>? contextMap,
+      DateTime? timestamp,
+    }) async {};
+    addTearDown(errorLogger.resetForTest);
   });
 
   group('LocationSectionWidget', () {


### PR DESCRIPTION
## Summary

First bundle of Epic #2146 (codebase exception-handling audit). The Privacy Dashboard is the host of the very feature that surfaces the exportable error log — its own catches were going to \`debugPrint\` only, so the screen letting users save the log was failing to record its own internal errors there.

**Routed through \`errorLogger.log\`:**
- \`privacy_dashboard_screen.dart\` — 3 catches (share fallback / share file save / downloads save) → \`ErrorLayer.ui\` / \`ErrorLayer.storage\`.
- \`feedback_token_section.dart\` — 3 secure-storage catches (read / write / delete) → \`ErrorLayer.storage\`.
- \`tank_sync_section.dart\` — \`switchToAnonymous\` catch → \`ErrorLayer.sync\` (snackbar kept).
- \`location_section_widget.dart\` — GPS-update catch → \`ErrorLayer.ui\` (snackbar kept).

**Test infra:** two existing test files set \`errorLogger.spoolEnqueueOverride\` to a no-op in setUp (with \`addTearDown(errorLogger.resetForTest)\`) so the spool's Hive box-open doesn't trip the test framework's zone-error guard.

\`privacy_dashboard_screen.dart\` trimmed back under the 400-line gate by tightening the new comments — substance unchanged.

## Test plan

- [x] \`flutter analyze\` — 3 pre-existing infos, 0 errors.
- [x] \`flutter test test/features/profile test/lint\` — 388 pass.
- [x] \`flutter test test/lint/file_length_test.dart\` — under cap.
- [x] \`flutter test test/l10n/localization_completeness_test.dart\` — 23 locales at 100%.
- [ ] Manual: trigger a Downloads-write failure on device → entry appears on the next error-log export.

Refs #2146 — remaining bundles per the Epic body: search/route → consumption → widget → setup/feature-mgmt/alerts → core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)