### PR TITLE
refactor(search,route): route catches through errorLogger (#2146 bundle 2)

### DIFF
--- a/lib/features/route_search/presentation/widgets/city_autocomplete_field.dart
+++ b/lib/features/route_search/presentation/widgets/city_autocomplete_field.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/services/location_search_service.dart';
 
 /// Reusable text field with debounced city autocomplete suggestions.
@@ -99,7 +100,11 @@ class _CityAutocompleteFieldState extends State<CityAutocompleteField> {
           }
         }
       } catch (e, st) {
-        debugPrint('Route autocomplete failed: $e\n$st');
+        // #2146 — route to the exportable log so autocomplete
+        // failures are recoverable from a bug report.
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+          'where': 'CityAutocompleteField: search',
+        }));
         if (mounted) setState(() => _isLoading = false);
       }
     });

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../../core/location/location_service.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/services/location_search_provider.dart';
 import '../../../../core/services/location_search_service.dart';
 import '../../../../core/utils/frame_callbacks.dart';
@@ -98,7 +99,11 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       ref.read(routeInputControllerProvider.notifier).setStartCoords(coords);
       final l10n = AppLocalizations.of(context);
       _startController.text = l10n?.currentLocation ?? 'Current location';
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      // #2146 — route to the exportable log; the snackbar is transient.
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': 'RouteInput._useGpsForStart',
+      }));
       if (mounted) {
         final l10n = AppLocalizations.of(context);
         SnackBarHelper.showError(
@@ -219,7 +224,11 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       ];
 
       widget.onSearch(waypoints);
-    } catch (e, st) { // ignore: unused_catch_stack
+    } catch (e, st) {
+      // #2146 — route to the exportable log; the snackbar is transient.
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': 'RouteInput.resolveAndSearch',
+      }));
       if (mounted) {
         SnackBarHelper.showError(context,
             '${AppLocalizations.of(context)?.errorUnknown ?? "Error"}: $e');

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/error/exceptions.dart';
+import '../../../core/logging/error_logger.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
@@ -174,7 +177,13 @@ class RouteSearchState extends _$RouteSearchState {
       try {
         country = await geocoding.coordinatesToCountryCode(lat, lng);
       } catch (e, st) {
-        debugPrint('RouteSearch: country detection failed at $lat,$lng: $e\n$st');
+        // #2146 — non-fatal (falls through to fallbackService) but
+        // surface on the log so country-detection blackholes are
+        // recoverable from a bug report.
+        unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+          'where': 'RouteSearch: fuel country detection',
+          'lat': lat, 'lng': lng,
+        }));
       }
 
       // Reuse cached service if country unchanged
@@ -226,7 +235,12 @@ class RouteSearchState extends _$RouteSearchState {
           );
           if (detected != null) countryCode = detected;
         } catch (e, st) {
-          debugPrint('RouteSearch EV: country detection failed: $e\n$st');
+          // #2146 — non-fatal (uses fallbackCountry) but surface
+          // so triage can spot misconfigured geocoding chains.
+          unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+            'where': 'RouteSearch EV: country detection',
+            'lat': point.latitude, 'lng': point.longitude,
+          }));
         }
 
         final result = await service.searchStations(
@@ -242,7 +256,13 @@ class RouteSearchState extends _$RouteSearchState {
           }
         }
       } catch (e, st) {
-        debugPrint('RouteSearch EV: sample point query failed: $e\n$st');
+        // #2146 — sample failures are tolerated (other points still
+        // yield results), but route to the exportable log so
+        // recurring blackouts of EV results are recoverable.
+        unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+          'where': 'RouteSearch EV: sample point query',
+          'lat': point.latitude, 'lng': point.longitude,
+        }));
       }
     }
 

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'e5abbb2e98c012de1d7e0236736467254f0b7337';
+String _$routeSearchStateHash() => r'468181118db0d8a5310822537b21d9b1bb818563';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/data/services/ev_charging_service.dart
+++ b/lib/features/search/data/services/ev_charging_service.dart
@@ -1,9 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
+import 'dart:async';
 
+import 'package:dio/dio.dart';
+
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/services/dio_factory.dart';
 import '../../../../core/services/mixins/station_service_helpers.dart';
 import '../../../../core/services/service_result.dart';
@@ -155,7 +157,12 @@ class EVChargingService with StationServiceHelpers {
         countryCode: addr['Country']?['ISOCode']?.toString(),
       );
     } catch (e, st) {
-      debugPrint('EV station parse failed: $e\n$st');
+      // #2146 — silent parse failures used to never reach the
+      // exportable log; route via errorLogger so a malformed OCM
+      // record is recoverable from a bug report.
+      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: const {
+        'where': 'EvChargingService: station parse',
+      }));
       return null;
     }
   }
@@ -200,7 +207,12 @@ class EVChargingService with StationServiceHelpers {
       final dt = DateTime.parse(iso);
       return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
     } catch (e, st) {
-      debugPrint('EV date parse failed: $e\n$st');
+      // #2146 — route to the exportable log; date drift surfaces
+      // as a broken EV station detail otherwise.
+      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+        'where': 'EvChargingService: date parse',
+        'iso': iso,
+      }));
       return null;
     }
   }

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -10,6 +10,7 @@ import '../../../../app/shell/settings_app_bar_action.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/location_consent.dart';
 import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -199,9 +200,12 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               }
             } catch (e, st) {
               // #1692 — never surface a raw exception toString() to the
-              // user; show a localized, actionable message instead. The
-              // cause is kept for support via debugPrint below.
-              debugPrint('SearchScreen GPS update failed: $e\n$st');
+              // user; show a localized, actionable message instead.
+              // #2146 — route to the exportable log so the cause is
+              // recoverable from a bug report.
+              unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+                'where': 'SearchScreen: userPosition.updateFromGps',
+              }));
               if (!context.mounted) return;
               SnackBarHelper.showError(
                 context,

--- a/lib/features/search/presentation/widgets/pay_with_app_button.dart
+++ b/lib/features/search/presentation/widgets/pay_with_app_button.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
+import '../../../../core/logging/error_logger.dart';
 import '../../../../core/utils/payment_app_launcher.dart';
 import '../../../../l10n/app_localizations.dart';
 
@@ -49,7 +52,12 @@ class PayWithAppButton extends StatelessWidget {
     try {
       await launcher(app);
     } on Exception catch (e, st) {
-      debugPrint('PayWithAppButton launch failed: $e\n$st');
+      // #2146 — route to the exportable log so a missing deep-link
+      // handler is visible from a bug report.
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {
+        'where': 'PayWithAppButton._launch',
+        'app': app.displayName,
+      }));
     }
   }
 }

--- a/lib/features/search/providers/cross_border_suggestion_provider.dart
+++ b/lib/features/search/providers/cross_border_suggestion_provider.dart
@@ -1,12 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/country/border_proximity.dart';
 import '../../../core/country/country_provider.dart';
 import '../../../core/location/user_position_provider.dart';
+import '../../../core/logging/error_logger.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/utils/station_extensions.dart';
@@ -167,7 +169,12 @@ Future<List<Station>> _safeNeighborSearch({
     );
     return result.data;
   } catch (e, st) {
-    debugPrint('cross-border probe ($countryCode) failed: $e\n$st');
+    // #2146 — route to the user-exportable log so silent
+    // cross-border probe failures are recoverable from bug reports.
+    unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+      'where': 'cross_border_suggestion_provider: probe',
+      'countryCode': countryCode,
+    }));
     return const [];
   }
 }

--- a/lib/features/search/providers/search_provider_orchestration.dart
+++ b/lib/features/search/providers/search_provider_orchestration.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/location/user_position_provider.dart';
+import '../../../core/logging/error_logger.dart';
 import '../../../core/services/geocoding_chain.dart';
 import '../../../core/services/service_result.dart';
 import '../domain/entities/fuel_type.dart';
@@ -30,7 +33,11 @@ Future<void> autoUpdatePositionIfEnabled(Ref ref) async {
   try {
     await ref.read(userPositionProvider.notifier).updateFromGps();
   } on Exception catch (e, st) {
-    debugPrint('GPS auto-update failed: $e\n$st');
+    // #2146 — route to the user-exportable log; the search continues
+    // without GPS so the user still gets results.
+    unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {
+      'where': 'search_provider: autoUpdatePositionIfEnabled',
+    }));
   }
 }
 
@@ -78,7 +85,13 @@ Future<String?> tryReverseGeocode(
     );
     return addrResult.data;
   } on Exception catch (e, st) {
-    debugPrint('Reverse geocoding failed: $e\n$st');
+    // #2146 — non-fatal, but route so silent failures surface in
+    // the exportable log for bug-report triage.
+    unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+      'where': 'search_provider: tryReverseGeocode',
+      'lat': lat,
+      'lng': lng,
+    }));
     return null;
   }
 }

--- a/test/features/search/providers/search_provider_orchestration_test.dart
+++ b/test/features/search/providers/search_provider_orchestration_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/services/geocoding_chain.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
@@ -102,7 +103,22 @@ class _RecordingUserPosition extends UserPosition {
   }
 }
 
+/// #2146 — orchestration helpers now log catches via errorLogger.
+/// In tests Hive isn't initialised, so silence the spool path.
+void _silenceErrorLogger() {
+  errorLogger.spoolEnqueueOverride = ({
+    required String isolateTaskName,
+    required Object error,
+    StackTrace? stack,
+    Map<String, dynamic>? contextMap,
+    DateTime? timestamp,
+  }) async {};
+}
+
 void main() {
+  setUp(_silenceErrorLogger);
+  tearDown(errorLogger.resetForTest);
+
   group('classifySearchError', () {
     final stack = StackTrace.current;
 

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -11,6 +11,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/location/location_service.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/services/geocoding_chain.dart';
 import 'package:tankstellen/core/services/service_providers.dart';
 import 'package:tankstellen/core/services/service_result.dart';
@@ -104,6 +105,16 @@ void main() {
   late MockGeocodingChain mockGeocoding;
 
   setUp(() {
+    // #2146 — silence the spool so errorLogger.log inside catches
+    // doesn't trip the test framework's zone-error guard.
+    errorLogger.spoolEnqueueOverride = ({
+      required String isolateTaskName,
+      required Object error,
+      StackTrace? stack,
+      Map<String, dynamic>? contextMap,
+      DateTime? timestamp,
+    }) async {};
+
     fakeStorage = FakeHiveStorage();
     mockStationService = MockStationService();
     mockGeocoding = MockGeocodingChain();
@@ -116,6 +127,8 @@ void main() {
     ));
     registerFallbackValue(CancelToken());
   });
+
+  tearDown(errorLogger.resetForTest);
 
   ProviderContainer createContainer() {
     final c = ProviderContainer(overrides: [


### PR DESCRIPTION
## Summary

Second bundle of Epic #2146. Covers \`lib/features/search/\` + \`lib/features/route_search/\` — the highest-traffic user-facing flows, where silent \`debugPrint\` catches were the dominant pattern.

**Routed through \`errorLogger.log\` (11 catches across 9 files):**
- \`search_screen.dart\` — GPS update (\`ErrorLayer.ui\`).
- \`search_provider_orchestration.dart\` — auto-GPS (\`ErrorLayer.providers\`) + reverse-geocode (\`ErrorLayer.services\`).
- \`cross_border_suggestion_provider.dart\` — probe (\`ErrorLayer.services\`).
- \`ev_charging_service.dart\` — station parse + date parse (\`ErrorLayer.services\`).
- \`pay_with_app_button.dart\` — launch (\`ErrorLayer.ui\`).
- \`route_search_provider.dart\` — 3 catches: fuel + EV country detection, EV sample-point query (\`ErrorLayer.services\`).
- \`route_input.dart\` — 2 catches: GPS-for-start + resolveAndSearch (\`ErrorLayer.ui\`).
- \`city_autocomplete_field.dart\` — autocomplete-search (\`ErrorLayer.ui\`).

**Test infra:** \`search_provider_test\` + \`search_provider_orchestration_test\` set \`errorLogger.spoolEnqueueOverride\` to a no-op in setUp so the spool's Hive box-open doesn't trip the zone-error guard.

## Test plan

- [x] \`flutter analyze\` — 3 pre-existing infos, 0 errors.
- [x] \`flutter test test/features/search test/features/route_search test/lint\` — 910 pass.

Refs #2146 — remaining bundles: consumption → widget → setup/feature-mgmt/alerts → core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)