### PR TITLE
feat(consumption): calibrate physicsScale from OBD2 ground-truth trips (#2392)

### DIFF
--- a/lib/features/consumption/domain/services/physics_scale_calibrator.dart
+++ b/lib/features/consumption/domain/services/physics_scale_calibrator.dart
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../vehicle/domain/entities/gps_calibration_matrix.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../trip_recorder.dart'; // TripSample + re-exported TripSummary/TripKind
+import 'gps_fuel_estimator.dart';
+import 'gps_live_fuel_estimator.dart';
+
+/// Refines a vehicle's [GpsCalibrationMatrix.physicsScale] from an
+/// **OBD2 ground-truth trip** (Epic #2385 / #2392, ADR 0012).
+///
+/// The GPS-only live estimator ([GpsLiveFuelEstimator]) emits a physics
+/// road-load L/100 km that is only as good as its class-default body
+/// params (mass / Cd / frontal area / Crr). On a trip recorded *with* an
+/// OBD2 dongle the measured per-100 km consumption is ground truth, so
+/// we can ask: "what would the physics model have predicted for this
+/// exact drive?" — by replaying the trip's stored GPS samples through
+/// [GpsLiveFuelEstimator] — and nudge `physicsScale` toward
+/// `measured / predicted`. That single per-vehicle scalar then carries
+/// over to the same vehicle's GPS-only trips (where no dongle is present)
+/// so the live number tracks measured reality.
+///
+/// This service ONLY touches `physicsScale`. It never re-measures the
+/// OBD2 fuel (that's the recorder's job and stays the source of truth)
+/// and never changes the live estimator's math — it feeds the estimator
+/// a better scale.
+///
+/// ## Update rule (smoothed, clamped)
+///
+/// A multiplicative EWMA so one noisy trip can't snap the scale around:
+///
+/// ```
+/// ratio    = obd2Avg / physicsPredicted     (predicted incl. current scale)
+/// newScale = oldScale × (1 + α·(ratio − 1))
+///          = oldScale + α·(oldScale·ratio − oldScale)
+/// ```
+///
+/// with α = [alpha] (0.3 — matches [GpsMatrixReconciler.dampingAlpha]).
+/// Because `physicsPredicted` already includes `oldScale`, at steady
+/// state `physicsPredicted → obd2Avg`, the ratio → 1, and the scale
+/// stops moving — i.e. it converges to `obd2Avg / rawPhysics`. The
+/// result is [GpsCalibrationMatrix.clamped] to the
+/// `[physicsScaleMin, physicsScaleMax]` band.
+///
+/// ## Gating (skip degenerate trips)
+///
+/// [calibrate] returns the matrix **unchanged** (never null) when the
+/// trip carries no usable ground truth or signal:
+///
+/// - not a [TripKind.gpsPlusObd2] trip (GPS-only has no ground truth);
+/// - [TripSummary.avgLPer100Km] null or non-positive;
+/// - [TripSummary.fuelRateSuspect] (the OBD2 fuel cross-check tripped);
+/// - measured average outside the plausibility band;
+/// - shorter than [minDistanceKm] or [minDurationSeconds];
+/// - fewer than [minSamples] replayable GPS samples, or the replay
+///   produced no moving distance (predicted average undefined / ≤ 0).
+///
+/// Pure: no I/O, no providers. The caller resolves the vehicle + its
+/// matrix, calls [calibrate], and persists the returned matrix back via
+/// `VehicleProfile.copyWith(gpsCalibration: …)`.
+class PhysicsScaleCalibrator {
+  const PhysicsScaleCalibrator._();
+
+  /// EWMA smoothing factor — how hard one ground-truth trip tugs the
+  /// scale toward the observed ratio. 0.3 ≈ "trust this trip 30 %, the
+  /// prior scale 70 %"; ~3 consistent trips close a 30 % gap. Mirrors
+  /// `GpsMatrixReconciler.dampingAlpha` so both calibration paths feel
+  /// the same.
+  static const double alpha = 0.3;
+
+  /// Minimum trip distance (km) worth calibrating from. Shorter trips
+  /// are dominated by cold-start enrichment + GPS warm-up noise, so
+  /// their measured average is a poor physics target.
+  static const double minDistanceKm = 2.0;
+
+  /// Minimum trip duration (s) worth calibrating from.
+  static const double minDurationSeconds = 120.0;
+
+  /// Minimum replayable GPS samples — need at least a handful of ticks
+  /// for the road-load integral to mean anything.
+  static const int minSamples = 10;
+
+  /// Largest sample-to-sample gap (s) still replayed. A longer gap is a
+  /// GPS dropout / pause; integrating across it fabricates distance, so
+  /// we skip the interval (mirrors the recorder's gap guard).
+  static const double _maxGapSeconds = 60.0;
+
+  /// Compute an updated calibration [matrix] for [vehicle] from the
+  /// just-completed [summary] + its stored [samples]. Returns the
+  /// matrix UNCHANGED when the trip is not a valid ground-truth source
+  /// (see the gating list in the class doc) — callers can always persist
+  /// the result; it's a no-op when nothing was learned.
+  ///
+  /// [matrix] may be null (cold-start): the calibrator seeds from
+  /// [GpsCalibrationMatrix.coldStart] (physicsScale 1.0) so the first
+  /// ground-truth trip still steps a real scale off the default.
+  static GpsCalibrationMatrix calibrate({
+    required VehicleProfile? vehicle,
+    required GpsCalibrationMatrix? matrix,
+    required TripSummary summary,
+    required List<TripSample> samples,
+  }) {
+    final base = matrix ?? GpsCalibrationMatrix.coldStart();
+
+    // ─── Ground-truth gating ───
+    if (summary.kind != TripKind.gpsPlusObd2) return base;
+    if (summary.fuelRateSuspect) return base;
+    final obd2Avg = summary.avgLPer100Km;
+    if (obd2Avg == null || obd2Avg <= 0) return base;
+    if (obd2Avg < GpsFuelEstimator.minLPer100Km ||
+        obd2Avg > GpsFuelEstimator.maxLPer100Km) {
+      return base;
+    }
+
+    // ─── Signal gating ───
+    if (summary.distanceKm < minDistanceKm) return base;
+    final durationSeconds = _durationSeconds(summary, samples);
+    if (durationSeconds < minDurationSeconds) return base;
+    if (samples.length < minSamples) return base;
+
+    // ─── Replay the trip through the physics estimator (with the
+    // current scale) to get what it WOULD have predicted ───
+    final predicted = _replayPredictedAvg(vehicle, base, samples);
+    if (predicted == null || predicted <= 0) return base;
+
+    // ─── Smoothed multiplicative EWMA toward measured / predicted ───
+    final ratio = obd2Avg / predicted;
+    final newScale = base.physicsScale * (1 + alpha * (ratio - 1));
+
+    return base.copyWith(physicsScale: newScale).clamped();
+  }
+
+  /// Replay [samples] through a [GpsLiveFuelEstimator] built for
+  /// [vehicle] + [matrix] (so the current `physicsScale` is applied) and
+  /// return the scaled predicted trip-average L/100 km, or null when the
+  /// replay covered no moving distance.
+  ///
+  /// The estimator integrates litres WITHOUT the scale (see
+  /// [GpsLiveFuelEstimator.runningAvgLPer100Km]), so we multiply by the
+  /// matrix scale here to make `predicted` comparable to the scaled
+  /// instant figure the user actually sees — keeping the EWMA a true
+  /// self-correcting residual update.
+  static double? _replayPredictedAvg(
+    VehicleProfile? vehicle,
+    GpsCalibrationMatrix matrix,
+    List<TripSample> samples,
+  ) {
+    final ordered = [...samples]
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    final estimator = GpsLiveFuelEstimator.forVehicle(vehicle, matrix);
+
+    for (var i = 1; i < ordered.length; i++) {
+      final prev = ordered[i - 1];
+      final cur = ordered[i];
+      final dt =
+          cur.timestamp.difference(prev.timestamp).inMilliseconds / 1000.0;
+      if (dt <= 0 || dt > _maxGapSeconds) continue; // gap — skip
+      estimator.onSample(
+        speedMps: cur.speedKmh / 3.6,
+        prevSpeedMps: prev.speedKmh / 3.6,
+        dtSeconds: dt,
+        // Grade is gated off: replaying stored GPS altitude blind is the
+        // same noise the live path refuses to feed (ADR 0012). The OBD2
+        // ground truth already baked grade into the measured average, so
+        // the scale absorbs the systematic part.
+      );
+    }
+
+    final rawAvg = estimator.runningAvgLPer100Km;
+    if (rawAvg == null || rawAvg <= 0) return null;
+    return rawAvg * matrix.physicsScale;
+  }
+
+  /// Trip duration in seconds — prefers the summary's start/end stamps,
+  /// falling back to the sample span when those are absent.
+  static double _durationSeconds(
+    TripSummary summary,
+    List<TripSample> samples,
+  ) {
+    final start = summary.startedAt;
+    final end = summary.endedAt;
+    if (start != null && end != null) {
+      final s = end.difference(start).inMilliseconds / 1000.0;
+      if (s > 0) return s;
+    }
+    if (samples.length < 2) return 0;
+    final ordered = [...samples]
+      ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    return ordered.last.timestamp
+            .difference(ordered.first.timestamp)
+            .inMilliseconds /
+        1000.0;
+  }
+}

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -22,6 +22,7 @@ import '../data/obd2/trip_recording_controller.dart';
 import '../data/trip_history_repository.dart';
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/entities/trip_start_stage.dart';
+import '../domain/services/physics_scale_calibrator.dart';
 import '../domain/trip_recorder.dart';
 import 'gps_only_recording_pipeline.dart';
 import 'obd2_recording_pipeline.dart';
@@ -945,6 +946,11 @@ class TripRecording extends _$TripRecording {
         gpsSampleDiagnostics: gpsSampleDiagnostics,
       ));
       ref.read(tripHistoryListProvider.notifier).refresh();
+      // #2392 — calibrate the vehicle's physicsScale from this trip's
+      // OBD2 ground truth (no-op for GPS-only / suspect / too-short
+      // trips). Fire-and-forget: a calibration failure must never derail
+      // the trip-save flow.
+      unawaited(_calibratePhysicsScale(summary, samples, vehicleId));
       // Phase 5 (#1004): bump the launcher-icon badge so the user sees
       // "something happened while I was driving" without opening the
       // app. The decrement fires when the user lands on the trip
@@ -984,6 +990,37 @@ class TripRecording extends _$TripRecording {
       }
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording._saveToHistory'}));
+    }
+  }
+
+  /// Refine the trip's vehicle physicsScale from OBD2 ground truth
+  /// (#2392). Delegates the gating + EWMA math to the pure
+  /// [PhysicsScaleCalibrator]; here we just resolve the vehicle, persist
+  /// the result, and refresh the list. No-op when nothing was learned
+  /// (the calibrator returns the matrix unchanged), so we only write +
+  /// invalidate when the scale actually moved.
+  Future<void> _calibratePhysicsScale(
+    TripSummary summary,
+    List<TripSample> samples,
+    String? vehicleId,
+  ) async {
+    if (vehicleId == null || samples.isEmpty) return;
+    try {
+      final repo = ref.read(vehicleProfileRepositoryProvider);
+      final vehicle = repo.getById(vehicleId);
+      if (vehicle == null) return;
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: vehicle,
+        matrix: vehicle.gpsCalibration,
+        summary: summary,
+        samples: samples,
+      );
+      if (updated == vehicle.gpsCalibration) return;
+      await repo.save(vehicle.copyWith(gpsCalibration: updated));
+      ref.invalidate(vehicleProfileListProvider);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+          context: const {'where': 'TripRecording._calibratePhysicsScale'}));
     }
   }
 

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'cbe7bab9439d5432890d89294956ff29c59fb763';
+String _$tripRecordingHash() => r'e5781f7ddad2e182c4cbcacdfa5e4053e43a85ea';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/lib/features/vehicle/domain/entities/gps_calibration_matrix.dart
+++ b/lib/features/vehicle/domain/entities/gps_calibration_matrix.dart
@@ -45,6 +45,15 @@ abstract class GpsCalibrationMatrix with _$GpsCalibrationMatrix {
   static const double accelEventCostMin = 0.0;
   static const double accelEventCostMax = 3.0;
 
+  /// Sane band for [physicsScale] (#2392). The OBD2-ground-truth
+  /// calibrator clamps to this so a single mis-measured trip can't
+  /// wreck every future GPS-only live estimate — a scale outside
+  /// [0.5, 2.0] would mean the physics class-defaults are off by more
+  /// than 2× either way, which is a vehicle-param bug, not something
+  /// the live number should chase.
+  static const double physicsScaleMin = 0.5;
+  static const double physicsScaleMax = 2.0;
+
   /// Population-median seeds for cold-start when no WLTP is set.
   static const double defaultBaselineLPer100Km = 6.5;
   static const double defaultIdleCost = 1.2;
@@ -152,6 +161,7 @@ abstract class GpsCalibrationMatrix with _$GpsCalibrationMatrix {
             highSpeedPenalty.clamp(highSpeedPenaltyMin, highSpeedPenaltyMax),
         accelEventCost:
             accelEventCost.clamp(accelEventCostMin, accelEventCostMax),
+        physicsScale: physicsScale.clamp(physicsScaleMin, physicsScaleMax),
       );
 
   /// Whether the 7-coef expansion has been activated yet.

--- a/test/features/consumption/domain/services/physics_scale_calibrator_test.dart
+++ b/test/features/consumption/domain/services/physics_scale_calibrator_test.dart
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/services/gps_live_fuel_estimator.dart';
+import 'package:tankstellen/features/consumption/domain/services/physics_scale_calibrator.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/gps_calibration_matrix.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+
+const _vehicle = VehicleProfile(
+  id: 'v1',
+  name: 'test',
+  curbWeightKg: 1500,
+  preferredFuelType: 'petrol',
+);
+
+final _epoch = DateTime.utc(2026, 1, 1, 8);
+
+/// A steady-cruise GPS sample stream: [ticks] samples at constant
+/// [speedKmh], 1 s apart. Long enough + far enough to clear the
+/// calibrator's signal gates by default.
+List<TripSample> _cruiseSamples({
+  double speedKmh = 90,
+  int ticks = 200,
+}) =>
+    List<TripSample>.generate(
+      ticks,
+      (i) => TripSample(
+        timestamp: _epoch.add(Duration(seconds: i)),
+        speedKmh: speedKmh,
+        rpm: 2000,
+        // OBD2 trips carry a fuel rate on their samples; the value is
+        // irrelevant to the replay (the physics model ignores it) but
+        // its presence is the "this was a dongle trip" marker.
+        fuelRateLPerHour: 5,
+      ),
+    );
+
+/// A gpsPlusObd2 [TripSummary] over [samples] with a measured
+/// [avgLPer100Km], distance + duration derived from the sample span so
+/// the signal gates pass.
+TripSummary _summary({
+  required List<TripSample> samples,
+  required double? avgLPer100Km,
+  TripKind kind = TripKind.gpsPlusObd2,
+  bool fuelRateSuspect = false,
+  double? distanceKm,
+}) {
+  final start = samples.first.timestamp;
+  final end = samples.last.timestamp;
+  final seconds = end.difference(start).inSeconds.toDouble();
+  // distance from the constant cruise speed unless overridden.
+  final km = distanceKm ?? samples.first.speedKmh / 3.6 * seconds / 1000.0;
+  return TripSummary(
+    distanceKm: km,
+    maxRpm: 2000,
+    highRpmSeconds: 0,
+    idleSeconds: 0,
+    harshBrakes: 0,
+    harshAccelerations: 0,
+    avgLPer100Km: avgLPer100Km,
+    startedAt: start,
+    endedAt: end,
+    fuelRateSuspect: fuelRateSuspect,
+    kind: kind,
+  );
+}
+
+/// The raw (scale-1.0) physics prediction the calibrator replays — used
+/// to build expectations independent of the calibrator's internals.
+double _rawPredicted(List<TripSample> samples) {
+  final e = GpsLiveFuelEstimator.forVehicle(_vehicle, null);
+  for (var i = 1; i < samples.length; i++) {
+    final dt = samples[i]
+            .timestamp
+            .difference(samples[i - 1].timestamp)
+            .inMilliseconds /
+        1000.0;
+    e.onSample(
+      speedMps: samples[i].speedKmh / 3.6,
+      prevSpeedMps: samples[i - 1].speedKmh / 3.6,
+      dtSeconds: dt,
+    );
+  }
+  return e.runningAvgLPer100Km!;
+}
+
+void main() {
+  group('PhysicsScaleCalibrator.calibrate — direction', () {
+    test('measured < predicted lowers physicsScale toward the ratio', () {
+      final samples = _cruiseSamples();
+      final predicted = _rawPredicted(samples); // scale 1.0
+      // Measure clearly below the physics prediction.
+      final measured = predicted * 0.7;
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: const GpsCalibrationMatrix(physicsScale: 1.0),
+        summary: _summary(samples: samples, avgLPer100Km: measured),
+        samples: samples,
+      );
+
+      // One EWMA step toward ratio 0.7 with alpha 0.3:
+      // 1.0 * (1 + 0.3*(0.7 - 1)) = 0.91.
+      const ratio = 0.7;
+      const expected = 1.0 * (1 + PhysicsScaleCalibrator.alpha * (ratio - 1));
+      expect(updated.physicsScale, closeTo(expected, 1e-9));
+      expect(updated.physicsScale, lessThan(1.0));
+    });
+
+    test('measured > predicted raises physicsScale toward the ratio', () {
+      final samples = _cruiseSamples();
+      final predicted = _rawPredicted(samples);
+      final measured = predicted * 1.4;
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: const GpsCalibrationMatrix(physicsScale: 1.0),
+        summary: _summary(samples: samples, avgLPer100Km: measured),
+        samples: samples,
+      );
+      const ratio = 1.4;
+      const expected = 1.0 * (1 + PhysicsScaleCalibrator.alpha * (ratio - 1));
+      expect(updated.physicsScale, closeTo(expected, 1e-9));
+      expect(updated.physicsScale, greaterThan(1.0));
+    });
+
+    test('a perfectly-matching trip leaves physicsScale unchanged', () {
+      final samples = _cruiseSamples();
+      final predicted = _rawPredicted(samples);
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: const GpsCalibrationMatrix(physicsScale: 1.0),
+        summary: _summary(samples: samples, avgLPer100Km: predicted),
+        samples: samples,
+      );
+      expect(updated.physicsScale, closeTo(1.0, 1e-9));
+    });
+  });
+
+  group('PhysicsScaleCalibrator.calibrate — clamp band', () {
+    test('a wildly-low measured trip cannot push scale below the floor', () {
+      final samples = _cruiseSamples();
+      // Start already near the floor; a tiny measured value would push
+      // below 0.5 without the clamp.
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: const GpsCalibrationMatrix(
+            physicsScale: GpsCalibrationMatrix.physicsScaleMin),
+        summary: _summary(samples: samples, avgLPer100Km: 0.5),
+        samples: samples,
+      );
+      expect(updated.physicsScale,
+          greaterThanOrEqualTo(GpsCalibrationMatrix.physicsScaleMin));
+    });
+
+    test('a wildly-high measured trip cannot push scale above the ceiling',
+        () {
+      final samples = _cruiseSamples();
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: const GpsCalibrationMatrix(
+            physicsScale: GpsCalibrationMatrix.physicsScaleMax),
+        summary: _summary(samples: samples, avgLPer100Km: 30),
+        samples: samples,
+      );
+      expect(updated.physicsScale,
+          lessThanOrEqualTo(GpsCalibrationMatrix.physicsScaleMax));
+    });
+  });
+
+  group('PhysicsScaleCalibrator.calibrate — gating (no-op trips)', () {
+    const matrix = GpsCalibrationMatrix(physicsScale: 1.2);
+    final samples = _cruiseSamples();
+    final predicted = _rawPredicted(samples);
+
+    test('GPS-only trip (no ground truth) does not change the scale', () {
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: matrix,
+        summary: _summary(
+          samples: samples,
+          avgLPer100Km: predicted * 0.5,
+          kind: TripKind.gpsOnly,
+        ),
+        samples: samples,
+      );
+      expect(updated.physicsScale, matrix.physicsScale);
+      expect(updated, matrix);
+    });
+
+    test('a suspect fuel-rate trip does not change the scale', () {
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: matrix,
+        summary: _summary(
+          samples: samples,
+          avgLPer100Km: predicted * 0.5,
+          fuelRateSuspect: true,
+        ),
+        samples: samples,
+      );
+      expect(updated, matrix);
+    });
+
+    test('a null measured average does not change the scale', () {
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: matrix,
+        summary: _summary(samples: samples, avgLPer100Km: null),
+        samples: samples,
+      );
+      expect(updated, matrix);
+    });
+
+    test('a too-short trip (below the distance gate) does not change scale',
+        () {
+      final shortSamples = _cruiseSamples(ticks: 30); // ~0.75 km @ 90 km/h
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: matrix,
+        summary: _summary(
+          samples: shortSamples,
+          avgLPer100Km: 5,
+          distanceKm: 1.0, // below minDistanceKm (2.0)
+        ),
+        samples: shortSamples,
+      );
+      expect(updated, matrix);
+    });
+
+    test('a brief trip (below the duration gate) does not change scale', () {
+      final brief = _cruiseSamples(ticks: 8); // 7 s span, < minSamples too
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: matrix,
+        summary: _summary(
+          samples: brief,
+          avgLPer100Km: 5,
+          distanceKm: 10, // distance fine, but duration/samples too small
+        ),
+        samples: brief,
+      );
+      expect(updated, matrix);
+    });
+
+    test('no samples does not change the scale', () {
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: matrix,
+        summary: TripSummary(
+          distanceKm: 10,
+          maxRpm: 2000,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: 0,
+          avgLPer100Km: 5,
+          startedAt: _epoch,
+          endedAt: _epoch.add(const Duration(minutes: 10)),
+        ),
+        samples: const [],
+      );
+      expect(updated, matrix);
+    });
+  });
+
+  group('PhysicsScaleCalibrator.calibrate — convergence', () {
+    test('repeated consistent trips converge toward the true ratio', () {
+      final samples = _cruiseSamples();
+      final predicted = _rawPredicted(samples); // raw, scale 1.0
+      // The vehicle truly burns 1.3x what the raw physics predicts; every
+      // trip measures that consistently. The scale should converge toward
+      // 1.3 (the ratio of measured / rawPredicted).
+      const trueRatio = 1.3;
+      final measured = predicted * trueRatio;
+
+      GpsCalibrationMatrix matrix =
+          const GpsCalibrationMatrix(physicsScale: 1.0);
+      for (var trip = 0; trip < 25; trip++) {
+        matrix = PhysicsScaleCalibrator.calibrate(
+          vehicle: _vehicle,
+          matrix: matrix,
+          summary: _summary(samples: samples, avgLPer100Km: measured),
+          samples: samples,
+        );
+      }
+      expect(matrix.physicsScale, closeTo(trueRatio, 0.02));
+    });
+
+    test('converges from a stale over-estimate back down to the true ratio',
+        () {
+      final samples = _cruiseSamples();
+      final predicted = _rawPredicted(samples);
+      const trueRatio = 0.85;
+      final measured = predicted * trueRatio;
+
+      // Start from a bad, too-high scale (e.g. a prior mis-calibration).
+      GpsCalibrationMatrix matrix =
+          const GpsCalibrationMatrix(physicsScale: 1.8);
+      for (var trip = 0; trip < 30; trip++) {
+        matrix = PhysicsScaleCalibrator.calibrate(
+          vehicle: _vehicle,
+          matrix: matrix,
+          summary: _summary(samples: samples, avgLPer100Km: measured),
+          samples: samples,
+        );
+      }
+      expect(matrix.physicsScale, closeTo(trueRatio, 0.02));
+    });
+  });
+
+  group('PhysicsScaleCalibrator.calibrate — cold start', () {
+    test('a null matrix seeds from coldStart and still steps the scale', () {
+      final samples = _cruiseSamples();
+      final predicted = _rawPredicted(samples);
+      final updated = PhysicsScaleCalibrator.calibrate(
+        vehicle: _vehicle,
+        matrix: null,
+        summary: _summary(samples: samples, avgLPer100Km: predicted * 0.7),
+        samples: samples,
+      );
+      // coldStart scale is 1.0 → one step toward 0.7.
+      const expected = 1.0 * (1 + PhysicsScaleCalibrator.alpha * (0.7 - 1));
+      expect(updated.physicsScale, closeTo(expected, 1e-9));
+    });
+  });
+}

--- a/test/features/vehicle/domain/entities/gps_calibration_matrix_test.dart
+++ b/test/features/vehicle/domain/entities/gps_calibration_matrix_test.dart
@@ -68,6 +68,17 @@ void main() {
       expect(c.accelEventCost,
           GpsCalibrationMatrix.accelEventCostMin);
     });
+
+    test('clamps physicsScale to its band (#2392)', () {
+      const tooHigh = GpsCalibrationMatrix(physicsScale: 5.0);
+      const tooLow = GpsCalibrationMatrix(physicsScale: 0.1);
+      const inBand = GpsCalibrationMatrix(physicsScale: 1.3);
+      expect(tooHigh.clamped().physicsScale,
+          GpsCalibrationMatrix.physicsScaleMax);
+      expect(
+          tooLow.clamped().physicsScale, GpsCalibrationMatrix.physicsScaleMin);
+      expect(inBand.clamped().physicsScale, 1.3);
+    });
   });
 
   group('GpsCalibrationMatrix.maturity', () {

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -74,7 +74,12 @@ void main() {
     'lib/features/consumption/presentation/widgets/trip_path_map_card.dart':
         463,
     'lib/features/consumption/providers/consumption_providers.dart': 879,
-    'lib/features/consumption/providers/trip_recording_provider.dart': 1125,
+    // #2392 — re-grandfathered 1125 → 1162: wired the OBD2-ground-truth
+    // physicsScale calibration into `_saveToHistory` (one fire-and-forget
+    // call + the `_calibratePhysicsScale` resolve/persist helper; the EWMA
+    // math itself lives in the standalone `PhysicsScaleCalibrator`).
+    // Decomposition of this god-class is tracked under #2187/#2188/#2190.
+    'lib/features/consumption/providers/trip_recording_provider.dart': 1162,
     'lib/features/feature_management/data/legacy_toggle_migrator.dart': 647,
     'lib/features/map/presentation/widgets/station_map_layers.dart': 544,
     'lib/features/profile/presentation/widgets/feature_management_section.dart':


### PR DESCRIPTION
## What

After a completed **OBD2 (`gpsPlusObd2`) trip** — where the measured per-100 km consumption is ground truth — nudge the per-vehicle `GpsCalibrationMatrix.physicsScale` toward `measured / physicsPredicted`, so the GPS-only live physics estimator (`gps_live_fuel_estimator.dart`) tracks this vehicle's measured reality on later dongle-less trips. Part of Epic #2385, follows ADR 0012.

## How — `PhysicsScaleCalibrator` (new pure-domain service)

- **Replay**: re-runs the trip's stored GPS samples through `GpsLiveFuelEstimator` (with the current scale) to get what the physics model *would have* predicted for that exact drive.
- **Smoothed update (EMA + clamp)**: a multiplicative EWMA so one noisy trip can't snap the scale around —

  ```
  ratio    = measured / physicsPredicted     (predicted incl. current scale)
  newScale = oldScale * (1 + α*(ratio - 1))   α = 0.3
  ```

  Because `physicsPredicted` includes the current scale, this is a self-correcting residual update: at steady state `physicsPredicted → measured`, the ratio → 1, and the scale stops moving — converging to `measured / rawPhysics`.
- **Clamp band `[0.5, 2.0]`**: new `GpsCalibrationMatrix.physicsScaleMin/Max`, now applied in `clamped()`, so a single mis-measured trip can't wreck every future estimate.
- **Gating**: returns the matrix **unchanged** (a true no-op) for GPS-only trips, suspect fuel-rate trips, null/implausible measured average, trips under 2 km or 120 s, or fewer than 10 replayable samples.

## Wiring

Hooked into `TripRecordingNotifier._saveToHistory` as a fire-and-forget call that resolves the vehicle, calls the calibrator, and persists only when the scale actually moved. **The OBD2 measurement path and the live estimator's math are untouched** — this only feeds the estimator a better `physicsScale`.

Fill-up reconciliation against pump litres stays on the existing `GpsMatrixReconciler.baseline` path; extending the same EWMA to `physicsScale` per fill-up window is a clear follow-up (the OBD2-trip path is the ground truth this issue scopes).

## Tests

- measured `<` predicted lowers the scale toward the ratio (EMA-smoothed); measured `>` predicted raises it; a matching trip leaves it unchanged.
- Clamp holds at both band edges.
- Every degenerate-trip no-op (GPS-only / suspect / null avg / too short / too few samples / no samples).
- Convergence toward the true ratio over many consistent trips — both up from 1.0 and back down from a stale 1.8.
- Cold-start (null matrix) seeds + steps; plus a `clamped()` physicsScale case on the matrix.

`flutter analyze` clean; consumption-domain + provider suites green; `no_hardcoded_ui_strings_test` green. **No new ARB strings** (calibration is pure domain/data logic — the UI is #2390/#2391). No codegen/l10n drift (the one `.g.dart` provider-hash change from editing the `@riverpod` notifier is committed). `file_length` snapshot for `trip_recording_provider.dart` re-grandfathered 1125 → 1162 for the wiring.

Closes #2392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
