### PR TITLE
fix(obd2): clear _pending on BLE write-throw so the transport isn't poisoned (#2453)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -161,17 +161,27 @@ class BluetoothObd2Transport implements Obd2Transport {
     _buffer.clear();
     final completer = Completer<String>();
     _pending = completer;
-    await _channel.write(command.codeUnits);
-    return completer.future.timeout(
-      timeout,
-      onTimeout: () {
-        _pending = null;
-        throw TimeoutException(
-          'ELM327 did not respond within $timeout',
-          timeout,
-        );
-      },
-    );
+    // Clear `_pending` on EVERY exit — success, timeout *or* a throwing
+    // write (#2453). Before, if `_channel.write()` threw (device-not-
+    // connected / GATT timeout) with `_pending` still set, every later
+    // command tripped the concurrent-sendCommand guard and the transport
+    // stayed poisoned. The `identical` guard leaves a normally-completed
+    // command alone — `_onBytes` already nulled `_pending`, or a later
+    // command reassigned it — so finally only clears the slot it still owns.
+    try {
+      await _channel.write(command.codeUnits);
+      return await completer.future.timeout(
+        timeout,
+        onTimeout: () {
+          throw TimeoutException(
+            'ELM327 did not respond within $timeout',
+            timeout,
+          );
+        },
+      );
+    } finally {
+      if (identical(_pending, completer)) _pending = null;
+    }
   }
 
   void _onBytes(List<int> chunk) {

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
@@ -194,6 +194,62 @@ void main() {
               'the 5 s read timeout');
     });
 
+    test(
+        '#2453 — a throwing write surfaces the error to ITS caller AND '
+        'leaves the transport recoverable (next command succeeds)', () async {
+      final channel = _ScriptedChannel();
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // First command's write rejects mid-session (device-not-connected /
+      // GATT-write failure). Before #2453 this left `_pending` set, so the
+      // NEXT command tripped the concurrent-sendCommand guard forever.
+      final boom = Exception('GATT write failed: device not connected');
+      channel.scriptWriteThrows('010C\r', boom);
+      // The recovery command writes fine and gets a normal reply.
+      channel.scriptResponse('010D\r', '41 0D 3C >');
+
+      // 1) The failing command surfaces the write error to its caller.
+      await expectLater(
+        transport.sendCommand('010C\r'),
+        throwsA(same(boom)),
+        reason: 'the write error must reach the command that triggered it',
+      );
+
+      // 2) The NEXT command does NOT throw concurrent-sendCommand — the
+      //    transport recovered because `_pending` was cleared on the throw.
+      final reply = await transport.sendCommand('010D\r');
+      expect(reply, contains('41 0D 3C'),
+          reason: 'transport must recover: _pending was cleared on the '
+              'throwing write, so the next command proceeds normally');
+    });
+
+    test(
+        '#2453 — a read timeout still throws TimeoutException AND leaves the '
+        'transport recoverable for the next command', () async {
+      final channel = _ScriptedChannel();
+      // First command's reply never carries the '>' prompt, so it can only
+      // resolve via the read timeout. Use a short timeout to keep the test
+      // fast.
+      channel.scriptResponse('010C\r', '41 0C 1A F8 ');
+      channel.scriptResponse('010D\r', '41 0D 3C >');
+      final transport = BluetoothObd2Transport(
+        channel,
+        readTimeout: const Duration(milliseconds: 50),
+      );
+      await transport.connect();
+
+      await expectLater(
+        transport.sendCommand('010C\r'),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      // The timeout cleared `_pending` (via the finally), so the next
+      // command is not blocked by the stale in-flight slot.
+      final reply = await transport.sendCommand('010D\r');
+      expect(reply, contains('41 0D 3C'));
+    });
+
     test('disconnect closes the channel and flips isConnected to false',
         () async {
       final channel = _ScriptedChannel();
@@ -218,6 +274,7 @@ void main() {
 
 class _ScriptedChannel implements ElmByteChannel {
   final Map<String, List<List<int>>> _chunksByCommand = {};
+  final Map<String, Object> _writeThrowsByCommand = {};
   final StreamController<List<int>> _controller =
       StreamController<List<int>>.broadcast();
   final List<List<int>> _writes = [];
@@ -230,6 +287,13 @@ class _ScriptedChannel implements ElmByteChannel {
   void scriptChunkedResponse(String command, List<String> chunks) {
     _chunksByCommand[command] =
         chunks.map((c) => c.codeUnits).toList();
+  }
+
+  /// #2453 — make `write()` THROW for a given command, simulating a
+  /// device-not-connected / GATT-write failure mid-session. The write is
+  /// still recorded (so order assertions see it) before it throws.
+  void scriptWriteThrows(String command, Object error) {
+    _writeThrowsByCommand[command] = error;
   }
 
   /// #2295 — simulate a forwarded notify-stream error (what the real BLE
@@ -257,6 +321,13 @@ class _ScriptedChannel implements ElmByteChannel {
   Future<void> write(List<int> bytes) async {
     _writes.add(bytes);
     final command = String.fromCharCodes(bytes);
+    final throwFor = _writeThrowsByCommand[command];
+    if (throwFor != null) {
+      // #2453 — the underlying BLE/GATT write rejected. The transport must
+      // surface this to the caller AND clear `_pending` so the next command
+      // isn't poisoned.
+      throw throwFor;
+    }
     final chunks = _chunksByCommand[command];
     if (chunks == null) {
       // Unknown command — send NO DATA> so the transport doesn't hang.


### PR DESCRIPTION
## Root cause (#2453)

`BluetoothObd2Transport._sendRaw` set `_pending = completer` **before**
`await _channel.write(...)`. The success path clears `_pending` in
`_onBytes`; the timeout path cleared it in `onTimeout`. But if
`_channel.write()` itself **throws** (device-not-connected / GATT write
timeout), `_sendRaw` propagated the error with `_pending` still set. Every
subsequent `_sendRaw` then tripped the `_pending != null` guard with
`StateError: concurrent sendCommand is not allowed` — the transport stayed
**poisoned** for the rest of the session.

## Fix

Wrap the write + awaited response in `try/finally` so `_pending` is cleared
on **every** exit — success, timeout, *or* a throwing write:

```dart
_pending = completer;
try {
  await _channel.write(command.codeUnits);
  return await completer.future.timeout(timeout, onTimeout: () {
    throw TimeoutException('ELM327 did not respond within $timeout', timeout);
  });
} finally {
  if (identical(_pending, completer)) _pending = null;
}
```

- The redundant `_pending = null` is removed from the `onTimeout` closure
  (the `finally` now owns clearing it).
- The `identical(_pending, completer)` guard means `finally` only clears the
  slot it still owns — a normally-completed command (already nulled by
  `_onBytes`, or reassigned by a later command) is left untouched.
- The public `sendCommand` queue (#1972) is unchanged. The
  concurrent-sendCommand guard stays as the defensive invariant — now
  genuinely unreachable in normal operation.

## Regression test

A scripted channel whose `write()` **throws** for a given command asserts:

1. The failing command surfaces the write error to **its** caller
   (`sendCommand` future completes with that error).
2. The **next** `sendCommand` does **not** throw concurrent-sendCommand — it
   proceeds (write succeeds → returns the response). The transport recovered
   (`_pending` was cleared).

A companion test confirms a read timeout still throws `TimeoutException` and
likewise leaves the transport clean for the next command. Verified the new
write-throw test **fails against the unfixed source** and passes with the fix.

No ARB or codegen drift.

Closes #2453

🤖 Generated with [Claude Code](https://claude.com/claude-code)
