### PR TITLE
fix(widget): background-isolate Box-not-found + AppWidgetProvider ClassNotFound (field errors)

### DIFF
--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -319,6 +319,12 @@ class HiveBoxes {
     final cipher = await _loadCipher();
     await Hive.openBox(settings, encryptionCipher: cipher);
     await Hive.openBox(favorites, encryptionCipher: cipher);
+    // #2205 — the background widget-update path (HomeWidgetService via
+    // ProfilesHiveStore) reads the active profile for preferred fuel +
+    // last-known GPS. Without this the BG isolate threw
+    // `HiveError: Box not found` on every favorites/nearest widget
+    // refresh (32 field traces).
+    await Hive.openBox(profiles, encryptionCipher: cipher);
     await Hive.openBox(alerts, encryptionCipher: cipher);
     await Hive.openBox(cache, encryptionCipher: cipher);
     await Hive.openBox(priceHistory, encryptionCipher: cipher);

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -319,12 +319,7 @@ class HiveBoxes {
     final cipher = await _loadCipher();
     await Hive.openBox(settings, encryptionCipher: cipher);
     await Hive.openBox(favorites, encryptionCipher: cipher);
-    // #2205 — the background widget-update path (HomeWidgetService via
-    // ProfilesHiveStore) reads the active profile for preferred fuel +
-    // last-known GPS. Without this the BG isolate threw
-    // `HiveError: Box not found` on every favorites/nearest widget
-    // refresh (32 field traces).
-    await Hive.openBox(profiles, encryptionCipher: cipher);
+    await Hive.openBox(profiles, encryptionCipher: cipher); // #2205 BG widget
     await Hive.openBox(alerts, encryptionCipher: cipher);
     await Hive.openBox(cache, encryptionCipher: cipher);
     await Hive.openBox(priceHistory, encryptionCipher: cipher);

--- a/lib/features/widget/data/home_widget_service.dart
+++ b/lib/features/widget/data/home_widget_service.dart
@@ -59,6 +59,18 @@ String get _widgetGroupId =>
 // was dropped from the manifest.
 const _widgetAndroidName = 'FuelPriceWidgetProvider';
 
+/// #2206 — the AppWidgetProvider lives in the Gradle **namespace**
+/// `de.tankstellen.tankstellen` (the manifest `.FuelPriceWidgetProvider`
+/// receiver), which differs from the **applicationId**
+/// `de.tankstellen.fuelprices`. home_widget resolves [_widgetAndroidName]
+/// against the applicationId, so it looked for
+/// `de.tankstellen.fuelprices.FuelPriceWidgetProvider` and threw
+/// `ClassNotFoundException` on every update. Passing the fully-qualified
+/// name (used as-is by home_widget, ahead of androidName) fixes it.
+// i18n-ignore: Android class identifier, not user-facing text.
+const _widgetQualifiedAndroidName =
+    'de.tankstellen.tankstellen.FuelPriceWidgetProvider';
+
 /// Maximum number of stations to include in widget data.
 const _maxWidgetStations = 5;
 
@@ -96,6 +108,7 @@ class HomeWidgetService {
         await HomeWidget.saveWidgetData('stations_json', '[]');
         await HomeWidget.updateWidget(
           androidName: _widgetAndroidName,
+          qualifiedAndroidName: _widgetQualifiedAndroidName,
         );
         return;
       }
@@ -125,6 +138,7 @@ class HomeWidgetService {
 
       await HomeWidget.updateWidget(
         androidName: _widgetAndroidName,
+        qualifiedAndroidName: _widgetQualifiedAndroidName,
       );
       debugPrint('HomeWidget: favorites updated with ${stations.length} stations');
     } catch (e, st) {
@@ -159,7 +173,8 @@ class HomeWidgetService {
           pricePredictor: pricePredictor,
         );
         final payload = await builder.build();
-        await HomeWidget.updateWidget(androidName: _widgetAndroidName);
+        await HomeWidget.updateWidget(androidName: _widgetAndroidName,
+          qualifiedAndroidName: _widgetQualifiedAndroidName);
         debugPrint(
           'HomeWidget: nearest (real search) updated — '
           'count=${payload.stations.length} '
@@ -188,6 +203,7 @@ class HomeWidgetService {
         await HomeWidget.saveWidgetData('nearest_is_stale', false);
         await HomeWidget.updateWidget(
           androidName: _widgetAndroidName,
+          qualifiedAndroidName: _widgetQualifiedAndroidName,
         );
         return;
       }
@@ -225,6 +241,7 @@ class HomeWidgetService {
 
       await HomeWidget.updateWidget(
         androidName: _widgetAndroidName,
+        qualifiedAndroidName: _widgetQualifiedAndroidName,
       );
       debugPrint('HomeWidget: nearest updated with ${stations.length} stations');
     } catch (e, st) {

--- a/test/core/storage/hive_boxes_test.dart
+++ b/test/core/storage/hive_boxes_test.dart
@@ -148,7 +148,7 @@ void main() {
         }
       });
 
-      test('initInIsolate() opens the five background boxes', () {
+      test('initInIsolate() opens the six background boxes', () {
         final source =
             File('lib/core/storage/hive_boxes.dart').readAsStringSync();
 
@@ -159,11 +159,14 @@ void main() {
         expect(isolateMatch, isNotNull);
         final isolateBody = isolateMatch!.group(1)!;
 
-        // Background isolate opens settings, favorites, alerts, cache,
-        // priceHistory (not profiles)
+        // Background isolate opens settings, favorites, profiles, alerts,
+        // cache, priceHistory. #2205 — profiles is required: the BG
+        // widget-update path reads the active profile, and omitting it
+        // threw `HiveError: Box not found` in the field.
         for (final boxName in [
           'settings',
           'favorites',
+          'profiles',
           'alerts',
           'cache',
           'priceHistory',


### PR DESCRIPTION
## Summary
Two production widget bugs found in an uploaded field error-log export (50 traces).

- **Closes #2205** — background isolate threw `HiveError: Box not found` on every widget refresh (32 traces). `HomeWidgetService` reads the active profile via `ProfilesHiveStore` → `Hive.box('profiles')`, but `HiveBoxes.initInIsolate()` never opened `profiles`. Now opened (encrypted); test guard updated.
- **Closes #2206** — `HomeWidget.updateWidget(androidName:)` resolved against the applicationId `de.tankstellen.fuelprices`, but the receiver is in the namespace `de.tankstellen.tankstellen` → `ClassNotFoundException` (13 traces), so the widget never updated. Now passes `qualifiedAndroidName` at all five call sites.

(The 3 `SocketException` + 2 `PostgrestException` traces are transient offline/backend errors with correct handling — no code change.)

Full analyze clean (2 pre-existing infos); widget + storage tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
