### PR TITLE
refactor(trips): extract DroppedSessionManager from TripRecordingController (#2188)

### DIFF
--- a/lib/features/consumption/data/obd2/dropped_session_host.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_host.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../domain/trip_recorder.dart';
+
+/// Seam the `DroppedSessionManager` uses to read and drive the
+/// recording session it is recovering, without owning the recording
+/// loop itself (#2188).
+///
+/// The manager owns the *reaction* to a connection drop — the silent-
+/// reconnect window, the visible-drop escalation, the grace timer, the
+/// reconnect scanner and the paused/history Hive persistence. But the
+/// emit loop, the scheduler, the drop *detector* and the trip-identity
+/// fields stay on the controller. This interface is the narrow set of
+/// callbacks + getters the reaction needs from its host so the two
+/// halves stay decoupled and the manager is unit-testable against a
+/// fake host (no real `Obd2Service` / scheduler required).
+abstract class DroppedSessionHost {
+  /// Stop the PID polling loop — called the instant a drop is detected
+  /// so no further transport chatter happens while we recover.
+  void stopScheduler();
+
+  /// Resume the PID polling loop after a silent reconnect inside the
+  /// #1904 window. Production gates this on "not paused / not stopped"
+  /// itself; the manager just asks.
+  void startScheduler();
+
+  /// Clear the drop *detector*'s sliding window + silent-failure latch
+  /// so a fresh post-recovery stretch can fire again.
+  void resetDropDetector();
+
+  /// Re-arm only the transport-error sliding window (NOT the silent-
+  /// failure latch) — done when a drop fires so a burst of trailing
+  /// errors from the same outage doesn't immediately re-trigger.
+  void clearDropDetectorErrorWindow();
+
+  /// Re-publish the recording state on the controller's state stream.
+  void emitState();
+
+  /// Drive the controller's ordinary resume path — cancels the grace
+  /// timer, clears the paused row, flips back to recording. Called by
+  /// the reconnect scanner when the adapter comes back AFTER the drop
+  /// went visible.
+  void resumeFromReconnect();
+
+  /// Build the in-flight [TripSummary] for the paused-trip snapshot.
+  TripSummary buildInProgressSummary();
+
+  /// Build the FINAL [TripSummary] (distance provenance, gear coaching,
+  /// VE) for grace-window auto-finalisation.
+  TripSummary buildFinalSummary();
+
+  // --- Lifecycle flags (read + write) ---------------------------------
+
+  bool get pausedDueToDrop;
+  set pausedDueToDrop(bool value);
+
+  bool get stopped;
+  set stopped(bool value);
+
+  bool get started;
+  set started(bool value);
+
+  /// True while the user has tapped pause — read so a silent reconnect
+  /// respects a pause that landed during the window.
+  bool get paused;
+
+  // --- Trip identity / snapshot payload (read-only) -------------------
+
+  String? get sessionId;
+  String? get vehicleId;
+  String? get vin;
+  double? get odometerStartKm;
+  double? get odometerLatestKm;
+  bool get automatic;
+}

--- a/lib/features/consumption/data/obd2/dropped_session_manager.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_manager.dart
@@ -1,0 +1,403 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../../../../core/logging/error_logger.dart';
+import '../../../../core/storage/hive_boxes.dart';
+import '../trip_history_repository.dart';
+import 'adapter_reconnect_scanner.dart';
+import 'auto_record_trace_log.dart';
+import 'dropped_session_host.dart';
+import 'paused_trip_repository.dart';
+
+/// Why a recording transitioned into the paused-due-to-drop state
+/// (#1330 phase 3). Distinguishes the two failure modes that share the
+/// pause-with-grace recovery path:
+///
+///  * [transportError] — repeated transport-level failures (BT link
+///    dropped, three consecutive errors within the window, or a typed
+///    `Obd2DisconnectedException`). User-visible surface: "OBD2
+///    connection lost".
+///  * [silentFailure] — adapter connected + answering, but every high-
+///    priority PID parse returns null for the silent-failure threshold's
+///    worth of consecutive ticks (ECU off, protocol mismatch, defective
+///    adapter firmware).
+enum TripDropReason {
+  transportError,
+  silentFailure,
+}
+
+/// Owns the connection-drop RECOVERY lifecycle for a single recording
+/// session — the second slice of the #2167/#2188 god-class
+/// decomposition of `TripRecordingController`.
+///
+/// Everything that happens AFTER the drop *detector* (#1679) decides
+/// "this is a drop": the #1904 silent-reconnect window, the visible-drop
+/// escalation, the #797 grace timer + auto-finalise, the reconnect-
+/// scanner orchestration (#797 phase 3) and the paused/history Hive
+/// persistence. The emit loop, the scheduler, the drop detector and the
+/// trip-identity fields stay on the controller; the manager reaches them
+/// through the injected [DroppedSessionHost] so the recording loop and
+/// the recovery state machine stay decoupled — mirroring the pure,
+/// dependency-light collaborator style of `TripDistanceResolver` (#2187)
+/// and `TripDropDetector` (#1679).
+///
+/// Every collaborator is injected (the clock, both Hive repo overrides,
+/// the scanner factory, the host seam) so a unit test can wire a fake
+/// host + in-memory repos + a hand-driven scanner and exercise every
+/// branch deterministically without a real `Obd2Service`, scheduler, or
+/// wall-clock timer.
+class DroppedSessionManager {
+  final DroppedSessionHost _host;
+  final DateTime Function() _now;
+
+  /// Grace window before a paused-due-to-drop session auto-finalises
+  /// (#797 phase 1). Production default is 15 minutes; tests pass small
+  /// values to exercise the auto-finalise path.
+  final Duration _pauseGraceWindow;
+
+  /// #1904 — how long a transport drop stays invisible while the
+  /// reconnect scanner tries to get the adapter back. `Duration.zero`
+  /// disables the silent window (every drop is visible at once).
+  final Duration _silentReconnectWindow;
+
+  /// Pinned adapter MAC the reconnect scanner searches for. Null when
+  /// the vehicle profile carries no adapter pairing — the scanner is
+  /// then never started and the grace window is the sole recovery path.
+  final String? _pinnedAdapterMac;
+
+  /// Factory that builds the reconnect scanner from the pinned MAC + the
+  /// on-reconnect callback. Null in production unit contexts that don't
+  /// wire the BT scan layer.
+  final AdapterReconnectScanner? Function(
+    String pinnedMac,
+    VoidCallback onReconnect,
+  )? _reconnectScannerFactory;
+
+  /// Test overrides — in-memory repos. Production passes null and both
+  /// are resolved lazily from the open Hive box on use.
+  final PausedTripRepository? _pausedRepoOverride;
+  final TripHistoryRepository? _historyRepoOverride;
+
+  Timer? _graceTimer;
+  Timer? _silentReconnectTimer;
+  AdapterReconnectScanner? _reconnectScanner;
+
+  /// #1904 — true between a transport drop and either a silent
+  /// reconnect or the escalation to the visible drop.
+  bool _silentlyReconnecting = false;
+
+  /// Reason the most recent drop fired. Null when no drop has occurred
+  /// or after a resume / silent recovery cleared it.
+  TripDropReason? _dropReason;
+
+  DroppedSessionManager({
+    required DroppedSessionHost host,
+    required DateTime Function() now,
+    required Duration pauseGraceWindow,
+    required Duration silentReconnectWindow,
+    String? pinnedAdapterMac,
+    AdapterReconnectScanner? Function(
+      String pinnedMac,
+      VoidCallback onReconnect,
+    )? reconnectScannerFactory,
+    PausedTripRepository? pausedRepo,
+    TripHistoryRepository? historyRepo,
+  })  : _host = host,
+        _now = now,
+        _pauseGraceWindow = pauseGraceWindow,
+        _silentReconnectWindow = silentReconnectWindow,
+        _pinnedAdapterMac = pinnedAdapterMac,
+        _reconnectScannerFactory = reconnectScannerFactory,
+        _pausedRepoOverride = pausedRepo,
+        _historyRepoOverride = historyRepo;
+
+  /// Why the session is in (or last entered) the paused-due-to-drop
+  /// state (#1330 phase 3). Null when not in that state.
+  TripDropReason? get dropReason => _dropReason;
+
+  /// #1904 — true while inside the invisible reconnect window (a
+  /// transport drop the scanner is trying to clear before the banner).
+  bool get silentlyReconnecting => _silentlyReconnecting;
+
+  /// The auto-reconnect scanner currently in flight, or null when none
+  /// is wired / running. Exposed for the controller's
+  /// `debugReconnectScanner` test hook.
+  AdapterReconnectScanner? get reconnectScanner => _reconnectScanner;
+
+  /// React to a detected connection drop (#797 / #1904). A
+  /// `transportError` drop first enters the invisible reconnect window
+  /// (scheduler stopped, scanner probing, host still reporting
+  /// `recording`); only if [_silentReconnectWindow] elapses with no
+  /// reconnect does it escalate to the visible state. A `silentFailure`
+  /// drop escalates straight to visible — reconnecting the Bluetooth
+  /// link cannot revive a dead ECU.
+  void handleDrop({
+    TripDropReason reason = TripDropReason.transportError,
+  }) {
+    if (_host.pausedDueToDrop || _silentlyReconnecting) return;
+    // #1920 — trace every detected drop so a failed recording session
+    // can be analysed from the exportable OBD2 diagnostic log.
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.dropDetected,
+      mac: _pinnedAdapterMac,
+      detail: reason.name,
+    );
+    _host.stopScheduler();
+    _host.clearDropDetectorErrorWindow();
+    _persistPausedSnapshot();
+    if (reason == TripDropReason.transportError &&
+        _silentReconnectWindow > Duration.zero) {
+      _silentlyReconnecting = true;
+      _dropReason = reason;
+      // #1920 — record entry into the #1904 invisible reconnect window.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.silentReconnectStarted,
+        mac: _pinnedAdapterMac,
+      );
+      _startReconnectScanner();
+      _silentReconnectTimer?.cancel();
+      _silentReconnectTimer =
+          Timer(_silentReconnectWindow, _escalateToVisibleDrop);
+      // Deliberately no emitState() — an in-presence drop the scanner
+      // is about to clear must stay invisible to the UI.
+      return;
+    }
+    _enterVisibleDrop(reason);
+  }
+
+  /// Flip into the visible pause-with-grace state: stop is already done
+  /// by [handleDrop]; this starts the grace timer, ensures a reconnect
+  /// scanner is running, and emits so the pause banner appears.
+  void _enterVisibleDrop(TripDropReason reason) {
+    _host.pausedDueToDrop = true;
+    _dropReason = reason;
+    _graceTimer?.cancel();
+    _graceTimer = Timer(_pauseGraceWindow, _onGraceWindowElapsed);
+    // The scanner may already be running from the silent window.
+    if (_reconnectScanner == null) _startReconnectScanner();
+    _host.emitState();
+  }
+
+  /// #1904 — the silent reconnect window elapsed without the adapter
+  /// coming back; surface the drop to the user.
+  void _escalateToVisibleDrop() {
+    _silentReconnectTimer = null;
+    if (!_silentlyReconnecting || _host.pausedDueToDrop || _host.stopped) {
+      return;
+    }
+    _silentlyReconnecting = false;
+    // #1920 — record the escalation: the silent window elapsed without
+    // the adapter coming back, so the drop is now visible to the user.
+    AutoRecordTraceLog.add(
+      AutoRecordEventKind.dropEscalatedToVisible,
+      mac: _pinnedAdapterMac,
+    );
+    _enterVisibleDrop(_dropReason ?? TripDropReason.transportError);
+  }
+
+  /// Kick off the auto-reconnect scanner (#797 phase 3) if both a
+  /// pinned adapter MAC AND a scanner factory are wired. No-op
+  /// otherwise — the grace timer remains the sole recovery path then.
+  void _startReconnectScanner() {
+    final mac = _pinnedAdapterMac;
+    final factory = _reconnectScannerFactory;
+    if (mac == null || factory == null) return;
+    final scanner = factory(mac, onScannerReconnect);
+    if (scanner == null) return;
+    _reconnectScanner = scanner;
+    // Fire-and-forget — start() is an async scheduler boot that
+    // shouldn't block the drop handler. Errors inside the scanner are
+    // already caught internally.
+    unawaited(scanner.start());
+  }
+
+  /// Reaction when the reconnect scanner finds the adapter again. The
+  /// scanner self-stops before firing this callback.
+  void onScannerReconnect() {
+    _reconnectScanner = null;
+    if (_silentlyReconnecting) {
+      // #1904 — reconnected inside the silent window: resume polling
+      // without the user ever having seen a pause. Mirrors the
+      // drop-recovery half of resume() but skips the pausedDueToDrop
+      // teardown (it was never set) and the emitState pause-banner
+      // churn — the state was `recording` throughout.
+      _silentReconnectTimer?.cancel();
+      _silentReconnectTimer = null;
+      _silentlyReconnecting = false;
+      _dropReason = null;
+      _host.resetDropDetector();
+      clearPausedTripRow();
+      // #1920 — record the silent-path recovery: the adapter came back
+      // inside the #1904 window and the user never saw a pause.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.silentReconnectSucceeded,
+        mac: _pinnedAdapterMac,
+      );
+      // Respect a user pause that landed during the silent window.
+      if (!_host.paused && !_host.stopped) _host.startScheduler();
+      _host.emitState();
+      return;
+    }
+    // Reconnected after the drop went visible — the ordinary resume()
+    // path cancels the grace timer and clears the paused-trips row.
+    if (_host.pausedDueToDrop) {
+      // #1920 — record the visible-path recovery: the adapter came back
+      // after the pause banner had already been shown.
+      AutoRecordTraceLog.add(
+        AutoRecordEventKind.reconnectSucceeded,
+        mac: _pinnedAdapterMac,
+      );
+      _host.resumeFromReconnect();
+    }
+  }
+
+  /// Tear down the in-flight reconnect scanner. Best-effort; safe to
+  /// call when none is running.
+  Future<void> stopReconnectScanner() async {
+    final scanner = _reconnectScanner;
+    if (scanner == null) return;
+    _reconnectScanner = null;
+    try {
+      await scanner.stop();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {
+            'where': 'DroppedSessionManager stop reconnect scanner'
+          }));
+    }
+  }
+
+  /// Persist the in-progress trip snapshot to the paused-trips box on
+  /// drop (#797 phase 1). Fire-and-forget; Hive errors are logged by
+  /// the repo and must not throw back into the scheduler callback.
+  void _persistPausedSnapshot() {
+    final repo = _resolvePausedRepo();
+    final id = _host.sessionId;
+    if (repo == null || id == null) return;
+    final summary = _host.buildInProgressSummary();
+    final entry = PausedTripEntry(
+      id: id,
+      vehicleId: _host.vehicleId,
+      vin: _host.vin,
+      summary: summary,
+      odometerStartKm: _host.odometerStartKm,
+      odometerLatestKm: _host.odometerLatestKm,
+      pausedAt: _now(),
+      // #1004 phase 4-WAL — flag persists so the launch-time recovery
+      // service knows whether to bump the launcher-icon badge if the app
+      // is killed before the grace timer fires.
+      automatic: _host.automatic,
+    );
+    repo.save(entry);
+  }
+
+  /// Delete this session's row from the paused-trips box — the session
+  /// is live again, so leaving the partial behind would let a later
+  /// pause stomp the in-memory state. Best-effort.
+  void clearPausedTripRow() {
+    final id = _host.sessionId;
+    if (id == null) return;
+    _resolvePausedRepo()?.delete(id);
+  }
+
+  /// Grace-window auto-finalise (#797). Stops the scanner first so a
+  /// late reconnect can't race an already-finalised trip, finalises the
+  /// partial into the trip-history box, deletes the paused row, then
+  /// flips the host into the stopped state.
+  Future<void> _onGraceWindowElapsed() async {
+    if (!_host.pausedDueToDrop) return;
+    // Stop the scanner before finalising — otherwise a late reconnect
+    // would race against an already-finalised trip.
+    await stopReconnectScanner();
+    final id = _host.sessionId;
+    final repo = _resolvePausedRepo();
+    final historyRepo = _resolveHistoryRepo();
+    final summary = _host.buildFinalSummary();
+    if (historyRepo != null && id != null) {
+      try {
+        await historyRepo.save(TripHistoryEntry(
+          id: id,
+          vehicleId: _host.vehicleId,
+          summary: summary,
+        ));
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+            context: const {
+              'where': 'DroppedSessionManager grace finalise failed'
+            }));
+      }
+    }
+    if (repo != null && id != null) {
+      await repo.delete(id);
+    }
+    _host.pausedDueToDrop = false;
+    _host.stopped = true;
+    _host.started = false;
+    _graceTimer = null;
+    _host.emitState();
+  }
+
+  PausedTripRepository? _resolvePausedRepo() {
+    final override = _pausedRepoOverride;
+    if (override != null) return override;
+    if (!Hive.isBoxOpen(HiveBoxes.obd2PausedTrips)) return null;
+    try {
+      return PausedTripRepository(
+        box: Hive.box<String>(HiveBoxes.obd2PausedTrips),
+      );
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {'where': 'DroppedSessionManager paused repo'}));
+      return null;
+    }
+  }
+
+  TripHistoryRepository? _resolveHistoryRepo() {
+    final override = _historyRepoOverride;
+    if (override != null) return override;
+    if (!Hive.isBoxOpen(TripHistoryRepository.boxName)) return null;
+    try {
+      return TripHistoryRepository(
+        box: Hive.box<String>(TripHistoryRepository.boxName),
+      );
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {'where': 'DroppedSessionManager history repo'}));
+      return null;
+    }
+  }
+
+  /// Cancel the grace timer + clear the drop reason — called by the
+  /// controller's resume() before it clears the paused row and re-arms
+  /// the detector. Scanner teardown stays the caller's job.
+  void cancelGrace() {
+    _graceTimer?.cancel();
+    _graceTimer = null;
+    _dropReason = null;
+  }
+
+  /// Tear down every pending timer + the silent-reconnect flag — called
+  /// by the controller's stop(). Scanner teardown is awaited separately
+  /// by stop() via [stopReconnectScanner].
+  void cancelAllTimers() {
+    _graceTimer?.cancel();
+    _graceTimer = null;
+    _silentReconnectTimer?.cancel();
+    _silentReconnectTimer = null;
+    _silentlyReconnecting = false;
+  }
+
+  /// Test seam: synchronously drive the grace-window finalisation path
+  /// without waiting for the real timer. Plain (not `@visibleForTesting`)
+  /// because the controller's own test-only `debugExpireGraceWindow`
+  /// hook delegates here — mirroring `TripDistanceResolver`'s seam style.
+  Future<void> expireGraceWindowNow() async {
+    _graceTimer?.cancel();
+    await _onGraceWindowElapsed();
+  }
+}

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -4,9 +4,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:hive/hive.dart';
 
-import '../../../../core/storage/hive_boxes.dart';
 import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../domain/entities/gps_sample_diagnostic.dart';
@@ -14,7 +12,8 @@ import '../../domain/services/gear_inference.dart';
 import '../../domain/trip_recorder.dart';
 import '../trip_history_repository.dart';
 import 'adapter_reconnect_scanner.dart';
-import 'auto_record_trace_log.dart';
+import 'dropped_session_host.dart';
+import 'dropped_session_manager.dart';
 import 'elm327_protocol.dart';
 import 'live_sample_snapshot.dart';
 import 'obd2_breadcrumb_collector.dart';
@@ -37,6 +36,10 @@ import '../../../../core/logging/error_logger.dart';
 export 'trip_distance_source.dart'
     show kDistanceSourceReal, kDistanceSourceVirtual, kDistanceSourceGps;
 export 'trip_live_reading.dart' show TripLiveReading;
+// #2188 — TripDropReason moved with the drop-RECOVERY state machine into
+// DroppedSessionManager. Re-export it here so the providers / widgets /
+// tests that import it from this file keep working unchanged.
+export 'dropped_session_manager.dart' show TripDropReason;
 
 /// Public recording state exposed by [TripRecordingController]
 /// (#797 phase 1).
@@ -58,8 +61,8 @@ export 'trip_live_reading.dart' show TripLiveReading;
 /// scanner. Phase 1's job is to make the state observable so the
 /// follow-up PR can react to it.
 ///
-/// phase 3 (#797) wires an [AdapterReconnectScanner] into
-/// [_handleDrop]: while the controller is in
+/// phase 3 (#797) wires an [AdapterReconnectScanner] into the
+/// drop-recovery state machine: while the controller is in
 /// [TripRecordingControllerState.pausedDueToDrop] the scanner
 /// periodically probes for the pinned adapter's MAC. On a
 /// reconnect the scanner fires [TripRecordingController.resume]
@@ -70,26 +73,6 @@ enum TripRecordingControllerState {
   paused,
   pausedDueToDrop,
   stopped,
-}
-
-/// Why the controller transitioned into
-/// [TripRecordingControllerState.pausedDueToDrop] (#1330 phase 3).
-///
-/// Distinguishes the two failure modes that share the
-/// pause-with-grace recovery path:
-///
-///  * [transportError] — repeated transport-level failures
-///    (BT link dropped, three consecutive errors within the window,
-///    or a typed `Obd2DisconnectedException`). The user-visible
-///    surface is "OBD2 connection lost".
-///  * [silentFailure] — adapter is connected and answering, but every
-///    high-priority PID parse returns null for [_silentFailureThreshold]
-///    consecutive ticks. ECU off, vehicle protocol mismatch, defective
-///    adapter firmware. Without this signal the user sees "trip
-///    recorded" with empty charts and no notification (#1330).
-enum TripDropReason {
-  transportError,
-  silentFailure,
 }
 
 /// Drives the priority-tiered PID polling loop that feeds an
@@ -142,9 +125,9 @@ enum TripDropReason {
 ///   - the partial [TripSummary] (distance, fuel estimate so far,
 ///     harsh counters, odometer reads, VIN) is serialised to the
 ///     `obd2_paused_trips` Hive box,
-///   - a grace timer starts for [_pauseGraceWindow]; if [resume] isn't
-///     called before it fires, the paused entry is finalised into the
-///     normal trip history as if [stop] had run.
+///   - a grace timer starts for the configured pause-grace window; if
+///     [resume] isn't called before it fires, the paused entry is
+///     finalised into the normal trip history as if [stop] had run.
 ///
 /// Phase 1 exposes the state machine without wiring a UI banner —
 /// phase 2 brings the auto-reconnect scanner + snackbar UX.
@@ -205,62 +188,26 @@ class TripRecordingController {
   /// in [_runTransport].
   final Duration _schedulerTickRate;
 
-  /// Optional override — tests inject an in-memory box via a fake
-  /// repo so they don't have to spin up the real Hive box. Production
-  /// passes null and the controller resolves the box lazily from
-  /// [HiveBoxes.obd2PausedTrips] when a drop actually occurs.
-  final PausedTripRepository? _pausedRepoOverride;
-
-  /// Optional override — tests inject a lightweight fake that skips
-  /// the Hive round-trip when auto-finalising a paused trip after the
-  /// grace window elapses. Production uses [TripHistoryRepository]
-  /// against the `obd2_trip_history` Hive box.
-  final TripHistoryRepository? _historyRepoOverride;
-
-  /// Grace window before a paused-due-to-drop session auto-finalises
-  /// (#797 phase 1). Defaults to 15 minutes — long enough for a
-  /// toll-booth stop, short enough that a forgotten session can't
-  /// clog up the paused-trips box forever. Tests pass small values
-  /// (e.g. 100 ms) to exercise the auto-finalise path.
-  final Duration _pauseGraceWindow;
-
-  /// #1904 — how long a transport drop stays invisible while the
-  /// reconnect scanner tries to get the adapter back. If the scanner
-  /// reconnects inside this window the user never sees a pause; if it
-  /// elapses the controller escalates to the visible drop state.
-  /// `Duration.zero` disables the silent window (every drop is visible
-  /// at once — the pre-#1904 behaviour).
-  final Duration _silentReconnectWindow;
-
   /// Owns the connection-drop *detection* heuristics — the #797
   /// transport-error sliding window and the #1330 silent-failure
   /// null-parse counter — extracted into a focused collaborator
-  /// (#1679). The controller keeps the *reaction* ([_handleDrop],
-  /// grace timer, reconnect scanner). Built in the constructor body
-  /// so it can capture the resolved [_now] clock.
+  /// (#1679). The controller keeps only the lifecycle guard
+  /// ([_registerTransportError] / [_observeHighPriorityParse]); the
+  /// drop *reaction* (grace timer, reconnect scanner, paused/history
+  /// persistence) lives in [_droppedSession] (#2188). Built in the
+  /// constructor body so it can capture the resolved [_now] clock.
   late final TripDropDetector _dropDetector;
 
-  /// Pinned adapter MAC that the auto-reconnect scanner (#797 phase 3)
-  /// will search for when a drop flips us into
-  /// [TripRecordingControllerState.pausedDueToDrop]. Null-able
-  /// because the vehicle profile may not carry an adapter pairing
-  /// yet (fresh profiles, or users who never ran the picker). When
-  /// null the scanner is not started and the grace-window path
-  /// remains the only recovery mechanism.
-  final String? _pinnedAdapterMac;
-
-  /// Factory used by [_handleDrop] to construct the reconnect
-  /// scanner (#797 phase 3). Takes the pinned MAC + the callback to
-  /// fire on reconnect and returns a fresh scanner. Tests inject a
-  /// fake factory that returns an in-memory scanner with a clock
-  /// they control; production passes null and the controller builds
-  /// nothing — wiring the real BT scan layer is the provider's job.
-  final AdapterReconnectScanner? Function(
-    String pinnedMac,
-    VoidCallback onReconnect,
-  )? _reconnectScannerFactory;
-
-  AdapterReconnectScanner? _reconnectScanner;
+  /// Owns the connection-drop RECOVERY lifecycle — the #1904 silent-
+  /// reconnect window, the visible-drop escalation, the #797 grace
+  /// timer + auto-finalise, the reconnect-scanner orchestration and the
+  /// paused/history Hive persistence — extracted into a focused
+  /// collaborator (#2188). The controller keeps the emit loop, the
+  /// scheduler, the drop detector, and the trip-identity fields; the
+  /// manager reaches those through a [DroppedSessionHost] adapter. Built
+  /// in the constructor body so it can capture the resolved [_now]
+  /// clock + the host seam.
+  late final DroppedSessionManager _droppedSession;
 
   final StreamController<TripLiveReading> _liveController =
       StreamController<TripLiveReading>.broadcast();
@@ -270,7 +217,6 @@ class TripRecordingController {
 
   PidScheduler? _scheduler;
   Timer? _emitTimer;
-  Timer? _graceTimer;
   DateTime? _startedAt;
   DateTime? _lastSampleAt;
   double? _odometerStartKm;
@@ -296,27 +242,11 @@ class TripRecordingController {
   bool _stopped = false;
   String? _sessionId; // ISO start-ts, stable across pause→resume cycles
 
-  /// #1904 — true between a transport drop and either a silent
-  /// reconnect or the escalation to the visible [_pausedDueToDrop].
-  /// While set, the scheduler is stopped but the controller still
-  /// reports `recording` — the user sees no pause banner for a drop
-  /// the reconnect scanner is about to clear within seconds.
-  bool _silentlyReconnecting = false;
-
-  /// #1904 — fires when the silent reconnect window elapses without
-  /// the adapter coming back; escalates to the visible drop state.
-  Timer? _silentReconnectTimer;
-
-  /// Reason the most recent [_handleDrop] fired (#1330 phase 3).
-  /// Null when no drop has occurred. Read by the provider so the
-  /// pause banner can surface a different message on silent-failure
-  /// vs transport-error.
-  TripDropReason? _dropReason;
-
   /// Why the controller flipped into
   /// [TripRecordingControllerState.pausedDueToDrop] (#1330 phase 3).
-  /// Null when the controller is not in that state.
-  TripDropReason? get dropReason => _dropReason;
+  /// Null when the controller is not in that state. Delegates to the
+  /// drop-recovery state machine (#2188).
+  TripDropReason? get dropReason => _droppedSession.dropReason;
 
   /// Owns the trip's distance-resolution concern — the three-tier
   /// odometer-delta / GPS-track / virtual-odometer selection and the two
@@ -399,20 +329,24 @@ class TripRecordingController {
         _referenceVehicle = referenceVehicle,
         _vehicleId = vehicleId,
         _schedulerOverride = scheduler,
-        _pausedRepoOverride = pausedRepo,
-        _historyRepoOverride = historyRepo,
-        _pauseGraceWindow = pauseGraceWindow,
-        _silentReconnectWindow = silentReconnectWindow,
         _schedulerTickRate = schedulerTickRate,
-        _pinnedAdapterMac = pinnedAdapterMac,
         _automatic = automatic,
-        _reconnectScannerFactory = reconnectScannerFactory,
         _breadcrumbCollector = breadcrumbCollector {
     _dropDetector = TripDropDetector(
       now: _now,
       dropWindow: dropWindow,
       dropThreshold: dropThreshold,
       silentFailureThreshold: silentFailureThreshold,
+    );
+    _droppedSession = DroppedSessionManager(
+      host: _DroppedSessionHostAdapter(this),
+      now: _now,
+      pauseGraceWindow: pauseGraceWindow,
+      silentReconnectWindow: silentReconnectWindow,
+      pinnedAdapterMac: pinnedAdapterMac,
+      reconnectScannerFactory: reconnectScannerFactory,
+      pausedRepo: pausedRepo,
+      historyRepo: historyRepo,
     );
     _distance = TripDistanceResolver(
       maxIntegrationGapSeconds: _integrationGapCapSeconds,
@@ -486,10 +420,9 @@ class TripRecordingController {
   void resume() {
     if (!_paused && !_pausedDueToDrop) return;
     if (_pausedDueToDrop) {
-      _graceTimer?.cancel();
-      _graceTimer = null;
+      // Cancel the grace timer + clear the drop-reaction reason.
+      _droppedSession.cancelGrace();
       _pausedDueToDrop = false;
-      _dropReason = null;
       // #1330 phase 3 — clear the silent-failure latch so a
       // post-resume stretch of nulls can fire again. Without this,
       // a user who resumes after a silent-failure drop and then hits
@@ -501,8 +434,8 @@ class TripRecordingController {
       // tapped "Resume" manually on the pause banner before the
       // scanner reconnected. Either way, no scanner should survive
       // the resume transition.
-      unawaited(_stopReconnectScanner());
-      _clearPausedTripRow();
+      unawaited(_droppedSession.stopReconnectScanner());
+      _droppedSession.clearPausedTripRow();
     }
     _paused = false;
     _scheduler?.start();
@@ -644,14 +577,11 @@ class TripRecordingController {
     _scheduler?.stop();
     _emitTimer?.cancel();
     _emitTimer = null;
-    _graceTimer?.cancel();
-    _graceTimer = null;
-    // #1904 — tear down a pending silent-reconnect window so it can't
-    // escalate after the trip has stopped.
-    _silentReconnectTimer?.cancel();
-    _silentReconnectTimer = null;
-    _silentlyReconnecting = false;
-    await _stopReconnectScanner();
+    // #1904 / #2188 — tear down the grace timer + the pending silent-
+    // reconnect window so neither can fire after the trip has stopped,
+    // and stop the reconnect scanner.
+    _droppedSession.cancelAllTimers();
+    await _droppedSession.stopReconnectScanner();
     _started = false;
     _stopped = true;
     _pausedDueToDrop = false;
@@ -916,7 +846,7 @@ class TripRecordingController {
   void _registerTransportError(Object error) {
     if (_pausedDueToDrop || _stopped) return;
     if (_dropDetector.registerTransportError(error)) {
-      _handleDrop();
+      _droppedSession.handleDrop();
     }
   }
 
@@ -928,11 +858,12 @@ class TripRecordingController {
   /// different PID, because we're trying to detect "ECU is dead",
   /// not "this specific PID is unsupported".
   ///
-  /// Once the counter reaches [_silentFailureThreshold] AND the
+  /// Once the counter reaches the silent-failure threshold AND the
   /// transport-error drop hasn't already fired, [_onSilentFailure]
-  /// drives the same pause-with-grace path that [_handleDrop] does
-  /// for transport errors, but stamps a [TripDropReason.silentFailure]
-  /// reason so the UI can surface a different message.
+  /// drives the same pause-with-grace path that the drop-recovery
+  /// manager runs for transport errors, but stamps a
+  /// [TripDropReason.silentFailure] reason so the UI can surface a
+  /// different message.
   void _observeHighPriorityParse(Object? parsedValue) {
     if (parsedValue != null) {
       // ANY successful high-priority parse clears the window — we're
@@ -952,258 +883,16 @@ class TripRecordingController {
   /// Silent-failure handler (#1330 phase 3). Fired exactly once per
   /// recording session when the drop detector's consecutive-null
   /// counter crosses the threshold. Drives the same pause-with-grace
-  /// recovery as [_handleDrop] for transport errors, but tags the drop
-  /// with [TripDropReason.silentFailure] so the UI surfaces "OBD2
-  /// adapter connected but not returning data" instead of "OBD2
-  /// connection lost".
+  /// recovery the drop-recovery manager runs for transport errors, but
+  /// tags the drop with [TripDropReason.silentFailure] so the UI
+  /// surfaces "OBD2 adapter connected but not returning data" instead
+  /// of "OBD2 connection lost".
   void _onSilentFailure() {
     debugPrint(
       'TripRecordingController: silent-failure detected — '
       '${_dropDetector.consecutiveNullReads} consecutive null PID parses',
     );
-    _handleDrop(reason: TripDropReason.silentFailure);
-  }
-
-  /// React to a detected connection drop.
-  ///
-  /// #1904 — a `transportError` drop (the Bluetooth link hiccupped)
-  /// first enters an *invisible* reconnect window: the scheduler stops
-  /// and the reconnect scanner starts, but the controller keeps
-  /// reporting `recording`, so the user sees no pause banner. The
-  /// adapter is usually still in range and the scanner gets it back
-  /// within seconds — a reconnect inside the window resumes polling
-  /// silently. Only if [_silentReconnectWindow] elapses with no
-  /// reconnect — the adapter is genuinely gone — does the controller
-  /// escalate to the visible [_pausedDueToDrop] banner.
-  ///
-  /// A `silentFailure` drop (the ECU stopped answering while the link
-  /// is healthy) escalates straight to the visible state — reconnecting
-  /// the Bluetooth link cannot revive a dead ECU.
-  void _handleDrop({
-    TripDropReason reason = TripDropReason.transportError,
-  }) {
-    if (_pausedDueToDrop || _silentlyReconnecting) return;
-    // #1920 — trace every detected drop so a failed recording session
-    // can be analysed from the exportable OBD2 diagnostic log.
-    AutoRecordTraceLog.add(
-      AutoRecordEventKind.dropDetected,
-      mac: _pinnedAdapterMac,
-      detail: reason.name,
-    );
-    _scheduler?.stop();
-    _dropDetector.clearErrorWindow();
-    _persistPausedSnapshot();
-    if (reason == TripDropReason.transportError &&
-        _silentReconnectWindow > Duration.zero) {
-      _silentlyReconnecting = true;
-      _dropReason = reason;
-      // #1920 — record entry into the #1904 invisible reconnect window.
-      AutoRecordTraceLog.add(
-        AutoRecordEventKind.silentReconnectStarted,
-        mac: _pinnedAdapterMac,
-      );
-      _startReconnectScanner();
-      _silentReconnectTimer?.cancel();
-      _silentReconnectTimer =
-          Timer(_silentReconnectWindow, _escalateToVisibleDrop);
-      // Deliberately no _emitState() — an in-presence drop the scanner
-      // is about to clear must stay invisible to the UI.
-      return;
-    }
-    _enterVisibleDrop(reason);
-  }
-
-  /// Flip into the visible pause-with-grace state: stop is already
-  /// done by [_handleDrop]; this starts the grace timer, ensures a
-  /// reconnect scanner is running, and emits so the pause banner
-  /// appears.
-  void _enterVisibleDrop(TripDropReason reason) {
-    _pausedDueToDrop = true;
-    _dropReason = reason;
-    _graceTimer?.cancel();
-    _graceTimer = Timer(_pauseGraceWindow, _onGraceWindowElapsed);
-    // The scanner may already be running from the silent window.
-    if (_reconnectScanner == null) _startReconnectScanner();
-    _emitState();
-  }
-
-  /// #1904 — the silent reconnect window elapsed without the adapter
-  /// coming back; surface the drop to the user.
-  void _escalateToVisibleDrop() {
-    _silentReconnectTimer = null;
-    if (!_silentlyReconnecting || _pausedDueToDrop || _stopped) return;
-    _silentlyReconnecting = false;
-    // #1920 — record the escalation: the silent window elapsed without
-    // the adapter coming back, so the drop is now visible to the user.
-    AutoRecordTraceLog.add(
-      AutoRecordEventKind.dropEscalatedToVisible,
-      mac: _pinnedAdapterMac,
-    );
-    _enterVisibleDrop(_dropReason ?? TripDropReason.transportError);
-  }
-
-  /// Delete this session's row from the paused-trips box — the session
-  /// is live again, so leaving the partial behind would let a later
-  /// pause stomp the in-memory state. Best-effort.
-  void _clearPausedTripRow() {
-    final id = _sessionId;
-    if (id == null) return;
-    _resolvePausedRepo()?.delete(id);
-  }
-
-  /// Kick off the auto-reconnect scanner (#797 phase 3) if both the
-  /// vehicle profile has a pinned adapter MAC AND the provider wired
-  /// in a scanner factory. No-op in either's absence — the grace
-  /// timer remains the sole recovery path in that case.
-  ///
-  /// The [AdapterReconnectScanner]'s `onReconnect` callback is set
-  /// to call [resume] here — which cancels the grace timer, clears
-  /// the paused-trips row, and resumes the scheduler. Tests that
-  /// want to observe the reconnect path can watch [stateChanges]
-  /// for the recording → pausedDueToDrop → recording sequence.
-  void _startReconnectScanner() {
-    final mac = _pinnedAdapterMac;
-    final factory = _reconnectScannerFactory;
-    if (mac == null || factory == null) return;
-    final scanner = factory(mac, _onScannerReconnect);
-    if (scanner == null) return;
-    _reconnectScanner = scanner;
-    // Fire-and-forget — start() is an async scheduler boot that
-    // shouldn't block the drop handler. Errors inside the scanner
-    // are already caught internally.
-    unawaited(scanner.start());
-  }
-
-  void _onScannerReconnect() {
-    // The scanner self-stops before firing this callback.
-    _reconnectScanner = null;
-    if (_silentlyReconnecting) {
-      // #1904 — reconnected inside the silent window: resume polling
-      // without the user ever having seen a pause. Mirrors the
-      // drop-recovery half of resume() but skips the _pausedDueToDrop
-      // teardown (it was never set) and the _emitState pause-banner
-      // churn — the state was `recording` throughout.
-      _silentReconnectTimer?.cancel();
-      _silentReconnectTimer = null;
-      _silentlyReconnecting = false;
-      _dropReason = null;
-      _dropDetector.reset();
-      _clearPausedTripRow();
-      // #1920 — record the silent-path recovery: the adapter came back
-      // inside the #1904 window and the user never saw a pause.
-      AutoRecordTraceLog.add(
-        AutoRecordEventKind.silentReconnectSucceeded,
-        mac: _pinnedAdapterMac,
-      );
-      // Respect a user pause that landed during the silent window.
-      if (!_paused && !_stopped) _scheduler?.start();
-      _emitState();
-      return;
-    }
-    // Reconnected after the drop went visible — the ordinary resume()
-    // path cancels the grace timer and clears the paused-trips row.
-    if (_pausedDueToDrop) {
-      // #1920 — record the visible-path recovery: the adapter came back
-      // after the pause banner had already been shown.
-      AutoRecordTraceLog.add(
-        AutoRecordEventKind.reconnectSucceeded,
-        mac: _pinnedAdapterMac,
-      );
-      resume();
-    }
-  }
-
-  Future<void> _stopReconnectScanner() async {
-    final scanner = _reconnectScanner;
-    if (scanner == null) return;
-    _reconnectScanner = null;
-    try {
-      await scanner.stop();
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController stop reconnect scanner'}));
-    }
-  }
-
-  void _persistPausedSnapshot() {
-    final repo = _resolvePausedRepo();
-    final id = _sessionId;
-    if (repo == null || id == null) return;
-    final summary = _recorder.buildSummary();
-    final entry = PausedTripEntry(
-      id: id,
-      vehicleId: _vehicleId,
-      vin: _vin,
-      summary: summary,
-      odometerStartKm: _odometerStartKm,
-      odometerLatestKm: _odometerLatestKm,
-      pausedAt: _now(),
-      // #1004 phase 4-WAL — flag persists so the launch-time recovery
-      // service knows whether to bump the launcher-icon badge if the
-      // app is killed before the grace timer fires.
-      automatic: _automatic,
-    );
-    // Fire-and-forget: the save is best-effort; Hive errors are
-    // logged by the repo and must not throw back into the scheduler
-    // callback.
-    repo.save(entry);
-  }
-
-  Future<void> _onGraceWindowElapsed() async {
-    if (!_pausedDueToDrop) return;
-    // Stop the scanner before finalising — otherwise a late
-    // reconnect would race against an already-finalised trip.
-    await _stopReconnectScanner();
-    final id = _sessionId;
-    final repo = _resolvePausedRepo();
-    final historyRepo = _resolveHistoryRepo();
-    final summary = _finaliseSummary();
-    if (historyRepo != null && id != null) {
-      try {
-        await historyRepo.save(TripHistoryEntry(
-          id: id,
-          vehicleId: _vehicleId,
-          summary: summary,
-        ));
-      } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController grace finalise failed'}));
-      }
-    }
-    if (repo != null && id != null) {
-      await repo.delete(id);
-    }
-    _pausedDueToDrop = false;
-    _stopped = true;
-    _started = false;
-    _graceTimer = null;
-    _emitState();
-  }
-
-  PausedTripRepository? _resolvePausedRepo() {
-    final override = _pausedRepoOverride;
-    if (override != null) return override;
-    if (!Hive.isBoxOpen(HiveBoxes.obd2PausedTrips)) return null;
-    try {
-      return PausedTripRepository(
-        box: Hive.box<String>(HiveBoxes.obd2PausedTrips),
-      );
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController paused repo'}));
-      return null;
-    }
-  }
-
-  TripHistoryRepository? _resolveHistoryRepo() {
-    final override = _historyRepoOverride;
-    if (override != null) return override;
-    if (!Hive.isBoxOpen(TripHistoryRepository.boxName)) return null;
-    try {
-      return TripHistoryRepository(
-        box: Hive.box<String>(TripHistoryRepository.boxName),
-      );
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController history repo'}));
-      return null;
-    }
+    _droppedSession.handleDrop(reason: TripDropReason.silentFailure);
   }
 
   void _emitState() {
@@ -1234,7 +923,9 @@ class TripRecordingController {
     // scheduler is stopped then, so the snapshot is stale — feeding it
     // to the recorder would integrate phantom distance/fuel from a
     // frozen speed over real elapsed time.
-    if (_paused || _pausedDueToDrop || _silentlyReconnecting) return;
+    if (_paused || _pausedDueToDrop || _droppedSession.silentlyReconnecting) {
+      return;
+    }
     if (_liveController.isClosed) return;
 
     final snap = _liveSampleSnapshot;
@@ -1349,14 +1040,14 @@ class TripRecordingController {
   void debugTriggerDrop({
     TripDropReason reason = TripDropReason.transportError,
   }) {
-    _handleDrop(reason: reason);
+    _droppedSession.handleDrop(reason: reason);
   }
 
   /// Exposed for tests: whether the controller is inside the #1904
   /// invisible reconnect window (a transport drop the scanner is
   /// trying to clear before it ever reaches the pause banner).
   @visibleForTesting
-  bool get debugSilentlyReconnecting => _silentlyReconnecting;
+  bool get debugSilentlyReconnecting => _droppedSession.silentlyReconnecting;
 
   /// Exposed for tests: run one command through the retrying transport
   /// path so the #1904 single-retry-on-transient-error behaviour can
@@ -1389,18 +1080,18 @@ class TripRecordingController {
   /// finalisation path. Useful with fake-async patterns where
   /// elapsing real wall-clock time is awkward.
   @visibleForTesting
-  Future<void> debugExpireGraceWindow() async {
-    _graceTimer?.cancel();
-    await _onGraceWindowElapsed();
-  }
+  Future<void> debugExpireGraceWindow() =>
+      _droppedSession.expireGraceWindowNow();
 
   /// Exposed for tests: the auto-reconnect scanner instance created
-  /// by [_handleDrop] (#797 phase 3). Null when no scanner factory
-  /// is wired in or no pinned MAC is known — also null again after
-  /// a successful reconnect or a stop(), because the controller
-  /// releases the reference as soon as it's no longer needed.
+  /// by the drop-recovery state machine (#797 phase 3 / #2188). Null
+  /// when no scanner factory is wired in or no pinned MAC is known —
+  /// also null again after a successful reconnect or a stop(), because
+  /// the manager releases the reference as soon as it's no longer
+  /// needed.
   @visibleForTesting
-  AdapterReconnectScanner? get debugReconnectScanner => _reconnectScanner;
+  AdapterReconnectScanner? get debugReconnectScanner =>
+      _droppedSession.reconnectScanner;
 
   /// Exposed for tests: inject a hand-crafted [TripSample] directly
   /// into the underlying [TripRecorder]. Used by the #797 phase 1
@@ -1456,4 +1147,80 @@ class TripRecordingController {
   void debugAppendGpsFix({required double latitude, required double longitude}) {
     _distance.debugAddGpsFix(latitude: latitude, longitude: longitude);
   }
+}
+
+/// Adapts [TripRecordingController]'s recording loop to the narrow
+/// [DroppedSessionHost] seam the drop-recovery state machine needs
+/// (#2188). Lives in the same library as the controller so it can
+/// delegate to its private lifecycle flags + collaborators without
+/// widening the controller's public API.
+///
+/// Every method here is a thin pass-through; the behaviour-preserving
+/// extraction lives in [DroppedSessionManager]. The adapter exists only
+/// so the manager stays unit-testable against a fake host while
+/// production wires the real controller.
+class _DroppedSessionHostAdapter implements DroppedSessionHost {
+  _DroppedSessionHostAdapter(this._c);
+
+  final TripRecordingController _c;
+
+  @override
+  void stopScheduler() => _c._scheduler?.stop();
+
+  @override
+  void startScheduler() => _c._scheduler?.start();
+
+  @override
+  void resetDropDetector() => _c._dropDetector.reset();
+
+  @override
+  void clearDropDetectorErrorWindow() => _c._dropDetector.clearErrorWindow();
+
+  @override
+  void emitState() => _c._emitState();
+
+  @override
+  void resumeFromReconnect() => _c.resume();
+
+  @override
+  TripSummary buildInProgressSummary() => _c._recorder.buildSummary();
+
+  @override
+  TripSummary buildFinalSummary() => _c._finaliseSummary();
+
+  @override
+  bool get pausedDueToDrop => _c._pausedDueToDrop;
+  @override
+  set pausedDueToDrop(bool value) => _c._pausedDueToDrop = value;
+
+  @override
+  bool get stopped => _c._stopped;
+  @override
+  set stopped(bool value) => _c._stopped = value;
+
+  @override
+  bool get started => _c._started;
+  @override
+  set started(bool value) => _c._started = value;
+
+  @override
+  bool get paused => _c._paused;
+
+  @override
+  String? get sessionId => _c._sessionId;
+
+  @override
+  String? get vehicleId => _c._vehicleId;
+
+  @override
+  String? get vin => _c._vin;
+
+  @override
+  double? get odometerStartKm => _c._odometerStartKm;
+
+  @override
+  double? get odometerLatestKm => _c._odometerLatestKm;
+
+  @override
+  bool get automatic => _c._automatic;
 }

--- a/test/features/consumption/data/obd2/dropped_session_manager_test.dart
+++ b/test/features/consumption/data/obd2/dropped_session_manager_test.dart
@@ -1,0 +1,487 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_reconnect_scanner.dart';
+import 'package:tankstellen/features/consumption/data/obd2/dropped_session_host.dart';
+import 'package:tankstellen/features/consumption/data/obd2/dropped_session_manager.dart';
+import 'package:tankstellen/features/consumption/data/obd2/paused_trip_repository.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Focused unit tests for the #2188 [DroppedSessionManager] — the
+/// connection-drop RECOVERY state machine extracted from
+/// `TripRecordingController`. Drives the manager against a fake
+/// [DroppedSessionHost] + in-memory Hive repos + a hand-driven scanner
+/// so every branch (persist-on-drop, silent window absorb vs escalate,
+/// reconnect-within / after-grace, grace auto-finalise) is exercised
+/// deterministically without a real `Obd2Service`, scheduler, or
+/// wall-clock timer.
+void main() {
+  group('DroppedSessionManager (#2188)', () {
+    late Directory tmpDir;
+    late Box<String> pausedBox;
+    late Box<String> historyBox;
+    late PausedTripRepository pausedRepo;
+    late TripHistoryRepository historyRepo;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('dropped_session_test_');
+      Hive.init(tmpDir.path);
+      pausedBox = await Hive.openBox<String>(
+        'paused_${DateTime.now().microsecondsSinceEpoch}',
+      );
+      historyBox = await Hive.openBox<String>(
+        'history_${DateTime.now().microsecondsSinceEpoch}',
+      );
+      pausedRepo = PausedTripRepository(box: pausedBox);
+      historyRepo = TripHistoryRepository(box: historyBox);
+    });
+
+    tearDown(() async {
+      await pausedBox.deleteFromDisk();
+      await historyBox.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    DateTime now() => DateTime(2026, 5, 28, 12);
+
+    DroppedSessionManager build(
+      _FakeHost host, {
+      Duration grace = const Duration(hours: 1),
+      Duration silentWindow = Duration.zero,
+      String? pinnedMac,
+      AdapterReconnectScanner? Function(String, VoidCallback)? scannerFactory,
+    }) {
+      return DroppedSessionManager(
+        host: host,
+        now: now,
+        pauseGraceWindow: grace,
+        silentReconnectWindow: silentWindow,
+        pinnedAdapterMac: pinnedMac,
+        reconnectScannerFactory: scannerFactory,
+        pausedRepo: pausedRepo,
+        historyRepo: historyRepo,
+      );
+    }
+
+    test('drop with silent window disabled persists the snapshot and '
+        'flips the host into the visible drop state', () {
+      final host = _FakeHost();
+      final mgr = build(host);
+
+      mgr.handleDrop();
+
+      expect(host.pausedDueToDrop, isTrue,
+          reason: 'a drop with no silent window must go straight to the '
+              'visible pause state');
+      expect(mgr.dropReason, TripDropReason.transportError);
+      expect(host.stopSchedulerCalls, 1,
+          reason: 'the scheduler must be stopped the instant a drop fires');
+      expect(host.clearErrorWindowCalls, 1);
+      expect(host.emitStateCalls, greaterThanOrEqualTo(1));
+      final saved = pausedRepo.loadAll();
+      expect(saved, hasLength(1),
+          reason: 'the in-progress snapshot must be persisted on drop');
+      expect(saved.single.id, host.sessionId);
+      expect(saved.single.vehicleId, host.vehicleId);
+    });
+
+    test('grace window expiry auto-finalises the paused trip into '
+        'history and removes the paused row', () async {
+      final host = _FakeHost();
+      final mgr = build(host);
+
+      mgr.handleDrop();
+      expect(pausedRepo.loadAll(), hasLength(1));
+
+      await mgr.expireGraceWindowNow();
+
+      expect(historyRepo.loadAll(), hasLength(1),
+          reason: 'grace expiry must finalise the partial trip into the '
+              'trip-history box');
+      expect(pausedRepo.loadAll(), isEmpty,
+          reason: 'the paused row must be deleted once finalised');
+      expect(host.stopped, isTrue);
+      expect(host.started, isFalse);
+      expect(host.pausedDueToDrop, isFalse);
+    });
+
+    test('grace expiry is a no-op when the host is no longer in the '
+        'paused-due-to-drop state (e.g. already resumed)', () async {
+      final host = _FakeHost();
+      final mgr = build(host);
+
+      mgr.handleDrop();
+      // Simulate a resume having already cleared the drop state.
+      host.pausedDueToDrop = false;
+      mgr.cancelGrace();
+
+      await mgr.expireGraceWindowNow();
+
+      expect(historyRepo.loadAll(), isEmpty,
+          reason: 'a cancelled / resumed session must not be finalised by '
+              'a late grace-window fire');
+    });
+
+    test('reconnect WITHIN the visible-drop window resumes the trip '
+        'via the host and stops the scanner before finalise', () async {
+      final host = _FakeHost();
+      VoidCallback? capturedOnReconnect;
+      final scanner = _FakeScanner();
+      final mgr = build(
+        host,
+        pinnedMac: 'AA:BB',
+        scannerFactory: (mac, onReconnect) {
+          capturedOnReconnect = onReconnect;
+          scanner.onReconnect = onReconnect;
+          return scanner;
+        },
+      );
+
+      mgr.handleDrop();
+      expect(host.pausedDueToDrop, isTrue);
+      expect(scanner.startCalls, 1,
+          reason: 'the visible drop must start the reconnect scanner');
+      expect(capturedOnReconnect, isNotNull);
+
+      // The scanner finds the adapter — fire its callback. (The fake
+      // wires resumeFromReconnect to clear the host state, mirroring
+      // the controller's resume().)
+      capturedOnReconnect!.call();
+
+      expect(host.resumeFromReconnectCalls, 1,
+          reason: 'a reconnect after the drop went visible must drive the '
+              'ordinary resume path');
+      expect(host.pausedDueToDrop, isFalse);
+
+      // The grace timer must have been cancelled by resume() — proven by
+      // a late grace-expiry being a no-op (no history written).
+      mgr.cancelGrace();
+      await mgr.expireGraceWindowNow();
+      expect(historyRepo.loadAll(), isEmpty,
+          reason: 'the scanner reconnect must beat the grace-window '
+              'auto-finalise to the punch');
+    });
+
+    test('reconnect AFTER the grace window finalised the trip is a '
+        'no-op — the host is already stopped', () async {
+      final host = _FakeHost();
+      VoidCallback? capturedOnReconnect;
+      final mgr = build(
+        host,
+        pinnedMac: 'AA:BB',
+        scannerFactory: (mac, onReconnect) {
+          capturedOnReconnect = onReconnect;
+          return _FakeScanner()..onReconnect = onReconnect;
+        },
+      );
+
+      mgr.handleDrop();
+      await mgr.expireGraceWindowNow();
+      expect(host.stopped, isTrue);
+      expect(historyRepo.loadAll(), hasLength(1));
+      final resumeCallsBefore = host.resumeFromReconnectCalls;
+
+      // A late scanner reconnect after finalise: pausedDueToDrop is
+      // already false, so onScannerReconnect must NOT re-resume.
+      capturedOnReconnect?.call();
+
+      expect(host.resumeFromReconnectCalls, resumeCallsBefore,
+          reason: 'a reconnect after the trip was finalised must not '
+              'resurrect it');
+      expect(historyRepo.loadAll(), hasLength(1),
+          reason: 'no duplicate finalisation from a late reconnect');
+    });
+
+    group('#1904 silent-reconnect window', () {
+      test('a transport drop with a silent window stays invisible — no '
+          'visible pause, scanner probing', () {
+        final host = _FakeHost();
+        final scanner = _FakeScanner();
+        final mgr = build(
+          host,
+          silentWindow: const Duration(seconds: 6),
+          pinnedMac: 'AA:BB',
+          scannerFactory: (mac, onReconnect) =>
+              scanner..onReconnect = onReconnect,
+        );
+
+        mgr.handleDrop();
+
+        expect(host.pausedDueToDrop, isFalse,
+            reason: 'a transport drop must NOT flip the visible state '
+                'while the silent window is open');
+        expect(mgr.silentlyReconnecting, isTrue);
+        expect(scanner.startCalls, 1,
+            reason: 'the scanner must probe during the silent window');
+        expect(host.emitStateCalls, 0,
+            reason: 'the silent window must stay invisible — no state '
+                'emission');
+        expect(pausedRepo.loadAll(), hasLength(1),
+            reason: 'the snapshot is still persisted so a process kill '
+                'mid-window is recoverable');
+      });
+
+      test('a silent reconnect inside the window resumes the scheduler '
+          'without ever showing a pause', () {
+        final host = _FakeHost();
+        VoidCallback? capturedOnReconnect;
+        final mgr = build(
+          host,
+          silentWindow: const Duration(seconds: 6),
+          pinnedMac: 'AA:BB',
+          scannerFactory: (mac, onReconnect) {
+            capturedOnReconnect = onReconnect;
+            return _FakeScanner()..onReconnect = onReconnect;
+          },
+        );
+
+        mgr.handleDrop();
+        expect(mgr.silentlyReconnecting, isTrue);
+
+        capturedOnReconnect!.call();
+
+        expect(mgr.silentlyReconnecting, isFalse,
+            reason: 'a successful silent reconnect must clear the flag');
+        expect(host.pausedDueToDrop, isFalse,
+            reason: 'the user never saw a pause');
+        expect(host.startSchedulerCalls, 1,
+            reason: 'a silent reconnect must restart the polling loop');
+        expect(host.resetDropDetectorCalls, 1);
+        expect(pausedRepo.loadAll(), isEmpty,
+            reason: 'a silent reconnect must clear the stranded partial');
+        expect(mgr.dropReason, isNull);
+      });
+
+      test('the silent window elapsing with no reconnect escalates to '
+          'the visible drop', () async {
+        final host = _FakeHost();
+        final mgr = build(
+          host,
+          // Tiny silent window so the real escalation timer fires fast.
+          silentWindow: const Duration(milliseconds: 30),
+          pinnedMac: 'AA:BB',
+          // A scanner that never calls onReconnect — adapter is gone.
+          scannerFactory: (mac, onReconnect) =>
+              _FakeScanner()..onReconnect = onReconnect,
+        );
+
+        mgr.handleDrop();
+        expect(host.pausedDueToDrop, isFalse,
+            reason: 'invisible while the silent window is still open');
+
+        // Wait past the 30 ms silent window so the escalation timer fires.
+        await Future<void>.delayed(const Duration(milliseconds: 120));
+
+        expect(mgr.silentlyReconnecting, isFalse);
+        expect(host.pausedDueToDrop, isTrue,
+            reason: 'an elapsed silent window with no reconnect must '
+                'surface the visible pause banner');
+        expect(mgr.dropReason, TripDropReason.transportError);
+
+        // Clean up the now-running grace timer.
+        mgr.cancelAllTimers();
+        await mgr.stopReconnectScanner();
+      });
+
+      test('a silentFailure drop bypasses the silent window — visible '
+          'immediately even when a silent window is configured', () {
+        final host = _FakeHost();
+        final mgr = build(
+          host,
+          silentWindow: const Duration(seconds: 6),
+          pinnedMac: 'AA:BB',
+          scannerFactory: (mac, onReconnect) =>
+              _FakeScanner()..onReconnect = onReconnect,
+        );
+
+        mgr.handleDrop(reason: TripDropReason.silentFailure);
+
+        expect(host.pausedDueToDrop, isTrue,
+            reason: 'a dead-ECU silentFailure cannot be cleared by a BT '
+                'reconnect, so it must go straight to the visible state');
+        expect(mgr.silentlyReconnecting, isFalse);
+        expect(mgr.dropReason, TripDropReason.silentFailure);
+      });
+    });
+
+    test('no pinned MAC / no factory → the scanner is never built; the '
+        'grace window is the sole recovery path', () async {
+      final host = _FakeHost();
+      var factoryCalls = 0;
+      final mgr = build(
+        host,
+        grace: const Duration(hours: 1),
+        scannerFactory: (mac, onReconnect) {
+          factoryCalls++;
+          return null;
+        },
+        // pinnedMac omitted → null.
+      );
+
+      mgr.handleDrop();
+      expect(factoryCalls, 0,
+          reason: 'the factory must not be invoked without a pinned MAC');
+      expect(mgr.reconnectScanner, isNull);
+
+      await mgr.expireGraceWindowNow();
+      expect(historyRepo.loadAll(), hasLength(1),
+          reason: 'without a scanner the grace-window auto-finalise is '
+              'the only recovery path');
+    });
+
+    test('restart with a persisted dropped session: a re-drop in a fresh '
+        'manager converges on the same paused-trips row', () {
+      // First "session" drops and persists.
+      final host1 = _FakeHost();
+      build(host1).handleDrop();
+      expect(pausedRepo.loadAll(), hasLength(1));
+
+      // Simulate an app restart: a brand-new manager + host with the
+      // SAME session id re-drops (e.g. the recovery service rehydrated
+      // the in-flight trip). The save overwrites at the same key, so the
+      // box still holds exactly one row for that session.
+      final host2 = _FakeHost()..sessionId = host1.sessionId;
+      build(host2).handleDrop();
+
+      final rows = pausedRepo.loadAll();
+      expect(rows, hasLength(1),
+          reason: 'a re-drop on the same session id must overwrite, not '
+              'duplicate, the persisted paused row');
+      expect(rows.single.id, host1.sessionId);
+    });
+
+    test('cancelAllTimers clears the silent flag so a stopped session '
+        'cannot escalate after teardown', () {
+      final host = _FakeHost();
+      final mgr = build(
+        host,
+        silentWindow: const Duration(seconds: 6),
+        pinnedMac: 'AA:BB',
+        scannerFactory: (mac, onReconnect) =>
+            _FakeScanner()..onReconnect = onReconnect,
+      );
+
+      mgr.handleDrop();
+      expect(mgr.silentlyReconnecting, isTrue);
+
+      mgr.cancelAllTimers();
+      expect(mgr.silentlyReconnecting, isFalse,
+          reason: 'stop()/cancelAllTimers must clear the silent flag so a '
+              'pending window can never escalate after teardown');
+    });
+  });
+}
+
+/// Deterministic fake of the recording session the manager recovers.
+/// Mirrors how `TripRecordingController` exposes its lifecycle to the
+/// manager: [resumeFromReconnect] clears the drop state the same way the
+/// real controller's resume() does, so the manager's reconnect path can
+/// be asserted end-to-end.
+class _FakeHost implements DroppedSessionHost {
+  int stopSchedulerCalls = 0;
+  int startSchedulerCalls = 0;
+  int resetDropDetectorCalls = 0;
+  int clearErrorWindowCalls = 0;
+  int emitStateCalls = 0;
+  int resumeFromReconnectCalls = 0;
+
+  @override
+  bool pausedDueToDrop = false;
+  @override
+  bool stopped = false;
+  @override
+  bool started = true;
+  @override
+  bool paused = false;
+
+  @override
+  String? sessionId = '2026-05-28T12:00:00.000';
+  @override
+  String? vehicleId = 'car-under-test';
+  @override
+  String? vin = 'WVWZZZ1JZXW000001';
+  @override
+  double? odometerStartKm = 1000.0;
+  @override
+  double? odometerLatestKm = 1005.0;
+  @override
+  bool automatic = false;
+
+  @override
+  void stopScheduler() => stopSchedulerCalls++;
+
+  @override
+  void startScheduler() => startSchedulerCalls++;
+
+  @override
+  void resetDropDetector() => resetDropDetectorCalls++;
+
+  @override
+  void clearDropDetectorErrorWindow() => clearErrorWindowCalls++;
+
+  @override
+  void emitState() => emitStateCalls++;
+
+  @override
+  void resumeFromReconnect() {
+    resumeFromReconnectCalls++;
+    // Mirror TripRecordingController.resume()'s drop-recovery half.
+    pausedDueToDrop = false;
+    startScheduler();
+  }
+
+  @override
+  TripSummary buildInProgressSummary() => _summary(distanceKm: 2.5);
+
+  @override
+  TripSummary buildFinalSummary() => _summary(distanceKm: 5.0);
+
+  TripSummary _summary({required double distanceKm}) => TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 2200,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: DateTime(2026, 5, 28, 12),
+        endedAt: DateTime(2026, 5, 28, 12, 10),
+      );
+}
+
+/// Observation-only scanner: records start()/stop() counts and lets a
+/// test fire its [onReconnect] manually. The real backoff math is
+/// covered by `adapter_reconnect_scanner_test.dart`.
+class _FakeScanner implements AdapterReconnectScanner {
+  VoidCallback? onReconnect;
+  int startCalls = 0;
+  int stopCalls = 0;
+  bool _scanning = false;
+
+  @override
+  String get pinnedMac => 'AA:BB';
+
+  @override
+  Duration get currentBackoff => const Duration(seconds: 5);
+
+  @override
+  bool get isScanning => _scanning;
+
+  @override
+  Future<void> start() async {
+    _scanning = true;
+    startCalls++;
+  }
+
+  @override
+  Future<void> stop() async {
+    _scanning = false;
+    stopCalls++;
+  }
+}


### PR DESCRIPTION
## What

Second slice (after #2187's `TripDistanceResolver`) of the #2167/#2188
god-class decomposition of `TripRecordingController`. Extracts the
connection-drop **recovery** lifecycle into a focused, unit-testable
`DroppedSessionManager`.

Closes #2188.

## What moved (verbatim, behaviour-preserving)

- **#1904 silent-reconnect window** — invisible drop → scanner probe →
  silent resume vs escalate-to-visible.
- **Visible-drop escalation + #797 grace timer + auto-finalise** into
  trip history when no resume arrives before the window elapses.
- **#797 phase-3 reconnect-scanner orchestration** — build/start/stop +
  the `onReconnect` reaction (silent-path vs visible-path recovery).
- **Paused/history Hive persistence** — persist-on-drop, lazy repo
  resolution (or test overrides), paused-row clearing.

Same grace + silent-reconnect durations, same persistence keys/format,
same #1920 trace-log events, same reconnect decision logic. This is a
pure refactor, **not** a behaviour change.

`TripDropReason` moved with the state machine and is re-exported from the
controller, so every existing caller (providers, pause-banner widget,
tests) compiles unchanged.

## How it's testable

The manager reaches the recording loop through an injected
`DroppedSessionHost` seam (its own file `dropped_session_host.dart`). In
production the controller's private `_DroppedSessionHostAdapter` wires
the real session; in tests a fake host + in-memory Hive repos + a
hand-driven scanner exercise every branch deterministically — no real
`Obd2Service`, scheduler, or wall-clock timer.

## Line counts

| File | Lines |
|---|---|
| `trip_recording_controller.dart` (before → after) | 1459 → 1226 (−233) |
| `dropped_session_manager.dart` (new) | 400 content (under the 400 cap) |
| `dropped_session_host.dart` (new seam) | 73 |
| `dropped_session_manager_test.dart` (new) | 487 |

Controller stays grandfathered in the file-length lint; the ratchet only
shrinks, so no baseline edit is needed.

## Verification

- `flutter analyze`: only the 2 pre-existing baseline info issues
  (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`).
  No new errors/warnings.
- `dart run build_runner build`: no `.g.dart` drift (no codegen inputs
  changed).
- `flutter test test/features/consumption/ test/lint/`: all pass —
  including the file-length lint, the existing controller drop/reconnect
  suites (delegation verified green), and 12 new manager tests covering
  persist-on-drop, grace-window auto-finalise, reconnect-within /
  after-grace, silent-window absorb / escalate, silentFailure
  straight-to-visible, no-pinned-MAC fallback, and restart-with-persisted
  -session (re-drop overwrites, not duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
