### PR TITLE
feat(obd2): commanded-λ (0144) + baro (0133) → real mixture & air-density in the fuel estimate (#2456)

### DIFF
--- a/lib/features/consumption/data/obd2/broken_map_detector.dart
+++ b/lib/features/consumption/data/obd2/broken_map_detector.dart
@@ -153,7 +153,7 @@ class BrokenMapDetector {
         // it never aborts the diesel probe (unlike the petrol path,
         // where baro is load-bearing).
         final dieselBaroRaw = await port.sendRaw(_baroCommand);
-        final dieselBaro = _parseBaroPressureKpa(dieselBaroRaw);
+        final dieselBaro = Elm327Parsers.parseBaroPressureKpa(dieselBaroRaw);
 
         // The "rev" step. #1621 phase 5 — when a prompt callback is
         // wired, ask the user to rev and key the re-read off the
@@ -194,7 +194,7 @@ class BrokenMapDetector {
       } else {
         // Petrol path: need baro to know the delta.
         final baroRaw = await port.sendRaw(_baroCommand);
-        final baro = _parseBaroPressureKpa(baroRaw);
+        final baro = Elm327Parsers.parseBaroPressureKpa(baroRaw);
         if (baro == null) return prior;
         observationScore = BrokenMapBeliefUpdater.vacuumMissingScore(
           baroKpa: baro,
@@ -308,26 +308,4 @@ class BrokenMapDetector {
       reason: reason,
     );
   }
-}
-
-/// Parse Mode 01 PID 0x33 (absolute barometric pressure) response.
-/// Single-byte payload, raw kPa (range 0-255). Returns null on NO DATA
-/// / malformed / wrong-PID echo. Inlined here because the existing
-/// [Elm327Parsers] catalog doesn't carry PID 0x33 (it isn't used
-/// elsewhere yet — this detector is the first consumer).
-double? _parseBaroPressureKpa(String raw) {
-  final clean = Elm327Parsers.cleanResponse(raw);
-  if (clean == null) return null;
-  // Tokens look like '41 33 XX' — split on whitespace, validate the
-  // mode-01 echo + PID, return the third byte.
-  final tokens = clean
-      .split(RegExp(r'\s+'))
-      .where((t) => t.isNotEmpty)
-      .toList();
-  if (tokens.length < 3) return null;
-  final mode = int.tryParse(tokens[0], radix: 16);
-  final pid = int.tryParse(tokens[1], radix: 16);
-  final value = int.tryParse(tokens[2], radix: 16);
-  if (mode != 0x41 || pid != 0x33 || value == null) return null;
-  return value.toDouble();
 }

--- a/lib/features/consumption/data/obd2/elm327_commands.dart
+++ b/lib/features/consumption/data/obd2/elm327_commands.dart
@@ -227,6 +227,22 @@ class Elm327Commands {
   /// Request fuel tank level input (%). Mode 01, PID 2F. (#717)
   static const fuelTankLevelCommand = '012F\r';
 
+  /// Request commanded equivalence ratio / λ. Mode 01, PID 44 (#2456).
+  /// Formula: λ = (256·A + B) / 32768 (dimensionless). λ ≈ 1.0 at
+  /// stoichiometry; <1 is a lean cruise mixture, >1 is power-enrichment.
+  /// Replacing the assumed-stoich AFR with `stoichAFR × λ` is the biggest
+  /// fuel-estimate accuracy win on the no-MAF speed-density path (the
+  /// Peugeot). Response: "41 44 XX YY".
+  static const commandedEquivalenceRatioCommand = '0144\r';
+
+  /// Request absolute barometric pressure (kPa). Mode 01, PID 33 (#2456).
+  /// Single-byte raw value. Already read best-effort by
+  /// `broken_map_detector`; now promoted to a first-class parser so the
+  /// speed-density estimator can feed measured ambient pressure
+  /// (altitude / weather) into the ideal-gas air-mass term instead of an
+  /// assumed sea-level value. Response: "41 33 XX".
+  static const baroPressureCommand = '0133\r';
+
   /// Request fuel type. Mode 01, PID 51. (#1399). Single-byte response
   /// per SAE-J1979 Table 6 — see [Elm327Parsers.parseFuelType] for the
   /// mapping. Used during the VIN-driven adapter-pair auto-population

--- a/lib/features/consumption/data/obd2/elm327_parsers.dart
+++ b/lib/features/consumption/data/obd2/elm327_parsers.dart
@@ -170,6 +170,30 @@ class Elm327Parsers {
     return bytes[2].toDouble();
   }
 
+  /// Parse absolute barometric pressure from Mode 01 PID 33 response
+  /// (#2456). Formula: kPa = A (single byte, raw value). Response:
+  /// "41 33 XX". Sea level is ~101 kPa; pressure drops ~1 kPa per ~100 m
+  /// of altitude, so a 1500 m pass reads ~84 kPa. Feeds the speed-density
+  /// air-mass term so altitude / weather scale the air charge correctly.
+  static double? parseBaroPressureKpa(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x33, minBytes: 3);
+    if (bytes == null) return null;
+    return bytes[2].toDouble();
+  }
+
+  /// Parse commanded equivalence ratio / λ from Mode 01 PID 44 response
+  /// (#2456). Formula: λ = (256·A + B) / 32768 (dimensionless). Response:
+  /// "41 44 XX YY". λ ≈ 1.0 at stoichiometry; <1 is a lean cruise
+  /// mixture (less fuel per unit air), >1 is power-enrichment (more
+  /// fuel). The effective AFR the engine is actually targeting is
+  /// `stoichAFR × λ`, which the fuel-rate estimator uses in place of the
+  /// assumed-stoich AFR when this PID is available.
+  static double? parseCommandedEquivalenceRatio(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x44, minBytes: 4);
+    if (bytes == null) return null;
+    return ((bytes[2] * 256) + bytes[3]) / 32768.0;
+  }
+
   /// Parse intake air temperature from Mode 01 PID 0F response (#800).
   /// Formula: °C = A − 40 (single byte). Response: "41 0F XX". Range
   /// −40 °C to 215 °C covers every drivable condition the sensor sees.

--- a/lib/features/consumption/data/obd2/elm327_protocol.dart
+++ b/lib/features/consumption/data/obd2/elm327_protocol.dart
@@ -76,6 +76,9 @@ class Elm327Protocol {
       Elm327Commands.shortTermFuelTrimCommand;
   static const longTermFuelTrimCommand = Elm327Commands.longTermFuelTrimCommand;
   static const fuelTankLevelCommand = Elm327Commands.fuelTankLevelCommand;
+  static const commandedEquivalenceRatioCommand =
+      Elm327Commands.commandedEquivalenceRatioCommand;
+  static const baroPressureCommand = Elm327Commands.baroPressureCommand;
   static const fuelTypeCommand = Elm327Commands.fuelTypeCommand;
   static const vinCommand = Elm327Commands.vinCommand;
   static const mfgOdometerCatalog = Elm327Commands.mfgOdometerCatalog;
@@ -114,6 +117,12 @@ class Elm327Protocol {
 
   static double? parseMafGramsPerSecond(String raw) =>
       Elm327Parsers.parseMafGramsPerSecond(raw);
+
+  static double? parseBaroPressureKpa(String raw) =>
+      Elm327Parsers.parseBaroPressureKpa(raw);
+
+  static double? parseCommandedEquivalenceRatio(String raw) =>
+      Elm327Parsers.parseCommandedEquivalenceRatio(raw);
 
   static double? parseManifoldPressureKpa(String raw) =>
       Elm327Parsers.parseManifoldPressureKpa(raw);

--- a/lib/features/consumption/data/obd2/fuel_rate_estimator.dart
+++ b/lib/features/consumption/data/obd2/fuel_rate_estimator.dart
@@ -105,6 +105,49 @@ const double kDefaultVolumetricEfficiency = 0.85;
 /// ideal-gas-law air-mass step of [estimateFuelRateLPerHourFromMap].
 const double _gasConstant = 287.0;
 
+/// Reference sea-level barometric pressure (kPa) for the speed-density
+/// air-density correction (#2456). When PID 0x33 (absolute baro) is
+/// available, the air charge is scaled by `baroKpa / kSeaLevelBaroKpa`
+/// so altitude / weather correctly reduce (or raise) the air mass — and
+/// therefore the fuel — versus the implicit sea-level assumption the
+/// pre-#2456 formula carried. 101.325 kPa is the ISA standard.
+const double kSeaLevelBaroKpa = 101.325;
+
+/// Lower clamp for the commanded equivalence ratio λ (PID 0x44, #2456).
+/// Real mixtures never run leaner than ~0.5 in normal operation; a value
+/// below this is garbage (stuck sensor / parse noise) and is rejected so
+/// it can't blow up the effective-AFR denominator.
+const double kMinLambda = 0.5;
+
+/// Upper clamp for the commanded equivalence ratio λ (#2456). Power
+/// enrichment rarely exceeds ~1.3–1.4; 1.5 is a generous ceiling that
+/// still rejects obvious garbage.
+const double kMaxLambda = 1.5;
+
+/// Translate a stoichiometric AFR into the effective AFR the ECU is
+/// actually commanding, given the commanded equivalence ratio λ
+/// (PID 0x44, #2456).
+///
+/// Convention used here (matching the SAE PID 0x44 semantics the app
+/// targets): λ > 1 is power-enrichment — the engine is burning a richer
+/// mixture, i.e. *more* fuel per unit air, so the effective AFR is
+/// *lower*; λ < 1 is a lean cruise mixture (less fuel, higher AFR).
+/// Because the fuel-rate math divides the air mass by the AFR, an
+/// effective AFR of `stoichAfr / λ` makes the derived fuel scale up with
+/// λ (λ = 1.2 → ~20 % more fuel) and down for lean cruise — the
+/// accuracy win this PID buys on cars without a direct fuel-rate or MAF
+/// PID (the Peugeot speed-density path).
+///
+/// [lambda] is clamped to [kMinLambda] … [kMaxLambda] to reject garbage
+/// before it reaches the denominator. A null [lambda] returns
+/// [stoichAfr] unchanged so a car that doesn't expose PID 0x44 derives
+/// fuel exactly as it did before #2456.
+double effectiveAfrForLambda(double stoichAfr, double? lambda) {
+  if (lambda == null) return stoichAfr;
+  final clamped = lambda.clamp(kMinLambda, kMaxLambda);
+  return stoichAfr / clamped;
+}
+
 /// Single source of truth for the (AFR, density) pair the MAF /
 /// speed-density fuel-rate math divides by (#2432). Both
 /// [Obd2Service.readFuelRateLPerHour] and
@@ -237,6 +280,19 @@ double? interpolateEtaV(List<EtaVCurvePoint> curve, double rpm) {
 /// so existing callers are unaffected. [volumetricEfficiency] remains
 /// the fallback whenever the curve yields nothing.
 ///
+/// #2456 — two optional ECU signals refine the estimate when available
+/// and leave it byte-for-byte unchanged when absent:
+///   - [lambda] (commanded equivalence ratio, PID 0x44): the [afr] is
+///     replaced with [effectiveAfrForLambda]`(afr, lambda)`, so a richer
+///     commanded mixture (λ > 1) yields proportionally more fuel and a
+///     lean cruise (λ < 1) less. Null → the assumed stoich [afr].
+///   - [baroKpa] (absolute barometric pressure, PID 0x33): the air mass
+///     is scaled by `baroKpa / kSeaLevelBaroKpa` so altitude / weather
+///     correctly thin (or enrich) the charge versus the implicit
+///     sea-level assumption. Null → factor 1.0 (today's behaviour). The
+///     factor is clamped to a sane 0.6 … 1.1 band so a malformed baro
+///     reading can't invert or explode the result.
+///
 /// Returns null when any input is non-positive — the ideal gas law
 /// breaks down at 0 K / 0 pressure and callers should surface "no
 /// data" rather than a bogus number.
@@ -249,6 +305,8 @@ double? estimateFuelRateLPerHourFromMap({
   double afr = kPetrolAfr,
   double fuelDensityGPerL = kPetrolDensityGPerL,
   List<EtaVCurvePoint> etaVCurve = const [],
+  double? baroKpa,
+  double? lambda,
 }) {
   final iatKelvin = iatCelsius + 273.15;
   if (mapKpa <= 0 ||
@@ -267,6 +325,16 @@ double? estimateFuelRateLPerHourFromMap({
   final airMassKgPerS =
       (mapPa * displacementM3 * intakesPerSecond * etaV) /
           (_gasConstant * iatKelvin);
-  final airMassGPerS = airMassKgPerS * 1000.0;
-  return airMassGPerS * 3600.0 / (afr * fuelDensityGPerL);
+  // #2456 — ambient air-density correction. A measured baro below sea
+  // level (altitude) thins the charge, above raises it; clamped so a
+  // garbage reading can't invert or blow up the air mass. Null → 1.0,
+  // i.e. the pre-#2456 sea-level assumption, unchanged.
+  final baroFactor = baroKpa == null
+      ? 1.0
+      : (baroKpa / kSeaLevelBaroKpa).clamp(0.6, 1.1);
+  final airMassGPerS = airMassKgPerS * 1000.0 * baroFactor;
+  // #2456 — when λ (PID 0x44) is present, divide by the ECU's commanded
+  // effective AFR instead of the assumed stoich AFR. Null → [afr].
+  final effectiveAfr = effectiveAfrForLambda(afr, lambda);
+  return airMassGPerS * 3600.0 / (effectiveAfr * fuelDensityGPerL);
 }

--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -63,6 +63,15 @@ class LiveSampleSnapshot {
   double? _latestLtft;
   double? _latestDirectFuelRate;
 
+  // #2456 — commanded equivalence ratio λ (PID 0x44) and absolute
+  // barometric pressure (PID 0x33). Both refine the MAF / speed-density
+  // fuel derivation when the car exposes them and stay null (today's
+  // behaviour, bit-for-bit) on cars that don't. λ is sampled fast (it
+  // tracks the mixture under load); baro is sampled slowly (it only
+  // changes with altitude / weather).
+  double? _latestLambda;
+  double? _latestBaroKpa;
+
   // #1374 phase 1 — most recent GPS fix, pushed in by the provider
   // when the `Feature.gpsTripPath` flag is enabled. The controller
   // does NOT subscribe to Geolocator itself — that decision lives at
@@ -240,6 +249,22 @@ class LiveSampleSnapshot {
         if (v != null) _latestLtft = v;
       },
     );
+    // #2456 — commanded λ (PID 0x44). The mixture swings between lean
+    // cruise and power-enrich on the timescale of throttle inputs, so
+    // 2 Hz keeps the effective-AFR refinement current without stealing
+    // the high-priority RPM / speed / MAF / MAP budget. supportsPid-
+    // gated: a car that rejects 0x44 never subscribes and the
+    // derivation falls back to the assumed stoich AFR.
+    if (_service.supportsPid(0x44)) {
+      scheduler.subscribe(
+        Elm327Protocol.commandedEquivalenceRatioCommand,
+        ScheduledPid(hz: 2.0),
+        (r) {
+          final v = Elm327Protocol.parseCommandedEquivalenceRatio(r);
+          if (v != null) _latestLambda = v;
+        },
+      );
+    }
 
     // ---- 0.1 Hz tier (low priority) -------------------------------
     scheduler.subscribe(
@@ -250,6 +275,20 @@ class LiveSampleSnapshot {
         if (v != null) _latestFuelLevelPercent = v;
       },
     );
+    // #2456 — absolute baro (PID 0x33). Ambient pressure only changes
+    // with altitude / weather, so a slow 0.5 Hz read is ample and keeps
+    // it well clear of the dynamics budget. supportsPid-gated: absent →
+    // the speed-density air-mass keeps its sea-level assumption.
+    if (_service.supportsPid(0x33)) {
+      scheduler.subscribe(
+        Elm327Protocol.baroPressureCommand,
+        ScheduledPid(hz: 0.5, priority: PidPriority.low),
+        (r) {
+          final v = Elm327Protocol.parseBaroPressureKpa(r);
+          if (v != null) _latestBaroKpa = v;
+        },
+      );
+    }
   }
 
   /// #1858 — the branch [deriveFuelRateLPerHour] resolved on its most
@@ -359,17 +398,21 @@ class LiveSampleSnapshot {
       return direct;
     }
 
-    // Step 2: MAF-based. L/h = MAF × 3600 / (AFR × density).
+    // Step 2: MAF-based. L/h = MAF × 3600 / (effectiveAFR × density).
+    // #2456 — when commanded λ (PID 0x44) has landed, the assumed stoich
+    // AFR is replaced with the ECU's effective AFR (richer mixture →
+    // more fuel). Null λ → `effectiveAfr == afr`, i.e. unchanged.
     final maf = _latestMaf;
     if (maf != null) {
-      final raw = maf * 3600.0 / (afr * density);
+      final effectiveAfr = effectiveAfrForLambda(afr, _latestLambda);
+      final raw = maf * 3600.0 / (effectiveAfr * density);
       final corrected = _applyTrim(raw);
       collector?.record(
         branch: Obd2BranchTag.maf,
         fuelRateLPerHour: corrected,
         mafGramsPerSecond: maf,
         rpm: _latestRpm,
-        afr: afr,
+        afr: effectiveAfr,
         fuelDensityGPerL: density,
         engineDisplacementCc: displacement.toDouble(),
         volumetricEfficiency: ve,
@@ -396,6 +439,15 @@ class LiveSampleSnapshot {
       );
       return null;
     }
+    // #2456 — feed the measured baro (PID 0x33) + commanded λ (PID 0x44)
+    // into the speed-density math when available: baro scales the air
+    // charge for altitude / weather, λ replaces the assumed stoich AFR.
+    // Both null → byte-for-byte the pre-#2456 result. The effective AFR
+    // is recorded in the breadcrumb so diagnostics reflect the real
+    // denominator.
+    final lambda = _latestLambda;
+    final baroKpa = _latestBaroKpa;
+    final effectiveAfr = effectiveAfrForLambda(afr, lambda);
     final raw = Obd2Service.estimateFuelRateLPerHourFromMap(
       mapKpa: mapKpa,
       iatCelsius: iat,
@@ -404,6 +456,8 @@ class LiveSampleSnapshot {
       volumetricEfficiency: ve,
       afr: afr,
       fuelDensityGPerL: density,
+      baroKpa: baroKpa,
+      lambda: lambda,
     );
     if (raw == null) {
       collector?.record(
@@ -425,7 +479,7 @@ class LiveSampleSnapshot {
       mapKpa: mapKpa,
       iatCelsius: iat,
       rpm: rpm,
-      afr: afr,
+      afr: effectiveAfr,
       fuelDensityGPerL: density,
       engineDisplacementCc: displacement.toDouble(),
       volumetricEfficiency: ve,

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -38,6 +38,7 @@ export 'fuel_rate_estimator.dart'
         kDefaultEngineDisplacementCc,
         kDefaultVolumetricEfficiency,
         resolveAfrDensity, // #2432 — fuel-type AFR/density lookup
+        effectiveAfrForLambda, // #2456 — commanded-λ effective AFR
         applyFuelTrimCorrection,
         estimateFuelRateLPerHourFromMap;
 
@@ -957,8 +958,14 @@ class Obd2Service implements Obd2RawCommandPort {
     if (isPidSupported(0x10)) {
       final maf = await readMafGramsPerSecond();
       if (maf != null) {
-        // Stoichiometric L/h = MAF × 3600 / (AFR × density).
-        final rate = maf * 3600.0 / (afr * fuelDensityGPerL);
+        // #2456 — when commanded λ (PID 0x44) is supported, divide by
+        // the ECU's effective AFR instead of the assumed stoich AFR.
+        // Unsupported / NO DATA → effectiveAfr == afr, unchanged.
+        final lambda =
+            isPidSupported(0x44) ? await readCommandedEquivalenceRatio() : null;
+        final effectiveAfr = estimator.effectiveAfrForLambda(afr, lambda);
+        // L/h = MAF × 3600 / (effectiveAFR × density).
+        final rate = maf * 3600.0 / (effectiveAfr * fuelDensityGPerL);
         final corrected = await _applyFuelTrimCorrection(rate);
         diagnostics.recordMaf(corrected: corrected, maf: maf);
         return corrected;
@@ -985,6 +992,13 @@ class Obd2Service implements Obd2RawCommandPort {
       );
       return null;
     }
+    // #2456 — refine with the measured baro (PID 0x33) air-density term
+    // and commanded λ (PID 0x44) effective AFR when the car exposes
+    // them. Both supportsPid-gated; absent → the estimator's null
+    // defaults reproduce the pre-#2456 result exactly.
+    final baroKpa = isPidSupported(0x33) ? await readBaroPressureKpa() : null;
+    final lambda =
+        isPidSupported(0x44) ? await readCommandedEquivalenceRatio() : null;
     final rate = estimator.estimateFuelRateLPerHourFromMap(
       mapKpa: mapKpa,
       iatCelsius: iatCelsius,
@@ -994,6 +1008,8 @@ class Obd2Service implements Obd2RawCommandPort {
       afr: afr,
       fuelDensityGPerL: fuelDensityGPerL,
       etaVCurve: etaVCurve,
+      baroKpa: baroKpa,
+      lambda: lambda,
     );
     if (rate == null) {
       diagnostics.recordNoBranch(
@@ -1078,6 +1094,8 @@ class Obd2Service implements Obd2RawCommandPort {
     double afr = estimator.kPetrolAfr,
     double fuelDensityGPerL = estimator.kPetrolDensityGPerL,
     List<EtaVCurvePoint> etaVCurve = const [],
+    double? baroKpa,
+    double? lambda,
   }) =>
       estimator.estimateFuelRateLPerHourFromMap(
         mapKpa: mapKpa,
@@ -1088,6 +1106,8 @@ class Obd2Service implements Obd2RawCommandPort {
         afr: afr,
         fuelDensityGPerL: fuelDensityGPerL,
         etaVCurve: etaVCurve,
+        baroKpa: baroKpa,
+        lambda: lambda,
       );
 
   /// Read mass air flow in g/s. (#717)
@@ -1109,6 +1129,24 @@ class Obd2Service implements Obd2RawCommandPort {
         Elm327Protocol.intakeAirTempCommand,
         Elm327Protocol.parseIntakeAirTempCelsius,
         label: 'intakeAirTemp',
+      );
+
+  /// Read absolute barometric pressure (kPa) via Mode 01 PID 0x33
+  /// (#2456). Feeds the speed-density air-density correction so altitude
+  /// / weather scale the air charge. Returns null when unsupported.
+  Future<double?> readBaroPressureKpa() => _readDouble(
+        Elm327Protocol.baroPressureCommand,
+        Elm327Protocol.parseBaroPressureKpa,
+        label: 'baroPressure',
+      );
+
+  /// Read commanded equivalence ratio / λ via Mode 01 PID 0x44 (#2456).
+  /// λ ≈ 1.0 at stoich; replaces the assumed stoich AFR in the MAF /
+  /// speed-density fuel math. Returns null when unsupported.
+  Future<double?> readCommandedEquivalenceRatio() => _readDouble(
+        Elm327Protocol.commandedEquivalenceRatioCommand,
+        Elm327Protocol.parseCommandedEquivalenceRatio,
+        label: 'commandedEquivalenceRatio',
       );
 
   /// Read short-term fuel trim bank 1 (%) (#813). Fast-feedback loop

--- a/test/features/consumption/data/obd2/elm327_parsers_test.dart
+++ b/test/features/consumption/data/obd2/elm327_parsers_test.dart
@@ -335,6 +335,95 @@ void main() {
     });
   });
 
+  group('parseBaroPressureKpa (PID 33) — #2456', () {
+    test('41 33 65 -> 101 kPa (~sea level)', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 33 65'), 101.0);
+    });
+
+    test('41 33 54 -> 84 kPa (~1500 m altitude)', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 33 54'), 84.0);
+    });
+
+    test('41 33 00 -> 0 kPa', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 33 00'), 0.0);
+    });
+
+    test('41 33 FF -> 255 kPa', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 33 FF'), 255.0);
+    });
+
+    test('strips > prompt + whitespace', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 33 65\r\n>'), 101.0);
+    });
+
+    test('wrong PID returns null', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 0B 65'), isNull);
+    });
+
+    test('short response returns null', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('41 33'), isNull);
+    });
+
+    test('NO DATA returns null', () {
+      expect(Elm327Parsers.parseBaroPressureKpa('NO DATA'), isNull);
+    });
+  });
+
+  group('parseCommandedEquivalenceRatio (PID 44) — #2456', () {
+    test('41 44 80 00 -> ~1.0 λ (stoichiometric)', () {
+      // (0x80*256 + 0) / 32768 = 32768 / 32768 = 1.0.
+      expect(
+        Elm327Parsers.parseCommandedEquivalenceRatio('41 44 80 00'),
+        closeTo(1.0, 0.0001),
+      );
+    });
+
+    test('41 44 00 00 -> 0.0 λ (minimum)', () {
+      expect(
+        Elm327Parsers.parseCommandedEquivalenceRatio('41 44 00 00'),
+        closeTo(0.0, 0.0001),
+      );
+    });
+
+    test('41 44 FF FF -> ~2.0 λ (maximum)', () {
+      // (0xFFFF) / 32768 = 65535 / 32768 ≈ 1.99997.
+      expect(
+        Elm327Parsers.parseCommandedEquivalenceRatio('41 44 FF FF'),
+        closeTo(2.0, 0.001),
+      );
+    });
+
+    test('41 44 99 9A -> ~1.2 λ (power enrichment)', () {
+      // (0x999A) / 32768 = 39322 / 32768 ≈ 1.2000.
+      expect(
+        Elm327Parsers.parseCommandedEquivalenceRatio('41 44 99 9A'),
+        closeTo(1.2, 0.001),
+      );
+    });
+
+    test('strips > prompt + whitespace', () {
+      expect(
+        Elm327Parsers.parseCommandedEquivalenceRatio('41 44 80 00\r\n>'),
+        closeTo(1.0, 0.0001),
+      );
+    });
+
+    test('wrong PID returns null', () {
+      expect(
+        Elm327Parsers.parseCommandedEquivalenceRatio('41 10 80 00'),
+        isNull,
+      );
+    });
+
+    test('short response returns null', () {
+      expect(Elm327Parsers.parseCommandedEquivalenceRatio('41 44 80'), isNull);
+    });
+
+    test('NO DATA returns null', () {
+      expect(Elm327Parsers.parseCommandedEquivalenceRatio('NO DATA'), isNull);
+    });
+  });
+
   group('parseIntakeAirTempCelsius (PID 0F)', () {
     test('41 0F 28 -> 0 °C (40 - 40)', () {
       expect(

--- a/test/features/consumption/data/obd2/fuel_rate_estimator_test.dart
+++ b/test/features/consumption/data/obd2/fuel_rate_estimator_test.dart
@@ -150,6 +150,122 @@ void main() {
     });
   });
 
+  group('effectiveAfrForLambda — #2456', () {
+    test('null λ returns the stoich AFR unchanged (no-PID fallback)', () {
+      expect(effectiveAfrForLambda(kPetrolAfr, null), kPetrolAfr);
+      expect(effectiveAfrForLambda(kDieselAfr, null), kDieselAfr);
+    });
+
+    test('λ = 1.0 returns the stoich AFR unchanged', () {
+      expect(effectiveAfrForLambda(kPetrolAfr, 1.0), closeTo(kPetrolAfr, 1e-9));
+    });
+
+    test('λ > 1 (power-enrich) lowers the effective AFR → more fuel', () {
+      // afrEff = stoich / λ; richer mixture means a smaller denominator.
+      expect(
+        effectiveAfrForLambda(kPetrolAfr, 1.2),
+        closeTo(kPetrolAfr / 1.2, 1e-9),
+      );
+      expect(effectiveAfrForLambda(kPetrolAfr, 1.2), lessThan(kPetrolAfr));
+    });
+
+    test('λ < 1 (lean cruise) raises the effective AFR → less fuel', () {
+      expect(
+        effectiveAfrForLambda(kPetrolAfr, 0.9),
+        closeTo(kPetrolAfr / 0.9, 1e-9),
+      );
+      expect(effectiveAfrForLambda(kPetrolAfr, 0.9), greaterThan(kPetrolAfr));
+    });
+
+    test('garbage λ is clamped to [kMinLambda, kMaxLambda]', () {
+      expect(
+        effectiveAfrForLambda(kPetrolAfr, 5.0),
+        closeTo(kPetrolAfr / kMaxLambda, 1e-9),
+      );
+      expect(
+        effectiveAfrForLambda(kPetrolAfr, 0.01),
+        closeTo(kPetrolAfr / kMinLambda, 1e-9),
+      );
+    });
+  });
+
+  group('estimateFuelRateLPerHourFromMap λ + baro — #2456', () {
+    const mapKpa = 65.0;
+    const iatCelsius = 30.0;
+    const rpm = 2500.0;
+
+    double rateWith({double? lambda, double? baroKpa}) {
+      return estimateFuelRateLPerHourFromMap(
+        mapKpa: mapKpa,
+        iatCelsius: iatCelsius,
+        rpm: rpm,
+        engineDisplacementCc: kDefaultEngineDisplacementCc,
+        volumetricEfficiency: kDefaultVolumetricEfficiency,
+        lambda: lambda,
+        baroKpa: baroKpa,
+      )!;
+    }
+
+    test('absent λ + absent baro equals the pre-#2456 stoich result', () {
+      final today = estimateFuelRateLPerHourFromMap(
+        mapKpa: mapKpa,
+        iatCelsius: iatCelsius,
+        rpm: rpm,
+        engineDisplacementCc: kDefaultEngineDisplacementCc,
+        volumetricEfficiency: kDefaultVolumetricEfficiency,
+      )!;
+      // Same call but explicitly passing nulls must be byte-for-byte equal.
+      expect(rateWith(lambda: null, baroKpa: null), today);
+    });
+
+    test('λ = 1.0 is identical to absent λ', () {
+      expect(rateWith(lambda: 1.0), closeTo(rateWith(lambda: null), 1e-9));
+    });
+
+    test('λ = 1.2 derives ~20 % more fuel than λ = 1.0 (richer)', () {
+      final stoich = rateWith(lambda: 1.0);
+      final rich = rateWith(lambda: 1.2);
+      expect(rich / stoich, closeTo(1.2, 0.001));
+    });
+
+    test('λ = 0.9 derives less fuel than λ = 1.0 (lean cruise)', () {
+      final stoich = rateWith(lambda: 1.0);
+      final lean = rateWith(lambda: 0.9);
+      expect(lean, lessThan(stoich));
+      expect(lean / stoich, closeTo(0.9, 0.001));
+    });
+
+    test('lower baro (altitude) reduces fuel vs sea level', () {
+      final seaLevel = rateWith(baroKpa: kSeaLevelBaroKpa);
+      final altitude = rateWith(baroKpa: 84.0); // ~1500 m
+      expect(altitude, lessThan(seaLevel));
+      // Air mass scales linearly with the baro factor.
+      expect(altitude / seaLevel, closeTo(84.0 / kSeaLevelBaroKpa, 0.001));
+    });
+
+    test('baro at sea-level reference equals absent baro', () {
+      expect(
+        rateWith(baroKpa: kSeaLevelBaroKpa),
+        closeTo(rateWith(baroKpa: null), 1e-9),
+      );
+    });
+
+    test('garbage low baro is clamped (factor floor 0.6)', () {
+      final clamped = rateWith(baroKpa: 10.0); // 10/101.325 ≈ 0.099 → 0.6
+      final unscaled = rateWith(baroKpa: null);
+      expect(clamped / unscaled, closeTo(0.6, 0.001));
+    });
+
+    test('λ and baro compose multiplicatively', () {
+      final base = rateWith(lambda: 1.0, baroKpa: kSeaLevelBaroKpa);
+      final both = rateWith(lambda: 1.2, baroKpa: 84.0);
+      expect(
+        both / base,
+        closeTo(1.2 * (84.0 / kSeaLevelBaroKpa), 0.001),
+      );
+    });
+  });
+
   group('resolveAfrDensity — #2432', () {
     VehicleProfile profileWith(String? fuel) => VehicleProfile(
           id: 'x',

--- a/test/features/consumption/data/obd2/obd2_service_maf_fallback_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_maf_fallback_test.dart
@@ -234,5 +234,111 @@ void main() {
       // cng ≠ diesel → petrol constants → ~3.389 L/h.
       expect(rate, closeTo(3.389, 0.01));
     });
+
+    // ---- #2456: commanded-λ (0144) + baro (0133) ---------------------
+
+    test(
+        'MAF path with λ (0144) absent (NO DATA): rate is byte-for-byte '
+        'the pre-#2456 stoich result', () async {
+      final service = await _connected({
+        '015E': 'NO DATA>',
+        '0110': mafLine,
+        '0144': 'NO DATA>', // λ unsupported / no data → fall back to stoich
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final rate = await service.readFuelRateLPerHour();
+      // Identical to the null-vehicle petrol MAF case: ~3.389 L/h.
+      expect(rate, closeTo(3.389, 0.01));
+    });
+
+    test(
+        'MAF path with λ = 1.2 (power-enrich) derives ~20 % more fuel '
+        'than the stoich result (#2456)', () async {
+      final service = await _connected({
+        '015E': 'NO DATA>',
+        '0110': mafLine,
+        '0144': '41 44 99 9A>', // (0x999A)/32768 ≈ 1.2 λ
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final rate = await service.readFuelRateLPerHour();
+      // 3.389 × 1.2 ≈ 4.067 L/h (effective AFR = 14.7 / 1.2).
+      expect(rate, closeTo(4.067, 0.02));
+    });
+
+    test(
+        'MAF path with λ = 0.9 (lean cruise) derives less fuel than the '
+        'stoich result (#2456)', () async {
+      final service = await _connected({
+        '015E': 'NO DATA>',
+        '0110': mafLine,
+        '0144': '41 44 73 33>', // (0x7333)/32768 ≈ 0.9 λ
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final rate = await service.readFuelRateLPerHour();
+      // 3.389 × 0.9 ≈ 3.050 L/h.
+      expect(rate, closeTo(3.050, 0.02));
+    });
+
+    test(
+        'speed-density path with low baro (altitude) derives less fuel '
+        'than the sea-level / no-baro result (#2456)', () async {
+      const sdResponses = {
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 28>', // MAP = 40 kPa
+        '010F': '41 0F 41>', // IAT = 25 °C
+        '010C': '41 0C 0C 80>', // RPM 800
+        '0144': 'NO DATA>', // λ absent → stoich
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      };
+      final seaLevel = await _connected({
+        ...sdResponses,
+        '0133': 'NO DATA>', // baro absent → sea-level assumption
+      });
+      final altitude = await _connected({
+        ...sdResponses,
+        '0133': '41 33 54>', // baro = 84 kPa (~1500 m)
+      });
+      final seaRate = await seaLevel.readFuelRateLPerHour();
+      final altRate = await altitude.readFuelRateLPerHour();
+      expect(seaRate, isNotNull);
+      expect(altRate, isNotNull);
+      expect(altRate!, lessThan(seaRate!));
+      // Air mass scales by baroFactor = 84 / 101.325 ≈ 0.829.
+      expect(altRate / seaRate, closeTo(84.0 / 101.325, 0.01));
+    });
+
+    test(
+        'speed-density path: λ + baro both absent reproduces the '
+        'pre-#2456 result exactly (#2456)', () async {
+      final withNoData = await _connected({
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 28>',
+        '010F': '41 0F 41>',
+        '010C': '41 0C 0C 80>',
+        '0133': 'NO DATA>',
+        '0144': 'NO DATA>',
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final baseline = await _connected({
+        '015E': 'NO DATA>',
+        '0110': 'NO DATA>',
+        '010B': '41 0B 28>',
+        '010F': '41 0F 41>',
+        '010C': '41 0C 0C 80>',
+        '0106': 'NO DATA>',
+        '0107': 'NO DATA>',
+      });
+      final a = await withNoData.readFuelRateLPerHour();
+      final b = await baseline.readFuelRateLPerHour();
+      expect(a, isNotNull);
+      expect(a, closeTo(b!, 1e-9));
+    });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -53,14 +53,30 @@ void main() {
     'lib/core/services/country_service_registry.dart': 887,
     'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
-    'lib/features/consumption/data/obd2/elm327_parsers.dart': 457,
-    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 471,
+    // #2456 — re-grandfathered 457 → 481: two new pure parsers,
+    // `parseBaroPressureKpa` (PID 0x33) and `parseCommandedEquivalenceRatio`
+    // (PID 0x44, commanded λ), each with their dartdoc, so the
+    // fuel-rate estimator can use the ECU's real mixture + ambient
+    // air-density instead of the assumed-stoich AFR / sea-level pressure.
+    'lib/features/consumption/data/obd2/elm327_parsers.dart': 481,
+    // #2456 — re-grandfathered 471 → 524: the live integrator gained λ
+    // (PID 0x44, 2 Hz) + baro (PID 0x33, 0.5 Hz) supportsPid-gated
+    // subscriptions and threads both into the MAF + speed-density fuel
+    // derivation (effective AFR + air-density correction). Decomposition
+    // is tracked separately by #2187/#2188.
+    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 524,
     // #2379 — re-grandfathered 1457 → 1468: threaded the
     // `logFailureAsError` flag through `connect()` (param + doc + the
     // guarded `if` around the now-conditional connect-failed trace) so a
     // recoverable connect attempt stops flooding the error log. Net +11;
     // decomposition is tracked separately by #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1468,
+    // #2456 — re-grandfathered 1468 → 1505: two new read helpers
+    // (`readBaroPressureKpa` PID 0x33, `readCommandedEquivalenceRatio`
+    // PID 0x44) + their supportsPid-gated use in the MAF + speed-density
+    // steps of `readFuelRateLPerHour` + the new optional params on the
+    // `estimateFuelRateLPerHourFromMap` forwarder. Decomposition tracked
+    // by #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1505,
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb


### PR DESCRIPTION
## What

Acquire two high-value OBD-II PIDs and feed the ECU's **real commanded mixture** and **measured ambient air-density** into the MAF + speed-density fuel-rate derivation — the biggest accuracy win for cars without a direct fuel-rate (0x5E) or MAF (0x10) PID, i.e. the no-MAF Peugeot whose consumption currently reads blank.

Child of Epic #2455.

## The formula shift

- **λ → effective AFR** (PID `0144`, commanded equivalence ratio, `λ = (256·A+B)/32768`):
  `effectiveAfrForLambda(stoichAfr, λ) = stoichAfr / λ`, clamped to `0.5 … 1.5`.
  A richer commanded mixture (λ > 1, power-enrich) shrinks the AFR denominator → **more** fuel; a lean cruise (λ < 1) → **less**. λ = 1.2 derives ~20 % more fuel than stoich.
- **baro + IAT → air density** (PID `0133`, absolute barometric pressure, kPa): the speed-density air mass is scaled by `baroKpa / 101.325 kPa`, clamped to `0.6 … 1.1`, so altitude / weather correctly thin (or enrich) the charge instead of an implicit sea-level assumption.

Both are threaded through the live integrator (`live_sample_snapshot`) **and** the pull-mode `Obd2Service.readFuelRateLPerHour`, so the two paths stay in lockstep.

## supportsPid fallback

Every change is `supportsPid`-gated and behind clean `!= null` checks. A car that exposes **neither** PID derives fuel **byte-for-byte** as it did before #2456 — `effectiveAfrForLambda(afr, null) == afr` and a null `baroKpa` is a factor of 1.0. The λ subscription runs at 2 Hz (tracks the mixture under load) and baro at 0.5 Hz (slow ambient signal), neither starving the high-priority RPM / speed / MAF / MAP budget.

## Files

- `elm327_commands.dart` / `elm327_parsers.dart` / `elm327_protocol.dart` — new `0144` / `0133` command constants + parsers (facade forwarders).
- `broken_map_detector.dart` — drops its duplicate inlined baro parse, reuses `Elm327Parsers.parseBaroPressureKpa`.
- `fuel_rate_estimator.dart` — `effectiveAfrForLambda` + `kSeaLevelBaroKpa` / `kMinLambda` / `kMaxLambda`; optional `baroKpa` + `lambda` params on `estimateFuelRateLPerHourFromMap`.
- `live_sample_snapshot.dart` — λ + baro latches, supportsPid-gated subscriptions, used in the MAF + speed-density branches.
- `obd2_service.dart` — `readBaroPressureKpa` / `readCommandedEquivalenceRatio` read helpers + their use in `readFuelRateLPerHour`; estimator export + static forwarder updated.

## Tests

λ + baro parse; the formula shift (λ=1.2 → ~20 % more, λ=0.9 → less, lower baro → less, multiplicative composition); supportsPid fallback proving absent → unchanged, asserted at both the pure-estimator and the full service level.

No ARB (λ/baro aren't surfaced yet — that's #2461). No codegen drift. `file_length_test` snapshots re-grandfathered with #2456 rationale.

Closes #2456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
