### PR TITLE
fix(obd2): swap the recording controller's service on reconnect + tear down the dead transport (no post-reconnect data loss / error flood) (#2524)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
+import 'obd2_connection_errors.dart';
 import 'obd2_read_timeout.dart';
 import 'obd2_transport.dart';
 
@@ -57,6 +58,16 @@ class BluetoothObd2Transport implements Obd2Transport {
   Future<void> connect() async {
     if (_connected) return;
     _firstCommandPending = true;
+    // #2524 — reset any state a previous link left behind so a reused or
+    // half-dead instance can't carry stale pending into the fresh link. A
+    // dropped session that never ran `disconnect()` can leave `_pending`
+    // pointing at a never-completing completer and `_buffer` holding a
+    // partial response; either one would poison the first command on the
+    // new channel (the concurrent-sendCommand guard, or a corrupt parse).
+    // Fail (not just drop) any stranded pending so a caller awaiting it
+    // unblocks instead of hanging forever.
+    _failPending(StateError('Transport reconnecting'));
+    _buffer.clear();
     await _channel.open();
     _subscription = _channel.incoming.listen(
       _onBytes,
@@ -142,10 +153,17 @@ class BluetoothObd2Transport implements Obd2Transport {
     // One in-flight command at a time — the ELM327 is half-duplex.
     // [sendCommand] serialises every caller onto `_queueTail`, so this
     // guard is now a defensive invariant: tripping it means a code path
-    // reached `_sendRaw` while another command was unfinished.
+    // reached `_sendRaw` while another command was unfinished — in
+    // practice a stranded `_pending` left behind by a half-dead link.
+    // #2524 — fail with a RECOVERABLE [Obd2DisconnectedException] (which
+    // the drop detector's `_isTypedDisconnect` already treats as a drop)
+    // instead of a raw `StateError`. The raw StateError surfaced as an
+    // ERROR trace in the user log; routing it through the drop path means
+    // the recording loop recovers (reconnect / pause-with-grace) and no
+    // error trace is logged.
     if (_pending != null) {
-      throw StateError(
-        'BluetoothObd2Transport: concurrent sendCommand is not allowed',
+      throw const Obd2DisconnectedException(
+        'BluetoothObd2Transport: concurrent sendCommand — link is recovering',
       );
     }
     // #2261 concern 5 — right-size the read timeout per command class

--- a/lib/features/consumption/data/obd2/dropped_session_host.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_host.dart
@@ -21,6 +21,15 @@ abstract class DroppedSessionHost {
   /// so no further transport chatter happens while we recover.
   void stopScheduler();
 
+  /// Tear down the CURRENT (now-dead) OBD2 service the instant a drop is
+  /// detected (#2524). Closes its transport channel and fails any command
+  /// stranded in the transport's `_pending` via `_failPending`, so the
+  /// abandoned half-dead instance can't later trip the
+  /// concurrent-sendCommand guard. Best-effort + fire-and-forget — the
+  /// link is already gone, so a disconnect error here is expected and must
+  /// not derail the recovery state machine.
+  void disconnectDroppedService();
+
   /// Resume the PID polling loop after a silent reconnect inside the
   /// #1904 window. Production gates this on "not paused / not stopped"
   /// itself; the manager just asks.

--- a/lib/features/consumption/data/obd2/dropped_session_manager.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_manager.dart
@@ -129,13 +129,11 @@ class DroppedSessionManager {
   /// `debugReconnectScanner` test hook.
   AdapterReconnectScanner? get reconnectScanner => _reconnectScanner;
 
-  /// React to a detected connection drop (#797 / #1904). A
-  /// `transportError` drop first enters the invisible reconnect window
-  /// (scheduler stopped, scanner probing, host still reporting
-  /// `recording`); only if [_silentReconnectWindow] elapses with no
-  /// reconnect does it escalate to the visible state. A `silentFailure`
-  /// drop escalates straight to visible — reconnecting the Bluetooth
-  /// link cannot revive a dead ECU.
+  /// React to a detected connection drop (#797 / #1904). A `transportError`
+  /// drop first enters the invisible reconnect window (scheduler stopped,
+  /// scanner probing, host still `recording`); only if [_silentReconnectWindow]
+  /// elapses with no reconnect does it escalate to visible. A `silentFailure`
+  /// drop escalates straight to visible — a reconnect cannot revive a dead ECU.
   void handleDrop({
     TripDropReason reason = TripDropReason.transportError,
   }) {
@@ -148,6 +146,9 @@ class DroppedSessionManager {
       detail: reason.name,
     );
     _host.stopScheduler();
+    // #2524 — tear down the now-dead service so its channel closes + any
+    // stranded `_pending` fails (else it later trips the concurrent guard).
+    _host.disconnectDroppedService();
     _host.clearDropDetectorErrorWindow();
     _persistPausedSnapshot();
     if (reason == TripDropReason.transportError &&
@@ -272,9 +273,9 @@ class DroppedSessionManager {
     }
   }
 
-  /// Persist the in-progress trip snapshot to the paused-trips box on
-  /// drop (#797 phase 1). Fire-and-forget; Hive errors are logged by
-  /// the repo and must not throw back into the scheduler callback.
+  /// Persist the in-progress trip snapshot to the paused-trips box on drop
+  /// (#797 phase 1). Fire-and-forget; Hive errors are logged by the repo and
+  /// must not throw back into the scheduler callback.
   void _persistPausedSnapshot() {
     final repo = _resolvePausedRepo();
     final id = _host.sessionId;
@@ -296,9 +297,9 @@ class DroppedSessionManager {
     repo.save(entry);
   }
 
-  /// Delete this session's row from the paused-trips box — the session
-  /// is live again, so leaving the partial behind would let a later
-  /// pause stomp the in-memory state. Best-effort.
+  /// Delete this session's row from the paused-trips box — the session is
+  /// live again, so leaving the partial behind would let a later pause stomp
+  /// the in-memory state. Best-effort.
   void clearPausedTripRow() {
     final id = _host.sessionId;
     if (id == null) return;
@@ -373,17 +374,17 @@ class DroppedSessionManager {
   }
 
   /// Cancel the grace timer + clear the drop reason — called by the
-  /// controller's resume() before it clears the paused row and re-arms
-  /// the detector. Scanner teardown stays the caller's job.
+  /// controller's resume() before it clears the paused row and re-arms the
+  /// detector. Scanner teardown stays the caller's job.
   void cancelGrace() {
     _graceTimer?.cancel();
     _graceTimer = null;
     _dropReason = null;
   }
 
-  /// Tear down every pending timer + the silent-reconnect flag — called
-  /// by the controller's stop(). Scanner teardown is awaited separately
-  /// by stop() via [stopReconnectScanner].
+  /// Tear down every pending timer + the silent-reconnect flag — called by
+  /// the controller's stop(). Scanner teardown is awaited separately by
+  /// stop() via [stopReconnectScanner].
   void cancelAllTimers() {
     _graceTimer?.cancel();
     _graceTimer = null;
@@ -394,8 +395,7 @@ class DroppedSessionManager {
 
   /// Test seam: synchronously drive the grace-window finalisation path
   /// without waiting for the real timer. Plain (not `@visibleForTesting`)
-  /// because the controller's own test-only `debugExpireGraceWindow`
-  /// hook delegates here — mirroring `TripDistanceResolver`'s seam style.
+  /// because the controller's `debugExpireGraceWindow` hook delegates here.
   Future<void> expireGraceWindowNow() async {
     _graceTimer?.cancel();
     await _onGraceWindowElapsed();

--- a/lib/features/consumption/data/obd2/pid_scheduler.dart
+++ b/lib/features/consumption/data/obd2/pid_scheduler.dart
@@ -9,6 +9,7 @@ import 'obd2_comm_diagnostics.dart';
 import 'pid_bandwidth_governor.dart';
 import 'pid_scheduler_comm_diagnostics.dart';
 import 'scheduled_pid.dart';
+import 'unresponsive_adapter_diagnostic.dart';
 
 // Re-export the per-PID config vocabulary (#2457) so existing call sites
 // that import `pid_scheduler.dart` keep seeing PidPriority / PidTier /
@@ -115,10 +116,16 @@ class PidScheduler {
   String? _inFlight;
   int _subscriptionCounter = 0;
 
-  /// When the last aggregated "adapter unresponsive" diagnostic was
-  /// emitted, used to rate-limit it to ≤1 per [_diagnosticWindow]. Null
-  /// until the first one fires.
-  DateTime? _lastDiagnosticAt;
+  /// #2524 — owns the "adapter broadly unresponsive" log-once-per-episode
+  /// decision (extracted so the selection core stays under the 400-line
+  /// cap). Logs ≤1 ERROR per episode transition; per-tick it is a
+  /// `debugPrint` breadcrumb, never an `errorLogger.log` flood (#2424/#2428).
+  late final UnresponsiveAdapterDiagnostic _unresponsiveDiagnostic =
+      UnresponsiveAdapterDiagnostic(
+    backoffThreshold: _backoffThreshold,
+    window: _diagnosticWindow,
+    clock: _clock,
+  );
 
   /// Bandwidth governor (#2457). Owns the achieved-reads windows + the
   /// demotion policy that protects the dynamics tier on a slow link. The
@@ -354,22 +361,11 @@ class PidScheduler {
     }
   }
 
-  /// Emit AT MOST ONE aggregated "adapter unresponsive" diagnostic per
-  /// [_diagnosticWindow] when [_backoffThreshold]+ PIDs are backed off —
-  /// a rate-limited replacement for the old one-error-per-PID-per-tick
-  /// flood that still makes a broadly-dead adapter visible in triage (#2379).
+  /// Surface a broadly-unresponsive adapter WITHOUT flooding the error log
+  /// (#2379 / #2524). Delegates the log-once-per-episode decision to
+  /// [UnresponsiveAdapterDiagnostic]; see that class for the contract.
   void _maybeEmitUnresponsiveDiagnostic(Object error, StackTrace stack) {
-    final downCount = backedOffCount;
-    if (downCount < _backoffThreshold) return;
-    final now = _clock();
-    final last = _lastDiagnosticAt;
-    if (last != null && now.difference(last) < _diagnosticWindow) return;
-    _lastDiagnosticAt = now;
-    unawaited(errorLogger.log(ErrorLayer.other, error, stack, context: {
-      'where': 'PidScheduler: OBD2 adapter unresponsive — '
-          '$downCount PIDs timing out',
-      'backedOffPids': downCount,
-    }));
+    _unresponsiveDiagnostic.onFailure(backedOffCount, error, stack);
   }
 }
 

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -535,9 +535,9 @@ class TripRecordingController {
     unawaited(() async {
       try {
         await old.disconnect();
-      } catch (e) {
+      } catch (e, st) {
         debugPrint('TripRecordingController.replaceService: '
-            'old service disconnect failed (already dead) — $e');
+            'old service disconnect failed (already dead) — $e\n$st');
       }
     }());
   }
@@ -1401,9 +1401,9 @@ class _DroppedSessionHostAdapter implements DroppedSessionHost {
     unawaited(() async {
       try {
         await svc.disconnect();
-      } catch (e) {
+      } catch (e, st) {
         debugPrint('TripRecordingController: dropped-service disconnect '
-            'failed (already dead) — $e');
+            'failed (already dead) — $e\n$st');
       }
     }());
   }

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -133,7 +133,17 @@ enum TripRecordingControllerState {
 /// Phase 1 exposes the state machine without wiring a UI banner —
 /// phase 2 brings the auto-reconnect scanner + snackbar UX.
 class TripRecordingController {
-  final Obd2Service _service;
+  /// The OBD2 service the recording loop reads through. NOT `final`
+  /// (#2524): an in-trip auto-reconnect builds a brand-new
+  /// [Obd2Service] + transport, and [replaceService] swaps this pointer
+  /// so [_runTransport] / [refreshOdometer] start polling the LIVE link
+  /// instead of the dead old one. Before #2524 this was bound once at
+  /// construction and never reassigned — the pipeline's `onConnected`
+  /// swapped only its OWN pointer, so the scheduler kept dereferencing
+  /// the original (closed) transport, every poll timed out at 2.5 s, a
+  /// stranded `_pending` tripped the concurrent-sendCommand guard, and
+  /// the rest of the drive recorded nothing.
+  Obd2Service _service;
   final TripRecorder _recorder;
   final Duration _pollInterval;
   final DateTime Function() _now;
@@ -493,6 +503,43 @@ class TripRecordingController {
     _paused = false;
     _scheduler?.start();
     _emitState();
+  }
+
+  /// Swap the recording loop onto a freshly-reconnected [Obd2Service]
+  /// (#2524).
+  ///
+  /// An in-trip auto-reconnect ([ReconnectConnector]) builds a BRAND-NEW
+  /// service + transport for the recovered link. [_runTransport] and
+  /// [refreshOdometer] dereference [_service] at call time, so until this
+  /// runs the scheduler keeps polling the DEAD old transport — every read
+  /// times out and the rest of the drive records nothing. Pointing
+  /// [_service] at the live service fixes that for every subsequent poll.
+  ///
+  /// The OLD service is torn down ([Obd2Service.disconnect]) so its
+  /// channel closes and any command stranded in its transport's `_pending`
+  /// is failed cleanly via the transport's `_failPending` — otherwise the
+  /// abandoned half-dead instance leaks its subscription and a stranded
+  /// pending could later trip the concurrent-sendCommand guard. A no-op
+  /// when [service] is already the current one (idempotent / defensive).
+  /// Best-effort: a disconnect failure on the already-dead old link must
+  /// never derail the just-recovered recording, so it is swallowed to a
+  /// breadcrumb.
+  void replaceService(Obd2Service service) {
+    final old = _service;
+    if (identical(old, service)) return;
+    _service = service;
+    // Tear down the abandoned link off the hot path. `disconnect()` is
+    // idempotent and never throws for the typed-closed states, but guard
+    // anyway — the old transport is already dead, so any error here is
+    // expected and must not reach the user error log.
+    unawaited(() async {
+      try {
+        await old.disconnect();
+      } catch (e) {
+        debugPrint('TripRecordingController.replaceService: '
+            'old service disconnect failed (already dead) — $e');
+      }
+    }());
   }
 
   /// Push the most recent GPS fix into the per-tick snapshot
@@ -1345,6 +1392,21 @@ class _DroppedSessionHostAdapter implements DroppedSessionHost {
 
   @override
   void stopScheduler() => _c._scheduler?.stop();
+
+  @override
+  void disconnectDroppedService() {
+    // #2524 — fail the dead transport's stranded `_pending` + close its
+    // channel off the hot path. Best-effort; the link is already gone.
+    final svc = _c._service;
+    unawaited(() async {
+      try {
+        await svc.disconnect();
+      } catch (e) {
+        debugPrint('TripRecordingController: dropped-service disconnect '
+            'failed (already dead) — $e');
+      }
+    }());
+  }
 
   @override
   void startScheduler() => _c._scheduler?.start();

--- a/lib/features/consumption/data/obd2/unresponsive_adapter_diagnostic.dart
+++ b/lib/features/consumption/data/obd2/unresponsive_adapter_diagnostic.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/logging/error_logger.dart';
+
+/// Owns the "OBD2 adapter broadly unresponsive" diagnostic decision for
+/// the [PidScheduler] (#2379 / #2524), extracted so the scheduler's
+/// selection core stays under the 400-line cap (mirrors the
+/// `PidSchedulerCommDiagnostics` split precedent).
+///
+/// The reclassification this enforces (#2524, matching the #2424/#2428
+/// precedent): a known-unresponsive adapter must NOT spool a per-tick
+/// ERROR. At most ONE real `errorLogger.log` ERROR is logged on the
+/// TRANSITION into an unresponsive *episode* ([backoffThreshold]+ PIDs
+/// backed off), gated by the episode latch AND a [window] rate limit.
+/// While the episode persists every qualifying tick emits only a
+/// `debugPrint` breadcrumb. The latch clears the moment enough PIDs
+/// recover (the backed-off count drops below the threshold), so a
+/// genuinely new outage logs a fresh ERROR.
+class UnresponsiveAdapterDiagnostic {
+  UnresponsiveAdapterDiagnostic({
+    required int backoffThreshold,
+    required Duration window,
+    required DateTime Function() clock,
+  })  : _backoffThreshold = backoffThreshold,
+        _window = window,
+        _clock = clock;
+
+  final int _backoffThreshold;
+  final Duration _window;
+  final DateTime Function() _clock;
+
+  bool _inEpisode = false;
+  DateTime? _lastLoggedAt;
+
+  /// Feed the per-tick failure outcome. [backedOffCount] is how many PIDs
+  /// are currently backed off; [error]/[stack] are the failure that
+  /// triggered this tick (logged only on a fresh episode transition).
+  void onFailure(int backedOffCount, Object error, StackTrace stack) {
+    if (backedOffCount < _backoffThreshold) {
+      _inEpisode = false; // recovered — re-arm for the next outage
+      return;
+    }
+    final msg = 'PidScheduler: OBD2 adapter unresponsive — '
+        '$backedOffCount PIDs timing out';
+    // Inside this episode → breadcrumb only, never a per-tick ERROR.
+    if (_inEpisode) {
+      debugPrint('$msg (still down)');
+      return;
+    }
+    // Transition INTO the episode: one ERROR (rate-limited) for triage.
+    _inEpisode = true;
+    final now = _clock();
+    final last = _lastLoggedAt;
+    if (last != null && now.difference(last) < _window) {
+      debugPrint('$msg (within diagnostic window; breadcrumb only)');
+      return;
+    }
+    _lastLoggedAt = now;
+    unawaited(errorLogger.log(ErrorLayer.other, error, stack,
+        context: {'where': msg, 'backedOffPids': backedOffCount}));
+  }
+}

--- a/lib/features/consumption/providers/obd2_recording_pipeline.dart
+++ b/lib/features/consumption/providers/obd2_recording_pipeline.dart
@@ -35,16 +35,14 @@ import 'trip_recording_state.dart';
 /// owned [Obd2Service], the [TripRecordingController] + its live /
 /// stateChanges subscriptions, the adapter-identity snapshot (#1312), the
 /// one-shot capability-probe latch (#2261), and the auto-reconnect scanner
-/// factory (#797 / #2245). The focused collaborators are *injected* from
-/// the notifier so they outlive a single recording and the test counters
-/// accumulate exactly as the inline fields did.
+/// factory (#797 / #2245). Focused collaborators are *injected* from the
+/// notifier so they outlive a single recording.
 ///
 /// Deliberately NOT owned: the Riverpod `state`, the last-trip identity
 /// fields, `_saveToHistory`, and the #1303 active-trip WAL (+ #1347
-/// cold-start recovery) stay on the notifier, reached through the
-/// [Obd2RecordingPipelineHost] — the WAL survives the recording loop being
-/// torn down (recovery runs with no pipeline at all), so it belongs to the
-/// notifier. The seed / flush cadence is driven through the same host hooks.
+/// cold-start recovery) stay on the notifier via [Obd2RecordingPipelineHost]
+/// — the WAL survives the recording loop being torn down (recovery runs with
+/// no pipeline at all). The seed / flush cadence uses the same host hooks.
 class Obd2RecordingPipeline implements RecordingPipeline {
   Obd2RecordingPipeline({
     required Ref ref,
@@ -143,13 +141,11 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     // of the legacy 0.85 literal until VeLearner converges. Null on no-match.
     final matchedReference = tryMatchReferenceVehicle(_ref, activeVehicle);
     // #2506 — build the SHARED GPS-physics live-estimate + coaching folder
-    // from the active vehicle + its calibration matrix (mirrors the
-    // GPS-only pipeline). Folded per no-fuel-PID tick inside the controller
-    // so the OBD2 live screen carries `~ estimated` consumption + GPS
-    // coaching instead of dashing the whole drive on a car that exposes no
-    // fuel-rate PID — live now mirrors the proven post-trip
-    // `Obd2GpsEstimateFallback`. A null vehicle / matrix falls back to the
-    // population-default class + cold-start scale.
+    // (mirrors the GPS-only pipeline). Folded per no-fuel-PID tick inside the
+    // controller so the OBD2 live screen carries `~ estimated` consumption +
+    // GPS coaching instead of dashing a no-fuel-PID car's whole drive — live
+    // mirrors the post-trip `Obd2GpsEstimateFallback`. Null vehicle / matrix
+    // → population-default class + cold-start scale.
     final gpsEstimateFolder = GpsLiveEstimateFolder.forVehicle(
       activeVehicle,
       activeVehicle?.gpsCalibration,
@@ -200,11 +196,10 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       final classified = _baselines.recordAndClassify(reading);
       _haptics.fireForBandTransition(_host.state.band, classified.band);
       // #2506 — surface the GPS coaching hint the controller computed on a
-      // no-fuel-PID tick. `MinimalDriveSummary` already swaps to the GPS
-      // coaching triplet when `reading.fuelRateLPerHour == null` and reads
-      // `state.gpsCoachingHint`, so publishing it here lights the chips on
-      // the OBD2 live screen exactly as it does for GPS-only trips. Null
-      // (a measured fuel rate is present, or no hint applies) clears it.
+      // no-fuel-PID tick. `MinimalDriveSummary` swaps to the GPS coaching
+      // triplet when `reading.fuelRateLPerHour == null` and reads
+      // `state.gpsCoachingHint`, so publishing it here lights the chips on the
+      // OBD2 live screen too. Null (measured fuel present / no hint) clears it.
       final gpsHint = ctl.latestGpsCoachingHint;
       _host.state = _host.state.copyWith(
         phase: _phaseFor(ctl),
@@ -239,8 +234,7 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       unawaited(_host.flushActiveSnapshot(force: true));
     });
     // #2274 concern 2 — going live clears any connecting stage so the
-    // recording screen swaps the inline progress card for the live
-    // metrics on the same frame.
+    // recording screen swaps the progress card for live metrics that frame.
     _host.state = _host.state.copyWith(
       phase: TripRecordingPhase.recording,
       clearConnectStage: true,
@@ -281,8 +275,8 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     // Snapshot the captured-samples buffer BEFORE stop() tears down the
     // controller — else the trip-detail charts render empty (#1040).
     final capturedSamples = List<TripSample>.unmodifiable(ctl.capturedSamples);
-    // #1458 phase 2 — snapshot the GPS cadence diagnostics BEFORE teardown,
-    // same reason. Always captured (empty when GPS off).
+    // #1458 phase 2 — snapshot GPS cadence diagnostics BEFORE teardown (same
+    // reason); always captured (empty when GPS off).
     final capturedGpsDiagnostics = List<GpsSampleDiagnostic>.unmodifiable(
       ctl.capturedGpsSampleDiagnostics,
     );
@@ -297,7 +291,7 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     final odometerStartKm = ctl.odometerStartKm;
     final odometerLatestKm = ctl.odometerLatestKm;
     // #2509 — GPS-fix count BEFORE teardown: lets the guard keep a real
-    // GPS-tracked drive whose OBD2 link was dead apart from a stationary stop.
+    // dead-OBD2 GPS-tracked drive apart from a stationary stop.
     final gpsFixCount = ctl.gpsFixCount;
     await _liveSub?.cancel();
     _liveSub = null;
@@ -385,9 +379,15 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       // scanner's repeated connect cycles. The connect callback prefers a
       // DIRECT GATT connect (works for clones that stop advertising in
       // standby) and only falls back to an RSSI-gated scan (#2245).
+      // #2524 — swap the pipeline's pointer (so stop() tears down the LIVE
+      // svc) AND the controller's via `replaceService` (so the loop polls the
+      // reconnected transport, not the closed one). See `replaceService`.
       final connector = ReconnectConnector(
         connection: connection,
-        onConnected: (svc) => _service = svc,
+        onConnected: (svc) {
+          _service = svc;
+          _controller?.replaceService(svc);
+        },
       );
       return AdapterReconnectScanner(
         pinnedMac: pinnedMac,

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
 import '../../../core/services/impl/osm_brand_enricher.dart';
@@ -135,6 +136,14 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       }, cancelToken: cancelToken);
       return parser.extractPrixCarburantsResults(response.data);
     } on DioException catch (e, st) {
+      // #2524 — an OFFLINE failure (no network) is expected and already
+      // handled (returns []), so it must NOT pollute the user error spool.
+      // Drop it to a debugPrint; only a real API error (4xx/5xx, malformed
+      // response) is worth an ERROR trace.
+      if (_isOffline(e)) {
+        debugPrint('Prix-Carburants ZIP fetch skipped — offline ($e)');
+        return [];
+      }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Prix-Carburants ZIP fetch failed'}));
       return [];
     }
@@ -157,9 +166,35 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       }, cancelToken: cancelToken);
       return parser.extractPrixCarburantsResults(response.data);
     } on DioException catch (e, st) {
+      // #2524 — see [_queryByPostalCode]: an offline failure is expected and
+      // swallowed (returns []); only a real API error gets an ERROR trace.
+      if (_isOffline(e)) {
+        debugPrint('Prix-Carburants geo fetch skipped — offline ($e)');
+        return [];
+      }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Prix-Carburants geo fetch failed'}));
       return [];
     }
+  }
+
+  /// Whether [e] is an offline / no-network failure rather than a real
+  /// API error (#2524). A "Failed host lookup" / SocketException surfaces
+  /// either as [DioExceptionType.connectionError] or, on some platforms,
+  /// as a [DioExceptionType.unknown] wrapping the raw SocketException — both
+  /// mean "the device has no working connection", which is expected and
+  /// already handled by returning an empty list, so it must not pollute the
+  /// error spool.
+  static bool _isOffline(DioException e) {
+    if (e.type == DioExceptionType.connectionError ||
+        e.type == DioExceptionType.connectionTimeout) {
+      return true;
+    }
+    if (e.type == DioExceptionType.unknown) {
+      // i18n-ignore: matching a platform exception class name, not UI text.
+      return e.error?.runtimeType.toString().contains('SocketException') ??
+          false;
+    }
+    return false;
   }
 
   /// Merge two raw API result lists, deduplicating by station id.

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
@@ -250,6 +250,47 @@ void main() {
       expect(reply, contains('41 0D 3C'));
     });
 
+    test(
+        '#2524 — a reconnect cycle leaves NO stranded _pending: a command '
+        'in flight when the link drops is failed, and the next command on '
+        'the reconnected instance succeeds', () async {
+      final channel = _ScriptedChannel();
+      // A reply that NEVER carries the prompt — the command can only resolve
+      // via a forwarded link error, leaving _pending set until then.
+      channel.scriptResponse('010C\r', '41 0C 1A F8 ');
+      channel.scriptResponse('010D\r', '41 0D 3C >');
+      final transport = BluetoothObd2Transport(
+        channel,
+        readTimeout: const Duration(seconds: 5),
+      );
+      await transport.connect();
+
+      // Fire a command and, mid-flight, drop the link via a forwarded
+      // channel error (the half-dead-reconnect trigger). The pending
+      // command must FAIL — never hang — so a caller awaiting it unblocks.
+      final pending = transport.sendCommand('010C\r');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      channel.injectError(Exception('GATT link dropped mid-command'));
+      await expectLater(pending, throwsA(isA<Exception>()),
+          reason: 'a stranded _pending must be failed cleanly on a link '
+              'drop, not left to time out / hang (#2524)');
+
+      // Reconnect the SAME instance. connect() resets _pending + _buffer so
+      // no stale state survives into the fresh link.
+      await transport.disconnect();
+      await transport.connect();
+      expect(transport.isConnected, isTrue);
+
+      // The next command does NOT trip the concurrent-sendCommand guard
+      // (which would now surface as Obd2DisconnectedException) and parses
+      // a clean reply — proving _pending was null + _buffer empty on the
+      // reconnected link.
+      final reply = await transport.sendCommand('010D\r');
+      expect(reply.trim(), '41 0D 3C',
+          reason: 'the reconnected instance starts with _pending == null + '
+              'an empty buffer, so the next command succeeds (#2524)');
+    });
+
     test('disconnect closes the channel and flips isConnected to false',
         () async {
       final channel = _ScriptedChannel();

--- a/test/features/consumption/data/obd2/dropped_session_manager_test.dart
+++ b/test/features/consumption/data/obd2/dropped_session_manager_test.dart
@@ -429,6 +429,7 @@ void main() {
 /// be asserted end-to-end.
 class _FakeHost implements DroppedSessionHost {
   int stopSchedulerCalls = 0;
+  int disconnectDroppedServiceCalls = 0;
   int startSchedulerCalls = 0;
   int resetDropDetectorCalls = 0;
   int clearErrorWindowCalls = 0;
@@ -465,6 +466,9 @@ class _FakeHost implements DroppedSessionHost {
 
   @override
   void stopScheduler() => stopSchedulerCalls++;
+
+  @override
+  void disconnectDroppedService() => disconnectDroppedServiceCalls++;
 
   @override
   void startScheduler() => startSchedulerCalls++;

--- a/test/features/consumption/data/obd2/pid_scheduler_test.dart
+++ b/test/features/consumption/data/obd2/pid_scheduler_test.dart
@@ -575,10 +575,15 @@ void main() {
     });
 
     test(
-        'the aggregated "adapter unresponsive" diagnostic is rate-limited '
-        'to ≤1 per window', () async {
-      // Four PIDs all time out → past the backoff threshold. Over many
-      // ticks the aggregated diagnostic must fire AT MOST ONCE per window.
+        'the aggregated "adapter unresponsive" diagnostic logs at most ONE '
+        'ERROR per unresponsive EPISODE — not per tick, not per window (#2524)',
+        () async {
+      // #2524 — reclassification: a known-unresponsive adapter must NOT
+      // spool a per-tick ERROR. At most one real ERROR is logged on the
+      // TRANSITION into the unresponsive state; while it persists, the
+      // aggregate is a debugPrint breadcrumb only. The errorlog_9 field
+      // report showed 39× TimeoutException + 6× StateError flooding the
+      // user error log from this single site after an in-trip reconnect.
       var fakeNow = DateTime(2026, 1, 1, 12);
       Future<String> transport(String command) async {
         throw Exception('timeout');
@@ -595,8 +600,8 @@ void main() {
       scheduler.start();
 
       // Pump ~40 ticks across ~10 s of simulated time. All four PIDs back
-      // off; the diagnostic could fire on every one of dozens of failing
-      // ticks if it weren't rate-limited.
+      // off and STAY backed off (one continuous episode). The old per-tick
+      // flood would log dozens of ERROR traces here.
       for (var i = 0; i < 40; i++) {
         await pump();
         fakeNow = fakeNow.add(const Duration(milliseconds: 250));
@@ -609,25 +614,93 @@ void main() {
           .where((e) => e.toString().contains('adapter unresponsive'))
           .toList();
       expect(diagnostics, hasLength(1),
-          reason: 'within a single 30 s window only one diagnostic may fire');
+          reason: 'one continuous unresponsive episode logs exactly one '
+              'ERROR — on the transition in, never per-tick');
       expect(diagnostics.single.layer, ErrorLayer.other);
 
-      // Cross the 30 s window and pump again — a second diagnostic is now
-      // allowed (proving it is windowed, not one-shot).
+      // Cross the 30 s window WITHOUT recovering. Because the episode never
+      // closed (the adapter stayed dead), NO second ERROR may fire — the
+      // gate is now the episode transition, not the wall-clock window.
       fakeNow = fakeNow.add(const Duration(seconds: 31));
       scheduler.start();
-      for (var i = 0; i < 4; i++) {
+      for (var i = 0; i < 8; i++) {
         await pump();
         fakeNow = fakeNow.add(const Duration(milliseconds: 250));
       }
       scheduler.stop();
       await pump();
-      final after = recorder.calls
+      final stillSameEpisode = recorder.calls
           .whereType<ContextualError>()
           .where((e) => e.toString().contains('adapter unresponsive'))
           .toList();
-      expect(after.length, greaterThanOrEqualTo(2),
-          reason: 'a fresh window permits another diagnostic');
+      expect(stillSameEpisode, hasLength(1),
+          reason: 'a still-open episode never re-logs, even across the '
+              'diagnostic window — no per-tick flood (#2524)');
+    });
+
+    test(
+        'a NEW unresponsive episode (after recovery) logs a fresh ERROR '
+        '(#2524)', () async {
+      // The episode latch closes when enough PIDs recover; a genuinely new
+      // outage afterwards is still surfaced exactly once.
+      var fakeNow = DateTime(2026, 1, 1, 12);
+      var failing = true;
+      Future<String> transport(String command) async {
+        if (failing) throw Exception('timeout');
+        return '41 ${command.substring(2, 4)} 00>';
+      }
+
+      final scheduler = PidScheduler(
+        transport: transport,
+        tickRate: const Duration(milliseconds: 5),
+        clock: () => fakeNow,
+      );
+      for (final pid in ['010C', '010D', '0105', '0106']) {
+        scheduler.subscribe(pid, ScheduledPid(hz: 5.0), (_) {});
+      }
+      scheduler.start();
+
+      // Episode 1 — all PIDs dead → one ERROR.
+      for (var i = 0; i < 30; i++) {
+        await pump();
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      final afterEpisode1 = recorder.calls
+          .whereType<ContextualError>()
+          .where((e) => e.toString().contains('adapter unresponsive'))
+          .length;
+      expect(afterEpisode1, 1, reason: 'episode 1 logs exactly one ERROR');
+
+      // Recover — every PID answers, so backedOffCount drops below the
+      // threshold and the episode latch closes. Pump generously so the
+      // round-robin reaches every PID at least once.
+      failing = false;
+      for (var i = 0; i < 80; i++) {
+        await pump();
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      expect(scheduler.backedOffCount, lessThan(3),
+          reason: 'a stretch of successes must drop the backed-off count '
+              'below the threshold so the unresponsive episode latch closes');
+
+      // Episode 2 — the adapter dies again well past the 30 s window. A
+      // genuinely new outage must surface a second ERROR.
+      failing = true;
+      fakeNow = fakeNow.add(const Duration(seconds: 31));
+      for (var i = 0; i < 30; i++) {
+        await pump();
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      scheduler.stop();
+      await pump();
+
+      final total = recorder.calls
+          .whereType<ContextualError>()
+          .where((e) => e.toString().contains('adapter unresponsive'))
+          .length;
+      expect(total, 2,
+          reason: 'a fresh unresponsive episode after recovery logs a '
+              'second ERROR — one per episode, not per tick (#2524)');
     });
   });
 

--- a/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
@@ -1,12 +1,17 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_reconnect_scanner.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/data/obd2/paused_trip_repository.dart';
@@ -504,7 +509,247 @@ void main() {
         await ctl.stop();
       });
     });
+
+    // ── #2524 — reconnect must swap the controller onto the LIVE service ──
+    //
+    // The existing #797/#1904 tests above reuse ONE healthy fake transport,
+    // so they never exercise the swap: a real in-trip reconnect builds a
+    // BRAND-NEW Obd2Service + transport. Without `replaceService` the
+    // recording loop keeps polling the DEAD old transport forever — every
+    // poll times out, a stranded `_pending` trips the concurrent-sendCommand
+    // guard, both flood the error log, and the rest of the drive records
+    // nothing.
+    group('reconnect builds a NEW transport — controller swap (#2524)', () {
+      // Capture errorLogger.log calls so we can assert NO concurrent-
+      // sendCommand StateError reaches the spool.
+      late _CaptureRecorder recorder;
+      setUp(() {
+        recorder = _CaptureRecorder();
+        errorLogger.resetForTest();
+        errorLogger.testRecorderOverride = recorder;
+      });
+      tearDown(errorLogger.resetForTest);
+
+      test(
+          'after replaceService the recording loop polls the LIVE transport '
+          '(samples flow), the OLD service is disconnected + its stranded '
+          'pending failed, and no concurrent StateError is error-logged',
+          () async {
+        // The OLD service: a half-dead transport. It answers the init /
+        // odometer / VIN reads (so trip-start completes), NO-DATAs other
+        // PIDs, but strands `010C` in _pending — the #2524 leak the swap
+        // must fail cleanly on disconnect.
+        final oldTransport =
+            _DeadTransport(initResponses(), strandCommand: '010C');
+        await oldTransport.connect();
+        // Strand a pending command on the dead transport (never resolves
+        // until disconnect fails it).
+        final stranded = oldTransport.sendCommand('010C');
+        var strandedFailed = false;
+        unawaited(stranded.then(
+          (_) {},
+          onError: (_) => strandedFailed = true,
+        ));
+
+        // The NEW, healthy transport built by the (simulated) reconnect.
+        final liveTransport = _LiveTransport({
+          ...initResponses(),
+          '010D': '41 0D 32>', // 50 km/h
+          '010C': '41 0C 0E A6>', // ~937 rpm
+        });
+        await liveTransport.connect();
+        final liveService = Obd2Service(liveTransport);
+
+        VoidCallback? capturedOnReconnect;
+        final ctl = TripRecordingController(
+          service: Obd2Service(oldTransport),
+          pollInterval: const Duration(milliseconds: 40),
+          schedulerTickRate: const Duration(milliseconds: 10),
+          vehicleId: 'car-2524',
+          pausedRepo: pausedRepo,
+          historyRepo: historyRepo,
+          pinnedAdapterMac: 'AA:BB',
+          // A scanner whose onReconnect we fire manually; on fire it stands
+          // in for ReconnectConnector.onConnected → ctl.replaceService.
+          reconnectScannerFactory: (mac, onReconnect) {
+            capturedOnReconnect = onReconnect;
+            return _ObservableScanner(
+              pinnedMac: mac,
+              onReconnect: onReconnect,
+              onStart: () {},
+              onStop: () {},
+            );
+          },
+        );
+
+        await ctl.start();
+        // Drop → enters the silent reconnect window. handleDrop tears down
+        // the OLD service (#2524), which fails its stranded _pending.
+        ctl.debugTriggerDrop();
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(strandedFailed, isTrue,
+            reason: 'the drop must disconnect the dead service so its '
+                'stranded _pending is failed cleanly, not left hanging');
+        expect(oldTransport.disconnectCount, greaterThanOrEqualTo(1),
+            reason: 'the OLD service must be disconnected on drop');
+
+        // Simulate the reconnect landing a NEW live service: this is what
+        // ReconnectConnector.onConnected → Obd2RecordingPipeline does.
+        ctl.replaceService(liveService);
+        capturedOnReconnect!.call();
+        expect(ctl.currentState, TripRecordingControllerState.recording,
+            reason: 'a silent reconnect keeps the state at recording');
+
+        // Collect live readings from the NEW transport. Before the fix the
+        // loop kept polling the dead old transport and nothing flowed.
+        final readings = <TripLiveReading>[];
+        final sub = ctl.live.listen(readings.add);
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        expect(readings.any((r) => r.speedKmh == 50), isTrue,
+            reason: '#2524 — after replaceService the scheduler must poll '
+                'the LIVE transport: the 50 km/h sample only exists there');
+        expect(liveTransport.pidPollCount, greaterThan(0),
+            reason: 'the live transport must actually receive PID polls');
+
+        // No concurrent-sendCommand StateError reached the error logger.
+        final stateErrors = recorder.calls.where((e) {
+          final s = e.toString().toLowerCase();
+          return e is StateError && s.contains('concurrent');
+        });
+        expect(stateErrors, isEmpty,
+            reason: 'the concurrent-sendCommand guard must never reach the '
+                'error logger as a raw StateError (#2524)');
+
+        await sub.cancel();
+        await ctl.stop();
+      });
+
+      test(
+          'replaceService is idempotent — passing the current service is a '
+          'no-op and does not disconnect it', () async {
+        final transport = _LiveTransport(initResponses());
+        await transport.connect();
+        final service = Obd2Service(transport);
+        final ctl = TripRecordingController(
+          service: service,
+          pollInterval: const Duration(minutes: 1),
+          vehicleId: 'car-2524-idem',
+          pausedRepo: pausedRepo,
+          historyRepo: historyRepo,
+        );
+        await ctl.start();
+
+        ctl.replaceService(service); // same instance
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        expect(transport.disconnectCount, 0,
+            reason: 'replaceService(currentService) must be a no-op');
+
+        await ctl.stop();
+      });
+    });
   });
+}
+
+/// Captures every `errorLogger.log` call routed through the foreground
+/// recorder seam (#2524 assertion (c)). Mirrors the fake in
+/// `pid_scheduler_test.dart`.
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// The OLD transport after a drop: its channel is dead but `_connected`
+/// stays true. It answers scripted commands (so trip-start's odometer /
+/// VIN reads complete) and NO-DATAs everything else, EXCEPT the single
+/// [strandCommand], which never resolves — modelling a command stranded
+/// in the half-dead instance's `_pending` until [disconnect] fails it (the
+/// #2524 leak the controller must tear down on reconnect).
+class _DeadTransport implements Obd2Transport {
+  _DeadTransport(this._responses, {this.strandCommand});
+
+  final Map<String, String> _responses;
+  final String? strandCommand;
+  bool _connected = false;
+  int disconnectCount = 0;
+  final List<Completer<String>> _stranded = <Completer<String>>[];
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<String> sendCommand(String command) {
+    if (!_connected) {
+      return Future.error(StateError('Not connected'));
+    }
+    final cmd = command.trim();
+    if (strandCommand != null && cmd == strandCommand) {
+      // Never resolves — stranded in _pending until disconnect fails it.
+      final c = Completer<String>();
+      _stranded.add(c);
+      return c.future;
+    }
+    return Future<String>.value(_responses[cmd] ?? 'NO DATA>');
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+    disconnectCount++;
+    for (final c in _stranded) {
+      if (!c.isCompleted) {
+        c.completeError(const Obd2DisconnectedException('link torn down'));
+      }
+    }
+    _stranded.clear();
+  }
+}
+
+/// The NEW, healthy transport built by a real reconnect: answers PIDs from
+/// a scripted map and counts live-PID polls so the test can prove the
+/// scheduler is hitting THIS transport after the swap (#2524).
+class _LiveTransport implements Obd2Transport {
+  _LiveTransport(this._responses);
+
+  final Map<String, String> _responses;
+  bool _connected = false;
+  int disconnectCount = 0;
+  int pidPollCount = 0;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    if (cmd == '010D' || cmd == '010C') pidPollCount++;
+    return _responses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async {
+    _connected = false;
+    disconnectCount++;
+  }
 }
 
 /// Test-local transport whose [sendCommand] throws for the first

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -142,7 +142,16 @@ void main() {
     // the baseline recorder so the fuzzy path can fill the climbing/loaded
     // bucket from a real road grade and/or load ramp (#2513). Pure wiring;
     // decomposition of this god-class is tracked by #2187/#2188/#2190.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1412,
+    // #2524 — re-grandfathered → 1471: the in-trip reconnect now swaps the
+    // controller's live service (`_service` made mutable + the new
+    // `replaceService` method that points the recording loop at the
+    // reconnected transport AND tears down the dead one) plus the
+    // `_DroppedSessionHostAdapter.disconnectDroppedService` hook that fails
+    // the dead transport's stranded `_pending` on a drop. Before this the
+    // loop polled the DEAD old transport forever → silent data loss + a
+    // timeout/StateError flood. Pure recovery wiring; decomposition of this
+    // god-class is tracked by #2187/#2188/#2190.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1471,
     // #2442 — re-grandfathered 496 → 513: the save flow now raises the
     // guided reconciliation workflow after a plein save (a 7-line
     // await-then-route call into the extracted


### PR DESCRIPTION
Closes #2524