### PR TITLE
fix(sync): harden TankSync trip-recording sync client + idempotent migration (#2239)

### DIFF
--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -59,20 +59,9 @@ class TripsSync {
       return;
     }
     try {
-      await client.from('trip_summaries').upsert({
-        'id': entry.id,
-        'user_id': userId,
-        'vehicle_id': entry.vehicleId,
-        'started_at': startedAt.toIso8601String(),
-        'ended_at': endedAt.toIso8601String(),
-        // The summary blob stays compact: just the entity's JSON form
-        // WITHOUT the per-tick `samples` and GPS-diagnostics arrays
-        // so a 60-min commute is ~1 KB instead of ~250 KB. The full-
-        // blob (samples + gpsd) goes to `public.trip_details` in
-        // [uploadDetails] right after.
-        'data': _compactSummaryJson(entry),
-        'updated_at': DateTime.now().toIso8601String(),
-      }, onConflict: 'user_id,id');
+      await client
+          .from('trip_summaries')
+          .upsert(buildSummaryRow(entry, userId), onConflict: 'user_id,id');
       debugPrint('TripsSync.uploadSummary: uploaded ${entry.id}');
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.uploadSummary FAILED for ${entry.id}'}));
@@ -205,7 +194,6 @@ class TripsSync {
         final id = r['id'];
         if (id is String) serverIds.add(id);
       }
-      final localIds = localEntries.map((e) => e.id).toSet();
 
       // Upload local-only entries — heals a missing server row from
       // a previous offline save without waiting for the next stop.
@@ -217,24 +205,17 @@ class TripsSync {
         await uploadSummary(entry);
       }
 
-      // Download server-only entries.
-      final downloaded = <TripHistoryEntry>[];
-      for (final r in serverRows) {
-        final id = r['id'];
-        if (id is! String || localIds.contains(id)) continue;
-        final data = r['data'];
-        if (data is! Map) continue;
-        try {
-          downloaded.add(
-            TripHistoryEntry.fromJson(data.cast<String, dynamic>()),
-          );
-        } catch (e, st) {
-          unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.merge decode failed for $id'}));
-        }
-      }
-      debugPrint('TripsSync.merge: local=${localIds.length} '
-          'server=${serverIds.length} downloaded=${downloaded.length}');
-      return [...localEntries, ...downloaded];
+      // Decode the server-only rows and return the union. The pure
+      // [mergeRows] step is what the app-launch caller persists back to
+      // the local Hive box — see `AppInitializer._runTripsSyncMerge`.
+      // Pinning that step in a unit test regression-guards the
+      // "download silently discarded" bug class (#2239 / the sibling
+      // AlertsSync defect).
+      final merged = mergeRows(localEntries, serverRows);
+      debugPrint('TripsSync.merge: local=${localEntries.length} '
+          'server=${serverIds.length} '
+          'downloaded=${merged.length - localEntries.length}');
+      return merged;
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.merge FAILED'}));
       return localEntries;
@@ -288,6 +269,66 @@ class TripsSync {
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.pruneOldDetails FAILED'}));
     }
+  }
+
+  /// Pure builder for one `public.trip_summaries` row — the exact
+  /// column map [uploadSummary] upserts. Extracted so a unit test can
+  /// pin every column (the wire `upsert` call can't be exercised
+  /// without a live Supabase client). [now] defaults to wall-clock and
+  /// is injectable so the `updated_at` assertion stays deterministic.
+  @visibleForTesting
+  static Map<String, dynamic> buildSummaryRow(
+    TripHistoryEntry entry,
+    String userId, {
+    DateTime? now,
+  }) {
+    return {
+      'id': entry.id,
+      'user_id': userId,
+      'vehicle_id': entry.vehicleId,
+      'started_at': entry.summary.startedAt!.toIso8601String(),
+      'ended_at': entry.summary.endedAt!.toIso8601String(),
+      // The summary blob stays compact: just the entity's JSON form
+      // WITHOUT the per-tick `samples` and GPS-diagnostics arrays so a
+      // 60-min commute is ~1 KB instead of ~250 KB. The full blob
+      // (samples + gpsd) goes to `public.trip_details` in
+      // [uploadDetails] right after.
+      'data': _compactSummaryJson(entry),
+      'updated_at': (now ?? DateTime.now()).toIso8601String(),
+    };
+  }
+
+  /// Pure merge step: returns `[...localEntries, ...server-only]` given
+  /// the raw `trip_summaries` rows fetched in [merge]. Server rows whose
+  /// id is already local are skipped (local wins), and a row that fails
+  /// to decode is dropped rather than aborting the whole merge.
+  ///
+  /// This is the value the app-launch caller persists back to the local
+  /// Hive box (`AppInitializer._runTripsSyncMerge`). It is the seam the
+  /// "download silently discarded" regression test (#2239) pins — the
+  /// sibling AlertsSync bug was the caller throwing this superset away,
+  /// so a trip recorded on another device never landed locally.
+  @visibleForTesting
+  static List<TripHistoryEntry> mergeRows(
+    List<TripHistoryEntry> localEntries,
+    List<Map<String, dynamic>> serverRows,
+  ) {
+    final localIds = localEntries.map((e) => e.id).toSet();
+    final downloaded = <TripHistoryEntry>[];
+    for (final r in serverRows) {
+      final id = r['id'];
+      if (id is! String || localIds.contains(id)) continue;
+      final data = r['data'];
+      if (data is! Map) continue;
+      try {
+        downloaded.add(
+          TripHistoryEntry.fromJson(data.cast<String, dynamic>()),
+        );
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync.mergeRows decode failed for $id'}));
+      }
+    }
+    return [...localEntries, ...downloaded];
   }
 }
 

--- a/supabase/migrations/20260507000001_trip_summaries_and_details.sql
+++ b/supabase/migrations/20260507000001_trip_summaries_and_details.sql
@@ -3,6 +3,11 @@
 --   public.trip_summaries — ~1 KB JSONB, queried for the trip-history list
 --   public.trip_details   — full pointSamples + gpsSampleDiagnostics, lazy-loaded
 -- Local-only by default; rows only land here once the user signs in to TankSync.
+--
+-- Applied to PROD on 2026-05-29 via MCP (it had been committed but never
+-- pushed — the missing tables were the entire "trip sync not working" bug,
+-- #2239). Every statement below is idempotent so a later `supabase db push`
+-- reconciles cleanly against the already-applied schema.
 
 CREATE TABLE IF NOT EXISTS public.trip_summaries (
   id TEXT NOT NULL,
@@ -17,11 +22,13 @@ CREATE TABLE IF NOT EXISTS public.trip_summaries (
 
 ALTER TABLE public.trip_summaries ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS trip_summaries_own ON public.trip_summaries;
 CREATE POLICY trip_summaries_own ON public.trip_summaries
   FOR ALL USING (user_id = auth.uid());
 
-CREATE INDEX trip_summaries_user_idx ON public.trip_summaries(user_id);
-CREATE INDEX trip_summaries_user_started_idx
+CREATE INDEX IF NOT EXISTS trip_summaries_user_idx
+  ON public.trip_summaries(user_id);
+CREATE INDEX IF NOT EXISTS trip_summaries_user_started_idx
   ON public.trip_summaries(user_id, started_at DESC);
 
 CREATE TABLE IF NOT EXISTS public.trip_details (
@@ -34,7 +41,9 @@ CREATE TABLE IF NOT EXISTS public.trip_details (
 
 ALTER TABLE public.trip_details ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS trip_details_own ON public.trip_details;
 CREATE POLICY trip_details_own ON public.trip_details
   FOR ALL USING (user_id = auth.uid());
 
-CREATE INDEX trip_details_user_idx ON public.trip_details(user_id);
+CREATE INDEX IF NOT EXISTS trip_details_user_idx
+  ON public.trip_details(user_id);

--- a/test/core/sync/trips_sync_test.dart
+++ b/test/core/sync/trips_sync_test.dart
@@ -1,26 +1,29 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
 import 'package:tankstellen/core/sync/trips_sync.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import '../../helpers/silence_error_logger.dart';
 
-/// #1479 phase 2 — surface-level coverage of [TripsSync].
+/// #1479 phase 2 / #2239 — coverage of [TripsSync].
 ///
-/// We don't stand up a real Supabase client here; the wire layer is
-/// exercised by the manual end-to-end checklist in
-/// `docs/guides/tanksync-trips.md` and by Phase 3's merge tests when
-/// they land. What we DO pin here:
-///   - `uploadSummary` is a no-op when nothing is signed in (does not
-///     throw, does not crash on a missing client).
-///   - `deleteSummary` is a no-op when nothing is signed in.
-///
-/// These are the "do-no-harm" guarantees the recording-stop hook
-/// relies on so an unauthenticated user with `consentSyncTrips=true`
-/// (rare, but possible if they signed out without revoking the
-/// consent) doesn't wedge the local save path.
+/// `TripsSync` reads the static `TankSyncClient.client` directly, so the
+/// live wire `upsert` / `select` calls can't be exercised in a unit test
+/// without a real Supabase client. Rather than mock the brittle
+/// query-builder chain, the column-shape and merge-union logic are
+/// factored into the pure, `@visibleForTesting` [TripsSync.buildSummaryRow]
+/// and [TripsSync.mergeRows] seams — the wire methods just delegate to
+/// them. These tests pin those seams plus the unauthenticated do-no-harm
+/// guards.
 void main() {
+  silenceErrorLoggerSpool();
+
   group('TripsSync', () {
     test('uploadSummary is a no-op when not signed in', () async {
       final entry = TripHistoryEntry(
@@ -118,6 +121,219 @@ void main() {
         expect(result, isNull,
             reason: 'unauth fetch must return null so the trip-detail '
                 'screen falls back to its empty-samples render path');
+      },
+    );
+  });
+
+  // ───────────────────────────────────────────────────────────────────
+  // #2239 — uploadSummary writes the expected `trip_summaries` columns.
+  // The wire `upsert` is delegated to the pure [buildSummaryRow]; pinning
+  // it here proves the column contract that the (already-deployed)
+  // migration's NOT-NULL `started_at` / `ended_at` + JSONB `data` rely
+  // on, and that the heavy samples / gpsd arrays are stripped from the
+  // compact summary blob.
+  // ───────────────────────────────────────────────────────────────────
+  group('TripsSync.buildSummaryRow — trip_summaries column contract', () {
+    test('emits every expected column with the compact (samples-stripped) '
+        'data blob', () {
+      final started = DateTime.utc(2026, 5, 28, 9, 0);
+      final ended = DateTime.utc(2026, 5, 28, 9, 42);
+      final entry = TripHistoryEntry(
+        id: '2026-05-28T09:00:00.000Z',
+        vehicleId: 'veh-42',
+        summary: TripSummary(
+          startedAt: started,
+          endedAt: ended,
+          distanceKm: 21.5,
+          maxRpm: 3200,
+          highRpmSeconds: 8,
+          idleSeconds: 40,
+          harshBrakes: 1,
+          harshAccelerations: 2,
+          avgLPer100Km: 6.1,
+          fuelLitersConsumed: 1.31,
+        ),
+        // Heavy per-tick payload that MUST NOT leak into the compact
+        // summary blob (it belongs in trip_details).
+        samples: [
+          TripSample(
+            timestamp: started,
+            speedKmh: 0,
+            rpm: 800,
+          ),
+          TripSample(
+            timestamp: started.add(const Duration(seconds: 1)),
+            speedKmh: 12,
+            rpm: 1500,
+          ),
+        ],
+      );
+
+      final now = DateTime.utc(2026, 5, 28, 10, 0);
+      final row = TripsSync.buildSummaryRow(entry, 'user-abc', now: now);
+
+      // Server-side filter columns + composite-key columns.
+      expect(row['id'], '2026-05-28T09:00:00.000Z');
+      expect(row['user_id'], 'user-abc');
+      expect(row['vehicle_id'], 'veh-42');
+      expect(row['started_at'], started.toIso8601String());
+      expect(row['ended_at'], ended.toIso8601String());
+      expect(row['updated_at'], now.toIso8601String());
+
+      // The compact `data` blob: a Map carrying the summary, but NOT the
+      // heavy `samples` / `gpsd` arrays.
+      final data = row['data'] as Map<String, dynamic>;
+      expect(data['id'], entry.id);
+      expect(data['vehicleId'], 'veh-42');
+      expect(data.containsKey('summary'), isTrue);
+      expect(data.containsKey('samples'), isFalse,
+          reason: 'samples must stay in trip_details, not the summary blob');
+      expect(data.containsKey('gpsd'), isFalse,
+          reason: 'gps diagnostics must stay in trip_details');
+
+      // The data blob is JSON-serialisable (Supabase JSONB round-trip).
+      expect(() => jsonEncode(data), returnsNormally);
+    });
+
+    test('the row decodes back through TripHistoryEntry.fromJson — the '
+        'shape merge() relies on for downloaded rows', () {
+      final started = DateTime.utc(2026, 5, 28, 7, 0);
+      final entry = TripHistoryEntry(
+        id: 'roundtrip-1',
+        vehicleId: 'veh-x',
+        summary: TripSummary(
+          startedAt: started,
+          endedAt: started.add(const Duration(minutes: 15)),
+          distanceKm: 7.2,
+          maxRpm: 2600,
+          highRpmSeconds: 0,
+          idleSeconds: 22,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+        ),
+      );
+      final row = TripsSync.buildSummaryRow(entry, 'u1');
+      final decoded = TripHistoryEntry.fromJson(
+        (row['data'] as Map).cast<String, dynamic>(),
+      );
+      expect(decoded.id, 'roundtrip-1');
+      expect(decoded.vehicleId, 'veh-x');
+      expect(decoded.summary.distanceKm, 7.2);
+      // Downloaded summaries carry no per-tick telemetry — that arrives
+      // lazily from trip_details on first open.
+      expect(decoded.samples, isEmpty);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────
+  // #2239 — REGRESSION for the "download silently discarded" bug class.
+  //
+  // The sibling AlertsSync defect was: merge() returned the merged
+  // superset but the CALLER threw the return value away, so a row
+  // recorded on another device never landed locally. TripsSync.merge
+  // delegates the decode-and-union to the pure [mergeRows]; these tests
+  // prove (a) downloaded rows ARE included in the returned superset and
+  // (b) when that superset is persisted exactly as
+  // `AppInitializer._runTripsSyncMerge` does it, the remote trip surfaces
+  // in the local store.
+  // ───────────────────────────────────────────────────────────────────
+  group('TripsSync.mergeRows — applies downloaded entries (#2239)', () {
+    Map<String, dynamic> serverRow(TripHistoryEntry e) => {
+          'id': e.id,
+          'data': TripsSync.buildSummaryRow(e, 'remote-user')['data'],
+        };
+
+    TripHistoryEntry mkEntry(String id, DateTime started) => TripHistoryEntry(
+          id: id,
+          vehicleId: 'veh-1',
+          summary: TripSummary(
+            startedAt: started,
+            endedAt: started.add(const Duration(minutes: 18)),
+            distanceKm: 9.4,
+            maxRpm: 2900,
+            highRpmSeconds: 3,
+            idleSeconds: 28,
+            harshBrakes: 0,
+            harshAccelerations: 0,
+          ),
+        );
+
+    test('server-only rows are appended to the local list (the superset '
+        'the caller must persist)', () {
+      final localA = mkEntry('local-a', DateTime.utc(2026, 5, 27, 8));
+      final remoteB = mkEntry('remote-b', DateTime.utc(2026, 5, 28, 8));
+
+      final merged = TripsSync.mergeRows(
+        [localA],
+        [serverRow(localA), serverRow(remoteB)],
+      );
+
+      final ids = merged.map((e) => e.id).toList();
+      expect(ids, containsAll(<String>['local-a', 'remote-b']),
+          reason: 'the downloaded remote trip MUST appear in the result; '
+              'discarding it is the bug this guards');
+      expect(merged.length, 2);
+    });
+
+    test('local entries win on id collision — no duplicate, local kept', () {
+      final shared = mkEntry('shared', DateTime.utc(2026, 5, 26, 8));
+      final merged = TripsSync.mergeRows([shared], [serverRow(shared)]);
+      expect(merged, hasLength(1));
+      expect(identical(merged.first, shared), isTrue,
+          reason: 'local-wins: the kept entry is the local instance');
+    });
+
+    test('a corrupt server row is skipped, not fatal to the merge', () {
+      final remoteB = mkEntry('remote-b', DateTime.utc(2026, 5, 28, 8));
+      final merged = TripsSync.mergeRows(
+        const [],
+        [
+          {'id': 'corrupt', 'data': 'not-a-map'}, // bad shape → skipped
+          serverRow(remoteB),
+        ],
+      );
+      expect(merged.map((e) => e.id), ['remote-b']);
+    });
+
+    test(
+      'persisting the merged superset (as AppInitializer does) surfaces the '
+      'remote trip in the local Hive store',
+      () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        final tmpDir =
+            Directory.systemTemp.createTempSync('trips_merge_persist_');
+        Hive.init(tmpDir.path);
+        final box = await Hive.openBox<String>(
+          'merge_${DateTime.now().microsecondsSinceEpoch}',
+        );
+        addTearDown(() async {
+          await box.deleteFromDisk();
+          await Hive.close();
+          tmpDir.deleteSync(recursive: true);
+        });
+
+        final repo = TripHistoryRepository(box: box);
+        // Device starts with one locally-recorded trip.
+        final localA = mkEntry('local-a', DateTime.utc(2026, 5, 27, 8));
+        await repo.save(localA);
+
+        // Sync pass downloads a trip recorded on another device.
+        final remoteB = mkEntry('remote-b', DateTime.utc(2026, 5, 28, 8));
+        final local = repo.loadAll();
+        final localIds = local.map((e) => e.id).toSet();
+        final merged = TripsSync.mergeRows(local, [serverRow(remoteB)]);
+
+        // Exactly the persist-back loop from
+        // AppInitializer._runTripsSyncMerge.
+        for (final entry in merged) {
+          if (localIds.contains(entry.id)) continue;
+          await repo.save(entry);
+        }
+
+        final after = repo.loadAll().map((e) => e.id).toSet();
+        expect(after, containsAll(<String>{'local-a', 'remote-b'}),
+            reason: 'the cross-device trip must be readable locally after '
+                'the merge is persisted');
       },
     );
   });


### PR DESCRIPTION
Closes #2239.

## Root cause (already fixed server-side)
TankSync trip-recording sync ("recorded trips don't appear on my other device") was failing because the migration `supabase/migrations/20260507000001_trip_summaries_and_details.sql` — which creates `public.trip_summaries` / `public.trip_details` — **had never been applied to prod**. Every upload failed with `PostgrestException: Could not find the table 'public.trip_details'`, silently (TripsSync swallows + logs by design). **The tables were created in prod on 2026-05-29 via MCP, out of band — not in this PR.** This PR is the client + migration-file hygiene + tests.

## What I verified (no behaviour change needed)
- **Upload IS wired** — `trip_recording_provider.dart` calls `TripsSync.uploadSummary(entry)` on trip save, gated by `tripsSyncEnabledProvider` (account ∧ cloudSync ∧ syncTrips). `uploadSummary` fans out to `uploadDetails`.
- **Download/merge IS applied, not discarded** — the only `TripsSync.merge()` caller, `AppInitializer._runTripsSyncMerge`, already captures the returned superset and persists server-only entries back to the local Hive box. This is **not** the sibling AlertsSync "discarded return value" defect.

So the client paths were already correct; the production failure was purely the undeployed migration.

## Changes
1. **Migration idempotency** — `DROP POLICY IF EXISTS … ; CREATE POLICY …` + `CREATE INDEX IF NOT EXISTS …` so a future `supabase db push` reconciles cleanly against the already-applied schema. No column changes. Added a comment noting the 2026-05-29 prod apply.
2. **Refactor (no behaviour change)** — extracted two pure `@visibleForTesting` seams the wire methods delegate to: `TripsSync.buildSummaryRow` (the exact `trip_summaries` column map) and `TripsSync.mergeRows` (the decode-and-union step). `TripsSync` reads the static `TankSyncClient.client` directly, so this is the seam that makes the contract unit-testable without mocking Supabase's query-builder chain.
3. **Tests** — column-contract test (every uploaded column + samples/gpsd stripped + JSON round-trip) and a **regression for the "download silently discarded" bug class**: `mergeRows` includes server-only rows, local wins on collision, corrupt rows are skipped, and persisting the superset exactly as `AppInitializer._runTripsSyncMerge` does surfaces the cross-device trip in a real Hive store.

## Out of scope
Cross-account trip sharing (sharing with a *different* account) — filed as #2240.

## Gate
- `flutter analyze`: `2 issues found.` (the 2 pre-existing infos; no new errors/warnings).
- `flutter test test/core/sync/ test/features/consumption/`: all pass (3091 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
