### PR TITLE
feat(alerts): complete radius-alert polish — names, fuel guard, radius cap, GPS (Epic #2208)

### DIFF
--- a/integration_test/golden_flow_integration_test.dart
+++ b/integration_test/golden_flow_integration_test.dart
@@ -503,6 +503,7 @@ void main() {
       final crossingSamples = [
         const StationPriceSample(
           stationId: 'gold-1-cheapest',
+          name: 'Gold Station',
           lat: 52.5200,
           lng: 13.4050,
           fuelType: 'diesel',
@@ -510,6 +511,7 @@ void main() {
         ),
         const StationPriceSample(
           stationId: 'gold-2',
+          name: 'Gold Station',
           lat: 52.5180,
           lng: 13.4030,
           fuelType: 'diesel',
@@ -558,6 +560,7 @@ void main() {
       final notCrossingSamples = [
         const StationPriceSample(
           stationId: 'gold-3',
+          name: 'Gold Station',
           lat: 52.5170,
           lng: 13.4020,
           fuelType: 'diesel',

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -667,7 +667,8 @@ RadiusAlertCopy _buildRadiusAlertCopy(RadiusAlertGroupedEvent event) {
   // should reflect everything the user could see if they tapped in.
   final total = event.matches.length + event.truncatedMoreCount;
   final lines = event.matches
-      .map((m) => '${m.stationId} ${m.pricePerLiter.toStringAsFixed(3)} €')
+      // #2211 — show the station name, not the raw id.
+      .map((m) => '${m.name} ${m.pricePerLiter.toStringAsFixed(3)} €')
       .toList();
   if (event.truncatedMoreCount > 0) {
     lines.add(isGerman

--- a/lib/features/alerts/domain/radius_alert_evaluator.dart
+++ b/lib/features/alerts/domain/radius_alert_evaluator.dart
@@ -16,6 +16,11 @@ import 'entities/radius_alert.dart';
 /// fuelType) combination you care about.
 class StationPriceSample {
   final String stationId;
+
+  /// User-facing station name (brand → name → street fallback). #2211 —
+  /// carried so the grouped radius-alert notification shows real names
+  /// instead of raw station ids.
+  final String name;
   final double lat;
   final double lng;
 
@@ -31,6 +36,7 @@ class StationPriceSample {
 
   const StationPriceSample({
     required this.stationId,
+    required this.name,
     required this.lat,
     required this.lng,
     required this.fuelType,
@@ -55,6 +61,7 @@ class StationPriceSample {
       if (price == null) continue;
       out.add(StationPriceSample(
         stationId: station.id,
+        name: station.displayName,
         lat: station.lat,
         lng: station.lng,
         fuelType: fuel.apiValue,

--- a/lib/features/alerts/domain/radius_alert_validators.dart
+++ b/lib/features/alerts/domain/radius_alert_validators.dart
@@ -21,10 +21,14 @@ class RadiusAlertValidators {
   }
 
   /// Predicate that mirrors the "Save" button's enabled state. The
-  /// rules are: a non-empty trimmed label, a parseable strictly
-  /// positive threshold, AND a center — either GPS coordinates OR a
-  /// non-empty postal code (the phase-3 worker geocodes postal-only
-  /// entries later).
+  /// rules are: a non-empty trimmed label, a parseable strictly positive
+  /// threshold, AND real GPS coordinates for the center.
+  ///
+  /// #2211 — a real center is now REQUIRED. Postal-code-only entries used
+  /// to save with a (0,0) center and never matched anything (no
+  /// geocoding step exists), so they were silently dead. [postalCode] is
+  /// still accepted (it's surfaced in the label) but no longer enables
+  /// save on its own; the user must pick a location or use GPS.
   static bool canSave({
     required String label,
     required String thresholdRaw,
@@ -35,8 +39,6 @@ class RadiusAlertValidators {
     if (label.trim().isEmpty) return false;
     final threshold = parseThreshold(thresholdRaw);
     if (threshold == null || threshold <= 0) return false;
-    final hasGps = centerLat != null && centerLng != null;
-    final hasPostal = postalCode.trim().isNotEmpty;
-    return hasGps || hasPostal;
+    return centerLat != null && centerLng != null;
   }
 }

--- a/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_create_sheet.dart
@@ -151,12 +151,11 @@ class _RadiusAlertCreateSheetState
         RadiusAlertValidators.parseThreshold(_thresholdController.text);
     if (threshold == null) return;
 
-    // Postal-code-only entries are parked at (0,0) until the phase-3
-    // worker geocodes them. The stored postal code lives in the
-    // label so the user can see what they asked for; the coordinates
-    // are filled in once the geocoding lands.
-    final lat = _centerLat ?? 0.0;
-    final lng = _centerLng ?? 0.0;
+    // #2211 — a real center is required (canSave enforces it). Guard
+    // defensively so we never persist a dead (0,0) alert.
+    final lat = _centerLat;
+    final lng = _centerLng;
+    if (lat == null || lng == null) return;
 
     final alert = RadiusAlert(
       id: (widget.idGenerator ?? _defaultId)(),

--- a/lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_form_fields.dart
@@ -39,8 +39,11 @@ class RadiusAlertLabelField extends StatelessWidget {
   }
 }
 
-/// Dropdown picking the fuel type the alert watches. Excludes
-/// [FuelType.all] — an alert needs a concrete fuel to compare against.
+/// Dropdown picking the fuel type the alert watches. #2211 — restricted
+/// to the fuels the background radius search (Tankerkönig) can actually
+/// return; offering LPG/CNG/H2/EV produced silently-dead alerts (no
+/// samples ever matched). [FuelType.all] is excluded — an alert needs a
+/// concrete fuel to compare against.
 class RadiusAlertFuelTypeField extends StatelessWidget {
   const RadiusAlertFuelTypeField({
     super.key,
@@ -48,20 +51,32 @@ class RadiusAlertFuelTypeField extends StatelessWidget {
     required this.onChanged,
   });
 
+  /// Fuels the background radius evaluator can actually surface.
+  static const evaluableFuels = [
+    FuelType.e5,
+    FuelType.e10,
+    FuelType.diesel,
+  ];
+
   final FuelType value;
   final ValueChanged<FuelType> onChanged;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    // Keep the current value selectable even if it's a legacy fuel no
+    // longer offered, so editing an old alert doesn't crash the dropdown.
+    final fuels = <FuelType>{
+      ...evaluableFuels,
+      if (value != FuelType.all) value,
+    }.toList();
     return DropdownButtonFormField<FuelType>(
       initialValue: value,
       decoration: InputDecoration(
         labelText: l10n?.alertsRadiusFuelType ?? 'Fuel type',
         border: const OutlineInputBorder(),
       ),
-      items: FuelType.values
-          .where((t) => t != FuelType.all)
+      items: fuels
           .map((t) => DropdownMenuItem(
                 value: t,
                 child: Text(t.displayName),
@@ -101,7 +116,8 @@ class RadiusAlertThresholdField extends StatelessWidget {
   }
 }
 
-/// 1–50 km slider for the search radius around the alert center.
+/// 1–25 km slider for the search radius around the alert center
+/// (capped at the Tankerkönig radius limit, #2211).
 class RadiusAlertRadiusSlider extends StatelessWidget {
   const RadiusAlertRadiusSlider({
     super.key,
@@ -130,10 +146,12 @@ class RadiusAlertRadiusSlider extends StatelessWidget {
           ],
         ),
         Slider(
-          value: value.clamp(1, 50),
+          // #2211 — cap at 25 km: Tankerkönig clamps radius searches to
+          // 25 km, so a larger value silently searched only 25.
+          value: value.clamp(1, 25),
           min: 1,
-          max: 50,
-          divisions: 49,
+          max: 25,
+          divisions: 24,
           label: '${value.round()} km',
           onChanged: onChanged,
         ),

--- a/test/features/alerts/data/radius_alert_runner_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_test.dart
@@ -108,6 +108,7 @@ void main() {
   }) {
     return StationPriceSample(
       stationId: stationId,
+      name: 'Test Station',
       lat: lat,
       lng: lng,
       fuelType: fuelType,

--- a/test/features/alerts/data/radius_alert_runner_throttle_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_throttle_test.dart
@@ -93,6 +93,7 @@ void main() {
 
   StationPriceSample sample({double price = 1.540}) => StationPriceSample(
         stationId: 's1',
+        name: 'Test Station',
         lat: 43.505,
         lng: 3.505,
         fuelType: 'diesel',

--- a/test/features/alerts/domain/radius_alert_evaluator_test.dart
+++ b/test/features/alerts/domain/radius_alert_evaluator_test.dart
@@ -46,6 +46,7 @@ void main() {
   }) {
     return StationPriceSample(
       stationId: stationId,
+      name: 'Test Station',
       lat: lat,
       lng: lng,
       fuelType: fuelType,

--- a/test/features/alerts/domain/radius_alert_validators_test.dart
+++ b/test/features/alerts/domain/radius_alert_validators_test.dart
@@ -125,7 +125,8 @@ void main() {
       );
     });
 
-    test('returns true when only postal code is set (geocode later)', () {
+    test('returns false when only a postal code is set — needs real GPS '
+        '(#2211; postal-only used to save a dead (0,0) alert)', () {
       expect(
         RadiusAlertValidators.canSave(
           label: 'Home diesel',
@@ -134,7 +135,7 @@ void main() {
           centerLng: null,
           postalCode: '34120',
         ),
-        isTrue,
+        isFalse,
       );
     });
 
@@ -164,8 +165,9 @@ void main() {
       );
     });
 
-    test('only one of GPS or postal needs to be set', () {
-      // GPS but no postal
+    test('GPS coordinates are required; postal code alone is not enough '
+        '(#2211)', () {
+      // GPS but no postal → OK
       expect(
         RadiusAlertValidators.canSave(
           label: 'L',
@@ -176,7 +178,7 @@ void main() {
         ),
         isTrue,
       );
-      // Postal but no GPS
+      // Postal but no GPS → not saveable (would be a dead (0,0) alert)
       expect(
         RadiusAlertValidators.canSave(
           label: 'L',
@@ -185,7 +187,7 @@ void main() {
           centerLng: null,
           postalCode: '34120',
         ),
-        isTrue,
+        isFalse,
       );
     });
   });

--- a/test/features/alerts/presentation/widgets/radius_alert_form_fields_test.dart
+++ b/test/features/alerts/presentation/widgets/radius_alert_form_fields_test.dart
@@ -116,10 +116,13 @@ void main() {
           .toSet();
 
       expect(menuValues, isNot(contains(FuelType.all)));
-      // Sanity-check: the concrete fuels we exclude `all` from are present.
+      // #2211 — restricted to the BG-evaluable fuels (E5/E10/diesel);
+      // LPG/CNG/H2/EV are excluded because the radius search can't surface
+      // them (they only ever produced silently-dead alerts).
       expect(menuValues, contains(FuelType.diesel));
       expect(menuValues, contains(FuelType.e10));
-      expect(menuValues.length, FuelType.values.length - 1);
+      expect(menuValues, isNot(contains(FuelType.lpg)));
+      expect(menuValues.length, RadiusAlertFuelTypeField.evaluableFuels.length);
     });
   });
 
@@ -183,8 +186,8 @@ void main() {
       expect(find.text('12 km'), findsOneWidget);
     });
 
-    testWidgets('exposes min=1, max=50, divisions=49 with synced label',
-        (tester) async {
+    testWidgets('exposes min=1, max=25, divisions=24 with synced label '
+        '(#2211 — capped at the Tankerkönig radius limit)', (tester) async {
       await tester.pumpWidget(
         _wrap(RadiusAlertRadiusSlider(
           value: 7,
@@ -195,8 +198,8 @@ void main() {
 
       final slider = tester.widget<Slider>(find.byType(Slider));
       expect(slider.min, 1);
-      expect(slider.max, 50);
-      expect(slider.divisions, 49);
+      expect(slider.max, 25);
+      expect(slider.divisions, 24);
       expect(slider.label, '7 km');
       expect(slider.value, 7);
     });


### PR DESCRIPTION
Closes #2211. Completes the radius feature (with #2210 scheduling, merged): notifications show station **names** not ids; fuel dropdown restricted to BG-evaluable fuels (E5/E10/diesel — others were silently dead); radius slider capped at 25 km (Tankerkönig limit); a real GPS center is required (postal-only saved a dead (0,0) alert). Full alerts suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)