### PR TITLE
docs+test: data-drive FR prefixes + version-control agent HARD RULES (#2353 #2355)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ docs/*
 # not inside docs/decisions/ which is reserved for ADRs).
 !docs/test-audit-*.md
 !docs/test-always-run-bucket-*.md
+# Version-controlled mirror of the agent HARD RULES (#2355) — CLAUDE.md stays
+# gitignored (#296), so the rules live here to reach a fresh clone.
+!docs/AGENT_RULES.md
 docs/guides/*
 !docs/guides/NETWORK_TESTS.md
 !docs/guides/NEW_COUNTRY.md

--- a/docs/AGENT_RULES.md
+++ b/docs/AGENT_RULES.md
@@ -1,0 +1,104 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# Agent HARD RULES
+
+These are the non-negotiable rules for any contributor — human or AI — working
+in this repository. They must **never** be violated under any circumstances.
+
+> **Why this file exists.** `CLAUDE.md` (which a Claude Code session auto-loads)
+> is deliberately gitignored (`.gitignore`, decision #296), so the HARD RULES
+> living there are local-only and do **not** propagate to a fresh clone or
+> another machine. This file is the version-controlled mirror: it travels with
+> the repo so the rules survive fresh checkouts everywhere (#2355). `CLAUDE.md`
+> stays gitignored and references this file — #296 is not reversed.
+
+## 1. No hard-coded user-facing text
+
+Every string a user can see — `Text`, `Tooltip`, `SnackBar`, `hintText`,
+`labelText`, `helperText`, `semanticLabel`, button labels, dialog text, AppBar
+titles, user-facing error/exception messages — **must** come from
+`AppLocalizations` (ARB). Never inline a translatable literal, not even "just
+for now".
+
+- Add new strings to the matching `lib/l10n/_fragments/` fragment (en + de),
+  then run `dart tool/build_arb.dart`, `dart tool/gen_pseudo_arb.dart`
+  (regenerates the `en_XA` text-expansion pseudo-locale, #1699) and
+  `flutter gen-l10n`.
+- The only exemptions are brand names / proper nouns (e.g. `GitHub`, `PayPal`,
+  `TankSync`), URLs, and language-neutral format masks. Each exemption must
+  carry an inline `// i18n-ignore: <reason>` comment.
+- Enforcement: `test/lint/no_hardcoded_ui_strings_test.dart`. Its baseline may
+  only ever **decrease**; the target is **0**. Never raise it.
+- Legacy cleanup is tracked by epic #1657.
+
+## 2. Never develop without an issue
+
+Every change traces to a GitHub issue. Large / multi-PR / multi-subsystem work
+is an Epic — file the Epic parent, get the breakdown validated by the
+maintainer, and only then file child issues.
+
+## 3. Clean-codegen-before-push (never ship stale generated code)
+
+Before every push, regenerate **from clean** — never incrementally — and commit
+**all** resulting drift. An incremental `build_runner build` keeps stale hashes
+that CI's clean run flags; the only safe sequence is:
+
+```bash
+dart run build_runner clean
+dart run build_runner build --delete-conflicting-outputs
+git add -- '*.g.dart' '*.freezed.dart'   # commit every change it produced
+```
+
+- A push that leaves any `*.g.dart` / `*.freezed.dart` diff uncommitted is a
+  **defect**, full stop — codegen drift has reached CI 4+ times in one session
+  (plus #2245), each costing a ~13-min round-trip. Never "fix it in the next
+  push".
+- Don't `dart format` whole generated files; commit only the codegen diff.
+
+## 4. Every new en ARB key must reach all 23 locales before push
+
+Adding a key to `app_en.arb` (or any `_fragments/` en fragment) and **not**
+fanning it out to every other locale is a **defect** — en+de-only additions
+trip the #1699 coverage gate in CI. The full pipeline must run and its output be
+committed before push:
+
+```bash
+dart run tool/build_arb.dart       # merge fragments -> canonical app_<locale>.arb
+dart tool/gen_pseudo_arb.dart      # regenerate the en_XA expansion pseudo-locale
+flutter gen-l10n                   # regenerate Dart bindings
+git add -- lib/l10n/               # commit the full fan-out
+```
+
+- Every locale ARB must contain every `app_en.arb` key. The autofill pipeline
+  (`tool/autofill_locales.dart`, run by `build_arb.dart`, #2335) carries new
+  keys to all 23 shipped locales (plus the `en_XA` pseudo-locale), machine-
+  filling any locale that lacks a key so the #1699 gate cannot be tripped.
+- A push that leaves an `lib/l10n/` diff uncommitted, or any locale below 100%
+  coverage, is a defect — never raise the baseline to "make it pass".
+- Enforcement: `test/l10n/localization_completeness_test.dart` makes it
+  CI-fatal. The handful of core French-reachable surfaces that must carry real
+  (not machine-filled) French translations are declared in
+  `test/l10n/french_required_prefixes.dart`.
+
+## Install the local pre-push gate
+
+HARD RULES #3 and #4 are enforced **locally**, before the ~13-minute CI
+round-trip, by an installable pre-push hook. Run this once after cloning (and
+again whenever the installer changes):
+
+```bash
+bash scripts/install_hooks.sh
+```
+
+The hook regenerates codegen + l10n from clean and **rejects the push** on any
+`*.g.dart` / `*.freezed.dart` / `lib/l10n/` drift. Emergency bypass — you then
+own the resulting CI red — is `SKIP_PREPUSH=1 git push`.
+
+---
+
+For everything beyond these four rules — architecture, the service-chain
+pattern, the TDD pyramid, GitHub flow, the feature-enum cascade and the
+autonomous-agent batching doctrine — see the `tankstellen-conventions` skill.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,6 +8,10 @@
 Thank you for your interest in contributing to Tankstellen, the free fuel price
 comparison app for Europe and beyond.
 
+> **Read first:** the four non-negotiable [agent HARD RULES](AGENT_RULES.md)
+> (no hard-coded strings, issue-first, clean-codegen-before-push, 23-locale ARB
+> fan-out) plus the local pre-push hook install pointer.
+
 ## Development Setup
 
 1. **Flutter SDK** 3.41.5+ installed and on your PATH

--- a/test/l10n/french_required_prefixes.dart
+++ b/test/l10n/french_required_prefixes.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Key-prefix allow-list of French-reachable surfaces that MUST be fully
+/// translated into `app_fr.arb` — no English fallback permitted.
+///
+/// Background: French is the project's primary user locale (#495). While the
+/// 23-locale autofill pipeline (#2335) now machine-fills every locale to 100%
+/// of `app_en.arb`, that fallback is an English-shaped placeholder. For the
+/// handful of *core user-facing surfaces* below we hold a harder bar: every
+/// matching key must carry a real French string in `app_fr.arb`, asserted by
+/// `test/l10n/localization_completeness_test.dart`.
+///
+/// Each entry is matched with `String.startsWith`, so a single value covers a
+/// whole `featureLabel_*` family as well as an exact key like
+/// `addServiceReminder` (which is a `startsWith` of itself).
+///
+/// ## Adding a new French-reachable surface
+///
+/// When a new screen/section that a French user can reach ships its strings,
+/// add the key prefix(es) here in ONE line — no test logic changes needed.
+/// Keep the trailing `// #NNNN` issue/incident reference so the rationale for
+/// each gate stays discoverable.
+///
+/// Every prefix below traces to a real shipped incident where a French user
+/// saw an English island in an otherwise-French screen.
+library;
+
+/// Prefixes (or exact keys) of `app_en.arb` keys that French MUST translate.
+const List<String> kFrenchRequiredPrefixes = <String>[
+  // #495 — onboarding wizard is the French user's first impression of the app
+  // and must not fall back to English.
+  'onboarding',
+
+  // #1218 — the Edit vehicle screen (calibration / service-reminder / VIN /
+  // vehicle-edit) was shipping mixed-locale on French.
+  'vehicle',
+  'calibrationMode',
+  'veReset',
+  'serviceReminder',
+  'addServiceReminder', // exact key — startsWith of itself
+  'vin',
+
+  // Fuel club cards (loyalty) settings sub-screen shipped en+de-only, so the
+  // whole screen — including the menu tile that opens it — was English for
+  // French users.
+  'loyalty',
+
+  // #1373 phase 2 — the Feature management section in Settings: every
+  // per-feature label, description and blocked-transition tooltip.
+  'featureManagementSection',
+  'featureLabel_',
+  'featureDescription_',
+  'featureBlockedEnable_',
+  'featureBlockedDisable_',
+
+  // #1374 phase 2 — the GPS trip-path overlay card on the trip detail screen.
+  'tripPath',
+
+  // #1401 phase 6 — the adapter-capability card on the Edit vehicle screen.
+  'obd2Capability',
+
+  // #1401 phase 7b — the verified-by-adapter badge on every fill-up card and
+  // the variance dialog inside the Add fill-up flow.
+  'fillUpReconciliation',
+
+  // #1439 — the auto-record consent scope-clarification badge, help dialog
+  // and revoke hint on the Edit vehicle screen.
+  'autoRecordConsent',
+];

--- a/test/l10n/localization_completeness_test.dart
+++ b/test/l10n/localization_completeness_test.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'french_required_prefixes.dart';
+
 void main() {
   group('Localization completeness', () {
     late Map<String, dynamic> referenceArb;
@@ -94,135 +96,27 @@ void main() {
       expect(germanMissing, isNull,
           reason: 'German (de) must have all keys from app_en.arb');
 
-      // #495 — French is the primary user locale; the wizard completion
-      // step was shipping in English because French lacked the
-      // `onboarding*` keys. French does not need to be fully complete
-      // yet (huge backlog), but every onboarding key MUST be present so
-      // the onboarding flow is fully localised for French users.
+      // French is the project's primary user locale (#495). A handful of
+      // core French-reachable surfaces must NOT fall back to English even
+      // though other locales may. Those surfaces are declared, one prefix
+      // per line, in `french_required_prefixes.dart` — adding a new
+      // French-reachable surface is a one-line data edit there, no test
+      // logic change. Each prefix's rationale (and originating incident) is
+      // documented alongside it in that file.
       final frenchMissing = missingReport['fr'] ?? const <String>[];
-      final frenchMissingOnboarding = frenchMissing
-          .where((k) => k.startsWith('onboarding'))
-          .toList()
-        ..sort();
-      expect(frenchMissingOnboarding, isEmpty,
-          reason: 'French (fr) must have every onboarding* key — the '
-              'wizard is the user\'s first impression of the app and '
-              'must not fall back to English for French users');
-
-      // #1218 — Edit vehicle was shipping mixed-locale on French because
-      // calibration / service-reminder / VIN / vehicle-edit keys lacked
-      // translations. Same rule as onboarding: these flows are core
-      // surfaces and must not fall back to English for French users.
-      final frenchMissingVehicleEdit = frenchMissing
+      final frenchMissingRequired = frenchMissing
           .where((k) =>
-              k.startsWith('vehicle') ||
-              k.startsWith('calibrationMode') ||
-              k.startsWith('veReset') ||
-              k.startsWith('serviceReminder') ||
-              k == 'addServiceReminder' ||
-              k.startsWith('vin'))
+              kFrenchRequiredPrefixes.any((prefix) => k.startsWith(prefix)))
           .toList()
         ..sort();
-      expect(frenchMissingVehicleEdit, isEmpty,
-          reason: 'French (fr) must have every vehicle-edit, calibration, '
-              'service-reminder and VIN key — the Edit vehicle screen '
-              'must not fall back to English for French users (#1218)');
-
-      // The Fuel Club Cards (loyalty) settings sub-screen shipped with
-      // only `en` + `de` ARB fragments, so French users saw an entirely
-      // English screen — including the menu tile that opens it. Same
-      // rule as onboarding / vehicle-edit: surfaces a French user can
-      // reach must not fall back to English.
-      final frenchMissingLoyalty = frenchMissing
-          .where((k) => k.startsWith('loyalty'))
-          .toList()
-        ..sort();
-      expect(frenchMissingLoyalty, isEmpty,
-          reason: 'French (fr) must have every loyalty* key — the '
-              'Fuel club cards screen and its add-card sheet must not '
-              'fall back to English for French users');
-
-      // #1373 phase 2 — the Feature management section in Settings is
-      // a French-reachable surface. Every per-feature label, description
-      // and blocked-transition tooltip must have a French translation
-      // so the section isn't a wall of English on French devices.
-      final frenchMissingFeatureMgmt = frenchMissing
-          .where((k) =>
-              k.startsWith('featureManagementSection') ||
-              k.startsWith('featureLabel_') ||
-              k.startsWith('featureDescription_') ||
-              k.startsWith('featureBlockedEnable_') ||
-              k.startsWith('featureBlockedDisable_'))
-          .toList()
-        ..sort();
-      expect(frenchMissingFeatureMgmt, isEmpty,
-          reason: 'French (fr) must have every featureManagement / '
-              'featureLabel_ / featureDescription_ / featureBlockedEnable_ / '
-              'featureBlockedDisable_ key — the Feature management section '
-              'in Settings must not fall back to English for French users '
-              '(#1373 phase 2)');
-
-      // #1374 phase 2 — the GPS trip-path overlay card on the trip
-      // detail screen is a French-reachable surface. Its title and
-      // subtitle must have French translations so the card isn't an
-      // English island in an otherwise French screen.
-      final frenchMissingTripPath = frenchMissing
-          .where((k) => k.startsWith('tripPath'))
-          .toList()
-        ..sort();
-      expect(frenchMissingTripPath, isEmpty,
-          reason: 'French (fr) must have every tripPath* key — the '
-              'GPS trip-path overlay on the trip detail screen must '
-              'not fall back to English for French users (#1374 '
-              'phase 2)');
-
-      // #1401 phase 6 — the adapter-capability card lives on the
-      // Edit-vehicle screen, which is a French-reachable surface
-      // (already enforced for `vehicle*` and `calibration*` keys).
-      // Same rule: every `obd2Capability*` key must be French so the
-      // tier label and OBDLink hint don't fall back to English.
-      final frenchMissingObd2Capability = frenchMissing
-          .where((k) => k.startsWith('obd2Capability'))
-          .toList()
-        ..sort();
-      expect(frenchMissingObd2Capability, isEmpty,
-          reason: 'French (fr) must have every obd2Capability* key — '
-              'the adapter-capability card on the Edit vehicle screen '
-              'must not fall back to English for French users (#1401 '
-              'phase 6)');
-
-      // #1401 phase 7b — the verified-by-adapter badge sits on every
-      // fill-up card and the variance dialog fires inside the Add
-      // fill-up flow, both reachable for French users. Every
-      // `fillUpReconciliation*` key must have a French translation
-      // so the chip label and confirmation prompt don't fall back to
-      // English on the Fuel tab.
-      final frenchMissingFillUpReconciliation = frenchMissing
-          .where((k) => k.startsWith('fillUpReconciliation'))
-          .toList()
-        ..sort();
-      expect(frenchMissingFillUpReconciliation, isEmpty,
-          reason: 'French (fr) must have every fillUpReconciliation* '
-              'key — the verified-by-adapter badge and variance prompt '
-              'on the fill-up flow must not fall back to English for '
-              'French users (#1401 phase 7b)');
-
-      // #1439 — the auto-record consent scope-clarification badge,
-      // help-icon explanation dialog and revoke hint live on the Edit
-      // vehicle screen. Every `autoRecordConsent*` key must have a
-      // French translation so the badge label, dialog title/body and
-      // tap-to-revoke hint don't fall back to English for French users
-      // (the original ambiguous label "Localisation en arrière-plan
-      // autorisée" was reported by a French-locale user).
-      final frenchMissingAutoRecordConsent = frenchMissing
-          .where((k) => k.startsWith('autoRecordConsent'))
-          .toList()
-        ..sort();
-      expect(frenchMissingAutoRecordConsent, isEmpty,
-          reason: 'French (fr) must have every autoRecordConsent* key — '
-              'the scope-clarification badge, help dialog and revoke '
-              'hint on the Edit vehicle screen must not fall back to '
-              'English for French users (#1439)');
+      expect(frenchMissingRequired, isEmpty,
+          reason: 'French (fr) must translate every key matching a '
+              'required surface prefix in french_required_prefixes.dart — '
+              'these core surfaces (onboarding, Edit vehicle, Feature '
+              'management, loyalty cards, trip-path, fill-up reconciliation, '
+              'auto-record consent, …) must not fall back to English for '
+              'French users. Add a prefix to french_required_prefixes.dart '
+              'when a new French-reachable surface ships.');
     });
 
     // #1699 — all 22 partial locales were brought to 100% coverage of


### PR DESCRIPTION
Bundles two dev-factory (#2332) consolidation children. Two commits, one per issue.

## #2353 — consolidate conventions + data-drive FR prefixes + capture deferred items
- **FR-prefix extraction (in this PR):** the eight inline French surface-prefix gates in `test/l10n/localization_completeness_test.dart` are extracted into a `const List<String> kFrenchRequiredPrefixes` in the new `test/l10n/french_required_prefixes.dart`, and the eight near-identical `expect` blocks collapse into one data-driven loop. Adding a new French-reachable surface is now a one-line data edit. Behaviour-preserving — all 23 locales still 100%, the #1699 gate is unchanged.
- **Conventions skill (lives outside the repo tree, edited in place):** added the **Feature-enum cascade checklist** (the ~6 places adding a `Feature` value touches: enum + dartdoc, `defaultManifest`, the `_featureLabel`/`_featureDescription`/`_blocked*` switches, the en/de/fr ARB + 23-locale fan-out, the `Feature.values.length` count test, codegen) and the **autonomous-agent file-affinity / shared-surface batching** doctrine (file-disjoint → separate agents; same file → one agent; shared surfaces = `lib/l10n/app_*.arb`, `*.g.dart`/`*.freezed.dart`, `.github/workflows/ci.yml`, the grandfathered file-length set).
- **Deferred long-tail:** appended a "Deferred / long-tail" checklist to the #2332 epic body capturing all ten lower-priority items so none is lost.

## #2355 — version-control the agent HARD RULES
- New version-controlled `docs/AGENT_RULES.md` mirrors the four HARD RULES (#1 no hard-coded strings / ARB, #2 issue-first, #3 clean-codegen-before-push, #4 every new en key fans out to all 23 locales) plus the `bash scripts/install_hooks.sh` pre-push-hook install pointer.
- `docs/*` is gitignored with a per-file allow-list, so `!docs/AGENT_RULES.md` was added so a fresh clone actually tracks it. **CLAUDE.md stays gitignored — #296 is not reversed** (that was option 1).
- One-line "Read first" pointer added to `docs/CONTRIBUTING.md`, plus a pointer from the conventions skill.

## Gate
- `flutter test test/l10n/ --exclude-tags=network` → **15/15 passed**, "all 23 locales at 100% of 1740 app_en.arb keys".
- `flutter analyze test/` → **no new issues** (the 1 reported `unnecessary_import` is pre-existing in `trip_kind_from_samples_test.dart`, untouched here).
- All touched files ≤ 400 lines.

Closes #2353
Closes #2355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
