### PR TITLE
refactor(ui): StationCardShell + evAccent token + locale-safe connector status + unify 4 station cards (#2493)

### DIFF
--- a/lib/core/theme/fuel_colors.dart
+++ b/lib/core/theme/fuel_colors.dart
@@ -15,20 +15,44 @@ import '../../features/search/domain/entities/fuel_type.dart';
 class FuelColors {
   FuelColors._();
 
+  /// Canonical EV accent — crystal-blue (`#4FC3F7`, #2143 / #2493).
+  ///
+  /// Cool, glassy, deliberately distinct from the muted-teal
+  /// [FuelTypeElectric] price hue (`#3B8079`). This is the SINGLE source
+  /// for the EV-surface accent: the kW headline, the left card stripe and
+  /// the connector-chip tints all reference it, replacing the three
+  /// divergent values that used to live in `ev_favorite_card.dart`
+  /// (`#4FC3F7`), `ev_station_card.dart` (teal `#009688`) and
+  /// `ev_connector_chips.dart` (`#2196F3`).
+  static const Color evAccent = Color(0xFF4FC3F7);
+
   static Color forType(FuelType type) => switch (type) {
-    FuelTypeE5()     => const Color(0xFF4F7C44),  // Muted green
-    FuelTypeE10()    => const Color(0xFF3B6FA0),  // Muted slate-blue
-    FuelTypeE98()    => const Color(0xFF7B4E86),  // Muted plum
-    FuelTypeDiesel() => const Color(0xFFBE7C1E),  // Muted ochre
+    FuelTypeE5() => const Color(0xFF4F7C44), // Muted green
+    FuelTypeE10() => const Color(0xFF3B6FA0), // Muted slate-blue
+    FuelTypeE98() => const Color(0xFF7B4E86), // Muted plum
+    FuelTypeDiesel() => const Color(0xFFBE7C1E), // Muted ochre
     FuelTypeDieselPremium() => const Color(0xFFB5573B), // Muted terracotta
-    FuelTypeE85()    => const Color(0xFF73904A),  // Muted olive
-    FuelTypeLpg()    => const Color(0xFF3C8794),  // Muted teal-cyan
-    FuelTypeCng()    => const Color(0xFF5C7079),  // Muted blue-grey
+    FuelTypeE85() => const Color(0xFF73904A), // Muted olive
+    FuelTypeLpg() => const Color(0xFF3C8794), // Muted teal-cyan
+    FuelTypeCng() => const Color(0xFF5C7079), // Muted blue-grey
     FuelTypeHydrogen() => const Color(0xFF4589AC), // Muted sky-blue
     FuelTypeElectric() => const Color(0xFF3B8079), // Muted teal
-    FuelTypeAll()    => const Color(0xFF6F6F6F),  // Neutral grey
+    FuelTypeAll() => const Color(0xFF6F6F6F), // Neutral grey
   };
 
   /// Lighter variant for backgrounds/fills
-  static Color forTypeLight(FuelType type) => forType(type).withValues(alpha: 0.15);
+  static Color forTypeLight(FuelType type) =>
+      forType(type).withValues(alpha: 0.15);
+
+  /// Left accent-stripe colour for a [StationCardShell] (#2493).
+  ///
+  /// Identical to [forType] for a concrete fuel, but the all-fuels case
+  /// resolves to the theme primary (forest green) instead of the
+  /// near-invisible neutral grey `#6F6F6F` that [forType] returns — so the
+  /// all-prices/favorite "all fuels" card actually shows a visible marker.
+  /// Needs a [BuildContext] for the theme primary, hence the separate API.
+  static Color stripeColor(BuildContext context, FuelType type) =>
+      type is FuelTypeAll
+      ? Theme.of(context).colorScheme.primary
+      : forType(type);
 }

--- a/lib/core/widgets/station_card_shell.dart
+++ b/lib/core/widgets/station_card_shell.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_radius.dart';
+
+/// The shared frame for every station card (#2493).
+///
+/// Before this widget the fuel `StationCard`, `EvFavoriteCard`,
+/// `EVStationCard` and `AllPricesStationCard` each hand-copied the same
+/// outer `Card` + `InkWell` + optional left accent stripe, and the copies
+/// had quietly drifted (different margins, elevations, radii, and an
+/// `EVStationCard` that used `BorderRadius.circular(12)` literals while
+/// others used the theme default). `StationCardShell` owns that frame once
+/// so the four cards share a single silhouette and only supply their
+/// distinct body + stripe colour.
+///
+/// Frame grammar:
+/// * margin `symmetric(horizontal: 8, vertical: 6)`
+/// * `Clip.antiAlias`
+/// * elevation `1` on dark, `2` on light (dark surfaces need less lift)
+/// * shape rounded to [AppRadius.lg] (12) — the canonical card radius
+/// * an [InkWell] tap target sharing the same radius
+/// * an optional left [BorderSide] accent stripe in [stripeColor]
+class StationCardShell extends StatelessWidget {
+  /// Colour of the left accent stripe. When `null` no stripe is drawn
+  /// (e.g. the all-prices card, which carries its colour in the per-fuel
+  /// badges instead).
+  final Color? stripeColor;
+
+  /// Width of the left accent stripe; ignored when [stripeColor] is null.
+  /// The cheapest-fuel card bumps this to `6` to emphasise the winner.
+  final double stripeWidth;
+
+  /// The card body. The shell supplies the frame; padding inside the body
+  /// is the caller's responsibility (it differs per card).
+  final Widget child;
+
+  /// Tap handler forwarded to the [InkWell].
+  final VoidCallback? onTap;
+
+  const StationCardShell({
+    super.key,
+    required this.child,
+    this.stripeColor,
+    this.stripeWidth = 4,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      clipBehavior: Clip.antiAlias,
+      elevation: isDark ? 1 : 2,
+      shape: RoundedRectangleBorder(borderRadius: AppRadius.lg),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: AppRadius.lg,
+        child: stripeColor == null
+            ? child
+            : DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border(
+                    left: BorderSide(color: stripeColor!, width: stripeWidth),
+                  ),
+                ),
+                child: child,
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/ev/domain/entities/charging_station.dart
+++ b/lib/features/ev/domain/entities/charging_station.dart
@@ -11,10 +11,22 @@ part 'charging_station.freezed.dart';
 part 'charging_station.g.dart';
 
 /// Real-time status of an individual [EvConnector].
+///
+/// Canonical, locale-independent status scale (#2493). Every upstream
+/// provider's free-form, often-English status string is normalised into
+/// one of these enum values at the data layer ([fromLabel]); the UI then
+/// switches colour/icon on the enum and localises only the display label,
+/// so the operational scale survives in all 23 locales instead of silently
+/// disappearing wherever the upstream string isn't English.
 enum ConnectorStatus {
   available('available'),
   occupied('occupied'),
   outOfOrder('out_of_order'),
+
+  /// Some, but not all, connectors/points at this position are usable
+  /// (OpenChargeMap "Partly Operational"). Distinct from [available] /
+  /// [outOfOrder] so the UI can warn rather than show all-clear.
+  partial('partial'),
   unknown('unknown');
 
   final String key;
@@ -30,23 +42,33 @@ enum ConnectorStatus {
 
   /// Best-effort heuristic mapping from the human-readable labels that
   /// OpenChargeMap returns ("Currently Available", "In Use", "Not
-  /// Operational", …) into the canonical [ConnectorStatus]. Used by the
-  /// legacy-format [EvConnector.fromJson] path so data persisted before
-  /// the #560 consolidation still rehydrates correctly.
+  /// Operational", "Partly Operational", …) into the canonical
+  /// [ConnectorStatus]. The single source of truth for status
+  /// normalisation (#2493) — both the live [EvConnector] construction in
+  /// the charging service and the legacy-format [EvConnector.fromJson]
+  /// path route through here, so the UI never has to string-match again.
   static ConnectorStatus fromLabel(String? label) {
     if (label == null) return ConnectorStatus.unknown;
     final lower = label.toLowerCase();
-    if (lower.contains('available') || lower == 'operational') {
-      return ConnectorStatus.available;
-    }
-    if (lower.contains('in use') || lower.contains('occupied')) {
-      return ConnectorStatus.occupied;
+    // Order matters. "Partly Operational" must precede the plain
+    // "operational"/"available" branch, and the negative "unavailable"
+    // branch must precede the positive "available" one — otherwise the
+    // substring "available" inside "unavailable" misreads a dead connector
+    // ("Temporarily Unavailable") as free (#2493).
+    if (lower.contains('partly') || lower.contains('partial')) {
+      return ConnectorStatus.partial;
     }
     if (lower.contains('not operational') ||
         lower.contains('out of order') ||
         lower.contains('unavailable') ||
         lower.contains('removed')) {
       return ConnectorStatus.outOfOrder;
+    }
+    if (lower.contains('available') || lower == 'operational') {
+      return ConnectorStatus.available;
+    }
+    if (lower.contains('in use') || lower.contains('occupied')) {
+      return ConnectorStatus.occupied;
     }
     return ConnectorStatus.unknown;
   }
@@ -116,8 +138,7 @@ Map<String, dynamic> _normalizeChargingStationJson(Map<String, dynamic> json) {
   if (!normalized.containsKey('latitude') && normalized.containsKey('lat')) {
     normalized['latitude'] = normalized['lat'];
   }
-  if (!normalized.containsKey('longitude') &&
-      normalized.containsKey('lng')) {
+  if (!normalized.containsKey('longitude') && normalized.containsKey('lng')) {
     normalized['longitude'] = normalized['lng'];
   }
   return normalized;
@@ -223,15 +244,13 @@ abstract class ChargingStation with _$ChargingStation {
       _$ChargingStationFromJson(_normalizeChargingStationJson(json));
 
   /// Whether any connector is currently reported as `available`.
-  bool get hasAvailableConnector => connectors
-      .any((c) => c.status == ConnectorStatus.available);
+  bool get hasAvailableConnector =>
+      connectors.any((c) => c.status == ConnectorStatus.available);
 
   /// Highest advertised max power across all connectors.
   double get maxPowerKw => connectors.isEmpty
       ? 0
-      : connectors
-          .map((c) => c.maxPowerKw)
-          .reduce((a, b) => a > b ? a : b);
+      : connectors.map((c) => c.maxPowerKw).reduce((a, b) => a > b ? a : b);
 
   /// Legacy alias matching the pre-#560 search-side `lat` getter. Keeps
   /// the rename from `lat`/`lng` to `latitude`/`longitude` a soft

--- a/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/ev/presentation/screens/ev_station_detail_screen.dart
@@ -4,7 +4,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -14,6 +13,7 @@ import '../../../search/providers/station_rating_provider.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart'
     show ConnectorType;
 import '../../domain/entities/charging_station.dart';
+import '../widgets/connector_status_style.dart';
 
 /// Detail view for a single [ChargingStation] with favorite toggle.
 ///
@@ -105,9 +105,7 @@ class EvStationDetailScreen extends ConsumerWidget {
               ),
             ),
             icon: const Icon(Icons.ev_station),
-            label: Text(
-              l10n?.chargingLogButtonLabel ?? 'Log charging',
-            ),
+            label: Text(l10n?.chargingLogButtonLabel ?? 'Log charging'),
             style: FilledButton.styleFrom(
               minimumSize: const Size.fromHeight(48),
             ),
@@ -171,35 +169,14 @@ class _ConnectorTile extends StatelessWidget {
     }
   }
 
-  static (String, Color) _statusBadge(
-    BuildContext context,
-    ConnectorStatus status,
-  ) {
-    final l10n = AppLocalizations.of(context);
-    switch (status) {
-      case ConnectorStatus.available:
-        return (
-          l10n?.evStatusAvailable ?? 'Available',
-          DarkModeColors.success(context)
-        );
-      case ConnectorStatus.occupied:
-        return (
-          l10n?.evStatusOccupied ?? 'Occupied',
-          DarkModeColors.warning(context)
-        );
-      case ConnectorStatus.outOfOrder:
-        return (
-          l10n?.evStatusOutOfOrder ?? 'Out of order',
-          DarkModeColors.error(context)
-        );
-      case ConnectorStatus.unknown:
-        return (l10n?.evStatusUnknown ?? 'Unknown', Colors.grey);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final (statusLabel, color) = _statusBadge(context, connector.status);
+    // #2493 — colour + label both resolve off the canonical enum via the
+    // shared [ConnectorStatusStyle], so this screen and the search-side
+    // `EVConnectorTile` can never disagree on what "available" looks like.
+    final status = connector.status;
+    final statusLabel = status.label(context);
+    final color = status.color(context);
     return Card(
       child: ListTile(
         leading: const Icon(Icons.power),
@@ -238,8 +215,9 @@ class _RatingRow extends ConsumerWidget {
         ...List.generate(5, (i) {
           final starIndex = i + 1;
           return GestureDetector(
-            onTap: () =>
-                ref.read(stationRatingsProvider.notifier).rate(stationId, starIndex),
+            onTap: () => ref
+                .read(stationRatingsProvider.notifier)
+                .rate(stationId, starIndex),
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 2),
               child: Icon(

--- a/lib/features/ev/presentation/widgets/connector_status_style.dart
+++ b/lib/features/ev/presentation/widgets/connector_status_style.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/entities/charging_station.dart';
+
+/// Locale-safe presentation for a [ConnectorStatus] (#2493).
+///
+/// Colour and icon switch on the canonical enum — never on the upstream
+/// free-form status string — so the operational scale renders identically
+/// in all 23 locales. Only the human-readable [label] is localised.
+///
+/// This is the single source of truth shared by the search-side
+/// `EVConnectorTile` and the EV station-detail screen, so the two surfaces
+/// can never drift apart on what "available" looks like again.
+extension ConnectorStatusStyle on ConnectorStatus {
+  /// Semantic status colour, adapting to light/dark for WCAG AA.
+  Color color(BuildContext context) => switch (this) {
+    ConnectorStatus.available => DarkModeColors.success(context),
+    ConnectorStatus.occupied => DarkModeColors.warning(context),
+    ConnectorStatus.partial => DarkModeColors.warning(context),
+    ConnectorStatus.outOfOrder => DarkModeColors.error(context),
+    ConnectorStatus.unknown => Theme.of(context).colorScheme.outline,
+  };
+
+  /// Status glyph, switched on the enum (not the upstream string).
+  IconData get icon => switch (this) {
+    ConnectorStatus.available => Icons.check_circle,
+    ConnectorStatus.occupied => Icons.access_time,
+    ConnectorStatus.partial => Icons.warning,
+    ConnectorStatus.outOfOrder => Icons.cancel,
+    ConnectorStatus.unknown => Icons.help_outline,
+  };
+
+  /// Localised display label. Falls back to English when no [l10n] is in
+  /// scope (e.g. tests pumped without localisations).
+  String label(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return switch (this) {
+      ConnectorStatus.available => l10n?.evStatusAvailable ?? 'Available',
+      ConnectorStatus.occupied => l10n?.evStatusOccupied ?? 'Occupied',
+      ConnectorStatus.partial => l10n?.evStatusPartial ?? 'Partly available',
+      ConnectorStatus.outOfOrder => l10n?.evStatusOutOfOrder ?? 'Out of order',
+      ConnectorStatus.unknown => l10n?.evStatusUnknown ?? 'Unknown',
+    };
+  }
+}

--- a/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
+++ b/lib/features/favorites/presentation/widgets/ev_favorite_card.dart
@@ -4,7 +4,9 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/entities/charging_station.dart';
 
@@ -14,18 +16,11 @@ import '../../../ev/domain/entities/charging_station.dart';
 /// the typed [EvConnector] instead of the previous free-form search
 /// side [Connector].
 ///
-/// #2229 — shares the fuel `StationCard`'s frame (margins, elevation,
-/// shape, leading status dot, title/operator/distance block, right
-/// detail column) so both favorite cards have one silhouette; the only
-/// visual difference is the left accent stripe — [crystalBlue] here vs
-/// the grey `FuelType.all` stripe on fuel cards.
+/// #2229 — shares the fuel `StationCard`'s frame (now the common
+/// [StationCardShell], #2493) so both favorite cards have one silhouette;
+/// the only visual difference is the left accent stripe — the canonical
+/// [FuelColors.evAccent] crystal-blue here vs the fuel stripe elsewhere.
 class EvFavoriteCard extends StatelessWidget {
-  /// Crystal-blue accent (#2143) — cool, glassy, distinct from the
-  /// muted-teal `FuelTypeElectric` (#3B8079). Used for both the kW
-  /// headline and (since #2229) the left accent stripe that marks the
-  /// card as EV, without borrowing the fuel palette.
-  static const Color crystalBlue = Color(0xFF4FC3F7);
-
   final ChargingStation station;
   final VoidCallback? onTap;
   final VoidCallback? onFavoriteTap;
@@ -69,80 +64,67 @@ class EvFavoriteCard extends StatelessWidget {
     return Semantics(
       label: semanticLabel,
       button: true,
-      child: Card(
-        // #2229 — same frame as the fuel `StationCard` so both favorite
-        // cards share one silhouette; the only difference is the left
-        // accent stripe colour (blue here vs grey for FuelType.all fuel
-        // cards).
-        margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-        clipBehavior: Clip.antiAlias,
-        elevation: theme.brightness == Brightness.dark ? 1 : 2,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(12),
-          child: Container(
-            decoration: const BoxDecoration(
-              border: Border(
-                left: BorderSide(color: crystalBlue, width: 4),
-              ),
-            ),
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                _EvStatusDot(available: available),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
+      // #2229 / #2493 — same frame as the fuel `StationCard` via the shared
+      // [StationCardShell]; the only difference is the left accent stripe
+      // colour (the canonical EV [FuelColors.evAccent] here vs the fuel
+      // stripe elsewhere).
+      child: StationCardShell(
+        onTap: onTap,
+        stripeColor: FuelColors.evAccent,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              _EvStatusDot(available: available),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      station.name,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (operatorName.isNotEmpty) ...[
+                      const SizedBox(height: 2),
                       Text(
-                        station.name,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
+                        operatorName,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                       ),
-                      if (operatorName.isNotEmpty) ...[
-                        const SizedBox(height: 2),
-                        Text(
-                          operatorName,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                      if (station.dist > 0) ...[
-                        const SizedBox(height: 2),
-                        Text(
-                          PriceFormatter.formatDistance(station.dist),
-                          style: theme.textTheme.bodySmall,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
                     ],
-                  ),
+                    if (station.dist > 0) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        PriceFormatter.formatDistance(station.dist),
+                        style: theme.textTheme.bodySmall,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
                 ),
-                const SizedBox(width: 8),
-                _EvDetailColumn(
-                  maxPowerKw: maxPower,
-                  available: available,
-                  total: total,
-                  connectorTypes: connectorTypes,
-                  availableLabel: availableLabel,
-                  onFavoriteTap: onFavoriteTap,
-                  removeFavoriteTooltip:
-                      l10n?.removeFavorite ?? 'Remove from favorites',
-                ),
-              ],
-            ),
+              ),
+              const SizedBox(width: 8),
+              _EvDetailColumn(
+                maxPowerKw: maxPower,
+                available: available,
+                total: total,
+                connectorTypes: connectorTypes,
+                availableLabel: availableLabel,
+                onFavoriteTap: onFavoriteTap,
+                removeFavoriteTooltip:
+                    l10n?.removeFavorite ?? 'Remove from favorites',
+              ),
+            ],
           ),
         ),
       ),
@@ -206,17 +188,13 @@ class _EvDetailColumn extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            const Icon(
-              Icons.bolt,
-              size: 16,
-              color: EvFavoriteCard.crystalBlue,
-            ),
+            const Icon(Icons.bolt, size: 16, color: FuelColors.evAccent),
             const SizedBox(width: 2),
             Text(
               '${maxPowerKw.round()} kW',
               style: theme.textTheme.titleLarge!.copyWith(
                 fontWeight: FontWeight.bold,
-                color: EvFavoriteCard.crystalBlue,
+                color: FuelColors.evAccent,
               ),
             ),
             const SizedBox(width: 4),

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';
 import '../../domain/entities/fuel_type.dart';
@@ -45,135 +46,131 @@ class AllPricesStationCard extends StatelessWidget {
   /// `BrandRegistry.independentLabel` (`'Independent'` from #482).
   /// `'Autoroute'` is a synthetic motorway tag, not a real brand, so
   /// the card keeps that exclusion on top.
-  bool get _hasBrand =>
-      hasRealBrand(station) && station.brand != 'Autoroute';
+  bool get _hasBrand => hasRealBrand(station) && station.brand != 'Autoroute';
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
 
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-      clipBehavior: Clip.antiAlias,
-      elevation: theme.brightness == Brightness.dark ? 1 : 2,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Header row: status dot + name + distance + favorite
-              Row(
-                children: [
-                  // Status indicator
-                  Container(
-                    width: 10,
-                    height: 10,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
+    // #2493 — shared frame via [StationCardShell]. This card carries no
+    // accent stripe (its colour lives in the per-fuel badges), so
+    // `stripeColor` is left null. The leading status dot is 12px to match
+    // the shared grammar used by the other three cards.
+    return StationCardShell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header row: status dot + name + distance + favorite
+            Row(
+              children: [
+                // Status indicator
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: station.isOpen
+                        ? DarkModeColors.success(context)
+                        : DarkModeColors.error(context),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // Station name
+                Expanded(
+                  child: Text(
+                    _hasBrand ? station.brand : station.street,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                // Status badge
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: station.isOpen
+                        ? DarkModeColors.success(
+                            context,
+                          ).withValues(alpha: 0.12)
+                        : DarkModeColors.error(context).withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    station.isOpen
+                        ? (l10n?.open ?? 'Open')
+                        : (l10n?.closed ?? 'Closed'),
+                    style: TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w600,
                       color: station.isOpen
                           ? DarkModeColors.success(context)
                           : DarkModeColors.error(context),
                     ),
                   ),
-                  const SizedBox(width: 8),
-                  // Station name
-                  Expanded(
-                    child: Text(
-                      _hasBrand ? station.brand : station.street,
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(width: 4),
+                // Favorite button
+                SizedBox(
+                  width: 32,
+                  height: 32,
+                  child: IconButton(
+                    padding: EdgeInsets.zero,
+                    iconSize: 20,
+                    icon: Icon(
+                      isFavorite ? Icons.star : Icons.star_border,
+                      color: isFavorite ? Colors.amber : null,
                     ),
+                    onPressed: onFavoriteTap,
+                    tooltip: isFavorite
+                        ? (l10n?.removeFavorite ?? 'Remove from favorites')
+                        : (l10n?.addFavorite ?? 'Add to favorites'),
                   ),
-                  // Status badge
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 6, vertical: 2),
-                    decoration: BoxDecoration(
-                      color: station.isOpen
-                          ? DarkModeColors.success(context)
-                              .withValues(alpha: 0.12)
-                          : DarkModeColors.error(context)
-                              .withValues(alpha: 0.12),
-                      borderRadius: BorderRadius.circular(8),
+                ),
+              ],
+            ),
+            const SizedBox(height: 2),
+            // Address + distance row
+            Row(
+              children: [
+                const SizedBox(width: 18), // Align with name
+                Expanded(
+                  child: Text(
+                    _hasBrand
+                        ? '${station.street}, ${station.postCode} ${station.place}'
+                        : '${station.postCode} ${station.place}',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
                     ),
-                    child: Text(
-                      station.isOpen
-                          ? (l10n?.open ?? 'Open')
-                          : (l10n?.closed ?? 'Closed'),
-                      style: TextStyle(
-                        fontSize: 10,
-                        fontWeight: FontWeight.w600,
-                        color: station.isOpen
-                            ? DarkModeColors.success(context)
-                            : DarkModeColors.error(context),
-                      ),
-                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(width: 4),
-                  // Favorite button
-                  SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: IconButton(
-                      padding: EdgeInsets.zero,
-                      iconSize: 20,
-                      icon: Icon(
-                        isFavorite ? Icons.star : Icons.star_border,
-                        color: isFavorite ? Colors.amber : null,
-                      ),
-                      onPressed: onFavoriteTap,
-                      tooltip: isFavorite
-                          ? 'Remove from favorites'
-                          : 'Add to favorites',
-                    ),
+                ),
+                Text(
+                  PriceFormatter.formatDistance(station.dist),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.primary,
                   ),
-                ],
-              ),
-              const SizedBox(height: 2),
-              // Address + distance row
-              Row(
-                children: [
-                  const SizedBox(width: 18), // Align with name
-                  Expanded(
-                    child: Text(
-                      _hasBrand
-                          ? '${station.street}, ${station.postCode} ${station.place}'
-                          : '${station.postCode} ${station.place}',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  Text(
-                    PriceFormatter.formatDistance(station.dist),
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: theme.colorScheme.primary,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 6),
-              // Fuel price badges
-              Wrap(
-                spacing: 6,
-                runSpacing: 4,
-                children: _buildFuelBadges(context),
-              ),
-            ],
-          ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            // Fuel price badges
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: _buildFuelBadges(context),
+            ),
+          ],
         ),
       ),
     );
@@ -196,18 +193,22 @@ class AllPricesStationCard extends StatelessWidget {
     for (final (fuelType, price, label) in fuelEntries) {
       // Only show fuels that are available or explicitly listed as unavailable
       final isUnavailable = station.unavailableFuels.contains(
-          fuelType.apiValue);
+        fuelType.apiValue,
+      );
       if (price == null && !isUnavailable) continue;
 
-      badges.add(_FuelBadge(
-        label: label,
-        price: price,
-        fuelType: fuelType,
-        isUnavailable: isUnavailable,
-        isCheapest: cheapestFlags[fuelType] ?? false,
-        isProfileFuel: profileFuelType != null &&
-            profileFuelType!.apiValue == fuelType.apiValue,
-      ));
+      badges.add(
+        _FuelBadge(
+          label: label,
+          price: price,
+          fuelType: fuelType,
+          isUnavailable: isUnavailable,
+          isCheapest: cheapestFlags[fuelType] ?? false,
+          isProfileFuel:
+              profileFuelType != null &&
+              profileFuelType!.apiValue == fuelType.apiValue,
+        ),
+      );
     }
 
     return badges;

--- a/lib/features/search/presentation/widgets/ev_connector_chips.dart
+++ b/lib/features/search/presentation/widgets/ev_connector_chips.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/fuel_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Compact wrap of colored "pills" identifying the connector types on
@@ -32,8 +33,14 @@ class EvConnectorChips extends StatelessWidget {
   /// Maps a connector type label to a brand-recognisable color. Returns
   /// neutral grey for unknown types so the pill still renders without
   /// breaking the layout.
+  ///
+  /// #2493 — the generic CCS chip now uses the canonical
+  /// [FuelColors.evAccent] crystal-blue instead of the ad-hoc Material
+  /// blue (`#2196F3`) it used to hard-code, so the EV accent is one token
+  /// across every surface. Type 2 / CHAdeMO / Tesla keep their deliberate
+  /// per-connector brand hues (green / orange / pink).
   static Color colorFor(String type) {
-    if (type.contains('CCS')) return const Color(0xFF2196F3); // Blue
+    if (type.contains('CCS')) return FuelColors.evAccent; // Crystal-blue
     if (type.contains('Type 2')) return const Color(0xFF4CAF50); // Green
     if (type.contains('CHAdeMO')) return const Color(0xFFFF9800); // Orange
     if (type.contains('Tesla')) return const Color(0xFFE91E63); // Pink
@@ -47,7 +54,7 @@ class EvConnectorChips extends StatelessWidget {
     final semanticLabel = visible.isEmpty
         ? (l10n?.evConnectorsNone ?? 'No connector information')
         : '${l10n?.evConnectorsLabel ?? "Available connectors"}: '
-            '${visible.join(", ")}';
+              '${visible.join(", ")}';
 
     return Semantics(
       container: true,

--- a/lib/features/search/presentation/widgets/ev_connector_tile.dart
+++ b/lib/features/search/presentation/widgets/ev_connector_tile.dart
@@ -3,8 +3,9 @@
 
 import 'package:flutter/material.dart';
 
-import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../ev/domain/entities/charging_station.dart';
+import '../../../ev/presentation/widgets/connector_status_style.dart';
+import 'ev_connector_chips.dart';
 
 /// A single connector row showing type, power, current type, quantity, and status.
 class EVConnectorTile extends StatelessWidget {
@@ -12,14 +13,26 @@ class EVConnectorTile extends StatelessWidget {
   const EVConnectorTile({super.key, required this.connector});
 
   String get _typeLabel => connector.rawType ?? connector.type.label;
-  String? get _statusLabel => connector.statusLabel;
+
+  /// Surface a status chip whenever the upstream told us anything — either
+  /// a free-form label string OR a normalised status that isn't
+  /// [ConnectorStatus.unknown]. The chip's colour, icon and text then all
+  /// derive from the canonical enum (#2493), so the operational scale shows
+  /// localised in every locale instead of only when the API string was
+  /// English.
+  bool get _hasStatus =>
+      connector.statusLabel != null ||
+      connector.status != ConnectorStatus.unknown;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final label = _typeLabel;
-    final status = _statusLabel;
-    final connColor = _connectorColor(label);
+    // #2493 — connector-family tints are a deliberate per-connector colour
+    // scheme (CCS/Type 2/CHAdeMO/Tesla); reuse the single map shared with
+    // the connector chips rather than re-declaring it here.
+    final connColor = EvConnectorChips.colorFor(label);
+    final status = connector.status;
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
@@ -32,66 +45,71 @@ class EVConnectorTile extends StatelessWidget {
             ),
             child: Text(
               label,
-              style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: connColor),
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: connColor,
+              ),
             ),
           ),
           const SizedBox(width: 12),
-          Text('${connector.maxPowerKw.round()} kW', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+          Text(
+            '${connector.maxPowerKw.round()} kW',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
           const SizedBox(width: 8),
           if (connector.currentType != null)
-            Text(connector.currentType!, style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+            Text(
+              connector.currentType!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           const Spacer(),
           if (connector.quantity > 0)
-            Text('x${connector.quantity}', style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
-          if (status != null) ...[
+            Text(
+              'x${connector.quantity}',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          if (_hasStatus) ...[
             const SizedBox(width: 8),
-            Builder(builder: (context) {
-              final statusCol = _statusColor(context, status);
-              return Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: statusCol.withValues(alpha: 0.15),
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(_statusIcon(status), size: 12, color: statusCol),
-                    const SizedBox(width: 3),
-                    Text(status, style: TextStyle(fontSize: 9, fontWeight: FontWeight.w600, color: statusCol)),
-                  ],
-                ),
-              );
-            }),
+            Builder(
+              builder: (context) {
+                final statusCol = status.color(context);
+                return Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical: 2,
+                  ),
+                  decoration: BoxDecoration(
+                    color: statusCol.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(status.icon, size: 12, color: statusCol),
+                      const SizedBox(width: 3),
+                      Text(
+                        status.label(context),
+                        style: TextStyle(
+                          fontSize: 9,
+                          fontWeight: FontWeight.w600,
+                          color: statusCol,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
           ],
         ],
       ),
     );
-  }
-
-  Color _statusColor(BuildContext context, String? status) {
-    if (status == null) return Theme.of(context).colorScheme.outline;
-    if (status.contains('Available') || status == 'Operational') return DarkModeColors.success(context);
-    if (status == 'In Use') return DarkModeColors.warning(context);
-    if (status.contains('Unavailable') || status == 'Not Operational') return DarkModeColors.error(context);
-    if (status == 'Partly Operational') return DarkModeColors.warning(context);
-    return Theme.of(context).colorScheme.outline;
-  }
-
-  IconData _statusIcon(String? status) {
-    if (status == null) return Icons.help_outline;
-    if (status.contains('Available') || status == 'Operational') return Icons.check_circle;
-    if (status == 'In Use') return Icons.access_time;
-    if (status.contains('Unavailable') || status == 'Not Operational') return Icons.cancel;
-    if (status == 'Partly Operational') return Icons.warning;
-    return Icons.help_outline;
-  }
-
-  Color _connectorColor(String type) {
-    if (type.contains('CCS')) return const Color(0xFF2196F3);
-    if (type.contains('Type 2')) return const Color(0xFF4CAF50);
-    if (type.contains('CHAdeMO')) return const Color(0xFFFF9800);
-    if (type.contains('Tesla')) return const Color(0xFFE91E63);
-    return const Color(0xFF757575);
   }
 }

--- a/lib/features/search/presentation/widgets/ev_station_card.dart
+++ b/lib/features/search/presentation/widgets/ev_station_card.dart
@@ -6,9 +6,9 @@ import 'package:flutter/material.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/domain/entities/ev_price.dart';
-import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_result_item.dart';
 import 'ev_connector_chips.dart';
 
@@ -41,144 +41,137 @@ class EVStationCard extends StatelessWidget {
     // #1785 — show a structured per-kWh / per-session price; free and
     // unclassifiable `usageCost` strings degrade to the raw value.
     final evPrice = EvPrice.parse(station.usageCost);
-    final priceLabel = evPrice.label(
+    final priceLabel =
+        evPrice.label(
           perKwhUnit: l10n?.refuelUnitPerKwh ?? '/kWh',
           perSessionUnit: l10n?.refuelUnitPerSession ?? '/session',
         ) ??
         station.usageCost;
 
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Container(
-          decoration: BoxDecoration(
-            border: Border(
-              left: BorderSide(
-                color: FuelColors.forType(FuelType.electric),
-                width: 4,
-              ),
+    // #2493 — shared frame via [StationCardShell]; the EV accent (stripe,
+    // ev-station glyph, kW headline, price label) is the single canonical
+    // [FuelColors.evAccent] crystal-blue, replacing the old teal `#009688`
+    // + muted-teal `FuelType.electric` stripe divergence.
+    return StationCardShell(
+      onTap: onTap,
+      stripeColor: FuelColors.evAccent,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: Row(
+          children: [
+            // Status indicator
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: station.isOperational == true
+                        ? DarkModeColors.success(context)
+                        : DarkModeColors.warning(context),
+                  ),
+                ),
+                const Padding(
+                  padding: EdgeInsets.only(top: 2),
+                  child: Icon(
+                    Icons.ev_station,
+                    size: 14,
+                    color: FuelColors.evAccent,
+                  ),
+                ),
+              ],
             ),
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-          child: Row(
-            children: [
-              // Status indicator
-              Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    width: 12,
-                    height: 12,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: station.isOperational == true
-                          ? DarkModeColors.success(context)
-                          : DarkModeColors.warning(context),
-                    ),
-                  ),
-                  const Padding(
-                    padding: EdgeInsets.only(top: 2),
-                    child: Icon(Icons.ev_station, size: 14,
-                        color: Color(0xFF009688)),
-                  ),
-                ],
-              ),
-              const SizedBox(width: 12),
+            const SizedBox(width: 12),
 
-              // Station info
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
+            // Station info
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    (station.operator?.isNotEmpty ?? false)
+                        ? station.operator!
+                        : station.name,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  if ((station.address ?? '').isNotEmpty)
                     Text(
-                      (station.operator?.isNotEmpty ?? false)
-                          ? station.operator!
-                          : station.name,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
+                      station.address!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
                       ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                    const SizedBox(height: 2),
-                    if ((station.address ?? '').isNotEmpty)
-                      Text(
-                        station.address!,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    Text(
-                      '${station.postCode ?? ''} ${station.place ?? ''}'.trim(),
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        Text(
-                          PriceFormatter.formatDistance(station.dist),
-                          style: theme.textTheme.bodySmall,
-                        ),
-                        if (priceLabel != null && priceLabel.isNotEmpty) ...[
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Text(
-                              priceLabel,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: const Color(0xFF009688),
-                                fontWeight: FontWeight.w600,
-                              ),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-
-              // Power + connectors
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  // Max power
                   Text(
-                    maxPower > 0 ? '${maxPower.round()} kW' : '--',
-                    style: theme.textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: const Color(0xFF009688),
+                    '${station.postCode ?? ''} ${station.place ?? ''}'.trim(),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
                     ),
                   ),
                   const SizedBox(height: 4),
-                  // Connector type chips
-                  EvConnectorChips(connectors: connectors),
+                  Row(
+                    children: [
+                      Text(
+                        PriceFormatter.formatDistance(station.dist),
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      if (priceLabel != null && priceLabel.isNotEmpty) ...[
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            priceLabel,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: FuelColors.evAccent,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
                 ],
               ),
-              // #1896 — favourite star, matching the fuel result cards.
-              if (onFavoriteTap != null)
-                IconButton(
-                  icon: Icon(
-                    isFavorite ? Icons.star : Icons.star_border,
+            ),
+
+            // Power + connectors
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                // Max power
+                Text(
+                  maxPower > 0 ? '${maxPower.round()} kW' : '--',
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: FuelColors.evAccent,
                   ),
-                  color: isFavorite ? DarkModeColors.warning(context) : null,
-                  tooltip: l10n?.favorites ?? 'Favorites',
-                  visualDensity: VisualDensity.compact,
-                  onPressed: onFavoriteTap,
                 ),
-            ],
-          ),
+                const SizedBox(height: 4),
+                // Connector type chips
+                EvConnectorChips(connectors: connectors),
+              ],
+            ),
+            // #1896 — favourite star, matching the fuel result cards.
+            if (onFavoriteTap != null)
+              IconButton(
+                icon: Icon(isFavorite ? Icons.star : Icons.star_border),
+                color: isFavorite ? DarkModeColors.warning(context) : null,
+                tooltip: l10n?.favorites ?? 'Favorites',
+                visualDensity: VisualDensity.compact,
+                onPressed: onFavoriteTap,
+              ),
+          ],
         ),
       ),
     );
   }
-
 }

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -10,6 +10,7 @@ import '../../../../core/utils/price_tier.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/animated_favorite_star.dart';
 import '../../../../core/widgets/animated_price_text.dart';
+import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';
 import '../../domain/entities/brand_registry.dart';
@@ -74,8 +75,7 @@ class StationCard extends StatelessWidget {
   /// helper excludes the legacy `'Station'` sentinel + the
   /// `BrandRegistry.independentLabel` (`'Independent'` from #482).
   /// `'Autoroute'` is a synthetic motorway tag, kept excluded here.
-  bool get _hasBrand =>
-      hasRealBrand(station) && station.brand != 'Autoroute';
+  bool get _hasBrand => hasRealBrand(station) && station.brand != 'Autoroute';
 
   double? get _displayPrice => station.priceFor(selectedFuelType);
 
@@ -106,10 +106,10 @@ class StationCard extends StatelessWidget {
   /// Returns `null` when neither path resolves — the caller falls
   /// back to the globally-set active profile currency.
   String? get _stationCurrency => Countries.countryForStation(
-        id: station.id,
-        lat: station.lat,
-        lng: station.lng,
-      )?.currencySymbol;
+    id: station.id,
+    lat: station.lat,
+    lng: station.lng,
+  )?.currencySymbol;
 
   @override
   Widget build(BuildContext context) {
@@ -128,61 +128,46 @@ class StationCard extends StatelessWidget {
         '$formattedPrice, $semanticStatus';
 
     final fuelColor = FuelColors.forType(selectedFuelType);
+    // #2493 — the stripe (unlike the price-text tint) uses the visible
+    // all-fuels colour so a `FuelType.all` card no longer shows the near-
+    // invisible neutral grey. Cheapest still wins with the success stripe.
+    final stripeColor = isCheapest
+        ? DarkModeColors.success(context)
+        : FuelColors.stripeColor(context, selectedFuelType);
 
     return Semantics(
       label: semanticLabel,
       button: true,
-      child: Card(
-        margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-        clipBehavior: Clip.antiAlias,
-        elevation:
-            Theme.of(context).brightness == Brightness.dark ? 1 : 2,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(12),
-          child: Container(
-            decoration: BoxDecoration(
-              border: Border(
-                left: BorderSide(
-                  color: isCheapest
-                      ? DarkModeColors.success(context)
-                      : fuelColor,
-                  width: isCheapest ? 6 : 4,
-                ),
+      child: StationCardShell(
+        onTap: onTap,
+        stripeColor: stripeColor,
+        stripeWidth: isCheapest ? 6 : 4,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              _StatusColumn(station: station),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _StationDetails(station: station, hasBrand: _hasBrand),
               ),
-            ),
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                _StatusColumn(station: station),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: _StationDetails(
-                    station: station,
-                    hasBrand: _hasBrand,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                _StationPriceColumn(
-                  station: station,
-                  selectedFuelType: selectedFuelType,
-                  price: price,
-                  currencyOverride: currencyOverride,
-                  fuelColor: fuelColor,
-                  isFavorite: isFavorite,
-                  isCheapest: isCheapest,
-                  priceTier: priceTier,
-                  rating: rating,
-                  profileFuelType: profileFuelType,
-                  loyaltyDiscount: _loyaltyDiscount,
-                  onFavoriteTap: onFavoriteTap,
-                ),
-              ],
-            ),
+              const SizedBox(width: 8),
+              _StationPriceColumn(
+                station: station,
+                selectedFuelType: selectedFuelType,
+                price: price,
+                currencyOverride: currencyOverride,
+                fuelColor: fuelColor,
+                isFavorite: isFavorite,
+                isCheapest: isCheapest,
+                priceTier: priceTier,
+                rating: rating,
+                profileFuelType: profileFuelType,
+                loyaltyDiscount: _loyaltyDiscount,
+                onFavoriteTap: onFavoriteTap,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -1032,6 +1032,7 @@
   "evStatusAvailable": "Verfügbar",
   "evStatusOccupied": "Belegt",
   "evStatusOutOfOrder": "Außer Betrieb",
+  "evStatusPartial": "Teilweise verfügbar",
   "openOnlyFilter": "Nur geöffnete",
   "saveAsDefaults": "Als Standard speichern",
   "criteriaSavedToProfile": "Als Standard gespeichert",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -1105,6 +1105,7 @@
   "evStatusAvailable": "Available",
   "evStatusOccupied": "Occupied",
   "evStatusOutOfOrder": "Out of order",
+  "evStatusPartial": "Partly available",
   "openOnlyFilter": "Open only",
   "saveAsDefaults": "Save as my defaults",
   "criteriaSavedToProfile": "Saved as defaults",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1040,6 +1040,7 @@
   "evStatusAvailable": "Verfügbar",
   "evStatusOccupied": "Belegt",
   "evStatusOutOfOrder": "Außer Betrieb",
+  "evStatusPartial": "Teilweise verfügbar",
   "openOnlyFilter": "Nur geöffnete",
   "saveAsDefaults": "Als Standard speichern",
   "criteriaSavedToProfile": "Als Standard gespeichert",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1115,6 +1115,7 @@
   "evStatusAvailable": "Available",
   "evStatusOccupied": "Occupied",
   "evStatusOutOfOrder": "Out of order",
+  "evStatusPartial": "Partly available",
   "openOnlyFilter": "Open only",
   "saveAsDefaults": "Save as my defaults",
   "criteriaSavedToProfile": "Saved as defaults",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -723,6 +723,7 @@
   "evStatusAvailable": "⟦Áṽáîłáƀłé ····⟧",
   "evStatusOccupied": "⟦Óççúƥîéđ ····⟧",
   "evStatusOutOfOrder": "⟦Óúŧ óƒ óřđéř ·····⟧",
+  "evStatusPartial": "⟦Ƥářŧłý áṽáîłáƀłé ·······⟧",
   "openOnlyFilter": "⟦Óƥéñ óñłý ····⟧",
   "saveAsDefaults": "⟦Šáṽé áš ɱý đéƒáúłŧš ·······⟧",
   "criteriaSavedToProfile": "⟦Šáṽéđ áš đéƒáúłŧš ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -2903,5 +2903,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4484,6 +4484,12 @@ abstract class AppLocalizations {
   /// **'Out of order'**
   String get evStatusOutOfOrder;
 
+  /// No description provided for @evStatusPartial.
+  ///
+  /// In en, this message translates to:
+  /// **'Partly available'**
+  String get evStatusPartial;
+
   /// No description provided for @openOnlyFilter.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2413,6 +2413,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get evStatusOutOfOrder => 'Извън строя';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Само отворени';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2401,6 +2401,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get evStatusOutOfOrder => 'Mimo provoz';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Pouze otevřené';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2396,6 +2396,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get evStatusOutOfOrder => 'Ude af drift';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Kun åbne';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2409,6 +2409,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get evStatusOutOfOrder => 'Außer Betrieb';
 
   @override
+  String get evStatusPartial => 'Teilweise verfügbar';
+
+  @override
   String get openOnlyFilter => 'Nur geöffnete';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2412,6 +2412,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get evStatusOutOfOrder => 'Εκτός λειτουργίας';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Μόνο ανοιχτοί';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2387,6 +2387,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get evStatusOutOfOrder => 'Out of order';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Open only';
 
   @override
@@ -8812,6 +8815,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get evStatusOutOfOrder => '⟦Óúŧ óƒ óřđéř ·····⟧';
+
+  @override
+  String get evStatusPartial => '⟦Ƥářŧłý áṽáîłáƀłé ·······⟧';
 
   @override
   String get openOnlyFilter => '⟦Óƥéñ óñłý ····⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2407,6 +2407,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get evStatusOutOfOrder => 'Fuera de servicio';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Solo abiertas';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2391,6 +2391,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get evStatusOutOfOrder => 'Rikkes';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Ainult avatud';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2395,6 +2395,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get evStatusOutOfOrder => 'Epäkunnossa';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Vain avoinna';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2414,6 +2414,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get evStatusOutOfOrder => 'Hors service';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Ouvertes uniquement';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2396,6 +2396,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get evStatusOutOfOrder => 'Izvan pogona';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Samo otvorene';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2407,6 +2407,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get evStatusOutOfOrder => 'Meghibásodott';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Csak nyitva';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2405,6 +2405,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get evStatusOutOfOrder => 'Fuori servizio';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Solo aperte';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2405,6 +2405,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get evStatusOutOfOrder => 'Neveikia';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Tik atidarytos';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2409,6 +2409,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get evStatusOutOfOrder => 'Nedarbojas';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Tikai atvērtās';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2395,6 +2395,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get evStatusOutOfOrder => 'Ute av drift';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Kun åpne';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2405,6 +2405,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get evStatusOutOfOrder => 'Buiten gebruik';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Alleen geopend';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2402,6 +2402,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get evStatusOutOfOrder => 'Awaria';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Tylko otwarte';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2410,6 +2410,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get evStatusOutOfOrder => 'Avariado';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Apenas abertos';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2407,6 +2407,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get evStatusOutOfOrder => 'Defect';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Numai deschise';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2406,6 +2406,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get evStatusOutOfOrder => 'Mimo prevádzky';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Iba otvorené';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2397,6 +2397,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get evStatusOutOfOrder => 'Izven obratovanja';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Samo odprte';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2397,6 +2397,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get evStatusOutOfOrder => 'Ur funktion';
 
   @override
+  String get evStatusPartial => 'Partly available';
+
+  @override
   String get openOnlyFilter => 'Endast öppna';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -2776,5 +2776,10 @@
   "@obd2HealthCopied": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "evStatusPartial": "Partly available",
+  "@evStatusPartial": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/core/widgets/station_card_shell_test.dart
+++ b/test/core/widgets/station_card_shell_test.dart
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/app_radius.dart';
+import 'package:tankstellen/core/widgets/station_card_shell.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  group('StationCardShell (#2493)', () {
+    testWidgets('owns the canonical card frame: margin, radius, clip', (
+      tester,
+    ) async {
+      await pumpApp(tester, const StationCardShell(child: Text('body')));
+
+      final card = tester.widget<Card>(find.byType(Card));
+      expect(
+        card.margin,
+        const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      );
+      expect(card.clipBehavior, Clip.antiAlias);
+      final shape = card.shape as RoundedRectangleBorder;
+      expect(shape.borderRadius, AppRadius.lg);
+      expect(find.text('body'), findsOneWidget);
+    });
+
+    testWidgets('elevation is 2 in light mode', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: StationCardShell(child: Text('x'))),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(tester.widget<Card>(find.byType(Card)).elevation, 2);
+    });
+
+    testWidgets('elevation is 1 in dark mode', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(),
+          home: const Scaffold(body: StationCardShell(child: Text('x'))),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(tester.widget<Card>(find.byType(Card)).elevation, 1);
+    });
+
+    testWidgets('draws a left stripe in the requested colour and width', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        const StationCardShell(
+          stripeColor: Color(0xFF123456),
+          stripeWidth: 6,
+          child: Text('body'),
+        ),
+      );
+
+      final box = tester.widget<DecoratedBox>(
+        find
+            .descendant(
+              of: find.byType(StationCardShell),
+              matching: find.byType(DecoratedBox),
+            )
+            .first,
+      );
+      final border = (box.decoration as BoxDecoration).border! as Border;
+      expect(border.left.color, const Color(0xFF123456));
+      expect(border.left.width, 6);
+    });
+
+    testWidgets('draws NO stripe when stripeColor is null', (tester) async {
+      await pumpApp(tester, const StationCardShell(child: Text('body')));
+      // The shell itself adds no bordered DecoratedBox when stripeColor is
+      // null (any DecoratedBox present would come from the Card/Material).
+      final bordered = tester
+          .widgetList<DecoratedBox>(
+            find.descendant(
+              of: find.byType(InkWell),
+              matching: find.byType(DecoratedBox),
+            ),
+          )
+          .where((b) {
+            final d = b.decoration;
+            return d is BoxDecoration && d.border is Border;
+          });
+      expect(bordered, isEmpty);
+    });
+
+    testWidgets('forwards taps through the InkWell', (tester) async {
+      var taps = 0;
+      await pumpApp(
+        tester,
+        StationCardShell(onTap: () => taps++, child: const Text('body')),
+      );
+      await tester.tap(find.text('body'));
+      expect(taps, 1);
+    });
+  });
+}

--- a/test/features/ev/domain/charging_station_test.dart
+++ b/test/features/ev/domain/charging_station_test.dart
@@ -22,31 +22,31 @@ import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dar
 void main() {
   group('ChargingStation entity', () {
     ChargingStation sample() => ChargingStation(
-          id: 'station-1',
-          name: 'Ionity Strasbourg',
-          operator: 'Ionity',
-          latitude: 48.5734,
-          longitude: 7.7521,
-          address: '67000 Strasbourg, France',
-          connectors: const [
-            EvConnector(
-              id: 'c1',
-              type: ConnectorType.ccs,
-              maxPowerKw: 350,
-              status: ConnectorStatus.available,
-              tariffId: 'tariff-1',
-            ),
-            EvConnector(
-              id: 'c2',
-              type: ConnectorType.type2,
-              maxPowerKw: 22,
-              status: ConnectorStatus.occupied,
-            ),
-          ],
-          amenities: const ['restroom', 'cafe'],
-          openingHours: const OpeningHours(twentyFourSeven: true),
-          lastUpdate: DateTime.utc(2026, 4, 8, 10, 0),
-        );
+      id: 'station-1',
+      name: 'Ionity Strasbourg',
+      operator: 'Ionity',
+      latitude: 48.5734,
+      longitude: 7.7521,
+      address: '67000 Strasbourg, France',
+      connectors: const [
+        EvConnector(
+          id: 'c1',
+          type: ConnectorType.ccs,
+          maxPowerKw: 350,
+          status: ConnectorStatus.available,
+          tariffId: 'tariff-1',
+        ),
+        EvConnector(
+          id: 'c2',
+          type: ConnectorType.type2,
+          maxPowerKw: 22,
+          status: ConnectorStatus.occupied,
+        ),
+      ],
+      amenities: const ['restroom', 'cafe'],
+      openingHours: const OpeningHours(twentyFourSeven: true),
+      lastUpdate: DateTime.utc(2026, 4, 8, 10, 0),
+    );
 
     test('JSON round-trip preserves every field', () {
       final original = sample();
@@ -82,16 +82,8 @@ void main() {
     test('openingHours with regular hours round-trips', () {
       const hours = OpeningHours(
         regularHours: [
-          RegularHours(
-            weekday: 1,
-            periodBegin: '06:00',
-            periodEnd: '22:00',
-          ),
-          RegularHours(
-            weekday: 7,
-            periodBegin: '08:00',
-            periodEnd: '20:00',
-          ),
+          RegularHours(weekday: 1, periodBegin: '06:00', periodEnd: '22:00'),
+          RegularHours(weekday: 7, periodBegin: '08:00', periodEnd: '20:00'),
         ],
       );
       final restored = OpeningHours.fromJson(hours.toJson());
@@ -176,10 +168,16 @@ void main() {
       final json = station.toJson();
       expect(json.containsKey('latitude'), isTrue);
       expect(json.containsKey('longitude'), isTrue);
-      expect(json.containsKey('lat'), isFalse,
-          reason: 'toJson must not emit the legacy lat key');
-      expect(json.containsKey('lng'), isFalse,
-          reason: 'toJson must not emit the legacy lng key');
+      expect(
+        json.containsKey('lat'),
+        isFalse,
+        reason: 'toJson must not emit the legacy lat key',
+      );
+      expect(
+        json.containsKey('lng'),
+        isFalse,
+        reason: 'toJson must not emit the legacy lng key',
+      );
       expect(json['latitude'], 48.85);
       expect(json['longitude'], 2.35);
     });
@@ -197,8 +195,7 @@ void main() {
       expect(restored, original);
     });
 
-    test(
-        'legacy-shape JSON (lat/lng) round-trips back to canonical output '
+    test('legacy-shape JSON (lat/lng) round-trips back to canonical output '
         'via fromJson -> toJson', () {
       final legacyJson = {
         'id': 'ocm-1',
@@ -216,70 +213,72 @@ void main() {
       expect(roundTripped.containsKey('lng'), isFalse);
     });
 
-    test('fromJson accepts full search-side payload with all ported fields',
-        () {
-      // Payload shape the pre-#560 EVChargingService emitted. Every
-      // field on the entity must rehydrate correctly from it.
-      final json = {
-        'id': 'ocm-456',
-        'name': 'Super Charger',
-        'operator': 'Ionity',
-        'lat': 48.8,
-        'lng': 2.3,
-        'dist': 5.2,
-        'address': 'Rue de Paris',
-        'postCode': '75001',
-        'place': 'Paris',
-        'connectors': [
-          {
-            'type': 'CCS Type 2',
-            'powerKW': 350.0,
-            'quantity': 4,
-            'currentType': 'DC',
-            'status': 'Currently Available',
-          },
-          {
-            'type': 'Type 2',
-            'powerKW': 22.0,
-            'quantity': 2,
-            'currentType': 'AC',
-          },
-        ],
-        'totalPoints': 6,
-        'isOperational': true,
-        'usageCost': '0.39 EUR/kWh',
-        'updatedAt': '27/03/2026',
-        'countryCode': 'FR',
-      };
+    test(
+      'fromJson accepts full search-side payload with all ported fields',
+      () {
+        // Payload shape the pre-#560 EVChargingService emitted. Every
+        // field on the entity must rehydrate correctly from it.
+        final json = {
+          'id': 'ocm-456',
+          'name': 'Super Charger',
+          'operator': 'Ionity',
+          'lat': 48.8,
+          'lng': 2.3,
+          'dist': 5.2,
+          'address': 'Rue de Paris',
+          'postCode': '75001',
+          'place': 'Paris',
+          'connectors': [
+            {
+              'type': 'CCS Type 2',
+              'powerKW': 350.0,
+              'quantity': 4,
+              'currentType': 'DC',
+              'status': 'Currently Available',
+            },
+            {
+              'type': 'Type 2',
+              'powerKW': 22.0,
+              'quantity': 2,
+              'currentType': 'AC',
+            },
+          ],
+          'totalPoints': 6,
+          'isOperational': true,
+          'usageCost': '0.39 EUR/kWh',
+          'updatedAt': '27/03/2026',
+          'countryCode': 'FR',
+        };
 
-      final station = ChargingStation.fromJson(json);
+        final station = ChargingStation.fromJson(json);
 
-      expect(station.id, 'ocm-456');
-      expect(station.name, 'Super Charger');
-      expect(station.operator, 'Ionity');
-      expect(station.latitude, 48.8);
-      expect(station.longitude, 2.3);
-      expect(station.dist, 5.2);
-      expect(station.address, 'Rue de Paris');
-      expect(station.postCode, '75001');
-      expect(station.place, 'Paris');
-      expect(station.connectors.length, 2);
-      expect(station.totalPoints, 6);
-      expect(station.isOperational, true);
-      expect(station.usageCost, '0.39 EUR/kWh');
-      expect(station.updatedAt, '27/03/2026');
-      expect(station.countryCode, 'FR');
+        expect(station.id, 'ocm-456');
+        expect(station.name, 'Super Charger');
+        expect(station.operator, 'Ionity');
+        expect(station.latitude, 48.8);
+        expect(station.longitude, 2.3);
+        expect(station.dist, 5.2);
+        expect(station.address, 'Rue de Paris');
+        expect(station.postCode, '75001');
+        expect(station.place, 'Paris');
+        expect(station.connectors.length, 2);
+        expect(station.totalPoints, 6);
+        expect(station.isOperational, true);
+        expect(station.usageCost, '0.39 EUR/kWh');
+        expect(station.updatedAt, '27/03/2026');
+        expect(station.countryCode, 'FR');
 
-      // Connector normalisation: free-form "CCS Type 2" -> enum + rawType
-      expect(station.connectors.first.type, ConnectorType.ccs);
-      expect(station.connectors.first.rawType, 'CCS Type 2');
-      expect(station.connectors.first.maxPowerKw, 350);
-      expect(station.connectors.first.powerKW, 350);
-      expect(station.connectors.first.currentType, 'DC');
-      expect(station.connectors.first.quantity, 4);
-      expect(station.connectors.first.status, ConnectorStatus.available);
-      expect(station.connectors.first.statusLabel, 'Currently Available');
-    });
+        // Connector normalisation: free-form "CCS Type 2" -> enum + rawType
+        expect(station.connectors.first.type, ConnectorType.ccs);
+        expect(station.connectors.first.rawType, 'CCS Type 2');
+        expect(station.connectors.first.maxPowerKw, 350);
+        expect(station.connectors.first.powerKW, 350);
+        expect(station.connectors.first.currentType, 'DC');
+        expect(station.connectors.first.quantity, 4);
+        expect(station.connectors.first.status, ConnectorStatus.available);
+        expect(station.connectors.first.statusLabel, 'Currently Available');
+      },
+    );
   });
 
   group('EvConnector.fromJson accepts both shapes', () {
@@ -298,25 +297,27 @@ void main() {
       expect(c.statusLabel, isNull);
     });
 
-    test('legacy search shape: powerKW + free-form type + free-form status',
-        () {
-      final json = {
-        'type': 'CHAdeMO',
-        'powerKW': 50.0,
-        'quantity': 2,
-        'currentType': 'DC',
-        'status': 'In Use',
-      };
-      final c = EvConnector.fromJson(json);
-      expect(c.type, ConnectorType.chademo);
-      expect(c.rawType, 'CHAdeMO');
-      expect(c.maxPowerKw, 50);
-      expect(c.powerKW, 50, reason: 'powerKW getter aliases maxPowerKw');
-      expect(c.quantity, 2);
-      expect(c.currentType, 'DC');
-      expect(c.status, ConnectorStatus.occupied);
-      expect(c.statusLabel, 'In Use');
-    });
+    test(
+      'legacy search shape: powerKW + free-form type + free-form status',
+      () {
+        final json = {
+          'type': 'CHAdeMO',
+          'powerKW': 50.0,
+          'quantity': 2,
+          'currentType': 'DC',
+          'status': 'In Use',
+        };
+        final c = EvConnector.fromJson(json);
+        expect(c.type, ConnectorType.chademo);
+        expect(c.rawType, 'CHAdeMO');
+        expect(c.maxPowerKw, 50);
+        expect(c.powerKW, 50, reason: 'powerKW getter aliases maxPowerKw');
+        expect(c.quantity, 2);
+        expect(c.currentType, 'DC');
+        expect(c.status, ConnectorStatus.occupied);
+        expect(c.statusLabel, 'In Use');
+      },
+    );
 
     test('legacy status "Not Operational" maps to outOfOrder', () {
       final c = EvConnector.fromJson({
@@ -326,6 +327,38 @@ void main() {
       });
       expect(c.status, ConnectorStatus.outOfOrder);
       expect(c.statusLabel, 'Not Operational');
+    });
+
+    test('#2493 — "Partly Operational" maps to the new partial status', () {
+      final c = EvConnector.fromJson({
+        'type': 'CCS',
+        'powerKW': 150.0,
+        'status': 'Partly Operational',
+      });
+      expect(c.status, ConnectorStatus.partial);
+      expect(c.statusLabel, 'Partly Operational');
+    });
+
+    test('#2493 — ConnectorStatus.fromLabel normalises the OCM scale', () {
+      // "partly/partial" wins over the bare "available" branch.
+      expect(
+        ConnectorStatus.fromLabel('Partly Operational'),
+        ConnectorStatus.partial,
+      );
+      expect(
+        ConnectorStatus.fromLabel('Currently Available'),
+        ConnectorStatus.available,
+      );
+      expect(
+        ConnectorStatus.fromLabel('Operational'),
+        ConnectorStatus.available,
+      );
+      expect(ConnectorStatus.fromLabel('In Use'), ConnectorStatus.occupied);
+      expect(
+        ConnectorStatus.fromLabel('Temporarily Unavailable'),
+        ConnectorStatus.outOfOrder,
+      );
+      expect(ConnectorStatus.fromLabel(null), ConnectorStatus.unknown);
     });
 
     test('connector without tariffId round-trips', () {

--- a/test/features/favorites/presentation/widgets/ev_favorite_card_test.dart
+++ b/test/features/favorites/presentation/widgets/ev_favorite_card_test.dart
@@ -4,6 +4,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/dark_mode_colors.dart';
+import 'package:tankstellen/core/theme/fuel_colors.dart';
+import 'package:tankstellen/core/widgets/station_card_shell.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/favorites/presentation/widgets/ev_favorite_card.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
@@ -15,64 +17,54 @@ ChargingStation _station({
   String name = 'IONITY Tournefeuille',
   String operator = 'IONITY',
   List<EvConnector> connectors = const [],
-}) =>
-    ChargingStation(
-      id: 'ev-1',
-      name: name,
-      operator: operator,
-      latitude: 43.5,
-      longitude: 1.4,
-      address: 'A64',
-      connectors: connectors,
-    );
+}) => ChargingStation(
+  id: 'ev-1',
+  name: name,
+  operator: operator,
+  latitude: 43.5,
+  longitude: 1.4,
+  address: 'A64',
+  connectors: connectors,
+);
 
 void main() {
   group('EvFavoriteCard', () {
-    testWidgets('renders name, operator, and a blue EV marker stripe',
-        (tester) async {
-      await pumpApp(
-        tester,
-        EvFavoriteCard(station: _station()),
-      );
-      expect(find.text('IONITY Tournefeuille'), findsOneWidget);
-      expect(find.text('IONITY'), findsOneWidget);
-      // #2229 — identical silhouette to the fuel card: the old
-      // ev_station leading icon is gone, replaced by the crystal-blue
-      // left accent stripe that marks the card as EV.
-      expect(find.byIcon(Icons.ev_station), findsNothing);
-      final blueStripe =
-          tester.widgetList<Container>(find.byType(Container)).where((c) {
-        final d = c.decoration;
-        return d is BoxDecoration &&
-            d.border is Border &&
-            (d.border! as Border).left.color == EvFavoriteCard.crystalBlue;
-      });
-      expect(blueStripe, isNotEmpty);
-    });
+    testWidgets(
+      'composes StationCardShell with the canonical evAccent stripe',
+      (tester) async {
+        await pumpApp(tester, EvFavoriteCard(station: _station()));
+        expect(find.text('IONITY Tournefeuille'), findsOneWidget);
+        expect(find.text('IONITY'), findsOneWidget);
+        // #2229 — identical silhouette to the fuel card: the old
+        // ev_station leading icon is gone, replaced by the EV accent stripe.
+        expect(find.byIcon(Icons.ev_station), findsNothing);
+        // #2493 — the frame is the shared shell, and its stripe is the SINGLE
+        // canonical [FuelColors.evAccent] token (no per-card crystal-blue).
+        final shell = tester.widget<StationCardShell>(
+          find.byType(StationCardShell),
+        );
+        expect(shell.stripeColor, FuelColors.evAccent);
+      },
+    );
 
-    testWidgets('hides operator row when operator is empty',
-        (tester) async {
-      await pumpApp(
-        tester,
-        EvFavoriteCard(station: _station(operator: '')),
-      );
+    testWidgets('hides operator row when operator is empty', (tester) async {
+      await pumpApp(tester, EvFavoriteCard(station: _station(operator: '')));
       expect(find.text('IONITY Tournefeuille'), findsOneWidget);
       // Only the station name should be present; no operator row.
       expect(find.textContaining('IONITY Tournefeuille,'), findsNothing);
     });
 
-    testWidgets('shows the highest connector power as max kW',
-        (tester) async {
+    testWidgets('shows the highest connector power as max kW', (tester) async {
       await pumpApp(
         tester,
         EvFavoriteCard(
-          station: _station(connectors: const [
-            EvConnector(
-                id: '1', type: ConnectorType.type2, maxPowerKw: 22),
-            EvConnector(id: '2', type: ConnectorType.ccs, maxPowerKw: 350),
-            EvConnector(
-                id: '3', type: ConnectorType.chademo, maxPowerKw: 50),
-          ]),
+          station: _station(
+            connectors: const [
+              EvConnector(id: '1', type: ConnectorType.type2, maxPowerKw: 22),
+              EvConnector(id: '2', type: ConnectorType.ccs, maxPowerKw: 350),
+              EvConnector(id: '3', type: ConnectorType.chademo, maxPowerKw: 50),
+            ],
+          ),
         ),
       );
       // 350 kW wins over 22 / 50
@@ -80,53 +72,60 @@ void main() {
     });
 
     testWidgets('shows 0 kW when no connectors are listed', (tester) async {
-      await pumpApp(
-        tester,
-        EvFavoriteCard(station: _station()),
-      );
+      await pumpApp(tester, EvFavoriteCard(station: _station()));
       expect(find.text('0 kW'), findsOneWidget);
     });
 
-    testWidgets('available/total count reflects connector status',
-        (tester) async {
+    testWidgets('available/total count reflects connector status', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         EvFavoriteCard(
-          station: _station(connectors: const [
-            EvConnector(
+          station: _station(
+            connectors: const [
+              EvConnector(
                 id: '1',
                 type: ConnectorType.ccs,
                 maxPowerKw: 150,
-                status: ConnectorStatus.available),
-            EvConnector(
+                status: ConnectorStatus.available,
+              ),
+              EvConnector(
                 id: '2',
                 type: ConnectorType.type2,
                 maxPowerKw: 22,
-                status: ConnectorStatus.occupied),
-            EvConnector(
+                status: ConnectorStatus.occupied,
+              ),
+              EvConnector(
                 id: '3',
                 type: ConnectorType.ccs,
                 maxPowerKw: 150,
-                status: ConnectorStatus.unknown),
-          ]),
+                status: ConnectorStatus.unknown,
+              ),
+            ],
+          ),
         ),
       );
       // 1 available / 3 total
       expect(find.textContaining('1/3'), findsOneWidget);
     });
 
-    testWidgets('availability label is green when any connector is free',
-        (tester) async {
+    testWidgets('availability label is green when any connector is free', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         EvFavoriteCard(
-          station: _station(connectors: const [
-            EvConnector(
+          station: _station(
+            connectors: const [
+              EvConnector(
                 id: '1',
                 type: ConnectorType.ccs,
                 maxPowerKw: 150,
-                status: ConnectorStatus.available),
-          ]),
+                status: ConnectorStatus.available,
+              ),
+            ],
+          ),
         ),
       );
       final icon = tester.widget<Icon>(find.byIcon(Icons.power));
@@ -136,18 +135,22 @@ void main() {
       );
     });
 
-    testWidgets('availability icon is grey when none available',
-        (tester) async {
+    testWidgets('availability icon is grey when none available', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         EvFavoriteCard(
-          station: _station(connectors: const [
-            EvConnector(
+          station: _station(
+            connectors: const [
+              EvConnector(
                 id: '1',
                 type: ConnectorType.ccs,
                 maxPowerKw: 150,
-                status: ConnectorStatus.occupied),
-          ]),
+                status: ConnectorStatus.occupied,
+              ),
+            ],
+          ),
         ),
       );
       final icon = tester.widget<Icon>(find.byIcon(Icons.power));
@@ -155,35 +158,41 @@ void main() {
     });
 
     testWidgets(
-        '#2143 deduplicates connector-type labels using rawType when present',
-        (tester) async {
-      await pumpApp(
-        tester,
-        EvFavoriteCard(
-          station: _station(connectors: const [
-            EvConnector(
-                id: '1',
-                type: ConnectorType.ccs,
-                rawType: 'CCS',
-                maxPowerKw: 150),
-            EvConnector(
-                id: '2',
-                type: ConnectorType.ccs,
-                rawType: 'CCS',
-                maxPowerKw: 150),
-            EvConnector(
-                id: '3',
-                type: ConnectorType.type2,
-                rawType: 'Type 2',
-                maxPowerKw: 22),
-          ]),
-        ),
-      );
-      // #2143 — chips swapped for a single joined label in the
-      // right-side detail column. CCS appears on 2 connectors but
-      // dedupes to one segment.
-      expect(find.text('CCS · Type 2'), findsOneWidget);
-    });
+      '#2143 deduplicates connector-type labels using rawType when present',
+      (tester) async {
+        await pumpApp(
+          tester,
+          EvFavoriteCard(
+            station: _station(
+              connectors: const [
+                EvConnector(
+                  id: '1',
+                  type: ConnectorType.ccs,
+                  rawType: 'CCS',
+                  maxPowerKw: 150,
+                ),
+                EvConnector(
+                  id: '2',
+                  type: ConnectorType.ccs,
+                  rawType: 'CCS',
+                  maxPowerKw: 150,
+                ),
+                EvConnector(
+                  id: '3',
+                  type: ConnectorType.type2,
+                  rawType: 'Type 2',
+                  maxPowerKw: 22,
+                ),
+              ],
+            ),
+          ),
+        );
+        // #2143 — chips swapped for a single joined label in the
+        // right-side detail column. CCS appears on 2 connectors but
+        // dedupes to one segment.
+        expect(find.text('CCS · Type 2'), findsOneWidget);
+      },
+    );
 
     testWidgets('tap on the card invokes onTap', (tester) async {
       var tapped = 0;
@@ -195,15 +204,11 @@ void main() {
       expect(tapped, 1);
     });
 
-    testWidgets('tap on the star icon invokes onFavoriteTap',
-        (tester) async {
+    testWidgets('tap on the star icon invokes onFavoriteTap', (tester) async {
       var removed = 0;
       await pumpApp(
         tester,
-        EvFavoriteCard(
-          station: _station(),
-          onFavoriteTap: () => removed++,
-        ),
+        EvFavoriteCard(station: _station(), onFavoriteTap: () => removed++),
       );
       await tester.tap(find.byIcon(Icons.star));
       expect(removed, 1);

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
+import 'package:tankstellen/core/widgets/station_card_shell.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/all_prices_station_card.dart';
@@ -14,73 +15,55 @@ import '../../../../fixtures/stations.dart';
 void main() {
   group('AllPricesStationCard', () {
     testWidgets('renders station brand name', (tester) async {
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: testStation),
-      );
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       expect(find.text('STAR'), findsOneWidget);
     });
 
     testWidgets('renders address line when brand is present', (tester) async {
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: testStation),
-      );
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       expect(find.textContaining('Hauptstr.'), findsOneWidget);
       expect(find.textContaining('10115'), findsOneWidget);
     });
 
     testWidgets('renders distance', (tester) async {
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: testStation),
-      );
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       expect(find.textContaining('1,5 km'), findsOneWidget);
     });
 
     testWidgets('shows open status badge when station is open', (tester) async {
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: testStation),
-      );
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       expect(find.text('Open'), findsOneWidget);
     });
 
-    testWidgets('shows closed status badge when station is closed',
-        (tester) async {
+    testWidgets('shows closed status badge when station is closed', (
+      tester,
+    ) async {
       final closedStation = testStationList[2]; // isOpen: false
 
-      await pumpApp(
-        tester,
-        AllPricesStationCard(station: closedStation),
-      );
+      await pumpApp(tester, AllPricesStationCard(station: closedStation));
 
       expect(find.text('Closed'), findsOneWidget);
     });
 
-    testWidgets('renders fuel price badges for available fuels',
-        (tester) async {
+    testWidgets('renders fuel price badges for available fuels', (
+      tester,
+    ) async {
       // testStation has e5, e10, diesel
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: testStation),
-      );
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       expect(find.text('E5'), findsOneWidget);
       expect(find.text('E10'), findsOneWidget);
       expect(find.text('Diesel'), findsOneWidget);
     });
 
-    testWidgets('does not render badges for unavailable fuels without price',
-        (tester) async {
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: testStation),
-      );
+    testWidgets('does not render badges for unavailable fuels without price', (
+      tester,
+    ) async {
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       // testStation has no e98, e85, lpg, cng prices and they are not in
       // unavailableFuels, so badges should not appear
@@ -90,8 +73,9 @@ void main() {
       expect(find.text('GNV'), findsNothing);
     });
 
-    testWidgets('shows out-of-stock badge for unavailable fuels',
-        (tester) async {
+    testWidgets('shows out-of-stock badge for unavailable fuels', (
+      tester,
+    ) async {
       const stationWithUnavailable = Station(
         id: 'test-unavail',
         name: 'Test Station',
@@ -119,10 +103,7 @@ void main() {
     testWidgets('renders favorite star when isFavorite=true', (tester) async {
       await pumpApp(
         tester,
-        const AllPricesStationCard(
-          station: testStation,
-          isFavorite: true,
-        ),
+        const AllPricesStationCard(station: testStation, isFavorite: true),
       );
 
       expect(find.byIcon(Icons.star), findsOneWidget);
@@ -133,10 +114,7 @@ void main() {
     testWidgets('renders unfilled star when isFavorite=false', (tester) async {
       await pumpApp(
         tester,
-        const AllPricesStationCard(
-          station: testStation,
-          isFavorite: false,
-        ),
+        const AllPricesStationCard(station: testStation, isFavorite: false),
       );
 
       expect(find.byIcon(Icons.star_border), findsOneWidget);
@@ -147,10 +125,7 @@ void main() {
 
       await pumpApp(
         tester,
-        AllPricesStationCard(
-          station: testStation,
-          onTap: () => tapped = true,
-        ),
+        AllPricesStationCard(station: testStation, onTap: () => tapped = true),
       );
 
       await tester.tap(find.byType(AllPricesStationCard));
@@ -190,7 +165,9 @@ void main() {
     });
 
     group('champion (cheapest) chip styling (#572)', () {
-      testWidgets('champion chip has filled fuel-type background', (tester) async {
+      testWidgets('champion chip has filled fuel-type background', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const AllPricesStationCard(
@@ -218,8 +195,12 @@ void main() {
 
         final container = tester.widget<Container>(badgeContainer);
         final decoration = container.decoration as BoxDecoration;
-        expect(decoration.color, dieselColor,
-            reason: 'Champion chip must use filled fuel-type color, not light alpha.');
+        expect(
+          decoration.color,
+          dieselColor,
+          reason:
+              'Champion chip must use filled fuel-type color, not light alpha.',
+        );
       });
 
       testWidgets('champion chip text is white for contrast', (tester) async {
@@ -237,54 +218,56 @@ void main() {
       });
 
       testWidgets('non-champion chip does not use white text', (tester) async {
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(station: testStation),
-        );
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
         // Without cheapestFlags, no chip is a champion; label uses the
         // fuel-type color on a light tinted background (not white-on-solid).
         final labelWidget = tester.widget<Text>(find.text('Diesel'));
-        expect(labelWidget.style?.color, isNot(Colors.white),
-            reason: 'Non-champion chip must not use white text.');
+        expect(
+          labelWidget.style?.color,
+          isNot(Colors.white),
+          reason: 'Non-champion chip must not use white text.',
+        );
       });
 
-      testWidgets('unavailable fuel never becomes champion (cheapestFlag ignored)',
-          (tester) async {
-        const stationWithUnavailable = Station(
-          id: 'u1',
-          name: 'u',
-          brand: 'TOT',
-          street: 's',
-          postCode: '1',
-          place: 'p',
-          lat: 0,
-          lng: 0,
-          e5: 1.5,
-          isOpen: true,
-          unavailableFuels: ['diesel'],
-        );
+      testWidgets(
+        'unavailable fuel never becomes champion (cheapestFlag ignored)',
+        (tester) async {
+          const stationWithUnavailable = Station(
+            id: 'u1',
+            name: 'u',
+            brand: 'TOT',
+            street: 's',
+            postCode: '1',
+            place: 'p',
+            lat: 0,
+            lng: 0,
+            e5: 1.5,
+            isOpen: true,
+            unavailableFuels: ['diesel'],
+          );
 
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(
-            station: stationWithUnavailable,
-            cheapestFlags: {FuelType.diesel: true},
-          ),
-        );
+          await pumpApp(
+            tester,
+            const AllPricesStationCard(
+              station: stationWithUnavailable,
+              cheapestFlags: {FuelType.diesel: true},
+            ),
+          );
 
-        final diesel = tester.widget<Text>(find.text('Diesel'));
-        expect(diesel.style?.color, isNot(Colors.white),
-            reason: 'Out-of-stock fuel must not render as champion.');
-      });
+          final diesel = tester.widget<Text>(find.text('Diesel'));
+          expect(
+            diesel.style?.color,
+            isNot(Colors.white),
+            reason: 'Out-of-stock fuel must not render as champion.',
+          );
+        },
+      );
     });
 
     group('distance prominence (#572)', () {
       testWidgets('distance uses bold bodyMedium style', (tester) async {
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(station: testStation),
-        );
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
         final distanceText = tester.widget<Text>(find.textContaining('km'));
         expect(distanceText.style?.fontWeight, FontWeight.bold);
@@ -310,10 +293,7 @@ void main() {
         isOpen: true,
       );
 
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: fullStation),
-      );
+      await pumpApp(tester, const AllPricesStationCard(station: fullStation));
 
       expect(find.text('E5'), findsOneWidget);
       expect(find.text('E10'), findsOneWidget);
@@ -346,38 +326,45 @@ void main() {
     });
 
     testWidgets(
-        '#2061 — the "Independent" sentinel does not leak into the title',
-        (tester) async {
-      // The French Prix Carburants parser tags brandless stations with
-      // `BrandRegistry.independentLabel` (== "Independent"). Before
-      // #2061 the search card rendered that sentinel as the title;
-      // after, it falls back to the street address (matching the
-      // detail screen).
-      const independentStation = Station(
-        id: 'indep-2061',
-        name: '',
-        brand: 'Independent',
-        street: '26 AVENUE DE VERDUN',
-        postCode: '34120',
-        place: 'Pézenas',
-        lat: 43.46,
-        lng: 3.42,
-        e10: 1.999,
-        isOpen: true,
-      );
+      '#2061 — the "Independent" sentinel does not leak into the title',
+      (tester) async {
+        // The French Prix Carburants parser tags brandless stations with
+        // `BrandRegistry.independentLabel` (== "Independent"). Before
+        // #2061 the search card rendered that sentinel as the title;
+        // after, it falls back to the street address (matching the
+        // detail screen).
+        const independentStation = Station(
+          id: 'indep-2061',
+          name: '',
+          brand: 'Independent',
+          street: '26 AVENUE DE VERDUN',
+          postCode: '34120',
+          place: 'Pézenas',
+          lat: 43.46,
+          lng: 3.42,
+          e10: 1.999,
+          isOpen: true,
+        );
 
-      await pumpApp(
-        tester,
-        const AllPricesStationCard(station: independentStation),
-      );
+        await pumpApp(
+          tester,
+          const AllPricesStationCard(station: independentStation),
+        );
 
-      expect(find.text('Independent'), findsNothing,
+        expect(
+          find.text('Independent'),
+          findsNothing,
           reason:
               'The Independent sentinel is an internal classification, '
-              'not a brand to render.');
-      expect(find.text('26 AVENUE DE VERDUN'), findsOneWidget,
-          reason: 'Brandless station falls back to the street as title.');
-    });
+              'not a brand to render.',
+        );
+        expect(
+          find.text('26 AVENUE DE VERDUN'),
+          findsOneWidget,
+          reason: 'Brandless station falls back to the street as title.',
+        );
+      },
+    );
 
     group('profile fuel highlight', () {
       testWidgets('profile fuel badge has larger dot', (tester) async {
@@ -404,8 +391,9 @@ void main() {
         expect(largeDots, findsOneWidget);
       });
 
-      testWidgets('profile fuel badge price uses fuel-type color',
-          (tester) async {
+      testWidgets('profile fuel badge price uses fuel-type color', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const AllPricesStationCard(
@@ -426,8 +414,9 @@ void main() {
         expect(labelWidget.style?.color, dieselColor);
       });
 
-      testWidgets('non-profile fuel badges remain at default size',
-          (tester) async {
+      testWidgets('non-profile fuel badges remain at default size', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const AllPricesStationCard(
@@ -445,12 +434,8 @@ void main() {
         expect(e5Text.style?.fontSize, 10.0);
       });
 
-      testWidgets('no highlight when profileFuelType is null',
-          (tester) async {
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(station: testStation),
-        );
+      testWidgets('no highlight when profileFuelType is null', (tester) async {
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
         // All dots should be 6px (default size)
         final largeDots = find.byWidgetPredicate((widget) {
@@ -466,9 +451,7 @@ void main() {
         expect(largeDots, findsNothing);
       });
 
-      testWidgets(
-          'profile fuel badge has thicker border',
-          (tester) async {
+      testWidgets('profile fuel badge has thicker border', (tester) async {
         await pumpApp(
           tester,
           const AllPricesStationCard(
@@ -483,8 +466,7 @@ void main() {
             final decoration = widget.decoration as BoxDecoration;
             if (decoration.border is Border) {
               final border = decoration.border as Border;
-              return border.top.width == 1.5 &&
-                  decoration.borderRadius != null;
+              return border.top.width == 1.5 && decoration.borderRadius != null;
             }
           }
           return false;
@@ -494,48 +476,46 @@ void main() {
       });
 
       testWidgets(
-          'unavailable fuel is not highlighted even when it matches profile',
-          (tester) async {
-        const stationWithUnavailable = Station(
-          id: 'test-unavail',
-          name: 'Test Station',
-          brand: 'TEST',
-          street: 'Test Str.',
-          postCode: '12345',
-          place: 'Berlin',
-          lat: 52.52,
-          lng: 13.40,
-          e5: 1.859,
-          diesel: 1.659,
-          isOpen: true,
-          unavailableFuels: ['e10'],
-        );
+        'unavailable fuel is not highlighted even when it matches profile',
+        (tester) async {
+          const stationWithUnavailable = Station(
+            id: 'test-unavail',
+            name: 'Test Station',
+            brand: 'TEST',
+            street: 'Test Str.',
+            postCode: '12345',
+            place: 'Berlin',
+            lat: 52.52,
+            lng: 13.40,
+            e5: 1.859,
+            diesel: 1.659,
+            isOpen: true,
+            unavailableFuels: ['e10'],
+          );
 
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(
-            station: stationWithUnavailable,
-            profileFuelType: FuelType.e10,
-          ),
-        );
+          await pumpApp(
+            tester,
+            const AllPricesStationCard(
+              station: stationWithUnavailable,
+              profileFuelType: FuelType.e10,
+            ),
+          );
 
-        // E10 badge should exist but show "Out of stock", not highlighted
-        expect(find.text('Out of stock'), findsOneWidget);
+          // E10 badge should exist but show "Out of stock", not highlighted
+          expect(find.text('Out of stock'), findsOneWidget);
 
-        // The E10 label should NOT have bold weight (unavailable overrides highlight)
-        final e10Label = find.text('E10');
-        expect(e10Label, findsOneWidget);
-        final e10Text = tester.widget<Text>(e10Label);
-        expect(e10Text.style?.fontWeight, FontWeight.w600);
-      });
+          // The E10 label should NOT have bold weight (unavailable overrides highlight)
+          final e10Label = find.text('E10');
+          expect(e10Label, findsOneWidget);
+          final e10Text = tester.widget<Text>(e10Label);
+          expect(e10Text.style?.fontWeight, FontWeight.w600);
+        },
+      );
     });
 
     group('card polish (#592)', () {
       testWidgets('card has 6dp vertical margin', (tester) async {
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(station: testStation),
-        );
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
         final card = tester.widget<Card>(find.byType(Card).first);
         expect(
@@ -545,22 +525,30 @@ void main() {
       });
 
       testWidgets('card uses elevation 2 in light mode', (tester) async {
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(station: testStation),
-        );
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
         final card = tester.widget<Card>(find.byType(Card).first);
         expect(card.elevation, 2.0);
       });
 
       testWidgets('card has 12dp rounded corners', (tester) async {
-        await pumpApp(
-          tester,
-          const AllPricesStationCard(station: testStation),
-        );
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
         final card = tester.widget<Card>(find.byType(Card).first);
         final shape = card.shape as RoundedRectangleBorder;
         expect(shape.borderRadius, BorderRadius.circular(12));
+      });
+    });
+
+    group('StationCardShell composition (#2493)', () {
+      testWidgets('built from the shared shell with no accent stripe', (
+        tester,
+      ) async {
+        await pumpApp(tester, const AllPricesStationCard(station: testStation));
+        final shell = tester.widget<StationCardShell>(
+          find.byType(StationCardShell),
+        );
+        // #2493 — the all-prices card carries its colour in the per-fuel
+        // badges, so the shared shell draws no left stripe.
+        expect(shell.stripeColor, isNull);
       });
     });
   });

--- a/test/features/search/presentation/widgets/ev_connector_chips_test.dart
+++ b/test/features/search/presentation/widgets/ev_connector_chips_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/fuel_colors.dart';
 import 'package:tankstellen/features/search/presentation/widgets/ev_connector_chips.dart';
 
 void main() {
@@ -43,23 +44,33 @@ void main() {
       expect(find.text('Tesla'), findsNothing);
     });
 
-    testWidgets('returns brand colors from EvConnectorChips.colorFor',
-        (tester) async {
-      expect(EvConnectorChips.colorFor('CCS'), const Color(0xFF2196F3));
+    testWidgets('returns brand colors from EvConnectorChips.colorFor', (
+      tester,
+    ) async {
+      // #2493 — the generic CCS chip uses the canonical EV accent token
+      // instead of an ad-hoc Material blue; the deliberate per-connector
+      // brand hues (Type 2 / CHAdeMO / Tesla) are unchanged.
+      expect(EvConnectorChips.colorFor('CCS'), FuelColors.evAccent);
       expect(EvConnectorChips.colorFor('Type 2'), const Color(0xFF4CAF50));
       expect(EvConnectorChips.colorFor('CHAdeMO'), const Color(0xFFFF9800));
-      expect(EvConnectorChips.colorFor('Tesla Supercharger'),
-          const Color(0xFFE91E63));
+      expect(
+        EvConnectorChips.colorFor('Tesla Supercharger'),
+        const Color(0xFFE91E63),
+      );
     });
 
-    testWidgets('falls back to neutral grey for unknown connector types',
-        (tester) async {
-      expect(EvConnectorChips.colorFor('Mystery Plug'),
-          const Color(0xFF757575));
+    testWidgets('falls back to neutral grey for unknown connector types', (
+      tester,
+    ) async {
+      expect(
+        EvConnectorChips.colorFor('Mystery Plug'),
+        const Color(0xFF757575),
+      );
     });
 
-    testWidgets('renders nothing visible when the connector list is empty',
-        (tester) async {
+    testWidgets('renders nothing visible when the connector list is empty', (
+      tester,
+    ) async {
       await pumpChips(tester, connectors: const []);
       // The Wrap still exists, but no Container chips inside it.
       expect(
@@ -72,27 +83,26 @@ void main() {
     });
 
     testWidgets(
-        'exposes a group Semantics label listing connectors (#566 a11y)',
-        (tester) async {
-      await pumpChips(tester, connectors: const ['CCS', 'Type 2']);
-      final handle = tester.ensureSemantics();
+      'exposes a group Semantics label listing connectors (#566 a11y)',
+      (tester) async {
+        await pumpChips(tester, connectors: const ['CCS', 'Type 2']);
+        final handle = tester.ensureSemantics();
 
-      // Parent Semantics announces the whole group — no chip-by-chip spam.
-      expect(
-        find.bySemanticsLabel('Available connectors: CCS, Type 2'),
-        findsOneWidget,
-      );
-      handle.dispose();
-    });
+        // Parent Semantics announces the whole group — no chip-by-chip spam.
+        expect(
+          find.bySemanticsLabel('Available connectors: CCS, Type 2'),
+          findsOneWidget,
+        );
+        handle.dispose();
+      },
+    );
 
-    testWidgets('empty list still exposes "no information" Semantics label',
-        (tester) async {
+    testWidgets('empty list still exposes "no information" Semantics label', (
+      tester,
+    ) async {
       await pumpChips(tester, connectors: const []);
       final handle = tester.ensureSemantics();
-      expect(
-        find.bySemanticsLabel('No connector information'),
-        findsOneWidget,
-      );
+      expect(find.bySemanticsLabel('No connector information'), findsOneWidget);
       handle.dispose();
     });
   });

--- a/test/features/search/presentation/widgets/ev_connector_tile_test.dart
+++ b/test/features/search/presentation/widgets/ev_connector_tile_test.dart
@@ -1,18 +1,22 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/ev_connector_tile.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
     show ConnectorType;
+import 'package:tankstellen/l10n/app_localizations_en.dart';
+import 'package:tankstellen/l10n/app_localizations_de.dart';
 
 import '../../../../helpers/pump_app.dart';
 
 void main() {
   group('EVConnectorTile', () {
-    testWidgets('renders connector type, power, current type, qty and status',
-        (tester) async {
+    testWidgets('renders connector type, power, current type, qty and status', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const EVConnectorTile(
@@ -33,27 +37,85 @@ void main() {
       expect(find.text('150 kW'), findsOneWidget);
       expect(find.text('DC'), findsOneWidget);
       expect(find.text('x2'), findsOneWidget);
-      expect(find.text('Operational'), findsOneWidget);
+      // #2493 — the status chip now shows the LOCALISED label for the
+      // canonical enum, not the upstream free-form English string. With an
+      // `available` status the en label is "Available", regardless of what
+      // the upstream `statusLabel` happened to read.
+      expect(find.text(AppLocalizationsEn().evStatusAvailable), findsOneWidget);
+      expect(find.text('Operational'), findsNothing);
     });
 
     testWidgets(
-        'renders without status when the connector has no statusLabel',
-        (tester) async {
+      'renders without status when the connector has no statusLabel',
+      (tester) async {
+        await pumpApp(
+          tester,
+          const EVConnectorTile(
+            connector: EvConnector(
+              id: 'c2',
+              type: ConnectorType.type2,
+              rawType: 'Type 2',
+              maxPowerKw: 22,
+              quantity: 1,
+            ),
+          ),
+        );
+
+        expect(find.text('Type 2'), findsOneWidget);
+        expect(find.text('22 kW'), findsOneWidget);
+        // No statusLabel + unknown status ⇒ no status chip at all.
+        expect(find.text(AppLocalizationsEn().evStatusUnknown), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'resolves status by ENUM (not English string) in a non-English locale',
+      (tester) async {
+        // #2493 — the regression this issue fixes: status used to be driven
+        // off hardcoded English string-equality, so in German (and the other
+        // 21 locales) the operational scale silently vanished. Here the
+        // upstream label is German and the status enum is `available`; the
+        // chip must still render, localised into German.
+        await pumpApp(
+          tester,
+          const EVConnectorTile(
+            connector: EvConnector(
+              id: 'c3',
+              type: ConnectorType.ccs,
+              rawType: 'CCS2',
+              maxPowerKw: 150,
+              status: ConnectorStatus.available,
+              statusLabel: 'Verfügbar',
+            ),
+          ),
+          locale: const Locale('de'),
+        );
+
+        expect(
+          find.text(AppLocalizationsDe().evStatusAvailable),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('renders the partial status with its localised label', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const EVConnectorTile(
           connector: EvConnector(
-            id: 'c2',
-            type: ConnectorType.type2,
-            rawType: 'Type 2',
-            maxPowerKw: 22,
-            quantity: 1,
+            id: 'c4',
+            type: ConnectorType.ccs,
+            rawType: 'CCS2',
+            maxPowerKw: 150,
+            status: ConnectorStatus.partial,
+            statusLabel: 'Partly Operational',
           ),
         ),
       );
 
-      expect(find.text('Type 2'), findsOneWidget);
-      expect(find.text('22 kW'), findsOneWidget);
+      expect(find.text(AppLocalizationsEn().evStatusPartial), findsOneWidget);
     });
   });
 }

--- a/test/features/search/presentation/widgets/ev_station_card_test.dart
+++ b/test/features/search/presentation/widgets/ev_station_card_test.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/fuel_colors.dart';
+import 'package:tankstellen/core/widgets/station_card_shell.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/presentation/widgets/ev_station_card.dart';
@@ -24,19 +26,21 @@ void main() {
     place: 'Berlin',
     connectors: [
       EvConnector(
-          id: 'c1',
-          type: ConnectorType.ccs,
-          rawType: 'CCS Type 2',
-          maxPowerKw: 350,
-          quantity: 4,
-          currentType: 'DC'),
+        id: 'c1',
+        type: ConnectorType.ccs,
+        rawType: 'CCS Type 2',
+        maxPowerKw: 350,
+        quantity: 4,
+        currentType: 'DC',
+      ),
       EvConnector(
-          id: 'c2',
-          type: ConnectorType.type2,
-          rawType: 'Type 2',
-          maxPowerKw: 22,
-          quantity: 2,
-          currentType: 'AC'),
+        id: 'c2',
+        type: ConnectorType.type2,
+        rawType: 'Type 2',
+        maxPowerKw: 22,
+        quantity: 2,
+        currentType: 'AC',
+      ),
     ],
     totalPoints: 6,
     isOperational: true,
@@ -115,10 +119,7 @@ void main() {
 
     testWidgets('shows station name when operator is empty', (tester) async {
       final noOperator = testStation.copyWith(operator: '');
-      await pumpApp(
-        tester,
-        EVStationCard(result: EVStationResult(noOperator)),
-      );
+      await pumpApp(tester, EVStationCard(result: EVStationResult(noOperator)));
 
       expect(find.text('Test Charger'), findsOneWidget);
     });
@@ -143,8 +144,9 @@ void main() {
         expect(find.byIcon(Icons.star_border), findsNothing);
       });
 
-      testWidgets('outlined star when not favourited; tap fires the callback',
-          (tester) async {
+      testWidgets('outlined star when not favourited; tap fires the callback', (
+        tester,
+      ) async {
         var tapped = 0;
         await pumpApp(
           tester,
@@ -171,6 +173,23 @@ void main() {
         );
         expect(find.byIcon(Icons.star), findsOneWidget);
         expect(find.byIcon(Icons.star_border), findsNothing);
+      });
+    });
+
+    group('StationCardShell composition (#2493)', () {
+      testWidgets('built from the shared shell with the evAccent stripe', (
+        tester,
+      ) async {
+        await pumpApp(
+          tester,
+          const EVStationCard(result: EVStationResult(testStation)),
+        );
+        final shell = tester.widget<StationCardShell>(
+          find.byType(StationCardShell),
+        );
+        // #2493 — single canonical EV accent (no teal `#009688` /
+        // `FuelType.electric` stripe divergence).
+        expect(shell.stripeColor, FuelColors.evAccent);
       });
     });
   });

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -7,6 +7,7 @@ import 'package:tankstellen/core/theme/dark_mode_colors.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/core/utils/price_tier.dart';
+import 'package:tankstellen/core/widgets/station_card_shell.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
@@ -21,10 +22,7 @@ void main() {
     testWidgets('renders station brand name', (tester) async {
       await pumpApp(
         tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-        ),
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
       );
 
       expect(find.text('STAR'), findsOneWidget);
@@ -33,10 +31,7 @@ void main() {
     testWidgets('renders station address', (tester) async {
       await pumpApp(
         tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-        ),
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
       );
 
       // Address + postcode combined on one line when brand is shown
@@ -67,10 +62,7 @@ void main() {
     testWidgets('renders distance in km', (tester) async {
       await pumpApp(
         tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-        ),
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
       );
 
       // testStation.dist = 1.5 → "1,5 km"
@@ -79,13 +71,18 @@ void main() {
 
     testWidgets('shows open indicator when isOpen=true', (tester) async {
       late Color expectedColor;
-      await pumpApp(tester, Builder(builder: (context) {
-        expectedColor = DarkModeColors.success(context);
-        return const StationCard(
-          station: testStation, // isOpen: true
-          selectedFuelType: FuelType.e10,
-        );
-      }));
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) {
+            expectedColor = DarkModeColors.success(context);
+            return const StationCard(
+              station: testStation, // isOpen: true
+              selectedFuelType: FuelType.e10,
+            );
+          },
+        ),
+      );
 
       // The open indicator is a circle with success color
       final containers = find.byWidgetPredicate((widget) {
@@ -100,16 +97,22 @@ void main() {
     });
 
     testWidgets('shows closed indicator when isOpen=false', (tester) async {
-      final closedStation = testStationList[2]; // station-expensive, isOpen: false
+      final closedStation =
+          testStationList[2]; // station-expensive, isOpen: false
 
       late Color expectedColor;
-      await pumpApp(tester, Builder(builder: (context) {
-        expectedColor = DarkModeColors.error(context);
-        return StationCard(
-          station: closedStation,
-          selectedFuelType: FuelType.e10,
-        );
-      }));
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) {
+            expectedColor = DarkModeColors.error(context);
+            return StationCard(
+              station: closedStation,
+              selectedFuelType: FuelType.e10,
+            );
+          },
+        ),
+      );
 
       // The closed indicator is a circle with error color
       final containers = find.byWidgetPredicate((widget) {
@@ -158,8 +161,9 @@ void main() {
       expect(tapped, isTrue);
     });
 
-    testWidgets('shows arrow_downward icon when priceTier is cheap',
-        (tester) async {
+    testWidgets('shows arrow_downward icon when priceTier is cheap', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const StationCard(
@@ -172,8 +176,7 @@ void main() {
       expect(find.byIcon(Icons.arrow_downward), findsOneWidget);
     });
 
-    testWidgets('shows remove icon when priceTier is average',
-        (tester) async {
+    testWidgets('shows remove icon when priceTier is average', (tester) async {
       await pumpApp(
         tester,
         const StationCard(
@@ -187,8 +190,9 @@ void main() {
       expect(find.byIcon(Icons.remove), findsOneWidget);
     });
 
-    testWidgets('shows arrow_upward icon when priceTier is expensive',
-        (tester) async {
+    testWidgets('shows arrow_upward icon when priceTier is expensive', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const StationCard(
@@ -201,22 +205,21 @@ void main() {
       expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
     });
 
-    testWidgets('does not show tier icon when priceTier is null',
-        (tester) async {
+    testWidgets('does not show tier icon when priceTier is null', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-        ),
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
       );
 
       expect(find.byIcon(Icons.arrow_downward), findsNothing);
       expect(find.byIcon(Icons.arrow_upward), findsNothing);
     });
 
-    testWidgets('does not show tier icon when priceTier is unknown',
-        (tester) async {
+    testWidgets('does not show tier icon when priceTier is unknown', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const StationCard(
@@ -242,30 +245,35 @@ void main() {
       );
 
       // 3 filled stars + 2 empty stars = 5 star icons total
-      final filledStars = find.byWidgetPredicate((widget) =>
-          widget is Icon && widget.icon == Icons.star && widget.size == 12);
-      final emptyStars = find.byWidgetPredicate((widget) =>
-          widget is Icon &&
-          widget.icon == Icons.star_border &&
-          widget.size == 12);
+      final filledStars = find.byWidgetPredicate(
+        (widget) =>
+            widget is Icon && widget.icon == Icons.star && widget.size == 12,
+      );
+      final emptyStars = find.byWidgetPredicate(
+        (widget) =>
+            widget is Icon &&
+            widget.icon == Icons.star_border &&
+            widget.size == 12,
+      );
       expect(filledStars, findsNWidgets(3));
       expect(emptyStars, findsNWidgets(2));
     });
 
-    testWidgets('does not show rating stars when rating is null',
-        (tester) async {
+    testWidgets('does not show rating stars when rating is null', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
-        const StationCard(
-          station: testStation,
-          selectedFuelType: FuelType.e10,
-        ),
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
       );
 
       // No 12px star icons should appear (the favorite star is 22px)
       final ratingStars = find.byWidgetPredicate(
-          (widget) => widget is Icon && widget.size == 12 &&
-              (widget.icon == Icons.star || widget.icon == Icons.star_border));
+        (widget) =>
+            widget is Icon &&
+            widget.size == 12 &&
+            (widget.icon == Icons.star || widget.icon == Icons.star_border),
+      );
       expect(ratingStars, findsNothing);
     });
 
@@ -279,8 +287,10 @@ void main() {
         ),
       );
 
-      final filledStars = find.byWidgetPredicate((widget) =>
-          widget is Icon && widget.icon == Icons.star && widget.size == 12);
+      final filledStars = find.byWidgetPredicate(
+        (widget) =>
+            widget is Icon && widget.icon == Icons.star && widget.size == 12,
+      );
       expect(filledStars, findsNWidgets(5));
     });
 
@@ -297,10 +307,12 @@ void main() {
       // Both the price RichText and the favorite IconButton should be
       // inside the same Row (the right-side price+fav row).
       // Verify both are rendered and the favorite icon is 22px (compact).
-      final favIcon = find.byWidgetPredicate((widget) =>
-          widget is Icon &&
-          widget.icon == Icons.star &&
-          widget.color == Colors.amber);
+      final favIcon = find.byWidgetPredicate(
+        (widget) =>
+            widget is Icon &&
+            widget.icon == Icons.star &&
+            widget.color == Colors.amber,
+      );
       expect(favIcon, findsOneWidget);
 
       // The favorite IconButton should be compact (32x32 SizedBox)
@@ -313,8 +325,9 @@ void main() {
       expect(sizedBox, findsOneWidget);
     });
 
-    testWidgets('renders amenity chips on single horizontal line',
-        (tester) async {
+    testWidgets('renders amenity chips on single horizontal line', (
+      tester,
+    ) async {
       const stationWithAmenities = Station(
         id: 'amenity-test',
         name: 'Test Station',
@@ -347,8 +360,9 @@ void main() {
       expect(find.byType(AmenityChips), findsOneWidget);
     });
 
-    testWidgets('calls onFavoriteTap when favorite button tapped',
-        (tester) async {
+    testWidgets('calls onFavoriteTap when favorite button tapped', (
+      tester,
+    ) async {
       var favTapped = false;
 
       await pumpApp(
@@ -367,8 +381,9 @@ void main() {
     });
 
     group('profile fuel highlight in all-fuels view', () {
-      testWidgets('shows all three price rows when FuelType.all selected',
-          (tester) async {
+      testWidgets('shows all three price rows when FuelType.all selected', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -383,36 +398,37 @@ void main() {
       });
 
       testWidgets(
-          'profile fuel row has larger dot when profileFuelType matches',
-          (tester) async {
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: testStation,
-            selectedFuelType: FuelType.all,
-            profileFuelType: FuelType.e10,
-          ),
-        );
+        'profile fuel row has larger dot when profileFuelType matches',
+        (tester) async {
+          await pumpApp(
+            tester,
+            const StationCard(
+              station: testStation,
+              selectedFuelType: FuelType.all,
+              profileFuelType: FuelType.e10,
+            ),
+          );
 
-        // The E10 row should have a larger dot (8px) while others have 6px
-        final containers = find.byWidgetPredicate((widget) {
-          if (widget is Container && widget.decoration is BoxDecoration) {
-            final decoration = widget.decoration as BoxDecoration;
-            final constraints = widget.constraints;
-            return decoration.shape == BoxShape.circle &&
-                constraints != null &&
-                constraints.maxWidth == 8.0 &&
-                constraints.maxHeight == 8.0;
-          }
-          return false;
-        });
-        // One 8px dot for the highlighted E10 row
-        expect(containers, findsOneWidget);
-      });
+          // The E10 row should have a larger dot (8px) while others have 6px
+          final containers = find.byWidgetPredicate((widget) {
+            if (widget is Container && widget.decoration is BoxDecoration) {
+              final decoration = widget.decoration as BoxDecoration;
+              final constraints = widget.constraints;
+              return decoration.shape == BoxShape.circle &&
+                  constraints != null &&
+                  constraints.maxWidth == 8.0 &&
+                  constraints.maxHeight == 8.0;
+            }
+            return false;
+          });
+          // One 8px dot for the highlighted E10 row
+          expect(containers, findsOneWidget);
+        },
+      );
 
-      testWidgets(
-          'profile fuel row label uses fuel-type color',
-          (tester) async {
+      testWidgets('profile fuel row label uses fuel-type color', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -431,9 +447,9 @@ void main() {
         expect(textWidget.style?.color, dieselColor);
       });
 
-      testWidgets(
-          'non-profile fuel rows do not use fuel-type label color',
-          (tester) async {
+      testWidgets('non-profile fuel rows do not use fuel-type label color', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -452,9 +468,7 @@ void main() {
         expect(e5Text.style?.color, isNot(equals(e5FuelColor)));
       });
 
-      testWidgets(
-          'no highlight when profileFuelType is null',
-          (tester) async {
+      testWidgets('no highlight when profileFuelType is null', (tester) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -478,9 +492,9 @@ void main() {
         expect(largeDots, findsNothing);
       });
 
-      testWidgets(
-          'no price rows when single fuel type selected (not all)',
-          (tester) async {
+      testWidgets('no price rows when single fuel type selected (not all)', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -515,43 +529,51 @@ void main() {
       });
 
       testWidgets(
-          'uk- prefix renders £ even when the active profile is France',
-          (tester) async {
-        PriceFormatter.setCountry('FR');
+        'uk- prefix renders £ even when the active profile is France',
+        (tester) async {
+          PriceFormatter.setCountry('FR');
 
-        const ukStation = Station(
-          id: 'uk-BP1',
-          name: 'BP Victoria',
-          brand: 'BP',
-          street: '1 Victoria St',
-          postCode: 'SW1E 6DE',
-          place: 'London',
-          lat: 51.4975,
-          lng: -0.1357,
-          dist: 1.5,
-          e5: 1.559,
-          e10: 1.459,
-          diesel: 1.529,
-          isOpen: true,
-        );
+          const ukStation = Station(
+            id: 'uk-BP1',
+            name: 'BP Victoria',
+            brand: 'BP',
+            street: '1 Victoria St',
+            postCode: 'SW1E 6DE',
+            place: 'London',
+            lat: 51.4975,
+            lng: -0.1357,
+            dist: 1.5,
+            e5: 1.559,
+            e10: 1.459,
+            diesel: 1.529,
+            isOpen: true,
+          );
 
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: ukStation,
-            selectedFuelType: FuelType.e5,
-          ),
-        );
+          await pumpApp(
+            tester,
+            const StationCard(
+              station: ukStation,
+              selectedFuelType: FuelType.e5,
+            ),
+          );
 
-        final rendered = priceRichText(tester);
-        expect(rendered, contains('£'),
-            reason: 'UK station must render its price in pounds');
-        expect(rendered, isNot(contains('€')),
-            reason: 'UK station must not use the profile € symbol');
-      });
+          final rendered = priceRichText(tester);
+          expect(
+            rendered,
+            contains('£'),
+            reason: 'UK station must render its price in pounds',
+          );
+          expect(
+            rendered,
+            isNot(contains('€')),
+            reason: 'UK station must not use the profile € symbol',
+          );
+        },
+      );
 
-      testWidgets(
-          'pt- prefix keeps € and matches the active FR profile', (tester) async {
+      testWidgets('pt- prefix keeps € and matches the active FR profile', (
+        tester,
+      ) async {
         PriceFormatter.setCountry('FR');
 
         const ptStation = Station(
@@ -571,43 +593,48 @@ void main() {
 
         await pumpApp(
           tester,
-          const StationCard(
-            station: ptStation,
-            selectedFuelType: FuelType.e5,
-          ),
+          const StationCard(station: ptStation, selectedFuelType: FuelType.e5),
         );
 
         expect(priceRichText(tester), contains('€'));
       });
 
       testWidgets(
-          'unprefixed Tankerkoenig UUID with German coordinates resolves '
-          'to € via bbox fallback (#516)', (tester) async {
-        // Under #516 the bounding-box fallback kicks in when the id
-        // carries no country prefix. testStation has a UUID + Berlin
-        // coords, so it must render with € regardless of the active
-        // profile — previously (#514) it would have fallen through
-        // to the profile currency.
-        PriceFormatter.setCountry('GB');
+        'unprefixed Tankerkoenig UUID with German coordinates resolves '
+        'to € via bbox fallback (#516)',
+        (tester) async {
+          // Under #516 the bounding-box fallback kicks in when the id
+          // carries no country prefix. testStation has a UUID + Berlin
+          // coords, so it must render with € regardless of the active
+          // profile — previously (#514) it would have fallen through
+          // to the profile currency.
+          PriceFormatter.setCountry('GB');
 
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: testStation,
-            selectedFuelType: FuelType.e5,
-          ),
-        );
+          await pumpApp(
+            tester,
+            const StationCard(
+              station: testStation,
+              selectedFuelType: FuelType.e5,
+            ),
+          );
 
-        final rendered = priceRichText(tester);
-        expect(rendered, contains('€'),
-            reason: 'Berlin coordinates must resolve to DE → € even '
-                'under a GB profile (bbox fallback)');
-        expect(rendered, isNot(contains('£')),
-            reason: 'a German station must not borrow the profile £');
-      });
+          final rendered = priceRichText(tester);
+          expect(
+            rendered,
+            contains('€'),
+            reason:
+                'Berlin coordinates must resolve to DE → € even '
+                'under a GB profile (bbox fallback)',
+          );
+          expect(
+            rendered,
+            isNot(contains('£')),
+            reason: 'a German station must not borrow the profile £',
+          );
+        },
+      );
 
-      testWidgets(
-          '#516: bare-numeric FR Prix-Carburants id at Paris coords '
+      testWidgets('#516: bare-numeric FR Prix-Carburants id at Paris coords '
           'renders € under a GB profile', (tester) async {
         // The exact scenario from the bug report screenshot: the
         // active profile is UK, a favorite French station has a raw
@@ -635,59 +662,64 @@ void main() {
 
         await pumpApp(
           tester,
-          const StationCard(
-            station: frStation,
-            selectedFuelType: FuelType.e10,
-          ),
+          const StationCard(station: frStation, selectedFuelType: FuelType.e10),
         );
 
         final rendered = priceRichText(tester);
-        expect(rendered, contains('€'),
-            reason: 'French coordinates must resolve to FR → € even '
-                'with a bare numeric id and a GB profile');
-        expect(rendered, isNot(contains('£')),
-            reason: 'French station must not inherit the profile £');
+        expect(
+          rendered,
+          contains('€'),
+          reason:
+              'French coordinates must resolve to FR → € even '
+              'with a bare numeric id and a GB profile',
+        );
+        expect(
+          rendered,
+          isNot(contains('£')),
+          reason: 'French station must not inherit the profile £',
+        );
       });
 
       testWidgets(
-          '#516: uk- prefixed station under a FR profile still renders £',
-          (tester) async {
-        // Mirror of the scenario above — the other direction, to prove
-        // the prefix path still works after #516 changes the resolver.
-        PriceFormatter.setCountry('FR');
+        '#516: uk- prefixed station under a FR profile still renders £',
+        (tester) async {
+          // Mirror of the scenario above — the other direction, to prove
+          // the prefix path still works after #516 changes the resolver.
+          PriceFormatter.setCountry('FR');
 
-        const ukStation = Station(
-          id: 'uk-MFG-Streatham',
-          name: 'MFG Streatham Leigham',
-          brand: 'ESSO',
-          street: '928.3 km',
-          postCode: 'SW16',
-          place: 'London',
-          lat: 51.42,
-          lng: -0.13,
-          dist: 928.3,
-          e5: 1.759,
-          e10: 1.579,
-          diesel: 1.939,
-          isOpen: true,
-        );
+          const ukStation = Station(
+            id: 'uk-MFG-Streatham',
+            name: 'MFG Streatham Leigham',
+            brand: 'ESSO',
+            street: '928.3 km',
+            postCode: 'SW16',
+            place: 'London',
+            lat: 51.42,
+            lng: -0.13,
+            dist: 928.3,
+            e5: 1.759,
+            e10: 1.579,
+            diesel: 1.939,
+            isOpen: true,
+          );
 
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: ukStation,
-            selectedFuelType: FuelType.e10,
-          ),
-        );
+          await pumpApp(
+            tester,
+            const StationCard(
+              station: ukStation,
+              selectedFuelType: FuelType.e10,
+            ),
+          );
 
-        final rendered = priceRichText(tester);
-        expect(rendered, contains('£'));
-        expect(rendered, isNot(contains('€')));
-      });
+          final rendered = priceRichText(tester);
+          expect(rendered, contains('£'));
+          expect(rendered, isNot(contains('€')));
+        },
+      );
 
-      testWidgets(
-          'mx- prefix renders the peso symbol under a FR profile',
-          (tester) async {
+      testWidgets('mx- prefix renders the peso symbol under a FR profile', (
+        tester,
+      ) async {
         PriceFormatter.setCountry('FR');
 
         const mxStation = Station(
@@ -708,25 +740,23 @@ void main() {
 
         await pumpApp(
           tester,
-          const StationCard(
-            station: mxStation,
-            selectedFuelType: FuelType.e5,
-          ),
+          const StationCard(station: mxStation, selectedFuelType: FuelType.e5),
         );
 
         final rendered = priceRichText(tester);
-        expect(rendered, contains('\$'),
-            reason: 'MX station must render the peso \$ symbol');
+        expect(
+          rendered,
+          contains('\$'),
+          reason: 'MX station must render the peso \$ symbol',
+        );
         expect(rendered, isNot(contains('€')));
       });
     });
 
     group('micro-animations (#595 — reverted by #2161)', () {
-      testWidgets(
-          '#2161 brand/name title is NOT a Hero anymore — the detail '
+      testWidgets('#2161 brand/name title is NOT a Hero anymore — the detail '
           'screen dropped the matching destination, so the card no '
-          'longer needs to animate into it',
-          (tester) async {
+          'longer needs to animate into it', (tester) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -740,12 +770,16 @@ void main() {
           final widget = element.widget as Hero;
           return widget.tag.toString().startsWith('station-name-');
         });
-        expect(matching, isEmpty,
-            reason: 'StationCard title Hero source must be gone (#2161)');
+        expect(
+          matching,
+          isEmpty,
+          reason: 'StationCard title Hero source must be gone (#2161)',
+        );
       });
 
-      testWidgets('favorite star is rendered via AnimatedFavoriteStar',
-          (tester) async {
+      testWidgets('favorite star is rendered via AnimatedFavoriteStar', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -766,8 +800,9 @@ void main() {
         );
       });
 
-      testWidgets('price display is wrapped in AnimatedPriceText',
-          (tester) async {
+      testWidgets('price display is wrapped in AnimatedPriceText', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -786,9 +821,9 @@ void main() {
     });
 
     group('loyalty discount (#1120)', () {
-      testWidgets(
-          'matching brand renders an effective price + badge',
-          (tester) async {
+      testWidgets('matching brand renders an effective price + badge', (
+        tester,
+      ) async {
         // testStation.brand == 'STAR' which is in BrandRegistry as
         // an alias of Orlen. Use a Total station instead.
         const totalStation = Station(
@@ -820,17 +855,24 @@ void main() {
           final richText = element.widget as RichText;
           return richText.text.toPlainText().contains('1,74');
         });
-        expect(hasEffective, isTrue,
-            reason: 'effective price (raw - discount) must be the headline');
+        expect(
+          hasEffective,
+          isTrue,
+          reason: 'effective price (raw - discount) must be the headline',
+        );
 
         // Raw price stays accessible — appears struck through in the badge.
         final hasRaw = find.textContaining('1,799');
-        expect(hasRaw, findsOneWidget,
-            reason: 'raw price must remain visible to the user');
+        expect(
+          hasRaw,
+          findsOneWidget,
+          reason: 'raw price must remain visible to the user',
+        );
       });
 
-      testWidgets('non-matching brand leaves the price unchanged',
-          (tester) async {
+      testWidgets('non-matching brand leaves the price unchanged', (
+        tester,
+      ) async {
         // testStation brand "STAR" canonicalises to Orlen — no
         // Total card applies. Headline price must stay 1,79⁹.
         await pumpApp(
@@ -861,83 +903,88 @@ void main() {
       });
 
       testWidgets(
-          'empty discount map leaves matching-brand stations unchanged',
-          (tester) async {
-        const totalStation = Station(
-          id: 'fr-totalenergies-2',
-          name: 'TotalEnergies Béziers',
-          brand: 'Total',
-          street: 'Boulevard Pasteur',
-          postCode: '34500',
-          place: 'Béziers',
-          lat: 43.34,
-          lng: 3.21,
-          dist: 1.0,
-          e10: 1.799,
-          isOpen: true,
-        );
+        'empty discount map leaves matching-brand stations unchanged',
+        (tester) async {
+          const totalStation = Station(
+            id: 'fr-totalenergies-2',
+            name: 'TotalEnergies Béziers',
+            brand: 'Total',
+            street: 'Boulevard Pasteur',
+            postCode: '34500',
+            place: 'Béziers',
+            lat: 43.34,
+            lng: 3.21,
+            dist: 1.0,
+            e10: 1.799,
+            isOpen: true,
+          );
 
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: totalStation,
-            selectedFuelType: FuelType.e10,
-            activeDiscountsByBrand: {},
-          ),
-        );
+          await pumpApp(
+            tester,
+            const StationCard(
+              station: totalStation,
+              selectedFuelType: FuelType.e10,
+              activeDiscountsByBrand: {},
+            ),
+          );
 
-        // Strike-through text is what the badge renders. Empty map
-        // → no badge → no strike-through.
-        final hasStrike = find.byWidgetPredicate((w) {
-          if (w is Text && w.style?.decoration == TextDecoration.lineThrough) {
-            return true;
-          }
-          return false;
-        });
-        expect(hasStrike, findsNothing);
-      });
+          // Strike-through text is what the badge renders. Empty map
+          // → no badge → no strike-through.
+          final hasStrike = find.byWidgetPredicate((w) {
+            if (w is Text &&
+                w.style?.decoration == TextDecoration.lineThrough) {
+              return true;
+            }
+            return false;
+          });
+          expect(hasStrike, findsNothing);
+        },
+      );
 
       testWidgets(
-          'zero discount is rejected (defensive — never floor below raw)',
-          (tester) async {
-        const totalStation = Station(
-          id: 'fr-totalenergies-3',
-          name: 'TotalEnergies Sète',
-          brand: 'TotalEnergies',
-          street: 'Quai',
-          postCode: '34200',
-          place: 'Sète',
-          lat: 43.40,
-          lng: 3.69,
-          dist: 1.0,
-          e10: 1.799,
-          isOpen: true,
-        );
+        'zero discount is rejected (defensive — never floor below raw)',
+        (tester) async {
+          const totalStation = Station(
+            id: 'fr-totalenergies-3',
+            name: 'TotalEnergies Sète',
+            brand: 'TotalEnergies',
+            street: 'Quai',
+            postCode: '34200',
+            place: 'Sète',
+            lat: 43.40,
+            lng: 3.69,
+            dist: 1.0,
+            e10: 1.799,
+            isOpen: true,
+          );
 
-        await pumpApp(
-          tester,
-          const StationCard(
-            station: totalStation,
-            selectedFuelType: FuelType.e10,
-            activeDiscountsByBrand: {'TotalEnergies': 0},
-          ),
-        );
+          await pumpApp(
+            tester,
+            const StationCard(
+              station: totalStation,
+              selectedFuelType: FuelType.e10,
+              activeDiscountsByBrand: {'TotalEnergies': 0},
+            ),
+          );
 
-        // Strike-through text would only appear if a real discount
-        // applied. 0 → no badge → no strike-through.
-        final hasStrike = find.byWidgetPredicate((w) {
-          if (w is Text && w.style?.decoration == TextDecoration.lineThrough) {
-            return true;
-          }
-          return false;
-        });
-        expect(hasStrike, findsNothing);
-      });
+          // Strike-through text would only appear if a real discount
+          // applied. 0 → no badge → no strike-through.
+          final hasStrike = find.byWidgetPredicate((w) {
+            if (w is Text &&
+                w.style?.decoration == TextDecoration.lineThrough) {
+              return true;
+            }
+            return false;
+          });
+          expect(hasStrike, findsNothing);
+        },
+      );
     });
 
     group('card polish (#592)', () {
-      testWidgets('card has 6dp vertical margin (breathing room)',
-          (tester) async {
+      testWidgets('card has 6dp vertical margin (breathing room)', (
+        tester,
+      ) async {
         await pumpApp(
           tester,
           const StationCard(
@@ -996,48 +1043,132 @@ void main() {
 
         final card = tester.widget<Card>(find.byType(Card).first);
         final shape = card.shape as RoundedRectangleBorder;
-        expect(
-          shape.borderRadius,
-          BorderRadius.circular(12),
-        );
+        expect(shape.borderRadius, BorderRadius.circular(12));
       });
     });
 
     testWidgets(
-        '#2061 — the "Independent" sentinel does not leak into the title',
-        (tester) async {
-      // The French Prix Carburants parser tags brandless stations with
-      // `BrandRegistry.independentLabel` (== "Independent"). Before
-      // #2061 the search card rendered that sentinel as the title;
-      // after, it falls back to the street address (matching the
-      // detail screen).
-      const independentStation = Station(
-        id: 'indep-2061',
-        name: '',
-        brand: 'Independent',
-        street: '26 AVENUE DE VERDUN',
-        postCode: '34120',
-        place: 'Pézenas',
-        lat: 43.46,
-        lng: 3.42,
-        e10: 1.999,
-        isOpen: true,
-      );
+      '#2061 — the "Independent" sentinel does not leak into the title',
+      (tester) async {
+        // The French Prix Carburants parser tags brandless stations with
+        // `BrandRegistry.independentLabel` (== "Independent"). Before
+        // #2061 the search card rendered that sentinel as the title;
+        // after, it falls back to the street address (matching the
+        // detail screen).
+        const independentStation = Station(
+          id: 'indep-2061',
+          name: '',
+          brand: 'Independent',
+          street: '26 AVENUE DE VERDUN',
+          postCode: '34120',
+          place: 'Pézenas',
+          lat: 43.46,
+          lng: 3.42,
+          e10: 1.999,
+          isOpen: true,
+        );
 
+        await pumpApp(
+          tester,
+          const StationCard(
+            station: independentStation,
+            selectedFuelType: FuelType.e10,
+          ),
+        );
+
+        expect(
+          find.text('Independent'),
+          findsNothing,
+          reason:
+              'The Independent sentinel is an internal classification, '
+              'not a brand to render.',
+        );
+        expect(
+          find.text('26 AVENUE DE VERDUN'),
+          findsOneWidget,
+          reason: 'Brandless station falls back to the street as title.',
+        );
+      },
+    );
+  });
+
+  group('StationCardShell composition (#2493)', () {
+    testWidgets('StationCard is built from the shared StationCardShell', (
+      tester,
+    ) async {
+      await pumpApp(
+        tester,
+        const StationCard(station: testStation, selectedFuelType: FuelType.e10),
+      );
+      expect(find.byType(StationCardShell), findsOneWidget);
+    });
+
+    testWidgets(
+      'the all-fuels stripe is a VISIBLE colour, not the invisible grey',
+      (tester) async {
+        late Color primary;
+        await pumpApp(
+          tester,
+          Builder(
+            builder: (context) {
+              primary = Theme.of(context).colorScheme.primary;
+              return const StationCard(
+                station: testStation,
+                selectedFuelType: FuelType.all,
+              );
+            },
+          ),
+        );
+
+        final shell = tester.widget<StationCardShell>(
+          find.byType(StationCardShell),
+        );
+        // #2493 — the all-fuels stripe must be the forest-green primary,
+        // never the near-invisible neutral grey `#6F6F6F` returned by
+        // FuelColors.forType(FuelType.all).
+        expect(shell.stripeColor, primary);
+        expect(shell.stripeColor, isNot(const Color(0xFF6F6F6F)));
+      },
+    );
+
+    testWidgets('a single concrete fuel uses its fuel stripe colour', (
+      tester,
+    ) async {
       await pumpApp(
         tester,
         const StationCard(
-          station: independentStation,
-          selectedFuelType: FuelType.e10,
+          station: testStation,
+          selectedFuelType: FuelType.diesel,
         ),
       );
+      final shell = tester.widget<StationCardShell>(
+        find.byType(StationCardShell),
+      );
+      expect(shell.stripeColor, FuelColors.forType(FuelType.diesel));
+    });
 
-      expect(find.text('Independent'), findsNothing,
-          reason:
-              'The Independent sentinel is an internal classification, '
-              'not a brand to render.');
-      expect(find.text('26 AVENUE DE VERDUN'), findsOneWidget,
-          reason: 'Brandless station falls back to the street as title.');
+    testWidgets('the cheapest card widens the stripe and uses success', (
+      tester,
+    ) async {
+      late Color success;
+      await pumpApp(
+        tester,
+        Builder(
+          builder: (context) {
+            success = DarkModeColors.success(context);
+            return const StationCard(
+              station: testStation,
+              selectedFuelType: FuelType.e10,
+              isCheapest: true,
+            );
+          },
+        ),
+      );
+      final shell = tester.widget<StationCardShell>(
+        find.byType(StationCardShell),
+      );
+      expect(shell.stripeColor, success);
+      expect(shell.stripeWidth, 6);
     });
   });
 }


### PR DESCRIPTION
Closes #2493

Part of #2487 (Wave 2 — station-card unification).

## What changed
1. **Locale-safe connector status** — `EVConnectorTile` no longer drives colour/icon off hardcoded English string-equality. It switches on the canonical `ConnectorStatus` enum (extended with a new `partial` state for OCM "Partly Operational"), localising only the display label. A shared `ConnectorStatusStyle` extension (colour + icon + label) is consumed by both the search tile and the EV detail screen so they can't drift. `ConnectorStatus.fromLabel` is now the single normalisation source and its branch order is fixed so "Temporarily Unavailable" no longer misreads as available.
2. **One canonical EV accent** — `FuelColors.evAccent = Color(0xFF4FC3F7)` (crystalBlue). Referenced from `ev_favorite_card`, `ev_station_card` and the generic CCS connector chip, dropping the teal `#009688` / blue `#2196F3` divergence. Type 2 / CHAdeMO / Tesla keep their deliberate per-connector hues.
3. **StationCardShell** — new `lib/core/widgets/station_card_shell.dart` owns the shared frame (margin, clip, elevation dark?1:2, `AppRadius.lg` shape, `InkWell`, optional left stripe). `StationCard`, `EvFavoriteCard`, `EVStationCard`, `AllPricesStationCard` all compose it. The all-fuels stripe now uses the visible forest-green primary (`FuelColors.stripeColor`) instead of the invisible `#6F6F6F`; the EV stripe is `evAccent`. AllPrices keeps no stripe (colour lives in its per-fuel badges); its status dot is reconciled 10→12px and its favorite tooltip moved to ARB.

## ARB fan-out
New key `evStatusPartial` (en "Partly available" / de "Teilweise verfügbar") fanned out to all 23 locales + en_XA via the full pipeline; generated bindings regenerated.

## Tests
Structural widget tests only (no goldens): all four cards compose `StationCardShell`, the EV accent resolves to the single `evAccent` token, the all-fuels stripe is non-grey, and connector status resolves by enum (incl. a German-locale path). `flutter analyze` (lib + test) clean; search/favorites/EV suites, `file_length`, `no_hardcoded_ui_strings`, `no_raw_card_in_features`, `test/l10n` and `test/i18n` all green. Zero codegen / l10n drift (clean rebuild verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
