### PR TITLE
feat(obd2): adaptive 4-tier polling + bandwidth governor + discover-all∩target (#2457)

### DIFF
--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -124,171 +124,180 @@ class LiveSampleSnapshot {
     _latestOemFuelLevelLitres = litres;
   }
 
-  /// Wire every priority tier's PID subscriptions onto [scheduler].
-  /// Each callback writes the latest parsed value into this snapshot;
-  /// high-priority callbacks additionally feed the silent-failure
-  /// observer, and the vehicle-speed callback feeds the virtual
-  /// odometer.
+  /// Wire the four cadence tiers' PID subscriptions onto [scheduler]
+  /// (#2457). Each callback writes the latest parsed value into this
+  /// snapshot; dynamics-tier callbacks also feed the silent-failure
+  /// observer, and the vehicle-speed callback feeds the virtual odometer.
+  ///
+  /// **Cadence tiers** (re-expressing the previous 3-tier layout on the
+  /// same weighted round-robin; the governor demotes deepest tiers first,
+  /// never [PidTier.dynamics], so RPM / speed never starve):
+  ///   - [PidTier.dynamics] ~5 Hz — RPM 010C, speed 010D, throttle 0111,
+  ///     + the fuel-rate driver (015E → MAF 0110 → MAP 010B speed-density).
+  ///   - [PidTier.mixture] ~2 Hz — λ 0144, engine load 0104.
+  ///   - [PidTier.slowCorrection] ~0.5 Hz — STFT 0106, LTFT 0107, IAT
+  ///     010F, baro 0133.
+  ///   - [PidTier.thermalContext] ~0.1 Hz — coolant 0105, fuel tank 012F.
+  /// (#2458 adds pedal to dynamics, abs-load/bank-2 to mixture, and
+  /// oil/ambient/voltage to thermal — slots are commented inline below.)
+  ///
+  /// **Discover-all ∩ target-set:** the live set is this target table ∩
+  /// the #811-discovered supported set. The unconditional core (RPM,
+  /// speed, throttle, load, IAT, coolant, STFT, LTFT, tank) carries no
+  /// gate — `isPidSupported` is don't-reject-blind so a probe-less clone
+  /// still rotates it. Optional PIDs (MAF, MAP, 015E, λ, baro) pass an
+  /// `optionalPid` gate, so a car supporting only {010C,010D,0104,0111}
+  /// subscribes exactly those plus the core. Adding a PID is a one-line
+  /// [_sub] call — the gate, tier, hz and priority travel together.
   void subscribeAllTiers(PidScheduler scheduler) {
-    // ---- 5 Hz tier (high priority) --------------------------------
-    // RPM and speed are consumed directly by TripSample → TripRecorder
-    // for distance/idle/harsh-accel accumulation, so they need the
-    // highest refresh we can squeeze out of the adapter.
-    scheduler.subscribe(
-      Elm327Protocol.engineRpmCommand,
-      ScheduledPid(hz: 5.0, priority: PidPriority.high),
-      (r) {
-        final v = Elm327Protocol.parseEngineRpm(r);
-        if (v != null) _latestRpm = v;
-        _onHighPriorityParse(v);
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.vehicleSpeedCommand,
-      ScheduledPid(hz: 5.0, priority: PidPriority.high),
-      (r) {
-        final v = Elm327Protocol.parseVehicleSpeed(r);
-        if (v != null) {
-          _latestSpeedKmh = v.toDouble();
-          _onSpeedSample(v.toDouble());
-        }
-        _onHighPriorityParse(v);
-      },
-    );
-    // MAF and MAP are the two alternate air-mass inputs to the fuel-
-    // rate derivation. Cheap cars (Peugeot 107) only have MAP+IAT;
-    // modern cars expose MAF. We subscribe both and let the snapshot-
-    // based derivation pick whichever landed most recently.
-    if (_service.supportsPid(0x10)) {
-      scheduler.subscribe(
-        Elm327Protocol.mafCommand,
-        ScheduledPid(hz: 5.0, priority: PidPriority.high),
-        (r) {
-          final v = Elm327Protocol.parseMafGramsPerSecond(r);
-          if (v != null) _latestMaf = v;
-          _onHighPriorityParse(v);
-        },
-      );
-    }
-    if (_service.supportsPid(0x0B)) {
-      scheduler.subscribe(
-        Elm327Protocol.intakeManifoldPressureCommand,
-        ScheduledPid(hz: 5.0, priority: PidPriority.high),
-        (r) {
-          final v = Elm327Protocol.parseManifoldPressureKpa(r);
-          if (v != null) _latestMapKpa = v;
-          _onHighPriorityParse(v);
-        },
-      );
-    }
-    scheduler.subscribe(
-      Elm327Protocol.throttlePositionCommand,
-      ScheduledPid(hz: 5.0, priority: PidPriority.high),
-      (r) {
-        final v = Elm327Protocol.parseThrottlePercent(r);
-        if (v != null) _latestThrottlePercent = v;
-        _onHighPriorityParse(v);
-      },
-    );
-    // PID 5E is only present on ~2014+ ECUs. Skip when #811 discovery
-    // already proved the car rejects it, to save the 200 ms round-
-    // trip of a guaranteed NO DATA.
-    if (_service.supportsPid(0x5E)) {
-      scheduler.subscribe(
-        Elm327Protocol.engineFuelRateCommand,
-        ScheduledPid(hz: 5.0, priority: PidPriority.high),
-        (r) {
-          final v = Elm327Protocol.parseFuelRateLPerHour(r);
-          if (v != null) _latestDirectFuelRate = v;
-          _onHighPriorityParse(v);
-        },
-      );
-    }
+    // ---- DYNAMICS tier (~5 Hz, high priority) ----------------------
+    // RPM and speed feed TripSample → TripRecorder for distance / idle /
+    // harsh-accel accumulation, so they need the highest refresh we can
+    // squeeze out of the adapter — and the governor's floor guards them.
+    _sub(scheduler, Elm327Protocol.engineRpmCommand,
+        hz: 5.0, priority: PidPriority.high, tier: PidTier.dynamics, (r) {
+      final v = Elm327Protocol.parseEngineRpm(r);
+      if (v != null) _latestRpm = v;
+      _onHighPriorityParse(v);
+    });
+    _sub(scheduler, Elm327Protocol.vehicleSpeedCommand,
+        hz: 5.0, priority: PidPriority.high, tier: PidTier.dynamics, (r) {
+      final v = Elm327Protocol.parseVehicleSpeed(r);
+      if (v != null) {
+        _latestSpeedKmh = v.toDouble();
+        _onSpeedSample(v.toDouble());
+      }
+      _onHighPriorityParse(v);
+    });
+    _sub(scheduler, Elm327Protocol.throttlePositionCommand,
+        hz: 5.0, priority: PidPriority.high, tier: PidTier.dynamics, (r) {
+      final v = Elm327Protocol.parseThrottlePercent(r);
+      if (v != null) _latestThrottlePercent = v;
+      _onHighPriorityParse(v);
+    });
+    // #2458 slot: accelerator-pedal (0149/014A/014B) — driver intent, 5 Hz.
+    //
+    // The fuel-rate driver: subscribe whichever the car exposes (015E
+    // direct → MAF → MAP speed-density) and let the snapshot derivation
+    // pick the richest branch that landed. All three optionalPid-gated.
+    _sub(scheduler, Elm327Protocol.engineFuelRateCommand,
+        hz: 5.0,
+        priority: PidPriority.high,
+        tier: PidTier.dynamics,
+        optionalPid: 0x5E, (r) {
+      final v = Elm327Protocol.parseFuelRateLPerHour(r);
+      if (v != null) _latestDirectFuelRate = v;
+      _onHighPriorityParse(v);
+    });
+    _sub(scheduler, Elm327Protocol.mafCommand,
+        hz: 5.0,
+        priority: PidPriority.high,
+        tier: PidTier.dynamics,
+        optionalPid: 0x10, (r) {
+      final v = Elm327Protocol.parseMafGramsPerSecond(r);
+      if (v != null) _latestMaf = v;
+      _onHighPriorityParse(v);
+    });
+    _sub(scheduler, Elm327Protocol.intakeManifoldPressureCommand,
+        hz: 5.0,
+        priority: PidPriority.high,
+        tier: PidTier.dynamics,
+        optionalPid: 0x0B, (r) {
+      final v = Elm327Protocol.parseManifoldPressureKpa(r);
+      if (v != null) _latestMapKpa = v;
+      _onHighPriorityParse(v);
+    });
 
-    // ---- 1 Hz tier (medium priority) ------------------------------
-    scheduler.subscribe(
-      Elm327Protocol.engineLoadCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseEngineLoad(r);
-        if (v != null) _latestEngineLoadPercent = v;
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.intakeAirTempCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseIntakeAirTempCelsius(r);
-        if (v != null) _latestIatCelsius = v;
-      },
-    );
-    // Coolant temp drifts slowly — 1 Hz is more than enough resolution
-    // for the cold-start surcharge heuristic (#1262 phase 2) to detect
-    // whether the trip ever crossed operating temperature.
-    scheduler.subscribe(
-      Elm327Protocol.coolantTempCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseCoolantTempCelsius(r);
-        if (v != null) _latestCoolantTempC = v;
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.shortTermFuelTrimCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseShortTermFuelTrim(r);
-        if (v != null) _latestStft = v;
-      },
-    );
-    scheduler.subscribe(
-      Elm327Protocol.longTermFuelTrimCommand,
-      ScheduledPid(hz: 1.0),
-      (r) {
-        final v = Elm327Protocol.parseLongTermFuelTrim(r);
-        if (v != null) _latestLtft = v;
-      },
-    );
-    // #2456 — commanded λ (PID 0x44). The mixture swings between lean
-    // cruise and power-enrich on the timescale of throttle inputs, so
-    // 2 Hz keeps the effective-AFR refinement current without stealing
-    // the high-priority RPM / speed / MAF / MAP budget. supportsPid-
-    // gated: a car that rejects 0x44 never subscribes and the
-    // derivation falls back to the assumed stoich AFR.
-    if (_service.supportsPid(0x44)) {
-      scheduler.subscribe(
-        Elm327Protocol.commandedEquivalenceRatioCommand,
-        ScheduledPid(hz: 2.0),
-        (r) {
-          final v = Elm327Protocol.parseCommandedEquivalenceRatio(r);
-          if (v != null) _latestLambda = v;
-        },
-      );
-    }
+    // ---- MIXTURE tier (~2 Hz, medium priority) ---------------------
+    // The mixture swings on the timescale of throttle inputs, so 2 Hz
+    // keeps the effective-AFR refinement current without stealing the
+    // dynamics budget. #2456 — commanded λ (0x44), optionalPid-gated:
+    // absent → the derivation falls back to the assumed stoich AFR.
+    _sub(scheduler, Elm327Protocol.commandedEquivalenceRatioCommand,
+        hz: 2.0, tier: PidTier.mixture, optionalPid: 0x44, (r) {
+      final v = Elm327Protocol.parseCommandedEquivalenceRatio(r);
+      if (v != null) _latestLambda = v;
+    });
+    _sub(scheduler, Elm327Protocol.engineLoadCommand,
+        hz: 2.0, tier: PidTier.mixture, (r) {
+      final v = Elm327Protocol.parseEngineLoad(r);
+      if (v != null) _latestEngineLoadPercent = v;
+    });
+    // #2458 slot: absolute load (0143), bank-2 fuel trims (0108/0109).
 
-    // ---- 0.1 Hz tier (low priority) -------------------------------
-    scheduler.subscribe(
-      Elm327Protocol.fuelTankLevelCommand,
-      ScheduledPid(hz: 0.1, priority: PidPriority.low),
-      (r) {
-        final v = Elm327Protocol.parseFuelLevelPercent(r);
-        if (v != null) _latestFuelLevelPercent = v;
-      },
-    );
-    // #2456 — absolute baro (PID 0x33). Ambient pressure only changes
-    // with altitude / weather, so a slow 0.5 Hz read is ample and keeps
-    // it well clear of the dynamics budget. supportsPid-gated: absent →
+    // ---- SLOW-CORRECTION tier (~0.5 Hz, medium priority) -----------
+    // Fuel trims + IAT drift slowly; the corrections only matter at the
+    // half-Hz scale of the fuel-rate integration.
+    _sub(scheduler, Elm327Protocol.shortTermFuelTrimCommand,
+        hz: 0.5, tier: PidTier.slowCorrection, (r) {
+      final v = Elm327Protocol.parseShortTermFuelTrim(r);
+      if (v != null) _latestStft = v;
+    });
+    _sub(scheduler, Elm327Protocol.longTermFuelTrimCommand,
+        hz: 0.5, tier: PidTier.slowCorrection, (r) {
+      final v = Elm327Protocol.parseLongTermFuelTrim(r);
+      if (v != null) _latestLtft = v;
+    });
+    _sub(scheduler, Elm327Protocol.intakeAirTempCommand,
+        hz: 0.5, tier: PidTier.slowCorrection, (r) {
+      final v = Elm327Protocol.parseIntakeAirTempCelsius(r);
+      if (v != null) _latestIatCelsius = v;
+    });
+    // #2456 — absolute baro (0x33). Ambient pressure changes only with
+    // altitude / weather, so 0.5 Hz is ample. optionalPid-gated: absent →
     // the speed-density air-mass keeps its sea-level assumption.
-    if (_service.supportsPid(0x33)) {
-      scheduler.subscribe(
-        Elm327Protocol.baroPressureCommand,
-        ScheduledPid(hz: 0.5, priority: PidPriority.low),
+    _sub(scheduler, Elm327Protocol.baroPressureCommand,
+        hz: 0.5, tier: PidTier.slowCorrection, optionalPid: 0x33, (r) {
+      final v = Elm327Protocol.parseBaroPressureKpa(r);
+      if (v != null) _latestBaroKpa = v;
+    });
+
+    // ---- THERMAL/CONTEXT tier (~0.1 Hz, low priority) --------------
+    // These change over minutes; first to be demoted under bandwidth
+    // pressure. 0.1 Hz coolant is ample for the cold-start surcharge
+    // heuristic (#1262 phase 2) to tell if the trip reached temperature.
+    _sub(scheduler, Elm327Protocol.coolantTempCommand,
+        hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext,
         (r) {
-          final v = Elm327Protocol.parseBaroPressureKpa(r);
-          if (v != null) _latestBaroKpa = v;
-        },
-      );
-    }
+      final v = Elm327Protocol.parseCoolantTempCelsius(r);
+      if (v != null) _latestCoolantTempC = v;
+    });
+    _sub(scheduler, Elm327Protocol.fuelTankLevelCommand,
+        hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext,
+        (r) {
+      final v = Elm327Protocol.parseFuelLevelPercent(r);
+      if (v != null) _latestFuelLevelPercent = v;
+    });
+    // #2458 slot: oil temp (015C), ambient air (0146), control-module
+    // voltage (0142) — all thermal/context, all 0.1 Hz.
+  }
+
+  /// Register one tier subscription on [scheduler] (#2457). Centralises
+  /// the discover-all ∩ target-set gate so each PID above is a single
+  /// line carrying its [hz], [tier], [priority] and optional [optionalPid]
+  /// gate together.
+  ///
+  /// When [optionalPid] is null the command is part of the unconditional
+  /// core and is always subscribed (relying on `isPidSupported`'s
+  /// don't-reject-blind semantics + the #2379 backoff to self-evict if
+  /// the car NO-DATAs it). When [optionalPid] is set, the command is only
+  /// subscribed if `_service.supportsPid(optionalPid)` — i.e. the target
+  /// PID intersected the car's discovered-supported set.
+  void _sub(
+    PidScheduler scheduler,
+    String command,
+    void Function(String response) onResult, {
+    required double hz,
+    required PidTier tier,
+    PidPriority priority = PidPriority.medium,
+    int? optionalPid,
+  }) {
+    if (optionalPid != null && !_service.supportsPid(optionalPid)) return;
+    scheduler.subscribe(
+      command,
+      ScheduledPid(hz: hz, priority: priority, tier: tier),
+      onResult,
+    );
   }
 
   /// #1858 — the branch [deriveFuelRateLPerHour] resolved on its most

--- a/lib/features/consumption/data/obd2/pid_bandwidth_governor.dart
+++ b/lib/features/consumption/data/obd2/pid_bandwidth_governor.dart
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+import 'scheduled_pid.dart';
+
+/// Read-only snapshot of the bandwidth governor's state (#2457), exposed
+/// through `PidScheduler.governorState` so the comm-diagnostics overlay
+/// (#2468) can surface it without taking a UI dependency. Purely
+/// descriptive — nothing here feeds back into selection.
+@immutable
+class GovernorState {
+  const GovernorState({
+    required this.achievedReadsPerSecond,
+    required this.dynamicsEffectiveHz,
+    required this.demotedCommands,
+  });
+
+  /// Achieved total reads/second across all PIDs over the rolling window.
+  /// 0 before any read completes.
+  final double achievedReadsPerSecond;
+
+  /// Effective refresh rate (reads/s) the slowest dynamics-tier PID is
+  /// actually achieving over the window — the metric the governor floors.
+  /// `double.infinity` when no dynamics PID has completed two reads yet
+  /// (not enough data to judge, so it never trips a demotion prematurely).
+  final double dynamicsEffectiveHz;
+
+  /// Commands currently demoted (target hz halved) to claw back budget
+  /// for the dynamics tier. Empty when the link has headroom. Unmodifiable.
+  final Set<String> demotedCommands;
+}
+
+/// Bandwidth governor for the `PidScheduler`'s weighted round-robin
+/// (#2457).
+///
+/// On a fast adapter the four cadence tiers all hit their target hz with
+/// budget to spare. On a slow ELM327 clone the *total* reads/second the
+/// link sustains is the binding constraint, and because selection weight
+/// grows with staleness, low-tier PIDs would otherwise nibble ticks away
+/// from RPM / speed. This governor measures the achieved per-PID hz over a
+/// rolling window and, when the [PidTier.dynamics] tier drops below
+/// [_dynamicsFloorHz], **demotes** the most-expendable PID (deepest tier
+/// first) by halving its target hz — freeing budget for the dynamics
+/// tier — then **restores** it once the tier clears [_dynamicsRestoreHz]
+/// with headroom (hysteresis prevents flapping). The dynamics tier is
+/// never itself demoted, so RPM / speed effective-hz never starves.
+///
+/// It owns no transport and no timer: the scheduler feeds it
+/// [recordRead] completions and calls [evaluate] each tick, reads
+/// [isDemoted] when computing selection weight, and exposes [state]
+/// verbatim. That keeps the scheduler's selection core small and this
+/// policy independently unit-testable.
+class PidBandwidthGovernor {
+  PidBandwidthGovernor({DateTime Function()? clock})
+      : _clock = clock ?? DateTime.now;
+
+  /// Effective per-PID floor (reads/s) the dynamics tier must hold. If
+  /// the slowest dynamics PID drops below this the governor demotes one
+  /// expendable PID. 3 Hz keeps RPM / speed responsive for harsh-accel
+  /// detection while leaving slack below the 5 Hz target for jitter.
+  static const double _dynamicsFloorHz = 3.0;
+
+  /// Hysteresis ceiling: an expendable PID is only *restored* once the
+  /// dynamics tier comfortably clears the floor, so the governor doesn't
+  /// flap demote↔restore tick-by-tick around the threshold.
+  static const double _dynamicsRestoreHz = 4.0;
+
+  /// Rolling window over which achieved reads/s (total and per-PID) are
+  /// measured. Long enough to smooth single-round-trip jitter, short
+  /// enough that the governor reacts within a few seconds.
+  static const Duration _governorWindow = Duration(seconds: 4);
+
+  /// Minimum gap between governor adjustments. One demotion/restore per
+  /// this interval lets the window re-measure the new steady state before
+  /// the next move — prevents over-correcting on a single slow window.
+  static const Duration _governorCooldown = Duration(seconds: 2);
+
+  /// Factor a demoted PID's target hz is multiplied by. Halving roughly
+  /// doubles its inter-read gap, handing the freed budget to faster tiers.
+  static const double demotionFactor = 0.5;
+
+  final DateTime Function() _clock;
+
+  /// Per-command policy metadata, registered alongside the scheduler
+  /// subscription so the governor can rank demotion candidates without a
+  /// reverse map back into the scheduler.
+  final Map<String, _PidMeta> _meta = <String, _PidMeta>{};
+
+  /// Completion timestamps of every read (success OR failure) inside the
+  /// rolling [_governorWindow], used to compute achieved total reads/s.
+  /// Trimmed each completion. Oldest-first.
+  final List<DateTime> _readTimestamps = <DateTime>[];
+
+  /// Commands currently demoted (target hz × [demotionFactor]). Empty
+  /// whenever the link has headroom.
+  final Set<String> _demoted = <String>{};
+
+  /// When the governor last demoted or restored a PID, to honour
+  /// [_governorCooldown]. Null until the first adjustment.
+  DateTime? _lastActionAt;
+
+  /// Most recent achieved reads/s across all PIDs (rolling window).
+  double _achievedReadsPerSecond = 0.0;
+
+  /// Register (or replace) the policy metadata for [command]. Called from
+  /// `PidScheduler.subscribe`.
+  void register(
+    String command, {
+    required PidTier tier,
+    required PidPriority priority,
+    required double hz,
+  }) {
+    _meta[command] = _PidMeta(tier: tier, priority: priority, hz: hz);
+  }
+
+  /// Forget [command] entirely and drop any demotion held against it, so a
+  /// re-subscribe starts clean. Called from `PidScheduler.unsubscribe`.
+  void unregister(String command) {
+    _meta.remove(command);
+    _demoted.remove(command);
+  }
+
+  /// Whether [command] is currently demoted. The scheduler multiplies the
+  /// PID's target hz by [demotionFactor] when this is true.
+  bool isDemoted(String command) => _demoted.contains(command);
+
+  /// Stamp a completed read (success OR failure) for [command] at [at]
+  /// into the global + per-PID rolling windows, trimming anything older
+  /// than [_governorWindow] and refreshing the cached total reads/s.
+  void recordRead(String command, DateTime at) {
+    _readTimestamps.add(at);
+    _meta[command]?.readTimestamps.add(at);
+    final cutoff = at.subtract(_governorWindow);
+    _trimBefore(_readTimestamps, cutoff);
+    final meta = _meta[command];
+    if (meta != null) _trimBefore(meta.readTimestamps, cutoff);
+    final span = _governorWindow.inMilliseconds / 1000.0;
+    _achievedReadsPerSecond = _readTimestamps.length / span;
+  }
+
+  /// Core governor step, run after each completed read. On a slow link
+  /// where the dynamics tier has dropped below [_dynamicsFloorHz], demote
+  /// the single most-expendable PID (deepest tier first). When the tier
+  /// has recovered above [_dynamicsRestoreHz] with headroom, restore the
+  /// least-expendable demoted PID. At most one move per [_governorCooldown]
+  /// so the window can re-measure between adjustments. The dynamics tier
+  /// is never itself eligible for demotion, so RPM / speed never starve.
+  void evaluate() {
+    if (_meta.isEmpty) return;
+    final now = _clock();
+    final last = _lastActionAt;
+    if (last != null && now.difference(last) < _governorCooldown) return;
+
+    final dynamicsHz = _dynamicsEffectiveHz();
+    // No measurable dynamics rate yet (cold start) → nothing to protect.
+    if (dynamicsHz == double.infinity) return;
+
+    if (dynamicsHz < _dynamicsFloorHz) {
+      final victim = _nextDemotionCandidate();
+      if (victim != null) {
+        _demoted.add(victim);
+        _lastActionAt = now;
+      }
+    } else if (dynamicsHz >= _dynamicsRestoreHz && _demoted.isNotEmpty) {
+      final restore = _nextRestoreCandidate();
+      if (restore != null) {
+        _demoted.remove(restore);
+        _lastActionAt = now;
+      }
+    }
+  }
+
+  /// Read-only snapshot for the comm-diagnostics overlay (#2468).
+  GovernorState get state => GovernorState(
+        achievedReadsPerSecond: _achievedReadsPerSecond,
+        dynamicsEffectiveHz: _dynamicsEffectiveHz(),
+        demotedCommands: Set<String>.unmodifiable(_demoted),
+      );
+
+  /// Effective hz the slowest dynamics-tier PID is achieving over the
+  /// rolling window. The *slowest* (min) because if any one dynamics PID
+  /// is being starved the whole tier is — flooring the worst case
+  /// protects RPM and speed equally. Returns [double.infinity] when no
+  /// dynamics PID has two timestamped reads yet (not enough data to judge,
+  /// so the governor never demotes on a cold start).
+  double _dynamicsEffectiveHz() {
+    var slowest = double.infinity;
+    for (final entry in _meta.entries) {
+      if (entry.value.tier != PidTier.dynamics) continue;
+      final hz = _achievedHzFor(entry.value);
+      if (hz != null && hz < slowest) slowest = hz;
+    }
+    return slowest;
+  }
+
+  /// Achieved reads/s for [meta] over the window, or null when it has
+  /// fewer than two timestamped reads (one read can't define a rate).
+  double? _achievedHzFor(_PidMeta meta) {
+    final stamps = meta.readTimestamps;
+    if (stamps.length < 2) return null;
+    final spanMs =
+        stamps.last.difference(stamps.first).inMicroseconds / 1000.0;
+    if (spanMs <= 0) return null;
+    // (n − 1) intervals across the measured span.
+    return (stamps.length - 1) / (spanMs / 1000.0);
+  }
+
+  /// The most-expendable not-yet-demoted, non-dynamics command, or null
+  /// when nothing is left to demote. Ranking (descending expendability):
+  /// deeper [PidTier], then lower [PidPriority], then larger configured hz.
+  String? _nextDemotionCandidate() {
+    String? best;
+    _PidMeta? bestMeta;
+    for (final entry in _meta.entries) {
+      final m = entry.value;
+      if (m.tier == PidTier.dynamics) continue;
+      if (_demoted.contains(entry.key)) continue;
+      if (bestMeta == null || _moreExpendable(m, bestMeta)) {
+        best = entry.key;
+        bestMeta = m;
+      }
+    }
+    return best;
+  }
+
+  /// The least-expendable currently-demoted command (restored first so we
+  /// unwind in reverse demotion order), or null when none are demoted.
+  String? _nextRestoreCandidate() {
+    String? best;
+    _PidMeta? bestMeta;
+    for (final entry in _meta.entries) {
+      if (!_demoted.contains(entry.key)) continue;
+      final m = entry.value;
+      if (bestMeta == null || _moreExpendable(bestMeta, m)) {
+        best = entry.key;
+        bestMeta = m;
+      }
+    }
+    return best;
+  }
+
+  /// True when [a] is more expendable than [b]: deeper tier, then lower
+  /// priority, then faster configured hz (a faster optional PID costs the
+  /// most budget, so it sheds load first).
+  static bool _moreExpendable(_PidMeta a, _PidMeta b) {
+    if (a.tier.index != b.tier.index) return a.tier.index > b.tier.index;
+    if (a.priority.index != b.priority.index) {
+      return a.priority.index > b.priority.index;
+    }
+    return a.hz > b.hz;
+  }
+
+  /// Drop leading entries in [stamps] strictly older than [cutoff]. The
+  /// list is oldest-first so a single front-prefix scan suffices.
+  static void _trimBefore(List<DateTime> stamps, DateTime cutoff) {
+    var drop = 0;
+    while (drop < stamps.length && stamps[drop].isBefore(cutoff)) {
+      drop++;
+    }
+    if (drop > 0) stamps.removeRange(0, drop);
+  }
+}
+
+/// Per-command policy + rolling read window the governor ranks on.
+class _PidMeta {
+  _PidMeta({required this.tier, required this.priority, required this.hz});
+
+  final PidTier tier;
+  final PidPriority priority;
+  final double hz;
+
+  /// Completion timestamps inside the rolling window (oldest-first).
+  final List<DateTime> readTimestamps = <DateTime>[];
+}

--- a/lib/features/consumption/data/obd2/pid_scheduler.dart
+++ b/lib/features/consumption/data/obd2/pid_scheduler.dart
@@ -5,44 +5,13 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import '../../../../core/logging/error_logger.dart';
+import 'pid_bandwidth_governor.dart';
+import 'scheduled_pid.dart';
 
-/// Priority tier used as a tiebreaker when two subscribed PIDs have an
-/// identical weight under the weighted round-robin selector.
-///
-/// The scheduler's primary selection metric is `(now − lastReadAt) × hz`,
-/// so priority only matters when two PIDs are _exactly_ tied — e.g. both
-/// subscribed on the same tick, or both have deterministic elapsed time.
-enum PidPriority { high, medium, low }
-
-/// Configuration for a single subscribed PID in the [PidScheduler].
-///
-/// The scheduler uses [hz] as the target refresh rate and computes each
-/// tick's winner from `(now − lastReadAt) × hz`. A higher [hz] drags the
-/// last-read timestamp toward "now" more aggressively, so fast-tier PIDs
-/// naturally win more ticks than slow-tier PIDs.
-///
-/// [priority] is consulted only to break weight ties — it is _not_ a
-/// hard override. A high-priority 0.1 Hz PID will still lose most ticks
-/// to a medium-priority 5 Hz PID because its weight grows 50× slower.
-class ScheduledPid {
-  ScheduledPid({
-    required this.hz,
-    this.priority = PidPriority.medium,
-  })  : assert(hz > 0, 'hz must be > 0'),
-        lastReadAt = null;
-
-  /// Target refresh rate in hertz (reads per second).
-  final double hz;
-
-  /// Tiebreaker when two PIDs have an identical weight this tick.
-  final PidPriority priority;
-
-  /// Timestamp of the most recent completed read, or `null` if the PID
-  /// has been subscribed but never read yet. A `null` here makes the PID
-  /// win the next tick unconditionally — a brand-new subscription should
-  /// get one initial read before the round-robin math kicks in.
-  DateTime? lastReadAt;
-}
+// Re-export the per-PID config vocabulary (#2457) so existing call sites
+// that import `pid_scheduler.dart` keep seeing PidPriority / PidTier /
+// ScheduledPid without a second import.
+export 'scheduled_pid.dart';
 
 /// Weighted round-robin scheduler for OBD-II PID polling.
 ///
@@ -77,6 +46,16 @@ class ScheduledPid {
 ///
 /// Recording is unaffected — a backed-off PID simply contributes fewer
 /// samples; the loop never stalls.
+///
+/// ## Bandwidth governor (#2457)
+///
+/// PIDs declare a [PidTier]. On a slow ELM327 clone the total reads/second
+/// the link sustains is the binding constraint, so the [PidBandwidthGovernor]
+/// demotes the most-expendable PID (deepest tier first) when the dynamics
+/// tier's effective hz drops below its floor, then restores it once headroom
+/// returns. The dynamics tier is never demoted, so RPM / speed never starve.
+/// Its demotions + achieved tick-rate are exposed read-only via
+/// [governorState] for the comm-diagnostics overlay (#2468).
 ///
 /// ## Phase 1 scope (#814)
 ///
@@ -138,6 +117,22 @@ class PidScheduler {
   /// until the first one fires.
   DateTime? _lastDiagnosticAt;
 
+  /// Bandwidth governor (#2457). Owns the achieved-reads windows + the
+  /// demotion policy that protects the dynamics tier on a slow link. The
+  /// scheduler feeds it read completions and queries its demotion set when
+  /// computing selection weight; it takes no transport / timer of its own.
+  late final PidBandwidthGovernor _governor =
+      PidBandwidthGovernor(clock: _clock);
+
+  /// Read-only snapshot of the bandwidth governor (#2457) for the
+  /// comm-diagnostics overlay (#2468): the achieved tick rate, the
+  /// dynamics tier's effective hz, and the currently-demoted commands.
+  GovernorState get governorState => _governor.state;
+
+  /// Commands currently demoted by the governor. Exposed for tests.
+  @visibleForTesting
+  Set<String> get demotedCommands => _governor.state.demotedCommands;
+
   /// Number of subscribed PIDs currently in the backed-off state
   /// (consecutive failures ≥ [_maxConsecutiveFailures]). Exposed for
   /// tests that assert backoff engaged / cleared.
@@ -164,15 +159,25 @@ class PidScheduler {
     void Function(String response) onResult,
   ) {
     _subs[command] = _Subscription(
+      command: command,
       config: config,
       onResult: onResult,
       order: _subscriptionCounter++,
     );
+    _governor.register(
+      command,
+      tier: config.tier,
+      priority: config.priority,
+      hz: config.hz,
+    );
   }
 
   /// Remove [command] from the rotation. A no-op if it isn't subscribed.
+  /// Also drops any governor demotion / read-window held against it so a
+  /// re-subscribe starts clean.
   void unsubscribe(String command) {
     _subs.remove(command);
+    _governor.unregister(command);
   }
 
   /// Start the periodic selection timer. Safe to call multiple times —
@@ -227,12 +232,25 @@ class PidScheduler {
     if (last == null) return double.infinity;
     final elapsedMs = now.difference(last).inMicroseconds / 1000.0;
     if (elapsedMs <= 0) return 0.0;
-    // A backed-off PID is selected at [_backoffHz] instead of its
-    // configured rate — far less often, so it neither floods the adapter
-    // nor starves healthy PIDs, while still being retried periodically so
-    // it resumes the instant it answers (#2379).
-    final hz = sub.isBackedOff ? _backoffHz : sub.config.hz;
-    return (elapsedMs / 1000.0) * hz;
+    return (elapsedMs / 1000.0) * _effectiveHz(sub);
+  }
+
+  /// The selection hz actually applied to [sub] this tick, after the two
+  /// dampers stack:
+  ///   - #2379 backoff: a PID that has failed [_maxConsecutiveFailures]
+  ///     times runs at [_backoffHz] (≈ 1/30 s) so a dead PID never crowds
+  ///     out healthy ones, yet is still retried periodically.
+  ///   - #2457 governor demotion: an expendable PID the governor has
+  ///     demoted runs at its configured hz × the governor's demotion
+  ///     factor, handing the freed budget to the dynamics tier on a slow
+  ///     link.
+  /// Backoff dominates (a dead PID stays at [_backoffHz] regardless).
+  double _effectiveHz(_Subscription sub) {
+    if (sub.isBackedOff) return _backoffHz;
+    final base = sub.config.hz;
+    return _governor.isDemoted(sub.command)
+        ? base * PidBandwidthGovernor.demotionFactor
+        : base;
   }
 
   /// Returns true if [candidateWeight]/[candidate] should replace
@@ -268,7 +286,9 @@ class PidScheduler {
     _inFlight = command;
     try {
       final response = await transport(command);
-      sub.config.lastReadAt = _clock();
+      final completedAt = _clock();
+      sub.config.lastReadAt = completedAt;
+      _governor.recordRead(command, completedAt);
       // A successful read clears any accumulated failure streak so the
       // PID resumes its configured cadence immediately (#2379).
       sub.consecutiveFailures = 0;
@@ -299,11 +319,17 @@ class PidScheduler {
       // tied on hz via the FIFO tiebreaker) and bump the failure streak.
       // Past [_maxConsecutiveFailures] the PID backs off to [_backoffHz]
       // (see [_weightFor]); a later success resets it.
-      sub.config.lastReadAt = _clock();
+      final completedAt = _clock();
+      sub.config.lastReadAt = completedAt;
+      _governor.recordRead(command, completedAt);
       sub.consecutiveFailures++;
       _maybeEmitUnresponsiveDiagnostic(e, st);
     } finally {
       _inFlight = null;
+      // Re-evaluate the bandwidth budget after every completed read (the
+      // achieved-hz window only changes when a read lands), AFTER
+      // `_inFlight` clears so a demotion takes effect on the next tick.
+      _governor.evaluate();
     }
   }
 
@@ -329,10 +355,15 @@ class PidScheduler {
 
 class _Subscription {
   _Subscription({
+    required this.command,
     required this.config,
     required this.onResult,
     required this.order,
   });
+
+  /// The OBD-II command this subscription polls (e.g. `'010C'`). Kept so
+  /// the governor can address demotions by command without a reverse map.
+  final String command;
 
   final ScheduledPid config;
   final void Function(String response) onResult;

--- a/lib/features/consumption/data/obd2/scheduled_pid.dart
+++ b/lib/features/consumption/data/obd2/scheduled_pid.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Per-PID configuration vocabulary shared by the `PidScheduler` selection
+/// core and the `PidBandwidthGovernor` policy: the tiebreaker priority, the
+/// cadence tier, and the [ScheduledPid] config object itself. Kept in its
+/// own file so neither collaborator has to depend on the other just to
+/// name a tier (#2457).
+library;
+
+/// Priority tier used as a tiebreaker when two subscribed PIDs have an
+/// identical weight under the weighted round-robin selector.
+///
+/// The scheduler's primary selection metric is `(now − lastReadAt) × hz`,
+/// so priority only matters when two PIDs are _exactly_ tied — e.g. both
+/// subscribed on the same tick, or both have deterministic elapsed time.
+enum PidPriority { high, medium, low }
+
+/// Cadence class a subscribed PID belongs to (#2457). The four tiers
+/// re-express the previous 3-tier layout on the same weighted round-robin
+/// and give the bandwidth governor a coarse axis along which to demote the
+/// least time-critical reads when an adapter can't keep up.
+///
+/// Carries no scheduling power of its own — selection is still driven
+/// purely by `(now − lastReadAt) × hz`. It only tells the governor which
+/// PIDs are safe to slow down (deeper = more expendable); [dynamics] is
+/// NEVER demoted, so speed / RPM never starve.
+enum PidTier {
+  /// ~5 Hz — RPM, speed, throttle, fuel-rate driver. Protected by the floor.
+  dynamics,
+
+  /// ~2 Hz — commanded λ, engine load. Mixture under load.
+  mixture,
+
+  /// ~0.5 Hz — STFT, LTFT, IAT, baro. Slow ECU corrections / ambient.
+  slowCorrection,
+
+  /// ~0.1 Hz — coolant, fuel-tank level. Thermal / context; demoted first.
+  thermalContext,
+}
+
+/// Configuration for a single subscribed PID in the `PidScheduler`.
+///
+/// The scheduler uses [hz] as the target refresh rate and computes each
+/// tick's winner from `(now − lastReadAt) × hz`. A higher [hz] drags the
+/// last-read timestamp toward "now" more aggressively, so fast-tier PIDs
+/// naturally win more ticks than slow-tier PIDs.
+///
+/// [priority] is consulted only to break weight ties — it is _not_ a
+/// hard override. A high-priority 0.1 Hz PID will still lose most ticks
+/// to a medium-priority 5 Hz PID because its weight grows 50× slower.
+class ScheduledPid {
+  ScheduledPid({
+    required this.hz,
+    this.priority = PidPriority.medium,
+    this.tier = PidTier.dynamics,
+  })  : assert(hz > 0, 'hz must be > 0'),
+        lastReadAt = null;
+
+  /// Target refresh rate in hertz (reads per second).
+  final double hz;
+
+  /// Tiebreaker when two PIDs have an identical weight this tick.
+  final PidPriority priority;
+
+  /// Cadence class this PID belongs to (#2457). Drives nothing in the core
+  /// selection math — it only tells the bandwidth governor which PIDs may
+  /// be slowed down ([PidTier.dynamics] is never demoted).
+  final PidTier tier;
+
+  /// Timestamp of the most recent completed read, or `null` if the PID
+  /// has been subscribed but never read yet. A `null` here makes the PID
+  /// win the next tick unconditionally — a brand-new subscription should
+  /// get one initial read before the round-robin math kicks in.
+  DateTime? lastReadAt;
+}

--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -206,4 +206,34 @@ class SupportedPidsResolver {
   /// Direct view of the supported-PID set for tests and diagnostics.
   /// Returns an unmodifiable empty set when discovery hasn't run.
   Set<int> get debugSupportedPids => Set.unmodifiable(_supportedPids ?? {});
+
+  /// Whether the supported-PID set has been resolved this session —
+  /// either discovered live or reloaded from the persistent cache during
+  /// [prime]. `false` means we're querying blind (a probe-less clone),
+  /// in which case [resolvedTargetSet] returns the full target set so the
+  /// unconditional core still rotates (#811 don't-reject-blind, #2457).
+  bool get isResolved => _supportedPids != null;
+
+  /// The live subscription set for [target] (#2457): the **discover-all ∩
+  /// target-set**. Given the polling layer's target PID table, return the
+  /// subset the car actually implements.
+  ///
+  ///   - Discovery has run → `target ∩ discovered`. A car supporting only
+  ///     {010C, 010D, 0104, 0111} resolves to exactly those of [target].
+  ///   - Discovery has NOT run (probe-less clone, blind session) → the
+  ///     full [target] unchanged. We don't know enough to drop any PID,
+  ///     so the unconditional core still rotates and unsupported PIDs
+  ///     self-evict via the scheduler's #2379 backoff.
+  ///
+  /// The discovered set itself is persisted once per adapter by [prime]
+  /// (keyed off adapterMac + make:model:year via the #2253 fallback key),
+  /// so this intersection costs no extra adapter I/O after the first scan.
+  /// Returned set is unmodifiable.
+  Set<int> resolvedTargetSet(Set<int> target) {
+    final discovered = _supportedPids;
+    if (discovered == null) return Set.unmodifiable(target);
+    return Set.unmodifiable(
+      target.where(discovered.contains).toSet(),
+    );
+  }
 }

--- a/test/features/consumption/data/obd2/live_sample_snapshot_subscription_test.dart
+++ b/test/features/consumption/data/obd2/live_sample_snapshot_subscription_test.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/live_sample_snapshot.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/pid_scheduler.dart';
+
+/// #2457 — subscribeAllTiers wires the live set = target table ∩
+/// discovered-supported. A car with only the four basic PIDs must
+/// subscribe exactly those plus the unconditional core; a fully-capable
+/// car subscribes the optional air-mass / mixture PIDs too.
+
+/// Trivial transport — the snapshot test never reads, it only inspects
+/// which commands got subscribed via the recording scheduler.
+class _StubTransport implements Obd2Transport {
+  @override
+  bool get isConnected => true;
+  @override
+  Future<void> connect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Future<String> sendCommand(String command) async => 'NO DATA';
+}
+
+/// [Obd2Service] whose supported-PID answer is driven by [_supported].
+/// `null` means "discovery never ran" → don't-reject-blind (`true` for
+/// every PID), matching the production resolver contract.
+class _SupportStubService extends Obd2Service {
+  _SupportStubService(this._supported) : super(_StubTransport());
+
+  final Set<int>? _supported;
+
+  @override
+  bool supportsPid(int pid) => _supported == null || _supported.contains(pid);
+  @override
+  bool isPidSupported(int pid) => supportsPid(pid);
+}
+
+/// Drives subscribeAllTiers on a scheduler whose transport records each
+/// distinct command, then returns the set of subscribed commands. Every
+/// PID is newly subscribed (lastReadAt == null → infinity weight), so the
+/// scheduler reads each at least once within a few ticks.
+Future<Set<String>> _subscribedCommands(Set<int>? supported) async {
+  final seen = <String>{};
+  final scheduler = PidScheduler(
+    transport: (cmd) async {
+      seen.add(cmd);
+      return 'NO DATA';
+    },
+    tickRate: const Duration(milliseconds: 2),
+  );
+  final snapshot = LiveSampleSnapshot(
+    service: _SupportStubService(supported),
+    onHighPriorityParse: (_) {},
+    onSpeedSample: (_) {},
+  );
+  snapshot.subscribeAllTiers(scheduler);
+  scheduler.start();
+  await Future<void>.delayed(const Duration(milliseconds: 300));
+  scheduler.stop();
+  await Future<void>.delayed(const Duration(milliseconds: 20));
+  return seen;
+}
+
+void main() {
+  // The unconditional core (no supportsPid gate): near-universal Mode-01.
+  final core = <String>{
+    Elm327Protocol.engineRpmCommand, // 010C
+    Elm327Protocol.vehicleSpeedCommand, // 010D
+    Elm327Protocol.throttlePositionCommand, // 0111
+    Elm327Protocol.engineLoadCommand, // 0104
+    Elm327Protocol.intakeAirTempCommand, // 010F
+    Elm327Protocol.coolantTempCommand, // 0105
+    Elm327Protocol.shortTermFuelTrimCommand, // 0106
+    Elm327Protocol.longTermFuelTrimCommand, // 0107
+    Elm327Protocol.fuelTankLevelCommand, // 012F
+  };
+  final optional = <String>{
+    Elm327Protocol.mafCommand, // 0110
+    Elm327Protocol.intakeManifoldPressureCommand, // 010B
+    Elm327Protocol.engineFuelRateCommand, // 015E
+    Elm327Protocol.commandedEquivalenceRatioCommand, // 0144
+    Elm327Protocol.baroPressureCommand, // 0133
+  };
+
+  test(
+      'a basic car {010C,010D,0104,0111} subscribes exactly those of the '
+      'target — the optional air-mass / mixture PIDs are NOT subscribed',
+      () async {
+    final subscribed =
+        await _subscribedCommands(<int>{0x0C, 0x0D, 0x04, 0x11});
+    // The four supported core PIDs are present.
+    expect(subscribed, containsAll(<String>{
+      Elm327Protocol.engineRpmCommand,
+      Elm327Protocol.vehicleSpeedCommand,
+      Elm327Protocol.engineLoadCommand,
+      Elm327Protocol.throttlePositionCommand,
+    }));
+    // None of the optional (gated) PIDs were subscribed.
+    for (final cmd in optional) {
+      expect(subscribed, isNot(contains(cmd)),
+          reason: '$cmd is optionalPid-gated and the car lacks it');
+    }
+  });
+
+  test(
+      'a fully-capable car subscribes the unconditional core PLUS every '
+      'optional PID', () async {
+    final all = <int>{
+      0x0C, 0x0D, 0x11, 0x04, 0x0F, 0x05, 0x06, 0x07, 0x2F, // core
+      0x10, 0x0B, 0x5E, 0x44, 0x33, // optional
+    };
+    final subscribed = await _subscribedCommands(all);
+    expect(subscribed, containsAll(core));
+    expect(subscribed, containsAll(optional));
+  });
+
+  test(
+      'a probe-less clone (discovery never ran) still rotates the full core '
+      '+ optional set (don\'t-reject-blind)', () async {
+    final subscribed = await _subscribedCommands(null);
+    expect(subscribed, containsAll(core),
+        reason: 'the unconditional core must always rotate');
+    expect(subscribed, containsAll(optional),
+        reason: 'blind session does not reject optional PIDs');
+  });
+}

--- a/test/features/consumption/data/obd2/pid_bandwidth_governor_test.dart
+++ b/test/features/consumption/data/obd2/pid_bandwidth_governor_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/pid_bandwidth_governor.dart';
+import 'package:tankstellen/features/consumption/data/obd2/scheduled_pid.dart';
+
+/// Unit tests for the #2457 bandwidth governor in isolation from the
+/// scheduler — driving it with synthetic read completions on a faked clock
+/// so the demote / restore policy is exercised deterministically.
+void main() {
+  // A fast dynamics-tier read: stamp `count` completions `gapMs` apart so
+  // the governor measures (count−1)/(span) reads/s for that PID.
+  void feedReads(
+    PidBandwidthGovernor g,
+    String command, {
+    required DateTime start,
+    required int count,
+    required int gapMs,
+  }) {
+    for (var i = 0; i < count; i++) {
+      g.recordRead(command, start.add(Duration(milliseconds: gapMs * i)));
+    }
+  }
+
+  group('PidBandwidthGovernor — tier ranking + demotion order', () {
+    test(
+        'a slow dynamics tier demotes the deepest tier first, sparing the '
+        'dynamics tier entirely', () {
+      var now = DateTime(2026, 1, 1, 12);
+      final g = PidBandwidthGovernor(clock: () => now);
+      g
+        ..register('010C', tier: PidTier.dynamics, priority: PidPriority.high, hz: 5)
+        ..register('0144', tier: PidTier.mixture, priority: PidPriority.medium, hz: 2)
+        ..register('0106',
+            tier: PidTier.slowCorrection, priority: PidPriority.medium, hz: 0.5)
+        ..register('012F',
+            tier: PidTier.thermalContext, priority: PidPriority.low, hz: 0.1);
+
+      // Dynamics PID achieving only ~2 Hz (500 ms gaps) — below the 3 Hz
+      // floor. Five reads → 4 intervals × 500 ms = 2 s span → 2 Hz.
+      feedReads(g, '010C', start: now, count: 5, gapMs: 500);
+      now = now.add(const Duration(seconds: 3)); // clear the cooldown
+      g.evaluate();
+
+      // Deepest tier (thermalContext) sheds load first; dynamics never.
+      expect(g.state.demotedCommands, contains('012F'));
+      expect(g.state.demotedCommands, isNot(contains('010C')),
+          reason: 'the dynamics tier must never be demoted');
+    });
+
+    test(
+        'persistent starvation walks demotions up the tiers, deepest first, '
+        'but stops short of the dynamics tier', () {
+      var now = DateTime(2026, 1, 1, 12);
+      final g = PidBandwidthGovernor(clock: () => now);
+      g
+        ..register('010C', tier: PidTier.dynamics, priority: PidPriority.high, hz: 5)
+        ..register('0144', tier: PidTier.mixture, priority: PidPriority.medium, hz: 2)
+        ..register('012F',
+            tier: PidTier.thermalContext, priority: PidPriority.low, hz: 0.1);
+
+      // Keep the dynamics tier perpetually slow (2 Hz) and re-evaluate
+      // across several cooldown windows.
+      for (var round = 0; round < 3; round++) {
+        feedReads(g, '010C', start: now, count: 5, gapMs: 500);
+        now = now.add(const Duration(seconds: 3));
+        g.evaluate();
+      }
+
+      // Both optional non-dynamics PIDs end up demoted (thermal before
+      // mixture), but 010C stays at full cadence.
+      expect(g.state.demotedCommands, containsAll(<String>{'012F', '0144'}));
+      expect(g.state.demotedCommands, isNot(contains('010C')));
+    });
+  });
+
+  group('PidBandwidthGovernor — restore on recovered headroom', () {
+    test('a demoted PID is restored once the dynamics tier clears the ceiling',
+        () {
+      var now = DateTime(2026, 1, 1, 12);
+      final g = PidBandwidthGovernor(clock: () => now);
+      g
+        ..register('010C', tier: PidTier.dynamics, priority: PidPriority.high, hz: 5)
+        ..register('012F',
+            tier: PidTier.thermalContext, priority: PidPriority.low, hz: 0.1);
+
+      // 1) Slow link → demote.
+      feedReads(g, '010C', start: now, count: 5, gapMs: 500); // 2 Hz
+      now = now.add(const Duration(seconds: 3));
+      g.evaluate();
+      expect(g.state.demotedCommands, contains('012F'));
+
+      // 2) Link recovers: dynamics PID now achieves 5 Hz (200 ms gaps) →
+      // above the 4 Hz restore ceiling. The fresh window must contain only
+      // the fast reads, so advance past the old slow stamps first.
+      now = now.add(const Duration(seconds: 5));
+      feedReads(g, '010C', start: now, count: 6, gapMs: 200); // 5 Hz
+      now = now.add(const Duration(seconds: 3));
+      g.evaluate();
+      expect(g.state.demotedCommands, isEmpty,
+          reason: 'headroom returned → the demoted PID is restored');
+    });
+  });
+
+  group('PidBandwidthGovernor — exposed read-only state (#2468)', () {
+    test('state surfaces achieved reads/s, dynamics hz and demotions', () {
+      final now = DateTime(2026, 1, 1, 12);
+      final g = PidBandwidthGovernor(clock: () => now);
+      g.register('010C',
+          tier: PidTier.dynamics, priority: PidPriority.high, hz: 5);
+
+      // No reads yet → cold-start sentinels.
+      expect(g.state.achievedReadsPerSecond, 0);
+      expect(g.state.dynamicsEffectiveHz, double.infinity);
+      expect(g.state.demotedCommands, isEmpty);
+
+      // Two reads 200 ms apart → 5 Hz dynamics, 2 reads / 4 s window.
+      feedReads(g, '010C', start: now, count: 2, gapMs: 200);
+      expect(g.state.dynamicsEffectiveHz, closeTo(5.0, 0.001));
+      expect(g.state.achievedReadsPerSecond, closeTo(2 / 4.0, 0.001));
+    });
+
+    test('unregister drops the demotion + clears it from state', () {
+      var now = DateTime(2026, 1, 1, 12);
+      final g = PidBandwidthGovernor(clock: () => now);
+      g
+        ..register('010C', tier: PidTier.dynamics, priority: PidPriority.high, hz: 5)
+        ..register('012F',
+            tier: PidTier.thermalContext, priority: PidPriority.low, hz: 0.1);
+      feedReads(g, '010C', start: now, count: 5, gapMs: 500); // 2 Hz
+      now = now.add(const Duration(seconds: 3));
+      g.evaluate();
+      expect(g.state.demotedCommands, contains('012F'));
+
+      g.unregister('012F');
+      expect(g.state.demotedCommands, isEmpty);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/pid_scheduler_test.dart
+++ b/test/features/consumption/data/obd2/pid_scheduler_test.dart
@@ -630,4 +630,125 @@ void main() {
           reason: 'a fresh window permits another diagnostic');
     });
   });
+
+  // ── #2457 — 4-tier cadence + bandwidth governor ─────────────────────
+  group('PidScheduler — cadence tiers + weight (#2457)', () {
+    test('the RR weight scales with the configured hz across all four tiers',
+        () {
+      // One PID per tier, all read the same 1 s ago → weight = elapsed ×
+      // hz, so the order is purely the hz ranking. This proves the four
+      // tiers ride the same weighted-RR and a deeper tier never out-
+      // competes a shallower one in steady state.
+      final setup = _schedulerWithClock(transport: _FakeTransport().call);
+      final scheduler = setup.scheduler;
+      final base = DateTime(2026, 1, 1, 12);
+      final readAt = base.subtract(const Duration(seconds: 1));
+      scheduler.subscribe(
+          '010C',
+          ScheduledPid(hz: 5.0, priority: PidPriority.high, tier: PidTier.dynamics)
+            ..lastReadAt = readAt,
+          (_) {});
+      scheduler.subscribe(
+          '0144',
+          ScheduledPid(hz: 2.0, tier: PidTier.mixture)..lastReadAt = readAt,
+          (_) {});
+      scheduler.subscribe(
+          '0106',
+          ScheduledPid(hz: 0.5, tier: PidTier.slowCorrection)
+            ..lastReadAt = readAt,
+          (_) {});
+      scheduler.subscribe(
+          '012F',
+          ScheduledPid(hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext)
+            ..lastReadAt = readAt,
+          (_) {});
+
+      // Dynamics (5 Hz) has the largest weight → wins.
+      expect(scheduler.pickNextCommand(base), '010C');
+    });
+
+    test('a tier default does not gate selection — only weight does', () {
+      // A high-priority thermal PID (deep tier) still loses to a medium
+      // dynamics PID, proving the tier is metadata, not a hard override.
+      final setup = _schedulerWithClock(transport: _FakeTransport().call);
+      final scheduler = setup.scheduler;
+      final base = DateTime(2026, 1, 1, 12);
+      final readAt = base.subtract(const Duration(seconds: 1));
+      scheduler.subscribe(
+          '0105',
+          ScheduledPid(hz: 0.1, priority: PidPriority.high, tier: PidTier.thermalContext)
+            ..lastReadAt = readAt,
+          (_) {});
+      scheduler.subscribe(
+          '010C',
+          ScheduledPid(hz: 5.0, tier: PidTier.dynamics)..lastReadAt = readAt,
+          (_) {});
+      expect(scheduler.pickNextCommand(base), '010C');
+    });
+  });
+
+  group('PidScheduler — bandwidth governor end-to-end (#2457)', () {
+    test(
+        'a slow link demotes the lowest tier while RPM / speed keep their '
+        'effective-hz, restored once headroom returns', () async {
+      // Per-read transport delay is the slow-link knob. `slow` (200 ms per
+      // read) means even the two 5 Hz dynamics PIDs can only share ~5
+      // reads/s total — ~2.5 Hz each, below the 3 Hz floor — so the
+      // governor must demote an expendable PID. Flipping to fast (0 ms)
+      // gives ample headroom and the demotion is unwound.
+      var slow = true;
+      Future<String> transport(String command) async {
+        if (slow) await Future<void>.delayed(const Duration(milliseconds: 200));
+        final pid = command.substring(2, 4);
+        return '41 $pid 00>';
+      }
+
+      final scheduler = PidScheduler(
+        transport: transport,
+        tickRate: const Duration(milliseconds: 5),
+      );
+      final reads = <String, int>{'010C': 0, '010D': 0, '012F': 0, '0105': 0};
+      scheduler
+        ..subscribe('010C',
+            ScheduledPid(hz: 5.0, priority: PidPriority.high, tier: PidTier.dynamics),
+            (_) => reads['010C'] = reads['010C']! + 1)
+        ..subscribe('010D',
+            ScheduledPid(hz: 5.0, priority: PidPriority.high, tier: PidTier.dynamics),
+            (_) => reads['010D'] = reads['010D']! + 1)
+        ..subscribe('0105',
+            ScheduledPid(hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext),
+            (_) => reads['0105'] = reads['0105']! + 1)
+        ..subscribe('012F',
+            ScheduledPid(hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext),
+            (_) => reads['012F'] = reads['012F']! + 1)
+        ..start();
+
+      // Run the slow link long enough for the governor's 4 s window +
+      // 2 s cooldown to fire at least once.
+      await Future<void>.delayed(const Duration(seconds: 8));
+      // A thermal-tier PID is demoted to protect the dynamics tier; the
+      // dynamics PIDs are never demoted.
+      expect(scheduler.demotedCommands, isNotEmpty,
+          reason: 'the slow link should have demoted an expendable PID');
+      expect(scheduler.demotedCommands.any((c) => c == '012F' || c == '0105'),
+          isTrue,
+          reason: 'only thermal-tier PIDs are demoted on a slow link');
+      expect(scheduler.demotedCommands, isNot(contains('010C')));
+      expect(scheduler.demotedCommands, isNot(contains('010D')));
+
+      // Dynamics PIDs still got the lion's share of the budget.
+      final dynamicsReads = reads['010C']! + reads['010D']!;
+      final thermalReads = reads['0105']! + reads['012F']!;
+      expect(dynamicsReads, greaterThan(thermalReads),
+          reason: 'RPM / speed must out-poll the demoted thermal tier');
+
+      // Link recovers → the governor restores the demoted PID.
+      slow = false;
+      await Future<void>.delayed(const Duration(seconds: 8));
+      scheduler.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      expect(scheduler.demotedCommands, isEmpty,
+          reason: 'headroom returned → demotions are unwound');
+    });
+  });
 }

--- a/test/features/consumption/data/obd2/supported_pids_resolver_target_test.dart
+++ b/test/features/consumption/data/obd2/supported_pids_resolver_target_test.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/supported_pids_resolver.dart';
+
+/// #2457 — discover-all ∩ target-set. The live subscription set is the
+/// target PID table intersected with the car's discovered-supported set,
+/// with the #811 don't-reject-blind fallback when discovery never ran.
+void main() {
+  // The #2457 target table (the PIDs subscribed post-#2456).
+  const target = <int>{
+    0x0C, 0x0D, 0x10, 0x0B, 0x11, 0x5E, // dynamics
+    0x44, 0x04, // mixture
+    0x06, 0x07, 0x0F, 0x33, // slow-correction
+    0x05, 0x2F, // thermal/context
+  };
+
+  SupportedPidsResolver buildResolver() => SupportedPidsResolver(
+        // discoverSupportedPids walks 0100..01C0; we hand it canned
+        // bitmaps via this send closure per test as needed. Default: a
+        // resolver with no discovery run (blind session).
+        send: (cmd) async => 'NO DATA',
+        isConnected: () => true,
+      );
+
+  group('SupportedPidsResolver.isResolved', () {
+    test('false before any discovery (blind session)', () {
+      expect(buildResolver().isResolved, isFalse);
+    });
+  });
+
+  group('SupportedPidsResolver.resolvedTargetSet — discover-all ∩ target', () {
+    test(
+        'a probe-less clone (no discovery) resolves to the FULL target set '
+        'so the unconditional core still rotates', () {
+      final resolver = buildResolver();
+      // No discovery has run → don't-reject-blind: the whole target set is
+      // returned unchanged.
+      expect(resolver.resolvedTargetSet(target), unorderedEquals(target));
+    });
+
+    test(
+        'a basic car supporting only {0C,0D,04,11} subscribes exactly those '
+        '— not the full target', () async {
+      // Drive discovery with a bitmap that advertises only the four basic
+      // PIDs. 0100 covers PIDs 01..20; set bits for 04, 0C, 0D, 11.
+      // Standard supported-PIDs bitmap: 4 bytes, MSB = PID 01. We craft a
+      // response by hand for those four bits (and clear the next-range
+      // flag so the scan stops after 0100).
+      final supported = <int>{0x04, 0x0C, 0x0D, 0x11};
+      final resolver = SupportedPidsResolver(
+        send: (cmd) async {
+          if (cmd.startsWith('0100')) {
+            return _bitmapResponse(0x00, supported);
+          }
+          return 'NO DATA';
+        },
+        isConnected: () => true,
+      );
+      final discovered = await resolver.discoverSupportedPids();
+      expect(discovered, unorderedEquals(supported),
+          reason: 'sanity: discovery parsed the four supported PIDs');
+
+      final resolved = resolver.resolvedTargetSet(target);
+      expect(resolved, unorderedEquals(<int>{0x0C, 0x0D, 0x04, 0x11}),
+          reason: 'target ∩ discovered keeps only the four the car has');
+      // The optional air-mass / mixture PIDs are dropped.
+      for (final absent in <int>{0x10, 0x0B, 0x5E, 0x44, 0x33}) {
+        expect(resolved, isNot(contains(absent)));
+      }
+    });
+
+    test('the resolved set is unmodifiable', () {
+      final resolved = buildResolver().resolvedTargetSet(target);
+      expect(() => resolved.add(0xFF), throwsUnsupportedError);
+    });
+  });
+}
+
+/// Build a Mode-01 supported-PIDs bitmap response for [groupBase] (e.g.
+/// 0x00 for the 0100 query) advertising [supported] and clearing the
+/// next-range flag. The 4 data bytes have the MSB of byte 0 = PID
+/// (groupBase + 1), matching the SAE J1979 layout the parser decodes.
+String _bitmapResponse(int groupBase, Set<int> supported) {
+  var bits = 0;
+  for (final pid in supported) {
+    final offset = pid - groupBase; // 1..32
+    if (offset < 1 || offset > 32) continue;
+    bits |= 1 << (32 - offset);
+  }
+  final hex = bits.toRadixString(16).padLeft(8, '0').toUpperCase();
+  const mode = 0x41; // response to Mode 01
+  final pid = groupBase.toRadixString(16).padLeft(2, '0').toUpperCase();
+  final bytes = <String>[
+    for (var i = 0; i < 8; i += 2) hex.substring(i, i + 2),
+  ];
+  return '${mode.toRadixString(16).toUpperCase()} $pid ${bytes.join(' ')}>';
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -64,7 +64,13 @@ void main() {
     // subscriptions and threads both into the MAF + speed-density fuel
     // derivation (effective AFR + air-density correction). Decomposition
     // is tracked separately by #2187/#2188.
-    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 524,
+    // #2457 — re-grandfathered 524 → 533: subscribeAllTiers re-expressed
+    // as four cadence tiers (PidTier) + the centralised `_sub` helper that
+    // carries the discover-all ∩ target-set gate (optionalPid) so each PID
+    // is a one-line tier assignment, with #2458 tier slots commented in.
+    // Net +9 is the helper + its dartdoc, not new branching. Decomposition
+    // is tracked separately by #2187/#2188.
+    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 533,
     // #2379 — re-grandfathered 1457 → 1468: threaded the
     // `logFailureAsError` flag through `connect()` (param + doc + the
     // guarded `if` around the now-conditional connect-failed trace) so a


### PR DESCRIPTION
Child of Epic #2455. Reorganises OBD-II PID polling so adding PIDs never starves speed/RPM and each car polls the largest subset it supports.

## Cadence tiers (4, on the existing weighted-RR)

`PidTier` is metadata only — selection is still pure `(now − lastReadAt) × hz`, so a deeper-tier PID eventually wins a slot on staleness without out-competing the dynamics tier in steady state.

| Tier | hz | PIDs |
|------|----|------|
| DYNAMICS | ~5 Hz | RPM `010C`, speed `010D`, throttle `0111`, fuel-driver `015E`→`0110`→`010B` |
| MIXTURE | ~2 Hz | λ `0144`, engine load `0104` |
| SLOW-CORRECTION | ~0.5 Hz | STFT `0106`, LTFT `0107`, IAT `010F`, baro `0133` |
| THERMAL/CONTEXT | ~0.1 Hz | coolant `0105`, fuel tank `012F` |

(#2458 tier slots — pedal → dynamics, abs-load/bank-2 → mixture, oil/ambient/voltage → thermal — are commented in. Adding a PID is a one-line `_sub` call carrying its gate + tier + hz + priority.)

## Bandwidth governor — the RPM/speed-floor guarantee

New `PidBandwidthGovernor` measures achieved reads/s over a rolling 4 s window. When the **dynamics tier's effective hz drops below a 3 Hz floor** (a slow ELM327 clone), it **demotes the most-expendable PID** (deepest tier first, then lowest priority, then largest hz) by halving its target hz — freeing budget for the dynamics tier — then **restores** it once the tier clears a 4 Hz ceiling with headroom (hysteresis prevents flapping). The **dynamics tier is never demoted**, so RPM/speed never starve. The #2379 3-fail→1/30 s backoff is kept, so unsupported-but-subscribed PIDs still self-evict.

## Exposed read-only state (for #2468)

`PidScheduler.governorState` → `GovernorState { achievedReadsPerSecond, dynamicsEffectiveHz, demotedCommands }`. The comm-diagnostics overlay reads these; this PR only exposes them.

## Discover-all ∩ target-set

`subscribeAllTiers` wires the live set = target PID table ∩ #811-discovered-supported. The unconditional core (RPM/speed/throttle/load/IAT/coolant/STFT/LTFT/tank) stays don't-reject-blind so a probe-less clone still rotates it; optional PIDs (MAF/MAP/`015E`/λ/baro) are `supportsPid`-gated. A car supporting only `{010C,010D,0104,0111}` subscribes exactly those + core. New `SupportedPidsResolver.resolvedTargetSet`/`isResolved` expose the intersection (the discovered set is persisted once per adapter by `prime`).

## Tests
- Governor demote/restore + tier ranking (deepest-first, dynamics spared) in isolation.
- RR weight respects hz across all four tiers; tier never gates selection.
- Discover-all ∩ target at the resolver layer and the snapshot layer (basic car → exactly its four PIDs + core; fully-capable → core + optional; blind clone → full set).
- End-to-end slow-link: lowest tier demoted, RPM/speed out-poll it, restored once headroom returns.
- Existing `pid_scheduler` + full obd2 suite stay green.

Zero ARB, zero codegen drift (no `@riverpod`/freezed touched). `PidPriority`/`PidTier`/`ScheduledPid` extracted to `scheduled_pid.dart` to keep `pid_scheduler.dart` under the 400-line cap; `live_sample_snapshot.dart` re-grandfathered 524→533.

Closes #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
