### PR TITLE
refactor(quality): reusability/perf/extensibility hardening wave 1 (Epic #2167)

### DIFF
--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../core/storage/storage_providers.dart';
 import '../core/utils/frame_callbacks.dart';
+import '../core/widgets/snackbar_helper.dart';
 import '../features/feature_management/application/feature_flags_provider.dart';
 import '../features/feature_management/domain/conso_mode.dart';
 import '../features/feature_management/domain/consumption_tab_visibility.dart';
@@ -179,13 +180,14 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
       await settings.putSetting(_swipeHintStorageKey, true);
       if (!mounted) return;
       final l10n = AppLocalizations.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(
-          l10n?.swipeBetweenTabsHint ??
-              'Tip: swipe left or right to switch between tabs.',
-        ),
+      // #2173 — route through SnackBarHelper so the liveRegion announce
+      // (#1692) isn't bypassed; plain info, no visual change.
+      SnackBarHelper.show(
+        context,
+        l10n?.swipeBetweenTabsHint ??
+            'Tip: swipe left or right to switch between tabs.',
         duration: const Duration(seconds: 5),
-      ));
+      );
     } catch (e, st) {
       debugPrint('ShellScreen: swipe hint skipped: $e\n$st');
     }
@@ -250,9 +252,7 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
             _currentIndex != kTrajetsBranchIndex) {
           return;
         }
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(tabHiddenNotice)),
-        );
+        SnackBarHelper.show(context, tabHiddenNotice);
         _goToPage(0);
       });
     } else if (showConsumption &&

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -575,12 +575,16 @@ class Countries {
       all.where((c) => c.verified).toList(growable: false);
 
   /// Find country by ISO code.
-  static CountryConfig? byCode(String code) {
-    for (final c in all) {
-      if (c.code == code) return c;
-    }
-    return null;
-  }
+  /// Code → config lookup, built once from [all]. #2184 — byCode is on a
+  /// per-station hot path (currency/locale resolution for favorites and
+  /// cross-border rows), so an O(1) map beats the old linear scan.
+  /// Case-sensitive on the canonical uppercase ISO code, exactly like the
+  /// previous `c.code == code` scan.
+  static final Map<String, CountryConfig> _byCode = {
+    for (final c in all) c.code: c,
+  };
+
+  static CountryConfig? byCode(String code) => _byCode[code];
 
   /// Detect country from system locale.
   static CountryConfig fromLocale(String localeStr) {

--- a/lib/core/services/approach_detector.dart
+++ b/lib/core/services/approach_detector.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 import 'package:geolocator/geolocator.dart';
 
 import '../../features/search/domain/entities/station.dart';
+import '../utils/geo_utils.dart' as geo;
 
 /// State emitted by [ApproachDetector] (#2085 / ADR 0011).
 ///
@@ -182,27 +183,15 @@ class ApproachDetector {
     return Duration(milliseconds: (clamped * 1000).round());
   }
 
-  /// Great-circle distance in metres — same haversine as
-  /// `GpsDrivingFeatures` to keep all geo math in one shape.
+  /// Great-circle distance in metres. Delegates to the shared
+  /// [geo.distanceMeters] so the haversine lives in one place (#2169).
   static double distanceMeters(
     double lat1,
     double lng1,
     double lat2,
     double lng2,
-  ) {
-    const earthR = 6371000.0;
-    final dLat = _toRad(lat2 - lat1);
-    final dLng = _toRad(lng2 - lng1);
-    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
-        math.cos(_toRad(lat1)) *
-            math.cos(_toRad(lat2)) *
-            math.sin(dLng / 2) *
-            math.sin(dLng / 2);
-    final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
-    return earthR * c;
-  }
-
-  static double _toRad(double deg) => deg * math.pi / 180.0;
+  ) =>
+      geo.distanceMeters(lat1, lng1, lat2, lng2);
 
   void _start() {
     _gpsSub = _gps.listen(_onPosition);

--- a/lib/core/utils/geo_utils.dart
+++ b/lib/core/utils/geo_utils.dart
@@ -5,7 +5,18 @@ import 'dart:math';
 
 import 'package:latlong2/latlong.dart';
 
+/// Earth's mean radius in metres (the value the GPS/approach/glide-coach
+/// callers have always used for their metre-precision haversine). Kept as
+/// a named constant so the metre formula has one source (#2169).
+const double earthRadiusMeters = 6371000.0;
+
 /// Haversine distance between two coordinates in kilometers.
+///
+/// Short-circuits a `(0,0)` endpoint to `0` — an unset coordinate is
+/// treated as "no distance" by the station-sorting / search callers.
+/// Callers that need a real distance for a genuine equator/prime-meridian
+/// point (GPS track integration, approach detection) must use
+/// [distanceMeters], which has no such guard.
 double distanceKm(double lat1, double lng1, double lat2, double lng2) {
   if (lat1 == 0 && lng1 == 0) return 0;
   if (lat2 == 0 && lng2 == 0) return 0;
@@ -15,6 +26,21 @@ double distanceKm(double lat1, double lng1, double lat2, double lng2) {
       cos(lat1 * pi / 180) * cos(lat2 * pi / 180) *
       sin(dLng / 2) * sin(dLng / 2);
   return 6371 * 2 * atan2(sqrt(a), sqrt(1 - a));
+}
+
+/// Haversine distance between two coordinates in metres.
+///
+/// Unlike [distanceKm] this does NOT short-circuit `(0,0)` endpoints —
+/// GPS-track and approach callers need a real distance even at the
+/// equator/prime meridian. Uses [earthRadiusMeters]; numerically
+/// identical to the per-feature copies it replaces (#2169).
+double distanceMeters(double lat1, double lng1, double lat2, double lng2) {
+  final dLat = (lat2 - lat1) * pi / 180;
+  final dLng = (lng2 - lng1) * pi / 180;
+  final a = sin(dLat / 2) * sin(dLat / 2) +
+      cos(lat1 * pi / 180) * cos(lat2 * pi / 180) *
+      sin(dLng / 2) * sin(dLng / 2);
+  return earthRadiusMeters * 2 * atan2(sqrt(a), sqrt(1 - a));
 }
 
 /// Computes how far along a polyline a given point is (in km from start).

--- a/lib/core/utils/price_formatter.dart
+++ b/lib/core/utils/price_formatter.dart
@@ -112,20 +112,4 @@ class PriceFormatter {
     // import between price_formatter.dart and unit_formatter.dart.
     return UnitFormatter.formatDistance(distanceKm, countryCode: countryCode);
   }
-
-  /// Get fuel type display name.
-  static String fuelTypeName(String fuelType) {
-    switch (fuelType.toLowerCase()) {
-      case 'e5':
-        return 'Super E5';
-      case 'e10':
-        return 'Super E10';
-      case 'diesel':
-        return 'Diesel';
-      case 'all':
-        return 'Alle';
-      default:
-        return fuelType;
-    }
-  }
 }

--- a/lib/core/utils/price_formatter.dart
+++ b/lib/core/utils/price_formatter.dart
@@ -4,66 +4,42 @@
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 
+import '../country/country_config.dart';
 import 'unit_formatter.dart';
 
 class PriceFormatter {
   PriceFormatter._();
 
-  /// Country code → locale mapping for number formatting.
-  /// Comma-decimal countries (most of Europe) use 'de_DE'.
-  /// Period-decimal countries use 'en_US'.
-  static const _localeMap = <String, String>{
-    'DE': 'de_DE',
-    'FR': 'fr_FR',
-    'AT': 'de_AT',
-    'ES': 'es_ES',
-    'IT': 'it_IT',
-    'PT': 'pt_PT',
-    'BE': 'fr_BE',
-    'LU': 'fr_LU',
-    'DK': 'da_DK',
-    'GB': 'en_GB',
-    'AU': 'en_AU',
-    'MX': 'es_MX',
-    'AR': 'es_AR',
-  };
-
-  /// Currency symbols per country.
-  static const _currencyMap = <String, String>{
-    'DE': '€',
-    'FR': '€',
-    'AT': '€',
-    'ES': '€',
-    'IT': '€',
-    'PT': '€',
-    'BE': '€',
-    'LU': '€',
-    'DK': 'kr',
-    'GB': '£',
-    'AU': '\$',
-    'MX': '\$',
-    'AR': '\$',
-  };
-
-  /// Active country code. Set by the app on country change.
-  static String _activeCountry = 'FR';
+  /// Active country config — the single source of truth for the
+  /// formatting locale and currency symbol. Resolved from
+  /// [CountryConfig] (`locale`, `currencySymbol`) so the formatter can
+  /// never drift from the registry the way the old hand-maintained
+  /// `_localeMap`/`_currencyMap` tables did (#2168). Those tables
+  /// silently omitted SI/KR/CL/RO and fell back to `en_US`/`€`, so a
+  /// Korean profile rendered € instead of ₩.
+  static CountryConfig _activeConfig =
+      Countries.byCode('FR') ?? Countries.germany;
 
   /// ISO code of the country currently set as active. Read-only
   /// from outside; mutate via [setCountry] to keep derived caches
   /// (format objects) in sync.
-  static String get activeCountry => _activeCountry;
+  static String get activeCountry => _activeConfig.code;
+
+  /// The resolved config for the active country. Exposed so
+  /// [UnitFormatter] reads the same locale source instead of keeping
+  /// its own parallel switch.
+  static CountryConfig get activeConfig => _activeConfig;
 
   /// Set the active country for price formatting.
   static void setCountry(String countryCode) {
-    _activeCountry = countryCode.toUpperCase();
+    _activeConfig =
+        Countries.byCode(countryCode.toUpperCase()) ?? Countries.germany;
     _cachedFullFormat = null;
   }
 
-  static String get _locale =>
-      _localeMap[_activeCountry] ?? 'en_US';
+  static String get _locale => _activeConfig.locale;
 
-  static String get currency =>
-      _currencyMap[_activeCountry] ?? '€';
+  static String get currency => _activeConfig.currencySymbol;
 
   // Lazy-initialized formatter that resets when country changes.
   static NumberFormat? _cachedFullFormat;

--- a/lib/core/utils/price_utils.dart
+++ b/lib/core/utils/price_utils.dart
@@ -13,6 +13,33 @@ import 'station_extensions.dart';
 double? priceForFuelType(Station station, FuelType fuelType) =>
     station.priceFor(fuelType);
 
+/// (min, max) price for [fuel] across [stations], for colour-gradient /
+/// price-tier classification. Returns `(0, 0)` when no station has a
+/// usable price.
+///
+/// Single source for the three identical loops that previously lived in
+/// the map layer, the driving map, and the search list (#2182). With
+/// [requirePositive] (default `false`) any non-null price counts — the
+/// map/driving layers' historical behaviour; the search list passes
+/// `true` to exclude zero / sentinel prices from its tiers.
+(double, double) priceRange(
+  Iterable<Station> stations,
+  FuelType fuel, {
+  bool requirePositive = false,
+}) {
+  double minP = double.infinity;
+  double maxP = 0;
+  for (final s in stations) {
+    final p = s.priceFor(fuel);
+    if (p != null && (!requirePositive || p > 0)) {
+      if (p < minP) minP = p;
+      if (p > maxP) maxP = p;
+    }
+  }
+  if (minP == double.infinity) return (0, 0);
+  return (minP, maxP);
+}
+
 /// Compares two stations by price for [fuelType]. Stations without a price sort last.
 int compareByPrice(Station a, Station b, FuelType fuelType) {
   final pa = priceForFuelType(a, fuelType) ?? AppConstants.noPriceSentinel;

--- a/lib/core/utils/price_utils.dart
+++ b/lib/core/utils/price_utils.dart
@@ -7,21 +7,11 @@ import '../../features/search/domain/entities/station.dart';
 import 'station_extensions.dart';
 
 /// Returns the price of the given [fuelType] for [station], or null if unavailable.
-double? priceForFuelType(Station station, FuelType fuelType) {
-  return switch (fuelType) {
-    FuelTypeE5() => station.e5,
-    FuelTypeE10() => station.e10,
-    FuelTypeE98() => station.e98,
-    FuelTypeDiesel() => station.diesel,
-    FuelTypeDieselPremium() => station.dieselPremium,
-    FuelTypeE85() => station.e85,
-    FuelTypeLpg() => station.lpg,
-    FuelTypeCng() => station.cng,
-    FuelTypeHydrogen() => null,
-    FuelTypeElectric() => null,
-    FuelTypeAll() => station.e10 ?? station.e5 ?? station.diesel,
-  };
-}
+///
+/// Delegates to the canonical [StationDisplay.priceFor] extension so the
+/// FuelType→price-field mapping lives in exactly one place (#2170).
+double? priceForFuelType(Station station, FuelType fuelType) =>
+    station.priceFor(fuelType);
 
 /// Compares two stations by price for [fuelType]. Stations without a price sort last.
 int compareByPrice(Station a, Station b, FuelType fuelType) {

--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -114,36 +114,9 @@ class UnitFormatter {
   static String _threeDecimals(double v) =>
       NumberFormat('0.000', _activeLocale).format(v);
 
-  static String get _activeLocale {
-    switch (PriceFormatter.activeCountry) {
-      case 'DE':
-        return 'de_DE';
-      case 'FR':
-        return 'fr_FR';
-      case 'AT':
-        return 'de_AT';
-      case 'ES':
-        return 'es_ES';
-      case 'IT':
-        return 'it_IT';
-      case 'PT':
-        return 'pt_PT';
-      case 'BE':
-        return 'fr_BE';
-      case 'LU':
-        return 'fr_LU';
-      case 'DK':
-        return 'da_DK';
-      case 'GB':
-        return 'en_GB';
-      case 'AU':
-        return 'en_AU';
-      case 'MX':
-        return 'es_MX';
-      case 'AR':
-        return 'es_AR';
-      default:
-        return 'en_US';
-    }
-  }
+  /// The active country's CLDR locale, sourced from the same
+  /// [CountryConfig] SSoT as [PriceFormatter] (#2168). Previously a
+  /// third copy of the country→locale switch that omitted SI/KR/CL/RO
+  /// and fell back to `en_US` (wrong decimal separator for those).
+  static String get _activeLocale => PriceFormatter.activeConfig.locale;
 }

--- a/lib/features/consumption/domain/driving_coaching.dart
+++ b/lib/features/consumption/domain/driving_coaching.dart
@@ -179,6 +179,31 @@ String? formatInstantConsumption(TripLiveReading r) {
 ///
 /// The window is expected to be ~5 seconds of samples (recorder
 /// owns the buffer length, the function is window-agnostic).
+/// Returns the trailing samples whose timestamp is after
+/// `reference - window`, scanning only the last [maxScan] samples so the
+/// per-emit cost is O(window) instead of O(trip) (#2174).
+///
+/// Previously the GPS-only recorder filtered the *entire* trip buffer on
+/// every position fix (`.where(...)` over all samples), making the cost
+/// grow linearly with trip duration. The samples arrive in timestamp
+/// order, so the recent window is a suffix; [maxScan] is far larger than
+/// any few-second window at GPS cadence, so the bounded scan still
+/// captures the full window even if a fix lands mildly out of order
+/// (gpsCoachingHint re-sorts internally regardless).
+List<TripSample> recentSamplesWithin(
+  List<TripSample> samples,
+  Duration window,
+  DateTime reference, {
+  int maxScan = 600,
+}) {
+  final cutoff = reference.subtract(window);
+  final start = samples.length > maxScan ? samples.length - maxScan : 0;
+  return [
+    for (final s in samples.getRange(start, samples.length))
+      if (s.timestamp.isAfter(cutoff)) s,
+  ];
+}
+
 DrivingCoachingHint? gpsCoachingHint(List<TripSample> recent) {
   if (recent.length < 3) return null;
   final sorted = [...recent]..sort((a, b) => a.timestamp.compareTo(b.timestamp));

--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -1,8 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:math' as math;
-
+import '../../../core/utils/geo_utils.dart' as geo;
 import 'trip_recorder.dart';
 
 /// Driving-style aggregate derived from a stream of [TripSample]s
@@ -243,25 +242,12 @@ class GpsDrivingFeatures {
   }
 
   /// Great-circle distance between two WGS-84 coordinates in metres.
-  /// Standard haversine — accurate enough for trajet legs (sub-metre
-  /// over kilometres, plenty for L/100 km estimates).
+  /// Delegates to the shared [geo.distanceMeters] (#2169).
   static double _haversineMeters(
     double lat1,
     double lng1,
     double lat2,
     double lng2,
-  ) {
-    const earthR = 6371000.0; // metres
-    final dLat = _toRad(lat2 - lat1);
-    final dLng = _toRad(lng2 - lng1);
-    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
-        math.cos(_toRad(lat1)) *
-            math.cos(_toRad(lat2)) *
-            math.sin(dLng / 2) *
-            math.sin(dLng / 2);
-    final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
-    return earthR * c;
-  }
-
-  static double _toRad(double deg) => deg * math.pi / 180.0;
+  ) =>
+      geo.distanceMeters(lat1, lng1, lat2, lng2);
 }

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -471,15 +471,15 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       final messenger = ScaffoldMessenger.maybeOf(context);
       if (messenger != null) {
         messenger.hideCurrentSnackBar();
+        // #2173 — plain info through SnackBarHelper (adds liveRegion
+        // announce; Key + duration preserved, no visual change).
         messenger.showSnackBar(
-          SnackBar(
+          SnackBarHelper.infoSnackBar(
+            l?.tripRecordingResumeHintMessage ??
+                'Recording continues in the background. Tap the red '
+                    'banner at the top of any screen to return.',
             key: const Key('tripRecordingResumeHintSnackBar'),
             duration: const Duration(seconds: 5),
-            content: Text(
-              l?.tripRecordingResumeHintMessage ??
-                  'Recording continues in the background. Tap the red '
-                      'banner at the top of any screen to return.',
-            ),
           ),
         );
       }
@@ -525,15 +525,14 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     final messenger = ScaffoldMessenger.maybeOf(context);
     if (messenger == null) return;
     final l = AppLocalizations.of(context);
+    // #2173 — plain info through SnackBarHelper (Key + duration kept).
     messenger.showSnackBar(
-      SnackBar(
+      SnackBarHelper.infoSnackBar(
+        l?.brokenMapSnackbarUnreliable ??
+            'MAP sensor reads incorrectly — fuel readings may be '
+                '50–80% too low. Try a different adapter.',
         key: const Key('brokenMapWarningSnackBar'),
         duration: const Duration(seconds: 8),
-        content: Text(
-          l?.brokenMapSnackbarUnreliable ??
-              'MAP sensor reads incorrectly — fuel readings may be '
-                  '50–80% too low. Try a different adapter.',
-        ),
       ),
     );
   }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -33,7 +33,8 @@ import '../data/obd2/trip_recording_controller.dart';
 import 'obd2_breadcrumb_provider.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/cold_start_baselines.dart';
-import '../domain/driving_coaching.dart' show gpsCoachingHint;
+import '../domain/driving_coaching.dart'
+    show gpsCoachingHint, recentSamplesWithin;
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/gps_driving_features.dart';
 import '../domain/services/gps_fuel_estimator.dart';
@@ -1300,13 +1301,16 @@ class TripRecording extends _$TripRecording {
     _gpsOnlySamples.add(sample);
     recorder.onSample(sample);
     final summary = recorder.buildSummary();
-    // #2058 — compute the GPS coaching hint from the most recent 5 s
-    // of samples on every position emit. Bounded slice so a long
-    // trajet's per-emit cost stays O(window) not O(trajet).
-    final cutoff = sample.timestamp.subtract(const Duration(seconds: 5));
-    final recent = _gpsOnlySamples
-        .where((s) => s.timestamp.isAfter(cutoff))
-        .toList();
+    // #2058/#2174 — GPS coaching hint from the most recent 5 s of
+    // samples on every emit. recentSamplesWithin scans only a bounded
+    // tail so the per-emit cost is O(window), not O(trajet) — the old
+    // `.where` over the whole buffer grew linearly with trip length
+    // (despite a comment claiming O(window)).
+    final recent = recentSamplesWithin(
+      _gpsOnlySamples,
+      const Duration(seconds: 5),
+      sample.timestamp,
+    );
     final coaching = gpsCoachingHint(recent);
     state = state.copyWith(
       phase: TripRecordingPhase.recording,

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'920cf723957f7fe810d5192ef29a5ea55e830b7b';
+String _$tripRecordingHash() => r'8479b9d4927b3457a0f8acb735b449b43017af28';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -15,7 +15,7 @@ import 'driving_marker_builder.dart';
 ///
 /// When [stations] is empty the map falls back to a default Berlin view so
 /// the screen still has a tile background while the search loads.
-class DrivingMapView extends StatelessWidget {
+class DrivingMapView extends StatefulWidget {
   final MapController mapController;
   final List<Station> stations;
   final FuelType selectedFuel;
@@ -34,63 +34,7 @@ class DrivingMapView extends StatelessWidget {
   static const _defaultCenter = LatLng(52.52, 13.405);
 
   @override
-  Widget build(BuildContext context) {
-    if (stations.isEmpty) {
-      return FlutterMap(
-        mapController: mapController,
-        options: const MapOptions(
-          initialCenter: _defaultCenter,
-          initialZoom: 12,
-        ),
-        children: [
-          // #2096 — was a raw TileLayer; routed through the
-          // hardened wrapper.
-          const SparkiloTileLayer(),
-        ],
-      );
-    }
-
-    final center = computeCenter(stations);
-    final priceRange = computePriceRange(stations, selectedFuel);
-
-    final markers = stations.map((station) {
-      return DrivingMarkerBuilder.build(
-        station,
-        selectedFuel,
-        priceRange.$1,
-        priceRange.$2,
-        onTap: () {
-          onInteraction();
-          onMarkerTap(station);
-        },
-      );
-    }).toList();
-
-    return FlutterMap(
-      mapController: mapController,
-      options: MapOptions(
-        initialCenter: center,
-        initialZoom: 13,
-        interactionOptions: const InteractionOptions(
-          flags: InteractiveFlag.drag |
-              InteractiveFlag.flingAnimation |
-              InteractiveFlag.doubleTapZoom,
-        ),
-        onTap: (_, _) => onInteraction(),
-      ),
-      children: [
-        // #2096 — was a raw TileLayer; routed through the hardened
-        // wrapper.
-        const SparkiloTileLayer(),
-        MarkerLayer(markers: markers),
-        const RichAttributionWidget(
-          attributions: [
-            TextSourceAttribution('OpenStreetMap contributors'),
-          ],
-        ),
-      ],
-    );
-  }
+  State<DrivingMapView> createState() => _DrivingMapViewState();
 
   /// Geographic centroid of the given stations.
   static LatLng computeCenter(List<Station> stations) {
@@ -110,4 +54,99 @@ class DrivingMapView extends StatelessWidget {
     FuelType fuel,
   ) =>
       priceRange(stations, fuel);
+}
+
+class _DrivingMapViewState extends State<DrivingMapView> {
+  // #2176 — centroid, price range and the oversized markers are memoised
+  // here and recomputed only when the station list identity or the
+  // selected fuel changes (mirrors StationMapLayers #1774). The driving
+  // screen rebuilds on a 30 s auto-lock setState; without this it
+  // re-ran two O(n) passes + re-allocated every marker each time.
+  LatLng? _center;
+  List<Marker> _markers = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _recompute();
+  }
+
+  @override
+  void didUpdateWidget(DrivingMapView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.stations, widget.stations) ||
+        oldWidget.selectedFuel != widget.selectedFuel) {
+      _recompute();
+    }
+  }
+
+  void _recompute() {
+    final stations = widget.stations;
+    if (stations.isEmpty) {
+      _center = null;
+      _markers = const [];
+      return;
+    }
+    _center = DrivingMapView.computeCenter(stations);
+    final range = DrivingMapView.computePriceRange(stations, widget.selectedFuel);
+    _markers = stations
+        .map(
+          (station) => DrivingMarkerBuilder.build(
+            station,
+            widget.selectedFuel,
+            range.$1,
+            range.$2,
+            // Read the callbacks off `widget` at tap time so a memoised
+            // marker still dispatches to the current handlers.
+            onTap: () {
+              widget.onInteraction();
+              widget.onMarkerTap(station);
+            },
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.stations.isEmpty) {
+      return FlutterMap(
+        mapController: widget.mapController,
+        options: const MapOptions(
+          initialCenter: DrivingMapView._defaultCenter,
+          initialZoom: 12,
+        ),
+        children: const [
+          // #2096 — was a raw TileLayer; routed through the
+          // hardened wrapper.
+          SparkiloTileLayer(),
+        ],
+      );
+    }
+
+    return FlutterMap(
+      mapController: widget.mapController,
+      options: MapOptions(
+        initialCenter: _center!,
+        initialZoom: 13,
+        interactionOptions: const InteractionOptions(
+          flags: InteractiveFlag.drag |
+              InteractiveFlag.flingAnimation |
+              InteractiveFlag.doubleTapZoom,
+        ),
+        onTap: (_, _) => widget.onInteraction(),
+      ),
+      children: [
+        // #2096 — was a raw TileLayer; routed through the hardened
+        // wrapper.
+        const SparkiloTileLayer(),
+        MarkerLayer(markers: _markers),
+        const RichAttributionWidget(
+          attributions: [
+            TextSourceAttribution('OpenStreetMap contributors'),
+          ],
+        ),
+      ],
+    );
+  }
 }

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -103,21 +103,11 @@ class DrivingMapView extends StatelessWidget {
   }
 
   /// (min, max) price for [fuel] across the given stations. Returns (0, 0)
-  /// when no station has a price.
+  /// when no station has a price. Delegates to the shared [priceRange]
+  /// helper (#2182) — accepts any non-null price, as before.
   static (double, double) computePriceRange(
     List<Station> stations,
     FuelType fuel,
-  ) {
-    double minP = double.infinity;
-    double maxP = 0;
-    for (final s in stations) {
-      final p = priceForFuelType(s, fuel);
-      if (p != null) {
-        if (p < minP) minP = p;
-        if (p > maxP) maxP = p;
-      }
-    }
-    if (minP == double.infinity) return (0, 0);
-    return (minP, maxP);
-  }
+  ) =>
+      priceRange(stations, fuel);
 }

--- a/lib/features/ev/presentation/widgets/ev_map_overlay.dart
+++ b/lib/features/ev/presentation/widgets/ev_map_overlay.dart
@@ -18,26 +18,26 @@ import 'ev_marker_widget.dart';
 /// Pulls results from [evStationsProvider], applies the current filter,
 /// and clusters markers independently of fuel-station markers so the two
 /// layers never collide visually.
-class EvMapLayer extends ConsumerWidget {
+class EvMapLayer extends ConsumerStatefulWidget {
   final EvViewport viewport;
 
   const EvMapLayer({super.key, required this.viewport});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final async = ref.watch(evStationsProvider(viewport));
-    return async.when(
-      data: (stations) => _buildLayer(context, stations),
-      loading: () => const SizedBox.shrink(),
-      error: (_, _) => const SizedBox.shrink(),
-    );
-  }
+  ConsumerState<EvMapLayer> createState() => _EvMapLayerState();
+}
 
-  Widget _buildLayer(BuildContext context, List<ChargingStation> stations) {
-    if (stations.isEmpty) return const SizedBox.shrink();
-    final theme = Theme.of(context);
+class _EvMapLayerState extends ConsumerState<EvMapLayer> {
+  // #2175 — the marker list is memoised here and recomputed only when
+  // the station list identity changes, mirroring the fuel layer's #1774
+  // fix. EvMapLayer is rebuilt fresh in NearbyMapView.build on every EV
+  // toggle / search / app-resume, so without this it re-allocated every
+  // Marker + a fresh onTap closure on each host rebuild.
+  List<ChargingStation>? _lastStations;
+  List<Marker> _markers = const [];
 
-    final markers = stations
+  void _recomputeMarkers(List<ChargingStation> stations) {
+    _markers = stations
         .map(
           (s) => EvMarkerWidget.buildMarker(
             s,
@@ -49,6 +49,27 @@ class EvMapLayer extends ConsumerWidget {
           ),
         )
         .toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(evStationsProvider(widget.viewport));
+    return async.when(
+      data: _buildLayer,
+      loading: () => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildLayer(List<ChargingStation> stations) {
+    if (stations.isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+
+    if (!identical(stations, _lastStations)) {
+      _lastStations = stations;
+      _recomputeMarkers(stations);
+    }
+    final markers = _markers;
 
     if (stations.length > 20) {
       return MarkerClusterLayerWidget(

--- a/lib/features/ev/presentation/widgets/ev_marker_widget.dart
+++ b/lib/features/ev/presentation/widgets/ev_marker_widget.dart
@@ -53,27 +53,32 @@ class EvMarkerWidget extends StatelessWidget {
     final color = colorFor(context, station);
     final maxPower = station.maxPowerKw.round();
 
-    return GestureDetector(
-      onTap: onTap,
-      child: Semantics(
-        label: 'EV charging station ${station.name}, $maxPower kW',
-        button: true,
-        child: Container(
-          decoration: BoxDecoration(
-            color: color,
-            shape: BoxShape.circle,
-            border: Border.all(color: Colors.white, width: 2),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.3),
-                blurRadius: 4,
-              ),
-            ],
-          ),
-          child: const Icon(
-            Icons.ev_station,
-            color: Colors.white,
-            size: 24,
+    // #2178 — isolate each marker's raster, matching the fuel marker
+    // (StationMarker). Without it, a repaint of one marker dirties the
+    // whole layer raster when markers cluster/animate.
+    return RepaintBoundary(
+      child: GestureDetector(
+        onTap: onTap,
+        child: Semantics(
+          label: 'EV charging station ${station.name}, $maxPower kW',
+          button: true,
+          child: Container(
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(color: Colors.white, width: 2),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.3),
+                  blurRadius: 4,
+                ),
+              ],
+            ),
+            child: const Icon(
+              Icons.ev_station,
+              color: Colors.white,
+              size: 24,
+            ),
           ),
         ),
       ),

--- a/lib/features/glide_coach/domain/services/imminent_signal_detector.dart
+++ b/lib/features/glide_coach/domain/services/imminent_signal_detector.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../../core/utils/geo_utils.dart' as geo;
 import '../../data/traffic_signal_repository.dart';
 import '../entities/traffic_signal.dart';
 
@@ -28,11 +29,6 @@ const double _kDefaultHorizonMeters = 200.0;
 /// flanks; the forward-cone filter rejects anything spurious that
 /// sneaks in.
 const double _kBboxLateralPaddingMeters = 50.0;
-
-/// Mean Earth radius in metres (WGS-84 sphere approximation). Good to
-/// ~0.5 % at urban distances — well below the resolution that matters
-/// for fuel-coast decisions.
-const double _kEarthRadiusMeters = 6371000.0;
 
 /// Input record for [ImminentSignalDetector] — the minimal GPS shape
 /// the detector needs. Adapter providers (phase 3) will marshal a
@@ -181,22 +177,15 @@ class ImminentSignalDetector {
   }
 
   /// Great-circle distance in metres via the haversine formula.
+  /// Delegates to the shared [geo.distanceMeters] (#2169).
   @visibleForTesting
-  static double distanceMeters(LatLng from, LatLng to) {
-    final lat1 = _degToRad(from.latitude);
-    final lat2 = _degToRad(to.latitude);
-    final deltaLat = _degToRad(to.latitude - from.latitude);
-    final deltaLng = _degToRad(to.longitude - from.longitude);
-
-    final a =
-        math.sin(deltaLat / 2) * math.sin(deltaLat / 2) +
-        math.cos(lat1) *
-            math.cos(lat2) *
-            math.sin(deltaLng / 2) *
-            math.sin(deltaLng / 2);
-    final c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
-    return _kEarthRadiusMeters * c;
-  }
+  static double distanceMeters(LatLng from, LatLng to) =>
+      geo.distanceMeters(
+        from.latitude,
+        from.longitude,
+        to.latitude,
+        to.longitude,
+      );
 
   /// Smallest absolute arc between two bearings in degrees [0, 180].
   /// Wraps correctly at 360°: `bearingDeltaDegrees(355, 5)` is 10, not

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -11,7 +11,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../../../../core/constants/app_constants.dart';
 import '../../data/retry_network_tile_provider.dart';
-import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/utils/price_utils.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import 'price_legend.dart';
@@ -171,20 +171,6 @@ class StationMapLayers extends StatefulWidget {
     return LatLng(sumLat / stations.length, sumLng / stations.length);
   }
 
-  /// Get min/max price range for color gradient.
-  static (double, double) _getPriceRange(List<Station> stations, FuelType fuel) {
-    double minP = double.infinity;
-    double maxP = 0;
-    for (final s in stations) {
-      final p = s.priceFor(fuel);
-      if (p != null) {
-        if (p < minP) minP = p;
-        if (p > maxP) maxP = p;
-      }
-    }
-    if (minP == double.infinity) return (0, 0);
-    return (minP, maxP);
-  }
 }
 
 class _StationMapLayersState extends State<StationMapLayers> {
@@ -240,8 +226,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// Recompute the memoised price range + marker list from the current
   /// widget inputs.
   void _recomputeMarkers() {
-    _priceRange =
-        StationMapLayers._getPriceRange(widget.stations, widget.selectedFuel);
+    _priceRange = priceRange(widget.stations, widget.selectedFuel);
     final ids = widget.selectedStationIds;
     final hasSelection = ids != null && ids.isNotEmpty;
     _markers = widget.stations.map((station) {

--- a/lib/features/price_history/presentation/widgets/price_stats_card.dart
+++ b/lib/features/price_history/presentation/widgets/price_stats_card.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/price_stats.dart';
 
@@ -11,12 +12,10 @@ import '../../domain/entities/price_stats.dart';
 /// a trend indicator arrow.
 class PriceStatsCard extends StatelessWidget {
   final PriceStats stats;
-  final String currencySymbol;
 
   const PriceStatsCard({
     super.key,
     required this.stats,
-    this.currencySymbol = '\u20ac',
   });
 
   @override
@@ -60,10 +59,10 @@ class PriceStatsCard extends StatelessWidget {
     );
   }
 
-  String _formatPrice(double? price) {
-    if (price == null) return '--';
-    return '${price.toStringAsFixed(3)} $currencySymbol';
-  }
+  // #2172 — route through PriceFormatter so the value uses the active
+  // country's locale (decimal separator) and currency symbol instead of
+  // a hardcoded toStringAsFixed(3) + euro-defaulted param.
+  String _formatPrice(double? price) => PriceFormatter.formatPrice(price);
 }
 
 class _StatItem extends StatelessWidget {

--- a/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
@@ -85,8 +85,12 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
     required FuelType fuelType,
     required double segmentKm,
   }) {
-    // Same segment logic as uniform, but with price-first ordering
+    // Same segment logic as uniform, but with price-first ordering.
+    // #2183 — carry the leader's price in a parallel map so the
+    // per-station comparison is O(1) instead of re-scanning `results`
+    // for the current leader (was O(n²)). uniform/balanced already do this.
     final segmentCheapest = <int, String>{};
+    final segmentCheapestPrice = <int, double>{};
 
     for (final item in results) {
       if (item is FuelStationResult) {
@@ -108,18 +112,12 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
 
         final price = station.priceFor(fuelType);
         if (price != null) {
-          final currentBest = segmentCheapest[segmentIdx];
-          if (currentBest == null) {
+          final currentBestPrice = segmentCheapestPrice[segmentIdx];
+          // Strict < keeps first-occurrence-wins on equal prices,
+          // matching the previous behaviour.
+          if (currentBestPrice == null || price < currentBestPrice) {
             segmentCheapest[segmentIdx] = station.id;
-          } else {
-            final currentBestItem = results
-                .whereType<FuelStationResult>()
-                .where((r) => r.id == currentBest)
-                .firstOrNull;
-            final currentBestPrice = currentBestItem?.station.priceFor(fuelType);
-            if (currentBestPrice == null || price < currentBestPrice) {
-              segmentCheapest[segmentIdx] = station.id;
-            }
+            segmentCheapestPrice[segmentIdx] = price;
           }
         }
       }

--- a/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
@@ -228,6 +228,9 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
     required double segmentKm,
   }) {
     final segmentCheapest = <int, String>{};
+    // #2183 — O(1) leader lookup via a parallel price map (was an
+    // O(n²) re-scan of `results`).
+    final segmentCheapestPrice = <int, double>{};
     for (final item in results) {
       if (item is FuelStationResult) {
         final station = item.station;
@@ -248,19 +251,11 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
         final segmentIdx = (nearestSampleIdx * 15 / segmentKm).floor();
         final price = station.priceFor(fuelType);
         if (price != null) {
-          final currentBest = segmentCheapest[segmentIdx];
-          if (currentBest == null) {
+          final currentBestPrice = segmentCheapestPrice[segmentIdx];
+          // Strict < keeps first-occurrence-wins on equal prices.
+          if (currentBestPrice == null || price < currentBestPrice) {
             segmentCheapest[segmentIdx] = station.id;
-          } else {
-            final currentBestItem = results
-                .whereType<FuelStationResult>()
-                .where((r) => r.id == currentBest)
-                .firstOrNull;
-            final currentBestPrice =
-                currentBestItem?.station.priceFor(fuelType);
-            if (currentBestPrice == null || price < currentBestPrice) {
-              segmentCheapest[segmentIdx] = station.id;
-            }
+            segmentCheapestPrice[segmentIdx] = price;
           }
         }
       }

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -8,6 +8,7 @@ import '../../../../app/responsive_search_layout.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_tier.dart';
+import '../../../../core/utils/price_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/services/widgets/freshness_badge.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';

--- a/lib/features/search/presentation/widgets/search_results_list_parts.dart
+++ b/lib/features/search/presentation/widgets/search_results_list_parts.dart
@@ -47,20 +47,11 @@ Map<String, Map<FuelType, bool>> _computeCheapestFlagsFor(
   return result;
 }
 
-/// Get min/max price range for tier classification.
-(double, double) _getPriceRangeFor(List<Station> stations, FuelType fuel) {
-  double minP = double.infinity;
-  double maxP = 0;
-  for (final s in stations) {
-    final p = s.priceFor(fuel);
-    if (p != null && p > 0) {
-      if (p < minP) minP = p;
-      if (p > maxP) maxP = p;
-    }
-  }
-  if (minP == double.infinity) return (0.0, 0.0);
-  return (minP, maxP);
-}
+/// Get min/max price range for tier classification. Delegates to the
+/// shared [priceRange] helper (#2182); the search list excludes
+/// zero/sentinel prices from its tiers, hence `requirePositive: true`.
+(double, double) _getPriceRangeFor(List<Station> stations, FuelType fuel) =>
+    priceRange(stations, fuel, requirePositive: true);
 
 /// Collapsible section that wraps [BrandFilterChips] inside an expandable
 /// toggle. When collapsed, only a "Brands" label with a chevron is shown.

--- a/lib/features/station_services/austria/econtrol_station_service.dart
+++ b/lib/features/station_services/austria/econtrol_station_service.dart
@@ -20,10 +20,16 @@ import '../../../core/logging/error_logger.dart';
 class EControlStationService with StationServiceHelpers implements StationService {
   static const _baseUrl = 'https://api.e-control.at/sprit/1.0';
 
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 10),
-    receiveTimeout: const Duration(seconds: 10),
-  );
+  final Dio _dio;
+
+  /// #2181 — Dio is injectable so tests can assert request shape;
+  /// defaults to the standard factory in production.
+  EControlStationService({Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 10),
+            );
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -22,10 +22,15 @@ import '../../../core/logging/error_logger.dart';
 /// We download all, calculate distances locally, and filter by radius.
 /// Prices are in DKK (Danish Kroner).
 class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin implements StationService {
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 15),
-    receiveTimeout: const Duration(seconds: 15),
-  );
+  final Dio _dio;
+
+  /// #2181 — Dio injectable for tests; defaults to the standard factory.
+  DenmarkStationService({Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 15),
+            );
 
   // In-memory cache
   List<Station>? _cachedStations;

--- a/lib/features/station_services/italy/mise_station_service.dart
+++ b/lib/features/station_services/italy/mise_station_service.dart
@@ -26,11 +26,16 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
   static const _pricesUrl =
       'https://www.mimit.gov.it/images/exportCSV/prezzo_alle_8.csv';
 
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 20),
-    receiveTimeout: const Duration(seconds: 60),
-    responseType: ResponseType.plain,
-  );
+  final Dio _dio;
+
+  /// #2181 — Dio injectable for tests; defaults to the standard factory.
+  MiseStationService({Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 20),
+              receiveTimeout: const Duration(seconds: 60),
+              responseType: ResponseType.plain,
+            );
 
   // In-memory cache of parsed data
   Map<String, _StationData>? _cachedStations;

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -26,10 +26,15 @@ class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implem
       'https://sedeaplicaciones.minetur.gob.es/ServiciosRESTCarburantes'
       '/PreciosCarburantes';
 
-  final Dio _dio = DioFactory.create(
-    connectTimeout: const Duration(seconds: 20),
-    receiveTimeout: const Duration(seconds: 30),
-  );
+  final Dio _dio;
+
+  /// #2181 — Dio injectable for tests; defaults to the standard factory.
+  MitecoStationService({Dio? dio})
+      : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 20),
+              receiveTimeout: const Duration(seconds: 30),
+            );
 
   // Cache the province list and full station data to avoid repeated large downloads
   List<_Province>? _cachedProvinces;

--- a/lib/features/widget/data/nearest_widget_data_builder.dart
+++ b/lib/features/widget/data/nearest_widget_data_builder.dart
@@ -15,6 +15,7 @@ import '../../../core/storage/storage_keys.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/utils/station_extensions.dart';
 import 'predictive_payload.dart';
 import '../../../core/logging/error_logger.dart';
 
@@ -285,7 +286,7 @@ class NearestWidgetDataBuilder {
         )?.currencySymbol ??
         '';
 
-    final price = _priceForFuel(station, fuel);
+    final price = station.priceFor(fuel);
     final priceFormatted =
         price != null ? price.toStringAsFixed(3) : '';
 
@@ -320,20 +321,6 @@ class NearestWidgetDataBuilder {
       'e10': station.e10,
       'diesel': station.diesel,
       if (predictive != null) ...predictive,
-    };
-  }
-
-  static double? _priceForFuel(Station s, FuelType fuel) {
-    return switch (fuel) {
-      FuelTypeE5() => s.e5,
-      FuelTypeE10() => s.e10,
-      FuelTypeE98() => s.e98,
-      FuelTypeDiesel() => s.diesel,
-      FuelTypeDieselPremium() => s.dieselPremium,
-      FuelTypeE85() => s.e85,
-      FuelTypeLpg() => s.lpg,
-      FuelTypeCng() => s.cng,
-      _ => s.e10 ?? s.e5 ?? s.diesel,
     };
   }
 

--- a/test/core/language/language_provider_test.dart
+++ b/test/core/language/language_provider_test.dart
@@ -3,11 +3,32 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/language/language_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 void main() {
   group('AppLanguages.all', () {
-    test('has 23 entries', () {
-      expect(AppLanguages.all.length, equals(23));
+    // #2179 — pin the picker to the locales the app actually ships
+    // instead of a magic count, so adding/removing an ARB locale that
+    // isn't mirrored in AppLanguages.all fails loudly. The en_XA
+    // pseudo-locale (text-expansion harness, #1699) is intentionally
+    // not user-selectable, so it is excluded.
+    test('exactly matches AppLocalizations.supportedLocales (minus en_XA)',
+        () {
+      final shipped = AppLocalizations.supportedLocales
+          .where((l) => l.countryCode != 'XA')
+          .map((l) => l.languageCode)
+          .toSet();
+      final picker = AppLanguages.all.map((l) => l.code).toSet();
+      expect(picker, equals(shipped));
+    });
+
+    test('length equals the shipped locale count (no magic number)', () {
+      final shippedCount = AppLocalizations.supportedLocales
+          .where((l) => l.countryCode != 'XA')
+          .map((l) => l.languageCode)
+          .toSet()
+          .length;
+      expect(AppLanguages.all.length, equals(shippedCount));
     });
 
     test('all codes are unique (no duplicates)', () {

--- a/test/core/utils/geo_utils_test.dart
+++ b/test/core/utils/geo_utils_test.dart
@@ -65,6 +65,33 @@ void main() {
     });
   });
 
+  group('distanceMeters (#2169 — shared metre haversine)', () {
+    test('Berlin to Paris is approximately 878 km', () {
+      final m = distanceMeters(52.5200, 13.4050, 48.8566, 2.3522);
+      expect(m / 1000, closeTo(878, 5));
+    });
+
+    test('agrees with distanceKm * 1000 for a normal pair', () {
+      final m = distanceMeters(52.5200, 13.4050, 48.1351, 11.5820);
+      final km = distanceKm(52.5200, 13.4050, 48.1351, 11.5820);
+      expect(m, closeTo(km * 1000, 1e-6));
+    });
+
+    test('does NOT short-circuit a (0,0) endpoint (unlike distanceKm)', () {
+      // The metre callers (approach/GPS) need a real distance even at
+      // the equator/prime meridian. ~0.009° lng at the equator ≈ 1 km.
+      expect(distanceMeters(0, 0, 0, 0.009), closeTo(1000, 5));
+      // distanceKm would have returned its null-island 0 here.
+      expect(distanceKm(0, 0, 0, 0.009), 0.0);
+    });
+
+    test('symmetry: A-B equals B-A', () {
+      final ab = distanceMeters(52.5200, 13.4050, 48.1351, 11.5820);
+      final ba = distanceMeters(48.1351, 11.5820, 52.5200, 13.4050);
+      expect(ab, closeTo(ba, 1e-6));
+    });
+  });
+
   group('distanceAlongPolyline', () {
     // Simple straight-line polyline: Paris (48.0, 2.0) -> (48.1, 2.1) -> (48.2, 2.2)
     final polyline = [

--- a/test/core/utils/price_formatter_test.dart
+++ b/test/core/utils/price_formatter_test.dart
@@ -63,6 +63,23 @@ void main() {
         PriceFormatter.setCountry('DK');
         expect(PriceFormatter.currency, 'kr');
       });
+
+      // #2168 — these were silently omitted from the old _currencyMap
+      // and fell back to '€'. They now resolve from CountryConfig.
+      test('KRW for South Korea', () {
+        PriceFormatter.setCountry('KR');
+        expect(PriceFormatter.currency, '₩');
+      });
+
+      test('CLP for Chile', () {
+        PriceFormatter.setCountry('CL');
+        expect(PriceFormatter.currency, '\$');
+      });
+
+      test('RON for Romania', () {
+        PriceFormatter.setCountry('RO');
+        expect(PriceFormatter.currency, 'lei');
+      });
     });
 
     group('null and zero handling', () {
@@ -105,7 +122,40 @@ void main() {
 
       test('unknown country defaults to USD-style', () {
         PriceFormatter.setCountry('ZZ');
-        expect(PriceFormatter.currency, '€'); // default
+        expect(PriceFormatter.currency, '€'); // default → Germany
+      });
+    });
+
+    group('CountryConfig SSoT (#2168 — no silent fallback)', () {
+      test('currency symbol matches CountryConfig for every '
+          'registered country', () {
+        for (final c in Countries.all) {
+          PriceFormatter.setCountry(c.code);
+          expect(
+            PriceFormatter.currency,
+            c.currencySymbol,
+            reason: '${c.code} must render its config currencySymbol, '
+                'not a silent fallback',
+          );
+          expect(
+            PriceFormatter.activeConfig.locale,
+            c.locale,
+            reason: '${c.code} must resolve its config locale',
+          );
+        }
+      });
+
+      test('Chile (es_CL) uses comma decimal separator '
+          '(was en_US dot under the old table)', () {
+        PriceFormatter.setCountry('CL');
+        final formatted = PriceFormatter.formatPriceCompact(1.459);
+        expect(formatted, contains(','));
+        expect(formatted, isNot(contains('.')));
+      });
+
+      test('Romania (ro_RO) uses comma decimal separator', () {
+        PriceFormatter.setCountry('RO');
+        expect(PriceFormatter.formatPriceCompact(1.459), contains(','));
       });
     });
   });

--- a/test/core/utils/price_utils_test.dart
+++ b/test/core/utils/price_utils_test.dart
@@ -78,6 +78,39 @@ void main() {
     });
   });
 
+  // #2182 — single source for the three (min,max) price-range loops.
+  group('priceRange', () {
+    test('returns (min, max) across stations', () {
+      final stations = [
+        _makeStation(e10: 1.799),
+        _makeStation(e10: 1.659),
+        _makeStation(e10: 1.899),
+      ];
+      expect(priceRange(stations, FuelType.e10), (1.659, 1.899));
+    });
+
+    test('returns (0, 0) when no station has a price', () {
+      final stations = [_makeStation(), _makeStation()];
+      expect(priceRange(stations, FuelType.e10), (0.0, 0.0));
+    });
+
+    test('default accepts any non-null price incl. zero/negative '
+        '(map/driving behaviour)', () {
+      final stations = [_makeStation(e10: 0.0), _makeStation(e10: 1.5)];
+      // requirePositive defaults false → 0.0 is counted as the min.
+      expect(priceRange(stations, FuelType.e10), (0.0, 1.5));
+    });
+
+    test('requirePositive excludes zero / sentinel prices '
+        '(search-list behaviour)', () {
+      final stations = [_makeStation(e10: 0.0), _makeStation(e10: 1.5)];
+      expect(
+        priceRange(stations, FuelType.e10, requirePositive: true),
+        (1.5, 1.5),
+      );
+    });
+  });
+
   group('priceForFuelType', () {
     test('returns e5 price for FuelType.e5', () {
       final station = _makeStation(e5: 1.659);

--- a/test/core/utils/price_utils_test.dart
+++ b/test/core/utils/price_utils_test.dart
@@ -53,6 +53,31 @@ Station _makeStation({
 }
 
 void main() {
+  // #2170 — priceForFuelType now delegates to Station.priceFor. This
+  // parity test locks the two in lockstep so a new FuelType added to
+  // only one switch can never silently diverge again.
+  group('priceForFuelType ≡ Station.priceFor (single source)', () {
+    test('agrees with the extension for every FuelType value', () {
+      final s = _makeStation(
+        e5: 1.659,
+        e10: 1.599,
+        e98: 1.899,
+        diesel: 1.549,
+        dieselPremium: 1.749,
+        e85: 0.899,
+        lpg: 0.799,
+        cng: 1.199,
+      );
+      for (final ft in FuelType.values) {
+        expect(
+          priceForFuelType(s, ft),
+          equals(s.priceFor(ft)),
+          reason: 'priceForFuelType must delegate to priceFor for $ft',
+        );
+      }
+    });
+  });
+
   group('priceForFuelType', () {
     test('returns e5 price for FuelType.e5', () {
       final station = _makeStation(e5: 1.659);

--- a/test/features/consumption/domain/recent_samples_within_test.dart
+++ b/test/features/consumption/domain/recent_samples_within_test.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/driving_coaching.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+TripSample _sampleAt(DateTime t) =>
+    TripSample(timestamp: t, speedKmh: 50, rpm: 1500);
+
+void main() {
+  final base = DateTime(2026, 5, 28, 12, 0, 0);
+
+  group('recentSamplesWithin (#2174)', () {
+    test('matches a full .where scan for an in-order stream', () {
+      // 1000 samples, 1 Hz.
+      final samples = [
+        for (var i = 0; i < 1000; i++)
+          _sampleAt(base.add(Duration(seconds: i))),
+      ];
+      final reference = samples.last.timestamp;
+      const window = Duration(seconds: 5);
+
+      final got = recentSamplesWithin(samples, window, reference);
+      final naive = samples
+          .where((s) => s.timestamp.isAfter(reference.subtract(window)))
+          .toList();
+
+      expect(got, equals(naive));
+      // 5 s window at 1 Hz → the 5 samples strictly after cutoff.
+      expect(got.length, 5);
+    });
+
+    test('only scans the bounded tail (per-emit cost is O(window))', () {
+      // 10 samples over 10 s; cap the scan to the last 3.
+      final samples = [
+        for (var i = 0; i < 10; i++)
+          _sampleAt(base.add(Duration(seconds: i))),
+      ];
+      final got = recentSamplesWithin(
+        samples,
+        const Duration(seconds: 30), // would include all 10 by time
+        samples.last.timestamp,
+        maxScan: 3,
+      );
+      // Bounded to the last 3 samples even though all 10 are within 30 s.
+      expect(got.length, 3);
+      expect(got, equals(samples.sublist(7)));
+    });
+
+    test('tolerates a mildly out-of-order fix within the scanned tail', () {
+      final samples = [
+        _sampleAt(base),
+        _sampleAt(base.add(const Duration(seconds: 1))),
+        _sampleAt(base.add(const Duration(seconds: 3))),
+        // Out of order: arrived after the 3 s fix but stamped 2 s.
+        _sampleAt(base.add(const Duration(seconds: 2))),
+        _sampleAt(base.add(const Duration(seconds: 4))),
+      ];
+      final got = recentSamplesWithin(
+        samples,
+        const Duration(seconds: 5),
+        base.add(const Duration(seconds: 4)),
+      );
+      // The reordered 2 s sample is still in the tail and within window.
+      expect(got.length, 5);
+    });
+
+    test('returns empty when nothing is within the window', () {
+      final samples = [
+        _sampleAt(base),
+        _sampleAt(base.add(const Duration(seconds: 1))),
+      ];
+      final got = recentSamplesWithin(
+        samples,
+        const Duration(seconds: 5),
+        base.add(const Duration(seconds: 100)),
+      );
+      expect(got, isEmpty);
+    });
+
+    test('handles a buffer shorter than maxScan', () {
+      final samples = [_sampleAt(base), _sampleAt(base.add(const Duration(seconds: 1)))];
+      final got = recentSamplesWithin(
+        samples,
+        const Duration(seconds: 5),
+        samples.last.timestamp,
+        maxScan: 600,
+      );
+      expect(got.length, 2);
+    });
+  });
+}

--- a/test/features/driving/presentation/widgets/driving_map_view_test.dart
+++ b/test/features/driving/presentation/widgets/driving_map_view_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_map_view.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
@@ -100,6 +102,55 @@ void main() {
 
       expect(min, closeTo(1.50, 1e-9));
       expect(max, closeTo(1.50, 1e-9));
+    });
+  });
+
+  group('DrivingMapView memoisation (#2176)', () {
+    testWidgets('reuses the marker list across rebuilds when stations '
+        'are unchanged', (tester) async {
+      final controller = MapController();
+      addTearDown(controller.dispose);
+      final stations = [
+        _station(id: 'a', lat: 52.0, lng: 13.0),
+        _station(id: 'b', lat: 52.1, lng: 13.1),
+      ];
+      final rebuild = ValueNotifier<int>(0);
+      addTearDown(rebuild.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 400,
+              height: 600,
+              child: ValueListenableBuilder<int>(
+                valueListenable: rebuild,
+                // Fresh callbacks each rebuild — must NOT force a recompute.
+                builder: (_, _, _) => DrivingMapView(
+                  mapController: controller,
+                  stations: stations,
+                  selectedFuel: FuelType.e10,
+                  onMarkerTap: (_) {},
+                  onInteraction: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final first = tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers;
+      rebuild.value++;
+      await tester.pump();
+      final second =
+          tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers;
+
+      expect(
+        identical(first, second),
+        isTrue,
+        reason: 'markers must be memoised when the station list is unchanged',
+      );
     });
   });
 }

--- a/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
+++ b/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
@@ -232,6 +232,41 @@ void main() {
       // `MarkerLayer` from the <=20 branch must not appear.
       expect(find.byType(MarkerLayer), findsNothing);
     });
+
+    testWidgets('memoises the marker list across host rebuilds (#2175)',
+        (tester) async {
+      final stations = List.generate(
+        5,
+        (i) => buildStation('s$i', lat: i * 0.001, lng: i * 0.001),
+      );
+      final rebuild = ValueNotifier<int>(0);
+      addTearDown(rebuild.dispose);
+
+      await pumpApp(
+        tester,
+        ValueListenableBuilder<int>(
+          valueListenable: rebuild,
+          builder: (_, __, ___) =>
+              hostInMap(EvMapLayer(viewport: viewport)),
+        ),
+        overrides: [
+          evStationsProvider(viewport).overrideWith((_) async => stations),
+        ],
+      );
+
+      final first = tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers;
+      // Force a host rebuild WITHOUT changing the station list identity.
+      rebuild.value++;
+      await tester.pump();
+      final second = tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers;
+
+      expect(
+        identical(first, second),
+        isTrue,
+        reason: 'marker list must be memoised, not re-allocated, when the '
+            'station list is unchanged',
+      );
+    });
   });
 }
 

--- a/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
+++ b/test/features/ev/presentation/widgets/ev_map_overlay_test.dart
@@ -246,8 +246,11 @@ void main() {
         tester,
         ValueListenableBuilder<int>(
           valueListenable: rebuild,
-          builder: (_, __, ___) =>
-              hostInMap(EvMapLayer(viewport: viewport)),
+          // Deliberately non-const: a fresh EvMapLayer widget each rebuild
+          // is what re-runs its State.build, so the memoisation guard is
+          // actually exercised (a const widget would short-circuit).
+          // ignore: prefer_const_constructors
+          builder: (_, _, _) => hostInMap(EvMapLayer(viewport: viewport)),
         ),
         overrides: [
           evStationsProvider(viewport).overrideWith((_) async => stations),

--- a/test/features/price_history/presentation/widgets/price_stats_card_test.dart
+++ b/test/features/price_history/presentation/widgets/price_stats_card_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/price_history/data/repositories/price_history_repository.dart';
 import 'package:tankstellen/features/price_history/presentation/widgets/price_stats_card.dart';
 
@@ -10,6 +11,12 @@ import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('PriceStatsCard', () {
+    // #2172 — the card now formats via PriceFormatter (active-country
+    // locale + currency). Pin GB so the dot-decimal assertions below
+    // hold; restore the FR default afterwards.
+    setUp(() => PriceFormatter.setCountry('GB'));
+    tearDown(() => PriceFormatter.setCountry('FR'));
+
     testWidgets('renders min, max, avg values', (tester) async {
       const stats = PriceStats(
         min: 1.399,

--- a/test/features/route_search/data/strategies/cheapest_search_strategy_test.dart
+++ b/test/features/route_search/data/strategies/cheapest_search_strategy_test.dart
@@ -232,4 +232,39 @@ void main() {
       expect(results[1].id, 'end');
     });
   });
+
+  // #2183 — computeBestStops was previously untested for cheapest; these
+  // pin the per-segment leader semantics the O(1) refactor must preserve.
+  group('computeBestStops — cheapest leader (#2183)', () {
+    Map<int, String>? bestFor(List<Station> stations) => strategy.computeBestStops(
+          route: shortRoute,
+          results: [for (final s in stations) FuelStationResult(s)],
+          fuelType: FuelType.diesel,
+          segmentKm: 50.0, // one segment — all stations compete together
+        );
+
+    test('picks the cheaper station regardless of order', () {
+      final dear = makeStation(id: 'dear', lat: 48.0, lng: 2.0, diesel: 1.80);
+      final cheap = makeStation(id: 'cheap', lat: 48.01, lng: 2.01, diesel: 1.60);
+
+      final cheapFirst = bestFor([cheap, dear]);
+      final cheapSecond = bestFor([dear, cheap]);
+
+      expect(cheapFirst!.values, contains('cheap'));
+      expect(cheapFirst.values, isNot(contains('dear')));
+      // Order must not change the winner.
+      expect(cheapSecond!.values, contains('cheap'));
+      expect(cheapSecond.values, isNot(contains('dear')));
+    });
+
+    test('equal prices keep the first-seen station', () {
+      final first = makeStation(id: 'first', lat: 48.0, lng: 2.0, diesel: 1.70);
+      final second =
+          makeStation(id: 'second', lat: 48.01, lng: 2.01, diesel: 1.70);
+
+      final best = bestFor([first, second]);
+      expect(best!.values, contains('first'));
+      expect(best.values, isNot(contains('second')));
+    });
+  });
 }

--- a/test/features/route_search/data/strategies/eco_route_search_strategy_test.dart
+++ b/test/features/route_search/data/strategies/eco_route_search_strategy_test.dart
@@ -4,6 +4,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/features/route_search/data/strategies/eco_route_search_strategy.dart';
+import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
 
 /// Build a synthetic OSRM `routes[]` JSON entry with the metadata
 /// the strategy actually reads — geometry coordinates, distance,
@@ -380,6 +384,56 @@ void main() {
         consumptionLPer100km: 7,
       );
       expect(saved, 0.0);
+    });
+  });
+
+  // #2183 — computeBestStops was previously untested for eco; same
+  // per-segment leader semantics as cheapest after the O(1) refactor.
+  group('EcoRouteSearchStrategy.computeBestStops (#2183)', () {
+    final strategy = EcoRouteSearchStrategy();
+    const route = RouteInfo(
+      geometry: [LatLng(48.0, 2.0), LatLng(48.1, 2.1), LatLng(48.2, 2.2)],
+      distanceKm: 30.0,
+      durationMinutes: 25.0,
+      samplePoints: [LatLng(48.0, 2.0), LatLng(48.1, 2.1), LatLng(48.2, 2.2)],
+    );
+
+    Station station(String id, double lat, double lng, double diesel) => Station(
+          id: id,
+          name: 'Station $id',
+          brand: 'Brand $id',
+          street: 'Street',
+          postCode: '75000',
+          place: 'Paris',
+          lat: lat,
+          lng: lng,
+          dist: 1.0,
+          diesel: diesel,
+          isOpen: true,
+        );
+
+    Map<int, String>? bestFor(List<Station> stations) =>
+        strategy.computeBestStops(
+          route: route,
+          results: [for (final s in stations) FuelStationResult(s)],
+          fuelType: FuelType.diesel,
+          segmentKm: 50.0,
+        );
+
+    test('picks the cheaper station regardless of order', () {
+      final dear = station('dear', 48.0, 2.0, 1.80);
+      final cheap = station('cheap', 48.01, 2.01, 1.60);
+      expect(bestFor([cheap, dear])!.values, contains('cheap'));
+      expect(bestFor([dear, cheap])!.values, contains('cheap'));
+      expect(bestFor([dear, cheap])!.values, isNot(contains('dear')));
+    });
+
+    test('equal prices keep the first-seen station', () {
+      final first = station('first', 48.0, 2.0, 1.70);
+      final second = station('second', 48.01, 2.01, 1.70);
+      final best = bestFor([first, second]);
+      expect(best!.values, contains('first'));
+      expect(best.values, isNot(contains('second')));
     });
   });
 }

--- a/test/features/station_services/austria/econtrol_station_service_test.dart
+++ b/test/features/station_services/austria/econtrol_station_service_test.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
@@ -756,6 +759,54 @@ void main() {
       expect(station.diesel, isNull);
     });
   });
+
+  // #2181 — Dio is now injectable; assert a passed Dio is actually used
+  // for outbound requests (the seam that lets request shape be tested).
+  group('Dio injection (#2181)', () {
+    test('routes requests through the injected Dio', () async {
+      final adapter = _RecordingAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      final injected = EControlStationService(dio: dio);
+
+      await injected.searchStations(
+        const SearchParams(lat: 48.2, lng: 16.37, radiusKm: 10.0),
+      );
+
+      expect(adapter.requestUris, isNotEmpty);
+      expect(
+        adapter.requestUris.every((u) => u.contains('api.e-control.at')),
+        isTrue,
+        reason: 'all requests must go through the injected Dio to the '
+            'e-control endpoint',
+      );
+    });
+  });
+}
+
+/// Minimal [HttpClientAdapter] that records request URIs and returns an
+/// empty JSON array, so the injection seam can be asserted without a live
+/// network call.
+class _RecordingAdapter implements HttpClientAdapter {
+  final List<String> requestUris = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestUris.add(options.uri.toString());
+    return ResponseBody.fromString(
+      jsonEncode(<dynamic>[]),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }
 
 /// Replicates E-Control parsing logic for isolated testing.

--- a/test/features/widget/data/nearest_widget_data_builder_test.dart
+++ b/test/features/widget/data/nearest_widget_data_builder_test.dart
@@ -361,6 +361,43 @@ void main() {
       expect(stationService.lastParams!.fuelType, FuelType.diesel);
     });
 
+    // #2170 — the builder's private _priceForFuel had a `_` wildcard
+    // that returned the e10/e5/diesel fallback for electric/hydrogen,
+    // so an EV-preferring profile saw a petrol price mislabelled as the
+    // preferred fuel. Collapsing onto Station.priceFor returns null for
+    // electric (Station carries no EV price field) — an empty price, not
+    // a wrong one.
+    test('preferred electric fuel renders no price (null) instead of a '
+        'petrol fallback', () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.5200);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.4050);
+      profiles.activeProfileJson = {
+        'id': 'p1',
+        'name': 'EV',
+        'preferredFuelType': 'electric',
+        'defaultSearchRadius': 10.0,
+      };
+      stationService.stationsToReturn = [
+        _stationFixture(
+          id: 'de-0',
+          brand: 'Shell',
+          street: 'Str0',
+          place: 'Berlin',
+          lat: 52.52,
+          lng: 13.40,
+          e10: 1.799,
+          e5: 1.859,
+          diesel: 1.659,
+        ),
+      ];
+
+      final result = await builder.build();
+
+      expect(result.stations, hasLength(1));
+      expect(result.stations.first['preferred_fuel_price'], isNull);
+      expect(result.stations.first['priceFormatted'], '');
+    });
+
     test('on second call after network failure, returns last successful '
         'payload flagged isStale=true', () async {
       await settings.putSetting(StorageKeys.userPositionLat, 52.5200);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -18,11 +18,9 @@ void main() {
       expect(PriceFormatter.formatDistance(null), '--');
     });
 
-    test('returns fuel type name', () {
-      expect(PriceFormatter.fuelTypeName('e5'), 'Super E5');
-      expect(PriceFormatter.fuelTypeName('e10'), 'Super E10');
-      expect(PriceFormatter.fuelTypeName('diesel'), 'Diesel');
-      expect(PriceFormatter.fuelTypeName('all'), 'Alle');
-    });
+    // #2171 — PriceFormatter.fuelTypeName was a dead, non-localized
+    // re-implementation of FuelType.displayName (it hardcoded the
+    // German 'Alle', a HARD-RULE violation). Deleted; fuel display
+    // names come from FuelType.displayName, covered in fuel_type_test.
   });
 }


### PR DESCRIPTION
## Summary
Implements the **wave-1** children of the code-quality hardening Epic #2167 — the Opus 4.8 focused audit across **reusability/SSoT, design-patterns/OO, performance, and extensibility**. Every finding was adversarially verified against the working tree before filing; this PR lands the contained, low/medium-risk subset, each with the regression test the verification mandated.

16 commits, one per closed issue. Full `flutter analyze` is clean (the only 2 issues are pre-existing infos in untouched files); the full local suite (5787 tests) passes.

## Reusability / single-source-of-truth
- **Closes #2168** — `PriceFormatter`/`UnitFormatter` read the `CountryConfig` SSoT instead of three shadow locale/currency tables that omitted SI/KR/CL/RO (KR rendered € not ₩, etc.). *Live correctness fix.*
- **Closes #2170** — collapse the triplicated `FuelType→price` switch onto `Station.priceFor` (+ EV electric→null guard test).
- **Closes #2171** — delete dead `PriceFormatter.fuelTypeName` (hardcoded German `'Alle'`, HARD-RULE violation).
- **Closes #2172** — `PriceStatsCard` formats via `PriceFormatter` (locale + currency), drops the euro-defaulted param.
- **Closes #2182** — unify the three `(min,max)` price-range loops into one `priceRange` helper.

## Performance
- **Closes #2174** — bound the GPS-only coaching scan to O(window) (was O(trip) every fix).
- **Closes #2175** — memoise `EvMapLayer` markers (ConsumerStatefulWidget, identity-guarded) + identity test.
- **Closes #2176** — memoise `DrivingMapView` centroid/range/markers.
- **Closes #2178** — per-marker `RepaintBoundary` on EV markers (fuel parity).
- **Closes #2183** — O(1) per-segment leader lookup in cheapest/eco `computeBestStops` (was O(n²)) + new tests.
- **Closes #2184** — `Countries.byCode` is now an O(1) map (per-station hot path).

## Extensibility
- **Closes #2179** — `AppLanguages.all` ⟷ `supportedLocales` parity test, drop the magic `23`.
- **Closes #2181** — make `Dio` injectable in the AT/DK/IT/ES services + injection test.

## Design-patterns
- Partially addresses **#2173** — route the 4 plain raw SnackBars through `SnackBarHelper` (adds the liveRegion announce; zero visual change).

## Deferred / partial (kept open for review — see per-issue comments)
- **#2169** (haversine) — the 3 metre-based copies are consolidated here; the km-radius copies + `gps_track_distance`'s pinned `6371.0088` radius remain (would shift user-visible trip distances).
- **#2173** (snackbar) — the icon-carrying coaching + file-saved success toasts remain (change appearance; need a device check + a new helper builder).
- **#2177** (fitCamera guard) — deferred: interacts with the hard-won cold-start grey-tile cure, not coverable by the existing tests.
- **#2180** (fuel-type drift) — deferred: a user-facing multi-country search change whose correct per-feed fuel sets need maintainer review (AR's hidden CNG is a real bug).

The remaining Epic #2167 children (god-class slices, consumption-unit migration, brand consolidation, config/baseURL surface, etc.) were verified as larger/riskier and filed as follow-ups, not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
