### PR TITLE
refactor(quality): wave 4 — baseUrl, cache docs, catalog isolate, config index (Epic #2167)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,67 @@
+# Configuration surfaces
+
+> Single index of every place the app reads configuration from, how to
+> override each value, and the precedence when more than one source
+> exists. Filed as #2194 (Epic #2167) because config was spread across
+> five mechanisms with no map.
+
+The app has **five** distinct configuration mechanisms. They are
+intentionally separate (build-identity vs secrets vs user/runtime vs
+tuning constants), but a contributor needs one place to find them.
+
+## 1. `--dart-define` flags (compile-time, CI/build)
+
+| Flag | Read in | Purpose | Override |
+|---|---|---|---|
+| `CHANNEL` | `lib/features/feature_management/application/feature_flags_provider.dart` | `production` vs `beta` feature channel | `flutter build … --dart-define=CHANNEL=beta` |
+| `SENTRY_DSN` | `lib/app/app_initializer.dart` | Crash-reporting endpoint (empty → Sentry disabled) | `--dart-define=SENTRY_DSN=…` |
+| `COMMUNITY_SUPABASE_URL` / `COMMUNITY_SUPABASE_ANON_KEY` | `lib/core/.../community_config.dart` | TankSync community backend (URL + public anon key) | `--dart-define=…` |
+
+These bake into the binary; changing one requires a rebuild.
+
+## 2. Asset-bundled JSON (dev fallback)
+
+- `assets/tanksync_config.json` — read in `community_config.dart` as a
+  **fallback** Supabase config for local/dev builds.
+
+**Precedence:** the `--dart-define` values (mechanism 1) win when set;
+the asset JSON is only consulted when the dart-defines are empty. Do not
+ship real secrets in the asset — it's a dev convenience.
+
+## 3. Hive-backed (user/runtime, persisted on device)
+
+- Per-country API keys — `lib/core/services/country_service_registry.dart`
+  (e.g. the Tankerkönig key entered in Settings).
+- Feature flags / app profile — the feature-management subsystem.
+- User preferences (active country, preferred fuel, search radius, etc.).
+
+These are user-owned and mutable at runtime; no rebuild needed.
+
+## 4. Compile-time constants (tuning)
+
+- `lib/core/constants/app_constants.dart` — radius defaults, refresh
+  interval + jitter.
+- `lib/core/constants/api_constants.dart` — upstream base URL(s), radius
+  bounds, min refresh interval.
+- `lib/core/cache/cache_manager.dart` — cache TTLs (see the doc comments
+  there for the rationale, #2195).
+
+Deliberately compile-time (sensible defaults, rarely changed). A future
+`RuntimeConfig`/remote-config layer could make the genuinely-tunable ones
+overridable — see #2195.
+
+## 5. Android Gradle flavor (`distribution`)
+
+- `android/app/build.gradle.kts` defines a `distribution` flavor
+  (`play` / `fdroid`) controlling store-specific build wiring.
+
+**This is orthogonal to `CHANNEL`** (mechanism 1): `distribution`
+selects the *store target* (Play vs F-Droid); `CHANNEL` selects the
+*feature channel* (production vs beta). A `play` build can be either
+channel and vice-versa.
+
+---
+
+_When adding a new config value, record it here and pick the mechanism
+deliberately: build-identity → dart-define or flavor; secret → dart-define
+(never assets); user/runtime → Hive; pure tuning → a constant._

--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -22,13 +22,83 @@ part 'cache_manager.g.dart';
 /// | geocode        | 24 hours   | ZIP code coordinates are stable     |
 /// | stationData    | 30 min     | Favorites offline view              |
 /// | citySearch     | 30 min     | City name lookups are stable        |
+///
+/// ### Policy: these TTLs are intentionally compile-time
+///
+/// Every value below is a `const` baked in at build time. There is
+/// deliberately **no** runtime or remote-config override: the durations are
+/// tuned against the Tankerkoenig data contract (a 5-minute price update
+/// cadence and rate limit) rather than against per-user preference, so a
+/// tunable knob would mostly invite values that desync from upstream and
+/// either over-fetch (hammering the rate limit) or serve stale prices.
+/// Keeping them fixed also keeps the cache behaviour reproducible in tests.
+///
+/// This is a deliberate trade-off, not an oversight. If a future need arises
+/// to A/B-test freshness or to react to upstream changes without an app
+/// release, route these through a `RuntimeConfig` / remote-config layer that
+/// supplies overrides while falling back to the constants below as defaults.
 class CacheTtl {
   CacheTtl._();
+
+  /// TTL for nearby-station search results (price + position list).
+  ///
+  /// 5 minutes because the underlying fuel prices change frequently and a
+  /// search list is dominated by those prices; longer would surface stale
+  /// figures, shorter would defeat the cache between back-to-back queries.
+  /// Matches [prices] and the Tankerkoenig update cadence on purpose.
+  ///
+  /// Intentionally compile-time (see class-level policy note); a future
+  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration stationSearch = Duration(minutes: 5);
+
+  /// TTL for a single station's detail payload (address, hours, brand).
+  ///
+  /// 15 minutes because detail data is mostly slow-changing metadata
+  /// (opening hours, address) rather than live prices, so it tolerates a
+  /// longer cache than a search list while still refreshing within a visit.
+  ///
+  /// Intentionally compile-time (see class-level policy note); a future
+  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration stationDetail = Duration(minutes: 15);
+
+  /// TTL for a bulk price lookup keyed by station ids.
+  ///
+  /// 5 minutes to match the Tankerkoenig price-update cadence and rate
+  /// limit: refreshing faster cannot yield newer data and risks tripping
+  /// the upstream limit, refreshing slower serves stale prices.
+  ///
+  /// Intentionally compile-time (see class-level policy note); a future
+  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration prices = Duration(minutes: 5);
+
+  /// TTL for forward/reverse geocode results (ZIP <-> coordinates).
+  ///
+  /// 24 hours because ZIP-code centroids and place coordinates are
+  /// effectively static; caching for a day avoids repeated geocoder calls
+  /// for the same query with no meaningful staleness risk.
+  ///
+  /// Intentionally compile-time (see class-level policy note); a future
+  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration geocode = Duration(hours: 24);
+
+  /// TTL for a favourited station's cached snapshot (offline view).
+  ///
+  /// 30 minutes as a middle ground: long enough that opening the favourites
+  /// list offline shows a recent snapshot, short enough that a returning
+  /// online user re-fetches reasonably fresh prices.
+  ///
+  /// Intentionally compile-time (see class-level policy note); a future
+  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration stationData = Duration(minutes: 30);
+
+  /// TTL for city-name autocomplete / lookup results.
+  ///
+  /// 30 minutes because city-name -> location mappings are stable; caching
+  /// avoids re-querying the lookup service for the same typed prefix within
+  /// a session without risking stale results.
+  ///
+  /// Intentionally compile-time (see class-level policy note); a future
+  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration citySearch = Duration(minutes: 30);
 }
 

--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -12,9 +12,39 @@ class ApiConstants {
   static const String pricesEndpoint = '/prices.php';
   static const String complaintEndpoint = '/complaint.php';
 
+  // ---------------------------------------------------------------------------
+  // Tankerkoenig upstream contract limits.
+  //
+  // The four constants below mirror hard limits of the Tankerkoenig API. They
+  // are intentionally compile-time `const` with no runtime or remote-config
+  // override: they are dictated by the upstream service, not by user or app
+  // preference, so a tunable knob could only ever drift out of sync with the
+  // server and cause rejected requests or rate-limit hits. Keeping them fixed
+  // also keeps request-building deterministic in tests. This is a deliberate
+  // trade-off, not an oversight: should the upstream lift a limit and we want
+  // to react without an app release, route these through a `RuntimeConfig` /
+  // remote-config layer that supplies overrides while falling back to these
+  // constants as defaults.
+  // ---------------------------------------------------------------------------
+
+  /// Maximum search radius (km) accepted by the Tankerkoenig `list` endpoint.
+  /// Requests above this are rejected upstream. Compile-time by contract.
   static const int maxRadiusKm = 25;
+
+  /// Default search radius (km) used when a caller does not specify one.
+  /// 10 km balances coverage against query cost and stays within
+  /// [maxRadiusKm]. Compile-time by policy.
   static const int defaultRadiusKm = 10;
+
+  /// Maximum number of station ids accepted by one `prices` batch request.
+  /// Tankerkoenig caps a bulk price query at 10 ids; larger batches must be
+  /// chunked by the caller. Compile-time by contract.
   static const int maxPriceQueryIds = 10;
+
+  /// Minimum interval between price refreshes against the upstream.
+  /// 5 minutes matches the Tankerkoenig update cadence and rate limit:
+  /// refreshing faster cannot surface newer data and risks the limit.
+  /// Compile-time by contract.
   static const Duration minRefreshInterval = Duration(minutes: 5);
 
   /// Test coordinates (Berlin city center) used for API key validation.

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -25,11 +25,47 @@ class AppConstants {
   /// Shared User-Agent for all HTTP clients.
   static String get userAgent => '$appPackage/$appVersion';
 
+  // ---------------------------------------------------------------------------
+  // Search radius + auto-refresh policy.
+  //
+  // The radius and refresh values below are intentionally compile-time `const`
+  // with no runtime or remote-config override. They are bounded by the
+  // upstream Tankerkoenig contract (25 km max radius, 5-minute price cadence /
+  // rate limit), so a user- or server-tunable knob would mostly let callers
+  // pick values that desync from upstream and either over-fetch or show stale
+  // prices. Fixing them also keeps search and refresh behaviour reproducible
+  // in tests. This is a deliberate trade-off, not an oversight: if a future
+  // need arises to tune freshness per-user or react to upstream changes
+  // without an app release, route these through a `RuntimeConfig` /
+  // remote-config layer that supplies overrides while falling back to these
+  // constants as defaults.
+  // ---------------------------------------------------------------------------
+
+  /// Default nearby-search radius (km) for a fresh install / unset preference.
+  /// 10 km balances result coverage against query cost; sits inside the
+  /// [minSearchRadiusKm]..[maxSearchRadiusKm] band. Compile-time by policy.
   static const double defaultSearchRadiusKm = 10.0;
+
+  /// Upper bound the user may select for the search radius (km).
+  /// Pinned to the Tankerkoenig upstream cap (25 km); a larger value would be
+  /// rejected by the API. Compile-time by policy (mirrors
+  /// `ApiConstants.maxRadiusKm`).
   static const double maxSearchRadiusKm = 25.0;
+
+  /// Lower bound the user may select for the search radius (km).
+  /// 1 km keeps "nearby" meaningful and avoids zero-result queries.
+  /// Compile-time by policy.
   static const double minSearchRadiusKm = 1.0;
 
+  /// Floor for the auto-refresh cadence of the station/price list.
+  /// 5 minutes matches the Tankerkoenig price-update cadence and rate limit:
+  /// refreshing faster cannot surface newer data and risks the upstream
+  /// limit. Compile-time by policy (mirrors `ApiConstants.minRefreshInterval`).
   static const Duration minAutoRefreshInterval = Duration(minutes: 5);
+
+  /// Maximum random delay added to each auto-refresh tick to spread requests.
+  /// Up to 30 s of jitter de-synchronises many clients so they do not all hit
+  /// the upstream on the same wall-clock boundary. Compile-time by policy.
   static const Duration refreshJitterMax = Duration(seconds: 30);
 
   static const String osmTileUrl =

--- a/lib/features/station_services/argentina/argentina_station_service.dart
+++ b/lib/features/station_services/argentina/argentina_station_service.dart
@@ -26,15 +26,20 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
   // resource under TLS, so there's no reason to fetch the open-data
   // CSV in clear text (MITM could inject malicious rows, and the
   // integrity check downstream only catches the header schema).
-  static const _csvUrl =
+  static const String defaultCsvUrl =
       'https://datos.energia.gob.ar/dataset/'
       '1c181390-5045-475e-94dc-410429be4b17/resource/'
       '80ac25de-a44a-4445-9215-090cf55cfda5/download/'
       'precios-en-surtidor-resolucin-3142016.csv';
 
   /// Default production constructor.
-  ArgentinaStationService()
-      : _dio = DioFactory.create(
+  ///
+  /// #2193 — accepts an optional [baseUrl] (the CSV endpoint) so tests can
+  /// point the service at a fake host; defaults to [defaultCsvUrl] so
+  /// production + the registry factory are unaffected.
+  ArgentinaStationService({String? baseUrl})
+      : _csvUrl = baseUrl ?? defaultCsvUrl,
+        _dio = DioFactory.create(
           connectTimeout: const Duration(seconds: 20),
           receiveTimeout: const Duration(seconds: 60),
           responseType: ResponseType.plain,
@@ -42,11 +47,14 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
 
   /// Test-only constructor that accepts a preconfigured [Dio] (usually with
   /// a [MockAdapter]) so the cert-error classification path (#837) can be
-  /// driven without hitting the network.
+  /// driven without hitting the network. #2193 — also accepts an optional
+  /// [baseUrl] (the CSV endpoint), defaulting to [defaultCsvUrl].
   @visibleForTesting
-  ArgentinaStationService.withDio(this._dio);
+  ArgentinaStationService.withDio(this._dio, {String? baseUrl})
+      : _csvUrl = baseUrl ?? defaultCsvUrl;
 
   final Dio _dio;
+  final String _csvUrl;
 
   // Cache parsed stations
   List<_RawStation>? _cachedStations;
@@ -162,10 +170,14 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
     }
   }
 
-  /// Hostname of the Argentina open-data CSV — kept in a constant so the
-  /// certificate error message names the exact provider the user should
-  /// contact (#837).
-  static const _csvHost = 'datos.energia.gob.ar';
+  /// Hostname of the Argentina open-data CSV — derived from [_csvUrl] so
+  /// the certificate error message names the exact provider the user should
+  /// contact (#837). Falls back to the default host when the URL has no
+  /// authority (e.g. a relative test URL).
+  String get _csvHost {
+    final host = Uri.tryParse(_csvUrl)?.host ?? '';
+    return host.isNotEmpty ? host : 'datos.energia.gob.ar';
+  }
 
   /// Detect whether a [DioException] is a TLS/certificate validation
   /// failure. Dio 5.x signals most cert errors via

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -30,15 +30,20 @@ import '../../../core/logging/error_logger.dart';
 class PrixCarburantsStationService with StationServiceHelpers implements StationService {
   final OsmBrandEnricher? _enricher;
   final Dio _dio;
+  final String _baseUrl;
 
-  PrixCarburantsStationService({OsmBrandEnricher? enricher, Dio? dio})
-      : _enricher = enricher,
+  PrixCarburantsStationService({
+    OsmBrandEnricher? enricher,
+    Dio? dio,
+    String? baseUrl,
+  })  : _enricher = enricher,
         _dio = dio ?? DioFactory.create(
           connectTimeout: const Duration(seconds: 15),
           receiveTimeout: const Duration(seconds: 15),
-        );
+        ),
+        _baseUrl = baseUrl ?? defaultBaseUrl;
 
-  static const _baseUrl =
+  static const String defaultBaseUrl =
       'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets'
       '/prix-des-carburants-en-france-flux-instantane-v2/records';
 

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -22,19 +22,23 @@ import '../../../core/logging/error_logger.dart';
 /// Strategy: fetch all stations, calculate distances locally, filter by radius.
 /// The full dataset (~12,000 stations) is cached aggressively.
 class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implements StationService {
-  static const _baseUrl =
+  static const String defaultBaseUrl =
       'https://sedeaplicaciones.minetur.gob.es/ServiciosRESTCarburantes'
       '/PreciosCarburantes';
 
   final Dio _dio;
+  final String _baseUrl;
 
   /// #2181 — Dio injectable for tests; defaults to the standard factory.
-  MitecoStationService({Dio? dio})
+  /// #2193 — [baseUrl] injectable too, harmonising the override surface
+  /// with Portugal / Slovenia / South Korea; defaults to [defaultBaseUrl].
+  MitecoStationService({Dio? dio, String? baseUrl})
       : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 20),
               receiveTimeout: const Duration(seconds: 30),
-            );
+            ),
+        _baseUrl = baseUrl ?? defaultBaseUrl;
 
   // Cache the province list and full station data to avoid repeated large downloads
   List<_Province>? _cachedProvinces;

--- a/lib/features/vehicle/data/reference_vehicle_catalog_provider.dart
+++ b/lib/features/vehicle/data/reference_vehicle_catalog_provider.dart
@@ -3,6 +3,7 @@
 
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -23,8 +24,22 @@ const String referenceVehicleCatalogAssetPath =
 /// read this provider; the cached `List<ReferenceVehicle>` is shared.
 @Riverpod(keepAlive: true)
 Future<List<ReferenceVehicle>> referenceVehicleCatalog(Ref ref) async {
+  // The asset load stays on the main isolate (rootBundle is not available
+  // off it), but the ~142 KB JSON decode + N× fromJson deserialization is
+  // pushed to a background isolate via compute() so it can't jank the UI
+  // on first read (#2192). Mirrors the compute(_parseCsv, …) pattern in
+  // argentina_station_service.dart.
   final raw = await rootBundle.loadString(referenceVehicleCatalogAssetPath);
-  final decoded = jsonDecode(raw);
+  return compute(_parseCatalog, raw);
+}
+
+/// Top-level parser run on a background isolate by [referenceVehicleCatalog].
+///
+/// Decodes the catalog JSON and deserializes each entry into a
+/// [ReferenceVehicle]. Must stay top-level (no captured state) so it can be
+/// dispatched through [compute].
+List<ReferenceVehicle> _parseCatalog(String json) {
+  final decoded = jsonDecode(json);
   if (decoded is! List) {
     // The asset is checked into source — a malformed file is a
     // shipping bug, not a runtime condition. Throw loudly so CI

--- a/lib/features/vehicle/data/reference_vehicle_catalog_provider.g.dart
+++ b/lib/features/vehicle/data/reference_vehicle_catalog_provider.g.dart
@@ -68,7 +68,7 @@ final class ReferenceVehicleCatalogProvider
 }
 
 String _$referenceVehicleCatalogHash() =>
-    r'63a58d8821fa273613204b24d52bebbb5e0b7f6b';
+    r'31d88b020fecaa29c63a1e11aa8820274975fe88';
 
 /// Returns the best catalog match for [make], [model], and [year], or
 /// `null` if no entry covers the trio (#950 phase 1).

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -1072,6 +1072,55 @@ void main() {
       expect(result.data, isNotEmpty);
     });
   });
+
+  // #2193 — the baseUrl override surface mirrors the Dio injection style:
+  // an injected baseUrl must be the host the request is actually sent to,
+  // so tests can point the service at a fake endpoint.
+  group('PrixCarburantsStationService baseUrl injection (#2193)', () {
+    test('defaultBaseUrl points at the gouv.fr flux-instantane dataset', () {
+      expect(
+        PrixCarburantsStationService.defaultBaseUrl,
+        contains('data.economie.gouv.fr'),
+      );
+      expect(
+        PrixCarburantsStationService.defaultBaseUrl,
+        endsWith('/records'),
+      );
+    });
+
+    test('injected baseUrl is used as the request URL', () async {
+      final adapter = _TrackingMockAdapter()..addResponse({'results': const []});
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(
+        dio: dio,
+        baseUrl: 'https://fake.test/prix/records',
+      );
+
+      await svc.searchStations(const SearchParams(
+        lat: 48.85, lng: 2.35, radiusKm: 5.0,
+      ));
+
+      expect(adapter.requestCount, 1);
+      expect(adapter.lastRequestUri, startsWith('https://fake.test/prix/records'));
+      expect(
+        adapter.lastRequestUri,
+        isNot(contains('data.economie.gouv.fr')),
+        reason: 'the default URL must not be hit when baseUrl is overridden',
+      );
+    });
+
+    test('defaults to defaultBaseUrl when baseUrl is omitted', () async {
+      final adapter = _TrackingMockAdapter()..addResponse({'results': const []});
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      await svc.searchStations(const SearchParams(
+        lat: 48.85, lng: 2.35, radiusKm: 5.0,
+      ));
+
+      expect(adapter.lastRequestUri, startsWith('https://data.economie.gouv.fr'));
+    });
+  });
 }
 
 /// Mock Dio adapter that tracks requests and returns canned responses.

--- a/test/features/vehicle/data/reference_vehicle_catalog_provider_test.dart
+++ b/test/features/vehicle/data/reference_vehicle_catalog_provider_test.dart
@@ -50,6 +50,34 @@ void main() {
       }
     });
 
+    test(
+        'returns the parsed catalog (decoded off the UI isolate via compute, '
+        '#2192)', () async {
+      // #2192 moved the jsonDecode + fromJson off the UI isolate into a
+      // compute() background isolate. This asserts the awaited Future still
+      // resolves to fully deserialized ReferenceVehicle instances — i.e.
+      // the result survives the isolate round-trip — not just raw maps.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final catalog =
+          await container.read(referenceVehicleCatalogProvider.future);
+
+      expect(catalog, isA<List<ReferenceVehicle>>());
+      expect(catalog, isNotEmpty);
+      expect(catalog.first, isA<ReferenceVehicle>());
+
+      // A known catalog entry must come back as a usable entity.
+      final peugeot208 = catalog.firstWhere(
+        (v) =>
+            v.make.toLowerCase() == 'peugeot' &&
+            v.model.toLowerCase() == '208',
+        orElse: () => throw StateError('expected a Peugeot 208 entry'),
+      );
+      expect(peugeot208.make, 'Peugeot');
+      expect(peugeot208.displacementCc, greaterThan(0));
+    });
+
     test('shares the same list instance on repeated reads (keepAlive cache)',
         () async {
       final container = ProviderContainer();


### PR DESCRIPTION
## Summary
Epic #2167 wave-4. Four follow-ups:

- **Closes #2193** — unify the baseUrl override surface: FR/ES/AR services now accept an optional `baseUrl` (defaulting to a public `defaultBaseUrl`), harmonising with PT/SI/KR; AR derives its cert-error host from the URL. FR injection test added.
- **Closes #2195** — document/justify the compile-time cache TTL + refresh constants (comments only).
- **Closes #2192** — decode the 142 KB reference-vehicle catalog off the UI isolate via `compute()`.
- **Closes #2194** — add `docs/CONFIGURATION.md`, a single index of the five config surfaces.

Full analyze clean (2 pre-existing infos); station_services + vehicle tests pass; `build_runner` clean (regenerated catalog provider hash committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
