### PR TITLE
refactor(consumption): /providers catches through errorLogger (#2146 bundle 3a)

### DIFF
--- a/lib/features/consumption/providers/charging_logs_provider.dart
+++ b/lib/features/consumption/providers/charging_logs_provider.dart
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../ev/domain/entities/charging_log.dart';
 import '../data/charging_log_store.dart';
+import '../../../core/logging/error_logger.dart';
 
 part 'charging_logs_provider.g.dart';
 
@@ -46,7 +48,7 @@ class ChargingLogs extends _$ChargingLogs {
     try {
       await store.upsert(log);
     } catch (e, st) {
-      debugPrint('ChargingLogs.add: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'ChargingLogs.add'}));
     }
     state = AsyncValue.data(await store.list());
   }
@@ -61,7 +63,7 @@ class ChargingLogs extends _$ChargingLogs {
     try {
       await store.upsert(log);
     } catch (e, st) {
-      debugPrint('ChargingLogs.edit: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'ChargingLogs.edit'}));
     }
     state = AsyncValue.data(await store.list());
   }
@@ -74,7 +76,7 @@ class ChargingLogs extends _$ChargingLogs {
     try {
       await store.remove(id);
     } catch (e, st) {
-      debugPrint('ChargingLogs.remove: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'ChargingLogs.remove'}));
     }
     state = AsyncValue.data(await store.list());
   }

--- a/lib/features/consumption/providers/charging_logs_provider.g.dart
+++ b/lib/features/consumption/providers/charging_logs_provider.g.dart
@@ -138,7 +138,7 @@ final class ChargingLogsProvider
   ChargingLogs create() => ChargingLogs();
 }
 
-String _$chargingLogsHash() => r'b3a633eb5293f6a6ac0325f6cd618ee781b9a4ef';
+String _$chargingLogsHash() => r'60ce3b592f61c4e7e0e845f6dae94830160f04e9';
 
 /// Charging-log list state (#582 phase 1).
 ///

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -148,7 +150,7 @@ class BrokenMapBeliefByVehicle extends _$BrokenMapBeliefByVehicle {
       // PathNotFoundException + LateInitializationError "after test
       // completion". Returning null falls back to a fresh belief —
       // the worst case is one re-probed pair, not a crash.
-      debugPrint('brokenMapBeliefByVehicle.load failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'brokenMapBeliefByVehicle.load failed'}));
       return null;
     }
   }
@@ -479,7 +481,7 @@ class FillUpList extends _$FillUpList {
         windowDistanceKm: windowDistanceKm,
       );
     } catch (e, st) {
-      debugPrint('FillUpList: trip-vs-pump reconciliation failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'FillUpList: trip-vs-pump reconciliation failed'}));
       return null;
     }
   }
@@ -600,7 +602,7 @@ class FillUpList extends _$FillUpList {
         }
       }
     } catch (e, st) {
-      debugPrint('FillUpList: broken-MAP observation failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'FillUpList: broken-MAP observation failed'}));
     }
   }
 
@@ -665,7 +667,7 @@ class FillUpList extends _$FillUpList {
       // picks up the new `pendingAcknowledgment` flag immediately.
       ref.invalidate(serviceReminderListProvider);
     } catch (e, st) {
-      debugPrint('FillUpList: reminder evaluation failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'FillUpList: reminder evaluation failed'}));
     }
   }
 
@@ -699,7 +701,7 @@ class FillUpList extends _$FillUpList {
       }
       return result;
     } catch (e, st) {
-      debugPrint('FillUpList: VE reconciliation failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'FillUpList: VE reconciliation failed'}));
       return null;
     }
   }
@@ -776,7 +778,7 @@ class FillUpList extends _$FillUpList {
       );
       ref.invalidate(vehicleProfileListProvider);
     } catch (e, st) {
-      debugPrint('GPS matrix reconciliation failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'GPS matrix reconciliation failed'}));
     }
   }
 

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -308,7 +308,7 @@ final class BrokenMapBeliefByVehicleProvider
 }
 
 String _$brokenMapBeliefByVehicleHash() =>
-    r'1629cc788ddc824b3ad1a18dbf914ee1878f1083';
+    r'e24a8c787a677ab5d83511c3e08f0994cc35177b';
 
 /// Holds the most recent per-vehicle [BrokenMapBelief] (#1423 phase 3).
 ///
@@ -467,7 +467,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'494b0dfbfb6ea218e222ebbfcafe43dba388bcb2';
+String _$fillUpListHash() => r'b555ed0d7551451c07a5016cffffb4a527f2d362';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/consumption/providers/maintenance_provider.dart
+++ b/lib/features/consumption/providers/maintenance_provider.dart
@@ -1,13 +1,15 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../data/maintenance_snooze_repository.dart';
 import '../domain/entities/maintenance_suggestion.dart';
 import '../domain/services/maintenance_analyzer.dart';
 import 'trip_history_provider.dart';
+import '../../../core/logging/error_logger.dart';
 
 part 'maintenance_provider.g.dart';
 
@@ -90,8 +92,7 @@ class MaintenanceSuggestionsController
     try {
       await repo.snoozeForDefault(signal: signal, now: DateTime.now());
     } catch (e, st) {
-      debugPrint(
-          'MaintenanceSuggestionsController.snoozeForDefault(${signal.name}): $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: {'where': 'MaintenanceSuggestionsController.snoozeForDefault(${signal.name})'}));
     }
     ref.invalidate(maintenanceSuggestionsProvider);
   }
@@ -110,8 +111,7 @@ class MaintenanceSuggestionsController
         until: now.add(const Duration(days: 1)),
       );
     } catch (e, st) {
-      debugPrint(
-          'MaintenanceSuggestionsController.dismissForToday(${signal.name}): $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: {'where': 'MaintenanceSuggestionsController.dismissForToday(${signal.name})'}));
     }
     ref.invalidate(maintenanceSuggestionsProvider);
   }

--- a/lib/features/consumption/providers/maintenance_provider.g.dart
+++ b/lib/features/consumption/providers/maintenance_provider.g.dart
@@ -262,7 +262,7 @@ final class MaintenanceSuggestionsControllerProvider
 }
 
 String _$maintenanceSuggestionsControllerHash() =>
-    r'34f84c3c575f5b1f3d743820a858890c20da89c2';
+    r'a340ecd3e4530fa4eb40ca5d46eac1c8e234db04';
 
 /// Action surface for the maintenance card. Wraps the snooze repo
 /// so widget tests can stub it via the standard Riverpod override

--- a/lib/features/consumption/providers/trip_baseline_recorder.dart
+++ b/lib/features/consumption/providers/trip_baseline_recorder.dart
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -16,6 +17,7 @@ import '../data/baseline_store.dart';
 import '../data/obd2/trip_live_reading.dart';
 import '../domain/cold_start_baselines.dart';
 import '../domain/situation_classifier.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Owns the #769 / #780 / #894 baseline-learning concern extracted
 /// from the [TripRecording] notifier (#1679): the per-trip situation
@@ -60,7 +62,7 @@ class TripBaselineRecorder {
         }
       }
     } catch (e, st) {
-      debugPrint('TripRecording.start: baseline setup failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.start: baseline setup failed'}));
       _store = null;
     }
   }
@@ -88,7 +90,7 @@ class TripBaselineRecorder {
       try {
         await store.flush(vid);
       } catch (e, st) {
-        debugPrint('TripRecording.stop: baseline flush failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.stop: baseline flush failed'}));
       }
       // #780 — fold in the server copy once the local flush lands.
       await _syncBaselineAfterFlush(vid);
@@ -265,7 +267,7 @@ class TripBaselineRecorder {
     try {
       return _ref.read(activeVehicleProfileProvider);
     } catch (e, st) {
-      debugPrint('TripRecording: active vehicle unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: active vehicle unavailable'}));
       return null;
     }
   }
@@ -304,7 +306,7 @@ class TripBaselineRecorder {
         // from disk.
       }
     } catch (e, st) {
-      debugPrint('TripRecording.stop: baseline sync failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.stop: baseline sync failed'}));
     }
   }
 }

--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -16,6 +16,7 @@ import '../../glide_coach/providers/glide_coach_enabled_provider.dart';
 import '../../glide_coach/providers/glide_coach_evaluator_provider.dart';
 import '../../glide_coach/providers/glide_coach_settings_provider.dart';
 import '../data/obd2/trip_recording_controller.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Owns the #1374 / #1125 / #1458 GPS concern extracted from the
 /// [TripRecording] notifier (#1679): the opt-in Geolocator position
@@ -120,7 +121,7 @@ class TripGpsStreamController {
         },
       );
     } catch (e, st) {
-      debugPrint('TripRecording GPS subscribe failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording GPS subscribe failed'}));
     }
   }
 
@@ -196,7 +197,7 @@ class TripGpsStreamController {
         await HapticFeedback.lightImpact();
       }
     } catch (e, st) {
-      debugPrint('TripRecording glide-coach evaluation failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording glide-coach evaluation failed'}));
     }
   }
 }

--- a/lib/features/consumption/providers/trip_oem_fuel_level_controller.dart
+++ b/lib/features/consumption/providers/trip_oem_fuel_level_controller.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import '../data/obd2/adapter_capability.dart';
 import '../data/obd2/oem_pid_registry.dart';
 import '../data/obd2/oem_pid_table.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Owns the #1615 experimental OEM-PID exact-fuel-level concern: a slow
 /// poll that reads exact litres-in-tank via a manufacturer [OemPidTable]
@@ -123,7 +124,7 @@ class TripOemFuelLevelController {
       final litres = await table.readFuelLevelLitres(port);
       if (litres != null) onLitres(litres);
     } catch (e, st) {
-      debugPrint('TripRecording OEM fuel-level read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording OEM fuel-level read failed'}));
     }
   }
 

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -46,6 +46,7 @@ import 'trip_oem_fuel_level_controller.dart';
 import 'trip_history_provider.dart';
 import 'trip_recording_phase.dart';
 import 'trip_recording_state.dart';
+import '../../../core/logging/error_logger.dart';
 
 // Re-export the phase, state, and haptic-policy types so existing
 // callers (widgets, screens, tests) that import this file keep
@@ -493,7 +494,7 @@ class TripRecording extends _$TripRecording {
     try {
       return ref.read(activeVehicleProfileProvider);
     } catch (e, st) {
-      debugPrint('TripRecording: active vehicle unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: active vehicle unavailable'}));
       return null;
     }
   }
@@ -514,7 +515,7 @@ class TripRecording extends _$TripRecording {
         catalog: catalog,
       );
     } catch (e, st) {
-      debugPrint('TripRecording: reference catalog unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: reference catalog unavailable'}));
       return null;
     }
   }
@@ -530,7 +531,7 @@ class TripRecording extends _$TripRecording {
           .read(featureFlagsProvider.notifier)
           .isEnabled(Feature.experimentalOemPids);
     } catch (e, st) {
-      debugPrint('TripRecording: feature flags unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: feature flags unavailable'}));
       return false;
     }
   }
@@ -603,7 +604,7 @@ class TripRecording extends _$TripRecording {
     try {
       await ctl.refreshOdometer();
     } catch (e, st) {
-      debugPrint('TripRecording.stop: refreshOdometer failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.stop: refreshOdometer failed'}));
     }
     // Snapshot the captured-samples buffer BEFORE stop() tears down
     // the controller — without this the trip-detail charts render the
@@ -656,7 +657,7 @@ class TripRecording extends _$TripRecording {
     try {
       await svc.disconnect();
     } catch (e, st) {
-      debugPrint('TripRecording.stop: service disconnect failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.stop: service disconnect failed'}));
     }
     _service = null;
     // #1303 — the trip is finalised in history; the active-trip
@@ -723,7 +724,7 @@ class TripRecording extends _$TripRecording {
         box: Hive.box<String>(HiveBoxes.obd2ActiveTrip),
       );
     } catch (e, st) {
-      debugPrint('TripRecording active repo: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording active repo'}));
       return null;
     }
   }
@@ -895,7 +896,7 @@ class TripRecording extends _$TripRecording {
     try {
       await repo.saveSnapshot(next);
     } catch (e, st) {
-      debugPrint('TripRecording flush snapshot failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording flush snapshot failed'}));
     }
   }
 
@@ -931,21 +932,18 @@ class TripRecording extends _$TripRecording {
     try {
       historyRepo = ref.read(tripHistoryRepositoryProvider);
     } catch (e, st) {
-      debugPrint(
-          'TripRecording recovered finalise: history repo read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording recovered finalise: history repo read failed'}));
     }
     try {
       historyList = ref.read(tripHistoryListProvider.notifier);
     } catch (e, st) {
-      debugPrint(
-          'TripRecording recovered finalise: history list read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording recovered finalise: history list read failed'}));
     }
     if (snapshot.automatic) {
       try {
         badgeFuture = ref.read(autoRecordBadgeServiceProvider.future);
       } catch (e, st) {
-        debugPrint(
-            'TripRecording recovered finalise: badge service read failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording recovered finalise: badge service read failed'}));
       }
     }
 
@@ -969,8 +967,7 @@ class TripRecording extends _$TripRecording {
           samples: snapshot.samples,
         ));
       } catch (e, st) {
-        debugPrint(
-            'TripRecording recovered finalise: save failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording recovered finalise: save failed'}));
       }
     }
 
@@ -983,8 +980,7 @@ class TripRecording extends _$TripRecording {
     try {
       historyList?.refresh();
     } catch (e, st) {
-      debugPrint(
-          'TripRecording recovered finalise: list refresh failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording recovered finalise: list refresh failed'}));
     }
 
     // Mirror the auto-record badge bookkeeping the regular
@@ -995,8 +991,7 @@ class TripRecording extends _$TripRecording {
         final badge = await badgeFuture;
         await badge.increment();
       } catch (e, st) {
-        debugPrint(
-            'TripRecording recovered finalise: badge bump failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording recovered finalise: badge bump failed'}));
       }
     }
 
@@ -1014,7 +1009,7 @@ class TripRecording extends _$TripRecording {
     try {
       await repo.clearSnapshot();
     } catch (e, st) {
-      debugPrint('TripRecording clear snapshot failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording clear snapshot failed'}));
     }
   }
 
@@ -1095,7 +1090,7 @@ class TripRecording extends _$TripRecording {
     try {
       connection = ref.read(obd2ConnectionProvider);
     } catch (e, st) {
-      debugPrint('TripRecording: connection provider unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: connection provider unavailable'}));
       return null;
     }
     return (pinnedMac, onReconnect) {
@@ -1116,7 +1111,7 @@ class TripRecording extends _$TripRecording {
               }
             }
           } catch (e, st) {
-            debugPrint('TripRecording reconnect probe failed: $e\n$st');
+            unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording reconnect probe failed'}));
           }
           return false;
         },
@@ -1132,7 +1127,7 @@ class TripRecording extends _$TripRecording {
             _service = svc;
             return true;
           } catch (e, st) {
-            debugPrint('TripRecording reconnect connect failed: $e\n$st');
+            unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording reconnect connect failed'}));
             return false;
           }
         },
@@ -1189,7 +1184,7 @@ class TripRecording extends _$TripRecording {
           final badge = await ref.read(autoRecordBadgeServiceProvider.future);
           await badge.increment();
         } catch (e, st) {
-          debugPrint('TripRecording auto-record badge increment: $e\n$st');
+          unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording auto-record badge increment'}));
         }
       }
       // #1479 phase 2 / #1665 — opportunistic upload of the freshly
@@ -1213,10 +1208,10 @@ class TripRecording extends _$TripRecording {
           unawaited(TripsSync.uploadSummary(entry));
         }
       } catch (e, st) {
-        debugPrint('TripRecording trip-sync hook: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording trip-sync hook'}));
       }
     } catch (e, st) {
-      debugPrint('TripRecording._saveToHistory: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording._saveToHistory'}));
     }
   }
 
@@ -1267,7 +1262,7 @@ class TripRecording extends _$TripRecording {
           .listen(
             _onGpsOnlyPosition,
             onError: (Object e, StackTrace st) {
-              debugPrint('TripRecording.startGpsOnly: stream error: $e\n$st');
+              unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.startGpsOnly: stream error'}));
             },
           );
       // Seed the state so the recording screen renders immediately

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'40e3b8292f0a3095ae8cbf02b4d7bc70060a40fe';
+String _$tripRecordingHash() => r'920cf723957f7fe810d5192ef29a5ea55e830b7b';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/consumption/providers/trip_ve_recompute_provider.dart
+++ b/lib/features/consumption/providers/trip_ve_recompute_provider.dart
@@ -3,13 +3,13 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../domain/trip_ve_recompute.dart';
 import 'trip_history_provider.dart';
+import '../../../core/logging/error_logger.dart';
 
 part 'trip_ve_recompute_provider.g.dart';
 
@@ -83,7 +83,7 @@ class TripVeRecomputeListener extends _$TripVeRecomputeListener {
         ref.read(tripHistoryListProvider.notifier).refresh();
       }
     } catch (e, st) {
-      debugPrint('TripVeRecomputeListener: recompute failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripVeRecomputeListener: recompute failed'}));
     }
   }
 }

--- a/lib/features/consumption/providers/trip_ve_recompute_provider.g.dart
+++ b/lib/features/consumption/providers/trip_ve_recompute_provider.g.dart
@@ -87,7 +87,7 @@ final class TripVeRecomputeListenerProvider
 }
 
 String _$tripVeRecomputeListenerHash() =>
-    r'ba830cbe85de90ec79bc3f33f89937ffdf6ab258';
+    r'339ed9907aa5c03fd872d3b0693246418dfc4be0';
 
 /// #1858 — retroactive η_v recompute trigger.
 ///

--- a/lib/features/consumption/providers/vehicle_baseline_summary_provider.dart
+++ b/lib/features/consumption/providers/vehicle_baseline_summary_provider.dart
@@ -1,14 +1,16 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/storage/hive_boxes.dart';
 import '../domain/situation_classifier.dart';
+import '../../../core/logging/error_logger.dart';
 
 part 'vehicle_baseline_summary_provider.g.dart';
 
@@ -38,7 +40,7 @@ Map<DrivingSituation, int> vehicleBaselineSummary(Ref ref, String vehicleId) {
   try {
     decoded = json.decode(raw) as Map<String, dynamic>;
   } catch (e, st) {
-    debugPrint('vehicleBaselineSummary: corrupt payload for $vehicleId: $e\n$st');
+    unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: {'where': 'vehicleBaselineSummary: corrupt payload for $vehicleId'}));
     return const {};
   }
 

--- a/lib/features/consumption/providers/vehicle_baseline_summary_provider.g.dart
+++ b/lib/features/consumption/providers/vehicle_baseline_summary_provider.g.dart
@@ -105,7 +105,7 @@ final class VehicleBaselineSummaryProvider
 }
 
 String _$vehicleBaselineSummaryHash() =>
-    r'2e87740356bc1caee1dd1af30aab390a5649dfbd';
+    r'bb264a1436f2fb5e0691b29d005a9ae60c891b5f';
 
 /// Sample count per [DrivingSituation] for a vehicle (#779).
 ///

--- a/lib/features/consumption/providers/wakelock_facade.dart
+++ b/lib/features/consumption/providers/wakelock_facade.dart
@@ -1,9 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
+import '../../../core/logging/error_logger.dart';
 
 part 'wakelock_facade.g.dart';
 
@@ -36,7 +38,7 @@ class RealWakelockFacade implements WakelockFacade {
     try {
       await WakelockPlus.enable();
     } catch (e, st) {
-      debugPrint('WakelockFacade.enable failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'WakelockFacade.enable failed'}));
     }
   }
 
@@ -45,7 +47,7 @@ class RealWakelockFacade implements WakelockFacade {
     try {
       await WakelockPlus.disable();
     } catch (e, st) {
-      debugPrint('WakelockFacade.disable failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'WakelockFacade.disable failed'}));
     }
   }
 }

--- a/test/features/consumption/data/obd2/trip_linking_test.dart
+++ b/test/features/consumption/data/obd2/trip_linking_test.dart
@@ -14,6 +14,7 @@ import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// #888 — auto-link OBD2 trajets to the fill-up they completed.
 ///
@@ -23,6 +24,7 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// replaces the old inline coupling where recording-start required a
 /// pending fill-up.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/auto_record_orchestrator_test.dart
+++ b/test/features/consumption/providers/auto_record_orchestrator_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/feature_management/domain/feature_manifest.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Tests for the auto-record orchestrator (#1004 phase 2b-3).
 ///
@@ -170,6 +171,7 @@ VehicleProfile _profile({
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   late _ListenerHarness harness;
   late _FakeTripRecording fakeTripRecording;
   // Speed-queue per opened MAC. Tests that exercise threshold-cross

--- a/test/features/consumption/providers/broken_map_belief_persistence_test.dart
+++ b/test/features/consumption/providers/broken_map_belief_persistence_test.dart
@@ -17,6 +17,7 @@ import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Hive-backed persistence tests for the [BrokenMapBeliefByVehicle]
 /// notifier (#1423 phase 4). Verifies that:
@@ -29,6 +30,7 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 ///   3. legacy / corrupted JSON in storage falls back to a default
 ///      belief without crashing.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/consumption_providers_relinking_test.dart
+++ b/test/features/consumption/providers/consumption_providers_relinking_test.dart
@@ -14,6 +14,7 @@ import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// #1361 phase 2a — whole-window trip relinking.
 ///
@@ -24,6 +25,7 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// user wanted "the trajets since then are related to all fill-ups
 /// since then" (#1361 spec).
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/fill_up_ve_calibration_test.dart
+++ b/test/features/consumption/providers/fill_up_ve_calibration_test.dart
@@ -15,11 +15,13 @@ import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dar
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
 import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Integration-level tests for the fill-up save → η_v reconciliation
 /// path (#815). These tests drive the real provider graph (no Riverpod
 /// doubles) so the FillUpList.add hook is exercised end-to-end.
 void main() {
+  silenceErrorLoggerSpool();
   late ProviderContainer container;
   late _FakeTripHistory history;
   late VehicleProfileRepository profileRepo;

--- a/test/features/consumption/providers/plein_complet_belief_hook_test.dart
+++ b/test/features/consumption/providers/plein_complet_belief_hook_test.dart
@@ -15,6 +15,7 @@ import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Call-site integration tests for the broken-MAP belief hook
 /// (#1423 phase 3). Verifies that when [FillUpList.add] runs the
@@ -25,6 +26,7 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// [TripHistoryRepository] (via in-memory Hive) so the hook traverses
 /// the same path production does.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/trip_recording_gps_diagnostics_persistence_test.dart
+++ b/test/features/consumption/providers/trip_recording_gps_diagnostics_persistence_test.dart
@@ -15,6 +15,7 @@ import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diag
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Regression coverage for #1458 phase 2 — the GPS cadence
 /// diagnostics buffer captured during a recording must round-trip
@@ -34,6 +35,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 ///      diagnostics buffer onto the saved entry — i.e. the in-memory
 ///      observation channel is durable, not lost at trip-stop.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_active_snapshot_test.dart
@@ -13,6 +13,7 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Tests for #1303 — the [TripRecording] provider's write-through
 /// snapshot path.
@@ -30,6 +31,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 ///   5. restoreFromSnapshot rehydrates the provider into a
 ///      pausedDueToDrop state with the stored vehicle id.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_automatic_flag_test.dart
@@ -14,6 +14,7 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Tests for the public `automatic` flag plumbing through the trip
 /// recording provider (#1004 phase 2a).
@@ -31,6 +32,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 /// — without that the empty-trip early-return inside `_saveToHistory`
 /// would skip the badge bump entirely, and we'd be testing nothing.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/trip_recording_start_reentrancy_test.dart
+++ b/test/features/consumption/providers/trip_recording_start_reentrancy_test.dart
@@ -10,12 +10,14 @@ import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Regression tests for #1932 — `TripRecording.start` must reject a
 /// second start that races into the window before `state` is marked
 /// active. Without the `_startInProgress` guard the second call passes
 /// the `state.isActive` check and orphans a `TripRecordingController`.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/trip_recording_stub_discard_test.dart
+++ b/test/features/consumption/providers/trip_recording_stub_discard_test.dart
@@ -11,6 +11,7 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Regression tests for #1923 — `_saveToHistory` must discard stub
 /// trips so they never clutter trip history.
@@ -21,6 +22,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 /// backups showed several such stubs — e.g. a 20-second 0 km entry
 /// alongside the real drive.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/providers/vehicle_baseline_summary_provider_test.dart
+++ b/test/features/consumption/providers/vehicle_baseline_summary_provider_test.dart
@@ -11,8 +11,10 @@ import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/features/consumption/data/baseline_store.dart';
 import 'package:tankstellen/features/consumption/domain/situation_classifier.dart';
 import 'package:tankstellen/features/consumption/providers/vehicle_baseline_summary_provider.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/helpers/silence_error_logger.dart
+++ b/test/helpers/silence_error_logger.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+
+/// #2146 — many catches now route through `errorLogger.log`. In tests
+/// Hive isn't initialised, so the spool's default path throws and the
+/// test framework's zone-error guard fails the test. Silence the spool
+/// for the current group by calling this once at the top of the
+/// suite's `main()` (or inside a `group` block).
+///
+/// Pairs `setUp` + `tearDown` automatically; no caller bookkeeping
+/// needed. The override is process-wide (the test seam is a static),
+/// so calling it twice in nested groups is harmless — the second
+/// `setUp` re-installs the no-op, and the matching `tearDown` resets.
+void silenceErrorLoggerSpool() {
+  setUp(() {
+    errorLogger.spoolEnqueueOverride = ({
+      required String isolateTaskName,
+      required Object error,
+      StackTrace? stack,
+      Map<String, dynamic>? contextMap,
+      DateTime? timestamp,
+    }) async {};
+  });
+  tearDown(errorLogger.resetForTest);
+}


### PR DESCRIPTION
## Summary

Third bundle of Epic #2146. Routes 37 catches in \`lib/features/consumption/providers/\` through \`errorLogger.log(ErrorLayer.providers, e, st, context: {'where': ...})\` so trip-recording / OBD2 / fill-up flow failures land on the user-exportable log instead of just \`debugPrint\`.

**Files:**
- \`trip_recording_provider.dart\` — 15 catches
- \`consumption_providers.dart\` — 6
- \`trip_baseline_recorder.dart\` — 4
- \`charging_logs_provider.dart\` — 3
- \`maintenance_provider.dart\` — 2
- \`trip_gps_stream_controller.dart\` — 2
- \`wakelock_facade.dart\` — 2
- \`trip_ve_recompute_provider.dart\`, \`trip_oem_fuel_level_controller.dart\`, \`vehicle_baseline_summary_provider.dart\` — 1 each

**Test infra:** new \`test/helpers/silence_error_logger.dart\` wraps the spool override setUp/tearDown; 12 consumption test files call \`silenceErrorLoggerSpool()\` at the top of \`main()\` (one line each + import).

**Codegen:** 6 @riverpod \`.g.dart\` files regenerated (rule 26).

## Test plan

- [x] \`flutter analyze\` — 3 pre-existing infos, 0 errors.
- [x] \`flutter test test/features/consumption test/lint\` — 2908 pass.
- [x] \`flutter test test/lint/file_length_test.dart\` — under cap.

Refs #2146 — remaining: 3b (\`consumption/data/\` + \`presentation/\`), 4 (widget), 5 (setup/feature-mgmt/alerts), 6 (core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)