### PR TITLE
perf(map): guard NearbyMapView fitCamera against redundant per-build scheduling (#2177)

### DIFF
--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -27,7 +27,7 @@ import '../../../../core/logging/error_logger.dart';
 /// Column and produced a visible grey strip between the AppBar and
 /// the map whenever a fallback fired — a permanent ~32 dp tax on
 /// every "stations were fetched via the secondary API" session.
-class NearbyMapView extends ConsumerWidget {
+class NearbyMapView extends ConsumerStatefulWidget {
   final AsyncValue searchState;
   final dynamic selectedFuel;
   final double searchRadiusKm;
@@ -42,7 +42,37 @@ class NearbyMapView extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NearbyMapView> createState() => _NearbyMapViewState();
+
+  /// Decides whether a post-frame `fitCamera` should be scheduled for a
+  /// freshly-computed [next] fit target, given the [last] target we
+  /// already fitted to (null on first build). Extracted as a pure
+  /// predicate so the guard can be unit-tested without driving a real
+  /// [MapController] (#2177).
+  ///
+  /// The first fit (`last == null`) and any genuine change to the search
+  /// bounds return `true`; an identical re-fit returns `false`. flutter_map's
+  /// [LatLngBounds] implements value-based `==`/`hashCode`, so the
+  /// comparison is a cheap structural check on south/north/east/west.
+  @visibleForTesting
+  static bool shouldFit(LatLngBounds? last, LatLngBounds next) => last != next;
+}
+
+class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
+  /// The bounds the camera was last fitted to. Held in State so a redundant
+  /// rebuild (EV-toggle tap, app resume, unrelated provider change) does
+  /// not re-schedule an identical `fitCamera` (#2177). Set when we SCHEDULE
+  /// the post-frame fit — not inside the callback — so that if the fit
+  /// itself triggers a rebuild, the next build computes the same bounds,
+  /// sees they equal `_lastFitBounds`, and skips: no fit→rebuild→fit loop.
+  LatLngBounds? _lastFitBounds;
+
+  @override
+  Widget build(BuildContext context) {
+    final searchState = widget.searchState;
+    final selectedFuel = widget.selectedFuel;
+    final searchRadiusKm = widget.searchRadiusKm;
+    final mapController = widget.mapController;
     final l10n = AppLocalizations.of(context);
 
     return searchState.when(
@@ -99,20 +129,34 @@ class NearbyMapView extends ConsumerWidget {
         // Fit map viewport to the search radius when results change so the
         // user immediately sees the entire searched area instead of having
         // to zoom out manually.
+        //
+        // #2177 — guard the schedule against redundant per-build re-fits.
+        // `build` runs on every EV-toggle tap, app resume, and unrelated
+        // provider change; an unguarded post-frame `fitCamera` snapped the
+        // camera back to the search bounds each time (fighting the user's
+        // manual pan and, during the cold-start window, forcing a TileLayer
+        // reset). We only schedule when the fit target actually changed
+        // since the last fit. `_lastFitBounds` is set HERE (at schedule
+        // time, not in the callback) so a fit→rebuild→fit loop cannot form:
+        // the next build computes the same bounds, finds them equal, skips.
         final bounds =
             StationMapLayers.boundsForRadius(center, searchRadiusKm);
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          try {
-            mapController.fitCamera(
-              CameraFit.bounds(
-                bounds: bounds,
-                padding: const EdgeInsets.all(32),
-              ),
-            );
-          } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Map fitCamera failed'}));
-          }
-        });
+        if (NearbyMapView.shouldFit(_lastFitBounds, bounds)) {
+          _lastFitBounds = bounds;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            try {
+              mapController.fitCamera(
+                CameraFit.bounds(
+                  bounds: bounds,
+                  padding: const EdgeInsets.all(32),
+                ),
+              );
+            } catch (e, st) {
+              unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Map fitCamera failed'}));
+            }
+          });
+        }
 
         return Stack(
           children: [
@@ -188,7 +232,7 @@ class NearbyMapView extends ConsumerWidget {
               color: theme.colorScheme.primary.withValues(alpha: 0.3)),
           const SizedBox(width: 4),
           Text(
-            '${searchRadiusKm.round()} km ${l10n?.searchRadius ?? "radius"}',
+            '${widget.searchRadiusKm.round()} km ${l10n?.searchRadius ?? "radius"}',
             style: theme.textTheme.bodySmall,
           ),
           const Spacer(),

--- a/test/features/map/presentation/widgets/nearby_map_view_test.dart
+++ b/test/features/map/presentation/widgets/nearby_map_view_test.dart
@@ -1,18 +1,230 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/map/presentation/widgets/nearby_map_view.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../../helpers/pump_app.dart';
 
 void main() {
-  group('NearbyMapView', () {
-    test('NearbyMapView is a widget', () {
-      expect(NearbyMapView, isNotNull);
+  group('NearbyMapView.shouldFit (#2177 guard predicate)', () {
+    final boundsA = LatLngBounds(
+      const LatLng(48.0, 2.0),
+      const LatLng(49.0, 3.0),
+    );
+    final boundsAClone = LatLngBounds(
+      const LatLng(48.0, 2.0),
+      const LatLng(49.0, 3.0),
+    );
+    final boundsB = LatLngBounds(
+      const LatLng(43.0, 3.0),
+      const LatLng(44.0, 4.0),
+    );
+
+    test('first fit (last == null) always fits', () {
+      expect(NearbyMapView.shouldFit(null, boundsA), isTrue);
     });
 
-    test('NearbyMapView is a ConsumerWidget subclass', () {
-      // Verify it extends ConsumerWidget by checking the type hierarchy.
-      expect(NearbyMapView, isA<Type>());
+    test('identical (value-equal) bounds skip the re-fit', () {
+      // A redundant rebuild (EV toggle, app resume) recomputes the SAME
+      // bounds; the guard must skip scheduling another fitCamera.
+      expect(NearbyMapView.shouldFit(boundsA, boundsAClone), isFalse);
+      expect(NearbyMapView.shouldFit(boundsA, boundsA), isFalse);
+    });
+
+    test('changed bounds fit again', () {
+      // A genuinely new search area must still fit.
+      expect(NearbyMapView.shouldFit(boundsA, boundsB), isTrue);
     });
   });
+
+  group('NearbyMapView fitCamera scheduling (#2177)', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('nearby_map_fit_test_');
+      Hive.init(tempDir.path);
+      await HiveStorage.initForTest();
+    });
+
+    tearDown(() async {
+      await Hive.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    const parisStations = [
+      Station(
+        id: 'fr-paris-1',
+        name: 'Paris Station 1',
+        brand: 'Total',
+        street: 'Rue de Rivoli',
+        houseNumber: '10',
+        postCode: '75001',
+        place: 'Paris',
+        lat: 48.8606,
+        lng: 2.3376,
+        dist: 0.5,
+        e10: 1.729,
+        isOpen: true,
+      ),
+    ];
+
+    const lyonStations = [
+      Station(
+        id: 'fr-lyon-1',
+        name: 'Lyon Station 1',
+        brand: 'BP',
+        street: 'Rue de la Republique',
+        houseNumber: '5',
+        postCode: '69001',
+        place: 'Lyon',
+        lat: 45.7640,
+        lng: 4.8357,
+        dist: 0.3,
+        e10: 1.699,
+        isOpen: true,
+      ),
+    ];
+
+    AsyncValue resultFor(List<Station> stations) => AsyncValue.data(
+          ServiceResult(
+            data: stations.map((s) => FuelStationResult(s)).toList(),
+            source: ServiceSource.tankerkoenigApi,
+            fetchedAt: DateTime.now(),
+          ),
+        );
+
+    Widget viewFor(
+      AsyncValue searchState,
+      _CountingMapController controller,
+    ) =>
+        SizedBox(
+          width: 800,
+          height: 1000,
+          child: NearbyMapView(
+            searchState: searchState,
+            selectedFuel: FuelType.e10,
+            searchRadiusKm: 19,
+            mapController: controller,
+          ),
+        );
+
+    testWidgets(
+      'fits once on first data and does NOT re-fit on a same-bounds rebuild',
+      (tester) async {
+        final controller = _CountingMapController();
+        addTearDown(controller.dispose);
+
+        await pumpApp(
+          tester,
+          _Rebuildable(
+            controller: controller,
+            viewFor: viewFor,
+            initial: resultFor(parisStations),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(controller.fitCount, 1,
+            reason: 'the first data fit must fire exactly once');
+
+        // Force a genuine rebuild that recomputes the SAME fit target: a
+        // brand-new ServiceResult object holding the same Paris station, so
+        // the `searchState` reference changes (a real rebuild + recompute)
+        // but the resulting bounds are value-equal. This mirrors the
+        // redundant rebuilds in production (EV-toggle tap, app resume,
+        // unrelated provider change). The guard must skip the re-fit.
+        final state =
+            tester.state<_RebuildableState>(find.byType(_Rebuildable));
+        state.show(resultFor(parisStations));
+        await tester.pumpAndSettle();
+
+        expect(controller.fitCount, 1,
+            reason: 'an unchanged fit target must NOT re-fit the camera');
+      },
+    );
+
+    testWidgets(
+      'fits again when the search bounds genuinely change',
+      (tester) async {
+        final controller = _CountingMapController();
+        addTearDown(controller.dispose);
+
+        await pumpApp(
+          tester,
+          _Rebuildable(
+            controller: controller,
+            viewFor: viewFor,
+            initial: resultFor(parisStations),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(controller.fitCount, 1, reason: 'first fit on initial data');
+
+        // Swap to a different search area (Lyon) — new bounds, must re-fit.
+        final state =
+            tester.state<_RebuildableState>(find.byType(_Rebuildable));
+        state.show(resultFor(lyonStations));
+        await tester.pumpAndSettle();
+
+        expect(controller.fitCount, 2,
+            reason: 'a genuinely changed fit target must fit again');
+      },
+    );
+  });
+}
+
+/// A [MapController] that counts `fitCamera` calls while behaving exactly
+/// like the real controller (it subclasses [MapControllerImpl], so it binds
+/// to the [FlutterMap] correctly and every other member is the genuine
+/// implementation). Lets the test observe how many real fits NearbyMapView
+/// actually scheduled — the #2177 regression surface.
+class _CountingMapController extends MapControllerImpl {
+  int fitCount = 0;
+
+  @override
+  bool fitCamera(CameraFit cameraFit) {
+    fitCount++;
+    return super.fitCamera(cameraFit);
+  }
+}
+
+/// Test harness whose [State] can swap the [searchState] passed to
+/// NearbyMapView, so a test can drive a genuine (or value-equal) rebuild.
+class _Rebuildable extends StatefulWidget {
+  final _CountingMapController controller;
+  final Widget Function(AsyncValue, _CountingMapController) viewFor;
+  final AsyncValue initial;
+
+  const _Rebuildable({
+    required this.controller,
+    required this.viewFor,
+    required this.initial,
+  });
+
+  @override
+  State<_Rebuildable> createState() => _RebuildableState();
+}
+
+class _RebuildableState extends State<_Rebuildable> {
+  late AsyncValue _state = widget.initial;
+
+  void show(AsyncValue next) => setState(() => _state = next);
+
+  @override
+  Widget build(BuildContext context) =>
+      widget.viewFor(_state, widget.controller);
 }


### PR DESCRIPTION
Closes #2177

## Problem
`NearbyMapView` scheduled a post-frame `fitCamera` inside `build()` with no guard, so it re-fitted the camera to the search bounds on **every** rebuild (EV-toggle tap, app resume, any watched-provider change). That snapped the camera back — fighting the user's manual pan — and, during the 12 s cold-start window, re-fired a full `TileLayer` reset (tile drop + refetch) on each gratuitous `MapEventSource.fitCamera`.

## Fix
Convert `NearbyMapView` to a `ConsumerStatefulWidget` and gate the schedule on whether the fit target actually changed:

- State holds `_lastFitBounds`.
- `build` computes `bounds` exactly as before and only schedules the post-frame `fitCamera` when `NearbyMapView.shouldFit(_lastFitBounds, bounds)` is `true`. `flutter_map`'s `LatLngBounds` has value-based `==`/`hashCode`, so the compare is a cheap structural check on south/north/east/west.
- **Only WHEN changes** — WHAT (the bounds) and HOW (32 dp padding) are untouched.

### Behaviour preserved
- **First fit:** `_lastFitBounds` starts `null` → `shouldFit(null, bounds)` is `true` → fits.
- **Changed search area:** value-distinct bounds → fits again.
- **Redundant rebuild:** value-equal bounds → skipped.

### Loop-safety
`_lastFitBounds` is assigned at **schedule** time (not in the callback), so if the fit itself triggers a rebuild, the next build computes the same bounds, finds them equal, and skips — no `fit→rebuild→fit` loop. A `mounted` guard is added to the callback (matching `TripPathMapCard`, per the adversarial-verification note). The `onRecenter` button still fires `fitCamera` unconditionally (explicit user action).

The empty→populated / `centerChanged` resets in `StationMapLayers.didUpdateWidget` continue to cover the cold-start first-data fit path; the first fit here still fires (`_lastFitBounds` starts `null`).

## Tests
- `NearbyMapView.shouldFit` pure-predicate unit test: first (`null`) / identical (value-equal) / changed.
- Two widget tests counting **real** `fitCamera` calls via a `MapControllerImpl` subclass: **1** fit on first data, **still 1** after a value-equal rebuild, **2** after a genuine bounds change.

## Verification
- `flutter analyze`: `2 issues found` — the same 2 pre-existing `info` issues as master (`radius_alert_map_picker.dart`, `trip_kind_from_samples_test.dart`); none in touched files.
- `flutter test test/features/map/` → all 132 pass. `flutter test test/lint/` → all pass (no-hardcoded-strings baseline intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
