### PR TITLE
feat(ui): compact TabSwitcher tabs — icon beside label, ~48px not ~72px (#2237)

### DIFF
--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -493,6 +493,12 @@ found in the audit (`ConsumptionScreen` `TabBar`, `FavoritesScreen`
 
 **Visual contract:**
 
+Each tab is a **compact single row** — icon *beside* the label, not
+Material's default stacked `icon:`/`text:` (which renders ~72 dp tall).
+The compact row fits ~49 dp. Colours/weight stay unset on the child so
+the `TabBar` theme drives the selected ↔ unselected animation for both
+the Icon (via `IconTheme`) and the Text (via `DefaultTextStyle`).
+
 ```dart
 return Material(
   color: Colors.transparent,
@@ -500,8 +506,21 @@ return Material(
     tabs: [
       for (final entry in tabs)
         Tab(
-          icon: entry.icon != null ? Icon(entry.icon) : null,
-          text: entry.label,
+          child: Semantics(
+            label: entry.semanticLabel ?? entry.label,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (entry.icon != null) ...[
+                  Icon(entry.icon, size: 18),
+                  const SizedBox(width: 8),
+                ],
+                Flexible(
+                  child: Text(entry.label, overflow: TextOverflow.ellipsis),
+                ),
+              ],
+            ),
+          ),
         ),
     ],
     controller: DefaultTabController.of(context),

--- a/lib/core/widgets/tab_switcher.dart
+++ b/lib/core/widgets/tab_switcher.dart
@@ -43,8 +43,18 @@ class TabSwitcher extends StatelessWidget implements PreferredSizeWidget {
     this.onTap,
   });
 
+  /// Compact single-row tab height. The default Material layout stacks
+  /// the icon above the label (`Tab(icon:, text:)`) which renders ~72 dp
+  /// tall (75 dp incl. the bottom divider). We lay icon + label out
+  /// side-by-side instead (see [build]): each [Tab] is the text-only
+  /// `kTextTabBarHeight` (46 dp) — still ≥ the 48 dp touch target once
+  /// the indicator/divider is included — and the whole [TabBar] renders
+  /// 49 dp. `preferredSize` is set to that measured 49 dp so an
+  /// `AppBar.bottom:` host reserves exactly the right amount.
+  static const double _compactHeight = kTextTabBarHeight + 1;
+
   @override
-  Size get preferredSize => const Size.fromHeight(kTextTabBarHeight);
+  Size get preferredSize => const Size.fromHeight(_compactHeight);
 
   @override
   Widget build(BuildContext context) {
@@ -67,8 +77,30 @@ class TabSwitcher extends StatelessWidget implements PreferredSizeWidget {
         tabs: [
           for (final entry in tabs)
             Tab(
-              icon: entry.icon != null ? Icon(entry.icon) : null,
-              text: entry.label,
+              // Compact single-row layout: icon beside the label rather
+              // than Material's default stacked `icon:`/`text:` (which
+              // renders ~72 dp tall). Colours/weight are intentionally
+              // left unset so the surrounding `TabBar` theme drives the
+              // selected ↔ unselected animation for both the Icon (via
+              // IconTheme) and the Text (via DefaultTextStyle).
+              child: Semantics(
+                label: entry.semanticLabel ?? entry.label,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (entry.icon != null) ...[
+                      Icon(entry.icon, size: 18),
+                      const SizedBox(width: 8),
+                    ],
+                    Flexible(
+                      child: Text(
+                        entry.label,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
         ],
       ),

--- a/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_tab_icons_test.dart
@@ -126,11 +126,20 @@ void main() {
       expect(tabs, hasLength(2),
           reason: 'EV profile must render the Fuel + Charging switcher');
 
-      // Every Tab must carry an icon — the visual contract this issue
-      // locked across both Conso and Favoris.
-      for (final tab in tabs) {
-        expect(tab.icon, isNotNull,
-            reason: 'Conso sub-tab is missing its leading icon — #1163.');
+      // Every Tab must render a leading icon — the visual contract this
+      // issue locked across both Conso and Favoris. #2237 made the tab
+      // layout compact (icon beside label inside `Tab.child` rather than
+      // the stacked `Tab.icon`), so we assert the rendered Icon inside
+      // each Tab instead of the now-unused `Tab.icon` field.
+      for (final tabFinder in [
+        find.byType(Tab).at(0),
+        find.byType(Tab).at(1),
+      ]) {
+        expect(
+          find.descendant(of: tabFinder, matching: find.byType(Icon)),
+          findsOneWidget,
+          reason: 'Conso sub-tab is missing its leading icon — #1163.',
+        );
       }
 
       // Spot-check the specific icons defined in `consumption_screen.dart`.

--- a/test/features/favorites/presentation/screens/favorites_screen_tab_icons_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_tab_icons_test.dart
@@ -46,12 +46,21 @@ void main() {
         expect(tabs, hasLength(2),
             reason: 'FavoritesScreen has exactly two sub-tabs');
 
-        // Each Tab must have an Icon child (the symptom the issue
-        // describes is that historically these were null).
-        for (final tab in tabs) {
-          expect(tab.icon, isNotNull,
-              reason: 'Every Favoris sub-tab must carry an icon to match '
-                  'the Conso style — #1163.');
+        // Each Tab must render an Icon child (the symptom the issue
+        // describes is that historically these were absent). #2237 made
+        // the tab layout compact (icon beside label inside `Tab.child`
+        // rather than the stacked `Tab.icon`), so we assert the rendered
+        // Icon inside each Tab instead of the now-unused `Tab.icon` field.
+        for (final tabFinder in [
+          find.byType(Tab).at(0),
+          find.byType(Tab).at(1),
+        ]) {
+          expect(
+            find.descendant(of: tabFinder, matching: find.byType(Icon)),
+            findsOneWidget,
+            reason: 'Every Favoris sub-tab must carry an icon to match '
+                'the Conso style — #1163.',
+          );
         }
 
         // Targeted icon presence — find by IconData on the rendered tree.


### PR DESCRIPTION
Closes #2237

## Problem

User feedback on the Favoris screen: the "Favoris / Alertes de prix" tab selector stacks the **icon ABOVE the label** (Material's default `Tab(icon:, text:)`), eating ~72 dp of vertical space below the AppBar. There is exactly one shared widget — `lib/core/widgets/tab_switcher.dart` (`TabSwitcher`) — behind every such selector (Favoris/Alertes, Conso Fuel/Charging, any future Carbon usage), so fixing it fixes them all.

## Change

Render each tab as a single **compact row** (icon beside label) instead of stacked:

- `Tab(child: Semantics(label: semanticLabel ?? label, child: Row([Icon(size:18), SizedBox(8), Flexible(Text(ellipsis))])))`.
- `preferredSize` reduced from `kTextTabBarHeight` to the measured compact height (`kTextTabBarHeight + 1` = 49 dp).

## Before / after (measured in a widget test)

| | rendered TabBar | rendered Tab |
|---|---|---|
| before (stacked) | 75 dp | 72 dp |
| after (compact) | **49 dp** | 46 dp |

~26 dp / 35% reclaimed below the AppBar. Each Tab is 46 dp → ≥48 dp touch target once the indicator is included.

## Invariants preserved

- **Colour animation:** Icon/Text on the row carry no explicit colour, so the `TabBar`'s `labelColor` / `unselectedLabelColor` keep driving the selected ↔ unselected transition via `IconTheme` + `DefaultTextStyle`.
- **a11y:** child wrapped in `Semantics(label: entry.semanticLabel ?? entry.label)`.
- **Finders:** `find.text(label)` and `find.byIcon(icon)` still resolve (verified).
- **Public API** (`TabSwitcher`, `TabSwitcherEntry`) unchanged — all call sites untouched.

## Goldens

No golden PNG changed. `test/goldens/tab_appbar_consistency_test.dart` is a **structural** test (asserts AppBar heights + Semantics wrapping, reads no PNG — see its own docstring); running it with `--update-goldens` produced no diff. No baseline pixel-golden (`fuel_type_selector_*`, `service_status_banner_*`, `station_card_*`) includes a TabSwitcher.

## Tests

- `test/core/widgets/tab_switcher_test.dart`, `test/lint/tab_switcher_canonical_test.dart` — pass.
- `test/features/favorites/presentation/`, `test/features/consumption/presentation/screens/` — pass (incl. tab-icons, trajets, charging).
- `test/goldens/` — pass.
- The two `_tab_icons_test.dart` files previously asserted the internal `Tab.icon` field; updated to assert the rendered `Icon` inside each `Tab` (the icon moved into `Tab.child`).
- `flutter analyze` → only the 2 pre-existing infos (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`); no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
