### PR TITLE
fix(pip,banner): show estimated ~L/100km on GPS-only trips instead of elapsed (#2390)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -231,8 +231,21 @@ class _Content extends StatelessWidget {
     // eco-coaching chip surfaced from the live reading. Both pieces
     // are silent when the data isn't available so the strip degrades
     // gracefully on cars without a fuel-rate PID.
-    final instantConsumption =
-        (live != null && !paused) ? formatInstantConsumption(live) : null;
+    //
+    // #2390 — on a GPS-only trajet there's no OBD2 fuel rate, so
+    // `formatInstantConsumption` returns null; fall back to the live
+    // physics estimate rendered as `~X.X L/100` (reusing the OBD2 unit
+    // token, leading `~` flagging it an estimate per ADR 0012). The OBD2
+    // measured path stays tilde-free; a null estimate (warm-up / OBD2
+    // trip) leaves the slot silent as before.
+    final gpsEstimate =
+        (live != null && !paused) ? live.gpsEstimatedLPer100Km : null;
+    final instantConsumption = (live != null && !paused)
+        ? (formatInstantConsumption(live) ??
+            (gpsEstimate != null
+                ? '~${gpsEstimate.toStringAsFixed(1)} L/100'
+                : null))
+        : null;
     final coachingHintValue = (live != null && !paused)
         ? coachingHint(live, situation: state.situation, band: state.band)
         : null;

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -25,11 +25,12 @@ import '../../providers/trip_recording_provider.dart';
 /// └──────────────────────┘
 /// ```
 ///
-/// When the trip carries no OBD2 fuel-rate samples (GPS-only trajet,
-/// or before the OBD2 stream produces the first reading), the figure
-/// renders as `~` followed by a placeholder. The `~` prefix flags the
-/// number as an estimate when the GPS-matrix estimator (#F of Epic
-/// #2055) lands — until then the placeholder is a literal dash.
+/// On a GPS-only trajet (no OBD2 fuel-rate samples) the big figure is
+/// the live physics estimate rendered as `~X.X L/100 km` once the
+/// estimator has warmed up (#2390 / Epic #2385) — the leading `~` flags
+/// it an estimate per ADR 0012. Before the estimate lands (warm-up /
+/// uncalibrated) the tile gracefully falls back to distance, then
+/// elapsed time, so no information-free placeholder is ever shown.
 ///
 /// The widget is paint-only — it does not own the recording state.
 /// The caller passes in the live [TripRecordingState] and a band
@@ -75,20 +76,27 @@ class TripRecordingPipView extends StatelessWidget {
 
   /// Default PiP layout (no approach radius hit) — picks the **most
   /// informative** metric for the big slot based on what the trajet
-  /// has produced so far (#2094). Three branches in priority order:
+  /// has produced so far (#2094 + #2390). Four branches, priority order:
   ///
   /// 1. **OBD2 live fuel rate available** → huge L/100 km (or L/h on
   ///    idle). Secondary row: distance + elapsed.
-  /// 2. **GPS-only, distance ≥ 0.1 km** → huge **distance**. The
-  ///    GPS-matrix L/100 km estimate is post-trip only (#2080), so
-  ///    nothing live to render in that slot; distance is the most
-  ///    useful real-time number. Secondary row: elapsed.
-  /// 3. **Pre-roll (distance ≈ 0)** → huge **elapsed time**. The user
+  /// 2. **GPS-only with a live estimate** (#2390) → huge **`~X.X`** with
+  ///    the same `L/100 km` caption the OBD2 branch uses. The leading
+  ///    `~` (a literal glyph, not translatable) marks it an estimate
+  ///    per ADR 0012. The figure comes from `gpsEstimatedLPer100Km`,
+  ///    non-null only on a moving GPS-only trajet once the estimator has
+  ///    warmed up. Secondary row: distance + elapsed.
+  /// 3. **GPS-only, no estimate yet, distance ≥ 0.1 km** → huge
+  ///    **distance**. The estimator is still warming up (or the matrix
+  ///    isn't calibrated); distance is the most useful real-time number.
+  ///    Secondary row: elapsed.
+  /// 4. **Pre-roll (distance ≈ 0)** → huge **elapsed time**. The user
   ///    sees the session is recording while the GPS warms up.
   ///    Secondary row: empty.
   ///
   /// The big `~` placeholder that wasted the tile pre-#2094 is gone —
-  /// no branch renders an information-free symbol huge.
+  /// no branch renders an information-free symbol huge; the `~` here
+  /// always precedes a real estimate.
   Widget _buildDefaultLayout(BuildContext context) {
     final l = AppLocalizations.of(context);
     final live = state.live;
@@ -98,6 +106,10 @@ class TripRecordingPipView extends StatelessWidget {
 
     // Resolve OBD2-derived live L/100 km (or L/h at idle).
     final raw = (live != null && !paused) ? formatInstantConsumption(live) : null;
+    // #2390 — GPS-only live estimate (null on OBD2 trips + during the
+    // estimator's warm-up). The OBD2 `raw` figure always wins over it.
+    final gpsEstimate =
+        (live != null && !paused) ? live.gpsEstimatedLPer100Km : null;
 
     final String bigFigure;
     final String bigCaption;
@@ -111,8 +123,18 @@ class TripRecordingPipView extends StatelessWidget {
         if (distance != null) '${distance.toStringAsFixed(1)} km',
         if (elapsed != null) _fmtElapsed(elapsed),
       ];
+    } else if (gpsEstimate != null) {
+      // Branch 2 (#2390) — GPS-only live estimate: huge `~X.X` reusing
+      // the OBD2 path's `L/100 km` unit caption. `~` flags the estimate.
+      bigFigure = '~${gpsEstimate.toStringAsFixed(1)}';
+      bigCaption = 'L/100 km';
+      secondaryRow = [
+        if (distance != null) '${distance.toStringAsFixed(1)} km',
+        if (elapsed != null) _fmtElapsed(elapsed),
+      ];
     } else if (distance != null && distance >= 0.1) {
-      // Branch 2 — GPS-only mid-trajet: distance is the live signal.
+      // Branch 3 — GPS-only mid-trajet, no estimate yet: distance is the
+      // live signal (graceful fallback while the estimator warms up).
       bigFigure = distance.toStringAsFixed(1);
       bigCaption = 'km';
       secondaryRow = [

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -48,6 +48,9 @@ TripRecordingState _activeState({
   DrivingSituation situation = DrivingSituation.highwayCruise,
   double? delta,
   double? distance,
+  double? speedKmh,
+  double? fuelRateLPerHour,
+  double? gpsEstimatedLPer100Km,
 }) {
   return TripRecordingState(
     phase: TripRecordingPhase.recording,
@@ -59,6 +62,9 @@ TripRecordingState _activeState({
         : TripLiveReading(
             distanceKmSoFar: distance,
             elapsed: const Duration(minutes: 1),
+            speedKmh: speedKmh,
+            fuelRateLPerHour: fuelRateLPerHour,
+            gpsEstimatedLPer100Km: gpsEstimatedLPer100Km,
           ),
   );
 }
@@ -363,6 +369,69 @@ void main() {
         isNot(FuelColors.forType(FuelType.e85)),
         reason: 'no approach → the driving-band palette must win',
       );
+    });
+  });
+
+  // #2390 — the banner strip mirrors the PiP: on a GPS-only trajet the
+  // consumption slot (normally OBD2-only) shows the live physics
+  // estimate as "~X.X L/100"; OBD2 trips stay tilde-free; warm-up
+  // (null estimate) leaves the slot silent.
+  group('TripRecordingBanner GPS-only estimate strip (#2390)', () {
+    testWidgets('GPS-only trip with an estimate → "~X.X L/100" in the strip',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_activeState(
+              distance: 1.2,
+              fuelRateLPerHour: null, // GPS-only: no OBD2 fuel rate
+              gpsEstimatedLPer100Km: 6.4,
+            )),
+          ),
+        ],
+      );
+      expect(find.text('~6.4 L/100'), findsOneWidget);
+    });
+
+    testWidgets('OBD2 trip → real measured value, no "~"', (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_activeState(
+              distance: 1.2,
+              speedKmh: 70,
+              fuelRateLPerHour: 4.06, // OBD2 measured
+              gpsEstimatedLPer100Km: 6.4, // present but must be ignored
+            )),
+          ),
+        ],
+      );
+      // 4.06 L/h at 70 km/h → ~5.8 L/100, tilde-free.
+      expect(find.text('5.8 L/100'), findsOneWidget);
+      expect(find.textContaining('~'), findsNothing);
+    });
+
+    testWidgets('GPS-only warm-up (null estimate) → no consumption text',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const TripRecordingBanner(child: SizedBox()),
+        overrides: [
+          tripRecordingProvider.overrideWith(
+            () => _FakeTripRecording(_activeState(
+              distance: 1.2,
+              fuelRateLPerHour: null,
+              gpsEstimatedLPer100Km: null,
+            )),
+          ),
+        ],
+      );
+      expect(find.textContaining('L/100'), findsNothing);
+      expect(find.textContaining('~'), findsNothing);
     });
   });
 }

--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -32,12 +32,17 @@ TripRecordingState _activeState({
   Duration elapsed = const Duration(minutes: 8, seconds: 32),
   // Default fuel rate keeps tests on the OBD2 branch (#2094 Branch 1)
   // where the L/100 km marker is rendered — that's the canonical
-  // "default layout" for the legacy tests. Branch-2 (GPS-only) and
-  // Branch-3 (pre-roll) get their own dedicated tests further down.
+  // "default layout" for the legacy tests. The GPS-estimate branch
+  // (#2390), GPS-distance branch and pre-roll branch get their own
+  // dedicated tests further down.
   double? fuelRateLPerHour = 4.06,
+  // #2390 — GPS-only live physics estimate (L/100 km). Null on OBD2
+  // trips + during the estimator's warm-up.
+  double? gpsEstimatedLPer100Km,
+  TripRecordingPhase phase = TripRecordingPhase.recording,
 }) =>
     TripRecordingState(
-      phase: TripRecordingPhase.recording,
+      phase: phase,
       situation: DrivingSituation.highwayCruise,
       band: ConsumptionBand.normal,
       live: TripLiveReading(
@@ -45,6 +50,7 @@ TripRecordingState _activeState({
         distanceKmSoFar: distance,
         elapsed: elapsed,
         fuelRateLPerHour: fuelRateLPerHour,
+        gpsEstimatedLPer100Km: gpsEstimatedLPer100Km,
       ),
     );
 
@@ -330,6 +336,97 @@ void main() {
       expect(find.textContaining('4.0'), findsOneWidget);
       expect(find.text('elapsed'), findsNothing);
       expect(find.text('~'), findsNothing);
+    });
+  });
+
+  group('TripRecordingPipView (#2390) — GPS-only live estimate', () {
+    Widget buildWith({
+      double? fuelRate,
+      double? gpsEstimate,
+      double distance = 1.2,
+      Duration elapsed = const Duration(minutes: 7, seconds: 7),
+    }) =>
+        _wrap(TripRecordingPipView(
+          state: _activeState(
+            distance: distance,
+            elapsed: elapsed,
+            fuelRateLPerHour: fuelRate,
+            gpsEstimatedLPer100Km: gpsEstimate,
+          ),
+          backgroundColor: Colors.green,
+          foregroundColor: Colors.white,
+        ));
+
+    testWidgets(
+        'GPS-only trip with a live estimate → big "~X.X L/100 km", not '
+        'elapsed time', (tester) async {
+      // No OBD2 fuel rate, estimator has produced 6.4 L/100 km. The
+      // estimate becomes the hero with a leading "~" and the reused
+      // "L/100 km" unit caption — the elapsed time is demoted.
+      await tester.pumpWidget(buildWith(fuelRate: null, gpsEstimate: 6.4));
+      expect(find.text('~6.4'), findsOneWidget);
+      expect(find.text('L/100 km'), findsOneWidget);
+      // The elapsed time is NOT the hero figure (it moves to the
+      // secondary row instead of leading the tile).
+      expect(find.text('7m 7s'), findsOneWidget); // secondary row
+      // Distance also stays in the secondary row.
+      expect(find.text('1.2 km'), findsOneWidget);
+    });
+
+    testWidgets('OBD2 trip → real measured consumption, estimate path NOT '
+        'taken (tilde-free)', (tester) async {
+      // A real OBD2 fuel rate is present; even if an estimate were also
+      // present, the measured value wins and stays tilde-free.
+      await tester.pumpWidget(buildWith(fuelRate: 4.06, gpsEstimate: 6.4));
+      expect(find.text('L/100 km'), findsOneWidget);
+      // Measured value: 4.06 L/h at 70 km/h → ~5.8 L/100 km, no "~".
+      expect(find.text('5.8'), findsOneWidget);
+      expect(find.textContaining('~'), findsNothing);
+    });
+
+    testWidgets(
+        'GPS-only warm-up (null estimate) → falls back to distance/elapsed, '
+        'no "~" or blank', (tester) async {
+      // Estimator hasn't warmed up yet: estimate is null. With distance
+      // ≥ 0.1 km the tile gracefully shows distance (no "~", no blank).
+      await tester.pumpWidget(
+          buildWith(fuelRate: null, gpsEstimate: null, distance: 1.2));
+      expect(find.text('1.2'), findsOneWidget);
+      expect(find.text('km'), findsOneWidget);
+      expect(find.text('L/100 km'), findsNothing);
+      expect(find.textContaining('~'), findsNothing);
+    });
+
+    testWidgets(
+        'GPS-only pre-roll (null estimate, distance ≈ 0) → falls back to '
+        'elapsed, no "~"', (tester) async {
+      await tester.pumpWidget(buildWith(
+        fuelRate: null,
+        gpsEstimate: null,
+        distance: 0.0,
+        elapsed: const Duration(minutes: 7, seconds: 7),
+      ));
+      expect(find.text('7m 7s'), findsOneWidget);
+      expect(find.text('elapsed'), findsOneWidget);
+      expect(find.text('L/100 km'), findsNothing);
+      expect(find.textContaining('~'), findsNothing);
+    });
+
+    testWidgets('paused GPS-only trip suppresses the estimate', (tester) async {
+      // Paused → the estimate must not show (a stale reading would
+      // mislead); the tile shows distance instead.
+      await tester.pumpWidget(_wrap(TripRecordingPipView(
+        state: _activeState(
+          distance: 1.2,
+          fuelRateLPerHour: null,
+          gpsEstimatedLPer100Km: 6.4,
+          phase: TripRecordingPhase.paused,
+        ),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+      )));
+      expect(find.textContaining('~'), findsNothing);
+      expect(find.text('L/100 km'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## What

Part of Epic #2385 (GPS-only live fuel-consumption estimate).

On a **GPS-only** trajet the PiP tile previously led with elapsed time (or distance), and the banner strip showed no consumption at all — both surfaces only render the OBD2-measured `formatInstantConsumption` value, which is null without an OBD2 fuel-rate signal.

This wires the live physics estimate `TripLiveReading.gpsEstimatedLPer100Km` (added by #2419) into both surfaces:

- **`trip_recording_pip_view.dart` `_buildDefaultLayout`** — new branch between OBD2 (Branch 1) and the GPS-distance branch: when the estimate is non-null, the big figure becomes `~X.X` with the reused `L/100 km` unit caption; distance + elapsed stay in the secondary row.
- **`trip_recording_banner.dart` `_Content`** — the consumption slot falls back to `~X.X L/100` (reusing the OBD2 unit token) when there's no measured value.

## Behaviour

- **OBD2 trips: unchanged** — the measured value wins and stays tilde-free (the estimate is null on OBD2 trips anyway, and never overrides a measured reading).
- **Null estimate** (warm-up / insufficient signal) → graceful fallback to the previous behaviour (distance, then elapsed) — never `~null` or blank.
- **Paused** trips suppress the estimate.

## ARB-light

The leading `~` is a literal glyph (ADR 0012), not translatable. This **reuses the existing `L/100 km` / `L/100` unit label** the OBD2 path already renders — **no new ARB strings, no l10n fan-out**. The estimate's wording/caption polish is the separate #2393.

## Tests

PiP + banner widget tests cover:
- GPS-only with a live estimate → `~6.4 L/100 km` (PiP) / `~6.4 L/100` (banner), **not** elapsed.
- OBD2 trip → real measured value, estimate path not taken (tilde-free).
- GPS-only warm-up (null estimate) → falls back to distance, no `~`/blank.
- GPS-only pre-roll (null estimate, distance ≈ 0) → falls back to elapsed.
- Paused GPS-only → estimate suppressed.

`flutter analyze`, `file_length_test`, and `no_hardcoded_ui_strings_test` all green; zero codegen / l10n drift (clean build_runner + gen-l10n verified locally).

Closes #2390

🤖 Generated with [Claude Code](https://claude.com/claude-code)