### PR TITLE
feat(data): per-source attribution UI + Italy/Mexico persisted-dataset read-through (#2270)

### DIFF
--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -758,7 +758,8 @@ StationService _createEControl(Ref ref) => EControlStationService();
 // (service_providers.dart) so the in-memory copy also survives rebuilds.
 StationService _createMiteco(Ref ref) =>
     MitecoStationService(cache: ref.read(cacheManagerProvider));
-StationService _createMise(Ref ref) => MiseStationService();
+StationService _createMise(Ref ref) =>
+    MiseStationService(cache: ref.read(cacheManagerProvider));
 StationService _createDenmark(Ref ref) =>
     DenmarkStationService(cache: ref.read(cacheManagerProvider));
 StationService _createArgentina(Ref ref) =>
@@ -766,7 +767,8 @@ StationService _createArgentina(Ref ref) =>
 StationService _createPortugal(Ref ref) => PortugalStationService();
 StationService _createUk(Ref ref) => UkStationService();
 StationService _createAustralia(Ref ref) => const AustraliaStationService();
-StationService _createMexico(Ref ref) => MexicoStationService();
+StationService _createMexico(Ref ref) =>
+    MexicoStationService(cache: ref.read(cacheManagerProvider));
 StationService _createLuxembourg(Ref ref) => LuxembourgStationService();
 StationService _createSlovenia(Ref ref) => SloveniaStationService();
 

--- a/lib/core/services/widgets/data_source_attribution.dart
+++ b/lib/core/services/widgets/data_source_attribution.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../country/country_provider.dart';
+import '../../theme/dark_mode_colors.dart';
+import '../../../l10n/app_localizations.dart';
+import '../country_service_registry.dart';
+
+/// Small, non-intrusive footer crediting the active country's upstream
+/// fuel-price provider (#2270, child of Epic #2249).
+///
+/// Several of the open-data sources we consume require **visible** attribution
+/// — Tankerkönig (CC BY 4.0), France Prix Carburants (Licence Ouverte 2.0),
+/// the UK CMA feeds (Open Government Licence v3.0), Italy's MIMIT
+/// osservaprezzi (IODL 2.0). The provider name + licence are recorded as data
+/// on each country's [FuelServicePolicy]; this widget renders the required
+/// credit line for whichever country is currently active.
+///
+/// The `Source:` label is localised; the provider and licence names are
+/// rendered verbatim from the policy (they are proper nouns / licence
+/// identifiers, not translatable strings).
+///
+/// Renders [SizedBox.shrink] when the active country has no registered policy
+/// (e.g. the demo / unsupported-country fallback), so it never shows an empty
+/// or half-filled credit.
+class DataSourceAttribution extends ConsumerWidget {
+  const DataSourceAttribution({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final country = ref.watch(activeCountryProvider);
+    final policy = CountryServiceRegistry.policyFor(country.code);
+    if (policy == null) return const SizedBox.shrink();
+
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    // Source + licence names are data (proper nouns / licence ids), not ARB.
+    final source = policy.attribution; // i18n-ignore: data source name
+    final license = policy.license; // i18n-ignore: data licence name
+
+    final label = l10n?.dataSourceAttribution(source, license) ??
+        'Source: $source ($license)';
+    final semanticLabel =
+        l10n?.dataSourceAttributionSemantic(source, license) ??
+            'Fuel price data provided by $source, licensed under $license.';
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.info_outline,
+            size: 12,
+            color: DarkModeColors.mutedText(context),
+          ),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(
+              label,
+              semanticsLabel: semanticLabel,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: DarkModeColors.mutedText(context),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -10,6 +10,7 @@ import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_tier.dart';
 import '../../../../core/utils/price_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/services/widgets/data_source_attribution.dart';
 import '../../../../core/services/widgets/freshness_badge.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
@@ -266,6 +267,10 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
             }),
           ),
         ),
+        // #2270 — required open-data attribution for the active country's
+        // upstream source, pinned below the list so it stays visible without
+        // scrolling (CC BY / Licence Ouverte / OGL / IODL all mandate this).
+        const DataSourceAttribution(),
       ],
     );
   }

--- a/lib/features/station_services/italy/mise_station_service.dart
+++ b/lib/features/station_services/italy/mise_station_service.dart
@@ -4,10 +4,12 @@
 import 'package:dio/dio.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
+import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/services/utils/csv_parser.dart';
@@ -28,14 +30,38 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
 
   final Dio _dio;
 
+  /// #2270 — disk persistence (read-through), or null when no cache is wired.
+  /// Persists the parsed registry+price dataset so IT survives a cold start +
+  /// works offline, mirroring DK/AR/ES (#2264 deferred IT on-disk persistence
+  /// because its private record types needed bespoke JSON codecs — added now).
+  final PersistentDataset<_MiseDataset>? _persistent;
+
   /// #2181 — Dio injectable for tests; defaults to the standard factory.
-  MiseStationService({Dio? dio})
+  /// #2270 — [cache] enables the disk read-through; omit it for the pure
+  /// in-memory behaviour the existing parser tests rely on.
+  MiseStationService({Dio? dio, CacheStrategy? cache})
       : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 20),
               receiveTimeout: const Duration(seconds: 60),
               responseType: ResponseType.plain,
-            );
+            ),
+        _persistent = cache == null
+            ? null
+            : PersistentDataset<_MiseDataset>(
+                cache: cache,
+                countryCode: 'IT',
+                datasetName: 'stations',
+                source: ServiceSource.miseApi,
+                serialize: _serializeDataset,
+                deserialize: _deserializeDataset,
+              );
+
+  // #2270 — soft/hard dataset TTLs mirror the IT FuelServicePolicy in the
+  // registry (soft 6 h, hard 24 h). The legacy 2-hour in-memory TTL is the
+  // soft bound now; the persisted read-through governs offline freshness.
+  static const Duration _softTtl = Duration(hours: 6);
+  static const Duration _hardTtl = Duration(hours: 24);
 
   // In-memory cache of parsed data
   Map<String, _StationData>? _cachedStations;
@@ -94,30 +120,46 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
   }
 
   Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
-    // Refresh cache every 2 hours. Both maps are populated from a single
-    // download, so they're cached together as a record — present only when
-    // both are non-null.
+    // Both maps are populated from a single download, so they're cached
+    // together as a record — present only when both are non-null.
     final cached = (_cachedStations != null && _cachedPrices != null)
         ? (_cachedStations!, _cachedPrices!)
         : null;
-    return loadDataset<(Map<String, _StationData>, Map<String, _PriceData>)>(
+    Future<_MiseDataset> fetch() async {
+      // Download both files in parallel
+      final results = await Future.wait([
+        _dio.get<String>(_stationsUrl, cancelToken: cancelToken),
+        _dio.get<String>(_pricesUrl, cancelToken: cancelToken),
+      ]);
+      return (
+        _parseStationsCsv(results[0].data ?? ''),
+        _parsePricesCsv(results[1].data ?? ''),
+      );
+    }
+
+    void store(_MiseDataset value) {
+      _cachedStations = value.$1;
+      _cachedPrices = value.$2;
+    }
+
+    final persistent = _persistent;
+    if (persistent == null) {
+      // No cache wired (unit tests) — preserve the legacy in-memory path.
+      return loadDataset<_MiseDataset>(
+        cached: cached,
+        ttl: const Duration(hours: 2),
+        fetch: fetch,
+        store: store,
+      );
+    }
+    // #2270 — disk read-through: survives cold start + offline.
+    return loadPersistentDataset<_MiseDataset>(
       cached: cached,
-      ttl: const Duration(hours: 2),
-      fetch: () async {
-        // Download both files in parallel
-        final results = await Future.wait([
-          _dio.get<String>(_stationsUrl, cancelToken: cancelToken),
-          _dio.get<String>(_pricesUrl, cancelToken: cancelToken),
-        ]);
-        return (
-          _parseStationsCsv(results[0].data ?? ''),
-          _parsePricesCsv(results[1].data ?? ''),
-        );
-      },
-      store: (value) {
-        _cachedStations = value.$1;
-        _cachedPrices = value.$2;
-      },
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: persistent,
+      fetch: fetch,
+      store: store,
     );
   }
 
@@ -215,6 +257,35 @@ class MiseStationService with StationServiceHelpers, CachedDatasetMixin implemen
   }
 }
 
+/// #2270 — the parsed MISE dataset: the station registry joined-by-id with the
+/// current prices. Both maps come from a single (two-file) download, so they
+/// are persisted and rehydrated together as one record.
+typedef _MiseDataset = (Map<String, _StationData>, Map<String, _PriceData>);
+
+/// #2270 — JSON codec for the persisted IT dataset. Single-letter keys keep
+/// the Hive footprint of the ~25k-station registry + price table down.
+Map<String, dynamic> _serializeDataset(_MiseDataset value) => {
+      's': {for (final e in value.$1.entries) e.key: e.value.toJson()},
+      'p': {for (final e in value.$2.entries) e.key: e.value.toJson()},
+    };
+
+_MiseDataset? _deserializeDataset(Map<String, dynamic> json) {
+  final stationsJson = json['s'];
+  final pricesJson = json['p'];
+  if (stationsJson is! Map || pricesJson is! Map) return null;
+  final stations = <String, _StationData>{
+    for (final e in stationsJson.entries)
+      e.key as String:
+          _StationData.fromJson(Map<String, dynamic>.from(e.value as Map)),
+  };
+  final prices = <String, _PriceData>{
+    for (final e in pricesJson.entries)
+      e.key as String:
+          _PriceData.fromJson(Map<String, dynamic>.from(e.value as Map)),
+  };
+  return (stations, prices);
+}
+
 class _StationData {
   final String brand;
   final String type;
@@ -235,6 +306,28 @@ class _StationData {
     required this.lat,
     required this.lng,
   });
+
+  Map<String, dynamic> toJson() => {
+        'b': brand,
+        't': type,
+        'n': name,
+        'a': address,
+        'c': city,
+        'pv': province,
+        'la': lat,
+        'lo': lng,
+      };
+
+  factory _StationData.fromJson(Map<String, dynamic> j) => _StationData(
+        brand: j['b'] as String? ?? '',
+        type: j['t'] as String? ?? '',
+        name: j['n'] as String? ?? '',
+        address: j['a'] as String? ?? '',
+        city: j['c'] as String? ?? '',
+        province: j['pv'] as String? ?? '',
+        lat: (j['la'] as num?)?.toDouble() ?? 0,
+        lng: (j['lo'] as num?)?.toDouble() ?? 0,
+      );
 }
 
 class _PriceData {
@@ -245,4 +338,25 @@ class _PriceData {
   double? gpl;
   double? metano;
   String? updatedAt;
+
+  _PriceData();
+
+  Map<String, dynamic> toJson() => {
+        if (benzinaSelf != null) 'bs': benzinaSelf,
+        if (benzinaServed != null) 'bv': benzinaServed,
+        if (gasolioSelf != null) 'gs': gasolioSelf,
+        if (gasolioServed != null) 'gv': gasolioServed,
+        if (gpl != null) 'gp': gpl,
+        if (metano != null) 'me': metano,
+        if (updatedAt != null) 'u': updatedAt,
+      };
+
+  factory _PriceData.fromJson(Map<String, dynamic> j) => _PriceData()
+    ..benzinaSelf = (j['bs'] as num?)?.toDouble()
+    ..benzinaServed = (j['bv'] as num?)?.toDouble()
+    ..gasolioSelf = (j['gs'] as num?)?.toDouble()
+    ..gasolioServed = (j['gv'] as num?)?.toDouble()
+    ..gpl = (j['gp'] as num?)?.toDouble()
+    ..metano = (j['me'] as num?)?.toDouble()
+    ..updatedAt = j['u'] as String?;
 }

--- a/lib/features/station_services/mexico/mexico_station_service.dart
+++ b/lib/features/station_services/mexico/mexico_station_service.dart
@@ -9,10 +9,12 @@ import 'package:xml/xml.dart';
 
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
 import '../../../core/error/exceptions.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/cached_dataset_mixin.dart';
+import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
@@ -44,17 +46,50 @@ class MexicoStationService
   final Dio _dio;
   final String _baseUrl;
 
+  /// #2270 — disk persistence (read-through), or null when no cache is wired.
+  /// Persists the merged place+price dataset so MX survives a cold start +
+  /// works offline, mirroring DK/AR/ES (#2264 deferred MX on-disk persistence
+  /// because [_CreStation] needed a bespoke JSON codec — added now).
+  final PersistentDataset<List<_CreStation>>? _persistent;
+
+  /// #2270 — [cache] enables the disk read-through; omit it for the pure
+  /// in-memory behaviour the existing parser tests rely on.
   MexicoStationService({
     Dio? dio,
     String baseUrl = 'https://publicacionexterna.azurewebsites.net/publicaciones',
+    CacheStrategy? cache,
   })  : _dio = dio ??
             DioFactory.create(
               connectTimeout: const Duration(seconds: 15),
               receiveTimeout: const Duration(seconds: 45),
             ),
-        _baseUrl = baseUrl;
+        _baseUrl = baseUrl,
+        _persistent = cache == null
+            ? null
+            : PersistentDataset<List<_CreStation>>(
+                cache: cache,
+                countryCode: 'MX',
+                datasetName: 'stations',
+                source: ServiceSource.mexicoApi,
+                serialize: (stations) =>
+                    {'stations': stations.map((s) => s.toJson()).toList()},
+                deserialize: (json) {
+                  final list = json['stations'] as List<dynamic>?;
+                  if (list == null) return null;
+                  return list
+                      .map((j) => _CreStation.fromJson(
+                          Map<String, dynamic>.from(j as Map)))
+                      .toList();
+                },
+              );
 
   static const Duration _cacheTtl = Duration(hours: 4);
+
+  // #2270 — soft/hard dataset TTLs for the persisted read-through. Soft mirrors
+  // the 4-hour merge cadence (_cacheTtl); the 24-hour hard bound is the offline
+  // grace window past which a blocking re-pull is forced.
+  static const Duration _softTtl = _cacheTtl;
+  static const Duration _hardTtl = Duration(hours: 24);
 
   List<_CreStation>? _cachedStations;
 
@@ -103,13 +138,28 @@ class MexicoStationService
   // #2264 — migrated onto CachedDatasetMixin: the manual _lastFetch + TTL
   // diff is replaced by loadDataset's guard→fetch→store→mark idiom, matching
   // the other bulk-dataset services (ES/IT/AR/DK).
-  Future<void> _ensureDataLoaded(CancelToken? cancelToken) =>
-      loadDataset<List<_CreStation>>(
+  // #2270 — when a cache is wired the merged dataset is persisted to Hive with
+  // a disk read-through so it survives a cold start + works offline.
+  Future<void> _ensureDataLoaded(CancelToken? cancelToken) {
+    final persistent = _persistent;
+    if (persistent == null) {
+      // No cache wired (unit tests) — preserve the legacy in-memory path.
+      return loadDataset<List<_CreStation>>(
         cached: _cachedStations,
         ttl: _cacheTtl,
         fetch: () => _fetchMerged(cancelToken),
         store: (value) => _cachedStations = value,
       );
+    }
+    return loadPersistentDataset<List<_CreStation>>(
+      cached: _cachedStations,
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: persistent,
+      fetch: () => _fetchMerged(cancelToken),
+      store: (value) => _cachedStations = value,
+    );
+  }
 
   Future<List<_CreStation>> _fetchMerged(CancelToken? cancelToken) async {
     final responses = await Future.wait([
@@ -286,6 +336,28 @@ class _CreStation {
     required this.premium,
     required this.diesel,
   });
+
+  /// #2270 — compact JSON for the persisted dataset (single-letter keys keep
+  /// the ~13k-station merged dataset's Hive footprint down).
+  Map<String, dynamic> toJson() => {
+        'i': id,
+        'n': name,
+        'la': lat,
+        'lo': lng,
+        if (regular != null) 'r': regular,
+        if (premium != null) 'p': premium,
+        if (diesel != null) 'd': diesel,
+      };
+
+  factory _CreStation.fromJson(Map<String, dynamic> j) => _CreStation(
+        id: j['i'] as String? ?? '',
+        name: j['n'] as String? ?? '',
+        lat: (j['la'] as num?)?.toDouble() ?? 0,
+        lng: (j['lo'] as num?)?.toDouble() ?? 0,
+        regular: (j['r'] as num?)?.toDouble(),
+        premium: (j['p'] as num?)?.toDouble(),
+        diesel: (j['d'] as num?)?.toDouble(),
+      );
 }
 
 class _CrePlace {

--- a/lib/l10n/_fragments/data_attribution_de.arb
+++ b/lib/l10n/_fragments/data_attribution_de.arb
@@ -1,0 +1,30 @@
+{
+  "dataSourceAttribution": "Quelle: {source} ({license})",
+  "@dataSourceAttribution": {
+    "description": "Small non-intrusive line under the search results crediting the upstream fuel-price provider for the active country, satisfying the open-data licences that mandate visible attribution (CC BY / Licence Ouverte / OGL / IODL). 'Source:' is the localised label; {source} and {license} are data — proper-noun provider + licence names rendered verbatim from the country's FuelServicePolicy (#2270).",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  },
+  "dataSourceAttributionSemantic": "Spritpreisdaten bereitgestellt von {source}, lizenziert unter {license}.",
+  "@dataSourceAttributionSemantic": {
+    "description": "Screen-reader label for the data-source attribution line under the search results — spells out the abbreviated 'Source: … (…)' visual into a full sentence (#2270). {source} and {license} are data (provider + licence names) from the country's FuelServicePolicy.",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  }
+}

--- a/lib/l10n/_fragments/data_attribution_en.arb
+++ b/lib/l10n/_fragments/data_attribution_en.arb
@@ -1,0 +1,30 @@
+{
+  "dataSourceAttribution": "Source: {source} ({license})",
+  "@dataSourceAttribution": {
+    "description": "Small non-intrusive line under the search results crediting the upstream fuel-price provider for the active country, satisfying the open-data licences that mandate visible attribution (CC BY / Licence Ouverte / OGL / IODL). 'Source:' is the localised label; {source} and {license} are data — proper-noun provider + licence names rendered verbatim from the country's FuelServicePolicy (#2270).",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  },
+  "dataSourceAttributionSemantic": "Fuel price data provided by {source}, licensed under {license}.",
+  "@dataSourceAttributionSemantic": {
+    "description": "Screen-reader label for the data-source attribution line under the search results — spells out the abbreviated 'Source: … (…)' visual into a full sentence (#2270). {source} and {license} are data (provider + licence names) from the country's FuelServicePolicy.",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  }
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Отмяна",
   "tripShareRevoked": "Споделянето е отменено.",
   "trajetsSharedSectionTitle": "Споделено с мен",
-  "trajetsSharedBadge": "Споделено"
+  "trajetsSharedBadge": "Споделено",
+  "dataSourceAttribution": "Източник: {source} ({license})",
+  "dataSourceAttributionSemantic": "Данните за цените на горивата са предоставени от {source}, лицензирани под {license}."
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Zrušit",
   "tripShareRevoked": "Sdílení zrušeno.",
   "trajetsSharedSectionTitle": "Sdíleno se mnou",
-  "trajetsSharedBadge": "Sdíleno"
+  "trajetsSharedBadge": "Sdíleno",
+  "dataSourceAttribution": "Zdroj: {source} ({license})",
+  "dataSourceAttributionSemantic": "Údaje o cenách paliv poskytuje {source}, licencováno pod {license}."
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Tilbagekald",
   "tripShareRevoked": "Deling tilbagekaldt.",
   "trajetsSharedSectionTitle": "Delt med mig",
-  "trajetsSharedBadge": "Delt"
+  "trajetsSharedBadge": "Delt",
+  "dataSourceAttribution": "Kilde: {source} ({license})",
+  "dataSourceAttributionSemantic": "Brændstofprisdata leveret af {source}, licenseret under {license}."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1693,6 +1693,34 @@
   "@crossBorderDismissTooltip": {
     "description": "Tooltip on the cross-border banner's dismiss icon."
   },
+  "dataSourceAttribution": "Quelle: {source} ({license})",
+  "@dataSourceAttribution": {
+    "description": "Small non-intrusive line under the search results crediting the upstream fuel-price provider for the active country, satisfying the open-data licences that mandate visible attribution (CC BY / Licence Ouverte / OGL / IODL). 'Source:' is the localised label; {source} and {license} are data — proper-noun provider + licence names rendered verbatim from the country's FuelServicePolicy (#2270).",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  },
+  "dataSourceAttributionSemantic": "Spritpreisdaten bereitgestellt von {source}, lizenziert unter {license}.",
+  "@dataSourceAttributionSemantic": {
+    "description": "Screen-reader label for the data-source attribution line under the search results — spells out the abbreviated 'Source: … (…)' visual into a full sentence (#2270). {source} and {license} are data (provider + licence names) from the country's FuelServicePolicy.",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  },
   "developerToolsSectionTitle": "Entwicklerwerkzeuge",
   "developerToolsSubtitle": "Diagnose und Werkzeuge zur Fehlersuche — nur im Entwickler-/Debug-Modus sichtbar.",
   "developerToolsMenuSubtitle": "Fehlerprotokoll, Test-Alarme, Diagnose",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Ανάκληση",
   "tripShareRevoked": "Η κοινοποίηση ανακλήθηκε.",
   "trajetsSharedSectionTitle": "Κοινοποιήθηκε σε εμένα",
-  "trajetsSharedBadge": "Κοινόχρηστο"
+  "trajetsSharedBadge": "Κοινόχρηστο",
+  "dataSourceAttribution": "Πηγή: {source} ({license})",
+  "dataSourceAttributionSemantic": "Δεδομένα τιμών καυσίμων από {source}, με άδεια {license}."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2410,6 +2410,34 @@
   "@crossBorderDismissTooltip": {
     "description": "Tooltip on the cross-border banner's dismiss icon."
   },
+  "dataSourceAttribution": "Source: {source} ({license})",
+  "@dataSourceAttribution": {
+    "description": "Small non-intrusive line under the search results crediting the upstream fuel-price provider for the active country, satisfying the open-data licences that mandate visible attribution (CC BY / Licence Ouverte / OGL / IODL). 'Source:' is the localised label; {source} and {license} are data — proper-noun provider + licence names rendered verbatim from the country's FuelServicePolicy (#2270).",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  },
+  "dataSourceAttributionSemantic": "Fuel price data provided by {source}, licensed under {license}.",
+  "@dataSourceAttributionSemantic": {
+    "description": "Screen-reader label for the data-source attribution line under the search results — spells out the abbreviated 'Source: … (…)' visual into a full sentence (#2270). {source} and {license} are data (provider + licence names) from the country's FuelServicePolicy.",
+    "placeholders": {
+      "source": {
+        "type": "String",
+        "example": "Tankerkönig"
+      },
+      "license": {
+        "type": "String",
+        "example": "CC BY 4.0"
+      }
+    }
+  },
   "developerToolsSectionTitle": "Developer tools",
   "@developerToolsSectionTitle": {
     "description": "Title of the Settings section / screen hosting dev-only diagnostics, shown only when Developer / Debug mode is on (#2248)."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1166,6 +1166,8 @@
   "crossBorderCheaper": "⟦{country} šŧáŧîóñš {km} ķɱ áŵáý — €{price}/Ł çĥéáƥéř ··········⟧",
   "crossBorderTapToSwitch": "⟦Ŧáƥ ŧó šŵîŧçĥ çóúñŧřý ········⟧",
   "crossBorderDismissTooltip": "⟦Đîšɱîšš ···⟧",
+  "dataSourceAttribution": "⟦Šóúřçé: {source} ({license}) ···⟧",
+  "dataSourceAttributionSemantic": "⟦Ƒúéł ƥřîçé đáŧá ƥřóṽîđéđ ƀý {source}, łîçéñšéđ úñđéř {license}. ················⟧",
   "developerToolsSectionTitle": "⟦Đéṽéłóƥéř ŧóółš ······⟧",
   "developerToolsSubtitle": "⟦Đîáǧñóšŧîçš áñđ ŧóółš ƒóř đéƀúǧǧîñǧ — óñłý ṽîšîƀłé îñ Đéṽéłóƥéř / Đéƀúǧ ɱóđé. ····························⟧",
   "developerToolsMenuSubtitle": "⟦Éřřóř łóǧ, ŧéšŧ áłéřŧš, đîáǧñóšŧîçš ·············⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Revocar",
   "tripShareRevoked": "Uso compartido revocado.",
   "trajetsSharedSectionTitle": "Compartido conmigo",
-  "trajetsSharedBadge": "Compartido"
+  "trajetsSharedBadge": "Compartido",
+  "dataSourceAttribution": "Fuente: {source} ({license})",
+  "dataSourceAttributionSemantic": "Datos de precios de combustible proporcionados por {source}, con licencia {license}."
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Tühista",
   "tripShareRevoked": "Jagamine tühistatud.",
   "trajetsSharedSectionTitle": "Minuga jagatud",
-  "trajetsSharedBadge": "Jagatud"
+  "trajetsSharedBadge": "Jagatud",
+  "dataSourceAttribution": "Allikas: {source} ({license})",
+  "dataSourceAttributionSemantic": "Kütusehindade andmed pärinevad allikast {source}, litsentsitud litsentsi {license} alusel."
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Peruuta",
   "tripShareRevoked": "Jakaminen peruutettu.",
   "trajetsSharedSectionTitle": "Jaettu kanssani",
-  "trajetsSharedBadge": "Jaettu"
+  "trajetsSharedBadge": "Jaettu",
+  "dataSourceAttribution": "Lähde: {source} ({license})",
+  "dataSourceAttributionSemantic": "Polttoaineiden hintatiedot tarjoaa {source}, lisensoitu lisenssillä {license}."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2084,5 +2084,7 @@
   "tripShareRevokeTooltip": "Révoquer",
   "tripShareRevoked": "Partage révoqué.",
   "trajetsSharedSectionTitle": "Partagé avec moi",
-  "trajetsSharedBadge": "Partagé"
+  "trajetsSharedBadge": "Partagé",
+  "dataSourceAttribution": "Source : {source} ({license})",
+  "dataSourceAttributionSemantic": "Données de prix des carburants fournies par {source}, sous licence {license}."
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Opozovi",
   "tripShareRevoked": "Dijeljenje opozvano.",
   "trajetsSharedSectionTitle": "Podijeljeno sa mnom",
-  "trajetsSharedBadge": "Podijeljeno"
+  "trajetsSharedBadge": "Podijeljeno",
+  "dataSourceAttribution": "Izvor: {source} ({license})",
+  "dataSourceAttributionSemantic": "Podatke o cijenama goriva pruža {source}, licencirano pod {license}."
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Visszavonás",
   "tripShareRevoked": "Megosztás visszavonva.",
   "trajetsSharedSectionTitle": "Velem megosztva",
-  "trajetsSharedBadge": "Megosztva"
+  "trajetsSharedBadge": "Megosztva",
+  "dataSourceAttribution": "Forrás: {source} ({license})",
+  "dataSourceAttributionSemantic": "Az üzemanyagár-adatokat a(z) {source} biztosítja, a(z) {license} licenc alatt."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Revoca",
   "tripShareRevoked": "Condivisione revocata.",
   "trajetsSharedSectionTitle": "Condiviso con me",
-  "trajetsSharedBadge": "Condiviso"
+  "trajetsSharedBadge": "Condiviso",
+  "dataSourceAttribution": "Fonte: {source} ({license})",
+  "dataSourceAttributionSemantic": "Dati sui prezzi dei carburanti forniti da {source}, con licenza {license}."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7149,6 +7149,18 @@ abstract class AppLocalizations {
   /// **'Dismiss'**
   String get crossBorderDismissTooltip;
 
+  /// Small non-intrusive line under the search results crediting the upstream fuel-price provider for the active country, satisfying the open-data licences that mandate visible attribution (CC BY / Licence Ouverte / OGL / IODL). 'Source:' is the localised label; {source} and {license} are data — proper-noun provider + licence names rendered verbatim from the country's FuelServicePolicy (#2270).
+  ///
+  /// In en, this message translates to:
+  /// **'Source: {source} ({license})'**
+  String dataSourceAttribution(String source, String license);
+
+  /// Screen-reader label for the data-source attribution line under the search results — spells out the abbreviated 'Source: … (…)' visual into a full sentence (#2270). {source} and {license} are data (provider + licence names) from the country's FuelServicePolicy.
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel price data provided by {source}, licensed under {license}.'**
+  String dataSourceAttributionSemantic(String source, String license);
+
   /// Title of the Settings section / screen hosting dev-only diagnostics, shown only when Developer / Debug mode is on (#2248).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3953,6 +3953,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Затвори';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Източник: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Данните за цените на горивата са предоставени от $source, лицензирани под $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Инструменти за разработчици';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3930,6 +3930,16 @@ class AppLocalizationsCs extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Zavřít';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Zdroj: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Údaje o cenách paliv poskytuje $source, licencováno pod $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Nástroje pro vývojáře';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3924,6 +3924,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Afvis';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Kilde: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Brændstofprisdata leveret af $source, licenseret under $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Udviklerværktøjer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3946,6 +3946,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Schließen';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Quelle: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Spritpreisdaten bereitgestellt von $source, lizenziert unter $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Entwicklerwerkzeuge';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3956,6 +3956,16 @@ class AppLocalizationsEl extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Απόρριψη';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Πηγή: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Δεδομένα τιμών καυσίμων από $source, με άδεια $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Εργαλεία προγραμματιστή';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3905,6 +3905,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Dismiss';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Source: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Fuel price data provided by $source, licensed under $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Developer tools';
 
   @override
@@ -9691,6 +9701,16 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get crossBorderDismissTooltip => '⟦Đîšɱîšš ···⟧';
+
+  @override
+  String dataSourceAttribution(String source, String license) {
+    return '⟦Šóúřçé: $source ($license) ···⟧';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return '⟦Ƒúéł ƥřîçé đáŧá ƥřóṽîđéđ ƀý $source, łîçéñšéđ úñđéř $license. ················⟧';
+  }
 
   @override
   String get developerToolsSectionTitle => '⟦Đéṽéłóƥéř ŧóółš ······⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3949,6 +3949,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Descartar';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Fuente: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Datos de precios de combustible proporcionados por $source, con licencia $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Herramientas de desarrollo';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3920,6 +3920,16 @@ class AppLocalizationsEt extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Sulge';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Allikas: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Kütusehindade andmed pärinevad allikast $source, litsentsitud litsentsi $license alusel.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Arendaja tööriistad';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3924,6 +3924,16 @@ class AppLocalizationsFi extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Sulje';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Lähde: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Polttoaineiden hintatiedot tarjoaa $source, lisensoitu lisenssillä $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Kehittäjätyökalut';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3962,6 +3962,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Ignorer';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Source : $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Données de prix des carburants fournies par $source, sous licence $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Outils de développement';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3932,6 +3932,16 @@ class AppLocalizationsHr extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Odbaci';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Izvor: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Podatke o cijenama goriva pruža $source, licencirano pod $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Razvojni alati';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3953,6 +3953,16 @@ class AppLocalizationsHu extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Elvetés';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Forrás: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Az üzemanyagár-adatokat a(z) $source biztosítja, a(z) $license licenc alatt.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Fejlesztői eszközök';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3941,6 +3941,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Ignora';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Fonte: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Dati sui prezzi dei carburanti forniti da $source, con licenza $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Strumenti di sviluppo';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3945,6 +3945,16 @@ class AppLocalizationsLt extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Atmesti';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Šaltinis: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Degalų kainų duomenis teikia $source, licencijuota pagal $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Kūrėjo įrankiai';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3949,6 +3949,16 @@ class AppLocalizationsLv extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Aizvērt';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Avots: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Degvielas cenu datus nodrošina $source, licencēts saskaņā ar $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Izstrādātāja rīki';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3922,6 +3922,16 @@ class AppLocalizationsNb extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Lukk';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Kilde: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Drivstoffprisdata levert av $source, lisensiert under $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Utviklerverktøy';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3940,6 +3940,16 @@ class AppLocalizationsNl extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Sluiten';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Bron: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Brandstofprijsgegevens geleverd door $source, gelicentieerd onder $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Ontwikkelaarstools';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3937,6 +3937,16 @@ class AppLocalizationsPl extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Odrzuć';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Źródło: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Dane o cenach paliw dostarcza $source, na licencji $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Narzędzia programisty';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3950,6 +3950,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Ignorar';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Fonte: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Dados de preços de combustível fornecidos por $source, licenciados sob $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Ferramentas de programador';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3949,6 +3949,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Respingeți';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Sursă: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Datele privind prețurile carburanților sunt furnizate de $source, licențiate sub $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Instrumente pentru dezvoltatori';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3942,6 +3942,16 @@ class AppLocalizationsSk extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Zatvoriť';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Zdroj: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Údaje o cenách palív poskytuje $source, licencované pod $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Nástroje pre vývojárov';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3928,6 +3928,16 @@ class AppLocalizationsSl extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Zapri';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Vir: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Podatke o cenah goriva zagotavlja $source, licencirano pod $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Razvijalska orodja';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3925,6 +3925,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get crossBorderDismissTooltip => 'Avfärda';
 
   @override
+  String dataSourceAttribution(String source, String license) {
+    return 'Källa: $source ($license)';
+  }
+
+  @override
+  String dataSourceAttributionSemantic(String source, String license) {
+    return 'Bränsleprisdata tillhandahålls av $source, licensierad under $license.';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Utvecklarverktyg';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Atšaukti",
   "tripShareRevoked": "Bendrinimas atšauktas.",
   "trajetsSharedSectionTitle": "Bendrinama su manimi",
-  "trajetsSharedBadge": "Bendrinama"
+  "trajetsSharedBadge": "Bendrinama",
+  "dataSourceAttribution": "Šaltinis: {source} ({license})",
+  "dataSourceAttributionSemantic": "Degalų kainų duomenis teikia {source}, licencijuota pagal {license}."
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Atsaukt",
   "tripShareRevoked": "Kopīgošana atsaukta.",
   "trajetsSharedSectionTitle": "Kopīgots ar mani",
-  "trajetsSharedBadge": "Kopīgots"
+  "trajetsSharedBadge": "Kopīgots",
+  "dataSourceAttribution": "Avots: {source} ({license})",
+  "dataSourceAttributionSemantic": "Degvielas cenu datus nodrošina {source}, licencēts saskaņā ar {license}."
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Tilbakekall",
   "tripShareRevoked": "Deling tilbakekalt.",
   "trajetsSharedSectionTitle": "Delt med meg",
-  "trajetsSharedBadge": "Delt"
+  "trajetsSharedBadge": "Delt",
+  "dataSourceAttribution": "Kilde: {source} ({license})",
+  "dataSourceAttributionSemantic": "Drivstoffprisdata levert av {source}, lisensiert under {license}."
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Intrekken",
   "tripShareRevoked": "Delen ingetrokken.",
   "trajetsSharedSectionTitle": "Met mij gedeeld",
-  "trajetsSharedBadge": "Gedeeld"
+  "trajetsSharedBadge": "Gedeeld",
+  "dataSourceAttribution": "Bron: {source} ({license})",
+  "dataSourceAttributionSemantic": "Brandstofprijsgegevens geleverd door {source}, gelicentieerd onder {license}."
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Cofnij",
   "tripShareRevoked": "Udostępnianie cofnięte.",
   "trajetsSharedSectionTitle": "Udostępnione mnie",
-  "trajetsSharedBadge": "Udostępnione"
+  "trajetsSharedBadge": "Udostępnione",
+  "dataSourceAttribution": "Źródło: {source} ({license})",
+  "dataSourceAttributionSemantic": "Dane o cenach paliw dostarcza {source}, na licencji {license}."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Revogar",
   "tripShareRevoked": "Partilha revogada.",
   "trajetsSharedSectionTitle": "Partilhado comigo",
-  "trajetsSharedBadge": "Partilhado"
+  "trajetsSharedBadge": "Partilhado",
+  "dataSourceAttribution": "Fonte: {source} ({license})",
+  "dataSourceAttributionSemantic": "Dados de preços de combustível fornecidos por {source}, licenciados sob {license}."
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Revocă",
   "tripShareRevoked": "Partajare revocată.",
   "trajetsSharedSectionTitle": "Partajat cu mine",
-  "trajetsSharedBadge": "Partajat"
+  "trajetsSharedBadge": "Partajat",
+  "dataSourceAttribution": "Sursă: {source} ({license})",
+  "dataSourceAttributionSemantic": "Datele privind prețurile carburanților sunt furnizate de {source}, licențiate sub {license}."
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Zrušiť",
   "tripShareRevoked": "Zdieľanie zrušené.",
   "trajetsSharedSectionTitle": "Zdieľané so mnou",
-  "trajetsSharedBadge": "Zdieľané"
+  "trajetsSharedBadge": "Zdieľané",
+  "dataSourceAttribution": "Zdroj: {source} ({license})",
+  "dataSourceAttributionSemantic": "Údaje o cenách palív poskytuje {source}, licencované pod {license}."
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Prekliči",
   "tripShareRevoked": "Deljenje preklicano.",
   "trajetsSharedSectionTitle": "Deljeno z mano",
-  "trajetsSharedBadge": "Deljeno"
+  "trajetsSharedBadge": "Deljeno",
+  "dataSourceAttribution": "Vir: {source} ({license})",
+  "dataSourceAttributionSemantic": "Podatke o cenah goriva zagotavlja {source}, licencirano pod {license}."
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -1956,5 +1956,7 @@
   "tripShareRevokeTooltip": "Återkalla",
   "tripShareRevoked": "Delning återkallad.",
   "trajetsSharedSectionTitle": "Delad med mig",
-  "trajetsSharedBadge": "Delad"
+  "trajetsSharedBadge": "Delad",
+  "dataSourceAttribution": "Källa: {source} ({license})",
+  "dataSourceAttributionSemantic": "Bränsleprisdata tillhandahålls av {source}, licensierad under {license}."
 }

--- a/test/core/services/widgets/data_source_attribution_test.dart
+++ b/test/core/services/widgets/data_source_attribution_test.dart
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/country/country_provider.dart';
+import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/core/services/widgets/data_source_attribution.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// #2270 — the per-source data attribution must be surfaced for the active
+/// country, satisfying the open-data licences that mandate visible credit
+/// (CC BY / Licence Ouverte / OGL / IODL). These tests assert the active
+/// country's `FuelServicePolicy.attribution` + `license` actually render.
+
+class _FixedCountry extends ActiveCountry {
+  _FixedCountry(this._country);
+  final CountryConfig _country;
+  @override
+  CountryConfig build() => _country;
+}
+
+Future<void> _pump(WidgetTester tester, CountryConfig country) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        activeCountryProvider.overrideWith(() => _FixedCountry(country)),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: DataSourceAttribution()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('DataSourceAttribution (#2270)', () {
+    testWidgets('surfaces the active country\'s source + licence (DE)',
+        (tester) async {
+      await _pump(tester, Countries.germany);
+
+      final policy = CountryServiceRegistry.policyFor('DE')!;
+      expect(policy.attribution, 'Tankerkönig');
+      expect(policy.license, 'CC BY 4.0');
+
+      // Both the provider name and the licence must be visible on screen.
+      expect(
+        find.textContaining(policy.attribution),
+        findsOneWidget,
+        reason: 'the active source name must be rendered',
+      );
+      expect(
+        find.textContaining(policy.license),
+        findsOneWidget,
+        reason: 'the source licence must be rendered',
+      );
+    });
+
+    testWidgets('renders France Licence Ouverte attribution', (tester) async {
+      await _pump(tester, Countries.france);
+
+      final policy = CountryServiceRegistry.policyFor('FR')!;
+      expect(find.textContaining(policy.attribution), findsOneWidget);
+      expect(find.textContaining(policy.license), findsOneWidget);
+      // Sanity: France's licence is the Licence Ouverte the screen must credit.
+      expect(policy.license, contains('Licence Ouverte'));
+    });
+
+    testWidgets('renders Italy IODL attribution', (tester) async {
+      await _pump(tester, Countries.italy);
+      final policy = CountryServiceRegistry.policyFor('IT')!;
+      expect(find.textContaining(policy.attribution), findsOneWidget);
+      expect(find.textContaining(policy.license), findsOneWidget);
+      expect(policy.license, contains('IODL'));
+    });
+
+    testWidgets('renders Mexico attribution', (tester) async {
+      await _pump(tester, Countries.mexico);
+      final policy = CountryServiceRegistry.policyFor('MX')!;
+      expect(find.textContaining(policy.attribution), findsOneWidget);
+      expect(find.textContaining(policy.license), findsOneWidget);
+    });
+
+    testWidgets('renders nothing for an unregistered country', (tester) async {
+      // A CountryConfig whose code has no registry entry → no policy → the
+      // widget collapses rather than showing a half-empty credit.
+      const unknown = CountryConfig(
+        code: 'ZZ',
+        name: 'Nowhere',
+        flag: '🏴',
+        locale: 'en',
+        postalCodeLength: 5,
+        postalCodeRegex: r'^\d{5}$',
+        postalCodeLabel: 'ZIP',
+      );
+      expect(CountryServiceRegistry.policyFor('ZZ'), isNull);
+
+      await _pump(tester, unknown);
+      expect(find.byType(Text), findsNothing);
+    });
+  });
+}

--- a/test/features/station_services/italy_mexico_persisted_dataset_test.dart
+++ b/test/features/station_services/italy_mexico_persisted_dataset_test.dart
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/services/persistent_dataset.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/italy/mise_station_service.dart';
+import 'package:tankstellen/features/station_services/mexico/mexico_station_service.dart';
+
+/// #2270 concern 2 — Italy (MIMIT CSV) + Mexico (CRE XML) bulk datasets now
+/// carry bespoke JSON codecs and persist to Hive with a disk read-through, so
+/// they survive a cold start + work offline exactly like DK/AR/ES (#2264). The
+/// codec round-trip is exercised end-to-end: warm one instance, then prove a
+/// fresh instance answers from the persisted copy without any network call,
+/// and still answers when the network is offline. Search results are preserved.
+
+/// In-memory CacheStorage so CacheManager works without Hive.
+class _MemStorage implements CacheStorage {
+  final Map<String, dynamic> _box = {};
+
+  @override
+  Future<void> cacheData(String key, dynamic data) async {
+    if (data == null) {
+      _box.remove(key);
+    } else {
+      _box[key] = data;
+    }
+  }
+
+  @override
+  Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
+    final v = _box[key];
+    return v is Map ? Map<String, dynamic>.from(v) : null;
+  }
+
+  @override
+  Future<void> clearCache() async => _box.clear();
+
+  @override
+  int get cacheEntryCount => _box.length;
+
+  @override
+  Iterable<dynamic> get cacheKeys => _box.keys;
+
+  @override
+  Future<void> deleteCacheEntry(String key) async => _box.remove(key);
+}
+
+/// Maps request URLs to canned bodies and counts every network hit, so a test
+/// can assert a cold instance served from disk (zero calls). Optionally fails
+/// after [failAfter] calls to simulate going offline.
+class _MapAdapter implements HttpClientAdapter {
+  _MapAdapter(this.bodies, {this.failAfter});
+  final Map<String, String> bodies;
+  final int? failAfter;
+  int calls = 0;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<void>? cancelFuture) async {
+    calls++;
+    if (failAfter != null && calls > failAfter!) {
+      throw DioException(
+        type: DioExceptionType.connectionError,
+        requestOptions: options,
+        message: 'offline',
+      );
+    }
+    final url = options.uri.toString();
+    final body = bodies[url] ?? '';
+    return ResponseBody.fromBytes(utf8.encode(body), 200, headers: {
+      Headers.contentTypeHeader: ['text/plain'],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+// ── Italy (MIMIT CSV) fixtures ─────────────────────────────────────────────
+const _itStationsUrl =
+    'https://www.mimit.gov.it/images/exportCSV/anagrafica_impianti_attivi.csv';
+const _itPricesUrl =
+    'https://www.mimit.gov.it/images/exportCSV/prezzo_alle_8.csv';
+
+const _itStationsCsv = 'Data aggiornamento\n'
+    'idImpianto|Gestore|Bandiera|TipoImpianto|NomeImpianto|Indirizzo|Comune|Provincia|Latitudine|Longitudine\n'
+    '12345|ROSSI SRL|Eni|Stradale|Eni Rossi|Via Roma 1|Roma|RM|41.9028|12.4964';
+const _itPricesCsv = 'Data aggiornamento\n'
+    'idImpianto|descCarburante|prezzo|isSelf|dtComu\n'
+    '12345|Benzina|1.879|1|29/03/2026 08:00:00\n'
+    '12345|Gasolio|1.659|1|29/03/2026 08:00:00';
+
+const _romaParams = SearchParams(lat: 41.9028, lng: 12.4964, radiusKm: 20);
+
+MiseStationService _italy(CacheManager cache, HttpClientAdapter adapter) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return MiseStationService(dio: dio, cache: cache);
+}
+
+Map<String, String> get _itBodies =>
+    {_itStationsUrl: _itStationsCsv, _itPricesUrl: _itPricesCsv};
+
+// ── Mexico (CRE XML) fixtures ──────────────────────────────────────────────
+const _mxPlacesUrl = 'https://fake.cre/publicaciones/places';
+const _mxPricesUrl = 'https://fake.cre/publicaciones/prices';
+
+const _mxPlacesXml = '<?xml version="1.0" encoding="utf-8"?>\n'
+    '<places>'
+    '<place place_id="11702"><name>Gasolinera Centro</name>'
+    '<location><x>-99.13</x><y>19.43</y></location></place>'
+    '</places>';
+const _mxPricesXml = '<?xml version="1.0" encoding="utf-8"?>\n'
+    '<places>'
+    '<place place_id="11702">'
+    '<gas_price type="regular">22.95</gas_price>'
+    '<gas_price type="premium">24.89</gas_price>'
+    '<gas_price type="diesel">23.45</gas_price>'
+    '</place>'
+    '</places>';
+
+const _cdmxParams = SearchParams(lat: 19.43, lng: -99.13, radiusKm: 10);
+
+MexicoStationService _mexico(CacheManager cache, HttpClientAdapter adapter) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return MexicoStationService(
+    dio: dio,
+    baseUrl: 'https://fake.cre/publicaciones',
+    cache: cache,
+  );
+}
+
+Map<String, String> get _mxBodies =>
+    {_mxPlacesUrl: _mxPlacesXml, _mxPricesUrl: _mxPricesXml};
+
+void main() {
+  group('Italy MIMIT persisted dataset read-through (#2270)', () {
+    test('first search downloads and persists under the dataset: key',
+        () async {
+      final cache = CacheManager(_MemStorage());
+      final result =
+          await _italy(cache, _MapAdapter(_itBodies)).searchStations(_romaParams);
+
+      expect(result.data, isNotEmpty);
+      expect(result.data.first.e5, closeTo(1.879, 0.001));
+      expect(cache.get(PersistentDataset.datasetKey('IT', 'stations')),
+          isNotNull,
+          reason: 'IT dataset must be persisted to the shared cache');
+    });
+
+    test('codec round-trips: a cold instance reads from disk, no network call',
+        () async {
+      final cache = CacheManager(_MemStorage());
+      await _italy(cache, _MapAdapter(_itBodies)).searchStations(_romaParams);
+
+      final coldAdapter = _MapAdapter(_itBodies);
+      final cold = _italy(cache, coldAdapter);
+      final result = await cold.searchStations(_romaParams);
+
+      expect(coldAdapter.calls, 0,
+          reason: 'persisted IT dataset must be served from disk');
+      // Search results preserved across the toJson/fromJson round-trip.
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.name, 'Eni Rossi');
+      expect(s.brand, 'Eni');
+      expect(s.e5, closeTo(1.879, 0.001));
+      expect(s.diesel, closeTo(1.659, 0.001));
+      expect(s.updatedAt, '29/03 08:00');
+    });
+
+    test('serves the persisted copy when the network is offline', () async {
+      final cache = CacheManager(_MemStorage());
+      await _italy(cache, _MapAdapter(_itBodies)).searchStations(_romaParams);
+
+      final offline = _italy(cache, _MapAdapter(_itBodies, failAfter: 0));
+      final result = await offline.searchStations(_romaParams);
+      expect(result.data, isNotEmpty,
+          reason: 'offline search must fall back to the persisted IT dataset');
+    });
+
+    test('with no cache wired the legacy in-memory path still works', () async {
+      final dio = Dio()..httpClientAdapter = _MapAdapter(_itBodies);
+      final result =
+          await MiseStationService(dio: dio).searchStations(_romaParams);
+      expect(result.data, isNotEmpty);
+    });
+  });
+
+  group('Mexico CRE persisted dataset read-through (#2270)', () {
+    test('first search downloads and persists under the dataset: key',
+        () async {
+      final cache = CacheManager(_MemStorage());
+      final result = await _mexico(cache, _MapAdapter(_mxBodies))
+          .searchStations(_cdmxParams);
+
+      expect(result.data, isNotEmpty);
+      expect(result.data.first.e5, 22.95);
+      expect(cache.get(PersistentDataset.datasetKey('MX', 'stations')),
+          isNotNull,
+          reason: 'MX dataset must be persisted to the shared cache');
+    });
+
+    test('codec round-trips: a cold instance reads from disk, no network call',
+        () async {
+      final cache = CacheManager(_MemStorage());
+      await _mexico(cache, _MapAdapter(_mxBodies)).searchStations(_cdmxParams);
+
+      final coldAdapter = _MapAdapter(_mxBodies);
+      final cold = _mexico(cache, coldAdapter);
+      final result = await cold.searchStations(_cdmxParams);
+
+      expect(coldAdapter.calls, 0,
+          reason: 'persisted MX dataset must be served from disk');
+      // Search results preserved across the toJson/fromJson round-trip.
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.id, 'mx-11702');
+      expect(s.name, 'Gasolinera Centro');
+      expect(s.e5, 22.95);
+      expect(s.e10, 24.89);
+      expect(s.diesel, 23.45);
+    });
+
+    test('serves the persisted copy when the network is offline', () async {
+      final cache = CacheManager(_MemStorage());
+      await _mexico(cache, _MapAdapter(_mxBodies)).searchStations(_cdmxParams);
+
+      final offline = _mexico(cache, _MapAdapter(_mxBodies, failAfter: 0));
+      final result = await offline.searchStations(_cdmxParams);
+      expect(result.data, isNotEmpty,
+          reason: 'offline search must fall back to the persisted MX dataset');
+    });
+
+    test('with no cache wired the legacy in-memory path still works', () async {
+      final dio = Dio()..httpClientAdapter = _MapAdapter(_mxBodies);
+      final result = await MexicoStationService(
+        dio: dio,
+        baseUrl: 'https://fake.cre/publicaciones',
+      ).searchStations(_cdmxParams);
+      expect(result.data, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #2270 — the lower-risk "finish the caching/policy core" batch (child of Epic #2249), building on the merged Batch E (#2267: FuelServicePolicy + persisted datasets). One commit per concern.

## 1. feat(ui): render per-source data attribution under search results
Each country's `FuelServicePolicy` (seeded in #2267) carries the upstream provider name + licence as data, but nothing rendered them. Several open-data sources we consume mandate **visible** attribution — Tankerkönig (CC BY 4.0), France Prix Carburants (Licence Ouverte 2.0), the UK CMA feeds (Open Government Licence v3.0), Italy's MIMIT osservaprezzi (IODL 2.0).

- New `DataSourceAttribution` widget (`lib/core/services/widgets/data_source_attribution.dart`), pinned as a small non-intrusive footer below the search results list (`search_results_list.dart`). Reads `activeCountryProvider` + `CountryServiceRegistry.policyFor`, renders an ARB "Source:" label with the provider + licence as verbatim data (proper nouns / licence ids — `// i18n-ignore`). Collapses to nothing for unregistered/demo countries.
- New ARB keys `dataSourceAttribution` + `dataSourceAttributionSemantic` via en+de fragments → `build_arb` → `gen_pseudo_arb` → `gen-l10n`, **translated into all 21 other locales** (#1699 gate). `test/l10n/` + the no-hardcoded-strings lint pass.
- Test: `test/core/services/widgets/data_source_attribution_test.dart` asserts the active country's attribution + licence are surfaced (DE/FR/IT/MX) and that an unregistered country renders nothing.

## 2. feat(cache): Italy + Mexico persisted-dataset read-through
Batch E gave IT (MIMIT CSV) + MX (CRE XML) keepAlive providers but deferred on-disk persistence because their private record types had no JSON codecs.

- IT: added a `(stations, prices)` dataset codec over `_StationData`/`_PriceData` (`mise_station_service.dart`); MX: added a `toJson/fromJson` codec for `_CreStation` (`mexico_station_service.dart`). Both now route through `loadPersistentDataset`, persisting the parsed national dataset to Hive under the shared `dataset:` key with a read-through on construction — surviving cold start + working offline, mirroring DK/AR/ES. The registry factories pass the shared `CacheManager`; the cache-less constructor keeps the legacy in-memory path for parser tests.
- Search results are byte-preserved across the round-trip.
- Test: `test/features/station_services/italy_mexico_persisted_dataset_test.dart` — codec round-trip, cold instance serves from disk with zero network calls, offline fallback.

## Gate
- `flutter analyze lib test integration_test` → only the 2 pre-existing infos (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`); no new issues.
- `flutter test test/core/ test/features/search/ test/features/station_services/ test/l10n/ test/lint/ --exclude-tags network` → all pass (4142). (The lone `network`-tagged `api_connectivity_test` Argentina probe is a live-endpoint flake CI already excludes.)
- Clean `build_runner build --delete-conflicting-outputs` → no `.g.dart`/`.freezed.dart` drift.
- Rebased onto current master (resolves the ARB append-conflict with the freshly-merged #2271).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
