### PR TITLE
fix(codegen): regenerate stale trip_recording_provider.g.dart hash (unblocks PRs)

### DIFF
--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'4ef212e42d4ca9b76a2e4b80fa4c482271f92c4f';
+String _$tripRecordingHash() => r'f9006fa7cb0cb041a119abe545f155f8589a6774';
 
 /// App-wide owner of the trip recording (#726).
 ///


### PR DESCRIPTION
## Problem
`master` has stale committed codegen: `trip_recording_provider.g.dart`'s `_$tripRecordingHash` is `4ef212e4…` but a clean `build_runner build` produces `f9006fa7…`. The @riverpod source-hash covers the **entire** provider source (private bodies + imports), so a prior PR that changed the source but skipped regeneration ("public surface unchanged") left it stale. **Every branch cut from master inherits this and fails the codegen-drift gate** (a clean build), e.g. #2252, #2254.

## Fix
Regenerated `trip_recording_provider.g.dart` via `dart run build_runner build --delete-conflicting-outputs` on fresh master — the single drifting file. Once merged, the failing PRs just need a branch update to pick up the corrected generated file.

## Prevention (separate follow-ups)
- Every implementation agent now MUST run a clean codegen build + commit ALL `*.g.dart`/`*.freezed.dart` drift before pushing + run the gate's own `git diff --exit-code` check locally — never skip codegen on a 'public surface unchanged' assumption.

Co-Authored-By: Claude Opus 4.8 (1M context)