### PR TITLE
feat(l10n): move OSM map attribution label to ARB across 23 locales (#2402)

### DIFF
--- a/lib/core/services/impl/flutter_map_provider.dart
+++ b/lib/core/services/impl/flutter_map_provider.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../../../features/map/data/sparkilo_tile_layer.dart';
 import '../../constants/app_constants.dart';
+import '../../widgets/osm_attribution.dart';
 import '../map_provider.dart';
 
 /// Default [MapProvider] implementation backed by flutter_map + OSM tiles.
@@ -128,13 +129,8 @@ class FlutterMapProvider implements MapProvider {
   }
 
   @override
-  Widget buildAttribution() {
-    return const RichAttributionWidget(
-      attributions: [
-        TextSourceAttribution('OpenStreetMap contributors'),
-      ],
-    );
-  }
+  // Localized OSM credit (#2402) — resolves the ARB wrapper at build time.
+  Widget buildAttribution() => const OsmAttribution();
 
   @override
   dynamic createController() => MapController();

--- a/lib/core/widgets/osm_attribution.dart
+++ b/lib/core/widgets/osm_attribution.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+import '../../l10n/app_localizations.dart';
+
+/// The proper-noun brand credited in the OpenStreetMap tile attribution.
+///
+/// Kept as a single literal so it is never mistranslated and so the
+/// `mapAttributionOsm` ARB key only ever carries the translatable
+/// structural wording around it (#2402). OpenStreetMap's tile-usage
+/// policy mandates this visible credit on every map.
+const String _osmBrand = 'OpenStreetMap'; // i18n-ignore: brand / proper noun
+
+/// Builds the localized OpenStreetMap tile-attribution string
+/// ("© OpenStreetMap contributors") for the current locale, with the
+/// brand kept literal.
+///
+/// Shared by every flutter_map screen so the wrapper text lives in ARB
+/// in exactly one place (#2402). Falls back to an English composition if
+/// localizations are not yet available.
+String osmAttributionText(BuildContext context) {
+  final l = AppLocalizations.of(context);
+  return l?.mapAttributionOsm(_osmBrand) ?? '© $_osmBrand contributors';
+}
+
+/// The standard flutter_map [RichAttributionWidget] credit for the
+/// OpenStreetMap tile source, with its label sourced from ARB (#2402).
+///
+/// Reused across the station, driving, trip-path, radius-picker and
+/// trajets maps so the attribution wording is localized once.
+class OsmAttribution extends StatelessWidget {
+  const OsmAttribution({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return RichAttributionWidget(
+      attributions: [
+        TextSourceAttribution(osmAttributionText(context)),
+      ],
+    );
+  }
+}

--- a/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
+++ b/lib/features/alerts/presentation/widgets/radius_alert_map_picker.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/location/user_position_provider.dart';
+import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -181,15 +182,11 @@ class _RadiusAlertMapPickerState extends ConsumerState<RadiusAlertMapPicker> {
                 flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
               ),
             ),
-            children: [
+            children: const [
               // #2096 — was a raw TileLayer; routed through the
               // hardened wrapper for retry + cancellation resilience.
-              const SparkiloTileLayer(),
-              const RichAttributionWidget(
-                attributions: [
-                  TextSourceAttribution('OpenStreetMap contributors'),
-                ],
-              ),
+              SparkiloTileLayer(),
+              OsmAttribution(),
             ],
           ),
           // Fixed crosshair marking the picked location. Sits on top

--- a/lib/features/consumption/presentation/screens/trajets_map_screen.dart
+++ b/lib/features/consumption/presentation/screens/trajets_map_screen.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../../core/sharing/public_file_exporter.dart';
+import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -252,11 +253,7 @@ class _MapState extends State<_Map> {
               ),
           ],
         ),
-        const RichAttributionWidget(
-          attributions: [
-            TextSourceAttribution('OpenStreetMap contributors'),
-          ],
-        ),
+        const OsmAttribution(),
       ],
     );
   }

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -8,6 +8,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/driving_insights_analyzer.dart';
@@ -360,11 +361,7 @@ class _TripPathMapState extends State<_TripPathMap> {
             ...hardAccelMarkers,
           ],
         ),
-        const RichAttributionWidget(
-          attributions: [
-            TextSourceAttribution('OpenStreetMap contributors'),
-          ],
-        ),
+        const OsmAttribution(),
       ],
     );
   }

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/utils/price_utils.dart';
+import '../../../../core/widgets/osm_attribution.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
@@ -141,11 +142,7 @@ class _DrivingMapViewState extends State<DrivingMapView> {
         // wrapper.
         const SparkiloTileLayer(),
         MarkerLayer(markers: _markers),
-        const RichAttributionWidget(
-          attributions: [
-            TextSourceAttribution('OpenStreetMap contributors'),
-          ],
-        ),
+        const OsmAttribution(),
       ],
     );
   }

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -10,6 +10,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../../data/sparkilo_tile_layer.dart';
 import '../../../../core/utils/price_utils.dart';
+import '../../../../core/widgets/osm_attribution.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import 'price_legend.dart';
@@ -373,12 +374,8 @@ class _StationMapLayersState extends State<StationMapLayers> {
             }),
             // Extra layers (e.g. EV overlay)
             ...widget.extraLayers,
-            // Attribution
-            const RichAttributionWidget(
-              attributions: [
-                TextSourceAttribution('OpenStreetMap contributors'),
-              ],
-            ),
+            // Attribution — localized OSM credit (#2402).
+            const OsmAttribution(),
           ],
         ),
         // Zoom controls

--- a/lib/features/profile/presentation/widgets/about_section.dart
+++ b/lib/features/profile/presentation/widgets/about_section.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../l10n/app_localizations.dart';
 
 class AboutSection extends StatelessWidget {
@@ -131,9 +132,9 @@ class AboutSection extends StatelessWidget {
               mode: LaunchMode.externalApplication,
             ),
           ),
-          const ListTile(
-            leading: Icon(Icons.map),
-            title: Text(AppConstants.osmAttribution),
+          ListTile(
+            leading: const Icon(Icons.map),
+            title: Text(osmAttributionText(context)),
           ),
         ],
       ),

--- a/lib/l10n/_fragments/data_attribution_de.arb
+++ b/lib/l10n/_fragments/data_attribution_de.arb
@@ -12,5 +12,15 @@
         "example": "CC BY 4.0"
       }
     }
+  },
+  "mapAttributionOsm": "© {brand}-Mitwirkende",
+  "@mapAttributionOsm": {
+    "description": "Map-tile attribution shown on every OpenStreetMap-tiled map (the flutter_map RichAttributionWidget on the station/driving/trip/radius-picker maps and the about screen's data-source list). OSM's tile-usage policy mandates the visible '© OpenStreetMap contributors' credit. Only the surrounding structural wording ('© … contributors') is translatable; {brand} is the proper-noun 'OpenStreetMap', passed verbatim from the call site (kept literal there under an i18n-ignore brand exemption) so it can never be mistranslated. Keep the leading © and the {brand} token in every translation (#2402).",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/_fragments/data_attribution_en.arb
+++ b/lib/l10n/_fragments/data_attribution_en.arb
@@ -12,5 +12,15 @@
         "example": "CC BY 4.0"
       }
     }
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "description": "Map-tile attribution shown on every OpenStreetMap-tiled map (the flutter_map RichAttributionWidget on the station/driving/trip/radius-picker maps and the about screen's data-source list). OSM's tile-usage policy mandates the visible '© OpenStreetMap contributors' credit. Only the surrounding structural wording ('© … contributors') is translatable; {brand} is the proper-noun 'OpenStreetMap', passed verbatim from the call site (kept literal there under an i18n-ignore brand exemption) so it can never be mistranslated. Keep the leading © and the {brand} token in every translation (#2402).",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/_fragments/data_attribution_fr.arb
+++ b/lib/l10n/_fragments/data_attribution_fr.arb
@@ -1,0 +1,3 @@
+{
+  "mapAttributionOsm": "© les contributeurs {brand}"
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1713,6 +1713,16 @@
       }
     }
   },
+  "mapAttributionOsm": "© {brand}-Mitwirkende",
+  "@mapAttributionOsm": {
+    "description": "Map-tile attribution shown on every OpenStreetMap-tiled map (the flutter_map RichAttributionWidget on the station/driving/trip/radius-picker maps and the about screen's data-source list). OSM's tile-usage policy mandates the visible '© OpenStreetMap contributors' credit. Only the surrounding structural wording ('© … contributors') is translatable; {brand} is the proper-noun 'OpenStreetMap', passed verbatim from the call site (kept literal there under an i18n-ignore brand exemption) so it can never be mistranslated. Keep the leading © and the {brand} token in every translation (#2402).",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
+  },
   "developerToolsSectionTitle": "Entwicklerwerkzeuge",
   "developerToolsSubtitle": "Diagnose und Werkzeuge zur Fehlersuche — nur im Entwickler-/Debug-Modus sichtbar.",
   "developerToolsMenuSubtitle": "Fehlerprotokoll, Test-Alarme, Diagnose",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2499,6 +2499,16 @@
       }
     }
   },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "description": "Map-tile attribution shown on every OpenStreetMap-tiled map (the flutter_map RichAttributionWidget on the station/driving/trip/radius-picker maps and the about screen's data-source list). OSM's tile-usage policy mandates the visible '© OpenStreetMap contributors' credit. Only the surrounding structural wording ('© … contributors') is translatable; {brand} is the proper-noun 'OpenStreetMap', passed verbatim from the call site (kept literal there under an i18n-ignore brand exemption) so it can never be mistranslated. Keep the leading © and the {brand} token in every translation (#2402).",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
+  },
   "developerToolsSectionTitle": "Developer tools",
   "@developerToolsSectionTitle": {
     "description": "Title of the Settings section / screen hosting dev-only diagnostics, shown only when Developer / Debug mode is on (#2248)."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1173,6 +1173,7 @@
   "crossBorderTapToSwitch": "⟦Ŧáƥ ŧó šŵîŧçĥ çóúñŧřý ········⟧",
   "crossBorderDismissTooltip": "⟦Đîšɱîšš ···⟧",
   "dataSourceLinkSemantic": "⟦Óƥéñ ŧĥé {source} đáŧá šóúřçé ({license}) îñ ýóúř ƀřóŵšéř ··············⟧",
+  "mapAttributionOsm": "⟦© {brand} çóñŧřîƀúŧóřš ·····⟧",
   "developerToolsSectionTitle": "⟦Đéṽéłóƥéř ŧóółš ······⟧",
   "developerToolsSubtitle": "⟦Đîáǧñóšŧîçš áñđ ŧóółš ƒóř đéƀúǧǧîñǧ — óñłý ṽîšîƀłé îñ Đéṽéłóƥéř / Đéƀúǧ ɱóđé. ····························⟧",
   "developerToolsMenuSubtitle": "⟦Éřřóř łóǧ, ŧéšŧ áłéřŧš, đîáǧñóšŧîçš ·············⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2368,5 +2368,15 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© les contributeurs {brand}",
+  "@mapAttributionOsm": {
+    "description": "Map-tile attribution shown on every OpenStreetMap-tiled map (#2402). Hand-translated French. {brand} is the verbatim proper noun 'OpenStreetMap'.",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7200,6 +7200,12 @@ abstract class AppLocalizations {
   /// **'Open the {source} data source ({license}) in your browser'**
   String dataSourceLinkSemantic(String source, String license);
 
+  /// Map-tile attribution shown on every OpenStreetMap-tiled map (the flutter_map RichAttributionWidget on the station/driving/trip/radius-picker maps and the about screen's data-source list). OSM's tile-usage policy mandates the visible '© OpenStreetMap contributors' credit. Only the surrounding structural wording ('© … contributors') is translatable; {brand} is the proper-noun 'OpenStreetMap', passed verbatim from the call site (kept literal there under an i18n-ignore brand exemption) so it can never be mistranslated. Keep the leading © and the {brand} token in every translation (#2402).
+  ///
+  /// In en, this message translates to:
+  /// **'© {brand} contributors'**
+  String mapAttributionOsm(String brand);
+
   /// Title of the Settings section / screen hosting dev-only diagnostics, shown only when Developer / Debug mode is on (#2248).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3997,6 +3997,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Инструменти за разработчици';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3974,6 +3974,11 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Nástroje pro vývojáře';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3968,6 +3968,11 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Udviklerværktøjer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3990,6 +3990,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand-Mitwirkende';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Entwicklerwerkzeuge';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4000,6 +4000,11 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Εργαλεία προγραμματιστή';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3949,6 +3949,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Developer tools';
 
   @override
@@ -10116,6 +10121,11 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String dataSourceLinkSemantic(String source, String license) {
     return '⟦Óƥéñ ŧĥé $source đáŧá šóúřçé ($license) îñ ýóúř ƀřóŵšéř ··············⟧';
+  }
+
+  @override
+  String mapAttributionOsm(String brand) {
+    return '⟦© $brand çóñŧřîƀúŧóřš ·····⟧';
   }
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3993,6 +3993,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Herramientas de desarrollo';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3964,6 +3964,11 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Arendaja tööriistad';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3968,6 +3968,11 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Kehittäjätyökalut';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4006,6 +4006,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© les contributeurs $brand';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Outils de développement';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3976,6 +3976,11 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Razvojni alati';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3997,6 +3997,11 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Fejlesztői eszközök';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3985,6 +3985,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Strumenti di sviluppo';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3989,6 +3989,11 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Kūrėjo įrankiai';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3993,6 +3993,11 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Izstrādātāja rīki';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3966,6 +3966,11 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Utviklerverktøy';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3984,6 +3984,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Ontwikkelaarstools';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3981,6 +3981,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Narzędzia programisty';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3994,6 +3994,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Ferramentas de programador';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3993,6 +3993,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Instrumente pentru dezvoltatori';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3986,6 +3986,11 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Nástroje pre vývojárov';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3972,6 +3972,11 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Razvijalska orodja';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3969,6 +3969,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String mapAttributionOsm(String brand) {
+    return '© $brand contributors';
+  }
+
+  @override
   String get developerToolsSectionTitle => 'Utvecklarverktyg';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2240,5 +2240,16 @@
   "@tripRecordingEstimatedInfo": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "mapAttributionOsm": "© {brand} contributors",
+  "@mapAttributionOsm": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "brand": {
+        "type": "String",
+        "example": "OpenStreetMap"
+      }
+    }
   }
 }

--- a/test/core/services/impl/flutter_map_provider_test.dart
+++ b/test/core/services/impl/flutter_map_provider_test.dart
@@ -566,10 +566,13 @@ void main() {
   group('FlutterMapProvider — buildAttribution', () {
     const provider = FlutterMapProvider();
 
-    testWidgets('returns a RichAttributionWidget mentioning OSM contributors',
-        (WidgetTester tester) async {
+    testWidgets(
+        'returns a RichAttributionWidget crediting OSM (#2402 — localized '
+        'wrapper, brand kept literal)', (WidgetTester tester) async {
       final widget = provider.buildAttribution();
 
+      // No `AppLocalizations` in the tree, so the helper takes its English
+      // fallback composition — which still carries the © and the brand.
       await tester.pumpWidget(
         MaterialApp(
           home: FlutterMap(
@@ -589,7 +592,10 @@ void main() {
       expect(attribution.attributions, hasLength(1));
       final source =
           attribution.attributions.single as TextSourceAttribution;
-      expect(source.text, 'OpenStreetMap contributors');
+      // Brand stays literal; wrapper composes "© OpenStreetMap contributors".
+      expect(source.text, contains('OpenStreetMap'));
+      expect(source.text, startsWith('©'));
+      expect(source.text, '© OpenStreetMap contributors');
     });
   });
 }

--- a/test/core/widgets/osm_attribution_test.dart
+++ b/test/core/widgets/osm_attribution_test.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/widgets/osm_attribution.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// #2402 — the OpenStreetMap tile attribution wrapper now comes from the
+/// `mapAttributionOsm` ARB key. The "OpenStreetMap" brand stays a literal
+/// (i18n-ignore), so it must survive verbatim in every locale's rendered
+/// credit while the surrounding wording localizes.
+void main() {
+  Future<void> pumpInMap(WidgetTester tester, {required Locale locale}) async {
+    await pumpApp(
+      tester,
+      FlutterMap(
+        options: const MapOptions(
+          initialCenter: LatLng(48.0, 2.0),
+          initialZoom: 10,
+        ),
+        children: const [OsmAttribution()],
+      ),
+      locale: locale,
+    );
+  }
+
+  TextSourceAttribution readSource(WidgetTester tester) {
+    final widget = tester.widget<RichAttributionWidget>(
+      find.byType(RichAttributionWidget),
+    );
+    expect(widget.attributions, hasLength(1));
+    return widget.attributions.single as TextSourceAttribution;
+  }
+
+  group('OsmAttribution', () {
+    testWidgets('renders the English wrapper with the brand intact',
+        (tester) async {
+      await pumpInMap(tester, locale: const Locale('en'));
+
+      expect(find.byType(RichAttributionWidget), findsOneWidget);
+      final source = readSource(tester);
+      expect(source.text, '© OpenStreetMap contributors');
+    });
+
+    testWidgets('renders the German wrapper with the brand intact',
+        (tester) async {
+      await pumpInMap(tester, locale: const Locale('de'));
+
+      final source = readSource(tester);
+      // German localizes the wrapper but keeps the OpenStreetMap brand.
+      expect(source.text, '© OpenStreetMap-Mitwirkende');
+      expect(source.text, contains('OpenStreetMap'));
+    });
+
+    testWidgets('renders the French wrapper with the brand intact',
+        (tester) async {
+      await pumpInMap(tester, locale: const Locale('fr'));
+
+      final source = readSource(tester);
+      expect(source.text, '© les contributeurs OpenStreetMap');
+      expect(source.text, contains('OpenStreetMap'));
+    });
+  });
+
+  group('osmAttributionText', () {
+    testWidgets('composes the localized wrapper around the literal brand',
+        (tester) async {
+      late String resolved;
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) {
+            resolved = osmAttributionText(context);
+            return const SizedBox();
+          },
+        ),
+        locale: const Locale('de'),
+      );
+
+      expect(resolved, '© OpenStreetMap-Mitwirkende');
+      expect(resolved, contains('OpenStreetMap'));
+    });
+  });
+}

--- a/test/core/widgets/osm_attribution_test.dart
+++ b/test/core/widgets/osm_attribution_test.dart
@@ -17,12 +17,12 @@ void main() {
   Future<void> pumpInMap(WidgetTester tester, {required Locale locale}) async {
     await pumpApp(
       tester,
-      FlutterMap(
-        options: const MapOptions(
+      const FlutterMap(
+        options: MapOptions(
           initialCenter: LatLng(48.0, 2.0),
           initialZoom: 10,
         ),
-        children: const [OsmAttribution()],
+        children: [OsmAttribution()],
       ),
       locale: locale,
     );

--- a/test/features/profile/presentation/widgets/about_section_test.dart
+++ b/test/features/profile/presentation/widgets/about_section_test.dart
@@ -94,6 +94,19 @@ void main() {
           reason: 'attribution row should carry the open-in-new affordance');
     });
 
+    testWidgets(
+        'OSM map-data row renders the localized attribution with the brand '
+        'kept literal (#2402)', (tester) async {
+      await pumpApp(
+        tester,
+        const SingleChildScrollView(child: AboutSection()),
+      );
+
+      // English wrapper from the `mapAttributionOsm` ARB key; the
+      // OpenStreetMap brand survives verbatim.
+      expect(find.text('© OpenStreetMap contributors'), findsOneWidget);
+    });
+
     test('CreativeCommons URL constant is HTTPS and points at the CC BY page',
         () {
       expect(AppConstants.tankerkoenigCreativeCommonsUrl,


### PR DESCRIPTION
## What

Moves the OpenStreetMap tile-attribution wrapper into ARB so it is localized in all 23 shipped locales + the `en_XA` expansion pseudo-locale. Part of Epic #2394 (map reimplementation).

Previously the credit was hard-coded as `'OpenStreetMap contributors'` in five `RichAttributionWidget`s (station / driving / trip-path / radius-picker / trajets maps) plus the provider's `buildAttribution()`, and the about screen rendered the `AppConstants.osmAttribution` const directly.

## New ARB key

- **`mapAttributionOsm`** = `"© {brand} contributors"` — the only translatable string. Fanned out to **all 23 locales + `en_XA`** (every locale 100%).
  - `de` hand-translated: `© {brand}-Mitwirkende`
  - `fr` hand-translated: `© les contributeurs {brand}`
  - the other 21 locales carry the sanctioned #2335 machine-fill (English value, `x-mt: needs-native-review`)
  - `{brand}` is the proper-noun **"OpenStreetMap"**, passed verbatim from each call site and **kept literal under an `// i18n-ignore: brand / proper noun` exemption** so it can never be mistranslated.

## How

- New shared core widget **`OsmAttribution`** (`lib/core/widgets/osm_attribution.dart`) + helper `osmAttributionText(context)` compose the localized credit in one place. All six map surfaces and the about row now reuse it, so the brand literal + i18n-ignore live exactly once.
- No map behaviour or layout change — string source only.

## Exemptions (unchanged)

- **"OpenStreetMap"** stays a literal brand/proper-noun (`// i18n-ignore:`).
- The OSM copyright **URL** stays literal too.
- `no_hardcoded_ui_strings` baseline unchanged (**0**).

## Tests

- `OsmAttribution` renders the localized wrapper with the brand intact in **en / de / fr**.
- About-screen OSM row + provider `buildAttribution()` assert the localized / fallback `© OpenStreetMap contributors`.
- `flutter analyze` clean; `test/l10n/` + `test/i18n/` green (every locale 1772/1772 = 100%); `no_hardcoded_ui_strings` + `file_length` green.
- Zero `*.g.dart` / `*.freezed.dart` drift (verified against a clean `build_runner build`); full `lib/l10n/` fan-out committed.

Closes #2402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
