### PR TITLE
fix(obd2): reclassify TripRecordingController VIN-read transient as recoverable — #2379/#2424 follow-up (#2428)

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -27,7 +27,6 @@ import 'trip_drop_detector.dart';
 import 'trip_live_reading.dart';
 import 'trip_sample_buffer.dart';
 import 'virtual_odometer.dart';
-import '../../../../core/logging/error_logger.dart';
 
 // Re-export the DTO + distance-source constants so existing callers
 // (providers, widget tests) that import this file keep working after
@@ -908,8 +907,15 @@ class TripRecordingController {
     try {
       final raw = await _service.sendCommand(Elm327Protocol.vinCommand);
       return Elm327Protocol.parseVin(raw);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'TripRecordingController VIN read failed'}));
+    } catch (_) {
+      // #2428 (follow-up to #2379/#2424) — the one-shot VIN (0902) read is
+      // best-effort: a flaky/slow ELM327 times it out, the legacy
+      // concurrent-sendCommand StateError can fire, or the device drops
+      // mid-probe — and old ECUs / clone adapters never answer 0902. All
+      // EXPECTED and recoverable: we return null and the trip records fine
+      // without a VIN, so a transient here must NOT pollute the user error
+      // log (it was mis-tagged `[storage]`). The null return IS the signal.
+      debugPrint('OBD2 VIN read failed — recording trip without a VIN');
       return null;
     }
   }

--- a/test/features/consumption/data/obd2/trip_recording_controller_vin_logging_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_vin_logging_test.dart
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+
+/// #2428 (follow-up to #2379/#2424) — [TripRecordingController]'s one-shot
+/// VIN (0902) read at [TripRecordingController.start] is a best-effort
+/// identity lookup. On a flaky/slow ELM327 the `sendCommand` times out (or
+/// the legacy concurrent-send / device-not-connected fires) and the trip
+/// records fine without a VIN — but the catch still spooled one `[storage]`
+/// trace per affected user, exactly the flood #2379/#2424 reclassified
+/// elsewhere. This file pins the same contract: the recovered path records
+/// the trip AND produces ZERO `errorLogger` traces for that transient.
+
+/// Records every [errorLogger] trace so the test can assert on count —
+/// mirrors `supported_pids_resolver_logging_test.dart` (#2424) and
+/// `obd2_service_odometer_logging_test.dart` (#2379).
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// A [FakeObd2Transport] whose VIN (0902) command throws the supplied
+/// transient — the flaky-adapter scenario from the user logs. Every other
+/// command (the AT init handshake + odometer) answers normally, so the
+/// service connects and the trip records cleanly; only the VIN probe fails.
+class _VinThrowingTransport extends FakeObd2Transport {
+  _VinThrowingTransport(this._onVin, [super.responses]);
+
+  final Object Function() _onVin;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (command.trim() == Elm327Protocol.vinCommand.trim()) {
+      throw _onVin();
+    }
+    return super.sendCommand(command);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _CaptureRecorder recorder;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CaptureRecorder();
+    errorLogger.testRecorderOverride = recorder;
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  // The init handshake + a valid odometer so `start()` succeeds; the VIN
+  // command is the only one that throws (via _VinThrowingTransport).
+  Map<String, String> baseResponses() => {
+        'ATZ': 'ELM327 v1.5>',
+        'ATE0': 'OK>',
+        'ATL0': 'OK>',
+        'ATH0': 'OK>',
+        'ATSP0': 'OK>',
+        '01A6': '41 A6 00 01 6A 2C>', // 92716 raw → 9271.6 km
+      };
+
+  group('TripRecordingController VIN-read transient → zero traces (#2428)',
+      () {
+    test(
+        'a VIN-command TimeoutException leaves vin null, still records the '
+        'trip, and logs NO error trace', () async {
+      final transport = _VinThrowingTransport(
+        () => TimeoutException('ELM327 did not respond within 2.5s'),
+        baseResponses(),
+      );
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(minutes: 1), // never ticks in-test
+      );
+
+      await ctl.start();
+      // The trip proceeds normally: odometer was still read, recording is
+      // live — the VIN failure is a graceful no-op.
+      expect(ctl.isRecording, isTrue,
+          reason: 'a VIN-read transient must not abort the trip');
+      expect(ctl.odometerStartKm, closeTo(9271.6, 0.01),
+          reason: 'the trip records fine without a VIN');
+
+      final summary = await ctl.stop();
+
+      expect(ctl.vin, isNull,
+          reason: 'best-effort: a timed-out 0902 probe leaves the VIN null');
+      expect(summary.distanceKm, 0);
+      expect(recorder.calls, isEmpty,
+          reason: 'a transient VIN-read failure is expected/recoverable — '
+              'it must not pollute the user error log (#2379/#2424)');
+    });
+
+    test(
+        'the legacy concurrent-sendCommand StateError on the VIN command is '
+        'also silent', () async {
+      final transport = _VinThrowingTransport(
+        () => StateError('A sendCommand is in flight'),
+        baseResponses(),
+      );
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        pollInterval: const Duration(minutes: 1),
+      );
+
+      await ctl.start();
+      await ctl.stop();
+
+      expect(ctl.vin, isNull);
+      expect(recorder.calls, isEmpty,
+          reason: 'the legacy concurrent-sendCommand StateError is a '
+              'recoverable transient — no trace');
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -61,7 +61,14 @@ void main() {
     // recoverable connect attempt stops flooding the error log. Net +11;
     // decomposition is tracked separately by #2187/#2188.
     'lib/features/consumption/data/obd2/obd2_service.dart': 1468,
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1235,
+    // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
+    // dropped its `errorLogger.log([storage], …)` (and the now-unused
+    // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb
+    // + an 8-line comment documenting WHY the transient is reclassified
+    // (matching the #2379/#2424 precedent in this same map). Net +6: the
+    // explanatory rationale, not behaviour. Decomposition of this god-class
+    // is tracked under #2187/#2188/#2190.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1241,
     'lib/features/consumption/presentation/screens/add_fill_up_screen.dart':
         496,
     // #2380 — +5: closest-station radar card at the top of the


### PR DESCRIPTION
## The gap

#2379 (PR #2381) and #2424 (PR #2425) stopped the user error log from
being flooded with **recoverable** OBD2/BLE transients — but only across
`pid_scheduler.dart`, `obd2_service.dart`, `obd2_connection_service.dart`
and `supported_pids_resolver.dart`. They missed the analogous catch in
`TripRecordingController._readVinOnce()`: the one-shot VIN (Mode 09 PID
02 / `0902`) read at `start()`, which still spooled one `[storage]` trace
per affected user on a flaky / slow adapter.

The VIN read is a best-effort identity lookup via `sendCommand`. On a
flaky/slow ELM327 it times out (or the legacy concurrent-send
`StateError` / device-not-connected fires), and many old ECUs / clone
adapters never answer `0902` at all. The method already degrades
gracefully — it returns `null` and the trip records fine without a VIN —
so a transient here is **expected and recoverable**, not an error: the
`null` return IS the signal, and it must not pollute the user error log.

## The fix — consistent with #2424

Match #2424 exactly: **drop** the `errorLogger.log(ErrorLayer.storage, …)`,
catch `(_)`, and keep a `debugPrint` breadcrumb. The now-unused
`error_logger` import is removed. Control flow and the `null` return are
preserved verbatim; the recovered path produces **zero** `errorLogger`
traces, matching the #2379/#2424 "recovered path = zero traces" contract.

## Sibling-site audit

The controller's other `sendCommand` call sites were audited and left
as-is because they already treat transients correctly:

- **Start / refresh odometer reads** (`_service.readOdometerKm()`) —
  delegate to `Obd2Service.readOdometer`, already reclassified by #2379
  (returns `null` on timeout, no log); no `errorLogger.log` in the
  controller for these.
- **`_runTransport` protocol sends** (`_service.sendCommand(command)`) —
  a transient is absorbed by the #1904 silent retry and, on a survivor,
  routed through the drop detector + `rethrow`; there is no
  `errorLogger.log` to reclassify.

The remaining `errorLogger.log(ErrorLayer.storage, …)` sites in this file
are genuine **Hive / persistence** saves (paused-trip / history repos),
not OBD2-command transients, and are **out of scope** per the issue.

## Test

`test/features/consumption/data/obd2/trip_recording_controller_vin_logging_test.dart`
mirrors `supported_pids_resolver_logging_test.dart` (#2424). A
`FakeObd2Transport` subclass throws `TimeoutException` (and a variant
throwing the legacy `StateError`) on the `0902` command while answering
the init handshake + odometer normally, then asserts:

- the controller still records the trip (`isRecording`, odometer read);
- `vin` is left `null` (graceful degradation);
- **zero** `errorLogger` traces are recorded for that transient.

## Gate

- `flutter analyze`: clean on the changed files (the 2 remaining repo
  `info`s pre-exist on master, in untouched files).
- New test + the four `trip_recording_controller_*` suites + the full
  `test/features/consumption/data/obd2/` suite (1159) +
  `no_hardcoded_ui_strings_test` + `file_length_test`: all green.
- **file_length**: `trip_recording_controller.dart` is a grandfathered
  >400 file. Dropping the log + import (−1) but adding the documenting
  comment block + `debugPrint` nets +6, so its snapshot is
  re-grandfathered 1235 → 1241 with a comment (same treatment
  #2379/#2391/#2392 applied in this map).
- No ARB / user-facing strings. Full clean `build_runner build` produced
  **zero** `*.g.dart` / `*.freezed.dart` / `lib/l10n/` drift.

Closes #2428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
