### PR TITLE
refactor(obd2): direct-connect-by-MAC path with bounded timeout + dead-GATT teardown (#2242)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -35,6 +35,21 @@ abstract class BluetoothFacade {
   /// the given [profile] UUIDs. The returned channel is un-opened;
   /// the transport layer calls `open()` to run the GATT dance.
   ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile);
+
+  /// Build a byte channel straight from a known [mac] with NO scan
+  /// (#2242). Used by the direct-connect reconnect / pre-warm path:
+  /// `BluetoothDevice.fromId(mac)` addresses the adapter without first
+  /// re-discovering it over the air, which is essential for clones that
+  /// stop advertising in standby. No scan means no resolved profile, so
+  /// the generic FFF0 Nordic-UART UUIDs are used — the dominant ELM327
+  /// clone family. The returned channel's `open()` applies a bounded
+  /// connect timeout and tears down any stale GATT client first
+  /// (Android returns GATT_ERROR 133 otherwise). The channel is
+  /// un-opened; the caller runs `open()`.
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout,
+  });
 }
 
 /// Production façade — the only place in the codebase that directly
@@ -154,6 +169,25 @@ class PluginBluetoothFacade implements BluetoothFacade {
         writeChar: Guid(profile.writeCharUuid),
         notifyChar: Guid(profile.notifyCharUuid),
       ),
+    );
+  }
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    // No scan ⇒ no resolved profile. The FFF0 Nordic-UART family
+    // (Elm327BleUuids.vgate, = the generic-fff0 profile UUIDs) is the
+    // dominant ELM327 BLE clone, so it is the safe default for a
+    // direct-by-MAC connect. The 4 s connectTimeout is LOAD-BEARING:
+    // FBP `autoConnect:false` can otherwise block ~35 s on a sleeping
+    // adapter (#2242).
+    final device = BluetoothDevice.fromId(mac);
+    return FlutterBluePlusElmChannel(
+      device,
+      uuids: Elm327BleUuids.vgate,
+      connectTimeout: connectTimeout,
     );
   }
 }

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -46,6 +46,16 @@ class Elm327BleUuids {
 class FlutterBluePlusElmChannel implements ElmByteChannel {
   final BluetoothDevice _device;
   final Elm327BleUuids _uuids;
+
+  /// Optional bounded timeout passed to `device.connect` (#2242). When
+  /// null, `connect` is called with the legacy `mtu: null` form and no
+  /// explicit timeout (the scan-first path, where the device was just
+  /// seen advertising so a long connect block is unlikely). When set —
+  /// the direct-by-MAC path — `connect(autoConnect:false,
+  /// timeout: …)` bounds the attempt and `open()` first tears down any
+  /// stale GATT client to dodge Android GATT_ERROR 133.
+  final Duration? _connectTimeout;
+
   BluetoothCharacteristic? _writeChar;
   BluetoothCharacteristic? _notifyChar;
   StreamSubscription<List<int>>? _subscription;
@@ -56,7 +66,9 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
   FlutterBluePlusElmChannel(
     this._device, {
     Elm327BleUuids? uuids,
-  }) : _uuids = uuids ?? Elm327BleUuids.vgate;
+    Duration? connectTimeout,
+  })  : _uuids = uuids ?? Elm327BleUuids.vgate,
+        _connectTimeout = connectTimeout;
 
   @override
   bool get isOpen => _open;
@@ -67,7 +79,27 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
   @override
   Future<void> open() async {
     if (_open) return;
-    await _device.connect(autoConnect: false, mtu: null);
+    final timeout = _connectTimeout;
+    if (timeout == null) {
+      await _device.connect(autoConnect: false, mtu: null);
+    } else {
+      // Direct-by-MAC path (#2242). Tear down any stale GATT client for
+      // this device FIRST — Android returns GATT_ERROR 133 if a prior
+      // (dropped-but-not-closed) GATT connection is still open, which
+      // would silently force a fall back to the scan path. disconnect()
+      // is idempotent and a no-op when nothing is connected.
+      try {
+        await _device.disconnect();
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+          'where':
+              'FlutterBluePlusElmChannel: pre-connect dead-GATT teardown',
+        }));
+      }
+      // The explicit ~4 s timeout is LOAD-BEARING: FBP's
+      // autoConnect:false connect can otherwise block ~35 s.
+      await _device.connect(autoConnect: false, timeout: timeout);
+    }
     final services = await _device.discoverServices();
     final service = services.firstWhere(
       (s) => s.uuid == _uuids.service,

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -10,6 +10,8 @@ import 'adapter_registry.dart';
 import 'bluetooth_facade.dart';
 import 'bluetooth_obd2_transport.dart';
 import 'classic_bluetooth_facade.dart';
+import 'elm327_adapter.dart';
+import 'elm_byte_channel.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_permissions.dart';
 import 'obd2_service.dart';
@@ -39,6 +41,13 @@ class Obd2ConnectionService {
   /// [reconnectLast] when the caller wants to rehydrate the highest-
   /// RSSI adapter without opening the picker again.
   List<ResolvedObd2Candidate> _lastRanked = const [];
+
+  /// The channel opened by the most recent [connectByMacDirect] (#2242).
+  /// Retained so the NEXT direct connect can tear it down before
+  /// reopening — Android returns GATT_ERROR 133 if a stale GATT client
+  /// for the same device is still open, which would silently fall the
+  /// caller back to the scan path. Null once torn down / never used.
+  ElmByteChannel? _lastDirectChannel;
 
   Obd2ConnectionService({
     required this.registry,
@@ -109,22 +118,45 @@ class Obd2ConnectionService {
                   'facade is wired — app misconfiguration')))
           .channelFor(candidate.candidate.deviceId),
     };
-    final transport = BluetoothObd2Transport(channel);
-    final service = Obd2Service(transport);
     // #1312 — stamp adapter identity onto the service so the trip
     // recorder can persist it on the saved [TripHistoryEntry] and the
     // detail screen can name the device that produced the recording.
     // The friendly name falls back to the registry's display label
     // when the BLE advertisement was empty (matches the picker rule).
-    service.adapterMac = candidate.candidate.deviceId;
-    service.adapterName = candidate.candidate.deviceName.isEmpty
+    final name = candidate.candidate.deviceName.isEmpty
         ? candidate.profile.displayName
         : candidate.candidate.deviceName;
+    return _openAndInit(
+      channel: channel,
+      adapter: candidate.profile.adapter,
+      mac: candidate.candidate.deviceId,
+      name: name,
+    );
+  }
+
+  /// Shared channel → transport → service → init sequence used by both
+  /// the scan-based [connect] and the no-scan [connectByMacDirect]
+  /// (#2242). Keeping it in ONE place guarantees a direct connect
+  /// produces a session identical to the scan path — notably the
+  /// service-side ELM327 init (`adapter.initSequence` via
+  /// [Obd2Service.connect]), which the transport itself no longer runs
+  /// (#2233). Surfaces [Obd2AdapterUnresponsive] when init fails (the
+  /// channel is closed before the error is rethrown).
+  Future<Obd2Service> _openAndInit({
+    required ElmByteChannel channel,
+    required Elm327Adapter adapter,
+    required String mac,
+    required String name,
+  }) async {
+    final transport = BluetoothObd2Transport(channel);
+    final service = Obd2Service(transport);
+    service.adapterMac = mac;
+    service.adapterName = name;
     // #1330 — hand the per-adapter ELM327 adapter into [Obd2Service]
     // so its init sequence + timing matches the connected adapter's
     // quirks. Phase 1 ships only [GenericElm327Adapter], so runtime
     // behaviour is unchanged for every paired adapter.
-    final ok = await service.connect(adapter: candidate.profile.adapter);
+    final ok = await service.connect(adapter: adapter);
     if (!ok) {
       await service.disconnect();
       throw const Obd2AdapterUnresponsive();
@@ -179,6 +211,86 @@ class Obd2ConnectionService {
     if (match == null) return null;
     return connect(match);
   }
+
+  /// Direct-connect-by-MAC, NO scan (#2242). Shared infrastructure for
+  /// reliable in-trip reconnect and pre-warm: addresses the adapter via
+  /// `BluetoothDevice.fromId(mac)` and connects with a bounded ~4 s
+  /// timeout, skipping the ~5 s active scan that [connectByMac] does.
+  /// This is essential for ELM327 clones that stop advertising in
+  /// standby — a scan would never see them, but a direct GATT connect
+  /// still wakes them.
+  ///
+  /// Before opening, it tears down any channel left over from a prior
+  /// direct connect (`channel.close()` → `device.disconnect()`); Android
+  /// otherwise returns GATT_ERROR 133 on a stale GATT client and the
+  /// connect would silently fail. The channel's own `open()` also
+  /// pre-disconnects the device as a second guard.
+  ///
+  /// On timeout / any failure it FALLS BACK to the scan-based
+  /// [connectByMac] so behaviour is never worse than today: a successful
+  /// scan-path connect still returns a session; a genuinely-unreachable
+  /// adapter still returns null. Runs the SAME service-side init as the
+  /// scan path (via [_openAndInit]), so a direct connect yields a fully
+  /// initialised session identical to [connect].
+  ///
+  /// [timeout] bounds the GATT connect attempt (passed to the channel);
+  /// it is NOT a scan window. Returns null when both the direct attempt
+  /// and the scan fallback fail to produce a session.
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration timeout = const Duration(seconds: 4),
+  }) async {
+    // Tear down a prior direct channel BEFORE reopening (dead-GATT
+    // teardown). LOAD-BEARING on Android — a still-open GATT client for
+    // the same device yields GATT_ERROR 133 on the next connect.
+    await _teardownLastDirectChannel();
+
+    // No scan ⇒ no resolved profile. Use the registry's generic FFF0
+    // BLE profile for the adapter init quirks + display name; its UUIDs
+    // match the channel [channelForDirect] builds.
+    final generic = _genericBleProfile();
+    final channel = bluetooth.channelForDirect(mac, connectTimeout: timeout);
+    _lastDirectChannel = channel;
+    try {
+      return await _openAndInit(
+        channel: channel,
+        adapter: generic.adapter,
+        mac: mac,
+        name: generic.displayName,
+      );
+    } on Object catch (e, st) {
+      // Direct attempt failed (connect timeout, GATT 133, init timeout,
+      // missing characteristic, …). Close the half-open channel and
+      // fall back to the scan path so behaviour is never worse than
+      // today's [connectByMac].
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'Obd2ConnectionService.connectByMacDirect — '
+            'falling back to scan',
+      }));
+      await _teardownLastDirectChannel();
+      return connectByMac(mac);
+    }
+  }
+
+  Future<void> _teardownLastDirectChannel() async {
+    final prior = _lastDirectChannel;
+    _lastDirectChannel = null;
+    if (prior == null) return;
+    try {
+      await prior.close();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'Obd2ConnectionService: prior-direct-channel teardown',
+      }));
+    }
+  }
+
+  Obd2AdapterProfile _genericBleProfile() => registry.profiles.firstWhere(
+        (p) => p.id == 'generic-fff0',
+        orElse: () => registry.profiles.firstWhere(
+          (p) => p.transport == BluetoothTransport.ble,
+        ),
+      );
 }
 
 @Riverpod(keepAlive: true)

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -247,6 +247,124 @@ void main() {
       expect(await svc.connectBest(), isNull);
     });
   });
+
+  group('Obd2ConnectionService.connectByMacDirect (#2242)', () {
+    test('connects WITHOUT scanning on the happy path + runs init',
+        () async {
+      final directChannel = _FakeChannel(respondTo: _elmOkResponses());
+      final fake = _FakeFacade(
+        // Non-empty scan batches: if the direct path ever fell back to
+        // scan, this would be observable via scanInvoked.
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        directChannel: directChannel,
+      );
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: fake,
+      );
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+
+      expect(ready, isNotNull);
+      expect(ready!.isConnected, isTrue);
+      expect(fake.scanInvoked, isFalse,
+          reason: 'direct connect must NOT scan on the happy path');
+      expect(fake.directMac, 'aa:bb');
+      expect(directChannel.openCalls, 1);
+      await ready.disconnect();
+    });
+
+    test('passes a 4 s connect timeout to the facade by default',
+        () async {
+      final fake = _FakeFacade(
+        batches: const [[]],
+        directChannel: _FakeChannel(respondTo: _elmOkResponses()),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+      expect(fake.directTimeout, const Duration(seconds: 4));
+      await ready!.disconnect();
+    });
+
+    test('tears down a prior direct channel before reopening', () async {
+      final first = _FakeChannel(respondTo: _elmOkResponses());
+      final second = _FakeChannel(respondTo: _elmOkResponses());
+      var call = 0;
+      final fake = _SequencedDirectFacade(
+        sequence: [first, second],
+        onDirect: () => call++,
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready1 = await svc.connectByMacDirect('aa:bb');
+      expect(first.closeCalls, 0, reason: 'first channel still open');
+
+      final ready2 = await svc.connectByMacDirect('aa:bb');
+      expect(first.closeCalls, greaterThanOrEqualTo(1),
+          reason: 'prior channel must be torn down before the 2nd open');
+      expect(second.openCalls, 1);
+
+      await ready1?.disconnect();
+      await ready2?.disconnect();
+    });
+
+    test('falls back to the scan path when the direct open times out',
+        () async {
+      // Direct channel.open() throws (simulates connect timeout / GATT
+      // 133); the scan batch carries the same MAC so the fallback
+      // connectByMac succeeds.
+      final fake = _FakeFacade(
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        channel: _FakeChannel(respondTo: _elmOkResponses()),
+        directChannel: _FakeChannel(
+          openError: StateError('connect timed out'),
+        ),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+
+      expect(ready, isNotNull,
+          reason: 'scan fallback must still produce a session');
+      expect(fake.scanInvoked, isTrue,
+          reason: 'failed direct connect must fall back to scan');
+      await ready!.disconnect();
+    });
+
+    test('returns null when both direct AND scan fallback fail', () async {
+      final fake = _FakeFacade(
+        // Empty scan ⇒ connectByMac returns null on Obd2ScanTimeout.
+        batches: const [[]],
+        directChannel: _FakeChannel(
+          openError: StateError('connect timed out'),
+        ),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+      expect(ready, isNull);
+      expect(fake.scanInvoked, isTrue);
+    });
+  });
 }
 
 // --- helpers ---------------------------------------------------------
@@ -314,13 +432,33 @@ class _FakeFacade implements BluetoothFacade {
   final List<List<Obd2AdapterCandidate>> batches;
   final ElmByteChannel? channel;
   final Object? error;
-  _FakeFacade({required this.batches, this.channel, this.error});
+
+  /// Channel handed back by [channelForDirect] (#2242). When null the
+  /// direct path reuses [channel] / a silent fallback.
+  final ElmByteChannel? directChannel;
+
+  /// Set true the first time [scan] is iterated — lets the direct-connect
+  /// happy-path test assert NO scan occurred.
+  bool scanInvoked = false;
+
+  /// Args captured from the most recent [channelForDirect] call.
+  String? directMac;
+  Duration? directTimeout;
+  int directCalls = 0;
+
+  _FakeFacade({
+    required this.batches,
+    this.channel,
+    this.error,
+    this.directChannel,
+  });
 
   @override
   Stream<List<Obd2AdapterCandidate>> scan({
     required Set<String> serviceUuids,
     Duration timeout = const Duration(seconds: 8),
   }) async* {
+    scanInvoked = true;
     for (final batch in batches) {
       yield batch;
     }
@@ -339,6 +477,51 @@ class _FakeFacade implements BluetoothFacade {
     Obd2AdapterProfile profile,
   ) =>
       channel ?? _FakeChannel(silent: true);
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    directCalls++;
+    directMac = mac;
+    directTimeout = connectTimeout;
+    return directChannel ?? channel ?? _FakeChannel(silent: true);
+  }
+}
+
+/// Hands back a different direct channel per call so the teardown test
+/// can assert the FIRST channel is closed before the SECOND opens.
+class _SequencedDirectFacade implements BluetoothFacade {
+  final List<ElmByteChannel> sequence;
+  final void Function() onDirect;
+  int _i = 0;
+  _SequencedDirectFacade({required this.sequence, required this.onDirect});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(
+    String deviceId,
+    Obd2AdapterProfile profile,
+  ) =>
+      _FakeChannel(silent: true);
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    onDirect();
+    return sequence[_i++];
+  }
 }
 
 /// Minimal channel that answers every write with the canonical ELM327
@@ -347,10 +530,16 @@ class _FakeFacade implements BluetoothFacade {
 class _FakeChannel implements ElmByteChannel {
   final bool silent;
   final Map<String, String>? respondTo;
+
+  /// When set, [open] throws this — simulates a direct-connect timeout /
+  /// GATT_ERROR 133 so the service falls back to the scan path (#2242).
+  final Object? openError;
   final StreamController<List<int>> _ctrl = StreamController.broadcast();
   bool _open = false;
+  int openCalls = 0;
+  int closeCalls = 0;
 
-  _FakeChannel({this.silent = false, this.respondTo});
+  _FakeChannel({this.silent = false, this.respondTo, this.openError});
 
   @override
   bool get isOpen => _open;
@@ -360,6 +549,9 @@ class _FakeChannel implements ElmByteChannel {
 
   @override
   Future<void> open() async {
+    openCalls++;
+    final err = openError;
+    if (err != null) throw err;
     _open = true;
   }
 
@@ -373,8 +565,9 @@ class _FakeChannel implements ElmByteChannel {
 
   @override
   Future<void> close() async {
+    closeCalls++;
     _open = false;
-    await _ctrl.close();
+    if (!_ctrl.isClosed) await _ctrl.close();
   }
 }
 

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -346,6 +346,13 @@ class _StreamingFacade implements BluetoothFacade {
     Obd2AdapterProfile profile,
   ) =>
       _SilentChannel();
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) =>
+      _SilentChannel();
 }
 
 /// Silent channel — never answers, so the transport's init sequence

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -205,6 +205,14 @@ class _EmptyBluetoothFacade implements BluetoothFacade {
   ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) {
     throw UnimplementedError('not used in trajets_tab tests');
   }
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    throw UnimplementedError('not used in trajets_tab tests');
+  }
 }
 
 class _NoopObd2Service implements Obd2Service {

--- a/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
+++ b/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
@@ -632,6 +632,14 @@ class _UnusedBluetoothFacade implements BluetoothFacade {
   ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) {
     throw UnimplementedError();
   }
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    throw UnimplementedError();
+  }
 }
 
 class _NoOpRecorder implements TraceRecorder {

--- a/test/features/vehicle/providers/obd2_vin_reader_provider_test.dart
+++ b/test/features/vehicle/providers/obd2_vin_reader_provider_test.dart
@@ -304,6 +304,17 @@ class _UnusedBluetoothFacade implements BluetoothFacade {
       'tests — connectBest is overridden directly.',
     );
   }
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    throw UnimplementedError(
+      'BluetoothFacade.channelForDirect is not used by '
+      'Obd2VinReaderService tests.',
+    );
+  }
 }
 
 /// Test transport that returns a fixed response for one specific


### PR DESCRIPTION
## What

Adds `Obd2ConnectionService.connectByMacDirect(mac)` — a direct-connect-by-MAC path that skips BLE scanning. Shared infrastructure for reliable in-trip reconnect and pre-warm (child of Epic #2231).

It addresses the adapter via `BluetoothDevice.fromId(mac)` and connects with a bounded ~4s timeout instead of running `connectByMac`'s ~5s active scan. This is essential for ELM327 clones that stop advertising in standby — a scan never sees them, but a direct GATT connect still wakes them.

## How

- **`BluetoothFacade.channelForDirect(mac, {connectTimeout})`** builds an `ElmByteChannel` straight from a known MAC (no scan). With no scan there is no resolved profile, so it uses the generic FFF0 Nordic-UART UUIDs (the dominant ELM327 clone family).
- **`FlutterBluePlusElmChannel.open()`** now applies the bounded timeout via `device.connect(autoConnect:false, timeout:…)` — **LOAD-BEARING**: FBP's `autoConnect:false` can otherwise block ~35s — and **pre-disconnects any stale GATT client** to dodge Android `GATT_ERROR 133`, but only when a timeout is set (the scan-first path keeps its legacy `connect(autoConnect:false, mtu:null)` behaviour unchanged).
- **`connectByMacDirect`** tears down a prior direct channel before reopening (second GATT-133 guard), runs the **SAME service-side init** as the scan path via an extracted `_openAndInit` helper (the transport no longer self-inits, #2233 — the service owns init), and **falls back to scan-based `connectByMac` on any failure** so behaviour is never worse than today.
- **Not wired into the reconnect scanner** — that is #2231's next child (`reconnect direct-connect-first`). This PR only adds + tests the capability.

## Tests

New `connectByMacDirect` group asserts: connects WITHOUT scanning on the happy path; passes a 4s timeout to the facade; tears down a prior channel before reopening; falls back to the scan path on a direct-open timeout; returns null when both paths fail. Existing OBD2 + VIN + picker tests stay green (the new `channelForDirect` override was added to the four other `BluetoothFacade` fakes).

`flutter analyze` (lib + test + integration_test): only the 2 pre-existing infos. `flutter test test/features/consumption/ test/lint/`: all pass.

## Risk

Medium (BLE lifecycle). The timeout + GATT-teardown behaviour is exercised by fakes, not a real radio — **on-device smoke-test recommended post-merge** (direct reconnect to a real adapter, and a forced-drop → direct-reconnect cycle to confirm no GATT-133 fallback-to-scan).

Closes #2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
