### PR TITLE
fix(migration): explicitly REVOKE trip_shares RPC execute from anon

### DIFF
--- a/supabase/migrations/20260529000001_trip_shares.sql
+++ b/supabase/migrations/20260529000001_trip_shares.sql
@@ -149,6 +149,9 @@ $$;
 -- the default PUBLIC execute first so anonymous sessions can't probe.
 REVOKE ALL ON FUNCTION public.resolve_share_recipient(TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.resolve_share_recipient(TEXT) TO authenticated;
+-- Supabase grants `anon` separately from PUBLIC, so REVOKE FROM PUBLIC is not
+-- enough — explicitly deny anonymous callers (no unauthenticated email oracle).
+REVOKE EXECUTE ON FUNCTION public.resolve_share_recipient(TEXT) FROM anon;
 
 -- ───────────────────────────────────────────────────────────────────
 -- 5. Token claim (SECURITY DEFINER RPC)
@@ -185,3 +188,4 @@ $$;
 
 REVOKE ALL ON FUNCTION public.claim_trip_share(TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.claim_trip_share(TEXT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.claim_trip_share(TEXT) FROM anon;


### PR DESCRIPTION
The #2240 trip_shares migration used `REVOKE ALL FROM PUBLIC` to deny anon, but Supabase grants `anon` separately, so anon kept EXECUTE on `resolve_share_recipient` (an unauthenticated email→user_id oracle) + `claim_trip_share`. **Prod was already hardened via MCP** (verified: anon execute = false); this syncs the repo migration file so a future `supabase db push` can't re-open it.

Co-Authored-By: Claude Opus 4.8 (1M context)