### PR TITLE
refactor(snackbar): complete SnackBarHelper migration — iconated + success (Epic #2167)

### DIFF
--- a/lib/core/widgets/snackbar_helper.dart
+++ b/lib/core/widgets/snackbar_helper.dart
@@ -83,6 +83,24 @@ class SnackBarHelper {
         duration: duration,
       );
 
+  /// An informational [SnackBar] with a leading icon but the DEFAULT
+  /// SnackBar theme (no coloured background) — for coaching/info rows
+  /// like the eco-coach hint and the unpinned-recording warning (#2173).
+  /// The icon + text inherit the ambient content colour, so the visual
+  /// matches the previous hand-built rows while gaining the liveRegion
+  /// announce.
+  static SnackBar iconatedInfoSnackBar(
+    IconData icon,
+    String message, {
+    Duration duration = _infoDuration,
+    Key? key,
+  }) =>
+      SnackBar(
+        key: key,
+        content: _IconatedContent(icon: icon, message: message),
+        duration: duration,
+      );
+
   /// An error [SnackBar] — themed via [scheme] (`errorContainer`) with
   /// an error icon so the failure is signalled by more than colour.
   static SnackBar errorSnackBar(ColorScheme scheme, String message) =>
@@ -164,12 +182,16 @@ class _IconatedContent extends StatelessWidget {
   const _IconatedContent({
     required this.icon,
     required this.message,
-    required this.foreground,
+    this.foreground,
   });
 
   final IconData icon;
   final String message;
-  final Color foreground;
+
+  /// Foreground colour for the icon + text. Null → inherit the ambient
+  /// SnackBar content colour (used by [iconatedInfoSnackBar], #2173); the
+  /// success/error variants pass an explicit on-container colour.
+  final Color? foreground;
 
   @override
   Widget build(BuildContext context) {
@@ -179,7 +201,10 @@ class _IconatedContent extends StatelessWidget {
           Icon(icon, color: foreground, size: 20),
           const SizedBox(width: 12),
           Expanded(
-            child: Text(message, style: TextStyle(color: foreground)),
+            child: Text(
+              message,
+              style: foreground == null ? null : TextStyle(color: foreground),
+            ),
           ),
         ],
       ),

--- a/lib/features/consumption/presentation/screens/trajets_map_screen.dart
+++ b/lib/features/consumption/presentation/screens/trajets_map_screen.dart
@@ -143,7 +143,8 @@ class TrajetsMapScreen extends ConsumerWidget {
       );
       if (messenger == null) return;
       final ok = l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
-      messenger.showSnackBar(SnackBar(content: Text(ok)));
+      // #2173 — themed success toast (matches the sibling error path).
+      messenger.showSnackBar(SnackBarHelper.successSnackBar(scheme, ok));
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TrajetsMapScreen save GPX'}));
       if (messenger == null) return;

--- a/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_gpx_share.dart
@@ -64,7 +64,8 @@ Future<void> shareTripGpx(
     if (messenger == null) return;
     final ok =
         l?.savedToDownloadsFolder ?? 'Saved to your Downloads folder';
-    messenger.showSnackBar(SnackBar(content: Text(ok)));
+    // #2173 — themed success toast (matches the sibling error path).
+    messenger.showSnackBar(SnackBarHelper.successSnackBar(scheme, ok));
   } catch (e, st) {
     unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripDetailScreen save GPX'}));
     if (messenger == null) return;

--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -202,22 +202,15 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     final messenger = ScaffoldMessenger.maybeOf(context);
     if (messenger == null) return;
     messenger.hideCurrentSnackBar();
+    // #2173 — iconated info row through the centralized helper (adds the
+    // liveRegion announce; same icon/text/Key/duration as before).
     messenger.showSnackBar(
-      SnackBar(
+      SnackBarHelper.iconatedInfoSnackBar(
+        Icons.eco,
+        l?.hapticEcoCoachSnackBarMessage ??
+            'Easy on the throttle — coasting saves more',
         key: const Key('hapticEcoCoachSnackBar'),
         duration: const Duration(seconds: 4),
-        content: Row(
-          children: [
-            const Icon(Icons.eco, size: 20),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                l?.hapticEcoCoachSnackBarMessage ??
-                    'Easy on the throttle — coasting saves more',
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }
@@ -263,22 +256,13 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     final l = AppLocalizations.of(context);
     _unpinnedWarningShown = true;
     messenger.showSnackBar(
-      SnackBar(
+      SnackBarHelper.iconatedInfoSnackBar(
+        Icons.gps_off,
+        l?.tripRecordingUnpinnedWarning ??
+            'Pin the screen to keep GPS active during the trip '
+                '— Android may throttle GPS during sleep.',
         key: const Key('tripRecordingUnpinnedWarningSnackBar'),
         duration: const Duration(seconds: 8),
-        content: Row(
-          children: [
-            const Icon(Icons.gps_off, size: 20),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                l?.tripRecordingUnpinnedWarning ??
-                    'Pin the screen to keep GPS active during the trip '
-                        '— Android may throttle GPS during sleep.',
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_breadcrumb_overlay.dart
@@ -10,6 +10,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/providers/app_state_provider.dart';
 import '../../../../core/sharing/public_file_exporter.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../data/obd2/auto_record_trace_log.dart';
 import '../../data/obd2/obd2_breadcrumb_collector.dart';
@@ -138,11 +139,10 @@ class Obd2BreadcrumbOverlay extends ConsumerWidget {
         fileName: fileName,
         mimeType: 'application/json',
       );
+      // #2173 — route through SnackBarHelper for the liveRegion announce.
       messenger?.showSnackBar(
-        SnackBar(
-          content: Text(
-            l10n?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
-          ),
+        SnackBarHelper.infoSnackBar(
+          l10n?.savedToDownloadsFolder ?? 'Saved to your Downloads folder',
         ),
       );
     } on Object catch (e, st) {


### PR DESCRIPTION
Closes #2173. Adds `iconatedInfoSnackBar` (default-theme leading-icon row) + routes the eco-coach/unpinned hand-built snackbars + the three saved-to-Downloads success toasts through SnackBarHelper. Same icon/text/Key/duration; gains the liveRegion announce. Analyze clean; snackbar + trip-recording tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)