### PR TITLE
refactor(trips): split OBD2/GPS-only recording pipelines behind a strategy (#2190)

### DIFF
--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:geolocator/geolocator.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/logging/error_logger.dart';
+import '../../vehicle/domain/entities/gps_calibration_matrix.dart';
+import '../../vehicle/providers/vehicle_providers.dart';
+import '../data/obd2/trip_live_reading.dart';
+import '../domain/driving_coaching.dart'
+    show gpsCoachingHint, recentSamplesWithin;
+import '../domain/gps_driving_features.dart';
+import '../domain/services/gps_fuel_estimator.dart';
+import '../domain/trip_recorder.dart';
+import 'recording_pipeline.dart';
+import 'trip_recording_phase.dart';
+import 'trip_recording_state.dart';
+
+/// #2025 GPS-only recording pipeline, extracted from the [TripRecording]
+/// notifier behind the [RecordingPipeline] strategy seam (#2190).
+///
+/// Lets users record a trajet without an OBD2 dongle: samples come from
+/// Geolocator, the [TripRecorder] accumulator runs the same harsh-event /
+/// distance / idle integration it does for OBD2 trips, and the persisted
+/// summary carries `kind: TripKind.gpsOnly` so downstream surfaces
+/// (confidence-tier badge, recording-screen redesign) can adapt.
+///
+/// ## What this owns (moved off the notifier verbatim)
+///
+///   * the [TripRecorder] accumulator,
+///   * the Geolocator position [StreamSubscription],
+///   * the raw [TripSample] buffer + the trip-start timestamp,
+///   * the per-fix ingest ([_onPosition]) that synthesises a sample,
+///     feeds the recorder, and publishes the live reading + GPS coaching
+///     hint, and
+///   * the stop path that builds the final summary, runs the #2080
+///     GPS-fuel imputation, and persists.
+///
+/// ## What it deliberately does NOT own
+///
+/// Publishing the notifier's Riverpod `state`, the last-trip identity
+/// fields, and the shared `_saveToHistory` write stay on the notifier and
+/// are reached through the injected [RecordingPipelineHost] — exactly the
+/// host-seam idiom [DroppedSessionManager] uses (#2188). Riverpod-backed
+/// reads (the Geolocator wrapper, the active vehicle's calibration
+/// matrix) go through [_ref], mirroring [TripGpsStreamController].
+class GpsOnlyRecordingPipeline implements RecordingPipeline {
+  GpsOnlyRecordingPipeline({
+    required Ref ref,
+    required RecordingPipelineHost host,
+  })  : _ref = ref,
+        _host = host;
+
+  final Ref _ref;
+  final RecordingPipelineHost _host;
+
+  @override
+  bool get isGpsOnly => true;
+
+  /// Pure accumulator — same recorder the OBD2 path uses, so the
+  /// distance / harsh-event / idle integration is byte-identical.
+  TripRecorder? _recorder;
+  StreamSubscription<Position>? _sub;
+  final List<TripSample> _samples = [];
+  DateTime? _startedAt;
+
+  /// Open the Geolocator stream, prime the recorder, and seed the
+  /// recording state. Returns true once the stream is opened.
+  ///
+  /// Moved verbatim from `TripRecording.startGpsOnly`'s body — the
+  /// re-entrancy guard + `alreadyActive` short-circuit stay on the
+  /// notifier (they read `state.isActive` / `_startInProgress`, which
+  /// are notifier concerns), so this entry point assumes it is clear to
+  /// start.
+  void start() {
+    _recorder = TripRecorder(maxIntegrationGapSeconds: 30);
+    _samples.clear();
+    _startedAt = DateTime.now();
+    _host.lastTripStartedAt = DateTime.now();
+    _host.lastTripVehicleId = _host.readActiveVehicleId();
+    // Subscribe to the position stream at high accuracy — the
+    // post-trip map polyline + confidence-tier UX both want ~10 m
+    // precision. Permission failure is non-fatal: the stream errors
+    // and we log; the user sees an unmoving recording until they
+    // grant permission or stop.
+    final geo = _ref.read(geolocatorWrapperProvider);
+    _sub = geo
+        .getPositionStream(
+          locationSettings: const LocationSettings(
+            accuracy: LocationAccuracy.high,
+          ),
+        )
+        .listen(
+          _onPosition,
+          onError: (Object e, StackTrace st) {
+            unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+                context: const {
+                  'where': 'GpsOnlyRecordingPipeline.start: stream error'
+                }));
+          },
+        );
+    // Seed the state so the recording screen renders immediately
+    // (the first GPS fix can be 1-3 s away on a cold start).
+    _host.state = _host.state.copyWith(
+      phase: TripRecordingPhase.recording,
+      live: const TripLiveReading(
+        elapsed: Duration.zero,
+        distanceKmSoFar: 0,
+      ),
+    );
+  }
+
+  void _onPosition(Position p) {
+    final recorder = _recorder;
+    final startedAt = _startedAt;
+    if (recorder == null || startedAt == null) return;
+    // Geolocator can report a stale fix in the first emit before the
+    // GPS warms up — guard against speed = NaN / negative.
+    final speedMps = p.speed.isFinite && p.speed >= 0 ? p.speed : 0.0;
+    final sample = TripSample(
+      timestamp: p.timestamp,
+      speedKmh: speedMps * 3.6,
+      rpm: 0,
+      latitude: p.latitude.isFinite ? p.latitude : null,
+      longitude: p.longitude.isFinite ? p.longitude : null,
+      altitudeM: p.altitude.isFinite ? p.altitude : null,
+      hAccuracyM: p.accuracy.isFinite ? p.accuracy : null,
+      bearingDeg: p.heading.isFinite ? p.heading : null,
+    );
+    _samples.add(sample);
+    recorder.onSample(sample);
+    final summary = recorder.buildSummary();
+    // #2058/#2174 — GPS coaching hint from the most recent 5 s of
+    // samples on every emit. recentSamplesWithin scans only a bounded
+    // tail so the per-emit cost is O(window), not O(trajet) — the old
+    // `.where` over the whole buffer grew linearly with trip length
+    // (despite a comment claiming O(window)).
+    final recent = recentSamplesWithin(
+      _samples,
+      const Duration(seconds: 5),
+      sample.timestamp,
+    );
+    final coaching = gpsCoachingHint(recent);
+    _host.state = _host.state.copyWith(
+      phase: TripRecordingPhase.recording,
+      live: TripLiveReading(
+        speedKmh: sample.speedKmh,
+        distanceKmSoFar: summary.distanceKm,
+        elapsed: DateTime.now().difference(startedAt),
+      ),
+      gpsCoachingHint: coaching,
+      clearGpsCoachingHint: coaching == null,
+    );
+  }
+
+  @override
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
+    final recorder = _recorder;
+    await _sub?.cancel();
+    _sub = null;
+    if (recorder == null) {
+      _host.state = const TripRecordingState();
+      return const StoppedTripResult.empty();
+    }
+    final samples = List<TripSample>.unmodifiable(_samples);
+    // #2025 — derive `kind` from the actual sample stream rather than
+    // hardcoding `gpsOnly`. If [appendObd2Sample] (or any future
+    // mid-trip path) injected OBD2 samples into the buffer, the
+    // resulting kind correctly flips to `gpsPlusObd2`.
+    var summary = recorder.buildSummary().copyWith(
+          kind: TripKind.fromSamples(samples),
+        );
+    // #2080 — for GPS-only / hybrid trips (no OBD2 fuel-rate
+    // coverage), feed the sample stream through GpsDrivingFeatures +
+    // the active vehicle's GpsCalibrationMatrix to impute
+    // `avgLPer100Km` and `fuelLitersConsumed`. The fields stay null
+    // when no active vehicle exists, when the trajet has no
+    // distance, or when the OBD2 path already populated them
+    // (gpsPlusObd2 trips skip this branch — `summary.kind` is the
+    // gate).
+    if (summary.kind == TripKind.gpsOnly && summary.avgLPer100Km == null) {
+      final features = GpsDrivingFeatures.from(samples);
+      if (features != null) {
+        final vehicle = _ref.read(activeVehicleProfileProvider);
+        final matrix =
+            vehicle?.gpsCalibration ?? GpsCalibrationMatrix.coldStart();
+        final est = GpsFuelEstimator.estimate(
+          matrix: matrix,
+          features: features,
+        );
+        if (est != null) {
+          summary = summary.copyWith(
+            avgLPer100Km: est.lPer100Km,
+            fuelLitersConsumed: est.litersConsumed,
+          );
+        }
+      }
+    }
+    await _host.saveToHistory(
+      summary,
+      samples: samples,
+      automatic: automatic,
+    );
+    _recorder = null;
+    _samples.clear();
+    _startedAt = null;
+    _host.state = const TripRecordingState();
+    return StoppedTripResult(
+      summary: summary,
+      odometerStartKm: null,
+      odometerLatestKm: null,
+    );
+  }
+
+  /// #2025 — mid-trip upgrade hook. Appends an externally-built
+  /// [TripSample] (carrying OBD2 telemetry) to the in-progress buffer +
+  /// recorder so the final [TripSummary.kind] flips to `gpsPlusObd2` via
+  /// [TripKind.fromSamples].
+  ///
+  /// No-op once the pipeline has stopped (the recorder is null). Future
+  /// UX surface (banner: "OBD2 detected — attach to current trip?")
+  /// drives this; until then it exists so the acceptance scenario is
+  /// testable + the data layer supports it the moment any caller starts
+  /// producing OBD2-flavoured samples. Reached only through the notifier's
+  /// `@visibleForTesting` `debugAppendObd2SampleToGpsOnly`.
+  void appendObd2Sample(TripSample sample) {
+    final recorder = _recorder;
+    if (recorder == null) return;
+    _samples.add(sample);
+    recorder.onSample(sample);
+  }
+}

--- a/lib/features/consumption/providers/recording_pipeline.dart
+++ b/lib/features/consumption/providers/recording_pipeline.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../domain/entities/gps_sample_diagnostic.dart';
+import '../domain/trip_recorder.dart';
+import 'trip_recording_state.dart';
+
+/// Strategy seam for a complete trip-recording pipeline (#2190).
+///
+/// The [TripRecording] notifier historically owned two mutually-
+/// exclusive recording pipelines as sibling field sets and branched on
+/// an `if (_gpsOnlyMode)` boolean at every lifecycle boundary:
+///
+///   * the sensor-rich **OBD2** pipeline (engine signals via the
+///     [Obd2Service] / [TripRecordingController]), and
+///   * the **GPS-only** pipeline (#2025 — no dongle, samples synthesised
+///     from Geolocator fixes feeding a pure [TripRecorder]).
+///
+/// This interface lifts that branch into virtual dispatch: the notifier
+/// holds a single `RecordingPipeline?` selected at start (null = the
+/// inline OBD2 path; a [RecordingPipeline] = an alternate strategy such
+/// as [GpsOnlyRecordingPipeline]) and delegates the lifecycle operations
+/// that used to fork on the boolean. A future third source (CarPlay /
+/// Android Auto telemetry) becomes a new implementation rather than
+/// another `_xMode` bool and another `if`-branch on every method
+/// (open/closed — the #2190 motivation).
+///
+/// ## Why the OBD2 path stays inline (slice-3 scoping)
+///
+/// #2190 explicitly recommends staging the extraction — "interface +
+/// GPS-only impl first, OBD2 impl second" — because the OBD2 `start` /
+/// `stop` bodies are woven through ~15 notifier-private collaborators
+/// (baseline store, haptics, the GPS-fix stream, the OEM-PID poll, the
+/// debounced active-trip snapshot persistence, the reconnect-scanner
+/// factory, adapter-identity snapshotting, baseline flush + sync,
+/// service disconnect). Pulling all of that behind a uniform `start` /
+/// `stop` would widen the seam past a behaviour-preserving refactor.
+/// So the OBD2 path remains the notifier's inline default (`_pipeline ==
+/// null`) and only the genuinely self-contained GPS-only pipeline is
+/// extracted to a concrete strategy in this slice. The interface is
+/// shaped so an `Obd2RecordingPipeline` can adopt it later without
+/// disturbing callers.
+abstract class RecordingPipeline {
+  /// True for a GPS-only / dongle-less pipeline. Lets the notifier and
+  /// tests assert which strategy was selected without depending on the
+  /// concrete type.
+  bool get isGpsOnly;
+
+  /// Tear the pipeline down, persist the finished trip, and return the
+  /// [StoppedTripResult] the recording screen renders into its summary
+  /// view. [automatic] tags the saved entry as auto-recorded (#1004).
+  ///
+  /// Mirrors the contract of the notifier's own `stop` so the branch
+  /// `if (_gpsOnlyMode) return _stopGpsOnly(...)` collapses to a single
+  /// `return _pipeline!.stop(...)` delegation.
+  Future<StoppedTripResult> stop({bool automatic = false});
+}
+
+/// Narrow seam a [RecordingPipeline] uses to drive and read the
+/// [TripRecording] notifier without owning the notifier's Riverpod
+/// `state`, its trip-identity bookkeeping, or the shared history-write
+/// path (#2190).
+///
+/// Mirrors the injected-host idiom established by [DroppedSessionHost]
+/// (#2188): the pipeline owns the *recording* concern (its recorder, its
+/// sample buffer, its position subscription) while the bits that belong
+/// to the notifier — publishing `state`, the last-trip identity fields,
+/// and `_saveToHistory` — stay on the notifier and are reached through
+/// this interface. Keeps the pipeline unit-testable against a fake host
+/// (no real notifier / Riverpod container required).
+abstract class RecordingPipelineHost {
+  /// Read back the notifier's current public recording state.
+  TripRecordingState get state;
+
+  /// Publish a new recording state (the notifier's `state =` setter).
+  set state(TripRecordingState value);
+
+  /// Record the vehicle / start-time the in-flight trip is scoped to,
+  /// so the fill-up auto-link window can resolve it later (#888).
+  set lastTripVehicleId(String? value);
+  set lastTripStartedAt(DateTime? value);
+
+  /// Resolve the active vehicle profile id, swallowing provider-wiring
+  /// errors (returns null in widget tests / no-vehicle state).
+  String? readActiveVehicleId();
+
+  /// Persist the finished trip into the rolling trip-history log. Shared
+  /// with the OBD2 path — every trip (including discarded stubs, which
+  /// the implementation filters) flows through the same write so the
+  /// stub-discard + trip-sync + auto-record-badge bookkeeping is applied
+  /// identically regardless of pipeline.
+  Future<void> saveToHistory(
+    TripSummary summary, {
+    bool automatic,
+    List<TripSample> samples,
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics,
+  });
+}
+
+/// Returned by [TripRecording.stop] / [RecordingPipeline.stop]. Bundles
+/// the summary with the raw odometer reads so the save-as-fill-up flow
+/// can pre-fill the form.
+///
+/// Lives here (rather than on the notifier) because it is the
+/// [RecordingPipeline.stop] return type — keeping it next to the strategy
+/// seam avoids a circular import between the notifier and its pipelines.
+/// `TripRecording`'s library re-exports it so existing callers that import
+/// the provider keep resolving the type unchanged.
+class StoppedTripResult {
+  final TripSummary summary;
+  final double? odometerStartKm;
+  final double? odometerLatestKm;
+
+  const StoppedTripResult({
+    required this.summary,
+    required this.odometerStartKm,
+    required this.odometerLatestKm,
+  });
+
+  const StoppedTripResult.empty()
+      : summary = const TripSummary(
+          distanceKm: 0,
+          maxRpm: 0,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+        ),
+        odometerStartKm = null,
+        odometerLatestKm = null;
+
+  /// End-of-trip km, derived: latest odometer read if we have one,
+  /// otherwise start + integrated distance. Null when neither
+  /// odometer read ever succeeded.
+  double? get endOdometerKm =>
+      odometerLatestKm ??
+      (odometerStartKm == null
+          ? null
+          : odometerStartKm! + summary.distanceKm);
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -5,11 +5,8 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import '../../../core/location/geolocator_wrapper.dart';
 
 import '../../../core/feedback/auto_record_badge_provider.dart';
 import '../../../core/feedback/auto_record_badge_service.dart';
@@ -33,13 +30,10 @@ import '../data/obd2/trip_recording_controller.dart';
 import 'obd2_breadcrumb_provider.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/cold_start_baselines.dart';
-import '../domain/driving_coaching.dart'
-    show gpsCoachingHint, recentSamplesWithin;
 import '../domain/entities/gps_sample_diagnostic.dart';
-import '../domain/gps_driving_features.dart';
-import '../domain/services/gps_fuel_estimator.dart';
 import '../domain/trip_recorder.dart';
-import '../../vehicle/domain/entities/gps_calibration_matrix.dart';
+import 'gps_only_recording_pipeline.dart';
+import 'recording_pipeline.dart';
 import 'trip_baseline_recorder.dart';
 import 'trip_gps_stream_controller.dart';
 import 'trip_haptic_controller.dart';
@@ -62,6 +56,10 @@ export 'trip_recording_state.dart' show TripRecordingState;
 // `tripRecordingProvider.select((s) => s.dropReason)` resolve the
 // type without a second import.
 export '../data/obd2/trip_recording_controller.dart' show TripDropReason;
+// #2190 — StoppedTripResult moved next to the RecordingPipeline strategy
+// seam to avoid a circular import. Re-export it so the ~10 callers that
+// import this provider keep resolving the type without a new import.
+export 'recording_pipeline.dart' show StoppedTripResult;
 
 part 'trip_recording_provider.g.dart';
 
@@ -103,16 +101,14 @@ class TripRecording extends _$TripRecording {
   String? _adapterName;
   String? _adapterFirmware;
 
-  // #2025 — GPS-only recording mode. When `_gpsOnlyMode` is true the
-  // notifier is running a parallel pipeline that taps Geolocator
-  // directly, feeds a pure [TripRecorder], and persists with
-  // `kind: TripKind.gpsOnly` on stop. No `_controller` / `_service` is
-  // created in this mode — the OBD2 polling loop simply isn't started.
-  bool _gpsOnlyMode = false;
-  TripRecorder? _gpsOnlyRecorder;
-  StreamSubscription<Position>? _gpsOnlySub;
-  final List<TripSample> _gpsOnlySamples = [];
-  DateTime? _gpsOnlyStartedAt;
+  // #2190 — the selected alternate recording strategy, or null for the
+  // inline OBD2 path (the historical default). Selected at start: the
+  // dongle-less #2025 flow installs a [GpsOnlyRecordingPipeline] here and
+  // every former `if (_gpsOnlyMode)` lifecycle branch collapses to a
+  // single `_pipeline != null` virtual dispatch. A future third source
+  // (CarPlay / Android Auto telemetry) becomes another implementation
+  // rather than another `_xMode` bool (open/closed — #2190 motivation).
+  RecordingPipeline? _pipeline;
 
   // #1458 phase 2 — most recent app lifecycle state observed by the
   // wiring layer's [WidgetsBindingObserver]. Read by the GPS stream
@@ -169,6 +165,14 @@ class TripRecording extends _$TripRecording {
   /// without spinning up a real polling clock. Null between trips.
   @visibleForTesting
   TripRecordingController? get debugController => _controller;
+
+  /// Exposed for tests (#2190): true when an alternate GPS-only
+  /// [RecordingPipeline] is the selected strategy (i.e. the trip was
+  /// started via [startGpsOnly]), false for the inline OBD2 path or when
+  /// no trip is running. Lets the strategy-selection test assert which
+  /// pipeline the notifier picked without depending on the concrete type.
+  @visibleForTesting
+  bool get debugIsGpsOnlyActive => _pipeline?.isGpsOnly ?? false;
 
   /// Snapshot of the vehicle the last [startTrip] call was scoped to.
   /// Exposed so the save-as-fill-up path can figure out which
@@ -230,6 +234,17 @@ class TripRecording extends _$TripRecording {
   @override
   TripRecordingState build() {
     return const TripRecordingState();
+  }
+
+  /// #2190 — read / publish the recording state on behalf of an alternate
+  /// [RecordingPipeline]. The Riverpod `state` getter + setter are
+  /// protected to the notifier instance, so the [RecordingPipelineHost]
+  /// adapter routes its access through these methods rather than touching
+  /// `state` from outside the class — mirroring the `_emitState()` seam the
+  /// controller exposes to its [DroppedSessionHost] (#2188).
+  TripRecordingState _stateForPipeline() => state;
+  void _setStateFromPipeline(TripRecordingState value) {
+    state = value;
   }
 
   /// Standalone entry point for starting a trajet (#888).
@@ -581,10 +596,13 @@ class TripRecording extends _$TripRecording {
   /// wrapper below) so the launcher-icon badge increments only when
   /// the coordinator was the one that decided to save.
   Future<StoppedTripResult> stop({bool automatic = false}) async {
-    // #2025 — GPS-only mode runs its own teardown that bypasses the
-    // OBD2 controller / service entirely.
-    if (_gpsOnlyMode) {
-      return _stopGpsOnly(automatic: automatic);
+    // #2190 — an alternate strategy (e.g. #2025 GPS-only) runs its own
+    // teardown that bypasses the OBD2 controller / service entirely.
+    final pipeline = _pipeline;
+    if (pipeline != null) {
+      final result = await pipeline.stop(automatic: automatic);
+      _pipeline = null;
+      return result;
     }
     final ctl = _controller;
     final svc = _service;
@@ -1217,19 +1235,21 @@ class TripRecording extends _$TripRecording {
   }
 
   // ---------------------------------------------------------------------------
-  // #2025 — GPS-only recording path. Lets users record a trajet without
-  // an OBD2 dongle: samples come from Geolocator, the TripRecorder
+  // #2025 / #2190 — GPS-only recording path. Lets users record a trajet
+  // without an OBD2 dongle: samples come from Geolocator, the TripRecorder
   // accumulator runs the same harsh-event / distance / idle integration
   // it does for OBD2 trips, and the persisted summary carries
   // `kind: TripKind.gpsOnly` so downstream surfaces (confidence-tier
-  // badge, recording-screen redesign) can adapt.
+  // badge, recording-screen redesign) can adapt. The pipeline itself now
+  // lives in [GpsOnlyRecordingPipeline], selected into `_pipeline` here
+  // and driven through the [RecordingPipelineHost] seam below.
   // ---------------------------------------------------------------------------
 
   /// Start a GPS-only trajet recording (#2025). Skips the OBD2 service
-  /// + adapter picker entirely; instead opens a Geolocator stream and
-  /// feeds a pure [TripRecorder] with synthetic samples (speed from
-  /// `Position.speed`, all engine fields null, lat/lon/altitude/bearing
-  /// from the fix).
+  /// + adapter picker entirely; instead installs a [GpsOnlyRecordingPipeline]
+  /// that opens a Geolocator stream and feeds a pure [TripRecorder] with
+  /// synthetic samples (speed from `Position.speed`, all engine fields
+  /// null, lat/lon/altitude/bearing from the fix).
   ///
   /// Returns:
   ///  - [StartTripOutcome.started] when the stream was opened. Caller
@@ -1242,147 +1262,16 @@ class TripRecording extends _$TripRecording {
     }
     _startInProgress = true;
     try {
-      _gpsOnlyMode = true;
-      _gpsOnlyRecorder = TripRecorder(maxIntegrationGapSeconds: 30);
-      _gpsOnlySamples.clear();
-      _gpsOnlyStartedAt = DateTime.now();
-      _lastTripStartedAt = DateTime.now();
-      _lastTripVehicleId = _tryReadActiveVehicle()?.id;
-      // Subscribe to the position stream at high accuracy — the
-      // post-trip map polyline + confidence-tier UX both want ~10 m
-      // precision. Permission failure is non-fatal: the stream errors
-      // and we log; the user sees an unmoving recording until they
-      // grant permission or stop.
-      final geo = ref.read(geolocatorWrapperProvider);
-      _gpsOnlySub = geo
-          .getPositionStream(
-            locationSettings: const LocationSettings(
-              accuracy: LocationAccuracy.high,
-            ),
-          )
-          .listen(
-            _onGpsOnlyPosition,
-            onError: (Object e, StackTrace st) {
-              unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording.startGpsOnly: stream error'}));
-            },
-          );
-      // Seed the state so the recording screen renders immediately
-      // (the first GPS fix can be 1-3 s away on a cold start).
-      state = state.copyWith(
-        phase: TripRecordingPhase.recording,
-        live: const TripLiveReading(
-          elapsed: Duration.zero,
-          distanceKmSoFar: 0,
-        ),
+      final pipeline = GpsOnlyRecordingPipeline(
+        ref: ref,
+        host: _RecordingPipelineHostAdapter(this),
       );
+      _pipeline = pipeline;
+      pipeline.start();
       return StartTripOutcome.started;
     } finally {
       _startInProgress = false;
     }
-  }
-
-  void _onGpsOnlyPosition(Position p) {
-    final recorder = _gpsOnlyRecorder;
-    final startedAt = _gpsOnlyStartedAt;
-    if (recorder == null || startedAt == null || !_gpsOnlyMode) return;
-    // Geolocator can report a stale fix in the first emit before the
-    // GPS warms up — guard against speed = NaN / negative.
-    final speedMps = p.speed.isFinite && p.speed >= 0 ? p.speed : 0.0;
-    final sample = TripSample(
-      timestamp: p.timestamp,
-      speedKmh: speedMps * 3.6,
-      rpm: 0,
-      latitude: p.latitude.isFinite ? p.latitude : null,
-      longitude: p.longitude.isFinite ? p.longitude : null,
-      altitudeM: p.altitude.isFinite ? p.altitude : null,
-      hAccuracyM: p.accuracy.isFinite ? p.accuracy : null,
-      bearingDeg: p.heading.isFinite ? p.heading : null,
-    );
-    _gpsOnlySamples.add(sample);
-    recorder.onSample(sample);
-    final summary = recorder.buildSummary();
-    // #2058/#2174 — GPS coaching hint from the most recent 5 s of
-    // samples on every emit. recentSamplesWithin scans only a bounded
-    // tail so the per-emit cost is O(window), not O(trajet) — the old
-    // `.where` over the whole buffer grew linearly with trip length
-    // (despite a comment claiming O(window)).
-    final recent = recentSamplesWithin(
-      _gpsOnlySamples,
-      const Duration(seconds: 5),
-      sample.timestamp,
-    );
-    final coaching = gpsCoachingHint(recent);
-    state = state.copyWith(
-      phase: TripRecordingPhase.recording,
-      live: TripLiveReading(
-        speedKmh: sample.speedKmh,
-        distanceKmSoFar: summary.distanceKm,
-        elapsed: DateTime.now().difference(startedAt),
-      ),
-      gpsCoachingHint: coaching,
-      clearGpsCoachingHint: coaching == null,
-    );
-  }
-
-  Future<StoppedTripResult> _stopGpsOnly({bool automatic = false}) async {
-    final recorder = _gpsOnlyRecorder;
-    await _gpsOnlySub?.cancel();
-    _gpsOnlySub = null;
-    if (recorder == null) {
-      _gpsOnlyMode = false;
-      state = const TripRecordingState();
-      return const StoppedTripResult.empty();
-    }
-    final samples = List<TripSample>.unmodifiable(_gpsOnlySamples);
-    // #2025 — derive `kind` from the actual sample stream rather than
-    // hardcoding `gpsOnly`. If [_upgradeGpsOnlyToObd2] (or any future
-    // mid-trip path) injected OBD2 samples into the buffer, the
-    // resulting kind correctly flips to `gpsPlusObd2`.
-    var summary = recorder.buildSummary().copyWith(
-          kind: TripKind.fromSamples(samples),
-        );
-    // #2080 — for GPS-only / hybrid trips (no OBD2 fuel-rate
-    // coverage), feed the sample stream through GpsDrivingFeatures +
-    // the active vehicle's GpsCalibrationMatrix to impute
-    // `avgLPer100Km` and `fuelLitersConsumed`. The fields stay null
-    // when no active vehicle exists, when the trajet has no
-    // distance, or when the OBD2 path already populated them
-    // (gpsPlusObd2 trips skip this branch — `summary.kind` is the
-    // gate).
-    if (summary.kind == TripKind.gpsOnly &&
-        summary.avgLPer100Km == null) {
-      final features = GpsDrivingFeatures.from(samples);
-      if (features != null) {
-        final vehicle = ref.read(activeVehicleProfileProvider);
-        final matrix = vehicle?.gpsCalibration ??
-            GpsCalibrationMatrix.coldStart();
-        final est = GpsFuelEstimator.estimate(
-          matrix: matrix,
-          features: features,
-        );
-        if (est != null) {
-          summary = summary.copyWith(
-            avgLPer100Km: est.lPer100Km,
-            fuelLitersConsumed: est.litersConsumed,
-          );
-        }
-      }
-    }
-    await _saveToHistory(
-      summary,
-      samples: samples,
-      automatic: automatic,
-    );
-    _gpsOnlyMode = false;
-    _gpsOnlyRecorder = null;
-    _gpsOnlySamples.clear();
-    _gpsOnlyStartedAt = null;
-    state = const TripRecordingState();
-    return StoppedTripResult(
-      summary: summary,
-      odometerStartKm: null,
-      odometerLatestKm: null,
-    );
   }
 
   /// #2025 — mid-trip upgrade hook. Appends an externally-built
@@ -1397,48 +1286,52 @@ class TripRecording extends _$TripRecording {
   /// caller starts producing OBD2-flavoured samples.
   @visibleForTesting
   void debugAppendObd2SampleToGpsOnly(TripSample sample) {
-    if (!_gpsOnlyMode) return;
-    final recorder = _gpsOnlyRecorder;
-    if (recorder == null) return;
-    _gpsOnlySamples.add(sample);
-    recorder.onSample(sample);
+    final pipeline = _pipeline;
+    if (pipeline is! GpsOnlyRecordingPipeline) return;
+    pipeline.appendObd2Sample(sample);
   }
 }
 
-/// Returned by [TripRecording.stop]. Bundles the summary with the
-/// raw odometer reads so the save-as-fill-up flow can pre-fill the
-/// form.
-class StoppedTripResult {
-  final TripSummary summary;
-  final double? odometerStartKm;
-  final double? odometerLatestKm;
+/// Adapts the [TripRecording] notifier to the narrow
+/// [RecordingPipelineHost] seam an alternate [RecordingPipeline] needs
+/// (#2190). Lives in the same library as the notifier so it can reach the
+/// notifier's `state` setter, last-trip identity fields, the active-vehicle
+/// read, and the shared `_saveToHistory` write without widening the
+/// notifier's public API — mirroring the `_DroppedSessionHostAdapter`
+/// idiom on the controller (#2188).
+class _RecordingPipelineHostAdapter implements RecordingPipelineHost {
+  _RecordingPipelineHostAdapter(this._n);
 
-  const StoppedTripResult({
-    required this.summary,
-    required this.odometerStartKm,
-    required this.odometerLatestKm,
-  });
+  final TripRecording _n;
 
-  const StoppedTripResult.empty()
-      : summary = const TripSummary(
-          distanceKm: 0,
-          maxRpm: 0,
-          highRpmSeconds: 0,
-          idleSeconds: 0,
-          harshBrakes: 0,
-          harshAccelerations: 0,
-        ),
-        odometerStartKm = null,
-        odometerLatestKm = null;
+  @override
+  TripRecordingState get state => _n._stateForPipeline();
 
-  /// End-of-trip km, derived: latest odometer read if we have one,
-  /// otherwise start + integrated distance. Null when neither
-  /// odometer read ever succeeded.
-  double? get endOdometerKm =>
-      odometerLatestKm ??
-      (odometerStartKm == null
-          ? null
-          : odometerStartKm! + summary.distanceKm);
+  @override
+  set state(TripRecordingState value) => _n._setStateFromPipeline(value);
+
+  @override
+  set lastTripVehicleId(String? value) => _n._lastTripVehicleId = value;
+
+  @override
+  set lastTripStartedAt(DateTime? value) => _n._lastTripStartedAt = value;
+
+  @override
+  String? readActiveVehicleId() => _n._tryReadActiveVehicle()?.id;
+
+  @override
+  Future<void> saveToHistory(
+    TripSummary summary, {
+    bool automatic = false,
+    List<TripSample> samples = const [],
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
+  }) =>
+      _n._saveToHistory(
+        summary,
+        automatic: automatic,
+        samples: samples,
+        gpsSampleDiagnostics: gpsSampleDiagnostics,
+      );
 }
 
 /// Outcome surfaced by [TripRecording.startTrip] so the UI layer can

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'8479b9d4927b3457a0f8acb735b449b43017af28';
+String _$tripRecordingHash() => r'4ef212e42d4ca9b76a2e4b80fa4c482271f92c4f';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -1,0 +1,313 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
+import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/gps_only_recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_phase.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_state.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+/// Direct unit tests for the #2190 [GpsOnlyRecordingPipeline] strategy,
+/// driving it against a fake [RecordingPipelineHost] + a controllable
+/// fake Geolocator so the start / ingest / derive / finalise behaviour is
+/// pinned without spinning up the whole [TripRecording] notifier.
+///
+/// This is new coverage: the GPS-only pipeline was previously inlined on
+/// the notifier and had no provider-level test exercising start →
+/// position → stop end to end.
+void main() {
+  group('GpsOnlyRecordingPipeline (#2190)', () {
+    test('isGpsOnly is true', () {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      expect(harness.pipeline.isGpsOnly, isTrue);
+    });
+
+    test('start() opens exactly one high-accuracy stream, seeds the '
+        'recording state, and records last-trip identity', () {
+      final harness = _Harness(activeVehicleId: 'veh-42');
+      addTearDown(harness.dispose);
+
+      harness.pipeline.start();
+
+      expect(harness.geo.positionStreamCallCount, 1);
+      expect(harness.geo.lastAccuracy, LocationAccuracy.high);
+      expect(harness.host.state.phase, TripRecordingPhase.recording);
+      expect(harness.host.state.live, isNotNull);
+      expect(harness.host.state.live!.distanceKmSoFar, 0);
+      // Identity bookkeeping is delegated back to the host.
+      expect(harness.host.lastTripVehicleId, 'veh-42');
+      expect(harness.host.lastTripStartedAt, isNotNull);
+    });
+
+    test('each position fix is synthesised into a GPS sample (rpm 0, '
+        'engine fields null) and pushed into the live state', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 10.0, altitude: 120));
+      await _pump();
+
+      final live = harness.host.state.live;
+      expect(live, isNotNull);
+      // 10 m/s == 36 km/h.
+      expect(live!.speedKmh, closeTo(36.0, 1e-9));
+      expect(harness.host.state.phase, TripRecordingPhase.recording);
+    });
+
+    test('a negative / NaN stale first speed fix is clamped to 0', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: -1.0));
+      await _pump();
+
+      expect(harness.host.state.live!.speedKmh, 0.0);
+    });
+
+    test('stop() with no recorder activity returns empty + resets state',
+        () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      // No fix ever arrived — recorder exists but never got a sample.
+      final result = await harness.pipeline.stop();
+
+      // A 0-distance / 0-sample trajet is a stub: the summary holds 0 km
+      // and the host's save path is the stub filter (asserted in the
+      // notifier-level discard tests). State resets to idle.
+      expect(result.summary.distanceKm, 0);
+      expect(harness.host.state.phase, TripRecordingPhase.idle);
+    });
+
+    test('stop() builds a gpsOnly summary from the fixes and persists '
+        'through the host', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      // Two moving fixes 1 s apart → non-zero integrated distance.
+      final t0 = DateTime(2026, 5, 29, 8);
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 20.0, at: t0));
+      await _pump();
+      harness.geo.emit(_pos(43.41, 3.51, speedMps: 20.0,
+          at: t0.add(const Duration(seconds: 1))));
+      await _pump();
+
+      final result = await harness.pipeline.stop(automatic: true);
+
+      expect(harness.host.saved, hasLength(1));
+      final saved = harness.host.saved.single;
+      // Pure GPS samples (rpm 0, no fuel rate) → kind gpsOnly.
+      expect(saved.summary.kind, TripKind.gpsOnly);
+      expect(saved.automatic, isTrue);
+      expect(saved.samples, isNotEmpty);
+      // Result mirrors the persisted summary; no odometer for GPS-only.
+      expect(result.summary.kind, TripKind.gpsOnly);
+      expect(result.odometerStartKm, isNull);
+      expect(result.odometerLatestKm, isNull);
+      // State reset to idle after teardown.
+      expect(harness.host.state.phase, TripRecordingPhase.idle);
+    });
+
+    test('appendObd2Sample mid-trip flips the finalised kind to '
+        'gpsPlusObd2', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      final t0 = DateTime(2026, 5, 29, 9);
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 20.0, at: t0));
+      await _pump();
+      // An externally-built OBD2-flavoured sample (rpm > 0) joins the
+      // buffer — the #2025 mid-trip upgrade.
+      harness.pipeline.appendObd2Sample(TripSample(
+        timestamp: t0.add(const Duration(seconds: 1)),
+        speedKmh: 72,
+        rpm: 2000,
+      ));
+
+      await harness.pipeline.stop();
+
+      expect(harness.host.saved.single.summary.kind, TripKind.gpsPlusObd2);
+    });
+
+    test('appendObd2Sample after stop is a no-op (recorder gone)',
+        () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+      await harness.pipeline.stop();
+
+      // Must not throw even though the recorder is null post-stop.
+      harness.pipeline.appendObd2Sample(TripSample(
+        timestamp: DateTime(2026, 5, 29, 10),
+        speedKmh: 50,
+        rpm: 1500,
+      ));
+    });
+
+    test('stop() cancels the Geolocator subscription', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+      expect(harness.geo.activeListeners, 1);
+
+      await harness.pipeline.stop();
+
+      expect(harness.geo.activeListeners, 0);
+    });
+  });
+}
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+/// Wires a [GpsOnlyRecordingPipeline] to a fake host + fake Geolocator.
+class _Harness {
+  _Harness({String? activeVehicleId})
+      : host = _FakeHost(activeVehicleId: activeVehicleId) {
+    container = ProviderContainer(overrides: [
+      geolocatorWrapperProvider.overrideWithValue(geo),
+      // No active vehicle → the #2080 GPS-fuel imputation branch sees a
+      // null profile and leaves avg / litres null, mirroring a fresh
+      // install. (Production reads the real provider here.)
+      activeVehicleProfileProvider.overrideWith(() => _NoActiveVehicle()),
+    ]);
+    // A tiny capturing provider hands us a real Ref to feed the pipeline.
+    pipeline = container.read(_pipelineProvider(host));
+  }
+
+  final _FakeHost host;
+  final _RecordingGeolocator geo = _RecordingGeolocator();
+  late final ProviderContainer container;
+  late final GpsOnlyRecordingPipeline pipeline;
+
+  void dispose() {
+    container.dispose();
+    geo.dispose();
+  }
+}
+
+/// Family provider that constructs the pipeline with the provider's own
+/// [Ref] so the unit test exercises the real Riverpod read path the
+/// production notifier uses (geolocator wrapper + active-vehicle).
+final _pipelineProvider =
+    Provider.family<GpsOnlyRecordingPipeline, RecordingPipelineHost>(
+  (ref, host) => GpsOnlyRecordingPipeline(ref: ref, host: host),
+);
+
+class _NoActiveVehicle extends ActiveVehicleProfile {
+  @override
+  VehicleProfile? build() => null;
+}
+
+class _FakeHost implements RecordingPipelineHost {
+  _FakeHost({this.activeVehicleId});
+
+  final String? activeVehicleId;
+
+  @override
+  TripRecordingState state = const TripRecordingState();
+
+  @override
+  String? lastTripVehicleId;
+
+  @override
+  DateTime? lastTripStartedAt;
+
+  final List<_Saved> saved = [];
+
+  @override
+  String? readActiveVehicleId() => activeVehicleId;
+
+  @override
+  Future<void> saveToHistory(
+    TripSummary summary, {
+    bool automatic = false,
+    List<TripSample> samples = const [],
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
+  }) async {
+    saved.add(_Saved(
+      summary: summary,
+      automatic: automatic,
+      samples: samples,
+      gpsSampleDiagnostics: gpsSampleDiagnostics,
+    ));
+  }
+}
+
+class _Saved {
+  _Saved({
+    required this.summary,
+    required this.automatic,
+    required this.samples,
+    required this.gpsSampleDiagnostics,
+  });
+
+  final TripSummary summary;
+  final bool automatic;
+  final List<TripSample> samples;
+  final List<GpsSampleDiagnostic> gpsSampleDiagnostics;
+}
+
+Position _pos(
+  double lat,
+  double lng, {
+  double speedMps = 0,
+  double altitude = 0,
+  DateTime? at,
+}) =>
+    Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: at ?? DateTime.now(),
+      accuracy: 5,
+      altitude: altitude,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: speedMps,
+      speedAccuracy: 0,
+    );
+
+/// Controllable fake [GeolocatorWrapper] — mirrors the one in
+/// trip_recording_provider_gps_test.dart.
+class _RecordingGeolocator extends GeolocatorWrapper {
+  int positionStreamCallCount = 0;
+  LocationAccuracy? lastAccuracy;
+  StreamController<Position>? _controller;
+  int activeListeners = 0;
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
+    positionStreamCallCount++;
+    lastAccuracy = locationSettings?.accuracy;
+    final prev = _controller;
+    if (prev != null && !prev.isClosed) prev.close();
+    _controller = StreamController<Position>(
+      onListen: () => activeListeners++,
+      onCancel: () => activeListeners--,
+    );
+    return _controller!.stream;
+  }
+
+  void emit(Position p) => _controller?.add(p);
+  void emitError(Object error) => _controller?.addError(error);
+
+  Future<void> dispose() async {
+    final c = _controller;
+    if (c != null && !c.isClosed) await c.close();
+  }
+}

--- a/test/features/consumption/providers/trip_recording_pipeline_selection_test.dart
+++ b/test/features/consumption/providers/trip_recording_pipeline_selection_test.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #2190 — pins which recording strategy the [TripRecording] notifier
+/// selects, and that the selection condition is unchanged: the dongle-
+/// less `startGpsOnly` entry point installs the GPS-only pipeline, while
+/// the OBD2 `start(service)` entry point runs the inline controller path
+/// (no alternate pipeline).
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('TripRecording strategy selection (#2190)', () {
+    test('startGpsOnly selects the GPS-only pipeline (no OBD2 controller)',
+        () async {
+      final fakeGeo = _FakeGeo();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      final outcome = await notifier.startGpsOnly();
+
+      expect(outcome, StartTripOutcome.started);
+      expect(notifier.debugIsGpsOnlyActive, isTrue,
+          reason: 'startGpsOnly must install the GPS-only pipeline');
+      // The OBD2 controller path is NOT taken — no controller exists.
+      expect(notifier.debugController, isNull);
+      expect(container.read(tripRecordingProvider).isActive, isTrue);
+
+      await notifier.stop();
+      // After stop the alternate pipeline is cleared.
+      expect(notifier.debugIsGpsOnlyActive, isFalse);
+    });
+
+    test('start(service) runs the inline OBD2 path (no GPS-only pipeline)',
+        () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+
+      expect(notifier.debugIsGpsOnlyActive, isFalse,
+          reason: 'the OBD2 start path must not install an alternate '
+              'pipeline');
+      expect(notifier.debugController, isNotNull);
+      expect(container.read(tripRecordingProvider).isActive, isTrue);
+
+      await notifier.stop();
+    });
+
+    test('startGpsOnly is a no-op while an OBD2 trip is already active',
+        () async {
+      final fakeGeo = _FakeGeo();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+
+      final outcome = await notifier.startGpsOnly();
+
+      expect(outcome, StartTripOutcome.alreadyActive);
+      // The OBD2 trip is untouched — still the controller path.
+      expect(notifier.debugIsGpsOnlyActive, isFalse);
+      expect(notifier.debugController, isNotNull);
+
+      await notifier.stop();
+    });
+  });
+}
+
+Map<String, String> _elmOk() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '01A6': '41 A6 00 01 6A 2C>',
+    };
+
+/// Controllable fake [GeolocatorWrapper]. Copies the proven shape from
+/// trip_recording_provider_gps_test.dart — the `emit` / `emitError`
+/// helpers keep the `close_sinks` analyzer happy by giving the field a
+/// traced sink consumer, and [dispose] closes the controller from the
+/// test's tearDown.
+class _FakeGeo extends GeolocatorWrapper {
+  StreamController<Position>? _controller;
+  int activeListeners = 0;
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
+    final prev = _controller;
+    if (prev != null && !prev.isClosed) {
+      prev.close();
+    }
+    _controller = StreamController<Position>(
+      onListen: () => activeListeners++,
+      onCancel: () => activeListeners--,
+    );
+    return _controller!.stream;
+  }
+
+  void emit(Position p) => _controller?.add(p);
+  void emitError(Object error) => _controller?.addError(error);
+
+  Future<void> dispose() async {
+    final c = _controller;
+    if (c != null && !c.isClosed) await c.close();
+  }
+}


### PR DESCRIPTION
Closes #2190.

Slice 3 (final) of the TripRecording god-class decomposition (parent #2167), after #2187 (TripDistanceResolver) and #2188 (DroppedSessionManager).

## Problem
The `TripRecording` notifier owned two complete, mutually-exclusive recording pipelines as sibling field sets and branched on an `if (_gpsOnlyMode)` boolean at every lifecycle boundary — the sensor-rich OBD2 path (`_service`/`_controller`) and the #2025 dongle-less GPS-only path (`_gpsOnlyMode`/`_gpsOnlyRecorder`/`_gpsOnlySub`/`_gpsOnlySamples`/`_gpsOnlyStartedAt`). Open/closed violation: a future third source meant another `_xMode` bool and another if-branch on every method.

## Change (behaviour-preserving Strategy extraction)
- New `RecordingPipeline` strategy interface (`stop({automatic})` + `isGpsOnly`) and a narrow injected `RecordingPipelineHost` seam, mirroring the slice-2 `DroppedSessionHost` idiom.
- New `GpsOnlyRecordingPipeline` concrete impl — the GPS-only start/ingest/derive/finalise bodies moved verbatim behind the host seam (same high-accuracy Geolocator stream, same synthetic-sample construction, same `TripKind.fromSamples` derivation, same #2080 `GpsFuelEstimator` imputation, same `_saveToHistory` write).
- The notifier now holds a single `RecordingPipeline? _pipeline`, selected at start; the `if (_gpsOnlyMode)` branch collapses to a `_pipeline != null` virtual dispatch. Selection logic is unchanged — `startGpsOnly` installs the GPS-only strategy, OBD2 `start(service)` stays the inline default (`_pipeline == null`).
- `StoppedTripResult` moved next to the strategy seam (it is the pipeline's return type) to avoid a notifier↔pipeline circular import; the provider re-exports it so all ~10 callers resolve it unchanged.

## What stayed on the notifier (and why)
The OBD2 start/stop bodies remain inline. They are woven through ~15 notifier-private collaborators (baseline store, haptics, GPS-fix stream, OEM-PID poll, debounced active-trip snapshot persistence, reconnect-scanner factory, adapter-identity snapshotting, baseline flush + sync, service disconnect). Pulling them behind a uniform start/stop would widen the seam past a behaviour-preserving refactor — #2190 itself flags the OBD2 impl as the deferred second stage and rates the risk high. The interface is shaped so an `Obd2RecordingPipeline` can adopt it later (open/closed achieved). This matches #2190's recommended staging: "interface + GPS-only impl first, OBD2 impl second".

## Line counts
- `trip_recording_provider.dart`: 1457 → 1350
- `recording_pipeline.dart`: 140 (new)
- `gps_only_recording_pipeline.dart`: 236 (new)

Both new files are well under the 400-line file-length cap.

## Tests
- New `gps_only_recording_pipeline_test.dart` (9 tests) — start/ingest/derive/finalise + mid-trip OBD2 upgrade + sub-cancellation, against a fake host + fake Geolocator. This is **new coverage**: the inlined GPS-only path had no provider-level test exercising start → position → stop.
- New `trip_recording_pipeline_selection_test.dart` (3 tests) — asserts `startGpsOnly` selects the GPS-only strategy (no OBD2 controller), `start(service)` runs the inline OBD2 path (no alternate pipeline), and `startGpsOnly` is a no-op while OBD2 is active.
- Full `test/features/consumption/` + `test/lint/` + the `trip_recording_journey_test` integration journey stay green (both-pipeline behaviour-preservation backstop). 2970 tests pass.

## Verification gate
- `dart run build_runner build` (clean): only the expected `trip_recording_provider.g.dart` hash changed (codegen input changed) — committed.
- `flutter analyze`: `2 issues found.` — exactly the two pre-existing info issues on master (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`). No new errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
