### PR TITLE
feat(obd2): connect/init/reconnect hardening batch (#2261)

### DIFF
--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -55,11 +55,13 @@ class HiveBoxes {
   static const String achievements = 'achievements';
 
   /// Supported-PID bitmap cache (#811). Keyed by VIN (preferred) or
-  /// `make:model:year` (fallback when the car doesn't return a VIN).
-  /// Values are sorted `List<int>` of PID indices the car implements
-  /// for Mode 01. Small, not PII, opened unencrypted like the other
-  /// OBD2 boxes.
+  /// `make:model:year` (fallback). Sorted `List<int>` of Mode-01 PID
+  /// indices the car implements. Small, not PII, opened unencrypted.
   static const String obd2SupportedPids = 'obd2_supported_pids';
+
+  /// Negotiated ELM327 protocol cache (#2261). Keyed `adapterMac(:vin)`;
+  /// value is the `ATDPN` protocol digit for warm `ATSP{n}` connects.
+  static const String obd2NegotiatedProtocol = 'obd2_negotiated_protocol';
 
   /// Odometer-based service reminders (#584). One JSON payload per
   /// reminder keyed by reminder id. Not PII (label + interval +
@@ -77,21 +79,17 @@ class HiveBoxes {
   static const String obd2PausedTrips = 'obd2_paused_trips';
 
   /// Write-through snapshot of the currently-recording OBD2 trip
-  /// (#1303). At most ONE entry — keyed on a fixed sentinel — that
-  /// the [TripRecording] provider rewrites every few seconds while a
-  /// trip is live. Survives a process death so the recovery service
-  /// can put the user back on the recording screen with their
-  /// captured samples on next launch. Same privacy treatment as the
-  /// other OBD2 boxes — unencrypted, opened once at startup.
+  /// (#1303). At most ONE entry — keyed on a fixed sentinel — that the
+  /// [TripRecording] provider rewrites every few seconds while a trip is
+  /// live. Survives a process death so the recovery service can put the
+  /// user back on the recording screen with their captured samples on
+  /// next launch. Unencrypted, opened once at startup.
   static const String obd2ActiveTrip = 'obd2_active_trip';
 
   /// Rolling price snapshots used by the price-drop velocity detector
-  /// (#579). One JSON payload per (station, fuel, timestamp) with a
-  /// synthetic key. Coords are captured per-snapshot so the detector
-  /// can filter by radius without re-joining against station data.
-  /// Pruned to the last 6 h on every write to keep the box small.
-  /// Unencrypted like the other OBD2 boxes — contains no PII beyond
-  /// public station coordinates.
+  /// (#579). One JSON payload per (station, fuel, timestamp); coords are
+  /// captured per-snapshot for radius filtering. Pruned to the last 6 h
+  /// on every write. Unencrypted — no PII beyond public coordinates.
   static const String priceSnapshots = 'price_snapshots';
 
   /// Ring buffer of background-isolate errors awaiting foreground
@@ -220,6 +218,7 @@ class HiveBoxes {
     obd2TripHistory,
     achievements,
     obd2SupportedPids,
+    obd2NegotiatedProtocol,
     serviceReminders,
     obd2PausedTrips,
     obd2ActiveTrip,
@@ -363,6 +362,7 @@ class HiveBoxes {
     await Hive.openBox<String>(serviceReminders);
     // #797 — paused trips box, string-typed JSON, matches runtime.
     await Hive.openBox<String>(obd2PausedTrips);
+    await Hive.openBox<String>(obd2NegotiatedProtocol); // #2261
     // #1303 — active-trip snapshot box, string-typed JSON.
     await Hive.openBox<String>(obd2ActiveTrip);
     // #579 — velocity detector snapshots. String-typed JSON so the

--- a/lib/features/consumption/data/obd2/adapter_capability.dart
+++ b/lib/features/consumption/data/obd2/adapter_capability.dart
@@ -157,7 +157,7 @@ CapabilityProbeResult classifyMultiFrameProbeResponse(String raw) {
 /// probe never throws — the connect flow stays resilient.
 Future<CapabilityProbeResult> probeMultiFrameCapability(
   Future<String> Function(String command) sendCommand, {
-  Duration timeout = const Duration(seconds: 4),
+  Duration timeout = const Duration(milliseconds: 1500),
 }) async {
   try {
     final raw = await sendCommand(multiFrameProbeCommand).timeout(timeout);

--- a/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
+++ b/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
@@ -56,8 +56,24 @@ class AdapterReconnectScanner {
   final String _pinnedMac;
   final AdapterInRangeProbe _probe;
   final AdapterConnectAttempt _connect;
+
+  /// Passive-wait connect callback used once the active-scan miss
+  /// ceiling is reached (#2261 concern 2). Null ⇒ the scanner keeps
+  /// active-scanning for the whole grace (pre-#2261 behaviour).
+  final AdapterConnectAttempt? _passiveConnect;
+
   final VoidCallback _onReconnect;
   final Duration _maxBackoff;
+
+  /// Number of consecutive active-scan misses after which the scanner
+  /// switches from battery-burning active 8 s scans to a single passive
+  /// autoConnect GATT wait for the remainder of the grace (#2261
+  /// concern 2). On a parked car the adapter never comes back, so after
+  /// ~5–6 fruitless active scans there is no point spinning the radio —
+  /// a passive GATT wait costs nothing and still wakes the link the
+  /// instant the adapter powers back up. Ignored when [_passiveConnect]
+  /// is null.
+  final int _missCeiling;
 
   /// Delay before the FIRST probe after a drop (#1991). A fresh drop is
   /// most often a transient BLE blip; probing near-immediately — rather
@@ -72,17 +88,28 @@ class AdapterReconnectScanner {
   bool _scanning = false;
   bool _cycleInFlight = false;
 
+  /// Consecutive active-scan misses so far this drop (#2261 concern 2).
+  int _consecutiveMisses = 0;
+
+  /// Latches `true` once [_missCeiling] is reached, so every later cycle
+  /// uses the cheap passive wait instead of an active scan (#2261).
+  bool _passiveMode = false;
+
   AdapterReconnectScanner({
     required String pinnedMac,
     required AdapterInRangeProbe probe,
     required AdapterConnectAttempt connect,
     required VoidCallback onReconnect,
+    AdapterConnectAttempt? passiveConnect,
+    int missCeiling = 5,
     Duration initialBackoff = const Duration(seconds: 5),
     Duration maxBackoff = const Duration(seconds: 60),
     Duration firstProbeDelay = const Duration(seconds: 1),
   })  : _pinnedMac = pinnedMac,
         _probe = probe,
         _connect = connect,
+        _passiveConnect = passiveConnect,
+        _missCeiling = missCeiling,
         _onReconnect = onReconnect,
         _maxBackoff = maxBackoff,
         _firstProbeDelay = firstProbeDelay,
@@ -102,6 +129,17 @@ class AdapterReconnectScanner {
   /// directly rather than timing successive fake-async advances.
   @visibleForTesting
   Duration get currentBackoff => _currentBackoff;
+
+  /// `true` once the active-scan miss ceiling was reached and the
+  /// scanner switched to the passive autoConnect GATT wait (#2261
+  /// concern 2). Exposed for tests + diagnostics.
+  @visibleForTesting
+  bool get isPassiveWaiting => _passiveMode;
+
+  /// Consecutive active-scan misses recorded this drop (#2261). Exposed
+  /// for tests asserting the ceiling switch.
+  @visibleForTesting
+  int get consecutiveMisses => _consecutiveMisses;
 
   /// Schedule the first probe cycle. Safe to call repeatedly — a
   /// second call while already scanning is a no-op so the caller
@@ -132,20 +170,28 @@ class AdapterReconnectScanner {
 
   /// One probe + optional connect round. Doubles backoff on miss /
   /// connect failure, fires [onReconnect] + self-stops on success.
+  ///
+  /// #2261 concern 2 — once [_consecutiveMisses] reaches [_missCeiling]
+  /// (and a [_passiveConnect] callback was supplied) the cycle switches
+  /// to passive mode: it skips the active in-range probe entirely and
+  /// instead does a single long-lived passive autoConnect GATT wait,
+  /// rescheduling at the capped backoff if that wait times out. This
+  /// stops the radio from burning battery on a parked car while still
+  /// waking the link the instant the adapter powers back up.
   Future<void> _runCycle() async {
     // Overlapping ticks would let two connects race each other,
     // which the transport is not designed to handle. Cheap guard.
     if (_cycleInFlight || !_scanning) return;
     _cycleInFlight = true;
     try {
+      if (_passiveMode) {
+        await _runPassiveCycle();
+        return;
+      }
       final inRange = await _probeSafely();
       if (!_scanning) return; // stop() raced — honour it
       if (!inRange) {
-        // Schedule the next retry at the current backoff, THEN double
-        // it — so the first retry after a fast first probe uses
-        // `initialBackoff`, not `initialBackoff × 2` (#1991).
-        _scheduleNext();
-        _doubleBackoff();
+        _registerMiss();
         return;
       }
       final ok = await _connectSafely();
@@ -159,13 +205,48 @@ class AdapterReconnectScanner {
         return;
       }
       // Probe said "in range" but connect failed (adapter busy,
-      // dance interrupted). Treat as a miss — schedule the retry,
-      // then double the backoff so we don't hammer the adapter.
-      _scheduleNext();
-      _doubleBackoff();
+      // dance interrupted). Treat as a miss.
+      _registerMiss();
     } finally {
       _cycleInFlight = false;
     }
+  }
+
+  /// A passive-mode cycle: wait on a passive autoConnect GATT connect
+  /// (no active scan). On success, fire [onReconnect] + self-stop; on a
+  /// timeout, reschedule another passive wait at the capped backoff.
+  Future<void> _runPassiveCycle() async {
+    final ok = await _connectSafely(passive: true);
+    if (!_scanning) return; // stop() raced during the passive wait
+    if (ok) {
+      await stop();
+      _onReconnect();
+      return;
+    }
+    // Passive wait timed out within its window — schedule the next one.
+    // Backoff is already pinned at maxBackoff (passive mode latched
+    // there), so this just paces the re-arm.
+    _scheduleNext();
+  }
+
+  /// Record an active-scan miss: schedule the next retry at the current
+  /// backoff (THEN double it — so the first retry after a fast first
+  /// probe uses `initialBackoff`, not `initialBackoff × 2`, #1991), and
+  /// flip into passive mode once the miss ceiling is reached (#2261).
+  void _registerMiss() {
+    _consecutiveMisses++;
+    if (_passiveConnect != null && _consecutiveMisses >= _missCeiling) {
+      // Ceiling reached — stop burning the radio. Pin the backoff at the
+      // ceiling so the passive-wait re-arm is paced, and run the first
+      // passive wait promptly.
+      _passiveMode = true;
+      _currentBackoff = _maxBackoff;
+      _timer?.cancel();
+      _timer = Timer(_firstProbeDelay, _runCycle);
+      return;
+    }
+    _scheduleNext();
+    _doubleBackoff();
   }
 
   Future<bool> _probeSafely() async {
@@ -177,9 +258,11 @@ class AdapterReconnectScanner {
     }
   }
 
-  Future<bool> _connectSafely() async {
+  Future<bool> _connectSafely({bool passive = false}) async {
+    final attempt = passive ? _passiveConnect : _connect;
+    if (attempt == null) return false;
     try {
-      return await _connect(_pinnedMac);
+      return await attempt(_pinnedMac);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AdapterReconnectScanner connect failed'}));
       return false;

--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -49,6 +49,7 @@ abstract class BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout,
+    bool autoConnect,
   });
 }
 
@@ -176,6 +177,7 @@ class PluginBluetoothFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
     // No scan ⇒ no resolved profile. The FFF0 Nordic-UART family
     // (Elm327BleUuids.vgate, = the generic-fff0 profile UUIDs) is the
@@ -183,11 +185,17 @@ class PluginBluetoothFacade implements BluetoothFacade {
     // direct-by-MAC connect. The 4 s connectTimeout is LOAD-BEARING:
     // FBP `autoConnect:false` can otherwise block ~35 s on a sleeping
     // adapter (#2242).
+    //
+    // #2261 concern 2 — `autoConnect:true` switches to a passive GATT
+    // wait (no bounded timeout): the reconnect scanner uses this once
+    // its active-scan miss ceiling is reached, so a parked car stops
+    // burning the radio on repeated active scans.
     final device = BluetoothDevice.fromId(mac);
     return FlutterBluePlusElmChannel(
       device,
       uuids: Elm327BleUuids.vgate,
-      connectTimeout: connectTimeout,
+      connectTimeout: autoConnect ? null : connectTimeout,
+      autoConnect: autoConnect,
     );
   }
 }

--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -99,6 +99,27 @@ class BluetoothObd2Transport implements Obd2Transport {
     return completer.future;
   }
 
+  /// #2261 concern 4 — forward link-tuning to the underlying channel
+  /// when it is a BLE [Obd2LinkTuner]. No-op for channels that don't
+  /// expose tuning (Classic SPP, test fakes), so callers can tune
+  /// unconditionally. Best-effort: the channel itself swallows platform
+  /// rejections.
+  Future<void> tuneForRecording() async {
+    final ch = _channel;
+    if (ch is Obd2LinkTuner) {
+      await (ch as Obd2LinkTuner).tuneForRecording();
+    }
+  }
+
+  /// Drop the link to balanced priority when only the 1 Hz auto-record
+  /// stream is live (#2261 concern 4).
+  Future<void> tuneForBackground() async {
+    final ch = _channel;
+    if (ch is Obd2LinkTuner) {
+      await (ch as Obd2LinkTuner).tuneForBackground();
+    }
+  }
+
   @override
   Future<void> disconnect() async {
     _connected = false;

--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
+import 'obd2_read_timeout.dart';
 import 'obd2_transport.dart';
 
 /// [Obd2Transport] that moves bytes over a generic [ElmByteChannel]
@@ -30,6 +31,12 @@ class BluetoothObd2Transport implements Obd2Transport {
   Completer<String>? _pending;
   bool _connected = false;
 
+  /// #2261 concern 5 — true until the FIRST command of a fresh link
+  /// completes. The first command faces a waking ECU / a pending
+  /// protocol search, so it gets a longer read-timeout class than the
+  /// same command would later. Reset on every [connect].
+  bool _firstCommandPending = true;
+
   /// Tail of the command queue. Every [sendCommand] chains onto this so
   /// overlapping callers — e.g. the VIN reader racing the auto-record
   /// PID poller, both sharing one transport — serialise instead of
@@ -49,6 +56,7 @@ class BluetoothObd2Transport implements Obd2Transport {
   @override
   Future<void> connect() async {
     if (_connected) return;
+    _firstCommandPending = true;
     await _channel.open();
     _subscription = _channel.incoming.listen(
       _onBytes,
@@ -140,17 +148,27 @@ class BluetoothObd2Transport implements Obd2Transport {
         'BluetoothObd2Transport: concurrent sendCommand is not allowed',
       );
     }
+    // #2261 concern 5 — right-size the read timeout per command class
+    // instead of a flat 5 s. Clamped to the configured [_readTimeout] so
+    // an explicit override still acts as a hard ceiling.
+    final cls = classifyReadTimeout(
+      command,
+      firstCommandOnFreshLink: _firstCommandPending,
+    );
+    _firstCommandPending = false;
+    final timeout = cls.timeout > _readTimeout ? _readTimeout : cls.timeout;
+
     _buffer.clear();
     final completer = Completer<String>();
     _pending = completer;
     await _channel.write(command.codeUnits);
     return completer.future.timeout(
-      _readTimeout,
+      timeout,
       onTimeout: () {
         _pending = null;
         throw TimeoutException(
-          'ELM327 did not respond within $_readTimeout',
-          _readTimeout,
+          'ELM327 did not respond within $timeout',
+          timeout,
         );
       },
     );

--- a/lib/features/consumption/data/obd2/connection_drop_debouncer.dart
+++ b/lib/features/consumption/data/obd2/connection_drop_debouncer.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+/// Debounces a raw BLE `connectionState == disconnected` edge into a
+/// *confirmed* drop signal (#2261 concern 1).
+///
+/// The ELM327 BLE link blips constantly: a momentary RF collision, a
+/// 2.4 GHz Wi-Fi burst, or the adapter's own supervision-timeout dance
+/// can flip `connectionState` to `disconnected` for a few hundred
+/// milliseconds and then heal itself. If every such edge tore the
+/// session down, a recoverable drive would end on a pothole.
+///
+/// This collaborator turns the raw edge into a confirmed drop only when
+/// EITHER:
+///   * the link stays down for [debounce] (a real disconnect — the
+///     adapter is gone), OR
+///   * [noteCommandFailure] is called while a disconnect edge is
+///     pending (the next OBD command also failed — the link is
+///     demonstrably unusable, so we don't wait out the full debounce).
+///
+/// A `connected` edge arriving before either fires CANCELS the pending
+/// drop — the blip self-healed and the session survives.
+///
+/// Pure of any BLE dependency so it is unit-testable with an injected
+/// clock-free [Timer] via [debounce]. The owning channel
+/// ([FlutterBluePlusElmChannel]) feeds it edges and wires [onConfirmed]
+/// to push the typed [Obd2DisconnectedException] onto the byte stream,
+/// which the transport's pending-command completer surfaces as a throw
+/// — so [TripDropDetector] fires in ~1–2 s instead of waiting out the
+/// ~15 s read timeout.
+class ConnectionDropDebouncer {
+  ConnectionDropDebouncer({
+    required void Function() onConfirmed,
+    Duration debounce = const Duration(milliseconds: 1500),
+  })  : _onConfirmed = onConfirmed,
+        _debounce = debounce;
+
+  final void Function() _onConfirmed;
+  final Duration _debounce;
+
+  Timer? _timer;
+  bool _confirmed = false;
+
+  /// `true` once a disconnect edge has landed and not yet been cleared
+  /// by a reconnect — i.e. a drop is being debounced or has confirmed.
+  bool get isPending => _timer != null || _confirmed;
+
+  /// `true` once the drop has been confirmed (debounce elapsed or a
+  /// command failed during the pending window). Stays latched until
+  /// [reset].
+  bool get isConfirmed => _confirmed;
+
+  /// Feed a raw BLE connection-state edge.
+  ///
+  ///   * `disconnected: true`  → arm the debounce (no-op if already armed
+  ///     or confirmed).
+  ///   * `disconnected: false` → a reconnect: cancel a pending debounce
+  ///     so a self-healed blip never confirms. Does NOT clear an already
+  ///     confirmed drop — the session is gone; recovery owns rebuilding.
+  void noteConnectionState({required bool disconnected}) {
+    if (disconnected) {
+      if (_confirmed || _timer != null) return;
+      _timer = Timer(_debounce, _confirm);
+    } else {
+      // Reconnected before the debounce elapsed → the blip healed.
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  /// Report that a command failed while a disconnect edge is pending.
+  /// Confirms the drop immediately — no point waiting out the rest of
+  /// the debounce when the link has already proven unusable. A no-op
+  /// when no disconnect is pending (a lone command timeout on an
+  /// otherwise-connected link is the read-timeout's concern, not ours).
+  void noteCommandFailure() {
+    if (_timer == null || _confirmed) return;
+    _confirm();
+  }
+
+  void _confirm() {
+    _timer?.cancel();
+    _timer = null;
+    if (_confirmed) return;
+    _confirmed = true;
+    _onConfirmed();
+  }
+
+  /// Clear all state so a fresh connection can reuse the debouncer.
+  void reset() {
+    _timer?.cancel();
+    _timer = null;
+    _confirmed = false;
+  }
+
+  /// Cancel any pending timer. Call on channel close.
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/lib/features/consumption/data/obd2/elm327_commands.dart
+++ b/lib/features/consumption/data/obd2/elm327_commands.dart
@@ -101,6 +101,19 @@ class Elm327Commands {
   /// Set protocol to automatic detection.
   static const autoProtocolCommand = 'ATSP0\r';
 
+  /// Describe the currently-active protocol as a NUMBER (#2261 concern
+  /// 3). After ATSP0 has auto-negotiated, `ATDPN` returns the resolved
+  /// protocol digit — prefixed with `A` when it was reached via the
+  /// auto-search (e.g. `A6` ⇒ auto-found protocol 6, `6` ⇒ pinned 6).
+  static const describeProtocolNumberCommand = 'ATDPN\r';
+
+  /// Pin the ELM327 to protocol [n] directly (#2261 concern 3) — a warm
+  /// connect skips the multi-second ATSP0 auto-search by replaying the
+  /// protocol cached from the previous session. [n] is the bare ELM327
+  /// protocol digit (1–9, A–C), i.e. the ATDPN value with the `A`
+  /// auto-flag stripped.
+  static String setProtocolCommand(String n) => 'ATSP$n\r';
+
   /// Turn off line feeds.
   static const lineFeedsOffCommand = 'ATL0\r';
 

--- a/lib/features/consumption/data/obd2/elm327_parsers.dart
+++ b/lib/features/consumption/data/obd2/elm327_parsers.dart
@@ -36,6 +36,48 @@ class Elm327Parsers {
     return cleaned;
   }
 
+  /// Parse the ELM327 `ATDPN` (describe-protocol-number) reply into the
+  /// bare protocol digit, stripping the leading `A` auto-flag (#2261
+  /// concern 3).
+  ///
+  /// `ATDPN` returns the resolved protocol as a single digit (`1`–`9`,
+  /// `A`–`C` for the CAN variants), prefixed with `A` when the protocol
+  /// was reached via the ATSP0 auto-search — e.g. `A6` ⇒ auto-found
+  /// protocol 6, `6` ⇒ explicitly pinned protocol 6. Both map to the
+  /// same pinnable digit `6`. We strip ONLY a leading `A`; the `A`–`C`
+  /// CAN protocol digits are themselves preserved.
+  ///
+  /// Returns null when the response is empty / a NO-DATA / error
+  /// placeholder, or carries no recognisable protocol digit — the
+  /// caller then keeps the safe ATSP0 fallback.
+  static String? parseProtocolNumber(String raw) {
+    var s = raw
+        .replaceAll('>', '')
+        .replaceAll('\r', ' ')
+        .replaceAll('\n', ' ')
+        .toUpperCase()
+        .trim();
+    if (s.isEmpty ||
+        s.contains('NO DATA') ||
+        s.contains('UNABLE') ||
+        s.contains('ERROR') ||
+        s.contains('?')) {
+      return null;
+    }
+    // Strip a single leading auto-flag `A`, then take the first
+    // protocol-digit token (`0`–`9` or `A`–`C`).
+    if (s.startsWith('A') && s.length >= 2) {
+      s = s.substring(1).trim();
+    }
+    final match = RegExp(r'^([0-9A-C])').firstMatch(s);
+    if (match == null) return null;
+    final digit = match.group(1)!;
+    // Protocol 0 is "automatic" — not a concrete pinnable protocol, so
+    // it is treated as "nothing to cache".
+    if (digit == '0') return null;
+    return digit;
+  }
+
   /// Parse vehicle speed from Mode 01 PID 0D response.
   /// Response format: "41 0D XX" where XX is speed in km/h.
   static int? parseVehicleSpeed(String raw) {

--- a/lib/features/consumption/data/obd2/elm327_protocol.dart
+++ b/lib/features/consumption/data/obd2/elm327_protocol.dart
@@ -45,6 +45,10 @@ class Elm327Protocol {
   static const resetCommand = Elm327Commands.resetCommand;
   static const echoOffCommand = Elm327Commands.echoOffCommand;
   static const autoProtocolCommand = Elm327Commands.autoProtocolCommand;
+  static const describeProtocolNumberCommand =
+      Elm327Commands.describeProtocolNumberCommand;
+  static String setProtocolCommand(String n) =>
+      Elm327Commands.setProtocolCommand(n);
   static const lineFeedsOffCommand = Elm327Commands.lineFeedsOffCommand;
   static const headersOffCommand = Elm327Commands.headersOffCommand;
   static const adaptiveTimingCommand = Elm327Commands.adaptiveTimingCommand;
@@ -81,6 +85,9 @@ class Elm327Protocol {
   // ---------------------------------------------------------------------------
 
   static String? cleanResponse(String raw) => Elm327Parsers.cleanResponse(raw);
+
+  static String? parseProtocolNumber(String raw) =>
+      Elm327Parsers.parseProtocolNumber(raw);
 
   static int? parseVehicleSpeed(String raw) =>
       Elm327Parsers.parseVehicleSpeed(raw);

--- a/lib/features/consumption/data/obd2/elm_byte_channel.dart
+++ b/lib/features/consumption/data/obd2/elm_byte_channel.dart
@@ -25,3 +25,29 @@ abstract class ElmByteChannel {
 
   bool get isOpen;
 }
+
+/// Optional capability mixin (#2261 concern 4) — channels backed by a
+/// BLE GATT link can tune the connection for throughput vs power. The
+/// trip recorder asks for high throughput while actively polling and
+/// drops to balanced when only the 1 Hz auto-record stream is live, so
+/// a parked-but-connected adapter doesn't hold the radio at high duty.
+///
+/// A separate opt-in interface (rather than methods on [ElmByteChannel])
+/// keeps every existing test fake free of boilerplate — only the BLE
+/// channel implements it; callers type-check before tuning.
+///
+/// Implementations MUST be best-effort: every call is wrapped in
+/// try/catch so a clone that rejects the platform call never breaks a
+/// recording session, and the calls are no-ops off Android / on the
+/// passive autoConnect path (FBP forbids requestMtu with autoConnect).
+abstract class Obd2LinkTuner {
+  /// Request a high-throughput link: `ConnectionPriority.high` plus a
+  /// best-effort MTU bump. Used while the trip recorder is actively
+  /// polling PIDs.
+  Future<void> tuneForRecording();
+
+  /// Drop back to `ConnectionPriority.balanced` — used when only the
+  /// 1 Hz auto-record movement-detection stream is live, so a connected
+  /// idle adapter stops holding the radio at high duty.
+  Future<void> tuneForBackground();
+}

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -45,9 +45,16 @@ class Elm327BleUuids {
 /// It is untested on iOS — flutter_blue_plus is cross-platform but
 /// iOS BLE ELM adapters are rare; add iOS-specific handling when the
 /// app starts supporting them.
-class FlutterBluePlusElmChannel implements ElmByteChannel {
+class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   final BluetoothDevice _device;
   final Elm327BleUuids _uuids;
+
+  /// #2261 concern 4 — best-effort MTU to request on a high-throughput
+  /// (recording) link. 247 is the practical ATT payload ceiling on most
+  /// Android BLE stacks; the actual negotiated value is whatever the
+  /// peripheral grants. Skipped entirely on the autoConnect passive
+  /// path (FBP forbids requestMtu there).
+  static const int _recordingMtu = 247;
 
   /// Optional bounded timeout passed to `device.connect` (#2242). When
   /// null, `connect` is called with the legacy `mtu: null` form and no
@@ -186,6 +193,49 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
       },
     );
     _open = true;
+    // #2261 concern 4 — a freshly-opened ACTIVE link is a recording
+    // link: ask for high throughput (high priority + best-effort MTU).
+    // Skipped on the passive autoConnect path — FBP forbids requestMtu
+    // with autoConnect:true, and a parked-car passive wait wants low
+    // power, not high duty. Best-effort: any rejection is swallowed.
+    if (!_autoConnect) {
+      await tuneForRecording();
+    }
+  }
+
+  @override
+  Future<void> tuneForRecording() async {
+    await _setConnectionPriority(ConnectionPriority.high);
+    // requestMtu is forbidden with autoConnect:true (FBP throws); the
+    // passive path never calls this, but guard anyway.
+    if (_autoConnect) return;
+    try {
+      await _device.requestMtu(_recordingMtu);
+    } catch (e, st) {
+      // Many clones reject a non-default MTU — harmless, the default
+      // 23-byte MTU still works. PHY (2M) is deliberately NOT requested:
+      // it is a trap on BLE 4.0/4.1 clones.
+      debugPrint('FlutterBluePlusElmChannel requestMtu skipped: $e\n$st');
+    }
+  }
+
+  @override
+  Future<void> tuneForBackground() async {
+    await _setConnectionPriority(ConnectionPriority.balanced);
+  }
+
+  /// Best-effort connection-priority request (#2261 concern 4). Android
+  /// only — FBP throws `androidOnly` elsewhere — so the try/catch keeps
+  /// iOS / a rejecting clone from ever breaking a session.
+  Future<void> _setConnectionPriority(ConnectionPriority priority) async {
+    try {
+      await _device.requestConnectionPriority(
+        connectionPriorityRequest: priority,
+      );
+    } catch (e, st) {
+      debugPrint('FlutterBluePlusElmChannel requestConnectionPriority '
+          'skipped: $e\n$st');
+    }
   }
 
   @override
@@ -198,12 +248,14 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
     // the ELM327 replies via notify anyway.
     try {
       await char.write(bytes, withoutResponse: true);
+      // ignore: catch_no_st
     } catch (e) {
       // #2261 concern 1 — a write failing WHILE a disconnect edge is
       // pending confirms the drop immediately rather than waiting out
       // the rest of the debounce: the link has proven unusable. A lone
       // write failure on an otherwise-connected link is a no-op for the
-      // debouncer and falls through to the caller as before.
+      // debouncer and falls through to the caller as before. Rethrow-only
+      // (the caller / transport classifies it) — no stack trace needed.
       _dropDebouncer.noteCommandFailure();
       rethrow;
     }

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
+import 'connection_drop_debouncer.dart';
 import 'elm_byte_channel.dart';
+import 'obd2_connection_errors.dart';
 import '../../../../core/logging/error_logger.dart';
 
 /// Standard SPP-over-BLE UUIDs exposed by Vgate vLinker and most
@@ -59,16 +61,40 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
   BluetoothCharacteristic? _writeChar;
   BluetoothCharacteristic? _notifyChar;
   StreamSubscription<List<int>>? _subscription;
+  StreamSubscription<BluetoothConnectionState>? _connStateSubscription;
   final StreamController<List<int>> _incoming =
       StreamController<List<int>>.broadcast();
   bool _open = false;
+
+  /// #2261 concern 1 — debounces a raw `connectionState == disconnected`
+  /// edge into a confirmed drop so a self-healing RF blip within the BLE
+  /// supervision timeout doesn't tear down a recoverable session, while
+  /// a genuine disconnect still surfaces in ~1–2 s (not the ~15 s read
+  /// timeout). On confirmation it pushes a typed [Obd2DisconnectedException]
+  /// onto the byte stream, which the transport's pending-command completer
+  /// re-throws so [TripDropDetector] classifies it as a typed drop.
+  late final ConnectionDropDebouncer _dropDebouncer;
 
   FlutterBluePlusElmChannel(
     this._device, {
     Elm327BleUuids? uuids,
     Duration? connectTimeout,
+    Duration dropDebounce = const Duration(milliseconds: 1500),
   })  : _uuids = uuids ?? Elm327BleUuids.vgate,
-        _connectTimeout = connectTimeout;
+        _connectTimeout = connectTimeout {
+    _dropDebouncer = ConnectionDropDebouncer(
+      debounce: dropDebounce,
+      onConfirmed: _onDropConfirmed,
+    );
+  }
+
+  /// Push the typed disconnect onto the byte stream so the transport's
+  /// in-flight `sendCommand` completer fails fast with a classified
+  /// error instead of waiting out the read timeout (#2261 concern 1).
+  void _onDropConfirmed() {
+    if (_incoming.isClosed) return;
+    _incoming.addError(const Obd2DisconnectedException());
+  }
 
   @override
   bool get isOpen => _open;
@@ -127,6 +153,20 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
         debugPrint('FlutterBluePlusElmChannel notify error: $e');
       },
     );
+    // #2261 concern 1 — subscribe to the device's connection-state
+    // stream so a real disconnect is noticed in ~1–2 s. The first
+    // emission is the current state (`connected`, since we just
+    // connected); the debouncer ignores `connected` edges, so this is a
+    // no-op until the link actually drops.
+    _dropDebouncer.reset();
+    _connStateSubscription = _device.connectionState.listen(
+      (state) => _dropDebouncer.noteConnectionState(
+        disconnected: state == BluetoothConnectionState.disconnected,
+      ),
+      onError: (e, st) {
+        debugPrint('FlutterBluePlusElmChannel connectionState error: $e');
+      },
+    );
     _open = true;
   }
 
@@ -138,12 +178,25 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
     }
     // withoutResponse lets the adapter write as fast as BLE allows;
     // the ELM327 replies via notify anyway.
-    await char.write(bytes, withoutResponse: true);
+    try {
+      await char.write(bytes, withoutResponse: true);
+    } catch (e) {
+      // #2261 concern 1 — a write failing WHILE a disconnect edge is
+      // pending confirms the drop immediately rather than waiting out
+      // the rest of the debounce: the link has proven unusable. A lone
+      // write failure on an otherwise-connected link is a no-op for the
+      // debouncer and falls through to the caller as before.
+      _dropDebouncer.noteCommandFailure();
+      rethrow;
+    }
   }
 
   @override
   Future<void> close() async {
     _open = false;
+    _dropDebouncer.dispose();
+    await _connStateSubscription?.cancel();
+    _connStateSubscription = null;
     await _subscription?.cancel();
     _subscription = null;
     try {

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -58,6 +58,16 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
   /// stale GATT client to dodge Android GATT_ERROR 133.
   final Duration? _connectTimeout;
 
+  /// #2261 concern 2 — passive autoConnect GATT wait. When true, `open()`
+  /// connects with `autoConnect:true` and NO bounded timeout: the OS
+  /// holds a low-power background GATT connection request that resolves
+  /// the instant the adapter (re)advertises. Used by the reconnect
+  /// scanner once its active-scan miss ceiling is reached, so a parked
+  /// car doesn't burn the radio on repeated active scans. autoConnect:true
+  /// forbids requestMtu (FBP throws), so the concern-4 MTU bump is
+  /// skipped entirely on this path.
+  final bool _autoConnect;
+
   BluetoothCharacteristic? _writeChar;
   BluetoothCharacteristic? _notifyChar;
   StreamSubscription<List<int>>? _subscription;
@@ -79,9 +89,11 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
     this._device, {
     Elm327BleUuids? uuids,
     Duration? connectTimeout,
+    bool autoConnect = false,
     Duration dropDebounce = const Duration(milliseconds: 1500),
   })  : _uuids = uuids ?? Elm327BleUuids.vgate,
-        _connectTimeout = connectTimeout {
+        _connectTimeout = connectTimeout,
+        _autoConnect = autoConnect {
     _dropDebouncer = ConnectionDropDebouncer(
       debounce: dropDebounce,
       onConfirmed: _onDropConfirmed,
@@ -106,7 +118,13 @@ class FlutterBluePlusElmChannel implements ElmByteChannel {
   Future<void> open() async {
     if (_open) return;
     final timeout = _connectTimeout;
-    if (timeout == null) {
+    if (_autoConnect) {
+      // #2261 concern 2 — passive autoConnect GATT wait. No bounded
+      // timeout: the OS keeps a low-power background connection request
+      // that resolves the moment the adapter advertises again.
+      // requestMtu is forbidden with autoConnect:true, so `mtu: null`.
+      await _device.connect(autoConnect: true, mtu: null);
+    } else if (timeout == null) {
       await _device.connect(autoConnect: false, mtu: null);
     } else {
       // Direct-by-MAC path (#2242). Tear down any stale GATT client for

--- a/lib/features/consumption/data/obd2/negotiated_protocol_cache.dart
+++ b/lib/features/consumption/data/obd2/negotiated_protocol_cache.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+/// Persistent cache of the ELM327 protocol number negotiated for a
+/// given adapter + vehicle (#2261 concern 3).
+///
+/// The very first connect to a car runs `ATSP0` and lets the ELM327
+/// auto-search every OBD protocol in turn — a multi-second probe on a
+/// slow clone. The negotiated protocol is stable for the life of the
+/// vehicle's ECU, so caching it and replaying `ATSP{n}` on warm
+/// connects skips the search entirely.
+///
+/// Key is `adapterMac(:vin)`: rooted on the adapter MAC because two
+/// adapters can negotiate differently on the same car (clone quirks),
+/// refined with the VIN when one is known. The value is the bare ELM327
+/// protocol digit (`1`–`9`, `A`–`C`) — the `ATDPN` reply with its
+/// leading `A` auto-flag stripped.
+///
+/// The underlying box is the unencrypted `Box<String>` opened by
+/// [HiveBoxes.initDeferred]. Tiny, not PII — mirrors the privacy
+/// treatment of [SupportedPidsCache] and the other OBD2 boxes.
+class NegotiatedProtocolCache {
+  final Box<String> _box;
+
+  NegotiatedProtocolCache(this._box);
+
+  /// Build the lookup key from an adapter MAC and an optional VIN
+  /// (#2261). Lower-cased so capitalisation never splits an entry.
+  /// Returns null when even the MAC is unavailable (an unstamped
+  /// service), at which point the caller skips the cache and keeps the
+  /// ATSP0 cold-search.
+  static String? keyFor({required String? adapterMac, String? vin}) {
+    final mac = adapterMac?.trim().toLowerCase();
+    if (mac == null || mac.isEmpty) return null;
+    final v = vin?.trim().toLowerCase();
+    if (v == null || v.isEmpty) return mac;
+    return '$mac:$v';
+  }
+
+  /// The cached protocol digit for [key], or null when there's no entry.
+  String? get(String key) {
+    final raw = _box.get(key);
+    if (raw == null || raw.isEmpty) return null;
+    return raw;
+  }
+
+  /// Persist the negotiated protocol [digit] under [key].
+  Future<void> put(String key, String digit) async {
+    final trimmed = digit.trim().toUpperCase();
+    if (trimmed.isEmpty) return;
+    await _box.put(key, trimmed);
+  }
+
+  /// Forget the cached protocol for [key] — called when a warm
+  /// `ATSP{n}` connect fails (UNABLE TO CONNECT / NO DATA), so the next
+  /// connect re-runs the ATSP0 auto-search and re-caches a fresh value.
+  Future<void> invalidate(String key) async {
+    try {
+      await _box.delete(key);
+    } catch (e, st) {
+      debugPrint('NegotiatedProtocolCache: invalidate("$key") failed: $e\n$st');
+    }
+  }
+
+  /// Delete every cached protocol. Handy when the user switches cars.
+  Future<void> clear() async {
+    await _box.clear();
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_cache_openers.dart
+++ b/lib/features/consumption/data/obd2/obd2_cache_openers.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:hive/hive.dart';
+
+import 'negotiated_protocol_cache.dart';
+import 'supported_pids_cache.dart';
+import '../../../../core/storage/hive_boxes.dart';
+
+/// Opens the deferred OBD2 caches the live [Obd2ConnectionService] wires
+/// into every session. Each returns null when its Hive box isn't open
+/// yet (early-boot connect, or a bare test harness that never
+/// initialised Hive) so building the connection service can never throw
+/// — the session then runs with the pre-cache behaviour (blind PID
+/// querying / cold ATSP0 auto-search every connect).
+
+/// #811 supported-PID bitmap cache.
+SupportedPidsCache? openSupportedPidsCache() {
+  if (!Hive.isBoxOpen(HiveBoxes.obd2SupportedPids)) return null;
+  return SupportedPidsCache(Hive.box<String>(HiveBoxes.obd2SupportedPids));
+}
+
+/// #2261 negotiated-protocol warm cache.
+NegotiatedProtocolCache? openNegotiatedProtocolCache() {
+  if (!Hive.isBoxOpen(HiveBoxes.obd2NegotiatedProtocol)) return null;
+  return NegotiatedProtocolCache(
+    Hive.box<String>(HiveBoxes.obd2NegotiatedProtocol),
+  );
+}

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
-import 'package:hive/hive.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'adapter_registry.dart';
@@ -13,12 +12,13 @@ import 'bluetooth_obd2_transport.dart';
 import 'classic_bluetooth_facade.dart';
 import 'elm327_adapter.dart';
 import 'elm_byte_channel.dart';
+import 'negotiated_protocol_cache.dart';
+import 'obd2_cache_openers.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_permissions.dart';
 import 'obd2_service.dart';
 import 'supported_pids_cache.dart';
 import '../../../../core/logging/error_logger.dart';
-import '../../../../core/storage/hive_boxes.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 
 part 'obd2_connection_service.g.dart';
@@ -28,7 +28,12 @@ part 'obd2_connection_service.g.dart';
 /// owner so the data layer never depends on the vehicle feature's
 /// providers directly — the Riverpod provider resolves the active
 /// profile and hands these three fields through.
-typedef Obd2VehicleKeyFields = ({String? make, String? model, int? year});
+typedef Obd2VehicleKeyFields = ({
+  String? make,
+  String? model,
+  int? year,
+  String? vin,
+});
 
 /// Binds scan results to the adapter registry and hands back a ready
 /// [Obd2Service] on connect (#741).
@@ -66,6 +71,12 @@ class Obd2ConnectionService {
   /// (blind PID querying, full support scan every connect).
   final SupportedPidsCache? supportedPidsCache;
 
+  /// Persistent negotiated-protocol cache (#2261 concern 3), wired into
+  /// every session built here. Null in tests / configs that don't
+  /// exercise it — the service then always runs the cold ATSP0
+  /// auto-search, exactly as before.
+  final NegotiatedProtocolCache? negotiatedProtocolCache;
+
   /// Lazily resolves the active vehicle's make / model / year so the
   /// supported-PID cache key can be refined past adapterMac-only
   /// (#2253). Read fresh on every connect because the active vehicle
@@ -78,6 +89,7 @@ class Obd2ConnectionService {
     required this.bluetooth,
     this.classicBluetooth,
     this.supportedPidsCache,
+    this.negotiatedProtocolCache,
     this.activeVehicleKeyFields,
   });
 
@@ -174,15 +186,21 @@ class Obd2ConnectionService {
     required String name,
   }) async {
     final transport = BluetoothObd2Transport(channel);
-    // #2253 — wire the dead #811 supported-PID cache into the live
-    // session. The key is rooted on the adapter MAC and refined with
-    // the active vehicle's make:model:year, so [Obd2Service.connect] →
-    // `prime()` can read a cached support bitmap WITHOUT first paying a
-    // multi-frame 0902 VIN read, and the recording loop skips PIDs the
-    // car doesn't implement. When no cache is wired this collapses to
-    // the pre-#2253 transport-only construction.
+    // #2253 — wire the #811 supported-PID cache into the live session.
+    // Key = adapterMac(+make:model:year), so `prime()` reads a cached
+    // support bitmap WITHOUT a multi-frame 0902 VIN read. No cache wired
+    // ⇒ pre-#2253 transport-only construction.
     final cache = supportedPidsCache;
     final vehicle = activeVehicleKeyFields?.call();
+    // #2261 concern 3 — resolve the warm-protocol cache key from the
+    // adapter MAC + the active vehicle's VIN (when known).
+    final protoCache = negotiatedProtocolCache;
+    final protoKey = protoCache == null
+        ? null
+        : NegotiatedProtocolCache.keyFor(
+            adapterMac: mac,
+            vin: vehicle?.vin,
+          );
     final service = Obd2Service(
       transport,
       pidsCache: cache,
@@ -194,6 +212,8 @@ class Obd2ConnectionService {
               model: vehicle?.model,
               year: vehicle?.year,
             ),
+      protocolCache: protoCache,
+      protocolCacheKey: protoKey,
     );
     service.adapterMac = mac;
     service.adapterName = name;
@@ -257,37 +277,19 @@ class Obd2ConnectionService {
     return connect(match);
   }
 
-  /// Direct-connect-by-MAC, NO scan (#2242). Shared infrastructure for
-  /// reliable in-trip reconnect and pre-warm: addresses the adapter via
-  /// `BluetoothDevice.fromId(mac)` and connects with a bounded ~4 s
-  /// timeout, skipping the ~5 s active scan that [connectByMac] does.
-  /// This is essential for ELM327 clones that stop advertising in
-  /// standby — a scan would never see them, but a direct GATT connect
-  /// still wakes them.
+  /// Direct-connect-by-MAC, NO scan (#2242). Addresses the adapter via
+  /// `BluetoothDevice.fromId(mac)` with a bounded ~4 s [timeout],
+  /// skipping the active scan — essential for ELM327 clones that stop
+  /// advertising in standby (a scan never sees them; a direct GATT
+  /// connect still wakes them). Tears down any prior direct channel
+  /// first (Android GATT_ERROR 133 on a stale client), runs the SAME
+  /// service-side init as [connect] via [_openAndInit].
   ///
-  /// Before opening, it tears down any channel left over from a prior
-  /// direct connect (`channel.close()` → `device.disconnect()`); Android
-  /// otherwise returns GATT_ERROR 133 on a stale GATT client and the
-  /// connect would silently fail. The channel's own `open()` also
-  /// pre-disconnects the device as a second guard.
-  ///
-  /// On timeout / any failure it FALLS BACK to the scan-based
-  /// [connectByMac] so behaviour is never worse than today: a successful
-  /// scan-path connect still returns a session; a genuinely-unreachable
-  /// adapter still returns null. Runs the SAME service-side init as the
-  /// scan path (via [_openAndInit]), so a direct connect yields a fully
-  /// initialised session identical to [connect].
-  ///
-  /// [timeout] bounds the GATT connect attempt (passed to the channel);
-  /// it is NOT a scan window. Returns null when both the direct attempt
-  /// and the scan fallback fail to produce a session.
-  ///
-  /// [fallbackToScan] (default `true`) controls the internal scan
-  /// fallback. The in-trip reconnect path (#2245) passes `false` so it
-  /// can own a single RSSI-gated scan fallback itself — gating the
-  /// connect on a relative-RSSI / two-consecutive-batch rule — rather
-  /// than double-scanning (once here, once in the reconnect probe). With
-  /// `false` a failed direct attempt returns null immediately.
+  /// On any failure it falls back to the scan-based [connectByMac], so
+  /// behaviour is never worse than today; returns null when both fail.
+  /// [fallbackToScan] `false` (the #2245 in-trip path, which owns its
+  /// own RSSI-gated scan) returns null immediately on a failed direct
+  /// attempt instead of double-scanning.
   Future<Obd2Service?> connectByMacDirect(
     String mac, {
     Duration timeout = const Duration(seconds: 4),
@@ -329,16 +331,11 @@ class Obd2ConnectionService {
   /// Passive autoConnect reconnect (#2261 concern 2). Opens a channel
   /// with `autoConnect:true` and NO bounded timeout, so the OS holds a
   /// low-power background GATT request that resolves the instant the
-  /// pinned adapter advertises again. Used by the reconnect scanner once
-  /// its active-scan miss ceiling is reached — a parked car then stops
-  /// burning the radio on repeated active 8 s scans for the remainder of
-  /// the 15-min grace.
-  ///
-  /// Unlike [connectByMacDirect] there is NO scan fallback (a passive
-  /// wait is the fallback) and NO requestMtu bump (FBP forbids it with
-  /// autoConnect:true). Returns null on any failure so the scanner keeps
-  /// its schedule. Runs the SAME service-side init as every other path
-  /// via [_openAndInit].
+  /// pinned adapter advertises again — used by the reconnect scanner
+  /// past its active-scan miss ceiling so a parked car stops burning the
+  /// radio. NO scan fallback (the passive wait IS the fallback) and NO
+  /// requestMtu (FBP forbids it with autoConnect). Returns null on any
+  /// failure; runs the SAME service-side init via [_openAndInit].
   Future<Obd2Service?> connectByMacPassive(String mac) async {
     await _teardownLastDirectChannel();
     final generic = _genericBleProfile();
@@ -389,26 +386,17 @@ Obd2ConnectionService obd2Connection(Ref ref) {
     bluetooth: const PluginBluetoothFacade(),
     classicBluetooth: const PluginClassicBluetoothFacade(),
     // #2253 — activate the #811 supported-PID cache in production.
-    supportedPidsCache: _openSupportedPidsCache(),
+    supportedPidsCache: openSupportedPidsCache(),
+    // #2261 concern 3 — activate the negotiated-protocol warm cache.
+    negotiatedProtocolCache: openNegotiatedProtocolCache(),
     activeVehicleKeyFields: () {
       // Defensive: the vehicle provider must never make a connect throw.
       try {
         final v = ref.read(activeVehicleProfileProvider);
-        return (make: v?.make, model: v?.model, year: v?.year);
+        return (make: v?.make, model: v?.model, year: v?.year, vin: v?.vin);
       } catch (_) {
-        return (make: null, model: null, year: null);
+        return (make: null, model: null, year: null, vin: null);
       }
     },
   );
-}
-
-/// Open the #811 supported-PID cache against the unencrypted box
-/// [HiveBoxes.init] opens after the first frame. Returns null when the
-/// box isn't open yet (early-boot connect, or a bare test harness that
-/// never initialised Hive) so building the connection service can never
-/// throw — the session then runs with the pre-#2253 no-cache behaviour
-/// (blind PID querying, full support scan every connect).
-SupportedPidsCache? _openSupportedPidsCache() {
-  if (!Hive.isBoxOpen(HiveBoxes.obd2SupportedPids)) return null;
-  return SupportedPidsCache(Hive.box<String>(HiveBoxes.obd2SupportedPids));
 }

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -326,6 +326,40 @@ class Obd2ConnectionService {
     }
   }
 
+  /// Passive autoConnect reconnect (#2261 concern 2). Opens a channel
+  /// with `autoConnect:true` and NO bounded timeout, so the OS holds a
+  /// low-power background GATT request that resolves the instant the
+  /// pinned adapter advertises again. Used by the reconnect scanner once
+  /// its active-scan miss ceiling is reached — a parked car then stops
+  /// burning the radio on repeated active 8 s scans for the remainder of
+  /// the 15-min grace.
+  ///
+  /// Unlike [connectByMacDirect] there is NO scan fallback (a passive
+  /// wait is the fallback) and NO requestMtu bump (FBP forbids it with
+  /// autoConnect:true). Returns null on any failure so the scanner keeps
+  /// its schedule. Runs the SAME service-side init as every other path
+  /// via [_openAndInit].
+  Future<Obd2Service?> connectByMacPassive(String mac) async {
+    await _teardownLastDirectChannel();
+    final generic = _genericBleProfile();
+    final channel = bluetooth.channelForDirect(mac, autoConnect: true);
+    _lastDirectChannel = channel;
+    try {
+      return await _openAndInit(
+        channel: channel,
+        adapter: generic.adapter,
+        mac: mac,
+        name: generic.displayName,
+      );
+    } on Object catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'Obd2ConnectionService.connectByMacPassive failed',
+      }));
+      await _teardownLastDirectChannel();
+      return null;
+    }
+  }
+
   Future<void> _teardownLastDirectChannel() async {
     final prior = _lastDirectChannel;
     _lastDirectChannel = null;

--- a/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
@@ -54,4 +54,4 @@ final class Obd2ConnectionProvider
   }
 }
 
-String _$obd2ConnectionHash() => r'e2282d7cbc02d7e0cf172c6fa3abeb1a2294224b';
+String _$obd2ConnectionHash() => r'f52d0cd5581de85e2965fe72f0d0702af07abe7c';

--- a/lib/features/consumption/data/obd2/obd2_read_timeout.dart
+++ b/lib/features/consumption/data/obd2/obd2_read_timeout.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Per-command read-timeout classes for the ELM327 link (#2261 concern
+/// 5).
+///
+/// A single fixed 5 s read timeout is both too slow (a trivial `ATE0`
+/// echo that will never come back stalls the whole queue for 5 s) and,
+/// for the protocol auto-search, occasionally too tight. These three
+/// classes right-size the wait per command:
+///
+///   * [trivialAt] (~1 s) — AT configuration echoes (ATE0, ATL0, ATH0,
+///     ATAT1, ATI, ATDPN, ATSP{n} with an explicit protocol). The
+///     adapter answers `OK`/a short string in tens of milliseconds;
+///     waiting 5 s for one that never comes is pure dead time.
+///   * [wake] (~2.5 s) — the reset / wake commands (ATZ, ATWS) where a
+///     slow clone re-enumerates, and the very first OBD request on a
+///     fresh link (the ECU may still be waking).
+///   * [protocolSearch] (~4.5 s) — `ATSP0` and the first OBD request
+///     that triggers the ELM327's protocol auto-search across every bus
+///     in turn. Starving this class would abort a search that was about
+///     to succeed.
+enum Obd2ReadTimeoutClass {
+  trivialAt(Duration(milliseconds: 1000)),
+  wake(Duration(milliseconds: 2500)),
+  protocolSearch(Duration(milliseconds: 4500));
+
+  const Obd2ReadTimeoutClass(this.timeout);
+  final Duration timeout;
+}
+
+/// Classify [command] (a raw ELM327 command string, with or without its
+/// trailing `\r`) into its read-timeout class (#2261 concern 5).
+///
+/// [firstCommandOnFreshLink] is true for the very first command sent
+/// after the channel opened — the ECU may still be waking, so even a
+/// trivial AT echo is given the [Obd2ReadTimeoutClass.wake] grace.
+Obd2ReadTimeoutClass classifyReadTimeout(
+  String command, {
+  bool firstCommandOnFreshLink = false,
+}) {
+  final c = command.trim().toUpperCase();
+
+  // Reset / wake — slow clones re-enumerate after a soft reset.
+  if (c == 'ATZ' || c == 'ATWS') return Obd2ReadTimeoutClass.wake;
+
+  // The ATSP0 auto-search walks every OBD protocol — the longest wait.
+  if (c == 'ATSP0') return Obd2ReadTimeoutClass.protocolSearch;
+
+  final isAt = c.startsWith('AT') || c.startsWith('ST');
+  if (isAt) {
+    // A trivial AT echo, unless it is the first thing on a fresh link.
+    return firstCommandOnFreshLink
+        ? Obd2ReadTimeoutClass.wake
+        : Obd2ReadTimeoutClass.trivialAt;
+  }
+
+  // An OBD request (mode 01/09/22, raw hex). The first one on a fresh
+  // link can still trigger / complete the protocol search, so it gets
+  // the longest class; subsequent OBD reads get the wake grace (the ECU
+  // can be momentarily busy) — still far tighter than the old flat 5 s.
+  return firstCommandOnFreshLink
+      ? Obd2ReadTimeoutClass.protocolSearch
+      : Obd2ReadTimeoutClass.wake;
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -9,6 +9,7 @@ import '../../../vehicle/domain/entities/reference_vehicle.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import 'adapter_capability.dart';
 import 'auto_record_trace_log.dart';
+import 'bluetooth_obd2_transport.dart';
 import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 import 'fuel_rate_diagnostics.dart';
@@ -1169,6 +1170,22 @@ class Obd2Service implements Obd2RawCommandPort {
     // track that proof — fall back to the local constant which is
     // both non-null and equal.
     return (id: _psaFuelLevelFrameId, payload: payload);
+  }
+
+  /// Ask the underlying BLE link for high throughput while actively
+  /// polling PIDs (#2261 concern 4) — high connection priority + a
+  /// best-effort MTU bump. No-op when the transport / channel doesn't
+  /// expose tuning (Classic SPP, fakes). Best-effort throughout.
+  Future<void> tuneLinkForRecording() async {
+    final t = _transport;
+    if (t is BluetoothObd2Transport) await t.tuneForRecording();
+  }
+
+  /// Drop the BLE link to balanced priority when only the 1 Hz
+  /// auto-record movement stream is live (#2261 concern 4).
+  Future<void> tuneLinkForBackground() async {
+    final t = _transport;
+    if (t is BluetoothObd2Transport) await t.tuneForBackground();
   }
 
   /// Close the transport connection. Safe to call multiple times.

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -264,6 +264,15 @@ class Obd2Service implements Obd2RawCommandPort {
     }
   }
 
+  /// Whether [command] is a reset / wake command that needs a settle
+  /// delay after it (#2261 concern 5) — ATZ (full reset) or ATWS (warm
+  /// start). Every other AT echo / OBD request is serialised by the
+  /// transport's prompt-wait and needs no extra sleep.
+  static bool _isResetCommand(String command) {
+    final c = command.trim().toUpperCase();
+    return c == 'ATZ' || c == 'ATWS';
+  }
+
   /// `true` when the underlying [Obd2Transport] currently has an open
   /// connection to the vehicle's ELM327 adapter.
   bool get isConnected => _transport.isConnected;
@@ -357,11 +366,17 @@ class Obd2Service implements Obd2RawCommandPort {
           response,
           sw.elapsedMilliseconds,
         );
-        // First command is the ATZ-style reset — its post-delay can
-        // differ from the rest on slow clones.
-        final delay =
-            i == 0 ? adapter.postResetDelay : adapter.interCommandDelay;
-        await Future.delayed(delay);
+        // #2261 concern 5 — drop the fixed inter-command sleep for
+        // trivial AT echoes: the prompt-wait in [BluetoothObd2Transport]
+        // already serialises one command per `>` reply, so a blind
+        // 100 ms sleep between ATE0/ATL0/ATH0/… is pure dead time on the
+        // critical path. Keep a SHORT settle ONLY after the reset/wake
+        // commands (ATZ/ATWS), where a slow clone re-enumerates and a
+        // back-to-back command can race the reset. The adapter still
+        // owns the actual settle duration via [postResetDelay].
+        if (_isResetCommand(sequence[i])) {
+          await Future.delayed(adapter.postResetDelay);
+        }
       }
 
       // Capture the firmware-version string and derive the runtime

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -13,6 +13,7 @@ import 'elm327_adapter.dart';
 import 'elm327_protocol.dart';
 import 'fuel_rate_diagnostics.dart';
 import 'fuel_rate_estimator.dart' as estimator;
+import 'negotiated_protocol_cache.dart';
 import 'obd2_breadcrumb_collector.dart';
 import 'obd2_debug_session.dart';
 import 'obd2_transport.dart';
@@ -117,12 +118,26 @@ class Obd2Service implements Obd2RawCommandPort {
   /// raw [Obd2BreadcrumbCollector].
   Obd2BreadcrumbRecorder? breadcrumbCollector;
 
+  /// Persistent negotiated-protocol cache (#2261 concern 3). When
+  /// present and [_protocolCacheKey] resolves, a warm connect replays
+  /// `ATSP{n}` for the cached protocol instead of paying the multi-second
+  /// `ATSP0` auto-search. Null in tests / configs that don't exercise it
+  /// — connect then always runs the cold ATSP0 search, exactly as before.
+  final NegotiatedProtocolCache? _protocolCache;
+
+  /// Lookup key for [_protocolCache] — `adapterMac(:vin)`. Supplied by
+  /// the owner so the data layer never resolves vehicle identity itself.
+  final String? _protocolCacheKey;
+
   Obd2Service(
     this._transport, {
     SupportedPidsCache? pidsCache,
     String? vehicleFallbackKey,
+    NegotiatedProtocolCache? protocolCache,
+    String? protocolCacheKey,
     this.breadcrumbCollector,
-  }) {
+  })  : _protocolCache = protocolCache,
+        _protocolCacheKey = protocolCacheKey {
     // #1916 — the supported-PIDs prime + discovery run during connect,
     // when the BLE link is least settled. Wrap their `_send` callback
     // with the same one-shot retry the init handshake now uses, so a
@@ -187,6 +202,67 @@ class Obd2Service implements Obd2RawCommandPort {
     return s;
   }
 
+  /// Look up the protocol digit cached for this adapter+vehicle, or null
+  /// when no cache is wired / no key resolves / no entry exists (#2261
+  /// concern 3). A non-null result drives a warm `ATSP{n}` init.
+  String? _cachedProtocolDigit() {
+    final cache = _protocolCache;
+    final key = _protocolCacheKey;
+    if (cache == null || key == null) return null;
+    try {
+      return cache.get(key);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'OBD2 negotiated-protocol cache read failed',
+      }));
+      return null;
+    }
+  }
+
+  /// Read `ATDPN`, strip the auto-flag, and persist the negotiated
+  /// protocol for next session (#2261 concern 3).
+  ///
+  /// When [warmConnect] is true (we pinned a cached `ATSP{n}`) and the
+  /// adapter cannot describe a working protocol — `ATDPN` returns a
+  /// NO-DATA / UNABLE / error placeholder — the cached protocol was
+  /// wrong (different car on the same adapter, ECU swapped). We then
+  /// invalidate the entry, fall back to the `ATSP0` auto-search, and
+  /// re-read ATDPN to re-cache the freshly negotiated value.
+  ///
+  /// Best-effort throughout: any send failure is swallowed so the
+  /// connect still succeeds with whatever protocol the init left active.
+  Future<void> _resolveAndCacheProtocol({required bool warmConnect}) async {
+    final cache = _protocolCache;
+    final key = _protocolCacheKey;
+    if (cache == null || key == null) return;
+    try {
+      var digit = Elm327Protocol.parseProtocolNumber(
+        await _withConnectRetry(
+          Elm327Protocol.describeProtocolNumberCommand,
+          _transport.sendCommand,
+        ),
+      );
+      if (digit == null && warmConnect) {
+        // The pinned protocol can't talk to this bus — drop it and
+        // re-run the cold ATSP0 auto-search, then re-read ATDPN.
+        await cache.invalidate(key);
+        await _transport.sendCommand(Elm327Protocol.autoProtocolCommand);
+        digit = Elm327Protocol.parseProtocolNumber(
+          await _transport.sendCommand(
+            Elm327Protocol.describeProtocolNumberCommand,
+          ),
+        );
+      }
+      if (digit != null) {
+        await cache.put(key, digit);
+      }
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'OBD2 negotiated-protocol resolve/cache failed',
+      }));
+    }
+  }
+
   /// `true` when the underlying [Obd2Transport] currently has an open
   /// connection to the vehicle's ELM327 adapter.
   bool get isConnected => _transport.isConnected;
@@ -245,10 +321,24 @@ class Obd2Service implements Obd2RawCommandPort {
       // matches the legacy hardcoded behaviour byte-for-byte: the
       // shared ELM init list followed by 100 ms after the first
       // command (ATZ) and 100 ms between each subsequent command.
+      //
+      // #2261 concern 3 — on a WARM connect, replay the protocol pinned
+      // last session: swap the `ATSP0` auto-search for `ATSP{n}` so the
+      // ELM327 skips the multi-second protocol probe. On a cold connect
+      // (no cache hit) the sequence is untouched and ATSP0 runs as before.
+      final warmProtocol = _cachedProtocolDigit();
       final sequence = <String>[
         ...adapter.initSequence,
         ...adapter.extraInitCommands,
       ];
+      if (warmProtocol != null) {
+        for (var i = 0; i < sequence.length; i++) {
+          if (sequence[i] == Elm327Protocol.autoProtocolCommand) {
+            sequence[i] = Elm327Protocol.setProtocolCommand(warmProtocol);
+            break;
+          }
+        }
+      }
       for (var i = 0; i < sequence.length; i++) {
         // #1925 — time each handshake command for the opt-in OBD2
         // debug log (a no-op when debug logging is off).
@@ -314,6 +404,13 @@ class Obd2Service implements Obd2RawCommandPort {
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 ATI firmware read failed'}));
       }
+
+      // #2261 concern 3 — read ATDPN to learn the negotiated protocol
+      // and persist it for next session's warm connect. When a warm
+      // ATSP{n} was attempted but the protocol can't actually talk to
+      // the bus, this re-runs ATSP0 + re-caches. Non-fatal: any failure
+      // just leaves the cache as-is and the connect still succeeds.
+      await _resolveAndCacheProtocol(warmConnect: warmProtocol != null);
 
       await _pids.prime();
 

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -90,9 +90,28 @@ class Obd2Service implements Obd2RawCommandPort {
   /// no production call site branches on this value yet.
   Obd2AdapterCapability _capability = Obd2AdapterCapability.standardOnly;
 
+  /// Firmware-string-claimed tier, captured at connect (#2261 concern
+  /// 6). The lazy multi-frame probe in [ensureCapabilityReconciled]
+  /// reconciles [_capability] down from this if the adapter can't
+  /// actually route a multi-frame request.
+  Obd2AdapterCapability _claimedCapability =
+      Obd2AdapterCapability.standardOnly;
+
+  /// `true` once the multi-frame `0902` probe has reconciled (or was
+  /// unnecessary because the claimed tier is already standardOnly). Lets
+  /// [ensureCapabilityReconciled] run at most once per connect (#2261).
+  bool _capabilityReconciled = true;
+
   /// Runtime capability tier of the connected adapter (#1401 phase 1).
   /// See [_capability] for semantics.
   Obd2AdapterCapability get capability => _capability;
+
+  /// `true` when the lazy multi-frame capability probe (#2261 concern 6)
+  /// still needs to run — i.e. the firmware claimed a tier above
+  /// standardOnly and [ensureCapabilityReconciled] hasn't confirmed it
+  /// yet. Exposed for the recorder to know whether a deferred probe is
+  /// still pending.
+  bool get capabilityNeedsReconcile => !_capabilityReconciled;
 
   /// Per-adapter ELM327 quirks (#1330). Set by [connect] from the
   /// caller-supplied `adapter` parameter; defaults to the
@@ -326,6 +345,10 @@ class Obd2Service implements Obd2RawCommandPort {
       // Clear the per-connection supported-PIDs cache. A new session
       // may be a different car / different adapter firmware.
       _pids.resetForNewConnection();
+      // #2261 concern 6 — a fresh connect re-arms the lazy capability
+      // probe; it stays armed only when the ATI block below claims a
+      // tier above standardOnly.
+      _capabilityReconciled = true;
 
       // Adapter-driven init sequence (#1330). [GenericElm327Adapter]
       // matches the legacy hardcoded behaviour byte-for-byte: the
@@ -405,18 +428,17 @@ class Obd2Service implements Obd2RawCommandPort {
           adapterFirmware = firmware;
         }
         _capability = detectCapabilityFromFirmwareString(firmware);
-
-        // #1614 — the ATI firmware string can lie: a v2.1-class clone
-        // routinely reports `v2.2` and is then classed oemPidsCapable,
-        // which would hang the OBD-II loop on OEM commands it cannot
-        // route. When the string claims a tier above standardOnly, run
-        // a runtime multi-frame ISO 15765 probe and downgrade if the
-        // adapter cannot actually reassemble a multi-frame reply.
-        if (_capability != Obd2AdapterCapability.standardOnly) {
-          final probe =
-              await probeMultiFrameCapability(_transport.sendCommand);
-          _capability = reconcileCapabilityWithProbe(_capability, probe);
-        }
+        // #2261 concern 6 — the multi-frame `0902` probe that downgrades
+        // a lying clone (#1614) used to run HERE, blocking connect for up
+        // to 4 s on the start critical path. It is now deferred to
+        // [ensureCapabilityReconciled], run lazily after the first
+        // samples, so perceived start is not delayed. The claimed tier
+        // above is what gating sees until then — safe, because standard
+        // PID collection never depends on it, and the lazy probe only
+        // ever LOWERS the tier (never enables a feature prematurely).
+        _claimedCapability = _capability;
+        _capabilityReconciled =
+            _capability == Obd2AdapterCapability.standardOnly;
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 ATI firmware read failed'}));
       }
@@ -1201,6 +1223,33 @@ class Obd2Service implements Obd2RawCommandPort {
   Future<void> tuneLinkForBackground() async {
     final t = _transport;
     if (t is BluetoothObd2Transport) await t.tuneForBackground();
+  }
+
+  /// Run the deferred multi-frame ISO 15765 capability probe (#2261
+  /// concern 6) at most once per connect, reconciling [capability] down
+  /// if the adapter can't actually route a multi-frame `0902` request.
+  ///
+  /// This is the work that #1614 used to do synchronously inside
+  /// [connect]; it is now pulled OFF the start critical path so a fresh
+  /// connect returns without waiting up to 1.5 s for the probe. The
+  /// recorder calls this lazily after the first samples — by then the
+  /// trip is already capturing standard PIDs, and the probe (which can
+  /// only LOWER the tier) tightens OEM-PID gating a moment later.
+  ///
+  /// A no-op when the claimed tier is already standardOnly (nothing to
+  /// downgrade) or when it has already run this connect. Never throws.
+  Future<void> ensureCapabilityReconciled() async {
+    if (_capabilityReconciled) return;
+    _capabilityReconciled = true;
+    if (_claimedCapability == Obd2AdapterCapability.standardOnly) return;
+    try {
+      final probe = await probeMultiFrameCapability(_transport.sendCommand);
+      _capability = reconcileCapabilityWithProbe(_claimedCapability, probe);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'OBD2 deferred capability probe failed',
+      }));
+    }
   }
 
   /// Close the transport connection. Safe to call multiple times.

--- a/lib/features/consumption/data/obd2/reconnect_connector.dart
+++ b/lib/features/consumption/data/obd2/reconnect_connector.dart
@@ -117,4 +117,24 @@ class ReconnectConnector {
     }
     return false;
   }
+
+  /// Passive-wait connect cycle for [mac] (#2261 concern 2). Handed to
+  /// the [AdapterReconnectScanner] as its `passiveConnect` callback: once
+  /// the scanner hits its active-scan miss ceiling it stops burning the
+  /// radio and waits on a low-power autoConnect GATT request instead.
+  /// Returns `true` once a session is established. Never throws.
+  Future<bool> attemptPassive(String mac) async {
+    try {
+      final svc = await connection.connectByMacPassive(mac);
+      if (svc != null) {
+        onConnected(svc);
+        return true;
+      }
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+        'where': 'ReconnectConnector passive connect failed',
+      }));
+    }
+    return false;
+  }
 }

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -1130,6 +1130,11 @@ class TripRecording extends _$TripRecording {
         pinnedMac: pinnedMac,
         probe: (mac) async => true,
         connect: connector.attempt,
+        // #2261 concern 2 — after the active-scan miss ceiling, switch to
+        // a passive autoConnect GATT wait for the rest of the 15-min
+        // grace so a parked car stops burning the radio. The 15-min
+        // grace itself is untouched (owned by DroppedSessionManager).
+        passiveConnect: connector.attemptPassive,
         onReconnect: onReconnect,
       );
     };

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -79,6 +79,11 @@ class TripRecording extends _$TripRecording {
   Obd2Service? _service;
   TripRecordingController? _controller;
 
+  /// #2261 concern 6 — one-shot latch so the deferred multi-frame
+  /// capability probe is kicked exactly once, on the first live sample
+  /// of a recording. Reset at [start] so each new trip re-probes.
+  bool _capabilityReconcileKicked = false;
+
   // #1932 — re-entrancy guard for [start]. `state` is only marked
   // active by the last line of `start()`, but `start()` has `await`s
   // before that, so a second start racing in the window between would
@@ -341,6 +346,9 @@ class TripRecording extends _$TripRecording {
   }) async {
     _lastTripStartedAt ??= DateTime.now();
     _service = service;
+    // #2261 concern 6 — re-arm the deferred capability probe for this
+    // recording; the first live sample kicks it.
+    _capabilityReconcileKicked = false;
     // #1312 — snapshot adapter identity NOW. The service is
     // disconnected during `stop` before `_saveToHistory` runs, so we
     // can't read these off the live service at save time. Best-effort
@@ -434,6 +442,15 @@ class TripRecording extends _$TripRecording {
     // recording UI on next launch.
     _seedActiveSnapshot();
     _liveSub = ctl.live.listen((reading) {
+      // #2261 concern 6 — the multi-frame `0902` capability probe was
+      // pulled off the connect critical path; run it lazily now that the
+      // first samples are landing. Fire-and-forget + one-shot (the
+      // service no-ops after the first run), so it never blocks the
+      // sample pipeline and only ever tightens OEM-PID gating.
+      if (!_capabilityReconcileKicked) {
+        _capabilityReconcileKicked = true;
+        unawaited(_service?.ensureCapabilityReconciled() ?? Future.value());
+      }
       final classified = _baselines.recordAndClassify(reading);
       _haptics.fireForBandTransition(state.band, classified.band);
       state = state.copyWith(

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'f9006fa7cb0cb041a119abe545f155f8589a6774';
+String _$tripRecordingHash() => r'892f202e9237b374c08c654c183d2832cc4d2eae';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'892f202e9237b374c08c654c183d2832cc4d2eae';
+String _$tripRecordingHash() => r'051aa58de10327508782172295d4ed98c8ef7a00';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
+++ b/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
@@ -265,5 +265,102 @@ void main() {
 
       await scanner.stop();
     });
+
+    group('bounded scan → passive autoConnect wait (#2261 concern 2)', () {
+      test('after the miss ceiling, switches to the passive connect path',
+          () async {
+        var activeConnectCalls = 0;
+        var passiveConnectCalls = 0;
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'MAC',
+          // Probe always says in-range; the active connect always fails,
+          // so every cycle is a miss and the ceiling is reached.
+          probe: (_) async => true,
+          connect: (_) async {
+            activeConnectCalls++;
+            return false;
+          },
+          passiveConnect: (_) async {
+            passiveConnectCalls++;
+            return false; // keep waiting so we can observe the mode
+          },
+          onReconnect: () {},
+          missCeiling: 3,
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+
+        await _waitFor(() => scanner.isPassiveWaiting,
+            timeout: const Duration(seconds: 3));
+        expect(scanner.isPassiveWaiting, isTrue,
+            reason: 'the scanner must flip to passive mode at the ceiling');
+        expect(activeConnectCalls, 3,
+            reason: 'exactly missCeiling active attempts before the switch');
+
+        await _waitFor(() => passiveConnectCalls >= 1,
+            timeout: const Duration(seconds: 2));
+        expect(passiveConnectCalls, greaterThanOrEqualTo(1),
+            reason: 'passive connect drives the remaining grace');
+        await scanner.stop();
+      });
+
+      test('a passive connect success fires onReconnect and self-stops',
+          () async {
+        var passiveCalls = 0;
+        var reconnects = 0;
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'MAC',
+          probe: (_) async => true,
+          connect: (_) async => false,
+          passiveConnect: (_) async {
+            passiveCalls++;
+            return true; // the parked car came back
+          },
+          onReconnect: () => reconnects++,
+          missCeiling: 2,
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+
+        await _waitFor(() => reconnects > 0,
+            timeout: const Duration(seconds: 3));
+        expect(passiveCalls, 1);
+        expect(reconnects, 1);
+        expect(scanner.isScanning, isFalse,
+            reason: 'a passive reconnect must self-stop the scanner');
+        await scanner.stop();
+      });
+
+      test('with NO passiveConnect, stays in active-scan mode forever',
+          () async {
+        var activeConnectCalls = 0;
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'MAC',
+          probe: (_) async => true,
+          connect: (_) async {
+            activeConnectCalls++;
+            return false;
+          },
+          onReconnect: () {},
+          // No passiveConnect — pre-#2261 behaviour preserved.
+          missCeiling: 2,
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+
+        await _waitFor(() => activeConnectCalls >= 4,
+            timeout: const Duration(seconds: 3));
+        expect(scanner.isPassiveWaiting, isFalse,
+            reason: 'without a passiveConnect callback the scanner never '
+                'switches — behaviour is unchanged from before #2261');
+        await scanner.stop();
+      });
+    });
   });
 }

--- a/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/smart_obd_adapter_test.dart
@@ -141,7 +141,8 @@ void main() {
 
   group('Obd2Service.connect with SmartObdAdapter (#1330 phase 2)', () {
     test(
-      'waits 400 ms after ATZ and 200 ms between subsequent init commands',
+      'settles 400 ms after ATZ only — no inter-command sleep between '
+      'trivial AT echoes (#2261 concern 5)',
       () async {
         final transport = _RecordingObd2Transport({
           'ATZ': 'ELM327 v1.5>',
@@ -172,21 +173,16 @@ void main() {
           reason: 'postResetDelay (gap before ATE0)',
         );
 
-        // Subsequent gaps reflect the 200 ms interCommandDelay.
+        // #2261 concern 5 — the interCommandDelay is no longer paid
+        // between trivial AT echoes (the transport prompt-wait already
+        // serialises them), so subsequent gaps are near-zero.
         for (var i = 2; i < transport.commands.length; i++) {
           final gap = transport.commands[i].at - transport.commands[i - 1].at;
           expect(
             gap,
-            greaterThanOrEqualTo(const Duration(milliseconds: 180)),
-            reason:
-                'interCommandDelay (gap before command $i = ${transport.commands[i].command})',
-          );
-          expect(
-            gap,
-            lessThan(const Duration(milliseconds: 380)),
-            reason:
-                'gap before command $i should reflect 200 ms interCommandDelay, '
-                'not the 400 ms postResetDelay',
+            lessThan(const Duration(milliseconds: 180)),
+            reason: 'no fixed inter-command sleep before command $i = '
+                '${transport.commands[i].command}',
           );
         }
       },

--- a/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
+++ b/test/features/consumption/data/obd2/adapters/v_linker_fs_adapter_test.dart
@@ -96,7 +96,8 @@ void main() {
 
   group('Obd2Service.connect with VLinkerFsAdapter (#1330 phase 2)', () {
     test(
-      'waits 200 ms after the first command and 50 ms between subsequent ones',
+      'settles 200 ms after ATZ only — no inter-command sleep between '
+      'trivial AT echoes (#2261 concern 5)',
       () async {
         final transport = _RecordingObd2Transport({
           'ATZ': 'ELM327 v1.5>',
@@ -130,24 +131,16 @@ void main() {
           reason: 'postResetDelay (gap before ATE0)',
         );
 
-        // Subsequent gaps reflect the 50 ms interCommandDelay.
+        // #2261 concern 5 — the interCommandDelay is no longer paid
+        // between trivial AT echoes (the transport prompt-wait already
+        // serialises them), so subsequent gaps are near-zero.
         for (var i = 2; i < transport.commands.length; i++) {
           final gap = transport.commands[i].at - transport.commands[i - 1].at;
           expect(
             gap,
-            greaterThanOrEqualTo(const Duration(milliseconds: 40)),
-            reason:
-                'interCommandDelay (gap before command $i = ${transport.commands[i].command})',
-          );
-          // Generous upper bound: real interCommandDelay should be
-          // ~50ms, well below the 200ms postReset value. This guards
-          // against accidentally swapping the two in the connect loop.
-          expect(
-            gap,
-            lessThan(const Duration(milliseconds: 180)),
-            reason:
-                'gap before command $i should reflect 50 ms interCommandDelay, '
-                'not the 200 ms postResetDelay',
+            lessThan(const Duration(milliseconds: 40)),
+            reason: 'no fixed inter-command sleep before command $i = '
+                '${transport.commands[i].command}',
           );
         }
       },

--- a/test/features/consumption/data/obd2/connection_drop_debouncer_test.dart
+++ b/test/features/consumption/data/obd2/connection_drop_debouncer_test.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'connection_drop_debouncer.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connection_errors.dart';
+
+import 'dart:async';
+
+/// #2261 concern 1 — connectionState-driven drop detection + debounce.
+void main() {
+  group('ConnectionDropDebouncer (#2261 concern 1)', () {
+    test('a disconnect held for the full debounce confirms the drop', () {
+      fakeAsync((async) {
+        var confirmed = 0;
+        final d = ConnectionDropDebouncer(
+          onConfirmed: () => confirmed++,
+          debounce: const Duration(milliseconds: 1500),
+        );
+
+        d.noteConnectionState(disconnected: true);
+        expect(d.isPending, isTrue);
+        expect(confirmed, 0, reason: 'not confirmed until the debounce elapses');
+
+        async.elapse(const Duration(milliseconds: 1499));
+        expect(confirmed, 0);
+
+        async.elapse(const Duration(milliseconds: 2));
+        expect(confirmed, 1, reason: 'confirmed once the debounce elapses');
+        expect(d.isConfirmed, isTrue);
+      });
+    });
+
+    test('a self-healing blip (reconnect before debounce) does NOT confirm',
+        () {
+      fakeAsync((async) {
+        var confirmed = 0;
+        final d = ConnectionDropDebouncer(
+          onConfirmed: () => confirmed++,
+          debounce: const Duration(milliseconds: 1500),
+        );
+
+        d.noteConnectionState(disconnected: true);
+        async.elapse(const Duration(milliseconds: 800));
+        // The link healed itself before the debounce elapsed.
+        d.noteConnectionState(disconnected: false);
+        async.elapse(const Duration(seconds: 5));
+
+        expect(confirmed, 0,
+            reason: 'a recoverable blip must never tear the session down');
+        expect(d.isPending, isFalse);
+        expect(d.isConfirmed, isFalse);
+      });
+    });
+
+    test('a command failure during the pending window confirms immediately',
+        () {
+      fakeAsync((async) {
+        var confirmed = 0;
+        final d = ConnectionDropDebouncer(
+          onConfirmed: () => confirmed++,
+          debounce: const Duration(seconds: 30),
+        );
+
+        d.noteConnectionState(disconnected: true);
+        async.elapse(const Duration(milliseconds: 100));
+        // Next command also failed — the link is demonstrably unusable.
+        d.noteCommandFailure();
+
+        expect(confirmed, 1,
+            reason: 'a failed command short-circuits the rest of the debounce');
+        expect(d.isConfirmed, isTrue);
+      });
+    });
+
+    test('a lone command failure with no pending disconnect is a no-op', () {
+      fakeAsync((async) {
+        var confirmed = 0;
+        final d = ConnectionDropDebouncer(onConfirmed: () => confirmed++);
+
+        d.noteCommandFailure();
+        async.elapse(const Duration(seconds: 5));
+
+        expect(confirmed, 0,
+            reason: 'a lone timeout on a connected link is the read-timeout\'s '
+                'concern, not a drop');
+      });
+    });
+
+    test('confirms only once even if the debounce + failure both fire', () {
+      fakeAsync((async) {
+        var confirmed = 0;
+        final d = ConnectionDropDebouncer(
+          onConfirmed: () => confirmed++,
+          debounce: const Duration(milliseconds: 500),
+        );
+
+        d.noteConnectionState(disconnected: true);
+        async.elapse(const Duration(seconds: 1)); // confirm via debounce
+        d.noteCommandFailure(); // already confirmed — no double fire
+        expect(confirmed, 1);
+      });
+    });
+
+    test('reset clears state so the debouncer can be reused', () {
+      fakeAsync((async) {
+        var confirmed = 0;
+        final d = ConnectionDropDebouncer(
+          onConfirmed: () => confirmed++,
+          debounce: const Duration(milliseconds: 500),
+        );
+
+        d.noteConnectionState(disconnected: true);
+        async.elapse(const Duration(seconds: 1));
+        expect(confirmed, 1);
+
+        d.reset();
+        expect(d.isConfirmed, isFalse);
+        expect(d.isPending, isFalse);
+
+        d.noteConnectionState(disconnected: true);
+        async.elapse(const Duration(seconds: 1));
+        expect(confirmed, 2, reason: 'a fresh drop fires again after reset');
+      });
+    });
+  });
+
+  group('transport surfaces a confirmed drop as Obd2DisconnectedException', () {
+    test(
+        'an Obd2DisconnectedException on the byte stream fails the in-flight '
+        'sendCommand with the typed error', () async {
+      final channel = _DropEmittingChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // Fire a command, then push the typed drop (as the channel does on
+      // a confirmed connectionState disconnect) before any reply arrives.
+      final pending = transport.sendCommand('010C\r');
+      channel.emitDrop();
+
+      await expectLater(pending, throwsA(isA<Obd2DisconnectedException>()),
+          reason: 'a confirmed BLE drop surfaces to the poller as a typed '
+              'disconnect, which TripDropDetector classifies in ~1–2 s');
+    });
+  });
+}
+
+/// Fake channel that, like [FlutterBluePlusElmChannel] on a confirmed
+/// connectionState disconnect, can push an [Obd2DisconnectedException]
+/// onto its byte stream instead of a reply.
+class _DropEmittingChannel implements ElmByteChannel {
+  final StreamController<List<int>> _controller =
+      StreamController<List<int>>.broadcast();
+  bool _open = false;
+
+  void emitDrop() => _controller.addError(const Obd2DisconnectedException());
+
+  @override
+  Future<void> open() async => _open = true;
+
+  @override
+  Future<void> close() async => _open = false;
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _controller.stream;
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    // No reply — the drop arrives via [emitDrop] instead.
+  }
+}

--- a/test/features/consumption/data/obd2/dropped_session_manager_test.dart
+++ b/test/features/consumption/data/obd2/dropped_session_manager_test.dart
@@ -474,6 +474,12 @@ class _FakeScanner implements AdapterReconnectScanner {
   bool get isScanning => _scanning;
 
   @override
+  bool get isPassiveWaiting => false;
+
+  @override
+  int get consecutiveMisses => 0;
+
+  @override
   Future<void> start() async {
     _scanning = true;
     startCalls++;

--- a/test/features/consumption/data/obd2/elm327_adapter_test.dart
+++ b/test/features/consumption/data/obd2/elm327_adapter_test.dart
@@ -98,8 +98,8 @@ void main() {
 
   group('Obd2Service.connect with default GenericElm327Adapter (#1330)', () {
     test(
-      'sends the legacy init sequence in order with a ~100 ms gap '
-      'between commands',
+      'sends the legacy init sequence in order, settling only after ATZ '
+      '(#2261 concern 5 trimmed the inter-command sleeps)',
       () async {
         final transport = _RecordingObd2Transport({
           'ATZ': 'ELM327 v1.5>',
@@ -127,16 +127,22 @@ void main() {
           'ATI',
         ]);
 
-        // Inter-command intervals are at least the configured 100 ms
-        // delay. Generous upper bound (250 ms) avoids flakiness on
-        // slow CI runners — the assertion that matters is "we DID
-        // wait", not the exact wall-clock value.
-        for (var i = 1; i < transport.commands.length; i++) {
+        // #2261 concern 5 — the ONLY settle is the postResetDelay after
+        // ATZ (so ATE0, the command at index 1, follows a ~100 ms gap).
+        // Every later command is serialised by the transport prompt-wait
+        // with no extra blind sleep, so those gaps are near-zero.
+        final gapAfterReset =
+            transport.commands[1].at - transport.commands[0].at;
+        expect(gapAfterReset,
+            greaterThanOrEqualTo(const Duration(milliseconds: 90)),
+            reason: 'a settle must follow ATZ');
+        for (var i = 2; i < transport.commands.length; i++) {
           final gap = transport.commands[i].at - transport.commands[i - 1].at;
           expect(
             gap,
-            greaterThanOrEqualTo(const Duration(milliseconds: 90)),
-            reason: 'gap before command $i (${transport.commands[i].command})',
+            lessThan(const Duration(milliseconds: 90)),
+            reason: 'no fixed inter-command sleep before trivial AT echo '
+                '$i (${transport.commands[i].command})',
           );
         }
       },

--- a/test/features/consumption/data/obd2/negotiated_protocol_cache_test.dart
+++ b/test/features/consumption/data/obd2/negotiated_protocol_cache_test.dart
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'negotiated_protocol_cache.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2261 concern 3 — ATDPN protocol cache + ATSP{n} on warm connect.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('Elm327Protocol protocol-number parsing + command (#2261)', () {
+    test('ATDPN strips the leading A auto-flag', () {
+      expect(Elm327Protocol.parseProtocolNumber('A6>'), '6');
+      expect(Elm327Protocol.parseProtocolNumber('6>'), '6');
+      expect(Elm327Protocol.parseProtocolNumber('A8\r\r>'), '8');
+    });
+
+    test('a CAN protocol digit (A–C) is preserved when not the auto-flag', () {
+      // `AA` = auto-flag A + protocol A (ISO 15765 11-bit 500k). Strip
+      // only the FIRST A, keep the protocol digit A.
+      expect(Elm327Protocol.parseProtocolNumber('AA>'), 'A');
+      expect(Elm327Protocol.parseProtocolNumber('C>'), 'C');
+    });
+
+    test('NO DATA / error / protocol-0 → null (nothing pinnable)', () {
+      expect(Elm327Protocol.parseProtocolNumber('NO DATA>'), isNull);
+      expect(Elm327Protocol.parseProtocolNumber('?>'), isNull);
+      expect(Elm327Protocol.parseProtocolNumber('UNABLE TO CONNECT>'), isNull);
+      expect(Elm327Protocol.parseProtocolNumber('A0>'), isNull);
+      expect(Elm327Protocol.parseProtocolNumber(''), isNull);
+    });
+
+    test('setProtocolCommand builds ATSP{n}', () {
+      expect(Elm327Protocol.setProtocolCommand('6'), 'ATSP6\r');
+      expect(Elm327Protocol.setProtocolCommand('A'), 'ATSPA\r');
+    });
+  });
+
+  group('NegotiatedProtocolCache.keyFor (#2261)', () {
+    test('roots on adapter MAC, refines with VIN when present', () {
+      expect(
+        NegotiatedProtocolCache.keyFor(adapterMac: 'AA:BB', vin: 'WVWZZZ123'),
+        'aa:bb:wvwzzz123',
+      );
+      expect(NegotiatedProtocolCache.keyFor(adapterMac: 'AA:BB'), 'aa:bb');
+      expect(NegotiatedProtocolCache.keyFor(adapterMac: null), isNull);
+    });
+  });
+
+  group('Obd2Service warm/cold protocol cache (#2261)', () {
+    late Directory tmpDir;
+    late Box<String> box;
+    late NegotiatedProtocolCache cache;
+    const key = 'aa:bb:vin1';
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('proto_cache_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>('proto_test');
+      cache = NegotiatedProtocolCache(box);
+    });
+
+    tearDown(() async {
+      await box.close();
+      await Hive.deleteBoxFromDisk('proto_test');
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    test(
+        'COLD connect (empty cache) runs ATSP0 then reads ATDPN and caches '
+        'the negotiated protocol', () async {
+      final t = _RecordingTransport(responses: {
+        'ATDPN': 'A6>', // auto-found protocol 6
+      });
+      final service = Obd2Service(
+        t,
+        protocolCache: cache,
+        protocolCacheKey: key,
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      expect(t.log, contains('ATSP0'),
+          reason: 'a cold connect must run the ATSP0 auto-search');
+      expect(t.log, isNot(contains('ATSP6')),
+          reason: 'no warm pin on a cold connect');
+      expect(t.log, contains('ATDPN'),
+          reason: 'the negotiated protocol must be read after init');
+      expect(cache.get(key), '6',
+          reason: 'the auto-flag-stripped protocol is persisted');
+    });
+
+    test(
+        'WARM connect (cache hit) pins ATSP{n} instead of ATSP0 and skips '
+        'the auto-search', () async {
+      await cache.put(key, '6');
+      final t = _RecordingTransport(responses: {
+        'ATDPN': '6>', // pinned protocol confirms
+      });
+      final service = Obd2Service(
+        t,
+        protocolCache: cache,
+        protocolCacheKey: key,
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      expect(t.log, contains('ATSP6'),
+          reason: 'a warm connect replays the cached protocol');
+      expect(t.log, isNot(contains('ATSP0')),
+          reason: 'the multi-second auto-search must be skipped');
+      expect(cache.get(key), '6');
+    });
+
+    test(
+        'WARM connect whose pinned protocol can\'t talk → falls back to '
+        'ATSP0 and re-caches the freshly negotiated protocol', () async {
+      await cache.put(key, '6'); // stale — wrong car on this adapter
+      final t = _RecordingTransport(responses: {
+        // First ATDPN (after the warm ATSP6) says it can't describe a
+        // protocol; after the fallback ATSP0 it reports protocol 3.
+        'ATDPN': '__SEQUENCE__',
+      }, atdpnSequence: ['NO DATA>', 'A3>']);
+      final service = Obd2Service(
+        t,
+        protocolCache: cache,
+        protocolCacheKey: key,
+      );
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      expect(t.log, contains('ATSP6'), reason: 'warm pin attempted first');
+      // After the warm ATDPN miss, the fallback ATSP0 must run.
+      expect(t.log.where((c) => c == 'ATSP0').length, 1,
+          reason: 'a warm protocol that can\'t talk falls back to ATSP0');
+      expect(cache.get(key), '3',
+          reason: 'the re-negotiated protocol replaces the stale entry');
+    });
+
+    test('no cache wired → no ATDPN, no warm pin (pre-#2261 behaviour)',
+        () async {
+      final t = _RecordingTransport(responses: const {});
+      final service = Obd2Service(t); // no protocolCache
+
+      final ok = await service.connect();
+      expect(ok, isTrue);
+      expect(t.log, contains('ATSP0'));
+      expect(t.log, isNot(contains('ATDPN')),
+          reason: 'without a cache the protocol is never probed/persisted');
+    });
+  });
+}
+
+/// Records every command and serves canned responses. Supports a
+/// per-command sequence for ATDPN so the warm-fallback path can return
+/// two different replies on its two reads.
+class _RecordingTransport implements Obd2Transport {
+  _RecordingTransport({
+    required this.responses,
+    this.atdpnSequence,
+  });
+
+  final Map<String, String> responses;
+  final List<String>? atdpnSequence;
+  int _atdpnIdx = 0;
+
+  final List<String> log = <String>[];
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+  @override
+  Future<void> connect() async => _connected = true;
+  @override
+  Future<void> disconnect() async => _connected = false;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    log.add(cmd);
+    if (cmd == 'ATDPN' && atdpnSequence != null) {
+      final seq = atdpnSequence!;
+      final reply = _atdpnIdx < seq.length ? seq[_atdpnIdx] : seq.last;
+      _atdpnIdx++;
+      return reply;
+    }
+    return responses[cmd] ?? 'OK>';
+  }
+}

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -13,6 +13,8 @@ import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'negotiated_protocol_cache.dart';
 import 'package:tankstellen/features/consumption/data/obd2/supported_pids_cache.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
@@ -499,7 +501,7 @@ void main() {
         ),
         supportedPidsCache: SupportedPidsCache(box),
         activeVehicleKeyFields: () =>
-            (make: 'Peugeot', model: '107', year: 2008),
+            (make: 'Peugeot', model: '107', year: 2008, vin: null),
       );
 
       final ready = await svc.connect(_resolvedVlinker(registry));
@@ -528,7 +530,7 @@ void main() {
         ),
         supportedPidsCache: SupportedPidsCache(box),
         activeVehicleKeyFields: () =>
-            (make: 'Peugeot', model: '107', year: 2008),
+            (make: 'Peugeot', model: '107', year: 2008, vin: null),
       );
 
       final ready = await svc.connect(_resolvedVlinker(registry));
@@ -564,6 +566,7 @@ Obd2ConnectionService _build({
   required Obd2PermissionState permState,
   required BluetoothFacade bt,
   SupportedPidsCache? supportedPidsCache,
+  NegotiatedProtocolCache? negotiatedProtocolCache,
   Obd2VehicleKeyFields Function()? activeVehicleKeyFields,
 }) =>
     Obd2ConnectionService(
@@ -571,6 +574,7 @@ Obd2ConnectionService _build({
       permissions: _FakePermissions(permState),
       bluetooth: bt,
       supportedPidsCache: supportedPidsCache,
+      negotiatedProtocolCache: negotiatedProtocolCache,
       activeVehicleKeyFields: activeVehicleKeyFields,
     );
 

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -399,6 +399,64 @@ void main() {
     });
   });
 
+  group('Obd2ConnectionService.connectByMacPassive (#2261 concern 2)', () {
+    test(
+        'opens an autoConnect channel, NO scan, NO bounded timeout, '
+        'runs init', () async {
+      final passiveChannel = _FakeChannel(respondTo: _elmOkResponses());
+      final fake = _FakeFacade(
+        // A non-empty batch would be observable via scanInvoked if the
+        // passive path ever scanned — it must not.
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        directChannel: passiveChannel,
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacPassive('aa:bb');
+
+      expect(ready, isNotNull);
+      expect(ready!.isConnected, isTrue);
+      expect(fake.directAutoConnect, isTrue,
+          reason: 'passive reconnect must request an autoConnect channel');
+      expect(fake.scanInvoked, isFalse,
+          reason: 'the passive wait must never scan — a passive GATT wait '
+              'IS the fallback');
+      await ready.disconnect();
+    });
+
+    test('returns null on failure WITHOUT a scan fallback', () async {
+      final fake = _FakeFacade(
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        directChannel: _FakeChannel(openError: StateError('passive wait off')),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacPassive('aa:bb');
+      expect(ready, isNull);
+      expect(fake.scanInvoked, isFalse,
+          reason: 'a failed passive wait does not scan — the scanner will '
+              're-arm another passive wait itself');
+    });
+  });
+
   group('Obd2ConnectionService supported-PID cache wiring — #2253', () {
     late Directory tmpDir;
     late Box<String> box;
@@ -581,6 +639,7 @@ class _FakeFacade implements BluetoothFacade {
   /// Args captured from the most recent [channelForDirect] call.
   String? directMac;
   Duration? directTimeout;
+  bool directAutoConnect = false;
   int directCalls = 0;
 
   _FakeFacade({
@@ -619,10 +678,12 @@ class _FakeFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
     directCalls++;
     directMac = mac;
     directTimeout = connectTimeout;
+    directAutoConnect = autoConnect;
     return directChannel ?? channel ?? _FakeChannel(silent: true);
   }
 }
@@ -655,6 +716,7 @@ class _SequencedDirectFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
     onDirect();
     return sequence[_i++];

--- a/test/features/consumption/data/obd2/obd2_link_tuning_test.dart
+++ b/test/features/consumption/data/obd2/obd2_link_tuning_test.dart
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2261 concern 4 — link tuning (connection priority + best-effort MTU)
+/// forwarded through the transport / service to the BLE channel.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('link tuning forwards to a tuner-capable channel (#2261)', () {
+    test('tuneForRecording / tuneForBackground reach the channel', () async {
+      final channel = _TunableChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      await transport.tuneForRecording();
+      await transport.tuneForBackground();
+
+      expect(channel.recordingCalls, 1);
+      expect(channel.backgroundCalls, 1);
+    });
+
+    test('Obd2Service forwards link tuning to a BLE transport', () async {
+      final channel = _TunableChannel();
+      final transport = BluetoothObd2Transport(channel);
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      await service.tuneLinkForRecording();
+      await service.tuneLinkForBackground();
+
+      expect(channel.recordingCalls, 1);
+      expect(channel.backgroundCalls, 1);
+    });
+
+    test('tuning is a safe no-op for a non-tuner channel', () async {
+      final channel = _PlainChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // Must not throw even though the channel is not an Obd2LinkTuner.
+      await transport.tuneForRecording();
+      await transport.tuneForBackground();
+    });
+
+    test('a tuner whose calls throw never propagates — best-effort', () async {
+      final channel = _ThrowingTunableChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // The channel's own try/catch absorbs the platform rejection.
+      await transport.tuneForRecording();
+      await transport.tuneForBackground();
+    });
+  });
+}
+
+class _PlainChannel implements ElmByteChannel {
+  // ignore: close_sinks
+  final StreamController<List<int>> _c =
+      StreamController<List<int>>.broadcast();
+  bool _open = false;
+  @override
+  Future<void> open() async => _open = true;
+  @override
+  Future<void> close() async => _open = false;
+  @override
+  bool get isOpen => _open;
+  @override
+  Stream<List<int>> get incoming => _c.stream;
+  @override
+  Future<void> write(List<int> bytes) async {}
+}
+
+class _TunableChannel extends _PlainChannel implements Obd2LinkTuner {
+  int recordingCalls = 0;
+  int backgroundCalls = 0;
+  @override
+  Future<void> tuneForRecording() async => recordingCalls++;
+  @override
+  Future<void> tuneForBackground() async => backgroundCalls++;
+}
+
+/// Mirrors the real channel's contract: its tuning methods catch
+/// platform rejections internally, so they never throw to the caller.
+class _ThrowingTunableChannel extends _PlainChannel implements Obd2LinkTuner {
+  @override
+  Future<void> tuneForRecording() async {
+    try {
+      throw StateError('androidOnly');
+    } catch (_) {/* swallowed, as the real channel does */}
+  }
+
+  @override
+  Future<void> tuneForBackground() async {
+    try {
+      throw StateError('androidOnly');
+    } catch (_) {/* swallowed */}
+  }
+}

--- a/test/features/consumption/data/obd2/obd2_read_timeout_test.dart
+++ b/test/features/consumption/data/obd2/obd2_read_timeout_test.dart
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_read_timeout.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2261 concern 5 — adaptive per-class read timeouts.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('classifyReadTimeout (#2261 concern 5)', () {
+    test('ATZ / ATWS → wake class', () {
+      expect(classifyReadTimeout('ATZ\r'), Obd2ReadTimeoutClass.wake);
+      expect(classifyReadTimeout('ATWS'), Obd2ReadTimeoutClass.wake);
+    });
+
+    test('ATSP0 → protocol-search class (the longest wait)', () {
+      expect(classifyReadTimeout('ATSP0\r'),
+          Obd2ReadTimeoutClass.protocolSearch);
+    });
+
+    test('a pinned ATSP{n} is a trivial AT, NOT a protocol search', () {
+      expect(classifyReadTimeout('ATSP6\r'), Obd2ReadTimeoutClass.trivialAt);
+    });
+
+    test('trivial AT echoes → trivialAt class', () {
+      for (final c in ['ATE0\r', 'ATL0\r', 'ATH0\r', 'ATAT1\r', 'ATI\r',
+        'ATDPN\r']) {
+        expect(classifyReadTimeout(c), Obd2ReadTimeoutClass.trivialAt,
+            reason: '$c should be a trivial AT echo');
+      }
+    });
+
+    test('the first command on a fresh link gets the wake grace', () {
+      // A trivial AT that would normally be trivialAt is upgraded to
+      // wake when it is the very first thing on a fresh link.
+      expect(
+        classifyReadTimeout('ATE0\r', firstCommandOnFreshLink: true),
+        Obd2ReadTimeoutClass.wake,
+      );
+    });
+
+    test('an OBD request: protocolSearch first, wake thereafter', () {
+      expect(
+        classifyReadTimeout('0100\r', firstCommandOnFreshLink: true),
+        Obd2ReadTimeoutClass.protocolSearch,
+      );
+      expect(classifyReadTimeout('010C\r'), Obd2ReadTimeoutClass.wake);
+    });
+
+    test('the timeout durations are ordered trivial < wake < protocol', () {
+      expect(
+          Obd2ReadTimeoutClass.trivialAt.timeout <
+              Obd2ReadTimeoutClass.wake.timeout,
+          isTrue);
+      expect(
+          Obd2ReadTimeoutClass.wake.timeout <
+              Obd2ReadTimeoutClass.protocolSearch.timeout,
+          isTrue);
+    });
+  });
+
+  group('BluetoothObd2Transport applies the per-class timeout (#2261)', () {
+    test(
+        'a trivial AT echo that never answers times out at ~1 s, not 5 s',
+        () async {
+      final channel = _SilentChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // The FIRST command would get the wake grace, so prime the link
+      // with one cheap command first (it also never answers, but we only
+      // care that the SECOND — a trivial AT — uses the trivialAt class).
+      final sw = Stopwatch()..start();
+      // ATE0 is the first command → wake class (~2.5 s). We assert the
+      // trivialAt path on a LATER command instead: send a successful one
+      // first to clear _firstCommandPending.
+      await _safeSend(transport, 'ATZ\r'); // first cmd, answered below
+      sw.stop();
+
+      // Now a trivial AT that never answers should time out near 1 s,
+      // well under the old flat 5 s.
+      final sw2 = Stopwatch()..start();
+      await expectLater(
+        transport.sendCommand('ATE0\r'),
+        throwsA(isA<TimeoutException>()),
+      );
+      sw2.stop();
+      expect(sw2.elapsed.inMilliseconds, lessThan(2000),
+          reason: 'a trivial AT echo must time out near its ~1 s class, '
+              'not the old flat 5 s');
+      expect(sw2.elapsed.inMilliseconds, greaterThanOrEqualTo(800),
+          reason: 'and not faster than its ~1 s class either');
+    });
+  });
+
+  group('Obd2Service.connect inter-command sleep trim (#2261 concern 5)', () {
+    test(
+        'a settle delay is applied ONLY after the reset command (ATZ), not '
+        'between trivial AT echoes', () async {
+      // An adapter with a LARGE inter-command delay and a tiny post-reset
+      // delay: the old code slept interCommandDelay between every command
+      // (~5 × 400 ms ≈ 2 s). The new code sleeps ONLY postResetDelay
+      // after ATZ, so the connect completes near-instantly.
+      final adapter = _SlowInterCommandAdapter();
+      final t = _AnsweringTransport();
+      final service = Obd2Service(t);
+
+      final sw = Stopwatch()..start();
+      final ok = await service.connect(adapter: adapter);
+      sw.stop();
+
+      expect(ok, isTrue);
+      expect(sw.elapsed.inMilliseconds, lessThan(300),
+          reason: 'no fixed inter-command sleep between trivial AT echoes — '
+              'the large interCommandDelay must NOT be paid 5×');
+    });
+  });
+}
+
+/// Adapter whose interCommandDelay is huge (would dominate connect time
+/// if it were still applied between every command) and whose
+/// postResetDelay is tiny (the only sleep the new code keeps).
+class _SlowInterCommandAdapter implements Elm327Adapter {
+  @override
+  String get id => 'slow-test';
+  @override
+  List<String> get initSequence =>
+      const ['ATZ\r', 'ATE0\r', 'ATL0\r', 'ATH0\r', 'ATSP0\r', 'ATAT1\r'];
+  @override
+  Duration get postResetDelay => const Duration(milliseconds: 5);
+  @override
+  Duration get interCommandDelay => const Duration(milliseconds: 400);
+  @override
+  List<String> get extraInitCommands => const [];
+  @override
+  String preParse(String raw) => raw;
+}
+
+/// Transport that answers every command instantly with OK.
+class _AnsweringTransport implements Obd2Transport {
+  bool _connected = false;
+  @override
+  bool get isConnected => _connected;
+  @override
+  Future<void> connect() async => _connected = true;
+  @override
+  Future<void> disconnect() async => _connected = false;
+  @override
+  Future<String> sendCommand(String command) async => 'OK>';
+}
+
+/// Send and swallow a timeout (used only to advance link state).
+Future<void> _safeSend(BluetoothObd2Transport t, String cmd) async {
+  try {
+    await t.sendCommand(cmd);
+  } catch (_) {/* expected timeout */}
+}
+
+/// Channel that opens but never emits a reply — every read times out.
+class _SilentChannel implements ElmByteChannel {
+  // ignore: close_sinks
+  final StreamController<List<int>> _c =
+      StreamController<List<int>>.broadcast();
+  bool _open = false;
+  @override
+  Future<void> open() async => _open = true;
+  @override
+  Future<void> close() async => _open = false;
+  @override
+  bool get isOpen => _open;
+  @override
+  Stream<List<int>> get incoming => _c.stream;
+  @override
+  Future<void> write(List<int> bytes) async {}
+}

--- a/test/features/consumption/data/obd2/obd2_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_test.dart
@@ -723,11 +723,41 @@ void main() {
     );
 
     // #1614 — runtime feature-probe that downgrades clones whose ATI
-    // firmware string lies about their tier.
-    group('runtime capability probe (#1614)', () {
+    // firmware string lies about their tier. #2261 concern 6 — the probe
+    // is now DEFERRED off the connect critical path: connect() leaves the
+    // claimed tier in place and ensureCapabilityReconciled() (run lazily
+    // after the first samples) does the downgrade.
+    group('runtime capability probe (#1614 / deferred #2261 concern 6)', () {
       test(
-          'a lying clone — ATI reports v2.2 but the multi-frame probe '
-          'fails — is downgraded below oemPidsCapable', () async {
+          'connect() does NOT send 0902 — the probe is off the critical '
+          'path (#2261 concern 6)', () async {
+        final sent = <String>[];
+        final transport = _RecordingTransport(
+          {
+            'ATZ': 'ELM327 v2.2>',
+            'ATE0': 'OK>',
+            'ATL0': 'OK>',
+            'ATH0': 'OK>',
+            'ATSP0': 'OK>',
+            'ATI': 'ELM327 v2.2>',
+            '0902': 'CAN ERROR>',
+          },
+          sent,
+        );
+        final service = Obd2Service(transport);
+        await service.connect();
+
+        expect(sent, isNot(contains('0902')),
+            reason: 'the multi-frame probe must not delay connect');
+        expect(service.capability, Obd2AdapterCapability.oemPidsCapable,
+            reason: 'connect leaves the firmware-claimed tier until the '
+                'deferred probe reconciles it');
+        expect(service.capabilityNeedsReconcile, isTrue);
+      });
+
+      test(
+          'a lying clone — ATI reports v2.2 but the deferred multi-frame '
+          'probe fails — is downgraded below oemPidsCapable', () async {
         final transport = FakeObd2Transport({
           'ATZ': 'ELM327 v2.2>',
           'ATE0': 'OK>',
@@ -740,6 +770,7 @@ void main() {
         });
         final service = Obd2Service(transport);
         await service.connect();
+        await service.ensureCapabilityReconciled();
 
         expect(service.capability, Obd2AdapterCapability.standardOnly);
         expect(
@@ -747,10 +778,11 @@ void main() {
               Obd2AdapterCapability.oemPidsCapable.index,
           isTrue,
         );
+        expect(service.capabilityNeedsReconcile, isFalse);
       });
 
       test(
-          'a genuine v2.2 adapter — ATI reports v2.2 and the probe '
+          'a genuine v2.2 adapter — ATI reports v2.2 and the deferred probe '
           'returns a valid multi-frame VIN reply — keeps oemPidsCapable',
           () async {
         final transport = FakeObd2Transport({
@@ -764,13 +796,39 @@ void main() {
         });
         final service = Obd2Service(transport);
         await service.connect();
+        await service.ensureCapabilityReconciled();
 
         expect(service.capability, Obd2AdapterCapability.oemPidsCapable);
       });
 
       test(
-          'a standardOnly adapter (ATI v1.5) skips the probe — no 0902 '
-          'is sent', () async {
+          'ensureCapabilityReconciled is a one-shot — a second call sends '
+          'no further 0902', () async {
+        final sent = <String>[];
+        final transport = _RecordingTransport(
+          {
+            'ATZ': 'ELM327 v2.2>',
+            'ATE0': 'OK>',
+            'ATL0': 'OK>',
+            'ATH0': 'OK>',
+            'ATSP0': 'OK>',
+            'ATI': 'ELM327 v2.2>',
+            '0902': 'CAN ERROR>',
+          },
+          sent,
+        );
+        final service = Obd2Service(transport);
+        await service.connect();
+        await service.ensureCapabilityReconciled();
+        await service.ensureCapabilityReconciled();
+
+        expect(sent.where((c) => c == '0902').length, 1,
+            reason: 'the deferred probe runs at most once per connect');
+      });
+
+      test(
+          'a standardOnly adapter (ATI v1.5) never probes — no 0902 even '
+          'after ensureCapabilityReconciled', () async {
         final sent = <String>[];
         final transport = _RecordingTransport(
           {
@@ -785,6 +843,10 @@ void main() {
         );
         final service = Obd2Service(transport);
         await service.connect();
+        expect(service.capabilityNeedsReconcile, isFalse,
+            reason: 'standardOnly has nothing to downgrade — no deferred '
+                'probe is armed');
+        await service.ensureCapabilityReconciled();
 
         expect(service.capability, Obd2AdapterCapability.standardOnly);
         expect(sent, isNot(contains('0902')));

--- a/test/features/consumption/data/obd2/reconnect_connector_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_connector_test.dart
@@ -46,6 +46,33 @@ void main() {
       await connected!.disconnect();
     });
 
+    test('attemptPassive opens an autoConnect channel and NEVER scans (#2261)',
+        () async {
+      final fake = _FakeFacade(
+        directChannel: _FakeChannel(respondTo: _elmOk()),
+        batches: [
+          [_cand('aa:bb', -55)],
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(fake),
+        onConnected: (s) => connected = s,
+      );
+
+      final ok = await connector.attemptPassive('aa:bb');
+
+      expect(ok, isTrue);
+      expect(connected, isNotNull);
+      expect(fake.passiveCalls, 1,
+          reason: 'the passive path must request an autoConnect channel');
+      expect(fake.directCalls, 0,
+          reason: 'the passive path must not use the active direct connect');
+      expect(fake.scanInvoked, isFalse,
+          reason: 'a passive GATT wait IS the fallback — it never scans');
+      await connected!.disconnect();
+    });
+
     test('falls back to the scan path only when direct fails — and scans '
         'exactly once', () async {
       final fake = _FakeFacade(
@@ -164,6 +191,7 @@ class _FakeFacade implements BluetoothFacade {
   bool scanInvoked = false;
   int scanCount = 0;
   int directCalls = 0;
+  int passiveCalls = 0;
 
   _FakeFacade({required this.batches, this.channel, this.directChannel});
 
@@ -190,8 +218,13 @@ class _FakeFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
-    directCalls++;
+    if (autoConnect) {
+      passiveCalls++;
+    } else {
+      directCalls++;
+    }
     return directChannel ?? channel ?? _FakeChannel(silent: true);
   }
 }

--- a/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
@@ -571,6 +571,12 @@ class _ObservableScanner implements AdapterReconnectScanner {
   bool get isScanning => _scanning;
 
   @override
+  bool get isPassiveWaiting => false;
+
+  @override
+  int get consecutiveMisses => 0;
+
+  @override
   Duration get currentBackoff => const Duration(seconds: 5);
 
   @override

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -351,6 +351,7 @@ class _StreamingFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) =>
       _SilentChannel();
 }

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -210,6 +210,7 @@ class _EmptyBluetoothFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
     throw UnimplementedError('not used in trajets_tab tests');
   }

--- a/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
+++ b/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
@@ -637,6 +637,7 @@ class _UnusedBluetoothFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
     throw UnimplementedError();
   }

--- a/test/features/vehicle/providers/obd2_vin_reader_provider_test.dart
+++ b/test/features/vehicle/providers/obd2_vin_reader_provider_test.dart
@@ -309,6 +309,7 @@ class _UnusedBluetoothFacade implements BluetoothFacade {
   ElmByteChannel channelForDirect(
     String mac, {
     Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
   }) {
     throw UnimplementedError(
       'BluetoothFacade.channelForDirect is not used by '


### PR DESCRIPTION
Aggregated batch (child of Epic #2231) bundling 6 cohesive OBD2 connect / init / reconnect reliability + latency improvements into one PR — they all touch the same connect path, so one PR avoids 6× CI and inter-PR conflicts on the channel / transport / scanner. One commit per concern.

Closes #2261.

## Concerns (one commit each)

1. **connectionState drop-detection + ~1.5s debounce** — the FBP channel subscribes to `device.connectionState`; a new `ConnectionDropDebouncer` turns a raw `disconnected` edge into a *confirmed* drop (debounce elapsed, or the next write also failed). On confirmation it pushes a typed `Obd2DisconnectedException` onto the byte stream, so `TripDropDetector` fires in ~1–2s instead of waiting out the ~15s read timeout. A self-healing RF blip that reconnects inside the debounce cancels the pending drop.
2. **Bounded reconnect scan → passive autoConnect wait** — `AdapterReconnectScanner` gains a ~5-miss ceiling; past it, it stops the battery-burning 8s active scans and waits on a low-power `autoConnect:true` GATT connect (`connectByMacPassive` / `attemptPassive`) for the rest of the grace. The 15-min grace is untouched. Opt-in: no `passiveConnect` callback ⇒ pre-existing behaviour.
3. **ATDPN protocol cache + ATSP{n} warm connect** — after init, read `ATDPN`, strip the `A` auto-flag, persist per `adapterMac(:vin)` (new Hive `obd2_negotiated_protocol` box). Warm connects swap `ATSP0` for `ATSP{n}` to skip the multi-second auto-search; a pinned protocol that can't talk falls back to `ATSP0` and re-caches.
4. **requestConnectionPriority(high) + best-effort MTU (Android, try/catch)** — a fresh active connect requests high priority + a best-effort 247-byte MTU; PHY (2M) is deliberately skipped; the passive autoConnect path skips MTU entirely (FBP forbids it). `tuneForRecording` / `tuneForBackground` exposed via an `Obd2LinkTuner` mixin through the transport + service so the recorder can drop to balanced when only the 1 Hz auto-record stream is live.
5. **Trim AT inter-command sleeps + adaptive read timeouts** — drop the fixed 100ms sleep between trivial AT echoes (the prompt-wait already serialises); keep a settle only after ATZ/ATWS. Replace the flat 5s read timeout with three classes (trivial AT ~1s / wake + first-command ~2.5s / ATSP0 + first-OBD protocol-search ~4.5s).
6. **0902 capability probe off the start critical path** — the multi-frame `0902` clone-downgrade probe (#1614) no longer blocks `connect()`; it is deferred to a one-shot `ensureCapabilityReconciled()` kicked lazily on the first live sample, and its timeout drops 4s → 1.5s. The probe can only lower the tier, so deferral never enables a feature prematurely.

## Tests
New/extended OBD2 unit tests per concern (fake-channel / scripted-transport pattern): drop-detection fires + debounces; scanner ceiling switch to passive wait; ATDPN parse + cache + warm ATSP{n} + ATSP0 re-cache fallback; link tuning forwarded best-effort; AT timing classes + inter-command sleep trim; deferred capability probe is one-shot and off the connect path. Existing OBD2 + adapter-timing tests updated to the new behaviour.

## Gate
- `flutter analyze` → only the 2 pre-existing infos (radius_alert_map_picker.dart:184, trip_kind_from_samples_test.dart:6); no new errors/warnings.
- `flutter test test/features/consumption/ test/lint/` → all pass (3037).
- Codegen clean build + `git diff --exit-code` clean.

## On-device smoke test
BLE link tuning, the passive autoConnect reconnect, and the ATDPN warm path exercise platform calls that fake channels can't reproduce — recommend an on-device smoke test with a real ELM327 BLE adapter (connect, drive, drop the link / park, observe fast drop detection + reconnect) before relying on the reconnect latency improvements in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
