### PR TITLE
refactor(consumption): /data + /presentation catches through errorLogger (#2146 bundle 3b)

### DIFF
--- a/lib/features/consumption/data/charging_log_store.dart
+++ b/lib/features/consumption/data/charging_log_store.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -8,6 +10,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/storage/hive_boxes.dart';
 import '../../ev/domain/entities/charging_log.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Hive-backed CRUD store for [ChargingLog] records (#582 phase 1).
 ///
@@ -38,7 +41,7 @@ class ChargingLogStore {
       if (!Hive.isBoxOpen(HiveBoxes.settings)) return null;
       return Hive.box(HiveBoxes.settings);
     } catch (e, st) {
-      debugPrint('ChargingLogStore: settings box unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ChargingLogStore: settings box unavailable'}));
       return null;
     }
   }
@@ -60,7 +63,7 @@ class ChargingLogStore {
         if (json == null) continue;
         out.add(ChargingLog.fromJson(json));
       } catch (e, st) {
-        debugPrint('ChargingLogStore.list: skipping $key: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'ChargingLogStore.list: skipping $key'}));
       }
     }
     out.sort((a, b) => a.date.compareTo(b.date));

--- a/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -15,6 +17,7 @@ import '../../../domain/entities/fill_up.dart';
 import '../../trip_history_repository.dart';
 import 'backup_xml_writer.dart';
 import 'backup_zipper.dart';
+import '../../../../../core/logging/error_logger.dart';
 
 /// Hook for the share-sheet handoff (#1317). Production uses
 /// `SharePlus.instance.share`; tests substitute a fake via
@@ -139,7 +142,7 @@ class FullBackupExporter {
         mimeType: 'application/zip',
       );
     } on Object catch (e, st) {
-      debugPrint('FullBackupExporter: save-to-downloads failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'FullBackupExporter: save-to-downloads failed'}));
     }
 
     // Keep the share-sink shape so existing test fakes (and any

--- a/lib/features/consumption/data/maintenance_snooze_repository.dart
+++ b/lib/features/consumption/data/maintenance_snooze_repository.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../../core/storage/hive_boxes.dart';
 import '../domain/entities/maintenance_suggestion.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Per-signal snooze persistence for the predictive-maintenance card
 /// (#1124).
@@ -44,8 +47,7 @@ class MaintenanceSnoozeRepository {
       if (!Hive.isBoxOpen(HiveBoxes.settings)) return null;
       return Hive.box(HiveBoxes.settings);
     } catch (e, st) {
-      debugPrint(
-          'MaintenanceSnoozeRepository: settings box unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'MaintenanceSnoozeRepository: settings box unavailable'}));
       return null;
     }
   }
@@ -98,8 +100,7 @@ class MaintenanceSnoozeRepository {
     try {
       return DateTime.tryParse(raw.toString());
     } catch (e, st) {
-      debugPrint(
-          'MaintenanceSnoozeRepository: corrupt timestamp for ${signal.name}: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'MaintenanceSnoozeRepository: corrupt timestamp for ${signal.name}'}));
       return null;
     }
   }

--- a/lib/features/consumption/data/obd2/active_trip_recovery_service.dart
+++ b/lib/features/consumption/data/obd2/active_trip_recovery_service.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../trip_history_repository.dart';
 import 'active_trip_repository.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Outcome of [ActiveTripRecoveryService.recover].
 ///
@@ -105,7 +108,7 @@ class ActiveTripRecoveryService {
     try {
       snapshot = _activeRepo.loadSnapshot();
     } catch (e, st) {
-      debugPrint('ActiveTripRecoveryService loadSnapshot failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ActiveTripRecoveryService loadSnapshot failed'}));
       return ActiveTripRecoveryOutcome.failed;
     }
     if (snapshot == null) {
@@ -123,7 +126,7 @@ class ActiveTripRecoveryService {
       try {
         await _activeRepo.clearSnapshot();
       } catch (e, st) {
-        debugPrint('ActiveTripRecoveryService clear stale failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ActiveTripRecoveryService clear stale failed'}));
         return ActiveTripRecoveryOutcome.failed;
       }
       // Stale auto-record snapshots still bump the unseen badge —
@@ -134,8 +137,7 @@ class ActiveTripRecoveryService {
         try {
           await cb();
         } catch (e, st) {
-          debugPrint(
-              'ActiveTripRecoveryService stale badge bump failed: $e\n$st');
+          unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ActiveTripRecoveryService stale badge bump failed'}));
         }
       }
       debugPrint(

--- a/lib/features/consumption/data/obd2/active_trip_repository.dart
+++ b/lib/features/consumption/data/obd2/active_trip_repository.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -8,6 +10,7 @@ import 'package:hive/hive.dart';
 
 import '../../domain/trip_recorder.dart';
 import 'paused_trip_repository.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Snapshot of an in-progress OBD2 recording that is healthy — i.e.
 /// the BT transport is alive and samples are still arriving — but
@@ -262,7 +265,7 @@ class ActiveTripRepository {
     try {
       await _box.put(_singletonKey, jsonEncode(snapshot.toJson()));
     } catch (e, st) {
-      debugPrint('ActiveTripRepository.saveSnapshot: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ActiveTripRepository.saveSnapshot'}));
     }
   }
 
@@ -277,7 +280,7 @@ class ActiveTripRepository {
       final json = (jsonDecode(raw) as Map).cast<String, dynamic>();
       return ActiveTripSnapshot.fromJson(json);
     } catch (e, st) {
-      debugPrint('ActiveTripRepository.loadSnapshot: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ActiveTripRepository.loadSnapshot'}));
       return null;
     }
   }
@@ -288,7 +291,7 @@ class ActiveTripRepository {
     try {
       await _box.delete(_singletonKey);
     } catch (e, st) {
-      debugPrint('ActiveTripRepository.clearSnapshot: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ActiveTripRepository.clearSnapshot'}));
     }
   }
 

--- a/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
+++ b/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Callback signature: "is the pinned adapter MAC currently
 /// discoverable?". Resolved by the scanner against the active
@@ -171,7 +172,7 @@ class AdapterReconnectScanner {
     try {
       return await _probe(_pinnedMac);
     } catch (e, st) {
-      debugPrint('AdapterReconnectScanner probe failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AdapterReconnectScanner probe failed'}));
       return false;
     }
   }
@@ -180,7 +181,7 @@ class AdapterReconnectScanner {
     try {
       return await _connect(_pinnedMac);
     } catch (e, st) {
-      debugPrint('AdapterReconnectScanner connect failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AdapterReconnectScanner connect failed'}));
       return false;
     }
   }

--- a/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
+++ b/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
@@ -420,7 +420,7 @@ class AutoTripCoordinator {
       try {
         await service.disconnect();
       } catch (e, st) {
-        debugPrint('AutoTripCoordinator: drop-orphan disconnect failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AutoTripCoordinator: drop-orphan disconnect failed'}));
       }
       return;
     }
@@ -622,7 +622,7 @@ class AutoTripCoordinator {
     try {
       await held.disconnect();
     } catch (e, st) {
-      debugPrint('AutoTripCoordinator: session close failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AutoTripCoordinator: session close failed'}));
     }
   }
 }

--- a/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/classic_bluetooth_facade.dart
@@ -3,12 +3,12 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 
 import 'adapter_registry.dart';
 import 'classic_elm_channel.dart';
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Facade over the Classic Bluetooth transport for OBD2 adapters
 /// (#761 abstraction, #763 real impl).
@@ -55,7 +55,7 @@ class PluginClassicBluetoothFacade implements ClassicBluetoothFacade {
               ))
           .toList();
     } on Exception catch (e, st) {
-      debugPrint('PluginClassicBluetoothFacade: bondedDevices failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'PluginClassicBluetoothFacade: bondedDevices failed'}));
     }
   }
 

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Standard Bluetooth Serial Port Profile UUID (#761). Every
 /// Classic-SPP ELM327 adapter (vLinker FS, OBDLink LX, generic
@@ -83,7 +84,7 @@ class ClassicElmChannel implements ElmByteChannel {
     try {
       await _plugin.disconnect();
     } catch (e, st) {
-      debugPrint('ClassicElmChannel: disconnect error (ignored): $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ClassicElmChannel: disconnect error (ignored)'}));
     }
     await _incoming.close();
   }

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'elm_byte_channel.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Standard SPP-over-BLE UUIDs exposed by Vgate vLinker and most
 /// ELM327 BLE clones (Nordic UART Service variant used by the
@@ -116,7 +117,7 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
     try {
       await _device.disconnect();
     } catch (e, st) {
-      debugPrint('FlutterBluePlusElmChannel: disconnect failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'FlutterBluePlusElmChannel: disconnect failed'}));
     }
     _writeChar = null;
     _notifyChar = null;

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'adapter_registry.dart';
@@ -14,6 +13,7 @@ import 'classic_bluetooth_facade.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_permissions.dart';
 import 'obd2_service.dart';
+import '../../../../core/logging/error_logger.dart';
 
 part 'obd2_connection_service.g.dart';
 
@@ -142,7 +142,7 @@ class Obd2ConnectionService {
     try {
       return await connect(_lastRanked.first);
     } on Obd2ConnectionError catch (e, st) {
-      debugPrint('Obd2ConnectionService.connectBest failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'Obd2ConnectionService.connectBest failed'}));
       rethrow;
     }
   }

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -18,6 +18,7 @@ import 'obd2_transport.dart';
 import 'oem_pid_table.dart';
 import 'supported_pids_cache.dart';
 import 'supported_pids_resolver.dart';
+import '../../../../core/logging/error_logger.dart';
 
 // Re-export the pure-math estimator + stoichiometric constants so
 // callers that only need the math (e.g. [TripRecordingController]'s
@@ -310,7 +311,7 @@ class Obd2Service implements Obd2RawCommandPort {
           _capability = reconcileCapabilityWithProbe(_capability, probe);
         }
       } catch (e, st) {
-        debugPrint('OBD2 ATI firmware read failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 ATI firmware read failed'}));
       }
 
       await _pids.prime();
@@ -324,7 +325,7 @@ class Obd2Service implements Obd2RawCommandPort {
       );
       return true;
     } catch (e, st) {
-      debugPrint('OBD2 connect failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 connect failed'}));
       // #1920 — record the failure so the diagnostic log shows the
       // connect attempt that never produced a session.
       AutoRecordTraceLog.add(
@@ -411,7 +412,7 @@ class Obd2Service implements Obd2RawCommandPort {
       if (brand == VehicleBrand.unknown) return null;
       return _readOdometerFromCatalogByBrand(brand);
     } catch (e, st) {
-      debugPrint('OBD2 readOdometer failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readOdometer failed'}));
       return null;
     }
   }
@@ -481,7 +482,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.vehicleSpeedCommand);
       return Elm327Protocol.parseVehicleSpeed(response);
     } catch (e, st) {
-      debugPrint('OBD2 readSpeed failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readSpeed failed'}));
       return null;
     }
   }
@@ -518,7 +519,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.engineRpmCommand);
       return Elm327Protocol.parseEngineRpm(response);
     } catch (e, st) {
-      debugPrint('OBD2 readRpm failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readRpm failed'}));
       return null;
     }
   }
@@ -934,7 +935,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.fuelTypeCommand);
       return Elm327Protocol.parseFuelType(response);
     } catch (e, st) {
-      debugPrint('OBD2 readFuelType failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readFuelType failed'}));
       return null;
     }
   }
@@ -963,7 +964,7 @@ class Obd2Service implements Obd2RawCommandPort {
       if (vin == null || vin.isEmpty) return null;
       return vin;
     } catch (e, st) {
-      debugPrint('OBD2 readVin failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readVin failed'}));
       return null;
     }
   }
@@ -1098,7 +1099,7 @@ class Obd2Service implements Obd2RawCommandPort {
         // Best-effort: the user has already cancelled, no point
         // crashing on a STMP write that might fail because the
         // channel is mid-disconnect.
-        debugPrint('OBD2 canFrameStream STMP failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 canFrameStream STMP failed'}));
       }
     }
 
@@ -1157,7 +1158,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(command);
       return parser(response);
     } catch (e, st) {
-      debugPrint('OBD2 read $label failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'OBD2 read $label failed'}));
       return null;
     }
   }

--- a/lib/features/consumption/data/obd2/paused_trip_recovery_service.dart
+++ b/lib/features/consumption/data/obd2/paused_trip_recovery_service.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../trip_history_repository.dart';
 import 'paused_trip_repository.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Launch-time recovery for paused-but-never-finalised trips
 /// (#1004 phase 4-WAL).
@@ -91,7 +94,7 @@ class PausedTripRecoveryService {
     try {
       entries = _pausedRepo.loadAll();
     } catch (e, st) {
-      debugPrint('PausedTripRecoveryService loadAll failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'PausedTripRecoveryService loadAll failed'}));
       return 0;
     }
     if (entries.isEmpty) return 0;

--- a/lib/features/consumption/data/obd2/paused_trip_repository.dart
+++ b/lib/features/consumption/data/obd2/paused_trip_repository.dart
@@ -1,12 +1,15 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
 import '../../domain/trip_recorder.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Snapshot of an in-progress OBD2 recording that was paused because
 /// the Bluetooth transport dropped (#797 phase 1).
@@ -140,7 +143,7 @@ class PausedTripRepository {
     try {
       await _box.put(entry.id, jsonEncode(entry.toJson()));
     } catch (e, st) {
-      debugPrint('PausedTripRepository.save: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'PausedTripRepository.save'}));
     }
   }
 
@@ -154,7 +157,7 @@ class PausedTripRepository {
       final json = (jsonDecode(raw) as Map).cast<String, dynamic>();
       return PausedTripEntry.fromJson(json);
     } catch (e, st) {
-      debugPrint('PausedTripRepository.load: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'PausedTripRepository.load'}));
       return null;
     }
   }
@@ -178,7 +181,7 @@ class PausedTripRepository {
     try {
       await _box.delete(id);
     } catch (e, st) {
-      debugPrint('PausedTripRepository.delete: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'PausedTripRepository.delete'}));
     }
   }
 }

--- a/lib/features/consumption/data/obd2/pid_scheduler.dart
+++ b/lib/features/consumption/data/obd2/pid_scheduler.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Priority tier used as a tiebreaker when two subscribed PIDs have an
 /// identical weight under the weighted round-robin selector.
@@ -212,7 +213,7 @@ class PidScheduler {
           sub.onResult(response);
         } catch (e, st) {
           // Callback errors must not stall the scheduler. Log and move on.
-          debugPrint('PidScheduler: onResult for $command threw: $e\n$st');
+          unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'PidScheduler: onResult for $command threw'}));
         }
       }
     } catch (e, st) {
@@ -223,7 +224,7 @@ class PidScheduler {
       // the healthy one starved by the FIFO tiebreaker. On the next
       // round the failing PID still gets retried when its weight wins,
       // just no more often than the cadence it was subscribed at.
-      debugPrint('PidScheduler: transport for $command threw: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'PidScheduler: transport for $command threw'}));
       sub.config.lastReadAt = _clock();
     } finally {
       _inFlight = null;

--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import 'elm327_protocol.dart';
 import 'supported_pids_cache.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Owns the #811 supported-PID concern, extracted from [Obd2Service]
 /// (#1679): the per-connection set of Mode 01 PIDs the car implements,
@@ -81,7 +84,7 @@ class SupportedPidsResolver {
         await cache.put(key, discovered);
       }
     } catch (e, st) {
-      debugPrint('OBD2 supported-PID cache prime failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 supported-PID cache prime failed'}));
     }
   }
 
@@ -95,7 +98,7 @@ class SupportedPidsResolver {
       final vin = Elm327Protocol.parseVin(response);
       if (vin != null && vin.isNotEmpty) return vin;
     } catch (e, st) {
-      debugPrint('OBD2 VIN read for cache key failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 VIN read for cache key failed'}));
     }
     return _vehicleFallbackKey;
   }
@@ -133,7 +136,7 @@ class SupportedPidsResolver {
         final nextRangeFlag = groupBase + 32;
         if (!bitmap.contains(nextRangeFlag)) break;
       } catch (e, st) {
-        debugPrint('OBD2 discoverSupportedPids failed on $command: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'OBD2 discoverSupportedPids failed on $command'}));
         break;
       }
     }

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -29,6 +29,7 @@ import 'trip_drop_detector.dart';
 import 'trip_live_reading.dart';
 import 'trip_sample_buffer.dart';
 import 'virtual_odometer.dart';
+import '../../../../core/logging/error_logger.dart';
 
 // Re-export the DTO + distance-source constants so existing callers
 // (providers, widget tests) that import this file keep working after
@@ -1172,7 +1173,7 @@ class TripRecordingController {
     try {
       await scanner.stop();
     } catch (e, st) {
-      debugPrint('TripRecordingController stop reconnect scanner: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController stop reconnect scanner'}));
     }
   }
 
@@ -1217,7 +1218,7 @@ class TripRecordingController {
           summary: summary,
         ));
       } catch (e, st) {
-        debugPrint('TripRecordingController grace finalise failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController grace finalise failed'}));
       }
     }
     if (repo != null && id != null) {
@@ -1239,7 +1240,7 @@ class TripRecordingController {
         box: Hive.box<String>(HiveBoxes.obd2PausedTrips),
       );
     } catch (e, st) {
-      debugPrint('TripRecordingController paused repo: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController paused repo'}));
       return null;
     }
   }
@@ -1253,7 +1254,7 @@ class TripRecordingController {
         box: Hive.box<String>(TripHistoryRepository.boxName),
       );
     } catch (e, st) {
-      debugPrint('TripRecordingController history repo: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController history repo'}));
       return null;
     }
   }
@@ -1272,7 +1273,7 @@ class TripRecordingController {
       final raw = await _service.sendCommand(Elm327Protocol.vinCommand);
       return Elm327Protocol.parseVin(raw);
     } catch (e, st) {
-      debugPrint('TripRecordingController VIN read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController VIN read failed'}));
       return null;
     }
   }

--- a/lib/features/consumption/data/receipt_override_registry.dart
+++ b/lib/features/consumption/data/receipt_override_registry.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Per-field regex override for a single receipt layout.
 ///
@@ -163,7 +166,7 @@ class ReceiptOverrideRegistry {
       // with no overrides rather than crashing when the catalogue has
       // not been shipped in a given build — the same pattern
       // `CommunityConfig.load()` uses for `tanksync_config.json`.
-      debugPrint('ReceiptOverrideRegistry: asset load failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ReceiptOverrideRegistry: asset load failed'}));
       return;
     }
 

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -10,6 +12,7 @@ import 'package:image_picker/image_picker.dart';
 
 import 'pump_display_parser.dart';
 import 'receipt_parser.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// Outcome of a single receipt capture: parsed fields plus the source
 /// OCR text and the path to the captured JPEG on disk. The caller is
@@ -169,7 +172,7 @@ class ReceiptScanService {
       debugPrint('OCR text (${text.length} chars):\n$text');
       return text;
     } catch (e, st) {
-      debugPrint('OCR scan failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OCR scan failed'}));
       return null;
     } finally {
       if (uprightTemp != null) await _tryDelete(uprightTemp);
@@ -198,7 +201,7 @@ class ReceiptScanService {
       await File(tempPath).writeAsBytes(upright);
       return tempPath;
     } catch (e, st) {
-      debugPrint('OCR orientation-bake failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OCR orientation-bake failed'}));
       return null;
     }
   }
@@ -207,7 +210,7 @@ class ReceiptScanService {
     try {
       await File(path).delete();
     } catch (e, st) {
-      debugPrint('OCR temp-file cleanup failed at $path: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'OCR temp-file cleanup failed at $path'}));
     }
   }
 
@@ -242,7 +245,7 @@ Uint8List? bakeImageOrientation(Uint8List jpegBytes) {
     return img.encodeJpg(upright, quality: 90);
   } catch (e, st) {
     // A malformed / non-JPEG file is not fatal — OCR the original.
-    debugPrint('bakeImageOrientation: decode failed: $e\n$st');
+    unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'bakeImageOrientation: decode failed'}));
     return null;
   }
 }
@@ -278,7 +281,7 @@ Uint8List? preprocessPumpDisplayForOcr(Uint8List jpegBytes) {
     return img.encodeJpg(boosted, quality: 90);
   } catch (e, st) {
     // A malformed / non-JPEG file is not fatal — OCR the original.
-    debugPrint('preprocessPumpDisplayForOcr: decode failed: $e\n$st');
+    unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'preprocessPumpDisplayForOcr: decode failed'}));
     return null;
   }
 }

--- a/lib/features/consumption/data/repositories/fill_up_repository.dart
+++ b/lib/features/consumption/data/repositories/fill_up_repository.dart
@@ -1,12 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 
 import '../../../../core/data/storage_repository.dart';
 import '../../../../core/storage/hive_boxes.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../domain/entities/fill_up.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Repository for CRUD operations on [FillUp] records.
 ///
@@ -33,7 +35,7 @@ class FillUpRepository {
       try {
         result.add(FillUp.fromJson(map));
       } catch (e, st) {
-        debugPrint('FillUpRepository: skipping malformed entry: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'FillUpRepository: skipping malformed entry'}));
       }
     }
     result.sort((a, b) => b.date.compareTo(a.date));

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -9,6 +9,7 @@ import 'package:hive/hive.dart';
 
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/trip_recorder.dart';
+import '../../../core/logging/error_logger.dart';
 
 /// One finalised trip as shown in the Trip history list (#726).
 ///
@@ -329,7 +330,7 @@ class TripHistoryRepository {
     try {
       await _box.put(entry.id, jsonEncode(entry.toJson()));
     } catch (e, st) {
-      debugPrint('TripHistoryRepository.save: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripHistoryRepository.save'}));
       return;
     }
     await _trim();
@@ -345,7 +346,7 @@ class TripHistoryRepository {
       try {
         hook(vehicleId);
       } catch (e, st) {
-        debugPrint('TripHistoryRepository.save onSavedHook: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripHistoryRepository.save onSavedHook'}));
       }
     }
   }
@@ -362,7 +363,7 @@ class TripHistoryRepository {
         final json = (jsonDecode(raw) as Map).cast<String, dynamic>();
         result.add(TripHistoryEntry.fromJson(json));
       } catch (e, st) {
-        debugPrint('TripHistoryRepository.loadAll: skipping $key: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'TripHistoryRepository.loadAll: skipping $key'}));
       }
     }
     result.sort((a, b) {

--- a/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_charging_log_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -13,6 +15,7 @@ import '../../domain/charging_log_readout.dart';
 import '../../domain/charging_log_validators.dart';
 import '../../providers/charging_logs_provider.dart';
 import '../widgets/charging_log_form_fields.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Form to add a new [ChargingLog] entry (#582 phase 2).
 ///
@@ -104,7 +107,7 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     try {
       activeId = ref.read(activeVehicleProfileProvider)?.id;
     } catch (e, st) {
-      debugPrint('AddChargingLog: active vehicle unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddChargingLog: active vehicle unavailable'}));
     }
     final evVehicles =
         vehicles.where((v) => v.isEv).toList(growable: false);
@@ -162,7 +165,7 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
       if (!mounted) return;
       Navigator.of(context).pop(true);
     } catch (e, st) {
-      debugPrint('AddChargingLog._save: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddChargingLog._save'}));
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -175,7 +178,7 @@ class _AddChargingLogScreenState extends ConsumerState<AddChargingLogScreen> {
     try {
       vehicles = ref.watch(vehicleProfileListProvider);
     } catch (e, st) {
-      debugPrint('AddChargingLog build: vehicle list unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddChargingLog build: vehicle list unavailable'}));
       vehicles = const [];
     }
     _initVehicleIfNeeded(vehicles);

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -29,6 +31,7 @@ import '../widgets/fill_up_pinned_save_bar.dart';
 import '../widgets/fill_up_scan_handlers.dart';
 import '../widgets/fill_up_variance_prompt.dart';
 import 'pump_display_camera_screen.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Form to add a new [FillUp] entry.
 class AddFillUpScreen extends ConsumerStatefulWidget {
@@ -152,7 +155,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     try {
       return ref.read(currentObd2FuelLevelLitresProvider);
     } catch (e, st) {
-      debugPrint('AddFillUp: OBD2 fuel-level read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddFillUp: OBD2 fuel-level read failed'}));
       return null;
     }
   }
@@ -176,13 +179,13 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       defaultId = profile?.defaultVehicleId;
       profilePreferred = profile?.preferredFuelType;
     } catch (e, st) {
-      debugPrint('AddFillUp: active profile unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddFillUp: active profile unavailable'}));
     }
     String? activeId;
     try {
       activeId = ref.read(activeVehicleProfileProvider)?.id;
     } catch (e, st) {
-      debugPrint('AddFillUp: active vehicle unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddFillUp: active vehicle unavailable'}));
     }
     _vehicleId = AddFillUpFuelResolver.pickInitialVehicleId(
       vehicles: vehicles,
@@ -374,7 +377,7 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     try {
       vehicles = ref.watch(vehicleProfileListProvider);
     } catch (e, st) {
-      debugPrint('AddFillUp build: vehicle list unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'AddFillUp build: vehicle list unavailable'}));
       vehicles = const [];
     }
     _initVehicleIfNeeded(vehicles);

--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/fuel_tab.dart';
 import '../widgets/obd2_status_chip.dart';
 import '../widgets/trajets_tab.dart';
 import 'add_charging_log_screen.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Which slice of the consumption feature a [ConsumptionScreen] renders.
 ///
@@ -150,7 +151,7 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
           : (l?.exportBackupReady ?? 'Backup ready — pick a destination');
       SnackBarHelper.showSuccess(context, message);
     } catch (e, st) {
-      debugPrint('ConsumptionScreen._runBackupExport failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'ConsumptionScreen._runBackupExport failed'}));
       if (!mounted) return;
       SnackBarHelper.showError(
         context,

--- a/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/pick_station_for_fill_up_screen.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +12,7 @@ import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/station.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Station-first entry point for the fill-up form (#715).
 ///
@@ -38,7 +41,7 @@ class PickStationForFillUpScreen extends ConsumerWidget {
       try {
         stations.add(Station.fromJson(raw));
       } catch (e, st) {
-        debugPrint('PickStationForFillUp: skipping malformed favorite $id: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: {'where': 'PickStationForFillUp: skipping malformed favorite $id'}));
       }
     }
     final profileFuel =

--- a/lib/features/consumption/presentation/screens/pump_display_camera_screen.dart
+++ b/lib/features/consumption/presentation/screens/pump_display_camera_screen.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../l10n/app_localizations.dart';
 import '../widgets/pump_display_reticle.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Full-screen in-app camera for capturing a pump display (#1868).
 ///
@@ -103,14 +106,14 @@ class _PumpDisplayCameraScreenState extends State<PumpDisplayCameraScreen>
       final denied = e.code == 'CameraAccessDenied' ||
           e.code == 'CameraAccessDeniedWithoutPrompt' ||
           e.code == 'CameraAccessRestricted';
-      debugPrint('PumpDisplayCameraScreen: camera setup failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'PumpDisplayCameraScreen: camera setup failed'}));
       setState(() {
         _initializing = false;
         _permissionDenied = denied;
         _failed = !denied;
       });
     } catch (e, st) {
-      debugPrint('PumpDisplayCameraScreen: camera unavailable: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'PumpDisplayCameraScreen: camera unavailable'}));
       if (mounted) {
         setState(() {
           _initializing = false;

--- a/lib/features/consumption/presentation/screens/trajets_map_screen.dart
+++ b/lib/features/consumption/presentation/screens/trajets_map_screen.dart
@@ -18,6 +18,7 @@ import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/exporters/gpx_exporter.dart';
 import '../../data/trip_history_repository.dart';
 import '../../providers/trip_history_provider.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Test seam: replace the OS share sheet hand-off with a callback that
 /// captures the outgoing payload (#2030). Lets widget tests assert on
@@ -144,7 +145,7 @@ class TrajetsMapScreen extends ConsumerWidget {
       final ok = l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
       messenger.showSnackBar(SnackBar(content: Text(ok)));
     } catch (e, st) {
-      debugPrint('TrajetsMapScreen save GPX: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TrajetsMapScreen save GPX'}));
       if (messenger == null) return;
       final errorMsg =
           l?.trajetsMapShareError ?? "Couldn't save the GPX file";

--- a/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -11,6 +13,7 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/exporters/gpx_exporter.dart';
 import '../../data/trip_history_repository.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Test-only override for the GPX save sink (#2032). Originally named
 /// `*ShareOverride` when this path used the OS share sheet; preserved
@@ -63,7 +66,7 @@ Future<void> shareTripGpx(
         l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
     messenger.showSnackBar(SnackBar(content: Text(ok)));
   } catch (e, st) {
-    debugPrint('TripDetailScreen save GPX: $e\n$st');
+    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen save GPX'}));
     if (messenger == null) return;
     final errorMsg = l?.trajetDetailShareError ?? "Couldn't save the GPX file";
     messenger.showSnackBar(SnackBarHelper.errorSnackBar(scheme, errorMsg));

--- a/lib/features/consumption/presentation/screens/trip_detail_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_screen.dart
@@ -23,6 +23,7 @@ import '../widgets/trip_detail_body.dart';
 import '../widgets/trip_detail_charts.dart';
 import 'trip_detail_gpx_share.dart';
 import 'trip_detail_sample_converter.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Test-only override for the lazy fetcher (#1541 phase 4). Lets the
 /// trip-detail widget test inject a fake fetch result without spinning
@@ -254,7 +255,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         if (!mounted) return;
         await ref.read(tripHistoryListProvider.notifier).save(hydrated);
       } catch (e, st) {
-        debugPrint('TripDetailScreen lazy-fetch: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen lazy-fetch'}));
       }
     });
   }
@@ -276,7 +277,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         // waiting for a route change.
         await ref.read(autoRecordBadgeCountProvider.notifier).refresh();
       } catch (e, st) {
-        debugPrint('TripDetailScreen badge decrement: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen badge decrement'}));
       }
     });
   }
@@ -309,7 +310,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       // Surface the failure to the user instead of silently swallowing
       // it — the snackbar tells them the share didn't go through, and
       // the debugPrint keeps the cause in `flutter logs` for support.
-      debugPrint('TripDetailScreen share image: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen share image'}));
       if (messenger == null) return;
       final errorMsg = l?.trajetDetailShareError ??
           "Couldn't generate share image";

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -29,6 +29,7 @@ import '../../providers/wakelock_facade.dart';
 import '../widgets/broken_map_widgets.dart';
 import '../widgets/minimal_drive_summary.dart';
 import '../widgets/obd2_breadcrumb_overlay.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Result returned when the user confirms saving a recorded trip
 /// from the summary screen (#726, #1185).
@@ -830,8 +831,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     } catch (e, st) {
       // A malformed fill-up set must not crash the summary card —
       // but log the cause rather than hiding it silently (#1682).
-      debugPrint(
-          'TripRecordingScreen: consumption summary calc failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripRecordingScreen: consumption summary calc failed'}));
       return null;
     }
   }

--- a/lib/features/consumption/presentation/widgets/bad_scan_report_sheet.dart
+++ b/lib/features/consumption/presentation/widgets/bad_scan_report_sheet.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -18,6 +20,7 @@ import '../../data/receipt_scan_service.dart';
 import 'bad_scan_form_view.dart';
 import 'bad_scan_issue_created_surface.dart';
 import 'bad_scan_report_formatters.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Test seams: widget tests substitute these for the real
 /// platform-channel / secure-storage backed implementations.
@@ -218,12 +221,12 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
       if (!mounted) return;
       setState(() => _createdIssueUrl = url);
     } on GithubReporterException catch (e, st) {
-      debugPrint('BadScanReportSheet: GitHub submission failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: GitHub submission failed'}));
       await _runShareFallback(showSnackbar: true);
     } catch (e, st) {
       // Secure-storage / image-read / unexpected errors — still fall
       // back so the user can always ship a report.
-      debugPrint('BadScanReportSheet: unexpected failure: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: unexpected failure'}));
       await _runShareFallback(showSnackbar: true);
     } finally {
       if (mounted) setState(() => _submitting = false);
@@ -267,7 +270,7 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     try {
       await share(params);
     } catch (e, st) {
-      debugPrint('BadScanReportSheet: share fallback itself failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: share fallback itself failed'}));
     }
   }
 
@@ -278,7 +281,7 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     try {
       await launcher(url);
     } catch (e, st) {
-      debugPrint('BadScanReportSheet: launchUrl failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: launchUrl failed'}));
     }
   }
 
@@ -286,7 +289,7 @@ class _BadScanReportSheetState extends ConsumerState<BadScanReportSheet> {
     try {
       return await File(path).readAsBytes();
     } catch (e, st) {
-      debugPrint('BadScanReportSheet: could not read scan image: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'BadScanReportSheet: could not read scan image'}));
       return Uint8List(0);
     }
   }

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -15,6 +15,7 @@ import '../../data/obd2/obd2_connection_errors.dart';
 import '../../data/obd2/obd2_connection_service.dart';
 import '../../data/obd2/obd2_service.dart';
 import '../obd2_connection_error_l10n.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Modal bottom sheet that drives the full scan → pick → connect flow
 /// (#743). Caller opens it with [showObd2AdapterPicker]; the future
@@ -54,7 +55,7 @@ Future<Obd2Service?> showObd2AdapterPicker(
       // Real connect failure (permission denied, init timeout). Drop
       // through to the sheet so the user can pick another adapter;
       // the snackbar surfaces the mishap.
-      debugPrint('showObd2AdapterPicker pinned connect failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'showObd2AdapterPicker pinned connect failed'}));
     }
     if (service != null) {
       return service;

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -17,6 +19,7 @@ import '../../data/obd2/obd2_diagnostic_report.dart';
 import '../../providers/obd2_breadcrumb_provider.dart';
 import 'broken_map_widgets.dart';
 import 'obd2_breadcrumb_row.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Hook for the share-sheet handoff of the OBD2 diagnostic log
 /// (#1920). Production uses `SharePlus.instance.share`; tests
@@ -75,7 +78,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       try {
         await sink(ShareParams(text: report));
       } catch (e, st) {
-        debugPrint('Obd2BreadcrumbOverlay diagnostic log sink: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay diagnostic log sink'}));
       }
     }
     await _alsoSaveToDownloads(
@@ -107,7 +110,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
       try {
         await sink(ShareParams(text: payload));
       } catch (e, st) {
-        debugPrint('Obd2BreadcrumbOverlay session XML sink: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay session XML sink'}));
       }
     }
     await _alsoSaveToDownloads(
@@ -143,7 +146,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
         ),
       );
     } on Object catch (e, st) {
-      debugPrint('Obd2BreadcrumbOverlay save-to-downloads failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay save-to-downloads failed'}));
     }
   }
 
@@ -159,7 +162,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     try {
       flag = ref.watch(obd2DebugOverlayProvider);
     } catch (e, st) {
-      debugPrint('Obd2BreadcrumbOverlay flag read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay flag read failed'}));
       flag = false;
     }
     final visible = kDebugMode || flag;
@@ -169,7 +172,7 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
     try {
       crumbs = ref.watch(obd2BreadcrumbsProvider);
     } catch (e, st) {
-      debugPrint('Obd2BreadcrumbOverlay crumbs read failed: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Obd2BreadcrumbOverlay crumbs read failed'}));
       crumbs = const [];
     }
     final l10n = AppLocalizations.of(context);

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -25,6 +27,7 @@ import 'monthly_insights_card.dart';
 import 'obd2_adapter_picker.dart';
 import 'trajet_row.dart';
 import 'trip_start_progress.dart';
+import '../../../../core/logging/error_logger.dart';
 
 /// Trajets tab body on the Consumption screen (#889).
 ///
@@ -129,7 +132,7 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
             context, e.localizedMessage(AppLocalizations.of(context)));
       }
     } catch (e, st) {
-      debugPrint('TrajetsTab._onStartRecording: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TrajetsTab._onStartRecording'}));
     } finally {
       if (mounted) setState(() => _startStage = null);
     }

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -10,6 +12,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/driving_insights_analyzer.dart';
 import 'trip_detail_charts.dart';
+import '../../../../core/logging/error_logger.dart';
 
 // ---------------------------------------------------------------------------
 // Phase 3 thresholds (#1374) — fixed defaults.
@@ -194,7 +197,7 @@ class _TripPathMapState extends State<_TripPathMap> {
           ),
         );
       } catch (e, st) {
-        debugPrint('TripPathMapCard fitCamera failed: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripPathMapCard fitCamera failed'}));
       }
     });
   }

--- a/test/features/consumption/data/exporters/backup/full_backup_exporter_test.dart
+++ b/test/features/consumption/data/exporters/backup/full_backup_exporter_test.dart
@@ -14,8 +14,10 @@ import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import '../../../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
   group('FullBackupExporter (#1317)', () {
     late Directory tempDir;
     late List<ShareParams> captured;

--- a/test/features/consumption/data/obd2/active_trip_recovery_service_test.dart
+++ b/test/features/consumption/data/obd2/active_trip_recovery_service_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/consumption/data/obd2/active_trip_recovery_
 import 'package:tankstellen/features/consumption/data/obd2/active_trip_repository.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Direct unit tests for [ActiveTripRecoveryService] (#1303).
 ///
@@ -28,6 +29,7 @@ import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 ///      after restoreFromSnapshot succeeds, not here),
 ///   7. failures inside loadSnapshot don't crash recovery.
 void main() {
+  silenceErrorLoggerSpool();
   group('ActiveTripRecoveryService (#1303)', () {
     late Directory tmpDir;
     late Box<String> box;

--- a/test/features/consumption/data/obd2/active_trip_repository_test.dart
+++ b/test/features/consumption/data/obd2/active_trip_repository_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/features/consumption/data/obd2/active_trip_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Direct unit tests for [ActiveTripRepository] (#1303).
 ///
@@ -20,6 +21,7 @@ import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 ///   5. the [ActiveTripRepository.isStale] helper agrees with the
 ///      24 h default.
 void main() {
+  silenceErrorLoggerSpool();
   group('ActiveTripRepository (#1303)', () {
     late Directory tmpDir;
     late Box<String> box;

--- a/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
+++ b/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_reconnect_scanner.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Small real-wall-clock delays keep the suite under a few seconds
 /// while still exercising the exponential-backoff math. The scanner
@@ -27,6 +28,7 @@ Future<void> _waitFor(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   group('AdapterReconnectScanner (#797 phase 3)', () {
     test('starts with initialBackoff and doubles on a missed probe',
         () async {

--- a/test/features/consumption/data/obd2/classic_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_elm_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_method_channel.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Captured call to [_FakeObd2ClassicMethodChannel.connect].
 class _ConnectCall {
@@ -69,6 +70,7 @@ class _FakeObd2ClassicMethodChannel extends Obd2ClassicMethodChannel {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   late _FakeObd2ClassicMethodChannel fake;
 
   setUp(() {

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -11,8 +11,10 @@ import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
   final registry = Obd2AdapterRegistry.defaults();
 
   group('Obd2ConnectionService.scan (#741)', () {

--- a/test/features/consumption/data/obd2/obd2_service_connect_retry_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_connect_retry_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Transport that throws on a configurable subset of commands and
 /// returns canned responses on the rest. Used to drive the connect-
@@ -50,6 +51,7 @@ class _FlakyTransport implements Obd2Transport {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   // Pin the retry settle to near-zero so the suite runs in
   // milliseconds — we're verifying the retry happens, not the
   // wall-clock spacing.

--- a/test/features/consumption/data/obd2/obd2_speed_stream_test.dart
+++ b/test/features/consumption/data/obd2/obd2_speed_stream_test.dart
@@ -10,6 +10,7 @@ import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart'
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_speed_stream.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Unit tests for [Obd2SpeedStream] (#1004 phase 2b-3).
 ///
@@ -73,6 +74,7 @@ class _ThrowingTransport implements Obd2Transport {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   const Duration shortPoll = Duration(milliseconds: 5);
   const String mac = 'AA:BB:CC:DD:EE:FF';
 

--- a/test/features/consumption/data/obd2/paused_trip_repository_test.dart
+++ b/test/features/consumption/data/obd2/paused_trip_repository_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/features/consumption/data/obd2/paused_trip_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Direct unit tests for [PausedTripRepository] (Refs #561).
 ///
@@ -16,6 +17,7 @@ import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 /// JSON shape (omits null optional fields), and resilience to corrupt
 /// payloads.
 void main() {
+  silenceErrorLoggerSpool();
   group('PausedTripRepository (#561)', () {
     late Directory tmpDir;
     late Box<String> box;

--- a/test/features/consumption/data/obd2/pid_scheduler_test.dart
+++ b/test/features/consumption/data/obd2/pid_scheduler_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/pid_scheduler.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Helper: build a scheduler wired to a deterministic clock. The returned
 /// `advance` function bumps the clock forward by [d] — use it instead of
@@ -52,6 +53,7 @@ class _FakeTransport {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   group('PidScheduler.pickNextCommand — selection math', () {
     test(
         'picks the PID with the largest (elapsed × hz) when all have '

--- a/test/features/consumption/data/receipt_override_registry_test.dart
+++ b/test/features/consumption/data/receipt_override_registry_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/receipt_override_registry.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// A minimal [AssetBundle] that serves one asset from memory. Used to
 /// exercise [ReceiptOverrideRegistry.load] without depending on
@@ -35,6 +36,7 @@ class _InMemoryBundle extends CachingAssetBundle {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   group('ReceiptOverrideRegistry', () {
     test('fromJsonString — valid map populates entries', () {
       const json = '''

--- a/test/features/consumption/data/receipt_scan_service_test.dart
+++ b/test/features/consumption/data/receipt_scan_service_test.dart
@@ -11,6 +11,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:tankstellen/features/consumption/data/pump_display_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_scan_service.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Unit tests for [ReceiptScanService] — the thin orchestration seam
 /// that glues the camera picker to the on-device OCR recognizer and
@@ -117,6 +118,7 @@ class _TempCapture {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ReceiptScanService.scanReceipt', () {

--- a/test/features/consumption/data/trip_history_repository_test.dart
+++ b/test/features/consumption/data/trip_history_repository_test.dart
@@ -8,8 +8,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tmpDir;

--- a/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
+++ b/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -92,6 +93,7 @@ Future<void> _pumpRecordingScreen(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('TripRecordingScreen pin toggle (#891)', () {

--- a/test/features/consumption/presentation/screens/add_charging_log_screen_test.dart
+++ b/test/features/consumption/presentation/screens/add_charging_log_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/consumption/providers/charging_logs_provide
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -46,6 +47,7 @@ class _PreloadedChargingLogs extends ChargingLogs {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AddChargingLogScreen (#582 phase 2)', () {

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_obd2_capture_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_obd2_capture_test.dart
@@ -15,6 +15,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Widget tests for the OBD2-fuel-level capture wiring on
 /// [AddFillUpScreen] (#1434).
@@ -161,6 +162,7 @@ Future<void> _fillFormAndSave(WidgetTester tester) async {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   group('AddFillUpScreen — OBD2 fuel-level capture (#1434)', () {
     testWidgets(
         'persists the provider value as fuelLevelBeforeL/After when active',

--- a/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_export_test.dart
@@ -14,6 +14,7 @@ import 'package:tankstellen/features/profile/providers/gamification_enabled_prov
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -108,6 +109,7 @@ Future<void> _pumpScreen(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {

--- a/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
+++ b/test/features/consumption/presentation/screens/trip_detail_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:tankstellen/features/consumption/providers/trip_history_provider
 import 'package:tankstellen/features/profile/providers/gamification_enabled_provider.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -168,6 +169,7 @@ Future<({_FixedTripHistoryList tripsNotifier})> _pumpDetail(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const vehicle = VehicleProfile(

--- a/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_degradation_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_degradation_test.dart
@@ -21,6 +21,7 @@ import 'package:tankstellen/features/driving/providers/haptic_eco_coach_provider
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -36,6 +37,7 @@ import '../../../../helpers/pump_app.dart';
 ///     the receipt-derived per-vehicle L/100 km from the fill-up
 ///     history is shown instead. The persistent banner appears.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late StreamController<CoachEvent> events;

--- a/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_broken_map_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/features/driving/haptic_eco_coach.dart';
 import 'package:tankstellen/features/driving/providers/haptic_eco_coach_provider.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -35,6 +36,7 @@ import '../../../../helpers/pump_app.dart';
 ///     0.9 — the snackbar covers the 0.7-0.9 band, the banner covers
 ///     >=0.9.
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late StreamController<CoachEvent> events;

--- a/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/consumption/domain/situation_classifier.dar
 import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -54,6 +55,7 @@ Future<void> _pumpRecordingScreen(WidgetTester tester) async {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('TripRecordingScreen — PageScaffold migration (#923 phase 3m)', () {

--- a/test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_save_test.dart
@@ -10,6 +10,7 @@ import 'package:tankstellen/features/consumption/presentation/screens/add_fill_u
 import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -126,6 +127,7 @@ Future<void> _pumpAndStop(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('TripRecordingScreen save (#1185)', () {

--- a/test/features/consumption/presentation/screens/trip_recording_screen_unpinned_warning_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_unpinned_warning_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/features/consumption/domain/situation_classifier.dar
 import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -73,6 +74,7 @@ class _FakeTripRecording extends TripRecording {
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('TripRecordingScreen unpinned-recording warning (#1458 phase 2)', () {

--- a/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
@@ -16,6 +16,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
 import 'package:tankstellen/features/driving/haptic_eco_coach.dart';
 import 'package:tankstellen/features/driving/providers/haptic_eco_coach_provider.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -128,6 +129,7 @@ Future<void> _pumpRecordingScreen(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('TripRecordingScreen visual eco-coach SnackBar (#1273)', () {

--- a/test/features/consumption/presentation/widgets/bad_scan_report_sheet_test.dart
+++ b/test/features/consumption/presentation/widgets/bad_scan_report_sheet_test.dart
@@ -16,6 +16,7 @@ import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_scan_service.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/bad_scan_report_sheet.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 /// Widget tests for [BadScanReportSheet].
 ///
@@ -23,6 +24,7 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 /// GitHub-ticket submission path — those tests live here and swap the
 /// [githubIssueReporterProvider] with provider overrides.
 void main() {
+  silenceErrorLoggerSpool();
   const outcome = ReceiptScanOutcome(
     parse: ReceiptParseResult(
       liters: 32.5,

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -14,8 +14,10 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/obd2_adapter_picker.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
   group('Obd2AdapterPickerSheet (#743)', () {
     testWidgets('shows the scanning state on open', (tester) async {
       final svc = _buildService(const [[]]);

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -21,6 +21,7 @@ import 'package:tankstellen/features/consumption/providers/trip_history_provider
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import '../../../../helpers/silence_error_logger.dart';
 
 import '../../../../helpers/pump_app.dart';
 
@@ -288,6 +289,7 @@ Future<void> _pumpTab(
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const combustionVehicle = VehicleProfile(


### PR DESCRIPTION
## Summary

Fourth bundle of Epic #2146. With this PR, the **entire \`lib/features/consumption/\`** subsystem (long-running OBD2 + trip recording + fill-up flows) is routed through \`errorLogger.log\`. Combined with bundle 3a (37 catches in \`providers/\`), bundle 3b converts 82 catches in \`data/\` (ErrorLayer.storage) + \`presentation/\` (ErrorLayer.ui).

**Test infra:** 27 affected test files now call \`silenceErrorLoggerSpool()\` (added in 3a) at the top of \`main()\`.

**Cleanups:** 8 'where' values carry \`\$interpolation\` and drop \`const\`; 3 unused \`flutter/foundation.dart\` imports stripped.

## Test plan

- [x] \`flutter analyze\` — 3 pre-existing infos, 0 errors.
- [x] \`flutter test test/features/consumption test/lint\` — 2908 pass.
- [x] Codegen regenerated.

Refs #2146 — remaining: 4 (widget), 5 (setup/feature-mgmt/alerts), 6 (core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)