### PR TITLE
fix/perf(sync,observability): GDPR delete-all completeness + batched sync upserts + telemetry efficiency/contracts

### DIFF
--- a/lib/core/sync/ratings_sync.dart
+++ b/lib/core/sync/ratings_sync.dart
@@ -54,6 +54,42 @@ class RatingsSync {
     }
   }
 
+  /// Upsert many station ratings in a SINGLE round-trip (#2319).
+  ///
+  /// Mirrors [FavoritesSync.merge]'s batch-upsert pattern for the same
+  /// `(user_id, station_id)` table shape: instead of N serial
+  /// `upsert` calls on initial sync, build one row list and ship it in
+  /// one request. No-op when the map is empty or the session isn't
+  /// authenticated. All ratings default to owner-private
+  /// (`is_shared = false`) — the per-rating share toggle still goes
+  /// through [upsert].
+  static Future<void> upsertAll(Map<String, int> ratings) async {
+    if (ratings.isEmpty) return;
+    final client = TankSyncClient.client;
+    final userId = client?.auth.currentUser?.id;
+    if (client == null || userId == null) return;
+
+    final now = DateTime.now().toIso8601String();
+    final rows = ratings.entries
+        .map((e) => {
+              'user_id': userId,
+              'station_id': e.key,
+              'rating': e.value,
+              'is_shared': false,
+              'updated_at': now,
+            })
+        .toList();
+
+    try {
+      await client
+          .from('station_ratings')
+          .upsert(rows, onConflict: 'user_id,station_id');
+      debugPrint('RatingsSync.upsertAll: ${rows.length} ratings in 1 round-trip');
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'RatingsSync.upsertAll FAILED'}));
+    }
+  }
+
   /// Delete a rating from the server. Typically called when the
   /// station is unfavorited (ratings live alongside favorites).
   static Future<void> delete(String stationId) async {

--- a/lib/core/sync/schema_verifier.dart
+++ b/lib/core/sync/schema_verifier.dart
@@ -37,19 +37,30 @@ class SchemaVerifier {
   ///
   /// Returns a map of table name → exists (true/false).
   /// Returns null if the client is not connected.
+  ///
+  /// #2310 — the existence probes are independent, so they run in
+  /// parallel via [Future.wait] (was a sequential per-table loop on the
+  /// wizard's connect / re-check tap). Each probe selects only `id`
+  /// (was `select('*')`, needlessly broad) with `limit(0)` so it never
+  /// transfers row data — a missing table / failed probe maps to false.
   static Future<Map<String, bool>?> checkSchema() async {
     final client = TankSyncClient.client;
     if (client == null) return null;
 
-    final result = <String, bool>{};
-    for (final table in [...requiredTables, ...optionalTables]) {
-      try {
-        await client.from(table).select('*').limit(0);
-        result[table] = true;
-      } catch (e, st) { unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'SchemaVerifier: table check failed'}));
-        result[table] = false;
-      }
-    }
+    final entries = await Future.wait(
+      [...requiredTables, ...optionalTables].map(
+        (table) => client
+            .from(table)
+            .select('id')
+            .limit(0)
+            .then((_) => MapEntry(table, true))
+            .catchError((Object e, StackTrace st) {
+          unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'SchemaVerifier: table check failed'}));
+          return MapEntry(table, false);
+        }),
+      ),
+    );
+    final result = Map<String, bool>.fromEntries(entries);
 
     debugPrint('SchemaVerifier: ${result.entries.where((e) => e.value).length}/${result.length} tables found');
     return result;

--- a/lib/core/sync/sync_provider.dart
+++ b/lib/core/sync/sync_provider.dart
@@ -213,10 +213,9 @@ class SyncState extends _$SyncState {
         if (favIds.isNotEmpty) await FavoritesSync.merge(favIds);
         final ignoredIds = storage.getIgnoredIds();
         if (ignoredIds.isNotEmpty) await IgnoredStationsSync.merge(ignoredIds);
-        final ratings = storage.getRatings();
-        for (final entry in ratings.entries) {
-          await RatingsSync.upsert(entry.key, entry.value);
-        }
+        // #2319 — batch every local rating into one upsert round-trip
+        // instead of N serial calls on connect.
+        await RatingsSync.upsertAll(storage.getRatings());
         debugPrint('InitialSync: complete');
       } catch (e, st) {
         unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'InitialSync failed (non-fatal)'}));

--- a/lib/core/sync/sync_provider.g.dart
+++ b/lib/core/sync/sync_provider.g.dart
@@ -73,7 +73,7 @@ final class SyncStateProvider extends $NotifierProvider<SyncState, SyncConfig> {
   }
 }
 
-String _$syncStateHash() => r'04b11cb27fe36422e4f07666f6f9b08cb5752079';
+String _$syncStateHash() => r'd1ae9a241e0fb9e2a31cfd87ad87bc6b3bd96ad3';
 
 /// Manages the cloud sync connection state.
 ///

--- a/lib/core/sync/trips_sync.dart
+++ b/lib/core/sync/trips_sync.dart
@@ -5,8 +5,11 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 import '../../features/consumption/data/trip_history_repository.dart';
 import 'supabase_client.dart';
+import 'trips_sync_json.dart';
 import '../../core/logging/error_logger.dart';
 
 /// Per-trip-summary sync with Supabase (#1479 phase 2).
@@ -102,7 +105,7 @@ class TripsSync {
       await client.from('trip_details').upsert({
         'id': entry.id,
         'user_id': userId,
-        'data': _detailsJson(entry),
+        'data': tripDetailsJson(entry),
         'updated_at': DateTime.now().toIso8601String(),
       }, onConflict: 'user_id,id');
       debugPrint('TripsSync.uploadDetails: uploaded ${entry.id}');
@@ -195,22 +198,16 @@ class TripsSync {
         if (id is String) serverIds.add(id);
       }
 
-      // Upload local-only entries — heals a missing server row from
-      // a previous offline save without waiting for the next stop.
+      // Upload local-only entries (heals a missing server row from a
+      // previous offline save). #2319 — batch the Nx2 round-trips into
+      // one upsert each instead of a serial per-entry loop.
       final localOnly =
           localEntries.where((e) => !serverIds.contains(e.id)).toList();
-      for (final entry in localOnly) {
-        // Reuse the single-row upload path to keep the JSON-shape
-        // contract centralised. Errors swallowed inside.
-        await uploadSummary(entry);
-      }
+      await _uploadBatch(client, userId, localOnly);
 
-      // Decode the server-only rows and return the union. The pure
-      // [mergeRows] step is what the app-launch caller persists back to
-      // the local Hive box — see `AppInitializer._runTripsSyncMerge`.
-      // Pinning that step in a unit test regression-guards the
-      // "download silently discarded" bug class (#2239 / the sibling
-      // AlertsSync defect).
+      // Decode server-only rows and return the union — the superset the
+      // app-launch caller persists back to Hive (see
+      // `AppInitializer._runTripsSyncMerge`; #2239 pins this seam).
       final merged = mergeRows(localEntries, serverRows);
       debugPrint('TripsSync.merge: local=${localEntries.length} '
           'server=${serverIds.length} '
@@ -220,6 +217,79 @@ class TripsSync {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'TripsSync.merge FAILED'}));
       return localEntries;
     }
+  }
+
+  /// Bulk-upload [entries] to `trip_summaries` + `trip_details` in one
+  /// upsert each (#2319), preserving the single-trip contracts: null-
+  /// timestamp entries are skipped (NOT-NULL summary columns), entries
+  /// with no samples/gpsd add no details row, and the two upserts are
+  /// isolated so one failure never blocks the other. The single-trip
+  /// [uploadSummary] path is untouched.
+  static Future<void> _uploadBatch(
+    SupabaseClient client,
+    String userId,
+    List<TripHistoryEntry> entries,
+  ) async {
+    await _batchUpsert(client, 'trip_summaries', buildSummaryRows(entries, userId));
+    await _batchUpsert(client, 'trip_details', buildDetailRows(entries, userId));
+  }
+
+  static Future<void> _batchUpsert(
+    SupabaseClient client,
+    String table,
+    List<Map<String, dynamic>> rows,
+  ) async {
+    if (rows.isEmpty) return;
+    try {
+      await client.from(table).upsert(rows, onConflict: 'user_id,id');
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'TripsSync._batchUpsert $table FAILED'}));
+    }
+  }
+
+  /// Pure multi-row analogue of [buildSummaryRow]. Null-timestamp
+  /// entries are skipped (mirrors the [uploadSummary] guard) so the
+  /// NOT-NULL `started_at` / `ended_at` columns are never violated. A
+  /// unit-testable seam for the batch contract.
+  @visibleForTesting
+  static List<Map<String, dynamic>> buildSummaryRows(
+    List<TripHistoryEntry> entries,
+    String userId, {
+    DateTime? now,
+  }) {
+    final rows = <Map<String, dynamic>>[];
+    for (final entry in entries) {
+      if (entry.summary.startedAt == null || entry.summary.endedAt == null) {
+        continue;
+      }
+      rows.add(buildSummaryRow(entry, userId, now: now));
+    }
+    return rows;
+  }
+
+  /// Pure multi-row analogue of the single-trip [uploadDetails] payload.
+  /// Entries with no `samples` AND no `gpsd` contribute nothing (matches
+  /// the single-trip no-op guard). A unit-testable seam.
+  @visibleForTesting
+  static List<Map<String, dynamic>> buildDetailRows(
+    List<TripHistoryEntry> entries,
+    String userId, {
+    DateTime? now,
+  }) {
+    final stamp = (now ?? DateTime.now()).toIso8601String();
+    final rows = <Map<String, dynamic>>[];
+    for (final entry in entries) {
+      if (entry.samples.isEmpty && entry.gpsSampleDiagnostics.isEmpty) {
+        continue;
+      }
+      rows.add({
+        'id': entry.id,
+        'user_id': userId,
+        'data': tripDetailsJson(entry),
+        'updated_at': stamp,
+      });
+    }
+    return rows;
   }
 
   /// Wipe every synced trip for the current user from BOTH
@@ -293,7 +363,7 @@ class TripsSync {
       // 60-min commute is ~1 KB instead of ~250 KB. The full blob
       // (samples + gpsd) goes to `public.trip_details` in
       // [uploadDetails] right after.
-      'data': _compactSummaryJson(entry),
+      'data': compactSummaryJson(entry),
       'updated_at': (now ?? DateTime.now()).toIso8601String(),
     };
   }
@@ -330,33 +400,4 @@ class TripsSync {
     }
     return [...localEntries, ...downloaded];
   }
-}
-
-/// Strips the per-tick `samples` and GPS-diagnostics arrays from a
-/// [TripHistoryEntry]'s JSON form so the upload payload stays under
-/// the 1 KB target for `public.trip_summaries.data` (#1479 phase 2).
-///
-/// The full-detail blob (samples + gpsd) is the phase-4 concern and
-/// lands in `public.trip_details` — keeping the summary tight here
-/// means the cross-device list view (phase 3) can paginate without
-/// dragging a year of trip telemetry through every fetch.
-Map<String, dynamic> _compactSummaryJson(TripHistoryEntry entry) {
-  final json = entry.toJson();
-  json.remove('samples');
-  json.remove('gpsd');
-  return json;
-}
-
-/// Mirror of [_compactSummaryJson] for the heavy blob: returns just
-/// `samples` + `gpsd` so the `trip_details.data` payload stays
-/// focused on the per-tick telemetry. Empty arrays are emitted
-/// explicitly so a future fetch round-trips through
-/// `TripHistoryEntry.fromJson` cleanly even when only one of the
-/// two arrays was populated at recording time.
-Map<String, dynamic> _detailsJson(TripHistoryEntry entry) {
-  final json = entry.toJson();
-  return {
-    'samples': json['samples'] ?? const [],
-    'gpsd': json['gpsd'] ?? const [],
-  };
 }

--- a/lib/core/sync/trips_sync_json.dart
+++ b/lib/core/sync/trips_sync_json.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../features/consumption/data/trip_history_repository.dart';
+
+/// Trip-sync JSON payload shapers, split out of `trips_sync.dart` so the
+/// wire/merge class stays under the file-length cap (#2319). Both are
+/// pure functions over [TripHistoryEntry.toJson].
+
+/// Strips the per-tick `samples` and GPS-diagnostics arrays from a
+/// [TripHistoryEntry]'s JSON form so the upload payload stays under the
+/// 1 KB target for `public.trip_summaries.data` (#1479 phase 2). The
+/// full-detail blob (samples + gpsd) lands in `public.trip_details` via
+/// [tripDetailsJson] instead.
+Map<String, dynamic> compactSummaryJson(TripHistoryEntry entry) {
+  final json = entry.toJson();
+  json.remove('samples');
+  json.remove('gpsd');
+  return json;
+}
+
+/// Mirror of [compactSummaryJson] for the heavy blob: returns just
+/// `samples` + `gpsd` for the `trip_details.data` payload. Empty arrays
+/// are emitted explicitly so a future fetch round-trips through
+/// `TripHistoryEntry.fromJson` cleanly even when only one of the two
+/// arrays was populated at recording time.
+Map<String, dynamic> tripDetailsJson(TripHistoryEntry entry) {
+  final json = entry.toJson();
+  return {
+    'samples': json['samples'] ?? const [],
+    'gpsd': json['gpsd'] ?? const [],
+  };
+}

--- a/lib/core/sync/user_data_sync.dart
+++ b/lib/core/sync/user_data_sync.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import 'supabase_client.dart';
+import 'trips_sync.dart';
 import '../../core/logging/error_logger.dart';
 
 /// GDPR data-management operations over the user's full server-side
@@ -79,18 +80,53 @@ class UserDataSync {
     }
   }
 
+  /// Every server-side table [deleteAll] must wipe for the GDPR
+  /// right-to-be-forgotten path, paired with the column the user's id
+  /// lives in (most are `user_id`; `price_reports` keys on
+  /// `reporter_id`). `trip_summaries` / `trip_details` are wiped via
+  /// [TripsSync.forgetAllForUser] rather than listed here, so they are
+  /// pinned by the `forgetAllForUser` helper instead.
+  ///
+  /// Kept `@visibleForTesting` and asserted against [fetchAll]'s read
+  /// set so a future table that becomes exportable but not deletable is
+  /// caught — the #2292 regression where trip history, itineraries,
+  /// OBD2 baselines and station ratings survived account deletion.
+  @visibleForTesting
+  static const deletableTables = <String, String>{
+    'favorites': 'user_id',
+    'alerts': 'user_id',
+    'push_tokens': 'user_id',
+    'price_reports': 'reporter_id',
+    'vehicles': 'user_id',
+    'fill_ups': 'user_id',
+    'itineraries': 'user_id',
+    'obd2_baselines': 'user_id',
+    'station_ratings': 'user_id',
+  };
+
   /// Delete every row the user owns across every sync table (GDPR
   /// right-to-be-forgotten). No-op when unauthenticated.
+  ///
+  /// Each table is deleted independently so a transient failure on one
+  /// (e.g. RLS hiccup on a table the user has no rows in) doesn't abort
+  /// the rest of the wipe — the user already confirmed the destructive
+  /// action.
   static Future<void> deleteAll() async {
     final client = TankSyncClient.client;
     final userId = client?.auth.currentUser?.id;
     if (client == null || userId == null) return;
 
-    await client.from('favorites').delete().eq('user_id', userId);
-    await client.from('alerts').delete().eq('user_id', userId);
-    await client.from('push_tokens').delete().eq('user_id', userId);
-    await client.from('price_reports').delete().eq('reporter_id', userId);
-    await client.from('vehicles').delete().eq('user_id', userId);
-    await client.from('fill_ups').delete().eq('user_id', userId);
+    for (final entry in deletableTables.entries) {
+      try {
+        await client.from(entry.key).delete().eq(entry.value, userId);
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.other, e, st,
+            context: {'where': 'UserDataSync.deleteAll FAILED for ${entry.key}'}));
+      }
+    }
+
+    // trip_summaries + trip_details — delegate to the canonical
+    // trip-wipe helper so the column contract stays in one place.
+    await TripsSync.forgetAllForUser();
   }
 }

--- a/lib/core/telemetry/storage/trace_storage.dart
+++ b/lib/core/telemetry/storage/trace_storage.dart
@@ -157,8 +157,12 @@ class TraceStorage {
   /// surface schema-drift to the user (and to keep the unreadable
   /// payload available under `unparsedRaw` for offline debugging).
   String exportAsJson() {
-    final traces = getAll();
-    final unparsed = getUnparsedRaw();
+    // #2310 — single deserialise pass: partition the box into parsed
+    // traces + unparsed raw maps once, instead of the former
+    // getAll()+getUnparsedRaw() double walk (each re-ran
+    // ErrorTrace.fromJson over every entry).
+    final (:traces, :unparsed) = _partition();
+    traces.sort((a, b) => b.timestamp.compareTo(a.timestamp));
     return const JsonEncoder.withIndent('  ').convert({
       'exportedAt': DateTime.now().toUtc().toIso8601String(),
       'traceCount': traces.length + unparsed.length,
@@ -169,12 +173,44 @@ class TraceStorage {
     });
   }
 
+  /// Single walk over `_box.values` that splits every entry into the
+  /// ones that decode via [ErrorTrace.fromJson] and the ones that don't
+  /// (returned as their coerced raw maps for offline debugging — #1301).
+  /// The shared seam behind [exportAsJson], so a corrupt-vs-valid box is
+  /// deserialised exactly once. The `traces` list is UNSORTED; callers
+  /// that need newest-first sort it themselves.
+  ({List<ErrorTrace> traces, List<Map<String, dynamic>> unparsed})
+      _partition() {
+    final traces = <ErrorTrace>[];
+    final unparsed = <Map<String, dynamic>>[];
+    for (final raw in _box.values) {
+      if (raw is! Map) continue;
+      final asMap = _jsonMapFrom(raw);
+      try {
+        traces.add(ErrorTrace.fromJson(asMap));
+      } on Object catch (e, st) {
+        // See [getAll] for the broad-catch rationale (#1301 / #1388).
+        debugPrint('TraceStorage: trace parse failed: $e\n$st');
+        unparsed.add(asMap);
+      }
+    }
+    return (traces: traces, unparsed: unparsed);
+  }
+
+  /// Prune on every error write. The common case (box at or under
+  /// [maxTraces] after the age filter) does exactly ONE deserialise +
+  /// sort pass: the age filter walks the single [getAll] list, then the
+  /// over-cap check is the O(1) [_box.length] — only when the box is
+  /// still over [maxTraces] do we re-fetch for the timestamp sort (#2310,
+  /// was two unconditional `getAll()` passes).
   Future<void> _prune() async {
     final cutoff = DateTime.now().subtract(maxAge);
     final all = getAll();
     for (final t in all) {
       if (t.timestamp.isBefore(cutoff)) await _box.delete(t.id);
     }
+    // O(1) box-length check — re-deserialise only when still over cap.
+    if (_box.length <= maxTraces) return;
     final remaining = getAll();
     if (remaining.length > maxTraces) {
       for (final t in remaining.sublist(maxTraces)) {

--- a/lib/core/telemetry/upload/trace_uploader.dart
+++ b/lib/core/telemetry/upload/trace_uploader.dart
@@ -29,7 +29,11 @@ class TraceUploader {
     if (raw == null) return TraceUploadConfig.disabled;
     try {
       return TraceUploadConfig.fromJson(Map<String, dynamic>.from(raw as Map));
-    } on FormatException catch (e, st) {
+    } on Object catch (e, st) {
+      // #2311 — `raw as Map` (schema drift) throws TypeError, and
+      // fromJson's per-field casts can too. Catch broadly (the #1301
+      // TraceStorage precedent) so corrupt/drifted config disables
+      // upload instead of silently killing the path with nothing logged.
       debugPrint('TraceUploader: config parse failed: $e\n$st');
       return TraceUploadConfig.disabled;
     }
@@ -40,15 +44,21 @@ class TraceUploader {
   }
 
   /// Upload trace if enabled. Fire-and-forget — never throws.
+  ///
+  /// #2311 — getConfig() is now read INSIDE the try and the catch is
+  /// broadened from `on DioException` to `on Object`, so the documented
+  /// "never throws" contract holds even when a non-Dio pre-request error
+  /// fires (e.g. a TypeError surfacing from a drifted config read or a
+  /// PII-scrub failure) — the upload is dropped, never propagated.
   Future<void> uploadIfEnabled(ErrorTrace trace) async {
-    final config = getConfig();
-    if (!config.enabled ||
-        config.serverUrl == null ||
-        config.serverUrl!.isEmpty) {
-      return;
-    }
-
     try {
+      final config = getConfig();
+      if (!config.enabled ||
+          config.serverUrl == null ||
+          config.serverUrl!.isEmpty) {
+        return;
+      }
+
       final dio = DioFactory.create(
         connectTimeout: const Duration(seconds: 5),
         receiveTimeout: const Duration(seconds: 5),
@@ -70,7 +80,10 @@ class TraceUploader {
             'Authorization': 'Bearer ${config.authToken}',
         }),
       );
-    } on DioException catch (e, st) {
+    } on Object catch (e, st) {
+      // Broad by design (#2311): any error — Dio network failure, a
+      // TypeError from config drift, a scrub failure — is swallowed so
+      // the fire-and-forget caller never sees an exception.
       debugPrint('TraceUploader: upload failed: $e\n$st');
     }
   }

--- a/test/core/sync/ratings_sync_test.dart
+++ b/test/core/sync/ratings_sync_test.dart
@@ -35,5 +35,21 @@ void main() {
       final map = await RatingsSync.fetchAll();
       expect(map, isEmpty);
     });
+
+    /// #2319 — batch upsert path. The wire `upsert` can't be exercised
+    /// without a live client, but the auth/empty guards (the only pure
+    /// surface) must hold so the initial-sync caller can fire it
+    /// unconditionally without a serial per-rating loop.
+    test('upsertAll is a no-op when unauthenticated', () async {
+      await RatingsSync.upsertAll({'st-1': 4, 'st-2': 5});
+    });
+
+    test('upsertAll short-circuits on an empty map without throwing',
+        () async {
+      // Empty map must early-return before touching the client so the
+      // caller (sync_provider initial sync) can pass getRatings()
+      // verbatim even when the user has rated nothing.
+      await RatingsSync.upsertAll(const {});
+    });
   });
 }

--- a/test/core/sync/schema_verifier_test.dart
+++ b/test/core/sync/schema_verifier_test.dart
@@ -29,6 +29,24 @@ void main() {
     });
   });
 
+  /// #2310 — checkSchema now fires its per-table existence probes in
+  /// parallel via Future.wait with `select('id').limit(0)` (was a
+  /// sequential `select('*')` loop). The live probes need a Supabase
+  /// client, so the only pure surface is the unconnected guard — these
+  /// pin that the parallel rewrite preserves the do-no-harm contract.
+  group('SchemaVerifier.checkSchema — unconnected guard (#2310)', () {
+    test('returns null when no client is connected', () async {
+      final schema = await SchemaVerifier.checkSchema();
+      expect(schema, isNull,
+          reason: 'no client → null, so callers fall back to the '
+              'not-ready render path rather than throwing');
+    });
+
+    test('isSchemaReady returns false when unconnected', () async {
+      expect(await SchemaVerifier.isSchemaReady(), isFalse);
+    });
+  });
+
   group('SchemaVerifier.getMigrationSql', () {
     test('returns only RLS SQL when all tables exist', () {
       final schema = <String, bool>{

--- a/test/core/sync/trips_sync_test.dart
+++ b/test/core/sync/trips_sync_test.dart
@@ -337,4 +337,93 @@ void main() {
       },
     );
   });
+
+  // ───────────────────────────────────────────────────────────────────
+  // #2319 — batch merge upload. merge() now collapses the Nx2 serial
+  // round-trips (uploadSummary + uploadDetails per local-only entry)
+  // into one upsert each, built by the pure [buildSummaryRows] /
+  // [buildDetailRows] seams. These pin that the batch path preserves
+  // the single-trip contracts: null-timestamp skip + samples/gpsd-empty
+  // skip + correct columns.
+  // ───────────────────────────────────────────────────────────────────
+  group('TripsSync.buildSummaryRows / buildDetailRows — batch (#2319)', () {
+    TripHistoryEntry batchEntry(
+      String id, {
+      DateTime? started,
+      DateTime? ended,
+      List<TripSample> samples = const [],
+    }) =>
+        TripHistoryEntry(
+          id: id,
+          vehicleId: 'veh-1',
+          summary: TripSummary(
+            startedAt: started,
+            endedAt: ended,
+            distanceKm: 10,
+            maxRpm: 2800,
+            highRpmSeconds: 0,
+            idleSeconds: 20,
+            harshBrakes: 0,
+            harshAccelerations: 0,
+          ),
+          samples: samples,
+        );
+
+    test('builds one summary row per entry with non-null timestamps', () {
+      final started = DateTime.utc(2026, 5, 28, 8);
+      final ended = started.add(const Duration(minutes: 20));
+      final rows = TripsSync.buildSummaryRows(
+        [
+          batchEntry('a', started: started, ended: ended),
+          batchEntry('b', started: started, ended: ended),
+        ],
+        'user-1',
+      );
+      expect(rows, hasLength(2));
+      expect(rows.map((r) => r['id']), containsAll(<String>['a', 'b']));
+      expect(rows.every((r) => r['user_id'] == 'user-1'), isTrue);
+    });
+
+    test('skips entries with null timestamps (NOT-NULL column contract)',
+        () {
+      final started = DateTime.utc(2026, 5, 28, 8);
+      final rows = TripsSync.buildSummaryRows(
+        [
+          batchEntry('valid',
+              started: started, ended: started.add(const Duration(minutes: 5))),
+          batchEntry('null-ts'), // no started/ended → must be skipped
+        ],
+        'user-1',
+      );
+      expect(rows.map((r) => r['id']), ['valid'],
+          reason: 'a null-timestamp entry cannot satisfy the NOT-NULL '
+              'started_at/ended_at columns and must be dropped from the batch');
+    });
+
+    test('builds a detail row only for entries carrying samples/gpsd', () {
+      final started = DateTime.utc(2026, 5, 28, 8);
+      final ended = started.add(const Duration(minutes: 12));
+      final withSamples = batchEntry(
+        'heavy',
+        started: started,
+        ended: ended,
+        samples: [TripSample(timestamp: started, speedKmh: 10, rpm: 1200)],
+      );
+      final empty = batchEntry('light', started: started, ended: ended);
+
+      final rows = TripsSync.buildDetailRows([withSamples, empty], 'user-1');
+      expect(rows.map((r) => r['id']), ['heavy'],
+          reason: 'an entry with no samples and no gpsd must contribute no '
+              'details row (matches the single-trip no-op guard)');
+      final data = rows.first['data'] as Map<String, dynamic>;
+      expect(data.containsKey('samples'), isTrue);
+      expect(data.containsKey('gpsd'), isTrue);
+    });
+
+    test('empty input lists produce empty batches (no wasted round-trip)',
+        () {
+      expect(TripsSync.buildSummaryRows(const [], 'u'), isEmpty);
+      expect(TripsSync.buildDetailRows(const [], 'u'), isEmpty);
+    });
+  });
 }

--- a/test/core/sync/user_data_sync_test.dart
+++ b/test/core/sync/user_data_sync_test.dart
@@ -21,4 +21,79 @@ void main() {
       await UserDataSync.deleteAll();
     });
   });
+
+  /// #2292 — the GDPR right-to-be-forgotten path previously wiped only
+  /// 6 tables and silently left trip history, itineraries, OBD2
+  /// baselines and station ratings on the server. The wire `delete`
+  /// calls can't be exercised without a live Supabase client, so the
+  /// table coverage is pinned through the `@visibleForTesting`
+  /// [UserDataSync.deletableTables] map (plus the trip tables wiped via
+  /// `TripsSync.forgetAllForUser`). This regression-guards a future
+  /// table that becomes exportable but not deletable.
+  group('UserDataSync.deletableTables — GDPR coverage (#2292)', () {
+    test('covers every table the old wipe handled', () {
+      // The original (incomplete) deletion set.
+      expect(
+        UserDataSync.deletableTables.keys,
+        containsAll(<String>[
+          'favorites',
+          'alerts',
+          'push_tokens',
+          'price_reports',
+          'vehicles',
+          'fill_ups',
+        ]),
+      );
+    });
+
+    test('adds the tables the regulatory defect omitted', () {
+      // The #2292 additions that must now be wiped on account deletion.
+      expect(
+        UserDataSync.deletableTables.keys,
+        containsAll(<String>[
+          'itineraries',
+          'obd2_baselines',
+          'station_ratings',
+        ]),
+      );
+    });
+
+    test('price_reports keys on reporter_id, every other table on user_id',
+        () {
+      expect(UserDataSync.deletableTables['price_reports'], 'reporter_id');
+      for (final entry in UserDataSync.deletableTables.entries) {
+        if (entry.key == 'price_reports') continue;
+        expect(entry.value, 'user_id',
+            reason: '${entry.key} should be keyed on user_id');
+      }
+    });
+
+    test(
+        'every exportable table is also deletable — trip tables go via '
+        'TripsSync.forgetAllForUser', () {
+      // `fetchAll` reads these into the Privacy Dashboard export; a
+      // right-to-be-forgotten request must wipe each one. trip_summaries
+      // + trip_details are deleted by TripsSync.forgetAllForUser (called
+      // inside deleteAll), so they're allowed to be absent from the map.
+      const wipedViaTripsSync = {'trip_summaries', 'trip_details'};
+      const exportedTables = {
+        'favorites',
+        'alerts',
+        'push_tokens',
+        // fetchAll keys this as 'reports' in the export map but reads the
+        // price_reports table.
+        'price_reports',
+        'itineraries',
+        'trip_summaries',
+        'trip_details',
+      };
+
+      for (final table in exportedTables) {
+        if (wipedViaTripsSync.contains(table)) continue;
+        expect(UserDataSync.deletableTables.containsKey(table), isTrue,
+            reason: '$table is exported by fetchAll but not wiped by '
+                'deleteAll — right-to-be-forgotten would leave it behind');
+      }
+    });
+  });
 }

--- a/test/core/telemetry/storage/trace_storage_test.dart
+++ b/test/core/telemetry/storage/trace_storage_test.dart
@@ -139,6 +139,116 @@ void main() {
       expect(all.first.id, 'trace-54');
     });
 
+    /// #2310 — prune is the single-pass fast path: store() triggers it
+    /// on every error write, so these pin that the age + maxTraces caps
+    /// are still correctly enforced after the redundant-pass removal.
+    group('prune single-pass (#2310)', () {
+      test('store() caps the box at maxTraces, keeping the newest', () async {
+        // Write maxTraces + 5 via the real store() path (which prunes).
+        final base = DateTime.now();
+        for (var i = 0; i < TraceStorage.maxTraces + 5; i++) {
+          final json = _makePlainJson(
+            id: 'trace-$i',
+            timestamp: base.add(Duration(seconds: i)),
+          );
+          final trace = ErrorTrace.fromJson(json);
+          await storage.store(trace);
+        }
+        // The box never exceeds the cap after a store-driven prune.
+        expect(storage.count, TraceStorage.maxTraces);
+        final ids = storage.getAll().map((t) => t.id).toSet();
+        // The 5 oldest were pruned; the newest survives.
+        expect(ids.contains('trace-${TraceStorage.maxTraces + 4}'), isTrue);
+        expect(ids.contains('trace-0'), isFalse);
+      });
+
+      test('store() drops entries older than maxAge in the same pass',
+          () async {
+        // One ancient trace (well beyond the 7-day window) + one fresh.
+        final ancient = _makePlainJson(
+          id: 'ancient',
+          timestamp: DateTime.now().subtract(const Duration(days: 30)),
+        );
+        await storage.store(ErrorTrace.fromJson(ancient));
+        final fresh = _makePlainJson(id: 'fresh', timestamp: DateTime.now());
+        await storage.store(ErrorTrace.fromJson(fresh));
+
+        final ids = storage.getAll().map((t) => t.id).toSet();
+        expect(ids, contains('fresh'));
+        expect(ids, isNot(contains('ancient')),
+            reason: 'the age filter must drop the >7d-old trace');
+      });
+
+      test(
+          'common case (under cap) leaves every recent trace intact after '
+          'store-driven prune', () async {
+        final base = DateTime.now();
+        for (var i = 0; i < 3; i++) {
+          await storage.store(ErrorTrace.fromJson(
+            _makePlainJson(id: 't-$i', timestamp: base.add(Duration(seconds: i))),
+          ));
+        }
+        expect(storage.count, 3);
+        expect(storage.getAll().map((t) => t.id),
+            containsAll(<String>['t-0', 't-1', 't-2']));
+      });
+    });
+
+    /// #2310 — exportAsJson now partitions the box in a single
+    /// deserialise pass. These pin that its output stays equivalent to
+    /// the previous getAll() + getUnparsedRaw() double-walk.
+    group('exportAsJson single-pass partition (#2310)', () {
+      Map<String, dynamic> brokenEntry(String id) =>
+          <String, dynamic>{'id': id, 'schemaVersion': 'unknown'};
+
+      test('parsed traces match getAll and unparsed match getUnparsedRaw',
+          () async {
+        final box = Hive.box('error_traces');
+        await box.put(
+            'v1', _makePlainJson(id: 'v1', timestamp: DateTime(2025, 1, 1)));
+        await box.put(
+            'v2', _makePlainJson(id: 'v2', timestamp: DateTime(2025, 2, 1)));
+        await box.put('bad', brokenEntry('bad'));
+
+        final decoded =
+            jsonDecode(storage.exportAsJson()) as Map<String, dynamic>;
+
+        // Parsed set equals getAll's ids (export sorts newest-first too).
+        final exportedTraceIds = (decoded['traces'] as List)
+            .map((t) => (t as Map<String, dynamic>)['id'])
+            .toList();
+        expect(exportedTraceIds, storage.getAll().map((t) => t.id).toList());
+
+        // Unparsed set equals getUnparsedRaw's ids.
+        final exportedUnparsedIds = (decoded['unparsedRaw'] as List)
+            .map((e) => (e as Map<String, dynamic>)['id'])
+            .toSet();
+        final rawIds =
+            storage.getUnparsedRaw().map((e) => e['id']).toSet();
+        expect(exportedUnparsedIds, rawIds);
+        expect(exportedUnparsedIds, {'bad'});
+
+        expect(decoded['parsedCount'], 2);
+        expect(decoded['unparsedCount'], 1);
+        expect(decoded['traceCount'], 3);
+      });
+
+      test('exported traces are sorted newest-first', () async {
+        final box = Hive.box('error_traces');
+        await box.put(
+            'old', _makePlainJson(id: 'old', timestamp: DateTime(2024, 1, 1)));
+        await box.put(
+            'new', _makePlainJson(id: 'new', timestamp: DateTime(2026, 1, 1)));
+
+        final decoded =
+            jsonDecode(storage.exportAsJson()) as Map<String, dynamic>;
+        final ids = (decoded['traces'] as List)
+            .map((t) => (t as Map<String, dynamic>)['id'])
+            .toList();
+        expect(ids, ['new', 'old']);
+      });
+    });
+
     test('getAll parses stored JSON back into ErrorTrace objects', () async {
       final json = _makePlainJson(id: 'parse-test');
       await Hive.box('error_traces').put('parse-test', json);

--- a/test/core/telemetry/upload/trace_uploader_test.dart
+++ b/test/core/telemetry/upload/trace_uploader_test.dart
@@ -128,20 +128,40 @@ void main() {
       expect(retrieved.authToken, 'my-token');
     });
 
-    test('getConfig throws on non-map stored data (code limitation)', () async {
-      // The `as Map` cast in getConfig throws TypeError, which is not caught
-      // by the FormatException handler. This documents the current behavior.
+    test('getConfig disables (no throw) on non-map stored data (#2311)',
+        () async {
+      // The `as Map` cast throws TypeError on schema drift. The broad
+      // `on Object` catch (#2311) must absorb it and disable upload
+      // rather than letting it escape and silently kill the path.
       await fakeStorage.putSetting('trace_upload_config', 'not-a-map');
-      expect(() => uploader.getConfig(), throwsA(isA<TypeError>()));
+      late TraceUploadConfig config;
+      expect(() => config = uploader.getConfig(), returnsNormally);
+      expect(config.enabled, isFalse,
+          reason: 'corrupt config must fall back to disabled');
     });
 
-    test('getConfig throws on map with wrong types (code limitation)', () async {
-      // fromJson does `as bool?` cast on the 'enabled' field. A string value
-      // throws TypeError, not FormatException. Documents this limitation.
+    test('getConfig disables (no throw) on a map with wrong field types '
+        '(#2311)', () async {
+      // fromJson's `as bool?` cast on a String 'enabled' throws TypeError,
+      // not FormatException — the broadened catch now handles it too.
       await fakeStorage.putSetting('trace_upload_config', <String, dynamic>{
         'enabled': 'not-a-bool',
       });
-      expect(() => uploader.getConfig(), throwsA(isA<TypeError>()));
+      late TraceUploadConfig config;
+      expect(() => config = uploader.getConfig(), returnsNormally);
+      expect(config.enabled, isFalse);
+    });
+
+    test('uploadIfEnabled never throws even with a non-map config (#2311)',
+        () async {
+      // The whole contract: a drifted config that would throw inside
+      // getConfig() (now read INSIDE the try) must not propagate out of
+      // the fire-and-forget upload path.
+      await fakeStorage.putSetting('trace_upload_config', 'not-a-map');
+      await expectLater(
+        uploader.uploadIfEnabled(_makeTrace()),
+        completes,
+      );
     });
 
     test('uploadIfEnabled does nothing when disabled', () async {


### PR DESCRIPTION
File-affinity batch of verified audit fixes (part of #2290, CAPSTONE #23) across the sync + telemetry subsystems. One commit per issue.

## Closes #2292 — GDPR deleteAll omits 5 tables (HIGH)
`UserDataSync.deleteAll()` wiped only 6 tables and silently skipped `trip_summaries`, `trip_details`, `itineraries`, `obd2_baselines`, `station_ratings`. Since `fetchAll()` exports trip summaries/details/itineraries into the Privacy Dashboard, a right-to-be-forgotten request left trip history, itineraries, OBD2 baselines and ratings on the server — a regulatory defect in a 17-country production app.
- `lib/core/sync/user_data_sync.dart` — delete now iterates a `@visibleForTesting deletableTables` map (table → id column) covering all 9 user-keyed tables, deletes each independently (a per-table failure no longer aborts the wipe), and delegates `trip_summaries`/`trip_details` to `TripsSync.forgetAllForUser`.
- Coverage test pins that every table `fetchAll` exports is also deletable.

## Closes #2319 — batch RatingsSync / TripsSync upserts (background, network efficiency)
- `lib/core/sync/ratings_sync.dart` — new `upsertAll(Map<String,int>)` ships all ratings in one upsert (mirrors `FavoritesSync.merge`); `sync_provider.dart` initial-sync loop replaced.
- `lib/core/sync/trips_sync.dart` — `merge()` now batch-upserts all local-only summaries + details in one round-trip each via the pure `buildSummaryRows` / `buildDetailRows` seams (was Nx2 serial after a reinstall), with the two upserts isolated. Per-entry contracts preserved (null-timestamp skip, samples/gpsd-empty skip); single-trip `uploadSummary` untouched. JSON shapers moved to `trips_sync_json.dart` to stay under the 400-line cap.

## Closes #2310 — trace-prune single-pass + parallel schema verifier
- `lib/core/telemetry/storage/trace_storage.dart` — `_prune()` common case does one deserialise pass (O(1) `_box.length` gate before any re-fetch); `exportAsJson()` partitions parsed/unparsed in a single `_partition()` walk.
- `lib/core/sync/schema_verifier.dart` — `checkSchema()` fires its existence probes in parallel via `Future.wait` with `select('id').limit(0)` (was a sequential `select('*')` loop).

## Closes #2311 — broaden TraceUploader catches (never-throws contract)
- `lib/core/telemetry/upload/trace_uploader.dart` — `getConfig()` catch broadened to `on Object` (a `TypeError` from `raw as Map` on schema drift was escaping); `uploadIfEnabled` now reads `getConfig()` inside the try with an `on Object` catch so no pre-request error propagates. The two tests that documented the old throwing behaviour now assert the disabled-without-throwing contract.

## Gate
- `flutter analyze lib/ test/` → only the 2 known pre-existing infos (`radius_alert_map_picker.dart:184`, `trip_kind_from_samples_test.dart:6`); no new issues.
- `flutter test test/core/sync test/core/telemetry test/lint --exclude-tags=network` → 374 passed. Downstream `tank_sync_journey` / `trip_sync_migration` / `app_initializer` / `data_transparency_provider` → 37 passed.
- No codegen drift (committed `sync_provider.g.dart` hash bump).

## Needs real-device / live-Supabase verification
The wire `delete` / `upsert` / `select` calls can only be unit-tested through their pure seams + auth guards. On a live TankSync account, confirm: (1) account deletion leaves zero rows in all 9 tables + `trip_summaries`/`trip_details`; (2) a post-reinstall trip merge collapses to single batch round-trips; (3) the schema wizard re-check still reports table presence correctly with the parallel `select('id')` probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
