### PR TITLE
fix(station-detail): drop AppBar title + Hero, fall back brand→name→street (#2161)

### DIFF
--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -58,38 +58,17 @@ class _StationDetails extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        // #595 — Hero flight from the card's brand/name to the detail app
-        // bar title. Text needs Material ancestry mid-flight so wrap in a
-        // transparent Material to avoid "Text requires Material" warnings.
-        Hero(
-          tag: 'station-name-${station.id}',
-          flightShuttleBuilder: (ctx, animation, direction, fromCtx, toCtx) {
-            return Material(
-              type: MaterialType.transparency,
-              child: DefaultTextStyle(
-                style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ) ??
-                    const TextStyle(fontWeight: FontWeight.bold),
-                child: Text(
-                  titleText,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            );
-          },
-          child: Material(
-            type: MaterialType.transparency,
-            child: Text(
-              titleText,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
+        // #2161 — was a Hero flight to the detail-screen title; the
+        // detail screen no longer shows the station name in its AppBar
+        // and no longer animates the title, so the source Hero is
+        // dropped too. Plain Text only.
+        Text(
+          titleText,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
           ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(height: 2),
         Text(

--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
-import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -14,7 +13,6 @@ import '../../../search/domain/entities/station.dart';
 import '../../providers/station_detail_provider.dart';
 import '../widgets/price_history_foldable.dart';
 import '../widgets/station_brand_header.dart';
-import '../widgets/station_brand_helpers.dart';
 import '../widgets/station_detail_app_bar_actions.dart';
 import '../widgets/station_info_section.dart';
 import '../widgets/station_prices_section.dart';
@@ -26,9 +24,14 @@ import '../widgets/station_status_row.dart';
 /// #1539 — the data state uses a `CustomScrollView` + `SliverAppBar`
 /// (pinned, `expandedHeight: 196`) so the rich status-row + brand-header
 /// block collapses out of view on scroll, leaving a 1-row compact bar
-/// (back arrow + station name + cheapest-price chip + actions). Loading
-/// and error states keep a plain fixed `AppBar` since there is no scroll
-/// content to sticky-collapse against.
+/// (back arrow + actions). Loading and error states keep a plain fixed
+/// `AppBar` since there is no scroll content to sticky-collapse against.
+///
+/// #2161 — the AppBar no longer renders the station name or the
+/// cheapest-price chip in its title slot. Both pieces of information
+/// are already prominent in the body (`StationBrandHeader` +
+/// `StationPricesSection`); the truncated `"Péz…"` in the title was
+/// distracting and the Hero fly-in from the search card was noise.
 class StationDetailScreen extends ConsumerWidget {
   final String stationId;
 
@@ -37,31 +40,17 @@ class StationDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final detailAsync = ref.watch(stationDetailProvider(stationId));
-    final l10n = AppLocalizations.of(context);
-
-    // #595 — derive a display title from the loaded station so the Hero
-    // flight from the search card lands on the matching brand/name.
-    // Falls back to the generic "Station" label until data loads.
-    final station = detailAsync.value?.data.station;
-    final appBarTitle = station != null
-        ? (hasRealBrand(station) ? station.brand : station.street)
-        : (l10n?.search ?? 'Station');
 
     return detailAsync.when(
       data: (result) => _StationDetailLoaded(
         stationId: stationId,
         detail: result.data,
         serviceResult: result,
-        appBarTitle: appBarTitle,
       ),
-      loading: () => _StationDetailPlain(
-        stationId: stationId,
-        appBarTitle: appBarTitle,
-        body: const ShimmerStationDetail(),
+      loading: () => const _StationDetailPlain(
+        body: ShimmerStationDetail(),
       ),
       error: (error, _) => _StationDetailPlain(
-        stationId: stationId,
-        appBarTitle: appBarTitle,
         body: ServiceChainErrorWidget(
           error: error,
           onRetry: () => ref.invalidate(stationDetailProvider(stationId)),
@@ -72,24 +61,18 @@ class StationDetailScreen extends ConsumerWidget {
 }
 
 /// Scaffold used by the loading and error states — fixed AppBar via
-/// `PageScaffold` (required by the #923 design-system lint), Hero-tagged
-/// title, back button. No sliver / collapse behaviour.
+/// `PageScaffold` (required by the #923 design-system lint), back
+/// button, no title (#2161). No sliver / collapse behaviour.
 class _StationDetailPlain extends StatelessWidget {
-  final String stationId;
-  final String appBarTitle;
   final Widget body;
 
-  const _StationDetailPlain({
-    required this.stationId,
-    required this.appBarTitle,
-    required this.body,
-  });
+  const _StationDetailPlain({required this.body});
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     return PageScaffold(
-      titleWidget: _HeroTitle(stationId: stationId, title: appBarTitle),
+      title: '',
       leading: IconButton(
         icon: const Icon(Icons.arrow_back),
         onPressed: () => context.pop(),
@@ -109,13 +92,11 @@ class _StationDetailLoaded extends StatelessWidget {
   final String stationId;
   final StationDetail detail;
   final ServiceResult<StationDetail> serviceResult;
-  final String appBarTitle;
 
   const _StationDetailLoaded({
     required this.stationId,
     required this.detail,
     required this.serviceResult,
-    required this.appBarTitle,
   });
 
   @override
@@ -123,7 +104,6 @@ class _StationDetailLoaded extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     final station = detail.station;
     final bottomPadding = MediaQuery.of(context).viewPadding.bottom;
-    final cheapest = _cheapestPrice(station);
 
     return Scaffold(
       body: CustomScrollView(
@@ -137,20 +117,6 @@ class _StationDetailLoaded extends StatelessWidget {
               icon: const Icon(Icons.arrow_back),
               onPressed: () => context.pop(),
               tooltip: l10n?.tooltipBack ?? 'Back',
-            ),
-            title: Row(
-              children: [
-                Flexible(
-                  child: _HeroTitle(
-                    stationId: stationId,
-                    title: appBarTitle,
-                  ),
-                ),
-                if (cheapest != null) ...[
-                  const SizedBox(width: 8),
-                  _CheapestPriceChip(price: cheapest),
-                ],
-              ],
             ),
             actions: [
               StationDetailAppBarActions(
@@ -215,93 +181,3 @@ class _StationDetailLoaded extends StatelessWidget {
   }
 }
 
-/// Hero-flighted station-name text. Wraps the title in the same Hero
-/// tag the search card uses so the brand label appears to fly into the
-/// detail screen header on push. Centralised here so all three states
-/// (loading, error, data) share the same animation source.
-class _HeroTitle extends StatelessWidget {
-  final String stationId;
-  final String title;
-
-  const _HeroTitle({required this.stationId, required this.title});
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      header: true,
-      child: Hero(
-        tag: 'station-name-$stationId',
-        flightShuttleBuilder: (ctx, animation, direction, fromCtx, toCtx) {
-          final theme = Theme.of(ctx);
-          return Material(
-            type: MaterialType.transparency,
-            child: DefaultTextStyle(
-              style: theme.appBarTheme.titleTextStyle ??
-                  theme.textTheme.titleLarge ??
-                  const TextStyle(fontWeight: FontWeight.bold),
-              child: Text(
-                title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          );
-        },
-        child: Material(
-          type: MaterialType.transparency,
-          child: Text(
-            title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Small pill next to the station name showing the cheapest fuel price
-/// at this station. Visible in both the expanded and collapsed
-/// SliverAppBar states so the user keeps a reference to the headline
-/// price after scrolling past the dedicated prices card.
-class _CheapestPriceChip extends StatelessWidget {
-  final double price;
-
-  const _CheapestPriceChip({required this.price});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: Text(
-        PriceFormatter.formatPrice(price),
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: theme.colorScheme.onPrimaryContainer,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-}
-
-/// Lowest non-null fuel price across the station's published fuels.
-/// Returns null when the station reports no prices.
-double? _cheapestPrice(Station s) {
-  final candidates = <double>[
-    if (s.e5 != null && s.e5! > 0) s.e5!,
-    if (s.e10 != null && s.e10! > 0) s.e10!,
-    if (s.diesel != null && s.diesel! > 0) s.diesel!,
-    if (s.dieselPremium != null && s.dieselPremium! > 0) s.dieselPremium!,
-    if (s.e98 != null && s.e98! > 0) s.e98!,
-    if (s.e85 != null && s.e85! > 0) s.e85!,
-    if (s.lpg != null && s.lpg! > 0) s.lpg!,
-    if (s.cng != null && s.cng! > 0) s.cng!,
-  ];
-  if (candidates.isEmpty) return null;
-  return candidates.reduce((a, b) => a < b ? a : b);
-}

--- a/lib/features/station_detail/presentation/widgets/station_brand_header.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_header.dart
@@ -37,10 +37,20 @@ class StationBrandHeader extends StatelessWidget {
         '${station.postCode} ${station.place}'.trim(),
     ].join(', ');
 
+    // #2161 — when the brand is empty/sentinel, fall back to the
+    // station name before the street. Matches the home-widget builder
+    // so a station that displays as "Intermarché" in the widget reads
+    // as "Intermarché" in the detail header too. `headingIsBrandOrName`
+    // tracks whether the heading is the brand/name (and therefore the
+    // address should appear as a subtitle) or the street fallback (in
+    // which case only the postCode + place should appear below).
+    final heading = stationDisplayHeading(station);
+    final headingIsBrandOrName = heading != station.street;
+
     return Semantics(
-      label:
-          '${hasRealBrand(station) ? station.brand : station.street}'
-          '${hasRealBrand(station) && station.brand != station.street ? ', $addressLine' : ''}',
+      label: headingIsBrandOrName && heading != addressLine
+          ? '$heading, $addressLine'
+          : heading,
       header: true,
       excludeSemantics: true,
       child: Row(
@@ -53,17 +63,16 @@ class StationBrandHeader extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  hasRealBrand(station) ? station.brand : station.street,
+                  heading,
                   style: theme.textTheme.headlineSmall?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                if (hasRealBrand(station) && station.brand != station.street)
+                if (headingIsBrandOrName)
                   Text(addressLine, style: theme.textTheme.bodyLarge)
                 else if (addressLine != station.street && addressLine.isNotEmpty)
-                  // Brand IS the street (independent station rendering) —
-                  // still surface postal code + place on a second line so
-                  // the user gets the city without the body Address block.
+                  // Heading IS the street — still surface postal code +
+                  // place on a second line so the user gets the city.
                   Text(
                     '${station.postCode} ${station.place}'.trim(),
                     style: theme.textTheme.bodyLarge,

--- a/lib/features/station_detail/presentation/widgets/station_brand_helpers.dart
+++ b/lib/features/station_detail/presentation/widgets/station_brand_helpers.dart
@@ -24,3 +24,19 @@ bool hasRealBrand(Station s) {
 /// bug (#482).
 bool isIndependentSentinel(Station s) =>
     s.brand == BrandRegistry.independentLabel || s.brand == 'Station';
+
+/// The bold heading shown at the top of the station-detail body.
+///
+/// #2161 — French stations from the official `prix-carburants.gouv.fr`
+/// feed often carry no `brand`, but their `name` is populated (e.g.
+/// `"Intermarché"` arrives via `Station.name`, not `Station.brand`).
+/// The home-screen widget already shows the name in that case
+/// (`nearest_widget_data_builder` line 279 has the same fallback) —
+/// the detail header has to match, otherwise a widget cold-launch
+/// renders the street in bold and the name disappears.
+String stationDisplayHeading(Station s) {
+  if (hasRealBrand(s)) return s.brand;
+  final name = s.name.trim();
+  if (name.isNotEmpty) return name;
+  return s.street;
+}

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -721,8 +721,11 @@ void main() {
       });
     });
 
-    group('micro-animations (#595)', () {
-      testWidgets('brand/name title is wrapped in a Hero with the station id',
+    group('micro-animations (#595 — reverted by #2161)', () {
+      testWidgets(
+          '#2161 brand/name title is NOT a Hero anymore — the detail '
+          'screen dropped the matching destination, so the card no '
+          'longer needs to animate into it',
           (tester) async {
         await pumpApp(
           tester,
@@ -735,12 +738,10 @@ void main() {
         final heroes = find.byType(Hero);
         final matching = heroes.evaluate().where((element) {
           final widget = element.widget as Hero;
-          return widget.tag ==
-              'station-name-51d4b477-a095-1aa0-e100-80009459e03a';
+          return widget.tag.toString().startsWith('station-name-');
         });
-        expect(matching, isNotEmpty,
-            reason: 'Station card title must be a Hero so the text flies '
-                'to the detail app bar on push.');
+        expect(matching, isEmpty,
+            reason: 'StationCard title Hero source must be gone (#2161)');
       });
 
       testWidgets('favorite star is rendered via AnimatedFavoriteStar',

--- a/test/features/station_detail/presentation/screens/station_detail_screen_test.dart
+++ b/test/features/station_detail/presentation/screens/station_detail_screen_test.dart
@@ -59,9 +59,9 @@ void main() {
         ],
       );
 
-      // The brand 'STAR' should be displayed — once in the app bar hero
-      // target (#595) and once in the body content row.
-      expect(find.text('STAR'), findsNWidgets(2));
+      // #2161 — the AppBar title slot no longer carries the brand, so
+      // 'STAR' renders exactly once, in the body brand-header block.
+      expect(find.text('STAR'), findsOneWidget);
     });
 
     testWidgets('renders price tiles for fuel types', (tester) async {
@@ -240,7 +240,8 @@ void main() {
     });
 
     testWidgets(
-        '#595: app bar title is wrapped in a Hero with the matching tag',
+        '#2161: app bar has NO station-name Hero and NO cheapest-price chip — '
+        'just back arrow + actions',
         (tester) async {
       final result = ServiceResult(
         data: const StationDetail(station: testStation),
@@ -263,15 +264,18 @@ void main() {
         ],
       );
 
+      // No Hero with the station-name tag — the title fly-in is gone
+      // (#595 reversed by #2161). Other Heroes on the screen (e.g. FAB)
+      // are unaffected, so we just check that none carry the
+      // station-name-* tag.
       final heroes = find.byType(Hero);
       final matching = heroes.evaluate().where((element) {
         final widget = element.widget as Hero;
-        return widget.tag ==
-            'station-name-51d4b477-a095-1aa0-e100-80009459e03a';
+        return widget.tag.toString().startsWith('station-name-');
       });
-      expect(matching, isNotEmpty,
-          reason: 'Detail screen must expose a matching hero tag so the '
-              'station card title can fly to the app bar on push.');
+      expect(matching, isEmpty,
+          reason: 'detail screen must NOT carry a station-name Hero '
+              '(#2161 — animation removed)');
     });
 
     testWidgets(

--- a/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
+++ b/test/features/station_detail/presentation/widgets/station_brand_header_test.dart
@@ -50,10 +50,59 @@ void main() {
         const StationBrandHeader(station: independent),
       );
 
-      // Independent stations fall back to street as headline and expose
-      // the localised "Independent station" subtitle.
-      expect(find.text('Some Street'), findsOneWidget);
+      // #2161 — when brand is the independent sentinel but `name` is
+      // populated, the name takes over the headline (the widget builder
+      // already does this — the detail header now matches). The
+      // localised "Independent station" subtitle still appears.
+      expect(find.text('Independent'), findsOneWidget);
       expect(find.text('Independent station'), findsOneWidget);
+    });
+
+    testWidgets(
+        '#2161 brand-empty + name-populated → name is the headline '
+        '(matches widget builder; widget cold-launch no longer renders '
+        'the street in bold)', (tester) async {
+      const fromWidget = Station(
+        id: 'fr-12345',
+        name: 'Intermarché',
+        brand: '',
+        street: 'Route St Thibéry',
+        postCode: '34550',
+        place: 'Bessan',
+        lat: 43.36,
+        lng: 3.40,
+        dist: 7.2,
+        isOpen: true,
+      );
+
+      await pumpApp(tester, const StationBrandHeader(station: fromWidget));
+
+      expect(find.text('Intermarché'), findsOneWidget,
+          reason: 'name must take over the headline when brand is empty');
+      // Subtitle carries the full address line.
+      expect(find.textContaining('Route St Thibéry'), findsAtLeast(1));
+      expect(find.textContaining('34550'), findsAtLeast(1));
+    });
+
+    testWidgets(
+        '#2161 brand-empty + name-empty → street is the headline',
+        (tester) async {
+      const bareStation = Station(
+        id: 'bare',
+        name: '',
+        brand: '',
+        street: 'Only Street',
+        postCode: '00000',
+        place: 'Nowhere',
+        lat: 0,
+        lng: 0,
+        isOpen: true,
+      );
+
+      await pumpApp(tester, const StationBrandHeader(station: bareStation));
+
+      expect(find.text('Only Street'), findsOneWidget,
+          reason: 'street is the last-resort headline');
     });
   });
 }


### PR DESCRIPTION
## Summary

Three closely-related fixes on the station-detail screen, reported in one session:

1. **Title fly-in animation removed.** Drop the `_HeroTitle` on both ends — search card `station_card_status.dart` and detail screen `station_detail_screen.dart`.
2. **AppBar title slot stripped.** No more truncated station name (`"Péz…"`) and no more cheapest-price chip (`"0,899 €"`) in the SliverAppBar title — the body's `StationBrandHeader` + `StationPricesSection` carry both prominently. AppBar is back arrow + actions.
3. **Widget cold-launch — brand-empty stations show the name, not the street.** Add `stationDisplayHeading(s)` helper with the `brand → name → street` fallback chain. Matches the home-widget builder (`nearest_widget_data_builder.dart` line 279), so an Intermarché that displays correctly in the widget now also displays correctly in the detail header.

Closes #2161

## Test plan

- [x] `flutter analyze` — no new findings
- [x] `flutter test test/lint/` green
- [x] `flutter test test/features/station_detail/` — 64 / 64 pass (updated 3 tests: `#595 Hero tag` → `#2161 no Hero`, `STAR findsNWidgets(2)` → `findsOneWidget`, new `#2161 brand-empty → name` + `brand+name-empty → street` cases)
- [x] `flutter test test/features/search/` — `station_card_test #595 Hero` updated to assert the Hero source is gone
- [x] `flutter test test/features/favorites/` `test/features/ev/` `test/accessibility/` green (one flaky Hive-spool race unrelated to this change — passes in isolation)
- [ ] Manual: cold-launch from widget → station detail shows "Intermarché" bold, not "Route St Thibéry"; AppBar is just back arrow + 4 action icons, no title; navigating from search results no longer fly-in animates the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)