### PR TITLE
fix(codegen): regenerate stale .g.dart leaked by #2322

### DIFF
--- a/lib/features/alerts/providers/radius_alerts_provider.g.dart
+++ b/lib/features/alerts/providers/radius_alerts_provider.g.dart
@@ -171,7 +171,7 @@ final class RadiusAlertsProvider
   RadiusAlerts create() => RadiusAlerts();
 }
 
-String _$radiusAlertsHash() => r'b4cf2fe8da369295935899013e44475715989830';
+String _$radiusAlertsHash() => r'67d47bec87f7308c5212362b18a42b918219bf01';
 
 /// Radius-watchlist state (#578 phase 1).
 ///

--- a/lib/features/favorites/providers/favorites_provider.g.dart
+++ b/lib/features/favorites/providers/favorites_provider.g.dart
@@ -68,7 +68,7 @@ final class FavoritesProvider
   }
 }
 
-String _$favoritesHash() => r'a0f8d9772032f97635ebe62ac95627a2a734cd00';
+String _$favoritesHash() => r'1efb68510d6e739050e48c67d8ac18868d1d421f';
 
 /// Manages the user's list of favorite station IDs.
 ///


### PR DESCRIPTION
Master was poisoned by #2322 merging with codegen-drift red (non-required at the time). Regenerated the two drifted provider .g.dart files via clean build_runner. codegen-drift is now required so master can't be poisoned again.