### PR TITLE
fix(obd2): in-trip reconnect tries direct-connect-first + relative-RSSI gate (#2245)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -236,9 +236,17 @@ class Obd2ConnectionService {
   /// [timeout] bounds the GATT connect attempt (passed to the channel);
   /// it is NOT a scan window. Returns null when both the direct attempt
   /// and the scan fallback fail to produce a session.
+  ///
+  /// [fallbackToScan] (default `true`) controls the internal scan
+  /// fallback. The in-trip reconnect path (#2245) passes `false` so it
+  /// can own a single RSSI-gated scan fallback itself — gating the
+  /// connect on a relative-RSSI / two-consecutive-batch rule — rather
+  /// than double-scanning (once here, once in the reconnect probe). With
+  /// `false` a failed direct attempt returns null immediately.
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
     Duration timeout = const Duration(seconds: 4),
+    bool fallbackToScan = true,
   }) async {
     // Tear down a prior direct channel BEFORE reopening (dead-GATT
     // teardown). LOAD-BEARING on Android — a still-open GATT client for
@@ -268,6 +276,7 @@ class Obd2ConnectionService {
             'falling back to scan',
       }));
       await _teardownLastDirectChannel();
+      if (!fallbackToScan) return null;
       return connectByMac(mac);
     }
   }

--- a/lib/features/consumption/data/obd2/reconnect_connector.dart
+++ b/lib/features/consumption/data/obd2/reconnect_connector.dart
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../../../core/logging/error_logger.dart';
+import 'adapter_registry.dart';
+import 'obd2_connection_service.dart';
+import 'obd2_service.dart';
+import 'reconnect_rssi_gate.dart';
+
+/// Drives a single in-trip reconnect attempt for a pinned adapter MAC,
+/// DIRECT-CONNECT-FIRST with an RSSI-gated scan fallback (#2245).
+///
+/// Pulled out of `_buildReconnectScannerFactory` so the connect policy
+/// is unit-testable in isolation against a real [Obd2ConnectionService]
+/// + fake facade, rather than buried in a provider closure.
+///
+/// One instance lives per drop (per [AdapterReconnectScanner] the
+/// controller builds), holding the small mutable bookkeeping the gate
+/// needs across the scanner's repeated connect cycles:
+///   * the strongest sighting seen so far ([_lastCandidate]),
+///   * the RSSI at the last SUCCESSFUL connect ([_lastSuccessfulRssi]) —
+///     the relative-RSSI gate baseline, and
+///   * how many back-to-back scan batches have carried the MAC
+///     ([_consecutiveBatchesSeen]).
+///
+/// On a successful connect the new [Obd2Service] is handed to
+/// [onConnected] (the provider swaps its owned `_service` pointer) and
+/// the attempt returns `true`.
+class ReconnectConnector {
+  final Obd2ConnectionService connection;
+
+  /// Hook invoked with the freshly-connected service so the owner can
+  /// swap its service pointer. Fired exactly once per successful attempt.
+  final void Function(Obd2Service service) onConnected;
+
+  ResolvedObd2Candidate? _lastCandidate;
+  int? _lastSuccessfulRssi;
+  var _consecutiveBatchesSeen = 0;
+
+  ReconnectConnector({
+    required this.connection,
+    required this.onConnected,
+  });
+
+  /// Strongest-seen candidate from the scan fallback. Exposed for tests.
+  ResolvedObd2Candidate? get lastCandidate => _lastCandidate;
+
+  /// RSSI recorded at the last successful scan-path connect this drop —
+  /// the relative gate baseline. Null until a scan-path connect lands.
+  int? get lastSuccessfulRssi => _lastSuccessfulRssi;
+
+  /// Run one connect cycle for [mac]: direct first, gated scan fallback.
+  /// Returns `true` once a session is established. Never throws —
+  /// failures are logged and surfaced as `false` so the scanner keeps
+  /// its backoff schedule.
+  Future<bool> attempt(String mac) async {
+    // 1) DIRECT-CONNECT FIRST — no scan. `fallbackToScan: false` keeps
+    //    the service from running its own (ungated) scan fallback, so we
+    //    never double-scan: the single scan below is ours and is gated.
+    try {
+      final direct = await connection.connectByMacDirect(
+        mac,
+        fallbackToScan: false,
+      );
+      if (direct != null) {
+        // A direct connect carries no RSSI (it never scanned), so the
+        // relative-RSSI baseline is left as-is — it is only ever set
+        // from a scan-path candidate, which has a real RSSI reading.
+        onConnected(direct);
+        return true;
+      }
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'ReconnectConnector direct connect failed',
+      }));
+    }
+
+    // 2) SCAN FALLBACK (ultimate). One scan window: track the strongest
+    //    sighting + consecutive-batch count, and only connect when the
+    //    relative-RSSI / two-batch gate passes.
+    try {
+      await for (final batch in connection.scan()) {
+        final seen = batch.where((c) => c.candidate.deviceId == mac);
+        if (seen.isEmpty) {
+          _consecutiveBatchesSeen = 0;
+          continue;
+        }
+        _consecutiveBatchesSeen++;
+        // Refresh lastCandidate to the strongest-seen advertisement.
+        for (final c in seen) {
+          if (_lastCandidate == null ||
+              c.candidate.rssi > _lastCandidate!.candidate.rssi) {
+            _lastCandidate = c;
+          }
+        }
+        final candidate = _lastCandidate!;
+        if (!shouldConnectFromScan(
+          lastSuccessfulRssi: _lastSuccessfulRssi,
+          seenRssi: candidate.candidate.rssi,
+          consecutiveBatchesSeen: _consecutiveBatchesSeen,
+        )) {
+          // Too weak AND not yet seen twice — keep scanning this window;
+          // a later batch may strengthen or repeat it.
+          continue;
+        }
+        final svc = await connection.connect(candidate);
+        _lastSuccessfulRssi = candidate.candidate.rssi;
+        onConnected(svc);
+        return true;
+      }
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'ReconnectConnector scan fallback failed',
+      }));
+    }
+    return false;
+  }
+}

--- a/lib/features/consumption/data/obd2/reconnect_rssi_gate.dart
+++ b/lib/features/consumption/data/obd2/reconnect_rssi_gate.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Pure decision for the in-trip reconnect SCAN fallback (#2245).
+///
+/// The reconnect path tries a direct GATT connect first; a scan is only
+/// used as the ultimate fallback. When the scan path IS reached we must
+/// decide whether a seen candidate is worth a connect attempt — a
+/// far-away or one-off blip is a waste of a connect dance (and risks
+/// latching onto the wrong, weaker advertisement of a neighbouring car's
+/// adapter).
+///
+/// Deliberately NOT an absolute −85 dBm cutoff: the RSSI a given car +
+/// phone combination sees at the dashboard varies wildly between
+/// vehicles. Instead we gate RELATIVELY against the RSSI observed at the
+/// last SUCCESSFUL connect this session, and additionally accept any MAC
+/// that has been seen across two consecutive scan batches (a stable,
+/// repeatable sighting, even if weak).
+///
+/// Connect when EITHER:
+///   * the just-seen RSSI is within [relativeDropDbm] of the baseline
+///     [lastSuccessfulRssi] (i.e. `seenRssi >= lastSuccessfulRssi −
+///     relativeDropDbm`), OR
+///   * the MAC has appeared in at least [requiredConsecutiveBatches]
+///     consecutive scan batches.
+///
+/// When [lastSuccessfulRssi] is null (no successful connect recorded
+/// yet this session) there is no relative baseline, so the decision
+/// falls back to the consecutive-batches rule alone.
+bool shouldConnectFromScan({
+  required int? lastSuccessfulRssi,
+  required int seenRssi,
+  required int consecutiveBatchesSeen,
+  int relativeDropDbm = 15,
+  int requiredConsecutiveBatches = 2,
+}) {
+  final seenEnoughTimes = consecutiveBatchesSeen >= requiredConsecutiveBatches;
+  if (lastSuccessfulRssi == null) return seenEnoughTimes;
+  final strongEnough = seenRssi >= lastSuccessfulRssi - relativeDropDbm;
+  return strongEnough || seenEnoughTimes;
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -22,10 +22,10 @@ import '../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/obd2/active_trip_repository.dart';
-import '../data/obd2/adapter_registry.dart';
 import '../data/obd2/adapter_reconnect_scanner.dart';
 import '../data/obd2/obd2_connection_service.dart';
 import '../data/obd2/obd2_service.dart';
+import '../data/obd2/reconnect_connector.dart';
 import '../data/obd2/trip_recording_controller.dart';
 import 'obd2_breadcrumb_provider.dart';
 import '../data/trip_history_repository.dart';
@@ -1113,43 +1113,23 @@ class TripRecording extends _$TripRecording {
       return null;
     }
     return (pinnedMac, onReconnect) {
-      ResolvedObd2Candidate? lastCandidate;
+      // One connector per drop holds the gate bookkeeping across the
+      // scanner's repeated connect cycles. The connect callback prefers a
+      // DIRECT GATT connect — which works even for clones that stop
+      // advertising in standby (a scan would never re-see them) — and
+      // only falls back to an RSSI-gated scan. The scanner probe always
+      // returns true so the connect step (and thus the direct attempt)
+      // is reached on every cycle; gating on scan-visibility — as the
+      // old probe did — was the dominant standby-clone reconnect failure
+      // (#2245).
+      final connector = ReconnectConnector(
+        connection: connection,
+        onConnected: (svc) => _service = svc,
+      );
       return AdapterReconnectScanner(
         pinnedMac: pinnedMac,
-        probe: (mac) async {
-          try {
-            // One scan window per probe — the service closes it at
-            // its built-in timeout. We take the first batch that
-            // contains the pinned MAC and short-circuit.
-            await for (final batch in connection.scan()) {
-              for (final c in batch) {
-                if (c.candidate.deviceId == mac) {
-                  lastCandidate = c;
-                  return true;
-                }
-              }
-            }
-          } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording reconnect probe failed'}));
-          }
-          return false;
-        },
-        connect: (mac) async {
-          final candidate = lastCandidate;
-          if (candidate == null) return false;
-          try {
-            final svc = await connection.connect(candidate);
-            // Swap the controller's owned service pointer and
-            // hand ownership of the old (dead) service over to
-            // GC. The controller's scheduler will re-prime
-            // against the new transport on the next tick.
-            _service = svc;
-            return true;
-          } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording reconnect connect failed'}));
-            return false;
-          }
-        },
+        probe: (mac) async => true,
+        connect: connector.attempt,
         onReconnect: onReconnect,
       );
     };

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -364,6 +364,36 @@ void main() {
       expect(ready, isNull);
       expect(fake.scanInvoked, isTrue);
     });
+
+    test(
+        'with fallbackToScan:false a failed direct attempt returns null '
+        'WITHOUT scanning (#2245)', () async {
+      // The in-trip reconnect path owns its own RSSI-gated scan fallback,
+      // so it opts out of the service's internal scan to avoid double
+      // scanning. A failed direct connect must surface as a plain null.
+      final fake = _FakeFacade(
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        directChannel: _FakeChannel(
+          openError: StateError('connect timed out'),
+        ),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready =
+          await svc.connectByMacDirect('aa:bb', fallbackToScan: false);
+      expect(ready, isNull);
+      expect(fake.scanInvoked, isFalse,
+          reason: 'fallbackToScan:false must skip the internal scan');
+    });
   });
 }
 

--- a/test/features/consumption/data/obd2/reconnect_connector_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_connector_test.dart
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/reconnect_connector.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// Exercises the in-trip reconnect connect policy (#2245): DIRECT connect
+/// first, RSSI-gated scan only as the ultimate fallback, no double-scan.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('ReconnectConnector — direct-first (#2245)', () {
+    test('connects via direct GATT WITHOUT scanning on the happy path',
+        () async {
+      final fake = _FakeFacade(
+        directChannel: _FakeChannel(respondTo: _elmOk()),
+        // A non-empty scan batch — if direct ever fell back to scan this
+        // would be observable via scanInvoked.
+        batches: [
+          [_cand('aa:bb', -55)],
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(fake),
+        onConnected: (s) => connected = s,
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isTrue);
+      expect(connected, isNotNull);
+      expect(fake.directCalls, 1,
+          reason: 'reconnect must try a direct connect first');
+      expect(fake.scanInvoked, isFalse,
+          reason: 'a successful direct connect must NOT scan (no double-scan)');
+      await connected!.disconnect();
+    });
+
+    test('falls back to the scan path only when direct fails — and scans '
+        'exactly once', () async {
+      final fake = _FakeFacade(
+        // Direct open throws ⇒ direct fails; scan carries a strong,
+        // repeated sighting so the gate passes on the 2nd batch.
+        directChannel: _FakeChannel(openError: StateError('GATT 133')),
+        channel: _FakeChannel(respondTo: _elmOk()),
+        batches: [
+          [_cand('aa:bb', -80)], // weak, seen once → gate skips
+          [_cand('aa:bb', -80)], // seen twice → gate passes
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(fake),
+        onConnected: (s) => connected = s,
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isTrue);
+      expect(connected, isNotNull);
+      expect(fake.directCalls, 1, reason: 'direct attempted first');
+      expect(fake.scanCount, 1,
+          reason: 'exactly one scan window — the connector owns the gated '
+              'fallback, the service does not double-scan');
+      await connected!.disconnect();
+    });
+
+    test('refreshes lastCandidate to the strongest-seen advertisement',
+        () async {
+      final fake = _FakeFacade(
+        directChannel: _FakeChannel(openError: StateError('GATT 133')),
+        channel: _FakeChannel(respondTo: _elmOk()),
+        batches: [
+          [_cand('aa:bb', -85)], // weak first
+          [_cand('aa:bb', -50)], // much stronger — becomes lastCandidate
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(fake),
+        onConnected: (s) => connected = s,
+      );
+
+      await connector.attempt('aa:bb');
+
+      expect(connector.lastCandidate, isNotNull);
+      expect(connector.lastCandidate!.candidate.rssi, -50,
+          reason: 'lastCandidate tracks the strongest sighting');
+      // No baseline existed this drop, so the strong 2nd sighting connects
+      // via the two-consecutive-batches rule and records its RSSI.
+      expect(connector.lastSuccessfulRssi, -50);
+      await connected?.disconnect();
+    });
+
+    test('skips a lone weak sighting (gate not satisfied) and returns false',
+        () async {
+      final fake = _FakeFacade(
+        directChannel: _FakeChannel(openError: StateError('GATT 133')),
+        channel: _FakeChannel(respondTo: _elmOk()),
+        batches: [
+          [_cand('aa:bb', -90)], // weak, seen exactly once → never connects
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(fake),
+        onConnected: (s) => connected = s,
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isFalse,
+          reason: 'no baseline + seen once + weak ⇒ gate skips, no connect');
+      expect(connected, isNull);
+    });
+  });
+}
+
+// --- helpers ---------------------------------------------------------
+
+Obd2ConnectionService _build(BluetoothFacade bt) => Obd2ConnectionService(
+      registry: Obd2AdapterRegistry.defaults(),
+      permissions: _GrantPermissions(),
+      bluetooth: bt,
+    );
+
+Obd2AdapterCandidate _cand(String mac, int rssi) => Obd2AdapterCandidate(
+      deviceId: mac,
+      deviceName: 'vLinker FD',
+      advertisedServiceUuids: const [],
+      rssi: rssi,
+    );
+
+Map<String, String> _elmOk() => {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+    };
+
+class _GrantPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+}
+
+class _FakeFacade implements BluetoothFacade {
+  final List<List<Obd2AdapterCandidate>> batches;
+  final ElmByteChannel? channel;
+  final ElmByteChannel? directChannel;
+
+  bool scanInvoked = false;
+  int scanCount = 0;
+  int directCalls = 0;
+
+  _FakeFacade({required this.batches, this.channel, this.directChannel});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    scanInvoked = true;
+    scanCount++;
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      channel ?? _FakeChannel(silent: true);
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+  }) {
+    directCalls++;
+    return directChannel ?? channel ?? _FakeChannel(silent: true);
+  }
+}
+
+class _FakeChannel implements ElmByteChannel {
+  final bool silent;
+  final Map<String, String>? respondTo;
+  final Object? openError;
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+
+  _FakeChannel({this.silent = false, this.respondTo, this.openError});
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+
+  @override
+  Future<void> open() async {
+    final err = openError;
+    if (err != null) throw err;
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    if (silent) return;
+    final cmd = String.fromCharCodes(bytes).trim();
+    final reply = respondTo?[cmd] ?? 'OK>';
+    _ctrl.add(reply.codeUnits);
+  }
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    if (!_ctrl.isClosed) await _ctrl.close();
+  }
+}

--- a/test/features/consumption/data/obd2/reconnect_rssi_gate_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_rssi_gate_test.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/reconnect_rssi_gate.dart';
+
+/// Unit tests for the pure relative-RSSI / two-consecutive-batch gate
+/// that the in-trip reconnect scan fallback uses (#2245). NOT an
+/// absolute −85 dBm cutoff — gates relative to the last successful
+/// connect this session.
+void main() {
+  group('shouldConnectFromScan (#2245)', () {
+    test('connects when the seen RSSI is within −15 dBm of the baseline',
+        () {
+      // Baseline −60, seen −70 ⇒ drop of 10, inside the 15 dBm window.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -60,
+          seenRssi: -70,
+          consecutiveBatchesSeen: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('connects exactly at the −15 dBm boundary', () {
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -60,
+          seenRssi: -75, // exactly baseline − 15
+          consecutiveBatchesSeen: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('skips a single weak sighting below the relative window', () {
+      // Baseline −60, seen −80 ⇒ drop of 20, beyond 15 dBm, seen once.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -60,
+          seenRssi: -80,
+          consecutiveBatchesSeen: 1,
+        ),
+        isFalse,
+      );
+    });
+
+    test('connects a weak sighting once it appears in two consecutive '
+        'batches', () {
+      // Same weak −80, but now seen twice — the stable-sighting rule
+      // overrides the relative-RSSI miss.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -60,
+          seenRssi: -80,
+          consecutiveBatchesSeen: 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test('with no baseline yet, gates purely on two consecutive batches',
+        () {
+      // First reconnect of the session: no relative baseline exists.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: null,
+          seenRssi: -50, // strong, but baseline is unknown
+          consecutiveBatchesSeen: 1,
+        ),
+        isFalse,
+        reason: 'no baseline ⇒ a single sighting is not enough',
+      );
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: null,
+          seenRssi: -90, // even very weak, if seen twice it connects
+          consecutiveBatchesSeen: 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a stronger-than-baseline sighting always connects', () {
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -70,
+          seenRssi: -50, // closer than baseline
+          consecutiveBatchesSeen: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('honours custom thresholds', () {
+      // Tighten the window to 5 dBm: a 10 dBm drop now fails the
+      // relative gate and, seen once, is skipped.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -60,
+          seenRssi: -70,
+          consecutiveBatchesSeen: 1,
+          relativeDropDbm: 5,
+        ),
+        isFalse,
+      );
+      // Require 3 consecutive batches: two sightings of a weak adapter
+      // are no longer enough.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: -60,
+          seenRssi: -90,
+          consecutiveBatchesSeen: 2,
+          requiredConsecutiveBatches: 3,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #2245. Child of Epic #2231 (P0); depends on #2242 (`connectByMacDirect`, merged).

## Problem
The in-trip reconnect scanner scanned (UUID-filtered ~8 s) and then connected a stale `lastCandidate`. That is fatal for ELM327 clones that stop advertising FFF0 in standby: a UUID-filtered scan never re-sees them, so reconnect never even attempts a connect.

## Fix — direct-connect-first, scan only as fallback
- The scanner **probe now always returns true** (`probe: (mac) async => true`) so the connect step — and thus the direct attempt — is reached on every cycle. Gating the connect on scan-visibility was the dominant standby-clone failure.
- The connect step calls `Obd2ConnectionService.connectByMacDirect(mac)` **first**. A new `fallbackToScan: false` flag opts out of the service's own (ungated) internal scan fallback so we **never double-scan** — the connector owns a single RSSI-gated scan fallback.
- **Relative-RSSI gate** (not an absolute −85 dBm cutoff): remembers the RSSI at the last successful scan-path connect this drop and gates at `baseline − 15 dBm`, **OR** requires the MAC in 2 consecutive scan batches. `lastCandidate` refreshes to the strongest-seen advertisement.

The direct-first + gated-scan-fallback policy lives in the new `ReconnectConnector`; the gate decision is the pure `shouldConnectFromScan` predicate — both unit-tested. The 15-min grace window and bounded-scan-then-passive-wait logic are untouched (separate child).

## Tests
- `reconnect_rssi_gate_test.dart` — 7 cases over the pure gate (strong/weak/seen-twice/no-baseline/custom thresholds).
- `reconnect_connector_test.dart` — direct happy path does NOT scan; scan fallback fires only on direct failure and scans exactly once; `lastCandidate` tracks the strongest sighting; lone weak sighting is skipped.
- `obd2_connection_service_test.dart` — `fallbackToScan:false` returns null without scanning.
- Existing reconnect tests stay green. `flutter analyze` clean (only the 2 pre-existing infos); `flutter test test/features/consumption/ test/lint/` all pass.

## Risk / verification
Medium (BLE reconnect). **On-device smoke-test recommended**: start a trip, force an adapter drop (standby a clone that stops advertising), confirm reconnect lands via the direct path inside the grace window without a banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
