### PR TITLE
test(lint): Platform-check lint + file-length growth ratchet (#2350 #2351)

### DIFF
--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -5,15 +5,28 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// Static-scan guard (#1680): no *new* handwritten Dart file in `lib/`
-/// may exceed [_lineLimit] lines.
+/// Static-scan guard (#1680 / #2351): no *new* handwritten Dart file in
+/// `lib/` may exceed [_lineLimit] lines, and no *grandfathered* file may
+/// **grow** beyond its snapshot line count.
 ///
-/// The ~400-line norm keeps files reviewable and decomposable. This
-/// guard enforces it for new files and **ratchets down** the existing
-/// debt: the [_grandfathered] set lists the files that were already
-/// over the limit when the guard was introduced. That set may only
-/// **shrink** — when an oversized file is decomposed below the limit
-/// it must be removed from the set; it can never be added to.
+/// ### Cap for new files
+/// The ~400-line norm keeps files reviewable and decomposable. Any file
+/// not in [_grandfatheredSnapshot] that exceeds the cap fails CI.
+///
+/// ### One-way ratchet for grandfathered files (#2351)
+/// Each grandfathered file was measured when it entered the set; that
+/// count is recorded in [_grandfatheredSnapshot]. The test enforces two
+/// invariants:
+///
+/// 1. **Shrink signal** — if a grandfathered file has been decomposed
+///    below the cap, the entry must be removed (stale-baseline check).
+/// 2. **Growth block** — if a grandfathered file's current line count
+///    *exceeds* its snapshot, CI fails immediately. This prevents
+///    balloon growth across PRs with no incremental signal.
+///
+/// When a file legitimately needs more lines during a refactoring, the
+/// snapshot entry must be updated in the same PR, with a comment
+/// explaining why.
 ///
 /// Generated files are not scanned: `.g.dart` / `.freezed.dart` and the
 /// `lib/l10n/app_localizations*.dart` outputs of `flutter gen-l10n`
@@ -21,35 +34,43 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   const lineLimit = 400;
 
-  // Files already over the limit when the guard landed (#1680). Debt —
-  // decompose these incrementally and delete each from this set as it
-  // drops below the limit. NEVER add an entry here.
-  const grandfathered = <String>{
-    'lib/app/app_initializer.dart',
-    'lib/core/background/background_service.dart',
-    'lib/core/country/country_config.dart',
-    'lib/core/services/country_service_registry.dart',
-    'lib/features/consumption/data/obd2/adapter_registry.dart',
-    'lib/features/consumption/data/obd2/auto_trip_coordinator.dart',
-    'lib/features/consumption/data/obd2/elm327_parsers.dart',
-    'lib/features/consumption/data/obd2/live_sample_snapshot.dart',
-    'lib/features/consumption/data/obd2/obd2_service.dart',
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart',
-    'lib/features/consumption/presentation/screens/add_fill_up_screen.dart',
-    'lib/features/consumption/presentation/screens/trip_recording_screen.dart',
-    'lib/features/consumption/presentation/widgets/broken_map_widgets.dart',
-    'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart',
-    'lib/features/consumption/presentation/widgets/trip_path_map_card.dart',
-    'lib/features/consumption/providers/consumption_providers.dart',
-    'lib/features/consumption/providers/trip_recording_provider.dart',
-    'lib/features/feature_management/data/legacy_toggle_migrator.dart',
-    'lib/features/map/presentation/widgets/station_map_layers.dart',
-    'lib/features/profile/presentation/widgets/feature_management_section.dart',
-    'lib/features/vehicle/domain/entities/vehicle_profile.dart',
-    'lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart',
-    'lib/features/vehicle/presentation/widgets/auto_record_section.dart',
-    'lib/features/vehicle/presentation/widgets/calibration_section.dart',
-    'lib/features/widget/data/home_widget_service.dart',
+  // Snapshot map: grandfathered path → line count at time of
+  // grandfathering (SPDX header excluded, same as the runtime count).
+  // The growth ratchet fails CI if current > snapshot. Update the value
+  // here when a legitimate re-grandfathering is needed (same PR, with
+  // a comment). NEVER add new entries — use decomposition instead.
+  const grandfatheredSnapshot = <String, int>{
+    'lib/app/app_initializer.dart': 934,
+    'lib/core/background/background_service.dart': 782,
+    'lib/core/country/country_config.dart': 723,
+    'lib/core/services/country_service_registry.dart': 868,
+    'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
+    'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
+    'lib/features/consumption/data/obd2/elm327_parsers.dart': 457,
+    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 471,
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1457,
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1235,
+    'lib/features/consumption/presentation/screens/add_fill_up_screen.dart':
+        496,
+    'lib/features/consumption/presentation/screens/trip_recording_screen.dart':
+        1064,
+    'lib/features/consumption/presentation/widgets/broken_map_widgets.dart':
+        439,
+    'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':
+        439,
+    'lib/features/consumption/presentation/widgets/trip_path_map_card.dart':
+        463,
+    'lib/features/consumption/providers/consumption_providers.dart': 879,
+    'lib/features/consumption/providers/trip_recording_provider.dart': 1125,
+    'lib/features/feature_management/data/legacy_toggle_migrator.dart': 647,
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 544,
+    'lib/features/profile/presentation/widgets/feature_management_section.dart':
+        706,
+    'lib/features/vehicle/domain/entities/vehicle_profile.dart': 453,
+    'lib/features/vehicle/presentation/screens/edit_vehicle_screen.dart': 806,
+    'lib/features/vehicle/presentation/widgets/auto_record_section.dart': 830,
+    'lib/features/vehicle/presentation/widgets/calibration_section.dart': 465,
+    'lib/features/widget/data/home_widget_service.dart': 696,
   };
 
   bool isScanned(String path) {
@@ -62,32 +83,65 @@ void main() {
     return true;
   }
 
+  int effectiveLines(File file) {
+    final rawLines = file.readAsLinesSync();
+    // The standard MIT SPDX header (#2053) adds 3 lines at the top of
+    // every file (copyright, SPDX-License-Identifier, blank). Discount
+    // it so the 400-line norm measures actual content, not boilerplate.
+    final headerOffset =
+        rawLines.length >= 2 &&
+                rawLines[0].contains('Copyright (c) 2026 Florian DITTGEN') &&
+                rawLines[1].contains('SPDX-License-Identifier')
+            ? 3
+            : 0;
+    return rawLines.length - headerOffset;
+  }
+
   test('no new Dart file in lib/ exceeds $lineLimit lines (#1680)', () {
     final offenders = <String>[];
     final stillOver = <String>{};
+    // Growth ratchet violations: grandfathered file grew beyond snapshot.
+    final grownFiles = <String>[];
+    // Decomposition candidates: grandfathered files now in 400-800 band.
+    final decompositionCandidates = <String>[];
 
     for (final entity in Directory('lib').listSync(recursive: true)) {
       if (entity is! File) continue;
       final path = entity.path;
       if (!isScanned(path)) continue;
-      final rawLines = entity.readAsLinesSync();
-      // The standard MIT SPDX header (#2053) adds 3 lines at the top of
-      // every file (copyright, SPDX-License-Identifier, blank). Discount
-      // it so the 400-line norm measures actual content, not boilerplate.
-      final headerOffset =
-          rawLines.length >= 2 &&
-                  rawLines[0]
-                      .contains('Copyright (c) 2026 Florian DITTGEN') &&
-                  rawLines[1].contains('SPDX-License-Identifier')
-              ? 3
-              : 0;
-      final lines = rawLines.length - headerOffset;
-      if (lines <= lineLimit) continue;
-      if (grandfathered.contains(path)) {
-        stillOver.add(path);
-      } else {
+      final lines = effectiveLines(entity);
+
+      if (grandfatheredSnapshot.containsKey(path)) {
+        if (lines > lineLimit) {
+          stillOver.add(path);
+          // Growth ratchet (#2351): fail if current > snapshot.
+          final snapshot = grandfatheredSnapshot[path]!;
+          if (lines > snapshot) {
+            grownFiles.add(
+              '$path  ($lines lines, snapshot $snapshot, '
+              'grew by ${lines - snapshot})',
+            );
+          }
+          // Soft signal: grandfathered files in the 400-800 band are
+          // prime decomposition candidates (#2187/#2188/#2190).
+          if (lines <= 800) {
+            decompositionCandidates.add('$path  ($lines lines)');
+          }
+        }
+        // lines <= lineLimit → file graduated; stale-baseline check below.
+      } else if (lines > lineLimit) {
         offenders.add('$path  ($lines lines)');
       }
+    }
+
+    // Soft print: list near-cap grandfathered files as decomposition hints.
+    if (decompositionCandidates.isNotEmpty) {
+      // ignore: avoid_print
+      print(
+        '\n[file_length_test] Decomposition candidates '
+        '(grandfathered, 400-800 lines):\n'
+        '${decompositionCandidates.join('\n')}\n',
+      );
     }
 
     expect(
@@ -100,16 +154,30 @@ void main() {
           '${offenders.join("\n")}',
     );
 
-    // Ratchet: a grandfathered file decomposed below the limit must be
-    // removed from `grandfathered` so the debt set only ever shrinks.
-    final staleBaseline = grandfathered.difference(stillOver);
+    // Growth ratchet (#2351): a grandfathered file must not grow beyond
+    // its snapshot line count.
+    expect(
+      grownFiles,
+      isEmpty,
+      reason:
+          'Grandfathered file(s) have GROWN beyond their snapshot. '
+          'Decompose the file or update the snapshot in this test with '
+          'a comment explaining why more lines are justified.\n'
+          '${grownFiles.join("\n")}',
+    );
+
+    // Shrink ratchet (#1680): a grandfathered file decomposed below the
+    // limit must be removed from the snapshot map so the debt baseline
+    // stays honest.
+    final staleBaseline =
+        grandfatheredSnapshot.keys.toSet().difference(stillOver);
     expect(
       staleBaseline,
       isEmpty,
       reason:
           'These files are no longer over $lineLimit lines — remove '
-          'them from the `grandfathered` set in this test so the debt '
-          'baseline stays honest:\n${staleBaseline.join("\n")}',
+          'them from the `grandfatheredSnapshot` map in this test so '
+          'the debt baseline stays honest:\n${staleBaseline.join("\n")}',
     );
   });
 }

--- a/test/lint/no_inline_platform_check_test.dart
+++ b/test/lint/no_inline_platform_check_test.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Static-scan guard (#2350): no handwritten Dart file in shared `lib/`
+/// code may branch on `Platform.isIOS`, `Platform.isAndroid`,
+/// `Platform.isMacOS`, `Platform.isLinux`, or `Platform.isWindows`
+/// outside the designated allowed locations.
+///
+/// **Why:** The plugin-pattern rule requires platform branching to be
+/// isolated in `impl/` directories or in platform-specific wrapper
+/// files (files with `ios_` / `android_` in their name). Inline
+/// `Platform.isXxx` in shared code couples the shared layer to the
+/// runtime platform, making unit-testing and future platform additions
+/// harder.
+///
+/// **Allowed locations (no scan):**
+/// - Any file inside an `impl/` sub-directory.
+/// - Files whose base name contains `ios_`, `android_`, `_ios`, or
+///   `_android` (i.e. already platform-scoped wrapper files).
+/// - Files in the explicit [_allowedPlatformWrappers] set that perform
+///   platform dispatch by design but are not yet named with the
+///   ios/android convention.
+///
+/// **Grandfathered set:** Files that were already violating the rule
+/// when the guard landed. The set may only **shrink** — remove a path
+/// once the inline check is eliminated; never add one.
+///
+/// Legacy clean-up tracked by epic #2332.
+void main() {
+  // Files whose name or location makes them legitimate platform
+  // wrappers even without ios_/android_ in the name. These are
+  // exempted from the scan entirely.
+  const allowedPlatformWrappers = <String>{
+    'lib/features/consumption/data/obd2/obd2_permissions.dart',
+  };
+
+  // Files already violating the rule when the guard landed (#2350).
+  // Debt — remove each once the inline Platform check is refactored.
+  // This set may only SHRINK; target is 0. NEVER add an entry here.
+  const grandfathered = <String>{
+    'lib/core/background/background_price_fetcher_provider.dart',
+    'lib/core/feedback/github_issue_reporter/error_reporter_context.dart',
+    'lib/core/sharing/public_file_exporter.dart',
+    'lib/core/telemetry/collectors/device_info_collector.dart',
+    'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart',
+    'lib/features/widget/data/home_widget_service.dart',
+  };
+
+  // Regex that matches an actual (non-comment) Platform.isXxx call.
+  // We strip single-line comments before matching to avoid false
+  // positives from doc comments that mention the API.
+  final platformCheckPattern = RegExp(r'\bPlatform\.is[A-Z][a-zA-Z]+');
+
+  bool isAllowed(String path) {
+    // Normalise separators so the checks work on Windows too.
+    final p = path.replaceAll(r'\', '/');
+    // 1. impl/ sub-directory
+    if (p.contains('/impl/')) return true;
+    // 2. Platform-scoped filename convention
+    final base = p.split('/').last;
+    if (base.startsWith('ios_') ||
+        base.startsWith('android_') ||
+        base.contains('_ios.dart') ||
+        base.contains('_android.dart')) {
+      return true;
+    }
+    // 3. Explicit platform-wrapper allow-list
+    if (allowedPlatformWrappers.contains(p)) return true;
+    return false;
+  }
+
+  bool isScanned(String path) {
+    if (!path.endsWith('.dart')) return false;
+    if (path.endsWith('.g.dart') || path.endsWith('.freezed.dart')) {
+      return false;
+    }
+    if (path.startsWith('lib/l10n/')) return false;
+    if (isAllowed(path)) return false;
+    return true;
+  }
+
+  // Strip `// …` single-line comments from a source line so that
+  // doc comments mentioning Platform.isIOS do not count as violations.
+  String stripLineComment(String line) {
+    final idx = line.indexOf('//');
+    return idx < 0 ? line : line.substring(0, idx);
+  }
+
+  test('no inline Platform.isXxx check outside impl/ or platform wrappers'
+      ' (#2350)', () {
+    final violations = <String>[];
+    final stillViolating = <String>{};
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File) continue;
+      final path = entity.path.replaceAll(r'\', '/');
+      if (!isScanned(path)) continue;
+
+      final lines = entity.readAsLinesSync();
+      var fileHasViolation = false;
+      for (var i = 0; i < lines.length; i++) {
+        final code = stripLineComment(lines[i]);
+        if (platformCheckPattern.hasMatch(code)) {
+          fileHasViolation = true;
+          if (!grandfathered.contains(path)) {
+            violations.add('$path:${i + 1}: ${lines[i].trim()}');
+          }
+        }
+      }
+      if (fileHasViolation && grandfathered.contains(path)) {
+        stillViolating.add(path);
+      }
+    }
+
+    expect(
+      violations,
+      isEmpty,
+      reason:
+          'Inline Platform.isXxx found in shared code outside impl/ or '
+          'platform-wrapper files. Refactor behind a plugin interface in '
+          'an impl/ directory instead.\n\nNew violations:\n'
+          '${violations.join('\n')}',
+    );
+
+    // Ratchet: once a grandfathered file no longer contains inline
+    // Platform checks it must be removed from the set so the debt
+    // baseline stays honest.
+    final staleBaseline = grandfathered.difference(stillViolating);
+    expect(
+      staleBaseline,
+      isEmpty,
+      reason:
+          'These files no longer contain inline Platform checks — remove '
+          'them from the `grandfathered` set in this test:\n'
+          '${staleBaseline.join('\n')}',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **#2350** — adds `test/lint/no_inline_platform_check_test.dart` that scans `lib/` for inline `Platform.isXxx` checks outside `impl/` directories and platform-wrapper files. Seeds a ratchet-down grandfathered set with the 6 currently-violating files; any new inline platform check in shared code fails CI immediately.
- **#2351** — extends `test/lint/file_length_test.dart` so the grandfathered set is a committed snapshot map of `path → line-count-at-grandfathering`. CI now fails if any grandfathered file grows beyond its snapshot (one-way growth ratchet). Adds a soft `print` listing grandfathered files in the 400–800 band as decomposition candidates.

## Violation / grandfathered sets captured

**#2350 — Platform check violations (6 files):**
- `lib/core/background/background_price_fetcher_provider.dart`
- `lib/core/feedback/github_issue_reporter/error_reporter_context.dart`
- `lib/core/sharing/public_file_exporter.dart`
- `lib/core/telemetry/collectors/device_info_collector.dart`
- `lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart`
- `lib/features/widget/data/home_widget_service.dart`

Allowed (not violations): `impl/` dirs, `ios_*`/`android_*` named files, `obd2_permissions.dart` (explicit platform-wrapper allow-set).

**#2351 — File-length snapshot:** 25 grandfathered files with line counts captured at grandfathering time (range: 439–1457 lines).

## Test plan

- [x] `flutter test test/lint/ --exclude-tags=network` — all 31 tests pass
- [x] `flutter analyze test/lint/` — no issues
- [x] Platform ratchet proof: appending `Platform.isAndroid` to `error_logger.dart` → test FAILS with the new violation listed
- [x] Growth ratchet proof: appending 2 lines to `elm327_parsers.dart` (snapshot 457) → test FAILS reporting "grew by 2"

🤖 Generated with [Claude Code](https://claude.com/claude-code)