### PR TITLE
chore(dev-factory): installable pre-push hook + checked-in branch-protection config (#2339, #2343)

### DIFF
--- a/scripts/configure_branch_protection.sh
+++ b/scripts/configure_branch_protection.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+# Source of truth for master's required-status-check protection (#2343).
+#
+# Why this exists: required checks + strict-mode used to live only in the
+# GitHub API + memory, so they regressed silently across sessions. PR #2322
+# auto-merged with `codegen-drift` RED because that check was non-required
+# at the time, and `strict=false` (set to kill O(N^2) BEHIND-churn) was an
+# undocumented API tweak. Encoding both here makes them auditable and safe
+# to re-apply.
+#
+# Usage:
+#   bash scripts/configure_branch_protection.sh            # PATCH live config
+#   bash scripts/configure_branch_protection.sh --verify   # GET + diff only
+#
+# Idempotent: re-running the PATCH converges to the same TARGET set.
+# `--verify` mutates nothing; it exits non-zero (printing the diff) when the
+# live required-check set diverges from TARGET.
+
+set -euo pipefail
+
+REPO="fdittgen-png/tankstellen"
+BRANCH="master"
+API_PATH="repos/${REPO}/branches/${BRANCH}/protection/required_status_checks"
+
+# TARGET required checks (dev-factory epic #2332).
+#
+# NOTE — this is the source of truth once the sibling issues land:
+#   * build-android / integration / startup-budget / l10n-gate are ADDED as
+#     required by issues #2337 / #2336 (the jobs themselves ship there).
+#   * coverage-merge is REMOVED by #2338 (phantom check, never produced a
+#     real status) — it MUST NOT appear in TARGET.
+# Until those merge, `--verify` will legitimately report drift against live.
+TARGET_CHECKS=(
+  "analyze"
+  "test (0)"
+  "test (1)"
+  "test (2)"
+  "test (3)"
+  "codegen-drift"
+  "build-android"
+  "integration"
+  "startup-budget"
+  "l10n-gate"
+)
+
+require_gh() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh CLI not found on PATH." >&2
+    exit 2
+  fi
+}
+
+# Emit the TARGET set, one check per line, sorted — for stable diffing.
+target_sorted() {
+  printf '%s\n' "${TARGET_CHECKS[@]}" | LC_ALL=C sort
+}
+
+# Fetch the live required-check contexts, one per line, sorted.
+live_sorted() {
+  gh api "$API_PATH" --jq '.contexts[]' 2>/dev/null | LC_ALL=C sort || true
+}
+
+# Fetch live strict flag ("true"/"false").
+live_strict() {
+  gh api "$API_PATH" --jq '.strict' 2>/dev/null || echo "unknown"
+}
+
+verify() {
+  require_gh
+  local target live strict status=0
+  target="$(target_sorted)"
+  live="$(live_sorted)"
+  strict="$(live_strict)"
+
+  echo "=== branch protection --verify: ${REPO}@${BRANCH} ==="
+  echo "strict (live): ${strict}   (target: false)"
+  echo ""
+
+  if [ "$strict" != "false" ]; then
+    echo "DRIFT: strict mode is '${strict}', target is 'false'." >&2
+    status=1
+  fi
+
+  if [ "$live" = "$target" ]; then
+    echo "Required checks: MATCH TARGET (${#TARGET_CHECKS[@]} checks)."
+    printf '  %s\n' "${TARGET_CHECKS[@]}"
+  else
+    echo "DRIFT: live required checks differ from TARGET." >&2
+    echo ""
+    echo "  Only in TARGET (missing from live — add these):"
+    comm -23 <(printf '%s\n' "$target") <(printf '%s\n' "$live") \
+      | sed 's/^/    + /' || true
+    echo "  Only in live (not in TARGET — remove these):"
+    comm -13 <(printf '%s\n' "$target") <(printf '%s\n' "$live") \
+      | sed 's/^/    - /' || true
+    status=1
+  fi
+
+  if [ "$status" -ne 0 ]; then
+    echo "" >&2
+    echo "Re-apply with: bash scripts/configure_branch_protection.sh" >&2
+  fi
+  return "$status"
+}
+
+apply() {
+  require_gh
+  # Build the JSON body: required_status_checks with strict=false and the
+  # TARGET contexts. PATCH is idempotent — same TARGET => same result.
+  local contexts_json
+  contexts_json="$(printf '%s\n' "${TARGET_CHECKS[@]}" \
+    | python3 -c 'import json,sys; print(json.dumps([l.rstrip("\n") for l in sys.stdin if l.strip()]))')"
+
+  echo "PATCHing ${API_PATH} -> strict=false, ${#TARGET_CHECKS[@]} required checks..."
+  gh api -X PATCH "$API_PATH" \
+    -H "Accept: application/vnd.github+json" \
+    --input - <<JSON
+{ "strict": false, "contexts": ${contexts_json} }
+JSON
+  echo "Done. Verifying..."
+  verify
+}
+
+main() {
+  case "${1:-}" in
+    --verify)
+      verify
+      ;;
+    "")
+      apply
+      ;;
+    *)
+      echo "Usage: $0 [--verify]" >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+# Installs the project pre-push hook into .git/hooks/pre-push.
+#
+# The hook enforces, locally and BEFORE the ~13-min CI round-trip, the two
+# failure modes that have repeatedly slipped to CI (see #2339):
+#   * stale generated code (`*.g.dart` / `*.freezed.dart`) — codegen drift
+#     hit 4+ times in a single night session plus #2245;
+#   * stale l10n fan-out (en+de-only ARB additions that never reached the
+#     other locales) — tripped the #1699 coverage gate twice on 2026-05-29.
+#
+# Run once after cloning (and whenever this installer changes):
+#   bash scripts/install_hooks.sh
+#
+# The hook is skippable for genuine emergencies with an explicit env var:
+#   SKIP_PREPUSH=1 git push
+#
+# Re-running this installer is safe: it overwrites the managed hook in place.
+
+set -euo pipefail
+
+# Resolve the repo root from this script's location so the installer works
+# from any CWD and inside linked worktrees (where .git is a file, not a dir).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# `git rev-parse --git-path hooks` resolves the correct hooks dir even when
+# core.hooksPath is overridden or we are inside a linked worktree.
+HOOKS_DIR="$(git rev-parse --git-path hooks)"
+mkdir -p "$HOOKS_DIR"
+HOOK_PATH="$HOOKS_DIR/pre-push"
+
+cat > "$HOOK_PATH" <<'HOOK'
+#!/usr/bin/env bash
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+#
+# MANAGED HOOK — installed by scripts/install_hooks.sh. Do not edit by hand;
+# edit the installer and re-run it instead.
+#
+# Pre-push gate. Runs the cheapest, highest-signal checks first so a failure
+# surfaces fast. Emergency bypass (use sparingly, you own the CI red):
+#   SKIP_PREPUSH=1 git push
+
+set -uo pipefail
+
+if [ "${SKIP_PREPUSH:-0}" = "1" ]; then
+  echo "pre-push: SKIP_PREPUSH=1 set — skipping all local gates (CI still runs)."
+  exit 0
+fi
+
+# Run from the top-level work tree so all relative paths resolve.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Flutter/Dart are not on the default PATH in this environment.
+export PATH="/Users/floriandittgen/development/flutter/bin:/opt/homebrew/bin:$PATH"
+
+if ! command -v flutter >/dev/null 2>&1; then
+  echo "pre-push ERROR: flutter not found on PATH." >&2
+  echo "  Fix PATH or bypass once with: SKIP_PREPUSH=1 git push" >&2
+  exit 1
+fi
+
+fail() {
+  echo "" >&2
+  echo "pre-push BLOCKED: $1" >&2
+  echo "  $2" >&2
+  echo "  Emergency bypass (you own the CI red): SKIP_PREPUSH=1 git push" >&2
+  exit 1
+}
+
+echo "pre-push: running local gates (bypass with SKIP_PREPUSH=1)..."
+
+# --- 1. Clean codegen (HARD RULE #3) -------------------------------------
+# Clean, not incremental: incremental builds keep stale hashes that CI's
+# clean run catches (see feedback_codegen_drift_local_gate memory).
+echo "pre-push [1/5]: regenerating code (build_runner clean && build)..."
+if ! dart run build_runner clean >/dev/null 2>&1; then
+  fail "build_runner clean failed" \
+       "Run 'dart run build_runner clean' and read the error."
+fi
+if ! dart run build_runner build --delete-conflicting-outputs; then
+  fail "build_runner build failed" \
+       "Run 'dart run build_runner build --delete-conflicting-outputs' and fix the error."
+fi
+
+# --- 2. No codegen drift -------------------------------------------------
+echo "pre-push [2/5]: checking for stale generated files..."
+if ! git diff --exit-code -- '*.g.dart' '*.freezed.dart'; then
+  fail "stale generated code (*.g.dart / *.freezed.dart)" \
+       "Regeneration changed committed files. Stage the drift and amend/commit: git add -- '*.g.dart' '*.freezed.dart'"
+fi
+
+# --- 3. No l10n fan-out drift (HARD RULE #4) -----------------------------
+# Every new en key must fan out to all locales via the autofill pipeline.
+echo "pre-push [3/5]: regenerating l10n and checking for drift..."
+if ! dart run tool/build_arb.dart; then
+  fail "tool/build_arb.dart failed" "Run 'dart run tool/build_arb.dart' and fix the error."
+fi
+if ! dart tool/gen_pseudo_arb.dart; then
+  fail "tool/gen_pseudo_arb.dart failed" "Run 'dart tool/gen_pseudo_arb.dart' and fix the error."
+fi
+if ! flutter gen-l10n; then
+  fail "flutter gen-l10n failed" "Run 'flutter gen-l10n' and fix the error."
+fi
+if ! git diff --exit-code -- lib/l10n/; then
+  fail "stale l10n fan-out (lib/l10n/)" \
+       "New en keys did not reach every locale (or pseudo-locale). Run the l10n pipeline, then: git add -- lib/l10n/"
+fi
+
+# --- 4. Static analysis --------------------------------------------------
+echo "pre-push [4/5]: flutter analyze..."
+if ! flutter analyze; then
+  fail "flutter analyze reported issues" "Fix the analyzer output above."
+fi
+
+# --- 5. Lint + l10n contract tests (cheap, network-free) -----------------
+echo "pre-push [5/5]: lint + l10n tests..."
+if ! flutter test test/lint/ test/l10n/ --exclude-tags=network; then
+  fail "lint / l10n tests failed" "Fix the failing tests above."
+fi
+
+echo "pre-push: all local gates passed."
+exit 0
+HOOK
+
+chmod +x "$HOOK_PATH"
+
+echo "Installed pre-push hook: $HOOK_PATH"
+echo "It runs: clean-codegen -> codegen-drift -> l10n fan-out -> analyze -> lint/l10n tests."
+echo "Emergency bypass: SKIP_PREPUSH=1 git push"


### PR DESCRIPTION
Two dev-factory durability gates from epic #2332, one commit each.

## #2339 — installable pre-push hook + CLAUDE.md HARD RULES #3/#4
`scripts/install_hooks.sh` installs an executable `.git/hooks/pre-push` that
runs, cheapest-failure-first:

1. `dart run build_runner clean && dart run build_runner build --delete-conflicting-outputs`
2. `git diff --exit-code -- '*.g.dart' '*.freezed.dart'` — codegen drift
3. `dart run tool/build_arb.dart && dart tool/gen_pseudo_arb.dart && flutter gen-l10n`, then `git diff --exit-code -- lib/l10n/` — l10n fan-out drift
4. `flutter analyze`
5. `flutter test test/lint/ test/l10n/ --exclude-tags=network`

Every failure prints an actionable fix. Emergency bypass: `SKIP_PREPUSH=1 git push`.
The hook resolves its path via `git rev-parse --git-path hooks`, so it installs
correctly inside linked worktrees too.

HARD RULE #3 (clean-codegen-before-push) and #4 (every new en ARB key fans out
to all 23 locales before push) are added to the project-local `CLAUDE.md`.
That file is **gitignored** (`.gitignore:66`, untracked since #296), so the
rule text is not in this diff — it is live in the loaded session context. The
maintainer should keep the local CLAUDE.md in sync.

## #2343 — branch protection as a checked-in, verified script
`scripts/configure_branch_protection.sh` is the source of truth for master's
required-status-check protection.

- default mode PATCHes `required_status_checks` to TARGET with `strict=false` (idempotent).
- `--verify` GETs the live config and exits non-zero with a diff on divergence (mutates nothing).

TARGET: `analyze`, `test (0..3)`, `codegen-drift`, `build-android`,
`integration`, `startup-budget`, `l10n-gate` — and **NOT** `coverage-merge`.
The four new checks are added as required by #2337/#2336; `coverage-merge` is
removed by #2338, so the script becomes authoritative once those land. The
PATCH is intentionally **not** applied here (maintainer/orchestrator applies it).

Current `--verify` against live (expected drift):
```
strict (live): false   (target: false)
DRIFT: live required checks differ from TARGET.
  Only in TARGET (missing from live — add these):
    + build-android
    + integration
    + l10n-gate
    + startup-budget
  Only in live (not in TARGET — remove these):
    - coverage-merge
```

## Validation
- `bash -n` clean on both scripts (shellcheck unavailable in env).
- `flutter analyze`: 2 pre-existing `info`s in unrelated master files; **0** new.
- Installer dry-run in a throwaway clone created an executable `pre-push`; the
  generated hook passes `bash -n`; `SKIP_PREPUSH=1` bypass exits 0; a simulated
  stale `.g.dart` is correctly rejected by the drift check.
- `--verify` exits non-zero showing the expected drift above.
- Did not touch `.github/workflows/`, `lib/l10n/**`, or `tool/build_arb.dart`.

Closes #2339
Closes #2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)
