### PR TITLE
feat(data): UK CMA CSV + FR flux ZIP bulk migrations behind a staged-rollout flag (#2277)

### DIFF
--- a/lib/core/services/bulk_migration_flags.dart
+++ b/lib/core/services/bulk_migration_flags.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Staged-rollout toggles for the whole-country bulk-file source migrations
+/// (#2277, child of Epic #2249).
+///
+/// Two countries are moving off a per-search network path onto a single
+/// whole-country bulk download that is persisted and local-filtered:
+///
+///  - **GB** — from the per-search fan-out across ~14 CMA retailer feeds
+///    ([UkStationService]) to one consolidated CMA / Fuel Finder file
+///    downloaded per ~12 h publication cadence ([UkCmaBulkStationService]).
+///  - **FR** — from polling `data.economie.gouv.fr` per search
+///    ([PrixCarburantsStationService]) to the whole-country *flux instantané*
+///    ZIP downloaded per ~10 min cadence ([PrixCarburantsFluxStationService]).
+///
+/// Because each rewrite changes a whole-country data path it ships **behind a
+/// flag that defaults to the LEGACY path**. The bulk path is opt-in / staged:
+/// the legacy per-search path stays the production default until each country
+/// is validated on-device, and remains intact as the fallback (flip the flag
+/// back to `false` to return to it with no other change).
+///
+/// This is deliberately a per-source **compile-time const config toggle**, not
+/// a `Feature` enum value: it gates data-source plumbing, never a user-visible
+/// capability, so it needs no `FeatureManifest` / feature-management / ARB
+/// cascade. The [CountryServiceRegistry] reads these flags to choose, per
+/// country, between the legacy ([SourceModel.polledApi]) policy + factory and
+/// the bulk ([SourceModel.bulkFile]) policy + factory.
+///
+/// ## How to flip a flag (staged rollout)
+///
+/// Set the relevant field below to `true` and rebuild. To roll a country back,
+/// set it to `false` again — the legacy service + policy are untouched, so the
+/// fallback is one edit away with no migration. The two flags are independent:
+/// UK and FR can be promoted separately.
+class BulkMigrationFlags {
+  const BulkMigrationFlags._();
+
+  /// `true` routes GB through the consolidated CMA bulk file
+  /// ([UkCmaBulkStationService] + the bulk policy); `false` (default) keeps
+  /// the legacy per-search retailer fan-out ([UkStationService]).
+  static const bool ukCmaBulk = false;
+
+  /// `true` routes FR through the *flux instantané* bulk ZIP
+  /// ([PrixCarburantsFluxStationService] + the bulk policy); `false` (default)
+  /// keeps the legacy per-search `data.economie.gouv.fr` polling
+  /// ([PrixCarburantsStationService]).
+  static const bool frFluxBulk = false;
+}

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -14,6 +14,7 @@ import '../../features/station_services/australia/australia_station_service.dart
 import '../../features/station_services/austria/econtrol_station_service.dart';
 import '../../features/station_services/chile/chile_station_service.dart';
 import '../../features/station_services/denmark/denmark_station_service.dart';
+import '../../features/station_services/france/prix_carburants_flux_station_service.dart';
 import '../../features/station_services/france/prix_carburants_station_service.dart';
 import '../../features/station_services/germany/tankerkoenig_station_service.dart';
 import '../../features/station_services/greece/greece_station_service.dart';
@@ -339,9 +340,10 @@ const _dkPolicy = FuelServicePolicy(
   license: 'Provider terms',
 );
 
-/// FR Prix Carburants — currently a polled/OSM-enriched search; the bulk flux
-/// ZIP migration is a later batch, so it is modelled as polled for now.
-const _frPolicy = FuelServicePolicy(
+/// FR Prix Carburants — LEGACY polled/OSM-enriched per-search query against
+/// data.economie.gouv.fr. Default until the bulk migration (#2277) is
+/// validated on-device.
+const _frPolicyLegacy = FuelServicePolicy(
   model: SourceModel.polledApi,
   minInterval: Duration(minutes: 30),
   datasetTtlSoft: Duration.zero,
@@ -350,6 +352,24 @@ const _frPolicy = FuelServicePolicy(
   attribution: 'Prix Carburants (data.economie.gouv.fr)',
   license: 'Licence Ouverte 2.0',
 );
+
+/// FR Prix Carburants — BULK *flux instantané* ZIP (#2277): one whole-country
+/// download per ~10 min cadence, persisted and local-filtered (never poll
+/// per-station). Soft TTL ≈ the 10-min flux cadence, hard TTL an offline-grace
+/// multiple. Selected only when `BulkMigrationFlags.frFluxBulk` is `true`.
+const _frPolicyBulk = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(minutes: 10),
+  datasetTtlSoft: Duration(minutes: 10),
+  datasetTtlHard: Duration(hours: 6),
+  searchResultTtl: Duration.zero,
+  attribution: 'Prix Carburants (flux instantané)',
+  license: 'Licence Ouverte 2.0',
+);
+
+/// Staged-rollout selection (#2277): legacy by default, bulk when flagged.
+const _frPolicy =
+    BulkMigrationFlags.frFluxBulk ? _frPolicyBulk : _frPolicyLegacy;
 
 /// Central registry of all country-specific station services.
 ///
@@ -767,6 +787,16 @@ StationService _createTankerkoenig(Ref ref) {
 }
 
 StationService _createPrixCarburants(Ref ref) {
+  // #2277 — staged rollout: the bulk *flux instantané* ZIP service when the
+  // flag is on (persisted whole-country dataset, local-filtered), otherwise
+  // the legacy per-search polling service. The bulk service receives the
+  // shared CacheManager for the disk read-through, like the other bulk
+  // datasets.
+  if (BulkMigrationFlags.frFluxBulk) {
+    return PrixCarburantsFluxStationService(
+      cache: ref.read(cacheManagerProvider),
+    );
+  }
   final enricher = ref.watch(osmBrandEnricherProvider);
   return PrixCarburantsStationService(enricher: enricher);
 }

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -25,7 +25,9 @@ import '../../features/station_services/romania/romania_station_service.dart';
 import '../../features/station_services/slovenia/slovenia_station_service.dart';
 import '../../features/station_services/south_korea/south_korea_station_service.dart';
 import '../../features/station_services/spain/miteco_station_service.dart';
+import '../../features/station_services/uk/uk_cma_bulk_station_service.dart';
 import '../../features/station_services/uk/uk_station_service.dart';
+import 'bulk_migration_flags.dart';
 import 'fuel_service_policy.dart';
 import 'impl/demo_station_service.dart';
 import 'impl/osm_brand_enricher.dart';
@@ -179,9 +181,10 @@ const _ptPolicy = FuelServicePolicy(
   license: 'Open data (DGEG)',
 );
 
-/// UK CMA Fuel Finder — polled fan-out across retailer feeds published daily
-/// under the CMA scheme; cache each search 6 h.
-const _ukPolicy = FuelServicePolicy(
+/// UK CMA Fuel Finder — LEGACY polled fan-out across retailer feeds published
+/// daily under the CMA scheme; cache each search 6 h. Default until the bulk
+/// migration (#2277) is validated on-device.
+const _ukPolicyLegacy = FuelServicePolicy(
   model: SourceModel.polledApi,
   minInterval: Duration(minutes: 30),
   datasetTtlSoft: Duration.zero,
@@ -190,6 +193,24 @@ const _ukPolicy = FuelServicePolicy(
   attribution: 'CMA Fuel Finder (retailer feeds)',
   license: 'Open Government Licence v3.0',
 );
+
+/// UK CMA Fuel Finder — BULK consolidated twice-daily file (#2277): one
+/// whole-country download per ~12 h publication cadence, persisted and
+/// local-filtered. Soft TTL ≈ the publish cadence, hard TTL an offline-grace
+/// multiple. Selected only when `BulkMigrationFlags.ukCmaBulk` is `true`.
+const _ukPolicyBulk = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(hours: 1),
+  datasetTtlSoft: Duration(hours: 12),
+  datasetTtlHard: Duration(hours: 48),
+  searchResultTtl: Duration.zero,
+  attribution: 'CMA Fuel Finder (consolidated)',
+  license: 'Open Government Licence v3.0',
+);
+
+/// Staged-rollout selection (#2277): legacy by default, bulk when flagged.
+const _ukPolicy =
+    BulkMigrationFlags.ukCmaBulk ? _ukPolicyBulk : _ukPolicyLegacy;
 
 /// LU — government-regulated uniform prices, polled; a daily refresh is ample
 /// since the price changes only by ministerial arrêté.
@@ -765,7 +786,13 @@ StationService _createDenmark(Ref ref) =>
 StationService _createArgentina(Ref ref) =>
     ArgentinaStationService(cache: ref.read(cacheManagerProvider));
 StationService _createPortugal(Ref ref) => PortugalStationService();
-StationService _createUk(Ref ref) => UkStationService();
+// #2277 — staged rollout: the consolidated CMA bulk-file service when the flag
+// is on (persisted whole-country dataset, local-filtered), otherwise the legacy
+// per-search retailer fan-out. The bulk service receives the shared
+// CacheManager for the disk read-through, like the other bulk datasets.
+StationService _createUk(Ref ref) => BulkMigrationFlags.ukCmaBulk
+    ? UkCmaBulkStationService(cache: ref.read(cacheManagerProvider))
+    : UkStationService();
 StationService _createAustralia(Ref ref) => const AustraliaStationService();
 StationService _createMexico(Ref ref) =>
     MexicoStationService(cache: ref.read(cacheManagerProvider));

--- a/lib/features/station_services/france/prix_carburants_flux_parser.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_parser.dart
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Pure parsing helpers for the French *flux instantané* bulk source (#2277).
+///
+/// The whole-country flux is published as a ZIP holding a single XML file
+/// (`PrixCarburants_instantane.xml`), refreshed every ~10 minutes. This module
+/// turns the raw ZIP bytes — or the inner XML string — into [Station]s without
+/// touching Dio, persistence, or any network state, so the ZIP/XML-shape
+/// contract (the thing the upstream breaks first) is exercised with small
+/// committed fixtures. Adding network or storage imports here defeats the
+/// point of the split, exactly as in `prix_carburants_parsers.dart`.
+///
+/// Schema (per the gouv.fr open-data documentation):
+///  - `<pdv id="…" latitude="…" longitude="…" cp="…" pop="…">` — coordinates
+///    are GeoDecimal × 100000 (divide by 100000 for WGS84).
+///  - `<adresse>` / `<ville>` child elements.
+///  - `<prix nom="Gazole|SP95|SP98|E10|E85|GPLc" valeur="…" maj="…"/>` — value
+///    in euros. A defensive thousandths fallback (value > 100 → ÷1000) guards
+///    the v1-style integer encoding without affecting euro-valued feeds.
+///
+/// Fuel-name → [Station] field mapping mirrors the legacy JSON parser exactly
+/// (`SP95→e5`, `E10→e10`, `SP98→e98`, `Gazole→diesel`, `E85→e85`, `GPLc→lpg`)
+/// and ids carry the `fr-` country prefix, so a given area returns the same
+/// stations the polled path returned.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:xml/xml.dart';
+
+import '../../search/domain/entities/station.dart';
+
+/// Decode the flux ZIP [bytes], locate the inner XML entry, and parse every
+/// point-of-sale into a [Station] (distance 0 — the caller stamps it per
+/// search). Returns `[]` when the ZIP holds no XML entry or it is empty.
+List<Station> parseFluxZip(List<int> bytes) {
+  final xml = extractFluxXml(bytes);
+  if (xml == null || xml.isEmpty) return const [];
+  return parseFluxXml(xml);
+}
+
+/// Pull the inner XML document text out of the flux ZIP. The archive holds a
+/// single `*.xml` entry; we take the first XML file regardless of its exact
+/// name so a rename upstream doesn't break parsing. Tolerant of Latin-1 /
+/// UTF-8 payloads (the flux is ISO-8859-1 historically).
+String? extractFluxXml(List<int> bytes) {
+  final archive = ZipDecoder().decodeBytes(bytes);
+  for (final file in archive.files) {
+    if (!file.isFile) continue;
+    if (!file.name.toLowerCase().endsWith('.xml')) continue;
+    return _decodeBytes(file.content);
+  }
+  return null;
+}
+
+/// Decode raw file bytes to a String, preferring UTF-8 and falling back to
+/// Latin-1 (the flux XML is historically ISO-8859-1, which UTF-8 rejects on
+/// accented bytes like the `é` in "Carrefour Hérault").
+String _decodeBytes(Uint8List bytes) {
+  try {
+    return utf8.decode(bytes);
+  } on FormatException {
+    return latin1.decode(bytes, allowInvalid: true);
+  }
+}
+
+/// Parse the flux XML document text into [Station]s. Exposed separately so the
+/// XML-shape contract can be tested without zipping a fixture first.
+List<Station> parseFluxXml(String xml) {
+  final XmlDocument doc;
+  try {
+    doc = XmlDocument.parse(xml);
+  } on XmlException {
+    return const [];
+  }
+
+  final stations = <Station>[];
+  for (final pdv in doc.findAllElements('pdv')) {
+    final station = parseFluxPdv(pdv);
+    if (station != null) stations.add(station);
+  }
+  return stations;
+}
+
+/// Parse a single `<pdv>` element into a [Station], or `null` when it carries
+/// no usable coordinates. Public for direct unit testing.
+Station? parseFluxPdv(XmlElement pdv) {
+  final lat = _coord(pdv.getAttribute('latitude'));
+  final lng = _coord(pdv.getAttribute('longitude'));
+  if (lat == null || lng == null || lat == 0 || lng == 0) return null;
+
+  final rawId = pdv.getAttribute('id')?.trim() ?? '';
+  final cp = pdv.getAttribute('cp')?.trim() ?? '';
+  final pop = pdv.getAttribute('pop')?.trim() ?? '';
+  final adresse = pdv.findElements('adresse').firstOrNull?.innerText.trim() ?? '';
+  final ville = pdv.findElements('ville').firstOrNull?.innerText.trim() ?? '';
+
+  double? e5, e10, e98, diesel, e85, lpg;
+  String? mostRecentMaj;
+  for (final prix in pdv.findElements('prix')) {
+    final nom = (prix.getAttribute('nom') ?? '').trim().toUpperCase();
+    final value = _price(prix.getAttribute('valeur'));
+    if (value == null) continue;
+    switch (nom) {
+      case 'SP95':
+        e5 ??= value;
+        break;
+      case 'E10':
+        e10 ??= value;
+        break;
+      case 'SP98':
+        e98 ??= value;
+        break;
+      case 'GAZOLE':
+        diesel ??= value;
+        break;
+      case 'E85':
+        e85 ??= value;
+        break;
+      case 'GPLC':
+        lpg ??= value;
+        break;
+    }
+    final maj = prix.getAttribute('maj');
+    if (maj != null && maj.isNotEmpty) {
+      if (mostRecentMaj == null || maj.compareTo(mostRecentMaj) > 0) {
+        mostRecentMaj = maj;
+      }
+    }
+  }
+
+  // #753 — scope the id with the `fr-` country prefix (matches the legacy
+  // JSON parser) so a French numeric id cannot collide with another country.
+  return Station(
+    id: rawId.isEmpty ? '' : (rawId.startsWith('fr-') ? rawId : 'fr-$rawId'),
+    name: adresse,
+    brand: _brandFor(pop, adresse, ville),
+    street: adresse,
+    postCode: cp,
+    place: ville,
+    lat: lat,
+    lng: lng,
+    dist: 0,
+    e5: e5,
+    e10: e10,
+    e98: e98,
+    diesel: diesel,
+    e85: e85,
+    lpg: lpg,
+    isOpen: true,
+    updatedAt: _formatMaj(mostRecentMaj),
+    stationType: pop.isEmpty ? null : pop,
+  );
+}
+
+/// GeoDecimal coordinate → WGS84 degrees (÷ 100000). Tolerates a value that is
+/// already in degrees (|v| ≤ 180) so a future schema that drops the scaling
+/// still parses.
+double? _coord(String? raw) {
+  if (raw == null || raw.trim().isEmpty) return null;
+  final v = double.tryParse(raw.trim());
+  if (v == null) return null;
+  return v.abs() > 180 ? v / 100000 : v;
+}
+
+/// Coerce the `valeur` attribute to euros. Documented as euros (e.g. 1.659);
+/// the `> 100` guard converts the legacy v1-style thousandths encoding
+/// (e.g. 1659) without disturbing euro-valued feeds.
+double? _price(String? raw) {
+  if (raw == null || raw.trim().isEmpty) return null;
+  final v = double.tryParse(raw.trim().replaceAll(',', '.'));
+  if (v == null) return null;
+  return v > 100 ? v / 1000 : v;
+}
+
+/// Format the most-recent `maj` ISO timestamp as `dd/MM HH:mm`, mirroring the
+/// legacy parser's `parsePrixCarburantsMostRecentUpdate` output shape.
+String? _formatMaj(String? maj) {
+  if (maj == null || maj.isEmpty) return null;
+  try {
+    final dt = DateTime.parse(maj);
+    return '${dt.day.toString().padLeft(2, '0')}/'
+        '${dt.month.toString().padLeft(2, '0')} '
+        '${dt.hour.toString().padLeft(2, '0')}:'
+        '${dt.minute.toString().padLeft(2, '0')}';
+  } on FormatException {
+    final cut = maj.length >= 16 ? maj.substring(0, 16) : maj;
+    return cut.replaceAll('T', ' ');
+  }
+}
+
+/// The flux XML carries no brand column, so reuse the autoroute fallback the
+/// legacy path uses: `pop == 'A'` → highway service area, else the `Independent`
+/// sentinel (#482) rendered as a localised "independent station" row. Address /
+/// ville substring brand detection stays in the legacy enricher path.
+String _brandFor(String pop, String adresse, String ville) {
+  if (pop == 'A') return 'Autoroute';
+  return 'Independent';
+}

--- a/lib/features/station_services/france/prix_carburants_flux_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_station_service.dart
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../search/data/models/search_params.dart';
+import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
+import '../../../core/services/dio_factory.dart';
+import '../../../core/services/mixins/cached_dataset_mixin.dart';
+import '../../../core/services/mixins/station_service_helpers.dart';
+import '../../../core/services/persistent_dataset.dart';
+import '../../../core/services/service_result.dart';
+import '../../../core/services/station_service.dart';
+import 'prix_carburants_flux_parser.dart' as flux;
+
+/// French Prix-Carburants **bulk-file** service (#2277).
+///
+/// The legacy [PrixCarburantsStationService] polls `data.economie.gouv.fr` on
+/// *every* search (one or two HTTP calls per query). This service instead
+/// downloads the whole-country *flux instantané* ZIP **once per ~10 min
+/// cadence**, parses it (ZIP → XML → [Station]s), persists the parsed list via
+/// [PersistentDataset] (survives cold start + offline), and answers every
+/// search by **local geo-filter** — it never polls per-station.
+///
+/// This also fixes the FR empty-result/cache contract: the legacy path returned
+/// an empty [ServiceResult] on a transient network error (so the chain cached
+/// nothing and re-hit the API next search). Here the persisted dataset is
+/// served on a network failure (stale-but-offline via
+/// [CachedDatasetMixin.loadPersistentDataset]), and a search with genuinely no
+/// nearby station returns empty *without* discarding the dataset.
+///
+/// Results are preserved: the flux parser maps the same fuel grades onto the
+/// same [Station] fields as the legacy JSON parser (`SP95→e5`, `E10→e10`,
+/// `SP98→e98`, `Gazole→diesel`, `E85→e85`, `GPLc→lpg`) with the `fr-` id prefix.
+///
+/// Only wired into the registry when `BulkMigrationFlags.frFluxBulk` is `true`
+/// (staged rollout, defaults to the legacy polling service).
+class PrixCarburantsFluxStationService
+    with StationServiceHelpers, CachedDatasetMixin
+    implements StationService {
+  final Dio _dio;
+  final String _zipUrl;
+
+  /// Disk persistence (read-through). When a [CacheStrategy] is supplied the
+  /// parsed national station list is persisted so it survives cold start +
+  /// works offline. Null in the pure-in-memory parser tests.
+  final PersistentDataset<List<Station>>? _persistent;
+
+  /// Default whole-country flux ZIP. ~1 MB, refreshed every ~10 minutes.
+  /// Overridable for tests / endpoint drift.
+  // i18n-ignore: gouv.fr open-data endpoint URL, not user-facing text
+  static const String defaultZipUrl =
+      'https://donnees.roulez-eco.fr/opendata/instantane';
+
+  PrixCarburantsFluxStationService({
+    Dio? dio,
+    String? zipUrl,
+    CacheStrategy? cache,
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 30),
+              responseType: ResponseType.bytes,
+            ),
+        _zipUrl = zipUrl ?? defaultZipUrl,
+        _persistent = cache == null
+            ? null
+            : PersistentDataset<List<Station>>(
+                cache: cache,
+                countryCode: 'FR',
+                datasetName: 'stations',
+                source: ServiceSource.prixCarburantsApi,
+                serialize: (stations) =>
+                    {'stations': stations.map((s) => s.toJson()).toList()},
+                deserialize: (json) {
+                  final list = json['stations'] as List<dynamic>?;
+                  if (list == null) return null;
+                  return list
+                      .map((j) =>
+                          Station.fromJson(Map<String, dynamic>.from(j as Map)))
+                      .toList();
+                },
+              );
+
+  /// Soft/hard dataset TTLs mirror the FR bulk [FuelServicePolicy] in the
+  /// registry (soft 10 min ≈ flux cadence, hard 6 h offline grace).
+  static const Duration _softTtl = Duration(minutes: 10);
+  static const Duration _hardTtl = Duration(hours: 6);
+
+  // In-memory copy of the parsed national dataset.
+  List<Station>? _cachedStations;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    try {
+      await _ensureDataLoaded(cancelToken: cancelToken);
+    } on DioException catch (e, st) {
+      // No persisted copy to fall back to AND no cached dataset → surface the
+      // network error to the chain (which then falls through to its own stale
+      // cache / error UI) rather than masking it as an empty result.
+      if (_cachedStations == null) {
+        throwApiException(e, defaultMessage: 'Erreur réseau', stackTrace: st);
+      }
+    }
+
+    final all = _cachedStations ?? const <Station>[];
+    final withDist = <Station>[
+      for (final s in all)
+        s.copyWith(dist: roundedDistance(params.lat, params.lng, s.lat, s.lng)),
+    ];
+
+    // Strict radius filter — unlike a top-N fallback, a far-from-France search
+    // correctly returns empty (the legacy path's #298/#315 radius contract).
+    final stations =
+        withDist.where((s) => s.dist <= params.radiusKm).toList();
+    sortStations(stations, params);
+
+    return wrapStations(stations, ServiceSource.prixCarburantsApi);
+  }
+
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
+    Future<List<Station>> fetch() => _downloadAndParse(cancelToken: cancelToken);
+    void store(List<Station> value) => _cachedStations = value;
+
+    final persistent = _persistent;
+    if (persistent == null) {
+      // No cache wired (unit tests) — pure in-memory soft-TTL behaviour.
+      return loadDataset<List<Station>>(
+        cached: _cachedStations,
+        ttl: _softTtl,
+        fetch: fetch,
+        store: store,
+      );
+    }
+    // Disk read-through: survives cold start + offline, refreshes past soft TTL.
+    return loadPersistentDataset<List<Station>>(
+      cached: _cachedStations,
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: persistent,
+      fetch: fetch,
+      store: store,
+    );
+  }
+
+  Future<List<Station>> _downloadAndParse({CancelToken? cancelToken}) async {
+    final response = await _dio.get<List<int>>(
+      _zipUrl,
+      cancelToken: cancelToken,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    final bytes = response.data;
+    if (bytes == null || bytes.isEmpty) return const [];
+    return flux.parseFluxZip(Uint8List.fromList(bytes));
+  }
+
+  /// Clears the in-memory dataset so the next search re-downloads. For tests.
+  @visibleForTesting
+  void clearCacheForTest() {
+    _cachedStations = null;
+    markDatasetRefreshedAt(const Duration(days: 3650));
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    // The flux dataset is the whole country, so a single-station lookup is a
+    // local find rather than a network call.
+    final all = _cachedStations;
+    if (all != null) {
+      for (final s in all) {
+        if (s.id == stationId) {
+          return ServiceResult(
+            data: StationDetail(station: s),
+            source: ServiceSource.prixCarburantsApi,
+            fetchedAt: DateTime.now(),
+          );
+        }
+      }
+    }
+    throwDetailUnavailable('Prix Carburants (flux)');
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return emptyPricesResult(ServiceSource.prixCarburantsApi);
+  }
+}

--- a/lib/features/station_services/uk/uk_cma_bulk_station_service.dart
+++ b/lib/features/station_services/uk/uk_cma_bulk_station_service.dart
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../search/data/models/search_params.dart';
+import '../../search/domain/entities/station.dart';
+import '../../../core/cache/cache_manager.dart';
+import '../../../core/services/dio_factory.dart';
+import '../../../core/services/mixins/cached_dataset_mixin.dart';
+import '../../../core/services/mixins/station_service_helpers.dart';
+import '../../../core/services/persistent_dataset.dart';
+import '../../../core/services/service_result.dart';
+import '../../../core/services/station_service.dart';
+import 'uk_station_service.dart';
+
+/// UK CMA / Fuel Finder **bulk-file** fuel-price service (#2277).
+///
+/// The legacy [UkStationService] fans out across ~14 retailer feeds on *every*
+/// search — slow, fragile and rate-risky. Under the Motor Fuel Price (Open
+/// Data) Regulations 2025 the same standardized station records are published
+/// as a single consolidated file (the Fuel Finder twice-daily download), so
+/// this service downloads that **once per ~12 h publication cadence**, persists
+/// it via [PersistentDataset] (survives cold start + offline), and answers
+/// every search by **local geo-filter** — no per-search network round-trip.
+///
+/// Results are preserved: the consolidated file carries the *same* standardized
+/// record schema as the retailer feeds, and this service parses each search
+/// through the identical [UkStationService.parseCmaStations] used by the legacy
+/// path, so a given area returns the same stations.
+///
+/// The consolidated download is JSON-shaped exactly like the retailer feeds
+/// (`{"stations": [ {site_id, brand, address, postcode, location:{latitude,
+/// longitude}, prices:{E5,E10,B7,...}} ]}`); the persisted dataset is the raw
+/// record list, re-filtered per search. The download URL is injectable so the
+/// subscription-issued consolidated endpoint is a one-line config change.
+///
+/// This service is only wired into the registry when
+/// `BulkMigrationFlags.ukCmaBulk` is `true` (staged rollout, defaults to the
+/// legacy fan-out).
+class UkCmaBulkStationService
+    with StationServiceHelpers, CachedDatasetMixin
+    implements StationService {
+  final Dio _dio;
+  final String _consolidatedUrl;
+
+  /// Disk persistence (read-through). When a [CacheStrategy] is supplied (the
+  /// registry factory passes the shared CacheManager) the parsed consolidated
+  /// record list is persisted to Hive so it survives a cold start and works
+  /// offline. Null in the pure-in-memory parser tests.
+  final PersistentDataset<List<Map<String, dynamic>>>? _persistent;
+
+  /// Default consolidated CMA / Fuel Finder download. Published twice daily
+  /// under the gov.uk Fuel Finder scheme; one file covers every forecourt.
+  /// Overridable so the subscription-issued URL (or an OAuth2-fronted variant)
+  /// drops in without touching the parse/persist/filter logic.
+  // i18n-ignore: gov.uk data endpoint URL, not user-facing text
+  static const String defaultConsolidatedUrl =
+      'https://www.fuel-finder.service.gov.uk/api/v1/prices/latest';
+
+  UkCmaBulkStationService({
+    Dio? dio,
+    String? consolidatedUrl,
+    CacheStrategy? cache,
+  })  : _dio = dio ??
+            DioFactory.create(
+              connectTimeout: const Duration(seconds: 15),
+              receiveTimeout: const Duration(seconds: 30),
+              responseType: ResponseType.json,
+            ),
+        _consolidatedUrl = consolidatedUrl ?? defaultConsolidatedUrl,
+        _persistent = cache == null
+            ? null
+            : PersistentDataset<List<Map<String, dynamic>>>(
+                cache: cache,
+                countryCode: 'GB',
+                datasetName: 'stations',
+                source: ServiceSource.ukApi,
+                serialize: (records) => {'records': records},
+                deserialize: (json) {
+                  final list = json['records'] as List<dynamic>?;
+                  if (list == null) return null;
+                  return list
+                      .map((r) => Map<String, dynamic>.from(r as Map))
+                      .toList();
+                },
+              );
+
+  /// Soft/hard dataset TTLs mirror the GB bulk [FuelServicePolicy] in the
+  /// registry (soft 12 h ≈ publication cadence, hard 48 h offline grace).
+  static const Duration _softTtl = Duration(hours: 12);
+  static const Duration _hardTtl = Duration(hours: 48);
+
+  // In-memory copy of the parsed consolidated records.
+  List<Map<String, dynamic>>? _cachedRecords;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    await _ensureDataLoaded(cancelToken: cancelToken);
+
+    // Local geo-filter through the SAME parser the legacy path uses, so a
+    // given area returns identical stations (radius filter + dedupe by
+    // site_id + sort-by-distance + cap-50 all live in parseCmaStations).
+    final stations = UkStationService.parseCmaStations(
+      _cachedRecords ?? const [],
+      lat: params.lat,
+      lng: params.lng,
+      radiusKm: params.radiusKm,
+    );
+
+    return ServiceResult(
+      data: stations,
+      source: ServiceSource.ukApi,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
+    Future<List<Map<String, dynamic>>> fetch() =>
+        _downloadConsolidated(cancelToken: cancelToken);
+    void store(List<Map<String, dynamic>> value) => _cachedRecords = value;
+
+    final persistent = _persistent;
+    if (persistent == null) {
+      // No cache wired (unit tests) — pure in-memory soft-TTL behaviour.
+      return loadDataset<List<Map<String, dynamic>>>(
+        cached: _cachedRecords,
+        ttl: _softTtl,
+        fetch: fetch,
+        store: store,
+      );
+    }
+    // Disk read-through: survives cold start + offline, refreshes past soft TTL.
+    return loadPersistentDataset<List<Map<String, dynamic>>>(
+      cached: _cachedRecords,
+      softTtl: _softTtl,
+      hardTtl: _hardTtl,
+      persistent: persistent,
+      fetch: fetch,
+      store: store,
+    );
+  }
+
+  /// Download + extract the consolidated record list. Tolerates the two
+  /// standardized envelope shapes (`{stations:[...]}` / `{data:[...]}`) and a
+  /// bare top-level list.
+  Future<List<Map<String, dynamic>>> _downloadConsolidated({
+    CancelToken? cancelToken,
+  }) async {
+    final response = await _dio.get<dynamic>(
+      _consolidatedUrl,
+      cancelToken: cancelToken,
+      options: Options(responseType: ResponseType.json),
+    );
+    return extractConsolidatedRecords(response.data);
+  }
+
+  /// Extract the standardized station-record list from the consolidated
+  /// envelope. Exposed for tests; mirrors the per-feed extraction the legacy
+  /// service does in `_fetchFeed`.
+  @visibleForTesting
+  static List<Map<String, dynamic>> extractConsolidatedRecords(dynamic data) {
+    List<dynamic> raw;
+    if (data is Map<String, dynamic>) {
+      raw = data['stations'] as List<dynamic>? ??
+          data['data'] as List<dynamic>? ??
+          const [];
+    } else if (data is List) {
+      raw = data;
+    } else {
+      return const [];
+    }
+    final out = <Map<String, dynamic>>[];
+    for (final r in raw) {
+      if (r is Map) out.add(Map<String, dynamic>.from(r));
+    }
+    return out;
+  }
+
+  /// Clears the in-memory dataset so the next search re-downloads. For tests.
+  @visibleForTesting
+  void clearCacheForTest() {
+    _cachedRecords = null;
+    markDatasetRefreshedAt(const Duration(days: 3650));
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(
+    String stationId,
+  ) async {
+    throwDetailUnavailable('CMA Fuel Finder');
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) async {
+    return emptyPricesResult(ServiceSource.ukApi);
+  }
+}

--- a/lib/features/station_services/uk/uk_station_service.dart
+++ b/lib/features/station_services/uk/uk_station_service.dart
@@ -161,8 +161,10 @@ class UkStationService with StationServiceHelpers implements StationService {
   /// filters to the search radius, dedupes by `site_id`, sorts by
   /// distance, and caps at 50 results.
   ///
-  /// Exposed for tests.
-  @visibleForTesting
+  /// Public shared parser: the legacy per-search fan-out and the #2277 bulk
+  /// consolidated path ([UkCmaBulkStationService]) both run their records
+  /// through this so a given area returns identical stations regardless of
+  /// which source delivered them.
   static List<Station> parseCmaStations(
     List<dynamic> items, {
     required double lat,

--- a/test/core/services/country_service_registry_test.dart
+++ b/test/core/services/country_service_registry_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/country/country_bounding_box.dart';
 import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/services/bulk_migration_flags.dart';
 import 'package:tankstellen/core/services/country_service_registry.dart';
 import 'package:tankstellen/core/services/fuel_service_policy.dart';
 import 'package:tankstellen/core/services/service_result.dart';
@@ -125,6 +126,39 @@ void main() {
         final de = CountryServiceRegistry.policyFor('DE')!;
         expect(de.minInterval, equals(const Duration(seconds: 60)));
         expect(de.searchResultTtl, equals(const Duration(minutes: 5)));
+      });
+    });
+
+    // #2277 — staged-rollout flag contract: BOTH bulk migrations default OFF,
+    // so GB + FR keep their LEGACY polledApi policy until each flag is flipped.
+    // The selected policy must match the flag state (a const ternary in the
+    // registry), so flipping a flag both swaps the service AND the cache model.
+    group('bulk-migration flags (#2277)', () {
+      test('both bulk flags default to false (legacy is the default path)', () {
+        expect(BulkMigrationFlags.ukCmaBulk, isFalse,
+            reason: 'UK CMA bulk must be opt-in / staged');
+        expect(BulkMigrationFlags.frFluxBulk, isFalse,
+            reason: 'FR flux bulk must be opt-in / staged');
+      });
+
+      test('GB policy model follows the ukCmaBulk flag', () {
+        final model = CountryServiceRegistry.policyFor('GB')!.model;
+        expect(
+          model,
+          BulkMigrationFlags.ukCmaBulk
+              ? SourceModel.bulkFile
+              : SourceModel.polledApi,
+        );
+      });
+
+      test('FR policy model follows the frFluxBulk flag', () {
+        final model = CountryServiceRegistry.policyFor('FR')!.model;
+        expect(
+          model,
+          BulkMigrationFlags.frFluxBulk
+              ? SourceModel.bulkFile
+              : SourceModel.polledApi,
+        );
       });
     });
 

--- a/test/features/station_services/france/prix_carburants_flux_test.dart
+++ b/test/features/station_services/france/prix_carburants_flux_test.dart
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/france/prix_carburants_flux_parser.dart'
+    as flux;
+import 'package:tankstellen/features/station_services/france/prix_carburants_flux_station_service.dart';
+
+/// #2277 — the FR *flux instantané* bulk-file path: download the whole-country
+/// ZIP once, parse (ZIP → XML → Station), persist, local-filter. Covers
+/// bulk-parse, results-preserved (same fuel→field mapping + `fr-` ids as the
+/// legacy JSON parser), download-once, and the empty-result / error contract.
+
+/// A minimal flux XML doc. Coordinates are GeoDecimal × 100000; prix valeur in
+/// euros; the documented fuel names map onto the same Station fields the legacy
+/// JSON parser uses.
+String _fluxXml(List<Map<String, dynamic>> pdvs) {
+  final buf = StringBuffer('<?xml version="1.0" encoding="UTF-8"?>\n<pdv_liste>');
+  for (final p in pdvs) {
+    buf.write('<pdv id="${p['id']}" '
+        'latitude="${p['lat']}" longitude="${p['lng']}" '
+        'cp="${p['cp'] ?? ''}" pop="${p['pop'] ?? 'R'}">');
+    buf.write('<adresse>${p['adresse'] ?? ''}</adresse>');
+    buf.write('<ville>${p['ville'] ?? ''}</ville>');
+    final prices = (p['prices'] as Map<String, dynamic>? ?? {});
+    prices.forEach((nom, valeur) {
+      buf.write('<prix nom="$nom" valeur="$valeur" '
+          'maj="2026-05-29T08:00:00+00:00"/>');
+    });
+    buf.write('</pdv>');
+  }
+  buf.write('</pdv_liste>');
+  return buf.toString();
+}
+
+/// Zip the flux XML the way the real flux ZIP is shaped: a single inner XML.
+Uint8List _fluxZip(String xml) {
+  final archive = Archive()
+    ..addFile(
+      ArchiveFile.bytes(
+        'PrixCarburants_instantane.xml',
+        utf8.encode(xml),
+      ),
+    );
+  return Uint8List.fromList(ZipEncoder().encode(archive));
+}
+
+/// Serves the same ZIP bytes for every request and counts downloads.
+class _ZipAdapter implements HttpClientAdapter {
+  final Uint8List bytes;
+  int requestCount = 0;
+
+  _ZipAdapter(this.bytes);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    return ResponseBody.fromBytes(
+      bytes,
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/zip'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// Serves a network error for every request.
+class _FailingAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    throw DioException(
+      requestOptions: options,
+      type: DioExceptionType.connectionError,
+      error: 'offline',
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+// 120 RUE LECLERC, Castelnau — lat 43.45, lng 3.52 (×100000 in the flux).
+Map<String, dynamic> _pdv({
+  required String id,
+  required double lat,
+  required double lng,
+  String adresse = '120 RUE LECLERC',
+  String ville = 'CASTELNAU',
+  String cp = '34290',
+  Map<String, dynamic>? prices,
+}) =>
+    {
+      'id': id,
+      'lat': (lat * 100000).round(),
+      'lng': (lng * 100000).round(),
+      'adresse': adresse,
+      'ville': ville,
+      'cp': cp,
+      'prices': prices ??
+          {
+            'SP95': 1.879,
+            'E10': 1.799,
+            'SP98': 1.929,
+            'Gazole': 1.659,
+            'E85': 0.899,
+            'GPLc': 0.999,
+          },
+    };
+
+const _castelnau = SearchParams(lat: 43.45, lng: 3.52, radiusKm: 10);
+
+void main() {
+  group('prix_carburants_flux_parser (pure XML)', () {
+    test('parses a pdv: coords ÷100000, fuel names → Station fields, fr- id',
+        () {
+      final stations = flux.parseFluxXml(_fluxXml([
+        _pdv(id: '34200002', lat: 43.45, lng: 3.52),
+      ]));
+
+      expect(stations, hasLength(1));
+      final s = stations.first;
+      expect(s.id, 'fr-34200002');
+      expect(s.lat, closeTo(43.45, 0.0001));
+      expect(s.lng, closeTo(3.52, 0.0001));
+      expect(s.street, '120 RUE LECLERC');
+      expect(s.postCode, '34290');
+      expect(s.place, 'CASTELNAU');
+      // Same fuel→field mapping as the legacy JSON parser.
+      expect(s.e5, closeTo(1.879, 0.0001)); // SP95
+      expect(s.e10, closeTo(1.799, 0.0001)); // E10
+      expect(s.e98, closeTo(1.929, 0.0001)); // SP98
+      expect(s.diesel, closeTo(1.659, 0.0001)); // Gazole
+      expect(s.e85, closeTo(0.899, 0.0001)); // E85
+      expect(s.lpg, closeTo(0.999, 0.0001)); // GPLc
+      expect(s.updatedAt, contains('29/05'));
+    });
+
+    test('autoroute brand when pop=A', () {
+      final xml = _fluxXml([
+        {
+          'id': '1',
+          'lat': 4345000,
+          'lng': 352000,
+          'adresse': 'AIRE',
+          'ville': '',
+          'cp': '',
+          'pop': 'A',
+          'prices': {'Gazole': 1.7},
+        },
+      ]);
+      expect(flux.parseFluxXml(xml).first.brand, 'Autoroute');
+    });
+
+    test('skips a pdv with no/zero coordinates', () {
+      final xml = _fluxXml([
+        {'id': 'BAD', 'lat': 0, 'lng': 0, 'prices': {'SP95': 1.8}},
+      ]);
+      expect(flux.parseFluxXml(xml), isEmpty);
+    });
+
+    test('thousandths fallback: valeur 1659 → 1.659', () {
+      final xml = _fluxXml([
+        _pdv(id: '5', lat: 43.45, lng: 3.52, prices: {'Gazole': 1659}),
+      ]);
+      expect(flux.parseFluxXml(xml).first.diesel, closeTo(1.659, 0.0001));
+    });
+
+    test('returns empty on malformed XML rather than throwing', () {
+      expect(flux.parseFluxXml('<not-closed'), isEmpty);
+    });
+
+    test('parseFluxZip: ZIP bytes → stations end-to-end', () {
+      final zip = _fluxZip(_fluxXml([_pdv(id: '9', lat: 43.45, lng: 3.52)]));
+      final stations = flux.parseFluxZip(zip);
+      expect(stations, hasLength(1));
+      expect(stations.first.id, 'fr-9');
+    });
+  });
+
+  group('PrixCarburantsFluxStationService', () {
+    Dio dioWith(Uint8List bytes) =>
+        Dio()..httpClientAdapter = _ZipAdapter(bytes);
+
+    test('implements StationService', () {
+      expect(PrixCarburantsFluxStationService(), isA<StationService>());
+    });
+
+    test('default ZIP URL targets the gouv.fr flux instantané', () {
+      expect(
+        PrixCarburantsFluxStationService.defaultZipUrl,
+        contains('donnees.roulez-eco.fr/opendata/instantane'),
+      );
+    });
+
+    test('downloads the ZIP and local-filters by radius', () async {
+      final zip = _fluxZip(_fluxXml([
+        _pdv(id: 'NEAR', lat: 43.45, lng: 3.52),
+        // ~600 km away — well outside a 10 km radius.
+        _pdv(id: 'FAR', lat: 48.85, lng: 2.35, cp: '75001'),
+      ]));
+      final svc = PrixCarburantsFluxStationService(dio: dioWith(zip));
+
+      final result = await svc.searchStations(_castelnau);
+      expect(result.source, ServiceSource.prixCarburantsApi);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.id, 'fr-NEAR');
+    });
+
+    test('downloads ONCE then serves later searches locally (no per-search poll)',
+        () async {
+      final adapter = _ZipAdapter(
+        _fluxZip(_fluxXml([_pdv(id: 'A', lat: 43.45, lng: 3.52)])),
+      );
+      final svc =
+          PrixCarburantsFluxStationService(dio: Dio()..httpClientAdapter = adapter);
+
+      await svc.searchStations(_castelnau);
+      await svc.searchStations(_castelnau);
+      await svc.searchStations(
+        const SearchParams(lat: 43.46, lng: 3.53, radiusKm: 5),
+      );
+
+      expect(adapter.requestCount, 1,
+          reason: 'one flux download serves every search — never poll per-station');
+    });
+
+    test('results PRESERVED: same fuel→field mapping + fr- ids as the parser',
+        () async {
+      final pdvs = [
+        _pdv(id: '1', lat: 43.451, lng: 3.521),
+        _pdv(id: '2', lat: 43.452, lng: 3.522),
+      ];
+      final svc =
+          PrixCarburantsFluxStationService(dio: dioWith(_fluxZip(_fluxXml(pdvs))));
+      final result = await svc.searchStations(_castelnau);
+
+      final ids = result.data.map((s) => s.id).toSet();
+      expect(ids, {'fr-1', 'fr-2'});
+      expect(result.data.first.e5, closeTo(1.879, 0.0001));
+    });
+
+    test('far-from-France search returns empty (radius contract, not error)',
+        () async {
+      final zip = _fluxZip(_fluxXml([_pdv(id: 'A', lat: 43.45, lng: 3.52)]));
+      final svc = PrixCarburantsFluxStationService(dio: dioWith(zip));
+
+      // Middle of the Pacific.
+      final result = await svc.searchStations(
+        const SearchParams(lat: 0, lng: -170, radiusKm: 5),
+      );
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.prixCarburantsApi);
+    });
+
+    test('network failure with no cached/persisted dataset surfaces an error',
+        () async {
+      // Fixes the FR empty-result/cache contract: the legacy path swallowed a
+      // network error into an empty ServiceResult (so the chain cached nothing
+      // and re-hit next search). Here a first-ever-search failure with nothing
+      // to serve is surfaced to the chain instead of masked as "no stations".
+      final svc = PrixCarburantsFluxStationService(
+        dio: Dio()..httpClientAdapter = _FailingAdapter(),
+      );
+      expect(
+        () => svc.searchStations(_castelnau),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('a fresh in-memory dataset serves a later search with no re-download',
+        () async {
+      // After one successful load the dataset is fresh (within the soft TTL),
+      // so a search that would otherwise fail the network never even attempts
+      // it — the cached set answers directly.
+      final adapter = _ZipAdapter(
+        _fluxZip(_fluxXml([_pdv(id: 'A', lat: 43.45, lng: 3.52)])),
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final svc = PrixCarburantsFluxStationService(dio: dio);
+
+      await svc.searchStations(_castelnau);
+      // Swap in a failing adapter; the fresh in-memory dataset must answer
+      // without touching the network.
+      dio.httpClientAdapter = _FailingAdapter();
+      final second = await svc.searchStations(_castelnau);
+      expect(second.data, hasLength(1));
+      expect(adapter.requestCount, 1);
+    });
+  });
+}

--- a/test/features/station_services/uk/uk_cma_bulk_station_service_test.dart
+++ b/test/features/station_services/uk/uk_cma_bulk_station_service_test.dart
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/uk/uk_cma_bulk_station_service.dart';
+import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
+
+/// #2277 — the UK consolidated CMA bulk-file path: ONE download, persisted,
+/// local-filtered. These cover bulk-parse (consolidated envelope → records),
+/// results-preserved-vs-legacy (same parser → same stations for an area), and
+/// the download-once-then-serve-locally contract.
+
+/// Counts requests and serves one canned consolidated body for every URL.
+class _CountingAdapter implements HttpClientAdapter {
+  final String body;
+  int requestCount = 0;
+
+  _CountingAdapter(this.body);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount++;
+    return ResponseBody.fromString(
+      body,
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _dioServing(String body) {
+  final dio = Dio();
+  dio.httpClientAdapter = _CountingAdapter(body);
+  return dio;
+}
+
+/// A consolidated file holds the SAME standardized records the retailer feeds
+/// publish — just unioned into one envelope.
+String _consolidated(List<Map<String, dynamic>> stations) =>
+    jsonEncode({'last_updated': '2026-05-29 08:00:00', 'stations': stations});
+
+Map<String, dynamic> _record({
+  required String siteId,
+  required String brand,
+  required double lat,
+  required double lng,
+  double e5 = 155.9,
+  double e10 = 145.9,
+  double diesel = 152.9,
+}) =>
+    {
+      'site_id': siteId,
+      'brand': brand,
+      'site_name': '$brand $siteId',
+      'address': '1 Test St',
+      'postcode': 'SW1E 6DE',
+      'town': 'London',
+      'location': {'latitude': lat, 'longitude': lng},
+      'prices': {'E5': e5, 'E10': e10, 'B7': diesel},
+    };
+
+const _london = SearchParams(lat: 51.5, lng: -0.12, radiusKm: 50);
+
+void main() {
+  group('UkCmaBulkStationService (public surface)', () {
+    test('implements StationService', () {
+      expect(UkCmaBulkStationService(), isA<StationService>());
+    });
+
+    test('default consolidated URL targets the gov.uk Fuel Finder scheme', () {
+      expect(
+        UkCmaBulkStationService.defaultConsolidatedUrl,
+        contains('fuel-finder.service.gov.uk'),
+      );
+    });
+
+    test('getStationDetail throws (unsupported)', () {
+      expect(
+        () => UkCmaBulkStationService().getStationDetail('uk-1'),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('getPrices returns empty map with ukApi source', () async {
+      final r = await UkCmaBulkStationService().getPrices(['uk-1']);
+      expect(r.data, isEmpty);
+      expect(r.source, ServiceSource.ukApi);
+    });
+  });
+
+  group('extractConsolidatedRecords (bulk-parse)', () {
+    test('reads the {stations:[...]} envelope', () {
+      final recs = UkCmaBulkStationService.extractConsolidatedRecords({
+        'stations': [
+          {'site_id': 'A'},
+          {'site_id': 'B'},
+        ],
+      });
+      expect(recs, hasLength(2));
+      expect(recs[0]['site_id'], 'A');
+    });
+
+    test('reads the {data:[...]} envelope variant', () {
+      final recs = UkCmaBulkStationService.extractConsolidatedRecords({
+        'data': [
+          {'site_id': 'A'},
+        ],
+      });
+      expect(recs, hasLength(1));
+    });
+
+    test('reads a bare top-level list', () {
+      final recs = UkCmaBulkStationService.extractConsolidatedRecords([
+        {'site_id': 'A'},
+        {'site_id': 'B'},
+        {'site_id': 'C'},
+      ]);
+      expect(recs, hasLength(3));
+    });
+
+    test('returns empty for an unexpected shape', () {
+      expect(
+        UkCmaBulkStationService.extractConsolidatedRecords('nonsense'),
+        isEmpty,
+      );
+    });
+  });
+
+  group('searchStations (download once → local-filter)', () {
+    test('parses the consolidated file and local-filters by radius', () async {
+      final body = _consolidated([
+        _record(siteId: 'LON', brand: 'BP', lat: 51.5, lng: -0.12),
+        // Edinburgh — far outside a 50 km London radius.
+        _record(siteId: 'EDI', brand: 'Shell', lat: 55.9533, lng: -3.1883),
+      ]);
+      final service =
+          UkCmaBulkStationService(dio: _dioServing(body));
+
+      final result = await service.searchStations(_london);
+
+      expect(result.source, ServiceSource.ukApi);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.id, 'uk-LON');
+    });
+
+    test('downloads ONCE then serves later searches from memory (no fan-out)',
+        () async {
+      final adapter = _CountingAdapter(_consolidated([
+        _record(siteId: 'LON', brand: 'BP', lat: 51.5, lng: -0.12),
+      ]));
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = UkCmaBulkStationService(dio: dio);
+
+      await service.searchStations(_london);
+      await service.searchStations(_london);
+      await service.searchStations(
+        const SearchParams(lat: 51.51, lng: -0.13, radiusKm: 10),
+      );
+
+      expect(adapter.requestCount, 1,
+          reason: 'one consolidated download serves every search');
+    });
+
+    test('results are PRESERVED: bulk == legacy parser for the same records',
+        () async {
+      final records = [
+        _record(siteId: 'A', brand: 'BP', lat: 51.501, lng: -0.121),
+        _record(siteId: 'B', brand: 'Tesco', lat: 51.49, lng: -0.14),
+        _record(siteId: 'C', brand: 'Esso', lat: 51.6, lng: -0.05),
+      ];
+
+      // Bulk path: persist all, local-filter.
+      final bulk = UkCmaBulkStationService(
+        dio: _dioServing(_consolidated(records)),
+      );
+      final bulkResult = await bulk.searchStations(_london);
+
+      // Legacy parser over the identical records.
+      final legacy = UkStationService.parseCmaStations(
+        records,
+        lat: _london.lat,
+        lng: _london.lng,
+        radiusKm: _london.radiusKm,
+      );
+
+      expect(
+        bulkResult.data.map((s) => s.id).toList(),
+        legacy.map((s) => s.id).toList(),
+        reason: 'bulk path must return the same stations, same order',
+      );
+      expect(bulkResult.data.first.e5, legacy.first.e5);
+    });
+  });
+}


### PR DESCRIPTION
## What

Migrate the **UK** and **FR** station services off their per-search network paths onto **whole-country bulk-file** sources — downloaded once per publication cadence, persisted, and served by local geo-filter — **behind a staged-rollout flag that defaults to the legacy path**. Builds on #2267 (`FuelServicePolicy` bulkFile model + `PersistentDataset` + the chain's bulk→local-filter branch).

Closes #2277.

## The two migrations (one commit each, both behind the flag)

### 1. UK → consolidated CMA / Fuel Finder file
- `UkCmaBulkStationService` downloads **one consolidated file once per ~12 h cadence**, persists it via `PersistentDataset` (cold-start + offline), and answers every search by **local geo-filter** — stopping the per-search fan-out across ~14 retailer feeds.
- **Results preserved:** both the legacy fan-out and the bulk path run records through the **same `UkStationService.parseCmaStations`** (promoted from `@visibleForTesting` to a shared public parser), so a given area returns the same stations, deduped + sorted-by-distance + capped at 50 identically.
- Source-format note (honesty): the regulations mandate a standardized **JSON-shaped record schema** (`{stations:[{site_id, brand, address, postcode, location:{latitude,longitude}, prices:{E5,E10,B7,…}}]}`) that every retailer and the consolidated file share. The consolidated download URL is **subscription/OAuth2-gated** on the developer portal, so `defaultConsolidatedUrl` is a sensible default and is **injectable** — dropping in the issued endpoint is a one-line config change with no parse/persist/filter rework.

### 2. FR → flux-instantané bulk ZIP
- `PrixCarburantsFluxStationService` downloads the **whole-country flux ZIP once per ~10 min cadence** (`https://donnees.roulez-eco.fr/opendata/instantane`), parses it (ZIP → XML → `Station` via the pure `prix_carburants_flux_parser`), persists the parsed list, and serves every search locally — **never polls per-station**.
- **Fixes the FR empty-result/cache contract:** the legacy path swallowed a network error into an empty `ServiceResult` (chain cached nothing, re-hit next search). Now a first-ever-search failure with nothing to serve is **surfaced to the chain**; a fresh dataset answers later searches with **no re-download**; a genuinely-far search returns empty **without discarding** the dataset.
- **Results preserved:** the flux parser maps the same fuel grades onto the same `Station` fields as the legacy JSON parser (`SP95→e5`, `E10→e10`, `SP98→e98`, `Gazole→diesel`, `E85→e85`, `GPLc→lpg`), divides GeoDecimal coords by 100000 (WGS84), and keeps the `fr-` id prefix.

## The flag (staged rollout)

`lib/core/services/bulk_migration_flags.dart` — a per-source **compile-time const config toggle**, two independent booleans **both defaulting to `false` (legacy)**:

```dart
class BulkMigrationFlags {
  static const bool ukCmaBulk = false;  // false → legacy retailer fan-out
  static const bool frFluxBulk = false; // false → legacy gouv.fr polling
}
```

The `CountryServiceRegistry` reads these to pick, **per country**, between the legacy (`polledApi`) policy + factory and the bulk (`bulkFile`) policy + factory.

**How to flip it (and roll back):** set `ukCmaBulk` / `frFluxBulk` to `true` and rebuild to promote a country to its bulk source; set it back to `false` to return to the legacy path. The legacy service + policy are untouched, so the **fallback is one edit away with no migration**. UK and FR are independent — promote them separately.

**No Feature enum cascade was needed** — this gates data-source plumbing, never a user-visible capability, so there is no `Feature` / `FeatureManifest` / feature-management / ARB (en+de + 21 other locales) / count-test cascade. (`test/l10n/` and `test/lint/` stay green regardless.)

## Tests

- **UK** (`uk_cma_bulk_station_service_test.dart`): consolidated-envelope bulk-parse (`{stations}`/`{data}`/bare-list), download-once-then-serve-locally, local-filter by radius, and **results-preserved** (bulk output == `parseCmaStations` over the same records).
- **FR** (`prix_carburants_flux_test.dart`): pure XML parse (coords ÷100000, fuel→field mapping, `fr-` id, autoroute brand, thousandths fallback, malformed-XML tolerance), `parseFluxZip` end-to-end (ZIP built in-test with `archive`), download-once, local-filter, **results-preserved**, far-from-France → empty (radius contract), network-failure-with-no-data surfaces an error, fresh-dataset serves later searches.
- **Registry** (`country_service_registry_test.dart`): both flags default `false`; GB/FR policy model follows its flag (flag-OFF → legacy `polledApi`).
- Existing UK/FR service tests + the `#2264` bulk-policy chain test stay green. No live-network tests added to the default suite (the real endpoints are only exercised behind the existing `@Tags(['network'])` probes).

## Gate

- `flutter analyze`: only the 2 pre-existing infos (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`); no new errors/warnings across lib/ + test/ + integration_test/.
- `flutter test test/core/ test/features/search/ test/features/station_services/ test/l10n/ test/lint/ --exclude-tags network` → **4170 passing**.
- Clean `build_runner build --delete-conflicting-outputs` → no `.g.dart`/`.freezed.dart` drift; `git diff --exit-code` clean.

## On-device verification

Recommended before flipping either flag to `true`: with `ukCmaBulk = true`, run a real UK search and confirm stations + prices match the legacy fan-out for the same area; with `frFluxBulk = true`, run a real FR search (GPS + postal-code) and confirm the same. Both flags ship `false`, so production behaviour is unchanged until that verification is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
