### PR TITLE
fix(ui): dark-mode contrast — scheme-aware profile/preset/price/chip colours (active-profile card legible) (#2526)

### DIFF
--- a/lib/core/theme/dark_mode_colors.dart
+++ b/lib/core/theme/dark_mode_colors.dart
@@ -48,6 +48,22 @@ class DarkModeColors {
           : const Color(0xFFC77800); // dark gold — 3.4:1 on white
 
   // ---------------------------------------------------------------------------
+  // Brand
+  // ---------------------------------------------------------------------------
+
+  /// Adaptive brand green (#2526).
+  ///
+  /// The brand identity green is the icon's `#2E7D32`. On a light surface it
+  /// clears AA comfortably, but as text/iconography on a dark surface it
+  /// collapses to ~3.4:1 (fails AA). On dark we substitute the scheme's
+  /// lighter `primary` (`#69A16B`), which clears AA (~5.8:1) on the dark card
+  /// surface while staying recognisably the same forest-green brand hue.
+  static Color brandGreen(BuildContext context) =>
+      Theme.of(context).brightness == Brightness.dark
+          ? Theme.of(context).colorScheme.primary // #69A16B on dark
+          : const Color(0xFF2E7D32); // icon brand green on light
+
+  // ---------------------------------------------------------------------------
   // Muted / secondary text
   // ---------------------------------------------------------------------------
 

--- a/lib/core/widgets/animated_price_text.dart
+++ b/lib/core/widgets/animated_price_text.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../theme/dark_mode_colors.dart';
+
 /// Wraps an arbitrary price widget (usually the card/detail RichText) in a
 /// one-shot "price changed" animation: subtle scale 1.0 → 1.15 → 1.0 over
 /// 500 ms and a brief green (drop) or red (increase) tint overlay.
@@ -25,11 +27,16 @@ class AnimatedPriceText extends StatefulWidget {
   /// `Text` price span so we don't duplicate formatting logic here.
   final Widget child;
 
-  /// Color flashed when price *drops* (new < old). Defaults to green.
-  final Color dropColor;
+  /// Color flashed when price *drops* (new < old). When null (#2526) it
+  /// resolves at build time to [DarkModeColors.success] so the flash is a
+  /// dark-mode-legible green (the old const `#2E7D32` green-800 read only
+  /// 3.59:1 on the dark surface).
+  final Color? dropColor;
 
-  /// Color flashed when price *increases* (new > old). Defaults to red.
-  final Color increaseColor;
+  /// Color flashed when price *increases* (new > old). When null (#2526) it
+  /// resolves at build time to [DarkModeColors.error] (the old const
+  /// `#C62828` red-800 read only 3.28:1 on the dark surface).
+  final Color? increaseColor;
 
   /// Animation duration. Default 500 ms per #595 spec.
   final Duration duration;
@@ -38,8 +45,8 @@ class AnimatedPriceText extends StatefulWidget {
     super.key,
     required this.price,
     required this.child,
-    this.dropColor = const Color(0xFF2E7D32), // Material green 800
-    this.increaseColor = const Color(0xFFC62828), // Material red 800
+    this.dropColor, // #2526 — null → DarkModeColors.success(context)
+    this.increaseColor, // #2526 — null → DarkModeColors.error(context)
     this.duration = const Duration(milliseconds: 500),
   });
 
@@ -51,7 +58,13 @@ class _AnimatedPriceTextState extends State<AnimatedPriceText>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _scale;
-  Color? _flashColor;
+
+  /// Whether a flash is currently armed, and its direction. The actual
+  /// colour is resolved in [build] (#2526) so it can read the live theme
+  /// brightness via [DarkModeColors] — `didUpdateWidget` has no usable
+  /// context for a scheme lookup. `null` means no flash is active; `true`
+  /// = price drop, `false` = price increase.
+  bool? _flashIsDrop;
 
   @override
   void initState() {
@@ -82,7 +95,7 @@ class _AnimatedPriceTextState extends State<AnimatedPriceText>
     if (oldPrice == null || newPrice == null) return;
     if (oldPrice == newPrice) return;
     setState(() {
-      _flashColor = newPrice < oldPrice ? widget.dropColor : widget.increaseColor;
+      _flashIsDrop = newPrice < oldPrice;
     });
     _controller
       ..reset()
@@ -97,6 +110,14 @@ class _AnimatedPriceTextState extends State<AnimatedPriceText>
 
   @override
   Widget build(BuildContext context) {
+    // #2526 — resolve the flash colour here so it tracks the live theme.
+    // An explicit [widget.dropColor] / [widget.increaseColor] wins; when
+    // null we fall back to the dark-mode-legible semantic colours.
+    final Color? tint = switch (_flashIsDrop) {
+      true => widget.dropColor ?? DarkModeColors.success(context),
+      false => widget.increaseColor ?? DarkModeColors.error(context),
+      null => null,
+    };
     // Animate a Transform.scale (subtle bounce) wrapping the child, plus
     // an overlay Container whose opacity fades the flash color from
     // ~0.25 at t=0 down to 0 at t=1. Kept simple so the scroll path
@@ -104,7 +125,6 @@ class _AnimatedPriceTextState extends State<AnimatedPriceText>
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        final tint = _flashColor;
         final t = _controller.value;
         // 0.25 → 0 linear fade. Peak low enough that text stays legible
         // when dark-mode palettes push the flash toward neon.

--- a/lib/core/widgets/star_rating.dart
+++ b/lib/core/widgets/star_rating.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 import '../../l10n/app_localizations.dart';
+import '../theme/dark_mode_colors.dart';
 
 /// Interactive 5-star rating widget.
 class StarRating extends StatelessWidget {
@@ -46,7 +47,13 @@ class StarRating extends StatelessWidget {
               child: Center(
                 child: Icon(
                   isFilled ? Icons.star : Icons.star_border,
-                  color: isFilled ? Colors.amber : Colors.grey.shade400,
+                  // #2526 — the amber/gold `warning` token clears AA on
+                  // both surfaces (3.4:1 light, 8.7:1 dark) where plain
+                  // `Colors.amber` was only ~1.6:1 on a light card; the
+                  // empty star uses the theme hint colour.
+                  color: isFilled
+                      ? DarkModeColors.warning(context)
+                      : DarkModeColors.hintText(context),
                   size: starSize,
                 ),
               ),

--- a/lib/features/driving/presentation/widgets/driving_map_view.dart
+++ b/lib/features/driving/presentation/widgets/driving_map_view.dart
@@ -67,8 +67,11 @@ class _DrivingMapViewState extends State<DrivingMapView> {
   List<Marker> _markers = const [];
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // #2526 — recompute here (not initState) so the markers can read the
+    // theme via `context` (the null-price badge resolves a theme hint
+    // colour) and re-run if the brightness changes mid-session.
     _recompute();
   }
 
@@ -97,6 +100,9 @@ class _DrivingMapViewState extends State<DrivingMapView> {
             widget.selectedFuel,
             range.$1,
             range.$2,
+            // #2526 — thread context so the null-price badge picks the
+            // theme hint colour instead of a hardcoded grey.
+            context: context,
             // Read the callbacks off `widget` at tap time so a memoised
             // marker still dispatches to the current handlers.
             onTap: () {

--- a/lib/features/driving/presentation/widgets/driving_marker_builder.dart
+++ b/lib/features/driving/presentation/widgets/driving_marker_builder.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/price_gradient.dart';
 import '../../../../core/utils/price_tier.dart';
@@ -23,15 +24,23 @@ class DrivingMarkerBuilder {
   DrivingMarkerBuilder._();
 
   /// Build a large [Marker] for driving mode, colored by relative price.
+  ///
+  /// #2526 — pass [context] so the null-price fallback resolves to the
+  /// theme's [DarkModeColors.hintText] (`outline`) instead of the
+  /// hardcoded `Colors.grey.shade400`, keeping the "no price" badge legible
+  /// in dark. The bright price palette is intentionally
+  /// brightness-independent: these badges float over map tiles (not the app
+  /// surface) and carry their own white outline + dark `black87` text.
   static Marker build(
     Station station,
     FuelType fuel,
     double minPrice,
     double maxPrice, {
     required VoidCallback onTap,
+    BuildContext? context,
   }) {
     final price = station.priceFor(fuel);
-    final color = _priceColor(price, minPrice, maxPrice);
+    final color = _priceColor(price, minPrice, maxPrice, context);
     final brand = truncateBrand(station.displayName, maxLength: _maxBrandLength);
     final tier = priceTierOf(price, minPrice, maxPrice);
 
@@ -108,13 +117,22 @@ class DrivingMarkerBuilder {
     Color(0xFFF44336),
   ];
 
-  static Color _priceColor(double? price, double minPrice, double maxPrice) =>
+  static Color _priceColor(
+    double? price,
+    double minPrice,
+    double maxPrice, [
+    BuildContext? context,
+  ]) =>
       priceGradientColor(
         price,
         minPrice,
         maxPrice,
         stops: _drivingStops,
-        nullColor: Colors.grey.shade400,
+        // #2526 — theme-resolved hint colour when a context is available,
+        // falling back to the legacy neutral grey otherwise.
+        nullColor: context != null
+            ? DarkModeColors.hintText(context)
+            : Colors.grey.shade400,
         flatColor: const Color(0xFF4CAF50),
       );
 }

--- a/lib/features/profile/presentation/widgets/profile_list_section.dart
+++ b/lib/features/profile/presentation/widgets/profile_list_section.dart
@@ -25,9 +25,18 @@ class ProfileListSection extends ConsumerWidget {
       children: [
         ...profiles.map((profile) {
           final isActive = profile.id == activeProfile?.id;
+          final cs = theme.colorScheme;
           return Card(
-            color: isActive ? theme.colorScheme.primaryContainer : null,
+            color: isActive ? cs.primaryContainer : null,
             child: ListTile(
+              // #2526 — the active card fills with `primaryContainer`, which in
+              // dark is a pale green (`#C9E1CA`). Letting the title/subtitle and
+              // leading icon default to `onSurface`/`onSurfaceVariant`
+              // (near-white) collapsed the card to ~1.1:1. Pin the on-colour to
+              // `onPrimaryContainer` (11:1) while active; inactive keeps the
+              // theme default.
+              textColor: isActive ? cs.onPrimaryContainer : null,
+              iconColor: isActive ? cs.onPrimaryContainer : null,
               leading: Icon(
                 isActive ? Icons.person : Icons.person_outline,
               ),

--- a/lib/features/profile/presentation/widgets/use_mode_section.dart
+++ b/lib/features/profile/presentation/widgets/use_mode_section.dart
@@ -153,20 +153,27 @@ class _PresetCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    const brandGreen = Color(0xFF2E7D32);
+    final cs = theme.colorScheme;
+    // #2526 — the active on-colour is now `onPrimaryContainer` (the
+    // scheme's guaranteed-legible pairing for a `primaryContainer`
+    // fill), replacing the hardcoded light brand-green `#2E7D32` that
+    // collapsed to ~1.16:1 on a dark surface.
+    final activeOn = cs.onPrimaryContainer;
     // #2116 — replaced the 2-px green outline + checkmark badge of
     // the selected state with a Material 3-style subtle tonal
-    // background (primaryContainer at low alpha) + raised elevation.
-    // The brand-green text + leading icon already carry the
-    // selected-state signal; the outline was visually competing with
-    // the label.
+    // background + raised elevation. The on-container text + leading
+    // icon carry the selected-state signal; the outline was visually
+    // competing with the label.
+    // #2526 — the fill was `primaryContainer.withValues(alpha: 0.4)`,
+    // which in dark resolves to a mid-tone grey-green on which neither
+    // the near-black `onPrimaryContainer` (2.7:1) nor brand green reads.
+    // The *solid* `primaryContainer` keeps the M3 tonal look while
+    // making `onPrimaryContainer` clear AA (11:1) in every theme.
     return Card(
       key: Key('useModeCard_${profile.name}'),
       elevation: isActive ? 1 : 0,
       margin: EdgeInsets.zero,
-      color: isActive
-          ? theme.colorScheme.primaryContainer.withValues(alpha: 0.4)
-          : null,
+      color: isActive ? cs.primaryContainer : null,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(10),
         side: BorderSide(color: theme.dividerColor, width: 1),
@@ -182,9 +189,7 @@ class _PresetCard extends StatelessWidget {
               Icon(
                 icon,
                 size: 32,
-                color: isActive
-                    ? brandGreen
-                    : theme.colorScheme.onSurfaceVariant,
+                color: isActive ? activeOn : cs.onSurfaceVariant,
               ),
               const SizedBox(width: 12),
               Expanded(
@@ -197,16 +202,14 @@ class _PresetCard extends StatelessWidget {
                           title,
                           style: theme.textTheme.titleMedium?.copyWith(
                             fontWeight: FontWeight.bold,
-                            color: isActive
-                                ? brandGreen
-                                : theme.colorScheme.onSurface,
+                            color: isActive ? activeOn : cs.onSurface,
                           ),
                         ),
                         if (isActive) ...[
                           const SizedBox(width: 6),
-                          const Icon(
+                          Icon(
                             Icons.check_circle,
-                            color: brandGreen,
+                            color: activeOn,
                             size: 16,
                           ),
                         ],
@@ -216,7 +219,10 @@ class _PresetCard extends StatelessWidget {
                     Text(
                       description,
                       style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+                        // #2526 — on the solid `primaryContainer` active fill,
+                        // `onSurfaceVariant` (light grey in dark) vanishes;
+                        // pin to `onPrimaryContainer` while active.
+                        color: isActive ? activeOn : cs.onSurfaceVariant,
                       ),
                     ),
                   ],

--- a/lib/features/search/presentation/widgets/ev_connector_chips.dart
+++ b/lib/features/search/presentation/widgets/ev_connector_chips.dart
@@ -39,18 +39,34 @@ class EvConnectorChips extends StatelessWidget {
   /// blue (`#2196F3`) it used to hard-code, so the EV accent is one token
   /// across every surface. Type 2 / CHAdeMO / Tesla keep their deliberate
   /// per-connector brand hues (green / orange / pink).
-  static Color colorFor(String type) {
-    if (type.contains('CCS')) return FuelColors.evAccent; // Crystal-blue
-    if (type.contains('Type 2')) return const Color(0xFF4CAF50); // Green
-    if (type.contains('CHAdeMO')) return const Color(0xFFFF9800); // Orange
-    if (type.contains('Tesla')) return const Color(0xFFE91E63); // Pink
-    return const Color(0xFF757575); // Grey
+  ///
+  /// #2526 — [brightness] makes the hue dark-safe. The light identity hues
+  /// (e.g. Tesla pink `#E91E63` read only ~3.9:1 as text on the dark
+  /// surface) are lightened on dark to a same-family variant that clears
+  /// AA, preserving per-connector identity. Callers that omit [brightness]
+  /// keep the canonical light identity hue (the value the chip-colour API
+  /// and its tests document).
+  static Color colorFor(String type, {Brightness brightness = Brightness.light}) {
+    final dark = brightness == Brightness.dark;
+    if (type.contains('CCS')) return FuelColors.evAccent; // Crystal-blue (already light)
+    if (type.contains('Type 2')) {
+      return dark ? const Color(0xFF81C784) : const Color(0xFF4CAF50); // Green
+    }
+    if (type.contains('CHAdeMO')) {
+      return dark ? const Color(0xFFFFB74D) : const Color(0xFFFF9800); // Orange
+    }
+    if (type.contains('Tesla')) {
+      return dark ? const Color(0xFFF06292) : const Color(0xFFE91E63); // Pink
+    }
+    return dark ? const Color(0xFFBDBDBD) : const Color(0xFF757575); // Grey
   }
 
   @override
   Widget build(BuildContext context) {
     final visible = connectors.take(maxConnectors).toList();
     final l10n = AppLocalizations.of(context);
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
     final semanticLabel = visible.isEmpty
         ? (l10n?.evConnectorsNone ?? 'No connector information')
         : '${l10n?.evConnectorsLabel ?? "Available connectors"}: '
@@ -64,12 +80,19 @@ class EvConnectorChips extends StatelessWidget {
           spacing: 4,
           runSpacing: 2,
           children: visible.map((type) {
-            final color = colorFor(type);
+            final color = colorFor(type, brightness: brightness);
             return Container(
               padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
               decoration: BoxDecoration(
-                color: color.withValues(alpha: 0.15),
+                // #2526 — raise the fill alpha on dark and add a hairline
+                // outline so the pill actually reads against the dark card
+                // (the 15%-alpha fill was near-invisible on a dark surface).
+                color: color.withValues(alpha: isDark ? 0.22 : 0.15),
                 borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: color.withValues(alpha: isDark ? 0.6 : 0.3),
+                  width: 1,
+                ),
               ),
               child: Text(
                 type,

--- a/lib/features/setup/presentation/widgets/profile_choice_step.dart
+++ b/lib/features/setup/presentation/widgets/profile_choice_step.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/app_profile_provider.dart';
 import '../../../feature_management/domain/app_profile.dart';
@@ -43,7 +44,10 @@ class ProfileChoiceStep extends ConsumerWidget {
             'Sparkilo', // i18n-ignore: brand wordmark / proper noun
             style: theme.textTheme.headlineLarge?.copyWith(
               fontWeight: FontWeight.bold,
-              color: const Color(0xFF2E7D32),
+              // #2526 — the wordmark was the light brand green `#2E7D32`
+              // (3.4:1 on the dark surface). Brightness-select so dark uses
+              // the lighter brand `primary` (#69A16B) and clears AA.
+              color: DarkModeColors.brandGreen(context),
             ),
             textAlign: TextAlign.center,
           ),
@@ -136,7 +140,10 @@ class _ProfileCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    const brandGreen = Color(0xFF2E7D32);
+    // #2526 — adaptive brand green: dark substitutes the scheme's lighter
+    // `primary` (#69A16B) so the active border/icon/title/check clear AA on
+    // the dark Card surface; light keeps the icon brand green `#2E7D32`.
+    final brandGreen = DarkModeColors.brandGreen(context);
     final borderColor = isActive ? brandGreen : theme.dividerColor;
     return Card(
       key: Key('profileCard_${profile.name}'),
@@ -178,7 +185,7 @@ class _ProfileCard extends StatelessWidget {
                         ),
                         if (isActive) ...[
                           const SizedBox(width: 8),
-                          const Icon(
+                          Icon(
                             Icons.check_circle,
                             color: brandGreen,
                             size: 20,

--- a/test/core/theme/dark_contrast_guard_test.dart
+++ b/test/core/theme/dark_contrast_guard_test.dart
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/theme.dart';
+import 'package:tankstellen/core/theme/contrast_utils.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
+import 'package:tankstellen/features/search/presentation/widgets/ev_connector_chips.dart';
+
+/// #2526 — structural (no-golden) contrast guard.
+///
+/// Instantiates the real [AppTheme.dark] / [AppTheme.light] schemes and
+/// asserts, via [ContrastUtils], that the on-colour/fill pairings the
+/// #2526 fixes pinned all clear WCAG AA. This guards against re-introducing
+/// a non-adaptive (hardcoded light brand-green / `primaryContainer`-fill +
+/// default-`onSurface`-text) combination that collapses to ~1.1–3.6:1 in
+/// dark.
+void main() {
+  /// Resolves a [ColorScheme] (+ a themed [BuildContext]) from a real
+  /// [AppTheme] and runs [body] against it.
+  Future<void> withScheme(
+    WidgetTester tester,
+    ThemeData theme,
+    void Function(ColorScheme cs, BuildContext context) body,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        // A key tied to the brightness forces a fresh element subtree when
+        // the same test pumps a second theme — otherwise the Builder is
+        // reused and keeps reading the previous theme.
+        key: ValueKey(theme.brightness),
+        theme: theme,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              body(Theme.of(context).colorScheme, context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  void expectAA(Color fg, Color bg, String label) {
+    final ratio = ContrastUtils.contrastRatio(fg, bg);
+    expect(
+      ratio,
+      greaterThanOrEqualTo(ContrastUtils.kMinContrastNormal),
+      reason: '$label: ${ratio.toStringAsFixed(2)}:1 (need >= 4.5)',
+    );
+  }
+
+  void expectAALarge(Color fg, Color bg, String label) {
+    final ratio = ContrastUtils.contrastRatio(fg, bg);
+    expect(
+      ratio,
+      greaterThanOrEqualTo(ContrastUtils.kMinContrastLarge),
+      reason: '$label: ${ratio.toStringAsFixed(2)}:1 (need >= 3.0)',
+    );
+  }
+
+  for (final entry in {'dark': AppTheme.dark, 'light': AppTheme.light}.entries) {
+    final mode = entry.key;
+    final builder = entry.value;
+
+    group('dark-contrast guard ($mode)', () {
+      testWidgets(
+        'onPrimaryContainer is legible on a solid primaryContainer fill '
+        '(active-profile card #1 + active preset card #2)',
+        (tester) async {
+          await withScheme(tester, builder(), (cs, _) {
+            expectAA(
+              cs.onPrimaryContainer,
+              cs.primaryContainer,
+              '$mode onPrimaryContainer vs primaryContainer',
+            );
+          });
+        },
+      );
+
+      testWidgets(
+        'adaptive brandGreen clears AA-large on the Card surface '
+        '(first-run wizard card #3)',
+        (tester) async {
+          await withScheme(tester, builder(), (cs, context) {
+            // The wizard `_ProfileCard` is a default `Card`, whose M3 fill
+            // is `surfaceContainerLow`. The brand wordmark/border/title
+            // sit on the scaffold surface.
+            expectAALarge(
+              DarkModeColors.brandGreen(context),
+              cs.surfaceContainerLow,
+              '$mode brandGreen vs Card surface',
+            );
+            expectAALarge(
+              DarkModeColors.brandGreen(context),
+              cs.surface,
+              '$mode brandGreen vs scaffold surface',
+            );
+          });
+        },
+      );
+
+      testWidgets(
+        'price-flash colours clear AA-large on the surface '
+        '(AnimatedPriceText #4)',
+        (tester) async {
+          await withScheme(tester, builder(), (cs, context) {
+            expectAALarge(
+              DarkModeColors.success(context),
+              cs.surface,
+              '$mode price-drop (success) vs surface',
+            );
+            expectAALarge(
+              DarkModeColors.error(context),
+              cs.surface,
+              '$mode price-increase (error) vs surface',
+            );
+          });
+        },
+      );
+
+      testWidgets(
+        'star-rating amber/gold clears AA-large on the surface '
+        '(StarRating #7)',
+        (tester) async {
+          await withScheme(tester, builder(), (cs, context) {
+            expectAALarge(
+              DarkModeColors.warning(context),
+              cs.surface,
+              '$mode star amber vs surface',
+            );
+          });
+        },
+      );
+    });
+  }
+
+  // #2526 — the reported EV-chip regression was the *dark*-surface chip
+  // text (e.g. Tesla pink `#E91E63` was 3.94:1). The brightened dark hues
+  // must clear AA-large; per-connector identity is preserved. (Chip text on
+  // a *light* card was never AA — those are decorative 10 px pills with a
+  // tinted fill + hairline outline, out of #2526's scope.)
+  testWidgets(
+    'dark EV connector chip text clears AA-large on the dark surface (#5)',
+    (tester) async {
+      await withScheme(tester, AppTheme.dark(), (cs, context) {
+        final brightness = Theme.of(context).brightness;
+        for (final type in const ['CCS', 'Type 2', 'CHAdeMO', 'Tesla']) {
+          expectAALarge(
+            EvConnectorChips.colorFor(type, brightness: brightness),
+            cs.surface,
+            'dark $type chip text vs surface',
+          );
+        }
+      });
+    },
+  );
+
+  testWidgets(
+    'brandGreen adapts: dark uses scheme primary, light keeps icon green',
+    (tester) async {
+      late Color darkBrand;
+      await withScheme(tester, AppTheme.dark(), (cs, context) {
+        darkBrand = DarkModeColors.brandGreen(context);
+        // On dark it is the scheme's lighter primary, not the hardcoded
+        // light brand green.
+        expect(darkBrand, cs.primary);
+        expect(darkBrand, isNot(const Color(0xFF2E7D32)));
+      });
+
+      late Color lightBrand;
+      await withScheme(tester, AppTheme.light(), (_, context) {
+        lightBrand = DarkModeColors.brandGreen(context);
+        // On light it keeps the icon brand green.
+        expect(lightBrand, const Color(0xFF2E7D32));
+      });
+
+      expect(
+        darkBrand,
+        isNot(equals(lightBrand)),
+        reason: 'brand green must brightness-select, not stay hardcoded',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Closes #2526