### PR TITLE
feat(trips): move 'Alle auf Karte anzeigen' into the Fahrten AppBar

### DIFF
--- a/lib/features/consumption/presentation/screens/consumption_screen.dart
+++ b/lib/features/consumption/presentation/screens/consumption_screen.dart
@@ -25,6 +25,7 @@ import '../widgets/fuel_tab.dart';
 import '../widgets/obd2_status_chip.dart';
 import '../widgets/trajets_tab.dart';
 import 'add_charging_log_screen.dart';
+import 'trajets_map_screen.dart';
 import '../../../../core/logging/error_logger.dart';
 
 /// Which slice of the consumption feature a [ConsumptionScreen] renders.
@@ -163,9 +164,28 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
   /// AppBar actions shared by both sections (#1901): the OBD2 status
   /// chip, the backup export button, the gated Carbon dashboard entry
   /// point, and the Settings action.
-  List<Widget> _appBarActions(AppLocalizations? l) => [
+  ///
+  /// When [tripIds] is non-null (Trajets section only, #2374) a map
+  /// IconButton is inserted immediately before the download button so
+  /// the user can reach the all-trips map without scrolling past the
+  /// monthly-comparison card.
+  List<Widget> _appBarActions(AppLocalizations? l,
+      {List<String>? tripIds}) =>
+      [
         // #797 phase 3 — title-bar chip announcing "OBD2 connected".
         const Obd2StatusChip(),
+        // #2374 — map action visible only on the Trajets section.
+        if (tripIds != null)
+          IconButton(
+            key: const Key('trajets_view_all_on_map'),
+            tooltip: l?.trajetsViewAllOnMap ?? 'View all on map',
+            icon: const Icon(Icons.map_outlined),
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => TrajetsMapScreen(tripIds: tripIds),
+              ),
+            ),
+          ),
         IconButton(
           key: const Key('export_backup'),
           tooltip: l?.exportBackupTooltip ?? 'Export backup',
@@ -230,14 +250,28 @@ class _ConsumptionScreenState extends ConsumerState<ConsumptionScreen>
   /// #1901 — the Trajets destination: OBD2 trip history. No FAB (the
   /// "Start recording" CTA lives in the tab header) and no in-screen
   /// tab bar.
+  ///
+  /// #2374 — computes the same vehicle-filtered trip IDs that [TrajetsTab]
+  /// renders, so the AppBar map action opens [TrajetsMapScreen] with exactly
+  /// the visible set of trips.
   Widget _buildTrajets(BuildContext context, AppLocalizations? l) {
     final activeVehicle = ref.watch(activeVehicleProfileProvider);
+    final allTrips = ref.watch(tripHistoryListProvider);
+    // Mirror TrajetsTab's filter: when a vehicle is active, show only that
+    // vehicle's trips (plus untagged legacy trips); otherwise show all.
+    final vehicleId = activeVehicle?.id;
+    final tripIds = (vehicleId == null
+            ? allTrips
+            : allTrips.where(
+                (t) => t.vehicleId == null || t.vehicleId == vehicleId))
+        .map((t) => t.id)
+        .toList(growable: false);
     return PageScaffold(
       title: l?.trajetsTabLabel ?? 'Trips',
       leading: _vehiclesLeading(l),
       bodyPadding: EdgeInsets.zero,
-      actions: _appBarActions(l),
-      body: TrajetsTab(vehicleId: activeVehicle?.id),
+      actions: _appBarActions(l, tripIds: tripIds),
+      body: TrajetsTab(vehicleId: vehicleId),
     );
   }
 

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -21,7 +21,6 @@ import '../../providers/trip_history_provider.dart';
 import '../../providers/trip_recording_provider.dart';
 import '../obd2_connection_error_l10n.dart';
 import '../screens/trip_recording_screen.dart';
-import '../screens/trajets_map_screen.dart';
 import 'maintenance_suggestion_card.dart';
 import 'monthly_insights_card.dart';
 import 'obd2_adapter_picker.dart';
@@ -270,38 +269,10 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
         },
       );
 
-      // #2030 — "View all on map" action. Discoverable inline (one
-      // tap reaches it) and lands the user on a new screen that
-      // overlays every visible trajet's polyline + offers an
-      // aggregate GPX export.
-      final mapAction = Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-        child: Align(
-          alignment: AlignmentDirectional.centerEnd,
-          child: TextButton.icon(
-            key: const Key('trajets_view_all_on_map'),
-            icon: const Icon(Icons.map_outlined),
-            label: Text(
-              l?.trajetsViewAllOnMap ?? 'View all on map',
-            ),
-            onPressed: () {
-              Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => TrajetsMapScreen(
-                    tripIds:
-                        filtered.map((e) => e.id).toList(growable: false),
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      );
-
-      // #2018 + #2030 — landscape / tablet split: left = monthly-insights
-      // + maintenance suggestions + "view all on map" action, right =
-      // trajets list. Narrow screens fall back to a single column with
-      // the same vertical order.
+      // #2018 — landscape / tablet split: left = monthly-insights
+      // + maintenance suggestions, right = trajets list. Narrow screens
+      // fall back to a single column with the same vertical order.
+      // #2374 — the "View all on map" action moved to the AppBar.
       if (isWideScreen(context)) {
         content = Row(
           children: [
@@ -318,7 +289,6 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
                   children: [
                     MonthlyInsightsCard(summary: monthlySummary),
                     const MaintenanceSuggestionList(),
-                    mapAction,
                     const SharedTripsSection(),
                   ],
                 ),
@@ -334,7 +304,6 @@ class _TrajetsTabState extends ConsumerState<TrajetsTab> {
           children: [
             MonthlyInsightsCard(summary: monthlySummary),
             const MaintenanceSuggestionList(),
-            mapAction,
             const SharedTripsSection(),
             Expanded(child: trajetsList),
           ],

--- a/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
+++ b/test/features/consumption/presentation/screens/consumption_screen_trajets_tab_test.dart
@@ -317,4 +317,94 @@ void main() {
   // `showTrajets` flag) rather than by ConsumptionScreen. That gate is
   // covered by `test/app/shell/shell_destinations_test.dart` and
   // `test/app/shell_nav_vehicle_gating_test.dart`.
+
+  // #2374 — "View all on map" moved from a standalone full-width
+  // TextButton.icon row in TrajetsTab into the Trajets AppBar as an
+  // IconButton, placed immediately before the download (↓) action.
+  group('ConsumptionScreen Trajets — map AppBar action (#2374)', () {
+    const vehicle = VehicleProfile(
+      id: 'v1',
+      name: 'Test vehicle',
+      type: VehicleType.combustion,
+    );
+
+    testWidgets(
+        'map IconButton is present in the AppBar when trips exist',
+        (tester) async {
+      final trips = <TripHistoryEntry>[
+        _entry(
+          id: 'trip-1',
+          vehicleId: 'v1',
+          startedAt: DateTime.utc(2026, 4, 22, 9),
+          distanceKm: 10.0,
+        ),
+      ];
+
+      await _pumpScreen(
+        tester,
+        trips: trips,
+        activeVehicle: vehicle,
+        vehicles: [vehicle],
+      );
+
+      // The AppBar map IconButton carries the localized tooltip and
+      // the map_outlined icon.
+      expect(
+        find.byKey(const Key('trajets_view_all_on_map')),
+        findsOneWidget,
+      );
+      final btn = tester.widget<IconButton>(
+        find.byKey(const Key('trajets_view_all_on_map')),
+      );
+      expect(btn.tooltip, 'View all on map');
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('trajets_view_all_on_map')),
+          matching: find.byIcon(Icons.map_outlined),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'map IconButton is present even with an empty trip list',
+        (tester) async {
+      await _pumpScreen(
+        tester,
+        activeVehicle: vehicle,
+        vehicles: [vehicle],
+      );
+
+      // The button is always present (empty tripIds list is valid for
+      // TrajetsMapScreen — it renders its own empty state).
+      expect(
+        find.byKey(const Key('trajets_view_all_on_map')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'standalone TextButton.icon row is absent from the body',
+        (tester) async {
+      final trips = <TripHistoryEntry>[
+        _entry(
+          id: 'trip-2',
+          vehicleId: 'v1',
+          startedAt: DateTime.utc(2026, 4, 22, 9),
+          distanceKm: 5.0,
+        ),
+      ];
+      await _pumpScreen(
+        tester,
+        trips: trips,
+        activeVehicle: vehicle,
+        vehicles: [vehicle],
+      );
+
+      // Pre-#2374 there was a TextButton.icon with this key in the
+      // body scroll area; it must be gone now.
+      expect(find.byType(TextButton), findsNothing);
+    });
+
+  });
 }


### PR DESCRIPTION
## Summary

- Moves the standalone full-width `TextButton.icon` row ("🗺 Alle auf Karte anzeigen") from `TrajetsTab` into the Trajets `AppBar` as a map `IconButton` (`Icons.map_outlined`), placed immediately before the download (↓) action
- Reuses the existing `trajetsViewAllOnMap` localized string as the tooltip (no new ARB keys, all 23 locales covered already)
- The `_buildTrajets` method in `ConsumptionScreen` computes the same vehicle-filtered trip IDs that `TrajetsTab` renders and passes them to `TrajetsMapScreen` — same navigation behaviour as before
- Three new widget tests assert: (1) map `IconButton` present with correct tooltip + `Icons.map_outlined` when trips exist, (2) button present even with empty list, (3) standalone `TextButton` is gone from the body

## Test plan

- [x] `flutter analyze lib/ test/` — no new issues
- [x] `flutter test test/features/consumption/ test/app/ test/lint/` — 3539 tests pass
- [x] `git diff --exit-code` — only 3 expected files changed, no codegen drift
- [x] 3 new widget tests green (`ConsumptionScreen Trajets — map AppBar action (#2374)`)

Closes #2374

🤖 Generated with [Claude Code](https://claude.com/claude-code)