### PR TITLE
ci: epic-checklist back-patch Action + dynamic nightly-failure issues (#2341 #2348)

### DIFF
--- a/.github/workflows/epic-backpatch.yml
+++ b/.github/workflows/epic-backpatch.yml
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: Epic checklist back-patch
+
+# #2341 — when a child issue is opened with a `Part of #<N>` /
+# `epic: #<N>` back-reference, rewrite the matching title-only task item
+# in the Epic's checklist to `- [ ] #<new> — <title>`, turning the Epic
+# body into a live merge-status dashboard (the #2167 gold standard)
+# without manual editing. No-op when there is no back-reference or no
+# fuzzily-matching title-only line.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  backpatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Back-patch parent Epic checklist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHILD_NUMBER: ${{ github.event.issue.number }}
+          CHILD_TITLE: ${{ github.event.issue.title }}
+          CHILD_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -euo pipefail
+
+          # 1. Find the parent Epic number: `Part of #<N>` or `epic: #<N>`.
+          EPIC=$(printf '%s' "$CHILD_BODY" \
+            | grep -ioE '(part of|epic:?)[[:space:]]*#[0-9]+' \
+            | grep -oE '[0-9]+' | head -n1 || true)
+          if [ -z "${EPIC:-}" ]; then
+            echo "No 'Part of #' / 'epic: #' reference — nothing to back-patch."
+            exit 0
+          fi
+          echo "Parent Epic candidate: #$EPIC"
+
+          # 2. Fetch the Epic body.
+          gh issue view "$EPIC" --json body --jq .body > epic-body.md || {
+            echo "Could not read Epic #$EPIC — skipping."; exit 0; }
+
+          # 3. Fuzzy-match a title-only task item and rewrite it. The
+          #    rewrite happens in Python for robust matching; it writes
+          #    the new body to new-body.md and prints MATCHED=1 on a hit.
+          MATCHED=$(python3 - "$CHILD_NUMBER" <<'PY'
+          import os, re, sys, difflib
+
+          child_no = sys.argv[1]
+          child_title = os.environ["CHILD_TITLE"].strip()
+
+          with open("epic-body.md", encoding="utf-8") as fh:
+              lines = fh.readlines()
+
+          def normalize(s: str) -> str:
+              # Lower-case, strip a leading `type(scope):` conventional
+              # prefix and punctuation, collapse whitespace — so a task
+              # item phrased loosely still matches the filed title.
+              s = s.lower().strip()
+              s = re.sub(r"^[a-z]+(\([^)]*\))?:\s*", "", s)
+              s = re.sub(r"[^a-z0-9 ]+", " ", s)
+              return re.sub(r"\s+", " ", s).strip()
+
+          child_norm = normalize(child_title)
+
+          # A title-only task item: `- [ ] <title>` (any checkbox state)
+          # that does NOT already carry a `#NNNN` issue reference.
+          item_re = re.compile(r"^(\s*[-*]\s*\[[ xX]\]\s*)(.+?)\s*$")
+          ref_re = re.compile(r"#\d+")
+
+          best_i, best_ratio, best_title = -1, 0.0, ""
+          for i, line in enumerate(lines):
+              m = item_re.match(line)
+              if not m:
+                  continue
+              text = m.group(2)
+              if ref_re.search(text):
+                  continue  # already back-patched
+              ratio = difflib.SequenceMatcher(
+                  None, child_norm, normalize(text)).ratio()
+              if ratio > best_ratio:
+                  best_i, best_ratio, best_title = i, ratio, text.strip()
+
+          # Require a strong fuzzy match to avoid mis-patching the wrong
+          # line; 0.6 tolerates prefix/punctuation drift but rejects
+          # unrelated items.
+          if best_i < 0 or best_ratio < 0.6:
+              print("MATCHED=0")
+              sys.exit(0)
+
+          prefix = item_re.match(lines[best_i]).group(1)
+          lines[best_i] = f"{prefix}#{child_no} — {best_title}\n"
+          with open("new-body.md", "w", encoding="utf-8") as fh:
+              fh.writelines(lines)
+          print(f"MATCHED=1 ratio={best_ratio:.2f} line={best_i}",
+                file=sys.stderr)
+          print("MATCHED=1")
+          PY
+          )
+
+          if ! printf '%s' "$MATCHED" | grep -q 'MATCHED=1'; then
+            echo "No title-only Epic task item matched #$CHILD_NUMBER — no-op."
+            exit 0
+          fi
+
+          # 4. Commit the rewritten checklist back to the Epic.
+          gh issue edit "$EPIC" --body-file new-body.md
+          echo "Back-patched Epic #$EPIC with child #$CHILD_NUMBER."

--- a/.github/workflows/nightly-flaky.yml
+++ b/.github/workflows/nightly-flaky.yml
@@ -12,6 +12,13 @@ name: Nightly Flaky + Network Suite
 #   - `network` — live-API tests (Italy MIMIT, Argentina, etc).
 #   - `flaky`   — platform-plugin tests whose channel timing is
 #                 unreliable in headless runners (share_plus, etc).
+#
+# #2348 — failure now opens (or comments on, when one already exists for
+# the day) a labelled, triage-ready `nightly-flaky failed <UTC date>`
+# bug instead of a buried comment on #1584; the next green nightly
+# auto-closes it. A zero-match guard also fails the run loudly if the
+# tag selector matches no tests (the #2003 `flaky && network` bug ran
+# zero tests for an unknown window — silently green-by-empty).
 
 on:
   schedule:
@@ -64,11 +71,65 @@ jobs:
         # intent — per this workflow's own header comment — is OR: "we
         # cover everything the PR/master path excludes". Use the
         # explicit Boolean form so the selector matches both buckets.
-        run: flutter test --tags 'flaky || network'
-      - name: Surface failure on tracking issue
+        #
+        # #2348 — zero-match guard. `flutter test` exits 79 with "No
+        # tests ran" when the selector matches nothing (the #2003
+        # `flaky && network` regression hit exactly this and stayed
+        # silently green-by-empty). Capture the run, and if it exits 79
+        # / reports no matching tests, fail loudly with a distinct
+        # message so the failure path opens a triage issue rather than
+        # the run passing on an empty selector.
+        run: |
+          set -o pipefail
+          flutter test --tags 'flaky || network' 2>&1 | tee test-output.log
+          status=${PIPESTATUS[0]}
+          if [ "$status" -eq 79 ] || grep -qiE 'No tests (ran|match)' test-output.log; then
+            echo "::error::nightly-flaky tag selector 'flaky || network' matched ZERO tests — regression of the #2003 empty-selector bug." >&2
+            exit 1
+          fi
+          exit "$status"
+
+      # #2348 — open (or comment on) a dedicated, labelled triage issue
+      # per failing night. Dedups against an already-open issue with the
+      # same `nightly-flaky failed <date>` title so a re-run / repeat
+      # failure on the same day comments rather than spawning duplicates.
+      - name: Open / update nightly-failure issue
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue comment 1584 --body \
-            "Nightly flaky+network run failed on $(date -u +%F): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          set -euo pipefail
+          TITLE="nightly-flaky failed $(date -u +%F)"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -n1)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" \
+              --body "Nightly flaky+network suite failed again. Run: $RUN_URL"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --label "type/bug,area/ci,P1-high" \
+              --body "Nightly flaky+network run failed. Run: $RUN_URL"
+          fi
+
+      # #2348 — a green nightly auto-closes any still-open
+      # `nightly-flaky failed …` triage issue so a fixed regression
+      # does not linger on the board.
+      - name: Close open nightly-failure issues on green
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue list --state open --label area/ci \
+            --search 'in:title "nightly-flaky failed"' \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("nightly-flaky failed")) | .number' \
+          | while read -r N; do
+              [ -n "$N" ] || continue
+              gh issue close "$N" \
+                --comment "Resolved by a green nightly-flaky run. Run: $RUN_URL"
+            done

--- a/.github/workflows/nightly-full.yml
+++ b/.github/workflows/nightly-full.yml
@@ -9,8 +9,11 @@ name: Nightly Full Test Suite
 # except `network` because the live-API tests can't run reliably from
 # GitHub-hosted runners).
 #
-# Failure surfaces by reopening / commenting on the tracking issue
-# (#1591) so the user sees it without having to check Actions UI.
+# #2348 — failure no longer buries itself in a comment on the year-old
+# tracking issue #1591. Instead each failing night opens (or, on a
+# repeat failure the same UTC day, comments on) a labelled, triage-ready
+# bug — `nightly-full failed <UTC date>` under the `area/ci` filter —
+# and the next green nightly auto-closes any still-open one.
 
 on:
   schedule:
@@ -53,10 +56,48 @@ jobs:
       - run: dart run build_runner build --delete-conflicting-outputs
       - name: Run full test suite (selector bypassed)
         run: flutter test --coverage --exclude-tags=network
-      - name: Surface failure on tracking issue
+
+      # #2348 — open (or comment on) a dedicated, labelled triage issue
+      # per failing night. Dedups against an already-open issue with the
+      # same `nightly-full failed <date>` title so a re-run / repeat
+      # failure on the same day comments rather than spawning duplicates.
+      - name: Open / update nightly-failure issue
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue comment 1591 --body \
-            "Nightly full-suite run failed on $(date -u +%F): https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          set -euo pipefail
+          TITLE="nightly-full failed $(date -u +%F)"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"$TITLE\") | .number" | head -n1)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" \
+              --body "Nightly full-suite failed again. Run: $RUN_URL"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --label "type/bug,area/ci,P1-high" \
+              --body "Nightly full-suite run failed. Run: $RUN_URL"
+          fi
+
+      # #2348 — a green nightly auto-closes any still-open
+      # `nightly-full failed …` triage issue so a fixed regression
+      # does not linger on the board.
+      - name: Close open nightly-failure issues on green
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh issue list --state open --label area/ci \
+            --search 'in:title "nightly-full failed"' \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("nightly-full failed")) | .number' \
+          | while read -r N; do
+              [ -n "$N" ] || continue
+              gh issue close "$N" \
+                --comment "Resolved by a green nightly-full run. Run: $RUN_URL"
+            done


### PR DESCRIPTION
Bundles two GitHub-Actions automations that both touch
`.github/workflows/`, one commit per issue.

## #2341 — Epic-checklist back-patch Action
New `.github/workflows/epic-backpatch.yml`, triggered on
`issues.opened`:
1. Parses the new issue body for `Part of #<N>` / `epic: #<N>`.
2. Fetches the parent Epic body.
3. Fuzzily matches a **title-only** task item (`- [ ] <title>` with no
   existing `#NNNN`) against the new issue's title — normalising
   conventional-commit prefixes + punctuation, requiring a `>=0.6`
   ratio, and skipping already-referenced lines.
4. Rewrites the line to `- [ ] #<new> — <title>` and commits via
   `gh issue edit --body-file`.

No-op (exit 0) when there is no back-reference, the Epic is unreadable,
or nothing matches. Turns new-style Epic checklists into live
merge-status dashboards (the #2167 gold standard) without manual edits.

## #2348 — Dynamic nightly-failure issues
Both `nightly-full.yml` and `nightly-flaky.yml` replace the hardcoded
comment-on-#1591/#1584 handling:
- **On failure:** open `nightly-<full|flaky> failed <UTC date>` labelled
  `type/bug,area/ci,P1-high` with the run URL; dedup against an open
  same-title issue (comment instead of duplicating same-day).
- **On green:** auto-close any still-open `nightly-<…> failed …` issue.
- **Zero-match guard:** nightly-flaky now fails loudly if its
  `flaky || network` selector matches zero tests (exit 79), guarding
  against a silent regression of the #2003 `flaky && network` bug.

## Validation
- All three workflow YAMLs parse (`python3 -c 'import yaml…'`).
- The embedded back-patch Python compiles and was unit-exercised
  locally (exact-match, fuzzy-match, no-match, already-patched, and
  both reference forms).
- `flutter test test/ci/` green (34/34, incl. the #2347 nightly-pin
  assertions — pins preserved).
- Labels `type/bug`, `area/ci`, `P1-high` all already exist; none
  created.

Closes #2341
Closes #2348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
