### PR TITLE
fix(obd2): stop flooding the error log with recoverable OBD2 transients + fix storage mis-tag (#2379)

### DIFF
--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -141,11 +141,17 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       // is idempotent and a no-op when nothing is connected.
       try {
         await _device.disconnect();
-      } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-          'where':
-              'FlutterBluePlusElmChannel: pre-connect dead-GATT teardown',
-        }));
+      } catch (e, _) {
+        // Best-effort pre-connect teardown of a stale GATT client. The
+        // connect below proceeds (and recovers) regardless — a failure
+        // here is RECOVERABLE and routine, never an error trace (#2379).
+        // Debug-only.
+        assert(() {
+          debugPrint(
+              'FlutterBluePlusElmChannel: pre-connect dead-GATT teardown '
+              'failed (proceeding): $e');
+          return true;
+        }());
       }
       // The explicit ~4 s timeout is LOAD-BEARING: FBP's
       // autoConnect:false connect can otherwise block ~35 s.
@@ -180,7 +186,10 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
         // (via `_failPending`) instead of sitting until the 5 s read
         // timeout, and log it so the drop is visible in release.
         if (!_incoming.isClosed) _incoming.addError(e, st);
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+        // OBD2/BLE GATT/ATT error, not local storage — `other` ("not yet
+        // classified") is the correct layer (#2379). Kept logged: this is
+        // a real link drop worth seeing in release triage.
+        unawaited(errorLogger.log(ErrorLayer.other, e, st,
             context: const {'where': 'FlutterBluePlusElmChannel notify error'}));
       },
     );
@@ -278,7 +287,8 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     try {
       await _device.disconnect();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'FlutterBluePlusElmChannel: disconnect failed'}));
+      // OBD2/BLE layer, not local storage (#2379).
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FlutterBluePlusElmChannel: disconnect failed'}));
     }
     // #2295 — close the broadcast controller on dispose (symmetry with
     // ClassicElmChannel.close()) so it doesn't leak across a reconnect.

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -193,6 +193,7 @@ class Obd2ConnectionService {
     required Elm327Adapter adapter,
     required String mac,
     required String name,
+    bool logFailureAsError = true,
   }) async {
     // #2253/#2261 — build the session with the supported-PID + warm
     // negotiated-protocol caches wired in (see [buildObd2Session]).
@@ -211,9 +212,9 @@ class Obd2ConnectionService {
     // #2268 concern 3 — a no-op override suppresses the wake window for a
     // MAC observed never to need it; null ⇒ honour the adapter policy.
     final wakeOverride = await adapterWakeCache?.overrideFor(mac);
-    // #1330 — the per-adapter ELM327 adapter sets the init sequence/timing.
-    final ok =
-        await service.connect(adapter: adapter, wakePolicyOverride: wakeOverride);
+    // #1330 init. #2379 — recoverable attempts suppress the fail trace.
+    final ok = await service.connect(adapter: adapter,
+        wakePolicyOverride: wakeOverride, logFailureAsError: logFailureAsError);
     // #2268 concern 3 — persist the observed wake outcome (a no-op unless
     // the bounded window actually ran on this connect).
     await adapterWakeCache?.recordObservation(mac, service.wakeObservation);
@@ -234,7 +235,8 @@ class Obd2ConnectionService {
     try {
       return await connect(_lastRanked.first);
     } on Obd2ConnectionError catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'Obd2ConnectionService.connectBest failed'}));
+      // #2379 — OBD2/BLE → `other`; still logged (final, rethrown).
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Obd2ConnectionService.connectBest failed'}));
       rethrow;
     }
   }
@@ -307,16 +309,12 @@ class Obd2ConnectionService {
         adapter: generic.adapter,
         mac: mac,
         name: generic.displayName,
+        logFailureAsError: false, // #2379 — recoverable (scan fallback)
       );
-    } on Object catch (e, st) {
-      // Direct attempt failed (connect timeout, GATT 133, init timeout,
-      // missing characteristic, …). Close the half-open channel and
-      // fall back to the scan path so behaviour is never worse than
-      // today's [connectByMac].
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'Obd2ConnectionService.connectByMacDirect — '
-            'falling back to scan',
-      }));
+    } on Object catch (_) {
+      // #2379 — a RECOVERABLE attempt (scan fallback below routinely
+      // succeeds): NOT an error trace. Inner connect already suppressed
+      // its trace; the outcome is owned by the orchestrator + breadcrumbs.
       await _teardownLastDirectChannel();
       if (!fallbackToScan) return null;
       return connectByMac(mac);
@@ -342,9 +340,11 @@ class Obd2ConnectionService {
         adapter: generic.adapter,
         mac: mac,
         name: generic.displayName,
+        logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
       );
     } on Object catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      // #2379 — OBD2/BLE, not local storage.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'Obd2ConnectionService.connectByMacPassive failed',
       }));
       await _teardownLastDirectChannel();
@@ -359,7 +359,8 @@ class Obd2ConnectionService {
     try {
       await prior.close();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      // #2379 — OBD2/BLE, not local storage.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'Obd2ConnectionService: prior-direct-channel teardown',
       }));
     }

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -347,7 +347,7 @@ class Obd2Service implements Obd2RawCommandPort {
     try {
       return cache.get(key);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'OBD2 negotiated-protocol cache read failed',
       }));
       return null;
@@ -392,7 +392,7 @@ class Obd2Service implements Obd2RawCommandPort {
         await cache.put(key, digit);
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'OBD2 negotiated-protocol resolve/cache failed',
       }));
     }
@@ -450,9 +450,15 @@ class Obd2Service implements Obd2RawCommandPort {
   /// [WakePolicy.noop] to suppress the bounded wake window for a MAC the
   /// cache recorded as never-needing it. Null ⇒ use the adapter's policy
   /// (a no-op for every generic adapter, so behaviour is unchanged).
+  ///
+  /// [logFailureAsError] (#2379) — `false` returns `false` silently (no
+  /// error trace) for callers that immediately recover (direct-by-MAC +
+  /// scan fallback, passive autoConnect); the final failure is logged by
+  /// the orchestrator + breadcrumbs. Default `true` for the final attempt.
   Future<bool> connect({
     Elm327Adapter adapter = const GenericElm327Adapter(),
     WakePolicy? wakePolicyOverride,
+    bool logFailureAsError = true,
   }) async {
     // #1920 — trace the connect attempt so a failed recording session
     // can be analysed from the exportable OBD2 diagnostic log.
@@ -582,7 +588,7 @@ class Obd2Service implements Obd2RawCommandPort {
         _capabilityReconciled =
             _capability == Obd2AdapterCapability.standardOnly;
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 ATI firmware read failed'}));
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 ATI firmware read failed'}));
       }
 
       // #2261 concern 3 — read ATDPN to learn the negotiated protocol
@@ -603,7 +609,11 @@ class Obd2Service implements Obd2RawCommandPort {
       );
       return true;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 connect failed'}));
+      // #2379 — recoverable attempts suppress this; only a final failure
+      // logs (OBD2/BLE → `other`). The breadcrumb below always records it.
+      if (logFailureAsError) {
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 connect failed'}));
+      }
       // #1920 — record the failure so the diagnostic log shows the
       // connect attempt that never produced a session.
       AutoRecordTraceLog.add(
@@ -689,8 +699,9 @@ class Obd2Service implements Obd2RawCommandPort {
       final brand = vehicleBrandFromVin(vin);
       if (brand == VehicleBrand.unknown) return null;
       return _readOdometerFromCatalogByBrand(brand);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readOdometer failed'}));
+    } catch (_) {
+      // #2379 — best-effort one-shot: an engine-off car times this out
+      // routinely. NOT an error; the null return is the signal, no trace.
       return null;
     }
   }
@@ -760,7 +771,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.vehicleSpeedCommand);
       return Elm327Protocol.parseVehicleSpeed(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readSpeed failed'}));
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readSpeed failed'}));
       return null;
     }
   }
@@ -797,7 +808,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.engineRpmCommand);
       return Elm327Protocol.parseEngineRpm(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readRpm failed'}));
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readRpm failed'}));
       return null;
     }
   }
@@ -1143,7 +1154,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.fuelTypeCommand);
       return Elm327Protocol.parseFuelType(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readFuelType failed'}));
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readFuelType failed'}));
       return null;
     }
   }
@@ -1172,7 +1183,7 @@ class Obd2Service implements Obd2RawCommandPort {
       if (vin == null || vin.isEmpty) return null;
       return vin;
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 readVin failed'}));
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readVin failed'}));
       return null;
     }
   }
@@ -1307,7 +1318,7 @@ class Obd2Service implements Obd2RawCommandPort {
         // Best-effort: the user has already cancelled, no point
         // crashing on a STMP write that might fail because the
         // channel is mid-disconnect.
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 canFrameStream STMP failed'}));
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 canFrameStream STMP failed'}));
       }
     }
 
@@ -1388,7 +1399,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final probe = await probeMultiFrameCapability(_transport.sendCommand);
       _capability = reconcileCapabilityWithProbe(_claimedCapability, probe);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'OBD2 deferred capability probe failed',
       }));
     }
@@ -1409,7 +1420,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(command);
       return parser(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'OBD2 read $label failed'}));
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'OBD2 read $label failed'}));
       return null;
     }
   }

--- a/lib/features/consumption/data/obd2/pid_scheduler.dart
+++ b/lib/features/consumption/data/obd2/pid_scheduler.dart
@@ -55,6 +55,29 @@ class ScheduledPid {
 /// exceeds [tickRate] the next tick finds `_inFlight != null` and simply
 /// waits — the scheduler never queues commands behind a slow adapter.
 ///
+/// ## Transient-failure handling (#2379)
+///
+/// Per-PID transport failures (timeout, NO DATA, adapter dropped) are
+/// **expected and recoverable** — engine-off cars NO-DATA half their
+/// PIDs, and a slow clone times out intermittently. They are NOT error-
+/// logged one-per-PID-per-tick (which flooded a real user's error log
+/// with ~50 of 54 traces). Instead:
+///
+/// - Each subscription counts consecutive failures. After
+///   [_maxConsecutiveFailures] in a row the PID is **backed off**: its
+///   selection weight is recomputed at [_backoffHz] (≈ once per 30 s)
+///   instead of its configured hz, so it neither floods the adapter nor
+///   starves healthy PIDs. A single successful read resets the counter
+///   and restores full cadence. The `lastReadAt` anti-starvation stamp
+///   is kept on every attempt (success OR failure), so a backed-off PID
+///   still climbs weight and is retried — just rarely.
+/// - When the adapter looks broadly unresponsive ([_backoffThreshold]+
+///   PIDs backed off) a SINGLE rate-limited aggregated diagnostic is
+///   emitted, at most once per [_diagnosticWindow].
+///
+/// Recording is unaffected — a backed-off PID simply contributes fewer
+/// samples; the loop never stalls.
+///
 /// ## Phase 1 scope (#814)
 ///
 /// This class is the selection engine only. The follow-up phase wires it
@@ -66,6 +89,29 @@ class PidScheduler {
     this.tickRate = const Duration(milliseconds: 100),
     DateTime Function()? clock,
   }) : _clock = clock ?? DateTime.now;
+
+  /// Consecutive per-PID transport failures before the PID is backed off
+  /// to [_backoffHz]. Three covers a brief blip (one slow round-trip,
+  /// one NO-DATA) without flapping, while reacting within a few seconds
+  /// to a genuinely dead PID.
+  static const int _maxConsecutiveFailures = 3;
+
+  /// Effective refresh rate a backed-off PID is selected at — ≈ once per
+  /// 30 s. Low enough that a dead PID never crowds out healthy ones, high
+  /// enough that it resumes promptly the moment the engine starts / the
+  /// adapter recovers.
+  static const double _backoffHz = 1.0 / 30.0;
+
+  /// How many PIDs must be simultaneously backed off before the adapter
+  /// is considered "broadly unresponsive" and the aggregated diagnostic
+  /// is worth emitting. One dead PID (e.g. an unsupported optional PID)
+  /// is normal and silent; several at once signals a real problem.
+  static const int _backoffThreshold = 3;
+
+  /// Minimum gap between aggregated "adapter unresponsive" diagnostics.
+  /// Caps the diagnostic at ≤1 per this window no matter how many PIDs
+  /// time out per tick.
+  static const Duration _diagnosticWindow = Duration(seconds: 30);
 
   /// Sends one OBD-II command and returns the raw adapter response.
   /// Typically `Obd2Transport.sendCommand`.
@@ -86,6 +132,18 @@ class PidScheduler {
   bool _running = false;
   String? _inFlight;
   int _subscriptionCounter = 0;
+
+  /// When the last aggregated "adapter unresponsive" diagnostic was
+  /// emitted, used to rate-limit it to ≤1 per [_diagnosticWindow]. Null
+  /// until the first one fires.
+  DateTime? _lastDiagnosticAt;
+
+  /// Number of subscribed PIDs currently in the backed-off state
+  /// (consecutive failures ≥ [_maxConsecutiveFailures]). Exposed for
+  /// tests that assert backoff engaged / cleared.
+  @visibleForTesting
+  int get backedOffCount =>
+      _subs.values.where((s) => s.isBackedOff).length;
 
   /// Whether [start] has been called and [stop] has not yet run.
   bool get isRunning => _running;
@@ -169,7 +227,12 @@ class PidScheduler {
     if (last == null) return double.infinity;
     final elapsedMs = now.difference(last).inMicroseconds / 1000.0;
     if (elapsedMs <= 0) return 0.0;
-    return (elapsedMs / 1000.0) * sub.config.hz;
+    // A backed-off PID is selected at [_backoffHz] instead of its
+    // configured rate — far less often, so it neither floods the adapter
+    // nor starves healthy PIDs, while still being retried periodically so
+    // it resumes the instant it answers (#2379).
+    final hz = sub.isBackedOff ? _backoffHz : sub.config.hz;
+    return (elapsedMs / 1000.0) * hz;
   }
 
   /// Returns true if [candidateWeight]/[candidate] should replace
@@ -206,29 +269,61 @@ class PidScheduler {
     try {
       final response = await transport(command);
       sub.config.lastReadAt = _clock();
+      // A successful read clears any accumulated failure streak so the
+      // PID resumes its configured cadence immediately (#2379).
+      sub.consecutiveFailures = 0;
       // Check subscription still exists — user may have unsubscribed
       // while the adapter round-trip was in flight.
       if (_subs.containsKey(command)) {
         try {
           sub.onResult(response);
         } catch (e, st) {
-          // Callback errors must not stall the scheduler. Log and move on.
-          unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'PidScheduler: onResult for $command threw'}));
+          // Callback errors are a real HANDLER bug — keep them logged so
+          // they surface in triage. They live in OUR code, not the BLE
+          // link, so the layer is `other` ("not yet classified"), not
+          // `storage` (#2379).
+          unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+            'where': 'PidScheduler: onResult for $command threw',
+          }));
         }
       }
     } catch (e, st) {
-      // Transport failures (timeout, NO DATA, adapter dropped) must not
-      // deadlock the loop OR starve healthy PIDs. We stamp lastReadAt
-      // anyway so the failing PID stops winning every tick — otherwise
-      // two PIDs with identical hz and one failing forever would leave
-      // the healthy one starved by the FIFO tiebreaker. On the next
-      // round the failing PID still gets retried when its weight wins,
-      // just no more often than the cadence it was subscribed at.
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'PidScheduler: transport for $command threw'}));
+      // Transport failures (timeout, NO DATA, adapter dropped) are
+      // EXPECTED and recoverable — an engine-off car NO-DATAs many PIDs,
+      // a slow clone times out intermittently. Logging one error trace
+      // per PID per tick flooded a real user's error log (#2379), so we
+      // do NOT error-log them here.
+      //
+      // We still stamp lastReadAt (anti-starvation: a forever-failing PID
+      // must stop winning every tick or it would starve a healthy PID
+      // tied on hz via the FIFO tiebreaker) and bump the failure streak.
+      // Past [_maxConsecutiveFailures] the PID backs off to [_backoffHz]
+      // (see [_weightFor]); a later success resets it.
       sub.config.lastReadAt = _clock();
+      sub.consecutiveFailures++;
+      _maybeEmitUnresponsiveDiagnostic(e, st);
     } finally {
       _inFlight = null;
     }
+  }
+
+  /// Emit AT MOST ONE aggregated "adapter unresponsive" diagnostic per
+  /// [_diagnosticWindow] when [_backoffThreshold]+ PIDs are backed off.
+  /// Replaces the old one-error-per-PID-per-tick flood with a single
+  /// rate-limited breadcrumb that still makes a broadly-dead adapter
+  /// visible in triage (#2379).
+  void _maybeEmitUnresponsiveDiagnostic(Object error, StackTrace stack) {
+    final downCount = backedOffCount;
+    if (downCount < _backoffThreshold) return;
+    final now = _clock();
+    final last = _lastDiagnosticAt;
+    if (last != null && now.difference(last) < _diagnosticWindow) return;
+    _lastDiagnosticAt = now;
+    unawaited(errorLogger.log(ErrorLayer.other, error, stack, context: {
+      'where': 'PidScheduler: OBD2 adapter unresponsive — '
+          '$downCount PIDs timing out',
+      'backedOffPids': downCount,
+    }));
   }
 }
 
@@ -244,4 +339,14 @@ class _Subscription {
 
   /// Monotonic subscription index used for FIFO tie-breaking.
   final int order;
+
+  /// Consecutive transport failures since the last successful read. Reset
+  /// to 0 on any success. Drives the [isBackedOff] state (#2379).
+  int consecutiveFailures = 0;
+
+  /// True once this PID has failed [PidScheduler._maxConsecutiveFailures]
+  /// times in a row — it is then selected at the slow backoff rate until
+  /// it next answers.
+  bool get isBackedOff =>
+      consecutiveFailures >= PidScheduler._maxConsecutiveFailures;
 }

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -6,6 +6,9 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_bluetooth_facade.dart';
@@ -401,6 +404,145 @@ void main() {
     });
   });
 
+  // ── #2379 — recovered-attempt connect logs must not flood ───────────
+  group('Obd2ConnectionService — connect-retry error-logging (#2379)', () {
+    late _CaptureRecorder recorder;
+
+    setUp(() {
+      errorLogger.resetForTest();
+      recorder = _CaptureRecorder();
+      errorLogger.testRecorderOverride = recorder;
+    });
+
+    tearDown(() {
+      // Restore the file-wide spool silencer that setUpAll installed.
+      errorLogger.resetForTest();
+      errorLogger.spoolEnqueueOverride = ({
+        required String isolateTaskName,
+        required Object error,
+        StackTrace? stack,
+        Map<String, dynamic>? contextMap,
+        DateTime? timestamp,
+      }) async {};
+    });
+
+    test(
+        'a direct attempt RECOVERED by the scan fallback emits NO '
+        '"falling back to scan" error trace (#2379)', () async {
+      // Direct channel.open() throws (connect timeout / GATT 133); the
+      // scan batch carries the same MAC so the fallback connectByMac
+      // succeeds. The direct attempt's own channel never reaches the
+      // ELM init, so the only thing this path used to log was the
+      // (now-suppressed) "falling back to scan" trace.
+      final fake = _FakeFacade(
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        channel: _FakeChannel(respondTo: _elmOkResponses()),
+        directChannel: _FakeChannel(
+          openError: StateError('connect timed out'),
+        ),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+
+      expect(ready, isNotNull, reason: 'scan fallback recovered the connect');
+      expect(fake.scanInvoked, isTrue);
+      // THE fix: the recovered first attempt is no longer an error trace.
+      // (The channel.open() throw is swallowed by Obd2Service.connect's
+      // transport.connect(), which on this code path logs nothing because
+      // open() — not init — failed, then connectByMacDirect's catch is now
+      // debug-only.) Net: a clean recovery with zero error traces.
+      expect(recorder.calls, isEmpty,
+          reason: 'a connect attempt recovered by the fallback flooded the '
+              'user error log — it must now be silent');
+      // Specifically: no "falling back to scan" trace survives.
+      expect(
+        recorder.calls
+            .whereType<ContextualError>()
+            .where((e) => e.toString().contains('falling back to scan')),
+        isEmpty,
+      );
+      await ready!.disconnect();
+    });
+
+    test(
+        'when BOTH direct AND scan fallback fail, connectByMacDirect emits '
+        'no "falling back to scan" trace (#2379)', () async {
+      // The recovered-attempt log is gone; the ultimate failure is owned
+      // upstream (RecordingStartCoordinator + AutoRecord breadcrumbs).
+      final fake = _FakeFacade(
+        batches: const [[]], // empty scan ⇒ connectByMac returns null
+        directChannel: _FakeChannel(
+          openError: StateError('connect timed out'),
+        ),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      final ready = await svc.connectByMacDirect('aa:bb');
+      expect(ready, isNull);
+      expect(
+        recorder.calls
+            .whereType<ContextualError>()
+            .where((e) => e.toString().contains('falling back to scan')),
+        isEmpty,
+        reason: 'connectByMacDirect no longer logs its recovered/retried '
+            'attempt — the caller owns the final-failure trace',
+      );
+      // And nothing that does survive carries the storage layer.
+      expect(
+        recorder.calls
+            .whereType<ContextualError>()
+            .where((e) => e.layer == ErrorLayer.storage),
+        isEmpty,
+        reason: 'no OBD2/BLE error may carry the storage layer',
+      );
+    });
+
+    test(
+        'a genuinely unrecovered connect failure (connectBest) IS still '
+        'logged — under ErrorLayer.other, never storage (#2379)', () async {
+      // connectBest surfaces a real, unrecovered failure to its caller
+      // (it rethrows). That genuine failure stays logged — but tagged
+      // `other`, not `storage`.
+      final fake = _FakeFacade(
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'aa:bb',
+              deviceName: 'vLinker FD',
+              advertisedServiceUuids: const [],
+              rssi: -55,
+            ),
+          ],
+        ],
+        // Silent channel ⇒ init never completes ⇒ Obd2AdapterUnresponsive.
+        channel: _FakeChannel(silent: true),
+      );
+      final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
+
+      // Populate _lastRanked so connectBest has a candidate to try.
+      await svc.scan(timeout: const Duration(milliseconds: 50)).toList();
+
+      await expectLater(svc.connectBest(), throwsA(isA<Obd2ConnectionError>()));
+      final logged = recorder.calls.whereType<ContextualError>().toList();
+      expect(logged, isNotEmpty,
+          reason: 'a genuinely unrecovered connect failure stays in triage');
+      expect(logged.every((e) => e.layer == ErrorLayer.other), isTrue,
+          reason: 'OBD2/BLE failures must not carry the storage layer');
+      expect(logged.any((e) => e.toString().contains('connectBest failed')),
+          isTrue);
+    });
+  });
+
   group('Obd2ConnectionService.connectByMacPassive (#2261 concern 2)', () {
     test(
         'opens an autoConnect channel, NO scan, NO bounded timeout, '
@@ -561,6 +703,25 @@ void main() {
 }
 
 // --- helpers ---------------------------------------------------------
+
+/// Captures every `errorLogger.log` routed through the foreground
+/// recorder seam without a Hive / Riverpod stack (#2379).
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
 
 Obd2ConnectionService _build({
   required Obd2PermissionState permState,

--- a/test/features/consumption/data/obd2/obd2_service_odometer_logging_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_odometer_logging_test.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// #2379 — `readOdometerKm` is a best-effort one-shot that already returns
+/// null on failure. A timeout (engine off / odometer-not-readable car)
+/// flooded a real user's error log, so its catch must NOT produce an
+/// error trace. This file pins that contract.
+
+const _initResponses = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+};
+
+/// Odometer-chain commands `readOdometerKm` walks: standard PID A6, the
+/// distance-since-DTC-cleared PID 31, and the VIN probe 0902. The engine-
+/// off car times these out.
+const _odometerChain = {'01A6', '0131', '0902'};
+
+/// Transport that completes connect() + init normally (unknown init/AT
+/// commands answer the benign `NO DATA>`, matching [FakeObd2Transport]),
+/// but throws a [TimeoutException] for the odometer-chain commands —
+/// exactly the engine-off-car scenario from the user logs.
+class _OdometerTimingOutTransport implements Obd2Transport {
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    if (_odometerChain.contains(cmd)) {
+      throw TimeoutException('ELM327 did not respond within 2.5s');
+    }
+    // AT init handshake + everything else answers benignly so connect()
+    // fully succeeds (no connect-path error to confound the assertion).
+    return _initResponses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+}
+
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _CaptureRecorder recorder;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CaptureRecorder();
+    errorLogger.testRecorderOverride = recorder;
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  test(
+      'readOdometerKm timeout returns null and logs NO error trace (#2379)',
+      () async {
+    final service = Obd2Service(_OdometerTimingOutTransport());
+    await service.connect();
+    // Guard: connect() itself produced no error trace, so any trace seen
+    // after readOdometerKm would be attributable to the odometer path.
+    expect(recorder.calls, isEmpty,
+        reason: 'connect() should be quiet for this transport');
+
+    final km = await service.readOdometerKm();
+
+    expect(km, isNull, reason: 'best-effort: a timeout yields null');
+    expect(recorder.calls, isEmpty,
+        reason: 'a readOdometer timeout is expected/recoverable — it must '
+            'not pollute the error log');
+  });
+}

--- a/test/features/consumption/data/obd2/pid_scheduler_test.dart
+++ b/test/features/consumption/data/obd2/pid_scheduler_test.dart
@@ -2,8 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/pid_scheduler.dart';
 import '../../../../helpers/silence_error_logger.dart';
+
+/// Captures every `errorLogger.log` call routed through the foreground
+/// recorder seam, without standing up Hive / Riverpod (#2379). Mirrors
+/// the fake in `test/core/logging/error_logger_test.dart`.
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
 
 /// Helper: build a scheduler wired to a deterministic clock. The returned
 /// `advance` function bumps the clock forward by [d] — use it instead of
@@ -376,6 +399,235 @@ void main() {
       expect(scheduler.pickNextCommand(now), '010C');
       scheduler.unsubscribe('010C');
       expect(scheduler.pickNextCommand(now), '010D');
+    });
+  });
+
+  // ── #2379 — transient-failure handling ──────────────────────────────
+  //
+  // These tests bind a capture recorder so they assert on what reached
+  // `errorLogger.log`. They run with a deterministic clock so backoff /
+  // rate-limit windows are advanced precisely rather than waited out.
+  group('PidScheduler — transient per-PID transport failures (#2379)', () {
+    late _CaptureRecorder recorder;
+
+    setUp(() {
+      errorLogger.resetForTest();
+      recorder = _CaptureRecorder();
+      errorLogger.testRecorderOverride = recorder;
+    });
+
+    tearDown(() {
+      // Re-install the file-wide spool silencer that setUpAll wired, so
+      // the selection-math group above keeps passing after these tests.
+      errorLogger.resetForTest();
+      errorLogger.spoolEnqueueOverride = ({
+        required String isolateTaskName,
+        required Object error,
+        StackTrace? stack,
+        Map<String, dynamic>? contextMap,
+        DateTime? timestamp,
+      }) async {};
+    });
+
+    /// Lets at least one real periodic tick fire (the scheduler's
+    /// `tickRate` is a real-wall-clock [Timer], even when the *weight*
+    /// clock is faked) and then drains the microtask queue so the
+    /// in-flight transport future + its catch/onResult settle before the
+    /// assertion runs.
+    Future<void> pump([Duration d = const Duration(milliseconds: 12)]) async {
+      await Future<void>.delayed(d);
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test(
+        'a single per-PID timeout logs NO error trace (no flood) but the '
+        'loop keeps advancing', () async {
+      // 010C times out every read; 010D is healthy. With one failure the
+      // PID is NOT yet backed off and — critically — nothing is logged.
+      final transport = _FakeTransport(throwOn: {'010C'});
+      final scheduler = PidScheduler(
+        transport: transport.call,
+        tickRate: const Duration(milliseconds: 20),
+      );
+      var goodReads = 0;
+      scheduler
+        ..subscribe('010C', ScheduledPid(hz: 5.0), (_) {})
+        ..subscribe('010D', ScheduledPid(hz: 5.0), (_) => goodReads++)
+        ..start();
+
+      // Just long enough for a couple of ticks — one or two 010C failures.
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      scheduler.stop();
+      await pump();
+
+      expect(transport.calls, contains('010C'),
+          reason: 'the failing PID was actually attempted');
+      expect(goodReads, greaterThanOrEqualTo(1),
+          reason: 'the healthy PID kept being polled');
+      // THE fix: a transient per-PID transport failure produces zero
+      // error traces (it used to log one per PID per tick).
+      expect(recorder.calls, isEmpty,
+          reason: 'transient per-PID failures must not be error-logged');
+    });
+
+    test(
+        'an onResult handler bug IS still logged — under ErrorLayer.other, '
+        'never storage', () async {
+      final transport = _FakeTransport();
+      final scheduler = PidScheduler(
+        transport: transport.call,
+        tickRate: const Duration(milliseconds: 20),
+      );
+      scheduler
+        ..subscribe('010C', ScheduledPid(hz: 5.0),
+            (_) => throw StateError('handler bug'))
+        ..start();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      scheduler.stop();
+      await pump();
+
+      expect(recorder.calls, isNotEmpty,
+          reason: 'a real handler bug must stay visible in triage');
+      final logged = recorder.calls.whereType<ContextualError>().toList();
+      expect(logged, isNotEmpty);
+      expect(logged.every((e) => e.layer == ErrorLayer.other), isTrue,
+          reason: 'OBD2/BLE diagnostics must not carry the storage layer');
+      expect(logged.any((e) => e.inner is StateError), isTrue);
+    });
+
+    test(
+        'a PID backs off after N consecutive failures and resumes full '
+        'cadence on the next success', () async {
+      // `failing` gates the transport: while true the PID times out, when
+      // flipped false it answers. This makes the test robust to tick
+      // jitter — we assert the STATE transition, not an exact tick count.
+      var fakeNow = DateTime(2026, 1, 1, 12);
+      var failing = true;
+      Future<String> transport(String command) async {
+        if (failing) throw Exception('timeout');
+        return '41 0C 00>';
+      }
+
+      final scheduler = PidScheduler(
+        transport: transport,
+        tickRate: const Duration(milliseconds: 5),
+        clock: () => fakeNow,
+      );
+      var reads = 0;
+      scheduler.subscribe('010C', ScheduledPid(hz: 5.0), (_) => reads++);
+      scheduler.start();
+
+      // Pump until the PID has accumulated ≥ N consecutive failures and
+      // engaged backoff. (Advancing fakeNow keeps successive reads
+      // distinct so the single PID keeps winning selection.)
+      for (var i = 0; i < 6 && scheduler.backedOffCount == 0; i++) {
+        await pump();
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      expect(scheduler.backedOffCount, 1,
+          reason: 'N consecutive failures must engage backoff');
+      expect(reads, 0, reason: 'nothing answered yet');
+
+      // Adapter recovers. While backed off the PID polls at ~1/30 Hz, so
+      // a sub-window gap would NOT select it — but a 31 s gap clears its
+      // backoff weight and it is retried, succeeds, and resets.
+      failing = false;
+      fakeNow = fakeNow.add(const Duration(seconds: 31));
+      await pump();
+      expect(reads, greaterThanOrEqualTo(1),
+          reason: 'a backed-off PID is still retried, just rarely');
+      expect(scheduler.backedOffCount, 0,
+          reason: 'a single success resets the failure streak → full cadence');
+
+      scheduler.stop();
+      await pump();
+      expect(recorder.calls, isEmpty,
+          reason: 'one dead PID (< threshold) never error-logs');
+    });
+
+    test(
+        'healthy PIDs are NOT starved while one PID is permanently dead',
+        () async {
+      // 010C always fails; 010D + 0111 are healthy. The dead PID must not
+      // crowd out the healthy ones once it is backed off.
+      final transport = _FakeTransport(throwOn: {'010C'});
+      final scheduler = PidScheduler(
+        transport: transport.call,
+        tickRate: const Duration(milliseconds: 10),
+      );
+      final reads = <String, int>{'010D': 0, '0111': 0};
+      scheduler
+        ..subscribe('010C', ScheduledPid(hz: 5.0), (_) {})
+        ..subscribe('010D', ScheduledPid(hz: 5.0),
+            (_) => reads['010D'] = reads['010D']! + 1)
+        ..subscribe('0111', ScheduledPid(hz: 5.0),
+            (_) => reads['0111'] = reads['0111']! + 1)
+        ..start();
+
+      await Future<void>.delayed(const Duration(milliseconds: 600));
+      scheduler.stop();
+      await pump();
+
+      for (final entry in reads.entries) {
+        expect(entry.value, greaterThanOrEqualTo(3),
+            reason: '${entry.key} starved by the dead 010C — backoff failed');
+      }
+    });
+
+    test(
+        'the aggregated "adapter unresponsive" diagnostic is rate-limited '
+        'to ≤1 per window', () async {
+      // Four PIDs all time out → past the backoff threshold. Over many
+      // ticks the aggregated diagnostic must fire AT MOST ONCE per window.
+      var fakeNow = DateTime(2026, 1, 1, 12);
+      Future<String> transport(String command) async {
+        throw Exception('timeout');
+      }
+
+      final scheduler = PidScheduler(
+        transport: transport,
+        tickRate: const Duration(milliseconds: 5),
+        clock: () => fakeNow,
+      );
+      for (final pid in ['010C', '010D', '0105', '0106']) {
+        scheduler.subscribe(pid, ScheduledPid(hz: 5.0), (_) {});
+      }
+      scheduler.start();
+
+      // Pump ~40 ticks across ~10 s of simulated time. All four PIDs back
+      // off; the diagnostic could fire on every one of dozens of failing
+      // ticks if it weren't rate-limited.
+      for (var i = 0; i < 40; i++) {
+        await pump();
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      scheduler.stop();
+      await pump();
+
+      final diagnostics = recorder.calls
+          .whereType<ContextualError>()
+          .where((e) => e.toString().contains('adapter unresponsive'))
+          .toList();
+      expect(diagnostics, hasLength(1),
+          reason: 'within a single 30 s window only one diagnostic may fire');
+      expect(diagnostics.single.layer, ErrorLayer.other);
+
+      // Cross the 30 s window and pump again — a second diagnostic is now
+      // allowed (proving it is windowed, not one-shot).
+      fakeNow = fakeNow.add(const Duration(seconds: 31));
+      scheduler.start();
+      for (var i = 0; i < 4; i++) {
+        await pump();
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      scheduler.stop();
+      await pump();
+      final after = recorder.calls
+          .whereType<ContextualError>()
+          .where((e) => e.toString().contains('adapter unresponsive'))
+          .toList();
+      expect(after.length, greaterThanOrEqualTo(2),
+          reason: 'a fresh window permits another diagnostic');
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -51,7 +51,12 @@ void main() {
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
     'lib/features/consumption/data/obd2/elm327_parsers.dart': 457,
     'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 471,
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1457,
+    // #2379 — re-grandfathered 1457 → 1468: threaded the
+    // `logFailureAsError` flag through `connect()` (param + doc + the
+    // guarded `if` around the now-conditional connect-failed trace) so a
+    // recoverable connect attempt stops flooding the error log. Net +11;
+    // decomposition is tracked separately by #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1468,
     'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1235,
     'lib/features/consumption/presentation/screens/add_fill_up_screen.dart':
         496,


### PR DESCRIPTION
Closes #2379.

A real user's error log was ~50 of 54 traces of **expected/recoverable** OBD2/BLE conditions — engine-off PID timeouts every ~2.5 s, plus a first direct-connect attempt that the scan fallback then recovered — all mis-tagged `[storage]`. None of these are errors; they should not pollute the error log.

## Per-site changes

**1. PidScheduler — THE flood** (`lib/features/consumption/data/obd2/pid_scheduler.dart`)
- Per-PID transport failures (timeout / NO DATA / drop) no longer error-log one trace per PID per tick.
- Each PID counts consecutive failures; after **3** in a row it **backs off** to `~1/30 Hz` selection weight (`_weightFor`), so it neither floods the adapter nor starves healthy PIDs. The existing `lastReadAt` anti-starvation stamp is kept on every attempt, and a backed-off PID is still retried periodically. A single success resets the streak → full cadence.
- When **≥3 PIDs** are simultaneously backed off, ONE **rate-limited aggregated** diagnostic ("OBD2 adapter unresponsive — N PIDs timing out") fires **at most once per 30 s** (`_maybeEmitUnresponsiveDiagnostic`), not one-per-PID-per-tick.
- The `onResult` callback-error catch (a real handler bug) stays logged, re-tagged `ErrorLayer.other`.

**2. readOdometer** (`obd2_service.dart`)
- Best-effort one-shot; an engine-off timeout no longer logs. The existing `null` return is the signal.

**3. Connect retries** (`obd2_connection_service.dart`, `obd2_service.dart`)
- Threaded `logFailureAsError` through `Obd2Service.connect`: the **recoverable** attempts (direct-by-MAC with its scan fallback, passive autoConnect) suppress their own "connect failed" trace; the **final** attempt (scan-picker / `connectBest`) keeps it.
- Dropped the `connectByMacDirect` "falling back to scan" trace — the recovered outcome is owned by `RecordingStartCoordinator` + the `AutoRecord` breadcrumbs.
- Verified call graph: `RecordingStartCoordinator.connectAndStart → connectByMacDirect → _openAndInit → Obd2Service.connect`. Only the recovered attempt is suppressed; final failure still logs (`connectBest` rethrow, coordinator catch, breadcrumbs).

**4. ErrorLayer mis-tag**
- Every OBD2/BLE `errorLogger.log(ErrorLayer.storage, …)` in `pid_scheduler`, `obd2_service`, `obd2_connection_service`, `flutter_blue_plus_elm_channel` → `ErrorLayer.other` (no new enum value; avoids the feature-enum cascade). Genuinely-unrecoverable failures stay logged, correctly tagged.

## Parameters chosen
- `_maxConsecutiveFailures = 3` — absorbs a brief blip, reacts within a few seconds to a dead PID.
- `_backoffHz = 1/30` (≈ once per 30 s) — a dead PID never crowds out healthy ones; resumes promptly on recovery.
- `_backoffThreshold = 3` PIDs — one dead optional PID is normal/silent; several at once = real problem.
- `_diagnosticWindow = 30 s` — caps the aggregated diagnostic at ≤1/window.

## How the logged scenario now yields ~0 traces
- Replaying connected-adapter + engine-off → per-PID timeouts: PidScheduler logs **nothing** per tick (verified by a unit test asserting zero `errorLogger` calls on a single timeout), and the aggregated diagnostic is capped at ≤1 per 30 s window even across 40 failing ticks.
- First direct-connect attempt recovered by scan: `connectByMacDirect` recovered path produces **zero** error traces (unit test) — both the inner `connect failed` (now suppressed via `logFailureAsError:false`) and the outer "falling back to scan" trace are gone.

## Gate
- `flutter analyze lib/ test/`: no new issues (2 pre-existing `info` in untouched files: `radius_alert_map_picker.dart`, `trip_kind_from_samples_test.dart`).
- `flutter test test/features/consumption/ test/lint/ --exclude-tags=network`: **3294 passed**, 6 skipped.
- `dart run build_runner build`: clean — `git diff` shows no `.g.dart` / `.freezed.dart` drift.
- File-length: `obd2_connection_service.dart` trimmed to 399 (< 400 cap); `obd2_service.dart` re-grandfathered 1457 → 1468 with a justifying comment.

## Tests added
- PidScheduler: single transient failure logs nothing; backs off after N consecutive + resumes on success; healthy PIDs not starved by a dead PID; aggregated diagnostic ≤1/window; handler bug still logged as `other`.
- `obd2_service_odometer_logging_test.dart`: readOdometer timeout returns null + logs nothing.
- Obd2ConnectionService: recovered connect logs no error; final `connectBest` failure logs once as `other`; no OBD2 path carries `ErrorLayer.storage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
