### PR TITLE
refactor(trips): extract TripDistanceResolver from TripRecordingController (#2187)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_distance_resolver.dart
+++ b/lib/features/consumption/data/obd2/trip_distance_resolver.dart
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../domain/gps_track_distance.dart';
+import 'trip_distance_source.dart';
+import 'virtual_odometer.dart';
+
+/// Owns the trip's distance-resolution concern — the pure, async-free,
+/// stream-free three-tier selection between the car's odometer delta, a
+/// haversine-summed GPS track, and the trapezoidal virtual-odometer
+/// integral — extracted from [TripRecordingController] as the first slice
+/// of the #2187 god-class decomposition.
+///
+/// ## Why this is a clean, isolated unit
+///
+/// The resolver holds the two rolling sample buffers it integrates over
+/// (`_speedSamples` for the virtual odometer, `_gpsTrack` for the GPS
+/// source) and nothing else — no timers, no streams, no Hive, no
+/// Riverpod. It mirrors the pure-Dart collaborator pattern already
+/// established for this class (`TripDropDetector`, `TripSampleBuffer`,
+/// #1679).
+///
+/// ## What it deliberately does NOT own
+///
+/// The odometer readings (`odometerStartKm` / `odometerLatestKm`) stay on
+/// the controller — they are shared state read and written at six other
+/// sites unrelated to distance (`start`, `refreshOdometer`, the public
+/// getters, paused-trip persistence, the live emit loop). Pulling them in
+/// here would widen the blast radius well beyond a behaviour-preserving
+/// extraction, so instead they are passed into [distanceKm] / [distanceSource]
+/// as arguments (#2187 adversarial-verification scoping).
+///
+/// ## Trimming asymmetry (preserved verbatim)
+///
+/// The production ingress paths [addSpeedSample] / [addGpsFix] cap the
+/// buffers at [kVirtualOdometerSampleCap], dropping the oldest slice. The
+/// `@visibleForTesting` ingress paths [debugAddSpeedSample] /
+/// [debugAddGpsFix] intentionally do NOT trim — they let a test build an
+/// arbitrarily long deterministic buffer. That deliberate asymmetry is
+/// preserved exactly as it was on the controller.
+class TripDistanceResolver {
+  /// Maximum Δt (seconds) between virtual-odometer samples that the
+  /// integrator bridges (#1927). Passed in from the controller so the
+  /// resolver shares the same integration-gap cap the recorder uses.
+  final double maxIntegrationGapSeconds;
+
+  /// Clock used to timestamp speed samples appended via [addSpeedSample].
+  /// Injected so the resolver matches whatever clock the controller was
+  /// constructed with (real or test fake).
+  final DateTime Function() _now;
+
+  /// Rolling buffer of `(timestamp, speedKmh)` samples used by the
+  /// virtual odometer (#800). Populated by the 5 Hz speed subscription
+  /// callback via [addSpeedSample]; capped at [kVirtualOdometerSampleCap]
+  /// so a forgotten recording can't eat unbounded memory. Fed to
+  /// [VirtualOdometer] at finalisation when the car doesn't expose a real
+  /// odometer.
+  final List<VirtualOdometerSample> _speedSamples = <VirtualOdometerSample>[];
+
+  /// Rolling buffer of GPS fixes for the #1979 GPS-distance source.
+  /// Appended by [addGpsFix] (one entry per Geolocator fix);
+  /// haversine-summed at finalisation when a usable track exists. Capped
+  /// at [kVirtualOdometerSampleCap] — the same generous bound the speed
+  /// buffer uses — so a forgotten recording stays bounded.
+  final List<GpsTrackPoint> _gpsTrack = <GpsTrackPoint>[];
+
+  TripDistanceResolver({
+    required this.maxIntegrationGapSeconds,
+    required DateTime Function() now,
+  }) : _now = now;
+
+  /// Append a speed sample to the virtual-odometer buffer, dropping the
+  /// oldest entry when the cap is hit. Called from the 5 Hz vehicle-speed
+  /// subscription.
+  void addSpeedSample(double speedKmh) {
+    _speedSamples.add(VirtualOdometerSample(
+      timestamp: _now(),
+      speedKmh: speedKmh,
+    ));
+    if (_speedSamples.length > kVirtualOdometerSampleCap) {
+      // Drop the oldest slice to keep memory bounded. Losing the early
+      // stretch biases the virtual-odometer low by the km we dropped; on
+      // a typical trip the cap is never hit.
+      _speedSamples.removeRange(
+        0,
+        _speedSamples.length - kVirtualOdometerSampleCap,
+      );
+    }
+  }
+
+  /// Append one real GPS fix to the #1979 track buffer, dropping the
+  /// oldest slice when the cap is hit. The controller calls this only for
+  /// non-null coordinate pairs — a null-coord call clears the per-tick
+  /// latch and is not a fix.
+  void addGpsFix(double latitude, double longitude) {
+    _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+    if (_gpsTrack.length > kVirtualOdometerSampleCap) {
+      _gpsTrack.removeRange(
+        0,
+        _gpsTrack.length - kVirtualOdometerSampleCap,
+      );
+    }
+  }
+
+  /// Distance covered by the current trip so far (#800), resolved against
+  /// the controller-held odometer readings passed in.
+  ///
+  /// Resolution order (#800 / #1979):
+  ///   1. the ground-truth `odometerLatest - odometerStart` when both
+  ///      readings are present AND moved forward by more than a
+  ///      noise-floor epsilon (odometer PIDs are quantised to 0.1 km on
+  ///      most cars — a 0.09-km delta is a sensor artefact);
+  ///   2. the haversine-summed GPS track, when a usable one was recorded
+  ///      — true road distance, free of the speed sensor's over-read;
+  ///   3. the trapezoidal integral of buffered speed samples via
+  ///      [VirtualOdometer], when the car exposes no odometer (Peugeot 107
+  ///      class) and no GPS track was captured.
+  double distanceKm({
+    required double? odometerStartKm,
+    required double? odometerLatestKm,
+  }) {
+    final real = _realOdometerDeltaKm(odometerStartKm, odometerLatestKm);
+    if (real != null) return real;
+    final gps = _gpsTrackDistanceKm();
+    if (gps != null) return gps;
+    return VirtualOdometer(
+      samples: _speedSamples,
+      maxGapSeconds: maxIntegrationGapSeconds,
+    ).integrateKm();
+  }
+
+  /// [kDistanceSourceReal] when [distanceKm] came from the car's odometer,
+  /// [kDistanceSourceGps] when it came from the haversine-summed GPS track
+  /// (#1979), [kDistanceSourceVirtual] when it came from [VirtualOdometer]
+  /// integration (#800). Persisted on the finalised [TripSummary] so the
+  /// fill-up flow and eco-analytics know whether to treat the km as a
+  /// ground truth or as an estimate.
+  String distanceSource({
+    required double? odometerStartKm,
+    required double? odometerLatestKm,
+  }) {
+    if (_realOdometerDeltaKm(odometerStartKm, odometerLatestKm) != null) {
+      return kDistanceSourceReal;
+    }
+    if (_gpsTrackDistanceKm() != null) return kDistanceSourceGps;
+    return kDistanceSourceVirtual;
+  }
+
+  /// `odometerLatest - odometerStart` if both are present and the delta is
+  /// above a small noise-floor epsilon (0.05 km — half the 0.1 km
+  /// quantisation most cars apply to PID A6). Returns null otherwise so
+  /// callers can fall back to the GPS / virtual odometer.
+  double? _realOdometerDeltaKm(double? start, double? latest) {
+    if (start == null || latest == null) return null;
+    final delta = latest - start;
+    if (delta < 0.05) return null;
+    return delta;
+  }
+
+  /// Haversine-summed distance of the buffered GPS track, or null when the
+  /// track is too sparse to trust (#1979): fewer than
+  /// [kMinGpsFixesForDistanceSource] fixes, or a sub-50 m total (a parked
+  /// car's GPS scatter). Callers then fall back to the virtual odometer.
+  double? _gpsTrackDistanceKm() {
+    if (_gpsTrack.length < kMinGpsFixesForDistanceSource) return null;
+    final km = GpsTrackDistance.haversineKm(_gpsTrack);
+    if (km < 0.05) return null;
+    return km;
+  }
+
+  /// Test seam: append a speed sample to the virtual-odometer buffer
+  /// WITHOUT the cap trim, so tests can build a deterministic buffer +
+  /// read [distanceKm] / [distanceSource] (#800). Mirrors the controller's
+  /// pre-extraction `debugRecordSpeedSample` semantics, which deliberately
+  /// skipped trimming. Not marked `@visibleForTesting` because the
+  /// controller's own (test-only) `debugRecordSpeedSample` pass-through
+  /// delegates here.
+  void debugAddSpeedSample({required double speedKmh, required DateTime at}) {
+    _speedSamples.add(
+      VirtualOdometerSample(timestamp: at, speedKmh: speedKmh),
+    );
+  }
+
+  /// Test seam: append a GPS fix to the #1979 track buffer WITHOUT the cap
+  /// trim, so tests can drive the GPS-distance path deterministically.
+  /// Mirrors the controller's pre-extraction `debugAppendGpsFix`
+  /// semantics. Plain (not `@visibleForTesting`) for the same reason as
+  /// [debugAddSpeedSample].
+  void debugAddGpsFix({required double latitude, required double longitude}) {
+    _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+  }
+
+  /// Read-only view of the captured speed samples. Surfaced so the
+  /// controller's (test-only) `debugSpeedSamples` getter can pass it
+  /// straight through.
+  List<VirtualOdometerSample> get debugSpeedSamples =>
+      List.unmodifiable(_speedSamples);
+}

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -10,7 +10,6 @@ import '../../../../core/storage/hive_boxes.dart';
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../domain/entities/gps_sample_diagnostic.dart';
-import '../../domain/gps_track_distance.dart';
 import '../../domain/services/gear_inference.dart';
 import '../../domain/trip_recorder.dart';
 import '../trip_history_repository.dart';
@@ -24,7 +23,7 @@ import 'obd2_debug_session.dart';
 import 'obd2_service.dart';
 import 'paused_trip_repository.dart';
 import 'pid_scheduler.dart';
-import 'trip_distance_source.dart';
+import 'trip_distance_resolver.dart';
 import 'trip_drop_detector.dart';
 import 'trip_live_reading.dart';
 import 'trip_sample_buffer.dart';
@@ -319,20 +318,14 @@ class TripRecordingController {
   /// Null when the controller is not in that state.
   TripDropReason? get dropReason => _dropReason;
 
-  /// Rolling buffer of `(timestamp, speedKmh)` samples used by the
-  /// virtual odometer (#800). Populated by the 5 Hz speed
-  /// subscription callback; capped at [_virtualOdometerSampleCap] so
-  /// a forgotten recording can't eat unbounded memory. Fed to
-  /// [VirtualOdometer] at finalisation when the car doesn't expose a
-  /// real odometer.
-  final List<VirtualOdometerSample> _speedSamples = <VirtualOdometerSample>[];
-
-  /// Rolling buffer of GPS fixes for the #1979 GPS-distance source.
-  /// Appended by [updateGpsFix] (one entry per Geolocator fix);
-  /// haversine-summed at finalisation when a usable track exists.
-  /// Capped at [kVirtualOdometerSampleCap] — the same generous bound
-  /// the speed buffer uses — so a forgotten recording stays bounded.
-  final List<GpsTrackPoint> _gpsTrack = <GpsTrackPoint>[];
+  /// Owns the trip's distance-resolution concern — the three-tier
+  /// odometer-delta / GPS-track / virtual-odometer selection and the two
+  /// rolling sample buffers it integrates over — extracted into a focused
+  /// pure-Dart collaborator (#2187). The controller keeps the odometer
+  /// readings ([_odometerStartKm] / [_odometerLatestKm]) and passes them
+  /// into the resolver per read. Built in the constructor body so it can
+  /// capture the resolved [_now] clock.
+  late final TripDistanceResolver _distance;
 
   /// Owns the #1040 captured-sample buffer and the #1458 GPS
   /// cadence-diagnostics buffer — both per-trip ring buffers
@@ -420,6 +413,10 @@ class TripRecordingController {
       dropWindow: dropWindow,
       dropThreshold: dropThreshold,
       silentFailureThreshold: silentFailureThreshold,
+    );
+    _distance = TripDistanceResolver(
+      maxIntegrationGapSeconds: _integrationGapCapSeconds,
+      now: _now,
     );
     _liveSampleSnapshot = LiveSampleSnapshot(
       service: _service,
@@ -536,13 +533,7 @@ class TripRecordingController {
     // #1979 — buffer every real fix for the GPS-distance source. A
     // null-coord call only clears the per-tick latch; it is not a fix.
     if (latitude != null && longitude != null) {
-      _gpsTrack.add(GpsTrackPoint(latitude, longitude));
-      if (_gpsTrack.length > kVirtualOdometerSampleCap) {
-        _gpsTrack.removeRange(
-          0,
-          _gpsTrack.length - kVirtualOdometerSampleCap,
-        );
-      }
+      _distance.addGpsFix(latitude, longitude);
     }
   }
 
@@ -842,16 +833,10 @@ class TripRecordingController {
   ///   3. the trapezoidal integral of buffered speed samples via
   ///      [VirtualOdometer], when the car exposes no odometer
   ///      (Peugeot 107 class) and no GPS track was captured.
-  double get currentDistanceKm {
-    final real = _realOdometerDeltaKm();
-    if (real != null) return real;
-    final gps = _gpsTrackDistanceKm();
-    if (gps != null) return gps;
-    return VirtualOdometer(
-      samples: _speedSamples,
-      maxGapSeconds: _integrationGapCapSeconds,
-    ).integrateKm();
-  }
+  double get currentDistanceKm => _distance.distanceKm(
+        odometerStartKm: _odometerStartKm,
+        odometerLatestKm: _odometerLatestKm,
+      );
 
   /// `'real'` when [currentDistanceKm] came from the car's odometer,
   /// `'gps'` when it came from the haversine-summed GPS track (#1979),
@@ -859,55 +844,17 @@ class TripRecordingController {
   /// (#800). Persisted on the finalised [TripSummary] so the fill-up
   /// flow and eco-analytics know whether to treat the km as a ground
   /// truth or as an estimate.
-  String get distanceSource {
-    if (_realOdometerDeltaKm() != null) return kDistanceSourceReal;
-    if (_gpsTrackDistanceKm() != null) return kDistanceSourceGps;
-    return kDistanceSourceVirtual;
-  }
-
-  /// `odometerLatest - odometerStart` if both are present and the
-  /// delta is above a small noise-floor epsilon (0.05 km — half the
-  /// 0.1 km quantisation most cars apply to PID A6). Returns null
-  /// otherwise so callers can fall back to the GPS / virtual odometer.
-  double? _realOdometerDeltaKm() {
-    final start = _odometerStartKm;
-    final latest = _odometerLatestKm;
-    if (start == null || latest == null) return null;
-    final delta = latest - start;
-    if (delta < 0.05) return null;
-    return delta;
-  }
-
-  /// Haversine-summed distance of the buffered GPS track, or null when
-  /// the track is too sparse to trust (#1979): fewer than
-  /// [kMinGpsFixesForDistanceSource] fixes, or a sub-50 m total (a
-  /// parked car's GPS scatter). Callers then fall back to the virtual
-  /// odometer.
-  double? _gpsTrackDistanceKm() {
-    if (_gpsTrack.length < kMinGpsFixesForDistanceSource) return null;
-    final km = GpsTrackDistance.haversineKm(_gpsTrack);
-    if (km < 0.05) return null;
-    return km;
-  }
+  String get distanceSource => _distance.distanceSource(
+        odometerStartKm: _odometerStartKm,
+        odometerLatestKm: _odometerLatestKm,
+      );
 
   /// Append a speed sample to the virtual-odometer buffer, dropping
   /// the oldest entry when the cap is hit. Called from the 5 Hz
-  /// vehicle-speed subscription.
-  void _recordSpeedSample(double speedKmh) {
-    _speedSamples.add(VirtualOdometerSample(
-      timestamp: _now(),
-      speedKmh: speedKmh,
-    ));
-    if (_speedSamples.length > kVirtualOdometerSampleCap) {
-      // Drop the oldest slice to keep memory bounded. Losing the
-      // early stretch biases the virtual-odometer low by the km we
-      // dropped; on a typical trip the cap is never hit.
-      _speedSamples.removeRange(
-        0,
-        _speedSamples.length - kVirtualOdometerSampleCap,
-      );
-    }
-  }
+  /// vehicle-speed subscription. Delegates to [TripDistanceResolver]
+  /// which owns the buffer (#2187).
+  void _recordSpeedSample(double speedKmh) =>
+      _distance.addSpeedSample(speedKmh);
 
   // ---------------------------------------------------------------------------
   // Scheduler wiring
@@ -1483,9 +1430,7 @@ class TripRecordingController {
     required double speedKmh,
     required DateTime at,
   }) {
-    _speedSamples.add(
-      VirtualOdometerSample(timestamp: at, speedKmh: speedKmh),
-    );
+    _distance.debugAddSpeedSample(speedKmh: speedKmh, at: at);
   }
 
   /// Exposed for tests: override the trip's start/latest odometer
@@ -1501,7 +1446,7 @@ class TripRecordingController {
   /// Exposed for tests: read-only view of the captured speed samples.
   @visibleForTesting
   List<VirtualOdometerSample> get debugSpeedSamples =>
-      List.unmodifiable(_speedSamples);
+      _distance.debugSpeedSamples;
 
   /// Exposed for tests: append a GPS fix to the #1979 track buffer
   /// without a live Geolocator stream, so tests can drive the
@@ -1509,6 +1454,6 @@ class TripRecordingController {
   /// deterministically.
   @visibleForTesting
   void debugAppendGpsFix({required double latitude, required double longitude}) {
-    _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+    _distance.debugAddGpsFix(latitude: latitude, longitude: longitude);
   }
 }

--- a/test/features/consumption/data/obd2/trip_distance_resolver_test.dart
+++ b/test/features/consumption/data/obd2/trip_distance_resolver_test.dart
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_distance_resolver.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_distance_source.dart';
+import 'package:tankstellen/features/consumption/data/obd2/virtual_odometer.dart';
+
+/// Direct unit tests for [TripDistanceResolver] (#2187), exercising the
+/// three-tier resolution order (real → gps → virtual), the noise-floor /
+/// sparse-track rejection edges, the integration-gap cap, and the
+/// production-trim-vs-debug-no-trim asymmetry — all without spinning up a
+/// controller, scheduler, or fake transport.
+void main() {
+  const gapCap = 15.0;
+  final fixedClock = DateTime.utc(2026, 4, 22, 11);
+
+  TripDistanceResolver build() =>
+      TripDistanceResolver(maxIntegrationGapSeconds: gapCap, now: () => fixedClock);
+
+  group('TripDistanceResolver — resolution order', () {
+    test('real odometer delta wins over GPS and virtual', () {
+      final r = build();
+      // A usable GPS track + speed samples that, if used, would not be 3 km.
+      for (var i = 0; i < 12; i++) {
+        r.debugAddGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var s = 0; s <= 60; s += 15) {
+        r.debugAddSpeedSample(speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
+
+      expect(
+        r.distanceSource(odometerStartKm: 100.0, odometerLatestKm: 103.0),
+        kDistanceSourceReal,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: 100.0, odometerLatestKm: 103.0),
+        closeTo(3.0, 1e-9),
+      );
+    });
+
+    test('GPS track wins over virtual when no real odometer', () {
+      final r = build();
+      // 12 fixes, 0.001 deg latitude apart (~111 m) → 11 legs ~1.223 km.
+      for (var i = 0; i < 12; i++) {
+        r.debugAddGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+      // Speed samples present but should be ignored (GPS beats virtual).
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var s = 0; s <= 60; s += 15) {
+        r.debugAddSpeedSample(speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
+
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceGps,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        closeTo(1.223, 0.03),
+      );
+    });
+
+    test('virtual odometer is the final fallback (no odometer, no GPS)', () {
+      final r = build();
+      // 30 km/h for 60 s = 0.5 km, sampled at the ≤15 s gap cap.
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var s = 0; s <= 60; s += 15) {
+        r.debugAddSpeedSample(speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
+
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceVirtual,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        closeTo(0.5, 0.01),
+      );
+    });
+
+    test('empty resolver → virtual source, zero distance', () {
+      final r = build();
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceVirtual,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        0.0,
+      );
+    });
+  });
+
+  group('TripDistanceResolver — real-odometer noise floor', () {
+    test('zero delta (start == latest) is rejected → falls through', () {
+      final r = build();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var s = 0; s <= 60; s += 15) {
+        r.debugAddSpeedSample(speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
+      expect(
+        r.distanceSource(odometerStartKm: 100.0, odometerLatestKm: 100.0),
+        kDistanceSourceVirtual,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: 100.0, odometerLatestKm: 100.0),
+        closeTo(0.5, 0.01),
+      );
+    });
+
+    test('sub-epsilon delta (< 0.05 km) is rejected as sensor artefact', () {
+      final r = build();
+      // 0.04 km delta is below the 0.05 km noise floor → null → fall back.
+      expect(
+        r.distanceSource(odometerStartKm: 0.0, odometerLatestKm: 0.04),
+        kDistanceSourceVirtual,
+      );
+      // No GPS / speed → 0.0 virtual.
+      expect(
+        r.distanceKm(odometerStartKm: 0.0, odometerLatestKm: 0.04),
+        0.0,
+      );
+    });
+
+    test('a clearly-above-epsilon delta (0.06 km) is accepted as real', () {
+      final r = build();
+      expect(
+        r.distanceSource(odometerStartKm: 0.0, odometerLatestKm: 0.06),
+        kDistanceSourceReal,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: 0.0, odometerLatestKm: 0.06),
+        closeTo(0.06, 1e-9),
+      );
+    });
+
+    test('negative delta (start > latest) is rejected', () {
+      final r = build();
+      expect(
+        r.distanceSource(odometerStartKm: 105.0, odometerLatestKm: 100.0),
+        kDistanceSourceVirtual,
+      );
+    });
+
+    test('one null odometer reading is rejected', () {
+      final r = build();
+      expect(
+        r.distanceSource(odometerStartKm: 100.0, odometerLatestKm: null),
+        kDistanceSourceVirtual,
+      );
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: 103.0),
+        kDistanceSourceVirtual,
+      );
+    });
+  });
+
+  group('TripDistanceResolver — GPS sparse / jitter rejection', () {
+    test('fewer than kMinGpsFixesForDistanceSource fixes is rejected', () {
+      final r = build();
+      // Only 5 fixes — below the 10-fix minimum.
+      for (var i = 0; i < 5; i++) {
+        r.debugAddGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+      // Speed fallback so the virtual path has something to integrate.
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var s = 0; s <= 60; s += 15) {
+        r.debugAddSpeedSample(speedKmh: 30, at: t0.add(Duration(seconds: s)));
+      }
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceVirtual,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        closeTo(0.5, 0.01),
+      );
+    });
+
+    test('enough fixes but sub-50 m total (parked scatter) is rejected', () {
+      final r = build();
+      // 12 fixes all at the same point → 0 km haversine → < 0.05 km → null.
+      for (var i = 0; i < 12; i++) {
+        r.debugAddGpsFix(latitude: 45.0, longitude: 5.0);
+      }
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceVirtual,
+      );
+    });
+
+    test('boundary: exactly kMinGpsFixesForDistanceSource usable fixes', () {
+      final r = build();
+      // 10 fixes ~111 m apart → 9 legs ~1.0 km, well above the 50 m floor.
+      for (var i = 0; i < kMinGpsFixesForDistanceSource; i++) {
+        r.debugAddGpsFix(latitude: 45.0 + i * 0.001, longitude: 5.0);
+      }
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceGps,
+      );
+    });
+  });
+
+  group('TripDistanceResolver — virtual-odometer integration-gap cap', () {
+    test('a gap longer than maxIntegrationGapSeconds is not bridged', () {
+      final r = build();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      // Two samples 60 s apart at 60 km/h: gap (60 s) > cap (15 s) → the
+      // pair is skipped → 0 km. (Matches VirtualOdometer.maxGapSeconds.)
+      r.debugAddSpeedSample(speedKmh: 60, at: t0);
+      r.debugAddSpeedSample(speedKmh: 60, at: t0.add(const Duration(seconds: 60)));
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        0.0,
+      );
+    });
+
+    test('distanceKm matches a hand-built VirtualOdometer over the buffer', () {
+      final r = build();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var s = 0; s <= 300; s += 15) {
+        r.debugAddSpeedSample(speedKmh: 60, at: t0.add(Duration(seconds: s)));
+      }
+      final expected =
+          VirtualOdometer(samples: r.debugSpeedSamples, maxGapSeconds: gapCap)
+              .integrateKm();
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        closeTo(expected, 1e-9),
+      );
+    });
+  });
+
+  group('TripDistanceResolver — trim asymmetry (#2187 preserved)', () {
+    test('production addSpeedSample trims at the cap; debug path does not', () {
+      // Production ingress trims to kVirtualOdometerSampleCap.
+      final trimmed = build();
+      for (var i = 0; i < kVirtualOdometerSampleCap + 5; i++) {
+        trimmed.addSpeedSample(50);
+      }
+      expect(trimmed.debugSpeedSamples.length, kVirtualOdometerSampleCap);
+
+      // Debug ingress intentionally does NOT trim — tests can build an
+      // arbitrarily long deterministic buffer past the cap.
+      final untrimmed = build();
+      final t0 = DateTime.utc(2026, 4, 22, 12);
+      for (var i = 0; i < kVirtualOdometerSampleCap + 5; i++) {
+        untrimmed.debugAddSpeedSample(
+          speedKmh: 50,
+          at: t0.add(Duration(milliseconds: i)),
+        );
+      }
+      expect(
+        untrimmed.debugSpeedSamples.length,
+        kVirtualOdometerSampleCap + 5,
+      );
+    });
+
+    test('production addGpsFix trims the GPS buffer at the cap', () {
+      final r = build();
+      for (var i = 0; i < kVirtualOdometerSampleCap + 3; i++) {
+        r.addGpsFix(45.0, 5.0);
+      }
+      // GPS buffer length is not directly exposed, but a capped buffer of
+      // identical points still resolves to virtual (0 km haversine); the
+      // assertion that matters is it did not throw / grow unbounded —
+      // exercised here via the resolution path staying well-formed.
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceVirtual,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Extracts a `TripDistanceResolver` out of the 1514-line `TripRecordingController` — the **first and lowest-risk slice** of the #2167 / #2187 god-class decomposition. Pure refactor: behaviour-preserving, no public API change, no ARB strings.

## Why

The distance-resolution concern (odometer-delta vs GPS-haversine vs virtual-odometer fallback + the two rolling buffers it integrates over) is async-free, stream-free, Hive-free and Riverpod-free — the cleanest cohesive slice to pull first. It now lives in a small, isolate-safe, independently testable unit, mirroring the established `TripDropDetector` / `TripSampleBuffer` pattern (#1679).

## What moved (verbatim)

- the two rolling buffers (`_speedSamples`, `_gpsTrack`)
- production trimming ingress (`addSpeedSample`, `addGpsFix`), capped at `kVirtualOdometerSampleCap`
- the three-tier resolution: real odometer delta → haversine GPS track → `VirtualOdometer` integral, with all noise-floor (0.05 km) / sparse-track (`kMinGpsFixesForDistanceSource`) / jitter edges intact
- the non-trimming debug ingress, preserving the **deliberate asymmetry**: production paths trim, the `@visibleForTesting` paths do not

## Scoping (per the issue's adversarial verification)

The odometer readings (`_odometerStartKm` / `_odometerLatestKm`) **stay on the controller** and are passed into `distanceKm()` / `distanceSource()` as arguments — they are shared state at six unrelated sites (start, refreshOdometer, public getters, paused-trip persistence, the live emit loop), so moving them would widen the blast radius beyond a clean slice. The controller delegates `currentDistanceKm` / `distanceSource` / `_recordSpeedSample` / the GPS-fix append / the debug hooks as thin pass-throughs.

## Verification

- `flutter analyze`: **2 issues found** — both pre-existing info-level (identical to master); no new errors/warnings.
- New `trip_distance_resolver_test.dart`: 16 tests (each tier winning, fallbacks, null/zero/negative odometer, sub-epsilon & boundary deltas, sparse/jitter GPS rejection, integration-gap cap, trim asymmetry) — all green.
- Existing `trip_recording_virtual_odometer_test.dart`: **unchanged, all 7 green** — proves behaviour preservation through the controller surface.
- `test/features/consumption/data/obd2` + `test/lint`: 1050 green (incl. file-length lint).
- `test/features/consumption/providers` + integration journey test: 214 green.
- No codegen drift (no `@riverpod`/freezed annotations touched).

## Line counts

| File | Lines |
|------|-------|
| `trip_recording_controller.dart` | 1514 → **1459** (-55; still grandfathered, no `file_length_test` baseline edit) |
| `trip_distance_resolver.dart` (new) | **198** (≤400) |

Closes #2187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
