### PR TITLE
fix(obd2): reclassify supported_pids_resolver transients as recoverable — #2379 follow-up (#2424)

### DIFF
--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -1,13 +1,10 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 
 import 'elm327_protocol.dart';
 import 'supported_pids_cache.dart';
-import '../../../../core/logging/error_logger.dart';
 
 /// Owns the #811 supported-PID concern, extracted from [Obd2Service]
 /// (#1679): the per-connection set of Mode 01 PIDs the car implements,
@@ -110,8 +107,15 @@ class SupportedPidsResolver {
       if (discovered.isNotEmpty) {
         await cache.put(key, discovered);
       }
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 supported-PID cache prime failed'}));
+    } catch (_) {
+      // #2424 (follow-up to #2379) — prime() is best-effort: a transient
+      // on a flaky/slow ELM327 (TimeoutException, the legacy concurrent-
+      // sendCommand StateError, device-not-connected) is EXPECTED and
+      // recoverable — the method just returns and the session falls back
+      // to blind querying. The graceful degradation IS the signal, so it
+      // must NOT pollute the user error log.
+      debugPrint('OBD2 supported-PID cache prime failed — '
+          'scanning blindly this session');
     }
   }
 
@@ -124,8 +128,13 @@ class SupportedPidsResolver {
       final response = await _send(Elm327Protocol.vinCommand);
       final vin = Elm327Protocol.parseVin(response);
       if (vin != null && vin.isNotEmpty) return vin;
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'OBD2 VIN read for cache key failed'}));
+    } catch (_) {
+      // #2424 (follow-up to #2379) — the VIN (0902) probe is best-effort:
+      // an engine-off / slow ELM327 times this out routinely, and many
+      // old ECUs / clone adapters never answer it. That's EXPECTED and
+      // recoverable — we fall back to [_vehicleFallbackKey] below, so a
+      // transient here must NOT pollute the user error log.
+      debugPrint('OBD2 VIN read for cache key failed — using fallback key');
     }
     return _vehicleFallbackKey;
   }
@@ -162,8 +171,16 @@ class SupportedPidsResolver {
         // flag. If it's not in the set we just parsed, stop walking.
         final nextRangeFlag = groupBase + 32;
         if (!bitmap.contains(nextRangeFlag)) break;
-      } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {'where': 'OBD2 discoverSupportedPids failed on $command'}));
+      } catch (_) {
+        // #2424 (follow-up to #2379) — the supported-PID scan is best-
+        // effort: a transient on a flaky/slow ELM327 (TimeoutException,
+        // the legacy concurrent-sendCommand StateError, device-not-
+        // connected) is EXPECTED and recoverable — we break and return
+        // whatever we've gathered (possibly empty → blind query). The
+        // graceful degradation IS the signal, so it must NOT pollute the
+        // user error log.
+        debugPrint('OBD2 discoverSupportedPids failed on $command — '
+            'returning ${supported.length} PIDs gathered so far');
         break;
       }
     }

--- a/test/features/consumption/data/obd2/supported_pids_resolver_logging_test.dart
+++ b/test/features/consumption/data/obd2/supported_pids_resolver_logging_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/supported_pids_cache.dart';
+import 'package:tankstellen/features/consumption/data/obd2/supported_pids_resolver.dart';
+
+/// #2424 (follow-up to #2379) — [SupportedPidsResolver] is best-effort:
+/// every catch site (prime, VIN-for-cache-key read, supported-PID scan)
+/// already degrades gracefully on a flaky/slow ELM327. A transient there
+/// (TimeoutException / concurrent-sendCommand StateError / device-not-
+/// connected) flooded a real user's error log mis-tagged `[storage]`.
+/// #2379 fixed the analogous floods elsewhere; this file pins the same
+/// contract for the resolver: the recovered path produces ZERO traces.
+
+/// Records every [errorLogger] trace so the test can assert on count —
+/// mirrors `obd2_service_odometer_logging_test.dart` (#2379).
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _CaptureRecorder recorder;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CaptureRecorder();
+    errorLogger.testRecorderOverride = recorder;
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  group('SupportedPidsResolver transient → zero error traces (#2424)', () {
+    test(
+        'discoverSupportedPids: a send TimeoutException returns gracefully '
+        'and logs NO error trace', () async {
+      final resolver = SupportedPidsResolver(
+        // Every supported-PID scan command times out — the flaky-adapter
+        // scenario from the user logs.
+        send: (_) async =>
+            throw TimeoutException('ELM327 did not respond within 2.5s'),
+        isConnected: () => true,
+      );
+
+      final pids = await resolver.discoverSupportedPids();
+
+      expect(pids, isEmpty,
+          reason: 'best-effort: a transient on the first scan command '
+              'yields an empty set → caller blind-queries');
+      expect(recorder.calls, isEmpty,
+          reason: 'a transient supported-PID scan failure is expected/'
+              'recoverable — it must not pollute the error log');
+    });
+
+    test(
+        'discoverSupportedPids: the legacy concurrent-sendCommand '
+        'StateError is also silent', () async {
+      final resolver = SupportedPidsResolver(
+        send: (_) async => throw StateError('A sendCommand is in flight'),
+        isConnected: () => true,
+      );
+
+      final pids = await resolver.discoverSupportedPids();
+
+      expect(pids, isEmpty);
+      expect(recorder.calls, isEmpty,
+          reason: 'the legacy concurrent-sendCommand StateError is a '
+              'recoverable transient — no trace');
+    });
+  });
+
+  group('SupportedPidsResolver.prime over a real cache (#2424)', () {
+    late Directory tmpDir;
+    late Box<String> box;
+    late SupportedPidsCache cache;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp
+          .createTempSync('supported_pids_resolver_logging_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>('supported_pids_resolver_logging');
+      cache = SupportedPidsCache(box);
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
+    });
+
+    test(
+        'every send times out → prime returns quietly, _resolveVehicleCacheKey '
+        'degrades to the fallback key, and ZERO traces are logged', () async {
+      // No cache entry exists, so prime() falls through: fallback-key
+      // probe misses → _resolveVehicleCacheKey reads the VIN (0902) which
+      // TIMES OUT → it returns the fallback key → cache miss for that key
+      // → discoverSupportedPids scans, which also TIMES OUT. Every catch
+      // site on the path fires; none of them may log.
+      final resolver = SupportedPidsResolver(
+        send: (_) async =>
+            throw TimeoutException('ELM327 did not respond within 2.5s'),
+        isConnected: () => true,
+        cache: cache,
+        vehicleFallbackKey: 'aa:bb:cc:dd:ee:ff',
+      );
+
+      // Should complete without throwing — graceful degradation.
+      await resolver.prime();
+
+      expect(resolver.debugSupportedPids, isEmpty,
+          reason: 'a fully-timing-out adapter leaves the set empty → '
+              'blind query this session');
+      expect(recorder.calls, isEmpty,
+          reason: 'prime / VIN-read / scan transients are all expected & '
+              'recoverable — the recovered path logs zero traces (#2379)');
+    });
+  });
+}


### PR DESCRIPTION
## The gap

#2379 (PR #2381) stopped the user error log from being flooded with
recoverable OBD2/BLE transients — but only in `pid_scheduler.dart`,
`obd2_service.dart` (`readOdometer`) and `obd2_connection_service.dart`.
It missed `supported_pids_resolver.dart`, whose three catch sites still
spooled one `[storage]` trace each for **expected + recoverable**
conditions on a flaky / slow ELM327:

1. `prime()` — `{'where': 'OBD2 supported-PID cache prime failed'}`
2. `_resolveVehicleCacheKey()` — `{'where': 'OBD2 VIN read for cache key failed'}`
3. `discoverSupportedPids()` per-command — `{'where': 'OBD2 discoverSupportedPids failed on $command'}`

All three already degrade gracefully:
- `prime()` returns and the session falls back to blind querying;
- `_resolveVehicleCacheKey()` returns the static fallback key (old ECUs /
  clone adapters routinely don't answer the 0902 VIN probe);
- `discoverSupportedPids()` breaks and returns what it has (possibly
  empty → blind query).

A transient here (`TimeoutException`, the legacy concurrent-`sendCommand`
`StateError`, FlutterBluePlus device-not-connected) is therefore **not an
error** — the return value / break IS the signal — and must not pollute
the error log.

## The fix — consistent with #2379

#2379's treatment for a **recoverable** transient (where the return value
is the signal) is to **drop the `errorLogger.log` entirely**, catch `(_)`,
and keep a `debugPrint` breadcrumb (cf. its `readOdometer` and
`connectByMacDirect` recovered paths). This PR applies exactly that to all
three resolver sites. Control flow and return values are preserved
verbatim; the now-unused `errorLogger` / `ErrorLayer` import is removed.

Result: the recovered path produces **zero** `errorLogger` storage traces,
matching #2379's "recovered path = zero traces" contract.

## Test

`test/features/consumption/data/obd2/supported_pids_resolver_logging_test.dart`
mirrors `obd2_service_odometer_logging_test.dart` (#2379). A fake `send`
that throws `TimeoutException` (and a variant throwing the legacy
`StateError`) on the VIN / scan commands asserts:
- `discoverSupportedPids()` returns the empty set;
- `prime()` over a real (missing) cache returns quietly, with
  `_resolveVehicleCacheKey()` degrading to the fallback key and the set
  left empty;
- **zero** `errorLogger` traces recorded for the recovered path.

## Gate
- `flutter analyze` (changed files): no issues.
- New test + `supported_pids_cache_test.dart` + the full
  `test/features/consumption/data/obd2/` suite (1156) + `no_hardcoded_ui_strings_test` + `file_length_test`: all green.
- `supported_pids_resolver.dart` is 209 lines (< 400 cap).
- No ARB / user-facing strings; no `*.g.dart` / `*.freezed.dart` /
  `lib/l10n/` drift (no codegen-bearing code touched).

Closes #2424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
