### PR TITLE
feat(obd2): acquire pedal/abs-load/bank-2 trims + persist new signals + diagnostic-capture flag (#2458, #2459)

### DIFF
--- a/lib/features/consumption/data/obd2/elm327_commands.dart
+++ b/lib/features/consumption/data/obd2/elm327_commands.dart
@@ -243,6 +243,58 @@ class Elm327Commands {
   /// assumed sea-level value. Response: "41 33 XX".
   static const baroPressureCommand = '0133\r';
 
+  /// Request short-term fuel trim, bank 2 (%). Mode 01, PID 08 (#2458).
+  /// Same formula as bank-1 STFT (`trim% = (A − 128) × 100 / 128`).
+  /// Only V-engines / boxer layouts run a second bank; on inline engines
+  /// the PID is absent and the fuel derivation stays on the bank-1
+  /// correction. Response: "41 08 XX".
+  static const shortTermFuelTrimBank2Command = '0108\r';
+
+  /// Request long-term fuel trim, bank 2 (%). Mode 01, PID 09 (#2458).
+  /// Same formula / bank-2 semantics as [shortTermFuelTrimBank2Command].
+  /// Captures the slow per-bank mixture offset on dual-bank engines.
+  /// Response: "41 09 XX".
+  static const longTermFuelTrimBank2Command = '0109\r';
+
+  /// Request absolute load value (%). Mode 01, PID 43 (#2458). Formula:
+  /// `load% = (256·A + B) × 100 / 255`. Unlike calculated engine load
+  /// (PID 04, capped at 100 %), absolute load is normalised against a
+  /// naturally-aspirated reference and so **exceeds 100 %** on boosted
+  /// engines under positive manifold pressure — a clean high-load proxy.
+  /// Response: "41 43 XX YY".
+  static const absoluteLoadCommand = '0143\r';
+
+  /// Request accelerator-pedal position D (%). Mode 01, PID 49 (#2458).
+  /// Formula: `% = A × 100 / 255`. One of three pedal channels the ECU
+  /// may expose (D/E/F, PIDs 49/4A/4B); the snapshot subscribes whichever
+  /// the car supports and takes the max as driver intent. Response:
+  /// "41 49 XX".
+  static const acceleratorPedalDCommand = '0149\r';
+
+  /// Request accelerator-pedal position E (%). Mode 01, PID 4A (#2458).
+  /// Same `A × 100 / 255` encoding as [acceleratorPedalDCommand].
+  /// Response: "41 4A XX".
+  static const acceleratorPedalECommand = '014A\r';
+
+  /// Request accelerator-pedal position F (%). Mode 01, PID 4B (#2458).
+  /// Same `A × 100 / 255` encoding as [acceleratorPedalDCommand].
+  /// Response: "41 4B XX".
+  static const acceleratorPedalFCommand = '014B\r';
+
+  /// Request engine oil temperature (°C). Mode 01, PID 5C (#2459).
+  /// Formula: °C = A − 40 (one-byte response, same encoding as coolant /
+  /// IAT). Persisted as an optional diagnostic context signal — slower
+  /// thermal mass than coolant, useful for warm-up modelling. Response:
+  /// "41 5C XX".
+  static const engineOilTempCommand = '015C\r';
+
+  /// Request ambient air temperature (°C). Mode 01, PID 46 (#2459).
+  /// Formula: °C = A − 40 (one-byte response). The true outside-air
+  /// temperature (vs IAT, which sits behind the intake and reads warm);
+  /// persisted as optional diagnostic context for air-density modelling.
+  /// Response: "41 46 XX".
+  static const ambientAirTempCommand = '0146\r';
+
   /// Request fuel type. Mode 01, PID 51. (#1399). Single-byte response
   /// per SAE-J1979 Table 6 — see [Elm327Parsers.parseFuelType] for the
   /// mapping. Used during the VIN-driven adapter-pair auto-population

--- a/lib/features/consumption/data/obd2/elm327_parsers.dart
+++ b/lib/features/consumption/data/obd2/elm327_parsers.dart
@@ -229,8 +229,20 @@ class Elm327Parsers {
   static double? parseLongTermFuelTrim(String raw) =>
       _parseFuelTrim(raw, 0x07);
 
-  /// Shared fuel-trim decoder used by PIDs 06 / 07 (and 08 / 09 when
-  /// we add bank-2 support). Returns null on NO DATA.
+  /// Parse short-term fuel trim bank 2 from Mode 01 PID 08 response
+  /// (#2458). Identical encoding to bank-1 STFT; only V / boxer engines
+  /// expose a second bank. Returns null on NO DATA (inline engines).
+  static double? parseShortTermFuelTrimBank2(String raw) =>
+      _parseFuelTrim(raw, 0x08);
+
+  /// Parse long-term fuel trim bank 2 from Mode 01 PID 09 response
+  /// (#2458). Identical encoding to bank-1 LTFT; the slow per-bank
+  /// offset on dual-bank engines. Returns null on NO DATA.
+  static double? parseLongTermFuelTrimBank2(String raw) =>
+      _parseFuelTrim(raw, 0x09);
+
+  /// Shared fuel-trim decoder used by PIDs 06 / 07 / 08 / 09. Returns
+  /// null on NO DATA.
   static double? _parseFuelTrim(String raw, int expectedPid) {
     final bytes = _parseModeOneBody(raw, expectedPid, minBytes: 3);
     if (bytes == null) return null;
@@ -242,6 +254,51 @@ class Elm327Parsers {
     final bytes = _parseModeOneBody(raw, expectedPid, minBytes: 3);
     if (bytes == null) return null;
     return bytes[2] * 100.0 / 255.0;
+  }
+
+  /// Parse accelerator-pedal position D from Mode 01 PID 49 response
+  /// (#2458). Formula: `% = A × 100 / 255`. The driver-intent signal —
+  /// distinct from absolute throttle (PID 11), which the ECU may damp
+  /// for traction / cruise. Response: "41 49 XX".
+  static double? parseAcceleratorPedalD(String raw) =>
+      _parse1BytePercent(raw, 0x49);
+
+  /// Parse accelerator-pedal position E from Mode 01 PID 4A response
+  /// (#2458). Same `A × 100 / 255` encoding. Response: "41 4A XX".
+  static double? parseAcceleratorPedalE(String raw) =>
+      _parse1BytePercent(raw, 0x4A);
+
+  /// Parse accelerator-pedal position F from Mode 01 PID 4B response
+  /// (#2458). Same `A × 100 / 255` encoding. Response: "41 4B XX".
+  static double? parseAcceleratorPedalF(String raw) =>
+      _parse1BytePercent(raw, 0x4B);
+
+  /// Parse absolute load value from Mode 01 PID 43 response (#2458).
+  /// Formula: `load% = (256·A + B) × 100 / 255`. Normalised against a
+  /// naturally-aspirated reference, so it **exceeds 100 %** on boosted
+  /// engines under positive manifold pressure (a clean high-load proxy).
+  /// Two-byte response: "41 43 XX YY".
+  static double? parseAbsoluteLoad(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x43, minBytes: 4);
+    if (bytes == null) return null;
+    return ((bytes[2] * 256) + bytes[3]) * 100.0 / 255.0;
+  }
+
+  /// Parse engine oil temperature from Mode 01 PID 5C response (#2459).
+  /// Formula: °C = A − 40 (single byte) — same encoding as coolant / IAT.
+  /// Response: "41 5C XX".
+  static double? parseEngineOilTempCelsius(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x5C, minBytes: 3);
+    if (bytes == null) return null;
+    return bytes[2].toDouble() - 40.0;
+  }
+
+  /// Parse ambient air temperature from Mode 01 PID 46 response (#2459).
+  /// Formula: °C = A − 40 (single byte). Response: "41 46 XX".
+  static double? parseAmbientAirTempCelsius(String raw) {
+    final bytes = _parseModeOneBody(raw, 0x46, minBytes: 3);
+    if (bytes == null) return null;
+    return bytes[2].toDouble() - 40.0;
   }
 
   /// Parse a supported-PIDs bitmap response (#811).

--- a/lib/features/consumption/data/obd2/elm327_protocol.dart
+++ b/lib/features/consumption/data/obd2/elm327_protocol.dart
@@ -79,6 +79,19 @@ class Elm327Protocol {
   static const commandedEquivalenceRatioCommand =
       Elm327Commands.commandedEquivalenceRatioCommand;
   static const baroPressureCommand = Elm327Commands.baroPressureCommand;
+  static const shortTermFuelTrimBank2Command =
+      Elm327Commands.shortTermFuelTrimBank2Command;
+  static const longTermFuelTrimBank2Command =
+      Elm327Commands.longTermFuelTrimBank2Command;
+  static const absoluteLoadCommand = Elm327Commands.absoluteLoadCommand;
+  static const acceleratorPedalDCommand =
+      Elm327Commands.acceleratorPedalDCommand;
+  static const acceleratorPedalECommand =
+      Elm327Commands.acceleratorPedalECommand;
+  static const acceleratorPedalFCommand =
+      Elm327Commands.acceleratorPedalFCommand;
+  static const engineOilTempCommand = Elm327Commands.engineOilTempCommand;
+  static const ambientAirTempCommand = Elm327Commands.ambientAirTempCommand;
   static const fuelTypeCommand = Elm327Commands.fuelTypeCommand;
   static const vinCommand = Elm327Commands.vinCommand;
   static const mfgOdometerCatalog = Elm327Commands.mfgOdometerCatalog;
@@ -138,6 +151,30 @@ class Elm327Protocol {
 
   static double? parseLongTermFuelTrim(String raw) =>
       Elm327Parsers.parseLongTermFuelTrim(raw);
+
+  static double? parseShortTermFuelTrimBank2(String raw) =>
+      Elm327Parsers.parseShortTermFuelTrimBank2(raw);
+
+  static double? parseLongTermFuelTrimBank2(String raw) =>
+      Elm327Parsers.parseLongTermFuelTrimBank2(raw);
+
+  static double? parseAbsoluteLoad(String raw) =>
+      Elm327Parsers.parseAbsoluteLoad(raw);
+
+  static double? parseAcceleratorPedalD(String raw) =>
+      Elm327Parsers.parseAcceleratorPedalD(raw);
+
+  static double? parseAcceleratorPedalE(String raw) =>
+      Elm327Parsers.parseAcceleratorPedalE(raw);
+
+  static double? parseAcceleratorPedalF(String raw) =>
+      Elm327Parsers.parseAcceleratorPedalF(raw);
+
+  static double? parseEngineOilTempCelsius(String raw) =>
+      Elm327Parsers.parseEngineOilTempCelsius(raw);
+
+  static double? parseAmbientAirTempCelsius(String raw) =>
+      Elm327Parsers.parseAmbientAirTempCelsius(raw);
 
   static Set<int>? parseSupportedPidsBitmap(String raw, int groupBase) =>
       Elm327Parsers.parseSupportedPidsBitmap(raw, groupBase);

--- a/lib/features/consumption/data/obd2/fuel_rate_estimator.dart
+++ b/lib/features/consumption/data/obd2/fuel_rate_estimator.dart
@@ -222,21 +222,36 @@ double effectiveAfrForLambda(double stoichAfr, double? lambda) {
   return (afr: kPetrolAfr, densityGPerL: kPetrolDensityGPerL);
 }
 
-/// Pure-math fuel-trim correction factor (#813). Exposed for unit
-/// tests and for callers that already hold the trim values.
+/// Pure-math fuel-trim correction factor (#813, bank-2 #2458). Exposed
+/// for unit tests and for callers that already hold the trim values.
 ///
-/// Formula: `corrected = raw × (1 + (STFT + LTFT) / 100)`. Positive
-/// trims mean the ECU is enriching the mixture — real fuel flow is
-/// higher than what stoichiometric math predicts. Negative trims
-/// mean the opposite. Summing STFT and LTFT is standard practice
-/// (HEM Data's canonical formula); they capture fast and slow
-/// corrections respectively.
+/// Formula: `corrected = raw × (1 + meanTrim / 100)`, where `meanTrim`
+/// is the bank-averaged sum of short- + long-term trims. Positive trims
+/// mean the ECU is enriching the mixture — real fuel flow is higher than
+/// what stoichiometric math predicts. Negative trims mean the opposite.
+/// Summing STFT and LTFT is standard practice (HEM Data's canonical
+/// formula); they capture fast and slow corrections respectively.
+///
+/// #2458 — when the car exposes bank-2 trims ([stftBank2] / [ltftBank2],
+/// PIDs 08 / 09), the two banks' (STFT + LTFT) totals are averaged so a
+/// V / boxer engine running asymmetric correction (e.g. bank 1 +6 %,
+/// bank 2 −2 %) gets the true mean (+2 %) instead of only bank 1. Either
+/// bank-2 trim being null (inline engine, or it hasn't landed yet) falls
+/// back to the bank-1-only total — byte-for-byte the pre-#2458 result.
 double applyFuelTrimCorrection(
   double raw, {
   required double stft,
   required double ltft,
+  double? stftBank2,
+  double? ltftBank2,
 }) {
-  return raw * (1.0 + (stft + ltft) / 100.0);
+  final bank1Total = stft + ltft;
+  if (stftBank2 == null || ltftBank2 == null) {
+    return raw * (1.0 + bank1Total / 100.0);
+  }
+  final bank2Total = stftBank2 + ltftBank2;
+  final meanTotal = (bank1Total + bank2Total) / 2.0;
+  return raw * (1.0 + meanTotal / 100.0);
 }
 
 /// Linearly interpolates an η_v(rpm) curve (#1625) at engine speed

--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -72,6 +72,32 @@ class LiveSampleSnapshot {
   double? _latestLambda;
   double? _latestBaroKpa;
 
+  // #2458 — bank-2 fuel trims (PIDs 0x08 / 0x09). Fold into the MAF /
+  // speed-density trim correction on dual-bank (V / boxer) engines;
+  // null on inline engines, where the correction stays bank-1-only.
+  double? _latestStftBank2;
+  double? _latestLtftBank2;
+
+  // #2458 — absolute load (PID 0x43, a boosted-engine high-load proxy
+  // that can exceed 100 %) and accelerator-pedal position (PIDs 0x49 /
+  // 0x4A / 0x4B; the snapshot stores the max of whichever channels the
+  // car exposes). Both acquired + persisted here; the driving-style
+  // consumption of pedal is #2460.
+  double? _latestAbsLoadPercent;
+  // Per-channel pedal latches (PIDs 0x49 / 0x4A / 0x4B). The three track
+  // the same physical pedal; `latestPedalPercent` returns the max of the
+  // most-recent non-null channels (the least-damped reading) rather than
+  // a running max across callbacks, which could never decrease.
+  double? _latestPedalD;
+  double? _latestPedalE;
+  double? _latestPedalF;
+
+  // #2459 — optional diagnostic-context thermal signals: engine oil
+  // temperature (PID 0x5C) and ambient air temperature (PID 0x46). Null
+  // on cars that don't expose them.
+  double? _latestOilTempC;
+  double? _latestAmbientTempC;
+
   // #1374 phase 1 — most recent GPS fix, pushed in by the provider
   // when the `Feature.gpsTripPath` flag is enabled. The controller
   // does NOT subscribe to Geolocator itself — that decision lives at
@@ -105,6 +131,31 @@ class LiveSampleSnapshot {
   double? get latestLongitude => _latestLongitude;
   double? get latestAltitudeM => _latestAltitudeM;
   double? get latestOemFuelLevelLitres => _latestOemFuelLevelLitres;
+
+  // #2456 / #2458 / #2459 — latest-value getters for the signals the
+  // controller's `_emit` persists onto each TripSample (#2459). The
+  // raw mixture inputs (MAF / MAP / STFT / LTFT) are read here too so the
+  // diagnostic-capture path can stamp them for post-hoc re-derivation.
+  double? get latestLambda => _latestLambda;
+  double? get latestBaroKpa => _latestBaroKpa;
+  double? get latestAbsLoadPercent => _latestAbsLoadPercent;
+
+  /// Accelerator-pedal position (%) — the max of whichever of the three
+  /// channels (D / E / F, PIDs 0x49 / 0x4A / 0x4B) have landed (#2458).
+  /// Null until at least one channel reports.
+  double? get latestPedalPercent {
+    double? best;
+    for (final v in [_latestPedalD, _latestPedalE, _latestPedalF]) {
+      if (v != null && (best == null || v > best)) best = v;
+    }
+    return best;
+  }
+  double? get latestOilTempC => _latestOilTempC;
+  double? get latestAmbientTempC => _latestAmbientTempC;
+  double? get latestMaf => _latestMaf;
+  double? get latestMapKpa => _latestMapKpa;
+  double? get latestStft => _latestStft;
+  double? get latestLtft => _latestLtft;
 
   /// Push the most recent GPS fix into the per-tick snapshot
   /// (#1374 phase 1; altitude added #1935 child A). Pass `null` for a
@@ -175,7 +226,36 @@ class LiveSampleSnapshot {
       if (v != null) _latestThrottlePercent = v;
       _onHighPriorityParse(v);
     });
-    // #2458 slot: accelerator-pedal (0149/014A/014B) — driver intent, 5 Hz.
+    // #2458 — accelerator-pedal (0149/014A/014B) — driver intent, 5 Hz.
+    // Three channels track the same physical pedal; subscribe whichever
+    // the car exposes and keep the running max (the least-damped reading).
+    // All optionalPid-gated, so a car with none subscribes none and
+    // _latestPedalPercent stays null. Pedal is acquired + persisted here;
+    // the driving-style consumption is #2460.
+    _sub(scheduler, Elm327Protocol.acceleratorPedalDCommand,
+        hz: 5.0,
+        priority: PidPriority.high,
+        tier: PidTier.dynamics,
+        optionalPid: 0x49, (r) {
+      final v = Elm327Protocol.parseAcceleratorPedalD(r);
+      if (v != null) _latestPedalD = v;
+    });
+    _sub(scheduler, Elm327Protocol.acceleratorPedalECommand,
+        hz: 5.0,
+        priority: PidPriority.high,
+        tier: PidTier.dynamics,
+        optionalPid: 0x4A, (r) {
+      final v = Elm327Protocol.parseAcceleratorPedalE(r);
+      if (v != null) _latestPedalE = v;
+    });
+    _sub(scheduler, Elm327Protocol.acceleratorPedalFCommand,
+        hz: 5.0,
+        priority: PidPriority.high,
+        tier: PidTier.dynamics,
+        optionalPid: 0x4B, (r) {
+      final v = Elm327Protocol.parseAcceleratorPedalF(r);
+      if (v != null) _latestPedalF = v;
+    });
     //
     // The fuel-rate driver: subscribe whichever the car exposes (015E
     // direct → MAF → MAP speed-density) and let the snapshot derivation
@@ -223,7 +303,13 @@ class LiveSampleSnapshot {
       final v = Elm327Protocol.parseEngineLoad(r);
       if (v != null) _latestEngineLoadPercent = v;
     });
-    // #2458 slot: absolute load (0143), bank-2 fuel trims (0108/0109).
+    // #2458 — absolute load (0143). High-load proxy (>100 % on boosted
+    // engines); optionalPid-gated, acquired + persisted. Mixture tier.
+    _sub(scheduler, Elm327Protocol.absoluteLoadCommand,
+        hz: 2.0, tier: PidTier.mixture, optionalPid: 0x43, (r) {
+      final v = Elm327Protocol.parseAbsoluteLoad(r);
+      if (v != null) _latestAbsLoadPercent = v;
+    });
 
     // ---- SLOW-CORRECTION tier (~0.5 Hz, medium priority) -----------
     // Fuel trims + IAT drift slowly; the corrections only matter at the
@@ -237,6 +323,19 @@ class LiveSampleSnapshot {
         hz: 0.5, tier: PidTier.slowCorrection, (r) {
       final v = Elm327Protocol.parseLongTermFuelTrim(r);
       if (v != null) _latestLtft = v;
+    });
+    // #2458 — bank-2 fuel trims (0108/0109). Only dual-bank (V / boxer)
+    // engines expose them; optionalPid-gated, so inline engines never
+    // subscribe and the trim correction stays bank-1-only. Slow tier.
+    _sub(scheduler, Elm327Protocol.shortTermFuelTrimBank2Command,
+        hz: 0.5, tier: PidTier.slowCorrection, optionalPid: 0x08, (r) {
+      final v = Elm327Protocol.parseShortTermFuelTrimBank2(r);
+      if (v != null) _latestStftBank2 = v;
+    });
+    _sub(scheduler, Elm327Protocol.longTermFuelTrimBank2Command,
+        hz: 0.5, tier: PidTier.slowCorrection, optionalPid: 0x09, (r) {
+      final v = Elm327Protocol.parseLongTermFuelTrimBank2(r);
+      if (v != null) _latestLtftBank2 = v;
     });
     _sub(scheduler, Elm327Protocol.intakeAirTempCommand,
         hz: 0.5, tier: PidTier.slowCorrection, (r) {
@@ -268,8 +367,19 @@ class LiveSampleSnapshot {
       final v = Elm327Protocol.parseFuelLevelPercent(r);
       if (v != null) _latestFuelLevelPercent = v;
     });
-    // #2458 slot: oil temp (015C), ambient air (0146), control-module
-    // voltage (0142) — all thermal/context, all 0.1 Hz.
+    // #2459 — oil temp (015C) + ambient air (0146): optional
+    // diagnostic-context thermal signals. Both optionalPid-gated and
+    // persisted only when present; thermal tier, 0.1 Hz.
+    _sub(scheduler, Elm327Protocol.engineOilTempCommand,
+        hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext, (r) {
+      final v = Elm327Protocol.parseEngineOilTempCelsius(r);
+      if (v != null) _latestOilTempC = v;
+    }, optionalPid: 0x5C);
+    _sub(scheduler, Elm327Protocol.ambientAirTempCommand,
+        hz: 0.1, priority: PidPriority.low, tier: PidTier.thermalContext, (r) {
+      final v = Elm327Protocol.parseAmbientAirTempCelsius(r);
+      if (v != null) _latestAmbientTempC = v;
+    }, optionalPid: 0x46);
   }
 
   /// Register one tier subscription on [scheduler] (#2457). Centralises
@@ -524,13 +634,22 @@ class LiveSampleSnapshot {
   }
 
   /// Apply the STFT + LTFT correction used on the MAF / speed-density
-  /// branches (#813). Returns [raw] unchanged when either trim hasn't
-  /// landed yet — better an uncorrected estimate than one shifted by
-  /// half the real signal.
+  /// branches (#813; bank-2 #2458). Returns [raw] unchanged when either
+  /// bank-1 trim hasn't landed yet — better an uncorrected estimate than
+  /// one shifted by half the real signal. When the car also exposes
+  /// bank-2 trims (PIDs 0x08 / 0x09), they're folded in so dual-bank
+  /// engines get the bank-averaged correction; null bank-2 trims fall
+  /// back to bank-1-only (byte-for-byte the pre-#2458 result).
   double _applyTrim(double raw) {
     final stft = _latestStft;
     final ltft = _latestLtft;
     if (stft == null || ltft == null) return raw;
-    return Obd2Service.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+    return Obd2Service.applyFuelTrimCorrection(
+      raw,
+      stft: stft,
+      ltft: ltft,
+      stftBank2: _latestStftBank2,
+      ltftBank2: _latestLtftBank2,
+    );
   }
 }

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -1111,7 +1111,20 @@ class Obd2Service implements Obd2RawCommandPort {
     final stft = await readShortTermFuelTrimPercent();
     final ltft = await readLongTermFuelTrimPercent();
     if (stft == null || ltft == null) return raw;
-    return estimator.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+    // #2458 — fold in bank-2 trims (PIDs 08 / 09) when the car exposes
+    // them so dual-bank engines get the bank-averaged correction. Both
+    // supportsPid-gated; absent → null → bank-1-only, unchanged.
+    final stft2 =
+        isPidSupported(0x08) ? await readShortTermFuelTrimBank2Percent() : null;
+    final ltft2 =
+        isPidSupported(0x09) ? await readLongTermFuelTrimBank2Percent() : null;
+    return estimator.applyFuelTrimCorrection(
+      raw,
+      stft: stft,
+      ltft: ltft,
+      stftBank2: stft2,
+      ltftBank2: ltft2,
+    );
   }
 
   /// Pure-math fuel-trim correction factor (#813).
@@ -1123,8 +1136,16 @@ class Obd2Service implements Obd2RawCommandPort {
     double raw, {
     required double stft,
     required double ltft,
+    double? stftBank2,
+    double? ltftBank2,
   }) =>
-      estimator.applyFuelTrimCorrection(raw, stft: stft, ltft: ltft);
+      estimator.applyFuelTrimCorrection(
+        raw,
+        stft: stft,
+        ltft: ltft,
+        stftBank2: stftBank2,
+        ltftBank2: ltftBank2,
+      );
 
   /// Pure-math speed-density fuel-rate estimator (#800).
   ///
@@ -1211,6 +1232,32 @@ class Obd2Service implements Obd2RawCommandPort {
         Elm327Protocol.longTermFuelTrimCommand,
         Elm327Protocol.parseLongTermFuelTrim,
         label: 'longTermFuelTrim',
+      );
+
+  /// Read short-term fuel trim bank 2 (%) via Mode 01 PID 0x08 (#2458).
+  /// Only dual-bank (V / boxer) engines answer; inline engines return
+  /// null and the correction stays on bank 1 alone.
+  Future<double?> readShortTermFuelTrimBank2Percent() => _readDouble(
+        Elm327Protocol.shortTermFuelTrimBank2Command,
+        Elm327Protocol.parseShortTermFuelTrimBank2,
+        label: 'shortTermFuelTrimBank2',
+      );
+
+  /// Read long-term fuel trim bank 2 (%) via Mode 01 PID 0x09 (#2458).
+  /// Same dual-bank semantics as [readShortTermFuelTrimBank2Percent].
+  Future<double?> readLongTermFuelTrimBank2Percent() => _readDouble(
+        Elm327Protocol.longTermFuelTrimBank2Command,
+        Elm327Protocol.parseLongTermFuelTrimBank2,
+        label: 'longTermFuelTrimBank2',
+      );
+
+  /// Read absolute load value (%) via Mode 01 PID 0x43 (#2458). Exceeds
+  /// 100 % on boosted engines under positive manifold pressure — a clean
+  /// high-load proxy. Returns null when unsupported.
+  Future<double?> readAbsoluteLoadPercent() => _readDouble(
+        Elm327Protocol.absoluteLoadCommand,
+        Elm327Protocol.parseAbsoluteLoad,
+        label: 'absoluteLoad',
       );
 
   /// Read fuel tank level, 0–100 %. (#717)

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -167,6 +167,24 @@ class TripRecordingController {
   /// the app was killed before the disconnect-save timer fired.
   final bool _automatic;
 
+  /// Per-trip 'diagnostic capture' flag (#2459 — default off; an
+  /// internal/dev flag, not a user setting, wired from
+  /// `Feature.debugMode`). When ON, `_emit` ALSO stamps the raw mixture
+  /// inputs (MAF / MAP / STFT / LTFT) onto each persisted [TripSample]
+  /// at a SLOW cadence (every [_diagnosticCaptureInterval], carried
+  /// forward in between) so a trip's fuel rate can be re-derived
+  /// post-hoc. Default OFF ⇒ those four keys are never written ⇒ zero
+  /// storage growth for the overwhelming majority of trips.
+  final bool _diagnosticCapture;
+
+  /// Minimum wall-clock spacing between diagnostic-capture raw-input
+  /// stamps (#2459). The fuel-derivation signals drift slowly, so a
+  /// ~1 Hz sample is ample for post-hoc re-derivation and keeps the
+  /// extra payload roughly 1/4 the per-tick emit cadence. Timestamp of
+  /// the last stamp is tracked in [_lastDiagnosticCaptureAt].
+  static const Duration _diagnosticCaptureInterval = Duration(seconds: 1);
+  DateTime? _lastDiagnosticCaptureAt;
+
   /// Optional override — tests inject a hand-built scheduler (usually
   /// with a tiny [PidScheduler.tickRate] + a fake transport) to
   /// exercise the scheduler ↔ controller wiring without touching the
@@ -313,12 +331,14 @@ class TripRecordingController {
     Duration schedulerTickRate = const Duration(milliseconds: 100),
     String? pinnedAdapterMac,
     bool automatic = false,
+    bool diagnosticCapture = false,
     AdapterReconnectScanner? Function(
       String pinnedMac,
       VoidCallback onReconnect,
     )? reconnectScannerFactory,
     Obd2BreadcrumbRecorder? breadcrumbCollector,
   })  : _service = service,
+        _diagnosticCapture = diagnosticCapture,
         _recorder = recorder ??
             TripRecorder(
                 maxIntegrationGapSeconds: _integrationGapCapSeconds),
@@ -956,6 +976,16 @@ class TripRecordingController {
     final throttlePercent = snap.latestThrottlePercent;
     final engineLoadPercent = snap.latestEngineLoadPercent;
     final coolantTempC = snap.latestCoolantTempC;
+    // #2459 — should this tick ALSO carry the diagnostic-capture raw
+    // mixture inputs? Only when the per-trip flag is on AND we're past
+    // the slow-cadence interval since the last stamp; otherwise the four
+    // raw keys stay null (carried-forward = simply not re-written) so the
+    // payload doesn't balloon at the 4 Hz emit rate.
+    final captureRaw = _diagnosticCapture &&
+        (_lastDiagnosticCaptureAt == null ||
+            nowTs.difference(_lastDiagnosticCaptureAt!) >=
+                _diagnosticCaptureInterval);
+    if (captureRaw) _lastDiagnosticCaptureAt = nowTs;
     // The recorder integrates fuel rate and Δt itself, so we only
     // hand it one TripSample per emit — not per PID callback. At a
     // 250 ms emit cadence that's 4 Hz into the recorder, matching
@@ -978,6 +1008,23 @@ class TripRecordingController {
         latitude: snap.latestLatitude,
         longitude: snap.latestLongitude,
         altitudeM: snap.latestAltitudeM,
+        // #2459 — the consumed-but-previously-unstored signals, stamped
+        // from the snapshot latest-value getters exactly like throttle.
+        // Each stays null on cars that don't expose the PID, so the
+        // compact-key serialization writes zero bytes for them.
+        lambda: snap.latestLambda,
+        baroKpa: snap.latestBaroKpa,
+        absLoadPercent: snap.latestAbsLoadPercent,
+        pedalPercent: snap.latestPedalPercent,
+        oilTempC: snap.latestOilTempC,
+        ambientTempC: snap.latestAmbientTempC,
+        // #2459 — diagnostic-capture raw mixture inputs, only on the
+        // slow-cadence ticks while the flag is on (else null = not
+        // written). Each is independently null-safe per PID support.
+        mafGramsPerSecond: captureRaw ? snap.latestMaf : null,
+        mapKpa: captureRaw ? snap.latestMapKpa : null,
+        stft: captureRaw ? snap.latestStft : null,
+        ltft: captureRaw ? snap.latestLtft : null,
       );
       _recorder.onSample(sample);
       _lastSampleAt = nowTs;

--- a/lib/features/consumption/data/trip_sample_codec.dart
+++ b/lib/features/consumption/data/trip_sample_codec.dart
@@ -10,12 +10,14 @@ import '../domain/trip_recorder.dart';
 /// fuel-rate key (`'fe'`) joined the per-sample schema.
 ///
 /// Compact key names ('t','s','r','f','fe','th','el','ct','la','lo',
-/// 'al','ha','be','ag') keep per-trip JSON small — a 39-min trip × 1 Hz
-/// lands around 19 KB compressed at this density. The timestamp uses
-/// millisecondsSinceEpoch so the JSON parses fast and round-trips
-/// precisely. Every optional key is emitted only when its field is
-/// non-null, so trips written before each key landed deserialise with
-/// the field null.
+/// 'al','ha','be','ag', + #2459 'lm','bp','aL','pp','ot','am' and the
+/// diagnostic-capture raw inputs 'mf','mp','sf','lf') keep per-trip JSON
+/// small — a 39-min trip × 1 Hz lands around 19 KB compressed at this
+/// density. The timestamp uses millisecondsSinceEpoch so the JSON parses
+/// fast and round-trips precisely. Every optional key is emitted only
+/// when its field is non-null, so trips written before each key landed
+/// deserialise with the field null and a car that doesn't expose a PID
+/// (or a trip with the diagnostic-capture flag off) adds zero bytes.
 Map<String, dynamic> sampleToJson(TripSample s) => {
       't': s.timestamp.millisecondsSinceEpoch,
       's': s.speedKmh,
@@ -36,6 +38,21 @@ Map<String, dynamic> sampleToJson(TripSample s) => {
       if (s.hAccuracyM != null) 'ha': s.hAccuracyM,
       if (s.bearingDeg != null) 'be': s.bearingDeg,
       if (s.accelG != null) 'ag': s.accelG,
+      // #2459 — consumed-but-previously-unstored signals. Each guarded so
+      // a car without the PID adds zero bytes.
+      if (s.lambda != null) 'lm': s.lambda,
+      if (s.baroKpa != null) 'bp': s.baroKpa,
+      if (s.absLoadPercent != null) 'aL': s.absLoadPercent,
+      if (s.pedalPercent != null) 'pp': s.pedalPercent,
+      if (s.oilTempC != null) 'ot': s.oilTempC,
+      if (s.ambientTempC != null) 'am': s.ambientTempC,
+      // #2459 — diagnostic-capture raw mixture inputs. Present only when
+      // the per-trip 'diagnostic capture' flag was on AND the car exposed
+      // the PID; default-off trips and legacy trips carry none.
+      if (s.mafGramsPerSecond != null) 'mf': s.mafGramsPerSecond,
+      if (s.mapKpa != null) 'mp': s.mapKpa,
+      if (s.stft != null) 'sf': s.stft,
+      if (s.ltft != null) 'lf': s.ltft,
     };
 
 TripSample sampleFromJson(Map<String, dynamic> j) => TripSample(
@@ -57,4 +74,16 @@ TripSample sampleFromJson(Map<String, dynamic> j) => TripSample(
       hAccuracyM: (j['ha'] as num?)?.toDouble(),
       bearingDeg: (j['be'] as num?)?.toDouble(),
       accelG: (j['ag'] as num?)?.toDouble(),
+      // #2459 — missing key → null so legacy trips and cars without the
+      // PID deserialise cleanly.
+      lambda: (j['lm'] as num?)?.toDouble(),
+      baroKpa: (j['bp'] as num?)?.toDouble(),
+      absLoadPercent: (j['aL'] as num?)?.toDouble(),
+      pedalPercent: (j['pp'] as num?)?.toDouble(),
+      oilTempC: (j['ot'] as num?)?.toDouble(),
+      ambientTempC: (j['am'] as num?)?.toDouble(),
+      mafGramsPerSecond: (j['mf'] as num?)?.toDouble(),
+      mapKpa: (j['mp'] as num?)?.toDouble(),
+      stft: (j['sf'] as num?)?.toDouble(),
+      ltft: (j['lf'] as num?)?.toDouble(),
     );

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -4,137 +4,14 @@
 import 'dart:math' as math;
 
 import 'harsh_event_detector.dart';
+import 'trip_sample.dart';
 import 'trip_summary.dart';
 
-// TripSummary lives in its own file (#1927 — keeps this file under the
-// 400-line guard) but is re-exported so importers of `trip_recorder.dart`
-// still see it as one unit.
+// TripSummary (#1927) and TripSample (#2459) live in their own files to
+// keep this one under the 400-line guard, but are re-exported so
+// importers of `trip_recorder.dart` still see them as one unit.
+export 'trip_sample.dart';
 export 'trip_summary.dart';
-
-/// One OBD2 sample tick — captured by the polling loop and fed into
-/// [TripRecorder] for metric accumulation.
-class TripSample {
-  final DateTime timestamp;
-  final double speedKmh;
-  final double rpm;
-  final double? fuelRateLPerHour;
-
-  /// GPS-physics **estimated** fuel rate in L/h (#2431). Populated ONLY
-  /// for OBD2/hybrid trips whose adapter+ECU supported none of the fuel
-  /// PIDs (PID 5E / MAF 0110 / speed-density MAP 010B), so
-  /// [fuelRateLPerHour] is null on every sample. It is the per-sample
-  /// distribution of the trip's GPS-physics L/100 km estimate over the
-  /// sample's speed (`L/100 km / 100 × speedKmh`), letting the
-  /// trip-detail fuel-rate chart render a clearly-marked *estimated*
-  /// series instead of "Keine Messwerte". Deliberately a SEPARATE field
-  /// from [fuelRateLPerHour] so a measured value and an estimate are
-  /// never confused — when a real fuel PID was seen this stays null and
-  /// the chart shows the measured series. Null for legacy trips, for
-  /// trips that DID get a real fuel signal, and at a standstill (no
-  /// per-distance figure is meaningful at v ≈ 0).
-  final double? estimatedFuelRateLPerHour;
-
-  /// Throttle position in percent (PID 0x11), if available. Cars
-  /// without PID 11 report null — the trip-detail throttle / RPM
-  /// histogram falls back to the RPM axis only in that case (#1261).
-  final double? throttlePercent;
-
-  /// Calculated engine load in percent (PID 0x04). Null when the car
-  /// doesn't surface the PID. Persisted so post-trip insights can
-  /// distinguish "uphill at 60 km/h" (high load) from "flat at 60 km/h"
-  /// (low load) instead of inferring from RPM alone (#1262).
-  final double? engineLoadPercent;
-
-  /// Engine coolant temperature in °C (PID 0x05). Null when the car
-  /// doesn't surface the PID. Persisted so the cold-start surcharge
-  /// heuristic (#1262 phase 2) can flag trips whose ECT never reached
-  /// operating temperature — those burn proportionally more fuel for
-  /// warm-up.
-  final double? coolantTempC;
-
-  /// GPS latitude in degrees (#1374 phase 1). Null when the
-  /// `Feature.gpsTripPath` flag is disabled (default), when no fix has
-  /// landed yet (cold-start indoors), or when the user revoked the
-  /// location permission. Persisted so a future map overlay (Phase 2)
-  /// and a per-segment heatmap (Phase 3) can render the recorded
-  /// trip's path. Legacy samples from trips recorded before this PR
-  /// deserialise with `latitude: null`.
-  final double? latitude;
-
-  /// GPS longitude in degrees (#1374 phase 1). Same null-semantics as
-  /// [latitude]; the two fields are always written and read together
-  /// — a half-set fix is meaningless on a map.
-  final double? longitude;
-
-  /// GPS altitude in metres (#1935 child A — epic #1935). Same
-  /// null-semantics as [latitude]/[longitude]: null when the
-  /// `Feature.gpsTripPath` flag is off, before the first fix, or when
-  /// the platform reports no altitude. Captured so the road-grade
-  /// calculator (#1941) can derive the trip's slope.
-  final double? altitudeM;
-
-  /// Reported horizontal accuracy of the GPS fix in metres (#2019).
-  /// Lets downstream filters reject jittery fixes from urban-canyon
-  /// readings before they feed the speed-derivative accel pipeline
-  /// (#2022) or the post-trip map polyline. Null with the same
-  /// semantics as [latitude] — no fix means no accuracy.
-  final double? hAccuracyM;
-
-  /// Bearing in degrees from true north (#2019). Populated when the
-  /// platform supplies it; null otherwise. The trip-detail map can
-  /// render directional arrowheads off this, and the gear-inference
-  /// heuristic (#2023) uses bearing-stability to gate "is this
-  /// straight-line cruise" decisions.
-  final double? bearingDeg;
-
-  /// Acceleration magnitude in g (#2019). Populated by the
-  /// speed-derivative low-pass pipeline (#2022) when no real
-  /// accelerometer feed is wired up; future hardware integrations may
-  /// overwrite this from raw sensor data. Null on legacy samples and
-  /// when the speed series is too short to differentiate.
-  final double? accelG;
-
-  const TripSample({
-    required this.timestamp,
-    required this.speedKmh,
-    required this.rpm,
-    this.fuelRateLPerHour,
-    this.estimatedFuelRateLPerHour,
-    this.throttlePercent,
-    this.engineLoadPercent,
-    this.coolantTempC,
-    this.latitude,
-    this.longitude,
-    this.altitudeM,
-    this.hAccuracyM,
-    this.bearingDeg,
-    this.accelG,
-  });
-
-  /// Return a copy with [estimatedFuelRateLPerHour] replaced (#2431).
-  /// The OBD2 GPS-estimate fallback uses it to stamp the per-sample
-  /// estimated fuel-rate series onto an already-captured sample without
-  /// disturbing its measured speed / RPM / GPS fields. Only the one
-  /// field is overridable because that is the sole post-capture mutation
-  /// the fallback performs.
-  TripSample copyWithEstimatedFuelRate(double? estimatedFuelRateLPerHour) =>
-      TripSample(
-        timestamp: timestamp,
-        speedKmh: speedKmh,
-        rpm: rpm,
-        fuelRateLPerHour: fuelRateLPerHour,
-        estimatedFuelRateLPerHour: estimatedFuelRateLPerHour,
-        throttlePercent: throttlePercent,
-        engineLoadPercent: engineLoadPercent,
-        coolantTempC: coolantTempC,
-        latitude: latitude,
-        longitude: longitude,
-        altitudeM: altitudeM,
-        hAccuracyM: hAccuracyM,
-        bearingDeg: bearingDeg,
-        accelG: accelG,
-      );
-}
 
 /// Pure-logic accumulator that turns a stream of OBD2 [TripSample]s
 /// into a [TripSummary]. The Bluetooth polling loop feeds samples in

--- a/lib/features/consumption/domain/trip_sample.dart
+++ b/lib/features/consumption/domain/trip_sample.dart
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// One OBD2 sample tick — captured by the polling loop and fed into
+/// [TripRecorder] for metric accumulation.
+///
+/// Extracted from `trip_recorder.dart` (#2459 — keeps that file under the
+/// 400-line guard once six optional signals + the diagnostic-capture raw
+/// mixture inputs joined the per-tick schema) and re-exported from it so
+/// existing importers see it as one unit.
+class TripSample {
+  final DateTime timestamp;
+  final double speedKmh;
+  final double rpm;
+  final double? fuelRateLPerHour;
+
+  /// GPS-physics **estimated** fuel rate in L/h (#2431). Populated ONLY
+  /// for OBD2/hybrid trips whose adapter+ECU supported none of the fuel
+  /// PIDs (PID 5E / MAF 0110 / speed-density MAP 010B), so
+  /// [fuelRateLPerHour] is null on every sample. It is the per-sample
+  /// distribution of the trip's GPS-physics L/100 km estimate over the
+  /// sample's speed (`L/100 km / 100 × speedKmh`), letting the
+  /// trip-detail fuel-rate chart render a clearly-marked *estimated*
+  /// series instead of "Keine Messwerte". Deliberately a SEPARATE field
+  /// from [fuelRateLPerHour] so a measured value and an estimate are
+  /// never confused — when a real fuel PID was seen this stays null and
+  /// the chart shows the measured series. Null for legacy trips, for
+  /// trips that DID get a real fuel signal, and at a standstill (no
+  /// per-distance figure is meaningful at v ≈ 0).
+  final double? estimatedFuelRateLPerHour;
+
+  /// Throttle position in percent (PID 0x11), if available. Cars
+  /// without PID 11 report null — the trip-detail throttle / RPM
+  /// histogram falls back to the RPM axis only in that case (#1261).
+  final double? throttlePercent;
+
+  /// Calculated engine load in percent (PID 0x04). Null when the car
+  /// doesn't surface the PID. Persisted so post-trip insights can
+  /// distinguish "uphill at 60 km/h" (high load) from "flat at 60 km/h"
+  /// (low load) instead of inferring from RPM alone (#1262).
+  final double? engineLoadPercent;
+
+  /// Engine coolant temperature in °C (PID 0x05). Null when the car
+  /// doesn't surface the PID. Persisted so the cold-start surcharge
+  /// heuristic (#1262 phase 2) can flag trips whose ECT never reached
+  /// operating temperature — those burn proportionally more fuel for
+  /// warm-up.
+  final double? coolantTempC;
+
+  /// GPS latitude in degrees (#1374 phase 1). Null when the
+  /// `Feature.gpsTripPath` flag is disabled (default), when no fix has
+  /// landed yet (cold-start indoors), or when the user revoked the
+  /// location permission. Persisted so a future map overlay (Phase 2)
+  /// and a per-segment heatmap (Phase 3) can render the recorded
+  /// trip's path. Legacy samples from trips recorded before this PR
+  /// deserialise with `latitude: null`.
+  final double? latitude;
+
+  /// GPS longitude in degrees (#1374 phase 1). Same null-semantics as
+  /// [latitude]; the two fields are always written and read together
+  /// — a half-set fix is meaningless on a map.
+  final double? longitude;
+
+  /// GPS altitude in metres (#1935 child A — epic #1935). Same
+  /// null-semantics as [latitude]/[longitude]: null when the
+  /// `Feature.gpsTripPath` flag is off, before the first fix, or when
+  /// the platform reports no altitude. Captured so the road-grade
+  /// calculator (#1941) can derive the trip's slope.
+  final double? altitudeM;
+
+  /// Reported horizontal accuracy of the GPS fix in metres (#2019).
+  /// Lets downstream filters reject jittery fixes from urban-canyon
+  /// readings before they feed the speed-derivative accel pipeline
+  /// (#2022) or the post-trip map polyline. Null with the same
+  /// semantics as [latitude] — no fix means no accuracy.
+  final double? hAccuracyM;
+
+  /// Bearing in degrees from true north (#2019). Populated when the
+  /// platform supplies it; null otherwise. The trip-detail map can
+  /// render directional arrowheads off this, and the gear-inference
+  /// heuristic (#2023) uses bearing-stability to gate "is this
+  /// straight-line cruise" decisions.
+  final double? bearingDeg;
+
+  /// Acceleration magnitude in g (#2019). Populated by the
+  /// speed-derivative low-pass pipeline (#2022) when no real
+  /// accelerometer feed is wired up; future hardware integrations may
+  /// overwrite this from raw sensor data. Null on legacy samples and
+  /// when the speed series is too short to differentiate.
+  final double? accelG;
+
+  // ---- #2459 — consumed-but-previously-unstored signals -------------
+  // All optional; null on cars that don't expose the PID and on legacy
+  // trips. Each persists with an `if(!=null)` compact-key guard so a car
+  // without the PID adds zero bytes (see `trip_sample_codec.dart`).
+
+  /// Commanded equivalence ratio / λ (PID 0x44, #2456 / persisted #2459).
+  /// The ECU's real commanded mixture; feeds the effective-AFR fuel
+  /// refinement. Null when the car doesn't expose PID 0x44.
+  final double? lambda;
+
+  /// Absolute barometric pressure in kPa (PID 0x33, #2456 / persisted
+  /// #2459). Measured ambient air pressure (altitude / weather). Null
+  /// when the car doesn't expose PID 0x33.
+  final double? baroKpa;
+
+  /// Absolute load value in percent (PID 0x43, #2458). A boosted-engine
+  /// high-load proxy that can exceed 100 %. Null when unsupported.
+  final double? absLoadPercent;
+
+  /// Accelerator-pedal position in percent (PIDs 0x49/0x4A/0x4B, #2458).
+  /// The max of whichever pedal channels the car exposes — driver
+  /// intent. Null when none is supported.
+  final double? pedalPercent;
+
+  /// Engine oil temperature in °C (PID 0x5C, #2459). Optional thermal
+  /// context. Null when unsupported.
+  final double? oilTempC;
+
+  /// Ambient air temperature in °C (PID 0x46, #2459). Optional thermal
+  /// context (true outside air, vs the warmer IAT). Null when unsupported.
+  final double? ambientTempC;
+
+  // ---- #2459 — diagnostic-capture raw mixture inputs ----------------
+  // Stored ONLY when the per-trip 'diagnostic capture' flag is on
+  // (default off) so the raw inputs that derived the fuel rate can be
+  // re-derived post-hoc. Sampled at SLOW cadence (carried forward, not
+  // every 250 ms) so storage doesn't balloon. Null whenever the flag is
+  // off, on legacy trips, and on cars that don't expose the PID.
+
+  /// Mass air flow in g/s (PID 0x10) — diagnostic-capture raw input.
+  final double? mafGramsPerSecond;
+
+  /// Intake manifold absolute pressure in kPa (PID 0x0B) —
+  /// diagnostic-capture raw input.
+  final double? mapKpa;
+
+  /// Short-term fuel trim bank 1 in percent (PID 0x06) —
+  /// diagnostic-capture raw input.
+  final double? stft;
+
+  /// Long-term fuel trim bank 1 in percent (PID 0x07) —
+  /// diagnostic-capture raw input.
+  final double? ltft;
+
+  const TripSample({
+    required this.timestamp,
+    required this.speedKmh,
+    required this.rpm,
+    this.fuelRateLPerHour,
+    this.estimatedFuelRateLPerHour,
+    this.throttlePercent,
+    this.engineLoadPercent,
+    this.coolantTempC,
+    this.latitude,
+    this.longitude,
+    this.altitudeM,
+    this.hAccuracyM,
+    this.bearingDeg,
+    this.accelG,
+    this.lambda,
+    this.baroKpa,
+    this.absLoadPercent,
+    this.pedalPercent,
+    this.oilTempC,
+    this.ambientTempC,
+    this.mafGramsPerSecond,
+    this.mapKpa,
+    this.stft,
+    this.ltft,
+  });
+
+  /// Return a copy with [estimatedFuelRateLPerHour] replaced (#2431).
+  /// The OBD2 GPS-estimate fallback uses it to stamp the per-sample
+  /// estimated fuel-rate series onto an already-captured sample without
+  /// disturbing its measured speed / RPM / GPS / diagnostic fields. Only
+  /// the one field is overridable because that is the sole post-capture
+  /// mutation the fallback performs.
+  TripSample copyWithEstimatedFuelRate(double? estimatedFuelRateLPerHour) =>
+      TripSample(
+        timestamp: timestamp,
+        speedKmh: speedKmh,
+        rpm: rpm,
+        fuelRateLPerHour: fuelRateLPerHour,
+        estimatedFuelRateLPerHour: estimatedFuelRateLPerHour,
+        throttlePercent: throttlePercent,
+        engineLoadPercent: engineLoadPercent,
+        coolantTempC: coolantTempC,
+        latitude: latitude,
+        longitude: longitude,
+        altitudeM: altitudeM,
+        hAccuracyM: hAccuracyM,
+        bearingDeg: bearingDeg,
+        accelG: accelG,
+        lambda: lambda,
+        baroKpa: baroKpa,
+        absLoadPercent: absLoadPercent,
+        pedalPercent: pedalPercent,
+        oilTempC: oilTempC,
+        ambientTempC: ambientTempC,
+        mafGramsPerSecond: mafGramsPerSecond,
+        mapKpa: mapKpa,
+        stft: stft,
+        ltft: ltft,
+      );
+}

--- a/lib/features/consumption/providers/obd2_recording_pipeline.dart
+++ b/lib/features/consumption/providers/obd2_recording_pipeline.dart
@@ -35,17 +35,16 @@ import 'trip_recording_state.dart';
 /// owned [Obd2Service], the [TripRecordingController] + its live /
 /// stateChanges subscriptions, the adapter-identity snapshot (#1312), the
 /// one-shot capability-probe latch (#2261), and the auto-reconnect scanner
-/// factory (#797 / #2245). The four focused collaborators are *injected*
-/// from the notifier so they outlive a single recording and the test
-/// counters accumulate exactly as the inline fields did.
+/// factory (#797 / #2245). The focused collaborators are *injected* from
+/// the notifier so they outlive a single recording and the test counters
+/// accumulate exactly as the inline fields did.
 ///
 /// Deliberately NOT owned: the Riverpod `state`, the last-trip identity
-/// fields, the shared `_saveToHistory` write, and the #1303 active-trip WAL
-/// snapshot (+ its #1347 cold-start recovery) stay on the notifier and are
-/// reached through the [Obd2RecordingPipelineHost] — the WAL survives the
-/// recording loop being torn down (recovery runs with no pipeline at all),
-/// so it belongs to the notifier. Behaviour-preserving: the seed / flush
-/// cadence is driven through the same host hooks the inline path used.
+/// fields, `_saveToHistory`, and the #1303 active-trip WAL (+ #1347
+/// cold-start recovery) stay on the notifier, reached through the
+/// [Obd2RecordingPipelineHost] — the WAL survives the recording loop being
+/// torn down (recovery runs with no pipeline at all), so it belongs to the
+/// notifier. The seed / flush cadence is driven through the same host hooks.
 class Obd2RecordingPipeline implements RecordingPipeline {
   Obd2RecordingPipeline({
     required Ref ref,
@@ -56,6 +55,7 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     required TripOemFuelLevelController oemFuel,
     required VehicleProfile? Function() readActiveVehicle,
     required bool Function() readOemPidsFlag,
+    required bool Function() readDiagnosticCaptureFlag,
   })  : _ref = ref,
         _host = host,
         _haptics = haptics,
@@ -63,7 +63,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
         _baselines = baselines,
         _oemFuel = oemFuel,
         _readActiveVehicle = readActiveVehicle,
-        _readOemPidsFlag = readOemPidsFlag;
+        _readOemPidsFlag = readOemPidsFlag,
+        _readDiagnosticCaptureFlag = readDiagnosticCaptureFlag;
 
   final Ref _ref;
   final Obd2RecordingPipelineHost _host;
@@ -73,6 +74,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
   final TripOemFuelLevelController _oemFuel;
   final VehicleProfile? Function() _readActiveVehicle;
   final bool Function() _readOemPidsFlag;
+  // #2459 — per-trip diagnostic-capture flag (Feature.debugMode).
+  final bool Function() _readDiagnosticCaptureFlag;
 
   Obd2Service? _service;
   TripRecordingController? _controller;
@@ -126,23 +129,18 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     // controller can tag any pause-on-drop snapshot (#797 phase 1).
     final activeVehicle = _readActiveVehicle();
     final eagerVehicleId = _readActiveVehicle()?.id;
-    // #797 phase 3 — pass the pinned MAC + a factory for the auto-reconnect
-    // scanner. Null MAC (unpaired vehicle) skips the scanner entirely and
-    // leaves the grace-window path as the sole recovery mechanism.
+    // #797 phase 3 — pinned MAC + auto-reconnect scanner factory. Null MAC
+    // (unpaired) skips the scanner; the grace window is the sole recovery.
     final pinnedMac = activeVehicle?.obd2AdapterMac;
-    // #1395 — wire the diagnostic breadcrumb sink for this trip. Both
-    // the controller and the underlying [Obd2Service] push through the
-    // SAME notifier (kept keepAlive across recordings) so the user can
-    // inspect the trace from the overlay after the recording screen pops.
+    // #1395 — wire the diagnostic breadcrumb sink for this trip; both the
+    // controller and the [Obd2Service] push through the SAME keepAlive
+    // notifier so the trace survives the recording screen popping.
     final breadcrumbs = _ref.read(obd2BreadcrumbsProvider.notifier);
-    // Clear any leftover breadcrumbs from a prior trip — fresh
-    // suspicion-rate denominator for THIS recording.
-    breadcrumbs.clear();
+    breadcrumbs.clear(); // fresh suspicion-rate denominator for THIS trip
     service.breadcrumbCollector = breadcrumbs;
     // #1422 phase 1 — match the active vehicle to the bundled catalog so
-    // the controller can fall through to the engine-tech-derived η_v
-    // default instead of the legacy 0.85 literal until VeLearner
-    // converges. Null on no-vehicle / no-catalog / no-match.
+    // the controller can use the engine-tech-derived η_v default instead
+    // of the legacy 0.85 literal until VeLearner converges. Null on no-match.
     final matchedReference = _tryMatchReferenceVehicle(activeVehicle);
     final ctl = TripRecordingController(
       service: service,
@@ -151,6 +149,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       vehicleId: eagerVehicleId,
       pinnedAdapterMac: pinnedMac,
       automatic: automatic,
+      // #2459 — diagnostic capture (Feature.debugMode); default off.
+      diagnosticCapture: _readDiagnosticCaptureFlag(),
       reconnectScannerFactory: _buildReconnectScannerFactory(),
       breadcrumbCollector: breadcrumbs,
     );

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -389,6 +389,7 @@ class TripRecording extends _$TripRecording {
       oemFuel: _oemFuel,
       readActiveVehicle: _tryReadActiveVehicle,
       readOemPidsFlag: _readOemPidsFlag,
+      readDiagnosticCaptureFlag: _readDiagnosticCaptureFlag,
     );
     _pipeline = pipeline;
     await pipeline.start(service, automatic: automatic);
@@ -420,6 +421,23 @@ class TripRecording extends _$TripRecording {
       return ref
           .read(featureFlagsProvider.notifier)
           .isEnabled(Feature.experimentalOemPids);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: feature flags unavailable'}));
+      return false;
+    }
+  }
+
+  /// #2459 — read the per-trip 'diagnostic capture' flag from
+  /// `Feature.debugMode` (Developer mode). Not a user-facing consumption
+  /// setting: it's the dev/diagnostics gate, so the raw mixture inputs
+  /// are only persisted when a developer has explicitly enabled Developer
+  /// mode. Swallows provider-wiring errors the same way [_readOemPidsFlag]
+  /// does → safe default off.
+  bool _readDiagnosticCaptureFlag() {
+    try {
+      return ref
+          .read(featureFlagsProvider.notifier)
+          .isEnabled(Feature.debugMode);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {'where': 'TripRecording: feature flags unavailable'}));
       return false;

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'e5781f7ddad2e182c4cbcacdfa5e4053e43a85ea';
+String _$tripRecordingHash() => r'bf230afbcc50e3443c07b669fb236605007276b7';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/data/obd2/elm327_parsers_test.dart
+++ b/test/features/consumption/data/obd2/elm327_parsers_test.dart
@@ -994,4 +994,167 @@ void main() {
       expect(Elm327Parsers.parseFuelType('41 51'), isNull);
     });
   });
+
+  group('parseShortTermFuelTrimBank2 (PID 08) — #2458', () {
+    test('41 08 80 -> 0% (stoichiometric)', () {
+      expect(
+        Elm327Parsers.parseShortTermFuelTrimBank2('41 08 80'),
+        closeTo(0.0, 0.0001),
+      );
+    });
+
+    test('41 08 90 -> ~12.5% (same encoding as bank 1)', () {
+      expect(
+        Elm327Parsers.parseShortTermFuelTrimBank2('41 08 90'),
+        closeTo(12.5, 0.0001),
+      );
+    });
+
+    test('41 08 00 -> -100%', () {
+      expect(
+        Elm327Parsers.parseShortTermFuelTrimBank2('41 08 00'),
+        closeTo(-100.0, 0.0001),
+      );
+    });
+
+    test('wrong PID (06 bank-1) returns null — PID echo isolation', () {
+      expect(Elm327Parsers.parseShortTermFuelTrimBank2('41 06 80'), isNull);
+    });
+
+    test('NO DATA (inline engine) returns null', () {
+      expect(Elm327Parsers.parseShortTermFuelTrimBank2('NO DATA'), isNull);
+    });
+  });
+
+  group('parseLongTermFuelTrimBank2 (PID 09) — #2458', () {
+    test('41 09 80 -> 0% (stoichiometric)', () {
+      expect(
+        Elm327Parsers.parseLongTermFuelTrimBank2('41 09 80'),
+        closeTo(0.0, 0.0001),
+      );
+    });
+
+    test('41 09 78 -> -6.25%', () {
+      // (120-128)*100/128 = -8*100/128 = -6.25
+      expect(
+        Elm327Parsers.parseLongTermFuelTrimBank2('41 09 78'),
+        closeTo(-6.25, 0.0001),
+      );
+    });
+
+    test('wrong PID (07 bank-1) returns null — PID echo isolation', () {
+      expect(Elm327Parsers.parseLongTermFuelTrimBank2('41 07 80'), isNull);
+    });
+
+    test('NO DATA (inline engine) returns null', () {
+      expect(Elm327Parsers.parseLongTermFuelTrimBank2('NO DATA'), isNull);
+    });
+  });
+
+  group('parseAbsoluteLoad (PID 43) — #2458', () {
+    test('41 43 00 FF -> 100% (255 = full NA reference)', () {
+      // (256*0 + 255)*100/255 = 100
+      expect(
+        Elm327Parsers.parseAbsoluteLoad('41 43 00 FF'),
+        closeTo(100.0, 0.0001),
+      );
+    });
+
+    test('41 43 01 00 -> ~100.39% (boosted, exceeds 100%)', () {
+      // (256*1 + 0)*100/255 = 256*100/255 ≈ 100.392
+      expect(
+        Elm327Parsers.parseAbsoluteLoad('41 43 01 00'),
+        closeTo(100.3922, 0.001),
+      );
+    });
+
+    test('41 43 02 00 -> ~200.78% (heavy boost)', () {
+      // (512)*100/255 ≈ 200.784
+      expect(
+        Elm327Parsers.parseAbsoluteLoad('41 43 02 00'),
+        closeTo(200.784, 0.01),
+      );
+    });
+
+    test('41 43 00 00 -> 0%', () {
+      expect(Elm327Parsers.parseAbsoluteLoad('41 43 00 00'), 0.0);
+    });
+
+    test('wrong PID echo (04 engine load) returns null', () {
+      expect(Elm327Parsers.parseAbsoluteLoad('41 04 00 FF'), isNull);
+    });
+
+    test('short (1-byte) response returns null', () {
+      expect(Elm327Parsers.parseAbsoluteLoad('41 43 00'), isNull);
+    });
+
+    test('NO DATA returns null', () {
+      expect(Elm327Parsers.parseAbsoluteLoad('NO DATA'), isNull);
+    });
+  });
+
+  group('accelerator-pedal D/E/F (PIDs 49/4A/4B) — #2458', () {
+    test('41 49 FF -> 100%', () {
+      expect(
+        Elm327Parsers.parseAcceleratorPedalD('41 49 FF'),
+        closeTo(100.0, 0.0001),
+      );
+    });
+
+    test('41 49 80 -> ~50.2%', () {
+      // 128*100/255 ≈ 50.196
+      expect(
+        Elm327Parsers.parseAcceleratorPedalD('41 49 80'),
+        closeTo(50.196, 0.001),
+      );
+    });
+
+    test('41 4A 00 -> 0% (channel E)', () {
+      expect(Elm327Parsers.parseAcceleratorPedalE('41 4A 00'), 0.0);
+    });
+
+    test('41 4B FF -> 100% (channel F)', () {
+      expect(
+        Elm327Parsers.parseAcceleratorPedalF('41 4B FF'),
+        closeTo(100.0, 0.0001),
+      );
+    });
+
+    test('channel D parser rejects a channel-E echo (PID isolation)', () {
+      expect(Elm327Parsers.parseAcceleratorPedalD('41 4A 80'), isNull);
+    });
+
+    test('NO DATA returns null on every channel', () {
+      expect(Elm327Parsers.parseAcceleratorPedalD('NO DATA'), isNull);
+      expect(Elm327Parsers.parseAcceleratorPedalE('NO DATA'), isNull);
+      expect(Elm327Parsers.parseAcceleratorPedalF('NO DATA'), isNull);
+    });
+  });
+
+  group('engine-oil / ambient temp (PIDs 5C / 46) — #2459', () {
+    test('41 5C 5A -> 50°C (A - 40)', () {
+      expect(Elm327Parsers.parseEngineOilTempCelsius('41 5C 5A'), 50.0);
+    });
+
+    test('41 5C 28 -> 0°C', () {
+      expect(Elm327Parsers.parseEngineOilTempCelsius('41 5C 28'), 0.0);
+    });
+
+    test('41 46 32 -> 10°C ambient', () {
+      expect(Elm327Parsers.parseAmbientAirTempCelsius('41 46 32'), 10.0);
+    });
+
+    test('41 46 00 -> -40°C (coldest)', () {
+      expect(Elm327Parsers.parseAmbientAirTempCelsius('41 46 00'), -40.0);
+    });
+
+    test('oil-temp parser rejects an ambient echo (PID isolation)', () {
+      expect(Elm327Parsers.parseEngineOilTempCelsius('41 46 5A'), isNull);
+    });
+
+    test('NO DATA returns null', () {
+      expect(Elm327Parsers.parseEngineOilTempCelsius('NO DATA'), isNull);
+      expect(Elm327Parsers.parseAmbientAirTempCelsius('NO DATA'), isNull);
+    });
+  });
 }

--- a/test/features/consumption/data/obd2/fuel_rate_estimator_test.dart
+++ b/test/features/consumption/data/obd2/fuel_rate_estimator_test.dart
@@ -44,6 +44,47 @@ void main() {
     });
   });
 
+  group('applyFuelTrimCorrection bank 2 — #2458', () {
+    test('null bank-2 trims → bank-1-only (unchanged from pre-#2458)', () {
+      // Both null → exactly the bank-1 result.
+      expect(
+        applyFuelTrimCorrection(10.0,
+            stft: 6.0, ltft: 4.0, stftBank2: null, ltftBank2: null),
+        closeTo(applyFuelTrimCorrection(10.0, stft: 6.0, ltft: 4.0), 0.0001),
+      );
+    });
+
+    test('one bank-2 trim null → falls back to bank-1-only', () {
+      // STFT2 present but LTFT2 null → can\'t form a bank-2 total, so
+      // the correction stays bank-1-only.
+      expect(
+        applyFuelTrimCorrection(10.0,
+            stft: 6.0, ltft: 4.0, stftBank2: 0.0, ltftBank2: null),
+        closeTo(11.0, 0.001),
+      );
+    });
+
+    test('both banks present → bank-averaged total', () {
+      // Bank 1 total +10 % (6+4), bank 2 total -2 % (-1-1) →
+      // mean +4 % → factor 1.04.
+      expect(
+        applyFuelTrimCorrection(10.0,
+            stft: 6.0, ltft: 4.0, stftBank2: -1.0, ltftBank2: -1.0),
+        closeTo(10.4, 0.001),
+      );
+    });
+
+    test('symmetric banks → same as a single bank (mean = bank total)', () {
+      // Both banks +10 % → mean +10 % → factor 1.10, identical to the
+      // bank-1-only +10 % result.
+      expect(
+        applyFuelTrimCorrection(20.0,
+            stft: 6.0, ltft: 4.0, stftBank2: 6.0, ltftBank2: 4.0),
+        closeTo(22.0, 0.001),
+      );
+    });
+  });
+
   group('estimateFuelRateLPerHourFromMap — #800', () {
     test('Peugeot 107 cruise canonical reading: 2500 RPM, 65 kPa, '
         '30 °C → plausible 2.5–6 L/h', () {

--- a/test/features/consumption/data/obd2/live_sample_snapshot_subscription_test.dart
+++ b/test/features/consumption/data/obd2/live_sample_snapshot_subscription_test.dart
@@ -85,6 +85,15 @@ void main() {
     Elm327Protocol.engineFuelRateCommand, // 015E
     Elm327Protocol.commandedEquivalenceRatioCommand, // 0144
     Elm327Protocol.baroPressureCommand, // 0133
+    // #2458 / #2459 — newly-acquired optional PIDs.
+    Elm327Protocol.acceleratorPedalDCommand, // 0149
+    Elm327Protocol.acceleratorPedalECommand, // 014A
+    Elm327Protocol.acceleratorPedalFCommand, // 014B
+    Elm327Protocol.absoluteLoadCommand, // 0143
+    Elm327Protocol.shortTermFuelTrimBank2Command, // 0108
+    Elm327Protocol.longTermFuelTrimBank2Command, // 0109
+    Elm327Protocol.engineOilTempCommand, // 015C
+    Elm327Protocol.ambientAirTempCommand, // 0146
   };
 
   test(
@@ -112,7 +121,8 @@ void main() {
       'optional PID', () async {
     final all = <int>{
       0x0C, 0x0D, 0x11, 0x04, 0x0F, 0x05, 0x06, 0x07, 0x2F, // core
-      0x10, 0x0B, 0x5E, 0x44, 0x33, // optional
+      0x10, 0x0B, 0x5E, 0x44, 0x33, // optional (#2456 and earlier)
+      0x49, 0x4A, 0x4B, 0x43, 0x08, 0x09, 0x5C, 0x46, // #2458/#2459
     };
     final subscribed = await _subscribedCommands(all);
     expect(subscribed, containsAll(core));

--- a/test/features/consumption/data/obd2/obd2_service_maf_fallback_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_maf_fallback_test.dart
@@ -192,6 +192,43 @@ void main() {
     });
 
     test(
+        'MAF path folds in bank-2 trims when present — dual-bank engine '
+        'gets the bank-averaged correction (#2458)', () async {
+      // Bank 1 total +10 % (STFT +6 %, LTFT +4 %), bank 2 total -10 %
+      // (STFT -6 %, LTFT -4 %) → mean 0 % → factor 1.0 → raw MAF rate.
+      // 0x86 = +6.25 %, 0x80 = 0 %, 0x7A = -6.25 % approx; pick clean
+      // symmetric values: bank1 +6.25/+6.25, bank2 -6.25/-6.25 → mean 0.
+      final service = await _connected({
+        '015E': 'NO DATA>',
+        '0110': mafLine,
+        '0106': '41 06 88>', // STFT b1: (136-128)*100/128 = +6.25 %
+        '0107': '41 07 88>', // LTFT b1: +6.25 %
+        '0108': '41 08 78>', // STFT b2: (120-128)*100/128 = -6.25 %
+        '0109': '41 09 78>', // LTFT b2: -6.25 %
+      });
+      final rate = await service.readFuelRateLPerHour();
+      // Symmetric banks → mean trim 0 → no correction → raw petrol rate.
+      expect(rate, closeTo(3.389, 0.02));
+    });
+
+    test(
+        'inline engine (bank-2 NO DATA) → bank-1-only correction, '
+        'byte-for-byte the pre-#2458 result (#2458)', () async {
+      // Bank-1 +6.25/+6.25 = +12.5 % → factor 1.125. Bank-2 absent.
+      final withBank2 = await _connected({
+        '015E': 'NO DATA>',
+        '0110': mafLine,
+        '0106': '41 06 88>',
+        '0107': '41 07 88>',
+        '0108': 'NO DATA>', // inline engine: no bank 2
+        '0109': 'NO DATA>',
+      });
+      final rate = await withBank2.readFuelRateLPerHour();
+      // 3.389 × 1.125 ≈ 3.813.
+      expect(rate, closeTo(3.813, 0.03));
+    });
+
+    test(
         'nothing supported (5E / 10 / MAP / IAT / RPM all NO DATA) '
         'returns null — pre-#800 contract', () async {
       final service = await _connected({

--- a/test/features/consumption/data/obd2/trip_recording_controller_diagnostic_capture_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_diagnostic_capture_test.dart
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2458 / #2459 — end-to-end: the new PIDs flow scheduler → snapshot →
+/// `_emit` → captured TripSample. The six consumed-but-unstored signals
+/// are ALWAYS stamped (like throttle); the four raw mixture inputs are
+/// stamped only when the per-trip diagnostic-capture flag is on.
+
+const _init = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+  '01A6': 'NO DATA>',
+};
+
+/// A car that exposes the new PIDs. Speed-density path (no 5E / MAF) so
+/// the fuel branch still resolves and the raw MAP/IAT/RPM land too.
+const _richPidResponses = {
+  '010C': '41 0C 1A F8>', // RPM 1726
+  '010D': '41 0D 32>', // speed 50 km/h
+  '0111': '41 11 40>', // throttle ~25 %
+  '0110': '41 10 04 00>', // MAF 10.24 g/s (diagnostic raw input)
+  '010B': '41 0B 41>', // MAP 65 kPa (diagnostic raw input)
+  '010F': '41 0F 46>', // IAT 30 °C
+  '0106': '41 06 88>', // STFT +6.25 % (diagnostic raw input)
+  '0107': '41 07 84>', // LTFT +3.125 % (diagnostic raw input)
+  '0144': '41 44 80 00>', // λ 1.0
+  '0133': '41 33 5F>', // baro 95 kPa
+  '0143': '41 43 01 00>', // absolute load ~100.4 % (boosted proxy)
+  '0149': '41 49 99>', // pedal D ~60 %
+  '015C': '41 5C 6E>', // oil temp 70 °C
+  '0146': '41 46 32>', // ambient 10 °C
+};
+
+Future<Obd2Service> _service() async {
+  final svc = Obd2Service(FakeObd2Transport({..._init, ..._richPidResponses}));
+  await svc.connect();
+  return svc;
+}
+
+/// Run the controller's scheduler long enough for the new PIDs to land,
+/// then capture one emit and return the captured sample.
+Future<TripSample> _captureOneSample({required bool diagnosticCapture}) async {
+  final svc = await _service();
+  final ctl = TripRecordingController(
+    service: svc,
+    pollInterval: const Duration(minutes: 1), // no auto-tick
+    schedulerTickRate: const Duration(milliseconds: 2),
+    diagnosticCapture: diagnosticCapture,
+  );
+  await ctl.start();
+  // Let the weighted round-robin read each newly-subscribed PID at least
+  // once (all start with lastReadAt == null → infinite weight).
+  await Future<void>.delayed(const Duration(milliseconds: 400));
+  ctl.debugEmitNow();
+  final samples = ctl.capturedSamples;
+  expect(samples, isNotEmpty, reason: 'an emit with speed/rpm must capture');
+  final sample = samples.last;
+  await ctl.stop();
+  return sample;
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('#2459 _emit stamps the consumed-but-unstored signals', () {
+    test('λ / baro / absLoad / pedal / oil / ambient are stamped '
+        '(capture flag OFF — they are always persisted)', () async {
+      final s = await _captureOneSample(diagnosticCapture: false);
+      expect(s.lambda, closeTo(1.0, 0.001));
+      expect(s.baroKpa, 95.0);
+      expect(s.absLoadPercent, greaterThan(100.0)); // boosted proxy
+      expect(s.pedalPercent, closeTo(60.0, 1.0));
+      expect(s.oilTempC, 70.0);
+      expect(s.ambientTempC, 10.0);
+    });
+
+    test('with capture OFF the raw mixture inputs stay null '
+        '(zero storage growth)', () async {
+      final s = await _captureOneSample(diagnosticCapture: false);
+      expect(s.mafGramsPerSecond, isNull);
+      expect(s.mapKpa, isNull);
+      expect(s.stft, isNull);
+      expect(s.ltft, isNull);
+    });
+
+    test('with capture ON the raw mixture inputs are stamped', () async {
+      final s = await _captureOneSample(diagnosticCapture: true);
+      expect(s.mafGramsPerSecond, closeTo(10.24, 0.1));
+      expect(s.mapKpa, 65.0);
+      expect(s.stft, closeTo(6.25, 0.1));
+      expect(s.ltft, closeTo(3.125, 0.1));
+      // The consumed-but-unstored signals are still present too.
+      expect(s.lambda, closeTo(1.0, 0.001));
+      expect(s.pedalPercent, closeTo(60.0, 1.0));
+    });
+  });
+
+  group('a car WITHOUT the new PIDs stores nothing extra (#2458/#2459)', () {
+    test('all new signals + raw inputs null even with capture ON', () async {
+      // Minimal car: only RPM + speed answer; everything else NO DATA.
+      final svc = Obd2Service(FakeObd2Transport({
+        ..._init,
+        '010C': '41 0C 1A F8>',
+        '010D': '41 0D 32>',
+      }));
+      await svc.connect();
+      final ctl = TripRecordingController(
+        service: svc,
+        pollInterval: const Duration(minutes: 1),
+        schedulerTickRate: const Duration(milliseconds: 2),
+        diagnosticCapture: true, // even with capture ON
+      );
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+      ctl.debugEmitNow();
+      final s = ctl.capturedSamples.last;
+      await ctl.stop();
+      expect(s.lambda, isNull);
+      expect(s.baroKpa, isNull);
+      expect(s.absLoadPercent, isNull);
+      expect(s.pedalPercent, isNull);
+      expect(s.oilTempC, isNull);
+      expect(s.ambientTempC, isNull);
+      expect(s.mafGramsPerSecond, isNull);
+      expect(s.mapKpa, isNull);
+      expect(s.stft, isNull);
+      expect(s.ltft, isNull);
+    });
+  });
+}

--- a/test/features/consumption/data/trip_sample_codec_test.dart
+++ b/test/features/consumption/data/trip_sample_codec_test.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/trip_sample_codec.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #2459 — the consumed-but-previously-unstored signals + the
+/// diagnostic-capture raw mixture inputs round-trip through the compact
+/// codec, add ZERO bytes when absent, and deserialise as null on legacy
+/// trips.
+void main() {
+  final ts = DateTime(2026, 5, 30, 12);
+
+  group('#2459 new optional signals — round-trip', () {
+    test('all six consumed-but-unstored signals round-trip', () {
+      final s = TripSample(
+        timestamp: ts,
+        speedKmh: 80,
+        rpm: 2100,
+        fuelRateLPerHour: 5.5,
+        lambda: 1.12,
+        baroKpa: 97.0,
+        absLoadPercent: 142.0, // boosted, >100 %
+        pedalPercent: 63.0,
+        oilTempC: 88.0,
+        ambientTempC: 11.0,
+      );
+      final back = sampleFromJson(sampleToJson(s));
+      expect(back.lambda, 1.12);
+      expect(back.baroKpa, 97.0);
+      expect(back.absLoadPercent, 142.0);
+      expect(back.pedalPercent, 63.0);
+      expect(back.oilTempC, 88.0);
+      expect(back.ambientTempC, 11.0);
+    });
+
+    test('absent signals add ZERO keys (zero bytes when unsupported)', () {
+      final s = TripSample(timestamp: ts, speedKmh: 50, rpm: 1500);
+      final json = sampleToJson(s);
+      for (final key in ['lm', 'bp', 'aL', 'pp', 'ot', 'am']) {
+        expect(json.containsKey(key), isFalse,
+            reason: '$key must be omitted when the field is null');
+      }
+      // And those round-trip back as null.
+      final back = sampleFromJson(json);
+      expect(back.lambda, isNull);
+      expect(back.baroKpa, isNull);
+      expect(back.absLoadPercent, isNull);
+      expect(back.pedalPercent, isNull);
+      expect(back.oilTempC, isNull);
+      expect(back.ambientTempC, isNull);
+    });
+
+    test('a legacy sample (no new keys) deserialises every field null', () {
+      // Hand-built legacy payload: only the pre-#2459 keys.
+      final legacy = <String, dynamic>{
+        't': ts.millisecondsSinceEpoch,
+        's': 60.0,
+        'r': 1700.0,
+        'th': 25.0,
+      };
+      final back = sampleFromJson(legacy);
+      expect(back.speedKmh, 60.0);
+      expect(back.throttlePercent, 25.0);
+      expect(back.lambda, isNull);
+      expect(back.absLoadPercent, isNull);
+      expect(back.pedalPercent, isNull);
+      expect(back.mafGramsPerSecond, isNull);
+      expect(back.stft, isNull);
+    });
+  });
+
+  group('#2459 diagnostic-capture raw mixture inputs', () {
+    test('raw inputs round-trip when present (capture on)', () {
+      final s = TripSample(
+        timestamp: ts,
+        speedKmh: 80,
+        rpm: 2100,
+        mafGramsPerSecond: 12.4,
+        mapKpa: 78.0,
+        stft: 3.5,
+        ltft: -1.5,
+      );
+      final json = sampleToJson(s);
+      expect(json['mf'], 12.4);
+      expect(json['mp'], 78.0);
+      expect(json['sf'], 3.5);
+      expect(json['lf'], -1.5);
+      final back = sampleFromJson(json);
+      expect(back.mafGramsPerSecond, 12.4);
+      expect(back.mapKpa, 78.0);
+      expect(back.stft, 3.5);
+      expect(back.ltft, -1.5);
+    });
+
+    test('capture OFF (raw inputs null) writes NO raw-input keys', () {
+      // A normal default-off trip: the six new signals may be present,
+      // but the four raw-input keys must be absent → no storage growth.
+      final s = TripSample(
+        timestamp: ts,
+        speedKmh: 80,
+        rpm: 2100,
+        fuelRateLPerHour: 5.5,
+        lambda: 1.0,
+      );
+      final json = sampleToJson(s);
+      for (final key in ['mf', 'mp', 'sf', 'lf']) {
+        expect(json.containsKey(key), isFalse,
+            reason: '$key must be omitted when diagnostic capture is off');
+      }
+    });
+  });
+}

--- a/test/features/consumption/providers/obd2_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/obd2_recording_pipeline_test.dart
@@ -209,6 +209,7 @@ final _pipelineProvider =
     oemFuel: TripOemFuelLevelController(),
     readActiveVehicle: () => null,
     readOemPidsFlag: () => false,
+    readDiagnosticCaptureFlag: () => false,
   ),
 );
 

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -62,7 +62,13 @@ void main() {
     // (PID 0x44, commanded λ), each with their dartdoc, so the
     // fuel-rate estimator can use the ECU's real mixture + ambient
     // air-density instead of the assumed-stoich AFR / sea-level pressure.
-    'lib/features/consumption/data/obd2/elm327_parsers.dart': 481,
+    // #2458/#2459 — re-grandfathered 481 → 538: nine new pure parsers,
+    // each with dartdoc — bank-2 trims (0x08/0x09), absolute load (0x43),
+    // accelerator-pedal D/E/F (0x49/0x4A/0x4B), engine-oil (0x5C) +
+    // ambient-air (0x46) temps. All trivial decoders reusing the existing
+    // `_parseFuelTrim` / `_parse1BytePercent` / `_parseModeOneBody`
+    // plumbing. Decomposition tracked separately by #2187/#2188.
+    'lib/features/consumption/data/obd2/elm327_parsers.dart': 538,
     // #2456 — re-grandfathered 471 → 524: the live integrator gained λ
     // (PID 0x44, 2 Hz) + baro (PID 0x33, 0.5 Hz) supportsPid-gated
     // subscriptions and threads both into the MAF + speed-density fuel
@@ -74,7 +80,14 @@ void main() {
     // is a one-line tier assignment, with #2458 tier slots commented in.
     // Net +9 is the helper + its dartdoc, not new branching. Decomposition
     // is tracked separately by #2187/#2188.
-    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 533,
+    // #2458/#2459 — re-grandfathered 533 → 652: filled the #2457 tier
+    // slots with nine supportsPid-gated subscriptions (pedal D/E/F →
+    // dynamics, abs-load → mixture, bank-2 trims → slow, oil + ambient →
+    // thermal) + their latches and latest-value getters that `_emit`
+    // persists onto each TripSample (#2459), + the bank-2 fold into
+    // `_applyTrim`. Each is a one-line `_sub` call carrying its own gate.
+    // Decomposition is tracked separately by #2187/#2188.
+    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 652,
     // #2379 — re-grandfathered 1457 → 1468: threaded the
     // `logFailureAsError` flag through `connect()` (param + doc + the
     // guarded `if` around the now-conditional connect-failed trace) so a
@@ -93,7 +106,12 @@ void main() {
     // `Obd2DebugSessionRecorder.recordHandshakeCommand` calls (all
     // `if(!enabled)`-gated, no-op in prod). Decomposition tracked by
     // #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1552,
+    // #2458 — re-grandfathered 1552 → 1599: bank-2 trim folded into
+    // `_applyFuelTrimCorrection` (supportsPid-gated PIDs 0x08/0x09) + the
+    // updated `applyFuelTrimCorrection` static forwarder + three new read
+    // helpers (bank-2 STFT/LTFT, absolute load 0x43). Decomposition tracked
+    // by #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1599,
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb
@@ -101,7 +119,12 @@ void main() {
     // (matching the #2379/#2424 precedent in this same map). Net +6: the
     // explanatory rationale, not behaviour. Decomposition of this god-class
     // is tracked under #2187/#2188/#2190.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1241,
+    // #2459 — re-grandfathered 1241 → 1288: the per-trip 'diagnostic
+    // capture' flag (field + dartdoc + slow-cadence interval/guard) and
+    // the `_emit` stamping of the six consumed-but-unstored signals
+    // (λ/baro/absLoad/pedal/oil/ambient) + the slow-cadence raw mixture
+    // inputs (MAF/MAP/STFT/LTFT). Decomposition tracked by #2187/#2188/#2190.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1288,
     // #2442 — re-grandfathered 496 → 513: the save flow now raises the
     // guided reconciliation workflow after a plein save (a 7-line
     // await-then-route call into the extracted
@@ -154,7 +177,11 @@ void main() {
     // call + the `_calibratePhysicsScale` resolve/persist helper; the EWMA
     // math itself lives in the standalone `PhysicsScaleCalibrator`).
     // Decomposition of this god-class is tracked under #2187/#2188/#2190.
-    'lib/features/consumption/providers/trip_recording_provider.dart': 1162,
+    // #2459 — re-grandfathered 1162 → 1180: the `_readDiagnosticCaptureFlag`
+    // closure (mirrors `_readOemPidsFlag`: reads Feature.debugMode, swallows
+    // provider-wiring errors → safe off) + its injection into the pipeline.
+    // Decomposition tracked by #2187/#2188/#2190.
+    'lib/features/consumption/providers/trip_recording_provider.dart': 1180,
     'lib/features/feature_management/data/legacy_toggle_migrator.dart': 647,
     'lib/features/map/presentation/widgets/station_map_layers.dart': 544,
     // #2382 — +5 for Feature.approachOverlay's three per-feature switch


### PR DESCRIPTION
Two aggregated children of Epic #2455 as one coherent PR — acquire the
high-value driving/consumption PIDs (#2458), then persist the
consumed-but-unstored signals behind compact `if(!=null)` keys + a
per-trip diagnostic-capture flag (#2459). Built off latest master
(post-#2456 λ/baro, #2457 tiered scheduler, #2479 comm-diagnostics).

## #2458 — acquire pedal / abs-load / bank-2 trims
New parsers + command constants + `Elm327Protocol` facade forwarders
(mirroring #2456):
- **accelerator pedal** `0149/014A/014B` (A·100/255) — DYNAMICS tier
  ~5 Hz; the snapshot subscribes whichever channels exist and exposes
  `pedal = max(D,E,F)` (driver intent; consumption is #2460).
- **absolute load** `0143` ((256A+B)·100/255, >100 % on boost) —
  MIXTURE tier ~2 Hz; high-load proxy.
- **bank-2 STFT/LTFT** `0108/0109` ((A−128)·100/128) — SLOW-CORRECTION
  tier ~0.5 Hz.
- **oil/ambient temp** `015C/0146` (A−40) — THERMAL tier ~0.1 Hz
  (optional context for #2459).

All subscriptions go through the #2457 `_sub` `optionalPid` gate, so a
car lacking a PID never subscribes and stores nothing extra.

**Use:** `applyFuelTrimCorrection` now takes optional bank-2 STFT/LTFT
and averages the two banks' totals (null bank-2 → byte-for-byte the
bank-1-only result), threaded through both `live_sample_snapshot._applyTrim`
and the pull-mode `Obd2Service._applyFuelTrimCorrection`. 0143 is an
available high-load proxy.

## #2459 — persist the consumed-but-unstored signals
Optional nullable `TripSample` fields with compact keys + `if(!=null)`
guards (zero bytes when absent): λ `lm`, baro `bp`, absLoad `aL`, pedal
`pp`, oilTemp `ot`, ambient `am`. `_emit` stamps them from the snapshot
latest-value getters exactly like throttle.

Per-trip **diagnostic-capture flag** (default OFF; internal/dev, wired
from `Feature.debugMode`): when on, `_emit` ALSO stores raw mixture
inputs MAF `mf` / MAP `mp` / STFT `sf` / LTFT `lf` at a slow (~1 Hz,
carried-forward) cadence for post-hoc re-derivation. Default off ⇒ those
four keys are never written ⇒ zero storage growth.

`TripSample` extracted to `trip_sample.dart` (re-exported from
`trip_recorder.dart`) to stay under the 400-line guard; the codec
read+write round-trips every new key and legacy trips deserialise them
as null.

## Tests
Parser decode + PID-echo isolation for every new PID; bank-2 trim
correction (null/one-null fallback, bank-averaged, symmetric=single);
MAF-branch bank-2 fold applied vs inline fallback; subscription gate
(basic car subscribes none, capable/blind subscribes all); codec
round-trip + zero-keys-when-absent + legacy-null; end-to-end controller
scheduler→snapshot→`_emit` stamping with diagnostic-capture on/off; a car
WITHOUT the new PIDs stores nothing extra even with capture ON.

No-PID cars are unchanged · zero ARB drift · codegen committed
(`trip_recording_provider.g.dart` hash). `flutter analyze` clean.

Closes #2458
Closes #2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
