### PR TITLE
fix(map): paint cheapest (green) price markers on top of overlapping markers (#2434)

### DIFF
--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -3,6 +3,7 @@
 
 import 'dart:math' as math;
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
@@ -135,6 +136,41 @@ class StationMapLayers extends StatefulWidget {
     return LatLng(sumLat / stations.length, sumLng / stations.length);
   }
 
+  /// Order [stations] so that, when their markers are handed to the
+  /// (cluster) layer, the CHEAPEST (green/günstig) marker is painted ON
+  /// TOP of any more-expensive (orange/red) markers it overlaps (#2434).
+  ///
+  /// flutter_map / flutter_map_marker_cluster paint markers in the order
+  /// of the source list — a marker LATER in the list is painted on top of
+  /// earlier ones. For individually-overlapping (un-clustered) price
+  /// bubbles at the reported zoom, this list order governs the overlap,
+  /// because the cluster layer recurses its nodes in insertion order and
+  /// `MarkerLayer` paints in list order. So the rule is:
+  ///   - sort by the RESOLVED display price (see [bestDisplayPrice]) —
+  ///     the SAME price the marker is COLOURED by (#2400) — DESCENDING:
+  ///     most expensive first (painted at the bottom), cheapest last
+  ///     (painted on top), so colour and stacking always agree;
+  ///   - markers with NO comparable price ([bestDisplayPrice] null → the
+  ///     grey "--" bubble) sort to the very FRONT (the bottom of the
+  ///     stack) so a price-less marker can never cover a real green one.
+  ///
+  /// Returns a NEW list; the input is not mutated. A stable sort keeps the
+  /// relative order of equal-priced stations.
+  static List<Station> orderedByPriceForPainting(
+    List<Station> stations,
+    FuelType selectedFuel,
+  ) {
+    // A null resolved price is treated as the most-expensive bucket
+    // (+infinity) so, under a descending sort, it lands first → painted
+    // at the very bottom, beneath every priced marker.
+    double sortKey(Station s) =>
+        bestDisplayPrice(s, selectedFuel)?.price ?? double.infinity;
+    final ordered = List<Station>.of(stations);
+    // Descending: highest price first (bottom), lowest last (top).
+    mergeSort<Station>(ordered,
+        compare: (a, b) => sortKey(b).compareTo(sortKey(a)));
+    return ordered;
+  }
 }
 
 class _StationMapLayersState extends State<StationMapLayers> {
@@ -176,7 +212,16 @@ class _StationMapLayersState extends State<StationMapLayers> {
     _priceRange = resolvedPriceRange(widget.stations, widget.selectedFuel);
     final ids = widget.selectedStationIds;
     final hasSelection = ids != null && ids.isNotEmpty;
-    _markers = widget.stations.map((station) {
+    // #2434 — order so the cheapest (green) marker paints ON TOP of the
+    // more-expensive ones it overlaps. The (cluster) layer paints in
+    // source-list order (later = on top), so we sort price-descending:
+    // expensive at the bottom, cheapest last/on top, price-less markers
+    // beneath everything. Same resolved price the marker is coloured by.
+    final ordered = StationMapLayers.orderedByPriceForPainting(
+      widget.stations,
+      widget.selectedFuel,
+    );
+    _markers = ordered.map((station) {
       final isPastel = hasSelection && !ids.contains(station.id);
       return StationMarkerBuilder.build(
         context,

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -224,6 +224,107 @@ void main() {
       },
     );
   });
+
+  group('StationMapLayers.orderedByPriceForPainting (#2434)', () {
+    // The (cluster) layer paints in source-list order — a marker LATER
+    // in the list paints ON TOP of earlier ones. The helper must order
+    // stations so the cheapest (green) marker ends up LAST (top) and a
+    // price-less marker ends up FIRST (bottom, beneath every real price).
+    Station station(String id, {double? diesel, double? e10}) => Station(
+          id: id,
+          name: id,
+          brand: 'Brand $id',
+          street: 'Street',
+          houseNumber: '1',
+          postCode: '10178',
+          place: 'Berlin',
+          lat: 52.0,
+          lng: 13.0,
+          dist: 1.0,
+          diesel: diesel,
+          e10: e10,
+          isOpen: true,
+        );
+
+    test('orders cheapest LAST (painted on top), most expensive FIRST', () {
+      final cheap = station('cheap', diesel: 1.50);
+      final mid = station('mid', diesel: 1.70);
+      final expensive = station('expensive', diesel: 1.90);
+
+      // Feed them in an arbitrary order.
+      final ordered = StationMapLayers.orderedByPriceForPainting(
+        [mid, expensive, cheap],
+        FuelType.diesel,
+      );
+
+      // Bottom → top of the paint stack: expensive, mid, cheap.
+      expect(
+        ordered.map((s) => s.id).toList(),
+        ['expensive', 'mid', 'cheap'],
+        reason: 'cheapest must be LAST so it paints on top of the rest',
+      );
+    });
+
+    test('price-less stations sink to the BOTTOM (front of the list)', () {
+      final cheap = station('cheap', diesel: 1.50);
+      final expensive = station('expensive', diesel: 1.90);
+      final noPrice = station('noprice'); // no diesel, no fallback fuel
+
+      final ordered = StationMapLayers.orderedByPriceForPainting(
+        [cheap, noPrice, expensive],
+        FuelType.diesel,
+      );
+
+      // The null-price marker is first (very bottom) so it can never
+      // cover a real green one; cheapest is still last (top).
+      expect(ordered.first.id, 'noprice',
+          reason: 'price-less marker must sit beneath every priced one');
+      expect(ordered.last.id, 'cheap',
+          reason: 'cheapest priced marker must still paint on top');
+    });
+
+    test(
+        'orders by the RESOLVED display price (fallback fuel), matching '
+        'the marker colour', () {
+      // User has DIESEL selected. `fallback` has no diesel but a cheap
+      // E10 — its marker is coloured by that fallback price (#2400), so
+      // the z-order must use the same resolved price, not the (null)
+      // selected-fuel price.
+      final dieselExpensive = station('diesel-expensive', diesel: 1.95);
+      final fallbackCheap = station('fallback-cheap', e10: 1.40);
+
+      final ordered = StationMapLayers.orderedByPriceForPainting(
+        [dieselExpensive, fallbackCheap],
+        FuelType.diesel,
+      );
+
+      // The resolved-cheap fallback station paints on top of the
+      // diesel-expensive one, agreeing with their green/red colours.
+      expect(ordered.last.id, 'fallback-cheap');
+      expect(ordered.first.id, 'diesel-expensive');
+    });
+
+    test('is a pure function — does not mutate the input list', () {
+      final input = [
+        station('a', diesel: 1.90),
+        station('b', diesel: 1.50),
+      ];
+      final before = input.map((s) => s.id).toList();
+      StationMapLayers.orderedByPriceForPainting(input, FuelType.diesel);
+      expect(input.map((s) => s.id).toList(), before,
+          reason: 'helper must return a new list, leaving the input intact');
+    });
+
+    test('is stable for equal prices (preserves relative order)', () {
+      final first = station('first', diesel: 1.70);
+      final second = station('second', diesel: 1.70);
+      final ordered = StationMapLayers.orderedByPriceForPainting(
+        [first, second],
+        FuelType.diesel,
+      );
+      expect(ordered.map((s) => s.id).toList(), ['first', 'second']);
+    });
+  });
 }
 
 const _seedStation = Station(


### PR DESCRIPTION
## What

On the map, overlapping price markers painted the most-expensive (orange/red) bubble on top of a cheaper (green/günstig) one, depending on station arrival order. This makes the marker source list paint the **cheapest marker on top**.

## Ordering rule

Sort the marker source list by the **resolved display price** — the *same* `bestDisplayPrice` the marker is coloured by (#2400) — **descending**, right before it is handed to the (cluster) layer:

- most expensive first → painted at the **bottom**;
- cheapest last → painted on **top**, so colour and stacking always agree;
- markers with **no comparable price** (`bestDisplayPrice` null → the grey `--` bubble) sort to the very front → the **bottom** of the stack, so a price-less marker can never cover a real green one.

A stable `mergeSort` keeps the relative order of equal-priced stations. The helper `StationMapLayers.orderedByPriceForPainting` is pure and returns a new list (input is not mutated).

## Clustering finding

`flutter_map` and `flutter_map_marker_cluster` (8.2.2) both paint markers in **source-list order** — a marker later in the list paints on top of earlier ones. For the individually-overlapping (un-clustered) price bubbles at the reported zoom, the cluster layer's `recursively` walks its child nodes in **insertion order** and `_buildMobileTransformStack` appends each marker to the layer `Stack` in that order; `MarkerLayer` likewise paints in list order. So the input list order governs the overlap painting for un-clustered markers — no separate z-API is needed; pre-sorting the source list is sufficient. (Count-cluster bubbles at low zoom are unaffected; this only changes which individual bubble wins an overlap.)

## Tests

`orderedByPriceForPainting` unit tests cover: cheapest last / most-expensive first; price-less stations sinking to the bottom while the cheapest stays on top; ordering by the resolved fallback price (matching the marker colour); purity (no input mutation); and stability for equal prices.

Closes #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)
