### PR TITLE
fix(ui): PriceFormatter.formatTotal + route total-cost sites + corrections neutral recolour (#2491)

### DIFF
--- a/lib/core/utils/price_formatter.dart
+++ b/lib/core/utils/price_formatter.dart
@@ -35,17 +35,54 @@ class PriceFormatter {
     _activeConfig =
         Countries.byCode(countryCode.toUpperCase()) ?? Countries.germany;
     _cachedFullFormat = null;
+    _cachedTotalFormat = null;
+    _cachedPerKmFormat = null;
   }
 
   static String get _locale => _activeConfig.locale;
 
   static String get currency => _activeConfig.currencySymbol;
 
+  /// ISO 4217 code of the active currency (e.g. `EUR`, `KRW`). Drives
+  /// the zero-decimal decision in [formatTotal] — see [_zeroDecimal].
+  static String get _currencyCode => _activeConfig.currency;
+
+  /// Currencies that carry no minor unit, so a total is whole-numbered
+  /// (₩1050, not ₩1050,00). Keyed off the ISO 4217 code so the set
+  /// stays correct as countries are added. Covers the registered
+  /// zero-decimal currencies (KRW, CLP) plus the common ones a future
+  /// country might bring (JPY, VND, …).
+  static const Set<String> _zeroDecimalCurrencies = {
+    'KRW', 'CLP', 'JPY', 'VND', 'IDR', 'HUF', 'ISK', 'PYG',
+    'XOF', 'XAF', 'XPF', 'RWF', 'UGX', 'DJF', 'GNF', 'KMF', 'VUV',
+  };
+
+  static bool get _zeroDecimal =>
+      _zeroDecimalCurrencies.contains(_currencyCode);
+
   // Lazy-initialized formatter that resets when country changes.
   static NumberFormat? _cachedFullFormat;
 
   static NumberFormat get _fullFormat =>
       _cachedFullFormat ??= NumberFormat('0.000', _locale);
+
+  // Lazy-initialized total-currency formatter (2 dp, or 0 dp for a
+  // zero-decimal currency). Resets when the active country changes.
+  static NumberFormat? _cachedTotalFormat;
+
+  static NumberFormat get _totalFormat => _cachedTotalFormat ??=
+      NumberFormat.currency(
+        locale: _locale,
+        symbol: '',
+        decimalDigits: _zeroDecimal ? 0 : 2,
+      );
+
+  // Lazy-initialized per-km formatter (3 dp, no symbol). Resets when
+  // the active country changes.
+  static NumberFormat? _cachedPerKmFormat;
+
+  static NumberFormat get _perKmFormat =>
+      _cachedPerKmFormat ??= NumberFormat('0.000', _locale);
 
   /// Format price as plain string (e.g., "1,459 €" or "1.459 £").
   ///
@@ -62,6 +99,40 @@ class PriceFormatter {
   static String formatPriceCompact(double? price) {
     if (price == null || price <= 0) return '--';
     return _fullFormat.format(price);
+  }
+
+  /// Format a TOTAL amount (a fill-up cost, a charging session, the
+  /// month's spend) in the active currency — two decimals, or zero for
+  /// a zero-decimal currency like KRW / CLP / JPY.
+  ///
+  /// This is distinct from [formatPrice], which is the per-litre
+  /// formatter at three decimals (`1,459 €`). Routing a total through
+  /// the per-litre formatter is the bug behind a 1.05 € trip rendering
+  /// `1,047 €` (#2491). The symbol is appended with a space to match
+  /// [formatPrice]'s placement so per-litre and total figures read as
+  /// the same money on one card.
+  ///
+  /// Pass [currencyOverride] to force a specific symbol — mirrors
+  /// [formatPrice] for cross-country rows (see #514).
+  static String formatTotal(double? amount, {String? currencyOverride}) {
+    if (amount == null) return '--';
+    final cur = currencyOverride ?? currency;
+    // NumberFormat.currency with an empty symbol still reserves the
+    // symbol slot — for a suffix-symbol locale (fr_FR's `#,##0.00 ¤`)
+    // that leaves a trailing space, so trim before re-appending our
+    // own symbol to avoid a doubled separator ("1,05  €").
+    final number = _totalFormat.format(amount).trim();
+    return '$number $cur';
+  }
+
+  /// Format a cost-per-distance value (e.g. €/km) at three decimals,
+  /// locale-aware, without a currency symbol — the consumption stats
+  /// "Avg /km" tile. Three decimals because a per-km cost is a fraction
+  /// of a currency unit (0,105 €/km); the symbol is supplied by the
+  /// surrounding label, not this method.
+  static String formatPerKm(double? amount) {
+    if (amount == null) return '--';
+    return _perKmFormat.format(amount);
   }
 
   /// Build a TextSpan with the 9/10ths digit in superscript.

--- a/lib/features/consumption/presentation/widgets/charging_log_card.dart
+++ b/lib/features/consumption/presentation/widgets/charging_log_card.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/entities/charging_log.dart';
 
@@ -30,9 +31,13 @@ class ChargingLogCard extends StatelessWidget {
         ? log.stationName!
         : (l?.chargingStationName ?? 'Station');
     final kwhStr = log.kWh.toStringAsFixed(1);
-    final costStr = log.costEur.toStringAsFixed(2);
+    // #2491 — a charging-session cost is a TOTAL: route it through
+    // formatTotal (locale-aware 2 dp + the active currency symbol)
+    // instead of a hand-rolled toStringAsFixed(2) with a hardcoded
+    // " € " glyph that was wrong in every non-euro country.
+    final costStr = PriceFormatter.formatTotal(log.costEur);
     final subtitle =
-        '$dateStr  •  $kwhStr kWh  •  $costStr €  •  ${log.chargeTimeMin} min';
+        '$dateStr  •  $kwhStr kWh  •  $costStr  •  ${log.chargeTimeMin} min';
 
     return Semantics(
       container: true,

--- a/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
+++ b/lib/features/consumption/presentation/widgets/consumption_stats_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/utils/price_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/feature.dart';
@@ -164,8 +165,9 @@ class ConsumptionStatsCard extends ConsumerWidget {
                   child: _StatTile(
                     icon: Icons.euro,
                     label: l?.statAvgCostPerKm ?? 'Avg /km',
+                    // #2491 — locale-aware 3 dp via formatPerKm.
                     value: avgCostKm != null
-                        ? avgCostKm.toStringAsFixed(3)
+                        ? PriceFormatter.formatPerKm(avgCostKm)
                         : '—',
                   ),
                 ),
@@ -185,7 +187,8 @@ class ConsumptionStatsCard extends ConsumerWidget {
                   child: _StatTile(
                     icon: Icons.payments_outlined,
                     label: l?.statTotalSpent ?? 'Total spent',
-                    value: stats.totalSpent.toStringAsFixed(2),
+                    // #2491 — locale-aware 2 dp + currency symbol.
+                    value: PriceFormatter.formatTotal(stats.totalSpent),
                   ),
                 ),
               ],
@@ -201,6 +204,7 @@ class ConsumptionStatsCard extends ConsumerWidget {
             // own line, never folded into the headline Total L. Shown
             // only when at least one correction landed in a closed
             // window so the line stays out of the way otherwise.
+            // #2491 — neutral onSurfaceVariant, not warning (#2487).
             if (stats.correctionLitersTotal > 0) ...[
               const SizedBox(height: 4),
               Text(
@@ -209,7 +213,7 @@ class ConsumptionStatsCard extends ConsumerWidget {
                     ) ??
                     'Corrections: +${stats.correctionLitersTotal.toStringAsFixed(1)} L',
                 style: theme.textTheme.bodySmall?.copyWith(
-                  color: DarkModeColors.warning(context),
+                  color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
             ],

--- a/lib/features/consumption/presentation/widgets/fill_up_card.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_card.dart
@@ -3,7 +3,6 @@
 
 import 'package:flutter/material.dart';
 
-import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/unit_formatter.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -69,8 +68,10 @@ class FillUpCard extends StatelessWidget {
     // records logged before this change will re-format on the fly when
     // the user changes country — acceptable as a transitional step.
     final distance = UnitFormatter.formatDistance(fillUp.odometerKm);
-    final costStr =
-        '${fillUp.totalCost.toStringAsFixed(2)} ${PriceFormatter.currency}';
+    // #2491 — a fill-up cost is a TOTAL: route it through formatTotal
+    // (locale-aware 2 dp + currency symbol) instead of a hand-rolled
+    // toStringAsFixed(2) that hardcodes the dot separator.
+    final costStr = PriceFormatter.formatTotal(fillUp.totalCost);
     final ppl = UnitFormatter.formatPricePerUnit(fillUp.pricePerLiter);
     // #1401 phase 7b — only render the verified-by-adapter chip when
     // both fuel-level captures are present. Either missing → no chip.
@@ -179,10 +180,15 @@ class FillUpCard extends StatelessWidget {
   String _pad(int n) => n.toString().padLeft(2, '0');
 }
 
-/// #1902 — the slim amber row a correction [FillUp] collapses to. It
-/// carries only the auto-correction label and the adjusted volume on a
-/// single line: the date, cost, fuel type and odometer of a system
-/// adjustment are noise next to the real fill-ups it sits between.
+/// #1902 — the slim row a correction [FillUp] collapses to. It carries
+/// only the auto-correction label and the adjusted volume on a single
+/// line: the date, cost, fuel type and odometer of a system adjustment
+/// are noise next to the real fill-ups it sits between.
+///
+/// #2491 — the accent moved OFF the shared `warning`-orange token onto
+/// the theme's neutral `tertiary`. A correction is informational, not a
+/// warning; the orange token carried 6+ unrelated meanings (#2487) and
+/// shouting "attention" at a routine auto-adjustment was misleading.
 class _CorrectionRow extends StatelessWidget {
   final String volume;
   final VoidCallback? onTap;
@@ -193,7 +199,7 @@ class _CorrectionRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
-    final correctionColor = DarkModeColors.warning(context);
+    final correctionColor = theme.colorScheme.tertiary;
 
     return Card(
       margin: const EdgeInsets.fromLTRB(16, 2, 16, 2),

--- a/lib/features/consumption/presentation/widgets/trip_summary_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_summary_card.dart
@@ -133,7 +133,10 @@ class TripSummaryCard extends ConsumerWidget {
             if (fuelCost != null)
               _SummaryRow(
                 label: l?.trajetDetailFieldFuelCost ?? 'Fuel cost',
-                value: PriceFormatter.formatPrice(fuelCost),
+                // #2491 — a trip cost is a TOTAL, not a per-litre price:
+                // route it through formatTotal (2 dp + currency symbol)
+                // so a 1.05 € trip reads "1,05 €", not "1,047 €".
+                value: PriceFormatter.formatTotal(fuelCost),
               ),
             _SummaryRow(
               label: l?.trajetDetailFieldAvgSpeed ?? 'Avg speed',

--- a/test/core/utils/price_formatter_test.dart
+++ b/test/core/utils/price_formatter_test.dart
@@ -114,6 +114,111 @@ void main() {
       });
     });
 
+    // #2491 — formatTotal is the TOTAL-currency formatter (2 dp, or 0
+    // dp for a zero-decimal currency) — distinct from the per-litre
+    // formatPrice (3 dp). The regression it fixes: a 1.05 € trip total
+    // rendered "1,047 €" because it was routed through formatPrice.
+    group('formatTotal (#2491)', () {
+      test('rounds to 2 decimals — a 1.047 input is "1,05 €", not '
+          '"1,047" (the bug)', () {
+        PriceFormatter.setCountry('DE');
+        final formatted = PriceFormatter.formatTotal(1.047);
+        expect(formatted, '1,05 €');
+        // The per-litre 3-decimal artefact must be gone.
+        expect(formatted, isNot(contains('047')));
+      });
+
+      test('German locale: comma separator + 2 dp + € suffix', () {
+        PriceFormatter.setCountry('DE');
+        expect(PriceFormatter.formatTotal(12.5), '12,50 €');
+        // Thousands grouping uses the German dot.
+        expect(PriceFormatter.formatTotal(1234.5), '1.234,50 €');
+      });
+
+      test('French locale: comma decimal separator + 2 dp', () {
+        PriceFormatter.setCountry('FR');
+        final formatted = PriceFormatter.formatTotal(1.05);
+        expect(formatted, contains(','));
+        expect(formatted, isNot(contains('.')));
+        expect(formatted, contains('€'));
+      });
+
+      test('UK locale: dot decimal separator + £ suffix', () {
+        PriceFormatter.setCountry('GB');
+        final formatted = PriceFormatter.formatTotal(1.05);
+        expect(formatted, '1.05 £');
+        expect(formatted, isNot(contains(',')));
+      });
+
+      test('exactly two decimals are always shown (no trailing trim)', () {
+        PriceFormatter.setCountry('GB');
+        expect(PriceFormatter.formatTotal(7.8), '7.80 £');
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.formatTotal(7.8), '7,80 €');
+      });
+
+      test('KRW is a zero-decimal currency — whole number, ₩ suffix', () {
+        PriceFormatter.setCountry('KR');
+        // 1050.0 → no minor unit → "1,050 ₩" (grouping comma, but no
+        // fractional part at all).
+        expect(PriceFormatter.formatTotal(1050), '1,050 ₩');
+        // A sub-unit input rounds to a whole number — no decimals.
+        expect(PriceFormatter.formatTotal(1.047), '1 ₩');
+        expect(PriceFormatter.formatTotal(1.6), '2 ₩');
+      });
+
+      test('CLP is also zero-decimal (Chilean peso)', () {
+        PriceFormatter.setCountry('CL');
+        // 1234.5 rounds to a whole number of pesos (es_CL groups with a
+        // dot, so "1.235 $") — no fractional minor unit is shown.
+        expect(PriceFormatter.formatTotal(1234.5), '1.235 \$');
+        expect(PriceFormatter.formatTotal(99.4), '99 \$');
+      });
+
+      test('no doubled space between number and symbol (#2491 trim)', () {
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.formatTotal(1.05), isNot(contains('  ')));
+      });
+
+      test('null amount returns --', () {
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.formatTotal(null), '--');
+      });
+
+      test('zero is a real total (not a sentinel) → "0,00 €"', () {
+        PriceFormatter.setCountry('FR');
+        // Unlike formatPrice, a total of 0 is meaningful (e.g. a
+        // free charge / a 0-cost correction) so it formats, not "--".
+        expect(PriceFormatter.formatTotal(0), '0,00 €');
+      });
+
+      test('honours currencyOverride for cross-country rows', () {
+        PriceFormatter.setCountry('FR');
+        final formatted =
+            PriceFormatter.formatTotal(1.05, currencyOverride: '£');
+        expect(formatted, contains('£'));
+        expect(formatted, isNot(contains('€')));
+      });
+    });
+
+    group('formatPerKm (#2491)', () {
+      test('3 decimals, locale-aware, no currency symbol', () {
+        PriceFormatter.setCountry('FR');
+        expect(PriceFormatter.formatPerKm(0.105), '0,105');
+        PriceFormatter.setCountry('GB');
+        expect(PriceFormatter.formatPerKm(0.105), '0.105');
+      });
+
+      test('rounds to 3 decimals', () {
+        PriceFormatter.setCountry('GB');
+        expect(PriceFormatter.formatPerKm(0.12345), '0.123');
+      });
+
+      test('null returns --', () {
+        expect(PriceFormatter.formatPerKm(null), '--');
+      });
+    });
+
     group('setCountry', () {
       test('case insensitive', () {
         PriceFormatter.setCountry('gb');

--- a/test/features/consumption/presentation/fill_up_card_test.dart
+++ b/test/features/consumption/presentation/fill_up_card_test.dart
@@ -145,14 +145,21 @@ void main() {
       );
 
       // #1902 — the correction collapses to a slim row with a 2 px
-      // orange rule (down from the old 4 px full border).
+      // rule (down from the old 4 px full border).
+      // #2491 — that rule moved OFF the warning-orange token onto the
+      // theme's neutral tertiary: a correction is informational, not a
+      // warning, so it must NOT borrow the attention colour.
       final card = tester.widget<Card>(find.byType(Card));
       final shape = card.shape;
       expect(shape, isA<RoundedRectangleBorder>());
       final border = (shape! as RoundedRectangleBorder).side;
+      final ctx = tester.element(find.byType(Card));
+      expect(border.color, Theme.of(ctx).colorScheme.tertiary);
       expect(
         border.color,
-        DarkModeColors.warning(tester.element(find.byType(Card))),
+        isNot(DarkModeColors.warning(ctx)),
+        reason: '#2491 — the correction accent must not use the '
+            'overloaded warning-orange token',
       );
       expect(border.width, 2);
       // The slim correction row is not a full ListTile.
@@ -220,10 +227,13 @@ void main() {
 
     await pumpApp(tester, const ConsumptionStatsCard(stats: stats));
 
-    expect(find.text('8.00'), findsOneWidget); // avg L/100km
-    expect(find.text('0.120'), findsOneWidget); // avg cost/km
-    expect(find.text('120.0'), findsOneWidget); // total liters
-    expect(find.text('180.00'), findsOneWidget); // total spent
+    // This file runs with the FR default formatter locale (see the
+    // "50,0 L" / "1,600 €/L" assertions above), so #2491's locale-aware
+    // formatTotal/formatPerKm print comma decimals + the € symbol.
+    expect(find.text('8.00'), findsOneWidget); // avg L/100km (toStringAsFixed)
+    expect(find.text('0,120'), findsOneWidget); // avg cost/km (formatPerKm, FR)
+    expect(find.text('120.0'), findsOneWidget); // total liters (toStringAsFixed)
+    expect(find.text('180,00 €'), findsOneWidget); // total spent (formatTotal)
     expect(find.textContaining('3'), findsWidgets); // fill up count
   });
 

--- a/test/features/consumption/presentation/widgets/charging_log_card_test.dart
+++ b/test/features/consumption/presentation/widgets/charging_log_card_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/charging_log_card.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
 
@@ -36,6 +37,12 @@ ChargingLog _log({
 }
 
 void main() {
+  // #2491 — the cost glyph now comes from PriceFormatter.formatTotal,
+  // which formats in the active country's locale. Pin GB so the cost
+  // keeps the dot-decimal "7.85" shape the subtitle assertions use
+  // (and a deterministic £ symbol regardless of test ordering).
+  setUp(() => PriceFormatter.setCountry('GB'));
+
   group('ChargingLogCard — base structure', () {
     testWidgets('renders a Card and ListTile', (tester) async {
       await pumpApp(tester, ChargingLogCard(log: _log()));
@@ -120,7 +127,7 @@ void main() {
         ),
       );
       expect(
-        find.text('2026-04-25  •  22.5 kWh  •  7.85 €  •  35 min'),
+        find.text('2026-04-25  •  22.5 kWh  •  7.85 £  •  35 min'),
         findsOneWidget,
       );
     });
@@ -138,9 +145,10 @@ void main() {
           ),
         ),
       );
-      // 22.47 → 22.5 via toStringAsFixed(1); 7.8 → 7.80 via toStringAsFixed(2).
+      // 22.47 → 22.5 via toStringAsFixed(1); 7.8 → "7.80 £" via
+      // PriceFormatter.formatTotal (2 dp, GB locale dot separator).
       expect(
-        find.text('2026-04-25  •  22.5 kWh  •  7.80 €  •  12 min'),
+        find.text('2026-04-25  •  22.5 kWh  •  7.80 £  •  12 min'),
         findsOneWidget,
       );
     });
@@ -172,7 +180,7 @@ void main() {
         ),
       );
       const expectedLabel =
-          'Ionity Castelnau, 2026-04-25  •  22.5 kWh  •  7.85 €  •  35 min';
+          'Ionity Castelnau, 2026-04-25  •  22.5 kWh  •  7.85 £  •  35 min';
       expect(
         find.bySemanticsLabel(expectedLabel),
         findsOneWidget,

--- a/test/features/consumption/presentation/widgets/consumption_stats_card_test.dart
+++ b/test/features/consumption/presentation/widgets/consumption_stats_card_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/consumption/domain/entities/consumption_stats.dart';
 import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
 import 'package:tankstellen/features/consumption/domain/entities/pending_reconciliation.dart';
@@ -86,6 +87,12 @@ ConsumptionStats _stats({
 }
 
 void main() {
+  // #2491 — the avg-cost/km tile now formats via
+  // PriceFormatter.formatPerKm and the total-spent tile via
+  // formatTotal, both locale-aware. Pin GB so the figures keep their
+  // dot-decimal shape and the total carries a deterministic £ symbol.
+  setUp(() => PriceFormatter.setCountry('GB'));
+
   group('ConsumptionStatsCard — title', () {
     testWidgets('renders the localized "Consumption stats" title',
         (tester) async {
@@ -179,8 +186,9 @@ void main() {
         ConsumptionStatsCard(stats: _stats(totalSpent: 123.456)),
       );
 
-      // 123.456 → "123.46" via toStringAsFixed(2)
-      expect(find.text('123.46'), findsOneWidget);
+      // #2491 — 123.456 → "123.46 £" via PriceFormatter.formatTotal
+      // (2 dp + currency symbol, GB locale dot separator).
+      expect(find.text('123.46 £'), findsOneWidget);
     });
 
     testWidgets('renders the localized total-spent label', (tester) async {
@@ -253,9 +261,9 @@ void main() {
       );
 
       expect(find.text('6.40'), findsOneWidget); // avg L/100km
-      expect(find.text('0.105'), findsOneWidget); // avg cost/km
+      expect(find.text('0.105'), findsOneWidget); // avg cost/km (formatPerKm)
       expect(find.text('120.0'), findsOneWidget); // total liters
-      expect(find.text('198.40'), findsOneWidget); // total spent
+      expect(find.text('198.40 £'), findsOneWidget); // total spent (formatTotal)
       expect(find.text('Fill-ups: 3'), findsOneWidget);
       expect(find.text('—'), findsNothing); // no nullable fallbacks fired
     });

--- a/test/features/consumption/presentation/widgets/trip_summary_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_summary_card_test.dart
@@ -467,12 +467,14 @@ void main() {
       );
 
       expect(find.text('Fuel cost'), findsOneWidget);
-      // PriceFormatter.formatPrice with FR locale prints the value
-      // with three decimals and a non-breaking space + €.
+      // #2491 — a trip cost is a TOTAL, so the card now uses
+      // formatTotal (2 dp + € suffix): 0.4455 → "0,45 €" in FR, not
+      // the old per-litre 3-decimal "0,446 €" (the bug this fixes).
       expect(
-        find.text(PriceFormatter.formatPrice(0.4455)),
+        find.text(PriceFormatter.formatTotal(0.4455)),
         findsOneWidget,
       );
+      expect(find.text('0,45 €'), findsOneWidget);
     });
 
     testWidgets('hides the cost row when the provider returns null',


### PR DESCRIPTION
Closes #2491