### PR TITLE
feat(history): collect each viewed station's prices once per day (Epic #2208)

### DIFF
--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -32,6 +32,7 @@ import '../storage/storage_keys.dart';
 import '../utils/json_extensions.dart';
 import 'background_price_fetcher_provider.dart';
 import 'background_retry.dart';
+import 'daily_collection.dart';
 import 'hive_isolate_lock.dart';
 import '../../core/logging/error_logger.dart';
 
@@ -189,7 +190,11 @@ Future<void> _refreshPricesAndCheckAlerts() async {
     await HiveStorage.loadApiKey();
     final apiKey = storage.getApiKey();
 
-    // 1. Get favorite + alert station IDs (union for batch price fetch)
+    // 1. Build the station-id set to fetch. Favorites + active-alert
+    //    stations are always refreshed; #2212 — every previously-viewed
+    //    ("collected") station is also gathered ONCE PER DAY so its price
+    //    history keeps growing even if it isn't a favorite.
+    final now = DateTime.now();
     final favoriteIds = storage.getFavoriteIds();
     final repo = AlertRepository(storage);
     final alerts = repo.getAlerts();
@@ -197,8 +202,23 @@ Future<void> _refreshPricesAndCheckAlerts() async {
         .where((a) => a.isActive)
         .map((a) => a.stationId)
         .toSet();
-    final allStationIds = {...favoriteIds, ...alertStationIds}.toList();
-    debugPrint('BackgroundService: ${favoriteIds.length} favorites, ${alertStationIds.length} alert stations, ${allStationIds.length} total');
+    bool collectedToday(String id) {
+      final recs = storage.getPriceRecords(id);
+      if (recs.isEmpty) return false;
+      final last =
+          DateTime.tryParse(recs.last['recordedAt']?.toString() ?? '');
+      return last != null && isSameDay(last, now);
+    }
+
+    final allStationIds = stationsToCollect(
+      favorites: favoriteIds,
+      alerts: alertStationIds.toList(),
+      viewed: storage.getPriceHistoryKeys(),
+      collectedToday: collectedToday,
+    );
+    debugPrint('BackgroundService: ${favoriteIds.length} favorites, '
+        '${alertStationIds.length} alert stations, '
+        '${allStationIds.length} total (incl. once-a-day viewed)');
 
     if (allStationIds.isEmpty) {
       // #609 — users without favorites still need a populated nearest
@@ -210,7 +230,6 @@ Future<void> _refreshPricesAndCheckAlerts() async {
     // 2. Fetch prices for all stations via the shared Tankerkoenig batch
     //    fetcher. The fetcher handles chunking + parsing + retry — see
     //    TankerkoenigBatchPriceFetcher.
-    final now = DateTime.now();
     final dio = Dio(BaseOptions(
       connectTimeout: BackgroundService.bgConnectTimeout,
       receiveTimeout: BackgroundService.bgReceiveTimeout,

--- a/lib/core/background/daily_collection.dart
+++ b/lib/core/background/daily_collection.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Computes the station-id set the background task should fetch prices for
+/// (#2212).
+///
+/// [favorites] and [alerts] are always included — they are the
+/// user-consented, frequently-refreshed sets. [viewed] is the set of
+/// stations the user has previously collected (any station with recorded
+/// price history); each is included only when it has NOT already been
+/// collected today, so a viewed station's prices are gathered **once per
+/// day** rather than on every hourly run. [collectedToday] returns true
+/// when the station already has a price-history record for the current
+/// calendar day.
+List<String> stationsToCollect({
+  required List<String> favorites,
+  required List<String> alerts,
+  required List<String> viewed,
+  required bool Function(String id) collectedToday,
+}) {
+  final ids = <String>{...favorites, ...alerts};
+  for (final id in viewed) {
+    if (!collectedToday(id)) ids.add(id);
+  }
+  return ids.toList();
+}
+
+/// Whether two timestamps fall on the same calendar day (local time).
+bool isSameDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;

--- a/test/core/background/daily_collection_test.dart
+++ b/test/core/background/daily_collection_test.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/daily_collection.dart';
+
+void main() {
+  group('stationsToCollect (#2212)', () {
+    test('always includes favorites and active alerts', () {
+      final ids = stationsToCollect(
+        favorites: ['f1', 'f2'],
+        alerts: ['a1'],
+        viewed: const [],
+        collectedToday: (_) => false,
+      );
+      expect(ids.toSet(), {'f1', 'f2', 'a1'});
+    });
+
+    test('includes a viewed station only when not yet collected today', () {
+      final ids = stationsToCollect(
+        favorites: const [],
+        alerts: const [],
+        viewed: ['v1', 'v2'],
+        collectedToday: (id) => id == 'v1', // v1 already has today's record
+      );
+      expect(ids, ['v2']);
+    });
+
+    test('viewed station collected daily, then skipped same day', () {
+      // Before today's record: included.
+      expect(
+        stationsToCollect(
+            favorites: const [],
+            alerts: const [],
+            viewed: ['v1'],
+            collectedToday: (_) => false),
+        ['v1'],
+      );
+      // After today's record: skipped.
+      expect(
+        stationsToCollect(
+            favorites: const [],
+            alerts: const [],
+            viewed: ['v1'],
+            collectedToday: (_) => true),
+        isEmpty,
+      );
+    });
+
+    test('de-dups across favorites / alerts / viewed', () {
+      final ids = stationsToCollect(
+        favorites: ['s1'],
+        alerts: ['s1'],
+        viewed: ['s1'],
+        collectedToday: (_) => false,
+      );
+      expect(ids, ['s1']);
+    });
+
+    test('favorites are refreshed even if already collected today', () {
+      // collectedToday only gates `viewed`; favorites always included.
+      final ids = stationsToCollect(
+        favorites: ['f1'],
+        alerts: const [],
+        viewed: ['f1'],
+        collectedToday: (_) => true,
+      );
+      expect(ids, ['f1']);
+    });
+  });
+
+  group('isSameDay', () {
+    test('true for same calendar day, false across midnight', () {
+      expect(isSameDay(DateTime(2026, 5, 29, 0, 1), DateTime(2026, 5, 29, 23, 59)),
+          isTrue);
+      expect(isSameDay(DateTime(2026, 5, 29, 23, 59), DateTime(2026, 5, 30, 0, 1)),
+          isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #2212 (Epic #2208). The background task now collects every previously-viewed/"collected" station's prices **once per day** (favorites/alerts keep their frequent cadence; viewed stations skipped if already recorded today), so price history grows for every station the user has engaged with — not just favorites. Pure `stationsToCollect()`/`isSameDay()` helper, unit-tested; reuses the existing batch fetcher + dedup/retention; stays gated by the alert-driven schedule (Tankerkönig ToS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)