### PR TITLE
refactor(quality): reuse/SSoT wave 2 — geo, loadDataset, average (Epic #2167)

### DIFF
--- a/lib/core/services/approach_detector.dart
+++ b/lib/core/services/approach_detector.dart
@@ -8,6 +8,7 @@ import 'package:geolocator/geolocator.dart';
 
 import '../../features/search/domain/entities/station.dart';
 import '../utils/geo_utils.dart' as geo;
+import '../utils/num_extensions.dart';
 
 /// State emitted by [ApproachDetector] (#2085 / ADR 0011).
 ///
@@ -219,10 +220,7 @@ class ApproachDetector {
     }
   }
 
-  double _avgSpeed() {
-    if (_recentSpeeds.isEmpty) return 0;
-    return _recentSpeeds.reduce((a, b) => a + b) / _recentSpeeds.length;
-  }
+  double _avgSpeed() => _recentSpeeds.average;
 
   void _schedulePoll() {
     _pollTimer?.cancel();

--- a/lib/core/services/impl/osm_brand_enricher.dart
+++ b/lib/core/services/impl/osm_brand_enricher.dart
@@ -3,11 +3,11 @@
 
 import 'dart:async';
 
-import 'dart:math';
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../data/storage_repository.dart';
 import '../../storage/storage_providers.dart';
+import '../../utils/geo_utils.dart' as geo;
 import '../dio_factory.dart';
 import '../../../features/search/domain/entities/brand_registry.dart';
 import '../../../features/search/domain/entities/station.dart';
@@ -203,14 +203,11 @@ class OsmBrandEnricher {
     return trimmed;
   }
 
-  static double _distKm(double lat1, double lng1, double lat2, double lng2) {
-    final dLat = (lat2 - lat1) * pi / 180;
-    final dLng = (lng2 - lng1) * pi / 180;
-    final a = sin(dLat / 2) * sin(dLat / 2) +
-        cos(lat1 * pi / 180) * cos(lat2 * pi / 180) *
-        sin(dLng / 2) * sin(dLng / 2);
-    return 6371 * 2 * atan2(sqrt(a), sqrt(1 - a));
-  }
+  // #2169 — delegate to the canonical geo_utils.distanceKm rather than a
+  // hand-rolled haversine. Real POI/station coords only, so the (0,0)
+  // null-island short-circuit never triggers here.
+  static double _distKm(double lat1, double lng1, double lat2, double lng2) =>
+      geo.distanceKm(lat1, lng1, lat2, lng2);
 }
 
 class _Poi {

--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -16,4 +16,24 @@ mixin CachedDatasetMixin {
 
   /// Mark the in-memory dataset as just refreshed.
   void markDatasetRefreshed() => _datasetCachedAt = DateTime.now();
+
+  /// Generic guard→fetch→store→mark idiom shared by the dataset services.
+  ///
+  /// Returns [cached] verbatim when it is non-null and still within [ttl].
+  /// Otherwise awaits [fetch], hands the result to [store], stamps the cache
+  /// as fresh via [markDatasetRefreshed], and returns the freshly fetched
+  /// value. Services that cache more than one field can pass a record (or any
+  /// composite) as `T` and unpack it inside [store].
+  Future<T> loadDataset<T>({
+    required T? cached,
+    required Duration ttl,
+    required Future<T> Function() fetch,
+    required void Function(T value) store,
+  }) async {
+    if (cached != null && isDatasetFresh(ttl)) return cached;
+    final value = await fetch();
+    store(value);
+    markDatasetRefreshed();
+    return value;
+  }
 }

--- a/lib/core/services/price_sanity.dart
+++ b/lib/core/services/price_sanity.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../utils/num_extensions.dart';
+
 /// Per-country price validation to flag suspicious fuel prices.
 ///
 /// Checks prices against absolute thresholds and relative deviation
@@ -66,7 +68,7 @@ class PriceSanity {
   static double? average(List<double?> prices) {
     final valid = prices.whereType<double>().where((p) => p > 0).toList();
     if (valid.isEmpty) return null;
-    return valid.reduce((a, b) => a + b) / valid.length;
+    return valid.average;
   }
 
   /// Get the threshold range for a country (for display/testing).

--- a/lib/core/utils/num_extensions.dart
+++ b/lib/core/utils/num_extensions.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Numeric helpers shared across the app.
+///
+/// Replaces the hand-rolled `xs.reduce((a, b) => a + b) / xs.length` /
+/// `sum / xs.length` arithmetic-mean idiom that was duplicated across many
+/// call sites. Centralising it removes the easy-to-get-wrong empty-list
+/// division (which yields `NaN`) — [average] returns `0` for an empty
+/// iterable.
+///
+/// Usage:
+/// ```dart
+/// final mean = [1, 2, 3].average;            // 2.0
+/// final speed = samples.map((s) => s.speedKmh).average;
+/// ```
+extension NumIterableStats on Iterable<num> {
+  /// The arithmetic mean of the elements, as a [double].
+  ///
+  /// Returns `0` for an empty iterable instead of throwing / producing
+  /// `NaN`. Call sites that need a different empty sentinel should guard
+  /// emptiness themselves before calling.
+  double get average =>
+      isEmpty ? 0 : map((e) => e.toDouble()).reduce((a, b) => a + b) / length;
+}

--- a/lib/features/achievements/domain/trip_metrics.dart
+++ b/lib/features/achievements/domain/trip_metrics.dart
@@ -3,6 +3,7 @@
 
 import 'dart:math' as math;
 
+import '../../../core/utils/num_extensions.dart';
 import '../../consumption/data/trip_history_repository.dart';
 import '../../consumption/domain/trip_recorder.dart';
 
@@ -167,7 +168,7 @@ class TripMetrics {
       if (s.speedKmh >= _movingSpeedThresholdKmh) moving.add(s.speedKmh);
     }
     if (moving.length < 2) return double.infinity;
-    final mean = moving.reduce((a, b) => a + b) / moving.length;
+    final mean = moving.average;
     var sumSq = 0.0;
     for (final v in moving) {
       final d = v - mean;

--- a/lib/features/consumption/domain/services/eco_score_calculator.dart
+++ b/lib/features/consumption/domain/services/eco_score_calculator.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../../../../core/utils/num_extensions.dart';
 import '../entities/eco_score.dart';
 import '../entities/fill_up.dart';
 
@@ -96,8 +97,7 @@ class EcoScoreCalculator {
     }
     if (baselineSamples.isEmpty) return null;
 
-    final baseline =
-        baselineSamples.reduce((a, b) => a + b) / baselineSamples.length;
+    final baseline = baselineSamples.average;
     if (baseline <= 0) return null;
 
     final deltaPercent = (currentLp100 - baseline) / baseline * 100;

--- a/lib/features/consumption/domain/services/gps_matrix_reconciler.dart
+++ b/lib/features/consumption/domain/services/gps_matrix_reconciler.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../../../../core/utils/num_extensions.dart';
 import '../../../vehicle/domain/entities/gps_calibration_matrix.dart';
 import '../gps_driving_features.dart';
 
@@ -98,9 +99,7 @@ class GpsMatrixReconciler {
       ),
       residual * residual,
     ];
-    final variance = updatedResiduals.isEmpty
-        ? 0.0
-        : updatedResiduals.reduce((a, b) => a + b) / updatedResiduals.length;
+    final variance = updatedResiduals.average;
 
     return matrix
         .copyWith(

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/utils/num_extensions.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
@@ -153,11 +154,7 @@ class TripSummaryCard extends ConsumerWidget {
     String unknown,
   ) {
     if (samples.isEmpty) return unknown;
-    var sum = 0.0;
-    for (final s in samples) {
-      sum += s.speedKmh;
-    }
-    final avg = sum / samples.length;
+    final avg = samples.map((s) => s.speedKmh).average;
     return '${avg.toStringAsFixed(1)} km/h';
   }
 

--- a/lib/features/driving/haptic_eco_coach.dart
+++ b/lib/features/driving/haptic_eco_coach.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../core/logging/error_logger.dart';
+import '../../core/utils/num_extensions.dart';
 import '../consumption/data/obd2/trip_live_reading.dart';
 
 /// One coach fire decision (#1273).
@@ -220,8 +221,7 @@ class HapticEcoCoach {
         .whereType<double>()
         .toList(growable: false);
     if (throttleSamples.isEmpty) return false;
-    final avgThrottle =
-        throttleSamples.reduce((a, b) => a + b) / throttleSamples.length;
+    final avgThrottle = throttleSamples.average;
     if (avgThrottle <= throttleThresholdPercent) return false;
 
     final speedSamples = _window

--- a/lib/features/price_history/data/repositories/price_history_repository.dart
+++ b/lib/features/price_history/data/repositories/price_history_repository.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/foundation.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../../core/data/storage_repository.dart';
+import '../../../../core/utils/num_extensions.dart';
 import '../../domain/entities/price_stats.dart';
 import '../models/price_record.dart';
 
@@ -87,7 +88,7 @@ class PriceHistoryRepository {
     final current = prices.first;
     final min = prices.reduce((a, b) => a < b ? a : b);
     final max = prices.reduce((a, b) => a > b ? a : b);
-    final avg = prices.reduce((a, b) => a + b) / prices.length;
+    final avg = prices.average;
 
     // Trend: compare newest vs oldest in window
     final trend = _calculateTrend(prices);

--- a/lib/features/price_history/providers/price_prediction_provider.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.dart
@@ -4,6 +4,7 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/country/country_config.dart';
+import '../../../core/utils/num_extensions.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
 import '../../feature_management/domain/feature_dependency_graph.dart';
@@ -77,7 +78,7 @@ PricePrediction? pricePrediction(
     hourBuckets.putIfAbsent(v.hourOfDay, () => []).add(v.priceEur);
   }
   final hourlyAverages = hourBuckets.entries.map((e) {
-    final avg = e.value.reduce((a, b) => a + b) / e.value.length;
+    final avg = e.value.average;
     return HourlyAverage(
       hour: e.key,
       avgPrice: double.parse(avg.toStringAsFixed(4)),
@@ -92,7 +93,7 @@ PricePrediction? pricePrediction(
     dayBuckets.putIfAbsent(v.dayOfWeek, () => []).add(v.priceEur);
   }
   final dailyAverages = dayBuckets.entries.map((e) {
-    final avg = e.value.reduce((a, b) => a + b) / e.value.length;
+    final avg = e.value.average;
     return DayOfWeekAverage(
       dayOfWeek: e.key,
       avgPrice: double.parse(avg.toStringAsFixed(4)),
@@ -200,10 +201,8 @@ double? _computeHolidayPremium(List<FeatureVector> vectors) {
   if (holidayPrices.length < _kMinHolidaySamples) return null;
   if (nonHolidayPrices.isEmpty) return null;
 
-  final hAvg =
-      holidayPrices.reduce((a, b) => a + b) / holidayPrices.length;
-  final nAvg = nonHolidayPrices.reduce((a, b) => a + b) /
-      nonHolidayPrices.length;
+  final hAvg = holidayPrices.average;
+  final nAvg = nonHolidayPrices.average;
   final delta = hAvg - nAvg;
   return double.parse(delta.toStringAsFixed(3));
 }

--- a/lib/features/price_history/providers/price_prediction_provider.g.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.g.dart
@@ -102,7 +102,7 @@ final class PricePredictionProvider
   }
 }
 
-String _$pricePredictionHash() => r'd11db7fbfbcbc3bfddcb78134ae75712cec1e0ff';
+String _$pricePredictionHash() => r'99c1d56e4f9dda52ca30ef12d972108dd42e2562';
 
 /// Computes "best time to fill" predictions from locally stored price history.
 ///

--- a/lib/features/route_search/data/strategies/uniform_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/uniform_search_strategy.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:latlong2/latlong.dart';
@@ -239,7 +238,7 @@ List<String> _filterAndSortIsolate(_FilterSortPayload payload) {
   for (final p in payload.points) {
     double minDist = double.infinity;
     for (int i = 0; i < polyLen; i += step) {
-      final d = _haversineKm(
+      final d = distanceKm(
         p.lat,
         p.lng,
         payload.polyLats[i],
@@ -265,37 +264,24 @@ List<String> _filterAndSortIsolate(_FilterSortPayload payload) {
   return [for (final entry in survivors) entry.$1.id];
 }
 
-double _haversineKm(double lat1, double lng1, double lat2, double lng2) {
-  const earthKm = 6371.0;
-  const deg2rad = 3.141592653589793 / 180.0;
-  final dLat = (lat2 - lat1) * deg2rad;
-  final dLng = (lng2 - lng1) * deg2rad;
-  final a = _sin(dLat / 2) * _sin(dLat / 2) +
-      _cos(lat1 * deg2rad) *
-          _cos(lat2 * deg2rad) *
-          _sin(dLng / 2) *
-          _sin(dLng / 2);
-  return 2 * earthKm * _atan2(_sqrt(a), _sqrt(1 - a));
-}
-
 double _distanceAlongPolylineKm(
   double lat,
   double lng,
   List<double> polyLats,
   List<double> polyLngs,
 ) {
-  // Same shape as core/utils/geo_utils.dart distanceAlongPolyline,
-  // re-implemented inline so the isolate has no UI-side imports.
+  // #2169 — uses the isolate-safe geo_utils.distanceKm (only dart:math
+  // + latlong2 imports), matching the survivors loop above.
   double accumulated = 0;
   double bestAlong = 0;
   double bestDist = double.infinity;
   for (int i = 0; i < polyLats.length - 1; i++) {
-    final segStart = _haversineKm(lat, lng, polyLats[i], polyLngs[i]);
+    final segStart = distanceKm(lat, lng, polyLats[i], polyLngs[i]);
     if (segStart < bestDist) {
       bestDist = segStart;
       bestAlong = accumulated;
     }
-    accumulated += _haversineKm(
+    accumulated += distanceKm(
       polyLats[i],
       polyLngs[i],
       polyLats[i + 1],
@@ -304,7 +290,7 @@ double _distanceAlongPolylineKm(
   }
   // Final point.
   if (polyLats.isNotEmpty) {
-    final last = _haversineKm(
+    final last = distanceKm(
         lat, lng, polyLats.last, polyLngs.last);
     if (last < bestDist) {
       bestAlong = accumulated;
@@ -313,7 +299,3 @@ double _distanceAlongPolylineKm(
   return bestAlong;
 }
 
-double _sin(double x) => math.sin(x);
-double _cos(double x) => math.cos(x);
-double _atan2(double y, double x) => math.atan2(y, x);
-double _sqrt(double x) => math.sqrt(x);

--- a/lib/features/search/providers/cross_border_provider.dart
+++ b/lib/features/search/providers/cross_border_provider.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/country/border_proximity.dart';
 import '../../../core/country/country_provider.dart';
 import '../../../core/location/user_position_provider.dart';
+import '../../../core/utils/num_extensions.dart';
 import '../../../core/utils/station_extensions.dart';
 import '../domain/entities/cross_border_comparison.dart';
 import 'search_provider.dart';
@@ -51,7 +52,7 @@ List<CrossBorderComparison> crossBorderComparisons(Ref ref) {
 
   if (prices.isEmpty) return const [];
 
-  final avgPrice = prices.reduce((a, b) => a + b) / prices.length;
+  final avgPrice = prices.average;
 
   return nearbyBorders.map((border) {
     return CrossBorderComparison(

--- a/lib/features/search/providers/cross_border_provider.g.dart
+++ b/lib/features/search/providers/cross_border_provider.g.dart
@@ -86,4 +86,4 @@ final class CrossBorderComparisonsProvider
 }
 
 String _$crossBorderComparisonsHash() =>
-    r'2b5ae2c92a8a7e804832789baa87b683a5800d22';
+    r'fbf282a5fcfd2b8421c7cc41ae58e5d81ac5c423';

--- a/lib/features/search/providers/cross_border_suggestion_provider.dart
+++ b/lib/features/search/providers/cross_border_suggestion_provider.dart
@@ -11,6 +11,7 @@ import '../../../core/location/user_position_provider.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
+import '../../../core/utils/num_extensions.dart';
 import '../../../core/utils/station_extensions.dart';
 import '../data/models/search_params.dart';
 import '../domain/entities/cross_border_suggestion.dart';
@@ -83,7 +84,7 @@ Future<CrossBorderSuggestion?> crossBorderSuggestion(Ref ref) async {
       .where((p) => p > 0)
       .toList();
   if (localPrices.isEmpty) return null;
-  final localAvg = localPrices.reduce((a, b) => a + b) / localPrices.length;
+  final localAvg = localPrices.average;
 
   // Detect nearby borders within the issue's 25 km radius.
   final nearbyBorders = detectNearbyBorders(
@@ -128,8 +129,7 @@ Future<CrossBorderSuggestion?> crossBorderSuggestion(Ref ref) async {
         .where((p) => p > 0)
         .toList();
     if (neighborPrices.isEmpty) continue;
-    final neighborAvg =
-        neighborPrices.reduce((a, b) => a + b) / neighborPrices.length;
+    final neighborAvg = neighborPrices.average;
 
     final delta = localAvg - neighborAvg;
     if (delta <= 0) continue; // not actually cheaper — skip

--- a/lib/features/search/providers/cross_border_suggestion_provider.g.dart
+++ b/lib/features/search/providers/cross_border_suggestion_provider.g.dart
@@ -172,7 +172,7 @@ final class CrossBorderSuggestionProvider
 }
 
 String _$crossBorderSuggestionHash() =>
-    r'3be95edb40f9144ee405eb3dfa42bbf8c511397a';
+    r'94789eb3147da0736e6490d83daf77a739721e1d';
 
 /// Set of neighbor country codes the user has dismissed during this
 /// session. Resets on app restart (StateNotifier with no persistence).

--- a/lib/features/station_services/argentina/argentina_station_service.dart
+++ b/lib/features/station_services/argentina/argentina_station_service.dart
@@ -183,15 +183,17 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
         haystack.contains('HANDSHAKE');
   }
 
-  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) async {
-    if (_cachedStations != null && isDatasetFresh(const Duration(hours: 6))) {
-      return;
-    }
-
-    final response = await _dio.get<String>(_csvUrl, cancelToken: cancelToken);
-    _cachedStations = await compute(_parseCsv, response.data ?? '');
-    markDatasetRefreshed();
-  }
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) =>
+      loadDataset<List<_RawStation>>(
+        cached: _cachedStations,
+        ttl: const Duration(hours: 6),
+        fetch: () async {
+          final response =
+              await _dio.get<String>(_csvUrl, cancelToken: cancelToken);
+          return compute(_parseCsv, response.data ?? '');
+        },
+        store: (value) => _cachedStations = value,
+      );
 
   /// Expected CSV header columns from the Argentina open data endpoint.
   /// Used as an integrity check to detect MITM tampering or format changes

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -63,21 +63,21 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
     }
   }
 
-  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) async {
-    if (_cachedStations != null && isDatasetFresh(const Duration(minutes: 5))) {
-      return;
-    }
-
-    // Fetch all 3 sources in parallel
-    final results = await Future.wait([
-      _fetchOk(cancelToken: cancelToken),
-      _fetchShell(cancelToken: cancelToken),
-      _fetchQ8(),
-    ]);
-
-    _cachedStations = [...results[0], ...results[1], ...results[2]];
-    markDatasetRefreshed();
-  }
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) =>
+      loadDataset<List<Station>>(
+        cached: _cachedStations,
+        ttl: const Duration(minutes: 5),
+        fetch: () async {
+          // Fetch all 3 sources in parallel
+          final results = await Future.wait([
+            _fetchOk(cancelToken: cancelToken),
+            _fetchShell(cancelToken: cancelToken),
+            _fetchQ8(),
+          ]);
+          return [...results[0], ...results[1], ...results[2]];
+        },
+        store: (value) => _cachedStations = value,
+      );
 
   /// OK — https://mobility-prices.ok.dk/api/v1/fuel-prices
   Future<List<Station>> _fetchOk({CancelToken? cancelToken}) async {

--- a/lib/features/station_services/italy/mise_station_service.dart
+++ b/lib/features/station_services/italy/mise_station_service.dart
@@ -93,23 +93,32 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
     }
   }
 
-  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) async {
-    // Refresh cache every 2 hours
-    if (_cachedStations != null &&
-        _cachedPrices != null &&
-        isDatasetFresh(const Duration(hours: 2))) {
-      return;
-    }
-
-    // Download both files in parallel
-    final results = await Future.wait([
-      _dio.get<String>(_stationsUrl, cancelToken: cancelToken),
-      _dio.get<String>(_pricesUrl, cancelToken: cancelToken),
-    ]);
-
-    _cachedStations = _parseStationsCsv(results[0].data ?? '');
-    _cachedPrices = _parsePricesCsv(results[1].data ?? '');
-    markDatasetRefreshed();
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
+    // Refresh cache every 2 hours. Both maps are populated from a single
+    // download, so they're cached together as a record — present only when
+    // both are non-null.
+    final cached = (_cachedStations != null && _cachedPrices != null)
+        ? (_cachedStations!, _cachedPrices!)
+        : null;
+    return loadDataset<(Map<String, _StationData>, Map<String, _PriceData>)>(
+      cached: cached,
+      ttl: const Duration(hours: 2),
+      fetch: () async {
+        // Download both files in parallel
+        final results = await Future.wait([
+          _dio.get<String>(_stationsUrl, cancelToken: cancelToken),
+          _dio.get<String>(_pricesUrl, cancelToken: cancelToken),
+        ]);
+        return (
+          _parseStationsCsv(results[0].data ?? ''),
+          _parsePricesCsv(results[1].data ?? ''),
+        );
+      },
+      store: (value) {
+        _cachedStations = value.$1;
+        _cachedPrices = value.$2;
+      },
+    );
   }
 
   Map<String, _StationData> _parseStationsCsv(String csv) {

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -159,32 +159,33 @@ class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implem
 
   Future<List<Map<String, dynamic>>> _fetchStationsByProvince(
     String provinceId, {CancelToken? cancelToken}
-  ) async {
+  ) {
     // Use cache if fresh (< 10 minutes)
-    if (_cachedStations != null && isDatasetFresh(const Duration(minutes: 10))) {
-      return _cachedStations!;
-    }
+    return loadDataset<List<Map<String, dynamic>>>(
+      cached: _cachedStations,
+      ttl: const Duration(minutes: 10),
+      fetch: () async {
+        final response = await _dio.get(
+          '$_baseUrl/EstacionesTerrestres/FiltroProvincia/$provinceId',
+          cancelToken: cancelToken,
+        );
 
-    final response = await _dio.get(
-      '$_baseUrl/EstacionesTerrestres/FiltroProvincia/$provinceId',
-      cancelToken: cancelToken,
+        final data = response.data;
+        if (data is! Map<String, dynamic>) {
+          throw const ApiException(message: 'Invalid MITECO response');
+        }
+
+        if (data['ResultadoConsulta'] != 'OK') {
+          throw ApiException(
+            message: data['ResultadoConsulta']?.toString() ?? 'API error',
+          );
+        }
+
+        final list = data['ListaEESSPrecio'] as List<dynamic>? ?? [];
+        return list.cast<Map<String, dynamic>>();
+      },
+      store: (value) => _cachedStations = value,
     );
-
-    final data = response.data;
-    if (data is! Map<String, dynamic>) {
-      throw const ApiException(message: 'Invalid MITECO response');
-    }
-
-    if (data['ResultadoConsulta'] != 'OK') {
-      throw ApiException(
-        message: data['ResultadoConsulta']?.toString() ?? 'API error',
-      );
-    }
-
-    final list = data['ListaEESSPrecio'] as List<dynamic>? ?? [];
-    _cachedStations = list.cast<Map<String, dynamic>>();
-    markDatasetRefreshed();
-    return _cachedStations!;
   }
 
   Station? _parseStation(

--- a/lib/features/widget/data/home_widget_service.dart
+++ b/lib/features/widget/data/home_widget_service.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 
 import 'dart:convert';
 import 'dart:io' show Platform;
-import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:home_widget/home_widget.dart';
@@ -14,6 +13,7 @@ import '../../../core/country/country_config.dart';
 import '../../../core/data/storage_repository.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/storage/storage_keys.dart';
+import '../../../core/utils/geo_utils.dart' as geo;
 import '../../profile/data/models/user_profile.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import 'home_widget_json.dart';
@@ -473,29 +473,17 @@ class HomeWidgetService {
 
   /// Haversine formula to calculate distance in km between two GPS points.
   ///
-  /// Public for testing.
+  /// Public for testing. #2169 — delegates to the canonical
+  /// geo_utils.distanceKm (same 6371 km radius) instead of a hand-rolled
+  /// haversine copy.
   @visibleForTesting
   static double haversineDistanceKm(
     double lat1,
     double lon1,
     double lat2,
     double lon2,
-  ) {
-    const earthRadiusKm = 6371.0;
-    final dLat = _degreesToRadians(lat2 - lat1);
-    final dLon = _degreesToRadians(lon2 - lon1);
-
-    final a = sin(dLat / 2) * sin(dLat / 2) +
-        cos(_degreesToRadians(lat1)) *
-            cos(_degreesToRadians(lat2)) *
-            sin(dLon / 2) *
-            sin(dLon / 2);
-    final c = 2 * atan2(sqrt(a), sqrt(1 - a));
-
-    return earthRadiusKm * c;
-  }
-
-  static double _degreesToRadians(double degrees) => degrees * pi / 180;
+  ) =>
+      geo.distanceKm(lat1, lon1, lat2, lon2);
 
   static double? _toDouble(dynamic value) {
     if (value is double) return value;

--- a/test/core/services/mixins/cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/cached_dataset_mixin_test.dart
@@ -46,4 +46,72 @@ void main() {
       expect(other.isDatasetFresh(const Duration(minutes: 5)), false);
     });
   });
+
+  group('CachedDatasetMixin.loadDataset', () {
+    test('returns cached without fetching when fresh', () async {
+      var fetchCalls = 0;
+      var storeCalls = 0;
+      // Stamp the cache as fresh first.
+      cached.markDatasetRefreshed();
+
+      final result = await cached.loadDataset<List<int>>(
+        cached: const [1, 2, 3],
+        ttl: const Duration(minutes: 5),
+        fetch: () async {
+          fetchCalls++;
+          return const [9, 9, 9];
+        },
+        store: (_) => storeCalls++,
+      );
+
+      expect(result, const [1, 2, 3]);
+      expect(fetchCalls, 0, reason: 'fresh cache must not trigger a fetch');
+      expect(storeCalls, 0, reason: 'fresh cache must not re-store');
+    });
+
+    test('fetches, stores and marks fresh when stale', () async {
+      var fetchCalls = 0;
+      int? stored;
+      // Marked, but TTL of zero makes it immediately stale.
+      cached.markDatasetRefreshed();
+      expect(cached.isDatasetFresh(Duration.zero), false);
+
+      final result = await cached.loadDataset<int>(
+        cached: 1,
+        ttl: Duration.zero,
+        fetch: () async {
+          fetchCalls++;
+          return 42;
+        },
+        store: (value) => stored = value,
+      );
+
+      expect(result, 42);
+      expect(fetchCalls, 1);
+      expect(stored, 42);
+      // markDatasetRefreshed was called, so a positive TTL is now fresh.
+      expect(cached.isDatasetFresh(const Duration(minutes: 5)), true);
+    });
+
+    test('fetches when cached is null even within TTL', () async {
+      var fetchCalls = 0;
+      String? stored;
+      // Fresh by time, but no cached value yet.
+      cached.markDatasetRefreshed();
+
+      final result = await cached.loadDataset<String>(
+        cached: null,
+        ttl: const Duration(minutes: 5),
+        fetch: () async {
+          fetchCalls++;
+          return 'loaded';
+        },
+        store: (value) => stored = value,
+      );
+
+      expect(result, 'loaded');
+      expect(fetchCalls, 1, reason: 'null cache must fetch regardless of TTL');
+      expect(stored, 'loaded');
+    });
+  });
 }

--- a/test/core/utils/num_extensions_test.dart
+++ b/test/core/utils/num_extensions_test.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/num_extensions.dart';
+
+void main() {
+  group('NumIterableStats.average', () {
+    test('computes the mean of multiple elements', () {
+      expect([1.0, 2.0, 3.0].average, 2.0);
+      expect([2.0, 4.0, 6.0, 8.0].average, 5.0);
+    });
+
+    test('returns the single element for a one-element iterable', () {
+      expect([42.0].average, 42.0);
+    });
+
+    test('returns 0 for an empty iterable', () {
+      expect(<num>[].average, 0.0);
+      expect(<double>[].average, 0.0);
+      expect(<int>[].average, 0.0);
+    });
+
+    test('works for ints and returns a double', () {
+      expect([1, 2, 3, 4].average, 2.5);
+      expect([10, 20].average, isA<double>());
+      expect([10, 20].average, 15.0);
+    });
+
+    test('handles negative values', () {
+      expect([-2.0, 2.0].average, 0.0);
+      expect([-4, -2, 0].average, -2.0);
+    });
+
+    test('works on a lazy Iterable, not just a List', () {
+      final lazy = Iterable<num>.generate(5, (i) => i); // 0,1,2,3,4
+      expect(lazy.average, 2.0);
+    });
+
+    test('works on a mapped Iterable of doubles', () {
+      final speeds = [10, 20, 30].map((v) => v.toDouble());
+      expect(speeds.average, 20.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Epic #2167 wave-2 (reuse/SSoT). Three verified follow-ups:

- **Closes #2169** — finish the haversine consolidation: osm_brand_enricher, home_widget_service and the uniform-search isolate path now delegate to `geo_utils.distanceKm`; `gps_track_distance` is kept as a documented pinned-radius (6371.0088 + jitter-floor) exception.
- **Closes #2200** — add `CachedDatasetMixin.loadDataset<T>` and adopt it in the 4 national-dataset services (AR/DK/IT/ES), collapsing the repeated guard→fetch→store→mark idiom.
- **Closes #2198** — add `Iterable<num>.average` and migrate 13 hand-rolled mean idioms.

Full `flutter analyze` clean (2 pre-existing infos in untouched files); 5222 tests pass across all touched areas. Each issue is one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
