### PR TITLE
feat(consumption): pure reconciliation comparison-basis + invariant function (#2440)

### DIFF
--- a/lib/features/consumption/domain/services/reconciliation_basis.dart
+++ b/lib/features/consumption/domain/services/reconciliation_basis.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../entities/fill_up.dart';
+import '../trip_summary.dart';
+
+/// The agreed comparison basis for the guided reconciliation workflow
+/// (Epic #2439, child #2440).
+///
+/// Today the two consumption surfaces (fill-ups vs trajets) don't
+/// reconcile, and the legacy silent auto-correction (#1361) makes them
+/// diverge MORE. This record is the SINGLE SOURCE OF TRUTH the cross-view
+/// invariant test asserts against: it puts both sides of the comparison
+/// on the basis the maintainer validated (2026-05-30) so the figures
+/// "conclude with the same results".
+///
+/// The semantics encoded here (Epic decisions #3 + #4):
+/// - **Total L honesty** — [fuelTotalLiters] is what the user actually
+///   pumped (real fills only); correction litres are NOT folded in.
+/// - **Corrections + virtual trips both count on the TRAJETS side** — a
+///   correction fill and a virtual trip are each an explicit stand-in for
+///   unrecorded burn, so both belong to [trajetsTotalLiters] even though
+///   a correction physically lives in the fill-up store.
+/// - **Signed [residualLiters]** — `fuelTotal − trajetsTotal`. The hard
+///   invariant is `residual == 0` AFTER reconciliation, and
+///   `residual == gap` BEFORE any correction/virtual is added.
+typedef ReconciliationBasis = ({
+  /// Σ real pumped litres — fills where NOT [FillUp.isCorrection].
+  /// Mirrors the "Total L" the user sees; correction entries are
+  /// excluded so Total L stays honest about what came out of the pump.
+  double fuelTotalLiters,
+
+  /// Σ `trip.fuelLitersConsumed` (null → 0) **+** Σ correction-fill
+  /// litres **+** Σ virtual-trip litres. The trajets side of the
+  /// comparison: recorded burn plus every explicit stand-in for
+  /// unrecorded burn.
+  double trajetsTotalLiters,
+
+  /// `fuelTotalLiters − trajetsTotalLiters`, signed. `0` once the window
+  /// reconciles; equal to the pre-correction gap otherwise. Negative
+  /// when the trajets side exceeds real pumped litres (integrator ran
+  /// hot, or an over-large virtual/correction was attributed).
+  double residualLiters,
+});
+
+/// Computes the agreed [ReconciliationBasis] for ONE tank window.
+///
+/// PURE: inputs in, value out. No repository, no provider, no
+/// persistence, no widget — and it does NOT alter detector behaviour or
+/// any save path (that stays in #2441). Callers pass the window's fills
+/// (including any correction entries) and trips (including any
+/// virtual/reconciliation trips); classification is by [FillUp.isCorrection]
+/// and the [isVirtualTrip] predicate.
+///
+/// [isVirtualTrip] defaults to "never virtual". `TripSummary` has no
+/// virtual flag yet, so #2444 injects synthetic trips and wires this
+/// predicate (e.g. by id-set membership or a future `isVirtual` field)
+/// WITHOUT changing this function's contract — the basis math is already
+/// correct regardless of how a trip is identified as virtual.
+///
+/// Both [windowFills] and [windowTrips] are expected to already be scoped
+/// to a single tank window by the caller (e.g. via [Reconciler]'s window
+/// logic). This function does no windowing of its own — it only classifies
+/// and sums.
+ReconciliationBasis reconciliationBasis({
+  required List<FillUp> windowFills,
+  required List<TripSummary> windowTrips,
+  bool Function(TripSummary trip) isVirtualTrip = _neverVirtual,
+}) {
+  var fuelTotal = 0.0;
+  var correctionTotal = 0.0;
+  for (final fill in windowFills) {
+    if (fill.isCorrection) {
+      correctionTotal += fill.liters;
+    } else {
+      fuelTotal += fill.liters;
+    }
+  }
+
+  var recordedConsumed = 0.0;
+  var virtualTotal = 0.0;
+  for (final trip in windowTrips) {
+    final liters = trip.fuelLitersConsumed ?? 0;
+    if (isVirtualTrip(trip)) {
+      virtualTotal += liters;
+    } else {
+      recordedConsumed += liters;
+    }
+  }
+
+  final trajetsTotal = recordedConsumed + correctionTotal + virtualTotal;
+  return (
+    fuelTotalLiters: fuelTotal,
+    trajetsTotalLiters: trajetsTotal,
+    residualLiters: fuelTotal - trajetsTotal,
+  );
+}
+
+bool _neverVirtual(TripSummary trip) => false;

--- a/test/features/consumption/domain/services/reconciliation_basis_test.dart
+++ b/test/features/consumption/domain/services/reconciliation_basis_test.dart
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/services/reconciliation_basis.dart';
+import 'package:tankstellen/features/consumption/domain/trip_summary.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Unit tests for [reconciliationBasis] (#2440). The function is PURE —
+/// every test passes window fills + trips directly and asserts on the
+/// returned record, without Hive, Riverpod, or any UI.
+void main() {
+  FillUp makeFill({
+    String id = 'fill',
+    required double liters,
+    bool isCorrection = false,
+  }) =>
+      FillUp(
+        id: id,
+        date: DateTime(2026, 4, 10),
+        liters: liters,
+        totalCost: liters * 1.5,
+        odometerKm: 10000,
+        fuelType: FuelType.e10,
+        vehicleId: 'veh-a',
+        isCorrection: isCorrection,
+      );
+
+  TripSummary makeTrip({
+    required double? fuel,
+    String? id,
+  }) =>
+      TripSummary(
+        distanceKm: 100,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuel,
+        // Encode a synthetic identity in startedAt so the virtual
+        // predicate has something stable to key on.
+        startedAt: id == 'virtual'
+            ? DateTime(2026, 4, 11)
+            : DateTime(2026, 4, 10),
+      );
+
+  group('reconciliationBasis — fuelTotal', () {
+    test('counts only real pumped litres; corrections excluded', () {
+      final basis = reconciliationBasis(
+        windowFills: [
+          makeFill(id: 'a', liters: 40),
+          makeFill(id: 'b', liters: 10),
+          makeFill(id: 'corr', liters: 5, isCorrection: true),
+        ],
+        windowTrips: const [],
+      );
+      // Real pumped = 40 + 10; the 5 L correction is NOT in fuelTotal.
+      expect(basis.fuelTotalLiters, 50);
+    });
+
+    test('zero fills → fuelTotal 0', () {
+      final basis = reconciliationBasis(
+        windowFills: const [],
+        windowTrips: const [],
+      );
+      expect(basis.fuelTotalLiters, 0);
+    });
+  });
+
+  group('reconciliationBasis — trajetsTotal', () {
+    test('= consumed + correction litres + virtual-trip litres', () {
+      final basis = reconciliationBasis(
+        windowFills: [
+          makeFill(id: 'a', liters: 50),
+          makeFill(id: 'corr', liters: 5, isCorrection: true),
+        ],
+        windowTrips: [
+          makeTrip(fuel: 30),
+          makeTrip(fuel: 8, id: 'virtual'),
+        ],
+        isVirtualTrip: (t) => t.startedAt == DateTime(2026, 4, 11),
+      );
+      // 30 recorded + 5 correction + 8 virtual = 43.
+      expect(basis.trajetsTotalLiters, 43);
+      // fuelTotal stays honest at the real pumped 50.
+      expect(basis.fuelTotalLiters, 50);
+    });
+
+    test('null fuelLitersConsumed trips contribute 0', () {
+      final basis = reconciliationBasis(
+        windowFills: [makeFill(liters: 40)],
+        windowTrips: [
+          makeTrip(fuel: null),
+          makeTrip(fuel: 12),
+        ],
+      );
+      expect(basis.trajetsTotalLiters, 12);
+    });
+
+    test('a virtual trip with null fuel contributes 0', () {
+      final basis = reconciliationBasis(
+        windowFills: [makeFill(liters: 40)],
+        windowTrips: [makeTrip(fuel: null, id: 'virtual')],
+        isVirtualTrip: (t) => t.startedAt == DateTime(2026, 4, 11),
+      );
+      expect(basis.trajetsTotalLiters, 0);
+    });
+  });
+
+  group('reconciliationBasis — residual invariant', () {
+    test('residual == gap before any correction/virtual', () {
+      // Pumped 50, consumed 42 → gap 8.
+      final basis = reconciliationBasis(
+        windowFills: [makeFill(liters: 50)],
+        windowTrips: [makeTrip(fuel: 42)],
+      );
+      expect(basis.residualLiters, 8);
+    });
+
+    test('residual == 0 when a correction of exactly the gap is added', () {
+      // Pumped 50, consumed 42, gap 8 → add an 8 L correction fill.
+      final basis = reconciliationBasis(
+        windowFills: [
+          makeFill(id: 'a', liters: 50),
+          makeFill(id: 'corr', liters: 8, isCorrection: true),
+        ],
+        windowTrips: [makeTrip(fuel: 42)],
+      );
+      // fuelTotal stays 50 (Total L honesty); trajetsTotal = 42 + 8 = 50.
+      expect(basis.fuelTotalLiters, 50);
+      expect(basis.trajetsTotalLiters, 50);
+      expect(basis.residualLiters, 0);
+    });
+
+    test('residual == 0 when a virtual trip of exactly the gap is added', () {
+      // Pumped 50, consumed 42, gap 8 → add an 8 L virtual trip.
+      final basis = reconciliationBasis(
+        windowFills: [makeFill(liters: 50)],
+        windowTrips: [
+          makeTrip(fuel: 42),
+          makeTrip(fuel: 8, id: 'virtual'),
+        ],
+        isVirtualTrip: (t) => t.startedAt == DateTime(2026, 4, 11),
+      );
+      expect(basis.fuelTotalLiters, 50);
+      expect(basis.trajetsTotalLiters, 50);
+      expect(basis.residualLiters, 0);
+    });
+
+    test('negative gap → negative residual (sign correctness)', () {
+      // Pumped 40, consumed 45 → integrator ran hot, gap −5.
+      final basis = reconciliationBasis(
+        windowFills: [makeFill(liters: 40)],
+        windowTrips: [makeTrip(fuel: 45)],
+      );
+      expect(basis.residualLiters, -5);
+    });
+
+    test('empty window → all zero', () {
+      final basis = reconciliationBasis(
+        windowFills: const [],
+        windowTrips: const [],
+      );
+      expect(basis.fuelTotalLiters, 0);
+      expect(basis.trajetsTotalLiters, 0);
+      expect(basis.residualLiters, 0);
+    });
+  });
+
+  group('reconciliationBasis — virtual predicate default', () {
+    test('default treats every trip as recorded (none virtual)', () {
+      // Without a predicate, the "virtual" trip counts as recorded burn.
+      final basis = reconciliationBasis(
+        windowFills: [makeFill(liters: 50)],
+        windowTrips: [
+          makeTrip(fuel: 30),
+          makeTrip(fuel: 8, id: 'virtual'),
+        ],
+      );
+      // 30 + 8 both on the recorded side; no double-count.
+      expect(basis.trajetsTotalLiters, 38);
+      expect(basis.residualLiters, 12);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds `reconciliationBasis()` — a **pure** function (`lib/features/consumption/domain/services/reconciliation_basis.dart`) that puts the two consumption surfaces (fill-ups vs trajets) on the comparison basis the maintainer validated for Epic #2439, so the cross-view invariant test has a single source of truth. First, safe foundation child of the Epic.

## The basis (Epic decisions #3 + #4)

- **`fuelTotalLiters`** = Σ real pumped litres — fills where **NOT** `isCorrection`. **Total L honesty**: correction litres are never folded in here.
- **`trajetsTotalLiters`** = Σ `trip.fuelLitersConsumed` (null → 0) **+** Σ correction-fill litres **+** Σ virtual-trip litres. A correction fill and a virtual trip are *both* explicit stand-ins for unrecorded burn, so both count on the **trajets** side of the comparison — even though a correction physically lives in the fill-up store.
- **`residualLiters`** = `fuelTotalLiters − trajetsTotalLiters` (signed). Invariant: `== gap` before any reconciliation, `== 0` after a correction/virtual of exactly the gap is added on **either** side. Negative when the trajets side exceeds real pumped litres.

## Contract

```dart
typedef ReconciliationBasis = ({
  double fuelTotalLiters,
  double trajetsTotalLiters,
  double residualLiters,
});

ReconciliationBasis reconciliationBasis({
  required List<FillUp> windowFills,
  required List<TripSummary> windowTrips,
  bool Function(TripSummary trip) isVirtualTrip = _neverVirtual, // default: none virtual
});
```

`TripSummary` has no virtual flag yet, so virtual-trip classification is accepted via the `isVirtualTrip` **predicate** (defaulting to "never virtual"). #2444 can inject synthetic trips and wire this predicate **without changing this function's contract** — the basis math is already correct regardless of how a trip is identified as virtual. The function does no windowing of its own; callers pass an already-scoped tank window.

## Scope / safety

- **Pure** — inputs in, value out. No repository, no provider, no persistence, no widget, no UI.
- **No behaviour change** — does NOT alter `Reconciler.reconcile()`'s detector behaviour or any save path (that's #2441).
- No user-facing strings (no ARB). No `@freezed`/`@riverpod` types touched — verified **zero codegen/l10n drift** after a clean `build_runner` build.

## Tests

`test/features/consumption/domain/services/reconciliation_basis_test.dart` — fuelTotal counts only real pumped litres (corrections excluded); trajetsTotal = consumed + correction litres + virtual-trip litres; null `fuelLitersConsumed` contributes 0; residual == gap before, == 0 when a correction **or** a virtual of exactly the gap is added; negative-gap sign correctness; empty/zero window; default predicate treats all trips as recorded.

Green: new test + `reconciler_test` + full consumption domain suite (604) + `file_length_test` + `no_hardcoded_ui_strings_test`. `flutter analyze lib test` clean (the one remaining `info` is a pre-existing `unnecessary_import` in `trip_kind_from_samples_test.dart`, untouched by this branch).

Closes #2440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
