### PR TITLE
refactor(quality): wave 3 — price gradient, route geometry, consumption units, obd2 diag (Epic #2167)

### DIFF
--- a/lib/core/utils/price_gradient.dart
+++ b/lib/core/utils/price_gradient.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+/// Normalized 0..1 position of [price] within the [min]..[max] range.
+///
+/// Returns 0 for a degenerate range (`max <= min`). Shared by the marker
+/// colour gradient and the price-tier classifier so colour and tier use
+/// one normalization (#2196).
+double normalizedPrice(double price, double min, double max) {
+  if (max <= min) return 0;
+  return ((price - min) / (max - min)).clamp(0.0, 1.0);
+}
+
+/// Four-stop price gradient: `stops[0]` (cheapest) → `stops[3]` (most
+/// expensive), with breakpoints at 1/3 and 2/3 of the range.
+///
+/// Returns [nullColor] when [price] is null and [flatColor] when the
+/// range is degenerate (`max <= min`). Callers pass their own palette and
+/// fallbacks so each marker style keeps its exact colours (#2196).
+Color priceGradientColor(
+  double? price,
+  double min,
+  double max, {
+  required List<Color> stops,
+  required Color nullColor,
+  required Color flatColor,
+}) {
+  if (price == null) return nullColor;
+  if (max <= min) return flatColor;
+  final t = normalizedPrice(price, min, max);
+  if (t < 0.33) return Color.lerp(stops[0], stops[1], t / 0.33)!;
+  if (t < 0.66) return Color.lerp(stops[1], stops[2], (t - 0.33) / 0.33)!;
+  return Color.lerp(stops[2], stops[3], (t - 0.66) / 0.34)!;
+}

--- a/lib/core/utils/price_tier.dart
+++ b/lib/core/utils/price_tier.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/material.dart';
 
+import 'price_gradient.dart';
+
 /// Price tier classification for accessibility — ensures price levels
 /// are distinguishable without relying on color alone (WCAG 1.4.1).
 enum PriceTier {
@@ -27,8 +29,9 @@ enum PriceTier {
 /// - expensive: 66%–100%
 PriceTier priceTierOf(double? price, double minPrice, double maxPrice) {
   if (price == null) return PriceTier.unknown;
-  if (maxPrice <= minPrice) return PriceTier.cheap;
-  final t = ((price - minPrice) / (maxPrice - minPrice)).clamp(0.0, 1.0);
+  // #2196 — share normalizedPrice with the marker gradient. A degenerate
+  // range yields 0 → cheap, matching the previous max<=min behaviour.
+  final t = normalizedPrice(price, minPrice, maxPrice);
   if (t < 0.33) return PriceTier.cheap;
   if (t < 0.66) return PriceTier.average;
   return PriceTier.expensive;

--- a/lib/core/utils/station_extensions.dart
+++ b/lib/core/utils/station_extensions.dart
@@ -41,3 +41,10 @@ extension StationDisplay on Station {
   }
 }
 
+/// Truncate [brand] to [maxLength] characters, appending an ellipsis when
+/// it overflows. Shared by the map and driving marker builders (#2196).
+String truncateBrand(String brand, {required int maxLength}) {
+  if (brand.length <= maxLength) return brand;
+  return '${brand.substring(0, maxLength - 1)}…';
+}
+

--- a/lib/core/utils/unit_formatter.dart
+++ b/lib/core/utils/unit_formatter.dart
@@ -103,6 +103,18 @@ class UnitFormatter {
   static String pricePerUnitSuffix({String? countryCode}) =>
       _resolve(countryCode).pricePerUnitSuffix;
 
+  /// Format an average / instantaneous consumption value with its
+  /// unit mask — `L/100 km` for combustion, `kWh/100 km` for EV.
+  ///
+  /// SSoT for the consumption mask that was previously copy-pasted
+  /// across the consumption widgets (#2185). Intentionally keeps the
+  /// **dot** decimal (`toStringAsFixed(1)`) rather than the active
+  /// locale's separator: the shipped consumption widget tests assert
+  /// exact strings like `6.4 L/100 km`, and the mask itself is a
+  /// language-neutral format mask, so it stays as-is.
+  static String formatConsumption(double value, {required bool isEv}) =>
+      '${value.toStringAsFixed(1)} ${isEv ? 'kWh/100 km' : 'L/100 km'}';
+
   /// Format a double with one decimal in the *active locale* so
   /// metric countries render "2,3 km" (comma) and English-locale
   /// countries render "2.3 km" (dot). Using `toStringAsFixed` would

--- a/lib/features/consumption/data/obd2/fuel_rate_diagnostics.dart
+++ b/lib/features/consumption/data/obd2/fuel_rate_diagnostics.dart
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'obd2_breadcrumb_collector.dart';
+
+/// Diagnostic collaborator extracted from
+/// `Obd2Service.readFuelRateLPerHour` (#2191). Owns the breadcrumb /
+/// cross-check side-channel so the read method itself reads as a clean
+/// three-step fallback: compute the value, delegate the diagnostics.
+///
+/// The breadcrumb trace (which PID path resolved the rate, the
+/// stoichiometric constants in play) and the two sanity bounds
+/// (suspicious-low at cruise, PID 5E vs MAF divergence) were
+/// previously interleaved into the hot read path (#1395). Pulling them
+/// here keeps the read method behaviour-identical — same breadcrumbs
+/// emitted, same value returned — while isolating the "why does the
+/// trip say 1 L/100 km" diagnostics into one testable unit.
+///
+/// Construct one per `readFuelRateLPerHour` call: it captures the
+/// per-call resolved constants (AFR, density, displacement, VE) plus
+/// the live-read tear-offs the cross-checks need, so the read method
+/// passes only the branch-specific values at each emit point.
+///
+/// All methods are no-ops when [collector] is null — the production
+/// one-shot read paths (e.g. VIN decode) wire no collector, and the
+/// `?.` short-circuit must stay free.
+class FuelRateDiagnostics {
+  /// The optional ring-buffer recorder. Null on paths that don't trace
+  /// fuel-rate samples; every emit method short-circuits when absent.
+  final Obd2BreadcrumbRecorder? collector;
+
+  /// Stoichiometric AFR resolved for this read (14.7 petrol, 14.5
+  /// diesel, or a manual override). Stamped on every breadcrumb and
+  /// used to derive the MAF cross-check rate.
+  final double afr;
+
+  /// Fuel density in g/L resolved for this read. Stamped on every
+  /// breadcrumb and used to derive the MAF cross-check rate.
+  final double fuelDensityGPerL;
+
+  /// Engine displacement in cc (pre-coerced to double for the
+  /// recorder, which renders it as a plain number). Stamped on every
+  /// breadcrumb.
+  final double engineDisplacementCc;
+
+  /// Volumetric efficiency resolved for this read. Stamped on every
+  /// breadcrumb.
+  final double volumetricEfficiency;
+
+  /// Reads current engine RPM. Used by the suspicious-low sanity bound
+  /// (a sub-0.3 L/h reading at > 1500 RPM is almost always noise).
+  final Future<double?> Function() readRpm;
+
+  /// Whether PID 0x10 (MAF) is implemented. Gates the 5E-vs-MAF
+  /// cross-check — skipped entirely on cars without a MAF sensor.
+  final bool Function() isMafSupported;
+
+  /// Reads mass air flow in g/s. Used by the 5E-vs-MAF cross-check.
+  final Future<double?> Function() readMaf;
+
+  const FuelRateDiagnostics({
+    required this.collector,
+    required this.afr,
+    required this.fuelDensityGPerL,
+    required this.engineDisplacementCc,
+    required this.volumetricEfficiency,
+    required this.readRpm,
+    required this.isMafSupported,
+    required this.readMaf,
+  });
+
+  /// Records the PID 5E direct-read breadcrumb and runs both sanity
+  /// bounds against it:
+  ///
+  ///   - **A (suspicious-low):** a `directRate < 0.3 L/h` while the
+  ///     engine is spinning above 1500 RPM flags the sample but does
+  ///     NOT drop it — the caller still surfaces the value; the
+  ///     suspicion ratio rolls up at trip-end.
+  ///   - **B (5E-vs-MAF divergence):** when MAF is also available, the
+  ///     MAF-derived rate is compared; > 50 % divergence flags the
+  ///     most-recent breadcrumb as `5e-vs-maf-divergent`.
+  ///
+  /// Issues at most one extra RPM read (only when [directRate] is
+  /// already below the 0.3 L/h floor) and one extra MAF read (only
+  /// when MAF is supported) — identical to the inlined behaviour.
+  Future<void> recordPid5E(double directRate) async {
+    final recorder = collector;
+    if (recorder == null) return;
+
+    // Sanity bound A: implausibly-low at non-idle RPM. PID 5E values
+    // < 0.3 L/h while the engine is spinning above 1500 RPM are almost
+    // always sensor noise / stuck PID — flag but DON'T drop.
+    String? lowFlag;
+    String? lowDetail;
+    double? rpmAtSample;
+    if (directRate < 0.3) {
+      rpmAtSample = await readRpm();
+      if (rpmAtSample != null && rpmAtSample > 1500) {
+        lowFlag = Obd2BreadcrumbCollector.flagSuspiciousLow;
+        lowDetail = 'directRate=${directRate.toStringAsFixed(2)};'
+            'rpm=${rpmAtSample.toStringAsFixed(0)}';
+      }
+    }
+    recorder.record(
+      branch: Obd2BranchTag.pid5E,
+      fuelRateLPerHour: directRate,
+      pid5ELPerHour: directRate,
+      rpm: rpmAtSample,
+      afr: afr,
+      fuelDensityGPerL: fuelDensityGPerL,
+      engineDisplacementCc: engineDisplacementCc,
+      volumetricEfficiency: volumetricEfficiency,
+      flag: lowFlag,
+      flagDetail: lowDetail,
+    );
+
+    // Sanity bound B: when MAF is also available, run the MAF-derived
+    // rate and compare. > 50 % divergence flags the sample as
+    // 5e-vs-maf-divergent. The diagnostic value is in having BOTH
+    // numbers side-by-side — the caller still uses the direct reading.
+    if (isMafSupported()) {
+      final mafCross = await readMaf();
+      if (mafCross != null) {
+        final mafDerived = mafCross * 3600.0 / (afr * fuelDensityGPerL);
+        if (mafDerived > 0 &&
+            (directRate - mafDerived).abs() / mafDerived > 0.5) {
+          recorder.recordFlag(
+            Obd2BreadcrumbCollector.flag5eVsMafDivergent,
+            'direct=${directRate.toStringAsFixed(2)};'
+                'mafDerived=${mafDerived.toStringAsFixed(2)};'
+                'maf=${mafCross.toStringAsFixed(2)}',
+          );
+        }
+      }
+    }
+  }
+
+  /// Records the MAF-branch breadcrumb. [corrected] is the trim-applied
+  /// rate the caller surfaces; [maf] is the raw g/s read.
+  void recordMaf({required double corrected, required double maf}) {
+    collector?.record(
+      branch: Obd2BranchTag.maf,
+      fuelRateLPerHour: corrected,
+      mafGramsPerSecond: maf,
+      afr: afr,
+      fuelDensityGPerL: fuelDensityGPerL,
+      engineDisplacementCc: engineDisplacementCc,
+      volumetricEfficiency: volumetricEfficiency,
+    );
+  }
+
+  /// Records the speed-density-branch breadcrumb. [corrected] is the
+  /// trim-applied rate; the MAP / IAT / RPM inputs are stamped for the
+  /// overlay.
+  void recordSpeedDensity({
+    required double corrected,
+    required double mapKpa,
+    required double iatCelsius,
+    required double rpm,
+  }) {
+    collector?.record(
+      branch: Obd2BranchTag.speedDensity,
+      fuelRateLPerHour: corrected,
+      mapKpa: mapKpa,
+      iatCelsius: iatCelsius,
+      rpm: rpm,
+      afr: afr,
+      fuelDensityGPerL: fuelDensityGPerL,
+      engineDisplacementCc: engineDisplacementCc,
+      volumetricEfficiency: volumetricEfficiency,
+    );
+  }
+
+  /// Records a `none`-branch breadcrumb — no fuel-rate value resolved
+  /// this tick. Captured for completeness so the overlay can show
+  /// "[--] no rate" rows. [mapKpa] / [iatCelsius] / [rpm] are the
+  /// partial speed-density inputs gathered so far (any may be null).
+  void recordNoBranch({
+    double? mapKpa,
+    double? iatCelsius,
+    double? rpm,
+  }) {
+    collector?.record(
+      branch: Obd2BranchTag.none,
+      mapKpa: mapKpa,
+      iatCelsius: iatCelsius,
+      rpm: rpm,
+      afr: afr,
+      fuelDensityGPerL: fuelDensityGPerL,
+      engineDisplacementCc: engineDisplacementCc,
+      volumetricEfficiency: volumetricEfficiency,
+    );
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -11,6 +11,7 @@ import 'adapter_capability.dart';
 import 'auto_record_trace_log.dart';
 import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
+import 'fuel_rate_diagnostics.dart';
 import 'fuel_rate_estimator.dart' as estimator;
 import 'obd2_breadcrumb_collector.dart';
 import 'obd2_debug_session.dart';
@@ -630,10 +631,24 @@ class Obd2Service implements Obd2RawCommandPort {
         (isDiesel
             ? estimator.kDieselDensityGPerL
             : estimator.kPetrolDensityGPerL);
-    // #1395 — pre-coerce displacement to double for breadcrumb pushes
-    // (the recorder typed displacement as `double?` so the overlay can
-    // render it as a plain number; the estimator below stays on int).
-    final displacementForCrumb = engineDisplacementCc.toDouble();
+    // #1395 / #2191 — the diagnostic side-channel (breadcrumb trace +
+    // the suspicious-low / 5E-vs-MAF sanity bounds) lives in this
+    // collaborator so the fallback chain below reads clean: compute
+    // the value, delegate the diagnostics. It captures the per-call
+    // resolved constants here (displacement pre-coerced to double for
+    // the recorder, which renders it as a plain number) plus the
+    // live-read tear-offs the cross-checks need.
+    final diagnostics = FuelRateDiagnostics(
+      collector: breadcrumbCollector,
+      afr: afr,
+      fuelDensityGPerL: fuelDensityGPerL,
+      engineDisplacementCc: engineDisplacementCc.toDouble(),
+      volumetricEfficiency: volumetricEfficiency,
+      readRpm: readRpm,
+      isMafSupported: () => isPidSupported(0x10),
+      readMaf: readMafGramsPerSecond,
+    );
+
     // Step 1: direct fuel-rate PID (already post-trim — no correction).
     // Skipped when #811 discovery proved the car doesn't implement PID 5E.
     double? directRate;
@@ -644,63 +659,8 @@ class Obd2Service implements Obd2RawCommandPort {
         label: 'fuelRate',
       );
     }
-
-    // #1395 — record the PID 5E read into the diagnostic collector
-    // BEFORE returning it. The caller surfaces the value to the trip
-    // integrator unchanged; the breadcrumb is the only place a
-    // suspicious-low / 5E-vs-MAF guard can fire without polluting the
-    // hot path.
     if (directRate != null) {
-      // Cross-check sanity bound A: implausibly-low at non-idle RPM.
-      // PID 5E values < 0.3 L/h while the engine is spinning above
-      // 1500 RPM are almost always sensor noise / stuck PID — flag
-      // but DON'T drop, the integrator still uses the value and the
-      // trip-end suspicion ratio rolls up to TripSummary.fuelRateSuspect.
-      String? lowFlag;
-      String? lowDetail;
-      double? rpmAtSample;
-      if (directRate < 0.3) {
-        rpmAtSample = await readRpm();
-        if (rpmAtSample != null && rpmAtSample > 1500) {
-          lowFlag = Obd2BreadcrumbCollector.flagSuspiciousLow;
-          lowDetail = 'directRate=${directRate.toStringAsFixed(2)};'
-              'rpm=${rpmAtSample.toStringAsFixed(0)}';
-        }
-      }
-      breadcrumbCollector?.record(
-        branch: Obd2BranchTag.pid5E,
-        fuelRateLPerHour: directRate,
-        pid5ELPerHour: directRate,
-        rpm: rpmAtSample,
-        afr: afr,
-        fuelDensityGPerL: fuelDensityGPerL,
-        engineDisplacementCc: displacementForCrumb,
-        volumetricEfficiency: volumetricEfficiency,
-        flag: lowFlag,
-        flagDetail: lowDetail,
-      );
-
-      // Cross-check sanity bound B: when MAF is also available, run
-      // the MAF-derived rate and compare. > 50 % divergence flags the
-      // sample as 5e-vs-maf-divergent. We do this even after the
-      // direct return below because the diagnostic value is in
-      // having BOTH numbers side-by-side — the integrator still uses
-      // the direct PID 5E reading.
-      if (isPidSupported(0x10)) {
-        final mafCross = await readMafGramsPerSecond();
-        if (mafCross != null) {
-          final mafDerived = mafCross * 3600.0 / (afr * fuelDensityGPerL);
-          if (mafDerived > 0 &&
-              (directRate - mafDerived).abs() / mafDerived > 0.5) {
-            breadcrumbCollector?.recordFlag(
-              Obd2BreadcrumbCollector.flag5eVsMafDivergent,
-              'direct=${directRate.toStringAsFixed(2)};'
-                  'mafDerived=${mafDerived.toStringAsFixed(2)};'
-                  'maf=${mafCross.toStringAsFixed(2)}',
-            );
-          }
-        }
-      }
+      await diagnostics.recordPid5E(directRate);
       return directRate;
     }
 
@@ -713,15 +673,7 @@ class Obd2Service implements Obd2RawCommandPort {
         // Stoichiometric L/h = MAF × 3600 / (AFR × density).
         final rate = maf * 3600.0 / (afr * fuelDensityGPerL);
         final corrected = await _applyFuelTrimCorrection(rate);
-        breadcrumbCollector?.record(
-          branch: Obd2BranchTag.maf,
-          fuelRateLPerHour: corrected,
-          mafGramsPerSecond: maf,
-          afr: afr,
-          fuelDensityGPerL: fuelDensityGPerL,
-          engineDisplacementCc: displacementForCrumb,
-          volumetricEfficiency: volumetricEfficiency,
-        );
+        diagnostics.recordMaf(corrected: corrected, maf: maf);
         return corrected;
       }
     }
@@ -732,28 +684,17 @@ class Obd2Service implements Obd2RawCommandPort {
     if (!isPidSupported(0x0B) ||
         !isPidSupported(0x0F) ||
         !isPidSupported(0x0C)) {
-      breadcrumbCollector?.record(
-        branch: Obd2BranchTag.none,
-        afr: afr,
-        fuelDensityGPerL: fuelDensityGPerL,
-        engineDisplacementCc: displacementForCrumb,
-        volumetricEfficiency: volumetricEfficiency,
-      );
+      diagnostics.recordNoBranch();
       return null;
     }
     final mapKpa = await readManifoldPressureKpa();
     final iatCelsius = await readIntakeAirTempCelsius();
     final rpm = await readRpm();
     if (mapKpa == null || iatCelsius == null || rpm == null) {
-      breadcrumbCollector?.record(
-        branch: Obd2BranchTag.none,
+      diagnostics.recordNoBranch(
         mapKpa: mapKpa,
         iatCelsius: iatCelsius,
         rpm: rpm,
-        afr: afr,
-        fuelDensityGPerL: fuelDensityGPerL,
-        engineDisplacementCc: displacementForCrumb,
-        volumetricEfficiency: volumetricEfficiency,
       );
       return null;
     }
@@ -768,29 +709,19 @@ class Obd2Service implements Obd2RawCommandPort {
       etaVCurve: etaVCurve,
     );
     if (rate == null) {
-      breadcrumbCollector?.record(
-        branch: Obd2BranchTag.none,
+      diagnostics.recordNoBranch(
         mapKpa: mapKpa,
         iatCelsius: iatCelsius,
         rpm: rpm,
-        afr: afr,
-        fuelDensityGPerL: fuelDensityGPerL,
-        engineDisplacementCc: displacementForCrumb,
-        volumetricEfficiency: volumetricEfficiency,
       );
       return null;
     }
     final corrected = await _applyFuelTrimCorrection(rate);
-    breadcrumbCollector?.record(
-      branch: Obd2BranchTag.speedDensity,
-      fuelRateLPerHour: corrected,
+    diagnostics.recordSpeedDensity(
+      corrected: corrected,
       mapKpa: mapKpa,
       iatCelsius: iatCelsius,
       rpm: rpm,
-      afr: afr,
-      fuelDensityGPerL: fuelDensityGPerL,
-      engineDisplacementCc: displacementForCrumb,
-      volumetricEfficiency: volumetricEfficiency,
     );
     return corrected;
   }

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/storage/storage_keys.dart';
 import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/utils/unit_formatter.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -754,7 +755,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     } else {
       avgValue = liveAvg == null
           ? '—'
-          : '${liveAvg.toStringAsFixed(1)} L/100 km';
+          : UnitFormatter.formatConsumption(liveAvg, isEv: false);
     }
 
     return Column(
@@ -826,7 +827,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
       final stats = ConsumptionStats.fromFillUps(fills);
       final avg = stats.avgConsumptionL100km;
       if (avg == null) return null;
-      return '${avg.toStringAsFixed(1)} L/100 km';
+      return UnitFormatter.formatConsumption(avg, isEv: false);
     } catch (e, st) {
       // A malformed fill-up set must not crash the summary card —
       // but log the cause rather than hiding it silently (#1682).
@@ -863,7 +864,7 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
           label: l?.tripMetricAvgConsumption ?? 'Avg',
           value: s.avgLPer100Km == null
               ? '—'
-              : '${s.avgLPer100Km!.toStringAsFixed(1)} L/100 km',
+              : UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: false),
         ),
         const SizedBox(height: 8),
         _MetricCard(

--- a/lib/features/consumption/presentation/widgets/eco_score_badge.dart
+++ b/lib/features/consumption/presentation/widgets/eco_score_badge.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/eco_score.dart';
 
@@ -34,8 +35,8 @@ class EcoScoreBadge extends StatelessWidget {
 
     // Compose the badge text from the localised consumption unit +
     // the raw delta; the delta itself (+/− and %) is locale-neutral.
-    final consumptionText =
-        l10n?.ecoScoreConsumption(lp100Text) ?? '$lp100Text L/100 km';
+    final consumptionText = l10n?.ecoScoreConsumption(lp100Text) ??
+        UnitFormatter.formatConsumption(score.litersPer100Km, isEv: false);
     final badgeText = '$consumptionText · $deltaText';
 
     final tooltip = l10n?.ecoScoreTooltip(avgText) ??

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -155,7 +155,10 @@ class FillUpCard extends StatelessWidget {
                 l?.ecoScoreConsumption(
                       rawLPer100Km!.toStringAsFixed(1),
                     ) ??
-                    '${rawLPer100Km!.toStringAsFixed(1)} L/100 km',
+                    UnitFormatter.formatConsumption(
+                      rawLPer100Km!,
+                      isEv: false,
+                    ),
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                   fontWeight: FontWeight.w600,

--- a/lib/features/consumption/presentation/widgets/minimal_drive_summary.dart
+++ b/lib/features/consumption/presentation/widgets/minimal_drive_summary.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/driving_coaching.dart';
 import '../../providers/trip_recording_provider.dart';
@@ -60,7 +61,7 @@ class MinimalDriveSummary extends ConsumerWidget {
     final scheme = theme.colorScheme;
     final headline = liveAvg == null
         ? '—'
-        : '${liveAvg.toStringAsFixed(1)} L/100 km';
+        : UnitFormatter.formatConsumption(liveAvg, isEv: false);
 
     // #2058 — when the trajet has no fuel-rate data (GPS-only mode),
     // swap the OBD2-derived tile triplet (shift-up / shift-down /

--- a/lib/features/consumption/presentation/widgets/trajet_row.dart
+++ b/lib/features/consumption/presentation/widgets/trajet_row.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
@@ -113,7 +114,10 @@ class TrajetRow extends StatelessWidget {
                                   s.avgLPer100Km!.toStringAsFixed(1),
                                   avgUnit,
                                 ) ??
-                                '${s.avgLPer100Km!.toStringAsFixed(1)} $avgUnit',
+                                UnitFormatter.formatConsumption(
+                                  s.avgLPer100Km!,
+                                  isEv: isEv,
+                                ),
                           ),
                         if (s.coldStartSurcharge)
                           _Chip(

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/utils/num_extensions.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/trip_history_repository.dart';
@@ -46,7 +47,6 @@ class TripSummaryCard extends ConsumerWidget {
     final theme = Theme.of(context);
     final s = entry.summary;
     final unknown = l?.trajetDetailFieldValueUnknown ?? '—';
-    final avgUnit = isEv ? 'kWh/100 km' : 'L/100 km';
 
     // #1209 — estimated trip cost from the most recent fill-up's
     // price-per-litre. Hidden on EV trips (the helper still returns
@@ -64,7 +64,7 @@ class TripSummaryCard extends ConsumerWidget {
         : unknown;
     final avgConsumption = s.avgLPer100Km == null
         ? unknown
-        : '${s.avgLPer100Km!.toStringAsFixed(1)} $avgUnit';
+        : UnitFormatter.formatConsumption(s.avgLPer100Km!, isEv: isEv);
     final fuelUsed = s.fuelLitersConsumed == null
         ? unknown
         : '${s.fuelLitersConsumed!.toStringAsFixed(2)} L';

--- a/lib/features/driving/presentation/widgets/driving_marker_builder.dart
+++ b/lib/features/driving/presentation/widgets/driving_marker_builder.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/utils/price_gradient.dart';
 import '../../../../core/utils/price_tier.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../search/domain/entities/fuel_type.dart';
@@ -31,7 +32,7 @@ class DrivingMarkerBuilder {
   }) {
     final price = station.priceFor(fuel);
     final color = _priceColor(price, minPrice, maxPrice);
-    final brand = _truncateBrand(station.displayName);
+    final brand = truncateBrand(station.displayName, maxLength: _maxBrandLength);
     final tier = priceTierOf(price, minPrice, maxPrice);
 
     return Marker(
@@ -97,36 +98,23 @@ class DrivingMarkerBuilder {
     );
   }
 
-  /// High-contrast price colors for driving mode.
+  /// High-contrast price colors for driving mode (#2196 \u2014 delegates to
+  /// the shared [priceGradientColor] with the bright driving palette).
   /// Bright green (cheapest) -> yellow -> red (most expensive).
-  static Color _priceColor(double? price, double minPrice, double maxPrice) {
-    if (price == null) return Colors.grey.shade400;
-    if (maxPrice <= minPrice) return const Color(0xFF4CAF50);
-    final t = ((price - minPrice) / (maxPrice - minPrice)).clamp(0.0, 1.0);
-    if (t < 0.33) {
-      return Color.lerp(
-        const Color(0xFF4CAF50),
-        const Color(0xFFFFEB3B),
-        t / 0.33,
-      )!;
-    } else if (t < 0.66) {
-      return Color.lerp(
-        const Color(0xFFFFEB3B),
-        const Color(0xFFFF9800),
-        (t - 0.33) / 0.33,
-      )!;
-    } else {
-      return Color.lerp(
-        const Color(0xFFFF9800),
-        const Color(0xFFF44336),
-        (t - 0.66) / 0.34,
-      )!;
-    }
-  }
+  static const _drivingStops = [
+    Color(0xFF4CAF50),
+    Color(0xFFFFEB3B),
+    Color(0xFFFF9800),
+    Color(0xFFF44336),
+  ];
 
-  /// Truncate brand name if longer than [_maxBrandLength].
-  static String _truncateBrand(String brand) {
-    if (brand.length <= _maxBrandLength) return brand;
-    return '${brand.substring(0, _maxBrandLength - 1)}\u2026';
-  }
+  static Color _priceColor(double? price, double minPrice, double maxPrice) =>
+      priceGradientColor(
+        price,
+        minPrice,
+        maxPrice,
+        stops: _drivingStops,
+        nullColor: Colors.grey.shade400,
+        flatColor: const Color(0xFF4CAF50),
+      );
 }

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -6,6 +6,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/utils/price_gradient.dart';
 import '../../../../core/utils/price_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../search/domain/entities/fuel_type.dart';
@@ -44,7 +45,7 @@ class StationMarkerBuilder {
     final price = priceForFuelType(station, fuel);
     final baseColor = priceColor(price, minPrice, maxPrice);
     final color = pastel ? _toPastel(baseColor) : baseColor;
-    final brand = _truncateBrand(station.displayName);
+    final brand = truncateBrand(station.displayName, maxLength: _maxBrandLength);
 
     // Accessibility (#566): TalkBack/VoiceOver read this as "Brand, price
     // EUR per litre, double-tap to view details" — otherwise the marker is
@@ -115,28 +116,28 @@ class StationMarkerBuilder {
   }
 
   /// Green (cheapest) -> Yellow -> Orange -> Red (most expensive).
-  static Color priceColor(double? price, double minPrice, double maxPrice) {
-    if (price == null) return Colors.grey;
-    if (maxPrice <= minPrice) return Colors.green;
-    final t = ((price - minPrice) / (maxPrice - minPrice)).clamp(0.0, 1.0);
-    if (t < 0.33) {
-      return Color.lerp(Colors.green, Colors.yellow, t / 0.33)!;
-    } else if (t < 0.66) {
-      return Color.lerp(Colors.yellow, Colors.orange, (t - 0.33) / 0.33)!;
-    } else {
-      return Color.lerp(Colors.orange, Colors.red, (t - 0.66) / 0.34)!;
-    }
-  }
+  /// #2196 \u2014 thin wrapper over the shared [priceGradientColor]; kept
+  /// public because tests assert its boundary colours directly.
+  static const _priceStops = [
+    Colors.green,
+    Colors.yellow,
+    Colors.orange,
+    Colors.red,
+  ];
+
+  static Color priceColor(double? price, double minPrice, double maxPrice) =>
+      priceGradientColor(
+        price,
+        minPrice,
+        maxPrice,
+        stops: _priceStops,
+        nullColor: Colors.grey,
+        flatColor: Colors.green,
+      );
 
   /// Convert a vivid color to a pastel/muted variant.
   static Color _toPastel(Color color) {
     // Blend with white at 60% to create pastel
     return Color.lerp(color, Colors.white, 0.6)!;
-  }
-
-  /// Truncate brand name if longer than [_maxBrandLength].
-  static String _truncateBrand(String brand) {
-    if (brand.length <= _maxBrandLength) return brand;
-    return '${brand.substring(0, _maxBrandLength - 1)}\u2026';
   }
 }

--- a/lib/features/route_search/data/strategies/balanced_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/balanced_search_strategy.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/foundation.dart';
-import 'package:latlong2/latlong.dart';
 
 import '../../../../core/utils/geo_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
@@ -12,6 +11,7 @@ import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
 import '../helpers/batch_query_helper.dart';
+import 'route_geometry.dart';
 
 /// Balanced strategy: finds stations with a good balance between
 /// price and distance from route (minimal detour).
@@ -55,7 +55,7 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
 
     for (final item in results) {
       if (item is FuelStationResult) {
-        final minDist = _minDistanceToPolyline(
+        final minDist = minDistanceToPolyline(
           item.station.lat, item.station.lng, route.geometry,
         );
         if (minDist <= detourLimit) {
@@ -72,11 +72,7 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
 
     // Sort by position along route (itinerary order)
     final items = scored.map((e) => e.$1).toList();
-    items.sort((a, b) {
-      final da = distanceAlongPolyline(a.lat, a.lng, route.geometry);
-      final db = distanceAlongPolyline(b.lat, b.lng, route.geometry);
-      return da.compareTo(db);
-    });
+    sortByItineraryOrder(items, route.geometry);
 
     return items;
   }
@@ -106,12 +102,12 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
             nearestSampleIdx = i;
           }
         }
-        final segmentIdx = (nearestSampleIdx * 15 / segmentKm).floor();
+        final segmentIdx = segmentIndexFor(nearestSampleIdx, segmentKm);
 
         final price = station.priceFor(fuelType);
         if (price != null) {
           // Balanced score: price + distance penalty
-          final routeDist = _minDistanceToPolyline(
+          final routeDist = minDistanceToPolyline(
             station.lat, station.lng, route.geometry,
           );
           final score = price + (routeDist * 0.1);
@@ -125,17 +121,5 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
     }
 
     return segmentBest.map((k, v) => MapEntry(k, v.$1));
-  }
-
-  double _minDistanceToPolyline(double lat, double lng, List<LatLng> polyline) {
-    if (polyline.isEmpty) return double.infinity;
-    double minDist = double.infinity;
-    final step = polyline.length > 300 ? 3 : 1;
-    for (int i = 0; i < polyline.length; i += step) {
-      final p = polyline[i];
-      final d = distanceKm(lat, lng, p.latitude, p.longitude);
-      if (d < minDist) minDist = d;
-    }
-    return minDist;
   }
 }

--- a/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/foundation.dart';
-import 'package:latlong2/latlong.dart';
 
 import '../../../../core/utils/geo_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
@@ -12,6 +11,7 @@ import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
 import '../helpers/batch_query_helper.dart';
+import 'route_geometry.dart';
 
 /// Strategy that prioritizes finding the cheapest stations along the route.
 ///
@@ -61,7 +61,7 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
     final filtered = <SearchResultItem>[];
     for (final item in results) {
       if (item is FuelStationResult) {
-        final minDist = _minDistanceToPolyline(
+        final minDist = minDistanceToPolyline(
           item.station.lat, item.station.lng, route.geometry,
         );
         if (minDist <= detourLimit) {
@@ -73,7 +73,7 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
     }
 
     // Sort by position along route (itinerary order)
-    _sortByItineraryOrder(filtered, route.geometry);
+    sortByItineraryOrder(filtered, route.geometry);
 
     return filtered;
   }
@@ -108,7 +108,7 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
             nearestSampleIdx = i;
           }
         }
-        final segmentIdx = (nearestSampleIdx * 15 / segmentKm).floor();
+        final segmentIdx = segmentIndexFor(nearestSampleIdx, segmentKm);
 
         final price = station.priceFor(fuelType);
         if (price != null) {
@@ -124,29 +124,5 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
     }
 
     return segmentCheapest;
-  }
-
-  double _minDistanceToPolyline(double lat, double lng, List<LatLng> polyline) {
-    if (polyline.isEmpty) return double.infinity;
-    double minDist = double.infinity;
-    final step = polyline.length > 300 ? 3 : 1;
-    for (int i = 0; i < polyline.length; i += step) {
-      final p = polyline[i];
-      final d = distanceKm(lat, lng, p.latitude, p.longitude);
-      if (d < minDist) minDist = d;
-    }
-    return minDist;
-  }
-
-  /// Sorts results by their position along the route polyline (itinerary order).
-  void _sortByItineraryOrder(
-    List<SearchResultItem> items,
-    List<LatLng> geometry,
-  ) {
-    items.sort((a, b) {
-      final da = distanceAlongPolyline(a.lat, a.lng, geometry);
-      final db = distanceAlongPolyline(b.lat, b.lng, geometry);
-      return da.compareTo(db);
-    });
   }
 }

--- a/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
@@ -15,6 +15,7 @@ import '../../domain/route_search_strategy.dart';
 import '../helpers/batch_query_helper.dart';
 import 'eco_route_candidate.dart';
 import 'eco_route_scoring.dart';
+import 'route_geometry.dart';
 
 // Re-export the value types so existing imports of
 // `eco_route_search_strategy.dart` continue to resolve
@@ -203,7 +204,7 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
     final filtered = <SearchResultItem>[];
     for (final item in results) {
       if (item is FuelStationResult) {
-        final minDist = _minDistanceToPolyline(
+        final minDist = minDistanceToPolyline(
           item.station.lat,
           item.station.lng,
           route.geometry,
@@ -216,7 +217,7 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
       }
     }
 
-    _sortByItineraryOrder(filtered, route.geometry);
+    sortByItineraryOrder(filtered, route.geometry);
     return filtered;
   }
 
@@ -248,7 +249,7 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
             nearestSampleIdx = i;
           }
         }
-        final segmentIdx = (nearestSampleIdx * 15 / segmentKm).floor();
+        final segmentIdx = segmentIndexFor(nearestSampleIdx, segmentKm);
         final price = station.priceFor(fuelType);
         if (price != null) {
           final currentBestPrice = segmentCheapestPrice[segmentIdx];
@@ -261,32 +262,5 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
       }
     }
     return segmentCheapest;
-  }
-
-  double _minDistanceToPolyline(
-    double lat,
-    double lng,
-    List<LatLng> polyline,
-  ) {
-    if (polyline.isEmpty) return double.infinity;
-    double minDist = double.infinity;
-    final step = polyline.length > 300 ? 3 : 1;
-    for (int i = 0; i < polyline.length; i += step) {
-      final p = polyline[i];
-      final d = geo.distanceKm(lat, lng, p.latitude, p.longitude);
-      if (d < minDist) minDist = d;
-    }
-    return minDist;
-  }
-
-  void _sortByItineraryOrder(
-    List<SearchResultItem> items,
-    List<LatLng> geometry,
-  ) {
-    items.sort((a, b) {
-      final da = geo.distanceAlongPolyline(a.lat, a.lng, geometry);
-      final db = geo.distanceAlongPolyline(b.lat, b.lng, geometry);
-      return da.compareTo(db);
-    });
   }
 }

--- a/lib/features/route_search/data/strategies/route_geometry.dart
+++ b/lib/features/route_search/data/strategies/route_geometry.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:latlong2/latlong.dart';
+
+import '../../../../core/utils/geo_utils.dart';
+import '../../../search/domain/entities/search_result_item.dart';
+
+/// Shared route-search geometry helpers (#2197).
+///
+/// `CheapestSearchStrategy`, `BalancedSearchStrategy` and
+/// `EcoRouteSearchStrategy` each carried byte-identical copies of the
+/// polyline-distance, itinerary-sort and segment-bucketing logic, and
+/// `route_search_provider.dart` inlined the same itinerary sort for its
+/// EV-along-route results. They are hoisted here so the math lives in
+/// one place; behaviour is bit-identical to the previous inlined copies.
+///
+/// `UniformSearchStrategy`'s isolate path (`_StationLite` /
+/// `_computeBestStopsSync` / `_filterAndSortIsolate`) deliberately keeps
+/// its own inlined geometry — it must stay free of UI-side imports so it
+/// can run inside a background isolate — and is intentionally NOT a
+/// consumer of these helpers.
+
+/// Approximate spacing, in km, between the sample points that
+/// `RoutingService._sampleAlongPolyline` (and
+/// `EcoRouteCandidate.toRouteInfo`) lay down along a route polyline.
+///
+/// The per-segment bucketing in [segmentIndexFor] re-uses this spacing
+/// to translate a nearest-sample-point index back into an along-route
+/// distance before dividing into segments. Kept as a named constant so
+/// the magic `15` the strategies used has one source (#2197). The
+/// sampler itself (`routing_service.dart:112`,
+/// `eco_route_candidate.dart:46`) still passes the literal `15.0` —
+/// that's a sampling-interval argument, distinct from this bucketing
+/// approximation, and deliberately left in place.
+const double kSamplePointSpacingKm = 15.0;
+
+/// Minimum great-circle distance (km) from a point to any vertex of
+/// [polyline]. Steps through every third vertex on long polylines
+/// (>300 vertices) to keep the scan cheap — the same approximation the
+/// strategies have always used. Returns `double.infinity` for an empty
+/// polyline.
+double minDistanceToPolyline(double lat, double lng, List<LatLng> polyline) {
+  if (polyline.isEmpty) return double.infinity;
+  double minDist = double.infinity;
+  final step = polyline.length > 300 ? 3 : 1;
+  for (int i = 0; i < polyline.length; i += step) {
+    final p = polyline[i];
+    final d = distanceKm(lat, lng, p.latitude, p.longitude);
+    if (d < minDist) minDist = d;
+  }
+  return minDist;
+}
+
+/// Sorts [items] in place by their position along [geometry]
+/// (itinerary order), nearest-to-start first.
+void sortByItineraryOrder(
+  List<SearchResultItem> items,
+  List<LatLng> geometry,
+) {
+  items.sort((a, b) {
+    final da = distanceAlongPolyline(a.lat, a.lng, geometry);
+    final db = distanceAlongPolyline(b.lat, b.lng, geometry);
+    return da.compareTo(db);
+  });
+}
+
+/// Map a nearest-sample-point index onto a per-segment bucket index.
+///
+/// Approximates the along-route distance as
+/// `nearestSampleIdx * kSamplePointSpacingKm`, then divides by
+/// [segmentKm] and floors — i.e. each `segmentKm`-wide stretch of the
+/// route is one bucket. Preserves the original
+/// `(nearestSampleIdx * 15 / segmentKm).floor()` semantics exactly.
+int segmentIndexFor(int nearestSampleIdx, double segmentKm) =>
+    (nearestSampleIdx * kSamplePointSpacingKm / segmentKm).floor();

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -9,7 +9,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/error/exceptions.dart';
 import '../../../core/logging/error_logger.dart';
-import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/country/country_provider.dart';
@@ -20,6 +19,7 @@ import '../../search/providers/ev_charging_service_provider.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
 import '../../profile/providers/profile_provider.dart';
+import '../data/strategies/route_geometry.dart';
 import '../data/services/routing_service.dart';
 import '../domain/entities/route_info.dart';
 import '../domain/route_search_result.dart';
@@ -267,11 +267,7 @@ class RouteSearchState extends _$RouteSearchState {
     }
 
     // Sort by position along route (itinerary order)
-    results.sort((a, b) {
-      final da = distanceAlongPolyline(a.lat, a.lng, route.geometry);
-      final db = distanceAlongPolyline(b.lat, b.lng, route.geometry);
-      return da.compareTo(db);
-    });
+    sortByItineraryOrder(results, route.geometry);
     return results;
   }
 

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'468181118db0d8a5310822537b21d9b1bb818563';
+String _$routeSearchStateHash() => r'68d50854b96011100d963d93bc6348d4d58c3574';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/test/core/utils/price_gradient_test.dart
+++ b/test/core/utils/price_gradient_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/price_gradient.dart';
+
+void main() {
+  group('normalizedPrice (#2196)', () {
+    test('maps min/mid/max to 0 / 0.5 / 1', () {
+      expect(normalizedPrice(1.0, 1.0, 3.0), 0.0);
+      expect(normalizedPrice(2.0, 1.0, 3.0), closeTo(0.5, 1e-9));
+      expect(normalizedPrice(3.0, 1.0, 3.0), 1.0);
+    });
+
+    test('clamps out-of-range values', () {
+      expect(normalizedPrice(0.0, 1.0, 3.0), 0.0);
+      expect(normalizedPrice(9.0, 1.0, 3.0), 1.0);
+    });
+
+    test('degenerate range (max <= min) returns 0', () {
+      expect(normalizedPrice(2.0, 3.0, 3.0), 0.0);
+      expect(normalizedPrice(2.0, 5.0, 3.0), 0.0);
+    });
+  });
+
+  group('priceGradientColor (#2196)', () {
+    const stops = [Colors.green, Colors.yellow, Colors.orange, Colors.red];
+
+    test('null price returns nullColor', () {
+      expect(
+        priceGradientColor(null, 1.0, 3.0,
+            stops: stops, nullColor: Colors.grey, flatColor: Colors.green),
+        Colors.grey,
+      );
+    });
+
+    test('degenerate range returns flatColor', () {
+      expect(
+        priceGradientColor(2.0, 3.0, 3.0,
+            stops: stops, nullColor: Colors.grey, flatColor: Colors.green),
+        Colors.green,
+      );
+    });
+
+    test('cheapest is greenest, most expensive is reddest', () {
+      final cheap = priceGradientColor(1.0, 1.0, 3.0,
+          stops: stops, nullColor: Colors.grey, flatColor: Colors.green);
+      final dear = priceGradientColor(3.0, 1.0, 3.0,
+          stops: stops, nullColor: Colors.grey, flatColor: Colors.green);
+      // green channel dominates at the cheap end, red at the dear end.
+      expect(cheap.g, greaterThan(cheap.r));
+      expect(dear.r, greaterThan(dear.g));
+    });
+
+    test('respects a custom palette (driving bright colours)', () {
+      const driving = [
+        Color(0xFF4CAF50),
+        Color(0xFFFFEB3B),
+        Color(0xFFFF9800),
+        Color(0xFFF44336),
+      ];
+      final c = priceGradientColor(1.0, 1.0, 3.0,
+          stops: driving,
+          nullColor: Colors.grey.shade400,
+          flatColor: const Color(0xFF4CAF50));
+      expect(c, const Color(0xFF4CAF50)); // t=0 → first stop exactly
+    });
+  });
+}

--- a/test/core/utils/station_extensions_test.dart
+++ b/test/core/utils/station_extensions_test.dart
@@ -143,4 +143,22 @@ void main() {
       expect(station.fullLocation, '12345 Berlin');
     });
   });
+
+  group('truncateBrand (#2196)', () {
+    test('returns the brand unchanged when within the limit', () {
+      expect(truncateBrand('Shell', maxLength: 14), 'Shell');
+      expect(truncateBrand('Exactly14chars', maxLength: 14), 'Exactly14chars');
+    });
+
+    test('truncates with an ellipsis when over the limit', () {
+      final out = truncateBrand('SuperLongBrandName', maxLength: 14);
+      expect(out, 'SuperLongBran…');
+      expect(out.length, 14);
+    });
+
+    test('respects a different maxLength', () {
+      expect(truncateBrand('SuperLongBrandName', maxLength: 16),
+          'SuperLongBrandN…');
+    });
+  });
 }

--- a/test/core/utils/unit_formatter_test.dart
+++ b/test/core/utils/unit_formatter_test.dart
@@ -134,4 +134,35 @@ void main() {
       expect(UnitFormatter.pricePerUnitSuffix(countryCode: 'DK'), 'kr/L');
     });
   });
+
+  group('formatConsumption', () {
+    test('combustion renders the L/100 km mask', () {
+      expect(UnitFormatter.formatConsumption(6.4, isEv: false), '6.4 L/100 km');
+    });
+
+    test('EV renders the kWh/100 km mask', () {
+      expect(
+        UnitFormatter.formatConsumption(18.2, isEv: true),
+        '18.2 kWh/100 km',
+      );
+    });
+
+    test('keeps a DOT decimal even under a comma locale (FR setUp)', () {
+      // The mask is a language-neutral format mask, and shipped widget
+      // tests assert exact dot strings \u2014 so the active FR comma locale
+      // must NOT bleed into the value.
+      expect(UnitFormatter.formatConsumption(7.0, isEv: false), '7.0 L/100 km');
+    });
+
+    test('rounds to exactly one decimal', () {
+      expect(
+        UnitFormatter.formatConsumption(5.849, isEv: false),
+        '5.8 L/100 km',
+      );
+      expect(
+        UnitFormatter.formatConsumption(12, isEv: true),
+        '12.0 kWh/100 km',
+      );
+    });
+  });
 }

--- a/test/features/consumption/data/obd2/fuel_rate_diagnostics_test.dart
+++ b/test/features/consumption/data/obd2/fuel_rate_diagnostics_test.dart
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/fuel_rate_diagnostics.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_breadcrumb_collector.dart';
+
+/// Focused unit tests for the fuel-rate diagnostic collaborator
+/// extracted out of `Obd2Service.readFuelRateLPerHour` (#2191). The
+/// end-to-end breadcrumb behaviour is still asserted through the
+/// service in `obd2_service_test.dart`; this isolates the separable
+/// diagnostics — the two sanity bounds and the branch breadcrumbs —
+/// from the BLE round-trips.
+void main() {
+  group('FuelRateDiagnostics (#2191)', () {
+    /// Builds a diagnostics collaborator with petrol constants and
+    /// caller-controllable RPM / MAF reads.
+    FuelRateDiagnostics build({
+      required Obd2BreadcrumbRecorder? collector,
+      double? rpm,
+      bool mafSupported = false,
+      double? maf,
+    }) {
+      return FuelRateDiagnostics(
+        collector: collector,
+        afr: 14.7,
+        fuelDensityGPerL: 745,
+        engineDisplacementCc: 1500,
+        volumetricEfficiency: 0.85,
+        readRpm: () async => rpm,
+        isMafSupported: () => mafSupported,
+        readMaf: () async => maf,
+      );
+    }
+
+    test('recordPid5E stamps a 5E breadcrumb with rate + constants', () async {
+      final c = Obd2BreadcrumbCollector();
+      await build(collector: c).recordPid5E(4.0);
+
+      expect(c.entries, hasLength(1));
+      final crumb = c.entries.first;
+      expect(crumb.branch, equals(Obd2BranchTag.pid5E));
+      expect(crumb.fuelRateLPerHour, closeTo(4.0, 0.01));
+      expect(crumb.pid5ELPerHour, closeTo(4.0, 0.01));
+      expect(crumb.afr, closeTo(14.7, 0.01));
+      expect(crumb.fuelDensityGPerL, closeTo(745, 0.5));
+      expect(crumb.flag, isNull);
+    });
+
+    test(
+        'sanity bound A: directRate < 0.3 at RPM > 1500 flags '
+        'suspicious-low', () async {
+      final c = Obd2BreadcrumbCollector();
+      await build(collector: c, rpm: 2176).recordPid5E(0.2);
+
+      expect(c.entries, hasLength(1));
+      expect(
+        c.entries.first.flag,
+        equals(Obd2BreadcrumbCollector.flagSuspiciousLow),
+      );
+      expect(c.entries.first.rpm, closeTo(2176, 0.5));
+      expect(c.suspiciousSampleCount, equals(1));
+    });
+
+    test(
+        'sanity bound A: directRate < 0.3 at idle RPM does NOT flag',
+        () async {
+      final c = Obd2BreadcrumbCollector();
+      await build(collector: c, rpm: 800).recordPid5E(0.2);
+
+      expect(c.entries.first.flag, isNull);
+      expect(c.suspiciousSampleCount, equals(0));
+    });
+
+    test(
+        'sanity bound A: a healthy rate never reads RPM (no flag)',
+        () async {
+      var rpmReads = 0;
+      final c = Obd2BreadcrumbCollector();
+      final diag = FuelRateDiagnostics(
+        collector: c,
+        afr: 14.7,
+        fuelDensityGPerL: 745,
+        engineDisplacementCc: 1500,
+        volumetricEfficiency: 0.85,
+        readRpm: () async {
+          rpmReads++;
+          return 2200;
+        },
+        isMafSupported: () => false,
+        readMaf: () async => null,
+      );
+
+      await diag.recordPid5E(4.0);
+
+      // Above the 0.3 L/h floor — the RPM read is skipped entirely.
+      expect(rpmReads, equals(0));
+      expect(c.entries.first.flag, isNull);
+    });
+
+    test(
+        'sanity bound B: 5E vs MAF divergence > 50 % flags '
+        '5e-vs-maf-divergent', () async {
+      final c = Obd2BreadcrumbCollector();
+      // MAF 10.24 g/s → derived ≈ 3.367 L/h. |16-3.37|/3.37 ≈ 3.7.
+      await build(collector: c, mafSupported: true, maf: 10.24)
+          .recordPid5E(16.0);
+
+      expect(c.entries, hasLength(1));
+      expect(
+        c.entries.first.flag,
+        equals(Obd2BreadcrumbCollector.flag5eVsMafDivergent),
+      );
+      expect(c.suspiciousSampleCount, equals(1));
+    });
+
+    test(
+        'sanity bound B: 5E vs MAF within 50 % does NOT flag', () async {
+      final c = Obd2BreadcrumbCollector();
+      // MAF 10.24 g/s → derived ≈ 3.367 L/h; 3.4 is well inside ±50 %.
+      await build(collector: c, mafSupported: true, maf: 10.24)
+          .recordPid5E(3.4);
+
+      expect(c.entries, hasLength(1));
+      expect(c.entries.first.flag, isNull);
+      expect(c.suspiciousSampleCount, equals(0));
+    });
+
+    test('sanity bound B: skipped entirely when MAF unsupported', () async {
+      var mafReads = 0;
+      final c = Obd2BreadcrumbCollector();
+      final diag = FuelRateDiagnostics(
+        collector: c,
+        afr: 14.7,
+        fuelDensityGPerL: 745,
+        engineDisplacementCc: 1500,
+        volumetricEfficiency: 0.85,
+        readRpm: () async => null,
+        isMafSupported: () => false,
+        readMaf: () async {
+          mafReads++;
+          return 10.24;
+        },
+      );
+
+      await diag.recordPid5E(16.0);
+
+      expect(mafReads, equals(0));
+      expect(c.entries.first.flag, isNull);
+    });
+
+    test('recordMaf stamps a MAF breadcrumb', () {
+      final c = Obd2BreadcrumbCollector();
+      build(collector: c).recordMaf(corrected: 3.2, maf: 10.24);
+
+      expect(c.entries, hasLength(1));
+      expect(c.entries.first.branch, equals(Obd2BranchTag.maf));
+      expect(c.entries.first.fuelRateLPerHour, closeTo(3.2, 0.01));
+      expect(c.entries.first.mafGramsPerSecond, closeTo(10.24, 0.01));
+    });
+
+    test('recordSpeedDensity stamps a speed-density breadcrumb', () {
+      final c = Obd2BreadcrumbCollector();
+      build(collector: c).recordSpeedDensity(
+        corrected: 2.5,
+        mapKpa: 65,
+        iatCelsius: 30,
+        rpm: 2500,
+      );
+
+      expect(c.entries, hasLength(1));
+      final crumb = c.entries.first;
+      expect(crumb.branch, equals(Obd2BranchTag.speedDensity));
+      expect(crumb.fuelRateLPerHour, closeTo(2.5, 0.01));
+      expect(crumb.mapKpa, closeTo(65, 0.01));
+      expect(crumb.iatCelsius, closeTo(30, 0.01));
+      expect(crumb.rpm, closeTo(2500, 0.01));
+    });
+
+    test('recordNoBranch stamps a none breadcrumb with partial inputs', () {
+      final c = Obd2BreadcrumbCollector();
+      build(collector: c).recordNoBranch(mapKpa: 65, iatCelsius: null, rpm: 0);
+
+      expect(c.entries, hasLength(1));
+      expect(c.entries.first.branch, equals(Obd2BranchTag.none));
+      expect(c.entries.first.mapKpa, closeTo(65, 0.01));
+      expect(c.entries.first.iatCelsius, isNull);
+    });
+
+    test('null collector — every emit method is a no-op', () async {
+      final diag = build(collector: null, rpm: 2200, mafSupported: true,
+          maf: 10.24);
+
+      // None of these should throw; nothing is recorded anywhere.
+      await diag.recordPid5E(0.2);
+      diag.recordMaf(corrected: 3.2, maf: 10.24);
+      diag.recordSpeedDensity(
+          corrected: 2.5, mapKpa: 65, iatCelsius: 30, rpm: 2500);
+      diag.recordNoBranch();
+    });
+  });
+}

--- a/test/features/route_search/data/strategies/route_geometry_test.dart
+++ b/test/features/route_search/data/strategies/route_geometry_test.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/route_search/data/strategies/route_geometry.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+void main() {
+  // #2197 — these pin the hoisted route-search geometry helpers so the
+  // three strategies (cheapest/balanced/eco) and the provider keep
+  // bit-identical behaviour after de-duplication.
+
+  group('kSamplePointSpacingKm', () {
+    test('is the 15 km sampling approximation the strategies used', () {
+      expect(kSamplePointSpacingKm, 15.0);
+    });
+  });
+
+  group('segmentIndexFor', () {
+    test('floors nearestSampleIdx * 15 / segmentKm against a known spacing', () {
+      // With a 50 km segment width and 15 km sample spacing, sample
+      // indices 0..3 (0,15,30,45 km) all fall in bucket 0, index 4
+      // (60 km) crosses into bucket 1, index 7 (105 km) into bucket 2.
+      const segmentKm = 50.0;
+      expect(segmentIndexFor(0, segmentKm), 0);
+      expect(segmentIndexFor(1, segmentKm), 0); // 15/50  -> 0.30
+      expect(segmentIndexFor(3, segmentKm), 0); // 45/50  -> 0.90
+      expect(segmentIndexFor(4, segmentKm), 1); // 60/50  -> 1.20
+      expect(segmentIndexFor(6, segmentKm), 1); // 90/50  -> 1.80
+      expect(segmentIndexFor(7, segmentKm), 2); // 105/50 -> 2.10
+    });
+
+    test('exact bucket boundary lands in the upper bucket', () {
+      // 10 km segments: index 2 -> 30 km -> exactly 3.0 -> bucket 3.
+      expect(segmentIndexFor(2, 10.0), 3);
+      // index 0 always bucket 0 regardless of segment width.
+      expect(segmentIndexFor(0, 10.0), 0);
+    });
+
+    test('is identical to the original inlined expression', () {
+      for (final idx in [0, 1, 5, 12, 37]) {
+        for (final seg in [10.0, 25.0, 50.0, 80.0]) {
+          expect(
+            segmentIndexFor(idx, seg),
+            (idx * 15 / seg).floor(),
+            reason: 'idx=$idx seg=$seg',
+          );
+        }
+      }
+    });
+  });
+
+  group('minDistanceToPolyline', () {
+    test('returns infinity for an empty polyline', () {
+      expect(minDistanceToPolyline(48.0, 2.0, const []), double.infinity);
+    });
+
+    test('returns 0 when the point sits on a vertex', () {
+      final line = [const LatLng(48.0, 2.0), const LatLng(48.1, 2.1)];
+      expect(minDistanceToPolyline(48.0, 2.0, line), 0);
+    });
+
+    test('finds the nearest vertex, not the first', () {
+      final line = [
+        const LatLng(48.0, 2.0),
+        const LatLng(49.0, 3.0),
+        const LatLng(48.5, 2.5),
+      ];
+      // Query right next to the middle/last vertices.
+      final d = minDistanceToPolyline(48.5, 2.5, line);
+      expect(d, lessThan(1.0));
+    });
+  });
+
+  group('sortByItineraryOrder', () {
+    Station makeStation(String id, double lat, double lng) => Station(
+          id: id,
+          name: 'Station $id',
+          brand: 'Brand $id',
+          street: 'Street $id',
+          postCode: '75000',
+          place: 'Paris',
+          lat: lat,
+          lng: lng,
+          dist: 1.0,
+          isOpen: true,
+        );
+
+    test('orders results by position along the route, start first', () {
+      final geometry = [
+        const LatLng(48.0, 2.0),
+        const LatLng(48.1, 2.1),
+        const LatLng(48.2, 2.2),
+      ];
+      final near = FuelStationResult(makeStation('start', 48.01, 2.01));
+      final far = FuelStationResult(makeStation('end', 48.19, 2.19));
+
+      final items = <SearchResultItem>[far, near];
+      sortByItineraryOrder(items, geometry);
+
+      expect(items.first.id, 'start');
+      expect(items.last.id, 'end');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Epic #2167 wave-3. Four verified follow-ups (one commit per issue; codegen hash regenerated):

- **Closes #2196** — extract a shared price-color gradient (`price_gradient.dart`: `normalizedPrice` + `priceGradientColor`) + `truncateBrand`; both marker builders delegate with their own palettes (byte-identical output); `priceColor` stays a public wrapper; `price_tier` shares `normalizedPrice`.
- **Closes #2197** — hoist the duplicated route-search geometry (min-distance-to-polyline, itinerary sort, segment-index math) into a shared `RouteGeometry` layer + `kSamplePointSpacingKm`; uniform's isolate path left inlined; behaviour bit-identical.
- **Closes #2185** — add `UnitFormatter.formatConsumption` (dot formatting preserved) and migrate the duplicated `L/100 km` / `kWh/100 km` mask sites.
- **Closes #2191** — extract fuel-rate breadcrumb/cross-check diagnostics out of `readFuelRateLPerHour` into a collaborator.

Full `flutter analyze` clean (2 pre-existing infos in untouched files); 3614 tests pass across all touched areas; `build_runner` clean (regenerated provider hash committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
