### PR TITLE
feat(obd2): diagnostics — channel/reconnect lifecycle + byte-channel framing counters (#2466, #2467)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
+++ b/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'obd2_comm_diagnostics.dart';
 import '../../../../core/logging/error_logger.dart';
 
 /// Callback signature: "is the pinned adapter MAC currently
@@ -95,6 +96,21 @@ class AdapterReconnectScanner {
   /// uses the cheap passive wait instead of an active scan (#2261).
   bool _passiveMode = false;
 
+  /// #2466 — measures elapsed time from [start] to the successful
+  /// reconnect, fed into the gated comm-diagnostics time-to-reconnect
+  /// reservoir. Null until [start] (and only allocated when the collector
+  /// is armed, so production pays nothing).
+  Stopwatch? _sinceStart;
+
+  /// #2466 — whether the backoff has escalated past its initial value
+  /// during this drop episode. Drives the silent-vs-visible reconnect
+  /// classification: a reconnect that lands before the first escalation
+  /// (the fast `firstProbeDelay` probe / first attempt) is SILENT — it
+  /// healed inside the controller's grace window and the user never saw a
+  /// banner; one that lands after any escalation (or in passive mode) is
+  /// VISIBLE.
+  bool _backoffEscalated = false;
+
   AdapterReconnectScanner({
     required String pinnedMac,
     required AdapterInRangeProbe probe,
@@ -148,6 +164,12 @@ class AdapterReconnectScanner {
   Future<void> start() async {
     if (_scanning) return;
     _scanning = true;
+    // #2466 — start the time-to-reconnect clock (gated; only allocate the
+    // Stopwatch when the collector is armed). The episode begins now: the
+    // controller constructs + starts the scanner the moment a drop fires.
+    _backoffEscalated = false;
+    _sinceStart =
+        Obd2CommDiagnostics.instance.enabled ? (Stopwatch()..start()) : null;
     // #1991 — first probe fast (a transient drop recovers quickest with
     // a near-immediate retry); subsequent misses fall back to the
     // exponential backoff via `_scheduleNext`.
@@ -201,6 +223,7 @@ class AdapterReconnectScanner {
         // re-enter the scanner (e.g. start a new one on the next
         // drop) without clashing with a stale timer.
         await stop();
+        _noteReconnectDiagnostics();
         _onReconnect();
         return;
       }
@@ -220,6 +243,10 @@ class AdapterReconnectScanner {
     if (!_scanning) return; // stop() raced during the passive wait
     if (ok) {
       await stop();
+      // A passive-mode reconnect is by definition VISIBLE — it only
+      // happens past the active-scan miss ceiling, long after the
+      // silent-reconnect grace window closed.
+      _noteReconnectDiagnostics();
       _onReconnect();
       return;
     }
@@ -240,6 +267,7 @@ class AdapterReconnectScanner {
       // ceiling so the passive-wait re-arm is paced, and run the first
       // passive wait promptly.
       _passiveMode = true;
+      _backoffEscalated = true; // #2466 — past the ceiling ⇒ visible
       _currentBackoff = _maxBackoff;
       _timer?.cancel();
       _timer = Timer(_firstProbeDelay, _runCycle);
@@ -272,5 +300,30 @@ class AdapterReconnectScanner {
   void _doubleBackoff() {
     final next = _currentBackoff * 2;
     _currentBackoff = next > _maxBackoff ? _maxBackoff : next;
+    // #2466 — the episode has now lasted past at least one missed cycle,
+    // so a reconnect from here on is VISIBLE (it landed after the fast
+    // first probe failed and the backoff grew).
+    _backoffEscalated = true;
+  }
+
+  /// #2466 — record one successful reconnect into the gated comm-health
+  /// collector: a silent-vs-visible tally plus the time-to-reconnect
+  /// measured from [start]. A no-op unless `Feature.debugMode` armed the
+  /// collector (the Stopwatch is only allocated then). Called once, right
+  /// before [_onReconnect] fires, after the scanner has self-stopped.
+  void _noteReconnectDiagnostics() {
+    final diag = Obd2CommDiagnostics.instance;
+    if (!diag.enabled) return;
+    final elapsed = _sinceStart?.elapsedMilliseconds;
+    _sinceStart = null;
+    // Silent ⇒ recovered before the backoff ever escalated (the fast
+    // firstProbeDelay probe / first attempt healed it inside the grace
+    // window); visible ⇒ it took at least one backoff step or passive mode.
+    final silent = !_backoffEscalated;
+    diag.noteConnectionEvent(
+      silentReconnect: silent,
+      visibleReconnect: !silent,
+      timeToReconnectMs: elapsed,
+    );
   }
 }

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -58,6 +58,7 @@ class ClassicElmChannel implements ElmByteChannel {
     final bool ok;
     try {
       ok = await _plugin.connect(address: address, uuid: sppUuid);
+      // ignore: catch_no_st — rethrow-only: the original stack is preserved by rethrow
     } catch (e) {
       // A thrown platform error during the RFCOMM open (bonding,
       // permissions). Bin coarsely, then rethrow unchanged.

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
+import 'obd2_comm_diagnostics.dart';
 import '../../../../core/logging/error_logger.dart';
 
 /// Standard Bluetooth Serial Port Profile UUID (#761). Every
@@ -46,23 +47,65 @@ class ClassicElmChannel implements ElmByteChannel {
   @override
   Future<void> open() async {
     if (_open) return;
-    final ok = await _plugin.connect(address: address, uuid: sppUuid);
+    // #2466 — gated comm-diagnostics connect-lifecycle tee. A no-op
+    // unless Feature.debugMode armed the collector; each call
+    // early-returns on `!enabled`, so production pays one cached-bool
+    // read per event.
+    final diag = Obd2CommDiagnostics.instance;
+    final connectSw = diag.enabled ? (Stopwatch()..start()) : null;
+    if (diag.enabled) diag.noteConnectionEvent(attempt: true);
+
+    final bool ok;
+    try {
+      ok = await _plugin.connect(address: address, uuid: sppUuid);
+    } catch (e) {
+      // A thrown platform error during the RFCOMM open (bonding,
+      // permissions). Bin coarsely, then rethrow unchanged.
+      if (diag.enabled) {
+        diag.noteConnectionEvent(
+          failureReason: _classifyClassicConnectFailure(e),
+        );
+      }
+      rethrow;
+    }
     if (!ok) {
+      // The plugin reported a clean RFCOMM-open failure (false, not a
+      // throw): the adapter is unbonded or out of range.
+      if (diag.enabled) {
+        diag.noteConnectionEvent(failureReason: 'rfcomm-open-fail');
+      }
       throw StateError(
         'ClassicElmChannel: failed to open RFCOMM socket to $address '
         '(plugin returned false). Adapter may not be bonded or is out '
         'of range.',
       );
     }
+    if (connectSw != null) {
+      connectSw.stop();
+      diag.noteConnectionEvent(
+        success: true,
+        timeToConnectMs: connectSw.elapsedMilliseconds,
+      );
+    }
     _subscription = _plugin.incoming.listen(
-      _incoming.add,
+      (bytes) {
+        // #2467 — tee the raw chunk into the gated comm-diagnostics
+        // wire-framing counters. Double-gated (kReleaseMode +
+        // collector.enabled), so production pays nothing.
+        noteObd2Framing(bytes);
+        _incoming.add(bytes);
+      },
       onError: (Object e, StackTrace st) {
         // #2295 — forward the socket error onto the byte stream so the
         // transport's pending `sendCommand` completer fails IMMEDIATELY
         // (via `_failPending`) instead of waiting out the read timeout,
         // and log it so the drop is visible in release.
         if (!_incoming.isClosed) _incoming.addError(e, st);
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+        // #2466 — a Classic-SPP socket error is a RECOVERABLE OBD2/BT link
+        // transient, not a local-storage fault. Tag it `other` to match
+        // [FlutterBluePlusElmChannel]'s #2379 convention (the two channels
+        // were inconsistent: BLE used `other`, Classic used `storage`).
+        unawaited(errorLogger.log(ErrorLayer.other, e, st,
             context: const {'where': 'ClassicElmChannel notify error'}));
       },
       onDone: () {
@@ -80,6 +123,20 @@ class ClassicElmChannel implements ElmByteChannel {
     await _plugin.write(bytes);
   }
 
+  /// Bin a Classic-SPP `open()` throw into a stable, low-cardinality
+  /// reason tag for the gated comm-diagnostics `failuresByReason` map
+  /// (#2466). A clean `connect → false` is handled separately as
+  /// `rfcomm-open-fail`; this covers the thrown-platform-error path
+  /// (bonding / permission).
+  static String _classifyClassicConnectFailure(Object e) {
+    final msg = e.toString().toUpperCase();
+    if (msg.contains('BOND') || msg.contains('PAIR')) return 'not-bonded';
+    if (msg.contains('RFCOMM') || msg.contains('SOCKET')) {
+      return 'rfcomm-open-fail';
+    }
+    return 'other';
+  }
+
   @override
   Future<void> close() async {
     _open = false;
@@ -88,7 +145,9 @@ class ClassicElmChannel implements ElmByteChannel {
     try {
       await _plugin.disconnect();
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'ClassicElmChannel: disconnect error (ignored)'}));
+      // #2466 — recoverable OBD2/BT teardown, not local storage (#2379).
+      // Was `storage`; now `other` to match [FlutterBluePlusElmChannel].
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'ClassicElmChannel: disconnect error (ignored)'}));
     }
     await _incoming.close();
   }

--- a/lib/features/consumption/data/obd2/elm_byte_channel.dart
+++ b/lib/features/consumption/data/obd2/elm_byte_channel.dart
@@ -1,6 +1,115 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/foundation.dart';
+
+import 'obd2_comm_diagnostics.dart';
+import 'obd2_response_class.dart';
+
+/// ELM327 prompt byte (`>`). The adapter emits it once per reply to mark
+/// "ready for the next command"; the transport accumulates incoming
+/// bytes until it arrives.
+const int _kPromptByte = 0x3E; // '>'
+
+/// Tee one raw incoming byte [chunk] from an ELM327 channel into the
+/// gated [Obd2CommDiagnostics] collector as cheap wire-framing counters
+/// (#2467, Wave-1 of Epic #2463).
+///
+/// **Two short-circuits, cheapest first**, so production pays nothing:
+///   1. `kReleaseMode` — the per-byte scan is the single most expensive
+///      thing the comm-diagnostics subsystem does, so a release build
+///      never even reads the collector flag (mirrors the
+///      `Obd2BreadcrumbOverlay` release short-circuit). Tree-shaken to a
+///      bare `return` in profile/release AOT.
+///   2. `Obd2CommDiagnostics.instance.enabled` — off unless
+///      `Feature.debugMode` armed the gate. A debug build with the gate
+///      off pays one cached-bool read + branch-not-taken per chunk.
+///
+/// Past the gates it decodes the chunk and records, via the shared
+/// [classifyObd2Response] vocabulary, exactly ONE framing observation
+/// per chunk:
+///   * any non-ASCII byte                       → garbage read (nonAscii)
+///   * a chunk that is nothing but a `>` prompt  → stray/unexpected prompt
+///   * `BUFFER FULL` / `CAN ERROR` / `UNABLE TO CONNECT` / `STOPPED` /
+///     other unrecognised ASCII chatter          → garbage read
+///   * a chunk with no terminating prompt        → partial frame
+///   * a chunk carrying bytes *after* its prompt → leftover buffer (the
+///     previous reply leaked into this read)
+///
+/// A clean, fully-terminated `…\r>` reply records nothing — only
+/// anomalies are counted, so the collector's framing totals stay a tally
+/// of wire trouble rather than of normal traffic.
+void noteObd2Framing(List<int> chunk) {
+  // (1) Heaviest guard first — never scan bytes in release.
+  if (kReleaseMode) return;
+  // (2) Gate: nothing unless developer mode armed the collector.
+  if (!Obd2CommDiagnostics.instance.enabled) return;
+  if (chunk.isEmpty) return;
+
+  final diag = Obd2CommDiagnostics.instance;
+
+  // (a) Non-ASCII byte ⇒ noisy wire / binary leak. Count once and stop —
+  // a garbage chunk has nothing further worth framing.
+  for (final b in chunk) {
+    if (b < 0x20 || b > 0x7E) {
+      // Tolerate the two ASCII line terminators the ELM frames replies
+      // with — CR (0x0D) / LF (0x0A) are structure, not garbage.
+      if (b == 0x0D || b == 0x0A) continue;
+      diag.noteFraming(garbage: true);
+      return;
+    }
+  }
+
+  final text = String.fromCharCodes(chunk);
+  final trimmed = text.trim();
+
+  // (b) A chunk that is nothing but the ready prompt — a stray `>` with
+  // no reply attached (a reset echo, a double-prompt from a clone).
+  if (trimmed == '>') {
+    diag.noteFraming(strayPrompt: true);
+    return;
+  }
+
+  // (c) Route the ASCII content through the single classifier so the ELM
+  // error vocabulary (BUFFER FULL / CAN ERROR / UNABLE TO CONNECT /
+  // STOPPED) lands in the garbage bucket with the same vocabulary every
+  // other comm-path layer uses. Only the EXPLICIT error vocab short-
+  // circuits here — a `garbage` classification on its own is ambiguous
+  // (an as-yet-incomplete hex frame like `41 0D` also classifies as
+  // garbage), so unknown/partial content falls through to the
+  // frame-boundary checks below where it is correctly a partial frame.
+  switch (classifyObd2Response(text)) {
+    case ResponseClass.bufferFull:
+    case ResponseClass.canError:
+    case ResponseClass.unrecognized:
+      diag.noteFraming(garbage: true);
+      return;
+    case ResponseClass.ok:
+    case ResponseClass.noData:
+    case ResponseClass.garbage:
+    case ResponseClass.timeout:
+      break; // recognised reply OR ambiguous/partial — frame checks below
+  }
+
+  // (d) Frame-boundary health: where does the prompt sit?
+  final promptAt = chunk.lastIndexOf(_kPromptByte);
+  if (promptAt < 0) {
+    // No terminating prompt in this chunk — a partial frame still being
+    // accumulated by the transport.
+    diag.noteFraming(partialFrame: true);
+    return;
+  }
+  // Bytes after the prompt mean the previous reply leaked into this read
+  // (the transport will carry them as leftover buffer into the next
+  // command's accumulation).
+  final hasTrailingPayload = chunk
+      .skip(promptAt + 1)
+      .any((b) => b != 0x0D && b != 0x0A && b != 0x20);
+  if (hasTrailingPayload) {
+    diag.noteFraming(leftoverBytes: true);
+  }
+}
+
 /// Raw byte pipe to an ELM327-compatible adapter.
 ///
 /// Abstracted so [BluetoothObd2Transport] can be unit-tested with a

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -141,6 +141,7 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     if (diag.enabled) diag.noteConnectionEvent(attempt: true);
     try {
       await _connectAndDiscover();
+      // ignore: catch_no_st — rethrow-only: the original stack is preserved by rethrow
     } catch (e) {
       if (diag.enabled) {
         diag.noteConnectionEvent(

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -8,6 +8,7 @@ import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'connection_drop_debouncer.dart';
 import 'elm_byte_channel.dart';
+import 'obd2_comm_diagnostics.dart';
 import 'obd2_connection_errors.dart';
 import '../../../../core/logging/error_logger.dart';
 
@@ -111,6 +112,13 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   /// in-flight `sendCommand` completer fails fast with a classified
   /// error instead of waiting out the read timeout (#2261 concern 1).
   void _onDropConfirmed() {
+    // #2466 — a debounce-CONFIRMED drop is a real mid-session link loss.
+    // Count it as a drop (gated; no-op unless Feature.debugMode is on).
+    // Raw `disconnected` edges that self-heal inside the debounce are
+    // binned separately below as `raw-edge-drop` so the confirmed-drop
+    // total stays a tally of genuine losses.
+    final diag = Obd2CommDiagnostics.instance;
+    if (diag.enabled) diag.noteConnectionEvent(drop: true);
     if (_incoming.isClosed) return;
     _incoming.addError(const Obd2DisconnectedException());
   }
@@ -124,6 +132,37 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   @override
   Future<void> open() async {
     if (_open) return;
+    // #2466 — gated comm-diagnostics connect-lifecycle tee. The whole
+    // block is a no-op unless `Feature.debugMode` armed the collector
+    // (the gate provider flips `enabled`); each call early-returns on
+    // `!enabled`, so production pays one cached-bool read per event.
+    final diag = Obd2CommDiagnostics.instance;
+    final connectSw = diag.enabled ? (Stopwatch()..start()) : null;
+    if (diag.enabled) diag.noteConnectionEvent(attempt: true);
+    try {
+      await _connectAndDiscover();
+    } catch (e) {
+      if (diag.enabled) {
+        diag.noteConnectionEvent(
+          failureReason: _classifyBleConnectFailure(e),
+        );
+      }
+      rethrow;
+    }
+    if (connectSw != null) {
+      connectSw.stop();
+      diag.noteConnectionEvent(
+        success: true,
+        timeToConnectMs: connectSw.elapsedMilliseconds,
+      );
+    }
+  }
+
+  /// The connect → service-discovery → notify-subscribe body of [open],
+  /// extracted so [open] can wrap it with the gated connect-lifecycle
+  /// diagnostics tee (#2466) without interleaving counters through the
+  /// platform calls.
+  Future<void> _connectAndDiscover() async {
     final timeout = _connectTimeout;
     if (_autoConnect) {
       // #2261 concern 2 — passive autoConnect GATT wait. No bounded
@@ -179,7 +218,13 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     );
     await _notifyChar!.setNotifyValue(true);
     _subscription = _notifyChar!.lastValueStream.listen(
-      (bytes) => _incoming.add(bytes),
+      (bytes) {
+        // #2467 — tee the raw chunk into the gated comm-diagnostics
+        // wire-framing counters. Double-gated (kReleaseMode +
+        // collector.enabled), so production pays nothing.
+        noteObd2Framing(bytes);
+        _incoming.add(bytes);
+      },
       onError: (e, st) {
         // #2295 — forward the GATT/ATT error onto the byte stream so the
         // transport's pending `sendCommand` completer fails IMMEDIATELY
@@ -200,9 +245,23 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     // no-op until the link actually drops.
     _dropDebouncer.reset();
     _connStateSubscription = _device.connectionState.listen(
-      (state) => _dropDebouncer.noteConnectionState(
-        disconnected: state == BluetoothConnectionState.disconnected,
-      ),
+      (state) {
+        final disconnected =
+            state == BluetoothConnectionState.disconnected;
+        // #2466 — a raw `disconnected` EDGE (before the debouncer
+        // confirms it) is binned as a recoverable transient, not a
+        // confirmed drop: most edges self-heal inside the supervision
+        // window. Only count it while the debouncer is idle, so a
+        // single drop episode contributes one raw-edge tally, not one
+        // per repeated edge. Gated; no-op unless Feature.debugMode is on.
+        if (disconnected) {
+          final diag = Obd2CommDiagnostics.instance;
+          if (diag.enabled && !_dropDebouncer.isPending) {
+            diag.noteConnectionEvent(failureReason: 'raw-edge-drop');
+          }
+        }
+        _dropDebouncer.noteConnectionState(disconnected: disconnected);
+      },
       onError: (e, st) {
         debugPrint('FlutterBluePlusElmChannel connectionState error: $e');
       },
@@ -225,7 +284,13 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     // passive path never calls this, but guard anyway.
     if (_autoConnect) return;
     try {
-      await _device.requestMtu(_recordingMtu);
+      final granted = await _device.requestMtu(_recordingMtu);
+      // #2466 — record the negotiated ATT MTU into the gated comm-health
+      // session (no-op unless Feature.debugMode armed the collector). The
+      // peripheral may grant less than requested; the granted value is the
+      // diagnostic one.
+      final diag = Obd2CommDiagnostics.instance;
+      if (diag.enabled) diag.recordAdapterIdentity(mtu: granted);
     } catch (e, st) {
       // Many clones reject a non-default MTU — harmless, the default
       // 23-byte MTU still works. PHY (2M) is deliberately NOT requested:
@@ -237,6 +302,31 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   @override
   Future<void> tuneForBackground() async {
     await _setConnectionPriority(ConnectionPriority.balanced);
+  }
+
+  /// Bin a BLE `open()` failure into a stable, low-cardinality reason tag
+  /// for the gated comm-diagnostics `failuresByReason` map (#2466). Kept
+  /// coarse + platform-derived so an exported error-log shows *why* a
+  /// connect failed (GATT timeout vs missing ELM service vs other) without
+  /// leaking a high-cardinality raw message.
+  static String _classifyBleConnectFailure(Object e) {
+    final msg = e.toString().toUpperCase();
+    if (msg.contains('TIMEOUT') || msg.contains('GATT_CONNECTION_TIMEOUT')) {
+      return 'gatt-connection-timeout';
+    }
+    // Android GATT_ERROR 133 — the catch-all "stack gave up" code, most
+    // often a stale GATT client or an out-of-range adapter.
+    if (msg.contains('133') || msg.contains('GATT_ERROR')) {
+      return 'gatt-error-133';
+    }
+    // The service / characteristic discovery `StateError`s thrown above.
+    if (e is StateError &&
+        (msg.contains('ELM327 SERVICE') ||
+            msg.contains('WRITE CHARACTERISTIC') ||
+            msg.contains('NOTIFY CHARACTERISTIC'))) {
+      return 'service-not-found';
+    }
+    return 'other';
   }
 
   /// Best-effort connection-priority request (#2261 concern 4). Android
@@ -271,6 +361,11 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       // write failure on an otherwise-connected link is a no-op for the
       // debouncer and falls through to the caller as before. Rethrow-only
       // (the caller / transport classifies it) — no stack trace needed.
+      // #2466 — bin the write failure as a recoverable transient reason
+      // (gated; no-op unless Feature.debugMode is on). It is distinct
+      // from a confirmed drop: a write can fail on a link that recovers.
+      final diag = Obd2CommDiagnostics.instance;
+      if (diag.enabled) diag.noteConnectionEvent(failureReason: 'write-fail');
       _dropDebouncer.noteCommandFailure();
       rethrow;
     }

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -483,17 +483,16 @@ class Obd2Service implements Obd2RawCommandPort {
       // it only moves off [WakeObservation.notRun] if the bounded wake
       // window actually runs (active policy, not cache-suppressed).
       wakeObservation = WakeObservation.notRun;
-      await _transport.connect();
 
-      // #2465 — open a comm-diagnostics session for this connect and tee
-      // the adapter identity + handshake transcript into it below. A pure
-      // no-op unless Feature.debugMode armed the collector (the gate
-      // provider flips `enabled`); the begin/record calls early-return on
-      // `!enabled`, so production pays one cached-bool read per event.
+      // #2465 — open a gated comm-diagnostics session (no-op unless
+      // Feature.debugMode armed the collector). #2466 — begin it BEFORE
+      // `_transport.connect()` opens the channel so the channel's gated
+      // connect-lifecycle counters attach to THIS session.
       Obd2CommDiagnostics.instance.beginSession(
         linkKind: linkKind,
         redactedMac: redactObd2Mac(adapterMac),
       );
+      await _transport.connect();
 
       // Clear the per-connection supported-PIDs cache. A new session
       // may be a different car / different adapter firmware.

--- a/test/features/consumption/data/obd2/adapter_reconnect_scanner_diagnostics_test.dart
+++ b/test/features/consumption/data/obd2/adapter_reconnect_scanner_diagnostics_test.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_reconnect_scanner.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_comm_diagnostics.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+const _kInitial = Duration(milliseconds: 10);
+const _kMax = Duration(milliseconds: 80);
+
+Future<void> _waitFor(
+  bool Function() cond, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!cond() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  setUp(Obd2CommDiagnostics.instance.reset);
+  tearDown(() {
+    Obd2CommDiagnostics.instance.enabled = false;
+    Obd2CommDiagnostics.instance.reset();
+  });
+
+  group('AdapterReconnectScanner → Obd2CommDiagnostics reconnect tee (#2466)',
+      () {
+    test(
+        'debugMode ON: a first-probe reconnect is SILENT with a '
+        'time-to-reconnect sample', () async {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      var reconnects = 0;
+      final scanner = AdapterReconnectScanner(
+        pinnedMac: 'AA:BB',
+        probe: (mac) async => mac == 'AA:BB', // in range immediately
+        connect: (_) async => true, // first attempt succeeds
+        onReconnect: () => reconnects++,
+        initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
+        maxBackoff: _kMax,
+      );
+      await scanner.start();
+      await _waitFor(() => reconnects > 0);
+      expect(scanner.isScanning, isFalse);
+
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.silentReconnects, 1,
+          reason: 'recovered on the fast first probe → silent');
+      expect(conn.visibleReconnects, 0);
+      expect(conn.timeToReconnectP50Ms, isNotNull,
+          reason: 'time-to-reconnect was sampled');
+      expect(conn.timeToReconnectP50Ms, greaterThanOrEqualTo(0));
+    });
+
+    test(
+        'debugMode ON: a reconnect that takes several missed probes is '
+        'VISIBLE', () async {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      var connectCalls = 0;
+      var reconnects = 0;
+      final scanner = AdapterReconnectScanner(
+        pinnedMac: 'MAC',
+        probe: (_) async => true, // always in range
+        connect: (_) async {
+          connectCalls++;
+          // First two attempts fail (backoff escalates), third succeeds.
+          return connectCalls >= 3;
+        },
+        onReconnect: () => reconnects++,
+        initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
+        maxBackoff: _kMax,
+      );
+      await scanner.start();
+      await _waitFor(() => reconnects > 0);
+
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.visibleReconnects, 1,
+          reason: 'recovered only after the backoff escalated → visible');
+      expect(conn.silentReconnects, 0);
+      expect(conn.timeToReconnectP50Ms, isNotNull);
+    });
+
+    test('debugMode OFF: a reconnect records nothing (pure no-op)', () async {
+      expect(Obd2CommDiagnostics.instance.enabled, isFalse);
+      Obd2CommDiagnostics.instance.beginSession();
+
+      var reconnects = 0;
+      final scanner = AdapterReconnectScanner(
+        pinnedMac: 'AA:BB',
+        probe: (mac) async => mac == 'AA:BB',
+        connect: (_) async => true,
+        onReconnect: () => reconnects++,
+        initialBackoff: _kInitial,
+        firstProbeDelay: _kInitial,
+        maxBackoff: _kMax,
+      );
+      await scanner.start();
+      await _waitFor(() => reconnects > 0);
+
+      // beginSession is itself a no-op when disabled ⇒ empty sentinel.
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.silentReconnects, 0);
+      expect(conn.visibleReconnects, 0);
+      expect(conn.timeToReconnectP50Ms, isNull);
+      // The reconnect itself still fired — behaviour is unchanged.
+      expect(reconnects, 1);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/classic_elm_channel_diagnostics_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_diagnostics_test.dart
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_elm_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_method_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_comm_diagnostics.dart';
+
+/// Captures every `errorLogger.log` call routed through the foreground
+/// recorder seam, retaining the [ContextualError] so the test can assert
+/// its [ErrorLayer]. Mirrors `obd2_connection_service_test.dart`.
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// In-memory double for [Obd2ClassicMethodChannel] — connect can return
+/// false (clean RFCOMM miss) or throw (bonding / permission), and the
+/// incoming stream can be driven to push bytes / errors.
+class _FakeClassicPlugin extends Obd2ClassicMethodChannel {
+  _FakeClassicPlugin();
+
+  bool connectResult = true;
+  Object? connectThrows;
+
+  @override
+  Future<bool> connect({required String address, required String uuid}) async {
+    if (connectThrows != null) throw connectThrows!;
+    return connectResult;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {}
+
+  int disconnectCalls = 0;
+  Object? disconnectError;
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    if (disconnectError != null) throw disconnectError!;
+  }
+
+  final StreamController<List<int>> incomingController =
+      StreamController<List<int>>.broadcast();
+
+  @override
+  Stream<List<int>> get incoming => incomingController.stream;
+
+  Future<void> dispose() async {
+    if (!incomingController.isClosed) await incomingController.close();
+  }
+}
+
+void main() {
+  late _FakeClassicPlugin fake;
+  late _CaptureRecorder recorder;
+
+  setUp(() {
+    fake = _FakeClassicPlugin();
+    Obd2CommDiagnostics.instance.reset();
+    errorLogger.resetForTest();
+    recorder = _CaptureRecorder();
+    errorLogger.testRecorderOverride = recorder;
+  });
+
+  tearDown(() async {
+    Obd2CommDiagnostics.instance.enabled = false;
+    Obd2CommDiagnostics.instance.reset();
+    errorLogger.resetForTest();
+    await fake.dispose();
+  });
+
+  group('ClassicElmChannel connect-lifecycle counters (#2466)', () {
+    test(
+        'debugMode ON: a successful open records attempt + success + '
+        'time-to-connect', () async {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession(linkKind: 'classic');
+
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await channel.open();
+
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.attempts, 1);
+      expect(conn.successes, 1);
+      expect(conn.failuresByReason, isEmpty);
+      expect(conn.timeToConnectP50Ms, isNotNull);
+
+      await channel.close();
+    });
+
+    test(
+        'debugMode ON: a clean connect→false bins as rfcomm-open-fail '
+        '(attempt counted, success not)', () async {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession(linkKind: 'classic');
+      fake.connectResult = false;
+
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await expectLater(channel.open(), throwsA(isA<StateError>()));
+
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.attempts, 1);
+      expect(conn.successes, 0);
+      expect(conn.failuresByReason['rfcomm-open-fail'], 1);
+    });
+
+    test('debugMode ON: a bonding throw bins as not-bonded', () async {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession(linkKind: 'classic');
+      fake.connectThrows = StateError('device not bonded — pair it first');
+
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await expectLater(channel.open(), throwsA(isA<StateError>()));
+
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.attempts, 1);
+      expect(conn.failuresByReason['not-bonded'], 1);
+    });
+
+    test('debugMode OFF: open records nothing and still connects', () async {
+      expect(Obd2CommDiagnostics.instance.enabled, isFalse);
+
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await channel.open();
+
+      expect(channel.isOpen, isTrue,
+          reason: 'connect behaviour is unchanged when the gate is off');
+      // No session begun + gate off ⇒ empty sentinel, zero counters.
+      final conn = Obd2CommDiagnostics.instance.snapshot().connection;
+      expect(conn.attempts, 0);
+      expect(conn.successes, 0);
+
+      await channel.close();
+    });
+  });
+
+  group('ClassicElmChannel ErrorLayer tagging fix (#2466 / #2379)', () {
+    test(
+        'a forwarded socket error logs under ErrorLayer.other, never '
+        'storage', () async {
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await channel.open();
+
+      // Drive a socket error up the plugin's incoming stream.
+      final sub = channel.incoming.listen((_) {}, onError: (_) {});
+      fake.incomingController.addError(Exception('socket reset'));
+      await Future<void>.delayed(Duration.zero);
+
+      final logged = recorder.calls.whereType<ContextualError>().toList();
+      expect(logged, isNotEmpty,
+          reason: 'the forwarded socket drop stays in release triage');
+      expect(
+        logged.where((e) => e.layer == ErrorLayer.storage),
+        isEmpty,
+        reason: 'a recoverable OBD2/BT transient must NOT carry storage — '
+            'this was the FBP-vs-Classic inconsistency #2466 fixes',
+      );
+      expect(logged.every((e) => e.layer == ErrorLayer.other), isTrue);
+
+      await sub.cancel();
+      await channel.close();
+    });
+
+    test('a disconnect error on close also logs under ErrorLayer.other',
+        () async {
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await channel.open();
+      fake.disconnectError = Exception('boom on disconnect');
+
+      await channel.close();
+
+      final logged = recorder.calls.whereType<ContextualError>().toList();
+      expect(logged, isNotEmpty);
+      expect(logged.where((e) => e.layer == ErrorLayer.storage), isEmpty);
+      expect(logged.every((e) => e.layer == ErrorLayer.other), isTrue);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/elm_byte_channel_framing_test.dart
+++ b/test/features/consumption/data/obd2/elm_byte_channel_framing_test.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_comm_diagnostics.dart';
+
+/// Encode an ASCII reply to the raw byte chunk an ELM327 channel would
+/// surface to [noteObd2Framing].
+List<int> _bytes(String s) => s.codeUnits;
+
+void main() {
+  // The framing tee writes into the process-wide singleton (mirrors the
+  // other comm-diagnostics tees). Reset around every test so counters
+  // never leak between cases.
+  setUp(Obd2CommDiagnostics.instance.reset);
+  tearDown(() {
+    Obd2CommDiagnostics.instance.enabled = false;
+    Obd2CommDiagnostics.instance.reset();
+  });
+
+  group('noteObd2Framing → Obd2CommDiagnostics (#2467)', () {
+    test('debugMode ON: a clean terminated reply records NO framing anomaly',
+        () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      // A well-framed positive-response line with its trailing prompt.
+      noteObd2Framing(_bytes('41 0D 3C\r>'));
+
+      final f = Obd2CommDiagnostics.instance.snapshot().framing;
+      expect(f.partialFrames, 0);
+      expect(f.leftoverBytes, 0);
+      expect(f.strayPrompts, 0);
+      expect(f.garbageReads, 0);
+    });
+
+    test('a frame with no terminating prompt → partial frame', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      // Mid-frame chunk: data but no `>` yet.
+      noteObd2Framing(_bytes('41 0D 3'));
+
+      expect(
+        Obd2CommDiagnostics.instance.snapshot().framing.partialFrames,
+        1,
+      );
+    });
+
+    test('payload bytes after the prompt → leftover buffer', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      // The previous reply leaked into this read: a terminated frame
+      // followed by the start of the next one.
+      noteObd2Framing(_bytes('41 0D 3C\r>41 0C'));
+
+      expect(
+        Obd2CommDiagnostics.instance.snapshot().framing.leftoverBytes,
+        1,
+      );
+    });
+
+    test('a chunk that is only a > prompt → stray prompt', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      noteObd2Framing(_bytes('>'));
+      noteObd2Framing(_bytes('\r>\r'));
+
+      expect(
+        Obd2CommDiagnostics.instance.snapshot().framing.strayPrompts,
+        2,
+      );
+    });
+
+    test('BUFFER FULL routes through the classifier → garbage read', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      noteObd2Framing(_bytes('BUFFER FULL\r>'));
+
+      expect(
+        Obd2CommDiagnostics.instance.snapshot().framing.garbageReads,
+        1,
+      );
+    });
+
+    test(
+        'the rest of the ELM error vocabulary (CAN ERROR / UNABLE TO '
+        'CONNECT / STOPPED) all bin as garbage', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      noteObd2Framing(_bytes('CAN ERROR\r>'));
+      noteObd2Framing(_bytes('UNABLE TO CONNECT\r>'));
+      noteObd2Framing(_bytes('STOPPED\r>'));
+
+      expect(
+        Obd2CommDiagnostics.instance.snapshot().framing.garbageReads,
+        3,
+      );
+    });
+
+    test('a non-ASCII (binary) byte → garbage read', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      // 0xFF is outside printable ASCII — a noisy wire / binary leak.
+      noteObd2Framing(<int>[0x41, 0xFF, 0x0D]);
+
+      expect(
+        Obd2CommDiagnostics.instance.snapshot().framing.garbageReads,
+        1,
+      );
+    });
+
+    test('CR / LF terminators are structure, not garbage', () {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+
+      // A partial frame carrying CR + LF must NOT be counted as garbage.
+      noteObd2Framing(<int>[0x34, 0x31, 0x0D, 0x0A]); // "41\r\n"
+
+      final f = Obd2CommDiagnostics.instance.snapshot().framing;
+      expect(f.garbageReads, 0);
+      expect(f.partialFrames, 1);
+    });
+
+    test('debugMode OFF: a partial frame + BUFFER FULL + garbage are no-ops',
+        () {
+      // Gate stays off (default). Even with a session begun nothing is
+      // recorded — `beginSession` itself is a no-op when disabled, so the
+      // snapshot is the empty sentinel.
+      expect(Obd2CommDiagnostics.instance.enabled, isFalse);
+      Obd2CommDiagnostics.instance.beginSession();
+
+      noteObd2Framing(_bytes('41 0D 3')); // partial
+      noteObd2Framing(_bytes('BUFFER FULL\r>')); // garbage
+      noteObd2Framing(<int>[0x41, 0xFF]); // non-ASCII garbage
+
+      final f = Obd2CommDiagnostics.instance.snapshot().framing;
+      expect(f.partialFrames, 0);
+      expect(f.leftoverBytes, 0);
+      expect(f.strayPrompts, 0);
+      expect(f.garbageReads, 0);
+    });
+  });
+}


### PR DESCRIPTION
WAVE-1 of Epic #2463 (dev-mode OBD2 comm-health diagnostics). Two
aggregated children, all behind `Feature.debugMode` (gate already wired
by #2479). Disjoint from the in-flight PID-AGG work — touches only the
channels + byte-channel + reconnect scanner, never
pid_scheduler/supported_pids_resolver/live_sample_snapshot/transport.

## #2466 — channel + reconnect lifecycle counters
- BLE + Classic channel `open()`: connect attempt / success (+
  time-to-connect) and failures binned by platform reason
  (gatt-connection-timeout / gatt-error-133 / service-not-found ·
  rfcomm-open-fail / not-bonded / other).
- BLE MTU grant recorded via `recordAdapterIdentity(mtu:)` on the
  granted value.
- Drops split raw-edge (recoverable `raw-edge-drop` reason) vs
  debounce-confirmed (real drop); write-fail binned as `write-fail`.
- Reconnect scanner: silent-vs-visible reconnects + time-to-reconnect
  into the collector's reservoir.
- `obd2_service.connect` begins the session BEFORE the channel opens
  (behaviour-neutral; gated no-op when disabled) so the channel counters
  attach to the right session.
- Fixes the `.storage`-vs-`.other` ErrorLayer inconsistency: Classic
  channel now logs recoverable OBD2/BT transients under `.other` to
  match the BLE channel (#2379) — regression asserted.

## #2467 — byte-channel framing counters
- `noteObd2Framing(chunk)` in `elm_byte_channel.dart`: partial-frame /
  leftover-buffer / stray-prompt / garbage-byte / nonAscii counters, with
  the ELM error vocab (BUFFER FULL / CAN ERROR / UNABLE TO CONNECT /
  STOPPED) routed through the shared `classifyObd2Response`.
- Double-gated cheapest-first: `kReleaseMode` short-circuit (mirrors
  obd2_breadcrumb_overlay) then `enabled`.

## Production is a no-op
Every tee is behind `if (Obd2CommDiagnostics.instance.enabled)` (off
unless debugMode armed it) and the per-byte framing scan additionally
behind `kReleaseMode`. Connect/channel/reconnect behaviour is unchanged.

## Tests
debugMode ON: connect-fail binned by reason, drop+reconnect (silent vs
visible + time-to-reconnect), partial frame + BUFFER FULL + garbage byte
all reflected in the snapshot. debugMode OFF: pure no-op, behaviour
unchanged. ErrorLayer-tagging fix has a regression assertion.

`flutter analyze` (lib+test) clean; obd2/channel/connection suites +
file_length + no_hardcoded_ui_strings green. No ARB / codegen drift
(collector model from #2474 unchanged).

Closes #2466
Closes #2467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
