### PR TITLE
chore(obd2): remove dead attempting/unreachable connection states

### DIFF
--- a/lib/features/consumption/presentation/widgets/obd2_status_dot.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_status_dot.dart
@@ -17,8 +17,7 @@ import '../../providers/obd2_connection_state_provider.dart';
 ///
 /// Colours:
 /// - green  = connected
-/// - amber  = attempting / retrying
-/// - red    = unreachable / permission denied
+/// - red    = permission denied
 /// - hidden = idle (no saved adapter)
 class Obd2StatusDot extends ConsumerWidget {
   const Obd2StatusDot({super.key});
@@ -61,16 +60,6 @@ class Obd2StatusDot extends ConsumerWidget {
         return (
           DarkModeColors.success(context),
           l?.obd2StatusConnected ?? 'OBD2 adapter: connected',
-        );
-      case Obd2ConnectionState.attempting:
-        return (
-          DarkModeColors.warning(context),
-          l?.obd2StatusAttempting ?? 'OBD2 adapter: connecting',
-        );
-      case Obd2ConnectionState.unreachable:
-        return (
-          DarkModeColors.error(context),
-          l?.obd2StatusUnreachable ?? 'OBD2 adapter: unreachable',
         );
       case Obd2ConnectionState.permissionDenied:
         return (
@@ -148,12 +137,6 @@ class Obd2StatusDot extends ConsumerWidget {
       case Obd2ConnectionState.connected:
         return l?.obd2StatusConnectedBody ??
             'Ready to record a trip.';
-      case Obd2ConnectionState.attempting:
-        return l?.obd2StatusAttemptingBody ??
-            'Connecting in the background…';
-      case Obd2ConnectionState.unreachable:
-        return l?.obd2StatusUnreachableBody ??
-            'Adapter out of range or already in use by another app.';
       case Obd2ConnectionState.permissionDenied:
         return l?.obd2StatusPermissionDeniedBody ??
             'Grant Bluetooth permission in system settings to reconnect automatically.';

--- a/lib/features/consumption/providers/obd2_connection_state_provider.dart
+++ b/lib/features/consumption/providers/obd2_connection_state_provider.dart
@@ -10,20 +10,15 @@ part 'obd2_connection_state_provider.g.dart';
 
 /// Coarse live state of the app-wide OBD2 adapter connection (#784).
 ///
-/// Mirrors the 5 cases the UI must distinguish:
+/// Mirrors the 3 cases the UI must distinguish:
 /// - [idle] — no saved adapter, or Bluetooth off; nothing to show.
-/// - [attempting] — a background reconnect is in flight.
 /// - [connected] — the adapter is paired and reachable; the app is
 ///   either actively recording or ready to.
-/// - [unreachable] — the last attempt failed (adapter off, out of
-///   range, already in use by another app). Retries in backoff.
 /// - [permissionDenied] — Bluetooth permission not granted; user
 ///   action required before any further attempts.
 enum Obd2ConnectionState {
   idle,
-  attempting,
   connected,
-  unreachable,
   permissionDenied,
 }
 
@@ -74,33 +69,12 @@ class Obd2ConnectionSnapshot {
 }
 
 /// App-wide owner of the OBD2 connection status (#784).
-///
-/// Phase-1 scope: state machine + API for callers (boot probe,
-/// manual disconnect, permission changes) to drive it. The actual
-/// boot-time Bluetooth scan + auto-connect isolate is deferred to
-/// the follow-up PR so this lands without coupling to the native
-/// plugin surface.
 @Riverpod(keepAlive: true)
 class Obd2ConnectionStatus extends _$Obd2ConnectionStatus {
   @override
   Obd2ConnectionSnapshot build() => const Obd2ConnectionSnapshot();
 
-  /// Record that a connection attempt is starting for the saved
-  /// [adapterName] / [adapterMac]. Called by the boot probe and by
-  /// manual retry actions. Drops any stale capability from a prior
-  /// connect — the new attempt will re-probe `ATI`.
-  void markAttempting({required String adapterName, required String adapterMac}) {
-    state = state.copyWith(
-      state: Obd2ConnectionState.attempting,
-      adapterName: adapterName,
-      adapterMac: adapterMac,
-      clearCapability: true,
-    );
-  }
-
-  /// Record that the adapter is now connected. Preserves the
-  /// adapter label in case a previous [markAttempting] never fired
-  /// (e.g. on a reconnection from a persisted cache).
+  /// Record that the adapter is now connected.
   ///
   /// [capability] should be the value read from the live
   /// `Obd2Service.capability` getter after init completes (#1401
@@ -117,17 +91,6 @@ class Obd2ConnectionStatus extends _$Obd2ConnectionStatus {
       adapterName: adapterName,
       adapterMac: adapterMac,
       capability: capability,
-    );
-  }
-
-  /// Record that the last attempt failed. The adapter label stays
-  /// so the popover can still name the thing the app is trying to
-  /// reach. Capability is dropped — the failure means we never got
-  /// (or trust) an `ATI` reading.
-  void markUnreachable() {
-    state = state.copyWith(
-      state: Obd2ConnectionState.unreachable,
-      clearCapability: true,
     );
   }
 

--- a/lib/features/consumption/providers/obd2_connection_state_provider.g.dart
+++ b/lib/features/consumption/providers/obd2_connection_state_provider.g.dart
@@ -9,32 +9,14 @@ part of 'obd2_connection_state_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 /// App-wide owner of the OBD2 connection status (#784).
-///
-/// Phase-1 scope: state machine + API for callers (boot probe,
-/// manual disconnect, permission changes) to drive it. The actual
-/// boot-time Bluetooth scan + auto-connect isolate is deferred to
-/// the follow-up PR so this lands without coupling to the native
-/// plugin surface.
 
 @ProviderFor(Obd2ConnectionStatus)
 final obd2ConnectionStatusProvider = Obd2ConnectionStatusProvider._();
 
 /// App-wide owner of the OBD2 connection status (#784).
-///
-/// Phase-1 scope: state machine + API for callers (boot probe,
-/// manual disconnect, permission changes) to drive it. The actual
-/// boot-time Bluetooth scan + auto-connect isolate is deferred to
-/// the follow-up PR so this lands without coupling to the native
-/// plugin surface.
 final class Obd2ConnectionStatusProvider
     extends $NotifierProvider<Obd2ConnectionStatus, Obd2ConnectionSnapshot> {
   /// App-wide owner of the OBD2 connection status (#784).
-  ///
-  /// Phase-1 scope: state machine + API for callers (boot probe,
-  /// manual disconnect, permission changes) to drive it. The actual
-  /// boot-time Bluetooth scan + auto-connect isolate is deferred to
-  /// the follow-up PR so this lands without coupling to the native
-  /// plugin surface.
   Obd2ConnectionStatusProvider._()
     : super(
         from: null,
@@ -63,15 +45,9 @@ final class Obd2ConnectionStatusProvider
 }
 
 String _$obd2ConnectionStatusHash() =>
-    r'ab14da187622ea41fad1dbb4a80bd1bbe85e9082';
+    r'35b5d18c18098aaa886bcddafac954ff48a98ba5';
 
 /// App-wide owner of the OBD2 connection status (#784).
-///
-/// Phase-1 scope: state machine + API for callers (boot probe,
-/// manual disconnect, permission changes) to drive it. The actual
-/// boot-time Bluetooth scan + auto-connect isolate is deferred to
-/// the follow-up PR so this lands without coupling to the native
-/// plugin surface.
 
 abstract class _$Obd2ConnectionStatus
     extends $Notifier<Obd2ConnectionSnapshot> {

--- a/test/features/consumption/presentation/widgets/obd2_status_chip_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_status_chip_test.dart
@@ -100,27 +100,12 @@ void main() {
     });
 
     testWidgets('stays hidden when an adapter is paired but the '
-        'connection is attempting', (tester) async {
-      // An adapter IS paired — the transient disconnect is the
-      // Obd2StatusDot's job to surface, so the chip stays quiet.
+        'connection is in permissionDenied — Obd2StatusDot owns '
+        'that signal, the chip stays quiet', (tester) async {
       await _pumpChip(
         tester,
         snapshot: const Obd2ConnectionSnapshot(
-          state: Obd2ConnectionState.attempting,
-          adapterName: 'vLinker FS',
-        ),
-        pairedAdapterMac: 'AA:BB:CC',
-      );
-      expect(find.byKey(const Key('obd2StatusChip')), findsNothing);
-      expect(find.byKey(const Key('obd2PairChip')), findsNothing);
-    });
-
-    testWidgets('stays hidden when an adapter is paired but the '
-        'connection is unreachable', (tester) async {
-      await _pumpChip(
-        tester,
-        snapshot: const Obd2ConnectionSnapshot(
-          state: Obd2ConnectionState.unreachable,
+          state: Obd2ConnectionState.permissionDenied,
           adapterName: 'vLinker FS',
         ),
         pairedAdapterMac: 'AA:BB:CC',

--- a/test/features/consumption/presentation/widgets/obd2_status_dot_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_status_dot_test.dart
@@ -80,8 +80,8 @@ void main() {
       expect(find.byKey(const Key('obd2StatusDotForget')), findsOneWidget);
     });
 
-    testWidgets('attempting state uses the amber semantics label '
-        'so colour-blind users hear the state, not just see it',
+    testWidgets('permissionDenied state renders the dot with an error '
+        'semantics label so TalkBack announces the action needed',
         (tester) async {
       await pumpApp(
         tester,
@@ -89,7 +89,7 @@ void main() {
         overrides: [
           obd2ConnectionStatusProvider.overrideWith(
             () => _FakeObd2Status(const Obd2ConnectionSnapshot(
-              state: Obd2ConnectionState.attempting,
+              state: Obd2ConnectionState.permissionDenied,
               adapterName: 'vLinker FS',
               adapterMac: 'AA:BB',
             )),
@@ -98,7 +98,7 @@ void main() {
       );
       final handle = tester.ensureSemantics();
       expect(
-        find.bySemanticsLabel('OBD2 adapter: connecting'),
+        find.bySemanticsLabel('OBD2 adapter: Bluetooth permission needed'),
         findsOneWidget,
       );
       handle.dispose();

--- a/test/features/consumption/providers/obd2_capability_provider_test.dart
+++ b/test/features/consumption/providers/obd2_capability_provider_test.dart
@@ -16,17 +16,6 @@ void main() {
       expect(container.read(currentObd2CapabilityProvider), isNull);
     });
 
-    test('returns null while attempting — capability is unknown until '
-        'init reads ATI', () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-      container.read(obd2ConnectionStatusProvider.notifier).markAttempting(
-            adapterName: 'vLinker FS',
-            adapterMac: 'AA:BB',
-          );
-      expect(container.read(currentObd2CapabilityProvider), isNull);
-    });
-
     test(
         'returns the stamped capability once the producer flips to '
         'connected with a value', () {
@@ -34,11 +23,9 @@ void main() {
       addTearDown(container.dispose);
       final notifier =
           container.read(obd2ConnectionStatusProvider.notifier);
-      notifier.markAttempting(
+      notifier.markConnected(
         adapterName: 'OBDLink MX+',
         adapterMac: 'AA:BB',
-      );
-      notifier.markConnected(
         capability: Obd2AdapterCapability.passiveCanCapable,
       );
       expect(
@@ -59,28 +46,6 @@ void main() {
         adapterMac: 'AA:BB',
         // capability omitted — null on the snapshot.
       );
-      expect(container.read(currentObd2CapabilityProvider), isNull);
-    });
-
-    test('returns null after markUnreachable — failure drops the '
-        'capability so the UI doesn\'t show stale OEM-PID hints '
-        'after the adapter went out of range', () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-      final notifier =
-          container.read(obd2ConnectionStatusProvider.notifier);
-      notifier.markAttempting(
-        adapterName: 'OBDLink MX+',
-        adapterMac: 'AA:BB',
-      );
-      notifier.markConnected(
-        capability: Obd2AdapterCapability.passiveCanCapable,
-      );
-      expect(
-        container.read(currentObd2CapabilityProvider),
-        Obd2AdapterCapability.passiveCanCapable,
-      );
-      notifier.markUnreachable();
       expect(container.read(currentObd2CapabilityProvider), isNull);
     });
 

--- a/test/features/consumption/providers/obd2_connection_state_provider_test.dart
+++ b/test/features/consumption/providers/obd2_connection_state_provider_test.dart
@@ -17,37 +17,6 @@ void main() {
       expect(s.hasVisibleIndicator, isFalse);
     });
 
-    test('markAttempting records adapter + switches state — '
-        'indicator becomes visible even before the connect resolves',
-        () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-      container.read(obd2ConnectionStatusProvider.notifier).markAttempting(
-            adapterName: 'vLinker FS',
-            adapterMac: 'A4:C1:38:00:00:01',
-          );
-      final s = container.read(obd2ConnectionStatusProvider);
-      expect(s.state, Obd2ConnectionState.attempting);
-      expect(s.adapterName, 'vLinker FS');
-      expect(s.hasVisibleIndicator, isTrue);
-    });
-
-    test('markUnreachable keeps the adapter label so the popover '
-        'can still name the target', () {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
-      final notifier =
-          container.read(obd2ConnectionStatusProvider.notifier);
-      notifier.markAttempting(
-        adapterName: 'vLinker FS',
-        adapterMac: 'AA:BB',
-      );
-      notifier.markUnreachable();
-      final s = container.read(obd2ConnectionStatusProvider);
-      expect(s.state, Obd2ConnectionState.unreachable);
-      expect(s.adapterName, 'vLinker FS');
-    });
-
     test('markIdle clears everything — "forget adapter" flow', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
@@ -68,16 +37,15 @@ void main() {
       expect(s.hasVisibleIndicator, isFalse);
     });
 
-    test('attempting → connected preserves the adapter label', () {
+    test('markConnected with name + MAC stamps both fields', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier =
           container.read(obd2ConnectionStatusProvider.notifier);
-      notifier.markAttempting(
+      notifier.markConnected(
         adapterName: 'vLinker FS',
         adapterMac: 'AA:BB',
       );
-      notifier.markConnected();
       final s = container.read(obd2ConnectionStatusProvider);
       expect(s.state, Obd2ConnectionState.connected);
       expect(s.adapterName, 'vLinker FS');
@@ -90,7 +58,7 @@ void main() {
       addTearDown(container.dispose);
       final notifier =
           container.read(obd2ConnectionStatusProvider.notifier);
-      notifier.markAttempting(
+      notifier.markConnected(
         adapterName: 'vLinker FS',
         adapterMac: 'AA:BB',
       );


### PR DESCRIPTION
## Summary
- `markAttempting()` and `markUnreachable()` had zero production call sites in `lib/` — grep confirmed no non-test callers. Only test stubs exercised them.
- Removes `attempting` and `unreachable` from `Obd2ConnectionState` enum (was 5 values, now 3: `idle`, `connected`, `permissionDenied`).
- Removes `markAttempting()` and `markUnreachable()` notifier methods from `Obd2ConnectionStatusProvider`.
- Removes the amber/unreachable UI branches from `Obd2StatusDot` (`_styleFor` and `_description` switch cases).
- Collapses two chip-test cases (`attempting`, `unreachable` → both proved chip is hidden) into one `permissionDenied` case.
- Regenerates `obd2_connection_state_provider.g.dart` (hash updated, stale Phase-1 docstring removed from codegen output).

## Grep proof of zero production callers
```
grep -rn "markAttempting|markUnreachable" lib/ --include="*.dart"
```
Result: only the provider file itself (defining them) and the l10n layer (comment in capability provider .g.dart). No non-test production call sites in `lib/`.

## Test plan
- [x] `flutter analyze lib/ test/` — 0 new issues (2 pre-existing info-level in unrelated files)
- [x] `flutter test test/features/consumption/ test/lint/ --exclude-tags=network` — 3260 tests passed, 6 skipped
- [x] `git diff --exit-code` — codegen drift intentional (.g.dart regenerated, hash updated)

Closes the `chore(obd2): remove dead attempting/unreachable connection-status states (S)` child of #2231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)