### PR TITLE
test(argentina): tag flaky live-network searchStations tests `network` (CI excludes)

### DIFF
--- a/test/features/station_services/argentina/argentina_station_service_test.dart
+++ b/test/features/station_services/argentina/argentina_station_service_test.dart
@@ -311,7 +311,12 @@ col0,col1,col2,TestCo,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,100.5,202
   });
 
   group('ArgentinaStationService searchStations', () {
-    test('searchStations throws ApiException on network failure', () async {
+    // #837 — hits the live datos.energia.gob.ar CSV, so the failure shape is
+    // nondeterministic across CI environments (flaked PR #2257). Tagged
+    // `network` so CI's --exclude-tags=network skips it; the deterministic
+    // error-path coverage lives in the withDio cert/connection tests below.
+    test('searchStations throws ApiException on network failure',
+        tags: 'network', () async {
       const params = SearchParams(
         lat: -34.6, lng: -58.4, radiusKm: 10.0,
       );
@@ -330,7 +335,8 @@ col0,col1,col2,TestCo,Dir,Loc,Prov,col7,col8,Nafta premium,col10,col11,100.5,202
       }
     });
 
-    test('searchStations returns valid ServiceResult type', () async {
+    test('searchStations returns valid ServiceResult type',
+        tags: 'network', () async {
       const params = SearchParams(
         lat: -34.6, lng: -58.4, radiusKm: 10.0,
       );


### PR DESCRIPTION
## Why
PR #2257 flaked on `test (2)` — two `ArgentinaStationService.searchStations` tests make REAL calls to `datos.energia.gob.ar` and only catch `ApiException`/`UpstreamCertificateException`, so any other failure shape on a given CI runner fails them nondeterministically. They pass locally (3/3) and passed #2259's run but flaked #2257's — #2257 only exposed them because regenerating `app_localizations_*.dart` ballooned its affected-only shard to ~the whole suite.

## Fix + prevention
Tag both with `tags: 'network'` so CI's `--exclude-tags=network` skips them (the exact precedent set by `mise_station_service_test`). Deterministic error-path coverage remains in the file's `withDio` cert/connection tests. This removes a real source of CI flakiness; the broader audit of untagged real-network tests is folded into the dev-factory capstone.

Co-Authored-By: Claude Opus 4.8 (1M context)