### PR TITLE
feat(consumption): emit live GPS fuel estimate into TripLiveReading + estimator ADR (#2389, #2386)

### DIFF
--- a/docs/decisions/0012-gps-live-consumption-estimator.md
+++ b/docs/decisions/0012-gps-live-consumption-estimator.md
@@ -1,0 +1,163 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# ADR 0012: GPS-only live consumption estimator
+
+**Status:** Accepted
+**Date:** 2026-05-30
+**Issue:** #2386
+**Parent Epic:** #2385
+
+## Context
+
+When a trajet records from GPS only (no OBD2 dongle, or a dropout), the
+post-trip GPS calibration matrix (ADR 0010, #2056) can impute a whole-trip
+**average** L/100 km after the trip ends — but it cannot produce a *live*
+figure while the user is driving. The recording screen, the PiP overlay,
+and the live banner therefore show a blank consumption read-out for the
+entire GPS-only trip, which reads as a missing feature next to the rich
+OBD2 live read-out.
+
+Epic #2385 sets out to surface a **live** GPS-only consumption estimate.
+The post-trip matrix is the wrong tool for this: it is a per-vehicle linear
+fit over *aggregate* driving-style features (idle / accel / high-speed
+shares) and is only meaningful once the whole trajet's feature totals
+exist. We need a model that consumes one GPS sample per ~1 Hz tick and
+emits an instantaneous figure that converges over the trip.
+
+Two families of live model were on the table:
+
+1. A **physics road-load model** — derive tractive power from speed +
+   acceleration + vehicle mass/drag/rolling-resistance, convert to fuel via
+   fuel-energy + driveline efficiency, anchored to OBD2 ground truth with a
+   single per-vehicle scale factor.
+2. A **fuzzy / driving-style classifier** — bucket the live signal into
+   eco/normal/aggressive style bands and map each band to a consumption
+   multiplier off the WLTP baseline.
+
+The forces at play: GPS gives us speed (and noisy altitude) but no engine
+signal; the figure must be live and per-tick; it must degrade gracefully
+with no calibration data; and it must be able to *learn* from the OBD2
+ground truth we already collect on dongle trips (the #2388 `physicsScale`).
+
+## Decision
+
+**GPS-only live consumption is a calibrated physics road-load model
+anchored to the vehicle baseline, calibrated from OBD2 ground truth via a
+single per-vehicle `physicsScale`. Fuzzy / driving-style classification is
+at most an optional modifier layered on top — it is NOT the primary
+model.**
+
+### The primary model — physics road-load
+
+Implemented as the pure-domain `GpsLiveFuelEstimator` (#2387). For each
+~1 Hz tick the tractive force at the wheels is
+
+```
+F = Crr·m·g                    (rolling resistance)
+  + ½·ρ·Cd·A·v²                (aerodynamic drag, ρ = 1.225 kg/m³)
+  + m·a                        (inertia — a is the low-passed accel)
+  + m·g·grade                  (only when grade is confident)
+```
+
+Power `P = max(0, F·v)` (no negative-power credit — coasting/braking burns
+idle fuel, it does not put fuel back in the tank). Fuel mass-flow combines
+tractive burn with a constant idle draw, and the instantaneous figure is
+
+```
+L/100 km = ṁ / v · 1e5 · physicsScale
+```
+
+valid only while moving (`v > 0.5 m/s`); at a standstill the figure is
+undefined (null) and only idle litres accumulate.
+
+### Anchoring & calibration — OBD2 is the ground truth
+
+- A single per-vehicle `GpsCalibrationMatrix.physicsScale` (#2388,
+  default 1.0) multiplies the raw physics output. This is the *one* knob
+  the OBD2-anchored calibration tunes: when a vehicle has been driven with
+  a dongle, the measured fuel-rate ground truth fits `physicsScale` so the
+  physics output matches reality, then that scale carries over to the
+  vehicle's GPS-only trips.
+- The body-load defaults (mass / Cd / frontal area / Crr) and the fuel-
+  energy / driveline params come from a vehicle-class table keyed on curb
+  weight + fuel type, so the model produces a plausible figure even with
+  **zero** calibration history (`physicsScale` 1.0).
+
+### Fuzzy / driving-style is at most a modifier — not the model
+
+A driving-style classifier could, later, nudge the figure (e.g. a small
+multiplier for sustained aggressive throttle that the pure road-load model
+under-counts). If it is ever added it sits *downstream* of the physics
+output as an optional correction, never as the source figure. The physics
+model — anchored to OBD2 — stays the primary, auditable basis. This keeps
+the model explainable (every term is a physical quantity), keeps the
+calibration story single-knob, and avoids a black-box style classifier
+becoming load-bearing for a number we surface to users.
+
+### Robustness
+
+- Acceleration is the finite difference of speed run through a **3-sample
+  moving-average low-pass** — mandatory to stop GPS speed jitter from
+  injecting phantom inertial spikes.
+- The grade term is gated off unless the grade is confident; raw GPS
+  altitude is too noisy to feed blindly.
+- Both the instant and running-average figures are clamped to the same
+  `[0.5, 30.0]` L/100 km plausibility band the post-trip estimator uses.
+
+### Surfacing (deferred)
+
+The live estimate is emitted into the recording pipeline now (#2389, the
+nullable `TripLiveReading.gpsEstimatedLPer100Km`) but its **display** is
+deferred. When surfaced, the figure carries a leading `~` to mark it as an
+estimate (not a measurement) plus a maturity / confidence signal — the
+display + confidence work lands in #2391 and #2393; the PiP wiring in
+#2390. On OBD2 trips the real measured value remains the source of truth
+and the estimate field stays null.
+
+## Consequences
+
+### Positive
+
+- GPS-only users get a live consumption read-out that was previously blank,
+  matching the OBD2 live experience.
+- The model is explainable end-to-end: every term is a physical quantity,
+  and calibration is a single human-readable scale factor.
+- One calibration knob (`physicsScale`) means OBD2 ground truth transfers
+  cleanly to GPS-only trips with no separate live-model fit.
+- Works with zero calibration history via the class-default table, then
+  improves as `physicsScale` converges.
+
+### Negative
+
+- A road-load model needs reasonable mass / Cd / frontal-area defaults; the
+  curb-weight class table is a coarse approximation for unusual bodies
+  (vans, heavily-loaded vehicles). The `physicsScale` anchor absorbs the
+  systematic part of this error once OBD2 data exists.
+- The model is combustion-oriented (fuel-energy + idle draw); EVs are out
+  of scope here and keep their own path, consistent with ADR 0010.
+- Without OBD2 history the figure is an un-anchored physics estimate — hence
+  the `~` prefix and confidence signal (#2391/#2393) so users read it as an
+  estimate, not a measurement.
+
+## Alternatives Considered
+
+- **Fuzzy / driving-style classifier as the primary model.** Rejected as
+  the primary: a style-band → multiplier mapping is a black box that is
+  hard to anchor to OBD2 ground truth and hard to explain, and it discards
+  the directly-usable physical signal (speed, accel, mass). It survives
+  only as an optional downstream modifier.
+- **Reuse the post-trip GPS calibration matrix (ADR 0010) live.** Rejected:
+  the matrix is a fit over *aggregate* whole-trajet feature shares; it has
+  no meaningful per-tick output and cannot converge live within a single
+  trip.
+- **Per-tick least-squares / Kalman fit of the road-load coefficients.**
+  Rejected for v1: GPS gives no independent fuel signal mid-trip to fit
+  against, so there is nothing to regress on live. The single-scale OBD2
+  anchor is simpler and is the only signal we actually have ground truth
+  for. Revisit if richer live signals appear.
+- **Hard-coded WLTP × speed-bucket lookup.** Rejected: ignores load,
+  acceleration, mass and grade entirely — the whole point of a live figure
+  is that it responds to how the car is being driven right now.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -45,3 +45,4 @@ reused. If a decision is reversed, the original ADR is marked
 | 0009 | Cross-platform default + plugin pattern | Accepted |
 | 0010 | GPS driving-style calibration matrix | Accepted |
 | 0011 | Approach-detection + speed-aware polling scheduler | Accepted |
+| 0012 | GPS-only live consumption estimator | Accepted |

--- a/lib/features/consumption/data/obd2/trip_live_reading.dart
+++ b/lib/features/consumption/data/obd2/trip_live_reading.dart
@@ -49,6 +49,21 @@ class TripLiveReading {
   final double? odometerStartKm;
   final double? odometerNowKm;
 
+  /// Live GPS-only fuel estimate in L/100 km (Epic #2385 / #2389),
+  /// produced by the calibrated physics road-load `GpsLiveFuelEstimator`
+  /// on trajets that have **no** OBD2 fuel-rate signal. Non-null only on
+  /// GPS-only recordings, and only once the vehicle is actually moving
+  /// (the estimator returns null at a standstill and before its accel
+  /// low-pass has warmed up). Already clamped to the estimator's
+  /// plausibility band.
+  ///
+  /// On OBD2 trips this stays null — the real measured fuel-rate /
+  /// [fuelLitersSoFar] is the source of truth and is never overwritten by
+  /// the estimate. The PiP / banner display of this figure (with a
+  /// leading "~" and a confidence signal) is deferred to #2390 / #2391;
+  /// this field is purely the data source those issues will read.
+  final double? gpsEstimatedLPer100Km;
+
   const TripLiveReading({
     this.speedKmh,
     this.rpm,
@@ -63,6 +78,7 @@ class TripLiveReading {
     required this.elapsed,
     this.odometerStartKm,
     this.odometerNowKm,
+    this.gpsEstimatedLPer100Km,
   });
 
   /// Live L/100 km estimate — uses trip-so-far totals, so early

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -16,6 +16,7 @@ import '../domain/driving_coaching.dart'
     show gpsCoachingHint, recentSamplesWithin;
 import '../domain/gps_driving_features.dart';
 import '../domain/services/gps_fuel_estimator.dart';
+import '../domain/services/gps_live_fuel_estimator.dart';
 import '../domain/trip_recorder.dart';
 import 'recording_pipeline.dart';
 import 'trip_recording_phase.dart';
@@ -78,6 +79,19 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
   final List<TripSample> _samples = [];
   DateTime? _startedAt;
 
+  /// #2389 — calibrated physics road-load estimator that turns the same
+  /// GPS speed stream into a live L/100 km figure for the PiP/banner
+  /// (display wired later in #2390/#2391). Resolved once at [start] from
+  /// the active vehicle + its calibration matrix; null when no vehicle
+  /// graph is wired (the estimate field then simply stays null).
+  GpsLiveFuelEstimator? _liveEstimator;
+
+  /// Previous fix's ground speed (m/s) + timestamp — the finite-diff
+  /// basis the estimator needs for acceleration. Null before the first
+  /// fix lands.
+  double? _prevSpeedMps;
+  DateTime? _prevSampleAt;
+
   /// Open the Geolocator stream, prime the recorder, and seed the
   /// recording state. Returns true once the stream is opened.
   ///
@@ -90,8 +104,18 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     _recorder = TripRecorder(maxIntegrationGapSeconds: 30);
     _samples.clear();
     _startedAt = DateTime.now();
+    _prevSpeedMps = null;
+    _prevSampleAt = null;
     _host.lastTripStartedAt = DateTime.now();
     _host.lastTripVehicleId = _host.readActiveVehicleId();
+    // #2389 — build the live physics estimator from the active vehicle +
+    // its calibration matrix (physicsScale #2388). A null vehicle / matrix
+    // falls back to the population-default class + cold-start scale, so the
+    // estimate still flows on a fresh install — it just isn't yet
+    // OBD2-anchored.
+    final vehicle = _tryReadActiveVehicle();
+    final matrix = vehicle?.gpsCalibration;
+    _liveEstimator = GpsLiveFuelEstimator.forVehicle(vehicle, matrix);
     // Subscribe to the position stream at high accuracy — the
     // post-trip map polyline + confidence-tier UX both want ~10 m
     // precision. Permission failure is non-fatal: the stream errors
@@ -144,6 +168,27 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     _samples.add(sample);
     recorder.onSample(sample);
     final summary = recorder.buildSummary();
+    // #2389 — fold this fix into the live physics estimator. The estimator
+    // does its own 3-sample accel low-pass + warm-up, so we just hand it
+    // the finite-diff inputs (current speed, previous speed, dt). Grade is
+    // left off (gradeConfident: false) — raw GPS altitude is too noisy to
+    // feed the inertial/grade term without smoothing (deferred). Returns
+    // null at a standstill / before warm-up, which is exactly what the
+    // live reading should carry then.
+    double? gpsEstimate;
+    final est = _liveEstimator;
+    final prevSpeed = _prevSpeedMps;
+    final prevAt = _prevSampleAt;
+    if (est != null && prevSpeed != null && prevAt != null) {
+      final dt = sample.timestamp.difference(prevAt).inMilliseconds / 1000.0;
+      gpsEstimate = est.onSample(
+        speedMps: speedMps,
+        prevSpeedMps: prevSpeed,
+        dtSeconds: dt,
+      );
+    }
+    _prevSpeedMps = speedMps;
+    _prevSampleAt = sample.timestamp;
     // #2058/#2174 — GPS coaching hint from the most recent 5 s of
     // samples on every emit. recentSamplesWithin scans only a bounded
     // tail so the per-emit cost is O(window), not O(trajet) — the old
@@ -161,6 +206,7 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
         speedKmh: sample.speedKmh,
         distanceKmSoFar: summary.distanceKm,
         elapsed: DateTime.now().difference(startedAt),
+        gpsEstimatedLPer100Km: gpsEstimate,
       ),
       gpsCoachingHint: coaching,
       clearGpsCoachingHint: coaching == null,
@@ -218,6 +264,9 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     _recorder = null;
     _samples.clear();
     _startedAt = null;
+    _liveEstimator = null;
+    _prevSpeedMps = null;
+    _prevSampleAt = null;
     _host.state = const TripRecordingState();
     return StoppedTripResult(
       summary: summary,

--- a/test/features/consumption/data/obd2/trip_live_reading_test.dart
+++ b/test/features/consumption/data/obd2/trip_live_reading_test.dart
@@ -24,6 +24,41 @@ void main() {
       expect(reading.fuelLitersSoFar, isNull);
       expect(reading.odometerStartKm, isNull);
       expect(reading.odometerNowKm, isNull);
+      // #2389 — the GPS-only live estimate defaults null so existing call
+      // sites (notably the OBD2 controller, which never sets it) compile
+      // unchanged and surface no estimate.
+      expect(reading.gpsEstimatedLPer100Km, isNull);
+    });
+
+    test('an OBD2-style reading keeps its real fuel value and leaves the '
+        'GPS estimate null — the estimate never clobbers ground truth '
+        '(#2389)', () {
+      // Mirrors what the OBD2 controller emits: a measured fuel-rate +
+      // litres-so-far, and no GPS estimate (the OBD2 path never sets it).
+      const reading = TripLiveReading(
+        distanceKmSoFar: 20.0,
+        elapsed: Duration(minutes: 15),
+        fuelRateLPerHour: 4.0,
+        fuelLitersSoFar: 1.0,
+      );
+      // The real measured average stays the source of truth.
+      expect(reading.liveAvgLPer100Km, closeTo(5.0, 1e-9));
+      expect(reading.fuelLitersSoFar, 1.0);
+      // The GPS estimate is absent on an OBD2 trip.
+      expect(reading.gpsEstimatedLPer100Km, isNull);
+    });
+
+    test('gpsEstimatedLPer100Km stores the value supplied by the GPS '
+        'pipeline (#2389)', () {
+      const reading = TripLiveReading(
+        distanceKmSoFar: 5.0,
+        elapsed: Duration(minutes: 3),
+        gpsEstimatedLPer100Km: 6.4,
+      );
+      expect(reading.gpsEstimatedLPer100Km, 6.4);
+      // It is independent of the measured fuel path, which stays null.
+      expect(reading.fuelLitersSoFar, isNull);
+      expect(reading.liveAvgLPer100Km, isNull);
     });
 
     test('coolantTempC stores the value supplied by the controller (#1262)',

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/domain/services/gps_fuel_estimator.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/gps_only_recording_pipeline.dart';
 import 'package:tankstellen/features/consumption/providers/recording_pipeline.dart';
@@ -67,6 +68,61 @@ void main() {
       // 10 m/s == 36 km/h.
       expect(live!.speedKmh, closeTo(36.0, 1e-9));
       expect(harness.host.state.phase, TripRecordingPhase.recording);
+    });
+
+    test('the very first fix carries a null GPS estimate (warm-up — no '
+        'previous speed for the accel finite-diff yet) (#2389)', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 15.0, at: DateTime(2026, 5, 30, 8)));
+      await _pump();
+
+      expect(harness.host.state.live!.gpsEstimatedLPer100Km, isNull,
+          reason: 'no prior fix → estimator has no dt/accel basis yet');
+    });
+
+    test('a moving GPS-only trip carries a sane live GPS fuel estimate '
+        'within the estimator clamps (#2389)', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      // A steady ~72 km/h cruise: feed several 1 s-apart fixes so the
+      // estimator's 3-sample accel low-pass warms up and emits an instant
+      // figure. (The 1st fix primes prevSpeed; the 2nd onward produce it.)
+      final t0 = DateTime(2026, 5, 30, 9);
+      for (var i = 0; i < 5; i++) {
+        harness.geo.emit(_pos(43.4 + i * 0.001, 3.5,
+            speedMps: 20.0, at: t0.add(Duration(seconds: i))));
+        await _pump();
+      }
+
+      final estimate = harness.host.state.live!.gpsEstimatedLPer100Km;
+      expect(estimate, isNotNull,
+          reason: 'a moving GPS-only trip must surface a live estimate');
+      // Clamped to the same plausibility band the post-trip estimator uses.
+      expect(estimate, greaterThanOrEqualTo(GpsFuelEstimator.minLPer100Km));
+      expect(estimate, lessThanOrEqualTo(GpsFuelEstimator.maxLPer100Km));
+    });
+
+    test('a stationary fix carries a null GPS estimate (no per-distance '
+        'figure at a standstill) (#2389)', () async {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+      harness.pipeline.start();
+
+      final t0 = DateTime(2026, 5, 30, 10);
+      // Two stopped fixes (0 m/s) — well below the estimator's move
+      // threshold, so the instant figure is undefined.
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 0.0, at: t0));
+      await _pump();
+      harness.geo.emit(_pos(43.4, 3.5,
+          speedMps: 0.0, at: t0.add(const Duration(seconds: 1))));
+      await _pump();
+
+      expect(harness.host.state.live!.gpsEstimatedLPer100Km, isNull);
     });
 
     test('a negative / NaN stale first speed fix is clamped to 0', () async {


### PR DESCRIPTION
## What

Part of Epic #2385 (GPS-only live fuel-consumption estimate). Two issues, one PR:

### #2389 — emit the live GPS fuel estimate into `TripLiveReading`
Wires the calibrated physics road-load `GpsLiveFuelEstimator` (#2387) into the GPS-only recording pipeline so each `TripLiveReading` on a GPS-only trajet carries an instantaneous L/100 km estimate.

- **New nullable field `TripLiveReading.gpsEstimatedLPer100Km`** (defaults null) — every existing call site, notably the OBD2 controller which never sets it, compiles unchanged and surfaces no estimate. `TripLiveReading` is a plain `@immutable` class (not freezed), so no codegen.
- `GpsOnlyRecordingPipeline` builds the estimator at `start()` from the active vehicle + its `GpsCalibrationMatrix` (`physicsScale` #2388), and folds each GPS fix into it — tracking the previous speed/timestamp for the accel finite-diff. Grade is left off (`gradeConfident: false`) since raw GPS altitude is too noisy; the estimator's own 3-sample low-pass, warm-up, and clamps apply.
- **On OBD2 trips the field stays null** — the real measured fuel value remains the source of truth and is never overwritten.

### #2386 — decision record
`docs/decisions/0012-gps-live-consumption-estimator.md`: GPS-only live consumption = **physics road-load model anchored to the vehicle baseline, calibrated from OBD2 ground truth via `physicsScale`**, with fuzzy/driving-style as at most an optional downstream modifier — NOT the primary model. References #2385/#2387/#2388 and notes estimates surface with a leading `~` + a maturity/confidence signal (implemented later in #2391/#2393). README index updated.

## Scope / deferral
This PR is **data plumbing + an ADR only**. The PiP/banner **display** of the estimate is deliberately deferred to #2390 (PiP) and #2391/#2393 (display + confidence/maturity). No UI is changed here, and **no new ARB strings are added**.

## Tests
- `gps_only_recording_pipeline_test.dart`: a moving GPS-only trip carries a clamped estimate; the first fix and a standstill both carry null (warm-up / no per-distance figure).
- `trip_live_reading_test.dart`: field defaults null; an OBD2-style reading keeps its real value and leaves the estimate null; the field stores a supplied value.
- ADR format test + the `no_hardcoded_ui_strings` lint test both green.

Closes #2389
Closes #2386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
