### PR TITLE
feat(price-history): readable Preisverlauf chart — price/date axes + tap tooltip (#2384)

### DIFF
--- a/lib/features/price_history/presentation/widgets/price_chart.dart
+++ b/lib/features/price_history/presentation/widgets/price_chart.dart
@@ -5,74 +5,193 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../../../../core/theme/fuel_colors.dart';
+import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../domain/entities/price_record.dart';
+import 'price_chart_axes.dart';
 
 /// A simple line chart that renders price history using [CustomPainter].
 ///
 /// No external chart library required. Draws a line from oldest (left)
-/// to newest (right) with dashed min/max reference lines.
-class PriceChart extends StatelessWidget {
+/// to newest (right) with dashed min/max reference lines, a price (€)
+/// Y-axis scale, date X-axis labels, and a tap/long-press tooltip that
+/// reveals the price + date of the nearest data point (#2384).
+class PriceChart extends StatefulWidget {
   final List<PriceRecord> records;
   final FuelType fuelType;
 
   const PriceChart({super.key, required this.records, required this.fuelType});
 
   @override
+  State<PriceChart> createState() => _PriceChartState();
+
+  /// Builds the ordered, oldest→newest list of plottable points for
+  /// [records] / [fuelType]. Exposed for testing the axis/label maths.
+  @visibleForTesting
+  static List<ChartPoint> pointsFor(
+    List<PriceRecord> records,
+    FuelType fuelType,
+  ) {
+    final reversed = records.reversed.toList();
+    final points = <ChartPoint>[];
+    for (int i = 0; i < reversed.length; i++) {
+      final price = priceForFuelType(reversed[i], fuelType);
+      if (price != null) {
+        points.add(ChartPoint(
+          index: i,
+          price: price,
+          date: reversed[i].recordedAt,
+        ));
+      }
+    }
+    return points;
+  }
+}
+
+class _PriceChartState extends State<PriceChart> {
+  /// Data-point index of the currently highlighted point (tap/long-press),
+  /// or null when nothing is selected.
+  int? _selected;
+
+  static const double _chartHeight = 132;
+
+  @override
+  void didUpdateWidget(PriceChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.records != widget.records ||
+        oldWidget.fuelType != widget.fuelType) {
+      _selected = null;
+    }
+  }
+
+  void _handlePointer(Offset localPos, Size size, List<ChartPoint> points) {
+    if (points.length < 2) return;
+    final nearest = PriceChartAxes.nearestPointIndex(localPos, size, points);
+    if (nearest != _selected) {
+      setState(() => _selected = nearest);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (records.isEmpty) {
+    if (widget.records.isEmpty) {
       final l = AppLocalizations.of(context);
       return SizedBox(
-        height: 120,
+        height: _chartHeight,
         child: Center(child: Text(l?.noPriceHistory ?? 'No price history yet')),
       );
     }
+
+    final theme = Theme.of(context);
+    final color = FuelColors.forType(widget.fuelType);
+    final points = PriceChart.pointsFor(widget.records, widget.fuelType);
+    final locale = Localizations.localeOf(context).toString();
+    final dateFormat = DateFormat.Md(locale);
+
+    final selected =
+        (_selected != null && _selected! < points.length) ? _selected : null;
+
     return SizedBox(
-      height: 120,
-      child: CustomPaint(
-        painter: _PriceChartPainter(
-          records: records,
-          fuelType: fuelType,
-          color: FuelColors.forType(fuelType),
+      height: _chartHeight,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final size = Size(constraints.maxWidth, constraints.maxHeight);
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapDown: (d) => _handlePointer(d.localPosition, size, points),
+            onLongPressStart: (d) =>
+                _handlePointer(d.localPosition, size, points),
+            onLongPressMoveUpdate: (d) =>
+                _handlePointer(d.localPosition, size, points),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Positioned.fill(
+                  child: CustomPaint(
+                    painter: _PriceChartPainter(
+                      points: points,
+                      color: color,
+                      axisColor: theme.colorScheme.onSurfaceVariant,
+                      dateFormat: dateFormat,
+                      selectedIndex: selected,
+                    ),
+                  ),
+                ),
+                if (selected != null)
+                  _PriceTooltip(
+                    point: points[selected],
+                    dateFormat: dateFormat,
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A small callout showing the selected point's price + date, e.g.
+/// "2,069 € · 23.05". Rendered as a real widget so it is legible at any
+/// scale and testable via `find.textContaining`.
+class _PriceTooltip extends StatelessWidget {
+  final ChartPoint point;
+  final DateFormat dateFormat;
+
+  const _PriceTooltip({required this.point, required this.dateFormat});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label =
+        '${PriceFormatter.formatPrice(point.price)} · ${dateFormat.format(point.date)}';
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.inverseSurface,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onInverseSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
         ),
-        size: Size.infinite,
       ),
     );
   }
 }
 
 class _PriceChartPainter extends CustomPainter {
-  final List<PriceRecord> records;
-  final FuelType fuelType;
+  final List<ChartPoint> points;
   final Color color;
+  final Color axisColor;
+  final DateFormat dateFormat;
+  final int? selectedIndex;
 
   _PriceChartPainter({
-    required this.records,
-    required this.fuelType,
+    required this.points,
     required this.color,
+    required this.axisColor,
+    required this.dateFormat,
+    required this.selectedIndex,
   });
 
   @override
   void paint(Canvas canvas, Size size) {
-    // Extract prices for the given fuel type, paired with their index
-    // Records are newest-first from the repository, so we reverse for
-    // left = oldest, right = newest.
-    final reversed = records.reversed.toList();
-    final dataPoints = <_DataPoint>[];
-
-    for (int i = 0; i < reversed.length; i++) {
-      final price = _priceForFuelType(reversed[i], fuelType);
-      if (price != null) {
-        dataPoints.add(_DataPoint(index: i, price: price));
-      }
-    }
-
-    if (dataPoints.isEmpty) return;
-    if (dataPoints.length == 1) {
-      // Single point: draw a dot in the center
+    if (points.isEmpty) return;
+    if (points.length == 1) {
       final dotPaint = Paint()
         ..color = color
         ..style = PaintingStyle.fill;
@@ -84,58 +203,37 @@ class _PriceChartPainter extends CustomPainter {
       return;
     }
 
-    // Determine Y axis bounds with a small padding
-    final prices = dataPoints.map((d) => d.price).toList();
-    final minPrice = prices.reduce(math.min);
-    final maxPrice = prices.reduce(math.max);
+    final layout = PriceChartAxes.layout(size, points);
 
-    // Add 5% padding top and bottom, handle case where min == max
-    final range = maxPrice - minPrice;
-    final padding = range > 0 ? range * 0.1 : 0.01;
-    final yMin = minPrice - padding;
-    final yMax = maxPrice + padding;
-
-    // Chart area with insets for labels
-    const leftInset = 8.0;
-    const rightInset = 8.0;
-    const topInset = 8.0;
-    const bottomInset = 8.0;
-
-    final chartWidth = size.width - leftInset - rightInset;
-    final chartHeight = size.height - topInset - bottomInset;
-
-    double xForIndex(int idx) {
-      if (dataPoints.length == 1) return leftInset + chartWidth / 2;
-      final first = dataPoints.first.index;
-      final last = dataPoints.last.index;
-      final totalSpan = last - first;
-      if (totalSpan == 0) return leftInset + chartWidth / 2;
-      return leftInset + ((idx - first) / totalSpan) * chartWidth;
+    // Y-axis price gridlines (min / mid / max) with €-labels.
+    for (final tick in layout.priceTicks) {
+      final y = layout.yForPrice(tick);
+      _drawLabel(
+        canvas,
+        PriceFormatter.formatPrice(tick),
+        Offset(0, y),
+        anchorMiddle: true,
+      );
     }
 
-    double yForPrice(double price) {
-      return topInset + chartHeight - ((price - yMin) / (yMax - yMin)) * chartHeight;
-    }
-
-    // Draw dashed horizontal lines for min and max
+    // Dashed horizontal guides for the observed min and max prices.
+    final guidePaint = Paint()
+      ..color = color.withAlpha(60)
+      ..strokeWidth = 1;
     _drawDashedLine(
       canvas,
-      Offset(leftInset, yForPrice(minPrice)),
-      Offset(size.width - rightInset, yForPrice(minPrice)),
-      Paint()
-        ..color = color.withAlpha(60)
-        ..strokeWidth = 1,
+      Offset(layout.left, layout.yForPrice(layout.minPrice)),
+      Offset(layout.right, layout.yForPrice(layout.minPrice)),
+      guidePaint,
     );
     _drawDashedLine(
       canvas,
-      Offset(leftInset, yForPrice(maxPrice)),
-      Offset(size.width - rightInset, yForPrice(maxPrice)),
-      Paint()
-        ..color = color.withAlpha(60)
-        ..strokeWidth = 1,
+      Offset(layout.left, layout.yForPrice(layout.maxPrice)),
+      Offset(layout.right, layout.yForPrice(layout.maxPrice)),
+      guidePaint,
     );
 
-    // Draw the price line
+    // The price line.
     final linePaint = Paint()
       ..color = color
       ..strokeWidth = 2.0
@@ -144,43 +242,100 @@ class _PriceChartPainter extends CustomPainter {
       ..strokeJoin = StrokeJoin.round;
 
     final path = Path();
-    path.moveTo(
-      xForIndex(dataPoints.first.index),
-      yForPrice(dataPoints.first.price),
-    );
-    for (int i = 1; i < dataPoints.length; i++) {
+    path.moveTo(layout.xForIndex(points.first.index),
+        layout.yForPrice(points.first.price));
+    for (int i = 1; i < points.length; i++) {
       path.lineTo(
-        xForIndex(dataPoints[i].index),
-        yForPrice(dataPoints[i].price),
-      );
+          layout.xForIndex(points[i].index), layout.yForPrice(points[i].price));
     }
     canvas.drawPath(path, linePaint);
 
-    // Draw gradient fill under the line
-    final fillPath = Path.from(path);
-    fillPath.lineTo(xForIndex(dataPoints.last.index), size.height - bottomInset);
-    fillPath.lineTo(xForIndex(dataPoints.first.index), size.height - bottomInset);
-    fillPath.close();
-
+    // Gradient fill under the line.
+    final fillPath = Path.from(path)
+      ..lineTo(layout.xForIndex(points.last.index), layout.bottom)
+      ..lineTo(layout.xForIndex(points.first.index), layout.bottom)
+      ..close();
     final fillPaint = Paint()
       ..shader = ui.Gradient.linear(
-        const Offset(0, topInset),
-        Offset(0, size.height - bottomInset),
+        Offset(0, layout.top),
+        Offset(0, layout.bottom),
         [color.withAlpha(40), color.withAlpha(5)],
       );
     canvas.drawPath(fillPath, fillPaint);
 
-    // Draw dots at each data point
+    // Data-point dots.
     final dotPaint = Paint()
       ..color = color
       ..style = PaintingStyle.fill;
-    for (final dp in dataPoints) {
+    for (final p in points) {
       canvas.drawCircle(
-        Offset(xForIndex(dp.index), yForPrice(dp.price)),
+        Offset(layout.xForIndex(p.index), layout.yForPrice(p.price)),
         3,
         dotPaint,
       );
     }
+
+    // Highlight the selected point with a ring.
+    if (selectedIndex != null && selectedIndex! < points.length) {
+      final sel = points[selectedIndex!];
+      final center =
+          Offset(layout.xForIndex(sel.index), layout.yForPrice(sel.price));
+      canvas.drawCircle(center, 5, dotPaint);
+      canvas.drawCircle(
+        center,
+        7,
+        Paint()
+          ..color = color
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2,
+      );
+    }
+
+    // X-axis date labels (first + last, plus middle ticks if they fit).
+    for (final tick in layout.dateTicks) {
+      final p = points[tick];
+      _drawLabel(
+        canvas,
+        dateFormat.format(p.date),
+        Offset(layout.xForIndex(p.index), size.height),
+        centerHorizontally: true,
+        clampX: size.width,
+      );
+    }
+  }
+
+  void _drawLabel(
+    Canvas canvas,
+    String text,
+    Offset anchor, {
+    bool anchorMiddle = false,
+    bool centerHorizontally = false,
+    double? clampX,
+  }) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: axisColor, fontSize: 9),
+      ),
+      textDirection: ui.TextDirection.ltr,
+    )..layout();
+
+    double dx = anchor.dx;
+    if (centerHorizontally) {
+      dx = anchor.dx - tp.width / 2;
+    }
+    if (clampX != null) {
+      dx = dx.clamp(0.0, math.max(0.0, clampX - tp.width));
+    }
+
+    double dy = anchor.dy;
+    if (anchorMiddle) {
+      dy = anchor.dy - tp.height / 2;
+    } else {
+      // Bottom-axis labels: sit just below the chart baseline.
+      dy = anchor.dy - tp.height;
+    }
+    tp.paint(canvas, Offset(dx, dy));
   }
 
   void _drawDashedLine(Canvas canvas, Offset start, Offset end, Paint paint) {
@@ -189,6 +344,7 @@ class _PriceChartPainter extends CustomPainter {
     final dx = end.dx - start.dx;
     final dy = end.dy - start.dy;
     final totalLength = math.sqrt(dx * dx + dy * dy);
+    if (totalLength == 0) return;
     final unitDx = dx / totalLength;
     final unitDy = dy / totalLength;
 
@@ -204,31 +360,28 @@ class _PriceChartPainter extends CustomPainter {
     }
   }
 
-  double? _priceForFuelType(PriceRecord record, FuelType fuelType) {
-    return switch (fuelType) {
-      FuelTypeE5() => record.e5,
-      FuelTypeE10() => record.e10,
-      FuelTypeE98() => record.e98,
-      FuelTypeDiesel() => record.diesel,
-      FuelTypeDieselPremium() => record.dieselPremium,
-      FuelTypeE85() => record.e85,
-      FuelTypeLpg() => record.lpg,
-      FuelTypeCng() => record.cng,
-      FuelTypeHydrogen() || FuelTypeElectric() || FuelTypeAll() => null,
-    };
-  }
-
   @override
   bool shouldRepaint(_PriceChartPainter oldDelegate) {
-    return oldDelegate.records != records ||
-        oldDelegate.fuelType != fuelType ||
-        oldDelegate.color != color;
+    return oldDelegate.points != points ||
+        oldDelegate.color != color ||
+        oldDelegate.axisColor != axisColor ||
+        oldDelegate.selectedIndex != selectedIndex;
   }
 }
 
-class _DataPoint {
-  final int index;
-  final double price;
-
-  const _DataPoint({required this.index, required this.price});
+/// Resolve the price for [fuelType] from a [PriceRecord]. Exposed for
+/// the chart point builder and its tests.
+@visibleForTesting
+double? priceForFuelType(PriceRecord record, FuelType fuelType) {
+  return switch (fuelType) {
+    FuelTypeE5() => record.e5,
+    FuelTypeE10() => record.e10,
+    FuelTypeE98() => record.e98,
+    FuelTypeDiesel() => record.diesel,
+    FuelTypeDieselPremium() => record.dieselPremium,
+    FuelTypeE85() => record.e85,
+    FuelTypeLpg() => record.lpg,
+    FuelTypeCng() => record.cng,
+    FuelTypeHydrogen() || FuelTypeElectric() || FuelTypeAll() => null,
+  };
 }

--- a/lib/features/price_history/presentation/widgets/price_chart_axes.dart
+++ b/lib/features/price_history/presentation/widgets/price_chart_axes.dart
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+import 'dart:ui';
+
+/// One plottable point of the price-history chart: its source index
+/// (oldest→newest ordinal), the price for the selected fuel, and the
+/// timestamp it was recorded.
+class ChartPoint {
+  final int index;
+  final double price;
+  final DateTime date;
+
+  const ChartPoint({
+    required this.index,
+    required this.price,
+    required this.date,
+  });
+}
+
+/// Pure layout maths for [PriceChart] — kept out of the painter so the
+/// painter file stays small and the projection / tick / hit-test logic
+/// is unit-testable without a canvas.
+class PriceChartLayout {
+  /// Inset reserved on the left for the €-axis labels.
+  static const double leftInset = 44.0;
+  static const double rightInset = 8.0;
+  static const double topInset = 10.0;
+
+  /// Inset reserved at the bottom for the date labels.
+  static const double bottomInset = 16.0;
+
+  final double minPrice;
+  final double maxPrice;
+  final double yMin;
+  final double yMax;
+  final double left;
+  final double right;
+  final double top;
+  final double bottom;
+  final double chartWidth;
+  final double chartHeight;
+  final int firstIndex;
+  final int lastIndex;
+
+  /// Prices to label on the Y axis (min / mid / max).
+  final List<double> priceTicks;
+
+  /// Data-point ordinals to label on the X axis.
+  final List<int> dateTicks;
+
+  const PriceChartLayout({
+    required this.minPrice,
+    required this.maxPrice,
+    required this.yMin,
+    required this.yMax,
+    required this.left,
+    required this.right,
+    required this.top,
+    required this.bottom,
+    required this.chartWidth,
+    required this.chartHeight,
+    required this.firstIndex,
+    required this.lastIndex,
+    required this.priceTicks,
+    required this.dateTicks,
+  });
+
+  double xForIndex(int idx) {
+    final span = lastIndex - firstIndex;
+    if (span == 0) return left + chartWidth / 2;
+    return left + ((idx - firstIndex) / span) * chartWidth;
+  }
+
+  double yForPrice(double price) {
+    final span = yMax - yMin;
+    if (span == 0) return top + chartHeight / 2;
+    return top + chartHeight - ((price - yMin) / span) * chartHeight;
+  }
+}
+
+/// Static façade for chart geometry: layout, tick selection and
+/// nearest-point hit-testing.
+class PriceChartAxes {
+  PriceChartAxes._();
+
+  static PriceChartLayout layout(Size size, List<ChartPoint> points) {
+    final prices = points.map((p) => p.price).toList();
+    final minPrice = prices.reduce(math.min);
+    final maxPrice = prices.reduce(math.max);
+
+    final range = maxPrice - minPrice;
+    final padding = range > 0 ? range * 0.1 : 0.01;
+    final yMin = minPrice - padding;
+    final yMax = maxPrice + padding;
+
+    const left = PriceChartLayout.leftInset;
+    final right = size.width - PriceChartLayout.rightInset;
+    const top = PriceChartLayout.topInset;
+    final bottom = size.height - PriceChartLayout.bottomInset;
+    final chartWidth = math.max(0.0, right - left);
+    final chartHeight = math.max(0.0, bottom - top);
+
+    // Price ticks: min, mid, max — but collapse to a single value when the
+    // series is flat so we never print three identical labels.
+    final List<double> priceTicks;
+    if (range > 0) {
+      priceTicks = [minPrice, (minPrice + maxPrice) / 2, maxPrice];
+    } else {
+      priceTicks = [minPrice];
+    }
+
+    return PriceChartLayout(
+      minPrice: minPrice,
+      maxPrice: maxPrice,
+      yMin: yMin,
+      yMax: yMax,
+      left: left,
+      right: right,
+      top: top,
+      bottom: bottom,
+      chartWidth: chartWidth,
+      chartHeight: chartHeight,
+      firstIndex: points.first.index,
+      lastIndex: points.last.index,
+      priceTicks: priceTicks,
+      dateTicks: _dateTicks(points, chartWidth),
+    );
+  }
+
+  /// Choose which data points get a date label. Always the first and last;
+  /// a middle tick is added when there is room (>~150 logical px) so labels
+  /// (~36 px wide for `dd.MM`) never overlap.
+  static List<int> _dateTicks(List<ChartPoint> points, double chartWidth) {
+    if (points.length < 2) return [0];
+    final ticks = <int>{0, points.length - 1};
+    if (chartWidth > 150 && points.length >= 3) {
+      ticks.add(points.length ~/ 2);
+    }
+    final list = ticks.toList()..sort();
+    return list;
+  }
+
+  /// Index into [points] of the point whose plotted x is nearest [localPos].
+  static int nearestPointIndex(
+    Offset localPos,
+    Size size,
+    List<ChartPoint> points,
+  ) {
+    final l = layout(size, points);
+    int best = 0;
+    double bestDist = double.infinity;
+    for (int i = 0; i < points.length; i++) {
+      final dx = (l.xForIndex(points[i].index) - localPos.dx).abs();
+      if (dx < bestDist) {
+        bestDist = dx;
+        best = i;
+      }
+    }
+    return best;
+  }
+}

--- a/test/features/price_history/presentation/widgets/price_chart_test.dart
+++ b/test/features/price_history/presentation/widgets/price_chart_test.dart
@@ -3,13 +3,37 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/price_history/data/models/price_record.dart';
 import 'package:tankstellen/features/price_history/presentation/widgets/price_chart.dart';
+import 'package:tankstellen/features/price_history/presentation/widgets/price_chart_axes.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
 import '../../../../helpers/pump_app.dart';
 
 void main() {
+  // Use a known country so the €/comma formatting is deterministic.
+  setUp(() => PriceFormatter.setCountry('DE'));
+
+  final threeRecords = [
+    PriceRecord(
+      stationId: 'test-1',
+      recordedAt: DateTime(2026, 3, 25),
+      diesel: 1.459,
+    ),
+    PriceRecord(
+      stationId: 'test-1',
+      recordedAt: DateTime(2026, 3, 26),
+      diesel: 1.479,
+    ),
+    PriceRecord(
+      stationId: 'test-1',
+      recordedAt: DateTime(2026, 3, 27),
+      diesel: 1.469,
+    ),
+  ];
+
   group('PriceChart', () {
     testWidgets('renders "No price history yet" when records is empty',
         (tester) async {
@@ -19,44 +43,24 @@ void main() {
       );
 
       expect(find.text('No price history yet'), findsOneWidget);
-      // Should not find a PriceChart-owned CustomPaint (only Scaffold's)
       expect(find.byType(PriceChart), findsOneWidget);
     });
 
     testWidgets('renders CustomPaint when records are provided',
         (tester) async {
-      final records = [
-        PriceRecord(
-          stationId: 'test-1',
-          recordedAt: DateTime(2026, 3, 25),
-          diesel: 1.459,
-        ),
-        PriceRecord(
-          stationId: 'test-1',
-          recordedAt: DateTime(2026, 3, 26),
-          diesel: 1.479,
-        ),
-        PriceRecord(
-          stationId: 'test-1',
-          recordedAt: DateTime(2026, 3, 27),
-          diesel: 1.469,
-        ),
-      ];
-
       await pumpApp(
         tester,
-        PriceChart(records: records, fuelType: FuelType.diesel),
+        PriceChart(records: threeRecords, fuelType: FuelType.diesel),
       );
 
       expect(find.text('No price history yet'), findsNothing);
-      // The PriceChart widget should be present and contain a CustomPaint
       expect(find.byType(PriceChart), findsOneWidget);
       expect(
         find.descendant(
           of: find.byType(PriceChart),
           matching: find.byType(CustomPaint),
         ),
-        findsOneWidget,
+        findsWidgets,
       );
     });
 
@@ -74,14 +78,140 @@ void main() {
         PriceChart(records: records, fuelType: FuelType.diesel),
       );
 
-      // Should render the CustomPaint (single dot case), no error text
       expect(find.text('No price history yet'), findsNothing);
       expect(
         find.descendant(
           of: find.byType(PriceChart),
           matching: find.byType(CustomPaint),
         ),
-        findsOneWidget,
+        findsWidgets,
+      );
+    });
+
+    testWidgets('tapping a point reveals a tooltip with its price + date',
+        (tester) async {
+      // The chart consumes records newest-first (the repository contract)
+      // and reverses them so the newest sits on the right.
+      await pumpApp(
+        tester,
+        PriceChart(
+          records: threeRecords.reversed.toList(),
+          fuelType: FuelType.diesel,
+        ),
+        locale: const Locale('de'),
+      );
+
+      // No tooltip until the user interacts.
+      expect(find.textContaining('·'), findsNothing);
+
+      // Tap near the right edge → newest point (1,469 € on 27.03).
+      final chart = find.byType(PriceChart);
+      final box = tester.getRect(chart);
+      await tester.tapAt(Offset(box.right - 4, box.center.dy));
+      await tester.pumpAndSettle();
+
+      // Tooltip shows the price and the localized date, joined by "·".
+      final tooltip = find.textContaining('·');
+      expect(tooltip, findsOneWidget);
+      final label = tester.widget<Text>(tooltip).data!;
+      expect(label, contains('1,469 €'));
+      expect(
+        label,
+        contains(DateFormat.Md('de').format(DateTime(2026, 3, 27))),
+      );
+    });
+  });
+
+  group('PriceChart.pointsFor', () {
+    test('orders points oldest→newest and carries date + price', () {
+      // Repository hands newest-first; the chart reverses to oldest-left.
+      final newestFirst = threeRecords.reversed.toList();
+      final points = PriceChart.pointsFor(newestFirst, FuelType.diesel);
+
+      expect(points.map((p) => p.price), [1.459, 1.479, 1.469]);
+      expect(points.first.date, DateTime(2026, 3, 25));
+      expect(points.last.date, DateTime(2026, 3, 27));
+    });
+
+    test('skips records that lack a price for the fuel type', () {
+      final mixed = [
+        PriceRecord(
+            stationId: 's', recordedAt: DateTime(2026, 1, 1), diesel: 1.5),
+        PriceRecord(stationId: 's', recordedAt: DateTime(2026, 1, 2), e10: 1.7),
+      ];
+      final points = PriceChart.pointsFor(mixed, FuelType.diesel);
+      expect(points.length, 1);
+      expect(points.single.price, 1.5);
+    });
+  });
+
+  group('PriceChartAxes', () {
+    final points = PriceChart.pointsFor(
+      threeRecords.reversed.toList(),
+      FuelType.diesel,
+    );
+
+    test('Y-axis price ticks span min, mid and max, formatted in €', () {
+      const size = Size(300, 132);
+      final layout = PriceChartAxes.layout(size, points);
+
+      expect(layout.priceTicks.length, 3);
+      expect(layout.priceTicks.first, 1.459); // min
+      expect(layout.priceTicks.last, 1.479); // max
+      // Mid is the average of min and max.
+      expect(layout.priceTicks[1], closeTo(1.469, 1e-9));
+
+      // Each tick renders a € price label via PriceFormatter.
+      final labels = layout.priceTicks.map(PriceFormatter.formatPrice).toList();
+      expect(labels.first, '1,459 €');
+      expect(labels.last, '1,479 €');
+    });
+
+    test('X-axis date ticks always include the first and last point', () {
+      const size = Size(300, 132);
+      final layout = PriceChartAxes.layout(size, points);
+
+      expect(layout.dateTicks.first, 0);
+      expect(layout.dateTicks.last, points.length - 1);
+    });
+
+    test('narrow charts drop the middle date tick to avoid overlap', () {
+      const narrow = Size(120, 132);
+      final layout = PriceChartAxes.layout(narrow, points);
+      expect(layout.dateTicks, [0, points.length - 1]);
+    });
+
+    test('flat series collapses to a single price tick', () {
+      final flat = [
+        PriceRecord(
+            stationId: 's', recordedAt: DateTime(2026, 1, 1), diesel: 1.5),
+        PriceRecord(
+            stationId: 's', recordedAt: DateTime(2026, 1, 2), diesel: 1.5),
+      ];
+      final flatPoints =
+          PriceChart.pointsFor(flat.reversed.toList(), FuelType.diesel);
+      final layout = PriceChartAxes.layout(const Size(300, 132), flatPoints);
+      expect(layout.priceTicks, [1.5]);
+    });
+
+    test('nearestPointIndex picks the point closest in x', () {
+      const size = Size(300, 132);
+      final layout = PriceChartAxes.layout(size, points);
+
+      // A tap exactly over the last point resolves to its index.
+      final lastX = layout.xForIndex(points.last.index);
+      final idx = PriceChartAxes.nearestPointIndex(
+        Offset(lastX, 60),
+        size,
+        points,
+      );
+      expect(idx, points.length - 1);
+
+      // A tap over the first point resolves to index 0.
+      final firstX = layout.xForIndex(points.first.index);
+      expect(
+        PriceChartAxes.nearestPointIndex(Offset(firstX, 60), size, points),
+        0,
       );
     });
   });


### PR DESCRIPTION
## What

Makes the station-detail **Preisverlauf** price-history line chart readable. Previously it had no axis labels and no way to read any point's value.

### Axes
- **Y (price):** min / mid / max gridline labels in € via `PriceFormatter`, aligned to the existing `yMin`/`yMax` bounds. The dashed min/max guide lines are kept. A flat series collapses to a single label.
- **X (date):** compact, locale-aware date labels (`DateFormat.Md`, e.g. `23.05` in de / `5/23` in en) for the first and last points, plus a middle tick when the chart is wide enough — spaced so they never overlap.

### Point readability
- `GestureDetector` hit-tests the nearest data point on **tap / long-press** and shows a small callout with `price · date` (e.g. `2,069 € · 23.05`). The selected point is ringed.

### Theme + performance
- Muted axis-label colour from the theme (`onSurfaceVariant`) and an `inverseSurface` tooltip — legible in **light and dark**.
- Pure layout / tick / hit-test maths extracted to `price_chart_axes.dart` so the painter file stays small (387 lines) and the geometry is unit-testable without a canvas. `shouldRepaint` compares points, colours and selection.

### Scope / constraints
- Touches **only** the price-history chart widgets: `price_chart.dart` (+ new `price_chart_axes.dart`) and its test. No trip/approach/obd2/carburant/map files.
- **No new ARB** — every label is a formatted price or date. Stats row (`price_stats_card.dart`) untouched.
- Both files under the 400-line cap. No `@riverpod`/freezed touched → no codegen drift.

## Tests
New tests in `price_chart_test.dart`:
- Y-axis ticks span min/mid/max and format in € via `PriceFormatter`.
- X-axis date ticks always include first + last; narrow charts drop the middle tick.
- `nearestPointIndex` hit-testing; flat-series single tick; `pointsFor` ordering.
- Widget test: tap → tooltip shows the point's price + localized date.

## Gate
- `flutter analyze` on the three changed files: **No issues found** (the 2 repo-wide infos are pre-existing in unrelated alerts/consumption files).
- `flutter test test/features/price_history/ test/features/station_detail/ test/lint/ --exclude-tags=network`: **All 280 tests passed**.
- `git diff` clean: only the 3 intended files, no generated/ARB/pubspec drift.

Closes #2384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
