### PR TITLE
feat(ui): two-column station-detail on landscape/wide (no more stretched portrait) (#2531)

### DIFF
--- a/lib/features/station_detail/presentation/screens/station_detail_screen.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../../app/responsive_search_layout.dart';
 import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/page_scaffold.dart';
@@ -18,6 +19,7 @@ import '../widgets/station_info_section.dart';
 import '../widgets/station_prices_section.dart';
 import '../widgets/station_rating_section.dart';
 import '../widgets/station_status_row.dart';
+import 'station_detail_wide_layout.dart';
 
 /// Detail screen for a single fuel station.
 ///
@@ -84,10 +86,19 @@ class _StationDetailPlain extends StatelessWidget {
   }
 }
 
-/// Loaded state — `CustomScrollView` + `SliverAppBar(pinned: true,
-/// expandedHeight: 196)`. Status row and brand header live inside the
-/// `flexibleSpace.background`, so they fade out as the bar collapses
-/// to its compact form on scroll past the prices card.
+/// Loaded state — adaptive on screen size (#2531, Epic #2525).
+///
+/// On **compact** (< 600dp / portrait phone) this is the original
+/// `CustomScrollView` + `SliverAppBar(pinned: true, expandedHeight: 196)`:
+/// status row and brand header live inside the `flexibleSpace.background`,
+/// so they fade out as the bar collapses to its compact form on scroll past
+/// the prices card. This path is byte-for-byte unchanged.
+///
+/// On **medium / expanded** (≥ 600dp / landscape / tablet) it delegates to
+/// [StationDetailWideLayout] — a normal (non-expanding) `PageScaffold`
+/// AppBar over a two-pane `Row` (status + brand header | prices + info +
+/// rating + history), each pane self-scrolling. Same section widgets, no
+/// route change (deep-link safe).
 class _StationDetailLoaded extends StatelessWidget {
   final String stationId;
   final StationDetail detail;
@@ -101,6 +112,16 @@ class _StationDetailLoaded extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Wide screens get the two-column layout; compact keeps the sliver
+    // header below, unchanged.
+    if (screenSizeOf(context) != ScreenSize.compact) {
+      return StationDetailWideLayout(
+        stationId: stationId,
+        detail: detail,
+        serviceResult: serviceResult,
+      );
+    }
+
     final l10n = AppLocalizations.of(context);
     final station = detail.station;
     final bottomPadding = MediaQuery.of(context).viewPadding.bottom;

--- a/lib/features/station_detail/presentation/screens/station_detail_wide_layout.dart
+++ b/lib/features/station_detail/presentation/screens/station_detail_wide_layout.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/services/service_result.dart';
+import '../../../../core/services/widgets/service_status_banner.dart';
+import '../../../../core/widgets/page_scaffold.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/station.dart';
+import '../widgets/price_history_foldable.dart';
+import '../widgets/station_brand_header.dart';
+import '../widgets/station_detail_app_bar_actions.dart';
+import '../widgets/station_info_section.dart';
+import '../widgets/station_prices_section.dart';
+import '../widgets/station_rating_section.dart';
+import '../widgets/station_status_row.dart';
+
+/// Two-column station-detail layout for medium / expanded screens (#2531,
+/// Epic #2525).
+///
+/// In landscape / wide / tablet the compact `CustomScrollView` +
+/// `SliverAppBar(expandedHeight: 196)` layout just stretches the portrait
+/// single column — the 196dp header band dominates and the body content is
+/// cramped into the same narrow column with the rest of the width wasted.
+///
+/// This variant drops the expanding header band for a normal (non-expanding)
+/// `PageScaffold` AppBar (back button + [StationDetailAppBarActions]) over a
+/// two-pane `Row`:
+///
+/// * LEFT pane (`flex: 2`) — the status row + brand header that used to live
+///   in the collapsing `flexibleSpace`, now in a self-scrolling column.
+/// * `VerticalDivider`.
+/// * RIGHT pane (`flex: 3`) — the service-status banner, prices, info,
+///   rating and the price-history foldable, also self-scrolling.
+///
+/// The SAME section widgets are reused verbatim — only the container
+/// changes. Each pane is its own [SingleChildScrollView] so the two panes
+/// scroll independently with no nested-scroll jank. The existing 16dp
+/// padding / 8dp inter-section spacing conventions are preserved.
+///
+/// Compact (< 600dp) keeps the original sliver layout — this widget is only
+/// reached when `screenSizeOf(context) != ScreenSize.compact`.
+class StationDetailWideLayout extends StatelessWidget {
+  final String stationId;
+  final StationDetail detail;
+  final ServiceResult<StationDetail> serviceResult;
+
+  const StationDetailWideLayout({
+    super.key,
+    required this.stationId,
+    required this.detail,
+    required this.serviceResult,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final station = detail.station;
+    final bottomPadding = MediaQuery.of(context).viewPadding.bottom;
+
+    return PageScaffold(
+      // No title (#2161 — the brand lives in the body header, not the
+      // AppBar title slot). The empty-string title is the escape hatch the
+      // plain loading / error states already use.
+      title: '',
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: () => context.pop(),
+        tooltip: l10n?.tooltipBack ?? 'Back',
+      ),
+      actions: [
+        StationDetailAppBarActions(
+          stationId: stationId,
+          station: station,
+        ),
+      ],
+      bodyPadding: EdgeInsets.zero,
+      body: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            flex: 2,
+            child: SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  StationStatusRow(
+                    station: station,
+                    serviceResult: serviceResult,
+                    stationId: stationId,
+                  ),
+                  const SizedBox(height: 8),
+                  StationBrandHeader(station: station),
+                ],
+              ),
+            ),
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(
+            flex: 3,
+            child: SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ServiceStatusBanner(result: serviceResult),
+                  StationPricesSection(station: station),
+                  const SizedBox(height: 8),
+                  StationInfoSection(station: station, detail: detail),
+                  const SizedBox(height: 8),
+                  StationRatingSection(stationId: stationId),
+                  const SizedBox(height: 8),
+                  // #1957 — the price-history chart is a tall,
+                  // detail-on-demand block; the foldable is collapsed by
+                  // default so it does not dominate the pane.
+                  PriceHistoryFoldable(stationId: stationId, station: station),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/station_detail/presentation/widgets/station_status_row.dart
+++ b/lib/features/station_detail/presentation/widgets/station_status_row.dart
@@ -64,12 +64,21 @@ class StationStatusRow extends ConsumerWidget {
                   ),
                 ),
                 const SizedBox(width: 6),
-                ExcludeSemantics(
-                  child: Text(
-                    _buildStatusText(station, serviceResult, l10n),
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: color,
-                      fontWeight: FontWeight.w600,
+                // Flexible + ellipsis so the status text yields instead of
+                // overflowing the row when the available width is narrow —
+                // e.g. the flex:2 left pane of the #2531 two-column wide
+                // layout, where the row competes with the trailing stars.
+                // Harmless in the full-width compact sliver header (the text
+                // never reaches the cap there).
+                Flexible(
+                  child: ExcludeSemantics(
+                    child: Text(
+                      _buildStatusText(station, serviceResult, l10n),
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: color,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
                 ),

--- a/test/features/station_detail/presentation/screens/station_detail_wide_layout_test.dart
+++ b/test/features/station_detail/presentation/screens/station_detail_wide_layout_test.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+import 'package:tankstellen/features/price_history/data/repositories/price_history_repository.dart';
+import 'package:tankstellen/features/price_history/providers/price_history_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_detail/presentation/screens/station_detail_screen.dart';
+import 'package:tankstellen/features/station_detail/presentation/screens/station_detail_wide_layout.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_brand_header.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_prices_section.dart';
+import 'package:tankstellen/features/station_detail/providers/station_detail_provider.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../mocks/mocks.dart';
+
+/// Structural responsive-layout coverage for StationDetailScreen (#2531,
+/// Epic #2525).
+///
+/// NO macOS goldens (per the cross-platform-golden rule). Instead this pins
+/// the adaptive branch structurally:
+///
+/// * at a wide width (≥ 600dp) the screen renders the [StationDetailWideLayout]
+///   two-pane variant — the brand header AND the prices section render
+///   simultaneously, and the AppBar is a NORMAL (non-expanding) one, NOT the
+///   196dp `SliverAppBar`.
+/// * at a compact width (< 600dp) it keeps the single `CustomScrollView` +
+///   `SliverAppBar` path, with no [StationDetailWideLayout].
+void main() {
+  const stationId = '51d4b477-a095-1aa0-e100-80009459e03a';
+
+  late MockHiveStorage mockStorage;
+  late List<Object> overrides;
+
+  setUp(() {
+    mockStorage = MockHiveStorage();
+    when(() => mockStorage.getPriceRecords(any())).thenReturn([]);
+    when(() => mockStorage.getPriceHistoryKeys()).thenReturn([]);
+    when(() => mockStorage.getRatings()).thenReturn({});
+    when(() => mockStorage.savePriceRecords(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => mockStorage.getRating(any())).thenReturn(null);
+
+    final result = ServiceResult(
+      data: const StationDetail(station: testStation),
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026, 3, 27, 10, 0, 0),
+    );
+    overrides = [
+      hiveStorageProvider.overrideWithValue(mockStorage),
+      priceHistoryRepositoryProvider
+          .overrideWithValue(PriceHistoryRepository(mockStorage)),
+      stationDetailProvider(stationId).overrideWith((_) async => result),
+      favoritesOverride([]),
+      isFavoriteOverride(stationId, false),
+    ];
+  });
+
+  Future<void> pumpAt(WidgetTester tester, Size size) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpApp(
+      tester,
+      const StationDetailScreen(stationId: stationId),
+      overrides: overrides,
+    );
+  }
+
+  group('StationDetailScreen responsive layout (#2531)', () {
+    testWidgets(
+      'wide (900x600) renders both panes + a normal AppBar, no SliverAppBar',
+      (tester) async {
+        await pumpAt(tester, const Size(900, 600));
+
+        // The two-column variant is mounted.
+        expect(find.byType(StationDetailWideLayout), findsOneWidget);
+
+        // BOTH panes render simultaneously — left brand header + right
+        // prices section coexist (the portrait sliver collapses one out of
+        // view; the two-column layout shows both at once).
+        expect(find.byType(StationBrandHeader), findsOneWidget);
+        expect(find.byType(StationPricesSection), findsOneWidget);
+
+        // The VerticalDivider between the two panes.
+        expect(find.byType(VerticalDivider), findsOneWidget);
+
+        // A NORMAL AppBar (PageScaffold), NOT the 196dp expanding sliver.
+        expect(find.byType(AppBar), findsOneWidget);
+        expect(find.byType(SliverAppBar), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'compact (400x800) keeps the single CustomScrollView + SliverAppBar',
+      (tester) async {
+        await pumpAt(tester, const Size(400, 800));
+
+        // No two-column variant on compact.
+        expect(find.byType(StationDetailWideLayout), findsNothing);
+
+        // The original sliver layout: a CustomScrollView with a SliverAppBar
+        // and no plain AppBar / VerticalDivider.
+        expect(find.byType(CustomScrollView), findsOneWidget);
+        expect(find.byType(SliverAppBar), findsOneWidget);
+        expect(find.byType(VerticalDivider), findsNothing);
+
+        // The body content still renders (brand header + prices section).
+        expect(find.byType(StationBrandHeader), findsOneWidget);
+        expect(find.byType(StationPricesSection), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #2531