### PR TITLE
refactor(brand): consolidate brand vocabularies behind BrandRegistry (#2186)

### DIFF
--- a/lib/core/utils/brand_logo_mapper.dart
+++ b/lib/core/utils/brand_logo_mapper.dart
@@ -63,6 +63,15 @@ class BrandLogoMapper {
     'lukoil': 'lukoil.com',
   };
 
+  /// The set of brand keys this mapper owns a logo domain for.
+  ///
+  /// Exposed (#2186) so a guard test can assert every key is a known
+  /// `BrandRegistry` canonical name or alias — preventing the logo map
+  /// and the brand registry from drifting apart (e.g. listing `star`
+  /// here after Star was folded into Orlen in the registry). Behaviour
+  /// is unchanged: [logoUrl] still keys off the raw lowercased brand.
+  static Iterable<String> get knownBrandKeys => _brandDomains.keys;
+
   /// Returns a logo URL for the given [brand], or `null` if unknown.
   ///
   /// Uses Clearbit Logo API (free, no key required, returns 128px PNG).

--- a/lib/features/search/domain/entities/brand_registry.dart
+++ b/lib/features/search/domain/entities/brand_registry.dart
@@ -193,6 +193,38 @@ class BrandRegistry {
     return null; // Unknown → "Others"
   }
 
+  /// Scan an arbitrary free-text [haystack] (an address, a receipt line,
+  /// an OSM `name`, a French `services` blob …) for the first recognisable
+  /// brand keyword and return its canonical name, or `null` when none is
+  /// found. This is the single-source-of-truth (#2186) replacement for the
+  /// hand-rolled `contains()` / keyword-scan tables that the receipt
+  /// detector and the France parser previously duplicated.
+  ///
+  /// Matching is case-insensitive and substring-based, driven entirely by
+  /// [brandAliases], so a rebrand (Star→Orlen, Caltex→Ampol, …) only ever
+  /// needs to be encoded once. Note that — unlike [canonicalize], which
+  /// expects a brand string and exact-matches first — this method is for
+  /// *text that may merely contain* a brand, so it is intentionally a pure
+  /// substring scan with no exact-match fast path.
+  ///
+  /// Callers that need keyword-anchoring (e.g. a trailing space to tell
+  /// `TOTAL ` apart from `TOTALENERGIES`, or `Total`→`Total` rather than
+  /// the canonical `TotalEnergies`) deliberately keep their own table —
+  /// those semantics diverge from the canonical vocabulary and folding
+  /// them in here would change observable output (see #2186 notes).
+  static String? canonicalFromText(String haystack) {
+    if (haystack.isEmpty) return null;
+    final lower = haystack.toLowerCase();
+    for (final entry in brandAliases.entries) {
+      for (final alias in entry.value) {
+        if (lower.contains(alias.toLowerCase())) {
+          return entry.key;
+        }
+      }
+    }
+    return null;
+  }
+
   /// Group stations by canonical brand. Unrecognized brands go to "Others".
   static Map<String, int> countByBrand(List<String> rawBrands) {
     final counts = <String, int>{};

--- a/test/core/utils/brand_logo_mapper_test.dart
+++ b/test/core/utils/brand_logo_mapper_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/utils/brand_logo_mapper.dart';
+import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
 
 void main() {
   group('BrandLogoMapper', () {
@@ -84,6 +85,33 @@ void main() {
 
       test('returns false for empty string', () {
         expect(BrandLogoMapper.hasLogo(''), isFalse);
+      });
+    });
+
+    // #2186 — drift guard. Every brand key the logo mapper owns a domain
+    // for must be a known BrandRegistry canonical name or alias, so the
+    // two vocabularies can never silently disagree (the original audit
+    // found `star` listed here after Star was folded into Orlen).
+    group('registry drift guard', () {
+      test('every logo key is a known BrandRegistry canonical or alias', () {
+        final knownLower = <String>{};
+        for (final entry in BrandRegistry.brandAliases.entries) {
+          knownLower.add(entry.key.toLowerCase());
+          for (final alias in entry.value) {
+            knownLower.add(alias.toLowerCase());
+          }
+        }
+
+        final orphans = BrandLogoMapper.knownBrandKeys
+            .where((k) => !knownLower.contains(k.toLowerCase()))
+            .toList();
+
+        expect(
+          orphans,
+          isEmpty,
+          reason: 'logo domains exist for keys absent from BrandRegistry '
+              '(would drift on a rebrand): $orphans',
+        );
       });
     });
   });

--- a/test/features/search/domain/entities/brand_registry_test.dart
+++ b/test/features/search/domain/entities/brand_registry_test.dart
@@ -176,5 +176,62 @@ void main() {
         expect(BrandRegistry.canonicalize('API'), 'IP');
       });
     });
+
+    // #2186 — single-source-of-truth substring scan that replaces the
+    // hand-rolled keyword tables in the receipt detector and FR parser.
+    group('canonicalFromText', () {
+      test('returns null for empty text', () {
+        expect(BrandRegistry.canonicalFromText(''), isNull);
+      });
+
+      test('returns null when no brand keyword is present', () {
+        expect(
+          BrandRegistry.canonicalFromText('garage du coin, rue de la paix'),
+          isNull,
+        );
+      });
+
+      test('finds a brand embedded in surrounding text', () {
+        expect(
+          BrandRegistry.canonicalFromText('TOTALENERGIES station service'),
+          'TotalEnergies',
+        );
+        expect(
+          BrandRegistry.canonicalFromText('bienvenue chez Shell autoroute'),
+          'Shell',
+        );
+        expect(
+          BrandRegistry.canonicalFromText('AUCHAN CENTRE COMMERCIAL'),
+          'Auchan',
+        );
+      });
+
+      test('is case-insensitive', () {
+        expect(BrandRegistry.canonicalFromText('aral autobahn'), 'Aral');
+        expect(BrandRegistry.canonicalFromText('CARREFOUR MARKET'), 'Carrefour');
+      });
+
+      // Rebrand cases the issue (#2186) explicitly calls out — these are
+      // the drift hot-spots when a brand is renamed across countries.
+      test('folds rebranded aliases to the canonical name', () {
+        expect(BrandRegistry.canonicalFromText('Star Tankstelle'), 'Orlen');
+        expect(BrandRegistry.canonicalFromText('Caltex highway'), 'Ampol');
+        expect(
+          BrandRegistry.canonicalFromText('Total Access péage A7'),
+          'TotalEnergies',
+        );
+        expect(BrandRegistry.canonicalFromText('Moeve estación'), 'Cepsa');
+      });
+
+      test('agrees with canonicalize for a clean brand string', () {
+        for (final brand in ['Shell', 'Repsol', 'Aral', 'Carrefour', 'YPF']) {
+          expect(
+            BrandRegistry.canonicalFromText(brand),
+            BrandRegistry.canonicalize(brand),
+            reason: 'text scan should match canonicalize for "$brand"',
+          );
+        }
+      });
+    });
   });
 }


### PR DESCRIPTION
Closes #2186

## Summary
Establishes `BrandRegistry` as the single source of truth (SSoT) for the
brand vocabulary that was previously duplicated across five lists, with a
**conservative, behaviour-preserving** scope. Every existing brand test
stays green; no observable output changes.

## The five vocabularies
| # | Location | Action |
|---|----------|--------|
| 1 | `BrandRegistry.brandAliases` (search/domain) | SSoT — extended with `canonicalFromText` |
| 2 | `BrandLogoMapper._brandDomains` (core/utils) | Drift-guarded (see below); behaviour unchanged |
| 3 | `brand_detection.detectBrand` (consumption) | **Left** — diverges (coarse layout keys, bare `total` is a no-match) |
| 4 | `brand_detection.extractStationName` (consumption) | **Left** — includes `elf`/`mol` absent from registry |
| 5 | FR `detectPrixCarburantsBrand.brandMap` (station_services/france) | **Left** — emits `'Total'`/`'Super U'`, trailing-space anchored |

## What was unified
- **`BrandRegistry.canonicalFromText(haystack)`** — the SSoT substring
  scan (driven by `brandAliases`) that the receipt detector and the FR
  parser hand-rolled. Adding/rebranding a brand (Star→Orlen, Caltex→Ampol,
  Total Access→TotalEnergies) now only needs encoding once.
- **Drift guard** — `BrandLogoMapper.knownBrandKeys` is exposed and a test
  asserts every logo domain key is a known registry canonical/alias. This
  permanently prevents the logo map and the registry from diverging (the
  audit found `star` still listed in the logo map after Star was folded
  into Orlen in the registry). Passes today.
- Tests for `canonicalFromText` covering the rebrand hot-spots.

## What was deliberately left, and why
The issue is flagged *risk: high*. Four of the five vocabularies emit
strings that **intentionally diverge** from the canonical vocabulary, each
locked by an existing test — folding them in would change observable
output, not consolidate it:
- FR parser returns the literal `'Total'` (not `'TotalEnergies'`) and
  `'Super U'` (not `'Système U'`) and uses trailing-space anchoring
  (`'TOTAL '`); `prix_carburants_station_service_test` asserts `'Total'`.
- Receipt `detectBrand` returns layout keys and treats bare `'total'`
  (no trailing space) as no-match.
- Receipt `extractStationName` includes `elf`/`mol`, absent from the
  registry, and would over-match every registry brand if registry-driven.
- `BrandLogoMapper.logoUrl` keys off the raw lowercased brand with no
  canonicalisation by design.

Per the SSoT anchor (`canonicalFromText`) + drift guard now in place, the
per-vocabulary rewiring can follow once each divergent semantic is
reconciled with maintainer sign-off — without the regression risk of
doing it blind here. Partial-but-correct over complete-but-behaviour-
changing.

## Verification
- `flutter analyze` — 2 issues, the same pre-existing infos as master (both
  in untouched files). No new errors/warnings.
- Tests green: `brand_registry_test`, `brand_logo_mapper_test`,
  `brand_detection_test`, `prix_carburants_station_service_test`, plus the
  full `test/features/search`, `test/features/station_detail`,
  `test/features/consumption/data/receipt_parser`,
  `test/core/services/impl` suites (1086 tests).
- File-length lint (`test/lint/`) green; touched files 237 / 89 lines.
- No codegen required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
