### PR TITLE
refactor: adopt SafeJsonAccessors in country services (#2199)

### DIFF
--- a/lib/features/station_services/uk/uk_station_service.dart
+++ b/lib/features/station_services/uk/uk_station_service.dart
@@ -10,6 +10,7 @@ import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/utils/geo_utils.dart';
+import '../../../core/utils/json_extensions.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
@@ -174,37 +175,39 @@ class UkStationService with StationServiceHelpers implements StationService {
     for (final item in items) {
       if (item is! Map) continue;
       try {
-        final location = item['location'];
-        final locMap = location is Map ? location : null;
-        final itemLat = (locMap?['latitude'] as num?)?.toDouble() ??
-            (item['lat'] as num?)?.toDouble();
-        final itemLng = (locMap?['longitude'] as num?)?.toDouble() ??
-            (item['lng'] as num?)?.toDouble();
+        final m = Map<String, dynamic>.from(item);
+        final locMap = m.getMap('location');
+        // #2199 — SafeJsonAccessors: getDouble accepts num OR numeric-string
+        // and returns null on missing/non-numeric. The previous `as num?`
+        // cast threw a CastError on a string-typed coordinate, which the
+        // per-item catch swallowed into a skipped station; getDouble parses
+        // it instead. Records with numeric coords (every CMA feed today)
+        // parse identically.
+        final itemLat = locMap?.getDouble('latitude') ?? m.getDouble('lat');
+        final itemLng = locMap?.getDouble('longitude') ?? m.getDouble('lng');
         if (itemLat == null || itemLng == null) continue;
 
         final dist = distanceKm(lat, lng, itemLat, itemLng);
         if (dist > radiusKm) continue;
 
-        final rawId = item['site_id']?.toString() ??
-            item['id']?.toString() ??
+        final rawId = m['site_id']?.toString() ??
+            m['id']?.toString() ??
             '${itemLat.toStringAsFixed(5)}_${itemLng.toStringAsFixed(5)}';
         final stationId = 'uk-$rawId';
         if (!seenIds.add(stationId)) continue;
 
-        final prices = item['prices'] is Map
-            ? Map<String, dynamic>.from(item['prices'] as Map)
-            : <String, dynamic>{};
+        final prices = m.getMap('prices') ?? <String, dynamic>{};
 
         stations.add(Station(
           id: stationId,
-          name: item['site_name']?.toString() ??
-              item['name']?.toString() ??
-              item['brand']?.toString() ??
+          name: m['site_name']?.toString() ??
+              m['name']?.toString() ??
+              m['brand']?.toString() ??
               '',
-          brand: item['brand']?.toString() ?? '',
-          street: item['address']?.toString() ?? '',
-          postCode: item['postcode']?.toString() ?? '',
-          place: item['town']?.toString() ?? item['locality']?.toString() ?? '',
+          brand: m['brand']?.toString() ?? '',
+          street: m['address']?.toString() ?? '',
+          postCode: m['postcode']?.toString() ?? '',
+          place: m['town']?.toString() ?? m['locality']?.toString() ?? '',
           lat: itemLat,
           lng: itemLng,
           dist: dist,

--- a/test/features/station_services/uk/uk_station_service_test.dart
+++ b/test/features/station_services/uk/uk_station_service_test.dart
@@ -438,6 +438,58 @@ void main() {
       expect(stations.first.name, 'First');
     });
 
+    // #2199 — SafeJsonAccessors regression coverage. These pin the
+    // observable behaviour after migrating the raw `as num?` / `as Map`
+    // casts to getDouble / getMap so a future change cannot silently
+    // alter which records parse.
+    test('parses string-typed coordinates via getDouble (robustness gain)',
+        () {
+      // Before #2199 a String latitude threw a CastError that the per-item
+      // catch swallowed into a skipped station; getDouble parses it instead.
+      final stations = parse([
+        {
+          'site_id': 'STR',
+          'site_name': 'String Coords',
+          'brand': 'BP',
+          'location': {'latitude': '51.5', 'longitude': '-0.12'},
+          'prices': {'E5': 145.9},
+        },
+      ]);
+      expect(stations, hasLength(1));
+      expect(stations.first.lat, closeTo(51.5, 0.0001));
+      expect(stations.first.lng, closeTo(-0.12, 0.0001));
+    });
+
+    test('still skips records with non-numeric coordinate strings', () {
+      // getDouble('abc') -> null, same as the old cast outcome (skipped).
+      final stations = parse([
+        {
+          'site_id': 'BAD',
+          'site_name': 'Bad Coords',
+          'location': {'latitude': 'not-a-number', 'longitude': '-0.12'},
+          'prices': <String, dynamic>{},
+        },
+      ]);
+      expect(stations, isEmpty);
+    });
+
+    test('degrades to empty prices when prices is not a map', () {
+      // getMap returns null for a non-map value -> `?? {}` -> no prices,
+      // identical to the previous `is Map ? ... : {}` guard.
+      final stations = parse([
+        {
+          'site_id': 'NOPRICE',
+          'site_name': 'No Prices',
+          'location': {'latitude': 51.5, 'longitude': -0.12},
+          'prices': 'not a map',
+        },
+      ]);
+      expect(stations, hasLength(1));
+      expect(stations.first.e5, isNull);
+      expect(stations.first.e10, isNull);
+      expect(stations.first.diesel, isNull);
+    });
+
     test('parsePenceForTest — null, non-numeric, pence, and pounds', () {
       expect(UkStationService.parsePenceForTest(null), isNull);
       expect(UkStationService.parsePenceForTest('abc'), isNull);


### PR DESCRIPTION
Closes #2199

## What

Adopt the existing `SafeJsonAccessors` extension (`lib/core/utils/json_extensions.dart`) in the UK CMA station parser (`UkStationService.parseCmaStations`), replacing the fragile raw `as Type?` JSON casts the helper was built to retire.

## Casts migrated

- `(locMap?['latitude'] as num?)?.toDouble()` → `locMap?.getDouble('latitude')` (+ longitude, + the `lat`/`lng` fallbacks)
- `item['prices'] is Map ? Map<String,dynamic>.from(...) : {}` → `m.getMap('prices') ?? {}`
- `final m = Map<String,dynamic>.from(item)` introduced once (`item` is already `is Map`-guarded) so the typed extension is callable; remaining `?.toString()` field reads retargeted from `item` to `m` (pure rename).

## Parse semantics preserved

- **Map access (prices/location): behaviour-identical.** `getMap` returns the map for a `Map<String,dynamic>`, converts a `Map<dynamic,dynamic>`, returns null (→ `?? {}`) for a non-map — same outcomes as the old `is Map ? .from : {}` guard. The old cast's throw on a non-map was never load-bearing.
- **Coordinate access: strictly more robust, happy path unchanged.** For numeric coords (every CMA feed today, and every existing test) `getDouble` is byte-identical to `(as num?)?.toDouble()`. The only divergence: a String-typed coordinate that the old cast turned into a swallowed CastError (dropped station) now parses. Non-numeric strings still yield null → station still skipped. This is the documented purpose of the helper.

## Tests

- Full existing UK suite stays green (happy path unchanged).
- 3 regression cases added on the directly-tested `parseCmaStations` path: string coords now parse, non-numeric coord strings still skip, non-map prices degrade to empty.

## Scope

UK only, per the issue's adversarial-verification guidance ("do NOT do all 16 in one PR", one service per commit, start with the flakiest/highest-cast feeds). UK is the single service whose parser is exercised by the real code (`@visibleForTesting parseCmaStations`), so the migration is provable. **Denmark and Austria are deferred**: their parsers are covered only by duplicated `_Testable*Parser` copies, so migrating the real service there would not be exercised by the suite — a follow-up should first refactor those tests to call the real code.

## Verification

- `flutter analyze` → `2 issues found` — the same two pre-existing info-level items as master (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`). No new diagnostics.
- `flutter test test/features/station_services/uk/ test/core/utils/json_extensions_test.dart` → all 76 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
