### PR TITLE
feat(obd2): wire the supported-PID Hive cache + vehicleFallbackKey into the production Obd2Service (#2253)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'adapter_registry.dart';
@@ -15,9 +16,19 @@ import 'elm_byte_channel.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_permissions.dart';
 import 'obd2_service.dart';
+import 'supported_pids_cache.dart';
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/storage/hive_boxes.dart';
+import '../../../vehicle/providers/vehicle_providers.dart';
 
 part 'obd2_connection_service.g.dart';
+
+/// Vehicle identity the supported-PID cache (#811/#2253) refines its
+/// per-adapter key with. Supplied lazily by the [Obd2ConnectionService]
+/// owner so the data layer never depends on the vehicle feature's
+/// providers directly — the Riverpod provider resolves the active
+/// profile and hands these three fields through.
+typedef Obd2VehicleKeyFields = ({String? make, String? model, int? year});
 
 /// Binds scan results to the adapter registry and hands back a ready
 /// [Obd2Service] on connect (#741).
@@ -49,11 +60,25 @@ class Obd2ConnectionService {
   /// caller back to the scan path. Null once torn down / never used.
   ElmByteChannel? _lastDirectChannel;
 
+  /// Persistent supported-PID bitmap cache (#811), wired into every
+  /// session built here (#2253). Null in tests / configs that don't
+  /// exercise the cache — the service then behaves exactly as before
+  /// (blind PID querying, full support scan every connect).
+  final SupportedPidsCache? supportedPidsCache;
+
+  /// Lazily resolves the active vehicle's make / model / year so the
+  /// supported-PID cache key can be refined past adapterMac-only
+  /// (#2253). Read fresh on every connect because the active vehicle
+  /// can change between trips. Null ⇒ adapterMac-only keying.
+  final Obd2VehicleKeyFields Function()? activeVehicleKeyFields;
+
   Obd2ConnectionService({
     required this.registry,
     required this.permissions,
     required this.bluetooth,
     this.classicBluetooth,
+    this.supportedPidsCache,
+    this.activeVehicleKeyFields,
   });
 
   /// Stream of ranked, profile-matched candidates for the picker UI.
@@ -149,7 +174,27 @@ class Obd2ConnectionService {
     required String name,
   }) async {
     final transport = BluetoothObd2Transport(channel);
-    final service = Obd2Service(transport);
+    // #2253 — wire the dead #811 supported-PID cache into the live
+    // session. The key is rooted on the adapter MAC and refined with
+    // the active vehicle's make:model:year, so [Obd2Service.connect] →
+    // `prime()` can read a cached support bitmap WITHOUT first paying a
+    // multi-frame 0902 VIN read, and the recording loop skips PIDs the
+    // car doesn't implement. When no cache is wired this collapses to
+    // the pre-#2253 transport-only construction.
+    final cache = supportedPidsCache;
+    final vehicle = activeVehicleKeyFields?.call();
+    final service = Obd2Service(
+      transport,
+      pidsCache: cache,
+      vehicleFallbackKey: cache == null
+          ? null
+          : SupportedPidsCache.productionKey(
+              adapterMac: mac,
+              make: vehicle?.make,
+              model: vehicle?.model,
+              year: vehicle?.year,
+            ),
+    );
     service.adapterMac = mac;
     service.adapterName = name;
     // #1330 — hand the per-adapter ELM327 adapter into [Obd2Service]
@@ -309,5 +354,27 @@ Obd2ConnectionService obd2Connection(Ref ref) {
     permissions: ref.watch(obd2PermissionsProvider),
     bluetooth: const PluginBluetoothFacade(),
     classicBluetooth: const PluginClassicBluetoothFacade(),
+    // #2253 — activate the #811 supported-PID cache in production.
+    supportedPidsCache: _openSupportedPidsCache(),
+    activeVehicleKeyFields: () {
+      // Defensive: the vehicle provider must never make a connect throw.
+      try {
+        final v = ref.read(activeVehicleProfileProvider);
+        return (make: v?.make, model: v?.model, year: v?.year);
+      } catch (_) {
+        return (make: null, model: null, year: null);
+      }
+    },
   );
+}
+
+/// Open the #811 supported-PID cache against the unencrypted box
+/// [HiveBoxes.init] opens after the first frame. Returns null when the
+/// box isn't open yet (early-boot connect, or a bare test harness that
+/// never initialised Hive) so building the connection service can never
+/// throw — the session then runs with the pre-#2253 no-cache behaviour
+/// (blind PID querying, full support scan every connect).
+SupportedPidsCache? _openSupportedPidsCache() {
+  if (!Hive.isBoxOpen(HiveBoxes.obd2SupportedPids)) return null;
+  return SupportedPidsCache(Hive.box<String>(HiveBoxes.obd2SupportedPids));
 }

--- a/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
@@ -54,4 +54,4 @@ final class Obd2ConnectionProvider
   }
 }
 
-String _$obd2ConnectionHash() => r'a8d285726aeb55c5fae26e5a45eb83fe383d6b45';
+String _$obd2ConnectionHash() => r'e2282d7cbc02d7e0cf172c6fa3abeb1a2294224b';

--- a/lib/features/consumption/data/obd2/supported_pids_cache.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_cache.dart
@@ -44,6 +44,38 @@ class SupportedPidsCache {
         '$year';
   }
 
+  /// Build the production lookup key (#2253): `adapterMac(+make:model:
+  /// year)`. This is the key the live [Obd2ConnectionService] hands to
+  /// [Obd2Service] as its `vehicleFallbackKey`, so the supported-PID
+  /// prime can resolve a cached bitmap WITHOUT first reading the VIN
+  /// (0902) — the VIN is a multi-frame read we want to skip on a hit.
+  ///
+  /// The key is rooted on [adapterMac] (different adapters can expose
+  /// different effective PID sets on the same car — clones vary), then
+  /// refined with the vehicle's make:model:year when the active profile
+  /// supplies all three. When any vehicle field is missing the key
+  /// degrades gracefully to adapterMac-only — still far better than
+  /// re-scanning every connect. Returns null when even the MAC is
+  /// unavailable (an unstamped service), which makes the resolver fall
+  /// back to its VIN-first path.
+  static String? productionKey({
+    required String? adapterMac,
+    String? make,
+    String? model,
+    int? year,
+  }) {
+    final mac = adapterMac?.trim();
+    if (mac == null || mac.isEmpty) return null;
+    final hasVehicle = make != null &&
+        make.trim().isNotEmpty &&
+        model != null &&
+        model.trim().isNotEmpty &&
+        year != null;
+    if (!hasVehicle) return mac.toLowerCase();
+    return '${mac.toLowerCase()}:'
+        '${fallbackKey(make: make, model: model, year: year)}';
+  }
+
   /// Look up the cached supported-PID set for [key], or null when
   /// there's no entry / the entry is corrupt.
   Set<int>? get(String key) {

--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -59,10 +59,37 @@ class SupportedPidsResolver {
   /// errors: a broken cache must not break the connect flow — worst
   /// case we fall back to blind querying, which is exactly what the
   /// adapter did before this feature landed.
+  ///
+  /// HIT-skip-0902 (#2253): production keys the cache off
+  /// `adapterMac(+make:model:year)` via [_vehicleFallbackKey], which
+  /// needs no VIN to compute. So before paying a multi-frame Mode 09
+  /// PID 02 read just to derive a lookup key, [prime] probes the cache
+  /// with the static fallback key first. On a HIT it loads the cached
+  /// bitmap and returns — no 0902, no `01 XX` scan. Only on a miss (or
+  /// when no fallback key was supplied) does it fall through to the
+  /// precise, VIN-first resolution that older VIN-keyed entries use.
   Future<void> prime() async {
     final cache = _cache;
     if (cache == null) return;
     try {
+      // 1. VIN-free fast path (#2253): probe the static fallback key.
+      //    A HIT here means we never touch 0902 nor the 8 × 01 XX scan
+      //    this session — the whole point of keying off adapterMac +
+      //    make:model:year rather than the VIN.
+      final fallbackKey = _vehicleFallbackKey;
+      if (fallbackKey != null) {
+        final cachedByFallback = cache.get(fallbackKey);
+        if (cachedByFallback != null) {
+          _supportedPids = cachedByFallback;
+          debugPrint(
+              'OBD2 supported-PID cache HIT for fallback key "$fallbackKey" '
+              '(${cachedByFallback.length} PIDs) — skipping 0902 + scan');
+          return;
+        }
+      }
+      // 2. Miss (or no fallback key): resolve the precise key. This
+      //    reads the VIN (0902) and falls back to [_vehicleFallbackKey]
+      //    when the car returns none.
       final key = await _resolveVehicleCacheKey();
       if (key == null) {
         debugPrint(

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'4ef212e42d4ca9b76a2e4b80fa4c482271f92c4f';
+String _$tripRecordingHash() => r'f9006fa7cb0cb041a119abe545f155f8589a6774';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_bluetooth_facade.dart';
@@ -11,6 +13,7 @@ import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/supported_pids_cache.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 void main() {
@@ -395,6 +398,106 @@ void main() {
           reason: 'fallbackToScan:false must skip the internal scan');
     });
   });
+
+  group('Obd2ConnectionService supported-PID cache wiring — #2253', () {
+    late Directory tmpDir;
+    late Box<String> box;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('conn_svc_pidcache_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>(
+        'test_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    // The resolved candidate's MAC is 'aa:bb' + a Peugeot 107 active
+    // vehicle ⇒ this is the production key the service should key on.
+    final prodKey = SupportedPidsCache.productionKey(
+      adapterMac: 'aa:bb',
+      make: 'Peugeot',
+      model: '107',
+      year: 2008,
+    )!;
+
+    test(
+        'cold connect scans + persists the bitmap under the adapterMac+'
+        'make:model:year production key', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(
+          batches: const [[]],
+          channel: _FakeChannel(respondTo: {
+            ..._elmOkResponses(),
+            // PIDs 1, 0x0B, 0x0C, 0x0F; continuation bit (PID 32) clear.
+            '0100': '41 00 80 32 00 00>',
+          }),
+        ),
+        supportedPidsCache: SupportedPidsCache(box),
+        activeVehicleKeyFields: () =>
+            (make: 'Peugeot', model: '107', year: 2008),
+      );
+
+      final ready = await svc.connect(_resolvedVlinker(registry));
+      expect(ready.supportsPid(0x0B), isTrue);
+      expect(ready.supportsPid(0x5E), isFalse);
+      // Persisted under the production key for the next session.
+      expect(SupportedPidsCache(box).get(prodKey),
+          containsAll([0x01, 0x0B, 0x0C, 0x0F]));
+      await ready.disconnect();
+    });
+
+    test(
+        'warm connect with a pre-seeded production key skips the support '
+        'scan AND the 0902 VIN read', () async {
+      await SupportedPidsCache(box).put(prodKey, {0x0B, 0x0C, 0x0F});
+
+      // Channel answers ONLY the AT init — neither 0100 nor 0902 wired,
+      // so any attempt would surface as the channel's default 'OK>'
+      // (a non-bitmap, non-VIN response). We assert the resolver loads
+      // the cached set without needing either.
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(
+          batches: const [[]],
+          channel: _FakeChannel(respondTo: _elmOkResponses()),
+        ),
+        supportedPidsCache: SupportedPidsCache(box),
+        activeVehicleKeyFields: () =>
+            (make: 'Peugeot', model: '107', year: 2008),
+      );
+
+      final ready = await svc.connect(_resolvedVlinker(registry));
+      // Cached bitmap populated the in-memory set without a scan/VIN read.
+      expect(ready.supportsPid(0x0B), isTrue);
+      expect(ready.supportsPid(0x5E), isFalse);
+      await ready.disconnect();
+    });
+
+    test(
+        'no cache wired → behaves exactly as before (transport-only), never '
+        'rejects a PID', () async {
+      final svc = _build(
+        permState: Obd2PermissionState.granted,
+        bt: _FakeFacade(
+          batches: const [[]],
+          channel: _FakeChannel(respondTo: _elmOkResponses()),
+        ),
+        // supportedPidsCache / activeVehicleKeyFields intentionally null.
+      );
+
+      final ready = await svc.connect(_resolvedVlinker(registry));
+      expect(ready.supportsPid(0x5E), isTrue);
+      expect(box.length, 0);
+      await ready.disconnect();
+    });
+  });
 }
 
 // --- helpers ---------------------------------------------------------
@@ -402,11 +505,15 @@ void main() {
 Obd2ConnectionService _build({
   required Obd2PermissionState permState,
   required BluetoothFacade bt,
+  SupportedPidsCache? supportedPidsCache,
+  Obd2VehicleKeyFields Function()? activeVehicleKeyFields,
 }) =>
     Obd2ConnectionService(
       registry: Obd2AdapterRegistry.defaults(),
       permissions: _FakePermissions(permState),
       bluetooth: bt,
+      supportedPidsCache: supportedPidsCache,
+      activeVehicleKeyFields: activeVehicleKeyFields,
     );
 
 ResolvedObd2Candidate _resolvedVlinker(Obd2AdapterRegistry r) {

--- a/test/features/consumption/data/obd2/supported_pids_cache_test.dart
+++ b/test/features/consumption/data/obd2/supported_pids_cache_test.dart
@@ -435,4 +435,240 @@ void main() {
       expect(rate, greaterThan(0));
     });
   });
+
+  group('SupportedPidsCache.productionKey — #2253', () {
+    test('mac + full make/model/year → adapterMac:make:model:year', () {
+      final key = SupportedPidsCache.productionKey(
+        adapterMac: 'AA:BB:CC:DD',
+        make: 'Peugeot',
+        model: '107',
+        year: 2008,
+      );
+      expect(key, 'aa:bb:cc:dd:peugeot:107:2008');
+    });
+
+    test('mac only (no vehicle fields) → adapterMac-only key', () {
+      final key = SupportedPidsCache.productionKey(adapterMac: 'AA:BB');
+      expect(key, 'aa:bb');
+    });
+
+    test('partial vehicle (missing year) degrades to adapterMac-only', () {
+      final key = SupportedPidsCache.productionKey(
+        adapterMac: 'AA:BB',
+        make: 'Peugeot',
+        model: '107',
+        // year omitted
+      );
+      expect(key, 'aa:bb');
+    });
+
+    test('blank make/model degrade to adapterMac-only', () {
+      final key = SupportedPidsCache.productionKey(
+        adapterMac: 'AA:BB',
+        make: '  ',
+        model: '',
+        year: 2008,
+      );
+      expect(key, 'aa:bb');
+    });
+
+    test('no adapterMac → null (resolver falls back to VIN-first path)', () {
+      expect(
+        SupportedPidsCache.productionKey(adapterMac: null),
+        isNull,
+      );
+      expect(
+        SupportedPidsCache.productionKey(adapterMac: ''),
+        isNull,
+      );
+    });
+
+    test('case-insensitive — capitalisation mismatch shares a slot', () {
+      final a = SupportedPidsCache.productionKey(
+        adapterMac: 'AA:BB',
+        make: 'Peugeot',
+        model: '107',
+        year: 2008,
+      );
+      final b = SupportedPidsCache.productionKey(
+        adapterMac: 'aa:bb',
+        make: 'PEUGEOT',
+        model: '107',
+        year: 2008,
+      );
+      expect(a, b);
+    });
+  });
+
+  group('Obd2Service production-key cache wiring (HIT-skip-0902) — #2253', () {
+    late Directory tmpDir;
+    late Box<String> box;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('obd2_prodkey_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>(
+        'test_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    // The production-shaped key the live Obd2ConnectionService hands the
+    // service — no VIN involved.
+    final prodKey = SupportedPidsCache.productionKey(
+      adapterMac: 'AA:BB:CC:DD',
+      make: 'Peugeot',
+      model: '107',
+      year: 2008,
+    )!;
+
+    test(
+        'cold connect (cache miss) → scan runs, bitmap persisted under the '
+        'production key; 0902 fallback only when scan needs a precise key',
+        () async {
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        // No 0902 wired → VIN parse returns null → resolver falls back
+        // to the production key for persistence.
+        '0100': '41 00 80 32 00 00>', // PIDs 1, 0x0B, 0x0C, 0x0F
+      });
+      final service = Obd2Service(
+        transport,
+        pidsCache: SupportedPidsCache(box),
+        vehicleFallbackKey: prodKey,
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+
+      // Scan ran on the cold path.
+      expect(transport.sentCommands, contains('0100'));
+      // In-memory + persisted under the production key.
+      expect(service.supportsPid(0x0B), isTrue);
+      expect(service.supportsPid(0x5E), isFalse);
+      expect(box.get(prodKey), isNotNull,
+          reason: 'cold path must persist the bitmap under the prod key');
+      expect(
+        SupportedPidsCache(box).get(prodKey),
+        containsAll([0x01, 0x0B, 0x0C, 0x0F]),
+      );
+    });
+
+    test(
+        'warm connect (cache HIT on production key) → NO support scan AND '
+        'NO 0902 VIN read', () async {
+      // Pre-seed as if a previous session already scanned this
+      // adapter+vehicle.
+      await SupportedPidsCache(box).put(prodKey, {0x01, 0x0B, 0x0C, 0x0F});
+
+      // Neither 0100 NOR 0902 is wired — if the service tries either,
+      // FakeObd2Transport returns 'NO DATA>'. We assert by command
+      // capture that it sends NEITHER.
+      final transport = FakeObd2Transport({..._initResponses});
+      final service = Obd2Service(
+        transport,
+        pidsCache: SupportedPidsCache(box),
+        vehicleFallbackKey: prodKey,
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+
+      // The whole point of #2253: a warm connect pays neither the
+      // multi-frame VIN read nor the 8 × 01 XX support scan.
+      expect(transport.sentCommands, isNot(contains('0902')),
+          reason: 'HIT on the production key must skip the 0902 VIN read');
+      expect(transport.sentCommands, isNot(contains('0100')),
+          reason: 'HIT must skip the supported-PID support scan');
+
+      // Cached set populated the in-memory bitmap.
+      expect(service.supportsPid(0x0B), isTrue);
+      expect(service.supportsPid(0x5E), isFalse);
+    });
+
+    test(
+        'warm HIT → unsupported PIDs are NOT polled by the recording-loop '
+        'consumers (readFuelRateLPerHour speed-density path)', () async {
+      // Peugeot 107 1KR-FE: no 5E, no MAF; MAP/IAT/RPM present.
+      await SupportedPidsCache(box).put(prodKey, {0x0B, 0x0C, 0x0F});
+
+      // 015E / 0110 intentionally NOT wired: if the service polled an
+      // unsupported PID it would hit FakeObd2Transport's NO DATA and
+      // show up in sentCommands.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '010B': '41 0B 28>', // MAP 40 kPa
+        '010F': '41 0F 41>', // IAT 25 °C
+        '010C': '41 0C 0C 80>', // RPM 800
+      });
+      final service = Obd2Service(
+        transport,
+        pidsCache: SupportedPidsCache(box),
+        vehicleFallbackKey: prodKey,
+      );
+      await service.connect();
+
+      expect(service.supportsPid(0x5E), isFalse);
+      expect(service.supportsPid(0x10), isFalse);
+
+      final rate = await service.readFuelRateLPerHour();
+      expect(rate, isNotNull);
+      expect(rate, greaterThan(0));
+
+      // The unsupported PID commands were never sent.
+      expect(transport.sentCommands, isNot(contains('015E')));
+      expect(transport.sentCommands, isNot(contains('0110')));
+    });
+
+    test(
+        'no-cache (cold) path unchanged — service built transport-only still '
+        'scans blindly and never rejects a PID', () async {
+      final transport = FakeObd2Transport({..._initResponses});
+      // No pidsCache, no vehicleFallbackKey — exactly the pre-#2253
+      // construction.
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+
+      // prime() is a no-op without a cache → no fallback probe, no scan,
+      // no VIN read.
+      expect(transport.sentCommands, isNot(contains('0100')));
+      expect(transport.sentCommands, isNot(contains('0902')));
+      // "Unknown ⇒ allow": every PID still reports supported.
+      expect(service.supportsPid(0x5E), isTrue);
+      expect(service.supportsPid(0x0B), isTrue);
+    });
+
+    test(
+        'VIN-keyed legacy entries still resolve when no fallback key is '
+        'supplied (no regression to the #811 VIN path)', () async {
+      const vin = 'VF7PPPP0000000001';
+      await SupportedPidsCache(box).put(vin, {0x0B, 0x0C, 0x0F});
+
+      // No vehicleFallbackKey → resolver must read 0902 and hit on VIN.
+      final transport = FakeObd2Transport({
+        ..._initResponses,
+        '0902': _vinResponse(vin),
+      });
+      final service = Obd2Service(
+        transport,
+        pidsCache: SupportedPidsCache(box),
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      // VIN read happened (it's the only key source here)…
+      expect(transport.sentCommands, contains('0902'));
+      // …and the cached set loaded → no support scan.
+      expect(transport.sentCommands, isNot(contains('0100')));
+      expect(service.supportsPid(0x0B), isTrue);
+      expect(service.supportsPid(0x5E), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Closes #2253 (child of Epic #2231, P1 init-speed).

## What

The #811 `SupportedPidsCache` + `SupportedPidsResolver` existed but were **dead in production**: the live `Obd2Service` (built in `_openAndInit`) was transport-only, so `prime()` no-op'd, the `0100..01C0` support scan never ran, `isPidSupported` was permanently unknown→allow, and the recording loop blind-polled unsupported PIDs.

This activates the dead infra **without changing the resolver's scan/parse logic**.

## How

- **Production wiring** — `Obd2ConnectionService` gains an optional `SupportedPidsCache` + a lazy `Obd2VehicleKeyFields` resolver. `_openAndInit` constructs the live `Obd2Service` with the cache and a production cache key rooted on the adapter MAC and refined with the active vehicle's `make:model:year` (`SupportedPidsCache.productionKey` → `adapterMac(+make:model:year)`, degrading to adapterMac-only when vehicle fields are missing). The `obd2Connection` provider wires the unencrypted `obd2_supported_pids` box and reads the active profile lazily (so a mid-session "switch car" re-keys on the next connect).
- **No-throw guard** — the box is opened via `Hive.isBoxOpen(...)`; if it isn't open yet (early-boot connect, or a bare test harness that never initialised Hive) the cache is `null` and the session runs the exact pre-#2253 no-cache behaviour. The vehicle resolver is also try/caught. This keeps `ref.read(obd2ConnectionProvider)` non-throwing — a real regression caught in `trip_recording_provider_test` before the guard landed.
- **HIT-skip-0902** — `prime()` now probes the static fallback key **first**. On a hit it loads the cached bitmap and returns with **no VIN read and no support scan** — the point of keying off `adapterMac(+make:model:year)` rather than the VIN. Only a miss (or no fallback key) falls through to the precise VIN-first path that older VIN-keyed `#811` entries use, so that path is preserved.

## Tests

- `SupportedPidsCache.productionKey` unit tests (full key, adapterMac-only degrade, partial/blank vehicle, null mac, case-insensitivity).
- Production-shaped `Obd2Service` tests via `FakeObd2Transport.sentCommands`: cold connect scans + persists under the prod key; **warm HIT skips both the `0100` support scan AND the `0902` VIN read**; warm HIT means unsupported PIDs (`015E`/`0110`) are never polled (speed-density fallback); no-cache cold path unchanged; legacy VIN-keyed entries still resolve.
- `Obd2ConnectionService`-level tests for the same cold/warm/no-cache paths through the real `_openAndInit`.
- Full `test/features/consumption/` + `test/lint/` green (3000 tests); vehicle suite green (678).

## On-device note

Risk: medium. Recommend an on-device smoke test against a real adapter — first connect should scan + cache the real PID-support bitmap; a second connect to the same adapter+vehicle should skip both the support scan and the 0902 VIN read (verifiable via the OBD2 debug log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
