### PR TITLE
feat(theme): make eco theme distinctly green + lift brand-green presence (#2244)

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -81,22 +81,47 @@ class AppTheme {
     );
   }
 
-  /// The green **Eco** theme (#1712) — the app's signature look, named
-  /// for the fuel-savings identity in the app icon.
+  /// The green **Eco** theme (#1712, redesigned #2244) — the app's
+  /// signature look, named for the fuel-savings identity in the app icon.
   ///
   /// It is a light-family theme (never dark — no harsh green-on-black),
-  /// built on the green `FlexScheme.money` palette. The `blendLevel` is
-  /// raised well above [light]'s 7 so surfaces are softly green-tinted
-  /// rather than stark white, keeping the green/white contrast gentle
-  /// while staying bright and readable.
+  /// but it is now an *unmistakably* green theme rather than the faint
+  /// off-white variant of [light] it used to be (#2244). The user feedback
+  /// was that eco "is a very slight variation of light"; this redesign
+  /// makes it deliberately, recognisably green and pushes the brand
+  /// identity colour (the icon's `#2E7D32`) front and centre:
+  ///
+  ///   * It is built on the same brand [_forestGreen] palette as [light]
+  ///     and [dark] — not the generic `FlexScheme.money` — so the identity
+  ///     green is the literal `#2E7D32` from the app icon.
+  ///   * `surfaceMode` is [FlexSurfaceMode.highScaffoldLevelSurface] with a
+  ///     high `blendLevel` (40): the scaffold background gets a 3× green
+  ///     blend so the *background* reads as a clear soft green, while
+  ///     cards/dialogs (level surfaces, 1×) keep a gentler tint so text and
+  ///     content stay legible on them.
+  ///   * The AppBar is filled with the brand green
+  ///     (`appBarStyle: primary` + `appBarBackgroundSchemeColor: primary`)
+  ///     so the chrome reads "eco" at a glance. Foreground defaults to the
+  ///     onPrimary complement (white); `#2E7D32` vs white is 5.13:1,
+  ///     comfortably past the WCAG AA 4.5:1 floor (see
+  ///     `core/theme/contrast_utils.dart`).
+  ///   * `blendOnLevel` is lifted (16 → 24) so primary containers and
+  ///     accents carry more brand green throughout the app.
+  ///
+  /// Scope: this brand-green-forward push is intentionally contained to
+  /// eco. [light] and [dark] keep their surface-coloured app bars; a
+  /// green-app-bar repaint of the default themes is a separate change.
   static ThemeData eco() {
     return FlexThemeData.light(
-      scheme: FlexScheme.money,
-      surfaceMode: FlexSurfaceMode.levelSurfacesLowScaffold,
-      blendLevel: 18,
+      colors: _forestGreen,
+      surfaceMode: FlexSurfaceMode.highScaffoldLevelSurface,
+      blendLevel: 40,
+      appBarStyle: FlexAppBarStyle.primary,
+      appBarElevation: 0.0,
       subThemesData: const FlexSubThemesData(
-        blendOnLevel: 16,
+        blendOnLevel: 24,
         blendOnColors: false,
+        appBarBackgroundSchemeColor: SchemeColor.primary,
         useMaterial3Typography: true,
         useM2StyleDividerInM3: true,
         inputDecoratorBorderType: FlexInputBorderType.outline,

--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/app/theme.dart';
+import 'package:tankstellen/core/theme/contrast_utils.dart';
 
 void main() {
   group('AppTheme.light', () {
@@ -45,5 +46,57 @@ void main() {
   test('light and dark have distinct brightness values', () {
     expect(AppTheme.light().brightness, Brightness.light);
     expect(AppTheme.dark().brightness, Brightness.dark);
+  });
+
+  group('AppTheme.eco (#2244 — distinctly green, brand-green-forward)', () {
+    final theme = AppTheme.eco();
+
+    test('is a light-family theme (never dark)', () {
+      expect(theme.brightness, Brightness.light);
+    });
+
+    test('primary is the brand green family', () {
+      final p = theme.colorScheme.primary;
+      expect(p.g, greaterThan(p.r));
+      expect(p.g, greaterThan(p.b));
+    });
+
+    test('AppBar is filled with the brand primary (the eco chrome cue)', () {
+      expect(theme.appBarTheme.backgroundColor, theme.colorScheme.primary);
+    });
+
+    test('AppBar foreground keeps WCAG AA contrast on the green bar', () {
+      final bg = theme.appBarTheme.backgroundColor!;
+      final fg = theme.appBarTheme.foregroundColor!;
+      expect(
+        ContrastUtils.meetsAA(fg, bg),
+        isTrue,
+        reason: 'AppBar text/icons on the green bar must meet AA (4.5:1); '
+            'got ${ContrastUtils.contrastRatio(fg, bg).toStringAsFixed(2)}:1.',
+      );
+    });
+
+    test('scaffold background is clearly green-tinted, not off-white', () {
+      // The high-scaffold blend pushes a visible green into the background:
+      // green channel must lead, and it must not be near-white (every
+      // channel >= 0xF0), which is what the old faint-variant eco produced.
+      final bg = theme.scaffoldBackgroundColor;
+      expect(bg.g, greaterThan(bg.r));
+      expect(bg.g, greaterThan(bg.b));
+      final nearWhite = bg.r >= 0.94 && bg.g >= 0.94 && bg.b >= 0.94;
+      expect(
+        nearWhite,
+        isFalse,
+        reason: 'eco scaffold must read as green, not near-white off-white.',
+      );
+    });
+
+    test('eco scaffold is visibly greener than the light theme scaffold', () {
+      // Quantify "distinctly different from light": the green-minus-red
+      // lead in eco must exceed light's, proving the stronger green tint.
+      final eco = theme.scaffoldBackgroundColor;
+      final lightBg = AppTheme.light().scaffoldBackgroundColor;
+      expect((eco.g - eco.r), greaterThan(lightBg.g - lightBg.r));
+    });
   });
 }


### PR DESCRIPTION
## What

Redesign the **eco** theme so it is unmistakably green instead of a faint off-white variant of the light theme, and push the product-identity green (the app icon's `#2E7D32`) front and centre.

User feedback that prompted this:
> "The themes are currently basically light, dark and a very slight variation of the light [eco]. Make the eco theme more different and use the product-identity colour more often (the green from the app icon)."

## How (`AppTheme.eco()` — FlexThemeData)

| lever | before | after |
| --- | --- | --- |
| palette | generic `FlexScheme.money` | brand `_forestGreen` (identity `#2E7D32`, same as the icon) |
| `surfaceMode` | `levelSurfacesLowScaffold` | `highScaffoldLevelSurface` (3× green into the scaffold) |
| `blendLevel` | 18 | 40 |
| AppBar | surface-coloured (looked like light) | **filled brand-green** (`appBarStyle: primary` + `appBarBackgroundSchemeColor: primary`, elevation 0) |
| `blendOnLevel` | 16 | 24 (more brand green on containers/accents) |

Result: green-tinted scaffold background, a lighter green card surface floating on it, a filled forest-green app bar with white text, and a green primary button.

## Scope

Contained to `eco()`. `light()` / `dark()` keep their surface-coloured app bars — a green-app-bar repaint of the default themes is a separate, riskier change (left as a follow-up).

## Accessibility

The filled app bar uses the brand green with the auto `onPrimary` (white) foreground: `#2E7D32` vs white = **5.13:1**, comfortably past the WCAG AA 4.5:1 floor. A new test asserts this via `ContrastUtils.meetsAA`.

## Goldens

No PNG regeneration needed. The pixel goldens render under Flutter's **default** Material theme (`pumpApp` builds a bare `MaterialApp` with no `theme:`), never under `eco()`, so this change does not touch any golden. The full golden suite stays green.

## Tests

- `flutter test test/core/theme/ test/app/theme_test.dart` → 57 passed (6 new eco assertions: light-family, brand-green primary, filled-primary AppBar, AA-contrast AppBar foreground, green-tinted-not-near-white scaffold, scaffold visibly greener than light).
- `flutter test test/goldens/` → 21 passed, no regeneration.
- `flutter test test/app/app_test.dart` → passed (constructs the real themes via `app.dart`).
- `flutter analyze` → only the 2 pre-existing infos (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`); no new issues.

## Visual check

A throwaway headless render confirmed the green app bar + green scaffold + green-on-green card. A quick look on a real device/emulator is still recommended for the final colour-on-glass judgement.

Closes #2244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
