### PR TITLE
feat(obd2): adapter wake batch — WakePolicy + bounded-settle retry + per-MAC wake cache (#2268)

### DIFF
--- a/lib/features/consumption/data/obd2/adapters/smart_obd_adapter.dart
+++ b/lib/features/consumption/data/obd2/adapters/smart_obd_adapter.dart
@@ -40,4 +40,12 @@ class SmartObdAdapter implements Elm327Adapter {
     final body = raw.substring(0, lastIdx).replaceAll('>', '');
     return body + raw.substring(lastIdx);
   }
+
+  // #2268 concern 1 — SmartOBD clones are slow to settle after ATZ but do
+  // not enter an ATLP standby that needs a wake nudge; their longer
+  // [postResetDelay] already covers re-enumeration. Strict no-op here so
+  // the wake batch stays opt-in for the STN-/OBDLink-class adapters that
+  // actually sleep.
+  @override
+  WakePolicy get wakePolicy => const WakePolicy.noop();
 }

--- a/lib/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart
+++ b/lib/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart
@@ -27,4 +27,9 @@ class VLinkerFsAdapter implements Elm327Adapter {
 
   @override
   String preParse(String raw) => raw;
+
+  // #2268 concern 1 — the vLinker FS is a fast, clean implementation that
+  // answers the first command immediately; no standby compensation.
+  @override
+  WakePolicy get wakePolicy => const WakePolicy.noop();
 }

--- a/lib/features/consumption/data/obd2/elm327_adapter.dart
+++ b/lib/features/consumption/data/obd2/elm327_adapter.dart
@@ -3,6 +3,67 @@
 
 import 'elm327_commands.dart';
 
+/// Per-adapter standby/wake behaviour (#2268 concern 1).
+///
+/// ELM327 clones differ in how they behave on the very first command
+/// after a fresh BLE/Classic open. Most generic clones answer the first
+/// `ATZ` immediately (the channel open already woke them). A minority of
+/// STN-/OBDLink-class adapters drop into an `ATLP` low-power sleep when
+/// the engine is off and need a longer settle — and possibly a single
+/// re-send — before the first command lands.
+///
+/// This value object is the per-adapter knob the connect path consults.
+/// The default is a strict NO-OP: [maySleep] `false`, [wakeSettle]
+/// [Duration.zero], [maxNudges] `0`. Every adapter paired today resolves
+/// to the no-op default (see [Elm327Adapter.wakePolicy]), so connect
+/// behaviour is byte-for-byte unchanged until a distinctive subclass
+/// opts in behind evidence.
+///
+/// Deliberately NOT an AT "wake byte" — a BLE client usually cannot wake
+/// an already-asleep ELM327 by writing a magic byte; the realistic lever
+/// is a longer settle window plus a bounded re-send of the FIRST command.
+class WakePolicy {
+  /// Whether this adapter is known to drop into a standby/sleep state
+  /// that the connect path should compensate for with an extra-settle
+  /// window on the first command. `false` ⇒ no extra settle at all.
+  final bool maySleep;
+
+  /// Extra settle window given to the FIRST init command on a fresh
+  /// connect when [maySleep] is `true`. Longer than the steady-state
+  /// [Elm327Adapter.interCommandDelay] because a sleeping adapter needs
+  /// time to spin its UART back up before it can answer. Capped by the
+  /// connect path so a mis-seeded value can't stall start indefinitely.
+  final Duration wakeSettle;
+
+  /// Maximum number of EXTRA re-sends of the first command inside the
+  /// wake window (a "nudge"), on top of the original attempt. `0` ⇒ no
+  /// nudge. The connect path treats this as a hard cap (one nudge is the
+  /// realistic value) so the wake batch can never become an unbounded
+  /// retry loop.
+  final int maxNudges;
+
+  const WakePolicy({
+    this.maySleep = false,
+    this.wakeSettle = Duration.zero,
+    this.maxNudges = 0,
+  });
+
+  /// The strict no-op default — no standby compensation whatsoever. This
+  /// is what every generic / today-paired adapter resolves to, keeping
+  /// connect behaviour unchanged.
+  const WakePolicy.noop()
+      : maySleep = false,
+        wakeSettle = Duration.zero,
+        maxNudges = 0;
+
+  /// `true` when this policy actually asks the connect path to do
+  /// something — i.e. it [maySleep] AND grants either a settle window or
+  /// at least one nudge. A `maySleep` policy with a zero window and zero
+  /// nudges is still inert, so the connect path can short-circuit on this.
+  bool get isActive =>
+      maySleep && (wakeSettle > Duration.zero || maxNudges > 0);
+}
+
 /// Per-adapter ELM327 protocol quirks (#1330).
 ///
 /// Phase 1: scaffolding only. The single implementation
@@ -46,6 +107,13 @@ abstract class Elm327Adapter {
   /// Default: identity. Adapter-specific subclasses can strip stray
   /// echoes etc.
   String preParse(String raw) => raw;
+
+  /// Standby/wake behaviour for this adapter (#2268 concern 1). Default
+  /// is the strict no-op [WakePolicy.noop] — no extra-settle window on
+  /// the first command, so connect behaviour is unchanged for every
+  /// adapter that doesn't override this. Only distinctive STN-/OBDLink-
+  /// class subclasses (none paired today) should seed `maySleep: true`.
+  WakePolicy get wakePolicy => const WakePolicy.noop();
 }
 
 /// Default adapter — values mirror today's hardcoded behaviour
@@ -71,4 +139,9 @@ class GenericElm327Adapter implements Elm327Adapter {
 
   @override
   String preParse(String raw) => raw;
+
+  // #2268 concern 1 — generic clones answer the first command after the
+  // channel open immediately; no standby compensation, strict no-op.
+  @override
+  WakePolicy get wakePolicy => const WakePolicy.noop();
 }

--- a/lib/features/consumption/data/obd2/obd2_adapter_wake_cache.dart
+++ b/lib/features/consumption/data/obd2/obd2_adapter_wake_cache.dart
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../../../core/data/storage_repository.dart';
+import '../../../../core/logging/error_logger.dart';
+import 'elm327_adapter.dart';
+import 'obd2_service.dart';
+
+/// Per-MAC observed-outcome wake cache (#2268 concern 3).
+///
+/// Records whether a specific physical adapter needs the bounded wake
+/// window (#2268 concern 2) on a fresh connect. Keyed per adapter MAC —
+/// NOT per firmware string: thousands of clones share the identical
+/// `ELM327 v1.5` `ATI` reply, so a firmware-string key would smear one
+/// flaky clone's behaviour across every adapter that ever reported the
+/// same version. The MAC (BLE remote-id / Classic address) is stable per
+/// physical device, which is exactly the granularity the wake decision
+/// wants.
+///
+/// The recorded value is an OBSERVED outcome, never raw first-command
+/// latency:
+///   * `true`  — a fresh-connect first command timed out AND a
+///     longer-settle re-send then succeeded ([WakeObservation.wokeAfterNudge]).
+///   * `false` — the wake window ran and the first command answered
+///     immediately ([WakeObservation.answeredImmediately]); this MAC
+///     never needs the window again and the connection service can
+///     suppress it forever.
+///
+/// Backed by [SettingsStorage] (the Hive `settings` box), reusing the
+/// `obd_adapter_blocklist.dart` pattern byte-for-byte: one entry per MAC
+/// under the [_keyPrefix] namespace plus an additive [_indexKey] roster
+/// (SettingsStorage exposes no key enumeration). Stateless and
+/// idempotent. Empty MACs are ignored — an unstamped service has no
+/// stable key to recall by next session.
+class Obd2AdapterWakeCache {
+  final SettingsStorage _storage;
+
+  const Obd2AdapterWakeCache(this._storage);
+
+  /// Settings-box key prefix; one entry per adapter MAC. Chosen to avoid
+  /// collisions with the `obdAdapterBroken:` blocklist keys and the rest
+  /// of the shared `settings` box.
+  static const _keyPrefix = 'obdAdapterWake:';
+
+  /// Settings-box key for the additive index of known adapter MACs.
+  /// [SettingsStorage] exposes no key-enumeration, so the cache keeps its
+  /// own roster: every [record] appends here, [entries] reads it back.
+  static const _indexKey = 'obdAdapterWake:__ids';
+
+  /// Normalise a MAC into a stable cache key — trimmed + lower-cased so
+  /// capitalisation never splits an entry. Returns null for an empty MAC.
+  static String? _normalise(String mac) {
+    final m = mac.trim().toLowerCase();
+    return m.isEmpty ? null : m;
+  }
+
+  /// Persists the observed [wakeNeeded] outcome for [mac]. No-op when
+  /// [mac] is empty — without a stable key the value would just leak.
+  /// Idempotent: a later observation overwrites the earlier one (e.g. an
+  /// adapter that woke once but answers immediately on later connects
+  /// flips to `false`).
+  Future<void> record(String mac, bool wakeNeeded) async {
+    final key = _normalise(mac);
+    if (key == null) return;
+    await _storage.putSetting('$_keyPrefix$key', wakeNeeded);
+    await _addToIndex(key);
+  }
+
+  /// Recalls the observed outcome for [mac]:
+  ///   * `true`  — known to need the wake window.
+  ///   * `false` — observed never to need it (suppress the window).
+  ///   * `null`  — never observed, [mac] empty, or a non-bool legacy
+  ///     value (defensive against Hive type drift). The connection
+  ///     service then lets the adapter's own [WakePolicy] decide.
+  Future<bool?> recall(String mac) async {
+    final key = _normalise(mac);
+    if (key == null) return null;
+    final raw = _storage.getSetting('$_keyPrefix$key');
+    if (raw is bool) return raw;
+    return null;
+  }
+
+  /// Resolve the wake-window override for [mac] (#2268 concern 3): a
+  /// no-op [WakePolicy] when the cache observed the MAC as never-needing
+  /// the window (so the connect path suppresses it), else null — honour
+  /// the adapter's own policy (a no-op for every generic adapter).
+  /// Best-effort: a read failure falls back to the adapter policy.
+  Future<WakePolicy?> overrideFor(String mac) async {
+    try {
+      return await recall(mac) == false ? const WakePolicy.noop() : null;
+    } catch (e, st) {
+      _logFailure('recall', e, st);
+      return null;
+    }
+  }
+
+  /// Persist the observed wake outcome for [mac] (#2268 concern 3).
+  /// Records `false` on [WakeObservation.answeredImmediately] and `true`
+  /// on [WakeObservation.wokeAfterNudge]; writes NOTHING for `notRun`
+  /// (window never ran) or `failed` (no positive evidence) — so the cache
+  /// only ever learns from a clean OBSERVED outcome. Best-effort.
+  Future<void> recordObservation(String mac, WakeObservation obs) async {
+    final bool wakeNeeded;
+    switch (obs) {
+      case WakeObservation.answeredImmediately:
+        wakeNeeded = false;
+      case WakeObservation.wokeAfterNudge:
+        wakeNeeded = true;
+      case WakeObservation.notRun:
+      case WakeObservation.failed:
+        return;
+    }
+    try {
+      await record(mac, wakeNeeded);
+    } catch (e, st) {
+      _logFailure('record', e, st);
+    }
+  }
+
+  void _logFailure(String op, Object e, StackTrace st) {
+    unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+      'where': 'Obd2AdapterWakeCache $op failed',
+    }));
+  }
+
+  /// Every MAC the cache has observed, keyed by its normalised MAC with
+  /// the recorded wakeNeeded flag. Reads the [_indexKey] roster then
+  /// recalls each entry; a MAC whose value was cleared is skipped.
+  Future<Map<String, bool>> entries() async {
+    final result = <String, bool>{};
+    for (final mac in _index()) {
+      final needed = await recall(mac);
+      if (needed != null) result[mac] = needed;
+    }
+    return result;
+  }
+
+  /// Removes [mac] from the cache — the escape hatch for an adapter
+  /// whose behaviour changed (re-flashed firmware, etc.). [SettingsStorage]
+  /// has no key-delete, so the value is neutralised to null (making
+  /// [recall] return null, as if never observed) and the id is dropped
+  /// from the index.
+  Future<void> clearEntry(String mac) async {
+    final key = _normalise(mac);
+    if (key == null) return;
+    await _storage.putSetting('$_keyPrefix$key', null);
+    final remaining = _index()..remove(key);
+    await _storage.putSetting(_indexKey, remaining);
+  }
+
+  /// Current index roster, read defensively against Hive type drift.
+  List<String> _index() {
+    final raw = _storage.getSetting(_indexKey);
+    if (raw is List) return raw.whereType<String>().toList();
+    return <String>[];
+  }
+
+  Future<void> _addToIndex(String mac) async {
+    final ids = _index();
+    if (ids.contains(mac)) return;
+    ids.add(mac);
+    await _storage.putSetting(_indexKey, ids);
+  }
+}

--- a/lib/features/consumption/data/obd2/obd2_cache_openers.dart
+++ b/lib/features/consumption/data/obd2/obd2_cache_openers.dart
@@ -3,7 +3,10 @@
 
 import 'package:hive/hive.dart';
 
+import 'bluetooth_obd2_transport.dart';
+import 'elm_byte_channel.dart';
 import 'negotiated_protocol_cache.dart';
+import 'obd2_service.dart';
 import 'supported_pids_cache.dart';
 import '../../../../core/storage/hive_boxes.dart';
 
@@ -26,4 +29,43 @@ NegotiatedProtocolCache? openNegotiatedProtocolCache() {
   return NegotiatedProtocolCache(
     Hive.box<String>(HiveBoxes.obd2NegotiatedProtocol),
   );
+}
+
+/// Build the [Obd2Service] for a freshly-opened [channel], wiring in the
+/// #811 supported-PID cache (#2253) and the #2261 negotiated-protocol
+/// warm cache and stamping the adapter [mac]/[name]. Centralised here so
+/// the scan and direct/passive connect paths in [Obd2ConnectionService]
+/// produce a byte-for-byte identical session. The vehicle [make]/[model]/
+/// [year]/[vin] refine the cache keys; null fields collapse to
+/// adapterMac-only keying.
+Obd2Service buildObd2Session({
+  required ElmByteChannel channel,
+  required String mac,
+  required String name,
+  SupportedPidsCache? pidsCache,
+  NegotiatedProtocolCache? protocolCache,
+  String? make,
+  String? model,
+  int? year,
+  String? vin,
+}) {
+  final service = Obd2Service(
+    BluetoothObd2Transport(channel),
+    pidsCache: pidsCache,
+    vehicleFallbackKey: pidsCache == null
+        ? null
+        : SupportedPidsCache.productionKey(
+            adapterMac: mac,
+            make: make,
+            model: model,
+            year: year,
+          ),
+    protocolCache: protocolCache,
+    protocolCacheKey: protocolCache == null
+        ? null
+        : NegotiatedProtocolCache.keyFor(adapterMac: mac, vin: vin),
+  );
+  service.adapterMac = mac;
+  service.adapterName = name;
+  return service;
 }

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -8,17 +8,18 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'adapter_registry.dart';
 import 'bluetooth_facade.dart';
-import 'bluetooth_obd2_transport.dart';
 import 'classic_bluetooth_facade.dart';
 import 'elm327_adapter.dart';
 import 'elm_byte_channel.dart';
 import 'negotiated_protocol_cache.dart';
+import 'obd2_adapter_wake_cache.dart';
 import 'obd2_cache_openers.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_permissions.dart';
 import 'obd2_service.dart';
 import 'supported_pids_cache.dart';
 import '../../../../core/logging/error_logger.dart';
+import '../../../../core/storage/storage_providers.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 
 part 'obd2_connection_service.g.dart';
@@ -77,6 +78,13 @@ class Obd2ConnectionService {
   /// auto-search, exactly as before.
   final NegotiatedProtocolCache? negotiatedProtocolCache;
 
+  /// Per-MAC observed-outcome wake cache (#2268 concern 3). A connect
+  /// reads it to suppress the bounded wake window for a MAC observed
+  /// never to need it, and writes back the fresh observation. Null ⇒ the
+  /// session always honours the adapter's own [WakePolicy] (a no-op for
+  /// every generic adapter, so behaviour is unchanged).
+  final Obd2AdapterWakeCache? adapterWakeCache;
+
   /// Lazily resolves the active vehicle's make / model / year so the
   /// supported-PID cache key can be refined past adapterMac-only
   /// (#2253). Read fresh on every connect because the active vehicle
@@ -90,6 +98,7 @@ class Obd2ConnectionService {
     this.classicBluetooth,
     this.supportedPidsCache,
     this.negotiatedProtocolCache,
+    this.adapterWakeCache,
     this.activeVehicleKeyFields,
   });
 
@@ -185,43 +194,29 @@ class Obd2ConnectionService {
     required String mac,
     required String name,
   }) async {
-    final transport = BluetoothObd2Transport(channel);
-    // #2253 — wire the #811 supported-PID cache into the live session.
-    // Key = adapterMac(+make:model:year), so `prime()` reads a cached
-    // support bitmap WITHOUT a multi-frame 0902 VIN read. No cache wired
-    // ⇒ pre-#2253 transport-only construction.
-    final cache = supportedPidsCache;
+    // #2253/#2261 — build the session with the supported-PID + warm
+    // negotiated-protocol caches wired in (see [buildObd2Session]).
     final vehicle = activeVehicleKeyFields?.call();
-    // #2261 concern 3 — resolve the warm-protocol cache key from the
-    // adapter MAC + the active vehicle's VIN (when known).
-    final protoCache = negotiatedProtocolCache;
-    final protoKey = protoCache == null
-        ? null
-        : NegotiatedProtocolCache.keyFor(
-            adapterMac: mac,
-            vin: vehicle?.vin,
-          );
-    final service = Obd2Service(
-      transport,
-      pidsCache: cache,
-      vehicleFallbackKey: cache == null
-          ? null
-          : SupportedPidsCache.productionKey(
-              adapterMac: mac,
-              make: vehicle?.make,
-              model: vehicle?.model,
-              year: vehicle?.year,
-            ),
-      protocolCache: protoCache,
-      protocolCacheKey: protoKey,
+    final service = buildObd2Session(
+      channel: channel,
+      mac: mac,
+      name: name,
+      pidsCache: supportedPidsCache,
+      protocolCache: negotiatedProtocolCache,
+      make: vehicle?.make,
+      model: vehicle?.model,
+      year: vehicle?.year,
+      vin: vehicle?.vin,
     );
-    service.adapterMac = mac;
-    service.adapterName = name;
-    // #1330 — hand the per-adapter ELM327 adapter into [Obd2Service]
-    // so its init sequence + timing matches the connected adapter's
-    // quirks. Phase 1 ships only [GenericElm327Adapter], so runtime
-    // behaviour is unchanged for every paired adapter.
-    final ok = await service.connect(adapter: adapter);
+    // #2268 concern 3 — a no-op override suppresses the wake window for a
+    // MAC observed never to need it; null ⇒ honour the adapter policy.
+    final wakeOverride = await adapterWakeCache?.overrideFor(mac);
+    // #1330 — the per-adapter ELM327 adapter sets the init sequence/timing.
+    final ok =
+        await service.connect(adapter: adapter, wakePolicyOverride: wakeOverride);
+    // #2268 concern 3 — persist the observed wake outcome (a no-op unless
+    // the bounded window actually ran on this connect).
+    await adapterWakeCache?.recordObservation(mac, service.wakeObservation);
     if (!ok) {
       await service.disconnect();
       throw const Obd2AdapterUnresponsive();
@@ -389,6 +384,10 @@ Obd2ConnectionService obd2Connection(Ref ref) {
     supportedPidsCache: openSupportedPidsCache(),
     // #2261 concern 3 — activate the negotiated-protocol warm cache.
     negotiatedProtocolCache: openNegotiatedProtocolCache(),
+    // #2268 concern 3 — per-MAC observed-outcome wake cache, backed by
+    // the shared `settings` box (same pattern as the broken-MAP blocklist).
+    adapterWakeCache:
+        Obd2AdapterWakeCache(ref.watch(settingsStorageProvider)),
     activeVehicleKeyFields: () {
       // Defensive: the vehicle provider must never make a connect throw.
       try {

--- a/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.g.dart
@@ -54,4 +54,4 @@ final class Obd2ConnectionProvider
   }
 }
 
-String _$obd2ConnectionHash() => r'f52d0cd5581de85e2965fe72f0d0702af07abe7c';
+String _$obd2ConnectionHash() => r'925de6fddf85763ba45824ae32bceb3c5d45c7e8';

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -41,6 +41,33 @@ export 'fuel_rate_estimator.dart'
         applyFuelTrimCorrection,
         estimateFuelRateLPerHourFromMap;
 
+/// What the bounded wake window observed on the FIRST init command of a
+/// fresh connect (#2268 concern 2). Drives the per-MAC observed-outcome
+/// wake cache (#2268 concern 3): the connection service records
+/// `wakeNeeded` only on a [wokeAfterNudge] outcome, and records
+/// `never-needed` only on an [answeredImmediately] outcome.
+enum WakeObservation {
+  /// The wake window did not run — either no [WakePolicy] was active for
+  /// this connect or it was suppressed by the cache. The connect path
+  /// has no evidence either way, so the cache must NOT be updated.
+  notRun,
+
+  /// The wake window ran and the FIRST command answered on the first
+  /// attempt — this adapter did not need waking on this connect. Strong
+  /// evidence the MAC never needs the window.
+  answeredImmediately,
+
+  /// The wake window ran, the FIRST command timed out / threw, and a
+  /// re-send after the longer settle then succeeded — observed proof the
+  /// adapter was asleep and the window recovered it.
+  wokeAfterNudge,
+
+  /// The wake window ran and every attempt (original + all nudges)
+  /// failed. No positive evidence — connect will fail downstream; the
+  /// cache must NOT be updated on a failed connect.
+  failed,
+}
+
 /// High-level OBD-II service for reading vehicle data.
 ///
 /// Wraps [Obd2Transport] and [Elm327Protocol] to provide a clean API
@@ -149,6 +176,14 @@ class Obd2Service implements Obd2RawCommandPort {
   /// the owner so the data layer never resolves vehicle identity itself.
   final String? _protocolCacheKey;
 
+  /// What the bounded wake window observed on the most recent [connect]
+  /// (#2268 concern 2). [WakeObservation.notRun] until a connect with an
+  /// active (non-suppressed) [WakePolicy] runs the window. The connection
+  /// service reads this after connect to update the per-MAC wake cache
+  /// (#2268 concern 3). Never updated on a connect that didn't run the
+  /// window, so a generic-adapter connect leaves it [notRun].
+  WakeObservation wakeObservation = WakeObservation.notRun;
+
   Obd2Service(
     this._transport, {
     SupportedPidsCache? pidsCache,
@@ -202,6 +237,86 @@ class Obd2Service implements Obd2RawCommandPort {
       await Future<void>.delayed(connectRetryDelay);
       return inner(command);
     }
+  }
+
+  /// Hard ceiling on the per-nudge wake settle (#2268 concern 2) so a
+  /// mis-seeded [WakePolicy.wakeSettle] can never stall trip-start
+  /// indefinitely. The window the connect path actually applies is
+  /// `min(wakeSettle, wakeSettleCap)`.
+  static const Duration wakeSettleCap = Duration(seconds: 3);
+
+  /// Hard ceiling on [WakePolicy.maxNudges] (#2268 concern 2). One nudge
+  /// is the realistic value (a single re-send after the adapter has had
+  /// time to wake); the cap guards against a runaway seeded value
+  /// turning the wake batch into an unbounded retry loop.
+  static const int maxNudgeCap = 2;
+
+  /// Test hook to scale the real wake-settle down to milliseconds so the
+  /// concern-2 unit tests don't wait real seconds. Production keeps it at
+  /// `1.0`. Multiplies the (already-capped) settle just before sleeping.
+  @visibleForTesting
+  static double wakeSettleScale = 1.0;
+
+  /// Bounded extra-settle + first-command nudge for a sleeping adapter
+  /// (#2268 concern 2).
+  ///
+  /// Runs ONLY when [policy.isActive] — i.e. a distinctive STN-/OBDLink-
+  /// class adapter opted in (none paired today) and the cache did not
+  /// suppress it. The first init command on a fresh open gets a
+  /// purpose-built window: the original attempt, then up to
+  /// `min(policy.maxNudges, maxNudgeCap)` RE-SENDS, each preceded by a
+  /// settle of `min(policy.wakeSettle, wakeSettleCap)`. This is longer
+  /// than the steady-state [_withConnectRetry] blip guard and is NOT an
+  /// AT "wake byte" — a BLE client cannot wake an ATLP-sleeping ELM327
+  /// with a magic byte; the lever is "wait, then ask again".
+  ///
+  /// Sets [wakeObservation] to the outcome so the connection service can
+  /// feed the per-MAC wake cache (concern 3). Returns the successful
+  /// response, or rethrows the LAST failure when every attempt failed so
+  /// the surrounding connect still fails exactly as it would today.
+  Future<String> _sendFirstCommandWithWake(
+    String command,
+    WakePolicy policy,
+  ) async {
+    final cappedSettleUs = policy.wakeSettle.inMicroseconds
+        .clamp(0, wakeSettleCap.inMicroseconds);
+    final settle = Duration(
+      microseconds: (cappedSettleUs * wakeSettleScale).round(),
+    );
+    final nudges = policy.maxNudges.clamp(0, maxNudgeCap);
+
+    // Attempt 0 — the original send. Immediate success ⇒ the adapter was
+    // already awake; strong evidence the MAC never needs the window.
+    try {
+      final response = await _transport.sendCommand(command);
+      wakeObservation = WakeObservation.answeredImmediately;
+      return response;
+    } catch (e, st) {
+      debugPrint('OBD2 wake: first command "$command" failed ($e), '
+          'entering bounded wake window\n$st');
+    }
+
+    // Nudges — settle, then re-send. A success here is observed proof the
+    // adapter was asleep and the window recovered it.
+    Object lastError = StateError('wake window had no nudges to try');
+    StackTrace lastStack = StackTrace.current;
+    for (var n = 0; n < nudges; n++) {
+      await Future<void>.delayed(settle);
+      try {
+        final response = await _transport.sendCommand(command);
+        wakeObservation = WakeObservation.wokeAfterNudge;
+        return response;
+      } catch (e, st) {
+        lastError = e;
+        lastStack = st;
+        debugPrint('OBD2 wake: nudge ${n + 1}/$nudges for "$command" '
+            'failed ($e)\n$st');
+      }
+    }
+
+    // Every attempt failed — rethrow so connect fails as it would today.
+    wakeObservation = WakeObservation.failed;
+    Error.throwWithStackTrace(lastError, lastStack);
   }
 
   /// AT command that asks the ELM327 to identify itself. Returns a
@@ -329,8 +444,15 @@ class Obd2Service implements Obd2RawCommandPort {
   ///      saves 8 × `01 XX` Bluetooth round-trips every session.
   ///   3. On cache miss, runs [discoverSupportedPids] and persists
   ///      the result under the chosen key for next time.
+  /// [wakePolicyOverride] (#2268 concern 2/3) lets the connection service
+  /// override the adapter's own [Elm327Adapter.wakePolicy] for THIS
+  /// connect based on the per-MAC observed-outcome cache: pass
+  /// [WakePolicy.noop] to suppress the bounded wake window for a MAC the
+  /// cache recorded as never-needing it. Null ⇒ use the adapter's policy
+  /// (a no-op for every generic adapter, so behaviour is unchanged).
   Future<bool> connect({
     Elm327Adapter adapter = const GenericElm327Adapter(),
+    WakePolicy? wakePolicyOverride,
   }) async {
     // #1920 — trace the connect attempt so a failed recording session
     // can be analysed from the exportable OBD2 diagnostic log.
@@ -340,6 +462,10 @@ class Obd2Service implements Obd2RawCommandPort {
     );
     try {
       _adapter = adapter;
+      // #2268 concern 2 — a fresh connect resets the wake observation;
+      // it only moves off [WakeObservation.notRun] if the bounded wake
+      // window actually runs (active policy, not cache-suppressed).
+      wakeObservation = WakeObservation.notRun;
       await _transport.connect();
 
       // Clear the per-connection supported-PIDs cache. A new session
@@ -372,6 +498,12 @@ class Obd2Service implements Obd2RawCommandPort {
           }
         }
       }
+      // #2268 concern 2 — resolve the effective wake policy for THIS
+      // connect. The cache (concern 3) can suppress the window by passing
+      // a no-op override; otherwise the adapter's own policy applies — a
+      // no-op for every generic adapter, so the first command goes through
+      // the unchanged [_withConnectRetry] path below.
+      final wakePolicy = wakePolicyOverride ?? adapter.wakePolicy;
       for (var i = 0; i < sequence.length; i++) {
         // #1925 — time each handshake command for the opt-in OBD2
         // debug log (a no-op when debug logging is off).
@@ -379,10 +511,20 @@ class Obd2Service implements Obd2RawCommandPort {
         // transient BLE blip during the init sequence is absorbed
         // rather than failing the whole connect attempt.
         final sw = Stopwatch()..start();
-        final response = await _withConnectRetry(
-          sequence[i],
-          _transport.sendCommand,
-        );
+        // #2268 concern 2 — the FIRST command on a fresh open gets the
+        // purpose-built bounded wake window when (and only when) an active
+        // wake policy applies. Every other command — and every first
+        // command for a generic adapter — runs the unchanged steady-state
+        // retry path, so behaviour is byte-for-byte the same by default.
+        final String response;
+        if (i == 0 && wakePolicy.isActive) {
+          response = await _sendFirstCommandWithWake(sequence[i], wakePolicy);
+        } else {
+          response = await _withConnectRetry(
+            sequence[i],
+            _transport.sendCommand,
+          );
+        }
         sw.stop();
         Obd2DebugSessionRecorder.recordHandshakeCommand(
           sequence[i],

--- a/test/features/consumption/data/obd2/elm327_adapter_test.dart
+++ b/test/features/consumption/data/obd2/elm327_adapter_test.dart
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapters/smart_obd_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapters/v_linker_fs_adapter.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_commands.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
@@ -93,6 +95,76 @@ void main() {
         adapter.preParse('41 0C 0F A0>'),
         '41 0C 0F A0>',
       );
+    });
+
+    test('wakePolicy is the strict no-op default (#2268 concern 1)', () {
+      const adapter = GenericElm327Adapter();
+      final policy = adapter.wakePolicy;
+      expect(policy.maySleep, isFalse,
+          reason: 'a generic clone must not trigger any wake compensation');
+      expect(policy.wakeSettle, Duration.zero);
+      expect(policy.maxNudges, 0);
+      expect(policy.isActive, isFalse,
+          reason: 'a no-op policy must report itself inert so the connect '
+              'path short-circuits before any extra settle');
+    });
+  });
+
+  group('WakePolicy value object (#2268 concern 1)', () {
+    test('default constructor is a strict no-op', () {
+      const policy = WakePolicy();
+      expect(policy.maySleep, isFalse);
+      expect(policy.wakeSettle, Duration.zero);
+      expect(policy.maxNudges, 0);
+      expect(policy.isActive, isFalse);
+    });
+
+    test('named noop() constructor matches the default no-op', () {
+      const policy = WakePolicy.noop();
+      expect(policy.maySleep, isFalse);
+      expect(policy.wakeSettle, Duration.zero);
+      expect(policy.maxNudges, 0);
+      expect(policy.isActive, isFalse);
+    });
+
+    test('isActive is true only when maySleep AND a window/nudge is granted',
+        () {
+      // maySleep alone with a zero window + zero nudges stays inert.
+      expect(
+        const WakePolicy(maySleep: true).isActive,
+        isFalse,
+        reason: 'maySleep with no settle and no nudge is still a no-op',
+      );
+      // A settle window with maySleep activates it.
+      expect(
+        const WakePolicy(
+          maySleep: true,
+          wakeSettle: Duration(milliseconds: 600),
+        ).isActive,
+        isTrue,
+      );
+      // A nudge alone with maySleep activates it.
+      expect(
+        const WakePolicy(maySleep: true, maxNudges: 1).isActive,
+        isTrue,
+      );
+      // A settle window WITHOUT maySleep is inert — maySleep is the gate.
+      expect(
+        const WakePolicy(wakeSettle: Duration(seconds: 1), maxNudges: 1)
+            .isActive,
+        isFalse,
+        reason: 'maySleep:false must override any seeded window/nudge',
+      );
+    });
+  });
+
+  group('Subclass wakePolicy defaults stay no-op (#2268 concern 1)', () {
+    test('VLinkerFsAdapter is no-op', () {
+      expect(const VLinkerFsAdapter().wakePolicy.isActive, isFalse);
+    });
+
+    test('SmartObdAdapter is no-op', () {
+      expect(const SmartObdAdapter().wakePolicy.isActive, isFalse);
     });
   });
 

--- a/test/features/consumption/data/obd2/obd2_adapter_wake_cache_test.dart
+++ b/test/features/consumption/data/obd2/obd2_adapter_wake_cache_test.dart
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_adapter_wake_cache.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// In-memory [SettingsStorage] double — mirrors the blocklist test's
+/// fake so the wake cache sees a real store implementation.
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> data = {};
+
+  @override
+  dynamic getSetting(String key) => data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('Obd2AdapterWakeCache (#2268 concern 3)', () {
+    late _FakeSettingsStorage storage;
+    late Obd2AdapterWakeCache cache;
+
+    setUp(() {
+      storage = _FakeSettingsStorage();
+      cache = Obd2AdapterWakeCache(storage);
+    });
+
+    test('recall returns null on a never-observed MAC', () async {
+      expect(await cache.recall('AA:BB:CC:DD:EE:FF'), isNull);
+    });
+
+    test('record(true) + recall round-trips wakeNeeded', () async {
+      await cache.record('AA:BB:CC:DD:EE:FF', true);
+      expect(await cache.recall('AA:BB:CC:DD:EE:FF'), isTrue);
+    });
+
+    test('record(false) + recall round-trips never-needed', () async {
+      await cache.record('AA:BB:CC:DD:EE:FF', false);
+      expect(await cache.recall('AA:BB:CC:DD:EE:FF'), isFalse);
+    });
+
+    test('keys are namespaced under obdAdapterWake: and lower-cased',
+        () async {
+      await cache.record('AA:BB:CC', true);
+      expect(storage.data.keys, contains('obdAdapterWake:aa:bb:cc'));
+    });
+
+    test('MAC is keyed case-insensitively — same physical device', () async {
+      await cache.record('AA:BB:CC', true);
+      expect(await cache.recall('aa:bb:cc'), isTrue,
+          reason: 'capitalisation must never split one device into two '
+              'cache entries');
+    });
+
+    test('empty MAC is a no-op for both record and recall', () async {
+      await cache.record('', true);
+      expect(storage.data.keys, isEmpty);
+      expect(await cache.recall(''), isNull);
+    });
+
+    test('a later observation overwrites the earlier one', () async {
+      await cache.record('AA:BB:CC', true);
+      await cache.record('AA:BB:CC', false);
+      expect(await cache.recall('AA:BB:CC'), isFalse);
+    });
+
+    test('recall returns null on a non-bool legacy value (type drift)',
+        () async {
+      storage.data['obdAdapterWake:aa:bb:cc'] = 'corrupted';
+      expect(await cache.recall('AA:BB:CC'), isNull);
+    });
+
+    group('entries() + clearEntry()', () {
+      test('entries() is empty before anything is recorded', () async {
+        expect(await cache.entries(), isEmpty);
+      });
+
+      test('entries() returns every recorded MAC with its flag', () async {
+        await cache.record('aa', true);
+        await cache.record('bb', false);
+        final entries = await cache.entries();
+        expect(entries.length, 2);
+        expect(entries['aa'], isTrue);
+        expect(entries['bb'], isFalse);
+      });
+
+      test('clearEntry removes the MAC from entries() and neutralises recall',
+          () async {
+        await cache.record('aa', true);
+        await cache.record('bb', false);
+        await cache.clearEntry('aa');
+        final entries = await cache.entries();
+        expect(entries.keys, isNot(contains('aa')));
+        expect(entries.keys, contains('bb'));
+        expect(await cache.recall('aa'), isNull);
+      });
+    });
+
+    group('overrideFor — drives wake-window suppression (#2268)', () {
+      test('a MAC recorded false yields a no-op suppression override',
+          () async {
+        await cache.record('aa', false);
+        final override = await cache.overrideFor('aa');
+        expect(override, isNotNull);
+        expect(override!.isActive, isFalse,
+            reason: 'a never-needed MAC must suppress the window via a '
+                'no-op WakePolicy');
+      });
+
+      test('a MAC recorded true yields null (honour the adapter policy)',
+          () async {
+        await cache.record('aa', true);
+        expect(await cache.overrideFor('aa'), isNull);
+      });
+
+      test('an unknown MAC yields null (honour the adapter policy)', () async {
+        expect(await cache.overrideFor('never-seen'), isNull);
+      });
+    });
+
+    group('recordObservation — only learns from observed outcomes (#2268)',
+        () {
+      test('answeredImmediately records never-needed (false)', () async {
+        await cache.recordObservation('aa', WakeObservation.answeredImmediately);
+        expect(await cache.recall('aa'), isFalse);
+      });
+
+      test('wokeAfterNudge records wakeNeeded (true)', () async {
+        await cache.recordObservation('aa', WakeObservation.wokeAfterNudge);
+        expect(await cache.recall('aa'), isTrue);
+      });
+
+      test('notRun records NOTHING — no evidence either way', () async {
+        await cache.recordObservation('aa', WakeObservation.notRun);
+        expect(await cache.recall('aa'), isNull);
+        expect(storage.data.keys, isEmpty);
+      });
+
+      test('failed records NOTHING — a failed connect is not positive proof',
+          () async {
+        await cache.recordObservation('aa', WakeObservation.failed);
+        expect(await cache.recall('aa'), isNull);
+        expect(storage.data.keys, isEmpty);
+      });
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/obd2_read_timeout_test.dart
+++ b/test/features/consumption/data/obd2/obd2_read_timeout_test.dart
@@ -144,6 +144,8 @@ class _SlowInterCommandAdapter implements Elm327Adapter {
   List<String> get extraInitCommands => const [];
   @override
   String preParse(String raw) => raw;
+  @override
+  WakePolicy get wakePolicy => const WakePolicy.noop();
 }
 
 /// Transport that answers every command instantly with OK.

--- a/test/features/consumption/data/obd2/obd2_service_wake_window_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_wake_window_test.dart
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_commands.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// Adapter that opts into the bounded wake window (#2268 concern 2) —
+/// stands in for the distinctive STN-/OBDLink-class adapters that are
+/// the only ones meant to seed `maySleep: true`. Init sequence + timing
+/// mirror the generic adapter so only the wake policy differs.
+class _SleepyAdapter implements Elm327Adapter {
+  const _SleepyAdapter({this.maxNudges = 1});
+
+  final int maxNudges;
+
+  @override
+  String get id => 'sleepy-test';
+  @override
+  List<String> get initSequence => Elm327Commands.initCommands;
+  @override
+  Duration get postResetDelay => const Duration(milliseconds: 1);
+  @override
+  Duration get interCommandDelay => const Duration(milliseconds: 1);
+  @override
+  List<String> get extraInitCommands => const [];
+  @override
+  String preParse(String raw) => raw;
+  @override
+  WakePolicy get wakePolicy => WakePolicy(
+        maySleep: true,
+        wakeSettle: const Duration(milliseconds: 600),
+        maxNudges: maxNudges,
+      );
+}
+
+/// Transport that fails the FIRST command a configurable number of times
+/// before answering, and counts attempts per command. Models a sleeping
+/// adapter that ignores the first write(s) until it has woken.
+class _SleepyTransport implements Obd2Transport {
+  _SleepyTransport({
+    this.failFirstCommandTimes = 0,
+    Map<String, String>? responses,
+  }) : _responses = responses ?? const {};
+
+  /// How many times the very first command sent after connect should
+  /// throw (a timeout) before it starts answering.
+  final int failFirstCommandTimes;
+  final Map<String, String> _responses;
+
+  final List<String> log = <String>[];
+  final Map<String, int> attempts = <String, int>{};
+  String? _firstCommand;
+  int _firstCommandFailures = 0;
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+  @override
+  Future<void> connect() async => _connected = true;
+  @override
+  Future<void> disconnect() async => _connected = false;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    log.add(cmd);
+    attempts[cmd] = (attempts[cmd] ?? 0) + 1;
+    _firstCommand ??= cmd;
+    if (cmd == _firstCommand &&
+        _firstCommandFailures < failFirstCommandTimes) {
+      _firstCommandFailures++;
+      throw StateError('simulated sleeping-adapter timeout on $cmd');
+    }
+    return _responses[cmd] ?? 'OK>';
+  }
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  setUp(() {
+    // Collapse the real 600 ms settle to ~near-zero so the suite runs in
+    // milliseconds — we verify the window DID run, not its wall-clock.
+    Obd2Service.wakeSettleScale = 0.0;
+    Obd2Service.connectRetryDelay = const Duration(milliseconds: 1);
+  });
+  tearDown(() {
+    Obd2Service.wakeSettleScale = 1.0;
+    Obd2Service.connectRetryDelay = const Duration(milliseconds: 150);
+  });
+
+  group('Default GenericElm327Adapter — wake window NEVER runs (#2268)', () {
+    test(
+        'a generic connect leaves wakeObservation notRun and does NOT '
+        'add an extra first-command send', () async {
+      final transport = _SleepyTransport(responses: const {
+        'ATZ': 'ELM327 v1.5>',
+        'ATI': 'ELM327 v1.5>',
+      });
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect();
+
+      expect(ok, isTrue);
+      expect(service.wakeObservation, WakeObservation.notRun,
+          reason: 'a no-op WakePolicy must never run the wake window');
+      expect(transport.attempts['ATZ'], 1,
+          reason: 'the first command must be sent exactly once for a '
+              'generic adapter — no extra wake nudge');
+    });
+  });
+
+  group('Active WakePolicy — bounded wake window (#2268 concern 2)', () {
+    test(
+        'first command answers immediately → answeredImmediately, no nudge',
+        () async {
+      final transport = _SleepyTransport(
+        failFirstCommandTimes: 0,
+        responses: const {'ATZ': 'ELM327 v1.5>', 'ATI': 'ELM327 v1.5>'},
+      );
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect(adapter: const _SleepyAdapter());
+
+      expect(ok, isTrue);
+      expect(service.wakeObservation, WakeObservation.answeredImmediately);
+      expect(transport.attempts['ATZ'], 1,
+          reason: 'an awake adapter answers on the first try — no re-send');
+    });
+
+    test(
+        'first command times out once then a nudge succeeds → wokeAfterNudge '
+        'with exactly ONE re-send', () async {
+      final transport = _SleepyTransport(
+        failFirstCommandTimes: 1,
+        responses: const {'ATZ': 'ELM327 v1.5>', 'ATI': 'ELM327 v1.5>'},
+      );
+      final service = Obd2Service(transport);
+
+      final ok = await service.connect(adapter: const _SleepyAdapter());
+
+      expect(ok, isTrue);
+      expect(service.wakeObservation, WakeObservation.wokeAfterNudge,
+          reason: 'a first-command timeout recovered by a longer-settle '
+              're-send is the observed wake outcome');
+      expect(transport.attempts['ATZ'], 2,
+          reason: 'original attempt + exactly one nudge');
+    });
+
+    test(
+        'maxNudges is a hard cap — two timeouts with a single nudge fails '
+        'the connect (bounded, not a loop)', () async {
+      final transport = _SleepyTransport(
+        // Fails twice, but the policy only grants one nudge.
+        failFirstCommandTimes: 2,
+        responses: const {'ATZ': 'ELM327 v1.5>'},
+      );
+      final service = Obd2Service(transport);
+
+      final ok =
+          await service.connect(adapter: const _SleepyAdapter(maxNudges: 1));
+
+      expect(ok, isFalse,
+          reason: 'when the single nudge also times out the connect must '
+              'fail rather than re-send forever');
+      expect(service.wakeObservation, WakeObservation.failed);
+      expect(transport.attempts['ATZ'], 2,
+          reason: 'original + one nudge = two attempts, then it bails');
+    });
+
+    test(
+        'wakePolicyOverride no-op SUPPRESSES the window even for a sleepy '
+        'adapter (cache says never-needed)', () async {
+      final transport = _SleepyTransport(
+        failFirstCommandTimes: 1,
+        responses: const {'ATZ': 'ELM327 v1.5>', 'ATI': 'ELM327 v1.5>'},
+      );
+      final service = Obd2Service(transport);
+
+      // The cache (concern 3) suppresses the window by passing a no-op
+      // override. The first command then runs the steady-state retry only.
+      final ok = await service.connect(
+        adapter: const _SleepyAdapter(),
+        wakePolicyOverride: const WakePolicy.noop(),
+      );
+
+      // With the window suppressed the single failure is still absorbed by
+      // the steady-state one-shot retry, but the wake observation must stay
+      // notRun so the cache is not updated from a suppressed connect.
+      expect(ok, isTrue);
+      expect(service.wakeObservation, WakeObservation.notRun,
+          reason: 'a suppressed window must record no observation');
+    });
+  });
+}


### PR DESCRIPTION
Aggregated OBD2 adapter wake batch (child of #2231), built on the merged connect batch (#2263). Three cohesive wake concerns, **one commit each**.

## Concerns

### 1. WakePolicy seam on `Elm327Adapter` (no-op default)
`WakePolicy { bool maySleep; Duration wakeSettle; int maxNudges }` plus a `wakePolicy` getter on the adapter seam. The default is a **strict no-op** (`maySleep:false`, zero settle, zero nudges) so Generic / vLinker FS / SmartOBD — every adapter paired today — resolve to it. `isActive` reports an inert policy so the connect path short-circuits. No STN/OBDLink `Elm327Adapter` subclasses exist yet, so nothing seeds `maySleep:true` — the seam lands empty, activated per-adapter behind evidence.

### 2. Bounded extra-settle + first-command retry
When (and only when) an active `WakePolicy` applies, the **first** init command on a fresh open gets a purpose-built bounded window: the original attempt, then up to `min(maxNudges, 2)` re-sends, each preceded by a settle of `min(wakeSettle, 3s)`. Longer than the steady-state `_withConnectRetry` blip guard, capped, and **not** an AT "wake byte" (a BLE client cannot wake an ATLP-sleeping ELM327). `connect()` records the outcome on `wakeObservation`. Reconnect routes through the same `connect()`, inheriting the dead-GATT teardown in `connectByMacDirect` (#2243).

### 3. Per-MAC observed-outcome wake cache (NOT per-firmware-string)
`Obd2AdapterWakeCache` keyed per adapter **MAC** (stable per physical device; the firmware string is shared by thousands of clones). Reuses the `obd_adapter_blocklist.dart` Hive pattern (`obdAdapterWake:` prefix + `__ids` index in the `settings` box). Records `wakeNeeded` **only** after an OBSERVED outcome — first command timed out on a fresh connect AND a longer-settle re-send then succeeded (`wokeAfterNudge`→true), or the window ran and the first command answered immediately (`answeredImmediately`→false, suppress forever). `notRun`/`failed` record nothing. Wired into `Obd2ConnectionService` via `overrideFor`/`recordObservation`.

## Default behaviour unchanged
No generic adapter has an active `WakePolicy`, so the wake window never runs, `wakeObservation` stays `notRun`, the cache stays empty, and connect is byte-for-byte unchanged for every paired adapter today.

## Tests
Per-concern, fake-channel: no-op default leaves generics unchanged; bounded-settle retry fires only under an active policy (immediate / one-nudge / capped-failure / cache-suppressed); per-MAC cache records/reads only observed outcomes. Existing OBD2 + connection-service tests stay green.

Codegen: clean `build_runner build`, `.g.dart` drift committed, `git diff --exit-code` clean. `flutter analyze lib test integration_test` → only the 2 pre-existing infos. File-length cap respected (session construction extracted into `buildObd2Session`).

Closes #2268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
