### PR TITLE
fix(observability+approach): errorLogger in itinerary/movement/achievements/GPS; ItineraryNotifier double-fetch guard + parallel upload

### DIFF
--- a/lib/core/location/movement_detection_provider.dart
+++ b/lib/core/location/movement_detection_provider.dart
@@ -3,11 +3,11 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../features/consumption/data/obd2/event_channel_cancel.dart';
+import '../logging/error_logger.dart';
 import '../utils/geo_utils.dart';
 import 'geolocator_wrapper.dart';
 
@@ -163,8 +163,9 @@ class MovementDetection extends _$MovementDetection {
         .getPositionStream(locationSettings: locationSettings)
         .listen(
       _onPositionUpdate,
-      onError: (Object error) {
-        debugPrint('Movement detection stream error: $error');
+      onError: (Object error, StackTrace st) {
+        state = state.copyWith(isActive: false);
+        unawaited(errorLogger.log(ErrorLayer.other, error, st, context: const {'where': 'MovementDetection GPS stream'}));
       },
     );
 

--- a/lib/core/location/movement_detection_provider.g.dart
+++ b/lib/core/location/movement_detection_provider.g.dart
@@ -59,7 +59,7 @@ final class MovementDetectionProvider
   }
 }
 
-String _$movementDetectionHash() => r'a9e97d7a37313d4aae713844f74626da331ca9f7';
+String _$movementDetectionHash() => r'193b3db1bd6d93af2cc260dc95c95430ec1b8b00';
 
 /// Provides movement detection state for driving mode.
 ///

--- a/lib/core/telemetry/storage/isolate_error_spool.dart
+++ b/lib/core/telemetry/storage/isolate_error_spool.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -63,7 +64,45 @@ class IsolateErrorSpool {
     if (Hive.isBoxOpen(boxName)) {
       return Hive.box<String>(boxName);
     }
-    return Hive.openBox<String>(boxName);
+    // `Hive.openBox` is a double-edged failure path: when Hive has not
+    // been initialised (e.g. a unit test that stands up a provider
+    // graph without a Hive temp dir, or a background isolate that woke
+    // before `Hive.init`) it both `rethrow`s to the awaiter AND
+    // completes its internal `_openingBoxes` completer with the same
+    // error. That cached completer has no listener, so its rejection
+    // surfaces as an *unhandled* async error in the surrounding zone —
+    // which derails the caller even though `enqueue` faithfully catches
+    // the rethrown copy. Run the open inside a guarded zone so the
+    // orphaned completer error is absorbed here instead of leaking to
+    // the root / test zone, preserving the "never throws" contract.
+    final completer = Completer<Box<String>>();
+    // The guarded zone returns the body future; we deliberately do not
+    // await it here — `enqueue` awaits `completer.future` instead, and
+    // the zone's onError absorbs the orphaned completer rejection.
+    unawaited(
+      runZonedGuarded<Future<void>>(
+        () async {
+          try {
+            completer.complete(await Hive.openBox<String>(boxName));
+          } catch (e, st) {
+            if (!completer.isCompleted) {
+              completer.completeError(e, st);
+            }
+          }
+        },
+        (error, stack) {
+          // The orphaned `_openingBoxes` completer rejection lands
+          // here. If our own completer hasn't resolved yet, forward the
+          // failure so `enqueue`'s try/catch can swallow it
+          // deterministically; otherwise the error is a duplicate and
+          // is dropped.
+          if (!completer.isCompleted) {
+            completer.completeError(error, stack);
+          }
+        },
+      ),
+    );
+    return completer.future;
   }
 
   /// Reset the test seam back to the default. Call from `tearDown`.

--- a/lib/features/achievements/data/achievements_repository.dart
+++ b/lib/features/achievements/data/achievements_repository.dart
@@ -1,11 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:hive/hive.dart';
 
+import '../../../core/logging/error_logger.dart';
 import '../domain/achievement.dart';
 
 /// Hive-backed persistence of earned achievements (#781). One JSON
@@ -35,7 +36,7 @@ class AchievementsRepository {
         final earned = EarnedAchievement.fromJson(json);
         if (earned != null) result.add(earned);
       } catch (e, st) {
-        debugPrint('AchievementsRepository.loadAll: skipping $key: $e\n$st');
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'AchievementsRepository.loadAll', 'key': key.toString()}));
       }
     }
     result.sort((a, b) => b.earnedAt.compareTo(a.earnedAt));

--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -116,8 +116,8 @@ class TripGpsStreamController {
           // flow that the evaluator itself runs.
           unawaited(_maybeFireGlideCoach(ctl, pos));
         },
-        onError: (Object error) {
-          debugPrint('TripRecording GPS stream error: $error');
+        onError: (Object error, StackTrace st) {
+          unawaited(errorLogger.log(ErrorLayer.providers, error, st, context: const {'where': 'TripRecording GPS stream'}));
         },
       );
     } catch (e, st) {

--- a/lib/features/favorites/providers/ev_favorites_provider.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.dart
@@ -74,7 +74,6 @@ class EvFavoriteStations extends _$EvFavoriteStations {
     ref.watch(favoritesProvider);
     final storage = ref.read(storageRepositoryProvider);
     final favoriteIds = storage.getEvFavoriteIds();
-    debugPrint('[EvFavoriteStations.build] favoriteIds=$favoriteIds');
     if (favoriteIds.isEmpty) return const [];
 
     final stations = <ChargingStation>[];
@@ -82,10 +81,7 @@ class EvFavoriteStations extends _$EvFavoriteStations {
 
     for (final id in favoriteIds) {
       final data = storage.getEvFavoriteStationData(id);
-      debugPrint(
-          '[EvFavoriteStations.build] id=$id dataKeys=${data?.keys.toList()}');
       if (data == null) {
-        debugPrint('[EvFavoriteStations.build] MISSING DATA for id=$id');
         orphaned.add(id);
         continue;
       }
@@ -97,12 +93,9 @@ class EvFavoriteStations extends _$EvFavoriteStations {
       }
     }
 
-    if (orphaned.isNotEmpty) {
-      debugPrint(
-          '[EvFavoriteStations.build] ${orphaned.length} orphan id(s) skipped: $orphaned');
+    if (kDebugMode && orphaned.isNotEmpty) {
+      debugPrint('[EvFavoriteStations.build] ${orphaned.length} orphan id(s) skipped: $orphaned');
     }
-    debugPrint(
-        '[EvFavoriteStations.build] returning ${stations.length} stations');
     return stations;
   }
 }

--- a/lib/features/favorites/providers/ev_favorites_provider.g.dart
+++ b/lib/features/favorites/providers/ev_favorites_provider.g.dart
@@ -208,7 +208,7 @@ final class EvFavoriteStationsProvider
 }
 
 String _$evFavoriteStationsHash() =>
-    r'bbb7ea1f275fb98fe6d52c4897a472d85733a230';
+    r'12349fdb0d2d9dd531b108070c31336e4e9cfdd3';
 
 /// Loads persisted EV station data for favorites.
 ///

--- a/lib/features/itinerary/presentation/screens/itineraries_screen.dart
+++ b/lib/features/itinerary/presentation/screens/itineraries_screen.dart
@@ -26,13 +26,11 @@ class ItinerariesScreen extends ConsumerStatefulWidget {
 }
 
 class _ItinerariesScreenState extends ConsumerState<ItinerariesScreen> {
-  @override
-  void initState() {
-    super.initState();
-    Future.microtask(() {
-      ref.read(itineraryProvider.notifier).loadFromServer();
-    });
-  }
+  // initState() intentionally omitted: the keepAlive ItineraryNotifier
+  // already kicks off _loadAndMerge() via a microtask in build(). A
+  // second unconditional fetch here would cause a redundant Supabase
+  // round-trip on every navigation. Use pull-to-refresh for an explicit
+  // reload (#2312).
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/itinerary/providers/itinerary_provider.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.dart
@@ -22,6 +22,8 @@ part 'itinerary_provider.g.dart';
 /// - Sync only adds/changes, never deletes (except explicit user delete)
 @Riverpod(keepAlive: true)
 class ItineraryNotifier extends _$ItineraryNotifier {
+  bool _mergeInFlight = false;
+
   @override
   List<SavedItinerary> build() {
     // Start with local data immediately
@@ -56,11 +58,18 @@ class ItineraryNotifier extends _$ItineraryNotifier {
   }
 
   /// Load from DB first, then merge with local (local wins on conflict).
+  ///
+  /// Concurrent invocations are coalesced: if a merge is already
+  /// in-flight the second caller returns immediately. This prevents the
+  /// double-fetch that would otherwise happen when build() and
+  /// initState() both call this at navigation time.
   Future<void> _loadAndMerge() async {
-    final syncState = ref.read(syncStateProvider);
-    if (!syncState.enabled) return;
-
+    if (_mergeInFlight) return;
+    _mergeInFlight = true;
     try {
+      final syncState = ref.read(syncStateProvider);
+      if (!syncState.enabled) return;
+
       final serverItineraries = await ItinerariesSync.fetchAll();
       if (serverItineraries.isEmpty) return;
 
@@ -81,15 +90,16 @@ class ItineraryNotifier extends _$ItineraryNotifier {
       merged.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
       state = merged;
 
-      // Upload local-only items to server (sync adds, never deletes)
+      // Upload local-only items to server in parallel (sync adds, never deletes).
       final serverIds = serverItineraries.map((i) => i.id).toSet();
-      for (final localItem in state) {
-        if (!serverIds.contains(localItem.id)) {
-          await ItinerariesSync.save(localItem);
-        }
+      final localOnly = state.where((i) => !serverIds.contains(i.id)).toList();
+      if (localOnly.isNotEmpty) {
+        await Future.wait(localOnly.map(ItinerariesSync.save));
       }
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItineraryNotifier._loadAndMerge'}));
+    } finally {
+      _mergeInFlight = false;
     }
   }
 

--- a/lib/features/itinerary/providers/itinerary_provider.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.dart
@@ -1,11 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../../core/data/storage_repository.dart';
+import '../../../core/logging/error_logger.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../../core/sync/itineraries_sync.dart';
 import '../../../core/sync/sync_provider.dart';
@@ -48,7 +50,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
         );
       }).toList();
     } catch (e, st) {
-      debugPrint('ItineraryNotifier._fromStorage FAILED: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ItineraryNotifier._fromStorage'}));
       return [];
     }
   }
@@ -86,10 +88,8 @@ class ItineraryNotifier extends _$ItineraryNotifier {
           await ItinerariesSync.save(localItem);
         }
       }
-
-      debugPrint('ItineraryNotifier: merged ${state.length} itineraries (${serverItineraries.length} from server)');
     } catch (e, st) {
-      debugPrint('ItineraryNotifier._loadAndMerge FAILED: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItineraryNotifier._loadAndMerge'}));
     }
   }
 
@@ -132,7 +132,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
     try {
       await ItinerariesSync.save(itinerary);
     } catch (e, st) {
-      debugPrint('ItineraryNotifier.saveRoute sync FAILED: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItineraryNotifier.saveRoute'}));
     }
 
     return true;
@@ -149,7 +149,7 @@ class ItineraryNotifier extends _$ItineraryNotifier {
     try {
       await ItinerariesSync.delete(id);
     } catch (e, st) {
-      debugPrint('ItineraryNotifier.delete sync FAILED: $e\n$st');
+      unawaited(errorLogger.log(ErrorLayer.sync, e, st, context: const {'where': 'ItineraryNotifier.delete'}));
     }
   }
 

--- a/lib/features/itinerary/providers/itinerary_provider.g.dart
+++ b/lib/features/itinerary/providers/itinerary_provider.g.dart
@@ -53,7 +53,7 @@ final class ItineraryNotifierProvider
   }
 }
 
-String _$itineraryNotifierHash() => r'924654b33108fe778016b7761ee8167bf11436f3';
+String _$itineraryNotifierHash() => r'bbd216c85b49e9bcf871571d2d59c4b0ba2e4087';
 
 /// Manages saved itineraries with local-first strategy:
 /// - Save locally first, then sync to DB

--- a/test/core/telemetry/storage/isolate_error_spool_test.dart
+++ b/test/core/telemetry/storage/isolate_error_spool_test.dart
@@ -185,6 +185,32 @@ void main() {
       );
     });
 
+    test(
+        'enqueue does not leak an unhandled async error when Hive is '
+        'uninitialised (default box factory)', () async {
+      // Regression for the PR #2321 test(2) failure: when #2307 routed
+      // GPS-stream errors through `errorLogger.log`, an uninitialised
+      // Hive made `Hive.openBox` complete its internal `_openingBoxes`
+      // completer with an error that had no listener — surfacing as an
+      // *unhandled* async error that failed otherwise-green tests even
+      // though `enqueue` caught the rethrown copy. The fix wraps the
+      // open in a guarded zone; this test pins that the default box
+      // factory (real `Hive.openBox`) is orphan-error-safe with no Hive
+      // directory bound.
+      await Hive.close();
+      IsolateErrorSpool.resetBoxFactoryForTest();
+      await expectLater(
+        IsolateErrorSpool.enqueue(
+          isolateTaskName: 'gps_stream',
+          error: Exception('permission revoked'),
+        ),
+        completes,
+      );
+      // Drain pending microtasks; an orphaned completer rejection would
+      // surface here and fail the test zone if the guard regressed.
+      await Future<void>.delayed(Duration.zero);
+    });
+
     test('peek returns an empty list when the box factory throws',
         () async {
       IsolateErrorSpool.boxFactory = () async {

--- a/test/features/achievements/data/achievements_repository_test.dart
+++ b/test/features/achievements/data/achievements_repository_test.dart
@@ -8,8 +8,11 @@ import 'package:hive/hive.dart';
 import 'package:tankstellen/features/achievements/data/achievements_repository.dart';
 import 'package:tankstellen/features/achievements/domain/achievement.dart';
 
+import '../../../helpers/silence_error_logger.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  silenceErrorLoggerSpool();
 
   late Directory tmpDir;
   late Box<String> box;

--- a/test/features/favorites/ev_favorite_end_to_end_test.dart
+++ b/test/features/favorites/ev_favorite_end_to_end_test.dart
@@ -17,6 +17,8 @@ import 'package:tankstellen/features/favorites/providers/favorites_provider.dart
 import 'package:tankstellen/features/search/presentation/screens/ev_station_detail_screen.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
+import '../../helpers/silence_error_logger.dart';
+
 /// End-to-end TDD test for #566: tapping the star on the EV station
 /// detail screen must:
 ///   1. Persist the station to EV favorite storage (so Favorites tab shows it)
@@ -27,6 +29,8 @@ import 'package:tankstellen/l10n/app_localizations.dart';
 /// `ev/` ChargingStation), backed by REAL Hive storage — no mocks for
 /// favorites or storage.
 void main() {
+  silenceErrorLoggerSpool();
+
   late Directory tempDir;
 
   setUp(() async {

--- a/test/features/itinerary/providers/itinerary_provider_test.dart
+++ b/test/features/itinerary/providers/itinerary_provider_test.dart
@@ -9,8 +9,11 @@ import 'package:tankstellen/core/sync/sync_provider.dart';
 import 'package:tankstellen/features/itinerary/providers/itinerary_provider.dart';
 
 import '../../../fakes/fake_hive_storage.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
+
   group('ItineraryNotifier', () {
     late FakeHiveStorage fakeStorage;
     late ProviderContainer container;


### PR DESCRIPTION
## Summary

- Routes all `debugPrint`-only error-catch paths in 5 files through `errorLogger` so they surface in production (no behavioural change)
- Fixes movement-detection stream error path to also set `isActive=false`
- Adds `_mergeInFlight` guard in `ItineraryNotifier._loadAndMerge` to coalesce concurrent calls (eliminates the redundant Supabase fetch caused by `initState()`)
- Replaces the sequential local-only upload loop with `Future.wait(...)` for parallel O(1) Supabase round-trips
- Removes redundant `initState()` fetch from `ItinerariesScreen` (provider's microtask already covers startup)
- Test files updated with `silenceErrorLoggerSpool()` to prevent spool Hive failures in unit tests

## Closes

Closes #2307
Closes #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)