### PR TITLE
feat(data): final Epic #2249 wave — BG DioFactory, StationPrices widen, conditional-GET, supabase split, completeness gate

### DIFF
--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:workmanager/workmanager.dart';
 
@@ -25,6 +24,7 @@ import '../telemetry/storage/isolate_error_spool.dart';
 import '../notifications/local_notification_service.dart';
 import '../../features/station_services/germany/tankerkoenig_batch_price_fetcher.dart';
 import '../../features/station_services/germany/tankerkoenig_station_service.dart';
+import '../services/dio_factory.dart';
 import '../storage/hive_storage.dart';
 import '../storage/storage_keys.dart';
 import '../utils/json_extensions.dart';
@@ -267,13 +267,13 @@ Future<void> _refreshPricesAndCheckAlerts() async {
       return;
     }
 
-    // 2. Fetch prices for all stations via the shared Tankerkoenig batch
-    //    fetcher. The fetcher handles chunking + parsing + retry — see
-    //    TankerkoenigBatchPriceFetcher.
-    final dio = Dio(BaseOptions(
+    // 2. Fetch prices via the shared Tankerkoenig batch fetcher (chunking +
+    //    parsing + retry). #2249 — DioFactory so the BG batch fetch inherits
+    //    the rate-limit + conditional-GET interceptors, not a raw request.
+    final dio = DioFactory.create(
       connectTimeout: BackgroundService.bgConnectTimeout,
       receiveTimeout: BackgroundService.bgReceiveTimeout,
-    ));
+    );
     final fetcher = TankerkoenigBatchPriceFetcher(
       dio: dio,
       batchSize: BackgroundService.tankerkoenigBatchSize,
@@ -664,12 +664,12 @@ Future<void> _runRadiusAlerts({
     return;
   }
 
-  final dio = Dio(BaseOptions(
+  // #2249 — rate-limited + conditional-GET Dio (radius-alert search).
+  final dio = DioFactory.create(
     baseUrl: 'https://creativecommons.tankerkoenig.de/json',
     connectTimeout: BackgroundService.bgConnectTimeout,
     receiveTimeout: BackgroundService.bgReceiveTimeout,
-    queryParameters: {'apikey': apiKey},
-  ));
+  )..options.queryParameters = {'apikey': apiKey};
   final service = TankerkoenigStationService(dio);
 
   final runner = RadiusAlertRunner(
@@ -758,12 +758,12 @@ Future<void> _refreshNearestWidgetFromSearch(HiveStorage storage) async {
     final apiKey = storage.getApiKey();
     final hasKey = apiKey != null && apiKey.isNotEmpty;
     if (hasKey) {
-      final dio = Dio(BaseOptions(
+      // #2249 — rate-limited + conditional-GET Dio (nearest-widget search).
+      final dio = DioFactory.create(
         baseUrl: 'https://creativecommons.tankerkoenig.de/json',
         connectTimeout: BackgroundService.bgConnectTimeout,
         receiveTimeout: BackgroundService.bgReceiveTimeout,
-        queryParameters: {'apikey': apiKey},
-      ));
+      )..options.queryParameters = {'apikey': apiKey};
       final service = TankerkoenigStationService(dio);
       await HomeWidgetService.updateNearestWidget(
         storage,

--- a/lib/core/data/impl/supabase_sync_repository.dart
+++ b/lib/core/data/impl/supabase_sync_repository.dart
@@ -68,6 +68,13 @@ class SupabaseSyncRepository implements SyncRepository {
       AlertsSync.merge(localAlerts);
 
   // ── Price History ──
+  //
+  // #2249 — cache↔Supabase split: local Hive history is the source of truth
+  // for what the user has seen; Supabase `price_snapshots` is a server-
+  // backfilled supplement that only covers DE today. [PriceHistorySync.fetch]
+  // gates non-DE stations to an empty list (no wasted round-trip), and
+  // [PriceHistorySync.mergeRemoteIntoLocal] de-duplicates the two histories by
+  // (stationId, recordedAt) for callers that union them.
 
   @override
   Future<List<Map<String, dynamic>>> fetchPriceHistory(String stationId,

--- a/lib/core/services/conditional_get_interceptor.dart
+++ b/lib/core/services/conditional_get_interceptor.dart
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// HTTP conditional-GET + offline-fallback interceptor for the Dio stack
+/// (#2249, child of Epic #2249).
+///
+/// Two complementary jobs, both keyed by request URI:
+///
+///  1. **Conditional GET (304 revalidation).** When a previous `GET` response
+///     carried an `ETag` and/or `Last-Modified`, the next identical `GET`
+///     re-sends them as `If-None-Match` / `If-Modified-Since`. If the upstream
+///     answers `304 Not Modified`, the interceptor resolves the request with
+///     the *cached* body + status `200` instead of an empty 304 — so callers
+///     never see a 304 and the bulk daily-file sources (FR/ES/IT/MX/AR) skip
+///     re-downloading a multi-MB body that hasn't changed.
+///
+///  2. **Hit-cache-on-network-failure.** When a `GET` fails with a connection
+///     error / timeout (no usable HTTP response), the interceptor serves the
+///     last cached body for that URI if one exists — stale-but-online beats a
+///     hard failure for a data fetch. Cache misses propagate the error
+///     unchanged so the chain's own stale-cache fallback still runs.
+///
+/// The store is in-memory and per-Dio (each [DioFactory.create] gets its own
+/// interceptor instance). It is intentionally *not* persisted: the
+/// whole-country datasets already have a disk read-through (PersistentDataset),
+/// and per-URI ETags are most valuable within a single app run / background
+/// burst. A small [maxEntries] LRU bound keeps memory flat.
+///
+/// Only `GET` is handled; mutating methods pass through untouched.
+class ConditionalGetInterceptor extends Interceptor {
+  ConditionalGetInterceptor({this.maxEntries = 64});
+
+  /// Max number of cached responses retained (LRU). Bulk-file sources hit one
+  /// or two stable URIs, so this is generous; the bound only guards against an
+  /// unexpected fan-out of distinct query strings.
+  final int maxEntries;
+
+  /// URI → cached conditional-GET entry. LinkedHashMap iteration order gives a
+  /// cheap LRU: re-insert on touch, evict the oldest when over [maxEntries].
+  final _store = <String, _CachedResponse>{};
+
+  /// Key a request by its full resolved URI (path + query). Two searches with
+  /// different query strings are distinct cache entries.
+  String _keyFor(RequestOptions options) => options.uri.toString();
+
+  bool _isGet(RequestOptions options) =>
+      options.method.toUpperCase() == 'GET';
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    if (_isGet(options)) {
+      final cached = _store[_keyFor(options)];
+      if (cached != null) {
+        if (cached.etag != null) {
+          options.headers['If-None-Match'] = cached.etag;
+        }
+        if (cached.lastModified != null) {
+          options.headers['If-Modified-Since'] = cached.lastModified;
+        }
+      }
+    }
+    handler.next(options);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    final options = response.requestOptions;
+    if (!_isGet(options)) {
+      handler.next(response);
+      return;
+    }
+
+    // A 304 can reach onResponse when a caller widens validateStatus to accept
+    // it; the default validateStatus (200-299 only) routes it through onError
+    // instead, handled below. Cover both.
+    if (response.statusCode == 304) {
+      final replay = _replay304(options, extra: response.extra);
+      if (replay != null) {
+        handler.resolve(replay);
+        return;
+      }
+      handler.next(response);
+      return;
+    }
+
+    _cacheIfValidated(response);
+    handler.next(response);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final options = err.requestOptions;
+    if (_isGet(options)) {
+      // Default-validateStatus path: a 304 arrives as a badResponse error.
+      // Replay the cached body as a 200 so callers never see the 304.
+      if (err.response?.statusCode == 304) {
+        final replay = _replay304(options, extra: err.response?.extra);
+        if (replay != null) {
+          handler.resolve(replay);
+          return;
+        }
+      }
+      // Hit-cache-on-network-failure: no usable HTTP response (timeout /
+      // connection drop) → serve the last cached body if we have one. A real
+      // 4xx/5xx with a body is the caller's to interpret, so it's excluded.
+      if (_isNetworkFailure(err)) {
+        final cached = _store[_keyFor(options)];
+        if (cached != null) {
+          debugPrint(
+            'ConditionalGetInterceptor: network failure on '
+            '${options.uri.path} → serving cached body',
+          );
+          handler.resolve(_synthetic(
+            options,
+            cached,
+            tag: 'offline',
+            message: 'OK (served from conditional-GET cache)',
+          ));
+          return;
+        }
+      }
+    }
+    handler.next(err);
+  }
+
+  /// Cache a 2xx GET response that carries an ETag and/or Last-Modified.
+  void _cacheIfValidated(Response response) {
+    final status = response.statusCode ?? 0;
+    if (status < 200 || status >= 300) return;
+    final etag = response.headers.value('etag');
+    final lastModified = response.headers.value('last-modified');
+    if (etag == null && lastModified == null) return;
+    _touch(
+      _keyFor(response.requestOptions),
+      _CachedResponse(
+        data: response.data,
+        etag: etag,
+        lastModified: lastModified,
+        headers: response.headers,
+      ),
+    );
+  }
+
+  /// Build the replay response for a 304, or null when nothing is cached for
+  /// this URI (header survived a store eviction).
+  Response? _replay304(RequestOptions options, {Map<String, dynamic>? extra}) {
+    final key = _keyFor(options);
+    final cached = _store[key];
+    if (cached == null) return null;
+    _touch(key, cached); // refresh LRU recency
+    return _synthetic(
+      options,
+      cached,
+      tag: '304',
+      message: 'OK (304 revalidated)',
+      extra: extra,
+    );
+  }
+
+  Response _synthetic(
+    RequestOptions options,
+    _CachedResponse cached, {
+    required String tag,
+    required String message,
+    Map<String, dynamic>? extra,
+  }) =>
+      Response(
+        requestOptions: options,
+        data: cached.data,
+        statusCode: 200,
+        statusMessage: message,
+        headers: cached.headers,
+        extra: {...?extra, 'tankstellen.conditionalGet': tag},
+      );
+
+  /// A failure with no usable HTTP response — connect/receive/send timeout or a
+  /// transport-level connection error. A response-bearing 4xx/5xx is excluded.
+  static bool _isNetworkFailure(DioException err) {
+    if (err.response != null) return false;
+    switch (err.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+        return true;
+      case DioExceptionType.badResponse:
+      case DioExceptionType.cancel:
+      case DioExceptionType.badCertificate:
+        return false;
+      case DioExceptionType.unknown:
+        // `unknown` covers SocketException wrapped by Dio — treat as network.
+        return true;
+    }
+  }
+
+  /// Insert/refresh [key] at the most-recent end and evict the oldest entry
+  /// when the store exceeds [maxEntries].
+  void _touch(String key, _CachedResponse entry) {
+    _store.remove(key);
+    _store[key] = entry;
+    while (_store.length > maxEntries) {
+      _store.remove(_store.keys.first);
+    }
+  }
+
+  /// Visible for testing: number of cached entries currently held.
+  @visibleForTesting
+  int get cacheSize => _store.length;
+}
+
+/// One cached conditional-GET response: the body plus the validators needed to
+/// revalidate it and the headers to replay on a 304 / offline hit.
+class _CachedResponse {
+  _CachedResponse({
+    required this.data,
+    required this.etag,
+    required this.lastModified,
+    required this.headers,
+  });
+
+  final dynamic data;
+  final String? etag;
+  final String? lastModified;
+  final Headers headers;
+}

--- a/lib/core/services/dio_factory.dart
+++ b/lib/core/services/dio_factory.dart
@@ -4,6 +4,7 @@
 import 'package:dio/dio.dart';
 
 import '../constants/app_constants.dart';
+import 'conditional_get_interceptor.dart';
 import 'rate_limit_interceptor.dart';
 
 /// Centralized Dio instance creation with consistent defaults.
@@ -30,6 +31,7 @@ class DioFactory {
     Duration? rateLimit = defaultRateLimit,
     int rateLimitJitterBaseMs = 0,
     int rateLimitJitterRangeMs = 500,
+    bool conditionalGet = true,
   }) {
     final dio = Dio(BaseOptions(
       baseUrl: baseUrl ?? '',
@@ -44,6 +46,12 @@ class DioFactory {
         jitterBaseMs: rateLimitJitterBaseMs,
         jitterRangeMs: rateLimitJitterRangeMs,
       ));
+    }
+    if (conditionalGet) {
+      // #2249 — added after the rate limiter so the limiter's onRequest gate
+      // runs first; this interceptor's onResponse/onError (304 revalidation
+      // + offline stale-hit) then runs on the way back out.
+      dio.interceptors.add(ConditionalGetInterceptor());
     }
     dio.interceptors.addAll(interceptors);
     return dio;

--- a/lib/core/services/impl/demo_station_service.dart
+++ b/lib/core/services/impl/demo_station_service.dart
@@ -139,7 +139,12 @@ class DemoStationService implements StationService {
       prices[id] = StationPrices(
         e5: cached?.e5 ?? 1.459,
         e10: cached?.e10 ?? 1.439,
+        e98: cached?.e98,
         diesel: cached?.diesel ?? 1.359,
+        dieselPremium: cached?.dieselPremium,
+        e85: cached?.e85,
+        lpg: cached?.lpg,
+        cng: cached?.cng,
         status: cached?.isOpen == true ? 'open' : 'closed',
       );
     }

--- a/lib/core/services/mixins/cached_dataset_mixin.dart
+++ b/lib/core/services/mixins/cached_dataset_mixin.dart
@@ -134,4 +134,69 @@ mixin CachedDatasetMixin {
       rethrow;
     }
   }
+
+  /// Completeness-gated variant of [loadPersistentDataset] (#2249).
+  ///
+  /// Multi-source datasets (e.g. DK's three brand feeds, fetched in parallel)
+  /// can come back **partial** when one source fails: the caller still gets a
+  /// usable-but-incomplete dataset rather than an exception. Pinning a partial
+  /// fetch under the full [hardTtl] would hide the missing source for hours.
+  ///
+  /// This variant runs [isComplete] on a freshly fetched dataset:
+  ///
+  ///  - **complete** → behaves exactly like [loadPersistentDataset]: store +
+  ///    persist with [hardTtl], mark fully fresh.
+  ///  - **partial** → persist under [shortTtl] (≪ hardTtl) and stamp the
+  ///    in-memory freshness clock so the dataset is treated as if it were
+  ///    already `(softTtl - shortTtl)` old. The data is served now, but the
+  ///    soft TTL elapses quickly so the very next search retries the missing
+  ///    source instead of pinning the gap.
+  ///
+  /// The read-through, dedup and offline-fallback semantics are identical to
+  /// [loadPersistentDataset] — only the post-fetch caching decision changes.
+  Future<T> loadPersistentDatasetGuarded<T>({
+    required T? cached,
+    required Duration softTtl,
+    required Duration hardTtl,
+    required Duration shortTtl,
+    required PersistentDataset<T> persistent,
+    required Future<T> Function() fetch,
+    required void Function(T value) store,
+    required bool Function(T value) isComplete,
+  }) async {
+    if (cached != null && isDatasetFresh(softTtl)) return cached;
+
+    if (cached == null || !isDatasetFresh(hardTtl)) {
+      final disk = persistent.read();
+      if (disk != null && disk.age <= hardTtl) {
+        store(disk.value);
+        markDatasetRefreshedAt(disk.age);
+        if (disk.age <= softTtl) return disk.value;
+      }
+    }
+
+    try {
+      final value = await _dedupedFetch<T>(fetch);
+      store(value);
+      if (isComplete(value)) {
+        markDatasetRefreshed();
+        await persistent.write(value, hardTtl: hardTtl);
+      } else {
+        // Partial — pin only briefly so the next search retries the gap.
+        // Stamp the clock so the soft TTL elapses after just [shortTtl].
+        final preAged = softTtl > shortTtl ? softTtl - shortTtl : Duration.zero;
+        markDatasetRefreshedAt(preAged);
+        await persistent.write(value, hardTtl: shortTtl);
+      }
+      return value;
+    } on Object {
+      final disk = persistent.read();
+      if (disk != null) {
+        store(disk.value);
+        markDatasetRefreshedAt(disk.age);
+        return disk.value;
+      }
+      rethrow;
+    }
+  }
 }

--- a/lib/core/services/station_service.dart
+++ b/lib/core/services/station_service.dart
@@ -9,32 +9,71 @@ import 'service_result.dart';
 
 /// Prices for a single station, returned by the batch price refresh endpoint.
 ///
-/// Contains nullable price fields for each fuel type. A null value means
-/// the station does not sell that fuel or the price is unavailable.
-/// The [status] field indicates whether the station is currently open.
+/// Carries a nullable price field for **every** priced fuel the [Station]
+/// entity exposes — e5, e10, e98, diesel, dieselPremium, e85, lpg, cng (#2249).
+/// Before this widening the model only held e5/e10/diesel, so a favorites /
+/// alerts price refresh silently dropped LPG / CNG / E98 / diesel-premium /
+/// E85 for fuel-rich countries (FR, IT, ES …): the fresh value existed on the
+/// wire but had nowhere to land and the old price was kept instead.
+///
+/// A null value means the station does not sell that fuel or the price is
+/// unavailable. The [status] field indicates whether the station is currently
+/// open. (Electric / hydrogen are not modelled here because they are not
+/// priced on the [Station] entity either — they would need their own units.)
 class StationPrices {
   final double? e5;
   final double? e10;
+  final double? e98;
   final double? diesel;
+  final double? dieselPremium;
+  final double? e85;
+  final double? lpg;
+  final double? cng;
   final String status;
 
-  const StationPrices({this.e5, this.e10, this.diesel, required this.status});
+  const StationPrices({
+    this.e5,
+    this.e10,
+    this.e98,
+    this.diesel,
+    this.dieselPremium,
+    this.e85,
+    this.lpg,
+    this.cng,
+    required this.status,
+  });
+
   bool get isOpen => status == 'open';
 
   Map<String, dynamic> toJson() => {
         'e5': e5,
         'e10': e10,
+        'e98': e98,
         'diesel': diesel,
+        'dieselPremium': dieselPremium,
+        'e85': e85,
+        'lpg': lpg,
+        'cng': cng,
         'status': status,
       };
 
   factory StationPrices.fromJson(Map<String, dynamic> json) => StationPrices(
-        e5: json['e5'] is num ? (json['e5'] as num).toDouble() : null,
-        e10: json['e10'] is num ? (json['e10'] as num).toDouble() : null,
-        diesel:
-            json['diesel'] is num ? (json['diesel'] as num).toDouble() : null,
+        e5: _price(json['e5']),
+        e10: _price(json['e10']),
+        e98: _price(json['e98']),
+        diesel: _price(json['diesel']),
+        dieselPremium: _price(json['dieselPremium']),
+        e85: _price(json['e85']),
+        lpg: _price(json['lpg']),
+        cng: _price(json['cng']),
         status: json['status'] as String? ?? 'closed',
       );
+
+  /// Coerce a raw JSON value to a `double?`: numbers become doubles, anything
+  /// else (null, `false` closed-sentinel, stray strings) becomes null. Shared
+  /// by every fuel field so the defensive contract is identical across them.
+  static double? _price(dynamic value) =>
+      value is num ? value.toDouble() : null;
 }
 
 /// Abstract interface for station data providers.

--- a/lib/core/sync/price_history_sync.dart
+++ b/lib/core/sync/price_history_sync.dart
@@ -3,34 +3,64 @@
 
 import 'dart:async';
 
-
+import '../country/country_config.dart';
 import 'supabase_client.dart';
 import '../../core/logging/error_logger.dart';
 
-/// Server-side price history queries, pulled out of [SyncService] (#727).
+/// Server-side price history queries, pulled out of [SyncService] (#727) and
+/// clarified into a cache↔Supabase contract by #2249.
 ///
-/// Price history is a read-only path for clients — Supabase writes
-/// happen server-side via scheduled Edge Functions. Splitting this
-/// method into its own class removes ~28 LOC from `sync_service.dart`
-/// and keeps each sync concern in a file that answers a single
-/// question (*"what do I write back?"* for SyncService, *"what do I
-/// read?"* here).
+/// ## Responsibilities (cache↔Supabase split, #2249)
 ///
-/// No authentication gating: `price_snapshots` is readable by anon
-/// clients (RLS policy grants SELECT to `authenticated` and `anon`),
-/// so the only failure modes are network and Supabase being offline
-/// — both handled by returning an empty list.
+/// Local Hive history (recorded on-device by the background refresh and the
+/// station-detail view) is the **source of truth for what the user has seen**.
+/// Supabase `price_snapshots` is a **server-backfilled supplement** that fills
+/// gaps when the local history is thin. This class:
+///
+///  - [fetch]es the remote supplement, **gated to DE** — Supabase only
+///    backfills German (Tankerkönig / MTS-K) snapshots today, so a remote read
+///    for any other country is a guaranteed-empty round-trip we now skip; and
+///  - exposes a pure [mergeRemoteIntoLocal] that **de-duplicates** the remote
+///    rows against the local records by `(stationId, recordedAt)` so a caller
+///    can union the two histories without double-counting a snapshot that
+///    exists in both stores.
+///
+/// Price history is read-only for clients — writes happen server-side via
+/// scheduled Edge Functions. `price_snapshots` is readable by anon clients
+/// (RLS grants SELECT to `authenticated` and `anon`), so the only failure
+/// modes are network and Supabase being offline — both return an empty list.
 class PriceHistorySync {
   PriceHistorySync._();
 
-  /// Fetch price history snapshots for [stationId] over the last
-  /// [days] days (default 30). Returns an empty list when the client
-  /// isn't configured or the fetch fails — callers must treat empty
-  /// as "no data" rather than "zero-price stations".
+  /// The only country Supabase currently backfills price history for. The
+  /// server-push phase scope is DE-only (matches the background recorder, which
+  /// is Tankerkönig-only); a remote fetch for any other origin returns nothing,
+  /// so [fetch] short-circuits it (#2249).
+  static const String backfilledCountry = 'DE';
+
+  /// Whether the remote `price_snapshots` table can have rows for [stationId].
+  /// Derived from the station-id country prefix; only [backfilledCountry] is
+  /// backed today. Exposed so callers (and tests) can pre-flight the gate.
+  static bool isRemotelyBackfilled(String stationId) =>
+      Countries.countryCodeForStationId(stationId) == backfilledCountry;
+
+  /// Fetch price history snapshots for [stationId] over the last [days] days
+  /// (default 30). Returns an empty list when:
+  ///
+  ///  - the station's country is not [backfilledCountry] (#2249 — skip the
+  ///    guaranteed-empty round-trip for non-DE stations),
+  ///  - the TankSync client isn't configured, or
+  ///  - the fetch fails.
+  ///
+  /// Callers must treat empty as "no remote data", never "zero-price station".
   static Future<List<Map<String, dynamic>>> fetch(
     String stationId, {
     int days = 30,
   }) async {
+    // #2249 — DE-only gate. Supabase has no rows for other countries, so a
+    // network call would always come back empty; skip it.
+    if (!isRemotelyBackfilled(stationId)) return [];
+
     final client = TankSyncClient.client;
     if (client == null) return [];
 
@@ -45,8 +75,87 @@ class PriceHistorySync {
           .order('recorded_at', ascending: true);
       return List<Map<String, dynamic>>.from(rows);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'PriceHistorySync.fetch FAILED'}));
+      unawaited(errorLogger.log(ErrorLayer.other, e, st,
+          context: const {'where': 'PriceHistorySync.fetch FAILED'}));
       return [];
     }
+  }
+
+  /// Merge server-backfilled [remoteRows] into the on-device [localRecords],
+  /// de-duplicating by `(stationId, recordedAt)` so a snapshot present in both
+  /// stores is counted once (#2249).
+  ///
+  /// Both inputs are the JSON-map shape used by `PriceRecord` /
+  /// `price_snapshots`. Local records win on a key collision (they are the
+  /// canonical on-device copy). The result is sorted **newest-first** to match
+  /// the local repository's contract. Pure + side-effect-free so it is trivially
+  /// unit-testable and reusable from any caller (station-detail view, a future
+  /// background backfill, …) without coupling to Hive or Supabase.
+  static List<Map<String, dynamic>> mergeRemoteIntoLocal({
+    required List<Map<String, dynamic>> localRecords,
+    required List<Map<String, dynamic>> remoteRows,
+    required String stationId,
+  }) {
+    final byKey = <String, Map<String, dynamic>>{};
+
+    // Remote first so a local record with the same key overwrites it.
+    for (final row in remoteRows) {
+      final normalized = _normalizeRemote(row, stationId);
+      final key = _dedupKey(normalized);
+      if (key != null) byKey[key] = normalized;
+    }
+    for (final rec in localRecords) {
+      final key = _dedupKey(rec);
+      if (key != null) byKey[key] = rec;
+    }
+
+    final merged = byKey.values.toList()
+      ..sort((a, b) {
+        final ta = _recordedAt(a);
+        final tb = _recordedAt(b);
+        if (ta == null && tb == null) return 0;
+        if (ta == null) return 1;
+        if (tb == null) return -1;
+        return tb.compareTo(ta); // newest first
+      });
+    return merged;
+  }
+
+  // PriceRecord JSON keys (json_serializable defaults — internal data keys,
+  // not user-facing strings). The remote `price_snapshots` table uses
+  // snake_case (`station_id`, `recorded_at`) which [_normalizeRemote] maps in.
+  static const _kStationId = 'stationId';
+  static const _kRecordedAt = 'recordedAt';
+
+  /// Convert a remote `price_snapshots` row (snake_case columns) into the
+  /// camelCase `PriceRecord` map shape the local store uses.
+  static Map<String, dynamic> _normalizeRemote(
+    Map<String, dynamic> row,
+    String stationId,
+  ) =>
+      {
+        _kStationId: row['station_id'] ?? stationId,
+        _kRecordedAt: row['recorded_at'],
+        'e5': row['e5'],
+        'e10': row['e10'],
+        'e98': row['e98'],
+        'diesel': row['diesel'],
+        'dieselPremium': row['diesel_premium'] ?? row['dieselPremium'],
+        'e85': row['e85'],
+        'lpg': row['lpg'],
+        'cng': row['cng'],
+      };
+
+  static String? _dedupKey(Map<String, dynamic> record) {
+    final ts = _recordedAt(record);
+    if (ts == null) return null;
+    final id = record[_kStationId]?.toString() ?? '';
+    return '$id@${ts.toIso8601String()}';
+  }
+
+  static DateTime? _recordedAt(Map<String, dynamic> record) {
+    final raw = record[_kRecordedAt];
+    if (raw == null) return null;
+    return DateTime.tryParse(raw.toString());
   }
 }

--- a/lib/features/favorites/providers/favorite_stations_provider.dart
+++ b/lib/features/favorites/providers/favorite_stations_provider.dart
@@ -192,10 +192,17 @@ class FavoriteStations extends _$FavoriteStations {
         final updated = stations.map((s) {
           final fresh = freshPrices[s.id];
           if (fresh == null) return s;
+          // #2249 — merge the full fuel set so a refresh no longer drops
+          // LPG / CNG / E98 / diesel-premium / E85 for fuel-rich countries.
           return s.copyWith(
             e5: fresh.e5 ?? s.e5,
             e10: fresh.e10 ?? s.e10,
+            e98: fresh.e98 ?? s.e98,
             diesel: fresh.diesel ?? s.diesel,
+            dieselPremium: fresh.dieselPremium ?? s.dieselPremium,
+            e85: fresh.e85 ?? s.e85,
+            lpg: fresh.lpg ?? s.lpg,
+            cng: fresh.cng ?? s.cng,
             isOpen: fresh.isOpen,
           );
         }).toList();

--- a/lib/features/favorites/providers/favorite_stations_provider.g.dart
+++ b/lib/features/favorites/providers/favorite_stations_provider.g.dart
@@ -73,7 +73,7 @@ final class FavoriteStationsProvider
   }
 }
 
-String _$favoriteStationsHash() => r'c6555029496b57133e54c20ba1cbfb1358c3478b';
+String _$favoriteStationsHash() => r'73ac24d2d6b762271c2a5945324e2082891bdb7e';
 
 /// Loads fuel station data for favorites and refreshes prices.
 ///

--- a/lib/features/station_services/denmark/denmark_station_service.dart
+++ b/lib/features/station_services/denmark/denmark_station_service.dart
@@ -97,14 +97,59 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
     }
   }
 
+  /// #2249 — short TTL applied to a *partial* multi-brand fetch so an
+  /// incomplete dataset (one brand feed down) is pinned only briefly and the
+  /// next search retries the missing source instead of holding the gap for
+  /// the full [_hardTtl].
+  static const Duration _partialTtl = Duration(minutes: 10);
+
+  /// Whether the most recent [_fetchAll] saw **every active brand source**
+  /// (OK + Shell) succeed. Q8 is excluded — it returns no coordinates today,
+  /// so its empty result is by-design, not a failure. Read by the
+  /// completeness gate in [_ensureDataLoaded].
+  bool _lastFetchComplete = true;
+
   Future<List<Station>> _fetchAll({CancelToken? cancelToken}) async {
-    // Fetch all 3 sources in parallel
+    // Fetch all sources in parallel. Each active brand reports success/failure
+    // so a single down feed downgrades completeness (→ short TTL) rather than
+    // silently caching a partial national dataset at the full TTL.
     final results = await Future.wait([
-      _fetchOk(cancelToken: cancelToken),
-      _fetchShell(cancelToken: cancelToken),
-      _fetchQ8(),
+      _fetchSource(() => _fetchOk(cancelToken: cancelToken)),
+      _fetchSource(() => _fetchShell(cancelToken: cancelToken)),
     ]);
-    return [...results[0], ...results[1], ...results[2]];
+    // Q8 has no coordinates — always empty, never counted toward completeness.
+    final q8 = await _fetchQ8();
+
+    // Every active source down → surface a network error. The persistent
+    // read-through catches it and serves the last good disk copy; the legacy
+    // in-memory path and searchStations' `on DioException` turn it into an
+    // ApiException instead of pinning an empty dataset.
+    if (results.every((r) => !r.ok)) {
+      throw DioException(
+        requestOptions: RequestOptions(path: 'dk-aggregate'),
+        type: DioExceptionType.connectionError,
+        error: 'DK: all brand feeds failed',
+      );
+    }
+    _lastFetchComplete = results.every((r) => r.ok);
+    return [
+      for (final r in results) ...r.stations,
+      ...q8,
+    ];
+  }
+
+  /// Run one brand fetcher, tagging whether it completed without a network
+  /// error. The brand fetchers themselves swallow [DioException] and return an
+  /// empty list, so we re-detect failure here by catching anything they
+  /// rethrow and, for the swallow path, treating a thrown error as a miss.
+  Future<({List<Station> stations, bool ok})> _fetchSource(
+    Future<List<Station>> Function() fetch,
+  ) async {
+    try {
+      return (stations: await fetch(), ok: true);
+    } on Object {
+      return (stations: const <Station>[], ok: false);
+    }
   }
 
   Future<void> _ensureDataLoaded({CancelToken? cancelToken}) {
@@ -119,13 +164,17 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
       );
     }
     // #2264 — disk read-through: survives cold start + offline.
-    return loadPersistentDataset<List<Station>>(
+    // #2249 — completeness gate: a partial fetch (a brand feed down) is cached
+    // under [_partialTtl] instead of [_hardTtl] so the gap is retried soon.
+    return loadPersistentDatasetGuarded<List<Station>>(
       cached: _cachedStations,
       softTtl: _softTtl,
       hardTtl: _hardTtl,
+      shortTtl: _partialTtl,
       persistent: persistent,
       fetch: () => _fetchAll(cancelToken: cancelToken),
       store: (value) => _cachedStations = value,
+      isComplete: (_) => _lastFetchComplete,
     );
   }
 
@@ -180,7 +229,10 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
       }).whereType<Station>().toList();
     } on DioException catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'DK OK fetch failed'}));
-      return [];
+      // #2249 — rethrow so the completeness gate sees a *failed* source (vs a
+      // genuinely empty feed). [_fetchSource] catches it and downgrades the
+      // dataset to a short TTL; the legacy in-memory path is unaffected.
+      rethrow;
     }
   }
 
@@ -232,7 +284,8 @@ class DenmarkStationService with StationServiceHelpers, CachedDatasetMixin imple
       }).whereType<Station>().toList();
     } on DioException catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'DK Shell fetch failed'}));
-      return [];
+      // #2249 — rethrow so the completeness gate downgrades to a short TTL.
+      rethrow;
     }
   }
 

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -273,7 +273,12 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
         prices[originalId] = StationPrices(
           e5: _toDouble(r['sp95_prix']),
           e10: _toDouble(r['e10_prix']),
+          // #2249 — France's feed also carries SP98, E85 and GPLc; surface
+          // them so a favorites/alerts refresh keeps the full fuel set.
+          e98: _toDouble(r['sp98_prix']),
           diesel: _toDouble(r['gazole_prix']),
+          e85: _toDouble(r['e85_prix']),
+          lpg: _toDouble(r['gplc_prix']),
           status: 'open',
         );
       }

--- a/test/core/background/background_service_test.dart
+++ b/test/core/background/background_service_test.dart
@@ -434,4 +434,38 @@ void main() {
       expect(service, isA<NotificationService>());
     });
   });
+
+  // #2249 — the background + widget isolates must obtain their Dio via the
+  // rate-limited factory, never by hand-rolling `Dio(BaseOptions(...))`. A raw
+  // Dio skips the RateLimitInterceptor (429/Retry-After) + conditional-GET
+  // interceptor, so the headless isolate could thunder at Tankerkönig. This is
+  // a source-scan guard rather than a runtime test because the Dios are built
+  // inside top-level isolate entrypoints that can't be exercised without a
+  // platform engine.
+  group('background isolate Dio construction (#2249)', () {
+    final source = File('lib/core/background/background_service.dart')
+        .readAsStringSync();
+
+    test('routes every Dio through DioFactory', () {
+      expect(
+        source.contains("import '../services/dio_factory.dart';"),
+        isTrue,
+        reason: 'background_service.dart must import DioFactory',
+      );
+      expect(
+        source.contains('DioFactory.create('),
+        isTrue,
+        reason: 'background isolate must build its Dio via DioFactory.create',
+      );
+    });
+
+    test('constructs no raw Dio(BaseOptions(...)) instances', () {
+      expect(
+        source.contains('Dio(BaseOptions('),
+        isFalse,
+        reason: 'raw Dio bypasses the rate-limit + conditional-GET '
+            'interceptors — use DioFactory.create instead',
+      );
+    });
+  });
 }

--- a/test/core/services/conditional_get_interceptor_test.dart
+++ b/test/core/services/conditional_get_interceptor_test.dart
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/conditional_get_interceptor.dart';
+import 'package:tankstellen/core/services/dio_factory.dart';
+
+void main() {
+  group('ConditionalGetInterceptor — 304 revalidation', () {
+    test('replays the cached body when the upstream answers 304', () async {
+      final adapter = _ScriptedAdapter([
+        // First GET: 200 + ETag.
+        _Step.ok({'price': 1.5}, etag: '"v1"'),
+        // Second GET: server sees If-None-Match and answers 304 (empty body).
+        _Step.notModified(),
+      ]);
+      final dio = _dioWith(adapter);
+
+      final first = await dio.get<Map>('https://x.test/data');
+      expect(first.statusCode, 200);
+      expect(first.data, {'price': 1.5});
+
+      final second = await dio.get<Map>('https://x.test/data');
+      // 304 is transparently turned into a 200 carrying the cached body.
+      expect(second.statusCode, 200);
+      expect(second.data, {'price': 1.5});
+      expect(second.extra['tankstellen.conditionalGet'], '304');
+
+      // The second request must have carried the validator.
+      expect(adapter.requests[1].headers['If-None-Match'], '"v1"');
+    });
+
+    test('sends If-Modified-Since from a cached Last-Modified', () async {
+      const lastMod = 'Wed, 21 Oct 2026 07:28:00 GMT';
+      final adapter = _ScriptedAdapter([
+        _Step.ok({'n': 1}, lastModified: lastMod),
+        _Step.notModified(),
+      ]);
+      final dio = _dioWith(adapter);
+
+      await dio.get<Map>('https://x.test/feed');
+      final second = await dio.get<Map>('https://x.test/feed');
+
+      expect(adapter.requests[1].headers['If-Modified-Since'], lastMod);
+      expect(second.data, {'n': 1});
+    });
+
+    test('different query strings are independent cache entries', () async {
+      final adapter = _ScriptedAdapter([
+        _Step.ok({'q': 'a'}, etag: '"a"'),
+        _Step.ok({'q': 'b'}, etag: '"b"'),
+      ]);
+      final dio = _dioWith(adapter);
+
+      final a = await dio.get<Map>('https://x.test/s?q=a');
+      final b = await dio.get<Map>('https://x.test/s?q=b');
+      expect(a.data, {'q': 'a'});
+      expect(b.data, {'q': 'b'});
+      // Neither request revalidated the other's entry.
+      expect(adapter.requests[1].headers.containsKey('If-None-Match'), isFalse);
+    });
+  });
+
+  group('ConditionalGetInterceptor — offline fallback', () {
+    test('serves the cached body when the network later fails', () async {
+      final adapter = _ScriptedAdapter([
+        _Step.ok({'price': 2.0}, etag: '"v2"'),
+        _Step.networkError(),
+      ]);
+      final dio = _dioWith(adapter);
+
+      final first = await dio.get<Map>('https://x.test/data');
+      expect(first.data, {'price': 2.0});
+
+      // Network drops on the next call — the cached body is served instead of
+      // throwing.
+      final second = await dio.get<Map>('https://x.test/data');
+      expect(second.statusCode, 200);
+      expect(second.data, {'price': 2.0});
+      expect(second.extra['tankstellen.conditionalGet'], 'offline');
+    });
+
+    test('propagates the error when nothing is cached yet', () async {
+      final adapter = _ScriptedAdapter([_Step.networkError()]);
+      final dio = _dioWith(adapter);
+
+      await expectLater(
+        dio.get<Map>('https://x.test/cold'),
+        throwsA(isA<DioException>()),
+      );
+    });
+
+    test('does not rescue a real 4xx/5xx (those carry a body)', () async {
+      final adapter = _ScriptedAdapter([
+        _Step.ok({'ok': true}, etag: '"v3"'),
+        _Step.status(500),
+      ]);
+      final dio = _dioWith(adapter);
+
+      await dio.get<Map>('https://x.test/data');
+      await expectLater(
+        dio.get<Map>('https://x.test/data'),
+        throwsA(isA<DioException>()),
+      );
+    });
+  });
+
+  group('ConditionalGetInterceptor — bookkeeping', () {
+    test('only GET responses with a validator are cached', () {
+      final interceptor = ConditionalGetInterceptor();
+      expect(interceptor.cacheSize, 0);
+    });
+
+    test('LRU bound evicts the oldest entry', () async {
+      final interceptor = ConditionalGetInterceptor(maxEntries: 2);
+      final adapter = _ScriptedAdapter([
+        _Step.ok({'i': 1}, etag: '"1"'),
+        _Step.ok({'i': 2}, etag: '"2"'),
+        _Step.ok({'i': 3}, etag: '"3"'),
+      ]);
+      final dio = Dio(BaseOptions())
+        ..httpClientAdapter = adapter
+        ..interceptors.add(interceptor);
+
+      await dio.get<Map>('https://x.test/a');
+      await dio.get<Map>('https://x.test/b');
+      await dio.get<Map>('https://x.test/c');
+      expect(interceptor.cacheSize, 2);
+    });
+  });
+
+  group('DioFactory wiring', () {
+    test('installs a ConditionalGetInterceptor by default', () {
+      final dio = DioFactory.create();
+      expect(
+        dio.interceptors.whereType<ConditionalGetInterceptor>(),
+        isNotEmpty,
+      );
+    });
+
+    test('conditionalGet: false opts out', () {
+      final dio = DioFactory.create(conditionalGet: false);
+      expect(
+        dio.interceptors.whereType<ConditionalGetInterceptor>(),
+        isEmpty,
+      );
+    });
+  });
+}
+
+Dio _dioWith(_ScriptedAdapter adapter) {
+  // Build through DioFactory so the test exercises the real interceptor wiring,
+  // but disable the rate limiter so the test doesn't sleep between calls.
+  final dio = DioFactory.create(rateLimit: null);
+  dio.httpClientAdapter = adapter;
+  return dio;
+}
+
+/// Drives a fixed script of responses, recording each request's options so
+/// tests can assert on the conditional headers that were sent.
+class _ScriptedAdapter implements HttpClientAdapter {
+  _ScriptedAdapter(this._steps);
+
+  final List<_Step> _steps;
+  final List<RequestOptions> requests = [];
+  int _i = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    if (_i >= _steps.length) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.unknown,
+        error: 'script exhausted',
+      );
+    }
+    return _steps[_i++].toResponseBody(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// One scripted upstream outcome.
+class _Step {
+  _Step._(this._build);
+
+  final ResponseBody Function(RequestOptions) _build;
+
+  ResponseBody toResponseBody(RequestOptions o) => _build(o);
+
+  static _Step ok(
+    Map<String, dynamic> body, {
+    String? etag,
+    String? lastModified,
+  }) {
+    return _Step._((o) {
+      final headers = <String, List<String>>{
+        'content-type': ['application/json'],
+      };
+      if (etag != null) headers['etag'] = [etag];
+      if (lastModified != null) headers['last-modified'] = [lastModified];
+      return ResponseBody.fromString(_json(body), 200, headers: headers);
+    });
+  }
+
+  static _Step notModified() {
+    return _Step._((o) => ResponseBody.fromString('', 304));
+  }
+
+  static _Step status(int code) {
+    return _Step._((o) => ResponseBody.fromString('{"err":true}', code,
+        headers: {
+          'content-type': ['application/json'],
+        }));
+  }
+
+  static _Step networkError() {
+    return _Step._((o) => throw DioException(
+          requestOptions: o,
+          type: DioExceptionType.connectionError,
+          error: 'simulated network drop',
+        ));
+  }
+}
+
+String _json(Map<String, dynamic> m) {
+  final entries = m.entries.map((e) {
+    final v = e.value;
+    final encoded = v is String ? '"$v"' : '$v';
+    return '"${e.key}":$encoded';
+  }).join(',');
+  return '{$entries}';
+}

--- a/test/core/services/mixins/cached_dataset_mixin_test.dart
+++ b/test/core/services/mixins/cached_dataset_mixin_test.dart
@@ -237,6 +237,84 @@ void main() {
     });
   });
 
+  group('CachedDatasetMixin.loadPersistentDatasetGuarded (#2249)', () {
+    test('complete fetch persists at the FULL hard TTL + marks fully fresh',
+        () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+
+      final result = await cached.loadPersistentDatasetGuarded<List<int>>(
+        cached: null,
+        softTtl: const Duration(hours: 2),
+        hardTtl: const Duration(hours: 12),
+        shortTtl: const Duration(minutes: 10),
+        persistent: persistent,
+        fetch: () async => [1, 2, 3],
+        store: (_) {},
+        isComplete: (_) => true,
+      );
+
+      expect(result, [1, 2, 3]);
+      // Persisted at the hard TTL (the entry's own expiry).
+      expect(cache.get(PersistentDataset.datasetKey('XX', 'nums'))?.ttl,
+          const Duration(hours: 12));
+      // Marked fully fresh — still within the soft TTL.
+      expect(cached.isDatasetFresh(const Duration(hours: 2)), isTrue);
+    });
+
+    test('PARTIAL fetch persists at the SHORT TTL + pre-ages the clock',
+        () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+
+      final result = await cached.loadPersistentDatasetGuarded<List<int>>(
+        cached: null,
+        softTtl: const Duration(hours: 2),
+        hardTtl: const Duration(hours: 12),
+        shortTtl: const Duration(minutes: 10),
+        persistent: persistent,
+        fetch: () async => [1, 2], // one brand feed missing
+        store: (_) {},
+        isComplete: (_) => false,
+      );
+
+      expect(result, [1, 2]);
+      // Persisted under the SHORT TTL so the gap isn't pinned for 12 h.
+      expect(cache.get(PersistentDataset.datasetKey('XX', 'nums'))?.ttl,
+          const Duration(minutes: 10));
+      // In-memory clock pre-aged to (soft - short) = 1h50m. The dataset stays
+      // soft-fresh for only the remaining `shortTtl` (10 min), then the next
+      // search refetches the gap:
+      //  - against the full soft TTL it's only ~10 min from going stale...
+      expect(cached.isDatasetFresh(const Duration(hours: 2)), isTrue);
+      //  - ...but a window just under the pre-aged age already reads stale,
+      //    proving the clock was pushed back ~1h50m (a fresh stamp would not).
+      expect(cached.isDatasetFresh(const Duration(hours: 1)), isFalse);
+      // And it remains fresh against the hard TTL (served now, offline-ok).
+      expect(cached.isDatasetFresh(const Duration(hours: 12)), isTrue);
+    });
+
+    test('serves disk fallback when the whole fetch throws (offline)',
+        () async {
+      final cache = _MemCache();
+      final persistent = _intDataset(cache);
+      await persistent.write([7], hardTtl: const Duration(hours: 12));
+
+      final result = await cached.loadPersistentDatasetGuarded<List<int>>(
+        cached: null,
+        softTtl: Duration.zero,
+        hardTtl: const Duration(hours: 12),
+        shortTtl: const Duration(minutes: 10),
+        persistent: persistent,
+        fetch: () async => throw Exception('all sources down'),
+        store: (_) {},
+        isComplete: (_) => true,
+      );
+
+      expect(result, [7], reason: 'a hard failure must serve the disk copy');
+    });
+  });
+
   group('concurrent-fetch guard (#2313)', () {
     test('loadDataset: two simultaneous cold calls issue ONE fetch', () async {
       var fetchCalls = 0;

--- a/test/core/services/station_prices_test.dart
+++ b/test/core/services/station_prices_test.dart
@@ -19,6 +19,32 @@ void main() {
       expect(p.status, 'open');
     });
 
+    test('carries the full FuelType-aligned set (#2249)', () {
+      // Before #2249 the model only held e5/e10/diesel, silently dropping
+      // LPG/CNG/E98/diesel-premium/E85 on a favorites/alerts refresh for
+      // fuel-rich countries. All eight priced fuels must now survive.
+      const p = StationPrices(
+        e5: 1.81,
+        e10: 1.79,
+        e98: 1.95,
+        diesel: 1.69,
+        dieselPremium: 1.85,
+        e85: 0.99,
+        lpg: 0.95,
+        cng: 1.49,
+        status: 'open',
+      );
+      expect(p.e5, closeTo(1.81, 0.0001));
+      expect(p.e10, closeTo(1.79, 0.0001));
+      expect(p.e98, closeTo(1.95, 0.0001));
+      expect(p.diesel, closeTo(1.69, 0.0001));
+      expect(p.dieselPremium, closeTo(1.85, 0.0001));
+      expect(p.e85, closeTo(0.99, 0.0001));
+      expect(p.lpg, closeTo(0.95, 0.0001));
+      expect(p.cng, closeTo(1.49, 0.0001));
+      expect(p.status, 'open');
+    });
+
     test('isOpen is true only for status == "open"', () {
       expect(
         const StationPrices(status: 'open').isOpen,
@@ -41,13 +67,23 @@ void main() {
       const p = StationPrices(
         e5: 1.859,
         e10: 1.799,
+        e98: 1.999,
         diesel: 1.659,
+        dieselPremium: 1.899,
+        e85: 0.989,
+        lpg: 0.949,
+        cng: 1.499,
         status: 'open',
       );
       expect(p.toJson(), {
         'e5': 1.859,
         'e10': 1.799,
+        'e98': 1.999,
         'diesel': 1.659,
+        'dieselPremium': 1.899,
+        'e85': 0.989,
+        'lpg': 0.949,
+        'cng': 1.499,
         'status': 'open',
       });
     });
@@ -57,7 +93,12 @@ void main() {
       final json = p.toJson();
       expect(json['e5'], 1.8);
       expect(json['e10'], isNull);
+      expect(json['e98'], isNull);
       expect(json['diesel'], isNull);
+      expect(json['dieselPremium'], isNull);
+      expect(json['e85'], isNull);
+      expect(json['lpg'], isNull);
+      expect(json['cng'], isNull);
       expect(json['status'], 'closed');
     });
   });
@@ -75,6 +116,30 @@ void main() {
       expect(p.e10, closeTo(1.799, 0.0001));
       expect(p.diesel, closeTo(1.659, 0.0001));
       expect(p.status, 'open');
+    });
+
+    test('full-set toJson→fromJson round-trip is lossless (#2249)', () {
+      const original = StationPrices(
+        e5: 1.811,
+        e10: 1.791,
+        e98: 1.951,
+        diesel: 1.691,
+        dieselPremium: 1.851,
+        e85: 0.991,
+        lpg: 0.951,
+        cng: 1.491,
+        status: 'open',
+      );
+      final restored = StationPrices.fromJson(original.toJson());
+      expect(restored.e5, closeTo(original.e5!, 0.0001));
+      expect(restored.e10, closeTo(original.e10!, 0.0001));
+      expect(restored.e98, closeTo(original.e98!, 0.0001));
+      expect(restored.diesel, closeTo(original.diesel!, 0.0001));
+      expect(restored.dieselPremium, closeTo(original.dieselPremium!, 0.0001));
+      expect(restored.e85, closeTo(original.e85!, 0.0001));
+      expect(restored.lpg, closeTo(original.lpg!, 0.0001));
+      expect(restored.cng, closeTo(original.cng!, 0.0001));
+      expect(restored.status, 'open');
     });
 
     test('null price values map to null on the model', () {

--- a/test/core/sync/price_history_sync_test.dart
+++ b/test/core/sync/price_history_sync_test.dart
@@ -4,30 +4,127 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/sync/price_history_sync.dart';
 
-/// Shape-only smoke tests for [PriceHistorySync] (#727 extract). Runs
-/// fully offline — exercises the "TankSync client is null → return empty
-/// list" guard without touching Supabase.
+/// Offline tests for [PriceHistorySync] (#727 extract, #2249 DE-gate +
+/// dedup-merge). Runs fully offline — exercises the country gate, the
+/// "TankSync client is null → empty list" guard, and the pure merge helper
+/// without touching Supabase.
 ///
 /// Live counterpart sits at `test/core/data/sync_repository_test.dart`
 /// under `@Tags(['network'])`; rerun that file (not this one) when the
 /// `price_snapshots` table schema or the TankSync RPC contract changes.
 /// See `docs/guides/NETWORK_TESTS.md`.
 void main() {
-  group('PriceHistorySync', () {
-    test('returns empty list when TankSync client is not configured',
+  group('PriceHistorySync.fetch', () {
+    test('returns empty for a DE station when client is not configured',
         () async {
-      // TankSyncClient isn't initialised in unit-test context, so
-      // `.client` resolves to null and `.fetch` takes the early return.
-      final rows = await PriceHistorySync.fetch('st-1');
+      // de- prefix passes the country gate; TankSyncClient.client is null in
+      // unit context, so the client-null guard returns empty.
+      final rows = await PriceHistorySync.fetch('de-1');
       expect(rows, isEmpty);
     });
 
+    test('short-circuits non-DE stations before any network call (#2249)',
+        () async {
+      // France/Italy/Spain etc. are not backfilled in Supabase — the gate
+      // returns empty without even reaching the client lookup.
+      expect(await PriceHistorySync.fetch('fr-123'), isEmpty);
+      expect(await PriceHistorySync.fetch('it-456'), isEmpty);
+      expect(await PriceHistorySync.fetch('es-789'), isEmpty);
+      // Unprefixed legacy id → unknown country → also gated out.
+      expect(await PriceHistorySync.fetch('st-1'), isEmpty);
+    });
+
     test('honours custom days parameter without throwing', () async {
-      // Days is passed to the server-side filter; the client-null guard
-      // still kicks in first. Any widening of the guard that breaks the
-      // named argument would trip this test.
-      final rows = await PriceHistorySync.fetch('st-1', days: 7);
+      final rows = await PriceHistorySync.fetch('de-1', days: 7);
       expect(rows, isEmpty);
+    });
+  });
+
+  group('PriceHistorySync.isRemotelyBackfilled', () {
+    test('true only for DE-prefixed station ids', () {
+      expect(PriceHistorySync.isRemotelyBackfilled('de-42'), isTrue);
+      expect(PriceHistorySync.isRemotelyBackfilled('fr-42'), isFalse);
+      expect(PriceHistorySync.isRemotelyBackfilled('it-42'), isFalse);
+      expect(PriceHistorySync.isRemotelyBackfilled('unknown'), isFalse);
+    });
+
+    test('backfilledCountry is DE', () {
+      expect(PriceHistorySync.backfilledCountry, 'DE');
+    });
+  });
+
+  group('PriceHistorySync.mergeRemoteIntoLocal', () {
+    Map<String, dynamic> local(String ts, {double? e5}) => {
+          'stationId': 'de-1',
+          'recordedAt': ts,
+          'e5': e5,
+        };
+    Map<String, dynamic> remote(String ts, {double? e5}) => {
+          'station_id': 'de-1',
+          'recorded_at': ts,
+          'e5': e5,
+        };
+
+    test('unions distinct timestamps, newest first', () {
+      final merged = PriceHistorySync.mergeRemoteIntoLocal(
+        stationId: 'de-1',
+        localRecords: [local('2026-05-03T10:00:00Z', e5: 1.7)],
+        remoteRows: [
+          remote('2026-05-01T10:00:00Z', e5: 1.5),
+          remote('2026-05-02T10:00:00Z', e5: 1.6),
+        ],
+      );
+      expect(merged, hasLength(3));
+      expect(merged.first['recordedAt'], '2026-05-03T10:00:00Z');
+      expect(merged.last['recordedAt'], '2026-05-01T10:00:00Z');
+    });
+
+    test('de-duplicates a snapshot present in both stores (local wins)', () {
+      const ts = '2026-05-02T10:00:00Z';
+      final merged = PriceHistorySync.mergeRemoteIntoLocal(
+        stationId: 'de-1',
+        localRecords: [local(ts, e5: 1.9)], // local value
+        remoteRows: [remote(ts, e5: 1.5)], // remote value for same instant
+      );
+      expect(merged, hasLength(1));
+      // Local record wins on the (stationId, recordedAt) collision.
+      expect(merged.single['e5'], 1.9);
+    });
+
+    test('normalizes remote snake_case columns into camelCase shape', () {
+      final merged = PriceHistorySync.mergeRemoteIntoLocal(
+        stationId: 'de-1',
+        localRecords: const [],
+        remoteRows: [
+          {
+            'station_id': 'de-9',
+            'recorded_at': '2026-05-02T10:00:00Z',
+            'e10': 1.79,
+            'diesel': 1.69,
+            'diesel_premium': 1.85,
+          },
+        ],
+      );
+      expect(merged, hasLength(1));
+      final r = merged.single;
+      expect(r['stationId'], 'de-9');
+      expect(r['recordedAt'], '2026-05-02T10:00:00Z');
+      expect(r['e10'], 1.79);
+      expect(r['diesel'], 1.69);
+      expect(r['dieselPremium'], 1.85);
+    });
+
+    test('drops records with an unparseable / missing timestamp', () {
+      final merged = PriceHistorySync.mergeRemoteIntoLocal(
+        stationId: 'de-1',
+        localRecords: [
+          {'stationId': 'de-1', 'recordedAt': 'not-a-date'},
+          {'stationId': 'de-1'}, // no timestamp at all
+        ],
+        remoteRows: [remote('2026-05-02T10:00:00Z', e5: 1.6)],
+      );
+      expect(merged, hasLength(1));
+      expect(merged.single['recordedAt'], '2026-05-02T10:00:00Z');
     });
   });
 }

--- a/test/features/favorites/providers/favorites_provider_test.dart
+++ b/test/features/favorites/providers/favorites_provider_test.dart
@@ -352,6 +352,47 @@ void main() {
       expect(updated.isOpen, isTrue);
     });
 
+    test('loadAndRefresh() merges the FULL widened fuel set (#2249)',
+        () async {
+      // Regression for the pre-#2249 drop: a fuel-rich-country refresh must
+      // carry LPG / CNG / E98 / diesel-premium / E85 into the station, not
+      // just e5/e10/diesel.
+      final station = testStationList[0];
+      await fakeStorage.setFavoriteIds([station.id]);
+      await fakeStorage.saveFavoriteStationData(station.id, station.toJson());
+
+      final mockService = MockStationService();
+      when(() => mockService.getPrices(any())).thenAnswer((_) async =>
+          ServiceResult(
+            data: {
+              station.id: const StationPrices(
+                e5: 1.811,
+                e10: 1.791,
+                e98: 1.951,
+                diesel: 1.691,
+                dieselPremium: 1.851,
+                e85: 0.991,
+                lpg: 0.951,
+                cng: 1.491,
+                status: 'open',
+              ),
+            },
+            source: ServiceSource.tankerkoenigApi,
+            fetchedAt: DateTime.now(),
+          ));
+
+      container = createContainer(mockService: mockService);
+      await container.read(favoriteStationsProvider.notifier).loadAndRefresh();
+
+      final updated =
+          container.read(favoriteStationsProvider).value!.data.first;
+      expect(updated.e98, 1.951);
+      expect(updated.dieselPremium, 1.851);
+      expect(updated.e85, 0.991);
+      expect(updated.lpg, 0.951);
+      expect(updated.cng, 1.491);
+    });
+
     test('loadAndRefresh() persists updated prices back to storage',
         () async {
       final station = testStationList[0];

--- a/test/features/station_services/denmark/denmark_station_service_test.dart
+++ b/test/features/station_services/denmark/denmark_station_service_test.dart
@@ -1,15 +1,20 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/features/station_services/denmark/denmark_station_service.dart';
+import 'package:tankstellen/core/services/persistent_dataset.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import '../../../helpers/silence_error_logger.dart';
 
 void main() {
+  silenceErrorLoggerSpool();
   late DenmarkStationService service;
 
   setUp(() {
@@ -547,6 +552,73 @@ void main() {
     });
   });
 
+  group('Denmark completeness gate (#2249)', () {
+    const okUrl = 'https://mobility-prices.ok.dk/api/v1/fuel-prices';
+    const shellUrl = 'https://shellpumpepriser.geoapp.me/v1/prices';
+    final datasetKey = PersistentDataset.datasetKey('DK', 'stations');
+
+    Map<String, dynamic> okBody() => {
+          'items': [
+            {
+              'facility_number': '1',
+              'coordinates': {'latitude': 55.6, 'longitude': 12.5},
+              'street': 'Main', 'house_number': '1', 'city': 'Copenhagen',
+              'postal_code': '1000',
+              'prices': [
+                {'product_name': 'Blyfri 95', 'price': 13.5},
+                {'product_name': 'Diesel', 'price': 12.9},
+              ],
+            },
+          ],
+        };
+    List<dynamic> shellBody() => [
+          {
+            'stationId': '9',
+            'brand': 'Shell',
+            'coordinates': {'latitude': '55.7', 'longitude': '12.6'},
+            'street': 'Side', 'houseNumber': '2', 'city': 'Aarhus',
+            'postalCode': '8000',
+            'prices': [
+              {'productName': '95', 'price': '13.6', 'lastUpdated': null},
+            ],
+          },
+        ];
+
+    test('a full fetch (both feeds up) persists at the HARD TTL', () async {
+      final cache = _MemCache();
+      final dio = Dio(BaseOptions())
+        ..httpClientAdapter = _DkRoutingAdapter({
+          okUrl: _DkOutcome.json(okBody()),
+          shellUrl: _DkOutcome.json(shellBody()),
+        });
+      final svc = DenmarkStationService(dio: dio, cache: cache);
+
+      await svc.searchStations(
+          const SearchParams(lat: 55.6, lng: 12.5, radiusKm: 50));
+
+      // Persisted under the 12-hour hard TTL.
+      expect(cache.get(datasetKey)?.ttl, const Duration(hours: 12));
+    });
+
+    test('a PARTIAL fetch (one feed down) persists at the SHORT TTL', () async {
+      final cache = _MemCache();
+      final dio = Dio(BaseOptions())
+        ..httpClientAdapter = _DkRoutingAdapter({
+          okUrl: _DkOutcome.json(okBody()),
+          shellUrl: _DkOutcome.fail(), // Shell feed down
+        });
+      final svc = DenmarkStationService(dio: dio, cache: cache);
+
+      final result = await svc.searchStations(
+          const SearchParams(lat: 55.6, lng: 12.5, radiusKm: 50));
+
+      // Still serves the OK stations…
+      expect(result.data, isNotEmpty);
+      // …but the incomplete dataset is pinned only briefly (10 min), not 12 h.
+      expect(cache.get(datasetKey)?.ttl, const Duration(minutes: 10));
+    });
+  });
+
   group('Denmark full station-building pipeline', () {
     late _TestableDenmarkParser parser;
 
@@ -813,4 +885,90 @@ class _TestableDenmarkParser {
       return null;
     }
   }
+}
+
+// ── Completeness-gate test doubles (#2249) ──────────────────────────────────
+
+/// In-memory [CacheStrategy] so the gate test can read back the TTL the
+/// dataset was persisted under.
+class _MemCache implements CacheStrategy {
+  final Map<String, CacheEntry> _store = {};
+
+  @override
+  Future<void> put(String key, Map<String, dynamic> data,
+      {required Duration ttl, required ServiceSource source}) async {
+    _store[key] = CacheEntry(
+        payload: data, storedAt: DateTime.now(), originalSource: source, ttl: ttl);
+  }
+
+  @override
+  CacheEntry? get(String key) => _store[key];
+
+  @override
+  CacheEntry? getFresh(String key) {
+    final e = _store[key];
+    if (e == null || e.isExpired) return null;
+    return e;
+  }
+}
+
+/// A scripted upstream outcome for one URL: a JSON body or a network failure.
+class _DkOutcome {
+  _DkOutcome._(this._build);
+  final ResponseBody Function(RequestOptions) _build;
+
+  static _DkOutcome json(dynamic body) =>
+      _DkOutcome._((o) => ResponseBody.fromString(
+            _encode(body),
+            200,
+            headers: {
+              'content-type': ['application/json'],
+            },
+          ));
+
+  static _DkOutcome fail() => _DkOutcome._((o) => throw DioException(
+        requestOptions: o,
+        type: DioExceptionType.connectionError,
+        error: 'simulated feed down',
+      ));
+
+  static String _encode(dynamic body) {
+    // Minimal JSON encoder for the fixed test fixtures (maps/lists/primitives).
+    if (body is Map) {
+      return '{${body.entries.map((e) => '"${e.key}":${_encode(e.value)}').join(',')}}';
+    }
+    if (body is List) {
+      return '[${body.map(_encode).join(',')}]';
+    }
+    if (body is String) return '"$body"';
+    if (body == null) return 'null';
+    return '$body';
+  }
+}
+
+/// Routes each request to the [_DkOutcome] registered for its URL, so the OK
+/// feed can succeed while the Shell feed fails in the same fetch.
+class _DkRoutingAdapter implements HttpClientAdapter {
+  _DkRoutingAdapter(this._routes);
+  final Map<String, _DkOutcome> _routes;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final outcome = _routes[options.uri.toString()];
+    if (outcome == null) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.unknown,
+        error: 'no route for ${options.uri}',
+      );
+    }
+    return outcome._build(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -61,6 +61,40 @@ void main() {
         expect(result.data, isA<Map<String, StationPrices>>());
         expect(result.source, ServiceSource.prixCarburantsApi);
       });
+
+      test('surfaces the FULL widened fuel set incl. SP98/E85/GPLc (#2249)',
+          () async {
+        // Pre-#2249 getPrices only mapped sp95/e10/gazole, dropping SP98
+        // (e98), E85 and GPLc (lpg) that France's feed carries — so a
+        // favorites refresh in France lost those fuels.
+        final adapter = _TrackingMockAdapter();
+        adapter.addResponse({
+          'results': [
+            {
+              'id': '1234',
+              'sp95_prix': 1.879,
+              'e10_prix': 1.799,
+              'sp98_prix': 1.929,
+              'gazole_prix': 1.659,
+              'e85_prix': 0.899,
+              'gplc_prix': 0.999,
+            },
+          ],
+        });
+        final dio = Dio(BaseOptions());
+        dio.httpClientAdapter = adapter;
+        final svc = PrixCarburantsStationService(dio: dio);
+
+        final result = await svc.getPrices(['fr-1234']);
+        final p = result.data['fr-1234'];
+        expect(p, isNotNull);
+        expect(p!.e5, closeTo(1.879, 0.001));
+        expect(p.e10, closeTo(1.799, 0.001));
+        expect(p.e98, closeTo(1.929, 0.001));
+        expect(p.diesel, closeTo(1.659, 0.001));
+        expect(p.e85, closeTo(0.899, 0.001));
+        expect(p.lpg, closeTo(0.999, 0.001));
+      });
     });
 
     group('searchStations', () {


### PR DESCRIPTION
Final autonomously-doable wave of Epic #2249 (data-layer hardening). One PR,
five conventional commits (one per item), single-writer to the data layer.

## Items (5 commits)

1. **fix(background): route isolate Dios through the rate-limited DioFactory.**
   The background price-refresh + home-widget isolates built raw
   `Dio(BaseOptions(...))` at three sites (batch price fetch, radius-alert
   search, nearest-widget search), bypassing the RateLimitInterceptor
   (429/Retry-After) and now the conditional-GET interceptor. All three now go
   through `DioFactory.create`. Source-scan guard added.

2. **feat(domain): widen `StationPrices` to the full FuelType set.**
   Was e5/e10/diesel only → silently dropped LPG/CNG/E98/diesel-premium/E85 on
   favorites/alerts refresh for fuel-rich countries. Widened to all eight priced
   fuels the `Station` entity carries; chain codec round-trips for free; France
   getPrices now also maps SP98/E85/GPLc. **3 construction sites** updated
   (model `fromJson`, demo service, France getPrices) + the favorites consumer.

3. **feat(http): conditional-GET (304 revalidation) + offline stale-hit
   interceptor.** New `ConditionalGetInterceptor`, default-on in
   `DioFactory.create`. Caches ETag/Last-Modified, re-sends
   If-None-Match/If-Modified-Since, replays a 304 as a 200 with the cached body,
   and serves the last cached body on a network failure. In-memory, per-Dio,
   LRU-bounded.

4. **refactor(supabase): clarify cache↔Supabase price-history
   responsibilities.** `PriceHistorySync.fetch` now gates non-DE stations to an
   empty list (Supabase only backfills DE); new pure `mergeRemoteIntoLocal`
   de-duplicates remote rows into local by (stationId, recordedAt). Repository
   documents the split.

5. **feat(datasets): completeness gate.** New
   `CachedDatasetMixin.loadPersistentDatasetGuarded` caches a *partial*
   multi-source fetch under a short TTL (+ pre-ages the in-memory clock) instead
   of the full hard TTL. Wired into Denmark (OK/Shell brand feeds): a down feed
   downgrades to a 10-min TTL; all feeds down throws so the disk read-through
   serves the last good copy.

## Gate
- `flutter analyze lib/ test/` — no new issues (2 pre-existing `info`s on master,
  in files this PR does not touch).
- `flutter test test/core/ test/features/station_services/ test/features/favorites/
  test/features/alerts/ test/lint/ --exclude-tags=network` — **3880 passed**.
- `git diff --exit-code` clean (no codegen drift; no @riverpod/freezed sources
  changed).

New/extended tests: StationPrices full-set constructor/toJson/fromJson +
lossless round-trip; favorites full-set merge regression; France getPrices
SP98/E85/GPLc; conditional-GET ETag/Last-Modified/304/offline/LRU + factory
wiring; PriceHistorySync DE gate + dedup-merge; completeness-gate
short-vs-hard TTL (mixin + Denmark integration).

Closes the last 5 items of #2249 (all 16 children now shipped).

Refs #2249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
