### PR TITLE
feat(data): caching + per-service-policy core batch (#2264)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -113,7 +113,9 @@ class AppInitializer {
     // are not needed for the first frame, so they run here too.
     _deferPostFirstFrame(() async {
       unawaited(HiveBoxes.initDeferred());
-      await CacheManager(storage).evictExpired();
+      // #2264 — bounded eviction (expiry + per-prefix budget + LRU byte
+      // ceiling) replaces the one-shot 500-key expiry cap.
+      await CacheManager(storage).evictBounded();
       await ProfileRepository(storage).migrateProfileCountryLanguage();
     });
 

--- a/lib/core/cache/cache_eviction_policy.dart
+++ b/lib/core/cache/cache_eviction_policy.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Tunables for `CacheManager.evictBounded` (#2264).
+///
+/// All compile-time so the eviction behaviour stays reproducible in tests
+/// (mirrors the `CacheTtl` policy stance — no runtime knob).
+class CacheEvictionPolicy {
+  /// Max entries kept per key prefix (`search:`, `detail:`, …). The oldest
+  /// entries beyond this per-prefix count are evicted so one noisy prefix
+  /// can't starve the rest.
+  final int prefixBudget;
+
+  /// Global ceiling on the total approximate payload size, in bytes. Past it
+  /// the LRU sweep evicts oldest-first (excluding `dataset:` entries).
+  final int maxBytes;
+
+  const CacheEvictionPolicy({
+    this.prefixBudget = 200,
+    this.maxBytes = 8 * 1024 * 1024,
+  });
+}

--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -1,10 +1,15 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../data/storage_repository.dart';
 import '../services/service_result.dart';
 import '../storage/storage_providers.dart';
+import 'cache_eviction_policy.dart';
+
+export 'cache_eviction_policy.dart' show CacheEvictionPolicy;
 
 part 'cache_manager.g.dart';
 
@@ -295,5 +300,91 @@ class CacheManager implements CacheStrategy {
       }
     }
     return evicted;
+  }
+
+  /// #2264 — bounded periodic eviction, replacing the one-shot startup
+  /// 500-key cap. Three passes, cheapest first: (1) expiry (> 3x TTL);
+  /// (2) per-prefix budget — keep the newest [CacheEvictionPolicy.prefixBudget]
+  /// entries per `type:` prefix, so one noisy prefix can't starve the rest;
+  /// (3) global LRU byte ceiling — if total payload size still exceeds
+  /// [CacheEvictionPolicy.maxBytes], evict oldest-first by `storedAt` until
+  /// under it. Persisted `dataset:` entries (the offline backbone) are exempt
+  /// from the byte sweep but still obey their prefix budget. Returns the
+  /// number of evicted entries; idempotent.
+  Future<int> evictBounded({CacheEvictionPolicy policy = const CacheEvictionPolicy()}) async {
+    var evicted = 0;
+
+    // Snapshot the entries once: (key, entry).
+    final entries = <MapEntry<String, CacheEntry>>[];
+    for (final raw in _storage.cacheKeys.toList()) {
+      if (raw is! String) continue;
+      final entry = get(raw);
+      if (entry == null) continue;
+      entries.add(MapEntry(raw, entry));
+    }
+
+    // Pass 1 — expiry (> 3x TTL).
+    final survivors = <MapEntry<String, CacheEntry>>[];
+    for (final e in entries) {
+      if (e.value.age > e.value.ttl * 3) {
+        await _storage.deleteCacheEntry(e.key);
+        evicted++;
+      } else {
+        survivors.add(e);
+      }
+    }
+
+    // Pass 2 — per-prefix budget (keep newest, evict oldest beyond budget).
+    final byPrefix = <String, List<MapEntry<String, CacheEntry>>>{};
+    for (final e in survivors) {
+      byPrefix.putIfAbsent(_prefixOf(e.key), () => []).add(e);
+    }
+    final budgeted = <MapEntry<String, CacheEntry>>[];
+    for (final group in byPrefix.values) {
+      group.sort((a, b) => b.value.storedAt.compareTo(a.value.storedAt));
+      for (var i = 0; i < group.length; i++) {
+        if (i < policy.prefixBudget) {
+          budgeted.add(group[i]);
+        } else {
+          await _storage.deleteCacheEntry(group[i].key);
+          evicted++;
+        }
+      }
+    }
+
+    // Pass 3 — global LRU byte ceiling (dataset: entries are protected).
+    var totalBytes = budgeted.fold<int>(0, (sum, e) => sum + _approxBytes(e.value));
+    if (totalBytes > policy.maxBytes) {
+      final evictable = budgeted
+          .where((e) => !e.key.startsWith('dataset:'))
+          .toList()
+        ..sort((a, b) => a.value.storedAt.compareTo(b.value.storedAt));
+      for (final e in evictable) {
+        if (totalBytes <= policy.maxBytes) break;
+        await _storage.deleteCacheEntry(e.key);
+        totalBytes -= _approxBytes(e.value);
+        evicted++;
+      }
+    }
+
+    return evicted;
+  }
+
+  /// The `type:` prefix of a cache key (everything up to and including the
+  /// first colon), or the whole key when it carries no colon.
+  static String _prefixOf(String key) {
+    final i = key.indexOf(':');
+    return i < 0 ? key : key.substring(0, i + 1);
+  }
+
+  /// Cheap byte estimate for an entry — the length of its JSON-encoded
+  /// payload. Avoids re-encoding the Hive envelope; good enough to drive the
+  /// LRU ceiling.
+  static int _approxBytes(CacheEntry entry) {
+    try {
+      return jsonEncode(entry.payload).length;
+    } on Object {
+      return 0;
+    }
   }
 }

--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -339,6 +339,14 @@ class Countries {
     exampleCity: 'Sydney',
     // AU forecourts quote cents-per-litre on signage.
     pricePerUnitSuffix: 'c/L',
+    // #2264 — AustraliaStationService is a documented stub that throws on
+    // every search (the legacy FuelCheckApp/v2 endpoint is retired and the
+    // replacement needs OAuth2 we don't ship; tracked in #804). Advertising
+    // it as verified put a country in the picker that can only ever error,
+    // so gate it out until #804 lands a working endpoint. The entry stays
+    // *registered* — an `au-` station id still resolves — it is only hidden
+    // from the user-facing pickers via [Countries.verified].
+    verified: false,
   );
 
   static const slovenia = CountryConfig(

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -689,6 +689,9 @@ class CountryServiceRegistry {
       cache,
       errorSource: entry.errorSource,
       countryCode: countryCode,
+      // #2264 — the chain branches on this to local-filter bulk datasets
+      // (no per-key cache) vs keep the per-key TTL cache for polled APIs.
+      policy: entry.policy,
     );
   }
 

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -26,6 +26,7 @@ import '../../features/station_services/slovenia/slovenia_station_service.dart';
 import '../../features/station_services/south_korea/south_korea_station_service.dart';
 import '../../features/station_services/spain/miteco_station_service.dart';
 import '../../features/station_services/uk/uk_station_service.dart';
+import 'fuel_service_policy.dart';
 import 'impl/demo_station_service.dart';
 import 'impl/osm_brand_enricher.dart';
 import 'service_providers.dart';
@@ -85,6 +86,13 @@ class CountryServiceEntry {
   /// Whether this country requires a user-provided API key.
   final bool requiresApiKey;
 
+  /// Typed data-source policy (#2264) — the single source of truth for the
+  /// cache TTLs and rate-limit interval the service layer reads. The
+  /// [StationServiceChain] branches on [FuelServicePolicy.model] to decide
+  /// whether to local-filter a persisted bulk dataset or keep a per-search-key
+  /// TTL cache; the rate limiter reads [FuelServicePolicy.minInterval].
+  final FuelServicePolicy policy;
+
   /// Factory that creates the raw [StationService] for this country.
   /// Receives a [Ref] for dependency injection.
   final StationService Function(Ref ref) createService;
@@ -94,6 +102,7 @@ class CountryServiceEntry {
     required this.errorSource,
     required this.boundingBox,
     required this.availableFuelTypes,
+    required this.policy,
     this.requiresApiKey = false,
     required this.createService,
   });
@@ -110,6 +119,216 @@ const List<FuelType> _defaultFuelTypes = [
   FuelType.electric,
   FuelType.all,
 ];
+
+// ---------------------------------------------------------------------------
+// Per-service data-source policies (#2264)
+// ---------------------------------------------------------------------------
+// Seeded from the Epic #2249 per-service audit. Each [CountryServiceEntry]
+// references exactly one of these; they are the single source of truth for
+// the cache TTLs + rate-limit interval the chain and Dio layer read. Values
+// are deliberately conservative — for bulk files the soft TTL is roughly the
+// upstream publish cadence and the hard TTL is a multiple of it (offline
+// grace), for polled APIs `searchResultTtl` matches how fast prices move and
+// `minInterval` matches the published / inferred rate limit.
+
+/// DE Tankerkönig — polled API, ~1 request/min published policy, prices on a
+/// 5-minute cadence. (#2264)
+const _dePolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(seconds: 60),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(minutes: 5),
+  attribution: 'Tankerkönig',
+  license: 'CC BY 4.0',
+);
+
+/// AT e-control — polled API; the Spritpreisrechner refreshes hourly, so a
+/// 1–2 h search TTL and a gentle 1 h min-interval keep us inside policy.
+const _atPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 2),
+  attribution: 'E-Control (Spritpreisrechner)',
+  license: 'CC BY 3.0 AT',
+);
+
+/// MX CRE — polled-then-merged feed that updates several times daily; cache
+/// the merged result 4 h and don't re-pull more often than that.
+const _mxPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 4),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 4),
+  attribution: 'Comisión Reguladora de Energía (CRE)',
+  license: 'Libre Uso MX',
+);
+
+/// PT DGEG — polled API; the portal publishes daily, so a 12 h search TTL and
+/// a 1 h min-interval are comfortable.
+const _ptPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 12),
+  attribution: 'DGEG (preçoscombustíveis)',
+  license: 'Open data (DGEG)',
+);
+
+/// UK CMA Fuel Finder — polled fan-out across retailer feeds published daily
+/// under the CMA scheme; cache each search 6 h.
+const _ukPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(minutes: 30),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 6),
+  attribution: 'CMA Fuel Finder (retailer feeds)',
+  license: 'Open Government Licence v3.0',
+);
+
+/// LU — government-regulated uniform prices, polled; a daily refresh is ample
+/// since the price changes only by ministerial arrêté.
+const _luPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 6),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 12),
+  attribution: 'gouvernement.lu',
+  license: 'CC0 1.0',
+);
+
+/// SI goriva.si — polled API; daily-ish updates.
+const _siPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 6),
+  attribution: 'goriva.si / Ministrstvo za gospodarstvo',
+  license: 'Open data (gov.si)',
+);
+
+/// KR OPINET — polled API; near-real-time prices, 5-minute search TTL.
+const _krPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(seconds: 60),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(minutes: 30),
+  attribution: 'OPINET (KNOC)',
+  license: 'KOGL Type 1',
+);
+
+/// CL CNE Bencina en Línea — polled API; daily-ish updates.
+const _clPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 6),
+  attribution: 'CNE (Comisión Nacional de Energía)',
+  license: 'Datos Abiertos CL',
+);
+
+/// GR Paratiritirio Timon — polled API (community FastAPI wrapper); prefecture
+/// observatory updates roughly daily.
+const _grPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 6),
+  attribution: 'Παρατηρητήριο Τιμών Υγρών Καυσίμων',
+  license: 'Open data (data.gov.gr)',
+);
+
+/// RO Monitorul Prețurilor — polled API; 15-minute upstream updates.
+const _roPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(minutes: 15),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(minutes: 30),
+  attribution: 'Consiliul Concurenței (Monitorul Prețurilor)',
+  license: 'Open data (RO)',
+);
+
+/// AU FuelCheck — stub (#804); throws on every search. Policy still recorded
+/// so the row exists once an endpoint lands; polled when it does.
+const _auPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(seconds: 60),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(minutes: 30),
+  attribution: 'NSW Government FuelCheck',
+  license: 'CC BY 4.0',
+);
+
+/// ES MITECO — bulk national dataset (~12k stations) downloaded per province
+/// and filtered locally; published daily.
+const _esPolicy = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(minutes: 30),
+  datasetTtlSoft: Duration(hours: 6),
+  datasetTtlHard: Duration(hours: 24),
+  searchResultTtl: Duration.zero,
+  attribution: 'Geoportal Gasolineras (MITECO)',
+  license: 'Open data (MITECO)',
+);
+
+/// IT MIMIT (osservaprezzi) — bulk CSV dataset published daily at 08:00.
+const _itPolicy = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(minutes: 30),
+  datasetTtlSoft: Duration(hours: 6),
+  datasetTtlHard: Duration(hours: 24),
+  searchResultTtl: Duration.zero,
+  attribution: 'MIMIT (osservaprezzi)',
+  license: 'IODL 2.0',
+);
+
+/// AR Secretaría de Energía — bulk CSV dataset (Resolución 314/2016); a few
+/// updates per day, large file.
+const _arPolicy = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration(hours: 6),
+  datasetTtlHard: Duration(hours: 24),
+  searchResultTtl: Duration.zero,
+  attribution: 'Secretaría de Energía (datos.energia.gob.ar)',
+  license: 'Open data (AR)',
+);
+
+/// DK — bulk national aggregate across OK / Shell / Q8 feeds, filtered
+/// locally; refreshed a few times daily.
+const _dkPolicy = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(minutes: 15),
+  datasetTtlSoft: Duration(hours: 2),
+  datasetTtlHard: Duration(hours: 12),
+  searchResultTtl: Duration.zero,
+  attribution: 'OK / Shell / Q8 (DK)',
+  license: 'Provider terms',
+);
+
+/// FR Prix Carburants — currently a polled/OSM-enriched search; the bulk flux
+/// ZIP migration is a later batch, so it is modelled as polled for now.
+const _frPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(minutes: 30),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(hours: 6),
+  attribution: 'Prix Carburants (data.economie.gouv.fr)',
+  license: 'Licence Ouverte 2.0',
+);
 
 /// Central registry of all country-specific station services.
 ///
@@ -155,6 +374,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _ptPolicy,
       createService: _createPortugal,
     ),
     CountryServiceEntry(
@@ -171,6 +391,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
         FuelType.electric, FuelType.all,
       ],
+      policy: _ukPolicy,
       createService: _createUk,
     ),
     CountryServiceEntry(
@@ -180,6 +401,7 @@ class CountryServiceRegistry {
         minLat: 54.0, maxLat: 58.0, minLng: 7.5, maxLng: 15.5,
       ),
       availableFuelTypes: _defaultFuelTypes,
+      policy: _dkPolicy,
       createService: _createDenmark,
     ),
     CountryServiceEntry(
@@ -196,6 +418,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _luPolicy,
       createService: _createLuxembourg,
     ),
     CountryServiceEntry(
@@ -216,6 +439,7 @@ class CountryServiceRegistry {
         FuelType.dieselPremium, FuelType.lpg, FuelType.cng,
         FuelType.electric, FuelType.all,
       ],
+      policy: _siPolicy,
       createService: _createSlovenia,
     ),
     // ── Continental EU (test order matters for shadow neighbours) ─────
@@ -226,6 +450,7 @@ class CountryServiceRegistry {
         minLat: 46.0, maxLat: 49.5, minLng: 9.0, maxLng: 17.5,
       ),
       availableFuelTypes: _defaultFuelTypes,
+      policy: _atPolicy,
       createService: _createEControl,
     ),
     CountryServiceEntry(
@@ -241,6 +466,7 @@ class CountryServiceRegistry {
         FuelType.e10, FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.e85, FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _frPolicy,
       createService: _createPrixCarburants,
     ),
     CountryServiceEntry(
@@ -254,6 +480,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.diesel, FuelType.lpg, FuelType.cng,
         FuelType.electric, FuelType.all,
       ],
+      policy: _itPolicy,
       createService: _createMise,
     ),
     CountryServiceEntry(
@@ -269,6 +496,7 @@ class CountryServiceRegistry {
         FuelType.dieselPremium, FuelType.lpg, FuelType.electric,
         FuelType.all,
       ],
+      policy: _esPolicy,
       createService: _createMiteco,
     ),
     CountryServiceEntry(
@@ -280,6 +508,7 @@ class CountryServiceRegistry {
       ),
       // DE: Tankerkönig publishes E5, E10, Diesel.
       availableFuelTypes: _defaultFuelTypes,
+      policy: _dePolicy,
       createService: _createTankerkoenig,
     ),
     // ── Non-EU countries (no overlap concerns) ─────────────────────────
@@ -290,6 +519,7 @@ class CountryServiceRegistry {
         minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0,
       ),
       availableFuelTypes: _defaultFuelTypes,
+      policy: _mxPolicy,
       createService: _createMexico,
     ),
     // CL before AR: Chile's narrow strip sits inside AR's generous
@@ -306,6 +536,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _clPolicy,
       createService: _createChile,
     ),
     CountryServiceEntry(
@@ -324,6 +555,7 @@ class CountryServiceRegistry {
         FuelType.dieselPremium, FuelType.cng, FuelType.electric,
         FuelType.all,
       ],
+      policy: _arPolicy,
       createService: _createArgentina,
     ),
     CountryServiceEntry(
@@ -342,6 +574,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e10, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _auPolicy,
       createService: _createAustralia,
     ),
     CountryServiceEntry(
@@ -358,6 +591,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _krPolicy,
       createService: _createSouthKorea,
     ),
     CountryServiceEntry(
@@ -374,6 +608,7 @@ class CountryServiceRegistry {
         FuelType.e5, FuelType.e98, FuelType.diesel,
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
+      policy: _grPolicy,
       createService: _createGreece,
     ),
     CountryServiceEntry(
@@ -392,6 +627,7 @@ class CountryServiceRegistry {
         FuelType.dieselPremium, FuelType.lpg, FuelType.electric,
         FuelType.all,
       ],
+      policy: _roPolicy,
       createService: _createRomania,
     ),
   ];
@@ -411,6 +647,11 @@ class CountryServiceRegistry {
   /// Returns the bounding box for [countryCode], or null when unregistered.
   static CountryBoundingBox? boundingBoxFor(String countryCode) =>
       _byCode[countryCode]?.boundingBox;
+
+  /// Returns the [FuelServicePolicy] for [countryCode], or null when
+  /// unregistered (#2264).
+  static FuelServicePolicy? policyFor(String countryCode) =>
+      _byCode[countryCode]?.policy;
 
   /// Ordered list of fuel types for [countryCode], or the default minimal
   /// set when the code is unregistered. Mirrors the historical

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -751,10 +751,18 @@ StationService _createPrixCarburants(Ref ref) {
 }
 
 StationService _createEControl(Ref ref) => EControlStationService();
+
+// #2264 — bulk-dataset services receive the shared CacheManager so their
+// parsed national dataset is persisted to Hive (read-through on the next
+// search), surviving cold start + offline. The providers are keepAlive
+// (service_providers.dart) so the in-memory copy also survives rebuilds.
+// MITECO/Spain is wired in concern 6 alongside the province-keying fix.
 StationService _createMiteco(Ref ref) => MitecoStationService();
 StationService _createMise(Ref ref) => MiseStationService();
-StationService _createDenmark(Ref ref) => DenmarkStationService();
-StationService _createArgentina(Ref ref) => ArgentinaStationService();
+StationService _createDenmark(Ref ref) =>
+    DenmarkStationService(cache: ref.read(cacheManagerProvider));
+StationService _createArgentina(Ref ref) =>
+    ArgentinaStationService(cache: ref.read(cacheManagerProvider));
 StationService _createPortugal(Ref ref) => PortugalStationService();
 StationService _createUk(Ref ref) => UkStationService();
 StationService _createAustralia(Ref ref) => const AustraliaStationService();

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -756,8 +756,8 @@ StationService _createEControl(Ref ref) => EControlStationService();
 // parsed national dataset is persisted to Hive (read-through on the next
 // search), surviving cold start + offline. The providers are keepAlive
 // (service_providers.dart) so the in-memory copy also survives rebuilds.
-// MITECO/Spain is wired in concern 6 alongside the province-keying fix.
-StationService _createMiteco(Ref ref) => MitecoStationService();
+StationService _createMiteco(Ref ref) =>
+    MitecoStationService(cache: ref.read(cacheManagerProvider));
 StationService _createMise(Ref ref) => MiseStationService();
 StationService _createDenmark(Ref ref) =>
     DenmarkStationService(cache: ref.read(cacheManagerProvider));

--- a/lib/core/services/fuel_service_policy.dart
+++ b/lib/core/services/fuel_service_policy.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// How a country's upstream fuel-price source delivers data.
+///
+/// This is the discriminator the [StationServiceChain] branches on (#2264):
+///
+///  - [polledApi] — a live HTTP endpoint queried per-search (lat/lng/radius),
+///    rate-limited by [FuelServicePolicy.minInterval] and cached per search
+///    key with [FuelServicePolicy.searchResultTtl]. DE Tankerkönig, AT
+///    e-control, MX CRE, PT DGEG, UK CMA all behave this way: each search is
+///    an upstream request.
+///
+///  - [bulkFile] — a whole-country dataset downloaded as one file/feed and
+///    filtered locally. ES MITECO (~12k stations), IT MIMIT, AR Secretaría de
+///    Energía, DK aggregate, etc. For these the per-search-key cache is
+///    pointless: every search hits the same in-memory/persisted dataset, so
+///    the chain answers "nearby" by local-filtering rather than re-hitting the
+///    network or storing one Hive entry per (lat,lng,radius,fuel) tuple. The
+///    dataset itself is governed by [FuelServicePolicy.datasetTtlSoft] /
+///    [FuelServicePolicy.datasetTtlHard].
+enum SourceModel {
+  /// Live endpoint queried per search; per-key TTL cache applies.
+  polledApi,
+
+  /// Whole-country dataset downloaded once and filtered locally.
+  bulkFile,
+}
+
+/// Typed, per-country data-source policy — the **single source of truth** for
+/// the cache + rate-limiter knobs the service layer reads (#2264, child of
+/// Epic #2249).
+///
+/// Before this type, the chain hard-coded one TTL for every country and the
+/// rate limit lived in each Dio factory call. Folding both into one config
+/// row per [CountryServiceEntry] means:
+///
+///  - the chain reads [model] to decide bulk-vs-polled behaviour,
+///  - the per-key cache reads [searchResultTtl] for polled sources,
+///  - the persisted-dataset read-through reads [datasetTtlSoft] (serve from
+///    disk + refresh in the background past this age) and [datasetTtlHard]
+///    (force a blocking re-download past this age),
+///  - the rate limiter reads [minInterval],
+///
+/// and adding a country becomes a config row rather than scattered edits.
+///
+/// [attribution] / [license] are **data**, not yet rendered — the
+/// attribution UI is a later batch. They live here as plain const strings so
+/// the policy row is the one place the legal text is recorded.
+class FuelServicePolicy {
+  /// How this source delivers data — the chain's bulk-vs-polled discriminator.
+  final SourceModel model;
+
+  /// Minimum spacing between two upstream requests for this source — the
+  /// token-bucket / rate-limit interval. For [SourceModel.bulkFile] sources
+  /// this throttles how often the *whole dataset* may be re-downloaded; for
+  /// [SourceModel.polledApi] it throttles per-search requests.
+  final Duration minInterval;
+
+  /// Soft dataset TTL ([SourceModel.bulkFile]): past this age the persisted
+  /// dataset is still served (offline-friendly), but the next search triggers
+  /// a background refresh. Ignored for [SourceModel.polledApi] sources.
+  final Duration datasetTtlSoft;
+
+  /// Hard dataset TTL ([SourceModel.bulkFile]): past this age the dataset is
+  /// considered too stale to serve without a blocking re-download. Always
+  /// `>= datasetTtlSoft`. Ignored for [SourceModel.polledApi] sources.
+  final Duration datasetTtlHard;
+
+  /// Per-search-key cache TTL ([SourceModel.polledApi]): how long a
+  /// `search:<country>:<lat>:<lng>:<radius>:<fuel>` Hive entry stays fresh.
+  /// Ignored for [SourceModel.bulkFile] sources (they local-filter instead).
+  final Duration searchResultTtl;
+
+  /// Human-readable attribution string for the upstream data provider.
+  ///
+  /// DATA, not a rendered UI string — the attribution UI ships in a later
+  /// batch. Brand/proper-noun + provider names only; safe as a const literal.
+  // i18n-ignore: data, rendered in a later batch
+  final String attribution;
+
+  /// SPDX-style or named licence under which the upstream data is published.
+  ///
+  /// DATA, not a rendered UI string — see [attribution].
+  // i18n-ignore: data, rendered in a later batch
+  final String license;
+
+  const FuelServicePolicy({
+    required this.model,
+    required this.minInterval,
+    required this.datasetTtlSoft,
+    required this.datasetTtlHard,
+    required this.searchResultTtl,
+    required this.attribution,
+    required this.license,
+  });
+
+  /// `true` when this source downloads a whole-country dataset and filters
+  /// it locally (the chain answers nearby without a network round-trip).
+  bool get isBulkFile => model == SourceModel.bulkFile;
+
+  /// `true` when this source is a live endpoint queried per search.
+  bool get isPolledApi => model == SourceModel.polledApi;
+}

--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../persistent_dataset.dart';
+
 /// Mixin for services that download a full national dataset and cache it
 /// in memory (MITECO, MISE, Argentina, Denmark).
 ///
@@ -16,6 +18,12 @@ mixin CachedDatasetMixin {
 
   /// Mark the in-memory dataset as just refreshed.
   void markDatasetRefreshed() => _datasetCachedAt = DateTime.now();
+
+  /// Stamp the in-memory freshness clock to [age] ago — used when a dataset
+  /// is rehydrated from disk so its remaining freshness reflects the persisted
+  /// copy's age, not the moment of rehydration (#2264).
+  void markDatasetRefreshedAt(Duration age) =>
+      _datasetCachedAt = DateTime.now().subtract(age);
 
   /// Generic guard→fetch→store→mark idiom shared by the dataset services.
   ///
@@ -35,5 +43,58 @@ mixin CachedDatasetMixin {
     store(value);
     markDatasetRefreshed();
     return value;
+  }
+
+  /// Persistence-aware variant of [loadDataset] (#2264). Adds a disk
+  /// read-through so a bulk dataset survives a cold start and works offline:
+  ///
+  ///  1. In-memory fresh (< [softTtl]) → return [cached] (no I/O).
+  ///  2. Else read the persisted copy via [persistent]:
+  ///       - younger than [hardTtl] → rehydrate [store] it, stamp the
+  ///         in-memory clock to the persisted age, and return it. (Past the
+  ///         soft TTL the caller may still trigger a background refresh, but
+  ///         the user sees data immediately + offline.)
+  ///  3. Else [fetch] from the network, [store] + persist with [hardTtl],
+  ///     mark fresh, and return.
+  ///  4. If [fetch] throws but a persisted copy of *any* age exists, serve it
+  ///     (stale-but-offline) rather than failing the whole search.
+  Future<T> loadPersistentDataset<T>({
+    required T? cached,
+    required Duration softTtl,
+    required Duration hardTtl,
+    required PersistentDataset<T> persistent,
+    required Future<T> Function() fetch,
+    required void Function(T value) store,
+  }) async {
+    if (cached != null && isDatasetFresh(softTtl)) return cached;
+
+    // Disk read-through — survives cold start + offline.
+    if (cached == null || !isDatasetFresh(hardTtl)) {
+      final disk = persistent.read();
+      if (disk != null && disk.age <= hardTtl) {
+        store(disk.value);
+        markDatasetRefreshedAt(disk.age);
+        if (disk.age <= softTtl) return disk.value;
+        // Soft-stale: fall through to refresh, but keep the disk copy as a
+        // fallback if the network is unavailable.
+      }
+    }
+
+    try {
+      final value = await fetch();
+      store(value);
+      markDatasetRefreshed();
+      await persistent.write(value, hardTtl: hardTtl);
+      return value;
+    } on Object {
+      // Network failed — serve any persisted copy rather than throw.
+      final disk = persistent.read();
+      if (disk != null) {
+        store(disk.value);
+        markDatasetRefreshedAt(disk.age);
+        return disk.value;
+      }
+      rethrow;
+    }
   }
 }

--- a/lib/core/services/persistent_dataset.dart
+++ b/lib/core/services/persistent_dataset.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../cache/cache_manager.dart';
+import 'service_result.dart';
+
+/// Disk-backed persistence for a whole-country bulk dataset (#2264).
+///
+/// Bulk-dataset services (ES MITECO, DK aggregate, …) parse a large national
+/// dataset and keep it in memory. Without persistence the dataset is gone on
+/// the next cold start, so the first search after launch always re-downloads
+/// — defeating the dataset's multi-hour TTL and giving zero offline coverage.
+///
+/// [PersistentDataset] wraps the shared [CacheStrategy] (Hive) with a stable
+/// per-country key plus JSON serialize / deserialize, and exposes soft/hard
+/// TTL semantics:
+///
+///  - [readWithin] returns the persisted dataset only when it is younger than
+///    the supplied age (used for the *hard* TTL — past it the caller must
+///    re-download before serving),
+///  - the [CacheEntry.age] of [read] lets the caller decide whether to trigger
+///    a background refresh (the *soft* TTL).
+///
+/// The dataset is stored under its own `dataset:` key prefix so the eviction
+/// policy (concern 5) can give it a dedicated budget and never evict it under
+/// the same pressure as ephemeral per-search entries.
+class PersistentDataset<T> {
+  final CacheStrategy _cache;
+  final String _key;
+  final ServiceSource _source;
+  final Map<String, dynamic> Function(T value) _serialize;
+  final T? Function(Map<String, dynamic> json) _deserialize;
+
+  /// [countryCode] keys the dataset; [datasetName] disambiguates services that
+  /// persist more than one dataset for the same country.
+  PersistentDataset({
+    required CacheStrategy cache,
+    required String countryCode,
+    required String datasetName,
+    required ServiceSource source,
+    required Map<String, dynamic> Function(T value) serialize,
+    required T? Function(Map<String, dynamic> json) deserialize,
+  })  : _cache = cache,
+        _key = datasetKey(countryCode, datasetName),
+        _source = source,
+        _serialize = serialize,
+        _deserialize = deserialize;
+
+  /// Stable cache key for a country's bulk dataset. Public so the eviction
+  /// policy and tests can reason about the `dataset:` prefix.
+  static String datasetKey(String countryCode, String datasetName) =>
+      'dataset:$countryCode:$datasetName';
+
+  /// The `dataset:` key prefix — entries under it are the persisted national
+  /// datasets, given a dedicated eviction budget (concern 5).
+  static const String keyPrefix = 'dataset:';
+
+  /// Persist [value]. The Hive entry's own TTL is set to [hardTtl] so a
+  /// generic expiry sweep never drops a dataset the caller still considers
+  /// servable; freshness decisions are made by the caller via soft/hard age.
+  Future<void> write(T value, {required Duration hardTtl}) =>
+      _cache.put(_key, _serialize(value), ttl: hardTtl, source: _source);
+
+  /// The persisted dataset and the age of the stored copy, or null when
+  /// nothing is persisted / it fails to deserialize.
+  ({T value, Duration age})? read() {
+    final entry = _cache.get(_key);
+    if (entry == null) return null;
+    final value = _deserialize(entry.payload);
+    if (value == null) return null;
+    return (value: value, age: entry.age);
+  }
+
+  /// The persisted dataset only when its stored copy is younger than
+  /// [maxAge] (the hard TTL); otherwise null.
+  T? readWithin(Duration maxAge) {
+    final hit = read();
+    if (hit == null) return null;
+    return hit.age <= maxAge ? hit.value : null;
+  }
+}

--- a/lib/core/services/service_providers.dart
+++ b/lib/core/services/service_providers.dart
@@ -54,7 +54,16 @@ Dio tankerkoenigDio(Ref ref) {
 /// truth for per-country service wiring — including Germany. Countries
 /// that require an API key fall back to [DemoStationService] from inside
 /// the registry's factory function when no key is configured.
-@riverpod
+///
+/// #2264 — `keepAlive`: bulk-dataset services (ES/IT/AR/DK) hold the parsed
+/// whole-country dataset in instance fields. Under the previous auto-dispose
+/// provider the service was rebuilt — and the in-memory dataset thrown away —
+/// every time the last listener detached, forcing a re-download far more
+/// often than the dataset's TTL. Keeping the provider alive lets the dataset
+/// (and its persisted Hive read-through) survive across the session; it still
+/// rebuilds when [activeCountryProvider] changes, which is the only time the
+/// service identity should change.
+@Riverpod(keepAlive: true)
 StationService stationService(Ref ref) {
   final country = ref.watch(activeCountryProvider);
   return _resolveServiceForCountry(ref, country.code);
@@ -68,7 +77,12 @@ StationService stationService(Ref ref) {
 /// Exposed as a `Provider.family` so tests can override per-country
 /// services without standing up the full `CountryServiceRegistry`.
 /// Production paths use the [stationServiceForCountry] sync helper.
-@riverpod
+///
+/// #2264 — `keepAlive` for the same bulk-dataset reason as
+/// [stationServiceProvider]: a per-country bulk service keeps its parsed
+/// dataset alive across rebuilds instead of re-downloading the whole country
+/// on every cross-country lookup.
+@Riverpod(keepAlive: true)
 StationService perCountryStationService(
   Ref ref,
   String countryCode,

--- a/lib/core/services/service_providers.g.dart
+++ b/lib/core/services/service_providers.g.dart
@@ -55,6 +55,15 @@ String _$tankerkoenigDioHash() => r'bf30524d1ff9225e6dd29e0a4b92c6cac725a4e3';
 /// truth for per-country service wiring — including Germany. Countries
 /// that require an API key fall back to [DemoStationService] from inside
 /// the registry's factory function when no key is configured.
+///
+/// #2264 — `keepAlive`: bulk-dataset services (ES/IT/AR/DK) hold the parsed
+/// whole-country dataset in instance fields. Under the previous auto-dispose
+/// provider the service was rebuilt — and the in-memory dataset thrown away —
+/// every time the last listener detached, forcing a re-download far more
+/// often than the dataset's TTL. Keeping the provider alive lets the dataset
+/// (and its persisted Hive read-through) survive across the session; it still
+/// rebuilds when [activeCountryProvider] changes, which is the only time the
+/// service identity should change.
 
 @ProviderFor(stationService)
 final stationServiceProvider = StationServiceProvider._();
@@ -65,6 +74,15 @@ final stationServiceProvider = StationServiceProvider._();
 /// truth for per-country service wiring — including Germany. Countries
 /// that require an API key fall back to [DemoStationService] from inside
 /// the registry's factory function when no key is configured.
+///
+/// #2264 — `keepAlive`: bulk-dataset services (ES/IT/AR/DK) hold the parsed
+/// whole-country dataset in instance fields. Under the previous auto-dispose
+/// provider the service was rebuilt — and the in-memory dataset thrown away —
+/// every time the last listener detached, forcing a re-download far more
+/// often than the dataset's TTL. Keeping the provider alive lets the dataset
+/// (and its persisted Hive read-through) survive across the session; it still
+/// rebuilds when [activeCountryProvider] changes, which is the only time the
+/// service identity should change.
 
 final class StationServiceProvider
     extends $FunctionalProvider<StationService, StationService, StationService>
@@ -75,13 +93,22 @@ final class StationServiceProvider
   /// truth for per-country service wiring — including Germany. Countries
   /// that require an API key fall back to [DemoStationService] from inside
   /// the registry's factory function when no key is configured.
+  ///
+  /// #2264 — `keepAlive`: bulk-dataset services (ES/IT/AR/DK) hold the parsed
+  /// whole-country dataset in instance fields. Under the previous auto-dispose
+  /// provider the service was rebuilt — and the in-memory dataset thrown away —
+  /// every time the last listener detached, forcing a re-download far more
+  /// often than the dataset's TTL. Keeping the provider alive lets the dataset
+  /// (and its persisted Hive read-through) survive across the session; it still
+  /// rebuilds when [activeCountryProvider] changes, which is the only time the
+  /// service identity should change.
   StationServiceProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
         name: r'stationServiceProvider',
-        isAutoDispose: true,
+        isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
@@ -108,7 +135,7 @@ final class StationServiceProvider
   }
 }
 
-String _$stationServiceHash() => r'67078979202079f40e27b6893f6f83287e9571e7';
+String _$stationServiceHash() => r'1a5459fd2f967babafab83d85d20b0c32fd0e358';
 
 /// Cross-country station service lookup (#753 widget tap path, #514
 /// favorites currency, #515 route search). Resolves the
@@ -118,6 +145,11 @@ String _$stationServiceHash() => r'67078979202079f40e27b6893f6f83287e9571e7';
 /// Exposed as a `Provider.family` so tests can override per-country
 /// services without standing up the full `CountryServiceRegistry`.
 /// Production paths use the [stationServiceForCountry] sync helper.
+///
+/// #2264 — `keepAlive` for the same bulk-dataset reason as
+/// [stationServiceProvider]: a per-country bulk service keeps its parsed
+/// dataset alive across rebuilds instead of re-downloading the whole country
+/// on every cross-country lookup.
 
 @ProviderFor(perCountryStationService)
 final perCountryStationServiceProvider = PerCountryStationServiceFamily._();
@@ -130,6 +162,11 @@ final perCountryStationServiceProvider = PerCountryStationServiceFamily._();
 /// Exposed as a `Provider.family` so tests can override per-country
 /// services without standing up the full `CountryServiceRegistry`.
 /// Production paths use the [stationServiceForCountry] sync helper.
+///
+/// #2264 — `keepAlive` for the same bulk-dataset reason as
+/// [stationServiceProvider]: a per-country bulk service keeps its parsed
+/// dataset alive across rebuilds instead of re-downloading the whole country
+/// on every cross-country lookup.
 
 final class PerCountryStationServiceProvider
     extends $FunctionalProvider<StationService, StationService, StationService>
@@ -142,13 +179,18 @@ final class PerCountryStationServiceProvider
   /// Exposed as a `Provider.family` so tests can override per-country
   /// services without standing up the full `CountryServiceRegistry`.
   /// Production paths use the [stationServiceForCountry] sync helper.
+  ///
+  /// #2264 — `keepAlive` for the same bulk-dataset reason as
+  /// [stationServiceProvider]: a per-country bulk service keeps its parsed
+  /// dataset alive across rebuilds instead of re-downloading the whole country
+  /// on every cross-country lookup.
   PerCountryStationServiceProvider._({
     required PerCountryStationServiceFamily super.from,
     required String super.argument,
   }) : super(
          retry: null,
          name: r'perCountryStationServiceProvider',
-         isAutoDispose: true,
+         isAutoDispose: false,
          dependencies: null,
          $allTransitiveDependencies: null,
        );
@@ -195,7 +237,7 @@ final class PerCountryStationServiceProvider
 }
 
 String _$perCountryStationServiceHash() =>
-    r'5c02f86c7bbf87b4ef08fdd20c2c9c93f6103ba1';
+    r'79b833834003864cb3a193f9e8f7ea184c6fe0f6';
 
 /// Cross-country station service lookup (#753 widget tap path, #514
 /// favorites currency, #515 route search). Resolves the
@@ -205,6 +247,11 @@ String _$perCountryStationServiceHash() =>
 /// Exposed as a `Provider.family` so tests can override per-country
 /// services without standing up the full `CountryServiceRegistry`.
 /// Production paths use the [stationServiceForCountry] sync helper.
+///
+/// #2264 — `keepAlive` for the same bulk-dataset reason as
+/// [stationServiceProvider]: a per-country bulk service keeps its parsed
+/// dataset alive across rebuilds instead of re-downloading the whole country
+/// on every cross-country lookup.
 
 final class PerCountryStationServiceFamily extends $Family
     with $FunctionalFamilyOverride<StationService, String> {
@@ -214,7 +261,7 @@ final class PerCountryStationServiceFamily extends $Family
         name: r'perCountryStationServiceProvider',
         dependencies: null,
         $allTransitiveDependencies: null,
-        isAutoDispose: true,
+        isAutoDispose: false,
       );
 
   /// Cross-country station service lookup (#753 widget tap path, #514
@@ -225,6 +272,11 @@ final class PerCountryStationServiceFamily extends $Family
   /// Exposed as a `Provider.family` so tests can override per-country
   /// services without standing up the full `CountryServiceRegistry`.
   /// Production paths use the [stationServiceForCountry] sync helper.
+  ///
+  /// #2264 — `keepAlive` for the same bulk-dataset reason as
+  /// [stationServiceProvider]: a per-country bulk service keeps its parsed
+  /// dataset alive across rebuilds instead of re-downloading the whole country
+  /// on every cross-country lookup.
 
   PerCountryStationServiceProvider call(String countryCode) =>
       PerCountryStationServiceProvider._(argument: countryCode, from: this);

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -10,9 +10,10 @@ import '../../features/search/data/models/search_params.dart';
 import '../../features/search/domain/entities/station.dart';
 import '../cache/cache_manager.dart';
 import '../error/exceptions.dart';
+import 'fuel_service_policy.dart';
 import 'service_result.dart';
 import 'station_service.dart';
-import '../../core/logging/error_logger.dart';
+import 'station_service_chain_codec.dart';
 
 /// Orchestrates station data retrieval with fallback:
 ///
@@ -23,11 +24,34 @@ import '../../core/logging/error_logger.dart';
 ///
 /// Accumulated errors from each step are attached to the result,
 /// so the UI can show what went wrong even when data was served.
+///
+/// ### Bulk-vs-polled search caching (#2264)
+///
+/// [searchStations] branches on the source's [FuelServicePolicy.model]:
+///
+///  - [SourceModel.polledApi] — each search is an upstream request, so the
+///    result is cached per `search:<country>:<lat>:<lng>:<radius>:<fuel>` key
+///    with the policy's `searchResultTtl` (the historical behaviour).
+///  - [SourceModel.bulkFile] — the primary already holds the whole-country
+///    dataset and local-filters it, so a per-search-key cache only duplicates
+///    that work and can serve a stale slice of a fresh dataset. The chain
+///    answers nearby directly from the primary (still coalesced + transient-
+///    retried), and the dataset's own freshness is governed by the persisted
+///    dataset cache (concern 3), not by a per-key Hive entry.
+///
+/// When no policy is supplied (legacy call sites + most chain unit tests) the
+/// chain defaults to the polled path with [CacheTtl.stationSearch], so its
+/// observable behaviour is unchanged.
 class StationServiceChain implements StationService {
   final StationService _primary;
   final CacheStrategy _cache;
   final ServiceSource _errorSource;
   final String countryCode;
+
+  /// Data-source policy (#2264). Controls whether [searchStations] uses the
+  /// per-key TTL cache (polled) or local-filters a bulk dataset (bulkFile),
+  /// and supplies the per-key TTL for polled sources. Null → polled defaults.
+  final FuelServicePolicy? _policy;
 
   /// In-flight request deduplication: concurrent calls for the same cache key
   /// share a single Future instead of hitting the API multiple times.
@@ -42,7 +66,9 @@ class StationServiceChain implements StationService {
   StationServiceChain(this._primary, this._cache, {
     ServiceSource errorSource = ServiceSource.tankerkoenigApi,
     this.countryCode = '',
-  }) : _errorSource = errorSource;
+    FuelServicePolicy? policy,
+  })  : _errorSource = errorSource,
+        _policy = policy;
 
   /// Generic cache-through + request coalescing.
   ///
@@ -265,20 +291,72 @@ class StationServiceChain implements StationService {
   Future<ServiceResult<List<Station>>> searchStations(
     SearchParams params, {
     CancelToken? cancelToken,
-  }) =>
-      _throughChain<List<Station>>(
-        cacheKey: CacheKey.stationSearch(
-          params.lat, params.lng, params.radiusKm, params.fuelType.apiValue,
-          countryCode: countryCode,
-          postalCode: params.postalCode,
-          locationName: params.locationName,
-        ),
-        apiCall: () => _primary.searchStations(params, cancelToken: cancelToken),
-        serialize: _serializeStationList,
-        deserialize: _deserializeStationList,
-        ttl: CacheTtl.stationSearch,
-        isValid: (stations) => stations.isNotEmpty,
-      );
+  }) {
+    // #2264 — bulk-file sources local-filter a persisted whole-country
+    // dataset, so a per-search-key cache only duplicates that work and can
+    // serve a stale slice; answer nearby straight from the primary instead.
+    if (_policy?.isBulkFile ?? false) {
+      return _bulkSearch(params, cancelToken: cancelToken);
+    }
+
+    return _throughChain<List<Station>>(
+      cacheKey: CacheKey.stationSearch(
+        params.lat, params.lng, params.radiusKm, params.fuelType.apiValue,
+        countryCode: countryCode,
+        postalCode: params.postalCode,
+        locationName: params.locationName,
+      ),
+      apiCall: () => _primary.searchStations(params, cancelToken: cancelToken),
+      serialize: serializeStationList,
+      deserialize: deserializeStationList,
+      // Polled sources use the policy's per-key TTL; fall back to the global
+      // default for legacy call sites that supply no policy.
+      ttl: _policy?.searchResultTtl ?? CacheTtl.stationSearch,
+      isValid: (stations) => stations.isNotEmpty,
+    );
+  }
+
+  /// Bulk-dataset search path (#2264): no per-key Hive cache. Adds only the
+  /// resilience layers that matter — in-flight coalescing + the single
+  /// transient retry — then returns the primary's result verbatim, so search
+  /// results are byte-identical to calling the primary directly.
+  Future<ServiceResult<List<Station>>> _bulkSearch(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    _evictStaleInFlight();
+    final key = 'bulk:${CacheKey.stationSearch(
+      params.lat, params.lng, params.radiusKm, params.fuelType.apiValue,
+      countryCode: countryCode,
+      postalCode: params.postalCode,
+      locationName: params.locationName,
+    )}';
+
+    if (_inFlight.containsKey(key)) {
+      final result = await _inFlight[key]!;
+      if (result.data is List<Station>) {
+        return ServiceResult<List<Station>>(
+          data: result.data as List<Station>,
+          source: result.source,
+          fetchedAt: result.fetchedAt,
+          isStale: result.isStale,
+          errors: result.errors,
+        );
+      }
+    }
+
+    final future = _callWithTransientRetry(
+      () => _primary.searchStations(params, cancelToken: cancelToken),
+    );
+    _inFlight[key] = future;
+    _inFlightTimestamps[key] = DateTime.now();
+    try {
+      return await future;
+    } finally {
+      unawaited(_inFlight.remove(key) ?? Future<void>.value());
+      _inFlightTimestamps.remove(key);
+    }
+  }
 
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
@@ -287,8 +365,8 @@ class StationServiceChain implements StationService {
       _throughChain<StationDetail>(
         cacheKey: CacheKey.stationDetail(stationId),
         apiCall: () => _primary.getStationDetail(stationId),
-        serialize: _serializeStationDetail,
-        deserialize: _deserializeStationDetail,
+        serialize: serializeStationDetail,
+        deserialize: deserializeStationDetail,
         ttl: CacheTtl.stationDetail,
       );
 
@@ -299,8 +377,8 @@ class StationServiceChain implements StationService {
       _throughChain<Map<String, StationPrices>>(
         cacheKey: CacheKey.prices(ids),
         apiCall: () => _primary.getPrices(ids),
-        serialize: _serializePrices,
-        deserialize: _deserializePrices,
+        serialize: serializePrices,
+        deserialize: deserializePrices,
         ttl: CacheTtl.prices,
       );
 
@@ -319,68 +397,4 @@ class StationServiceChain implements StationService {
     }
   }
 
-  // --- Serialization helpers (JSON-safe for Hive storage) ---
-
-  Map<String, dynamic> _serializeStationList(List<Station> stations) => {
-        'stations': stations.map((s) => s.toJson()).toList(),
-      };
-
-  List<Station>? _deserializeStationList(Map<String, dynamic> data) {
-    try {
-      final list = data['stations'] as List<dynamic>?;
-      if (list == null) return null;
-      return list
-          .map((j) => Station.fromJson(Map<String, dynamic>.from(j as Map)))
-          .toList();
-    } on FormatException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Cache: station list parse failed'}));
-      return null;
-    }
-  }
-
-  Map<String, dynamic> _serializeStationDetail(StationDetail detail) => {
-        'station': detail.station.toJson(),
-        'openingTimes': detail.openingTimes.map((ot) => ot.toJson()).toList(),
-        'overrides': detail.overrides,
-        'wholeDay': detail.wholeDay,
-        'state': detail.state,
-      };
-
-  StationDetail? _deserializeStationDetail(Map<String, dynamic> data) {
-    try {
-      final stationJson = data['station'] as Map<String, dynamic>?;
-      if (stationJson == null) return null;
-
-      final otList = data['openingTimes'] as List<dynamic>? ?? [];
-      return StationDetail(
-        station: Station.fromJson(stationJson),
-        openingTimes: otList
-            .map((j) => OpeningTime.fromJson(Map<String, dynamic>.from(j as Map)))
-            .toList(),
-        overrides: List<String>.from(data['overrides'] as List? ?? []),
-        wholeDay: data['wholeDay'] as bool? ?? false,
-        state: data['state'] as String?,
-      );
-    } on FormatException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Cache: station detail parse failed'}));
-      return null;
-    }
-  }
-
-  Map<String, dynamic> _serializePrices(Map<String, StationPrices> prices) => {
-        'prices': prices.map((k, v) => MapEntry(k, v.toJson())),
-      };
-
-  Map<String, StationPrices>? _deserializePrices(Map<String, dynamic> data) {
-    try {
-      final raw = data['prices'] as Map<String, dynamic>?;
-      if (raw == null) return null;
-      return raw.map(
-        (k, v) => MapEntry(k, StationPrices.fromJson(Map<String, dynamic>.from(v as Map))),
-      );
-    } on FormatException catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Cache: prices parse failed'}));
-      return null;
-    }
-  }
 }

--- a/lib/core/services/station_service_chain_codec.dart
+++ b/lib/core/services/station_service_chain_codec.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../core/logging/error_logger.dart';
+import '../../features/search/domain/entities/station.dart';
+import 'station_service.dart';
+
+/// JSON-safe (de)serialization helpers for the [StationServiceChain] cache
+/// envelopes. Extracted from `station_service_chain.dart` (#2264) to keep the
+/// chain itself under the file-length norm; these are pure, stateless codecs
+/// so they live cleanest as top-level functions.
+
+Map<String, dynamic> serializeStationList(List<Station> stations) => {
+      'stations': stations.map((s) => s.toJson()).toList(),
+    };
+
+List<Station>? deserializeStationList(Map<String, dynamic> data) {
+  try {
+    final list = data['stations'] as List<dynamic>?;
+    if (list == null) return null;
+    return list
+        .map((j) => Station.fromJson(Map<String, dynamic>.from(j as Map)))
+        .toList();
+  } on FormatException catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        context: const {'where': 'Cache: station list parse failed'}));
+    return null;
+  }
+}
+
+Map<String, dynamic> serializeStationDetail(StationDetail detail) => {
+      'station': detail.station.toJson(),
+      'openingTimes': detail.openingTimes.map((ot) => ot.toJson()).toList(),
+      'overrides': detail.overrides,
+      'wholeDay': detail.wholeDay,
+      'state': detail.state,
+    };
+
+StationDetail? deserializeStationDetail(Map<String, dynamic> data) {
+  try {
+    final stationJson = data['station'] as Map<String, dynamic>?;
+    if (stationJson == null) return null;
+
+    final otList = data['openingTimes'] as List<dynamic>? ?? [];
+    return StationDetail(
+      station: Station.fromJson(stationJson),
+      openingTimes: otList
+          .map((j) => OpeningTime.fromJson(Map<String, dynamic>.from(j as Map)))
+          .toList(),
+      overrides: List<String>.from(data['overrides'] as List? ?? []),
+      wholeDay: data['wholeDay'] as bool? ?? false,
+      state: data['state'] as String?,
+    );
+  } on FormatException catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        context: const {'where': 'Cache: station detail parse failed'}));
+    return null;
+  }
+}
+
+Map<String, dynamic> serializePrices(Map<String, StationPrices> prices) => {
+      'prices': prices.map((k, v) => MapEntry(k, v.toJson())),
+    };
+
+Map<String, StationPrices>? deserializePrices(Map<String, dynamic> data) {
+  try {
+    final raw = data['prices'] as Map<String, dynamic>?;
+    if (raw == null) return null;
+    return raw.map(
+      (k, v) =>
+          MapEntry(k, StationPrices.fromJson(Map<String, dynamic>.from(v as Map))),
+    );
+  } on FormatException catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.other, e, st,
+        context: const {'where': 'Cache: prices parse failed'}));
+    return null;
+  }
+}

--- a/lib/features/station_services/argentina/argentina_station_service.dart
+++ b/lib/features/station_services/argentina/argentina_station_service.dart
@@ -9,11 +9,13 @@ import 'package:flutter/foundation.dart';
 import 'argentina_fuel_classifier.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
+import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/services/utils/csv_parser.dart';
@@ -37,8 +39,12 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
   /// #2193 — accepts an optional [baseUrl] (the CSV endpoint) so tests can
   /// point the service at a fake host; defaults to [defaultCsvUrl] so
   /// production + the registry factory are unaffected.
-  ArgentinaStationService({String? baseUrl})
+  /// #2264 — [cache] enables the disk read-through (the registry passes the
+  /// shared CacheManager); omit it for the pure in-memory behaviour the
+  /// existing parser tests rely on.
+  ArgentinaStationService({String? baseUrl, CacheStrategy? cache})
       : _csvUrl = baseUrl ?? defaultCsvUrl,
+        _persistent = _buildPersistent(cache),
         _dio = DioFactory.create(
           connectTimeout: const Duration(seconds: 20),
           receiveTimeout: const Duration(seconds: 60),
@@ -50,11 +56,40 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
   /// driven without hitting the network. #2193 — also accepts an optional
   /// [baseUrl] (the CSV endpoint), defaulting to [defaultCsvUrl].
   @visibleForTesting
-  ArgentinaStationService.withDio(this._dio, {String? baseUrl})
-      : _csvUrl = baseUrl ?? defaultCsvUrl;
+  ArgentinaStationService.withDio(this._dio, {String? baseUrl, CacheStrategy? cache})
+      : _csvUrl = baseUrl ?? defaultCsvUrl,
+        _persistent = _buildPersistent(cache);
 
   final Dio _dio;
   final String _csvUrl;
+
+  /// #2264 — disk persistence (read-through), or null when no cache is wired.
+  final PersistentDataset<List<_RawStation>>? _persistent;
+
+  /// #2264 — soft/hard dataset TTLs mirror the AR FuelServicePolicy (soft 6 h,
+  /// hard 24 h); the legacy 6-hour in-memory TTL is the soft bound now.
+  static const Duration _softTtl = Duration(hours: 6);
+  static const Duration _hardTtl = Duration(hours: 24);
+
+  static PersistentDataset<List<_RawStation>>? _buildPersistent(
+    CacheStrategy? cache,
+  ) {
+    if (cache == null) return null;
+    return PersistentDataset<List<_RawStation>>(
+      cache: cache,
+      countryCode: 'AR',
+      datasetName: 'stations',
+      source: ServiceSource.argentinaApi,
+      serialize: (rows) => {'rows': rows.map((r) => r.toJson()).toList()},
+      deserialize: (json) {
+        final list = json['rows'] as List<dynamic>?;
+        if (list == null) return null;
+        return list
+            .map((j) => _RawStation.fromJson(Map<String, dynamic>.from(j as Map)))
+            .toList();
+      },
+    );
+  }
 
   // Cache parsed stations
   List<_RawStation>? _cachedStations;
@@ -195,17 +230,32 @@ class ArgentinaStationService with StationServiceHelpers, CachedDatasetMixin imp
         haystack.contains('HANDSHAKE');
   }
 
-  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) =>
-      loadDataset<List<_RawStation>>(
+  Future<List<_RawStation>> _fetchCsv({CancelToken? cancelToken}) async {
+    final response = await _dio.get<String>(_csvUrl, cancelToken: cancelToken);
+    return compute(_parseCsv, response.data ?? '');
+  }
+
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
+    final persistent = _persistent;
+    if (persistent == null) {
+      // No cache wired (unit tests) — preserve the legacy in-memory path.
+      return loadDataset<List<_RawStation>>(
         cached: _cachedStations,
         ttl: const Duration(hours: 6),
-        fetch: () async {
-          final response =
-              await _dio.get<String>(_csvUrl, cancelToken: cancelToken);
-          return compute(_parseCsv, response.data ?? '');
-        },
+        fetch: () => _fetchCsv(cancelToken: cancelToken),
         store: (value) => _cachedStations = value,
       );
+    }
+    // #2264 — disk read-through: survives cold start + offline.
+    return loadPersistentDataset<List<_RawStation>>(
+      cached: _cachedStations,
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: persistent,
+      fetch: () => _fetchCsv(cancelToken: cancelToken),
+      store: (value) => _cachedStations = value,
+    );
+  }
 
   /// Expected CSV header columns from the Argentina open data endpoint.
   /// Used as an integrity check to detect MITM tampering or format changes
@@ -299,6 +349,34 @@ class _RawStation {
     required this.lat,
     required this.lng,
   });
+
+  /// #2264 — compact JSON for the persisted dataset (single-letter keys keep
+  /// the ~700 KB national CSV's Hive footprint down).
+  Map<String, dynamic> toJson() => {
+        'e': empresa,
+        'd': direccion,
+        'l': localidad,
+        'pv': provincia,
+        'pr': producto,
+        'p': precio,
+        'f': fechaVigencia,
+        'b': bandera,
+        'la': lat,
+        'lo': lng,
+      };
+
+  factory _RawStation.fromJson(Map<String, dynamic> j) => _RawStation(
+        empresa: j['e'] as String? ?? '',
+        direccion: j['d'] as String? ?? '',
+        localidad: j['l'] as String? ?? '',
+        provincia: j['pv'] as String? ?? '',
+        producto: j['pr'] as String? ?? '',
+        precio: (j['p'] as num?)?.toDouble() ?? 0,
+        fechaVigencia: j['f'] as String? ?? '',
+        bandera: j['b'] as String? ?? '',
+        lat: (j['la'] as num?)?.toDouble() ?? 0,
+        lng: (j['lo'] as num?)?.toDouble() ?? 0,
+      );
 }
 
 class _MergedStation {

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -6,9 +6,11 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
+import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/logging/error_logger.dart';
@@ -24,13 +26,45 @@ import '../../../core/logging/error_logger.dart';
 class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin implements StationService {
   final Dio _dio;
 
+  /// #2264 — optional disk persistence (read-through). When a [CacheStrategy]
+  /// is supplied (the registry factory passes the shared CacheManager) the
+  /// parsed national dataset is persisted to Hive so it survives a cold start
+  /// and works offline. Null in unit tests that don't exercise persistence.
+  final PersistentDataset<List<Station>>? _persistent;
+
   /// #2181 — Dio injectable for tests; defaults to the standard factory.
-  DenmarkStationService({Dio? dio})
+  /// #2264 — [cache] enables the disk read-through; omit it for the pure
+  /// in-memory behaviour the existing parser tests rely on.
+  DenmarkStationService({Dio? dio, CacheStrategy? cache})
       : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 15),
               receiveTimeout: const Duration(seconds: 15),
-            );
+            ),
+        _persistent = cache == null
+            ? null
+            : PersistentDataset<List<Station>>(
+                cache: cache,
+                countryCode: 'DK',
+                datasetName: 'stations',
+                source: ServiceSource.denmarkApi,
+                serialize: (stations) =>
+                    {'stations': stations.map((s) => s.toJson()).toList()},
+                deserialize: (json) {
+                  final list = json['stations'] as List<dynamic>?;
+                  if (list == null) return null;
+                  return list
+                      .map((j) =>
+                          Station.fromJson(Map<String, dynamic>.from(j as Map)))
+                      .toList();
+                },
+              );
+
+  // #2264 — soft/hard dataset TTLs mirror the DK FuelServicePolicy in the
+  // registry (soft 2 h, hard 12 h). The legacy 5-minute in-memory TTL is
+  // superseded; the persisted read-through governs freshness now.
+  static const Duration _softTtl = Duration(hours: 2);
+  static const Duration _hardTtl = Duration(hours: 12);
 
   // In-memory cache
   List<Station>? _cachedStations;
@@ -63,21 +97,37 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
     }
   }
 
-  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) =>
-      loadDataset<List<Station>>(
+  Future<List<Station>> _fetchAll({CancelToken? cancelToken}) async {
+    // Fetch all 3 sources in parallel
+    final results = await Future.wait([
+      _fetchOk(cancelToken: cancelToken),
+      _fetchShell(cancelToken: cancelToken),
+      _fetchQ8(),
+    ]);
+    return [...results[0], ...results[1], ...results[2]];
+  }
+
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
+    final persistent = _persistent;
+    if (persistent == null) {
+      // No cache wired (unit tests) — preserve the legacy in-memory path.
+      return loadDataset<List<Station>>(
         cached: _cachedStations,
         ttl: const Duration(minutes: 5),
-        fetch: () async {
-          // Fetch all 3 sources in parallel
-          final results = await Future.wait([
-            _fetchOk(cancelToken: cancelToken),
-            _fetchShell(cancelToken: cancelToken),
-            _fetchQ8(),
-          ]);
-          return [...results[0], ...results[1], ...results[2]];
-        },
+        fetch: () => _fetchAll(cancelToken: cancelToken),
         store: (value) => _cachedStations = value,
       );
+    }
+    // #2264 — disk read-through: survives cold start + offline.
+    return loadPersistentDataset<List<Station>>(
+      cached: _cachedStations,
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: persistent,
+      fetch: () => _fetchAll(cancelToken: cancelToken),
+      store: (value) => _cachedStations = value,
+    );
+  }
 
   /// OK — https://mobility-prices.ok.dk/api/v1/fuel-prices
   Future<List<Station>> _fetchOk({CancelToken? cancelToken}) async {

--- a/lib/features/station_services/mexico/mexico_station_service.dart
+++ b/lib/features/station_services/mexico/mexico_station_service.dart
@@ -12,6 +12,7 @@ import '../../search/domain/entities/station.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
+import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
@@ -38,7 +39,7 @@ import '../../../core/logging/error_logger.dart';
 /// 4 hours — the CRE dataset updates several times daily but rarely
 /// faster than that.
 class MexicoStationService
-    with StationServiceHelpers
+    with StationServiceHelpers, CachedDatasetMixin
     implements StationService {
   final Dio _dio;
   final String _baseUrl;
@@ -56,7 +57,6 @@ class MexicoStationService
   static const Duration _cacheTtl = Duration(hours: 4);
 
   List<_CreStation>? _cachedStations;
-  DateTime? _lastFetch;
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
@@ -100,13 +100,18 @@ class MexicoStationService
     }
   }
 
-  Future<void> _ensureDataLoaded(CancelToken? cancelToken) async {
-    if (_cachedStations != null &&
-        _lastFetch != null &&
-        DateTime.now().difference(_lastFetch!) < _cacheTtl) {
-      return;
-    }
+  // #2264 — migrated onto CachedDatasetMixin: the manual _lastFetch + TTL
+  // diff is replaced by loadDataset's guard→fetch→store→mark idiom, matching
+  // the other bulk-dataset services (ES/IT/AR/DK).
+  Future<void> _ensureDataLoaded(CancelToken? cancelToken) =>
+      loadDataset<List<_CreStation>>(
+        cached: _cachedStations,
+        ttl: _cacheTtl,
+        fetch: () => _fetchMerged(cancelToken),
+        store: (value) => _cachedStations = value,
+      );
 
+  Future<List<_CreStation>> _fetchMerged(CancelToken? cancelToken) async {
     final responses = await Future.wait([
       _dio.get<String>(
         '$_baseUrl/places',
@@ -133,14 +138,13 @@ class MexicoStationService
       );
     }
 
-    _cachedStations = _mergeFeeds(placesXml: placesXml, pricesXml: pricesXml);
-    _lastFetch = DateTime.now();
-
-    if (_cachedStations!.isEmpty) {
+    final merged = _mergeFeeds(placesXml: placesXml, pricesXml: pricesXml);
+    if (merged.isEmpty) {
       throw const ApiException(
         message: 'CRE feeds parsed to zero stations (schema change?)',
       );
     }
+    return merged;
   }
 
   /// Parses the `/places` and `/prices` XML feeds and joins them by
@@ -239,27 +243,25 @@ class MexicoStationService
   @visibleForTesting
   void clearCacheForTest() {
     _cachedStations = null;
-    _lastFetch = null;
+    // #2264 — CachedDatasetMixin owns the freshness clock now; expire it so
+    // the next search re-fetches.
+    markDatasetRefreshedAt(const Duration(days: 3650));
   }
 
+  // #2264 — route the unsupported endpoints through the shared helpers
+  // (throwDetailUnavailable / emptyPricesResult) like the other services.
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
     String stationId,
   ) async {
-    throw const ApiException(
-      message: 'Station detail not supported for Mexico',
-    );
+    throwDetailUnavailable('CRE API');
   }
 
   @override
   Future<ServiceResult<Map<String, StationPrices>>> getPrices(
     List<String> ids,
   ) async {
-    return ServiceResult(
-      data: const {},
-      source: ServiceSource.mexicoApi,
-      fetchedAt: DateTime.now(),
-    );
+    return emptyPricesResult(ServiceSource.mexicoApi);
   }
 }
 

--- a/lib/features/station_services/portugal/portugal_station_service.dart
+++ b/lib/features/station_services/portugal/portugal_station_service.dart
@@ -238,24 +238,20 @@ class PortugalStationService
     return double.tryParse(cleaned);
   }
 
+  // #2264 — route the unsupported endpoints through the shared helpers
+  // (throwDetailUnavailable / emptyPricesResult) like the other services.
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
     String stationId,
   ) async {
-    throw const ApiException(
-      message: 'Station detail not supported for Portugal',
-    );
+    throwDetailUnavailable('DGEG API');
   }
 
   @override
   Future<ServiceResult<Map<String, StationPrices>>> getPrices(
     List<String> ids,
   ) async {
-    return ServiceResult(
-      data: const {},
-      source: ServiceSource.portugalApi,
-      fetchedAt: DateTime.now(),
-    );
+    return emptyPricesResult(ServiceSource.portugalApi);
   }
 }
 

--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -6,14 +6,15 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
 import '../../../core/error/exceptions.dart';
-import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
-import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
+import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/logging/error_logger.dart';
+import 'spain_provinces.dart';
 
 /// Spanish fuel prices from Geoportal Gasolineras (MITECO).
 /// Free, no API key, no registration.
@@ -21,28 +22,39 @@ import '../../../core/logging/error_logger.dart';
 /// The API has no coordinate/radius search — only by province/municipality.
 /// Strategy: fetch all stations, calculate distances locally, filter by radius.
 /// The full dataset (~12,000 stations) is cached aggressively.
-class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implements StationService {
+class MitecoStationService with StationServiceHelpers implements StationService {
   static const String defaultBaseUrl =
       'https://sedeaplicaciones.minetur.gob.es/ServiciosRESTCarburantes'
       '/PreciosCarburantes';
 
   final Dio _dio;
   final String _baseUrl;
+  final CacheStrategy? _cache;
 
   /// #2181 — Dio injectable for tests; defaults to the standard factory.
   /// #2193 — [baseUrl] injectable too, harmonising the override surface
   /// with Portugal / Slovenia / South Korea; defaults to [defaultBaseUrl].
-  MitecoStationService({Dio? dio, String? baseUrl})
+  /// #2264 — [cache] enables per-province disk persistence (read-through);
+  /// omit it for the pure in-memory behaviour the parser tests rely on.
+  MitecoStationService({Dio? dio, String? baseUrl, CacheStrategy? cache})
       : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 20),
               receiveTimeout: const Duration(seconds: 30),
             ),
-        _baseUrl = baseUrl ?? defaultBaseUrl;
+        _baseUrl = baseUrl ?? defaultBaseUrl,
+        _cache = cache;
 
-  // Cache the province list and full station data to avoid repeated large downloads
-  List<_Province>? _cachedProvinces;
-  List<Map<String, dynamic>>? _cachedStations;
+  // #2264 — soft/hard dataset TTLs mirror the ES FuelServicePolicy (soft 6 h,
+  // hard 24 h). The legacy single-list 10-minute cache is replaced by a
+  // per-province cache so province A's stations are never served for B.
+  static const Duration _softTtl = Duration(hours: 6);
+  static const Duration _hardTtl = Duration(hours: 24);
+
+  /// Per-province in-memory cache, keyed by `IDProvincia`. The previous single
+  /// unkeyed `_cachedStations` list meant the first province searched was
+  /// served for every later search regardless of location (#2264).
+  final Map<String, _ProvinceCache> _byProvince = {};
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
@@ -50,17 +62,24 @@ class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implem
     CancelToken? cancelToken,
   }) async {
     try {
-      // Find nearest province for the search coordinates
-      final provinceId = await _findNearestProvince(params.lat, params.lng, cancelToken: cancelToken);
+      // #2264 — fetch every province overlapping the search radius (a point
+      // near a border touches several) and merge, so a station physically
+      // nearby but administratively in the neighbour is not dropped.
+      final provinceIds =
+          spainProvincesNear(params.lat, params.lng, params.radiusKm);
 
-      // Fetch stations for that province
-      final rawStations = await _fetchStationsByProvince(provinceId, cancelToken: cancelToken);
-
-      // Parse all stations with distance
       final allStations = <Station>[];
-      for (final r in rawStations) {
-        final station = _parseStation(r, params.lat, params.lng);
-        if (station != null) allStations.add(station);
+      final seenIds = <String>{};
+      for (final provinceId in provinceIds) {
+        final rawStations =
+            await _stationsForProvince(provinceId, cancelToken: cancelToken);
+        for (final r in rawStations) {
+          final station = _parseStation(r, params.lat, params.lng);
+          // Dedupe across province borders by station id.
+          if (station != null && seenIds.add(station.id)) {
+            allStations.add(station);
+          }
+        }
       }
 
       // Filter by radius; if nothing found, return nearest 20
@@ -75,121 +94,86 @@ class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implem
     }
   }
 
-  /// Find the nearest Spanish province to the given coordinates.
-  Future<String> _findNearestProvince(double lat, double lng, {CancelToken? cancelToken}) async {
-    if (_cachedProvinces == null) {
-      final response = await _dio.get('$_baseUrl/Listados/Provincias/', cancelToken: cancelToken);
-      if (response.data is! List) {
-        throw const ApiException(message: 'Invalid province list response');
-      }
-      _cachedProvinces = (response.data as List).map((p) {
-        return _Province(
-          id: p['IDPovincia']?.toString() ?? p['IDProvincia']?.toString() ?? '',
-          name: p['Provincia']?.toString() ?? '',
-        );
-      }).toList();
+  /// Returns the raw station rows for one province, served from (in order):
+  /// the fresh in-memory copy, the persisted Hive copy (read-through, when a
+  /// cache is wired), then the network — and persisted on a fresh fetch.
+  Future<List<Map<String, dynamic>>> _stationsForProvince(
+    String provinceId, {
+    CancelToken? cancelToken,
+  }) async {
+    final mem = _byProvince[provinceId];
+    if (mem != null &&
+        DateTime.now().difference(mem.fetchedAt) < _softTtl) {
+      return mem.rows;
     }
 
-    // Province approximate centers (major city coordinates)
-    // Use these to find which province the user is closest to
-    const provinceCenters = {
-      '01': (42.8467, -2.6727),   // Álava
-      '02': (38.9943, -1.8585),   // Albacete
-      '03': (38.3452, -0.4810),   // Alicante
-      '04': (36.8340, -2.4637),   // Almería
-      '05': (40.6565, -4.6818),   // Ávila
-      '06': (38.8794, -6.9707),   // Badajoz
-      '07': (39.5696, 2.6502),    // Baleares
-      '08': (41.3851, 2.1734),    // Barcelona
-      '09': (42.3440, -3.6970),   // Burgos
-      '10': (39.4753, -6.3724),   // Cáceres
-      '11': (36.5271, -6.2886),   // Cádiz
-      '12': (39.9864, -0.0513),   // Castellón
-      '13': (38.9860, -3.9273),   // Ciudad Real
-      '14': (37.8882, -4.7794),   // Córdoba
-      '15': (43.3623, -8.4115),   // A Coruña
-      '16': (40.0704, -2.1374),   // Cuenca
-      '17': (41.9794, 2.8214),    // Girona
-      '18': (37.1773, -3.5986),   // Granada
-      '19': (40.6337, -3.1660),   // Guadalajara
-      '20': (43.3183, -1.9812),   // Guipúzcoa
-      '21': (37.2614, -6.9447),   // Huelva
-      '22': (42.1318, -0.4078),   // Huesca
-      '23': (37.7796, -3.7849),   // Jaén
-      '24': (42.5987, -5.5671),   // León
-      '25': (41.6176, 0.6200),    // Lleida
-      '26': (42.4650, -2.4500),   // La Rioja
-      '27': (43.0099, -7.5562),   // Lugo
-      '28': (40.4168, -3.7038),   // Madrid
-      '29': (36.7213, -4.4214),   // Málaga
-      '30': (37.9922, -1.1307),   // Murcia
-      '31': (42.8125, -1.6458),   // Navarra
-      '32': (42.3358, -7.8639),   // Ourense
-      '33': (43.3619, -5.8494),   // Asturias
-      '34': (42.0097, -4.5288),   // Palencia
-      '35': (28.1235, -15.4363),  // Las Palmas
-      '36': (42.4310, -8.6446),   // Pontevedra
-      '37': (40.9701, -5.6635),   // Salamanca
-      '38': (28.4636, -16.2518),  // S/C de Tenerife
-      '39': (43.4623, -3.8100),   // Cantabria
-      '40': (40.9429, -4.1088),   // Segovia
-      '41': (37.3891, -5.9845),   // Sevilla
-      '42': (41.7636, -2.4649),   // Soria
-      '43': (41.1189, 1.2445),    // Tarragona
-      '44': (40.3456, -1.1065),   // Teruel
-      '45': (39.8628, -4.0273),   // Toledo
-      '46': (39.4699, -0.3763),   // Valencia
-      '47': (41.6523, -4.7245),   // Valladolid
-      '48': (43.2630, -2.9350),   // Vizcaya
-      '49': (41.5033, -5.7446),   // Zamora
-      '50': (41.6488, -0.8891),   // Zaragoza
-      '51': (35.8894, -5.3213),   // Ceuta
-      '52': (35.2923, -2.9381),   // Melilla
-    };
-
-    String bestId = '28'; // Default: Madrid
-    double bestDist = double.infinity;
-
-    for (final entry in provinceCenters.entries) {
-      final d = distanceKm(lat, lng, entry.value.$1, entry.value.$2);
-      if (d < bestDist) {
-        bestDist = d;
-        bestId = entry.key;
+    final persistent = _persistentFor(provinceId);
+    if (persistent != null) {
+      final disk = persistent.read();
+      if (disk != null && disk.age <= _hardTtl) {
+        _byProvince[provinceId] =
+            _ProvinceCache(disk.value, DateTime.now().subtract(disk.age));
+        if (disk.age <= _softTtl) return disk.value;
       }
     }
 
-    return bestId;
+    try {
+      final rows = await _fetchProvince(provinceId, cancelToken: cancelToken);
+      _byProvince[provinceId] = _ProvinceCache(rows, DateTime.now());
+      await persistent?.write(rows, hardTtl: _hardTtl);
+      return rows;
+    } on Object {
+      // Network failed — serve any persisted/in-memory copy rather than throw.
+      final disk = persistent?.read();
+      if (disk != null) {
+        _byProvince[provinceId] =
+            _ProvinceCache(disk.value, DateTime.now().subtract(disk.age));
+        return disk.value;
+      }
+      if (mem != null) return mem.rows;
+      rethrow;
+    }
   }
 
-  Future<List<Map<String, dynamic>>> _fetchStationsByProvince(
-    String provinceId, {CancelToken? cancelToken}
+  PersistentDataset<List<Map<String, dynamic>>>? _persistentFor(
+    String provinceId,
   ) {
-    // Use cache if fresh (< 10 minutes)
-    return loadDataset<List<Map<String, dynamic>>>(
-      cached: _cachedStations,
-      ttl: const Duration(minutes: 10),
-      fetch: () async {
-        final response = await _dio.get(
-          '$_baseUrl/EstacionesTerrestres/FiltroProvincia/$provinceId',
-          cancelToken: cancelToken,
-        );
-
-        final data = response.data;
-        if (data is! Map<String, dynamic>) {
-          throw const ApiException(message: 'Invalid MITECO response');
-        }
-
-        if (data['ResultadoConsulta'] != 'OK') {
-          throw ApiException(
-            message: data['ResultadoConsulta']?.toString() ?? 'API error',
-          );
-        }
-
-        final list = data['ListaEESSPrecio'] as List<dynamic>? ?? [];
-        return list.cast<Map<String, dynamic>>();
-      },
-      store: (value) => _cachedStations = value,
+    final cache = _cache;
+    if (cache == null) return null;
+    return PersistentDataset<List<Map<String, dynamic>>>(
+      cache: cache,
+      countryCode: 'ES',
+      datasetName: 'province-$provinceId',
+      source: ServiceSource.mitecoApi,
+      serialize: (rows) => {'rows': rows},
+      deserialize: (json) => (json['rows'] as List<dynamic>?)
+          ?.map((e) => Map<String, dynamic>.from(e as Map))
+          .toList(),
     );
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchProvince(
+    String provinceId, {
+    CancelToken? cancelToken,
+  }) async {
+    final response = await _dio.get(
+      '$_baseUrl/EstacionesTerrestres/FiltroProvincia/$provinceId',
+      cancelToken: cancelToken,
+    );
+
+    final data = response.data;
+    if (data is! Map<String, dynamic>) {
+      throw const ApiException(message: 'Invalid MITECO response');
+    }
+
+    if (data['ResultadoConsulta'] != 'OK') {
+      throw ApiException(
+        message: data['ResultadoConsulta']?.toString() ?? 'API error',
+      );
+    }
+
+    final list = data['ListaEESSPrecio'] as List<dynamic>? ?? [];
+    return list.cast<Map<String, dynamic>>();
   }
 
   Station? _parseStation(
@@ -265,8 +249,11 @@ class MitecoStationService with StationServiceHelpers, CachedDatasetMixin implem
   }
 }
 
-class _Province {
-  final String id;
-  final String name;
-  const _Province({required this.id, required this.name});
+/// One province's cached raw rows + when they were fetched (#2264). Keyed by
+/// `IDProvincia` in [MitecoStationService._byProvince] so province A's
+/// stations are never served for a search in province B.
+class _ProvinceCache {
+  final List<Map<String, dynamic>> rows;
+  final DateTime fetchedAt;
+  const _ProvinceCache(this.rows, this.fetchedAt);
 }

--- a/lib/features/station_services/spain/spain_provinces.dart
+++ b/lib/features/station_services/spain/spain_provinces.dart
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../core/utils/geo_utils.dart';
+
+/// Approximate centre (capital-city coordinates) of each Spanish province,
+/// keyed by MITECO `IDProvincia`. Used to map a search point to the
+/// province(s) whose stations to fetch (#2264).
+///
+/// Extracted from `miteco_station_service.dart` so the province-keying +
+/// multi-province merge fix keeps the service file under the length norm.
+const Map<String, (double lat, double lng)> spainProvinceCenters = {
+  '01': (42.8467, -2.6727), // Álava
+  '02': (38.9943, -1.8585), // Albacete
+  '03': (38.3452, -0.4810), // Alicante
+  '04': (36.8340, -2.4637), // Almería
+  '05': (40.6565, -4.6818), // Ávila
+  '06': (38.8794, -6.9707), // Badajoz
+  '07': (39.5696, 2.6502), // Baleares
+  '08': (41.3851, 2.1734), // Barcelona
+  '09': (42.3440, -3.6970), // Burgos
+  '10': (39.4753, -6.3724), // Cáceres
+  '11': (36.5271, -6.2886), // Cádiz
+  '12': (39.9864, -0.0513), // Castellón
+  '13': (38.9860, -3.9273), // Ciudad Real
+  '14': (37.8882, -4.7794), // Córdoba
+  '15': (43.3623, -8.4115), // A Coruña
+  '16': (40.0704, -2.1374), // Cuenca
+  '17': (41.9794, 2.8214), // Girona
+  '18': (37.1773, -3.5986), // Granada
+  '19': (40.6337, -3.1660), // Guadalajara
+  '20': (43.3183, -1.9812), // Guipúzcoa
+  '21': (37.2614, -6.9447), // Huelva
+  '22': (42.1318, -0.4078), // Huesca
+  '23': (37.7796, -3.7849), // Jaén
+  '24': (42.5987, -5.5671), // León
+  '25': (41.6176, 0.6200), // Lleida
+  '26': (42.4650, -2.4500), // La Rioja
+  '27': (43.0099, -7.5562), // Lugo
+  '28': (40.4168, -3.7038), // Madrid
+  '29': (36.7213, -4.4214), // Málaga
+  '30': (37.9922, -1.1307), // Murcia
+  '31': (42.8125, -1.6458), // Navarra
+  '32': (42.3358, -7.8639), // Ourense
+  '33': (43.3619, -5.8494), // Asturias
+  '34': (42.0097, -4.5288), // Palencia
+  '35': (28.1235, -15.4363), // Las Palmas
+  '36': (42.4310, -8.6446), // Pontevedra
+  '37': (40.9701, -5.6635), // Salamanca
+  '38': (28.4636, -16.2518), // S/C de Tenerife
+  '39': (43.4623, -3.8100), // Cantabria
+  '40': (40.9429, -4.1088), // Segovia
+  '41': (37.3891, -5.9845), // Sevilla
+  '42': (41.7636, -2.4649), // Soria
+  '43': (41.1189, 1.2445), // Tarragona
+  '44': (40.3456, -1.1065), // Teruel
+  '45': (39.8628, -4.0273), // Toledo
+  '46': (39.4699, -0.3763), // Valencia
+  '47': (41.6523, -4.7245), // Valladolid
+  '48': (43.2630, -2.9350), // Vizcaya
+  '49': (41.5033, -5.7446), // Zamora
+  '50': (41.6488, -0.8891), // Zaragoza
+  '51': (35.8894, -5.3213), // Ceuta
+  '52': (35.2923, -2.9381), // Melilla
+};
+
+/// MITECO has no coordinate/radius search — only per-province. A search point
+/// near a province border (or with a large radius) overlaps several
+/// provinces, so the service must fetch + merge each (#2264).
+///
+/// Returns the province ids whose centre is within `[radiusKm] + [marginKm]`
+/// of ([lat], [lng]), always including the single nearest province so a search
+/// deep inside one province still resolves. [marginKm] (default 60 km, roughly
+/// a province half-width) absorbs the centre-vs-border approximation so a
+/// station physically nearby but administratively in the neighbour is not
+/// missed.
+List<String> spainProvincesNear(
+  double lat,
+  double lng,
+  double radiusKm, {
+  double marginKm = 60,
+}) {
+  var nearestId = '28'; // Madrid fallback
+  var nearestDist = double.infinity;
+  final within = <String>[];
+
+  for (final entry in spainProvinceCenters.entries) {
+    final d = distanceKm(lat, lng, entry.value.$1, entry.value.$2);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearestId = entry.key;
+    }
+    if (d <= radiusKm + marginKm) within.add(entry.key);
+  }
+
+  if (!within.contains(nearestId)) within.add(nearestId);
+  return within;
+}

--- a/lib/features/station_services/uk/uk_station_service.dart
+++ b/lib/features/station_services/uk/uk_station_service.dart
@@ -240,19 +240,17 @@ class UkStationService with StationServiceHelpers implements StationService {
     return price > 10 ? price / 100 : price;
   }
 
+  // #2264 — route the unsupported endpoints through the shared helpers
+  // (throwDetailUnavailable / emptyPricesResult) like the other services.
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(String stationId) async {
-    throw const ApiException(message: 'Station detail not supported for UK');
+    throwDetailUnavailable('CMA Fuel Finder');
   }
 
   @override
   Future<ServiceResult<Map<String, StationPrices>>> getPrices(
     List<String> ids,
   ) async {
-    return ServiceResult(
-      data: const {},
-      source: ServiceSource.ukApi,
-      fetchedAt: DateTime.now(),
-    );
+    return emptyPricesResult(ServiceSource.ukApi);
   }
 }

--- a/test/core/cache/cache_manager_test.dart
+++ b/test/core/cache/cache_manager_test.dart
@@ -567,4 +567,99 @@ void main() {
       }
     });
   });
+
+  group('CacheManager - evictBounded (#2264)', () {
+    // Store a fresh entry with an explicit storedAt + payload size.
+    Future<void> store(String key, DateTime storedAt, {int padBytes = 0}) {
+      return fakeStorage.cacheData(key, {
+        'payload': {'p': 'x' * padBytes},
+        'storedAt': storedAt.millisecondsSinceEpoch,
+        'source': ServiceSource.cache.index,
+        'ttlMs': const Duration(hours: 1).inMilliseconds,
+      });
+    }
+
+    test('still evicts entries older than 3x TTL', () async {
+      await fakeStorage.cacheData('very-old', {
+        'payload': {'stale': true},
+        'storedAt': DateTime.now()
+            .subtract(const Duration(hours: 1))
+            .millisecondsSinceEpoch,
+        'source': ServiceSource.cache.index,
+        'ttlMs': 1,
+      });
+      await cache.put('fresh', {'v': 1},
+          ttl: const Duration(hours: 24), source: ServiceSource.cache);
+
+      final evicted = await cache.evictBounded();
+      expect(evicted, equals(1));
+      expect(cache.get('very-old'), isNull);
+      expect(cache.get('fresh'), isNotNull);
+    });
+
+    test('enforces the per-prefix budget, keeping the newest', () async {
+      final now = DateTime.now();
+      // 5 search: entries, budget 3 → 2 oldest evicted.
+      for (var i = 0; i < 5; i++) {
+        await store('search:$i', now.subtract(Duration(minutes: i)));
+      }
+      // 2 detail: entries — both under budget, both survive.
+      await store('detail:a', now);
+      await store('detail:b', now);
+
+      final evicted =
+          await cache.evictBounded(policy: const CacheEvictionPolicy(prefixBudget: 3));
+
+      expect(evicted, equals(2));
+      // The two oldest searches (highest i) are gone.
+      expect(cache.get('search:4'), isNull);
+      expect(cache.get('search:3'), isNull);
+      expect(cache.get('search:0'), isNotNull);
+      expect(cache.get('detail:a'), isNotNull);
+      expect(cache.get('detail:b'), isNotNull);
+    });
+
+    test('evicts oldest-first once the byte ceiling is exceeded', () async {
+      final now = DateTime.now();
+      // Three ~1 KB entries; ceiling 2 KB → oldest must be evicted.
+      await store('search:old', now.subtract(const Duration(minutes: 10)),
+          padBytes: 1000);
+      await store('search:mid', now.subtract(const Duration(minutes: 5)),
+          padBytes: 1000);
+      await store('search:new', now, padBytes: 1000);
+
+      final evicted = await cache.evictBounded(
+        policy: const CacheEvictionPolicy(prefixBudget: 100, maxBytes: 2200),
+      );
+
+      expect(evicted, greaterThanOrEqualTo(1));
+      expect(cache.get('search:old'), isNull,
+          reason: 'oldest evicted first under byte pressure');
+      expect(cache.get('search:new'), isNotNull);
+    });
+
+    test('protects dataset: entries from the byte sweep', () async {
+      final now = DateTime.now();
+      // A large persisted dataset + two large searches; tiny ceiling.
+      await store('dataset:ES:stations',
+          now.subtract(const Duration(hours: 1)), padBytes: 2000);
+      await store('search:a', now.subtract(const Duration(minutes: 2)),
+          padBytes: 2000);
+      await store('search:b', now, padBytes: 2000);
+
+      await cache.evictBounded(
+        policy: const CacheEvictionPolicy(prefixBudget: 100, maxBytes: 1000),
+      );
+
+      expect(cache.get('dataset:ES:stations'), isNotNull,
+          reason: 'persisted dataset is exempt from the LRU byte sweep');
+    });
+
+    test('returns 0 when everything is within budget + ceiling', () async {
+      await cache.put('search:x', {'v': 1},
+          ttl: const Duration(hours: 1), source: ServiceSource.cache);
+      final evicted = await cache.evictBounded();
+      expect(evicted, equals(0));
+    });
+  });
 }

--- a/test/core/country/country_config_test.dart
+++ b/test/core/country/country_config_test.dart
@@ -22,21 +22,23 @@ void main() {
     });
   });
 
-  group('Countries.verified (#1828)', () {
-    test('contains exactly the 13 verified-endpoint countries', () {
-      expect(Countries.verified.length, equals(13));
+  group('Countries.verified (#1828, #2264)', () {
+    test('contains exactly the 12 verified-endpoint countries', () {
+      expect(Countries.verified.length, equals(12));
       expect(
         Countries.verified.map((c) => c.code).toSet(),
         equals({
-          'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB', 'AU',
+          'DE', 'FR', 'AT', 'ES', 'IT', 'DK', 'AR', 'PT', 'GB',
           'MX', 'LU', 'SI',
         }),
       );
     });
 
-    test('excludes the 4 unverified-endpoint countries', () {
+    test('excludes the 5 unverified-endpoint countries', () {
       final codes = Countries.verified.map((c) => c.code).toSet();
-      for (final gated in ['KR', 'CL', 'GR', 'RO']) {
+      // #2264 — AU joins the gated set: its service is a throwing stub
+      // (#804), so it can only ever error and must leave the picker.
+      for (final gated in ['KR', 'CL', 'GR', 'RO', 'AU']) {
         expect(codes, isNot(contains(gated)),
             reason: '$gated has an unverified endpoint — must be gated');
       }
@@ -48,12 +50,13 @@ void main() {
       expect(Countries.slovenia.verified, isTrue);
     });
 
-    test('KR / CL / GR / RO are flagged unverified', () {
+    test('KR / CL / GR / RO / AU are flagged unverified', () {
       for (final c in [
         Countries.southKorea,
         Countries.chile,
         Countries.greece,
         Countries.romania,
+        Countries.australia,
       ]) {
         expect(c.verified, isFalse, reason: '${c.code} must be gated');
       }

--- a/test/core/services/country_service_registry_test.dart
+++ b/test/core/services/country_service_registry_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_bounding_box.dart';
 import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/core/services/fuel_service_policy.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
@@ -51,6 +52,79 @@ void main() {
           reason: 'Registry entries and Countries.all should have '
               'the same number of entries',
         );
+      });
+    });
+
+    group('FuelServicePolicy (#2264)', () {
+      test('every entry carries a policy', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          expect(entry.policy, isNotNull,
+              reason: '${entry.countryCode} must declare a FuelServicePolicy');
+        }
+      });
+
+      test('policyFor returns the entry policy and null for unregistered', () {
+        expect(CountryServiceRegistry.policyFor('DE'), isNotNull);
+        expect(CountryServiceRegistry.policyFor('XX'), isNull);
+      });
+
+      test('every policy has non-empty attribution + license', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          expect(entry.policy.attribution, isNotEmpty,
+              reason: '${entry.countryCode} attribution');
+          expect(entry.policy.license, isNotEmpty,
+              reason: '${entry.countryCode} license');
+        }
+      });
+
+      test('every policy has a positive min-interval', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          expect(entry.policy.minInterval, greaterThan(Duration.zero),
+              reason: '${entry.countryCode} minInterval');
+        }
+      });
+
+      test('bulk-file policies declare soft <= hard dataset TTLs > 0', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          if (!entry.policy.isBulkFile) continue;
+          expect(entry.policy.datasetTtlSoft, greaterThan(Duration.zero),
+              reason: '${entry.countryCode} datasetTtlSoft');
+          expect(
+            entry.policy.datasetTtlHard >= entry.policy.datasetTtlSoft,
+            isTrue,
+            reason: '${entry.countryCode} hard >= soft',
+          );
+        }
+      });
+
+      test('polled-api policies declare a positive search-result TTL', () {
+        for (final entry in CountryServiceRegistry.entries) {
+          if (!entry.policy.isPolledApi) continue;
+          expect(entry.policy.searchResultTtl, greaterThan(Duration.zero),
+              reason: '${entry.countryCode} searchResultTtl');
+        }
+      });
+
+      test('ES / IT / AR / DK are modelled as bulkFile', () {
+        for (final code in ['ES', 'IT', 'AR', 'DK']) {
+          expect(CountryServiceRegistry.policyFor(code)!.model,
+              equals(SourceModel.bulkFile),
+              reason: '$code should be a bulk-file source');
+        }
+      });
+
+      test('DE / AT / MX / PT / UK are modelled as polledApi', () {
+        for (final code in ['DE', 'AT', 'MX', 'PT', 'GB']) {
+          expect(CountryServiceRegistry.policyFor(code)!.model,
+              equals(SourceModel.polledApi),
+              reason: '$code should be a polled-api source');
+        }
+      });
+
+      test('DE Tankerkönig polls at 1/min, prices fresh 5 min', () {
+        final de = CountryServiceRegistry.policyFor('DE')!;
+        expect(de.minInterval, equals(const Duration(seconds: 60)));
+        expect(de.searchResultTtl, equals(const Duration(minutes: 5)));
       });
     });
 

--- a/test/core/services/mixins/cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/cached_dataset_mixin_test.dart
@@ -2,9 +2,44 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
 import 'package:tankstellen/core/services/mixins/cached_dataset_mixin.dart';
+import 'package:tankstellen/core/services/persistent_dataset.dart';
+import 'package:tankstellen/core/services/service_result.dart';
 
 class _TestCached with CachedDatasetMixin {}
+
+/// Tiny in-memory CacheStrategy for the persistence tests.
+class _MemCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+
+  @override
+  Future<void> put(String key, Map<String, dynamic> data,
+      {required Duration ttl, required ServiceSource source}) async {
+    _store[key] = CacheEntry(
+        payload: data, storedAt: DateTime.now(), originalSource: source, ttl: ttl);
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) {
+    final e = _store[key];
+    if (e == null || e.isExpired) return null;
+    return e;
+  }
+}
+
+PersistentDataset<List<int>> _intDataset(CacheStrategy cache) =>
+    PersistentDataset<List<int>>(
+      cache: cache,
+      countryCode: 'XX',
+      datasetName: 'nums',
+      source: ServiceSource.cache,
+      serialize: (v) => {'v': v},
+      deserialize: (j) => (j['v'] as List).cast<int>(),
+    );
 
 void main() {
   late _TestCached cached;
@@ -112,6 +147,91 @@ void main() {
       expect(result, 'loaded');
       expect(fetchCalls, 1, reason: 'null cache must fetch regardless of TTL');
       expect(stored, 'loaded');
+    });
+  });
+
+  group('CachedDatasetMixin.loadPersistentDataset (#2264)', () {
+    test('fetches + persists when nothing is cached', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      var fetchCalls = 0;
+
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: const Duration(hours: 1),
+        hardTtl: const Duration(hours: 6),
+        persistent: persistent,
+        fetch: () async {
+          fetchCalls++;
+          return [1, 2, 3];
+        },
+        store: (_) {},
+      );
+
+      expect(result, [1, 2, 3]);
+      expect(fetchCalls, 1);
+      expect(persistent.read()?.value, [1, 2, 3],
+          reason: 'fetched dataset must be persisted');
+    });
+
+    test('reads through from disk without fetching when persisted + fresh',
+        () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      await persistent.write([9, 9], hardTtl: const Duration(hours: 6));
+
+      var fetchCalls = 0;
+      List<int>? stored;
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: const Duration(hours: 1),
+        hardTtl: const Duration(hours: 6),
+        persistent: persistent,
+        fetch: () async {
+          fetchCalls++;
+          return [0];
+        },
+        store: (v) => stored = v,
+      );
+
+      expect(result, [9, 9]);
+      expect(fetchCalls, 0, reason: 'fresh disk copy must skip the network');
+      expect(stored, [9, 9], reason: 'disk copy is rehydrated into memory');
+    });
+
+    test('falls back to persisted copy when fetch throws (offline)', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      await persistent.write([7], hardTtl: const Duration(hours: 6));
+
+      // Force a refresh attempt by leaving no in-memory copy and a soft TTL
+      // that the disk copy is already inside — but make fetch throw anyway by
+      // expiring it past soft via a zero soft TTL.
+      final result = await cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: Duration.zero,
+        hardTtl: const Duration(hours: 6),
+        persistent: persistent,
+        fetch: () async => throw Exception('offline'),
+        store: (_) {},
+      );
+
+      expect(result, [7], reason: 'offline must serve the persisted copy');
+    });
+
+    test('rethrows when fetch fails and nothing is persisted', () async {
+      final persistent = _intDataset(_MemCache());
+      expect(
+        () => cached.loadPersistentDataset<List<int>>(
+          cached: null,
+          softTtl: const Duration(hours: 1),
+          hardTtl: const Duration(hours: 6),
+          persistent: persistent,
+          fetch: () async => throw Exception('boom'),
+          store: (_) {},
+        ),
+        throwsException,
+      );
     });
   });
 }

--- a/test/core/services/station_service_chain_bulk_policy_test.dart
+++ b/test/core/services/station_service_chain_bulk_policy_test.dart
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/fuel_service_policy.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// #2264 concern 4 — the chain branches on [FuelServicePolicy.model]:
+/// bulkFile sources answer nearby straight from the primary (no per-key
+/// Hive cache), polled sources keep the per-key TTL cache.
+
+class _CountingService implements StationService {
+  int searchCalls = 0;
+  List<Station> stations = const [];
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    searchCalls++;
+    return ServiceResult(
+      data: stations,
+      source: ServiceSource.mitecoApi,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String id) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+          List<String> ids) async =>
+      throw UnimplementedError();
+}
+
+/// Records every put so the test can assert the per-key cache is/isn't used.
+class _SpyCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+  final List<String> putKeys = [];
+
+  @override
+  Future<void> put(String key, Map<String, dynamic> data,
+      {required Duration ttl, required ServiceSource source}) async {
+    putKeys.add(key);
+    _store[key] =
+        CacheEntry(payload: data, storedAt: DateTime.now(), originalSource: source, ttl: ttl);
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) {
+    final e = _store[key];
+    if (e == null || e.isExpired) return null;
+    return e;
+  }
+}
+
+const _bulkPolicy = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(minutes: 30),
+  datasetTtlSoft: Duration(hours: 6),
+  datasetTtlHard: Duration(hours: 24),
+  searchResultTtl: Duration.zero,
+  attribution: 'Test bulk',
+  license: 'Test',
+);
+
+const _polledPolicy = FuelServicePolicy(
+  model: SourceModel.polledApi,
+  minInterval: Duration(seconds: 60),
+  datasetTtlSoft: Duration.zero,
+  datasetTtlHard: Duration.zero,
+  searchResultTtl: Duration(minutes: 5),
+  attribution: 'Test polled',
+  license: 'Test',
+);
+
+SearchParams _params() => const SearchParams(
+      lat: 40.0,
+      lng: -3.0,
+      radiusKm: 5,
+      fuelType: FuelType.e5,
+    );
+
+void main() {
+  group('StationServiceChain bulk-vs-polled (#2264)', () {
+    test('bulkFile source never writes a per-key cache entry', () async {
+      final primary = _CountingService()
+        ..stations = [
+          const Station(
+            id: 'es-1',
+            name: 'A',
+            brand: 'A',
+            street: '',
+            postCode: '',
+            place: '',
+            lat: 40.0,
+            lng: -3.0,
+            dist: 0.1,
+            e5: 1.5,
+            isOpen: true,
+          ),
+        ];
+      final cache = _SpyCache();
+      final chain = StationServiceChain(primary, cache,
+          errorSource: ServiceSource.mitecoApi,
+          countryCode: 'ES',
+          policy: _bulkPolicy);
+
+      final result = await chain.searchStations(_params());
+
+      expect(result.data, hasLength(1));
+      expect(result.data.first.id, 'es-1');
+      expect(cache.putKeys, isEmpty,
+          reason: 'bulk source must not write the per-key cache');
+      expect(primary.searchCalls, 1);
+    });
+
+    test('bulkFile source preserves the primary result verbatim', () async {
+      final stations = [
+        const Station(
+          id: 'es-1',
+          name: 'A',
+          brand: 'A',
+          street: '',
+          postCode: '',
+          place: '',
+          lat: 40.0,
+          lng: -3.0,
+          dist: 0.1,
+          e5: 1.5,
+          isOpen: true,
+        ),
+      ];
+      final primary = _CountingService()..stations = stations;
+      final chain = StationServiceChain(primary, _SpyCache(),
+          countryCode: 'ES', policy: _bulkPolicy);
+
+      final result = await chain.searchStations(_params());
+      expect(result.data, equals(stations));
+      expect(result.source, ServiceSource.mitecoApi);
+    });
+
+    test('polledApi source still writes a per-key cache entry', () async {
+      final primary = _CountingService()
+        ..stations = [
+          const Station(
+            id: 'de-1',
+            name: 'B',
+            brand: 'B',
+            street: '',
+            postCode: '',
+            place: '',
+            lat: 40.0,
+            lng: -3.0,
+            dist: 0.1,
+            e5: 1.5,
+            isOpen: true,
+          ),
+        ];
+      final cache = _SpyCache();
+      final chain = StationServiceChain(primary, cache,
+          countryCode: 'DE', policy: _polledPolicy);
+
+      await chain.searchStations(_params());
+
+      expect(cache.putKeys, isNotEmpty,
+          reason: 'polled source must keep the per-key cache');
+      expect(cache.putKeys.single, startsWith('search:DE:'));
+    });
+
+    test('polledApi second search is served from the per-key cache', () async {
+      final primary = _CountingService()
+        ..stations = [
+          const Station(
+            id: 'de-1',
+            name: 'B',
+            brand: 'B',
+            street: '',
+            postCode: '',
+            place: '',
+            lat: 40.0,
+            lng: -3.0,
+            dist: 0.1,
+            e5: 1.5,
+            isOpen: true,
+          ),
+        ];
+      final chain = StationServiceChain(primary, _SpyCache(),
+          countryCode: 'DE', policy: _polledPolicy);
+
+      await chain.searchStations(_params());
+      await chain.searchStations(_params());
+
+      expect(primary.searchCalls, 1,
+          reason: 'fresh per-key cache must skip the second API call');
+    });
+  });
+}

--- a/test/features/station_services/persisted_dataset_read_through_test.dart
+++ b/test/features/station_services/persisted_dataset_read_through_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/services/persistent_dataset.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/argentina/argentina_station_service.dart';
+
+/// #2264 concern 3 — bulk datasets persist to Hive under a keepAlive provider
+/// and read-through on construction, so they survive a cold start + work
+/// offline. Driven via Argentina (a CSV bulk source) against a real
+/// [CacheManager] backed by an in-memory [CacheStorage].
+
+const _csv =
+    'indice_tiempo,idempresa,cuit,empresa,direccion,localidad,provincia,'
+    'region,idproducto,producto,idtipohorario,tipohorario,precio,fecha_vigencia,'
+    'idempresabandera,empresabandera,latitud,longitud,geojson\n'
+    '2026-01-01,1,1,YPF SA,Av Siempreviva 100,Buenos Aires,Buenos Aires,'
+    'Centro,2,Nafta (súper) entre 92 y 95 Ron,1,Diurno,1200.5,2026-01-01,'
+    '1,YPF,-34.6037,-58.3816,{}';
+
+/// In-memory CacheStorage so CacheManager works without Hive.
+class _MemStorage implements CacheStorage {
+  final Map<String, dynamic> _box = {};
+
+  @override
+  Future<void> cacheData(String key, dynamic data) async {
+    if (data == null) {
+      _box.remove(key);
+    } else {
+      _box[key] = data;
+    }
+  }
+
+  @override
+  Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
+    final v = _box[key];
+    return v is Map ? Map<String, dynamic>.from(v) : null;
+  }
+
+  @override
+  Future<void> clearCache() async => _box.clear();
+
+  @override
+  int get cacheEntryCount => _box.length;
+
+  @override
+  Iterable<dynamic> get cacheKeys => _box.keys;
+
+  @override
+  Future<void> deleteCacheEntry(String key) async => _box.remove(key);
+}
+
+/// Counts how many times the network adapter is hit, optionally failing.
+class _CountingAdapter implements HttpClientAdapter {
+  _CountingAdapter(this.body, {this.failAfter});
+  final String body;
+  final int? failAfter;
+  int calls = 0;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<void>? cancelFuture) async {
+    calls++;
+    if (failAfter != null && calls > failAfter!) {
+      throw DioException(
+        type: DioExceptionType.connectionError,
+        requestOptions: options,
+        message: 'offline',
+      );
+    }
+    return ResponseBody.fromBytes(utf8.encode(body), 200, headers: {
+      Headers.contentTypeHeader: ['text/csv'],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _params = SearchParams(lat: -34.6, lng: -58.4, radiusKm: 50.0);
+
+ArgentinaStationService _service(CacheManager cache, HttpClientAdapter adapter) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return ArgentinaStationService.withDio(dio, cache: cache);
+}
+
+void main() {
+  group('Persisted bulk dataset read-through (#2264)', () {
+    test('first search downloads and persists the dataset', () async {
+      final cache = CacheManager(_MemStorage());
+      final adapter = _CountingAdapter(_csv);
+      final result = await _service(cache, adapter).searchStations(_params);
+
+      expect(result.data, isNotEmpty);
+      expect(adapter.calls, 1);
+      // Persisted under the dataset: prefix.
+      final key = PersistentDataset.datasetKey('AR', 'stations');
+      expect(cache.get(key), isNotNull,
+          reason: 'dataset must be persisted to the shared cache');
+    });
+
+    test('a fresh instance reads the dataset from disk without a network call',
+        () async {
+      final cache = CacheManager(_MemStorage());
+      // Warm the cache via one instance.
+      await _service(cache, _CountingAdapter(_csv)).searchStations(_params);
+
+      // A brand-new instance (simulating a cold start / provider rebuild)
+      // sharing the same persisted cache must NOT hit the network.
+      final coldAdapter = _CountingAdapter(_csv);
+      final cold = _service(cache, coldAdapter);
+      final result = await cold.searchStations(_params);
+
+      expect(result.data, isNotEmpty);
+      expect(coldAdapter.calls, 0,
+          reason: 'persisted dataset must be served from disk, no re-download');
+    });
+
+    test('serves the persisted copy when the network is offline', () async {
+      final cache = CacheManager(_MemStorage());
+      await _service(cache, _CountingAdapter(_csv)).searchStations(_params);
+
+      // New instance, network always fails — must still answer from disk.
+      final offline = _service(
+        cache,
+        _CountingAdapter(_csv, failAfter: 0),
+      );
+      final result = await offline.searchStations(_params);
+      expect(result.data, isNotEmpty,
+          reason: 'offline search must fall back to the persisted dataset');
+    });
+
+    test('with no cache wired the legacy in-memory path still works', () async {
+      final adapter = _CountingAdapter(_csv);
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = ArgentinaStationService.withDio(dio); // no cache
+      final result = await service.searchStations(_params);
+      expect(result.data, isNotEmpty);
+      expect(result.source, ServiceSource.argentinaApi);
+    });
+  });
+}

--- a/test/features/station_services/spain/miteco_province_keying_test.dart
+++ b/test/features/station_services/spain/miteco_province_keying_test.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/spain/miteco_station_service.dart';
+import 'package:tankstellen/features/station_services/spain/spain_provinces.dart';
+
+/// #2264 concern 6 — MITECO's unkeyed `_cachedStations` served province A's
+/// stations for a search in province B. The fix keys the cache by provinceId
+/// and merges stations across province borders near the search point.
+
+/// Serves a distinct station per province so the test can prove which
+/// province('s) data a search returns. Counts hits per province path.
+class _PerProvinceAdapter implements HttpClientAdapter {
+  final Map<String, int> hits = {};
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<void>? cancelFuture) async {
+    final path = options.uri.path;
+    // Path ends with /FiltroProvincia/<id>
+    final id = path.split('/').last;
+    hits[id] = (hits[id] ?? 0) + 1;
+    final center = spainProvinceCenters[id]!;
+    final body = {
+      'ResultadoConsulta': 'OK',
+      'ListaEESSPrecio': [
+        {
+          'IDEESS': 'p$id',
+          'Rótulo': 'Station-$id',
+          'Dirección': 'Calle $id',
+          'Localidad': 'City-$id',
+          'C.P.': '00000',
+          // Put the station exactly at the province centre.
+          'Latitud': center.$1.toString().replaceAll('.', ','),
+          'Longitud (WGS84)': center.$2.toString().replaceAll('.', ','),
+          'Precio Gasolina 95 E5': '1,599',
+          'Horario': '24H',
+          'Margen': 'D',
+        },
+      ],
+    };
+    return ResponseBody.fromBytes(utf8.encode(jsonEncode(body)), 200, headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+MitecoStationService _service(HttpClientAdapter adapter) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return MitecoStationService(dio: dio);
+}
+
+void main() {
+  group('spainProvincesNear (#2264)', () {
+    test('a deep-interior point resolves to its single province', () {
+      // Madrid centre, tiny radius → just Madrid (28).
+      final ids = spainProvincesNear(40.4168, -3.7038, 1);
+      expect(ids, contains('28'));
+    });
+
+    test('always includes the nearest province even with a tiny radius', () {
+      final ids = spainProvincesNear(41.3851, 2.1734, 0.1); // Barcelona
+      expect(ids, contains('08'));
+    });
+
+    test('a large radius spans several neighbouring provinces', () {
+      final ids = spainProvincesNear(40.4168, -3.7038, 120); // Madrid + ring
+      expect(ids.length, greaterThan(1));
+      expect(ids, contains('28'));
+    });
+  });
+
+  group('MITECO province isolation + merge (#2264)', () {
+    test('a search in Barcelona does not serve Madrid-cached stations',
+        () async {
+      final adapter = _PerProvinceAdapter();
+      final service = _service(adapter);
+
+      // Warm the cache with a Madrid search.
+      final madrid = await service.searchStations(
+        const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5),
+      );
+      expect(madrid.data.map((s) => s.id), contains('es-p28'));
+
+      // Now search Barcelona — must NOT return the Madrid station.
+      final barca = await service.searchStations(
+        const SearchParams(lat: 41.3851, lng: 2.1734, radiusKm: 5),
+      );
+      final ids = barca.data.map((s) => s.id).toList();
+      expect(ids, contains('es-p08'),
+          reason: 'Barcelona search must return Barcelona stations');
+      expect(ids, isNot(contains('es-p28')),
+          reason: 'province A must not be served for province B (#2264)');
+    });
+
+    test('merges stations across province borders near the search point',
+        () async {
+      final adapter = _PerProvinceAdapter();
+      final service = _service(adapter);
+
+      // A wide-radius search around Madrid pulls in several provinces; the
+      // result must contain stations from more than one province id.
+      final result = await service.searchStations(
+        const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 150),
+      );
+      final provinceIds = result.data
+          .map((s) => s.id.replaceFirst('es-p', ''))
+          .toSet();
+      expect(provinceIds.length, greaterThan(1),
+          reason: 'border merge must span multiple provinces');
+    });
+
+    test('a repeat search in the same province reuses the cached province',
+        () async {
+      final adapter = _PerProvinceAdapter();
+      final service = _service(adapter);
+      const params = SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5);
+
+      await service.searchStations(params);
+      await service.searchStations(params);
+
+      expect(adapter.hits['28'], 1,
+          reason: 'second same-province search must hit the in-memory cache');
+    });
+  });
+}

--- a/test/features/station_services/unsupported_endpoint_uniformity_test.dart
+++ b/test/features/station_services/unsupported_endpoint_uniformity_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/mixins/cached_dataset_mixin.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/station_services/mexico/mexico_station_service.dart';
+import 'package:tankstellen/features/station_services/portugal/portugal_station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
+
+/// #2264 concern 7 — UK / PT / MX route their unsupported endpoints through
+/// the shared StationServiceHelpers (throwDetailUnavailable / emptyPricesResult)
+/// instead of inline throws + inline ServiceResults, and Mexico is on the
+/// CachedDatasetMixin like the other bulk-dataset services.
+
+void main() {
+  group('Mexico migrated onto CachedDatasetMixin (#2264)', () {
+    test('MexicoStationService is a CachedDatasetMixin', () {
+      expect(MexicoStationService(), isA<CachedDatasetMixin>());
+    });
+  });
+
+  group('Shared unsupported-endpoint helpers (#2264)', () {
+    final services = <String, StationService>{
+      'UK': UkStationService(),
+      'PT': PortugalStationService(),
+      'MX': MexicoStationService(),
+    };
+
+    for (final entry in services.entries) {
+      test('${entry.key} getStationDetail throws the shared ApiException',
+          () async {
+        try {
+          await entry.value.getStationDetail('${entry.key}-1');
+          fail('Expected ApiException');
+        } on ApiException catch (e) {
+          // throwDetailUnavailable stamps a "Detail not available from …"
+          // message — the shared helper's wording, not an inline literal.
+          expect(e.message, contains('Detail not available from'),
+              reason: '${entry.key} must use throwDetailUnavailable');
+        }
+      });
+
+      test('${entry.key} getPrices returns the shared empty result', () async {
+        final result = await entry.value.getPrices(['${entry.key}-1']);
+        expect(result.data, isEmpty);
+        expect(result.source, isA<ServiceSource>());
+      });
+    }
+  });
+}


### PR DESCRIPTION
Closes #2264. Aggregated data-layer batch (child of Epic #2249) — 7 cohesive concerns that all touch the shared registry / cache / chain, bundled into one PR (one commit each) to avoid conflicts. Builds on #2259 (FailureKind, merged). Search RESULTS are preserved throughout — these are caching / policy / compliance changes.

## Concerns (one commit each)

1. **fix(australia): `verified:false`** — `AustraliaStationService` is a throwing stub (#804); it left the picker. Stays registered (an `au-` id still resolves). Verified count 13 → 12.
2. **feat(registry): typed `FuelServicePolicy` per `CountryServiceEntry`** — `{SourceModel model, Duration minInterval, datasetTtlSoft, datasetTtlHard, searchResultTtl, String attribution, String license}`, seeded from the audit. The single source the chain TTLs + rate limiter read. attribution/license are DATA (attribution UI is a later batch), kept as const strings with an `i18n-ignore` note.
3. **feat(cache): persist bulk datasets under keepAlive + read-through** — both station-service providers are keepAlive; `PersistentDataset<T>` + `CachedDatasetMixin.loadPersistentDataset` add a Hive disk read-through (survives cold start + offline). Wired into Denmark, Argentina (+ Spain in concern 6). Italy/Mexico get session survival via keepAlive; their on-disk read-through is a noted follow-up (private record-type codecs).
4. **feat(cache): bulk searches → local filter; per-key TTL only for polled** — `StationServiceChain` branches on `policy.model`: bulkFile answers nearby straight from the primary (no per-key cache, byte-identical results); polledApi keeps the per-key TTL cache, now keyed off `policy.searchResultTtl`.
5. **feat(cache): bounded eviction** — `CacheManager.evictBounded()` replaces the one-shot 500-key cap: expiry → per-prefix budget → global LRU byte ceiling (8 MB). `dataset:` entries are exempt from the byte sweep.
6. **fix(spain): MITECO cache keyed by provinceId + multi-province merge** — the unkeyed `_cachedStations` served province A for B; now a `Map<provinceId, _ProvinceCache>` + cross-border merge (`spainProvincesNear`) + per-province persistence.
7. **chore(uniformity): Mexico → `CachedDatasetMixin`; UK/PT/MX → shared unsupported-endpoint helpers** (`throwDetailUnavailable` / `emptyPricesResult`).

## Gate

- Codegen: clean `build_runner build`, all `.g.dart`/`.freezed.dart` drift committed, `git diff --exit-code` clean.
- `flutter analyze` (lib + test + integration_test): only the 2 pre-existing infos (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`).
- `flutter test test/core/ test/features/search/ test/features/station_services/ test/lint/ test/l10n/ --exclude-tags=network`: all pass (the `network`-tagged live-API tests are excluded by CI as they can't run reliably without network).
- New tests per concern: policy presence/values; bulk-source no-cache vs polled per-key cache; persisted read-through (cold-start + offline); bounded eviction (prefix budget, LRU ceiling, dataset exemption); MITECO province isolation + cross-border merge; AU absent from picker; UK/PT/MX uniformity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
