### PR TITLE
fix(map): markers show the selected fuel price + nearby results stay visible (de-cluster the #2490 over-aggregation) (#2510)

### DIFF
--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -8,6 +8,7 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../../search/providers/search_provider.dart';
+import '../../../search/providers/search_screen_ui_provider.dart';
 import 'station_map_layers.dart';
 
 /// A reusable map widget that displays station markers from current search results.
@@ -39,6 +40,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
     final searchState = ref.watch(searchStateProvider);
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
     final searchRadius = ref.watch(searchRadiusProvider);
+    final sortMode = ref.watch(selectedSortModeProvider);
 
     return searchState.when(
       data: (result) {
@@ -65,6 +67,7 @@ class _InlineMapState extends ConsumerState<InlineMap> {
           zoom: zoom,
           searchRadiusKm: searchRadius,
           selectedFuel: selectedFuel,
+          sortMode: sortMode,
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -13,6 +13,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../ev/presentation/widgets/ev_map_overlay.dart';
 import '../../../ev/providers/ev_providers.dart';
 import '../../../search/domain/entities/search_result_item.dart';
+import '../../../search/providers/search_screen_ui_provider.dart';
 import 'station_map_layers.dart';
 
 /// Displays a map of nearby stations from the current search results.
@@ -86,6 +87,9 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
         }
 
         final showEv = ref.watch(evShowOnMapProvider);
+        // #2510 — the active list sort drives which stations the map
+        // emphasizes (full price bubble) vs renders as compact dots.
+        final sortMode = ref.watch(selectedSortModeProvider);
         final userPos = ref.read(userPositionProvider);
         // Center the viewport on the SEARCHED area, not the user's GPS.
         // Otherwise a ZIP/city search from a distant location (e.g. user
@@ -136,6 +140,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
                     zoom: zoom,
                     searchRadiusKm: searchRadiusKm,
                     selectedFuel: selectedFuel,
+                    sortMode: sortMode,
                     showRecenterButton: true,
                     onRecenter: () => mapController.fitCamera(
                       CameraFit.bounds(

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -14,6 +14,7 @@ import '../../../../core/utils/price_utils.dart';
 import '../../../../core/widgets/osm_attribution.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
+import '../../../search/presentation/widgets/sort_selector.dart';
 import 'price_legend.dart';
 import 'station_marker.dart';
 
@@ -53,6 +54,17 @@ class StationMapLayers extends StatefulWidget {
   final double zoom;
   final double searchRadiusKm;
   final FuelType selectedFuel;
+
+  /// The active list sort (#2510). Governs which stations are EMPHASIZED
+  /// on the map: the top-ranked few keep their full price bubble while
+  /// the rest render as compact price-band dots so a bounded result set
+  /// stays fully visible without the bubbles overlapping. `price` /
+  /// `priceDistance` emphasize the cheapest; everything else (distance,
+  /// 24h, rating, name) emphasizes the closest. Defaults to
+  /// [SortMode.price] — the savings-first emphasis — for callers (route,
+  /// driving, inline) that don't surface a sort selector.
+  final SortMode sortMode;
+
   final bool showRecenterButton;
   final VoidCallback? onRecenter;
   final List<LatLng>? routePolyline;
@@ -74,6 +86,7 @@ class StationMapLayers extends StatefulWidget {
     required this.zoom,
     required this.searchRadiusKm,
     required this.selectedFuel,
+    this.sortMode = SortMode.price,
     this.showRecenterButton = false,
     this.onRecenter,
     this.routePolyline,
@@ -138,22 +151,20 @@ class StationMapLayers extends StatefulWidget {
   }
 
   /// Order [stations] so that, when their markers are handed to the
-  /// (cluster) layer, the CHEAPEST (green/günstig) marker is painted ON
+  /// marker layer, the CHEAPEST (green/günstig) marker is painted ON
   /// TOP of any more-expensive (orange/red) markers it overlaps (#2434).
   ///
-  /// flutter_map / flutter_map_marker_cluster paint markers in the order
-  /// of the source list — a marker LATER in the list is painted on top of
-  /// earlier ones. For individually-overlapping (un-clustered) price
-  /// bubbles at the reported zoom, this list order governs the overlap,
-  /// because the cluster layer recurses its nodes in insertion order and
-  /// `MarkerLayer` paints in list order. So the rule is:
-  ///   - sort by the RESOLVED display price (see [bestDisplayPrice]) —
-  ///     the SAME price the marker is COLOURED by (#2400) — DESCENDING:
-  ///     most expensive first (painted at the bottom), cheapest last
-  ///     (painted on top), so colour and stacking always agree;
-  ///   - markers with NO comparable price ([bestDisplayPrice] null → the
-  ///     grey "--" bubble) sort to the very FRONT (the bottom of the
-  ///     stack) so a price-less marker can never cover a real green one.
+  /// flutter_map paints markers in the order of the source list — a marker
+  /// LATER in the list is painted on top of earlier ones. So the rule is:
+  ///   - sort by the SELECTED-fuel price (`station.priceFor(selectedFuel)`)
+  ///     — the SAME price the marker is COLOURED by and the SAME strict
+  ///     resolution the search list uses (#2510, reverting the #2400
+  ///     fallback chain) — DESCENDING: most expensive first (painted at
+  ///     the bottom), cheapest last (painted on top), so colour and
+  ///     stacking always agree;
+  ///   - markers with NO selected-fuel price (the grey "--" bubble) sort
+  ///     to the very FRONT (the bottom of the stack) so a price-less
+  ///     marker can never cover a real green one.
   ///
   /// Returns a NEW list; the input is not mutated. A stable sort keeps the
   /// relative order of equal-priced stations.
@@ -161,16 +172,62 @@ class StationMapLayers extends StatefulWidget {
     List<Station> stations,
     FuelType selectedFuel,
   ) {
-    // A null resolved price is treated as the most-expensive bucket
+    // A null selected-fuel price is treated as the most-expensive bucket
     // (+infinity) so, under a descending sort, it lands first → painted
     // at the very bottom, beneath every priced marker.
     double sortKey(Station s) =>
-        bestDisplayPrice(s, selectedFuel)?.price ?? double.infinity;
+        priceForFuelType(s, selectedFuel) ?? double.infinity;
     final ordered = List<Station>.of(stations);
     // Descending: highest price first (bottom), lowest last (top).
     mergeSort<Station>(ordered,
         compare: (a, b) => sortKey(b).compareTo(sortKey(a)));
     return ordered;
+  }
+
+  /// How many top-ranked stations keep their full price label; the rest
+  /// render as compact price-band dots (#2510). Small enough that the
+  /// emphasized bubbles stay legible at the search zoom, large enough to
+  /// surface the handful of stations a driver actually compares.
+  @visibleForTesting
+  static const int emphasisCount = 4;
+
+  /// At or above this many stations the map falls back to count-clustering
+  /// (#2510). A bounded nearby search (the 10-station / 10 km case) stays
+  /// well under this, so every result renders as its own marker; only a
+  /// genuinely huge / zoomed-far set collapses into tappable clusters
+  /// rather than painting hundreds of overlapping dots.
+  @visibleForTesting
+  static const int clusterThreshold = 80;
+
+  /// Rank [stations] for marker EMPHASIS per the active [sortMode] (#2510):
+  /// the cheapest stations first for a price-oriented sort, the closest
+  /// first otherwise. The first [StationMapLayers.emphasisCount] entries
+  /// get the full price bubble; the rest become compact dots. Stations
+  /// without a comparable value sort last so they never steal emphasis
+  /// from a station that has a real price/distance.
+  ///
+  /// Returns a NEW list; the input is not mutated. Stable for ties.
+  static List<Station> rankForEmphasis(
+    List<Station> stations,
+    FuelType selectedFuel,
+    SortMode sortMode,
+  ) {
+    final ranked = List<Station>.of(stations);
+    final byPrice =
+        sortMode == SortMode.price || sortMode == SortMode.priceDistance;
+    int compare(Station a, Station b) {
+      if (byPrice) {
+        // Cheapest first; price-less stations sort last (sentinel handled
+        // inside compareByPrice).
+        return compareByPrice(a, b, selectedFuel);
+      }
+      // Closest first for distance / 24h / rating / name sorts — distance
+      // is the universally available, savings-relevant tie-breaker.
+      return a.dist.compareTo(b.dist);
+    }
+
+    mergeSort<Station>(ranked, compare: compare);
+    return ranked;
   }
 }
 
@@ -206,18 +263,30 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// Recompute the memoised price range + marker list from the current
   /// widget inputs.
   void _recomputeMarkers() {
-    // #2400 — colour by the RESOLVED display price (selected fuel, else
-    // fallback) so a fallback-priced marker is coloured by the value it
-    // actually shows rather than appearing grey because the selected
-    // fuel was null.
-    _priceRange = resolvedPriceRange(widget.stations, widget.selectedFuel);
+    // #2510 — colour by the SELECTED-fuel price (the same strict
+    // resolution the list uses), not a fallback chain. A station without
+    // the selected fuel paints grey ("--") instead of being re-coloured
+    // by E10's price.
+    _priceRange = priceRange(widget.stations, widget.selectedFuel);
     final ids = widget.selectedStationIds;
     final hasSelection = ids != null && ids.isNotEmpty;
+
+    // #2510 — emphasis: the top-ranked stations per the active sort
+    // (cheapest for a price sort, closest otherwise) keep the full price
+    // bubble; the rest render as compact price-band dots so a bounded
+    // result set stays fully visible without the bubbles overlapping into
+    // an illegible pile. The set is small, so a Set lookup is cheap.
+    final emphasized = StationMapLayers.rankForEmphasis(
+      widget.stations,
+      widget.selectedFuel,
+      widget.sortMode,
+    ).take(StationMapLayers.emphasisCount).map((s) => s.id).toSet();
+
     // #2434 — order so the cheapest (green) marker paints ON TOP of the
-    // more-expensive ones it overlaps. The (cluster) layer paints in
+    // more-expensive ones it overlaps. The marker layer paints in
     // source-list order (later = on top), so we sort price-descending:
     // expensive at the bottom, cheapest last/on top, price-less markers
-    // beneath everything. Same resolved price the marker is coloured by.
+    // beneath everything. Same price the marker is coloured by.
     final ordered = StationMapLayers.orderedByPriceForPainting(
       widget.stations,
       widget.selectedFuel,
@@ -231,6 +300,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
         _priceRange.$1,
         _priceRange.$2,
         pastel: isPastel,
+        compact: !emphasized.contains(station.id),
       );
     }).toList();
   }
@@ -255,6 +325,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
     final stationsChanged = !identical(oldWidget.stations, widget.stations);
     if (stationsChanged ||
         oldWidget.selectedFuel != widget.selectedFuel ||
+        oldWidget.sortMode != widget.sortMode ||
         !identical(oldWidget.selectedStationIds, widget.selectedStationIds)) {
       _recomputeMarkers();
     }
@@ -391,37 +462,46 @@ class _StationMapLayersState extends State<StationMapLayers> {
                 ),
               ],
             ),
-            // Station markers — ALWAYS routed through the cluster layer.
-            // #1774 — `_markers` is memoised; this builder just places the
-            // pre-built list. #2490 — the prior `stations.length > 20` gate
-            // dropped to a raw [MarkerLayer] for small result sets, so a
-            // 10-station radius search rendered overlapping price bubbles
-            // that obscured each other. Routing every set through
-            // [MarkerClusterLayerWidget] means overlapping markers always
-            // collapse into a tappable cluster (spiderfy / zoom-to-bounds
-            // on tap, both the layer's defaults), and a single far-apart
-            // station still renders as its own bubble. A tighter
-            // `maxClusterRadius` (was 80) keeps nearby-but-distinct
-            // stations from over-merging at the search zoom.
+            // Station markers. #1774 — `_markers` is memoised; this
+            // builder just places the pre-built list.
+            //
+            // #2510 — a BOUNDED nearby-search result set renders every
+            // station as its OWN marker (a plain [MarkerLayer]), so a
+            // 10-station / 10 km search shows all ten — never hidden behind
+            // count bubbles. De-overlap is by emphasis, not aggregation:
+            // the top-ranked stations (cheapest / closest per the active
+            // sort) keep the full price label, the rest are compact dots
+            // (see `_recomputeMarkers`). This reverses the #2490
+            // over-correction that routed EVERY set through
+            // [MarkerClusterLayerWidget] and so collapsed a small radius
+            // search into "4"/"2"/"3" count clusters.
+            //
+            // Clustering is kept ONLY as a fallback for a genuinely huge /
+            // zoomed-far set ([StationMapLayers.clusterThreshold]+), where
+            // painting hundreds of overlapping dots would itself be
+            // illegible; the bounded nearby case never reaches it.
             if (_markers.isNotEmpty)
-              MarkerClusterLayerWidget(
-                options: MarkerClusterLayerOptions(
-                  maxClusterRadius: 50,
-                  markers: _markers,
-                  builder: (context, clusterMarkers) => Container(
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.primaryContainer,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Center(
-                      child: Text(
-                        '${clusterMarkers.length}',
-                        style: const TextStyle(fontWeight: FontWeight.bold),
+              if (widget.stations.length >= StationMapLayers.clusterThreshold)
+                MarkerClusterLayerWidget(
+                  options: MarkerClusterLayerOptions(
+                    maxClusterRadius: 50,
+                    markers: _markers,
+                    builder: (context, clusterMarkers) => Container(
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primaryContainer,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Center(
+                        child: Text(
+                          '${clusterMarkers.length}',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                       ),
                     ),
                   ),
-                ),
-              ),
+                )
+              else
+                MarkerLayer(markers: _markers),
             // Extra layers (e.g. EV overlay)
             ...widget.extraLayers,
             // Attribution — localized OSM credit (#2402).

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -8,7 +8,6 @@ import 'package:latlong2/latlong.dart';
 import '../../../../core/theme/price_band_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/price_gradient.dart';
-import '../../../../core/utils/price_utils.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
@@ -18,10 +17,13 @@ import '../../../search/domain/entities/station.dart';
 const double kStationMarkerWidth = 50;
 const double kStationMarkerHeight = 24;
 
-/// Wider marker used when a fallback-fuel label is prepended (#2400) so
-/// the short fuel code (`E10`, `Diesel`, …) plus the price both fit
-/// without the [FittedBox] crushing the price too small to read.
-const double kStationMarkerWideWidth = 74;
+/// A small price-less dot used for lower-ranked stations so a bounded
+/// nearby-search result set stays fully visible (#2510) without the full
+/// price bubbles overlapping into an illegible pile. The top-ranked
+/// stations (cheapest / closest per the active sort) keep the full price
+/// label; the rest render as these dots — still tappable, still coloured
+/// by their price band, never hidden behind a count cluster.
+const double kStationDotSize = 14;
 
 /// Maximum characters for the brand label before truncation (used in
 /// the tap-to-reveal tooltip).
@@ -38,16 +40,21 @@ class StationMarkerBuilder {
   /// the station detail page; long-press reveals the brand name as a
   /// tooltip.
   ///
-  /// #2400 — the displayed price comes from [bestDisplayPrice]: the
-  /// selected [fuel] when present, otherwise the first available fallback
-  /// fuel. When the shown fuel differs from [fuel] (e.g. a diesel-only
-  /// station while the user has E10 selected), a small fuel-code dot +
-  /// label is prepended so the price is never silently mislabelled —
-  /// mirroring `AllPricesStationCard`. `'--'` now appears ONLY for a
-  /// station with no usable price for any fuel.
+  /// #2510 — the displayed price is STRICTLY the user's selected [fuel]
+  /// price (`station.priceFor(fuel)`), mirroring the search LIST card
+  /// (`StationCard._displayPrice`). A station that has no price for the
+  /// selected fuel renders the language-neutral `'--'` placeholder — it
+  /// no longer silently falls back to E10 / another fuel, which made the
+  /// map read "E10 2,099" on an E85 search while the list showed the E85
+  /// price (reverting the #2400 fallback chain that caused the divergence).
+  /// The price-band colour is computed from that same selected-fuel price.
   ///
   /// When [pastel] is true, the marker uses muted/pastel colors for
   /// non-selected stations so that selected ones stand out.
+  ///
+  /// When [compact] is true, the marker renders as a small coloured dot
+  /// (no price text) — used for lower-ranked stations so a bounded result
+  /// set stays fully visible without the full bubbles overlapping (#2510).
   static Marker build(
     BuildContext context,
     Station station,
@@ -55,122 +62,118 @@ class StationMarkerBuilder {
     double minPrice,
     double maxPrice, {
     bool pastel = false,
+    bool compact = false,
   }) {
-    final resolved = bestDisplayPrice(station, fuel);
-    final price = resolved?.price;
-    final isFallback = resolved != null && resolved.shownFuel != fuel;
+    // #2510 — strict selected-fuel price, exactly like the list card. No
+    // fallback to another fuel: a station lacking the selected fuel shows
+    // "--", it must never be re-labelled with E10's price.
+    final price = station.priceFor(fuel);
     final baseColor = priceColor(price, minPrice, maxPrice);
     final color = pastel ? _toPastel(baseColor) : baseColor;
     final brand = truncateBrand(station.displayName, maxLength: _maxBrandLength);
-    final fallbackLabel =
-        isFallback ? shortFuelLabel(resolved.shownFuel) : '';
 
     // Accessibility (#566): TalkBack/VoiceOver read this as "Brand, price
     // EUR per litre, double-tap to view details" — otherwise the marker is
-    // an opaque gesture target with no announced role or content. When a
-    // fallback fuel is shown, the announced label names it so the price is
-    // never ambiguous.
-    final priceLabel = price != null
-        ? (isFallback
-            ? '$fallbackLabel ${PriceFormatter.formatPrice(price)}'
-            : PriceFormatter.formatPrice(price))
-        : 'price unavailable';
+    // an opaque gesture target with no announced role or content.
+    final priceLabel =
+        price != null ? PriceFormatter.formatPrice(price) : 'price unavailable';
     final semanticLabel = '$brand, $priceLabel';
 
     final priceText = price != null
         ? PriceFormatter.formatPriceCompact(price)
         : '--'; // i18n-ignore: language-neutral no-price placeholder
 
+    final Widget badge = compact
+        ? _dot(color, pastel)
+        : _priceBubble(color, pastel, priceText);
+
     return Marker(
       point: LatLng(station.lat, station.lng),
-      width: isFallback ? kStationMarkerWideWidth : kStationMarkerWidth,
-      height: kStationMarkerHeight,
+      width: compact ? kStationDotSize : kStationMarkerWidth,
+      height: compact ? kStationDotSize : kStationMarkerHeight,
       // #1772 — isolate each marker's raster so an animation or rebuild
       // on one marker (e.g. the selected-station pastel swap) does not
       // repaint the entire marker layer.
       child: RepaintBoundary(
         child: Semantics(
-        label: semanticLabel,
-        button: true,
-        child: GestureDetector(
-        onTap: () => GoRouter.of(context).push('/station/${station.id}'),
-        child: Tooltip(
-          message: brand,
-          waitDuration: const Duration(milliseconds: 300),
-          child: Container(
-            alignment: Alignment.center,
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-            decoration: BoxDecoration(
-              color: color.withValues(alpha: pastel ? 0.5 : 0.92),
-              borderRadius: BorderRadius.circular(6),
-              border: pastel
-                  ? null
-                  : Border.all(
-                      color: Colors.white.withValues(alpha: 0.8),
-                      width: 1,
-                    ),
-              boxShadow: pastel
-                  ? null
-                  : [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.25),
-                        blurRadius: 3,
-                        offset: const Offset(0, 1),
-                      ),
-                    ],
-            ),
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // Fallback fuel dot + code (mirrors AllPricesStationCard)
-                  // so a price for a fuel other than the selected one is
-                  // never shown unlabelled.
-                  if (isFallback) ...[
-                    Container(
-                      width: 6,
-                      height: 6,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: pastel ? Colors.black26 : Colors.black54,
-                      ),
-                    ),
-                    const SizedBox(width: 3),
-                    Text(
-                      fallbackLabel,
-                      style: TextStyle(
-                        fontWeight: FontWeight.w600,
-                        fontSize: 10,
-                        height: 1.0,
-                        color: pastel ? Colors.black38 : Colors.black87,
-                      ),
-                    ),
-                    const SizedBox(width: 4),
-                  ],
-                  Text(
-                    priceText,
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 12,
-                      height: 1.0,
-                      color: pastel ? Colors.black38 : Colors.black87,
-                    ),
-                  ),
-                ],
-              ),
+          label: semanticLabel,
+          button: true,
+          child: GestureDetector(
+            onTap: () => GoRouter.of(context).push('/station/${station.id}'),
+            child: Tooltip(
+              message: brand,
+              waitDuration: const Duration(milliseconds: 300),
+              child: badge,
             ),
           ),
         ),
       ),
+    );
+  }
+
+  /// The full colour-coded price bubble shown for emphasized stations.
+  static Widget _priceBubble(Color color, bool pastel, String priceText) {
+    return Container(
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: pastel ? 0.5 : 0.92),
+        borderRadius: BorderRadius.circular(6),
+        border: pastel
+            ? null
+            : Border.all(color: Colors.white.withValues(alpha: 0.8), width: 1),
+        boxShadow: pastel
+            ? null
+            : [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.25),
+                  blurRadius: 3,
+                  offset: const Offset(0, 1),
+                ),
+              ],
       ),
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text(
+          priceText,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 12,
+            height: 1.0,
+            color: pastel ? Colors.black38 : Colors.black87,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// A small price-less dot for a de-emphasized (lower-ranked) station —
+  /// keeps it visible + tappable without a label that would overlap its
+  /// neighbours (#2510).
+  static Widget _dot(Color color, bool pastel) {
+    return Container(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: pastel ? 0.5 : 0.92),
+        shape: BoxShape.circle,
+        border: pastel
+            ? null
+            : Border.all(color: Colors.white.withValues(alpha: 0.8), width: 1),
+        boxShadow: pastel
+            ? null
+            : [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.25),
+                  blurRadius: 2,
+                  offset: const Offset(0, 1),
+                ),
+              ],
       ),
     );
   }
 
   /// Green (cheapest) -> Amber -> Orange -> Red (most expensive).
-  /// #2196 \u2014 thin wrapper over the shared [priceGradientColor].
-  /// #2492 \u2014 the stops now come from the ONE canonical
+  /// #2196 — thin wrapper over the shared [priceGradientColor].
+  /// #2492 — the stops now come from the ONE canonical
   /// [PriceBandColors.ramp], shared with [PriceLegend] so the legend
   /// describes exactly what the markers paint. The old pure
   /// `Colors.yellow` (`#FFEB00`) was near-invisible on the white-bordered

--- a/test/features/map/map_reimpl_regression_test.dart
+++ b/test/features/map/map_reimpl_regression_test.dart
@@ -99,20 +99,53 @@ void main() {
     });
   });
 
-  group('NEVER-BLANK MARKER — a price-bearing station never shows "--" '
-      '(#2400)', () {
-    // A result set where each station has at least one non-null price, but
-    // NONE of them carries the selected fuel (E10) — the exact
-    // fuel-chip-divergence scenario. Every marker must show a real price.
-    final mismatchedSet = <Station>[
-      _station(id: 's-diesel', diesel: 1.699),
-      _station(id: 's-e5', e5: 1.859),
-      _station(id: 's-lpg', lpg: 0.799),
-      _station(id: 's-cng', cng: 1.199),
-    ];
+  group('SELECTED-FUEL MARKER — the marker matches the list, no fallback '
+      '(#2510)', () {
+    // #2510 reverses the #2400 fallback chain: the marker shows STRICTLY
+    // the selected fuel's price (exactly like the search LIST card). A
+    // station that lacks the selected fuel renders "--" — it must NOT be
+    // re-labelled with another fuel's price (the bug where an E85 search
+    // map read "E10 2,099" while the list showed the E85 price).
 
-    testWidgets('no marker in a price-bearing set renders "--" on a '
-        'mismatched fuel', (tester) async {
+    testWidgets(
+        'a marker shows the selected fuel price when the station carries it',
+        (tester) async {
+      // E85 selected; station has E85 (cheap) plus an E10 default. The
+      // marker must show the E85 price, never the E10 default.
+      final station = _station(id: 's-e85', e10: 2.099, e85: 0.799);
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        station,
+        FuelType.e85,
+        0.5,
+        2.5,
+      );
+      await pumpApp(
+        tester,
+        SizedBox(
+          width: marker.width,
+          height: marker.height,
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
+        ),
+      );
+      expect(find.text('0,799'), findsOneWidget);
+      expect(find.text('2,099'), findsNothing,
+          reason: 'the E10 default must never replace the selected E85 price');
+    });
+
+    testWidgets(
+        'a station lacking the selected fuel renders "--", NOT a fallback '
+        'price', (tester) async {
+      // Each station has a non-null price for SOME other fuel but NOT the
+      // selected E10 — the list shows a dash here, so the map must too.
+      final mismatchedSet = <Station>[
+        _station(id: 's-diesel', diesel: 1.699),
+        _station(id: 's-e5', e5: 1.859),
+        _station(id: 's-lpg', lpg: 0.799),
+        _station(id: 's-cng', cng: 1.199),
+      ];
       for (final station in mismatchedSet) {
         final marker = StationMarkerBuilder.build(
           tester.element(find.byType(Container).first),
@@ -131,9 +164,10 @@ void main() {
                 .child,
           ),
         );
-        expect(find.text('--'), findsNothing,
+        expect(find.text('--'), findsOneWidget,
             reason:
-                '${station.id} has a fallback price and must not render "--"');
+                '${station.id} has no E10 price → "--", matching the list, '
+                'no fallback');
       }
     });
 
@@ -156,7 +190,7 @@ void main() {
         ),
       );
       expect(find.text('--'), findsOneWidget,
-          reason: 'the true-empty case is the only legitimate "--"');
+          reason: 'a station with no usable price renders "--"');
     });
   });
 }
@@ -165,6 +199,7 @@ Station _station({
   required String id,
   double? e5,
   double? e10,
+  double? e85,
   double? diesel,
   double? lpg,
   double? cng,
@@ -180,6 +215,7 @@ Station _station({
       lng: 13.0,
       e5: e5,
       e10: e10,
+      e85: e85,
       diesel: diesel,
       lpg: lpg,
       cng: cng,

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -8,8 +8,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/features/map/data/sparkilo_tile_layer.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_marker.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/sort_selector.dart';
 
 void main() {
   group('StationMapLayers.zoomForRadius', () {
@@ -285,24 +287,24 @@ void main() {
     });
 
     test(
-        'orders by the RESOLVED display price (fallback fuel), matching '
-        'the marker colour', () {
-      // User has DIESEL selected. `fallback` has no diesel but a cheap
-      // E10 — its marker is coloured by that fallback price (#2400), so
-      // the z-order must use the same resolved price, not the (null)
-      // selected-fuel price.
-      final dieselExpensive = station('diesel-expensive', diesel: 1.95);
-      final fallbackCheap = station('fallback-cheap', e10: 1.40);
+        'orders by the STRICT selected-fuel price, matching the marker '
+        'colour (#2510)', () {
+      // User has DIESEL selected. `e10Only` has NO diesel price — under
+      // #2510 the marker shows "--" (no E10 fallback), so its z-order key
+      // is the null/price-less bucket: it sinks to the BOTTOM, beneath the
+      // real diesel marker. This reverts the #2400 fallback-price ordering.
+      final dieselPriced = station('diesel-priced', diesel: 1.95);
+      final e10Only = station('e10-only', e10: 1.40);
 
       final ordered = StationMapLayers.orderedByPriceForPainting(
-        [dieselExpensive, fallbackCheap],
+        [dieselPriced, e10Only],
         FuelType.diesel,
       );
 
-      // The resolved-cheap fallback station paints on top of the
-      // diesel-expensive one, agreeing with their green/red colours.
-      expect(ordered.last.id, 'fallback-cheap');
-      expect(ordered.first.id, 'diesel-expensive');
+      // The price-less (for diesel) station sits at the bottom; the real
+      // diesel marker paints on top of it.
+      expect(ordered.first.id, 'e10-only');
+      expect(ordered.last.id, 'diesel-priced');
     });
 
     test('is a pure function — does not mutate the input list', () {
@@ -327,12 +329,13 @@ void main() {
     });
   });
 
-  // #2490 — markers were only routed through the cluster layer when
-  // `stations.length > 20`, so a small radius search (e.g. 10 stations)
-  // dropped to a raw [MarkerLayer] and rendered overlapping price bubbles.
-  // Every non-empty set now goes through [MarkerClusterLayerWidget] so
-  // overlapping markers collapse into a tappable cluster.
-  group('StationMapLayers marker clustering (#2490)', () {
+  // #2510 — #2490 over-corrected: routing EVERY set through the cluster
+  // layer collapsed a bounded nearby search (10 stations / 10 km) into
+  // "4"/"2"/"3" count bubbles + one stray marker, HIDING the results. The
+  // bounded set must now render every station as its OWN marker (a plain
+  // [MarkerLayer]); clustering is kept only as a fallback for a genuinely
+  // huge / zoomed-far set (>= [StationMapLayers.clusterThreshold]).
+  group('StationMapLayers de-clustering (#2510)', () {
     List<Station> nStations(int n) => List.generate(
           n,
           (i) => Station(
@@ -346,7 +349,7 @@ void main() {
             // Cluster them tightly around the centre so overlap is realistic.
             lat: 52.5210 + i * 0.0005,
             lng: 13.4100 + i * 0.0005,
-            dist: 0.8,
+            dist: 0.8 + i * 0.1,
             diesel: 1.50 + i * 0.01,
             isOpen: true,
           ),
@@ -354,8 +357,9 @@ void main() {
 
     Future<void> pumpWith(
       WidgetTester tester,
-      List<Station> stations,
-    ) async {
+      List<Station> stations, {
+      SortMode sortMode = SortMode.price,
+    }) async {
       tester.view.physicalSize = const Size(900, 1600);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
@@ -374,34 +378,80 @@ void main() {
               zoom: 12,
               searchRadiusKm: 10,
               selectedFuel: FuelType.diesel,
+              sortMode: sortMode,
             ),
           ),
         ),
       );
     }
 
-    testWidgets('routes a SMALL (10-station) set through the cluster layer',
-        (tester) async {
-      await pumpWith(tester, nStations(10));
-      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
-    });
+    testWidgets(
+      'a 10-station nearby set renders individual markers, NOT a count '
+      'cluster',
+      (tester) async {
+        await pumpWith(tester, nStations(10));
+        // No count-cluster layer — every result stays visible.
+        expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+        // A plain MarkerLayer carries every station marker. (The centre
+        // marker is its own MarkerLayer, so there are two.)
+        expect(find.byType(MarkerLayer), findsWidgets);
+      },
+    );
 
-    testWidgets('routes a SINGLE station through the cluster layer',
+    testWidgets(
+      'every one of the 10 stations renders its own marker',
+      (tester) async {
+        await pumpWith(tester, nStations(10));
+        // Collect the markers from the station MarkerLayer(s) — exclude the
+        // single-marker centre layer.
+        final stationMarkers = tester
+            .widgetList<MarkerLayer>(find.byType(MarkerLayer))
+            .expand((l) => l.markers)
+            .where((m) => m.width != 20) // 20 == the centre dot
+            .toList();
+        // All 10 stations are present as individual markers, none hidden.
+        expect(stationMarkers.length, 10);
+      },
+    );
+
+    testWidgets(
+      'the cheapest stations are EMPHASIZED with the full price bubble '
+      'under a price sort',
+      (tester) async {
+        await pumpWith(tester, nStations(10), sortMode: SortMode.price);
+        // emphasisCount stations keep the full price bubble (width ==
+        // kStationMarkerWidth); the rest become compact dots (kStationDotSize).
+        final stationMarkers = tester
+            .widgetList<MarkerLayer>(find.byType(MarkerLayer))
+            .expand((l) => l.markers)
+            .where((m) => m.width != 20)
+            .toList();
+        final fullBubbles =
+            stationMarkers.where((m) => m.width == kStationMarkerWidth).length;
+        final dots =
+            stationMarkers.where((m) => m.width == kStationDotSize).length;
+        expect(fullBubbles, StationMapLayers.emphasisCount);
+        expect(dots, 10 - StationMapLayers.emphasisCount);
+      },
+    );
+
+    testWidgets('a SINGLE station renders as its own marker (no cluster)',
         (tester) async {
       await pumpWith(tester, const [_seedStation]);
-      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+      expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
 
-    testWidgets('routes a LARGE (40-station) set through the cluster layer',
-        (tester) async {
-      await pumpWith(tester, nStations(40));
-      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
-    });
+    testWidgets(
+      'a genuinely huge set (>= clusterThreshold) still falls back to '
+      'clustering',
+      (tester) async {
+        await pumpWith(tester, nStations(StationMapLayers.clusterThreshold));
+        expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+      },
+    );
 
-    testWidgets('renders no cluster layer for an empty station set',
+    testWidgets('renders no marker/cluster layer for an empty station set',
         (tester) async {
-      // Empty markers list → the cluster widget is skipped entirely so it
-      // never lays out an empty quadtree.
       await pumpWith(tester, const []);
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });

--- a/test/features/map/presentation/widgets/station_marker_test.dart
+++ b/test/features/map/presentation/widgets/station_marker_test.dart
@@ -273,36 +273,42 @@ void main() {
     });
   });
 
-  group('StationMarkerBuilder fallback fuel display (#2400)', () {
-    // Tankerkönig returns only the queried fuel's price. A diesel-only
-    // station while E10 is selected used to render "--"; it must now fall
-    // back to the diesel price with a labelled fuel code.
-    const dieselOnlyStation = Station(
-      id: 'diesel-only',
-      name: 'Diesel Only',
-      brand: 'TOTAL',
-      street: 'Rue Diesel',
-      postCode: '75001',
-      place: 'Paris',
-      lat: 48.0,
-      lng: 2.0,
-      diesel: 1.699,
+  group('StationMarkerBuilder selected-fuel price (#2510)', () {
+    // #2510 — the marker shows STRICTLY the selected fuel's price, exactly
+    // like the search LIST (`StationCard`). It must NOT fall back to E10 /
+    // another fuel: that #2400 fallback chain made the map read "E10
+    // 2,099" on an E85 search while the list showed the E85 price. A
+    // station lacking the selected fuel renders "--", never a re-labelled
+    // other-fuel price.
+
+    // A station that sells multiple fuels, including a cheap E85 — the
+    // real-world Intermarché / Pézenas case from the bug report.
+    const multiFuelStation = Station(
+      id: 'multi-fuel',
+      name: 'Intermarché',
+      brand: 'Intermarché',
+      street: 'Av. de Pézenas',
+      postCode: '34120',
+      place: 'Pézenas',
+      lat: 43.46,
+      lng: 3.42,
+      e10: 2.099,
+      diesel: 1.899,
+      e85: 0.799,
       isOpen: true,
     );
 
     testWidgets(
-      'a diesel-only station on an E10 search shows the diesel price, '
-      'never "--"',
+      'with E85 selected, a multi-fuel station shows the E85 price, '
+      'NOT the E10 default',
       (tester) async {
         final marker = StationMarkerBuilder.build(
           tester.element(find.byType(Container).first),
-          dieselOnlyStation,
-          FuelType.e10,
-          1.50,
-          2.00,
+          multiFuelStation,
+          FuelType.e85,
+          0.50,
+          2.50,
         );
-        // Fallback widens the marker so the fuel code + price both fit.
-        expect(marker.width, kStationMarkerWideWidth);
 
         await pumpApp(
           tester,
@@ -315,37 +321,39 @@ void main() {
           ),
         );
 
-        // The diesel price is shown (1.699 => "1,699"); never "--".
-        expect(find.text('1,699'), findsOneWidget);
-        expect(find.text('--'), findsNothing);
-        // The fallback fuel code is labelled so the price is unambiguous.
-        expect(find.text('Diesel'), findsOneWidget);
+        // The E85 price (0.799 => "0,799") is shown — matching the list.
+        expect(find.text('0,799'), findsOneWidget);
+        // The E10 default (2.099) must NOT appear, and there is no fuel
+        // code prefix — the selected fuel resolved directly.
+        expect(find.text('2,099'), findsNothing);
+        expect(find.text('E10'), findsNothing);
       },
     );
 
     testWidgets(
-      'a truly price-less station still shows "--"',
+      'a station lacking the selected fuel shows "--", NOT an E10 fallback',
       (tester) async {
-        const emptyStation = Station(
-          id: 'empty',
-          name: 'Empty',
-          brand: 'TEST',
-          street: 'Nowhere',
-          postCode: '00000',
-          place: 'Void',
-          lat: 0.0,
-          lng: 0.0,
+        // Diesel-only station while E85 is selected. The list would show a
+        // dash for E85 here; the marker must match — no fallback to diesel.
+        const dieselOnlyStation = Station(
+          id: 'diesel-only',
+          name: 'Diesel Only',
+          brand: 'TOTAL',
+          street: 'Rue Diesel',
+          postCode: '75001',
+          place: 'Paris',
+          lat: 48.0,
+          lng: 2.0,
+          diesel: 1.699,
           isOpen: true,
         );
         final marker = StationMarkerBuilder.build(
           tester.element(find.byType(Container).first),
-          emptyStation,
-          FuelType.e10,
-          1.50,
-          2.00,
+          dieselOnlyStation,
+          FuelType.e85,
+          0.50,
+          2.50,
         );
-        // No fallback fuel → no widening, no fuel label.
-        expect(marker.width, kStationMarkerWidth);
 
         await pumpApp(
           tester,
@@ -358,38 +366,69 @@ void main() {
           ),
         );
 
+        // Graceful dash — never the diesel price, never a fuel code.
         expect(find.text('--'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'no fallback label when the selected fuel has its own price',
-      (tester) async {
-        final marker = StationMarkerBuilder.build(
-          tester.element(find.byType(Container).first),
-          testStation, // has e10
-          FuelType.e10,
-          1.50,
-          2.00,
-        );
-        expect(marker.width, kStationMarkerWidth);
-
-        await pumpApp(
-          tester,
-          SizedBox(
-            width: marker.width,
-            height: marker.height,
-            child: (((marker.child as RepaintBoundary).child as Semantics)
-                    .child as GestureDetector)
-                .child,
-          ),
-        );
-
-        expect(find.text('1,799'), findsOneWidget);
-        // No fuel code when the selected fuel resolved directly.
+        expect(find.text('1,699'), findsNothing);
         expect(find.text('Diesel'), findsNothing);
-        expect(find.text('E10'), findsNothing);
       },
     );
+  });
+
+  group('StationMarkerBuilder compact dot (#2510)', () {
+    testWidgets('a compact marker is a small price-less dot', (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        testStation, // has e10 = 1.799
+        FuelType.e10,
+        1.50,
+        2.00,
+        compact: true,
+      );
+      // The dot is markedly smaller than the full price bubble.
+      expect(marker.width, kStationDotSize);
+      expect(marker.height, kStationDotSize);
+      expect(marker.width, lessThan(kStationMarkerWidth));
+
+      await pumpApp(
+        tester,
+        SizedBox(
+          width: marker.width,
+          height: marker.height,
+          child: (((marker.child as RepaintBoundary).child as Semantics)
+                  .child as GestureDetector)
+              .child,
+        ),
+      );
+
+      // No price label is painted on a compact dot — it is a pure colour
+      // swatch, so the bounded result set stays uncluttered.
+      expect(find.text('1,799'), findsNothing);
+    });
+
+    testWidgets('a compact marker still announces its price for a11y',
+        (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        testStation,
+        FuelType.e10,
+        1.50,
+        2.00,
+        compact: true,
+      );
+      await pumpApp(
+        tester,
+        SizedBox(
+          width: marker.width,
+          height: marker.height,
+          child: marker.child,
+        ),
+      );
+
+      final handle = tester.ensureSemantics();
+      // Even a de-emphasized dot stays a labelled button so a screen-
+      // reader user can find it (#566).
+      expect(find.bySemanticsLabel(RegExp(r'STAR.*1[.,]7')), findsOneWidget);
+      handle.dispose();
+    });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -193,7 +193,14 @@ void main() {
     // Decomposition tracked by #2187/#2188/#2190.
     'lib/features/consumption/providers/trip_recording_provider.dart': 1180,
     'lib/features/feature_management/data/legacy_toggle_migrator.dart': 647,
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 544,
+    // #2510 — re-grandfathered 544 → 562: the nearby-search map no longer
+    // hides results behind count-clusters. Adds the `rankForEmphasis`
+    // helper + two `@visibleForTesting` constants (emphasisCount,
+    // clusterThreshold) and the de-clustering branch (a bounded set renders
+    // a plain MarkerLayer with the top-ranked stations emphasized; only a
+    // huge/zoomed-far set falls back to clustering). Net +18 is the helper,
+    // the constants and their dartdoc. Decomposition tracked by #2187/#2188.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 562,
     // #2382 — +5 for Feature.approachOverlay's three per-feature switch
     // cases (label / description / blocked-enable). Intrinsic per-feature
     // growth in this switch-based section; full decomposition is its own


### PR DESCRIPTION
Closes #2510