### PR TITLE
ci: bundle CI/release fixes — docs-stub coverage, codegen-drift hardening, l10n-gate, nightly pins (#2333 #2334 #2336 #2347)

### DIFF
--- a/.github/workflows/ci-docs-stub.yml
+++ b/.github/workflows/ci-docs-stub.yml
@@ -41,3 +41,11 @@ jobs:
     needs: [test]
     steps:
       - run: echo "docs-only change — coverage-merge skipped (stub passes for branch protection)"
+
+  # #2336 — `l10n-gate` is required. ci.yml is path-ignored on docs-only
+  # PRs so its real l10n-gate never runs; docs PRs never touch
+  # `lib/l10n/` anyway. Pass-through stub so the context resolves.
+  l10n-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — l10n-gate skipped (stub passes for branch protection)"

--- a/.github/workflows/ci-docs-stub.yml
+++ b/.github/workflows/ci-docs-stub.yml
@@ -3,6 +3,26 @@
 
 name: CI
 
+# Docs-only "stub" workflow. `ci.yml` carries `paths-ignore` for
+# `**/*.md`, `docs/**`, `LICENSE`, `.gitignore`, so on a docs-only PR
+# the real CI workflow never runs — which means none of its required
+# status-check contexts are ever reported, and branch protection would
+# pin the PR at `mergeStateStatus: BLOCKED` forever. This workflow is
+# the mirror image: it triggers ONLY on those same paths and re-emits
+# every required-check context as a trivial pass, so docs-only PRs
+# satisfy branch protection and keep auto-merge autonomy.
+#
+# CONTRACT (keep in lock-step with branch protection's
+# required_status_checks): every required context MUST have a job here
+# whose name matches the context string EXACTLY. Matrix jobs surface as
+# `name (value)` (e.g. `test (0)`), so the `test` matrix below covers
+# `test (0)..test (3)`. Required contexts as of #2336:
+#   analyze, test (0..3), codegen-drift, l10n-gate,
+#   build-android, integration, startup-budget.
+# `coverage-merge` is retained as a stub during the transition window
+# until it is removed from required_status_checks (it is harmless: an
+# extra passing context never blocks a merge).
+
 on:
   push:
     branches: [master]
@@ -42,10 +62,38 @@ jobs:
     steps:
       - run: echo "docs-only change — coverage-merge skipped (stub passes for branch protection)"
 
-  # #2336 — `l10n-gate` is required. ci.yml is path-ignored on docs-only
-  # PRs so its real l10n-gate never runs; docs PRs never touch
-  # `lib/l10n/` anyway. Pass-through stub so the context resolves.
+  # #2333 — `codegen-drift` became a required check this session. Its
+  # context must resolve on docs-only PRs or every CHANGELOG / wiki /
+  # README PR sits BLOCKED forever. Pass-through stub.
+  codegen-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — codegen-drift skipped (stub passes for branch protection)"
+
+  # #2336 — `l10n-gate` is required. Docs PRs never touch `lib/l10n/`,
+  # so the real gate is a no-op for them; stub it so the context resolves.
   l10n-gate:
     runs-on: ubuntu-latest
     steps:
       - run: echo "docs-only change — l10n-gate skipped (stub passes for branch protection)"
+
+  # build-android / integration / startup-budget are becoming required
+  # this session. On a docs-only PR the real ci.yml is path-ignored and
+  # never runs, so — unlike a code-light PR where ci.yml's `changes`
+  # filter / job `if:` produces a `skipped` (passing) conclusion — these
+  # contexts would otherwise never be reported. Stub them here so the
+  # ONLY passing path on a docs-only PR is this workflow.
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — build-android skipped (stub passes for branch protection)"
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — integration skipped (stub passes for branch protection)"
+
+  startup-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — startup-budget skipped (stub passes for branch protection)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,52 @@ jobs:
             exit 1
           fi
 
+  # #2336 — fast, dedicated localization gate. Surfaces stale ARB
+  # fan-out and l10n/lint regressions in ~90s at push time instead of
+  # 7-8 min into the sharded test job (and, crucially, a check that
+  # actually exists on a DIRTY ARB PR — branch protection can require
+  # it, so a fan-out-conflict PR can no longer auto-merge unrun).
+  # NO Android, NO build_runner — pure ARB regen + diff + the
+  # l10n/lint test buckets. Steps:
+  #   1. Rebuild the canonical ARB from `_fragments/` + the pseudo
+  #      locale + Flutter's generated localizations.
+  #   2. `git diff --exit-code -- lib/l10n/` fails if any of step 1's
+  #      output differs from what was committed (someone edited a
+  #      fragment without rerunning the tooling).
+  #   3. Run the l10n + lint suites (network-tagged tests excluded;
+  #      they hit live APIs and live in other buckets).
+  l10n-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          # #1936 — pin Flutter (see ci.yml analyze job). Coupled to the
+          # ci.yml pin; bump deliberately, not by drift.
+          flutter-version: "3.41.9"
+          cache: true
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - run: flutter pub get
+      - name: Rebuild ARB + pseudo-locale + generated localizations
+        run: |
+          dart tool/build_arb.dart
+          dart tool/gen_pseudo_arb.dart
+          flutter gen-l10n
+      - name: Fail if committed ARB fan-out is stale
+        run: |
+          if ! git diff --exit-code -- lib/l10n/; then
+            echo "::error::Generated ARB / l10n output is stale. Run 'dart tool/build_arb.dart && dart tool/gen_pseudo_arb.dart && flutter gen-l10n' locally and commit the result." >&2
+            exit 1
+          fi
+      - name: Run l10n + lint test buckets
+        run: flutter test test/l10n/ test/lint/ --exclude-tags=network
+
   # #1581 — Test job sharded 4× across parallel runners. Each shard
   # runs `flutter test --total-shards=4 --shard-index=N` so every
   # test in the suite runs exactly once across the matrix. Wall clock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,23 @@ jobs:
           # local dev SDK). Bump deliberately, not by drift.
           flutter-version: "3.41.9"
           cache: true
+      # #2334 — deliberately do NOT cache `.dart_tool` here (only
+      # `~/.pub-cache`). The cache key is `hashFiles('pubspec.lock')`,
+      # so two PRs with the same lockfile but different `@riverpod` /
+      # `@freezed` source share build_runner's cached asset graph under
+      # `.dart_tool/build`. An *incremental* `build_runner build` then
+      # sees "no input changed", re-emits the prior `.g.dart`, and the
+      # `git diff` check passes against identically-stale committed
+      # files — the exact stale-hash vector that poisoned master in
+      # #2322 / #2245 (and `feedback_codegen_drift_local_gate.md`).
+      # Starting from a fresh `.dart_tool` forces a full, honest
+      # regeneration every run. `--delete-conflicting-outputs` only
+      # resolves output collisions, not stale internal hashes, so it is
+      # not a substitute. Cost is ~+30s — well under the ~2.5 min budget.
       - uses: actions/cache@v5
         with:
           path: |
             ~/.pub-cache
-            .dart_tool
           key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
           restore-keys: ${{ runner.os }}-pub-
       - run: flutter pub get

--- a/.github/workflows/nightly-flaky.yml
+++ b/.github/workflows/nightly-flaky.yml
@@ -36,6 +36,14 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #2347 — pin Flutter in lock-step with ci.yml. A floating
+          # `channel: stable` picked up an SDK whose Gradle plugin
+          # hard-failed on the tflite_flutter JVM-target mismatch
+          # (#1936); an unpinned nightly repeats that risk every night
+          # stable bumps, producing spurious red that masks real
+          # regressions and spams #1584. Keep this value identical to
+          # the ci.yml pin; bump both together, never by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/nightly-full.yml
+++ b/.github/workflows/nightly-full.yml
@@ -33,6 +33,14 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # #2347 — pin Flutter in lock-step with ci.yml. A floating
+          # `channel: stable` picked up an SDK whose Gradle plugin
+          # hard-failed on the tflite_flutter JVM-target mismatch
+          # (#1936); an unpinned nightly repeats that risk every night
+          # stable bumps, producing spurious red that masks real
+          # regressions and spams #1591. Keep this value identical to
+          # the ci.yml pin; bump both together, never by drift.
+          flutter-version: "3.41.9"
           cache: true
       - uses: actions/cache@v5
         with:

--- a/test/ci/ci_workflow_test.dart
+++ b/test/ci/ci_workflow_test.dart
@@ -271,6 +271,55 @@ void main() {
     });
   });
 
+  // #2333 / docs-PR safety — ci.yml is path-ignored on docs-only PRs, so
+  // the ONLY workflow that runs is ci-docs-stub.yml. Every context that
+  // is (or will be) a required status check must therefore have a stub
+  // job there whose name matches the context EXACTLY, or the docs PR
+  // sits BLOCKED forever.
+  group('ci-docs-stub covers every required check (#2333)', () {
+    late String stubYaml;
+
+    // The target required_status_checks set after the post-merge API
+    // change: build-android / integration / startup-budget / l10n-gate
+    // become required, the phantom coverage-merge is dropped. Matrix
+    // jobs (`test (0)..test (3)`) are covered by the `test` job header.
+    const requiredJobNames = <String>[
+      'analyze',
+      'test',
+      'codegen-drift',
+      'l10n-gate',
+      'build-android',
+      'integration',
+      'startup-budget',
+    ];
+
+    setUpAll(() {
+      final file = File('.github/workflows/ci-docs-stub.yml');
+      expect(file.existsSync(), isTrue,
+          reason: 'docs-stub workflow must exist');
+      stubYaml = file.readAsStringSync();
+    });
+
+    test('declares a stub job for every required check name', () {
+      for (final job in requiredJobNames) {
+        expect(_jobBody(stubYaml, job), isNotEmpty,
+            reason: 'ci-docs-stub.yml must declare a `$job:` stub job so '
+                'the `$job` required context resolves on docs-only PRs.');
+      }
+    });
+
+    test('the test stub keeps the 4-shard matrix so test (0..3) resolve',
+        () {
+      final testJob = _jobBody(stubYaml, 'test');
+      expect(testJob, contains('shard: [0, 1, 2, 3]'));
+    });
+
+    test('triggers only on docs paths (mirrors ci.yml paths-ignore)', () {
+      expect(stubYaml, contains("- '**/*.md'"));
+      expect(stubYaml, contains("- 'docs/**'"));
+    });
+  });
+
   // #2347 — both nightlies must pin the same Flutter version as ci.yml,
   // so a floating stable-channel bump can't silently change the nightly
   // SDK and spam the tracking issues with spurious red.

--- a/test/ci/ci_workflow_test.dart
+++ b/test/ci/ci_workflow_test.dart
@@ -236,6 +236,41 @@ void main() {
     });
   });
 
+  // #2336 — fast l10n gate exists in ci.yml and is stubbed for docs PRs.
+  group('l10n-gate job (#2336)', () {
+    late String l10nJob;
+
+    setUpAll(() {
+      l10nJob = _jobBody(ciYaml, 'l10n-gate');
+      expect(l10nJob, isNotEmpty, reason: 'l10n-gate job must exist in ci.yml');
+    });
+
+    test('runs the ARB rebuild trio', () {
+      expect(l10nJob, contains('dart tool/build_arb.dart'));
+      expect(l10nJob, contains('dart tool/gen_pseudo_arb.dart'));
+      expect(l10nJob, contains('flutter gen-l10n'));
+    });
+
+    test('diffs lib/l10n and runs the l10n + lint buckets', () {
+      expect(l10nJob, contains('git diff --exit-code -- lib/l10n/'));
+      expect(l10nJob,
+          contains('flutter test test/l10n/ test/lint/ --exclude-tags=network'));
+    });
+
+    test('does NOT run Android or build_runner (kept fast)', () {
+      expect(l10nJob.contains('build_runner'), isFalse);
+      expect(l10nJob.contains('setup-java'), isFalse);
+      expect(l10nJob.contains('flutter build'), isFalse);
+    });
+
+    test('has a matching pass-through stub in ci-docs-stub.yml', () {
+      final stub = File('.github/workflows/ci-docs-stub.yml').readAsStringSync();
+      expect(_jobBody(stub, 'l10n-gate'), isNotEmpty,
+          reason: 'docs-only PRs need an l10n-gate stub — ci.yml is '
+              'path-ignored on them.');
+    });
+  });
+
   // #2347 — both nightlies must pin the same Flutter version as ci.yml,
   // so a floating stable-channel bump can't silently change the nightly
   // SDK and spam the tracking issues with spurious red.

--- a/test/ci/ci_workflow_test.dart
+++ b/test/ci/ci_workflow_test.dart
@@ -174,4 +174,31 @@ void main() {
       expect(outdatedScript, contains('Major version updates available'));
     });
   });
+
+  // #2347 — both nightlies must pin the same Flutter version as ci.yml,
+  // so a floating stable-channel bump can't silently change the nightly
+  // SDK and spam the tracking issues with spurious red.
+  group('nightly Flutter version pin (#2347)', () {
+    // Single source of truth: whatever ci.yml pins, the nightlies match.
+    late String pinnedVersion;
+
+    setUpAll(() {
+      final match =
+          RegExp(r'''flutter-version:\s*["']([\d.]+)["']''').firstMatch(ciYaml);
+      expect(match, isNotNull,
+          reason: 'ci.yml must pin a flutter-version');
+      pinnedVersion = match!.group(1)!;
+    });
+
+    test('nightly-full pins the same flutter-version as ci.yml', () {
+      final yaml = File('.github/workflows/nightly-full.yml').readAsStringSync();
+      expect(yaml, contains('flutter-version: "$pinnedVersion"'));
+    });
+
+    test('nightly-flaky pins the same flutter-version as ci.yml', () {
+      final yaml =
+          File('.github/workflows/nightly-flaky.yml').readAsStringSync();
+      expect(yaml, contains('flutter-version: "$pinnedVersion"'));
+    });
+  });
 }

--- a/test/ci/ci_workflow_test.dart
+++ b/test/ci/ci_workflow_test.dart
@@ -5,6 +5,34 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+/// Returns the body of the named top-level job in [workflowYaml] — the
+/// lines from the `<jobName>:` header (indented exactly two spaces) up to
+/// but not including the next two-space-indented `<name>:` job header.
+///
+/// A deliberately simple line scanner rather than a YAML parser: it keeps
+/// the test dependency-free and the GitHub-Actions job grammar is regular
+/// enough (every top-level job is a key indented exactly two spaces) for a
+/// scan to be unambiguous.
+String _jobBody(String workflowYaml, String jobName) {
+  final lines = workflowYaml.split('\n');
+  final header = RegExp('^  $jobName:\\s*\$');
+  final anyJobHeader = RegExp(r'^  [A-Za-z0-9_-]+:\s*$');
+  final buffer = StringBuffer();
+  var inJob = false;
+  for (final line in lines) {
+    if (inJob) {
+      // A new two-space-indented `name:` line ends the current job.
+      if (anyJobHeader.hasMatch(line)) break;
+      buffer.writeln(line);
+      continue;
+    }
+    if (header.hasMatch(line)) {
+      inJob = true;
+    }
+  }
+  return buffer.toString();
+}
+
 /// Tests that verify the CI workflow file contains expected jobs and steps.
 void main() {
   late String ciYaml;
@@ -172,6 +200,39 @@ void main() {
 
     test('reports major version lag as informational', () {
       expect(outdatedScript, contains('Major version updates available'));
+    });
+  });
+
+  // #2334 — the codegen-drift job must NOT cache `.dart_tool`. Caching
+  // it keyed on pubspec.lock alone lets two PRs with the same lockfile
+  // share build_runner's incremental asset graph, so a stale `.g.dart`
+  // re-emits and the diff check passes against identically-stale
+  // committed files (the #2322 / #2245 poisoning vector).
+  group('codegen-drift stale-hash hardening (#2334)', () {
+    late String codegenJob;
+
+    setUpAll(() {
+      codegenJob = _jobBody(ciYaml, 'codegen-drift');
+      expect(codegenJob, isNotEmpty,
+          reason: 'codegen-drift job must exist in ci.yml');
+    });
+
+    test('codegen-drift job does NOT cache .dart_tool', () {
+      // Ignore comment lines — the rationale comment mentions `.dart_tool`
+      // in prose; what matters is no executable `path:` entry restores it.
+      final executable = codegenJob
+          .split('\n')
+          .where((l) => !l.trimLeft().startsWith('#'))
+          .join('\n');
+      expect(executable.contains('.dart_tool'), isFalse,
+          reason: 'codegen-drift must start from a fresh .dart_tool so '
+              'build_runner regenerates honestly — see #2334.');
+    });
+
+    test('codegen-drift still caches ~/.pub-cache and regenerates', () {
+      expect(codegenJob, contains('~/.pub-cache'));
+      expect(codegenJob,
+          contains('dart run build_runner build --delete-conflicting-outputs'));
     });
   });
 


### PR DESCRIPTION
## Summary

A bundle of GitHub-Actions fixes. All four touch `.github/workflows/*.yml`, so they ship in one PR (one commit per issue) to avoid serial CI churn and merge conflicts on the shared workflow files.

| Issue | Change |
| --- | --- |
| **#2333** | Add pass-through stubs to `ci-docs-stub.yml` for `codegen-drift` (newly required, was BLOCKING every docs-only PR) plus the soon-to-be-required `build-android` / `integration` / `startup-budget`. ci.yml is `paths-ignore`-d on docs PRs, so the stub workflow is the *only* one that runs there. |
| **#2334** | Drop `.dart_tool` from the `codegen-drift` cache `path:` (keep `~/.pub-cache`). The pubspec.lock-only cache key let two PRs share build_runner's incremental asset graph → stale `.g.dart` re-emit → `git diff` passes against identically-stale committed files. This is the vector that merged #2322 RED and poisoned master (also #2245). Fresh `.dart_tool` forces an honest full regen each run (~+30s, well under the 2.5 min budget). |
| **#2336** | Add a fast named `l10n-gate` job (no Android, no build_runner): rebuild ARB (`build_arb` + `gen_pseudo_arb` + `gen-l10n`) → `git diff --exit-code -- lib/l10n/` → `flutter test test/l10n/ test/lint/ --exclude-tags=network`. Plus its docs-stub. Surfaces stale ARB fan-out in ~90s at push instead of 7-8 min into the shard job, and is requirable so a DIRTY ARB PR can't auto-merge unrun. |
| **#2347** | Pin `flutter-version: '3.41.9'` (matching ci.yml) in `nightly-full.yml` and `nightly-flaky.yml`; both used a floating `channel: stable`. Documented as coupled to the ci.yml pin. |

Also adds `test/ci/ci_workflow_test.dart` coverage: (a) `codegen-drift` does not cache `.dart_tool`; (b) `ci-docs-stub.yml` declares a stub for every required check name; (c) both nightlies pin the same version ci.yml pins.

## Docs-PR safety audit

**Key fact:** `ci.yml` carries `paths-ignore` for `**/*.md`, `docs/**`, `LICENSE`, `.gitignore`. On a *pure docs-only PR* `ci.yml` never triggers — so its `changes`-filter / job-`if:` skip logic produces **no** contexts at all. The only workflow that runs is `ci-docs-stub.yml`. Therefore **every required context must have a name-exact stub in `ci-docs-stub.yml`** — the changes-filter cannot help docs PRs.

(The `changes` filter / job `if:` skips matter for *code-light* PRs — test-only / workflow-only — where ci.yml *does* run and `build-android` reports a passing `skipped` conclusion. They do nothing for docs-only PRs.)

Per-required-check resolution path on a **docs-only PR** (exact context-name match):

| Required context | Resolves via |
| --- | --- |
| `analyze` | existing stub |
| `test (0)` … `test (3)` | existing stub matrix (`shard: [0,1,2,3]`) |
| `codegen-drift` | **new stub** (this PR, #2333) |
| `l10n-gate` | **new stub** (this PR, #2336) |
| `build-android` | **new stub** (this PR, #2333) |
| `integration` | **new stub** (this PR, #2333) |
| `startup-budget` | **new stub** (this PR, #2333) |

On a **code PR** (ci.yml runs): `build-android` self-skips via the `changes.code` gate when no build-relevant file changed; `integration` / `startup-budget` always run (`needs: [analyze]`, no skip gate); `codegen-drift` / `l10n-gate` / `analyze` / `test` always run. No duplicate context is introduced — the stub workflow and ci.yml share the `name: CI` umbrella but never both run for the same PR (mutually-exclusive `paths` vs `paths-ignore`).

`coverage-merge` stub is **kept** during the transition window (it's harmless — an extra passing context never blocks a merge) and removed from required protection by the change below.

## Required-status-checks change to apply AFTER this merges

Make `build-android`, `integration`, `startup-budget`, `l10n-gate` required and drop the phantom `coverage-merge`. Current required set is `analyze, test (0)..test (3), coverage-merge, codegen-drift`. Apply:

```bash
gh api -X PATCH repos/:owner/:repo/branches/master/protection/required_status_checks \
  -f strict=false \
  -f 'checks[][context]=analyze' \
  -f 'checks[][context]=test (0)' \
  -f 'checks[][context]=test (1)' \
  -f 'checks[][context]=test (2)' \
  -f 'checks[][context]=test (3)' \
  -f 'checks[][context]=codegen-drift' \
  -f 'checks[][context]=l10n-gate' \
  -f 'checks[][context]=build-android' \
  -f 'checks[][context]=integration' \
  -f 'checks[][context]=startup-budget'
```

Target contexts after the patch: `analyze, test (0), test (1), test (2), test (3), codegen-drift, l10n-gate, build-android, integration, startup-budget` (— `coverage-merge`). Every one of these has a passing path on a docs-only PR via `ci-docs-stub.yml` (verified by `ci_workflow_test.dart`).

## Validation

- `python3 -c 'import yaml ...' .github/workflows/*.yml` → all parse.
- `flutter test test/ci/ --exclude-tags=network` → 34 passing.
- `flutter analyze test/ci/ci_workflow_test.dart` → no issues.
- The real proof is this PR's **own** CI running the modified workflows (codegen-drift with no `.dart_tool` cache, the new `l10n-gate` job).

Closes #2333
Closes #2334
Closes #2336
Closes #2347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
