### PR TITLE
fix(obd2): send the ELM327 init sequence once, not twice, per connect (#2233)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
-import 'elm327_protocol.dart';
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
 import 'obd2_transport.dart';
@@ -58,9 +57,17 @@ class BluetoothObd2Transport implements Obd2Transport {
         _failPending(e);
       },
     );
-    for (final command in Elm327Protocol.initCommands) {
-      await _sendRaw(command);
-    }
+    // #2233 — the transport NO LONGER runs the ELM327 init handshake.
+    // The init (ATZ/ATE0/ATL0/ATH0/ATSP0/ATAT1) is owned solely by
+    // [Obd2Service.connect], which sends `adapter.initSequence`. Running
+    // it here too sent the six commands TWICE per connect — the second
+    // ATZ wiped the first init's echo/header/protocol state and re-paid
+    // a 1–2 s clone re-enumeration. We still flip `_connected=true` here
+    // once the channel is open and subscribed, because [sendCommand]
+    // throws on `!_connected` and the service-side init must be able to
+    // send. Every production caller routes through [Obd2Service.connect]
+    // (directly or via [Obd2ConnectionService.connect]/`connectByMac`),
+    // so the adapter still receives exactly one init burst.
     _connected = true;
   }
 

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
@@ -7,7 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/'
     'bluetooth_obd2_transport.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 
 /// TDD tests for the Bluetooth OBD2 transport (#716).
 ///
@@ -19,11 +21,14 @@ import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart'
 /// fake channel.
 void main() {
   group('BluetoothObd2Transport (#716)', () {
-    test('connect runs the ELM init sequence and leaves isConnected=true',
+    test(
+        'connect opens the channel and leaves isConnected=true WITHOUT '
+        'sending the ELM init (init is the service\'s job now, #2233)',
         () async {
       final channel = _ScriptedChannel();
-      // Scripted per-command responses — the channel streams each one
-      // when the transport writes the matching command.
+      // Scripted per-command responses — present but the transport must
+      // no longer fire them on connect(): #2233 moved the init burst to
+      // [Obd2Service.connect] so it is sent exactly once, not twice.
       channel.scriptResponse('ATZ\r', 'ELM327 v1.5>');
       channel.scriptResponse('ATE0\r', 'OK>');
       channel.scriptResponse('ATL0\r', 'OK>');
@@ -33,7 +38,48 @@ void main() {
       final transport = BluetoothObd2Transport(channel);
       await transport.connect();
 
-      expect(transport.isConnected, isTrue);
+      expect(transport.isConnected, isTrue,
+          reason: '_connected must flip true so the service-side init '
+              'can send — sendCommand throws on !_connected');
+      expect(channel.isOpen, isTrue);
+      expect(channel.writesAsStrings, isEmpty,
+          reason: 'the transport no longer self-inits (#2233)');
+    });
+
+    // #2233 — regression guard: the ELM327 init handshake must run EXACTLY
+    // ONCE across a full transport.connect() + service-driven init. Before
+    // #2233 the transport ran the six AT commands AND Obd2Service.connect
+    // re-sent them, so ATZ went out twice — the second reset wiped state
+    // and re-paid a 1–2 s clone re-enumeration.
+    test('ATZ is sent exactly once across transport + service connect',
+        () async {
+      final channel = _ScriptedChannel();
+      // Script the full init + the firmware probe the service sends after
+      // the init burst (#1401), so the service connect completes cleanly.
+      channel.scriptResponse('ATZ\r', 'ELM327 v1.5>');
+      channel.scriptResponse('ATE0\r', 'OK>');
+      channel.scriptResponse('ATL0\r', 'OK>');
+      channel.scriptResponse('ATH0\r', 'OK>');
+      channel.scriptResponse('ATSP0\r', 'OK>');
+      channel.scriptResponse('ATAT1\r', 'OK>');
+      channel.scriptResponse('ATI\r', 'ELM327 v1.5>');
+
+      // The transport connect (channel open + subscribe, no init) followed
+      // by the single init owner: Obd2Service.connect drives
+      // adapter.initSequence over the SAME transport.
+      final transport = BluetoothObd2Transport(channel);
+      final service = Obd2Service(transport);
+      final connected = await service.connect(
+        adapter: const GenericElm327Adapter(),
+      );
+
+      expect(connected, isTrue);
+      final atzCount = channel.writesAsStrings
+          .where((w) => w == Elm327Protocol.resetCommand)
+          .length;
+      expect(atzCount, 1,
+          reason: 'the init handshake must run once, not twice (#2233)');
+      // The rest of the init burst is likewise sent once, in order.
       expect(channel.writesAsStrings, containsAllInOrder([
         Elm327Protocol.resetCommand,
         Elm327Protocol.echoOffCommand,

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -53,11 +53,18 @@ void main() {
       await tester.pump(const Duration(milliseconds: 50));
       await tester.tap(find.text('vLinker FD'));
       await tester.pump(); // state flip only — don't settle, the silent
-      // channel intentionally leaves a pending 5 s timeout that
+      // channel intentionally leaves a pending read timeout that
       // eventually surfaces as Obd2AdapterUnresponsive; we're only
       // asserting the optimistic "connecting" state got rendered.
       expect(find.byKey(const Key('obdPickerConnecting')), findsOneWidget);
-      // Drain the transport's 5s timeout so the test harness exits cleanly.
+      // Drain the init read timeouts so the test harness exits cleanly.
+      // #2233 moved the ELM327 init out of the transport into
+      // Obd2Service.connect, which wraps each command in a one-shot
+      // connect-retry (_withConnectRetry): the first ATZ times out
+      // (5 s), waits connectRetryDelay (150 ms), then retries and times
+      // out again (5 s). Pump past both timers + the retry delay so no
+      // timer is pending when the widget tree is disposed.
+      await tester.pump(const Duration(seconds: 6));
       await tester.pump(const Duration(seconds: 6));
       await tester.pump();
     });


### PR DESCRIPTION
Closes #2233 (child of Epic #2231).

## Problem
The ELM327 init burst (`ATZ`/`ATE0`/`ATL0`/`ATH0`/`ATSP0`/`ATAT1`) was sent **twice** per connect: `BluetoothObd2Transport.connect()` looped `Elm327Protocol.initCommands` **and** `Obd2Service.connect()` re-sent the same six as `adapter.initSequence`. The second `ATZ` wiped the first init's echo/header/protocol state and re-paid a 1–2 s clone re-enumeration — the biggest, lowest-risk start-latency win in the stack-hardening epic.

## Fix
- **Removed** the six-command init loop from `BluetoothObd2Transport.connect()`. The transport now only opens the channel, subscribes, and flips `_connected=true`.
- **Kept** `_connected=true` after `channel.open()`+subscribe — `sendCommand` throws on `!_connected`, and the service-side init must be able to send. `Obd2Service.connect()`'s `adapter.initSequence` is now the **single init owner**, so the adapter receives exactly one init burst.
- Dropped the now-unused `elm327_protocol` import from the transport.

## Caller audit (load-bearing)
Every `transport.connect()` / `BluetoothObd2Transport(` site that does **not** go through `Obd2Service.connect()`:
- `Obd2ConnectionService.connect()` — constructs the transport then calls `service.connect(adapter:)`; init runs once via the service. ✅
- `Obd2ConnectionService.connectByMac()` (used by `Obd2VinReaderService.readVin`) — routes through `connect()` → service init. ✅
- No production code path opens a bare transport and skips the service init.
- Tests: the transport's own tests called `transport.connect()` directly and asserted the init ran there → updated. `obd2_adapter_picker_test`'s "connecting state" test relied on the transport's read timeout firing; the timeout now fires inside the service init's one-shot retry (two 5 s waits + 150 ms retry delay), so the drain pump was extended.

## Tests
- Updated the transport "connect" test: `connect()` opens the channel and leaves `isConnected=true` **without** sending the init.
- **Added** a regression test asserting `ATZ` is sent **exactly once** across a full `BluetoothObd2Transport.connect()` + `Obd2Service.connect()` sequence.
- `flutter analyze`: clean apart from the 2 pre-existing info issues.
- `flutter test test/features/consumption/ test/lint/`: all pass (2969 tests).

## Note
Recommend an on-device smoke-test post-merge (real ELM327 clone) to confirm the single-init path connects cleanly on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
