### PR TITLE
fix(alerts): fire system notifications + schedule radius alerts (Epic #2208)

### DIFF
--- a/integration_test/golden_flow_integration_test.dart
+++ b/integration_test/golden_flow_integration_test.dart
@@ -116,6 +116,12 @@ class _CapturingNotificationService implements NotificationService {
   Future<void> initialize() async {}
 
   @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
+  @override
   Future<void> showPriceAlert({
     required int id,
     required String title,

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -424,21 +424,13 @@ class AppInitializer {
   }
 
   /// Schedule periodic price polling only when the user has at least one
-  /// active price alert (#713). Alerts are the only user-consented reason
-  /// to poll the station APIs on a regular schedule — per Tankerkönig's
+  /// active alert (#713). Alerts are the only user-consented reason to
+  /// poll the station APIs on a regular schedule — per Tankerkönig's
   /// terms of service, apps must use "requests on demand" and avoid
-  /// regular non-user-initiated requests.
-  static Future<void> _maybeInitBackground() async {
-    final storage = HiveStorage();
-    final rawAlerts = storage.getAlerts();
-    final hasActiveAlert = rawAlerts.any((a) => a['isActive'] == true);
-    if (!hasActiveAlert) {
-      debugPrint(
-          'AppInitializer: skipping background polling — no active alerts');
-      return;
-    }
-    await BackgroundService.init();
-  }
+  /// regular non-user-initiated requests. #2210 — delegates to
+  /// BackgroundService.reconcile so BOTH price and radius alerts gate
+  /// the scheduler (radius-only users were previously never scheduled).
+  static Future<void> _maybeInitBackground() => BackgroundService.reconcile();
 
   static Future<void> _safe(String label, Future<void> Function() body) async {
     try {

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -122,6 +122,34 @@ class BackgroundService {
     final fetcher = createBackgroundPriceFetcher();
     await fetcher.cancelAll();
   }
+
+  /// Start or stop background polling based on whether ANY user-consented
+  /// alert is active — a per-station [PriceAlert] OR a [RadiusAlert]
+  /// (#2210). Previously only price alerts gated the scheduler, so a
+  /// radius-only user got no WorkManager task and radius alerts never
+  /// fired. Idempotent: safe to call after every alert mutation and at
+  /// startup. Cancels only when BOTH alert kinds are empty.
+  static Future<void> reconcile() async {
+    try {
+      final hasPriceAlert =
+          HiveStorage().getAlerts().any((a) => a['isActive'] == true);
+      var hasRadiusAlert = false;
+      try {
+        hasRadiusAlert = (await RadiusAlertStore().list()).any((a) => a.enabled);
+      } catch (_) {
+        // Radius store unreadable (e.g. box not open) — treat as none.
+      }
+      if (hasPriceAlert || hasRadiusAlert) {
+        await init();
+      } else {
+        await cancelAll();
+      }
+    } catch (e, st) {
+      // Never let a scheduling hiccup crash an alert mutation or startup.
+      unawaited(errorLogger.log(ErrorLayer.background, e, st,
+          context: const {'where': 'BackgroundService.reconcile'}));
+    }
+  }
 }
 
 @pragma('vm:entry-point')

--- a/lib/core/notifications/local_notification_service.dart
+++ b/lib/core/notifications/local_notification_service.dart
@@ -52,6 +52,68 @@ class LocalNotificationService implements NotificationService {
       settings: initSettings,
       onDidReceiveNotificationResponse: _onDidReceiveNotificationResponse,
     );
+    // #2209 — create the channels explicitly at init so they exist
+    // before the first fire (v21 would lazily create on first show(),
+    // but explicit lets the user pre-configure them).
+    final android = plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    await android?.createNotificationChannel(const AndroidNotificationChannel(
+      _channelId,
+      _channelName,
+      description: _channelDescription,
+      importance: Importance.high,
+    ));
+    await android?.createNotificationChannel(const AndroidNotificationChannel(
+      _serviceChannelId,
+      _serviceChannelName,
+      description: _serviceChannelDescription,
+    ));
+  }
+
+  @override
+  Future<bool> requestPermission() async {
+    try {
+      final android = plugin.resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+      if (android != null) {
+        // #2209 — Android 13+ requires the runtime POST_NOTIFICATIONS
+        // grant; the manifest declaration alone is insufficient and
+        // show() silently no-ops until this is granted.
+        return await android.requestNotificationsPermission() ?? false;
+      }
+      final ios = plugin.resolvePlatformSpecificImplementation<
+          IOSFlutterLocalNotificationsPlugin>();
+      if (ios != null) {
+        return await ios.requestPermissions(
+              alert: true,
+              badge: true,
+              sound: true,
+            ) ??
+            false;
+      }
+      return true;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'NotificationService.requestPermission'}));
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> areNotificationsEnabled() async {
+    try {
+      final android = plugin.resolvePlatformSpecificImplementation<
+          AndroidFlutterLocalNotificationsPlugin>();
+      if (android != null) {
+        return await android.areNotificationsEnabled() ?? true;
+      }
+      return true;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'NotificationService.areNotificationsEnabled',
+      }));
+      return true;
+    }
   }
 
   /// Static entry point so flutter_local_notifications keeps a stable

--- a/lib/core/notifications/notification_service.dart
+++ b/lib/core/notifications/notification_service.dart
@@ -8,8 +8,21 @@
 /// The default implementation is [LocalNotificationService] which
 /// wraps `flutter_local_notifications`.
 abstract class NotificationService {
-  /// Initialize the notification subsystem (channels, permissions, etc.).
+  /// Initialize the notification subsystem (registers channels + the
+  /// tap callback). Does NOT request the runtime permission — call
+  /// [requestPermission] from a foreground/user-intent moment.
   Future<void> initialize();
+
+  /// Request the OS runtime notification permission (Android 13+
+  /// `POST_NOTIFICATIONS`, iOS authorization). Returns whether it is
+  /// granted. #2209 — without this, `show()` silently no-ops on
+  /// Android 13+ and no alert ever appears.
+  Future<bool> requestPermission();
+
+  /// Whether the OS currently allows this app to post notifications.
+  /// Used to surface a "notifications are off" recovery banner when the
+  /// user has alerts but has denied/disabled the permission.
+  Future<bool> areNotificationsEnabled();
 
   /// Display a price-alert notification.
   ///

--- a/lib/features/alerts/providers/alert_provider.dart
+++ b/lib/features/alerts/providers/alert_provider.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../../core/background/background_service.dart';
+import '../../../core/notifications/notification_providers.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/sync_provider.dart';
 import '../../../core/sync/alerts_sync.dart';
@@ -29,25 +30,26 @@ class AlertNotifier extends _$AlertNotifier {
   }
 
   Future<void> addAlert(PriceAlert alert) async {
-    final hadActive = _hasActive(state);
     final repo = ref.read(alertRepositoryProvider);
     await repo.saveAlert(alert);
     state = repo.getAlerts();
+    // #2209 — request the OS notification permission at the moment the
+    // user creates their first alert (clear intent → highest grant
+    // rate). Without it, Android 13+ silently drops every alert.
+    unawaited(ref.read(notificationServiceProvider).requestPermission());
     await _syncAlertsIfConnected();
-    await _reconcileBackgroundPolling(hadActive: hadActive);
+    await BackgroundService.reconcile();
   }
 
   Future<void> removeAlert(String id) async {
-    final hadActive = _hasActive(state);
     final repo = ref.read(alertRepositoryProvider);
     await repo.deleteAlert(id);
     state = repo.getAlerts();
     await _syncAlertsIfConnected();
-    await _reconcileBackgroundPolling(hadActive: hadActive);
+    await BackgroundService.reconcile();
   }
 
   Future<void> toggleAlert(String id) async {
-    final hadActive = _hasActive(state);
     final repo = ref.read(alertRepositoryProvider);
     final alerts = repo.getAlerts();
     final index = alerts.indexWhere((a) => a.id == id);
@@ -57,29 +59,8 @@ class AlertNotifier extends _$AlertNotifier {
     await repo.saveAlert(alert.copyWith(isActive: !alert.isActive));
     state = repo.getAlerts();
     await _syncAlertsIfConnected();
-    await _reconcileBackgroundPolling(hadActive: hadActive);
+    await BackgroundService.reconcile();
   }
-
-  /// Keep the WorkManager periodic task aligned with user intent (#713):
-  /// it only runs when at least one active alert exists — alerts are the
-  /// only user-consented reason to poll station prices on a schedule.
-  /// Transitioning false→true starts the task, true→false cancels it.
-  Future<void> _reconcileBackgroundPolling({required bool hadActive}) async {
-    final hasActive = _hasActive(state);
-    if (hadActive == hasActive) return;
-    try {
-      if (hasActive) {
-        await BackgroundService.init();
-      } else {
-        await BackgroundService.cancelAll();
-      }
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'AlertNotifier: background task reconcile failed'}));
-    }
-  }
-
-  static bool _hasActive(List<PriceAlert> alerts) =>
-      alerts.any((a) => a.isActive);
 
   Future<void> _syncAlertsIfConnected() async {
     try {

--- a/lib/features/alerts/providers/alert_provider.g.dart
+++ b/lib/features/alerts/providers/alert_provider.g.dart
@@ -83,7 +83,7 @@ final class AlertNotifierProvider
   }
 }
 
-String _$alertNotifierHash() => r'f25bc8a01e6c3f9b05174cd2de97380d3214e276';
+String _$alertNotifierHash() => r'ee847f2012edc3b0c03d076425abe2fd89d9fabf';
 
 abstract class _$AlertNotifier extends $Notifier<List<PriceAlert>> {
   List<PriceAlert> build();

--- a/lib/features/alerts/providers/radius_alerts_provider.dart
+++ b/lib/features/alerts/providers/radius_alerts_provider.dart
@@ -8,6 +8,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../data/radius_alert_dedup.dart';
 import '../data/radius_alert_store.dart';
 import '../domain/entities/radius_alert.dart';
+import '../../../core/background/background_service.dart';
 import '../../../core/logging/error_logger.dart';
 
 part 'radius_alerts_provider.g.dart';
@@ -50,6 +51,9 @@ class RadiusAlerts extends _$RadiusAlerts {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'RadiusAlerts.add'}));
     }
     state = AsyncValue.data(await store.list());
+    // #2210 — radius alerts must gate background polling too (not just
+    // per-station price alerts), or radius-only users never get scheduled.
+    await BackgroundService.reconcile();
   }
 
   /// Remove the alert with [id] and refresh state. No-op if unknown.
@@ -66,6 +70,9 @@ class RadiusAlerts extends _$RadiusAlerts {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'RadiusAlerts.remove'}));
     }
     state = AsyncValue.data(await store.list());
+    // #2210 — radius alerts must gate background polling too (not just
+    // per-station price alerts), or radius-only users never get scheduled.
+    await BackgroundService.reconcile();
   }
 
   /// Flip [RadiusAlert.enabled] on the alert with [id]. No-op when
@@ -88,5 +95,8 @@ class RadiusAlerts extends _$RadiusAlerts {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'RadiusAlerts.toggle'}));
     }
     state = AsyncValue.data(await store.list());
+    // #2210 — radius alerts must gate background polling too (not just
+    // per-station price alerts), or radius-only users never get scheduled.
+    await BackgroundService.reconcile();
   }
 }

--- a/lib/features/alerts/providers/radius_alerts_provider.g.dart
+++ b/lib/features/alerts/providers/radius_alerts_provider.g.dart
@@ -171,7 +171,7 @@ final class RadiusAlertsProvider
   RadiusAlerts create() => RadiusAlerts();
 }
 
-String _$radiusAlertsHash() => r'c751a9ef8480af9806d4f7471f18e34a0379bc93';
+String _$radiusAlertsHash() => r'195abe39ce71158ca7565a46c7a5b4d9eff8de78';
 
 /// Radius-watchlist state (#578 phase 1).
 ///

--- a/test/core/notifications/local_notification_service_test.dart
+++ b/test/core/notifications/local_notification_service_test.dart
@@ -37,6 +37,13 @@ class _FakeFlutterLocalNotificationsPlugin extends Fake
     return true;
   }
 
+  // #2209 — initialize() now resolves the Android impl to create
+  // channels; return null so the test skips that platform-specific path.
+  @override
+  T? resolvePlatformSpecificImplementation<
+          T extends FlutterLocalNotificationsPlatform>() =>
+      null;
+
   @override
   Future<void> show({
     required int id,

--- a/test/core/notifications/notification_service_test.dart
+++ b/test/core/notifications/notification_service_test.dart
@@ -8,6 +8,12 @@ import 'package:tankstellen/core/notifications/notification_service.dart';
 /// A fake [NotificationService] for testing that call sites work against
 /// the abstract interface without touching platform channels.
 class FakeNotificationService implements NotificationService {
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
   bool initialized = false;
   final List<({int id, String title, String body, String? payload})>
       shownAlerts = [];

--- a/test/features/alerts/data/radius_alert_runner_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_test.dart
@@ -18,6 +18,12 @@ import 'package:tankstellen/features/alerts/domain/radius_alert_evaluator.dart';
 /// [LocalNotificationService] — the service layer only needs
 /// `showPriceAlert` to reach it.
 class _FakeNotifier implements NotificationService {
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
   final List<({int id, String title, String body, String? payload})>
       priceAlerts = [];
 

--- a/test/features/alerts/data/radius_alert_runner_throttle_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_throttle_test.dart
@@ -20,6 +20,12 @@ import 'package:tankstellen/features/alerts/domain/radius_alert_evaluator.dart';
 /// throttler so a future refactor can't silently regress to the old
 /// "evaluate on every cycle" cadence.
 class _FakeNotifier implements NotificationService {
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
   final List<({int id, String title, String body, String? payload})>
       priceAlerts = [];
 

--- a/test/features/alerts/data/velocity_alert_runner_test.dart
+++ b/test/features/alerts/data/velocity_alert_runner_test.dart
@@ -19,6 +19,12 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// [LocalNotificationService] — the BG-isolate hook just needs
 /// `showPriceAlert` to reach it.
 class _FakeNotifier implements NotificationService {
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
   final List<({int id, String title, String body, String? payload})>
       priceAlerts = [];
 

--- a/test/features/alerts/providers/alert_provider_test.dart
+++ b/test/features/alerts/providers/alert_provider_test.dart
@@ -8,8 +8,39 @@ import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
 import 'package:tankstellen/features/alerts/data/repositories/alert_repository.dart';
 import 'package:tankstellen/features/alerts/providers/alert_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/core/notifications/notification_providers.dart';
+import 'package:tankstellen/core/notifications/notification_service.dart';
 
 import '../../../fakes/fake_hive_storage.dart';
+import '../../../helpers/silence_error_logger.dart';
+
+/// No-op NotificationService so addAlert's permission request + the
+/// background reconcile don't touch real plugins/Hive in unit tests.
+class _NoopNotificationService implements NotificationService {
+  int requestPermissionCalls = 0;
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<bool> requestPermission() async {
+    requestPermissionCalls++;
+    return true;
+  }
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+  @override
+  Future<void> showPriceAlert(
+      {required int id,
+      required String title,
+      required String body,
+      String? payload}) async {}
+  @override
+  Future<void> showServiceReminder(
+      {required int id, required String title, required String body}) async {}
+  @override
+  Future<void> cancelNotification(int id) async {}
+  @override
+  Future<void> cancelAll() async {}
+}
 
 PriceAlert _makeAlert({
   String id = 'alert-1',
@@ -33,6 +64,7 @@ PriceAlert _makeAlert({
 }
 
 void main() {
+  silenceErrorLoggerSpool();
   late FakeHiveStorage fakeStorage;
 
   setUp(() {
@@ -164,14 +196,25 @@ void main() {
 
   group('AlertNotifier (via ProviderContainer)', () {
     late ProviderContainer container;
+    late _NoopNotificationService noopNotifier;
 
     setUp(() {
+      // addAlert now requests the notification permission (#2209) and
+      // reconciles background polling (#2210); keep both off real
+      // plugins/Hive (spool silenced at main()).
+      noopNotifier = _NoopNotificationService();
       container = ProviderContainer(
         overrides: [
           hiveStorageProvider.overrideWithValue(fakeStorage),
+          notificationServiceProvider.overrideWithValue(noopNotifier),
         ],
       );
       addTearDown(container.dispose);
+    });
+
+    test('addAlert requests the notification permission (#2209)', () async {
+      await container.read(alertProvider.notifier).addAlert(_makeAlert());
+      expect(noopNotifier.requestPermissionCalls, 1);
     });
 
     test('build() returns alerts from AlertRepository', () async {

--- a/test/features/vehicle/domain/services/service_reminder_evaluator_test.dart
+++ b/test/features/vehicle/domain/services/service_reminder_evaluator_test.dart
@@ -15,6 +15,12 @@ import 'package:tankstellen/features/vehicle/domain/services/service_reminder_ev
 /// Duplicated on purpose so this test file stays self-contained and
 /// doesn't reach into another test file at import time.
 class _FakeNotificationService implements NotificationService {
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
   final List<({int id, String title, String body})> serviceReminders = [];
 
   @override


### PR DESCRIPTION
## Summary
Makes alerts actually reach the user (Epic #2208). Two root causes from the uploaded field error log:

- **Closes #2209** — the Android 13+ `POST_NOTIFICATIONS` runtime permission was never requested, so `flutter_local_notifications.show()` silently no-opped and **no alert ever appeared**. Adds `NotificationService.requestPermission()` + `areNotificationsEnabled()`, creates the channels explicitly in `initialize()`, and requests the permission when the user creates their first alert.
- **Closes #2210** — background polling was scheduled only for active per-station price alerts, so a **radius-only user got no WorkManager task** and radius alerts never fired. Adds `BackgroundService.reconcile()` (schedules when ANY price OR radius alert is active; cancels only when both empty; fully resilient) wired into both alert providers + startup.

Full analyze clean (2 pre-existing infos); 628 alert/notification/background/app tests pass; `build_runner` clean. Remaining Epic #2208 children (#2211 radius polish, #2212 daily history, + the notifications-disabled recovery banner) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
