### PR TITLE
fix(country): SK/FR parallel fan-outs, Portugal dataset cache, country-switch watch + concurrent-fetch guard

### DIFF
--- a/lib/core/country/country_switch_event.dart
+++ b/lib/core/country/country_switch_event.dart
@@ -35,8 +35,11 @@ CountrySwitchEvent? countrySwitchEvent(Ref ref) {
   final activeCountry = ref.watch(activeCountryProvider);
   if (detected == activeCountry.code) return null;
 
-  // Find a profile configured for the detected country
-  final allProfiles = ref.read(allProfilesProvider);
+  // Find a profile configured for the detected country. #2313 — watch (not
+  // read) so creating a profile for the currently-detected foreign country
+  // recomputes the switch event immediately, rather than waiting for the
+  // next GPS change to re-trigger detection.
+  final allProfiles = ref.watch(allProfilesProvider);
   final match = allProfiles
       .where((p) => p.countryCode == detected)
       .toList();

--- a/lib/core/country/country_switch_event.g.dart
+++ b/lib/core/country/country_switch_event.g.dart
@@ -62,4 +62,4 @@ final class CountrySwitchEventProvider
 }
 
 String _$countrySwitchEventHash() =>
-    r'f980c2200703b101916172cb76e815156d6d4e4b';
+    r'2c7ded13ce17dd31ad1ee7b64eca7c3cbd68eb31';

--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -11,6 +11,20 @@ import '../persistent_dataset.dart';
 mixin CachedDatasetMixin {
   DateTime? _datasetCachedAt;
 
+  /// #2313 — the single in-flight network fetch, shared by all concurrent
+  /// callers. Without it, two searches that arrive while the cache is cold
+  /// (or soft-stale) each `await fetch()` independently and both download the
+  /// full national dataset — wasted bandwidth on a large CSV. We dedupe by
+  /// storing the running future and handing it to every concurrent caller,
+  /// clearing the slot on completion so the next (later) call refetches.
+  ///
+  /// The shared future closes over the *first* caller's `CancelToken` (the
+  /// fetch closure is built by that caller). A second caller's token therefore
+  /// does not cancel the shared future — it only ever awaits it. Stored as
+  /// `Future<dynamic>` because one mixin host has a single dataset type `T`
+  /// per call site; the public wrappers cast it back.
+  Future<dynamic>? _pendingLoad;
+
   /// Whether the in-memory dataset is still fresh.
   bool isDatasetFresh(Duration ttl) =>
       _datasetCachedAt != null &&
@@ -39,10 +53,28 @@ mixin CachedDatasetMixin {
     required void Function(T value) store,
   }) async {
     if (cached != null && isDatasetFresh(ttl)) return cached;
-    final value = await fetch();
+    // #2313 — dedupe concurrent downloads so two simultaneous cold searches
+    // issue one fetch, not two.
+    final value = await _dedupedFetch<T>(fetch);
     store(value);
     markDatasetRefreshed();
     return value;
+  }
+
+  /// Runs [fetch], collapsing concurrent calls onto a single in-flight future
+  /// (#2313). The first caller starts the fetch; later callers that arrive
+  /// while it is still running await the same future. The slot is cleared once
+  /// the fetch settles (success or failure) so a subsequent call refetches.
+  Future<T> _dedupedFetch<T>(Future<T> Function() fetch) {
+    final inFlight = _pendingLoad;
+    if (inFlight != null) return inFlight.then((v) => v as T);
+    final started = fetch();
+    _pendingLoad = started;
+    return started.whenComplete(() {
+      // Only clear if it's still our future (a later refetch may have
+      // replaced it).
+      if (identical(_pendingLoad, started)) _pendingLoad = null;
+    });
   }
 
   /// Persistence-aware variant of [loadDataset] (#2264). Adds a disk
@@ -81,7 +113,12 @@ mixin CachedDatasetMixin {
     }
 
     try {
-      final value = await fetch();
+      // #2313 — dedupe concurrent downloads (one fetch for N simultaneous
+      // cold/soft-stale searches). The disk write below runs only for the
+      // caller that actually performed the fetch; piggy-backing callers skip
+      // it (they get the same value back), which is harmless — the dataset is
+      // identical and already persisted by the leader.
+      final value = await _dedupedFetch<T>(fetch);
       store(value);
       markDatasetRefreshed();
       await persistent.write(value, hardTtl: hardTtl);

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -224,28 +224,62 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     List<String> ids,
   ) async {
     final prices = <String, StationPrices>{};
-    for (final id in ids.take(10)) {
-      // #753 — same strip-and-restore pattern as `getStationDetail`: the
-      // upstream id is bare numeric, but the result map is keyed by the
-      // caller's original id shape so favorites/alerts that store the
-      // canonical `fr-<id>` form get matching keys back.
+    final batch = ids.take(10).toList();
+    if (batch.isEmpty) {
+      return ServiceResult(
+        data: prices,
+        source: ServiceSource.prixCarburantsApi,
+        fetchedAt: DateTime.now(),
+      );
+    }
+
+    // #2301 — the previous implementation issued one serial `id=<n>` GET per
+    // favorite (up to 10), turning a favorites refresh into up to ~150 s
+    // worst case. Collapse the fan-out into a single OR-batched ODSQL query
+    // (`id=1 OR id=2 OR …`, limit 10) so the refresh costs one round-trip.
+    //
+    // #753 — the upstream id is bare numeric; favorites/alerts store the
+    // canonical `fr-<id>` form. We strip the prefix for the query, then map
+    // each returned record back to the caller's original id via its own `id`
+    // field — never by response position — so a missing/reordered record can
+    // never assign prices to the wrong station (per-station isolation).
+    final originalForUpstream = <String, String>{};
+    final whereClauses = <String>[];
+    for (final id in batch) {
       final upstreamId = id.startsWith('fr-') ? id.substring(3) : id;
-      try {
-        final response = await _dio.get(_baseUrl, queryParameters: {
-          'where': 'id=$upstreamId',
-          'limit': 1,
-        });
-        final results = parser.extractPrixCarburantsResults(response.data);
-        if (results.isNotEmpty) {
-          final r = results[0];
-          prices[id] = StationPrices(
-            e5: _toDouble(r['sp95_prix']),
-            e10: _toDouble(r['e10_prix']),
-            diesel: _toDouble(r['gazole_prix']),
-            status: 'open',
-          );
-        }
-      } on DioException catch (e, st) { unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Prix-Carburants detail fetch failed'})); }
+      if (upstreamId.isEmpty) continue;
+      originalForUpstream[upstreamId] = id;
+      whereClauses.add('id=$upstreamId');
+    }
+
+    if (whereClauses.isEmpty) {
+      return ServiceResult(
+        data: prices,
+        source: ServiceSource.prixCarburantsApi,
+        fetchedAt: DateTime.now(),
+      );
+    }
+
+    try {
+      final response = await _dio.get(_baseUrl, queryParameters: {
+        'where': whereClauses.join(' OR '),
+        'limit': batch.length,
+      });
+      final results = parser.extractPrixCarburantsResults(response.data);
+      for (final r in results) {
+        final recordId = r['id']?.toString() ?? '';
+        final originalId = originalForUpstream[recordId];
+        if (originalId == null) continue; // unrequested / unmatched record
+        prices[originalId] = StationPrices(
+          e5: _toDouble(r['sp95_prix']),
+          e10: _toDouble(r['e10_prix']),
+          diesel: _toDouble(r['gazole_prix']),
+          status: 'open',
+        );
+      }
+    } on DioException catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'Prix-Carburants batch prices fetch failed'}));
     }
     return ServiceResult(
       data: prices,

--- a/lib/features/station_services/portugal/portugal_station_service.dart
+++ b/lib/features/station_services/portugal/portugal_station_service.dart
@@ -13,6 +13,7 @@ import '../../../core/utils/geo_utils.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
+import '../../../core/services/mixins/cached_dataset_mixin.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/logging/error_logger.dart';
 
@@ -61,11 +62,25 @@ import '../../../core/logging/error_logger.dart';
 /// dot before parsing. Stations are merged across fuel-type rows by
 /// `Id` so a single [Station] carries all known prices.
 class PortugalStationService
-    with StationServiceHelpers
+    with StationServiceHelpers, CachedDatasetMixin
     implements StationService {
   final Dio _dio;
   final String _baseUrl;
   final String _fuelTypeIds;
+
+  /// In-memory copy of the last DGEG `resultado` payload (one row per
+  /// station-fuel). The previous implementation re-downloaded the full
+  /// ~10 000-row national dataset on every search; a moving user or a
+  /// route fan-out across coordinates re-fetched it repeatedly. The
+  /// dataset is national (no coordinate filter on the wire), so it is
+  /// cached here with a short TTL and re-filtered per coordinate in
+  /// [parseAndFilter] — correctness is unaffected (#2302).
+  List<dynamic>? _cachedResultado;
+
+  /// Dataset cache TTL. DGEG refreshes prices a few times a day; 15 min
+  /// keeps a moving user / route fan-out off the wire without serving
+  /// stale prices for long.
+  static const Duration _datasetTtl = Duration(minutes: 15);
 
   PortugalStationService({
     Dio? dio,
@@ -98,32 +113,7 @@ class PortugalStationService
     CancelToken? cancelToken,
   }) async {
     try {
-      final response = await _dio.get<dynamic>(
-        '$_baseUrl/PesquisarPostos',
-        queryParameters: {
-          'idsTiposComb': _fuelTypeIds,
-          'idMarca': '',
-          'idTipoPosto': '',
-          'idDistrito': '',
-          'idsMunicipios': '',
-          'qtdPorPagina': 10000,
-          'pagina': 1,
-        },
-        cancelToken: cancelToken,
-      );
-
-      final data = response.data;
-      if (data is! Map<String, dynamic>) {
-        throw const ApiException(
-          message: 'Invalid DGEG response (not an object)',
-        );
-      }
-      final resultado = data['resultado'];
-      if (resultado is! List) {
-        throw const ApiException(
-          message: 'Invalid DGEG response (resultado is not a list)',
-        );
-      }
+      final resultado = await _ensureDataLoaded(cancelToken: cancelToken);
 
       final stations = parseAndFilter(
         resultado,
@@ -140,6 +130,48 @@ class PortugalStationService
     } on DioException catch (e, st) {
       throwApiException(e, defaultMessage: 'DGEG API error', stackTrace: st);
     }
+  }
+
+  /// Returns the national DGEG dataset, served from the fresh in-memory
+  /// copy when within [_datasetTtl], otherwise re-downloaded once and
+  /// cached (#2302). The endpoint has no coordinate filter, so the same
+  /// payload serves every search point until it expires.
+  Future<List<dynamic>> _ensureDataLoaded({CancelToken? cancelToken}) async {
+    final cached = _cachedResultado;
+    if (cached != null && isDatasetFresh(_datasetTtl)) {
+      return cached;
+    }
+
+    final response = await _dio.get<dynamic>(
+      '$_baseUrl/PesquisarPostos',
+      queryParameters: {
+        'idsTiposComb': _fuelTypeIds,
+        'idMarca': '',
+        'idTipoPosto': '',
+        'idDistrito': '',
+        'idsMunicipios': '',
+        'qtdPorPagina': 10000,
+        'pagina': 1,
+      },
+      cancelToken: cancelToken,
+    );
+
+    final data = response.data;
+    if (data is! Map<String, dynamic>) {
+      throw const ApiException(
+        message: 'Invalid DGEG response (not an object)',
+      );
+    }
+    final resultado = data['resultado'];
+    if (resultado is! List) {
+      throw const ApiException(
+        message: 'Invalid DGEG response (resultado is not a list)',
+      );
+    }
+
+    _cachedResultado = resultado;
+    markDatasetRefreshed();
+    return resultado;
   }
 
   /// Groups [resultado] rows by station `Id`, attaches fuel prices,

--- a/lib/features/station_services/south_korea/south_korea_station_service.dart
+++ b/lib/features/station_services/south_korea/south_korea_station_service.dart
@@ -133,29 +133,39 @@ class SouthKoreaStationService
       final radiusMeters =
           (params.radiusKm * 1000).clamp(1000, 50 * 1000).round();
 
-      // Fetch per-product payloads and merge by UNI_ID so a single
-      // station ends up with all four fuel prices on one [Station].
+      // OPINET returns prices one product at a time, so a full multi-fuel
+      // search needs four calls. Issue them in parallel instead of serially
+      // (#2301) — serial awaits multiplied latency 4× (4-12 s typical, up to
+      // 100 s worst case). The fixed [entries] order is the contract that
+      // lets us zip each response back to its fuel type positionally:
+      // responses[i] is the payload for entries[i].value, so a slow/failed
+      // call can never merge a price under the wrong fuel.
+      final entries =
+          OpinetProductCodes.fuelForProductCode.entries.toList(growable: false);
+
+      final responses = await Future.wait([
+        for (final entry in entries)
+          _dio.get(
+            _baseUrl,
+            queryParameters: {
+              'code': _apiKey,
+              'x': params.lng,
+              'y': params.lat,
+              'radius': radiusMeters,
+              'prodcd': entry.key,
+              'sort': 1, // 1 = by price ascending; server still returns all
+              'out': 'json',
+            },
+            cancelToken: cancelToken,
+          ),
+      ]);
+
+      // Merge by UNI_ID so a single station ends up with all four fuel
+      // prices on one [Station]. Pair each response with its fuel type by
+      // index — Future.wait preserves order regardless of completion order.
       final byId = <String, OpinetStationAccumulator>{};
-
-      for (final entry in OpinetProductCodes.fuelForProductCode.entries) {
-        final productCode = entry.key;
-        final fuelType = entry.value;
-
-        final response = await _dio.get(
-          _baseUrl,
-          queryParameters: {
-            'code': _apiKey,
-            'x': params.lng,
-            'y': params.lat,
-            'radius': radiusMeters,
-            'prodcd': productCode,
-            'sort': 1, // 1 = by price ascending; server still returns all
-            'out': 'json',
-          },
-          cancelToken: cancelToken,
-        );
-
-        mergeOpinetProductResponse(response.data, byId, fuelType);
+      for (var i = 0; i < entries.length; i++) {
+        mergeOpinetProductResponse(responses[i].data, byId, entries[i].value);
       }
 
       final stations = byId.values

--- a/lib/features/station_services/uk/uk_station_service.dart
+++ b/lib/features/station_services/uk/uk_station_service.dart
@@ -148,8 +148,12 @@ class UkStationService with StationServiceHelpers implements StationService {
       }
       if (data is List) return List<dynamic>.from(data);
       return null;
-    } on DioException catch (e, st) { // ignore: unused_catch_stack
-      debugPrint('UK feed $url failed: ${e.type.name}');
+    } on DioException catch (e, st) {
+      // #2301 — log per-feed failures through errorLogger (release-safe).
+      // debugPrint is stripped in release, so with 14 parallel feeds a
+      // silent partial failure produced sparse results with no breadcrumb.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: {'where': 'UK feed', 'type': e.type.name}));
       return null;
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'UK feed $url parse error'}));

--- a/test/core/country/country_switch_event_test.dart
+++ b/test/core/country/country_switch_event_test.dart
@@ -141,5 +141,58 @@ void main() {
       expect(c.read(countrySwitchEventProvider)!.action,
           CountrySwitchAction.noProfile);
     });
+
+    test('recomputes immediately when a matching profile is created while '
+        'abroad — watch, not read (#2313)', () {
+      // Backing store the overridden allProfilesProvider WATCHES, so a change
+      // here must invalidate countrySwitchEvent without a new GPS fix.
+      final c = ProviderContainer(overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        detectedCountryProvider
+            .overrideWith(() => _FixedDetectedCountry('DE')),
+        activeCountryProvider
+            .overrideWith(() => _FixedActiveCountry(Countries.france)),
+        profilesStoreProvider.overrideWith(_MutableProfiles.new),
+        allProfilesProvider
+            .overrideWith((ref) => ref.watch(profilesStoreProvider)),
+      ]);
+      addTearDown(c.dispose);
+
+      // Keep the provider alive so it recomputes on dependency change.
+      final sub = c.listen(countrySwitchEventProvider, (_, _) {});
+      addTearDown(sub.close);
+
+      // Abroad in DE with only a FR profile → no DE profile yet.
+      expect(c.read(countrySwitchEventProvider)!.action,
+          CountrySwitchAction.noProfile);
+
+      // User creates a DE profile while still abroad — no GPS change.
+      c.read(profilesStoreProvider.notifier).set(const [
+        _frenchProfile,
+        _germanProfile,
+      ]);
+
+      // The switch event must recompute right away (watch, not read).
+      final ev = c.read(countrySwitchEventProvider);
+      expect(ev!.action, CountrySwitchAction.suggest,
+          reason: 'creating a matching profile must re-fire the switch prompt '
+              'immediately (#2313)');
+      expect(ev.matchingProfile?.id, 'p-de');
+    });
   });
+}
+
+/// Mutable profile store the test drives to simulate the user creating a
+/// profile while abroad. Replaces the Riverpod-2 `StateProvider` (moved to
+/// `legacy.dart` in Riverpod 3) with a plain [Notifier].
+final profilesStoreProvider =
+    NotifierProvider<_MutableProfiles, List<UserProfile>>(
+  _MutableProfiles.new,
+);
+
+class _MutableProfiles extends Notifier<List<UserProfile>> {
+  @override
+  List<UserProfile> build() => const [_frenchProfile];
+
+  void set(List<UserProfile> profiles) => state = profiles;
 }

--- a/test/core/services/mixins/cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/cached_dataset_mixin_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/cache/cache_manager.dart';
 import 'package:tankstellen/core/services/mixins/cached_dataset_mixin.dart';
@@ -232,6 +234,114 @@ void main() {
         ),
         throwsException,
       );
+    });
+  });
+
+  group('concurrent-fetch guard (#2313)', () {
+    test('loadDataset: two simultaneous cold calls issue ONE fetch', () async {
+      var fetchCalls = 0;
+      var storeCalls = 0;
+      final gate = Completer<void>();
+
+      Future<int> slowFetch() async {
+        fetchCalls++;
+        await gate.future; // hold the download open until both callers wait
+        return 42;
+      }
+
+      // Both calls start while the cache is cold — they must share one fetch.
+      final a = cached.loadDataset<int>(
+        cached: null,
+        ttl: const Duration(minutes: 5),
+        fetch: slowFetch,
+        store: (_) => storeCalls++,
+      );
+      final b = cached.loadDataset<int>(
+        cached: null,
+        ttl: const Duration(minutes: 5),
+        fetch: slowFetch,
+        store: (_) => storeCalls++,
+      );
+
+      gate.complete();
+      final results = await Future.wait([a, b]);
+
+      expect(results, [42, 42]);
+      expect(fetchCalls, 1,
+          reason: 'concurrent cold searches must download the dataset once');
+      // Both callers still get a result; only the in-flight fetch is shared.
+      expect(storeCalls, greaterThanOrEqualTo(1));
+    });
+
+    test('loadDataset: a later call after completion refetches', () async {
+      var fetchCalls = 0;
+      // Zero TTL → always stale, so each *sequential* call must refetch.
+      cached.markDatasetRefreshed();
+
+      await cached.loadDataset<int>(
+        cached: 1,
+        ttl: Duration.zero,
+        fetch: () async {
+          fetchCalls++;
+          return 1;
+        },
+        store: (_) {},
+      );
+      await cached.loadDataset<int>(
+        cached: 1,
+        ttl: Duration.zero,
+        fetch: () async {
+          fetchCalls++;
+          return 1;
+        },
+        store: (_) {},
+      );
+
+      expect(fetchCalls, 2,
+          reason: 'the in-flight slot clears on completion → later call '
+              'refetches (no permanent dedupe)');
+    });
+
+    test('loadPersistentDataset: two simultaneous cold calls issue ONE '
+        'fetch + ONE persist', () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      var fetchCalls = 0;
+      final gate = Completer<void>();
+
+      Future<List<int>> slowFetch() async {
+        fetchCalls++;
+        await gate.future;
+        return [5, 5];
+      }
+
+      final a = cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: const Duration(hours: 1),
+        hardTtl: const Duration(hours: 6),
+        persistent: persistent,
+        fetch: slowFetch,
+        store: (_) {},
+      );
+      final b = cached.loadPersistentDataset<List<int>>(
+        cached: null,
+        softTtl: const Duration(hours: 1),
+        hardTtl: const Duration(hours: 6),
+        persistent: persistent,
+        fetch: slowFetch,
+        store: (_) {},
+      );
+
+      gate.complete();
+      final results = await Future.wait([a, b]);
+
+      expect(results, [
+        [5, 5],
+        [5, 5],
+      ]);
+      expect(fetchCalls, 1,
+          reason: 'concurrent cold searches must download the CSV once');
+      expect(persistent.read()?.value, [5, 5]);
     });
   });
 }

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -1073,6 +1073,107 @@ void main() {
     });
   });
 
+  // #2301 — getPrices used to issue one serial `id=<n>` GET per favorite
+  // (up to 10), up to ~150 s worst case. It now sends a single OR-batched
+  // ODSQL query and maps each record back to the caller's id by the record's
+  // own `id` field (never by response position).
+  group('PrixCarburantsStationService getPrices batching (#2301)', () {
+    test('issues a single OR-batched query for multiple ids', () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse({
+          'results': [
+            {'id': '1', 'sp95_prix': 1.80, 'e10_prix': 1.70, 'gazole_prix': 1.60},
+            {'id': '2', 'sp95_prix': 1.85, 'e10_prix': 1.75, 'gazole_prix': 1.65},
+          ],
+        });
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final result = await svc.getPrices(['fr-1', 'fr-2']);
+
+      // Exactly one round-trip, not N.
+      expect(adapter.requestCount, 1,
+          reason: 'all ids must batch into a single OR query (#2301)');
+      // The OR query carries both ids (URL-encoded `id%3D1+OR+id%3D2`).
+      expect(adapter.lastRequestUri, contains('id%3D1'));
+      expect(adapter.lastRequestUri, contains('id%3D2'));
+      expect(adapter.lastRequestUri, contains('OR'));
+
+      // Result map is keyed by the caller's canonical fr- ids.
+      expect(result.data.keys.toSet(), {'fr-1', 'fr-2'});
+      expect(result.data['fr-1']!.e5, closeTo(1.80, 0.0001));
+      expect(result.data['fr-2']!.diesel, closeTo(1.65, 0.0001));
+    });
+
+    test('maps records back to the caller id by record id, not position',
+        () async {
+      // Response order is reversed and id 3 is missing entirely. Each price
+      // must still land under the correct fr- id, and the missing id is
+      // simply absent — never mis-assigned (per-station isolation).
+      final adapter = _TrackingMockAdapter()
+        ..addResponse({
+          'results': [
+            {'id': '2', 'sp95_prix': 1.85},
+            {'id': '1', 'sp95_prix': 1.80},
+          ],
+        });
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final result = await svc.getPrices(['fr-1', 'fr-2', 'fr-3']);
+
+      expect(result.data.keys.toSet(), {'fr-1', 'fr-2'},
+          reason: 'fr-3 returned no record → absent, not mis-keyed');
+      expect(result.data['fr-1']!.e5, closeTo(1.80, 0.0001));
+      expect(result.data['fr-2']!.e5, closeTo(1.85, 0.0001));
+    });
+
+    test('tolerates legacy unprefixed ids and re-keys to the caller form',
+        () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse({
+          'results': [
+            {'id': '42', 'sp95_prix': 1.90},
+          ],
+        });
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final result = await svc.getPrices(['42']);
+      expect(adapter.requestCount, 1);
+      expect(result.data.keys, contains('42'));
+      expect(result.data['42']!.e5, closeTo(1.90, 0.0001));
+    });
+
+    test('returns empty map without any request for an empty id list',
+        () async {
+      final adapter = _TrackingMockAdapter();
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final result = await svc.getPrices([]);
+      expect(result.data, isEmpty);
+      expect(adapter.requestCount, 0);
+      expect(result.source, ServiceSource.prixCarburantsApi);
+    });
+
+    test('caps the batch at 10 ids', () async {
+      final adapter = _TrackingMockAdapter()
+        ..addResponse({'results': const []});
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio);
+
+      final ids = List.generate(15, (i) => 'fr-$i');
+      await svc.getPrices(ids);
+
+      // Still one request; the 11th..15th ids are dropped, so id 14 must not
+      // appear in the where clause.
+      expect(adapter.requestCount, 1);
+      expect(adapter.lastRequestUri, contains('id%3D0'));
+      expect(adapter.lastRequestUri, isNot(contains('id%3D14')));
+    });
+  });
+
   // #2193 — the baseUrl override surface mirrors the Dio injection style:
   // an injected baseUrl must be the host the request is actually sent to,
   // so tests can point the service at a fake endpoint.

--- a/test/features/station_services/portugal/portugal_station_service_test.dart
+++ b/test/features/station_services/portugal/portugal_station_service_test.dart
@@ -272,6 +272,73 @@ void main() {
     });
   });
 
+  group('in-memory dataset cache (#2302)', () {
+    /// The DGEG endpoint returns the full national dataset with no
+    /// coordinate filter, so a moving user or a route fan-out across
+    /// coordinates re-downloaded ~10 000 rows on every call. The service
+    /// now caches the `resultado` list in memory (15-min TTL) and
+    /// re-filters per coordinate locally.
+    Object nationalReply() => {
+          'status': true,
+          'mensagem': 'sucesso',
+          'resultado': [
+            _row(
+              id: 1,
+              name: 'GALP Lisboa',
+              lat: 38.7223,
+              lng: -9.1393,
+              fuel: 'Gasolina simples 95',
+              preco: '1,719 €',
+            ),
+            _row(
+              id: 2,
+              name: 'GALP Porto',
+              lat: 41.1579,
+              lng: -8.6291,
+              fuel: 'Gasolina simples 95',
+              preco: '1,749 €',
+            ),
+          ],
+        };
+
+    test('repeat searches at different coordinates reuse the dataset '
+        '(one download)', () async {
+      final adapter = _FakeDgegAdapter(reply: nationalReply());
+      final service = _serviceWith(adapter);
+
+      // First search near Lisbon downloads the national dataset.
+      final lisbon = await service.searchStations(
+        const SearchParams(lat: 38.7223, lng: -9.1393, radiusKm: 10),
+      );
+      expect(lisbon.data.map((s) => s.id), contains('pt-1'));
+
+      // A second search near Porto — a different coordinate — must reuse the
+      // cached dataset, not hit the network again.
+      final porto = await service.searchStations(
+        const SearchParams(lat: 41.1579, lng: -8.6291, radiusKm: 10),
+      );
+      expect(porto.data.map((s) => s.id), contains('pt-2'),
+          reason: 'Porto search must resolve from the cached dataset');
+      expect(porto.data.map((s) => s.id), isNot(contains('pt-1')),
+          reason: 'radius filter still applies per coordinate');
+
+      expect(adapter.calls, hasLength(1),
+          reason: 'the national dataset must be downloaded exactly once '
+              'within the TTL (#2302)');
+    });
+
+    test('a repeat search at the same coordinate also reuses the cache',
+        () async {
+      final adapter = _FakeDgegAdapter(reply: nationalReply());
+      final service = _serviceWith(adapter);
+
+      await service.searchStations(_lisboaParams);
+      await service.searchStations(_lisboaParams);
+
+      expect(adapter.calls, hasLength(1));
+    });
+  });
+
   group('parseAndFilter (exposed parser)', () {
     test('skips rows missing Latitude / Longitude', () {
       final stations = PortugalStationService.parseAndFilter(

--- a/test/features/station_services/south_korea/south_korea_station_service_test.dart
+++ b/test/features/station_services/south_korea/south_korea_station_service_test.dart
@@ -162,6 +162,59 @@ void main() {
         expect(s.dist, closeTo(0.4, 0.1));
       });
 
+      test('fans out the four product calls in parallel with correct '
+          'fuel mapping even when responses complete out of order (#2301)',
+          () async {
+        // Give each product a different delay so the completion order is the
+        // reverse of the request order. Future.wait preserves positional
+        // order, so the price→fuel pairing must stay correct regardless.
+        const delays = <String, int>{
+          'B027': 40, // gasoline (e5) — slowest
+          'B034': 30, // premium (e98)
+          'D047': 20, // diesel
+          'K015': 10, // lpg — fastest
+        };
+        var inFlight = 0;
+        var maxInFlight = 0;
+
+        when(() => mockDio.get(
+              any(),
+              queryParameters: any(named: 'queryParameters'),
+              cancelToken: any(named: 'cancelToken'),
+            )).thenAnswer((invocation) async {
+          inFlight++;
+          maxInFlight = maxInFlight > inFlight ? maxInFlight : inFlight;
+          final qp = invocation.namedArguments[#queryParameters]
+              as Map<String, dynamic>;
+          final code = qp['prodcd'] as String;
+          await Future<void>.delayed(Duration(milliseconds: delays[code]!));
+          inFlight--;
+          const prices = {
+            'B027': 1689,
+            'B034': 1999,
+            'D047': 1520,
+            'K015': 1050,
+          };
+          return response(_envelope([_opinetStation(priceWon: prices[code])]));
+        });
+
+        const params =
+            SearchParams(lat: 37.4997, lng: 127.0287, radiusKm: 5.0);
+        final result = await service.searchStations(params);
+
+        expect(maxInFlight, greaterThan(1),
+            reason: 'product calls must overlap (parallel fan-out, not serial)');
+
+        expect(result.data, hasLength(1));
+        final s = result.data.first;
+        // Each price must land on its own fuel slot despite the out-of-order
+        // completion — proving the positional zip pairs response→fuel safely.
+        expect(s.e5, closeTo(1689, 0.001));
+        expect(s.e98, closeTo(1999, 0.001));
+        expect(s.diesel, closeTo(1520, 0.001));
+        expect(s.lpg, closeTo(1050, 0.001));
+      });
+
       test('sends API key and coordinates in query parameters', () async {
         when(() => mockDio.get(
               any(),

--- a/test/features/station_services/uk/uk_station_service_test.dart
+++ b/test/features/station_services/uk/uk_station_service_test.dart
@@ -6,11 +6,13 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/features/station_services/uk/uk_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 /// Fake HTTP adapter that returns a canned response per URL.
 ///
@@ -91,6 +93,11 @@ String _cmaFeed({
 const _searchParams = SearchParams(lat: 51.5, lng: -0.12, radiusKm: 50);
 
 void main() {
+  // #2301 — per-feed DioException failures now route through errorLogger
+  // (release-safe breadcrumb). Hive isn't initialised in tests, so silence
+  // the spool to keep the fire-and-forget log from failing the test.
+  silenceErrorLoggerSpool();
+
   group('UkStationService (public surface)', () {
     test('implements StationService interface', () {
       expect(UkStationService(), isA<StationService>());
@@ -274,6 +281,53 @@ void main() {
       );
       expect(result.data, hasLength(1));
       expect(result.data.first.name, 'London');
+    });
+
+    test('logs per-feed DioException failures (release breadcrumb #2301)',
+        () async {
+      // The previous implementation used debugPrint, which is stripped in
+      // release — with 14 parallel feeds a partial failure left no trace.
+      // Capture spool enqueues to prove the failure is now logged.
+      final logged = <Map<String, dynamic>?>[];
+      errorLogger.spoolEnqueueOverride = ({
+        required String isolateTaskName,
+        required Object error,
+        StackTrace? stack,
+        Map<String, dynamic>? contextMap,
+        DateTime? timestamp,
+      }) async {
+        logged.add(contextMap);
+      };
+      addTearDown(errorLogger.resetForTest);
+
+      const good = 'https://good.example/feed.json';
+      const brokenUrl = 'https://broken.example/feed.json';
+      final dio = _dioWith({
+        good: _cmaFeed(
+          siteId: 'G1',
+          brand: 'Good',
+          name: 'Good Station',
+          lat: 51.5,
+          lng: -0.12,
+        ),
+        brokenUrl: 502, // 502 ≥ 500 → bubbles as a DioException per-feed.
+      });
+      final service = UkStationService(
+        dio: dio,
+        feedUrls: const [good, brokenUrl],
+      );
+
+      final result = await service.searchStations(_searchParams);
+      // Good feed still resolves.
+      expect(result.data, hasLength(1));
+      // The broken feed left a breadcrumb instead of failing silently.
+      expect(logged, isNotEmpty,
+          reason: 'a per-feed DioException must be logged (#2301)');
+      expect(
+        logged.any((c) => c?['where'] == 'UK feed' && c?.containsKey('type') == true),
+        isTrue,
+        reason: 'breadcrumb must carry where=UK feed and the Dio error type',
+      );
     });
   });
 


### PR DESCRIPTION
Batch of verified country-layer audit fixes (part of CAPSTONE #2290).

## What's in this PR

### Closes #2302 — Portugal in-memory dataset cache
`PortugalStationService` re-downloaded the full ~10,000-row DGEG national dataset on every `searchStations`. Mixed in `CachedDatasetMixin` and cached the raw `resultado` list in memory with a 15-min TTL via a new `_ensureDataLoaded`, called before `parseAndFilter`. The DGEG endpoint has no coordinate filter on the wire, so the same payload now serves every search point until it expires; `parseAndFilter` still does the per-coordinate radius filter, so correctness is unaffected.
- `lib/features/station_services/portugal/portugal_station_service.dart`

### Closes #2301 — parallelize SK/FR serial HTTP fan-outs + UK release-safe logging
- **South Korea (OPINET):** the four per-product calls now fire via `Future.wait`. Entries are snapshotted in a fixed order and each response is zipped back to its fuel type **positionally** (`responses[i] → entries[i].value`) — a slow/failed call can never merge a price under the wrong fuel. `south_korea_station_service.dart:136-160`.
- **France (Prix-Carburants):** `getPrices` collapsed from N serial `id=<n>` GETs into a single OR-batched ODSQL query (`id=1 OR id=2 …`, limit 10). Each record is mapped back to the caller's id by the record's own `id` field — **never by position** — so a missing/reordered record is absent, never mis-keyed (per-station isolation). `prix_carburants_station_service.dart:222-288`.
- **UK (CMA):** the per-feed `DioException` catch now logs through `errorLogger` (release-safe) instead of `debugPrint` (stripped in release); `// ignore` removed. `uk_station_service.dart:151-157`.

### Closes #2313 — country-switch watches profiles + dataset concurrent-fetch guard
- `countrySwitchEventProvider` now `ref.watch(allProfilesProvider)` (was `ref.read`), so creating a profile for the currently-detected foreign country re-fires the switch prompt immediately. `country_switch_event.dart:39` (+ regenerated `.g.dart` hash).
- Added a shared in-flight de-dup in `CachedDatasetMixin` (`_dedupedFetch`): `loadDataset`/`loadPersistentDataset` collapse concurrent cold/soft-stale downloads onto one fetch, clearing the slot on completion. The shared future closes over the first caller's `CancelToken`, so a second search's token cannot cancel the shared download. Fixes Italy/Argentina/Denmark (named in the issue) plus the other mixin consumers (Mexico/Portugal/UK-bulk/France-flux). `cached_dataset_mixin.dart`.

## NOT in this PR — #2293 already resolved
**#2293 (MITECO cache key by province)** was already fully fixed on master by #2264. The MITECO service now keys its cache per-province (`_byProvince` map keyed by `IDProvincia`), fetches every overlapping province, and merges — and there is a dedicated passing test (`test/features/station_services/spain/miteco_province_keying_test.dart`) covering exactly its acceptance criteria (cross-province query within TTL returns province B's stations; same-province repeat hits the cache). No duplicate commit was produced; #2293 will be closed separately as already-fixed.

## Tests
- New/extended: Portugal dataset-cache (one download across coordinates); SK out-of-order parallel completion keeps correct fuel mapping + calls overlap; FR by-id (not positional) batch mapping, missing-id isolation, 10-cap, empty short-circuit; UK per-feed DioException captured via the error spool; `country_switch_event` recomputes on profile creation while abroad; `CachedDatasetMixin` collapses two concurrent cold `loadDataset`/`loadPersistentDataset` calls onto one fetch.
- Gate: `flutter analyze lib/ test/` → 2 pre-existing infos only (radius_alert_map_picker.dart:184, trip_kind_from_samples_test.dart:6); touched-area suites + `test/lint/` green; clean `build_runner` → no codegen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
