### PR TITLE
fix(country): align supported vs available fuel types + add drift cross-check (#2180)

### DIFF
--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -212,8 +212,12 @@ class Countries {
     apiProvider: 'OK / Shell / Q8',
     attribution: 'Data: ok.dk, shell.dk, q8.dk',
     fuelTypes: ['Blyfri 95', 'Diesel'],
+    // #2180 — DenmarkStationService surfaces the single 95-octane grade
+    // ("Blyfri 95") as both e5 and e10, plus diesel. Add e10 so the
+    // profile picker matches what the search selector already shows.
     supportedFuelTypes: {
       FuelType.e5,
+      FuelType.e10,
       FuelType.diesel,
       FuelType.electric,
     },
@@ -236,9 +240,16 @@ class Countries {
     apiProvider: 'Secretaría de Energía',
     attribution: 'Datos: datos.energia.gob.ar',
     fuelTypes: ['Nafta', 'Gas Oil', 'GNC'],
+    // #2180 — aligned to what ArgentinaStationService actually emits:
+    // Nafta súper → e5/e10, Nafta premium → e98, Gas oil → diesel, Gas
+    // oil premium → dieselPremium, GNC → cng (see classifyArgentinaProduct
+    // and argentina_station_service.dart's Station mapping).
     supportedFuelTypes: {
       FuelType.e5,
+      FuelType.e10,
+      FuelType.e98,
       FuelType.diesel,
+      FuelType.dieselPremium,
       FuelType.cng,
       FuelType.electric,
     },
@@ -283,12 +294,15 @@ class Countries {
     postalCodeLabel: 'Postcode',
     apiProvider: 'CMA Fuel Finder',
     attribution: 'Data: Competition and Markets Authority',
-    fuelTypes: ['Unleaded', 'Super Unleaded', 'Diesel', 'Premium Diesel'],
+    fuelTypes: ['Unleaded', 'Super Unleaded', 'E10', 'Diesel'],
+    // #2180 — UkStationService parses the CMA feed into e5 (E5/unleaded),
+    // e10 (E10), e98 (super_unleaded), diesel (B7/diesel). It never emits
+    // dieselPremium, so drop it and add e10 to match the live selector.
     supportedFuelTypes: {
       FuelType.e5,
+      FuelType.e10,
       FuelType.e98,
       FuelType.diesel,
-      FuelType.dieselPremium,
       FuelType.electric,
     },
     examplePostalCode: 'SW1A 1AA',
@@ -366,9 +380,13 @@ class Countries {
     apiProvider: 'CRE / datos.gob.mx',
     attribution: 'Datos: Comisión Reguladora de Energía',
     fuelTypes: ['Regular', 'Premium', 'Diesel'],
+    // #2180 — MexicoStationService maps CRE's gas_price types to Station
+    // fields as regular → e5, premium → e10, diesel → diesel. The premium
+    // grade lands in the e10 slot, never e98, so the picker must offer e10
+    // (not e98) to match the data the search selector surfaces.
     supportedFuelTypes: {
       FuelType.e5,
-      FuelType.e98,
+      FuelType.e10,
       FuelType.diesel,
       FuelType.electric,
     },

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -163,7 +163,14 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: 49.5, maxLat: 61.0, minLng: -9.0, maxLng: 2.0,
       ),
-      availableFuelTypes: _defaultFuelTypes,
+      // GB (#2180): UkStationService parses the CMA feed into e5
+      // (E5/unleaded), e10 (E10), e98 (super_unleaded), diesel
+      // (B7/diesel). _defaultFuelTypes omitted e98, so super-unleaded
+      // stations could not be searched — promote to the explicit set.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.electric, FuelType.all,
+      ],
       createService: _createUk,
     ),
     CountryServiceEntry(
@@ -199,12 +206,15 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: 45.3, maxLat: 47.0, minLng: 13.3, maxLng: 16.7,
       ),
-      // Slovenia (#575): NMB-95 (e5), NMB-100 (e98), Dizel, Dizel
-      // Premium, LPG.
+      // Slovenia (#575): NMB-95 → e5 (also surfaced as e10 — single
+      // 95-octane grade), NMB-100/98 → e98, Dizel → diesel, Dizel
+      // Premium → dieselPremium, avtoplin-lpg → lpg, cng → cng. #2180:
+      // e10 + cng were missing here though SloveniaStationService emits
+      // both; added to match the service and the picker's supported set.
       availableFuelTypes: [
-        FuelType.e5, FuelType.e98, FuelType.diesel,
-        FuelType.dieselPremium, FuelType.lpg, FuelType.electric,
-        FuelType.all,
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.lpg, FuelType.cng,
+        FuelType.electric, FuelType.all,
       ],
       createService: _createSlovenia,
     ),
@@ -304,7 +314,16 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: -56.0, maxLat: -21.0, minLng: -74.0, maxLng: -53.0,
       ),
-      availableFuelTypes: _defaultFuelTypes,
+      // AR (#2180): ArgentinaStationService emits Nafta súper → e5/e10,
+      // Nafta premium → e98, Gas oil → diesel, Gas oil premium →
+      // dieselPremium, GNC → cng. Promoted off _defaultFuelTypes (which
+      // dropped cng/e98/dieselPremium) so the selector surfaces every
+      // fuel the CSV actually publishes — GNC stations were unsearchable.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.dieselPremium, FuelType.cng, FuelType.electric,
+        FuelType.all,
+      ],
       createService: _createArgentina,
     ),
     CountryServiceEntry(
@@ -313,7 +332,16 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: -44.0, maxLat: -9.5, minLng: 112.5, maxLng: 154.0,
       ),
-      availableFuelTypes: _defaultFuelTypes,
+      // AU (#2180): NSW FuelCheck publishes U91 → e5, U95 → e10, U98 →
+      // e98, Diesel → diesel, LPG → lpg. AustraliaStationService is a
+      // documented stub pending a working endpoint (#804), so there is no
+      // live emission to converge on; this mirrors the config's
+      // FuelCheck grade set instead of the unrelated _defaultFuelTypes
+      // fallback, keeping the picker and selector in agreement.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
+        FuelType.lpg, FuelType.electric, FuelType.all,
+      ],
       createService: _createAustralia,
     ),
     CountryServiceEntry(

--- a/test/core/country/country_fuel_parity_test.dart
+++ b/test/core/country/country_fuel_parity_test.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Cross-check guard for the two parallel fuel-type structures (#2180).
+///
+/// A country's fuel set is declared twice, in two files, with two
+/// consumers:
+///
+///  * [CountryConfig.supportedFuelTypes] — the **typed picker set**. Read
+///    by the profile fuel-type chip picker, the search fuel-type dropdown
+///    filter, and the cross-border fuel-availability suggestion. This is
+///    "which fuels can this country's user choose / search".
+///  * [CountryServiceEntry.availableFuelTypes] — the **selector list**.
+///    Read by the search fuel-type selector (`fuelTypesForCountry`). This
+///    is "which fuels the live search UI offers for this country", and it
+///    is sourced from the order the upstream station service publishes.
+///
+/// They had drifted (AR/MX/SI/DK in the original audit; GB/AU surfaced by
+/// this very test): a country could let a user *configure* a vehicle fuel
+/// the search selector never offered, or carry a registry fuel the picker
+/// hid — e.g. Argentine GNC stations had real prices the selector could
+/// never surface. The ground truth for both is what each
+/// `*_station_service.dart` actually maps onto [Station] fuel fields.
+///
+/// This test is the regression backstop: after the #2180 alignment, the
+/// two structures must agree (as sets, ignoring the search-time
+/// [FuelType.all] wildcard the registry appends) for **every** registered
+/// country. Adding a new country with mismatched lists fails here with a
+/// message naming the country and the exact offending fuels.
+void main() {
+  group('fuel-type parity: supportedFuelTypes vs availableFuelTypes (#2180)',
+      () {
+    String fmt(Iterable<FuelType> fuels) =>
+        (fuels.map((f) => f.apiValue).toList()..sort()).join(', ');
+
+    /// Registry fuel set with the search-time [FuelType.all] wildcard
+    /// stripped — the picker set never contains it (asserted separately in
+    /// country_supported_fuels_test.dart), so it is excluded from parity.
+    Set<FuelType> registrySet(String code) => CountryServiceRegistry
+        .fuelTypesFor(code)
+        .where((f) => f != FuelType.all)
+        .toSet();
+
+    test('every country: picker set == selector set (minus FuelType.all)',
+        () {
+      final mismatches = <String>[];
+      for (final country in Countries.all) {
+        final picker = country.supportedFuelTypes;
+        final selector = registrySet(country.code);
+
+        final pickerOnly = picker.difference(selector);
+        final selectorOnly = selector.difference(picker);
+        if (pickerOnly.isEmpty && selectorOnly.isEmpty) continue;
+
+        final parts = <String>[];
+        if (pickerOnly.isNotEmpty) {
+          parts.add('configured but never offered/searchable: '
+              '{${fmt(pickerOnly)}}');
+        }
+        if (selectorOnly.isNotEmpty) {
+          parts.add('offered by search but not configurable: '
+              '{${fmt(selectorOnly)}}');
+        }
+        mismatches.add('${country.code}: ${parts.join('; ')} '
+            '(supportedFuelTypes={${fmt(picker)}} '
+            'vs availableFuelTypes={${fmt(selector)}})');
+      }
+
+      expect(
+        mismatches,
+        isEmpty,
+        reason: 'CountryConfig.supportedFuelTypes and '
+            'CountryServiceEntry.availableFuelTypes have drifted. Each fuel '
+            'a country lists must be one its station service actually emits '
+            '(check lib/features/station_services/<country>/), and both '
+            'structures must agree. Offenders:\n  ${mismatches.join('\n  ')}',
+      );
+    });
+
+    test('regression: Argentina exposes GNC (cng) in BOTH structures (#2180)',
+        () {
+      // ArgentinaStationService maps the CSV "GNC" product onto Station.cng
+      // with a real price, so CNG stations must be both configurable and
+      // searchable — the original defect hid them from the search selector.
+      expect(
+        Countries.argentina.supportedFuelTypes,
+        contains(FuelType.cng),
+        reason: 'AR picker must offer CNG — GNC stations carry real prices',
+      );
+      expect(
+        registrySet('AR'),
+        contains(FuelType.cng),
+        reason: 'AR search selector must offer CNG — GNC stations carry '
+            'real prices the user must be able to search for',
+      );
+    });
+
+    test('regression: Slovenia exposes e10 + cng in BOTH structures (#2180)',
+        () {
+      // SloveniaStationService surfaces the single 95-octane grade as both
+      // e5 and e10, and maps the goriva.si "cng" key onto Station.cng. The
+      // registry previously omitted both.
+      for (final fuel in const [FuelType.e10, FuelType.cng]) {
+        expect(
+          Countries.slovenia.supportedFuelTypes,
+          contains(fuel),
+          reason: 'SI picker must offer ${fuel.apiValue}',
+        );
+        expect(
+          registrySet('SI'),
+          contains(fuel),
+          reason: 'SI search selector must offer ${fuel.apiValue}',
+        );
+      }
+    });
+
+    test('regression: Mexico offers e10 (premium grade) not e98 (#2180)', () {
+      // MexicoStationService maps CRE "premium" onto Station.e10, never
+      // e98, so the picker offering e98 was a dead, unsearchable option.
+      expect(Countries.mexico.supportedFuelTypes, contains(FuelType.e10));
+      expect(
+        Countries.mexico.supportedFuelTypes,
+        isNot(contains(FuelType.e98)),
+        reason: 'MX premium grade lands in the e10 slot, not e98',
+      );
+      expect(registrySet('MX'), contains(FuelType.e10));
+    });
+
+    test('regression: Denmark offers e10 in BOTH structures (#2180)', () {
+      // DenmarkStationService surfaces Blyfri 95 as both e5 and e10.
+      expect(Countries.denmark.supportedFuelTypes, contains(FuelType.e10));
+      expect(registrySet('DK'), contains(FuelType.e10));
+    });
+
+    test('regression: UK offers e10, drops dieselPremium (#2180)', () {
+      // UkStationService emits e5/e10/e98/diesel, never dieselPremium.
+      expect(Countries.unitedKingdom.supportedFuelTypes,
+          contains(FuelType.e10));
+      expect(
+        Countries.unitedKingdom.supportedFuelTypes,
+        isNot(contains(FuelType.dieselPremium)),
+        reason: 'GB CMA feed has no premium-diesel grade',
+      );
+      expect(registrySet('GB'), contains(FuelType.e98));
+    });
+  });
+}

--- a/test/features/search/domain/entities/fuel_types_for_country_test.dart
+++ b/test/features/search/domain/entities/fuel_types_for_country_test.dart
@@ -99,15 +99,22 @@ void main() {
       );
     });
 
-    test('SI — NMB-95/100, Diesel, Diesel Premium, LPG (#575)', () {
+    test('SI — NMB-95 (e5+e10)/100, Diesel, Diesel Premium, LPG, CNG '
+        '(#575, #2180)', () {
+      // #2180 — e10 + cng added: SloveniaStationService surfaces the single
+      // 95-octane grade as both e5 and e10, and maps the goriva.si "cng"
+      // key onto Station.cng. The registry now matches what the service
+      // emits and the country's supportedFuelTypes picker set.
       expect(
         fuelTypesForCountry('SI'),
         equals(<FuelType>[
           FuelType.e5,
+          FuelType.e10,
           FuelType.e98,
           FuelType.diesel,
           FuelType.dieselPremium,
           FuelType.lpg,
+          FuelType.cng,
           FuelType.electric,
           FuelType.all,
         ]),


### PR DESCRIPTION
## Summary

Each country declares its fuel set twice with no parity guard:

- **`CountryConfig.supportedFuelTypes`** — the profile/search **picker** set (what a user can configure as their vehicle fuel and filter searches by).
- **`CountryServiceEntry.availableFuelTypes`** — the search **selector** list (what the live fuel-type selector offers, sourced from the upstream publish order).

They had drifted. A user could configure a vehicle fuel the search selector never offered, or the registry could carry a fuel the picker hid. The most severe real defect: Argentine **GNC** stations carry real prices (`argentina_station_service.dart` maps `GNC → Station.cng`) that the search selector could never surface.

Ground truth for both structures is **what each `*_station_service.dart` actually maps onto `Station` fuel fields**. I derived each country's true set from the service code rather than blindly picking one structure as canonical (which would have dropped fuels the service genuinely emits — exactly the regression the issue's adversarial verification warned about for AR/SI).

The new cross-check test surfaced **two additional drift countries beyond the audit's four** (GB, AU).

## Per-country changes

| Country | Drift | Resolution | Data-source evidence |
|--|--|--|--|
| **AR** | picker had `cng` but not `e10/e98/dieselPremium`; registry (`_defaultFuelTypes`) had `e10` but not `cng/e98/dieselPremium` | converge **both** to `{e5,e10,e98,diesel,dieselPremium,cng,electric}` | `classifyArgentinaProduct` + mapping: Nafta súper→e5/e10, premium→e98, gas oil→diesel, gas oil premium→dieselPremium, GNC→cng |
| **DK** | picker missing `e10` | add `e10` to picker (registry already correct) | `denmark_station_service.dart` surfaces Blyfri 95 as both `e5` and `e10` |
| **MX** | picker had `e98` (never produced) and was missing `e10` | drop `e98`, add `e10` to picker (registry already correct) | `mexico_station_service.dart` maps CRE `premium → e10` field, never `e98` |
| **SI** | registry missing `e10` + `cng` | add `e10` + `cng` to registry (picker already correct) | `slovenia_station_service.dart` surfaces 95 as `e5`+`e10` and maps goriva.si `"cng" → cng` |
| **GB** | picker had `dieselPremium` (never produced) + missing `e10`; registry (`_defaultFuelTypes`) missing `e98` | drop `dieselPremium` + add `e10` to picker; add `e98` to registry | `uk_station_service.dart` emits `e5`/`e10`/`e98`(super_unleaded)/`diesel` only |
| **AU** | picker had `e98`+`lpg` the registry lacked | converge registry **up** to picker's documented FuelCheck grades `{e5,e10,e98,diesel,lpg,electric}` | service is a documented stub (#804) that throws — **no live emission**, so both sides mirror the documented NSW FuelCheck grade set (U91→e5, U95→e10, U98→e98, Diesel, LPG) rather than the unrelated `_defaultFuelTypes` fallback |

Behavior change: this alters which fuels AR/MX/SI/DK/GB/AU users can search/filter — intended, per the audit (current state was the defect). MX/DK registries needed no change (they already matched the corrected picker set).

## Cross-check test (regression backstop)

`test/core/country/country_fuel_parity_test.dart` iterates `Countries.all` and asserts `supportedFuelTypes` set-equals `availableFuelTypes` (minus the `FuelType.all` search-time wildcard) for **every** country, naming the offending country + exact fuels on failure. Adding a new country with mismatched lists now fails here. Includes targeted regression cases for AR (CNG in both), SI (e10+cng), MX (e10 not e98), DK (e10), GB (e10, no dieselPremium).

## Tests updated

- `fuel_types_for_country_test.dart` — SI assertion updated in lockstep with the registry change (added `e10`+`cng`). No other pinned per-country expectation touched any changed country (DE/FR/AT/ES/IT/LU/KR/CL/GR/RO unchanged).

## Verification

- `flutter analyze`: **2 issues found** — the same 2 pre-existing `info` issues as master (in `radius_alert_map_picker.dart` and `trip_kind_from_samples_test.dart`); no new errors/warnings.
- `flutter test test/core/ test/features/station_services/ test/features/search/ test/lint/ test/docs/new_country_guide_test.dart`: all pass (1480 in the full sweep; new parity test 6/6).
- No ARB strings touched (fuel display names are brand/proper-noun literals, already exempt). No codegen inputs changed (only `const` data lists in plain-Dart files).

Closes #2180

🤖 Generated with [Claude Code](https://claude.com/claude-code)
