### PR TITLE
feat(favorites): side-by-side layout in landscape (#2155)

### DIFF
--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -107,38 +107,60 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
       ],
       bodyPadding: EdgeInsets.zero,
       // #1441 — TabSwitcher lives inside the body so the AppBar height
-      // matches the other top-level tabs (Recherche, Carte, Conso,
-      // Paramètres). Keeping the switcher in `bottom:` made the AppBar
-      // visually taller than its siblings.
-      body: Column(
+      // matches the other top-level tabs. #2155 — drop the switcher and
+      // render the two panes side-by-side once the device has the room
+      // (landscape phone OR any width ≥600 dp).
+      body: _buildBody(context, l10n),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, AppLocalizations? l10n) {
+    final media = MediaQuery.of(context);
+    final isLandscape = media.orientation == Orientation.landscape;
+    final isWide = media.size.width >= 600;
+    if (isLandscape || isWide) {
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          TabSwitcher(
-            controller: _tabController,
-            tabs: [
-              TabSwitcherEntry(
-                label: l10n?.favorites ?? 'Favorites',
-                icon: Icons.star_outline,
-              ),
-              TabSwitcherEntry(
-                label: l10n?.priceAlerts ?? 'Price Alerts',
-                icon: Icons.notifications_outlined,
-              ),
-            ],
-          ),
           Expanded(
-            child: TabBarView(
-              controller: _tabController,
-              children: [
-                RepaintBoundary(
-                  key: _shareBoundaryKey,
-                  child: const FavoritesTab(),
-                ),
-                const AlertsTab(),
-              ],
+            child: RepaintBoundary(
+              key: _shareBoundaryKey,
+              child: const FavoritesTab(),
             ),
           ),
+          const VerticalDivider(width: 1, thickness: 1),
+          const Expanded(child: AlertsTab()),
         ],
-      ),
+      );
+    }
+    return Column(
+      children: [
+        TabSwitcher(
+          controller: _tabController,
+          tabs: [
+            TabSwitcherEntry(
+              label: l10n?.favorites ?? 'Favorites',
+              icon: Icons.star_outline,
+            ),
+            TabSwitcherEntry(
+              label: l10n?.priceAlerts ?? 'Price Alerts',
+              icon: Icons.notifications_outlined,
+            ),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              RepaintBoundary(
+                key: _shareBoundaryKey,
+                child: const FavoritesTab(),
+              ),
+              const AlertsTab(),
+            ],
+          ),
+        ),
+      ],
     );
   }
 

--- a/test/accessibility/rtl_layout_test.dart
+++ b/test/accessibility/rtl_layout_test.dart
@@ -387,6 +387,11 @@ void main() {
       List<Object> overrides() {
         final test = standardTestOverrides(favoriteIds: []);
         when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+        // #2155 — the wide-layout path mounts AlertsTab immediately, so
+        // stub the otherwise-unmocked getAlerts() call to avoid the
+        // AsyncValue.error blowing the test.
+        when(() => test.mockStorage.getAlerts())
+            .thenReturn(const <Map<String, dynamic>>[]);
         return [
           ...test.overrides,
           favoriteStationsProvider

--- a/test/app/landing_screen_integration_test.dart
+++ b/test/app/landing_screen_integration_test.dart
@@ -73,6 +73,11 @@ List<Object> _readyAppOverrides({
       .thenReturn(true);
   when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
   when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+  // #2155 — the favorites landing screen mounts AlertsTab immediately
+  // in the wide-layout path; stub getAlerts() so AsyncValue doesn't
+  // error out.
+  when(() => test.mockStorage.getAlerts())
+      .thenReturn(const <Map<String, dynamic>>[]);
   when(() => test.mockStorage.getActiveProfileId()).thenReturn('p1');
   when(() => test.mockStorage.getProfile('p1')).thenReturn({
     'id': 'p1',

--- a/test/features/favorites/presentation/screens/favorites_screen_share_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_share_test.dart
@@ -81,7 +81,13 @@ void main() {
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             locale: Locale('en'),
-            home: FavoritesScreen(),
+            // #2155 — pin to a portrait phone surface so the share
+            // boundary's RepaintBoundary doesn't fight the wide-row
+            // layout (the FavoritesTab pane width drops in half).
+            home: MediaQuery(
+              data: MediaQueryData(size: Size(360, 800)),
+              child: FavoritesScreen(),
+            ),
           ),
         ),
       );

--- a/test/features/favorites/presentation/screens/favorites_screen_tab_icons_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_tab_icons_test.dart
@@ -31,7 +31,12 @@ void main() {
 
         await pumpApp(
           tester,
-          const FavoritesScreen(),
+          // #2155 — pin to a portrait phone surface so the tab-based
+          // layout fires (≥600dp OR landscape → side-by-side).
+          const MediaQuery(
+            data: MediaQueryData(size: Size(360, 800)),
+            child: FavoritesScreen(),
+          ),
           overrides: test.overrides,
         );
 

--- a/test/features/favorites/presentation/screens/favorites_screen_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_test.dart
@@ -15,12 +15,22 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 import '../../../../fixtures/stations.dart';
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+import '../../../../mocks/mocks.dart' show MockStorageRepository;
 
 void main() {
+  // #2155 — the AlertsTab now mounts immediately in the wide-layout
+  // branch (default 800×600 test surface lands there); the previous
+  // tab layout already pre-built it via TabBarView, but the wide-row
+  // path surfaces an unmocked getAlerts() faster. Stub it suite-wide.
+  void stubAlerts(MockStorageRepository m) {
+    when(() => m.getAlerts()).thenReturn(const <Map<String, dynamic>>[]);
+  }
+
   group('FavoritesScreen', () {
     testWidgets('renders Scaffold', (tester) async {
       final test = standardTestOverrides(favoriteIds: []);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      stubAlerts(test.mockStorage);
 
       await pumpApp(
         tester,
@@ -34,6 +44,8 @@ void main() {
     testWidgets('renders app bar with Favorites title', (tester) async {
       final test = standardTestOverrides(favoriteIds: []);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      stubAlerts(test.mockStorage);
 
       await pumpApp(
         tester,
@@ -49,6 +61,8 @@ void main() {
       final test = standardTestOverrides(favoriteIds: []);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
+      stubAlerts(test.mockStorage);
+
       await pumpApp(
         tester,
         const FavoritesScreen(),
@@ -56,16 +70,19 @@ void main() {
       );
 
       // Empty state shows star_outline icon and "No favorites yet" text.
-      // #1163 — the Favoris sub-tab now also renders Icons.star_outline,
-      // so we expect at least 2 occurrences (one in the tab row, one in
-      // the empty-state body) instead of exactly one.
-      expect(find.byIcon(Icons.star_outline), findsAtLeast(2));
+      // #2155 — the default 800×600 test surface now lands in the wide
+      // layout (no tab switcher), so the only star_outline is the
+      // empty-state body icon. The portrait-tab test below pins the
+      // tab-row star case explicitly.
+      expect(find.byIcon(Icons.star_outline), findsOneWidget);
       expect(find.text('No favorites yet'), findsOneWidget);
     });
 
     testWidgets('shows hint text in empty state', (tester) async {
       final test = standardTestOverrides(favoriteIds: []);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      stubAlerts(test.mockStorage);
 
       await pumpApp(
         tester,
@@ -79,14 +96,22 @@ void main() {
       );
     });
 
-    testWidgets('shows tabs for Favorites and Price Alerts',
+    testWidgets(
+        'shows tabs for Favorites and Price Alerts (portrait phone)',
         (tester) async {
       final test = standardTestOverrides(favoriteIds: []);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
 
+      stubAlerts(test.mockStorage);
+
       await pumpApp(
         tester,
-        const FavoritesScreen(),
+        // #2155 — wrap in a portrait-phone-shaped MediaQuery so the
+        // tab layout fires (>=600dp OR landscape → side-by-side).
+        const MediaQuery(
+          data: MediaQueryData(size: Size(360, 800)),
+          child: FavoritesScreen(),
+        ),
         overrides: test.overrides,
       );
 
@@ -95,11 +120,59 @@ void main() {
       expect(find.text('Price Alerts'), findsOneWidget);
     });
 
+    testWidgets(
+        '#2155 landscape phone renders FavoritesTab + AlertsTab '
+        'side-by-side (no TabSwitcher)', (tester) async {
+      final test = standardTestOverrides(favoriteIds: []);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      stubAlerts(test.mockStorage);
+
+      await pumpApp(
+        tester,
+        const MediaQuery(
+          // Landscape phone: 800 x 360 (wide, short).
+          data: MediaQueryData(size: Size(800, 360)),
+          child: FavoritesScreen(),
+        ),
+        overrides: test.overrides,
+      );
+
+      // No tab switcher chip-row in landscape — "Price Alerts" appears
+      // only as the pane title row in AlertsTab, not as a tab label.
+      // The empty-state bodies of both panes should be visible at once.
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      expect(find.text('No favorites yet'), findsOneWidget);
+    });
+
+    testWidgets(
+        '#2155 wide portrait (tablet) also gets the side-by-side layout',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: []);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      stubAlerts(test.mockStorage);
+
+      await pumpApp(
+        tester,
+        const MediaQuery(
+          // Portrait tablet: 800 x 1200 (wide and tall).
+          data: MediaQueryData(size: Size(800, 1200)),
+          child: FavoritesScreen(),
+        ),
+        overrides: test.overrides,
+      );
+
+      expect(find.byType(VerticalDivider), findsOneWidget);
+    });
+
     testWidgets('renders station cards when favorites have data',
         (tester) async {
       final test = standardTestOverrides(
           favoriteIds: [testStation.id]);
       when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      stubAlerts(test.mockStorage);
 
       final result = ServiceResult(
         data: [testStation],


### PR DESCRIPTION
## Summary

On the Favoris tab, **Favoris + Alertes de prix now render side-by-side** when the device has horizontal room — landscape phone, tablet, split-screen, desktop. Portrait phone keeps today's TabSwitcher + TabBarView.

Signal: \`MediaQuery.orientation == landscape\` OR \`size.width >= 600 dp\` (matches the existing \`ScreenSize.medium\` breakpoint in \`responsive_search_layout.dart\`).

The TabController stays alive in both layouts so the active section survives a rotation cleanly. The Share AppBar action's \`RepaintBoundary\` still wraps the FavoritesTab pane in both layouts.

## Test plan

- [x] \`flutter analyze\` — 3 pre-existing infos, 0 errors.
- [x] \`flutter test test/features/favorites test/lint\` — 141 pass.
- [ ] Manual: rotate phone → side-by-side; rotate back → tab switcher; section survives both rotations.

Closes #2155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)