### PR TITLE
fix(map): LAYER 1 — end the grey-tile + "--" regression cycle at the root

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -70,7 +70,32 @@ class AppConstants {
 
   static const String osmTileUrl =
       'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
-  static String get osmUserAgent => userAgent;
+
+  /// Stable, version-free identity sent on every OSM/tile request
+  /// (#2396). OSM's tile-usage policy wants a *stable* User-Agent that
+  /// identifies the app, NOT one that changes on every release — a
+  /// per-version UA looks like many distinct clients to their abuse
+  /// heuristics. So this is deliberately the bare package id with no
+  /// `/appVersion` suffix. The versioned [userAgent] above is still used
+  /// by the data-API HTTP clients, where per-release identification is
+  /// useful for upstream debugging. Not user-facing (an HTTP header).
+  static const String osmUserAgent = appPackage;
+
+  /// Tile-proxy URL template (LAYER 2 / #2397). A Supabase `tiles` edge
+  /// function will fetch from OSM with a stable server-side UA and serve
+  /// tiles back with a 7-day `Cache-Control`, taking direct tile load off
+  /// OSM. NOT wired up yet: [SparkiloTileLayer] still defaults to
+  /// [osmTileUrl] (OSM-direct) until the proxy is deployed. When #2397
+  /// ships, #2396 flips SparkiloTileLayer's default to this constant and
+  /// pins the real deployed project subdomain. Not user-facing (a URL).
+  static const String tileProxyUrl =
+      'https://tankstellen.supabase.co/functions/v1/tiles/{z}/{x}/{y}';
+
+  /// Stable OSM-facing User-Agent the [tileProxyUrl] edge function imports
+  /// to identify itself to OSM (LAYER 2 / #2397). Carries a contact URL
+  /// per OSM policy. Not user-facing (an HTTP header).
+  static const String tileProxyOsmUserAgent =
+      'de.tankstellen.tile-proxy/1.0 (+https://github.com/fdittgen-png/tankstellen)';
 
   static const String tankerkoenigAttribution =
       'Daten von Tankerkoenig.de (CC BY 4.0)';

--- a/lib/core/services/impl/flutter_map_provider.dart
+++ b/lib/core/services/impl/flutter_map_provider.dart
@@ -22,7 +22,9 @@ class FlutterMapProvider implements MapProvider {
   String get name => 'OpenStreetMap';
 
   @override
-  TileLayerConfig get tileConfig => TileLayerConfig(
+  // #2396 — now `const`: `osmUserAgent` became a compile-time `const`
+  // (version-free) so all three args are constant.
+  TileLayerConfig get tileConfig => const TileLayerConfig(
         urlTemplate: AppConstants.osmTileUrl,
         userAgent: AppConstants.osmUserAgent,
         attribution: AppConstants.osmAttribution,

--- a/lib/core/utils/price_utils.dart
+++ b/lib/core/utils/price_utils.dart
@@ -13,6 +13,47 @@ import 'station_extensions.dart';
 double? priceForFuelType(Station station, FuelType fuelType) =>
     station.priceFor(fuelType);
 
+/// Fallback fuel order for [bestDisplayPrice] when the selected fuel has
+/// no price. Most-common pump fuels first so the marker shows the most
+/// representative price for a typical driver: E10 → E5 → Diesel →
+/// Diesel Premium → E85 → LPG → CNG.
+const List<FuelType> _displayFallbackOrder = [
+  FuelType.e10,
+  FuelType.e5,
+  FuelType.diesel,
+  FuelType.dieselPremium,
+  FuelType.e85,
+  FuelType.lpg,
+  FuelType.cng,
+];
+
+/// The price to SHOW for [station] given the user's [selected] fuel, and
+/// which fuel produced it (#2400).
+///
+/// Tankerkönig returns only the queried fuel's price, so after a fuel-chip
+/// change the map markers would read `null` for the new fuel until a
+/// re-search lands — rendering "--" even though the station clearly has a
+/// price for another fuel. This resolver returns:
+///   - the [selected]-fuel price when it is non-null, else
+///   - the first non-null price in [_displayFallbackOrder],
+/// reporting the [shownFuel] that produced it so the caller can label a
+/// fallback. Returns `null` ONLY when the station has no usable price for
+/// any fuel — the sole legitimate "--" case.
+({double price, FuelType shownFuel})? bestDisplayPrice(
+  Station station,
+  FuelType selected,
+) {
+  final selectedPrice = station.priceFor(selected);
+  if (selectedPrice != null) {
+    return (price: selectedPrice, shownFuel: selected);
+  }
+  for (final fuel in _displayFallbackOrder) {
+    final p = station.priceFor(fuel);
+    if (p != null) return (price: p, shownFuel: fuel);
+  }
+  return null;
+}
+
 /// (min, max) price for [fuel] across [stations], for colour-gradient /
 /// price-tier classification. Returns `(0, 0)` when no station has a
 /// usable price.
@@ -32,6 +73,31 @@ double? priceForFuelType(Station station, FuelType fuelType) =>
   for (final s in stations) {
     final p = s.priceFor(fuel);
     if (p != null && (!requirePositive || p > 0)) {
+      if (p < minP) minP = p;
+      if (p > maxP) maxP = p;
+    }
+  }
+  if (minP == double.infinity) return (0, 0);
+  return (minP, maxP);
+}
+
+/// (min, max) over each station's RESOLVED display price for [selected]
+/// (see [bestDisplayPrice]) — i.e. the selected fuel where present, else
+/// the fallback. Returns `(0, 0)` when no station resolves to a price.
+///
+/// The map marker colours by relative price (#2400); colouring over the
+/// resolved prices keeps a fallback-priced marker's colour consistent
+/// with the value it actually shows, instead of grey because the
+/// selected fuel was null.
+(double, double) resolvedPriceRange(
+  Iterable<Station> stations,
+  FuelType selected,
+) {
+  double minP = double.infinity;
+  double maxP = 0;
+  for (final s in stations) {
+    final p = bestDisplayPrice(s, selected)?.price;
+    if (p != null) {
       if (p < minP) minP = p;
       if (p > maxP) maxP = p;
     }

--- a/lib/core/utils/station_extensions.dart
+++ b/lib/core/utils/station_extensions.dart
@@ -48,3 +48,24 @@ String truncateBrand(String brand, {required int maxLength}) {
   return '${brand.substring(0, maxLength - 1)}…';
 }
 
+/// Short, language-neutral pump code for [fuel] — the same abbreviations
+/// the all-prices card uses (`E5`, `E10`, `Diesel`, `Diesel+`, `E85`,
+/// `GPL`, `GNV`). Used on the map marker to label a fallback price whose
+/// fuel differs from the user's selection (#2400). These are
+/// language-neutral fuel codes (brand-style proper nouns), not
+/// translatable prose.
+String shortFuelLabel(FuelType fuel) => switch (fuel) {
+      FuelTypeE5() => 'E5', // i18n-ignore: language-neutral fuel code
+      FuelTypeE10() => 'E10', // i18n-ignore: language-neutral fuel code
+      FuelTypeE98() => 'E98', // i18n-ignore: language-neutral fuel code
+      FuelTypeDiesel() => 'Diesel', // i18n-ignore: language-neutral fuel code
+      FuelTypeDieselPremium() =>
+        'Diesel+', // i18n-ignore: language-neutral fuel code
+      FuelTypeE85() => 'E85', // i18n-ignore: language-neutral fuel code
+      FuelTypeLpg() => 'GPL', // i18n-ignore: language-neutral fuel code
+      FuelTypeCng() => 'GNV', // i18n-ignore: language-neutral fuel code
+      FuelTypeHydrogen() => 'H2', // i18n-ignore: language-neutral fuel code
+      FuelTypeElectric() => 'EV', // i18n-ignore: language-neutral fuel code
+      FuelTypeAll() => '', // no label for the wildcard
+    };
+

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,7 +14,6 @@ import '../../../ev/presentation/widgets/ev_map_overlay.dart';
 import '../../../ev/providers/ev_providers.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import 'station_map_layers.dart';
-import '../../../../core/logging/error_logger.dart';
 
 /// Displays a map of nearby stations from the current search results.
 ///
@@ -59,14 +56,6 @@ class NearbyMapView extends ConsumerStatefulWidget {
 }
 
 class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
-  /// The bounds the camera was last fitted to. Held in State so a redundant
-  /// rebuild (EV-toggle tap, app resume, unrelated provider change) does
-  /// not re-schedule an identical `fitCamera` (#2177). Set when we SCHEDULE
-  /// the post-frame fit — not inside the callback — so that if the fit
-  /// itself triggers a rebuild, the next build computes the same bounds,
-  /// sees they equal `_lastFitBounds`, and skips: no fit→rebuild→fit loop.
-  LatLngBounds? _lastFitBounds;
-
   @override
   Widget build(BuildContext context) {
     final searchState = widget.searchState;
@@ -126,37 +115,14 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
           );
         }
 
-        // Fit map viewport to the search radius when results change so the
-        // user immediately sees the entire searched area instead of having
-        // to zoom out manually.
-        //
-        // #2177 — guard the schedule against redundant per-build re-fits.
-        // `build` runs on every EV-toggle tap, app resume, and unrelated
-        // provider change; an unguarded post-frame `fitCamera` snapped the
-        // camera back to the search bounds each time (fighting the user's
-        // manual pan and, during the cold-start window, forcing a TileLayer
-        // reset). We only schedule when the fit target actually changed
-        // since the last fit. `_lastFitBounds` is set HERE (at schedule
-        // time, not in the callback) so a fit→rebuild→fit loop cannot form:
-        // the next build computes the same bounds, finds them equal, skips.
+        // #2399 — the viewport is framed by `StationMapLayers` itself:
+        // `MapOptions.initialCameraFit` positions the first paint during
+        // layout, and a single guarded `didUpdateWidget` re-fit handles a
+        // changed search centre. The old per-build post-frame `fitCamera`
+        // here raced the (now-deleted) cold-start reset window and is
+        // gone. `bounds` is still computed for the recenter button.
         final bounds =
             StationMapLayers.boundsForRadius(center, searchRadiusKm);
-        if (NearbyMapView.shouldFit(_lastFitBounds, bounds)) {
-          _lastFitBounds = bounds;
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (!mounted) return;
-            try {
-              mapController.fitCamera(
-                CameraFit.bounds(
-                  bounds: bounds,
-                  padding: const EdgeInsets.all(32),
-                ),
-              );
-            } catch (e, st) {
-              unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'Map fitCamera failed'}));
-            }
-          });
-        }
 
         return Stack(
           children: [

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -1,7 +1,6 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -9,8 +8,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
-import '../../../../core/constants/app_constants.dart';
-import '../../data/retry_network_tile_provider.dart';
+import '../../data/sparkilo_tile_layer.dart';
 import '../../../../core/utils/price_utils.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
@@ -32,54 +30,20 @@ const double _kMaxZoom = 19.0;
 /// Used by both [MapScreen] (full-screen) and [InlineMap] (split-screen)
 /// to eliminate ~130 lines of duplicated map layer code.
 ///
-/// ## Why this is stateful (#1234 follow-up to #1164)
+/// ## One tile path (#2394 / #2398)
 ///
-/// The earlier grey-tile fix (LayoutBuilder gate + tab-flip incarnation
-/// rebuild) covers the offstage IndexedStack viewport-capture race, but
-/// the screen still rendered grey on cold-start in some scenarios. The
-/// reason: [RetryNetworkTileProvider] was created inside `build()` and
-/// rebuilt on every parent state change. flutter_map's TileLayer
-/// preserves its [TileImage] objects across `didUpdateWidget`, but each
-/// existing TileImage holds a reference to the OLD provider's
-/// [http.Client]; meanwhile the *new* provider's client is what fresh
-/// tile fetches use. The leaked-client churn produced two pathologies:
-///   1. The very first tile fetches went through an http.Client that
-///      was about to be discarded, occasionally racing with the next
-///      build's replacement provider before completing.
-///   2. The default `BuiltInMapCachingProvider` instance — created
-///      lazily inside the image provider — was being asked to cache
-///      tiles whose request was abandoned, leaving holes that only got
-///      backfilled when a later rebuild happened to re-issue the same
-///      coordinates against a stable provider.
-/// Holding a single tile provider per [StationMapLayers] lifetime —
-/// created in `initState`, disposed in `dispose` — eliminates both
-/// pathologies. The KeyedSubtree+incarnation rebuild in [MapScreen]
-/// already destroys this state on tab-flip, so the provider lifetime
-/// is bounded by the visible-tab lifetime.
-///
-/// ## Cold-start tile reset window (#1316 phase 3)
-///
-/// The single `addPostFrameCallback` reset added in #1234 fires
-/// before two later events that also invalidate TileLayer's captured
-/// viewport:
-///   1. `NearbyMapView` schedules its own post-frame `fitCamera` call
-///      every build — that move arrives AFTER the initState reset, so
-///      TileLayer reloads against the bootstrap camera and never
-///      sees the settled camera the user actually wants tiles for.
-///   2. `FlutterMap` only emits `MapEventNonRotatedSizeChange` once
-///      its internal LayoutBuilder lays out — also AFTER the
-///      initState reset. If the bootstrap layout was small (the
-///      <100px LayoutBuilder gate in [MapScreen] only catches the
-///      worst placeholder layouts), TileLayer captured a tiny tile
-///      range that survives the size update.
-/// Both produced the "3 tile patches over a grey background"
-/// symptom the user reported. The fix subscribes to
-/// [MapController.mapEventStream] for [_coldStartResetWindow] (3 s)
-/// and re-emits on the reset stream every time a programmatic move,
-/// `fitCamera`, or `nonRotatedSizeChange` event arrives. After the
-/// window the subscription cancels itself so steady-state pans use
-/// TileLayer's normal load-on-event path (resetting on every pan
-/// would briefly blank the visible tiles).
+/// The basemap renders through the single hardened [SparkiloTileLayer].
+/// Prior to #2398 this widget ran a *parallel* inline `TileLayer` plus a
+/// 12-second cold-start "reset window" that fired `TileLayer.reset` on
+/// every camera/size event during cold-start. That storm evicted tiles
+/// before they painted on a slow first round-trip — the recurring
+/// grey-tile bug (#757 → #1234 → #1316 → #1991 → #2044 → #2096 →
+/// #2122 → #2177). The reset machinery is deleted: there is exactly one
+/// tile path, every surface shares `abortObsoleteRequests: true`
+/// (the upstream default inside [SparkiloTileLayer]), and there is no
+/// reset stream to mis-fire. See `tile_layer_consistency_test.dart`
+/// (allowlist is now the single `sparkilo_tile_layer.dart`) and
+/// `station_map_layers_no_reset_test.dart`.
 class StationMapLayers extends StatefulWidget {
   final MapController mapController;
   final List<Station> stations;
@@ -174,46 +138,6 @@ class StationMapLayers extends StatefulWidget {
 }
 
 class _StationMapLayersState extends State<StationMapLayers> {
-  /// Held in state so a single [http.Client] lives for the entire
-  /// visible lifetime of the map. Recreating the provider on every
-  /// build (the prior bug) churned http.Client instances and produced
-  /// the cold-start grey-tile regression (#1234).
-  late final RetryNetworkTileProvider _tileProvider;
-
-  /// Stream that, when emitted, makes [TileLayer] drop all current
-  /// tile images and re-fetch the visible range from scratch. We fire
-  /// it once after the first frame to cover the case where TileLayer's
-  /// initial `didChangeDependencies` ran against a degenerate camera
-  /// and never re-issued requests when the camera settled.
-  final StreamController<void> _resetController =
-      StreamController<void>.broadcast();
-
-  /// Subscription on [MapController.mapEventStream] used during the
-  /// cold-start window to force a tile-reset every time the map size
-  /// or camera moves programmatically. Cancelled after
-  /// [_coldStartResetWindow] so steady-state interactions are not
-  /// disturbed (#1316 phase 3 — see class doc).
-  StreamSubscription<MapEvent>? _coldStartEventSub;
-
-  /// Timer that closes the cold-start reset window. Cancelled in
-  /// [dispose] so a late firing cannot touch a disposed state.
-  Timer? _coldStartCloseTimer;
-
-  /// How long to keep firing tile-resets on programmatic
-  /// size/camera changes after init. Twelve seconds covers the worst
-  /// observed cold-start sequence (offstage IndexedStack pre-mount
-  /// → onstage promotion → LayoutBuilder gate clears → FlutterMap
-  /// internal LayoutBuilder lays out → `fitCamera` post-frame
-  /// callback fires → camera settles). Originally 3 s but the user's
-  /// 2026-05-24 report showed a slow-network cold open where the
-  /// first search result + `fitCamera` arrived ~5-8 s after mount
-  /// — past the old window — leaving the grey-tile bug uncovered
-  /// until they tapped Refresh. Twelve seconds gives a healthy
-  /// margin for GPS resolution + first network round-trip on cellular
-  /// while still bounded enough that the user's first deliberate
-  /// zoom (10+ s in) is unaffected.
-  static const Duration _coldStartResetWindow = Duration(seconds: 12);
-
   /// #1774 — the marker list and the price range are memoised here and
   /// recomputed only when `stations` / `selectedFuel` /
   /// `selectedStationIds` actually change. `MapScreen` watches four
@@ -243,6 +167,12 @@ class _StationMapLayersState extends State<StationMapLayers> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    _recomputeMarkers();
+  }
+
+  @override
   void didUpdateWidget(StationMapLayers oldWidget) {
     super.didUpdateWidget(oldWidget);
     // Riverpod hands back the same `stations` / `selectedStationIds`
@@ -255,91 +185,6 @@ class _StationMapLayersState extends State<StationMapLayers> {
         !identical(oldWidget.selectedStationIds, widget.selectedStationIds)) {
       _recomputeMarkers();
     }
-    // Tap-the-refresh-button cure (#2025 follow-up). When stations
-    // transition from empty → populated (the first successful search
-    // after a cold open) OR when the camera-anchoring centre changes,
-    // force a TileLayer reset. This catches the case where the user
-    // opens Carte before a search has landed: the initial map renders
-    // with a bootstrap camera and TileLayer captured a degenerate
-    // viewport, the 3-second cold-start window closed silently, and
-    // the user sees a grey background until they tap Refresh. The
-    // reset stream is broadcast + cheap (a no-op when tiles are
-    // already loaded for the visible range), so re-firing it on the
-    // search-results-arrived transition is the safest cure.
-    final wasEmpty = oldWidget.stations.isEmpty;
-    final centerChanged = widget.center != oldWidget.center;
-    if ((wasEmpty && widget.stations.isNotEmpty) || centerChanged) {
-      if (!_resetController.isClosed) {
-        _resetController.add(null);
-      }
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _tileProvider = RetryNetworkTileProvider(abortObsoleteRequests: false);
-    _recomputeMarkers();
-
-    // First-paint reset: kick TileLayer once so any tiles that fetched
-    // against the bootstrap camera are dropped + reissued against the
-    // settled MapController state. Cheap (no-op when tiles are already
-    // loaded for the visible range) and fixes the grey-on-first-open
-    // case where neither the LayoutBuilder gate nor the
-    // _mapIncarnation listener catches the offstage→onstage transition
-    // (#1234).
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _resetController.isClosed) return;
-      _resetController.add(null);
-    });
-
-    // #1316 phase 3 — the single first-paint reset above fires before
-    // [NearbyMapView]'s post-frame `fitCamera` runs and before
-    // FlutterMap's own LayoutBuilder finishes propagating the real
-    // viewport size. Result: reset hits TileLayer with the bootstrap
-    // camera, TileLayer fetches a tiny tile set, then `fitCamera`
-    // moves the camera + the size-change event arrives — but
-    // TileLayer's reaction at that point only loads tiles INSIDE the
-    // already-captured (small) viewport, leaving most of the visible
-    // map grey (the "3 patches" symptom in the issue's screenshots).
-    //
-    // Fix: subscribe to the map event stream and re-fire the reset on
-    // every programmatic event that changes either the viewport size
-    // or the camera position during the [_coldStartResetWindow].
-    // After the window, unsubscribe — steady-state pans/zooms do not
-    // need a tile-pipeline reset (TileLayer's normal load-on-event
-    // path handles them just fine, and gratuitous resets would cause
-    // visible tile pop-in on every pan).
-    _coldStartEventSub =
-        widget.mapController.mapEventStream.listen(_onColdStartEvent);
-    _coldStartCloseTimer = Timer(_coldStartResetWindow, () {
-      _coldStartEventSub?.cancel();
-      _coldStartEventSub = null;
-    });
-  }
-
-  /// Fire a tile-reset on programmatic size/camera changes during the
-  /// cold-start window. Filters to events that actually invalidate the
-  /// captured viewport — pure user interaction (drag, scroll-wheel,
-  /// pinch) is ignored because if the user is interacting, the bug
-  /// did not reproduce on this open and we should not interrupt them.
-  void _onColdStartEvent(MapEvent event) {
-    if (!mounted || _resetController.isClosed) return;
-    final src = event.source;
-    final relevant = src == MapEventSource.nonRotatedSizeChange ||
-        src == MapEventSource.fitCamera ||
-        src == MapEventSource.mapController;
-    if (!relevant) return;
-    _resetController.add(null);
-  }
-
-  @override
-  void dispose() {
-    _coldStartCloseTimer?.cancel();
-    _coldStartEventSub?.cancel();
-    _resetController.close();
-    _tileProvider.dispose();
-    super.dispose();
   }
 
   @override
@@ -368,42 +213,13 @@ class _StationMapLayersState extends State<StationMapLayers> {
             ),
           ),
           children: [
-            TileLayer(
-              urlTemplate: AppConstants.osmTileUrl,
-              userAgentPackageName: AppConstants.osmUserAgent,
-              maxNativeZoom: 19,
-              maxZoom: 19,
-              // #757 — RetryNetworkTileProvider retries transient
-              // HTTP 429 / 5xx / connection errors with jittered
-              // backoff (200 ms, 800 ms). Combined with
-              // `evictErrorTileStrategy: notVisibleRespectMargin`
-              // below, a failed tile gets retried up to 3× and, if
-              // all attempts fail, is evicted as soon as it scrolls
-              // out of view so the next pan retries cleanly.
-              //
-              // #930 — flutter_map's default aborts in-flight tile
-              // fetches on pan. Our retry layer must not see those
-              // cancellations as errors. Hence explicit
-              // `abortObsoleteRequests: false` (in initState) plus
-              // cancellation-aware retry logic in the provider.
-              //
-              // #1234 — provider is held in state (initState/dispose),
-              // NOT rebuilt every frame. Recreating it churned
-              // http.Client instances and produced a cold-start
-              // grey-tile race the LayoutBuilder gate could not
-              // catch. The reset stream fires once after first paint
-              // to drop any tiles that captured a degenerate viewport.
-              tileProvider: _tileProvider,
-              reset: _resetController.stream,
-              evictErrorTileStrategy:
-                  EvictErrorTileStrategy.notVisibleRespectMargin,
-              errorTileCallback: (tile, error, stackTrace) {
-                debugPrint(
-                    'TileLayer error at (z:${tile.coordinates.z} '
-                    'x:${tile.coordinates.x} y:${tile.coordinates.y}): '
-                    '$error');
-              },
-            ),
+            // #2398 — the SINGLE hardened tile path. No inline TileLayer,
+            // no reset stream: the cold-start reset storm that evicted
+            // tiles before they painted is gone. `SparkiloTileLayer`
+            // owns its retry provider lifecycle and uses the upstream
+            // default `abortObsoleteRequests: true`, unified with every
+            // other map surface.
+            const SparkiloTileLayer(key: ValueKey('main-tiles')),
             // Route polyline (if in route search mode)
             if (widget.routePolyline != null &&
                 widget.routePolyline!.isNotEmpty)

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -147,6 +147,25 @@ class _StationMapLayersState extends State<StationMapLayers> {
   late List<Marker> _markers;
   late (double, double) _priceRange;
 
+  /// True once FlutterMap has laid out and emitted `onMapReady`. The
+  /// guarded `didUpdateWidget` fit waits on this so a `fitCamera` call
+  /// never lands before the controller has a real viewport (#2399).
+  bool _mapReady = false;
+
+  /// The bounds the camera was last fitted to. Held so a redundant
+  /// rebuild (EV-toggle, app resume, unrelated provider change) does not
+  /// re-schedule an identical `fitCamera`. Set at SCHEDULE time so a
+  /// fit→rebuild→fit loop cannot form (the next build computes the same
+  /// bounds, finds them equal, skips) — relocated from `NearbyMapView`
+  /// in #2399. First paint is positioned by `MapOptions.initialCameraFit`,
+  /// so this only handles the stations-arrived / centre-moved transition.
+  LatLngBounds? _lastFitBounds;
+
+  /// Bounds of the search circle around the current centre — the camera
+  /// target for both `initialCameraFit` and the post-ready re-fit.
+  LatLngBounds get _fitBounds =>
+      StationMapLayers.boundsForRadius(widget.center, widget.searchRadiusKm);
+
   /// Recompute the memoised price range + marker list from the current
   /// widget inputs.
   void _recomputeMarkers() {
@@ -170,6 +189,10 @@ class _StationMapLayersState extends State<StationMapLayers> {
   void initState() {
     super.initState();
     _recomputeMarkers();
+    // First paint is positioned by `MapOptions.initialCameraFit`, so the
+    // initial fit is already accounted for; record it so the post-ready
+    // re-fit doesn't redundantly re-snap to the same bounds.
+    _lastFitBounds = _fitBounds;
   }
 
   @override
@@ -185,6 +208,35 @@ class _StationMapLayersState extends State<StationMapLayers> {
         !identical(oldWidget.selectedStationIds, widget.selectedStationIds)) {
       _recomputeMarkers();
     }
+
+    // #2399 — the SINGLE re-fit. When stations are present and the
+    // camera-anchoring centre changed VALUE (e.g. a new search landed
+    // after a cold open, or a ZIP search jumped to another city),
+    // schedule exactly ONE post-frame `fitCamera`. Guarded by:
+    //   - non-empty stations (nothing to frame otherwise),
+    //   - a value-distinct centre (`LatLng` has value `==`),
+    //   - bounds not already fitted (`LatLngBounds` value `==`),
+    //   - `mounted` + `_mapReady` inside the callback.
+    // `_lastFitBounds` is set HERE (at schedule time, not in the
+    // callback) so a fit→rebuild→fit loop cannot form. This replaces the
+    // per-build post-frame fit that used to live in `NearbyMapView` and
+    // land inside the cold-start reset window (deleted in #2398).
+    final centerChanged = widget.center != oldWidget.center;
+    if (widget.stations.isNotEmpty && centerChanged) {
+      final bounds = _fitBounds;
+      // `LatLngBounds` has value `==`, so this skips an identical re-fit.
+      // `NearbyMapView.shouldFit` is the same pure predicate, kept there
+      // for its unit test; inlined here to avoid an import cycle.
+      if (_lastFitBounds != bounds) {
+        _lastFitBounds = bounds;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || !_mapReady) return;
+          widget.mapController.fitCamera(
+            CameraFit.bounds(bounds: bounds, padding: const EdgeInsets.all(32)),
+          );
+        });
+      }
+    }
   }
 
   @override
@@ -198,6 +250,25 @@ class _StationMapLayersState extends State<StationMapLayers> {
           options: MapOptions(
             initialCenter: widget.center,
             initialZoom: widget.zoom,
+            // #2399 — frame the search circle during the FIRST layout
+            // pass, not via a post-frame `fitCamera`. The old post-frame
+            // fit raced the (now-deleted) cold-start reset window and
+            // could land on a degenerate viewport. Positioning the
+            // camera as part of layout means the very first tile fetch
+            // already targets the right viewport — no reset needed.
+            initialCameraFit: CameraFit.bounds(
+              bounds:
+                  StationMapLayers.boundsForRadius(
+                      widget.center, widget.searchRadiusKm),
+              padding: const EdgeInsets.all(32),
+            ),
+            // #2399 — keep the FlutterMap (and its loaded tiles) alive
+            // when offstage in an IndexedStack so a tab flip back to the
+            // map doesn't tear down + cold-rebuild the tile pipeline.
+            keepAlive: true,
+            onMapReady: () {
+              if (mounted) _mapReady = true;
+            },
             // #1457 — clamp the camera to the tile-layer's max zoom (19)
             // so a programmatic `move(camera.zoom + 1)` past 19 doesn't
             // leave the user staring at a grey viewport (tiles only

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -169,7 +169,11 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// Recompute the memoised price range + marker list from the current
   /// widget inputs.
   void _recomputeMarkers() {
-    _priceRange = priceRange(widget.stations, widget.selectedFuel);
+    // #2400 — colour by the RESOLVED display price (selected fuel, else
+    // fallback) so a fallback-priced marker is coloured by the value it
+    // actually shows rather than appearing grey because the selected
+    // fuel was null.
+    _priceRange = resolvedPriceRange(widget.stations, widget.selectedFuel);
     final ids = widget.selectedStationIds;
     final hasSelection = ids != null && ids.isNotEmpty;
     _markers = widget.stations.map((station) {

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -17,6 +17,11 @@ import '../../../search/domain/entities/station.dart';
 const double kStationMarkerWidth = 50;
 const double kStationMarkerHeight = 24;
 
+/// Wider marker used when a fallback-fuel label is prepended (#2400) so
+/// the short fuel code (`E10`, `Diesel`, …) plus the price both fit
+/// without the [FittedBox] crushing the price too small to read.
+const double kStationMarkerWideWidth = 74;
+
 /// Maximum characters for the brand label before truncation (used in
 /// the tap-to-reveal tooltip).
 const _maxBrandLength = 14;
@@ -27,10 +32,18 @@ class StationMarkerBuilder {
 
   /// Build a compact [Marker] for a station, colored by relative price.
   ///
-  /// The marker shows only the price in bold inside a color-coded rounded
+  /// The marker shows the price in bold inside a color-coded rounded
   /// badge (green = cheap, orange = mid, red = expensive). Tapping opens
   /// the station detail page; long-press reveals the brand name as a
   /// tooltip.
+  ///
+  /// #2400 — the displayed price comes from [bestDisplayPrice]: the
+  /// selected [fuel] when present, otherwise the first available fallback
+  /// fuel. When the shown fuel differs from [fuel] (e.g. a diesel-only
+  /// station while the user has E10 selected), a small fuel-code dot +
+  /// label is prepended so the price is never silently mislabelled —
+  /// mirroring `AllPricesStationCard`. `'--'` now appears ONLY for a
+  /// station with no usable price for any fuel.
   ///
   /// When [pastel] is true, the marker uses muted/pastel colors for
   /// non-selected stations so that selected ones stand out.
@@ -42,22 +55,34 @@ class StationMarkerBuilder {
     double maxPrice, {
     bool pastel = false,
   }) {
-    final price = priceForFuelType(station, fuel);
+    final resolved = bestDisplayPrice(station, fuel);
+    final price = resolved?.price;
+    final isFallback = resolved != null && resolved.shownFuel != fuel;
     final baseColor = priceColor(price, minPrice, maxPrice);
     final color = pastel ? _toPastel(baseColor) : baseColor;
     final brand = truncateBrand(station.displayName, maxLength: _maxBrandLength);
+    final fallbackLabel =
+        isFallback ? shortFuelLabel(resolved.shownFuel) : '';
 
     // Accessibility (#566): TalkBack/VoiceOver read this as "Brand, price
     // EUR per litre, double-tap to view details" — otherwise the marker is
-    // an opaque gesture target with no announced role or content.
+    // an opaque gesture target with no announced role or content. When a
+    // fallback fuel is shown, the announced label names it so the price is
+    // never ambiguous.
     final priceLabel = price != null
-        ? PriceFormatter.formatPrice(price)
+        ? (isFallback
+            ? '$fallbackLabel ${PriceFormatter.formatPrice(price)}'
+            : PriceFormatter.formatPrice(price))
         : 'price unavailable';
     final semanticLabel = '$brand, $priceLabel';
 
+    final priceText = price != null
+        ? PriceFormatter.formatPriceCompact(price)
+        : '--'; // i18n-ignore: language-neutral no-price placeholder
+
     return Marker(
       point: LatLng(station.lat, station.lng),
-      width: kStationMarkerWidth,
+      width: isFallback ? kStationMarkerWideWidth : kStationMarkerWidth,
       height: kStationMarkerHeight,
       // #1772 — isolate each marker's raster so an animation or rebuild
       // on one marker (e.g. the selected-station pastel swap) does not
@@ -95,16 +120,43 @@ class StationMarkerBuilder {
             ),
             child: FittedBox(
               fit: BoxFit.scaleDown,
-              child: Text(
-                price != null
-                    ? PriceFormatter.formatPriceCompact(price)
-                    : '--',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 12,
-                  height: 1.0,
-                  color: pastel ? Colors.black38 : Colors.black87,
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Fallback fuel dot + code (mirrors AllPricesStationCard)
+                  // so a price for a fuel other than the selected one is
+                  // never shown unlabelled.
+                  if (isFallback) ...[
+                    Container(
+                      width: 6,
+                      height: 6,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: pastel ? Colors.black26 : Colors.black54,
+                      ),
+                    ),
+                    const SizedBox(width: 3),
+                    Text(
+                      fallbackLabel,
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 10,
+                        height: 1.0,
+                        color: pastel ? Colors.black38 : Colors.black87,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                  ],
+                  Text(
+                    priceText,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 12,
+                      height: 1.0,
+                      color: pastel ? Colors.black38 : Colors.black87,
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -20,6 +20,7 @@ import '../../../map/presentation/widgets/inline_map.dart';
 import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../station_detail/presentation/widgets/station_detail_inline.dart';
+import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_mode.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
@@ -125,6 +126,22 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // #2401 — Tankerkönig returns ONLY the queried fuel's price, so
+    // switching the fuel chip leaves the other fuels null. Re-run the
+    // last search whenever the selected fuel changes so the data layer
+    // refetches for the new fuel. `repeatLastSearch` is a no-op before
+    // the first search (no last query) and while one is in flight, so
+    // this is safe to fire on every chip change. Combined with the
+    // `bestDisplayPrice` resolver (#2400) the map is never blank even
+    // before the re-search lands.
+    ref.listen<FuelType>(selectedFuelTypeProvider, (prev, next) {
+      if (prev != next) {
+        unawaited(
+          ref.read(searchStateProvider.notifier).repeatLastSearch(),
+        );
+      }
+    });
+
     final l10n = AppLocalizations.of(context);
     final isWide = isWideScreen(context);
     final isLandscape =

--- a/test/core/constants/app_constants_test.dart
+++ b/test/core/constants/app_constants_test.dart
@@ -23,4 +23,50 @@ void main() {
       expect(AppConstants.appVersion, '99.0.0+9999');
     });
   });
+
+  group('OSM tile identity (#2396)', () {
+    // A digit-dot-digit version pattern (e.g. "5.0.0").
+    final versionPattern = RegExp(r'\d+\.\d+');
+
+    test('osmUserAgent is stable + version-free', () {
+      // OSM wants a STABLE identity, not one that changes per release.
+      // Even after the runtime version is bumped, the OSM UA must not
+      // carry a version number — otherwise every release looks like a
+      // fresh client to OSM's abuse heuristics.
+      AppConstants.setRuntimeVersion('7.3.1+7310');
+      expect(
+        versionPattern.hasMatch(AppConstants.osmUserAgent),
+        isFalse,
+        reason:
+            'osmUserAgent must be version-free (#2396) — it is the bare '
+            'package id, not "$AppConstants.userAgent".',
+      );
+      expect(AppConstants.osmUserAgent, AppConstants.appPackage);
+    });
+
+    test('the versioned userAgent stays versioned for data-API clients', () {
+      AppConstants.setRuntimeVersion('7.3.1+7310');
+      expect(
+        versionPattern.hasMatch(AppConstants.userAgent),
+        isTrue,
+        reason:
+            'Only the OSM/tile UA goes version-free; the data-API HTTP '
+            'clients keep the versioned identity.',
+      );
+    });
+
+    test('tileProxyUrl is a {z}/{x}/{y} Supabase functions template', () {
+      // LAYER 2 (#2397) constant — defined now, wired later. The shape is
+      // locked so the proxy contract test (LAYER 2) and the eventual
+      // SparkiloTileLayer default flip have a stable target.
+      expect(AppConstants.tileProxyUrl, contains('.supabase.co'));
+      expect(AppConstants.tileProxyUrl, contains('/functions/v1/tiles'));
+      expect(AppConstants.tileProxyUrl, contains('{z}/{x}/{y}'));
+    });
+
+    test('tileProxyOsmUserAgent carries a stable id + contact URL', () {
+      expect(AppConstants.tileProxyOsmUserAgent, contains('tile-proxy'));
+      expect(AppConstants.tileProxyOsmUserAgent, contains('https://'));
+    });
+  });
 }

--- a/test/core/utils/price_utils_test.dart
+++ b/test/core/utils/price_utils_test.dart
@@ -271,4 +271,67 @@ void main() {
       expect(station.fullLocation, equals('80331 München'));
     });
   });
+
+  group('bestDisplayPrice (#2400)', () {
+    test('returns the selected fuel price when present, labelled as it', () {
+      final s = _makeStation(e10: 1.599, diesel: 1.549);
+      final r = bestDisplayPrice(s, FuelType.e10);
+      expect(r, isNotNull);
+      expect(r!.price, 1.599);
+      expect(r.shownFuel, FuelType.e10);
+    });
+
+    test('falls back to the first available fuel when selected is null', () {
+      // Diesel-only station while E10 is selected — the recurring "--"
+      // case. Must resolve to the diesel price, labelled diesel.
+      final s = _makeStation(diesel: 1.699);
+      final r = bestDisplayPrice(s, FuelType.e10);
+      expect(r, isNotNull);
+      expect(r!.price, 1.699);
+      expect(r.shownFuel, FuelType.diesel);
+    });
+
+    test('fallback honours E10→E5→Diesel→…→CNG priority order', () {
+      // Selected = CNG (null); E5 + LPG present. E5 wins (earlier in the
+      // priority order than LPG).
+      final s = _makeStation(e5: 1.859, lpg: 0.799);
+      final r = bestDisplayPrice(s, FuelType.cng);
+      expect(r!.shownFuel, FuelType.e5);
+      expect(r.price, 1.859);
+    });
+
+    test('returns null only when the station has no usable price', () {
+      final s = _makeStation();
+      expect(bestDisplayPrice(s, FuelType.e10), isNull);
+    });
+  });
+
+  group('resolvedPriceRange (#2400)', () {
+    test('ranges over each station\'s resolved display price', () {
+      final stations = [
+        _makeStation(id: 'a', diesel: 1.50), // E10 null → diesel 1.50
+        _makeStation(id: 'b', e10: 1.70), // E10 present → 1.70
+        _makeStation(id: 'c', e5: 1.90), // E10 null → e5 1.90
+      ];
+      final (min, max) = resolvedPriceRange(stations, FuelType.e10);
+      expect(min, 1.50);
+      expect(max, 1.90);
+    });
+
+    test('returns (0, 0) when no station resolves to a price', () {
+      final stations = [_makeStation(id: 'x'), _makeStation(id: 'y')];
+      expect(resolvedPriceRange(stations, FuelType.e10), (0, 0));
+    });
+  });
+
+  group('shortFuelLabel (#2400)', () {
+    test('maps fuels to their language-neutral pump codes', () {
+      expect(shortFuelLabel(FuelType.e10), 'E10');
+      expect(shortFuelLabel(FuelType.e5), 'E5');
+      expect(shortFuelLabel(FuelType.diesel), 'Diesel');
+      expect(shortFuelLabel(FuelType.dieselPremium), 'Diesel+');
+      expect(shortFuelLabel(FuelType.lpg), 'GPL');
+      expect(shortFuelLabel(FuelType.cng), 'GNV');
+    });
+  });
 }

--- a/test/features/map/map_reimpl_regression_test.dart
+++ b/test/features/map/map_reimpl_regression_test.dart
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_marker.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// LAYER-1 regression suite for the map reimplementation (#2403).
+///
+/// These are the tests the four prior grey-tile / "--" fixes lacked.
+/// They fail loudly if either failure mode returns:
+///   - the parallel-TileLayer + reset storm (grey tiles), or
+///   - a marker rendering "--" while the station has a price for some
+///     other fuel (blank markers after a fuel-chip change).
+///
+/// The proxy URL + 7-day cache contract test is deferred to LAYER 2
+/// (#2397 deploys the edge function; the Deno-side contract test ships
+/// with it). The Dart-side proxy-URL/UA shape is already locked by
+/// `test/core/constants/app_constants_test.dart`.
+void main() {
+  group('NO RESET MACHINERY — the grey-tile storm cannot return (#2398)', () {
+    late String source;
+
+    setUpAll(() {
+      final f = File(
+        'lib/features/map/presentation/widgets/station_map_layers.dart',
+      );
+      expect(f.existsSync(), isTrue,
+          reason: 'station_map_layers.dart must exist');
+      source = f.readAsStringSync();
+    });
+
+    test('station_map_layers.dart has no reset controller', () {
+      expect(source.contains('_resetController'), isFalse,
+          reason:
+              'The reset-stream controller fired TileLayer.reset on every '
+              'cold-start camera/size event, evicting tiles before they '
+              'painted. It was deleted in #2398 and must not return.');
+    });
+
+    test('station_map_layers.dart does not subscribe to mapEventStream', () {
+      expect(source.contains('mapEventStream'), isFalse,
+          reason:
+              'The 12-second cold-start window subscribed to '
+              'MapController.mapEventStream and re-fired the reset on every '
+              'programmatic move — the root of the recurring grey-tile bug. '
+              'No such subscription may exist (#2398).');
+      // Belt-and-braces: none of the cold-start machinery names survive.
+      for (final banned in const [
+        '_coldStartEventSub',
+        '_coldStartCloseTimer',
+        '_coldStartResetWindow',
+        '_onColdStartEvent',
+      ]) {
+        expect(source.contains(banned), isFalse,
+            reason: '$banned is cold-start reset machinery deleted in #2398');
+      }
+    });
+
+    test('station_map_layers.dart renders the SINGLE SparkiloTileLayer', () {
+      // No raw inline TileLayer in the main map any more.
+      expect(source.contains('SparkiloTileLayer'), isTrue);
+      expect(RegExp(r'\bTileLayer\s*\(').hasMatch(source), isFalse,
+          reason:
+              'The main map must not instantiate a raw TileLayer — it goes '
+              'through SparkiloTileLayer (#2398).');
+    });
+  });
+
+  group('CONSISTENCY LINT — allowlist is exactly one entry (#2398)', () {
+    test('the consistency test allowlists ONLY sparkilo_tile_layer.dart', () {
+      final lintSource = File(
+        'test/features/map/tile_layer_consistency_test.dart',
+      ).readAsStringSync();
+
+      // The single legitimate raw-TileLayer call site.
+      expect(
+        lintSource.contains(
+          "'lib/features/map/data/sparkilo_tile_layer.dart'",
+        ),
+        isTrue,
+      );
+      // The main map must NOT be allowlisted any more.
+      expect(
+        lintSource.contains(
+          "'lib/features/map/presentation/widgets/station_map_layers.dart'",
+        ),
+        isFalse,
+        reason:
+            'station_map_layers.dart was removed from the allowlist in '
+            '#2398 — the parallel-TileLayer regression cannot recur.',
+      );
+    });
+  });
+
+  group('NEVER-BLANK MARKER — a price-bearing station never shows "--" '
+      '(#2400)', () {
+    // A result set where each station has at least one non-null price, but
+    // NONE of them carries the selected fuel (E10) — the exact
+    // fuel-chip-divergence scenario. Every marker must show a real price.
+    final mismatchedSet = <Station>[
+      _station(id: 's-diesel', diesel: 1.699),
+      _station(id: 's-e5', e5: 1.859),
+      _station(id: 's-lpg', lpg: 0.799),
+      _station(id: 's-cng', cng: 1.199),
+    ];
+
+    testWidgets('no marker in a price-bearing set renders "--" on a '
+        'mismatched fuel', (tester) async {
+      for (final station in mismatchedSet) {
+        final marker = StationMarkerBuilder.build(
+          tester.element(find.byType(Container).first),
+          station,
+          FuelType.e10, // selected fuel none of the stations carry
+          0.5,
+          2.0,
+        );
+        await pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+        expect(find.text('--'), findsNothing,
+            reason:
+                '${station.id} has a fallback price and must not render "--"');
+      }
+    });
+
+    testWidgets('a truly empty station DOES render "--"', (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        _station(id: 's-empty'),
+        FuelType.e10,
+        0.5,
+        2.0,
+      );
+      await pumpApp(
+        tester,
+        SizedBox(
+          width: marker.width,
+          height: marker.height,
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
+        ),
+      );
+      expect(find.text('--'), findsOneWidget,
+          reason: 'the true-empty case is the only legitimate "--"');
+    });
+  });
+}
+
+Station _station({
+  required String id,
+  double? e5,
+  double? e10,
+  double? diesel,
+  double? lpg,
+  double? cng,
+}) =>
+    Station(
+      id: id,
+      name: id,
+      brand: 'TEST',
+      street: 'Test St.',
+      postCode: '12345',
+      place: 'Test',
+      lat: 52.0,
+      lng: 13.0,
+      e5: e5,
+      e10: e10,
+      diesel: diesel,
+      lpg: lpg,
+      cng: cng,
+      isOpen: true,
+    );

--- a/test/features/map/presentation/widgets/nearby_map_view_test.dart
+++ b/test/features/map/presentation/widgets/nearby_map_view_test.dart
@@ -50,7 +50,7 @@ void main() {
     });
   });
 
-  group('NearbyMapView fitCamera scheduling (#2177)', () {
+  group('Camera lifecycle: initialCameraFit + single re-fit (#2399)', () {
     late Directory tempDir;
 
     setUp(() async {
@@ -122,7 +122,8 @@ void main() {
         );
 
     testWidgets(
-      'fits once on first data and does NOT re-fit on a same-bounds rebuild',
+      'first paint is framed by initialCameraFit + keepAlive; a same-bounds '
+      'rebuild does NOT re-fit',
       (tester) async {
         final controller = _CountingMapController();
         addTearDown(controller.dispose);
@@ -137,27 +138,36 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(controller.fitCount, 1,
-            reason: 'the first data fit must fire exactly once');
+        // #2399 — first paint is positioned by `MapOptions.initialCameraFit`
+        // applied during the first layout pass (flutter_map routes that one
+        // application through the controller, hence the baseline of 1). The
+        // OLD per-build post-frame `fitCamera` in NearbyMapView — which
+        // raced the cold-start reset window — is gone.
+        final flutterMap =
+            tester.widget<FlutterMap>(find.byType(FlutterMap));
+        expect(flutterMap.options.initialCameraFit, isNotNull,
+            reason: 'first paint must be framed via initialCameraFit');
+        expect(flutterMap.options.keepAlive, isTrue,
+            reason: 'keepAlive must be set so a tab flip keeps the tiles');
+        final baseline = controller.fitCount;
+        expect(baseline, lessThanOrEqualTo(1),
+            reason: 'at most the single initialCameraFit application');
 
-        // Force a genuine rebuild that recomputes the SAME fit target: a
-        // brand-new ServiceResult object holding the same Paris station, so
-        // the `searchState` reference changes (a real rebuild + recompute)
-        // but the resulting bounds are value-equal. This mirrors the
-        // redundant rebuilds in production (EV-toggle tap, app resume,
-        // unrelated provider change). The guard must skip the re-fit.
+        // A genuine rebuild recomputing the SAME bounds (new ServiceResult
+        // object, same Paris station) must NOT add a re-fit — `LatLngBounds`
+        // value `==` makes the guard skip it.
         final state =
             tester.state<_RebuildableState>(find.byType(_Rebuildable));
         state.show(resultFor(parisStations));
         await tester.pumpAndSettle();
 
-        expect(controller.fitCount, 1,
+        expect(controller.fitCount, baseline,
             reason: 'an unchanged fit target must NOT re-fit the camera');
       },
     );
 
     testWidgets(
-      'fits again when the search bounds genuinely change',
+      'exactly one re-fit per distinct search bounds (no fit loop)',
       (tester) async {
         final controller = _CountingMapController();
         addTearDown(controller.dispose);
@@ -172,16 +182,30 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(controller.fitCount, 1, reason: 'first fit on initial data');
+        // Baseline = the single initialCameraFit application on first paint.
+        final baseline = controller.fitCount;
 
-        // Swap to a different search area (Lyon) — new bounds, must re-fit.
+        // Swap to a different search area (Lyon): the centre changes value,
+        // so `StationMapLayers.didUpdateWidget` schedules exactly ONE fit.
         final state =
             tester.state<_RebuildableState>(find.byType(_Rebuildable));
         state.show(resultFor(lyonStations));
         await tester.pumpAndSettle();
 
-        expect(controller.fitCount, 2,
-            reason: 'a genuinely changed fit target must fit again');
+        expect(controller.fitCount, baseline + 1,
+            reason: 'a genuinely changed centre fits exactly once');
+
+        // Settle does not loop: a fit→rebuild→fit cycle would keep
+        // incrementing. `_lastFitBounds` is set at schedule time, so the
+        // post-fit rebuild recomputes the same bounds and skips.
+        await tester.pump(const Duration(milliseconds: 32));
+        expect(controller.fitCount, baseline + 1, reason: 'no fit loop');
+
+        // Back to Paris: a third distinct bounds → one more fit.
+        state.show(resultFor(parisStations));
+        await tester.pumpAndSettle();
+        expect(controller.fitCount, baseline + 2,
+            reason: 'each distinct bounds fits exactly once');
       },
     );
   });

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:tankstellen/features/map/data/retry_network_tile_provider.dart';
+import 'package:tankstellen/features/map/data/sparkilo_tile_layer.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
@@ -132,15 +132,12 @@ void main() {
   // #757: the retry+evict tile provider makes the nudge unnecessary.
   // A failed tile now retries at the HTTP layer and, if still
   // unresolved, is evicted from the cache as soon as it scrolls out
-  // of the keep-buffer margin. The structural assertion that
-  // `MapOptions.onMapReady != null` no longer holds and should not
-  // be resurrected — re-adding the jiggle would cancel in-flight
-  // retries (the #709 regression that was itself rolled back).
+  // of the keep-buffer margin.
 
-  group('StationMapLayers tile provider stability (#1234)', () {
+  group('StationMapLayers single tile path (#2398)', () {
     testWidgets(
-      'TileLayer keeps the same RetryNetworkTileProvider instance across '
-      'parent rebuilds — does NOT re-instantiate on every build',
+      'renders the basemap through the hardened SparkiloTileLayer — no '
+      'parallel inline TileLayer, no reset stream',
       (tester) async {
         // Wide-enough viewport so the FlutterMap actually mounts.
         tester.view.physicalSize = const Size(900, 1600);
@@ -151,16 +148,57 @@ void main() {
         final mapController = MapController();
         addTearDown(mapController.dispose);
 
-        // Helper to drive a fresh build with a different external key
-        // (the kind of trivial rebuild that, before #1234, churned the
-        // tile provider on every parent setState).
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StationMapLayers(
+                mapController: mapController,
+                stations: const [_seedStation],
+                center: const LatLng(52.5210, 13.4100),
+                zoom: 12,
+                searchRadiusKm: 10,
+                selectedFuel: FuelType.diesel,
+              ),
+            ),
+          ),
+        );
+
+        // Exactly one SparkiloTileLayer drives the basemap. Before
+        // #2398 the main map ran a parallel inline TileLayer with its
+        // own provider + a 12 s cold-start reset storm that evicted
+        // tiles before they painted (the recurring grey-tile bug). The
+        // unified path means there is one keyed tile widget and one
+        // reset behaviour shared with every other map surface.
+        expect(find.byType(SparkiloTileLayer), findsOneWidget);
+        final sparkilo =
+            tester.widget<SparkiloTileLayer>(find.byType(SparkiloTileLayer));
+        expect(sparkilo.key, const ValueKey('main-tiles'));
+        expect(
+          sparkilo.reset,
+          isNull,
+          reason:
+              'SparkiloTileLayer in the main map must NOT receive a reset '
+              'stream — the cold-start reset storm (#1316/#2025) that '
+              'evicted tiles before first paint was deleted in #2398.',
+        );
+      },
+    );
+
+    testWidgets(
+      'survives parent rebuilds without re-keying the tile widget '
+      '(provider lifetime is owned inside SparkiloTileLayer)',
+      (tester) async {
+        tester.view.physicalSize = const Size(900, 1600);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final mapController = MapController();
+        addTearDown(mapController.dispose);
+
         Widget pumpAt(int rebuildToken) => MaterialApp(
               home: Scaffold(
                 body: KeyedSubtree(
-                  // ValueKey changes only the OUTER subtree wrapper —
-                  // it's a no-op on StationMapLayers' own State, which
-                  // is what we want. We only want the parent build()
-                  // to run again.
                   key: ValueKey('rebuild-$rebuildToken'),
                   child: StationMapLayers(
                     mapController: mapController,
@@ -175,204 +213,14 @@ void main() {
             );
 
         await tester.pumpWidget(pumpAt(0));
-
-        TileLayer findTileLayer() => tester.widget<TileLayer>(
-              find.byType(TileLayer),
-            );
-
-        final providerOnFirstBuild = findTileLayer().tileProvider;
-        expect(
-          providerOnFirstBuild,
-          isA<RetryNetworkTileProvider>(),
-          reason:
-              'StationMapLayers must wire RetryNetworkTileProvider into '
-              'the TileLayer (not the default NetworkTileProvider) — the '
-              '#757 retry policy depends on it.',
-        );
-
-        // Rebuild via a parent setState analogue. Same widget instance
-        // (same State), but the TileLayer widget is re-instantiated.
-        // The State must hand it the SAME tile provider instance.
-        await tester.pumpWidget(pumpAt(0));
         await tester.pumpWidget(pumpAt(0));
         await tester.pumpWidget(pumpAt(0));
 
-        final providerAfterRebuilds = findTileLayer().tileProvider;
-        expect(
-          identical(providerOnFirstBuild, providerAfterRebuilds),
-          isTrue,
-          reason:
-              'TileLayer.tileProvider must remain identical across '
-              'StationMapLayers parent rebuilds. Recreating the provider '
-              'every build (the prior bug, #1234) churned http.Client '
-              'instances and produced cold-start grey tiles. Holding it '
-              'in State (initState/dispose) is the fix.',
-        );
-      },
-    );
-
-    testWidgets(
-      'TileLayer.reset stream is wired so a settled-camera kick can drop '
-      'tiles fetched against a degenerate viewport',
-      (tester) async {
-        tester.view.physicalSize = const Size(900, 1600);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.resetPhysicalSize);
-        addTearDown(tester.view.resetDevicePixelRatio);
-
-        final mapController = MapController();
-        addTearDown(mapController.dispose);
-
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: StationMapLayers(
-                mapController: mapController,
-                stations: const [_seedStation],
-                center: const LatLng(52.5210, 13.4100),
-                zoom: 12,
-                searchRadiusKm: 10,
-                selectedFuel: FuelType.diesel,
-              ),
-            ),
-          ),
-        );
-
-        final layer = tester.widget<TileLayer>(find.byType(TileLayer));
-        expect(
-          layer.reset,
-          isNotNull,
-          reason:
-              'TileLayer.reset must be wired so the post-first-frame '
-              'kick can force a tile reload — covers the cold-start case '
-              'where TileLayer captured a degenerate viewport before the '
-              'MapController settled (#1234).',
-        );
-      },
-    );
-  });
-
-  group('StationMapLayers cold-start tile reset window (#1316 phase 3)', () {
-    testWidgets(
-      'reset stream re-fires on programmatic camera moves during the '
-      'cold-start window so TileLayer reloads after `fitCamera` settles',
-      (tester) async {
-        tester.view.physicalSize = const Size(900, 1600);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.resetPhysicalSize);
-        addTearDown(tester.view.resetDevicePixelRatio);
-
-        final mapController = MapController();
-        addTearDown(mapController.dispose);
-
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: StationMapLayers(
-                mapController: mapController,
-                stations: const [_seedStation],
-                center: const LatLng(52.5210, 13.4100),
-                zoom: 12,
-                searchRadiusKm: 10,
-                selectedFuel: FuelType.diesel,
-              ),
-            ),
-          ),
-        );
-
-        // The initState first-paint reset fired during pumpWidget's
-        // post-frame stage, so a listener attached now misses it
-        // (broadcast streams do not replay). That part is already
-        // covered by the existing "TileLayer.reset stream is wired"
-        // test above. Here we focus on the phase-3 invariant: a
-        // programmatic camera move during the cold-start window must
-        // produce at least one fresh reset.
-        final reset = tester.widget<TileLayer>(find.byType(TileLayer)).reset!;
-        final emissions = <void>[];
-        final sub = reset.listen(emissions.add);
-        addTearDown(sub.cancel);
-
-        // Simulate `NearbyMapView`s post-frame `fitCamera` arriving
-        // AFTER the initState reset already fired. Before #1316
-        // phase 3, this left TileLayer with whatever tile range it
-        // computed at the bootstrap camera — typically only a handful
-        // of tiles around the (possibly stale) initial centre. Now
-        // the cold-start subscriber must catch this event and
-        // re-emit reset so TileLayer reloads against the settled
-        // camera.
-        mapController.move(const LatLng(43.4500, 3.4900), 12);
-        await tester.pump(const Duration(milliseconds: 16));
-
-        expect(
-          emissions,
-          isNotEmpty,
-          reason:
-              '#1316 — programmatic camera moves during the cold-start '
-              'window must re-emit on the reset stream so TileLayer '
-              'recomputes its visible-tile set against the settled '
-              'camera. Previously the initState reset fired against the '
-              'bootstrap camera; if `fitCamera` (or any controller move) '
-              'arrived later, TileLayer kept the small tile set from '
-              'the bootstrap camera, leaving most of the map grey.',
-        );
-      },
-    );
-
-    testWidgets(
-      'after the cold-start window, programmatic moves no longer trigger '
-      'extra resets (steady-state pans must not pop tiles)',
-      (tester) async {
-        tester.view.physicalSize = const Size(900, 1600);
-        tester.view.devicePixelRatio = 1.0;
-        addTearDown(tester.view.resetPhysicalSize);
-        addTearDown(tester.view.resetDevicePixelRatio);
-
-        final mapController = MapController();
-        addTearDown(mapController.dispose);
-
-        await tester.pumpWidget(
-          MaterialApp(
-            home: Scaffold(
-              body: StationMapLayers(
-                mapController: mapController,
-                stations: const [_seedStation],
-                center: const LatLng(52.5210, 13.4100),
-                zoom: 12,
-                searchRadiusKm: 10,
-                selectedFuel: FuelType.diesel,
-              ),
-            ),
-          ),
-        );
-
-        final reset = tester.widget<TileLayer>(find.byType(TileLayer)).reset!;
-        final emissions = <void>[];
-        final sub = reset.listen(emissions.add);
-        addTearDown(sub.cancel);
-
-        // Burn past the 12-second cold-start window (extended from
-        // 3 s in the #2025 follow-up to cover slow-network cold opens).
-        await tester.pump(const Duration(seconds: 13));
-        final baseline = emissions.length;
-
-        // Programmatic move AFTER the window — must not re-emit on
-        // the reset stream. TileLayer has its own load-on-event
-        // handling for steady-state pans; gratuitous resets pop the
-        // visible tiles back to their loading state.
-        mapController.move(const LatLng(43.4500, 3.4900), 12);
-        await tester.pump(const Duration(milliseconds: 16));
-
-        expect(
-          emissions.length,
-          baseline,
-          reason:
-              'After [_coldStartResetWindow] elapses, programmatic '
-              'camera moves must no longer fire the reset stream — '
-              'TileLayer\'s normal event-driven load path handles '
-              'steady-state pans and an extra reset would briefly '
-              'wipe the visible tiles. The cold-start subscription '
-              'must self-cancel.',
-        );
+        // The keyed SparkiloTileLayer is preserved across rebuilds, so
+        // its State (and the retry provider's http.Client) lives for
+        // the map's whole visible lifetime — the #1234 invariant now
+        // lives inside the wrapper rather than this widget.
+        expect(find.byType(SparkiloTileLayer), findsOneWidget);
       },
     );
   });

--- a/test/features/map/presentation/widgets/station_marker_test.dart
+++ b/test/features/map/presentation/widgets/station_marker_test.dart
@@ -222,4 +222,124 @@ void main() {
       expect(expensiveMarker.width, kStationMarkerWidth);
     });
   });
+
+  group('StationMarkerBuilder fallback fuel display (#2400)', () {
+    // Tankerkönig returns only the queried fuel's price. A diesel-only
+    // station while E10 is selected used to render "--"; it must now fall
+    // back to the diesel price with a labelled fuel code.
+    const dieselOnlyStation = Station(
+      id: 'diesel-only',
+      name: 'Diesel Only',
+      brand: 'TOTAL',
+      street: 'Rue Diesel',
+      postCode: '75001',
+      place: 'Paris',
+      lat: 48.0,
+      lng: 2.0,
+      diesel: 1.699,
+      isOpen: true,
+    );
+
+    testWidgets(
+      'a diesel-only station on an E10 search shows the diesel price, '
+      'never "--"',
+      (tester) async {
+        final marker = StationMarkerBuilder.build(
+          tester.element(find.byType(Container).first),
+          dieselOnlyStation,
+          FuelType.e10,
+          1.50,
+          2.00,
+        );
+        // Fallback widens the marker so the fuel code + price both fit.
+        expect(marker.width, kStationMarkerWideWidth);
+
+        await pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+
+        // The diesel price is shown (1.699 => "1,699"); never "--".
+        expect(find.text('1,699'), findsOneWidget);
+        expect(find.text('--'), findsNothing);
+        // The fallback fuel code is labelled so the price is unambiguous.
+        expect(find.text('Diesel'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'a truly price-less station still shows "--"',
+      (tester) async {
+        const emptyStation = Station(
+          id: 'empty',
+          name: 'Empty',
+          brand: 'TEST',
+          street: 'Nowhere',
+          postCode: '00000',
+          place: 'Void',
+          lat: 0.0,
+          lng: 0.0,
+          isOpen: true,
+        );
+        final marker = StationMarkerBuilder.build(
+          tester.element(find.byType(Container).first),
+          emptyStation,
+          FuelType.e10,
+          1.50,
+          2.00,
+        );
+        // No fallback fuel → no widening, no fuel label.
+        expect(marker.width, kStationMarkerWidth);
+
+        await pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+
+        expect(find.text('--'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'no fallback label when the selected fuel has its own price',
+      (tester) async {
+        final marker = StationMarkerBuilder.build(
+          tester.element(find.byType(Container).first),
+          testStation, // has e10
+          FuelType.e10,
+          1.50,
+          2.00,
+        );
+        expect(marker.width, kStationMarkerWidth);
+
+        await pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+
+        expect(find.text('1,799'), findsOneWidget);
+        // No fuel code when the selected fuel resolved directly.
+        expect(find.text('Diesel'), findsNothing);
+        expect(find.text('E10'), findsNothing);
+      },
+    );
+  });
 }

--- a/test/features/map/tile_layer_consistency_test.dart
+++ b/test/features/map/tile_layer_consistency_test.dart
@@ -26,18 +26,17 @@ void main() {
   test(
     'every TileLayer in lib/ goes through SparkiloTileLayer or is allowlisted (#2096)',
     () {
-      // Allowlisted files — these own their own retry-provider
-      // lifecycle and the inline TileLayer is intentional.
+      // Allowlist — the SINGLE place a raw TileLayer is allowed
+      // (#2398). `station_map_layers.dart` was removed from the
+      // allowlist once its parallel inline TileLayer + cold-start
+      // reset machinery was deleted and it routed through
+      // SparkiloTileLayer. The parallel-TileLayer regression that
+      // caused the recurring grey-tile bug cannot recur: any new
+      // raw `TileLayer(` outside the wrapper fails this lint.
       const allowlist = <String>{
         // The hardened wrapper itself — the ONE place a raw
         // TileLayer is allowed.
         'lib/features/map/data/sparkilo_tile_layer.dart',
-        // The main map. Holds the provider in state + wires the
-        // cold-start event-stream reset. A future cleanup can fold
-        // this into SparkiloTileLayer with an optional cold-start
-        // hook; until then the inline setup is allowlisted with
-        // its existing rationale documented in the file.
-        'lib/features/map/presentation/widgets/station_map_layers.dart',
       };
 
       final offenders = <String>[];

--- a/test/features/search/presentation/screens/search_screen_test.dart
+++ b/test/features/search/presentation/screens/search_screen_test.dart
@@ -2,14 +2,39 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/presentation/screens/search_screen.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_summary_bar.dart';
 import 'package:tankstellen/features/search/presentation/widgets/user_position_bar.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
+
+/// Spy [SearchState] that counts `repeatLastSearch` invocations without
+/// hitting the network — lets the #2401 test assert the fuel-chip change
+/// re-triggers the search exactly once.
+class _SpySearchState extends SearchState {
+  int repeatCount = 0;
+
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() =>
+      AsyncValue.data(ServiceResult(
+        data: const [],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime.now(),
+      ));
+
+  @override
+  Future<void> repeatLastSearch() async {
+    repeatCount++;
+  }
+}
 
 void main() {
   group('SearchScreen (results-first layout)', () {
@@ -143,6 +168,50 @@ void main() {
         matching: find.widgetWithIcon(IconButton, Icons.refresh),
       );
       expect(refreshInAppBar, findsOneWidget);
+    });
+
+    testWidgets(
+        'changing the selected fuel re-triggers the search exactly once (#2401)',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      final spy = _SpySearchState();
+
+      await pumpApp(
+        tester,
+        const SearchScreen(),
+        overrides: [
+          ...test.overrides,
+          userPositionNullOverride(),
+          searchStateProvider.overrideWith(() => spy),
+        ],
+      );
+      // A pump settles initState's post-frame auto-search attempt.
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SearchScreen)),
+      );
+
+      // No fuel change yet → the listener has not fired.
+      expect(spy.repeatCount, 0);
+
+      // Change the selected fuel chip → exactly one repeatLastSearch.
+      container.read(selectedFuelTypeProvider.notifier).select(FuelType.diesel);
+      await tester.pump();
+      expect(spy.repeatCount, 1,
+          reason: 'a fuel-chip change must re-run the last search once');
+
+      // Selecting the SAME fuel again must NOT fire (prev == next).
+      container.read(selectedFuelTypeProvider.notifier).select(FuelType.diesel);
+      await tester.pump();
+      expect(spy.repeatCount, 1,
+          reason: 'an unchanged selection must not re-trigger the search');
+
+      // A genuinely different fuel fires once more.
+      container.read(selectedFuelTypeProvider.notifier).select(FuelType.e5);
+      await tester.pump();
+      expect(spy.repeatCount, 2);
     });
 
     testWidgets('results area dominates the viewport (≥60% vertical)',


### PR DESCRIPTION
## LAYER 1 of Epic #2394 — map reimplementation (zero-infra, no-ARB)

Fixes the 2-month grey-tile + `--`-marker regression cycle at its **root**, not with another knob on the reset/abort machinery (the four prior band-aids #2044, #2096/#2097, #2122/#2123, #2177/#2221 all failed because they tuned the storm instead of deleting it).

### Root causes (validated against code)
- **Grey tiles:** the main map ran a *parallel inline `TileLayer`* plus a 12-second `_coldStartResetWindow` that fired `TileLayer.reset` on every camera/size event — evicting tiles before they painted on a slow first round-trip. It also used `abortObsoleteRequests: false` while every other surface used `true`, and a per-release versioned OSM UA.
- **`--` markers:** the marker used the strict selected-fuel price; Tankerkönig returns only the queried fuel's price and the chip didn't re-search, so markers read null after a fuel change.

### What this PR does (one commit per issue)
- **#2398** — delete the inline `TileLayer` + `_resetController` + `_coldStartEventSub`/`_coldStartCloseTimer`/`_coldStartResetWindow`/`_onColdStartEvent` and the reset firings; render through the single hardened `SparkiloTileLayer(key: ValueKey('main-tiles'))` (no reset stream → unified `abortObsoleteRequests: true`). Consistency-lint allowlist tightened to the single `sparkilo_tile_layer.dart`.
- **#2399** — camera via `MapOptions.initialCameraFit` (frames the search circle during layout, no post-frame race) + a single guarded `didUpdateWidget` re-fit (mounted + `_mapReady` via `onMapReady` + value-distinct centre) + `keepAlive: true`. The per-build post-frame `fitCamera` is removed from `nearby_map_view`; `shouldFit` stays as a pure predicate.
- **#2396 (LAYER 1 part)** — `osmUserAgent` is now the stable, version-free `de.tankstellen.app`; the versioned `userAgent` stays for data-API clients. Adds `tileProxyUrl` + `tileProxyOsmUserAgent` constants (defined, documented). `SparkiloTileLayer` still defaults to `osmTileUrl` (OSM-direct) — the proxy is not deployed yet, so we do **not** point at it. `BuiltInMapCachingProvider` stays default-on.
- **#2400** — `bestDisplayPrice(Station, FuelType)` resolver (selected fuel → first non-null E10→E5→Diesel→DieselPremium→E85→LPG→CNG, reporting which fuel); the marker shows the resolved price + a small fuel-code dot/label when the shown fuel differs (mirrors `AllPricesStationCard`), and colours over the resolved prices. `--` now appears **only** for a truly price-less station.
- **#2401** — `SearchScreen` re-triggers `repeatLastSearch()` when the fuel chip changes (no-op before the first search), closing the Tankerkönig fuel-scope divergence.
- **#2403 (LAYER 1 tests)** — regression suite: source-level no-`_resetController`/no-`mapEventStream` assertion, single-allowlist assertion, and a never-blank-marker widget test (mismatched-fuel set shows real prices; truly-empty shows `--`).

### Deferred to LAYER 2 (NOT in this PR)
- The Supabase `tiles` edge function (#2397)
- Flipping `SparkiloTileLayer`'s default to the proxy URL (#2396 finish)
- Moving the OSM attribution to ARB across all locales (#2402) — attribution stays inline; **no new ARB** here
- The Deno-side proxy URL + 7-day cache-header contract test (#2403 finish)

### Gate
- `flutter analyze lib/ test/`: no new issues (only 2 pre-existing `info`s in untouched files)
- `flutter test test/features/map/ test/features/search/ test/core/ test/lint/ --exclude-tags=network`: green (3658 tests)
- `git diff --exit-code`: clean (no codegen drift; no `@riverpod`/`freezed` sources touched)

Closes #2398
Closes #2399
Closes #2400
Closes #2401
Refs #2396 (LAYER 2 finishes the proxy default-flip)
Refs #2403 (LAYER 2 finishes the proxy-contract test)
Part of #2394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
