### PR TITLE
refactor(consumption): split reconciliation detect-vs-apply + expose pending gap (behaviour-neutral) (#2441)

### DIFF
--- a/lib/features/consumption/domain/entities/pending_reconciliation.dart
+++ b/lib/features/consumption/domain/entities/pending_reconciliation.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+import 'fill_up.dart';
+
+/// A reconciliation gap that the detector ([Reconciler.reconcile])
+/// flagged as needing a correction, surfaced for a future consumer to
+/// act on (Epic #2439 / #2441).
+///
+/// Today (#1361) the only consumer is the silent auto-save path — the
+/// seam still persists [correction] immediately, so this object is
+/// purely an *exposed hook* and changes nothing the user sees. The
+/// guided reconciliation workflow (#2442) will later read this pending
+/// gap, explain it to the user, and decide how to resolve it (correct
+/// the fill-ups, add a virtual trajet, or defer) instead of the silent
+/// save.
+///
+/// Immutable value object — no Riverpod, no Hive, fully unit-testable.
+/// Mirrors the hand-written `@immutable` style of [ReconciliationResult]
+/// so it stays codegen-free.
+@immutable
+class PendingReconciliation {
+  /// The synthetic correction [FillUp] the detector built for this gap.
+  /// On the silent-save path this is exactly the entry that is written
+  /// today; the workflow (#2442) will instead use it as the *proposed*
+  /// correction the user can confirm, edit, or reject.
+  final FillUp correction;
+
+  /// Sum of pumped litres across the plein-to-plein window (including
+  /// the closing plein). Mirrors `ReconciliationResult.pumped`.
+  final double pumped;
+
+  /// Sum of OBD-integrated trip fuel across the window. Mirrors
+  /// `ReconciliationResult.consumed`.
+  final double consumed;
+
+  /// `pumped - consumed` — the unaccounted litres the correction
+  /// backfills. Always positive for a pending gap (the detector only
+  /// emits a correction when the gap clears both thresholds).
+  final double gap;
+
+  /// Window-midpoint date the correction is dated at (the detector's
+  /// own midpoint between the window's first fill and the closing
+  /// plein).
+  final DateTime windowMidpointDate;
+
+  /// Window-midpoint odometer reading the correction carries.
+  final double windowMidpointOdometerKm;
+
+  /// The vehicle this gap belongs to. Null only in degenerate data
+  /// (vehicle-less fills never reach the detector's created branch).
+  final String? vehicleId;
+
+  const PendingReconciliation({
+    required this.correction,
+    required this.pumped,
+    required this.consumed,
+    required this.gap,
+    required this.windowMidpointDate,
+    required this.windowMidpointOdometerKm,
+    required this.vehicleId,
+  });
+
+  /// Build a [PendingReconciliation] from a created-action correction
+  /// [FillUp] and the window's pumped/consumed/gap figures. The window
+  /// midpoint date + odometer are read straight off [correction] (the
+  /// detector already placed it at the window midpoint), so this stays
+  /// a faithful, lossless projection of the detector's output.
+  factory PendingReconciliation.fromCorrection({
+    required FillUp correction,
+    required double pumped,
+    required double consumed,
+    required double gap,
+  }) {
+    return PendingReconciliation(
+      correction: correction,
+      pumped: pumped,
+      consumed: consumed,
+      gap: gap,
+      windowMidpointDate: correction.date,
+      windowMidpointOdometerKm: correction.odometerKm,
+      vehicleId: correction.vehicleId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PendingReconciliation &&
+          runtimeType == other.runtimeType &&
+          correction == other.correction &&
+          pumped == other.pumped &&
+          consumed == other.consumed &&
+          gap == other.gap &&
+          windowMidpointDate == other.windowMidpointDate &&
+          windowMidpointOdometerKm == other.windowMidpointOdometerKm &&
+          vehicleId == other.vehicleId;
+
+  @override
+  int get hashCode => Object.hash(
+        correction,
+        pumped,
+        consumed,
+        gap,
+        windowMidpointDate,
+        windowMidpointOdometerKm,
+        vehicleId,
+      );
+}

--- a/lib/features/consumption/providers/consumption_providers.dart
+++ b/lib/features/consumption/providers/consumption_providers.dart
@@ -26,11 +26,13 @@ import '../data/trip_history_repository.dart';
 import '../domain/entities/consumption_stats.dart';
 import '../domain/entities/eco_score.dart';
 import '../domain/entities/fill_up.dart';
+import '../domain/entities/pending_reconciliation.dart';
 import '../domain/gps_driving_features.dart';
 import '../domain/services/eco_score_calculator.dart';
 import '../domain/services/gps_matrix_reconciler.dart';
 import '../domain/services/reconciler.dart';
 import '../domain/trip_recorder.dart';
+import 'pending_reconciliation_provider.dart';
 import 'trip_history_provider.dart';
 
 part 'consumption_providers.g.dart';
@@ -462,9 +464,23 @@ class FillUpList extends _$FillUpList {
       );
       if (result == null) return null;
       final correction = result.correction;
-      if (correction != null) {
-        await fillRepo.save(correction);
-        state = fillRepo.getAll();
+      if (correction != null && result.action == ReconciliationAction.created) {
+        // Detect → apply seam (Epic #2439 / #2441): (1) surface the gap
+        // as a PendingReconciliation the workflow (#2442) can read, then
+        // (2) apply it. Behaviour-neutral — [applyReconciliation] still
+        // performs the silent save exactly as before.
+        final pending = PendingReconciliation.fromCorrection(
+          correction: correction,
+          pumped: result.pumped,
+          consumed: result.consumed,
+          gap: result.gap,
+        );
+        ref.read(pendingReconciliationsProvider.notifier).set(pending);
+        await applyReconciliation(pending);
+      } else {
+        // No correction this window — clear any stale gap so the
+        // workflow seam never reads one from a prior window.
+        ref.read(pendingReconciliationsProvider.notifier).set(null);
       }
       // Sum the window-trip distances — used by the broken-MAP hook
       // to convert pumped/consumed litres into L/100 km. Mirrors the
@@ -484,6 +500,22 @@ class FillUpList extends _$FillUpList {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'FillUpList: trip-vs-pump reconciliation failed'}));
       return null;
     }
+  }
+
+  /// Apply step of the detect-vs-apply seam (Epic #2439 / #2441) — the
+  /// single place ALL correction creation flows through. The detector
+  /// ([Reconciler.reconcile]) only DETECTS the gap and hands a
+  /// [PendingReconciliation] here; this method decides what to do.
+  ///
+  /// TODO #2442: replace silent save with the guided reconciliation
+  /// workflow — per Epic #2439 a correction must NEVER be created
+  /// without the user's consent. Until that lands this stays
+  /// behaviour-neutral: it persists the proposed correction exactly as
+  /// the pre-seam code did, so nothing the user sees changes on this PR.
+  Future<void> applyReconciliation(PendingReconciliation pending) async {
+    final repo = ref.read(fillUpRepositoryProvider);
+    await repo.save(pending.correction);
+    state = repo.getAll();
   }
 
   /// Sum the [TripSummary.distanceKm] across every trip in the same

--- a/lib/features/consumption/providers/consumption_providers.g.dart
+++ b/lib/features/consumption/providers/consumption_providers.g.dart
@@ -467,7 +467,7 @@ final class FillUpListProvider
   }
 }
 
-String _$fillUpListHash() => r'b555ed0d7551451c07a5016cffffb4a527f2d362';
+String _$fillUpListHash() => r'bc06e3a1dcee3428a66c9d76583aa8b30eabec83';
 
 /// Mutable list of all fill-ups, newest first.
 

--- a/lib/features/consumption/providers/pending_reconciliation_provider.dart
+++ b/lib/features/consumption/providers/pending_reconciliation_provider.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../domain/entities/pending_reconciliation.dart';
+
+part 'pending_reconciliation_provider.g.dart';
+
+/// Holds the most recent pending reconciliation gap surfaced by the
+/// detector (Epic #2439 / #2441).
+///
+/// This is the read-side seam the guided reconciliation workflow
+/// (#2442) will consume: when `Reconciler.reconcile` returns a created
+/// action, `FillUpList` publishes the [PendingReconciliation] here
+/// BEFORE applying it. Today the apply-step still performs the silent
+/// auto-save (behaviour-neutral — see `FillUpList.applyReconciliation`),
+/// so exposing the pending gap changes nothing the user sees; it is
+/// purely a hook the workflow will later take over.
+///
+/// Only the most recent gap is retained. Cleared to `null` for every
+/// non-created outcome (skipped / negative / no-trips / no gap) so a
+/// stale gap never lingers after a window that needs no correction.
+@Riverpod(keepAlive: true)
+class PendingReconciliations extends _$PendingReconciliations {
+  @override
+  PendingReconciliation? build() => null;
+
+  /// Publish the latest pending gap. Pass `null` to clear when the
+  /// most recent window produced no correction.
+  void set(PendingReconciliation? pending) {
+    state = pending;
+  }
+}

--- a/lib/features/consumption/providers/pending_reconciliation_provider.g.dart
+++ b/lib/features/consumption/providers/pending_reconciliation_provider.g.dart
@@ -1,0 +1,122 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_reconciliation_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Holds the most recent pending reconciliation gap surfaced by the
+/// detector (Epic #2439 / #2441).
+///
+/// This is the read-side seam the guided reconciliation workflow
+/// (#2442) will consume: when `Reconciler.reconcile` returns a created
+/// action, `FillUpList` publishes the [PendingReconciliation] here
+/// BEFORE applying it. Today the apply-step still performs the silent
+/// auto-save (behaviour-neutral — see `FillUpList.applyReconciliation`),
+/// so exposing the pending gap changes nothing the user sees; it is
+/// purely a hook the workflow will later take over.
+///
+/// Only the most recent gap is retained. Cleared to `null` for every
+/// non-created outcome (skipped / negative / no-trips / no gap) so a
+/// stale gap never lingers after a window that needs no correction.
+
+@ProviderFor(PendingReconciliations)
+final pendingReconciliationsProvider = PendingReconciliationsProvider._();
+
+/// Holds the most recent pending reconciliation gap surfaced by the
+/// detector (Epic #2439 / #2441).
+///
+/// This is the read-side seam the guided reconciliation workflow
+/// (#2442) will consume: when `Reconciler.reconcile` returns a created
+/// action, `FillUpList` publishes the [PendingReconciliation] here
+/// BEFORE applying it. Today the apply-step still performs the silent
+/// auto-save (behaviour-neutral — see `FillUpList.applyReconciliation`),
+/// so exposing the pending gap changes nothing the user sees; it is
+/// purely a hook the workflow will later take over.
+///
+/// Only the most recent gap is retained. Cleared to `null` for every
+/// non-created outcome (skipped / negative / no-trips / no gap) so a
+/// stale gap never lingers after a window that needs no correction.
+final class PendingReconciliationsProvider
+    extends $NotifierProvider<PendingReconciliations, PendingReconciliation?> {
+  /// Holds the most recent pending reconciliation gap surfaced by the
+  /// detector (Epic #2439 / #2441).
+  ///
+  /// This is the read-side seam the guided reconciliation workflow
+  /// (#2442) will consume: when `Reconciler.reconcile` returns a created
+  /// action, `FillUpList` publishes the [PendingReconciliation] here
+  /// BEFORE applying it. Today the apply-step still performs the silent
+  /// auto-save (behaviour-neutral — see `FillUpList.applyReconciliation`),
+  /// so exposing the pending gap changes nothing the user sees; it is
+  /// purely a hook the workflow will later take over.
+  ///
+  /// Only the most recent gap is retained. Cleared to `null` for every
+  /// non-created outcome (skipped / negative / no-trips / no gap) so a
+  /// stale gap never lingers after a window that needs no correction.
+  PendingReconciliationsProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pendingReconciliationsProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pendingReconciliationsHash();
+
+  @$internal
+  @override
+  PendingReconciliations create() => PendingReconciliations();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PendingReconciliation? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PendingReconciliation?>(value),
+    );
+  }
+}
+
+String _$pendingReconciliationsHash() =>
+    r'40796d569db141ff02094dcd8acb521bfa02f486';
+
+/// Holds the most recent pending reconciliation gap surfaced by the
+/// detector (Epic #2439 / #2441).
+///
+/// This is the read-side seam the guided reconciliation workflow
+/// (#2442) will consume: when `Reconciler.reconcile` returns a created
+/// action, `FillUpList` publishes the [PendingReconciliation] here
+/// BEFORE applying it. Today the apply-step still performs the silent
+/// auto-save (behaviour-neutral — see `FillUpList.applyReconciliation`),
+/// so exposing the pending gap changes nothing the user sees; it is
+/// purely a hook the workflow will later take over.
+///
+/// Only the most recent gap is retained. Cleared to `null` for every
+/// non-created outcome (skipped / negative / no-trips / no gap) so a
+/// stale gap never lingers after a window that needs no correction.
+
+abstract class _$PendingReconciliations
+    extends $Notifier<PendingReconciliation?> {
+  PendingReconciliation? build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref =
+        this.ref as $Ref<PendingReconciliation?, PendingReconciliation?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<PendingReconciliation?, PendingReconciliation?>,
+              PendingReconciliation?,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/test/features/consumption/providers/pending_reconciliation_seam_test.dart
+++ b/test/features/consumption/providers/pending_reconciliation_seam_test.dart
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/consumption/providers/pending_reconciliation_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import '../../../helpers/silence_error_logger.dart';
+
+/// Detect-vs-apply seam coverage (Epic #2439 / #2441).
+///
+/// Verifies the split introduced for the guided reconciliation
+/// workflow:
+///   - on a created action the [PendingReconciliations] provider
+///     surfaces the gap + the proposed correction (the read-side hook
+///     #2442 will consume), AND
+///   - the apply seam STILL performs the silent save today — the
+///     correction round-trips into the fill-up log exactly as before
+///     (behaviour-neutral; the behaviour flip is PR3/#2442), AND
+///   - non-created outcomes (skipped-below-threshold, clamped-negative,
+///     no-trips) surface NO pending gap.
+///
+/// Uses a real [TripHistoryRepository] over in-memory Hive so the seam
+/// traverses the same path production does — mirrors
+/// `plein_complet_belief_hook_test.dart`.
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late TripHistoryRepository historyRepo;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('pending_reconcile_seam_');
+    Hive.init(tmpDir.path);
+    final box = await Hive.openBox<String>(HiveBoxes.obd2TripHistory);
+    historyRepo = TripHistoryRepository(box: box);
+  });
+
+  tearDown(() async {
+    await Hive.box<String>(HiveBoxes.obd2TripHistory).deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<void> seedTrip({
+    required String id,
+    required String vehicleId,
+    required DateTime startedAt,
+    required double distanceKm,
+    required double fuelLitersConsumed,
+  }) {
+    return historyRepo.save(TripHistoryEntry(
+      id: id,
+      vehicleId: vehicleId,
+      summary: TripSummary(
+        distanceKm: distanceKm,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        fuelLitersConsumed: fuelLitersConsumed,
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(minutes: 30)),
+      ),
+    ));
+  }
+
+  FillUp mkFillUp({
+    required String id,
+    required DateTime date,
+    String vehicleId = 'veh-a',
+    double liters = 40,
+    double odometerKm = 10000,
+    bool isFullTank = true,
+  }) =>
+      FillUp(
+        id: id,
+        date: date,
+        liters: liters,
+        totalCost: liters * 1.5,
+        odometerKm: odometerKm,
+        fuelType: FuelType.e10,
+        vehicleId: vehicleId,
+        isFullTank: isFullTank,
+      );
+
+  test(
+      'created action → PendingReconciliations exposes the gap + correction '
+      'AND the silent save still happens (behaviour-neutral)', () async {
+    final container = makeContainer();
+
+    // Integrator only saw 5 L across 100 km; the closing plein pumps
+    // 12 L → a 7 L gap that clears both reconciler floors → created.
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+      odometerKm: 10000,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    // Read-side hook: the pending gap is surfaced for the workflow.
+    // The opening plein closes the PRIOR window (exclusive lower bound),
+    // so it doesn't count toward this window: pumped = closing(12);
+    // consumed = 5; gap = 7.
+    final pending = container.read(pendingReconciliationsProvider);
+    expect(pending, isNotNull, reason: 'a created action surfaces a gap');
+    expect(pending!.pumped, closeTo(12, 1e-9));
+    expect(pending.consumed, closeTo(5, 1e-9));
+    expect(pending.gap, closeTo(7, 1e-9));
+    expect(pending.vehicleId, 'veh-a');
+    // The proposed correction mirrors the detector's synthetic entry.
+    expect(pending.correction.isCorrection, isTrue);
+    expect(pending.correction.isFullTank, isFalse);
+    expect(pending.correction.liters, closeTo(7, 1e-9));
+    expect(pending.correction.id, 'correction_closing');
+    expect(pending.windowMidpointDate, pending.correction.date);
+    expect(
+      pending.windowMidpointOdometerKm,
+      pending.correction.odometerKm,
+    );
+
+    // Behaviour-neutral: the apply seam STILL saved the correction.
+    final stored = container.read(fillUpListProvider);
+    final corrections = stored.where((f) => f.isCorrection).toList();
+    expect(corrections, hasLength(1),
+        reason: 'the silent save still persists exactly one correction');
+    expect(corrections.single.liters, closeTo(7, 1e-9));
+    expect(corrections.single.id, 'correction_closing');
+  });
+
+  test('skippedBelowThreshold (pumped ≈ consumed) surfaces NO pending gap',
+      () async {
+    final container = makeContainer();
+
+    // Integrator saw 11.7 L; plein pumps 12 L → 0.3 L gap, below the
+    // 0.5 L absolute floor → skippedBelowThreshold.
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 11.7,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 0.0001, // negligible — keeps the window gap tiny
+      odometerKm: 10000,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    expect(container.read(pendingReconciliationsProvider), isNull);
+    expect(
+      container.read(fillUpListProvider).where((f) => f.isCorrection),
+      isEmpty,
+    );
+  });
+
+  test('clampedNegative (integrator over-reported) surfaces NO pending gap',
+      () async {
+    final container = makeContainer();
+
+    // Integrator saw 50 L but the window only pumped 12 L → negative
+    // gap → clampedNegative, no correction.
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 50,
+    );
+
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 0.0001,
+      odometerKm: 10000,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    expect(container.read(pendingReconciliationsProvider), isNull);
+    expect(
+      container.read(fillUpListProvider).where((f) => f.isCorrection),
+      isEmpty,
+    );
+  });
+
+  test('skippedNoTrips (no integrated fuel) surfaces NO pending gap',
+      () async {
+    final container = makeContainer();
+
+    // No trips seeded → reconciler returns skippedNoTrips.
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+      odometerKm: 10000,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+
+    expect(container.read(pendingReconciliationsProvider), isNull);
+    expect(
+      container.read(fillUpListProvider).where((f) => f.isCorrection),
+      isEmpty,
+    );
+  });
+
+  test('a created gap is cleared when a later clean window needs none',
+      () async {
+    final container = makeContainer();
+
+    // First window: high discrepancy → created → pending gap set.
+    await seedTrip(
+      id: 't1',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 1, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 5,
+    );
+    final notifier = container.read(fillUpListProvider.notifier);
+    await notifier.add(mkFillUp(
+      id: 'opening',
+      date: DateTime(2026, 4, 1, 8),
+      liters: 30,
+      odometerKm: 10000,
+    ));
+    await notifier.add(mkFillUp(
+      id: 'closing-1',
+      date: DateTime(2026, 4, 2, 18),
+      liters: 12,
+      odometerKm: 10100,
+    ));
+    expect(container.read(pendingReconciliationsProvider), isNotNull);
+
+    // Second window: matched integrator → skippedBelowThreshold → the
+    // stale gap must be cleared, not left dangling.
+    await seedTrip(
+      id: 't2',
+      vehicleId: 'veh-a',
+      startedAt: DateTime(2026, 4, 3, 9),
+      distanceKm: 100,
+      fuelLitersConsumed: 11.8,
+    );
+    await notifier.add(mkFillUp(
+      id: 'closing-2',
+      date: DateTime(2026, 4, 4, 18),
+      liters: 12,
+      odometerKm: 10200,
+    ));
+
+    expect(container.read(pendingReconciliationsProvider), isNull,
+        reason: 'a clean window clears the previous pending gap');
+  });
+}
+
+class _FakeSettingsStorage implements SettingsStorage {
+  final Map<String, dynamic> _data = {};
+
+  @override
+  dynamic getSetting(String key) => _data[key];
+
+  @override
+  Future<void> putSetting(String key, dynamic value) async {
+    _data[key] = value;
+  }
+
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -89,7 +89,14 @@ void main() {
         439,
     'lib/features/consumption/presentation/widgets/trip_path_map_card.dart':
         463,
-    'lib/features/consumption/providers/consumption_providers.dart': 879,
+    // #2441 — re-grandfathered 879 → 911: split the trip-vs-pump
+    // reconciliation into a detect-vs-apply seam. The detector still
+    // lives in reconciler.dart; the apply step (`applyReconciliation`)
+    // and the surface-or-clear branch must stay on `FillUpList` because
+    // they mutate its state. The PendingReconciliation value object and
+    // the PendingReconciliations notifier were already extracted to
+    // their own files; only the seam wiring remains here.
+    'lib/features/consumption/providers/consumption_providers.dart': 911,
     // #2392 — re-grandfathered 1125 → 1162: wired the OBD2-ground-truth
     // physicsScale calibration into `_saveToHistory` (one fire-and-forget
     // call + the `_calibratePhysicsScale` resolve/persist helper; the EWMA


### PR DESCRIPTION
## What & why (#2441, child of Epic #2439)

Separates **"detect the gap"** from **"apply the correction"** so the
silent fuel auto-correction can later be replaced by the guided
reconciliation workflow (#2442) — **without changing behaviour yet**
(no broken intermediate).

## The seam

- **Detector unchanged.** `Reconciler.reconcile()` is byte-for-byte
  identical — it still only computes pumped/consumed/gap and builds the
  synthetic correction `FillUp`.
- **Single apply seam.** `FillUpList.applyReconciliation(PendingReconciliation)`
  is now the *one* place ALL correction creation flows through. When the
  detector returns a `created` action, `_reconcileTripVsPump` (1) surfaces
  the gap as a `PendingReconciliation`, then (2) routes the save through
  `applyReconciliation`. The method carries the marker
  *"TODO #2442: replace silent save with the guided workflow."*
- **Exposed pending gap.** New immutable `PendingReconciliation` value
  object (correction + pumped/consumed/gap + window-midpoint
  date/odometer + vehicleId) and a `PendingReconciliations` Riverpod
  notifier expose the gap for the future workflow consumer. The pending
  state is cleared to `null` on every non-`created` outcome
  (skipped-below-threshold / clamped-negative / no-trips) so a stale gap
  never lingers.

## Behaviour is unchanged on this PR

By default the seam **still performs the silent save exactly as today** —
`applyReconciliation` calls `fillRepo.save(correction)` just like the
pre-seam code. This PR is a refactor + an exposed hook; the behaviour
flip (never create a correction without the workflow) is PR3/#2442.
No user-facing setting is introduced — per Epic #2439 any setting lives
inside the workflow. **No new ARB keys / no codegen drift beyond the new
notifier's `.g.dart`.**

## Tests

- `reconciler_test` (detector) stays green.
- `fill_up_receipt_reconciliation_journey_test` stays green — a
  correction `FillUp` is still created on a `created` action.
- New `pending_reconciliation_seam_test`: a `created` action exposes the
  correct gap + proposed correction **and** the silent save still
  persists it; `skippedBelowThreshold` / `clampedNegative` /
  `skippedNoTrips` expose nothing; a clean later window clears a stale gap.

Closes #2441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
