### PR TITLE
feat(receipt): multi-country receipt OCR — thread country/currency + config-drive currency extraction (#2272)

### DIFF
--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import '../../search/domain/entities/fuel_type.dart';
+import 'ocr/pump_ocr_config.dart';
 import 'receipt_override_registry.dart';
 import 'receipt_parser/brand_detection.dart';
 import 'receipt_parser/brand_layouts.dart';
@@ -40,15 +41,25 @@ class ReceiptParser {
   /// can't force `null` where the brand layout found something. The
   /// reconciliation guard (`liters × pricePerLiter ≈ totalCost`) runs
   /// AFTER overrides so a bad regex combo falls back gracefully.
-  ReceiptParseResult parse(String text, {String? stationId}) {
+  ///
+  /// #2273 — when [profile] is supplied (the active country's
+  /// [OcrLocaleProfile], threaded from [PumpOcrConfig] by
+  /// [ReceiptScanService]) the currency-aware field extractors read
+  /// totals/prices in that country's currency (GBP/£/p, kr, $, …). With
+  /// no [profile] the parser defaults to EUR, unchanged from before.
+  ReceiptParseResult parse(
+    String text, {
+    String? stationId,
+    OcrLocaleProfile? profile,
+  }) {
     final lines = text.split('\n').map((l) => l.trim()).toList();
     final fullText = lines.join(' ');
 
     final brand = detectBrand(lines, fullText);
     final initial = switch (brand) {
-      'super_u' => parseSuperU(fullText, lines),
-      'carrefour' => parseCarrefour(fullText, lines),
-      _ => parseGeneric(fullText, lines),
+      'super_u' => parseSuperU(fullText, lines, profile: profile),
+      'carrefour' => parseCarrefour(fullText, lines, profile: profile),
+      _ => parseGeneric(fullText, lines, profile: profile),
     };
 
     final withOverrides = _applyOverrides(initial, text, stationId);

--- a/lib/features/consumption/data/receipt_parser/brand_layouts.dart
+++ b/lib/features/consumption/data/receipt_parser/brand_layouts.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../ocr/pump_ocr_config.dart';
 import 'brand_detection.dart';
 import 'receipt_field_extractors.dart';
 import 'receipt_parse_result.dart';
@@ -9,19 +10,29 @@ import 'receipt_parse_result.dart';
 // compose the pure extractors from `receipt_field_extractors.dart`
 // into a `ReceiptParseResult`. Split out of `ReceiptParser` so each
 // layout is independently readable + unit-testable.
+//
+// #2273 — each layout takes an optional [profile] (the active country's
+// [OcrLocaleProfile]) and threads it into the currency-aware extractors
+// so GBP/£/p, kr, $ receipts read correctly. Super U / Carrefour are
+// French/EUR brands, so the profile only changes the generic fallbacks
+// on those; `parseGeneric` is where non-EUR receipts actually land.
 
 /// Super U / Système U layout. Labels observed on real receipts:
 ///   Volume   5.24 L
 ///   Prix     € 1.999/L
 ///   TOT TTC  € 10.47
-ReceiptParseResult parseSuperU(String text, List<String> lines) {
+ReceiptParseResult parseSuperU(
+  String text,
+  List<String> lines, {
+  OcrLocaleProfile? profile,
+}) {
   return ReceiptParseResult(
     liters: extractLiters(text),
     totalCost: matchFirst(text, [
       RegExp(r'tot\s*ttc\s*:?\s*€?\s*(\d+[.,]\d+)', caseSensitive: false),
       RegExp(r'total\s*ttc\s*:?\s*€?\s*(\d+[.,]\d+)', caseSensitive: false),
-    ]) ?? extractTotalCost(text),
-    pricePerLiter: extractPricePerLiter(text),
+    ]) ?? extractTotalCost(text, profile: profile),
+    pricePerLiter: extractPricePerLiter(text, profile: profile),
     date: extractDate(text),
     stationName: extractStationName(lines),
     fuelType: extractFuelType(text),
@@ -35,7 +46,11 @@ ReceiptParseResult parseSuperU(String text, List<String> lines) {
 ///   Quantite    = 5.27 L
 ///   Prix unit.  = 2,028 EUR
 ///   MONTANT REEL : 10.69 EUR
-ReceiptParseResult parseCarrefour(String text, List<String> lines) {
+ReceiptParseResult parseCarrefour(
+  String text,
+  List<String> lines, {
+  OcrLocaleProfile? profile,
+}) {
   return ReceiptParseResult(
     liters: matchFirst(text, [
       RegExp(r'quantit[eé]\s*[:=]\s*(\d+[.,]\d+)', caseSensitive: false),
@@ -43,11 +58,11 @@ ReceiptParseResult parseCarrefour(String text, List<String> lines) {
     totalCost: matchFirst(text, [
       RegExp(r'montant\s*(?:reel|r[eé]el|ttc)?\s*[:=]?\s*€?\s*(\d+[.,]\d+)',
           caseSensitive: false),
-    ]) ?? extractTotalCost(text),
+    ]) ?? extractTotalCost(text, profile: profile),
     pricePerLiter: matchFirst(text, [
       RegExp(r'prix\s*unit\.?\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
           caseSensitive: false),
-    ]) ?? extractPricePerLiter(text),
+    ]) ?? extractPricePerLiter(text, profile: profile),
     date: extractDate(text),
     stationName: extractStationName(lines),
     fuelType: extractFuelType(text),
@@ -55,12 +70,18 @@ ReceiptParseResult parseCarrefour(String text, List<String> lines) {
   );
 }
 
-/// Generic fallback — everything that isn't a known retailer.
-ReceiptParseResult parseGeneric(String text, List<String> lines) {
+/// Generic fallback — everything that isn't a known retailer. This is
+/// where non-EUR receipts (GB/£/p, kr, $) land, so the currency-aware
+/// extractors take the threaded [profile] (#2273).
+ReceiptParseResult parseGeneric(
+  String text,
+  List<String> lines, {
+  OcrLocaleProfile? profile,
+}) {
   return ReceiptParseResult(
     liters: extractLiters(text),
-    totalCost: extractTotalCost(text),
-    pricePerLiter: extractPricePerLiter(text),
+    totalCost: extractTotalCost(text, profile: profile),
+    pricePerLiter: extractPricePerLiter(text, profile: profile),
     date: extractDate(text),
     stationName: extractStationName(lines),
     fuelType: extractFuelType(text),

--- a/lib/features/consumption/data/receipt_parser/receipt_currency_profile.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_currency_profile.dart
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../ocr/pump_ocr_config.dart';
+
+/// Currency metadata the receipt field extractors need to read amounts
+/// off a paper receipt in the active country (#2273).
+///
+/// Replaces the EUR/€-hardcoded assumptions in `extractTotalCost` /
+/// `extractPricePerLiter` with a small, config-driven descriptor derived
+/// from the threaded [OcrLocaleProfile] (so the source of truth stays the
+/// `assets/ocr_config/index.json` `localeProfiles`, not a parallel
+/// table). Each descriptor carries:
+///
+///   - the major-unit symbols/codes that mark a total (`€`/`EUR`,
+///     `£`/`GBP`, `kr`/`DKK`, `$`/`USD`, …);
+///   - the minor-unit (subunit) marker used for per-litre prices
+///     (`p` pence in the UK, `c`/`¢` cents in the US), with the divisor
+///     to fold the subunit price back into the major unit;
+///   - the major-unit per-litre suffix forms (`p/L`, `c/L`, `kr/L`).
+///
+/// All symbols are DATA, not user-facing text (they replicate what is
+/// printed on the receipt), so no ARB routing is required.
+class ReceiptCurrencyProfile {
+  /// ISO currency code (e.g. `EUR`, `GBP`). i18n-ignore: data, not UI.
+  final String currencyCode;
+
+  /// Regex-escaped alternation of major-unit markers, symbol + code
+  /// (e.g. `€|EUR`, `£|GBP`, `kr|DKK`). Used as a non-capturing group
+  /// body, so callers wrap it in `(?:...)`.
+  final String majorUnitPattern;
+
+  /// Regex-escaped alternation of minor-unit (subunit) markers used when
+  /// a per-litre price is quoted in the subunit (e.g. `p` for UK pence,
+  /// `c|¢` for US cents). Empty when the currency has no subunit pricing
+  /// convention on fuel receipts.
+  final String minorUnitPattern;
+
+  /// How many subunits make one major unit (100 for pence/cents).
+  /// Per-litre prices quoted in the subunit are divided by this to get a
+  /// major-unit €/L-equivalent value.
+  final int minorUnitDivisor;
+
+  /// Plausible per-litre price band in the MAJOR unit. Mirrors the
+  /// pump-side [OcrLocaleProfile.priceMin]/[priceMax] so a subunit read
+  /// (e.g. `142.9 p/L` → `1.429 £/L`) can be range-validated identically.
+  final double priceMin;
+  final double priceMax;
+
+  const ReceiptCurrencyProfile({
+    required this.currencyCode,
+    required this.majorUnitPattern,
+    required this.minorUnitPattern,
+    required this.minorUnitDivisor,
+    required this.priceMin,
+    required this.priceMax,
+  });
+
+  bool get hasMinorUnit => minorUnitPattern.isNotEmpty;
+
+  /// `true` when [price] is a plausible per-litre unit price (major unit).
+  bool priceInRange(double price) => price >= priceMin && price <= priceMax;
+
+  /// The default EUR descriptor — the historical behaviour, used whenever
+  /// no [OcrLocaleProfile] is threaded so existing French/German receipts
+  /// parse exactly as before.
+  static const ReceiptCurrencyProfile euro = ReceiptCurrencyProfile(
+    currencyCode: 'EUR',
+    majorUnitPattern: '€|EUR',
+    minorUnitPattern: 'c(?:ent)?',
+    minorUnitDivisor: 100,
+    priceMin: 0.5,
+    priceMax: 4.0,
+  );
+
+  /// Build the currency descriptor for a threaded [profile], or the EUR
+  /// default when [profile] is null or its currency is unknown. The price
+  /// band is taken from the profile (config-driven) when present.
+  static ReceiptCurrencyProfile fromLocale(OcrLocaleProfile? profile) {
+    if (profile == null) return euro;
+    final base = _byCode[profile.currency.toUpperCase()] ?? euro;
+    // Prefer the config's own price band (per-country, JSON-sourced) so
+    // adding a country only means editing the asset, not this table.
+    return ReceiptCurrencyProfile(
+      currencyCode: base.currencyCode,
+      majorUnitPattern: base.majorUnitPattern,
+      minorUnitPattern: base.minorUnitPattern,
+      minorUnitDivisor: base.minorUnitDivisor,
+      priceMin: profile.priceMin,
+      priceMax: profile.priceMax,
+    );
+  }
+
+  // The per-currency symbol table. Adding a currency here (or a country
+  // to the JSON pointing at one of these codes) is all it takes to
+  // support a new market — the extractors are otherwise currency-blind.
+  static const Map<String, ReceiptCurrencyProfile> _byCode = {
+    'EUR': euro,
+    'GBP': ReceiptCurrencyProfile(
+      currencyCode: 'GBP',
+      // £ before the number, GBP after it; `p` (pence) is the per-litre
+      // subunit UK forecourts price in (e.g. `142.9p/L`).
+      majorUnitPattern: r'£|GBP',
+      minorUnitPattern: 'p',
+      minorUnitDivisor: 100,
+      priceMin: 0.8,
+      priceMax: 3.0,
+    ),
+    'USD': ReceiptCurrencyProfile(
+      currencyCode: 'USD',
+      majorUnitPattern: r'\$|USD',
+      // US pumps quote `c/gal` historically but `c/L` on metric receipts.
+      minorUnitPattern: r'c|¢',
+      minorUnitDivisor: 100,
+      priceMin: 0.5,
+      priceMax: 4.0,
+    ),
+    // Scandinavian kroner (DKK/SEK/NOK) all print `kr` as the symbol with
+    // no fuel-receipt subunit; the per-litre price is already in kroner.
+    // Diesel/petrol run ~12-25 kr/L across DK/SE/NO; keep a wide band.
+    'DKK': ReceiptCurrencyProfile(
+      currencyCode: 'DKK',
+      majorUnitPattern: 'kr|DKK',
+      minorUnitPattern: '',
+      minorUnitDivisor: 100,
+      priceMin: 5.0,
+      priceMax: 40.0,
+    ),
+    'SEK': ReceiptCurrencyProfile(
+      currencyCode: 'SEK',
+      majorUnitPattern: 'kr|SEK',
+      minorUnitPattern: '',
+      minorUnitDivisor: 100,
+      priceMin: 5.0,
+      priceMax: 40.0,
+    ),
+    'NOK': ReceiptCurrencyProfile(
+      currencyCode: 'NOK',
+      majorUnitPattern: 'kr|NOK',
+      minorUnitPattern: '',
+      minorUnitDivisor: 100,
+      priceMin: 5.0,
+      priceMax: 40.0,
+    ),
+  };
+}

--- a/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
@@ -4,6 +4,8 @@
 import 'package:flutter/foundation.dart';
 
 import '../../../search/domain/entities/fuel_type.dart';
+import '../ocr/pump_ocr_config.dart';
+import 'receipt_currency_profile.dart';
 
 // Pure-function extractors shared by the generic matcher and the
 // per-brand layouts. Kept top-level + stateless so they can be unit-
@@ -125,32 +127,42 @@ double? extractLiters(String text) {
 /// Matches patterns like "TOTAL 58.42", "MONTANT 58,42 EUR",
 /// "TOT TTC 10.47", "MONTANT REEL : 10.69", "€ 58.42".
 ///
-/// The generic `€ [amount]` fallback is only used when no explicit label
-/// matches and the amount is NOT immediately followed by `/L` — otherwise
-/// we would pick up the unit price as the total.
-double? extractTotalCost(String text) {
+/// #2273 — the currency is config-driven: an optional [profile] (the
+/// active country's [OcrLocaleProfile], threaded from [PumpOcrConfig])
+/// selects the major-unit symbols to match (`£`/`GBP`, `kr`/`DKK`,
+/// `$`/`USD`, …). With no [profile] it defaults to EUR/€, so existing
+/// French/German receipts parse exactly as before.
+///
+/// The labelled-amount fallback is only used when no explicit label
+/// matches and the amount is NOT immediately followed by a per-litre
+/// `/L` suffix — otherwise we would pick up the unit price as the total.
+double? extractTotalCost(String text, {OcrLocaleProfile? profile}) {
+  final currency = ReceiptCurrencyProfile.fromLocale(profile);
+  final sym = currency.majorUnitPattern;
+
   final labelled = matchFirst(text, [
     // TOTAL / TOT TTC / MONTANT[ REEL / TTC] / TTC / German labels.
-    // Accept ":" or "=" between label and amount, optional €.
+    // Accept ":" or "=" between label and amount, optional currency sym.
     RegExp(
       r'(?:total|tot\s*ttc|montant(?:\s*(?:ttc|reel|r[eé]el))?|ttc|'
       r'betrag|summe|gesamt)'
-      r'\s*[:=]?\s*€?\s*(\d+[.,]\d+)',
+      '\\s*[:=]?\\s*(?:$sym)?\\s*(\\d+[.,]\\d+)',
       caseSensitive: false,
     ),
   ]);
   if (labelled != null) return labelled;
 
-  // Heuristic fallback: gather every standalone amount attached to
-  // €/EUR that isn't a price-per-liter (no "/L" suffix), then pick
-  // the LARGEST. Rationale: on a fuel receipt the unit price, tax,
-  // and net all live around the total, but the total is almost
-  // always the biggest number on the paper. Picking "first" grabs
-  // the price-per-liter on column-layout receipts like Super U,
-  // where OCR emits "€ 1.999/L ... € 10.47" — or even skips the
-  // "/L" suffix, so "first" becomes 1.999.
+  // Heuristic fallback: gather every standalone amount attached to the
+  // currency symbol that isn't a price-per-liter (no "/L" suffix), then
+  // pick the LARGEST. Rationale: on a fuel receipt the unit price, tax,
+  // and net all live around the total, but the total is almost always
+  // the biggest number on the paper. Picking "first" grabs the
+  // price-per-liter on column-layout receipts like Super U, where OCR
+  // emits "€ 1.999/L ... € 10.47" — or even skips the "/L" suffix.
   final currencyPattern = RegExp(
-    r'(?:€\s*(\d+[.,]\d+)|(\d+[.,]\d+)\s*(?:€|EUR))(\s*/\s*[lL])?',
+    '(?:(?:$sym)\\s*(\\d+[.,]\\d+)|(\\d+[.,]\\d+)\\s*(?:$sym))'
+    r'(\s*/\s*[lL])?',
+    caseSensitive: false,
   );
   double? best;
   for (final match in currencyPattern.allMatches(text)) {
@@ -159,15 +171,14 @@ double? extractTotalCost(String text) {
     if (raw == null) continue;
     final value = parseDecimal(raw);
     if (value == null || value <= 0) continue;
-    // Filter obvious non-totals: nobody's total is < 1 €, nobody's
-    // total is > 10 000 €.
+    // Filter obvious non-totals: nobody's total is < 1, nobody's total
+    // is > 10 000 (major units).
     if (value < 1 || value > 10000) continue;
-    // #801 — 3-decimal European amounts like `1,990 €` are fuel
-    // price-per-liter, never totals. Without this guard on the
-    // TotalEnergies receipt the parser grabbed `1,990 €` as the
-    // total and the user saw 1.99 € in the form instead of 9.95 €.
-    // Totals are always 2-decimal in EUR.
-    if (decimalDigitCount(raw) >= 3 && value < 5) continue;
+    // #801 — a 3-decimal amount below the price ceiling (e.g. `1,990 €`,
+    // `1.429 £`) is the fuel price-per-liter, never the total. Totals
+    // are always 2-decimal. Use the currency's own price band so this
+    // holds for GBP/kr/$ too, not just EUR.
+    if (decimalDigitCount(raw) >= 3 && value <= currency.priceMax) continue;
     if (best == null || value > best) best = value;
   }
   return best;
@@ -185,43 +196,80 @@ int decimalDigitCount(String raw) {
 
 /// Matches price-per-liter: "1.899 €/L", "€ 1,999/L", "PU: 1,899",
 /// "PRIX/L 1.899", "Prix unit. = 2,028 EUR", "Literpreis: 1.799".
-double? extractPricePerLiter(String text) {
+///
+/// #2273 — config-driven currency. An optional [profile] selects the
+/// major-unit symbols AND the subunit convention, so a UK pence-per-litre
+/// quote like `142.9p/L` or a US `c/L` cent quote is read and folded back
+/// into the major unit (£1.429/L, $…/L). With no [profile] it defaults to
+/// EUR/€, unchanged from before.
+double? extractPricePerLiter(String text, {OcrLocaleProfile? profile}) {
+  final currency = ReceiptCurrencyProfile.fromLocale(profile);
+  final sym = currency.majorUnitPattern;
+
+  // Subunit (pence/cents) per-litre takes priority — its explicit unit
+  // marker (`p/L`, `c/L`) is the strongest signal and unambiguous.
+  if (currency.hasMinorUnit) {
+    final minorPrice = _extractMinorUnitPrice(text, currency);
+    if (minorPrice != null) return minorPrice;
+  }
+
   final labelled = matchFirst(text, [
     // "1.899 €/L" or "1,899 EUR/L" — also "1.999 €/ℓ" (U+2113).
-    RegExp(r'(\d+[.,]\d{2,3})\s*(?:€|EUR)\s*/\s*[lLℓ]'),
-    // "€ 1.999/L" or "EUR 1,999/L" / "€ 1.999/ℓ" — currency before number.
-    RegExp(r'(?:€|EUR)\s*(\d+[.,]\d{2,3})\s*/\s*[lLℓ]'),
-    // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je Liter.
-    // Also accepts `ℓ` in place of `l` in the slash-L forms.
+    RegExp('(\\d+[.,]\\d{2,3})\\s*(?:$sym)\\s*/\\s*[lLℓ]', caseSensitive: false),
+    // "€ 1.999/L" / "£ 1.429/L" — currency symbol before the number.
+    RegExp('(?:$sym)\\s*(\\d+[.,]\\d{2,3})\\s*/\\s*[lLℓ]', caseSensitive: false),
+    // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je
+    // Liter, plus generic English "Unit price" / "Price/L". Also accepts
+    // `ℓ` in place of `l` in the slash-L forms.
     RegExp(
       r'(?:prix\s*/\s*[lℓ]|prix\s*unit\.?|pu|preis\s*/\s*[lℓ]|'
-      r'preis\s*je\s*liter|literpreis)'
-      r'\s*[:=]?\s*€?\s*(\d+[.,]\d{2,3})',
+      r'preis\s*je\s*liter|literpreis|unit\s*price|price\s*/\s*[lℓ])'
+      '\\s*[:=]?\\s*(?:$sym)?\\s*(\\d+[.,]\\d{2,3})',
       caseSensitive: false,
     ),
   ]);
   if (labelled != null) return labelled;
 
-  // #801 — TotalEnergies / independent French receipts often emit
-  // the unit price as a bare `1,990 €` (3-decimal digits, no `/L`
-  // suffix) on the line below a `QTY x FUELCODE` item line. Without
-  // this heuristic the amount was either missed entirely or grabbed
-  // as the total. 3 decimal digits + euro suffix + plausible
-  // fuel-price range (0.5-3.0 €/L) is a strong enough signal to
-  // accept without the explicit `/L` marker.
-  // Note on the lookbehind-free check: `\b` after `€` doesn't hold
-  // (both `€` and a trailing space are non-word chars in Dart
-  // regex, so no boundary sits between them). The negative
-  // lookahead for `/L` is the only disambiguator we need — any
-  // 3-decimal euro amount NOT followed by `/L` is the unit price.
-  final bareFuelPrice =
-      RegExp(r'(\d+[.,]\d{3})\s*(?:€|EUR)(?!\s*/\s*[lLℓ])');
+  // #801 — TotalEnergies / independent French receipts often emit the
+  // unit price as a bare `1,990 €` (3-decimal, no `/L` suffix) on the
+  // line below a `QTY x FUELCODE` item line. 3 decimals + currency
+  // symbol + a plausible per-litre range is a strong enough signal to
+  // accept without the explicit `/L` marker. The negative lookahead for
+  // `/L` keeps it from re-matching the labelled forms above. Range comes
+  // from the currency profile so this holds for GBP/kr/$ too.
+  final bareFuelPrice = RegExp(
+    '(\\d+[.,]\\d{3})\\s*(?:$sym)(?!\\s*/\\s*[lLℓ])',
+    caseSensitive: false,
+  );
   for (final match in bareFuelPrice.allMatches(text)) {
     final raw = match.group(1);
     if (raw == null) continue;
     final value = parseDecimal(raw);
     if (value == null) continue;
-    if (value >= 0.5 && value <= 3.0) return value;
+    if (currency.priceInRange(value)) return value;
+  }
+  return null;
+}
+
+/// Reads a per-litre price quoted in the currency's SUBUNIT (UK pence
+/// `142.9p/L`, US cents `c/L`) and folds it into the major unit by
+/// dividing by [ReceiptCurrencyProfile.minorUnitDivisor]. Returns the
+/// major-unit value (e.g. `142.9p/L` → `1.429`) when it falls in the
+/// currency's plausible per-litre band, else null (#2273).
+double? _extractMinorUnitPrice(String text, ReceiptCurrencyProfile currency) {
+  final minor = currency.minorUnitPattern;
+  // "142.9p/L", "142,9 p / L", "139.9 c/L" — subunit marker then /L.
+  final pattern = RegExp(
+    '(\\d+(?:[.,]\\d+)?)\\s*(?:$minor)\\s*/\\s*[lLℓ]',
+    caseSensitive: false,
+  );
+  for (final match in pattern.allMatches(text)) {
+    final raw = match.group(1);
+    if (raw == null) continue;
+    final subunit = parseDecimal(raw);
+    if (subunit == null || subunit <= 0) continue;
+    final major = subunit / currency.minorUnitDivisor;
+    if (currency.priceInRange(major)) return major;
   }
   return null;
 }

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -97,7 +97,16 @@ class ReceiptScanService {
   /// from [ReceiptScanOutcome.imagePath] and delete when done (e.g.
   /// after the form is saved or after the user has shared a bad-scan
   /// report).
-  Future<ReceiptScanOutcome?> scanReceipt() async {
+  ///
+  /// #2273 — [country] (and, later, [brand]) thread the active region
+  /// into the parser, mirroring [scanPumpDisplay]. The country's
+  /// [OcrLocaleProfile] (from [PumpOcrConfig]) drives currency-aware
+  /// extraction so GBP/£/p, kr, $ receipts read correctly. With no
+  /// [country] the parser defaults to EUR, unchanged from before.
+  Future<ReceiptScanOutcome?> scanReceipt({
+    String? country,
+    String? brand,
+  }) async {
     final capture = await _capture();
     if (capture == null) return null;
     final text = await _recognise(capture);
@@ -105,8 +114,13 @@ class ReceiptScanService {
       await _tryDelete(capture);
       return null;
     }
+    OcrLocaleProfile? profile;
+    if (country != null) {
+      await _ocrConfig.load();
+      profile = _ocrConfig.profileFor(country);
+    }
     return ReceiptScanOutcome(
-      parse: _parser.parse(text),
+      parse: _parser.parse(text, profile: profile),
       ocrText: text,
       imagePath: capture,
     );

--- a/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
@@ -105,7 +105,13 @@ Future<void> runReceiptScan(
       service = ReceiptScanService();
       state.writeService(service);
     }
-    final outcome = await service.scanReceipt();
+    // #2273 — thread the active country/brand so the parser reads the
+    // receipt in the right currency (GBP/£/p, kr, $ …), mirroring how
+    // the pump path threads them into parsePumpDisplayImage.
+    final outcome = await service.scanReceipt(
+      country: state.activeCountry,
+      brand: state.stationBrand,
+    );
     if (outcome == null || !state.isMounted()) return;
     final result = outcome.parse;
 

--- a/test/features/consumption/data/receipt_parser/receipt_field_extractors_test.dart
+++ b/test/features/consumption/data/receipt_parser/receipt_field_extractors_test.dart
@@ -2,8 +2,39 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/ocr/pump_ocr_config.dart';
 import 'package:tankstellen/features/consumption/data/receipt_parser/receipt_field_extractors.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Per-country [OcrLocaleProfile]s for the currency-aware extraction
+/// tests (#2273). Mirror the bands shipped in `assets/ocr_config`.
+const _gb = OcrLocaleProfile(
+  country: 'GB',
+  currency: 'GBP',
+  decimalSeparator: '.',
+  priceMin: 0.8,
+  priceMax: 3.0,
+  volumeMax: 200,
+  totalMax: 500,
+);
+const _dk = OcrLocaleProfile(
+  country: 'DK',
+  currency: 'DKK',
+  decimalSeparator: ',',
+  priceMin: 5,
+  priceMax: 40,
+  volumeMax: 200,
+  totalMax: 2000,
+);
+const _us = OcrLocaleProfile(
+  country: 'US',
+  currency: 'USD',
+  decimalSeparator: '.',
+  priceMin: 0.5,
+  priceMax: 4.0,
+  volumeMax: 200,
+  totalMax: 500,
+);
 
 void main() {
   group('extractFuelType', () {
@@ -557,6 +588,142 @@ void main() {
 
     test('returns null for empty string', () {
       expect(extractPricePerLiter(''), isNull);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // #2273 — config-driven, multi-currency extraction. The threaded
+  // OcrLocaleProfile selects the currency symbols + subunit convention.
+  // EUR (no profile) keeps working; GBP/£/p, kr, $ now read correctly,
+  // and minor-unit (pence/cents) per-litre folds back to the major unit.
+  // -------------------------------------------------------------------
+  group('extractTotalCost — multi-currency (#2273)', () {
+    test('GBP "£ 58.42" total', () {
+      expect(extractTotalCost('£ 58.42', profile: _gb), closeTo(58.42, 0.001));
+    });
+
+    test('GBP "TOTAL £45.10", suffix "45.10 GBP" both read', () {
+      expect(
+          extractTotalCost('TOTAL £45.10', profile: _gb), closeTo(45.10, 0.001));
+      expect(
+          extractTotalCost('45.10 GBP', profile: _gb), closeTo(45.10, 0.001));
+    });
+
+    test('GBP fallback skips the pence-per-litre unit price', () {
+      // A UK receipt: "142.9 p/L" unit price + "£72.43" total. The total
+      // must win; the per-litre figure (different unit) is not a total.
+      const text = 'UNLEADED 142.9p/L\nTOTAL £72.43';
+      expect(extractTotalCost(text, profile: _gb), closeTo(72.43, 0.001));
+    });
+
+    test('GBP fallback treats a bare 3-decimal £ amount as the unit price',
+        () {
+      // "1.429 £" (3-decimal, within the GBP price band) is the £/L unit
+      // price, not the total → skipped; "20.00 £" is the total.
+      const text = '1.429 £\n20.00 £';
+      expect(extractTotalCost(text, profile: _gb), closeTo(20.00, 0.001));
+    });
+
+    test('DKK "kr" total "TOTAL 612,50 kr"', () {
+      expect(
+          extractTotalCost('TOTAL 612,50 kr', profile: _dk), closeTo(612.5, 0.1));
+    });
+
+    test('DKK suffix "DKK 612,50"', () {
+      expect(
+          extractTotalCost('612,50 DKK', profile: _dk), closeTo(612.5, 0.1));
+    });
+
+    test('USD "\$ 58.42" total', () {
+      expect(extractTotalCost(r'$ 58.42', profile: _us), closeTo(58.42, 0.001));
+    });
+
+    test('EUR default still works when no profile is threaded', () {
+      expect(extractTotalCost('TOTAL 58.42'), closeTo(58.42, 0.001));
+      expect(extractTotalCost('€ 10.47'), closeTo(10.47, 0.001));
+    });
+
+    test('GBP profile does not accidentally read a € amount', () {
+      // With a GBP profile the € symbol is not a recognised currency, so
+      // the bare fallback must not pick "€ 99.99" as a £ total.
+      expect(extractTotalCost('€ 99.99', profile: _gb), isNull);
+    });
+  });
+
+  group('extractPricePerLiter — multi-currency (#2273)', () {
+    test('GBP pence-per-litre "142.9p/L" → £1.429/L', () {
+      expect(
+        extractPricePerLiter('142.9p/L', profile: _gb),
+        closeTo(1.429, 0.0005),
+      );
+    });
+
+    test('GBP pence-per-litre with spaces "142,9 p / L"', () {
+      expect(
+        extractPricePerLiter('142,9 p / L', profile: _gb),
+        closeTo(1.429, 0.0005),
+      );
+    });
+
+    test('GBP major-unit "£1.429/L"', () {
+      expect(
+        extractPricePerLiter('£1.429/L', profile: _gb),
+        closeTo(1.429, 0.0005),
+      );
+    });
+
+    test('GBP "Unit price £1.429" English label', () {
+      expect(
+        extractPricePerLiter('Unit price £1.429', profile: _gb),
+        closeTo(1.429, 0.0005),
+      );
+    });
+
+    test('GBP pence price out of band is rejected', () {
+      // 50p/L → £0.50/L, below the GBP priceMin 0.8 → null.
+      expect(extractPricePerLiter('50.0p/L', profile: _gb), isNull);
+    });
+
+    test('DKK kroner-per-litre "13,49 kr/L"', () {
+      expect(
+        extractPricePerLiter('13,49 kr/L', profile: _dk),
+        closeTo(13.49, 0.005),
+      );
+    });
+
+    test('DKK bare 3-decimal in band "13,490 kr"', () {
+      expect(
+        extractPricePerLiter('13,490 kr', profile: _dk),
+        closeTo(13.49, 0.005),
+      );
+    });
+
+    test('USD cents-per-litre "139.9c/L" → \$1.399/L', () {
+      expect(
+        extractPricePerLiter('139.9c/L', profile: _us),
+        closeTo(1.399, 0.0005),
+      );
+    });
+
+    test('USD major-unit "\$1.399/L"', () {
+      expect(
+        extractPricePerLiter(r'$1.399/L', profile: _us),
+        closeTo(1.399, 0.0005),
+      );
+    });
+
+    test('EUR default still works when no profile is threaded', () {
+      expect(extractPricePerLiter('1.899 €/L'), closeTo(1.899, 0.001));
+      expect(extractPricePerLiter('1,990 €'), closeTo(1.990, 0.001));
+    });
+
+    test('end-to-end €/L-equivalent: 142.9 p/L equals 1.429 £/L', () {
+      // The pence read and the equivalent major-unit read must agree.
+      final pence = extractPricePerLiter('142.9p/L', profile: _gb);
+      final pounds = extractPricePerLiter('£1.429/L', profile: _gb);
+      expect(pence, isNotNull);
+      expect(pounds, isNotNull);
+      expect(pence, closeTo(pounds!, 0.0005));
     });
   });
 

--- a/test/features/consumption/data/receipt_scan_service_test.dart
+++ b/test/features/consumption/data/receipt_scan_service_test.dart
@@ -82,10 +82,18 @@ class _StubReceiptParser extends ReceiptParser {
 
   final ReceiptParseResult result;
   String? lastTextParsed;
+  OcrLocaleProfile? lastProfile;
+  int parseCalls = 0;
 
   @override
-  ReceiptParseResult parse(String text, {String? stationId}) {
+  ReceiptParseResult parse(
+    String text, {
+    String? stationId,
+    OcrLocaleProfile? profile,
+  }) {
+    parseCalls++;
     lastTextParsed = text;
+    lastProfile = profile;
     return result;
   }
 }
@@ -211,6 +219,59 @@ void main() {
       expect(outcome, isNull,
           reason: 'Service must still return null cleanly even when the '
               'temp file delete fails.');
+
+      await capture.dir.delete(recursive: true);
+    });
+
+    test('threads the active country profile into the parser (#2273)',
+        () async {
+      // The receipt path must mirror the pump path: when a country is
+      // passed, the country's OcrLocaleProfile (GB → GBP here) is loaded
+      // from the OCR config and handed to the parser so currency-aware
+      // extraction runs.
+      const configJson = '''
+{
+  "version": 1,
+  "localeProfiles": [
+    {"country":"GB","currency":"GBP","decimalSeparator":".",
+     "priceMin":0.8,"priceMax":3.0,"volumeMax":200.0,"totalMax":500.0}
+  ],
+  "brands": []
+}''';
+      final service = ReceiptScanService(
+        picker: picker,
+        recognizer: recognizer,
+        parser: parser,
+        pumpParser: const _StubPumpDisplayParser(PumpDisplayParseResult()),
+        ocrConfig: PumpOcrConfig.fromJsonString(configJson),
+      );
+      final capture = await _createTempCapture();
+      picker.pathToReturn = capture.path;
+      recognizer.textToReturn = 'TOTAL 75.00';
+
+      final outcome = await service.scanReceipt(country: 'GB');
+
+      expect(outcome, isNotNull);
+      expect(parser.lastProfile, isNotNull,
+          reason: 'a known country must resolve to a profile.');
+      expect(parser.lastProfile!.currency, 'GBP');
+
+      await capture.dir.delete(recursive: true);
+    });
+
+    test('passes a null profile when no country is supplied (#2273)',
+        () async {
+      // Backwards compatibility: scanReceipt() with no country must keep
+      // the parser on its EUR default (null profile), unchanged.
+      final capture = await _createTempCapture();
+      picker.pathToReturn = capture.path;
+      recognizer.textToReturn = 'TOTAL 75.00';
+
+      await service.scanReceipt();
+
+      expect(parser.parseCalls, 1);
+      expect(parser.lastProfile, isNull,
+          reason: 'no country → no profile → EUR default, as before.');
 
       await capture.dir.delete(recursive: true);
     });

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_two_buttons_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_two_buttons_test.dart
@@ -88,7 +88,10 @@ class _RoutingScanService extends ReceiptScanService {
   int pumpCalls = 0;
 
   @override
-  Future<ReceiptScanOutcome?> scanReceipt() async {
+  Future<ReceiptScanOutcome?> scanReceipt({
+    String? country,
+    String? brand,
+  }) async {
     receiptCalls++;
     return null;
   }


### PR DESCRIPTION
## What

Two autonomously-doable items of epic #2272 (multi-country receipt OCR). The pump path already threads country/brand + is config-driven (PR #2280/#2288); this brings the **receipt** path to parity.

### 1. Thread active country/currency into the receipt scan path
- `ReceiptScanService.scanReceipt({country, brand})` loads `PumpOcrConfig`, resolves the country's `OcrLocaleProfile`, and passes it into the parser — same shape as `parsePumpDisplayImage`.
- `ReceiptParser.parse(text, {stationId, profile})` threads the profile through brand dispatch into the extractors.
- `runReceiptScan` passes `state.activeCountry` / `state.stationBrand` (already populated by the screen).
- No country → null profile → EUR default (unchanged).

### 2. Config-drive receipt currency extraction
`extractTotalCost` / `extractPricePerLiter` were EUR/€-hardcoded. A small `ReceiptCurrencyProfile` derived from the threaded `OcrLocaleProfile` (reusing the existing `assets/ocr_config` currency metadata — no parallel config) now makes both currency-aware:

| Currency | Total | Per-litre |
|---|---|---|
| EUR (default) | `€`/`EUR` | `€/L`, bare 3-decimal |
| GBP | `£`/`GBP` | `£/L`, **pence `142.9p/L → £1.429/L`** |
| DKK/SEK/NOK | `kr`/code | `kr/L` |
| USD | `$`/`USD` | `$/L`, **cents `139.9c/L → $1.399/L`** |

Minor-unit (pence/cents) prices fold back into the major unit via the profile divisor and are range-checked against the country's price band. EUR keeps working.

## Tests
- Per-currency extraction unit tests (GBP/£/p, DKK kr, USD/$/c → correct total + €/L-equivalent), plus an end-to-end check that `142.9p/L` equals `£1.429/L`.
- Threading tests: a known country resolves to a profile (GB → GBP) handed to the parser; no country → null profile (EUR default).
- `flutter analyze lib/ test/`: no new issues (2 pre-existing infos untouched).
- `flutter test test/features/consumption/ test/lint/ --exclude-tags=network`: green (3287 passed).

## Notes
- Parsing logic is not user-facing → no ARB.
- No `@riverpod`/freezed surfaces touched → no codegen drift.
- All touched files < 400 lines.
- Epic #2272 stays **open** — the gated P2 consent-gated cloud/VLM fallback item is the only remaining child.

Refs #2272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
