### PR TITLE
fix(widget): refresh URI cold-launch dispatches to refresh notifier (#2159)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -48,6 +48,7 @@ import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
 import '../features/vehicle/data/vehicle_profile_migrator.dart';
 import '../features/vehicle/providers/vehicle_aggregate_updater_provider.dart';
 import '../features/widget/data/home_widget_service.dart';
+import '../features/widget/presentation/widget_uri_parser.dart';
 import '../features/widget/providers/nearest_widget_refresh_provider.dart';
 import '../features/widget/providers/pending_widget_uri_provider.dart';
 import 'router.dart';
@@ -559,9 +560,20 @@ class AppInitializer {
     try {
       final uri = await HomeWidget.initiallyLaunchedFromHomeWidget()
           .timeout(const Duration(milliseconds: 200));
-      if (uri != null) {
-        container.read(pendingWidgetUriProvider.notifier).set(uri);
+      if (uri == null) return;
+      // #2159 — the refresh-button URI is `tankstellenwidget://refresh`,
+      // which `widgetUriToPath` returns `null` for. If we stashed it,
+      // the router redirect would consume it (clear the stash) and
+      // navigate nowhere, leaving the user on the default landing
+      // screen and the widget unrefreshed. Dispatch directly to the
+      // refresh notifier instead — it's a side effect, not a route.
+      if (isWidgetRefreshUri(uri)) {
+        unawaited(
+          container.read(nearestWidgetRefreshProvider.notifier).refresh(),
+        );
+        return;
       }
+      container.read(pendingWidgetUriProvider.notifier).set(uri);
     } on TimeoutException {
       debugPrint(
         'AppInitializer: widget-launch probe timed out at 200 ms — '

--- a/test/app/app_initializer_test.dart
+++ b/test/app/app_initializer_test.dart
@@ -265,6 +265,46 @@ void main() {
       expect(mainSource, isNot(contains('SENTRY_DSN')));
     });
   });
+
+  group('Widget cold-launch URI dispatch (#2159)', () {
+    test(
+        '_stashWidgetLaunchUri intercepts refresh URIs before stashing',
+        () {
+      // #2159 — the refresh-button URI `tankstellenwidget://refresh`
+      // is NOT a route. If we let it flow into pendingWidgetUriProvider
+      // the router redirect consumes it (clears the stash) and
+      // widgetUriToPath returns null, so the user lands on the default
+      // landing screen and the widget never refreshes. The fix is to
+      // discriminate refresh URIs and call the refresh notifier
+      // directly, BEFORE the pending-URI stash.
+      final body = _extractMethodBody(
+          initSource, 'static Future<void> _stashWidgetLaunchUri');
+      expect(body, isNotNull,
+          reason: '_stashWidgetLaunchUri must exist');
+
+      final refreshCheck = body!.indexOf('isWidgetRefreshUri(uri)');
+      final refreshDispatch =
+          body.indexOf('nearestWidgetRefreshProvider.notifier');
+      final stash = body.indexOf('pendingWidgetUriProvider.notifier');
+
+      expect(refreshCheck, isNonNegative,
+          reason: 'must check isWidgetRefreshUri before stashing');
+      expect(refreshDispatch, isNonNegative,
+          reason: 'must dispatch refresh URIs to the refresh notifier');
+      expect(stash, isNonNegative,
+          reason: 'station URIs must still flow through the pending stash');
+
+      expect(refreshCheck, lessThan(stash),
+          reason:
+              'the refresh discriminator must run BEFORE the stash, '
+              'otherwise refresh URIs are consumed by the router redirect '
+              'and silently dropped');
+      expect(refreshDispatch, lessThan(stash),
+          reason:
+              'the refresh dispatch must run BEFORE the stash for the '
+              'same reason');
+    });
+  });
 }
 
 /// Extracts the body of the first method that starts with [signature].


### PR DESCRIPTION
## Summary

- Cold-launch via the widget refresh button (`tankstellenwidget://refresh`) was silently dropped — the URI was stashed in `pendingWidgetUriProvider`, the router redirect cleared it, and `widgetUriToPath` returned `null`, so the app landed on the default screen and the widget never refreshed.
- `AppInitializer._stashWidgetLaunchUri` now intercepts refresh URIs **before** stashing and dispatches directly to `nearestWidgetRefreshProvider.notifier.refresh()`. Station URIs still flow through the existing pending-URI path.
- Warm-tap refresh (already covered by `WidgetLaunchHandler._onRefresh`) and #2157's resume-time fallback are unchanged.

Closes #2159

## Test plan

- [x] `flutter analyze lib/app/app_initializer.dart test/app/app_initializer_test.dart` clean
- [x] Whole-repo `flutter analyze` — no new findings
- [x] `flutter test test/lint/` green
- [x] `flutter test test/app/ test/features/widget/` — 340 / 340 pass
- [x] New regression test pins `_stashWidgetLaunchUri` source-level: `isWidgetRefreshUri` check and `nearestWidgetRefreshProvider` dispatch both run before `pendingWidgetUriProvider.set`
- [ ] Manual: cold-launch the app via the widget's refresh button → row prices update; existing widget row tap still opens station detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)