### PR TITLE
feat(ui): ResponsiveMasterDetail shared scaffold + migrate hand-rolled wide layouts (split-screen foundation) (#2530)

### DIFF
--- a/lib/app/responsive_search_layout.dart
+++ b/lib/app/responsive_search_layout.dart
@@ -67,10 +67,19 @@ class ResponsiveLayoutWrapper extends StatelessWidget {
   /// If null, [compactBody] is shown full-width regardless of screen size.
   final Widget? detailBody;
 
+  /// When true, the side-by-side split is forced even on a compact-width
+  /// screen, using the medium (1:1) ratio. Lets a caller with its own
+  /// wider-trigger (e.g. Favorites' "landscape OR ≥600dp") keep splitting
+  /// on a sub-600 landscape phone while the breakpoint + ratio logic still
+  /// lives here. When false (the default), compact screens show only
+  /// [compactBody].
+  final bool forceSplit;
+
   const ResponsiveLayoutWrapper({
     super.key,
     required this.compactBody,
     this.detailBody,
+    this.forceSplit = false,
   });
 
   @override
@@ -78,7 +87,7 @@ class ResponsiveLayoutWrapper extends StatelessWidget {
     if (detailBody == null) return compactBody;
 
     final size = screenSizeOf(context);
-    if (size == ScreenSize.compact) return compactBody;
+    if (size == ScreenSize.compact && !forceSplit) return compactBody;
 
     // Check for foldable hinge
     final hinge = displayHingeOf(context);
@@ -90,7 +99,7 @@ class ResponsiveLayoutWrapper extends StatelessWidget {
       );
     }
 
-    // Medium: equal split; Expanded: 2:3 ratio
+    // Expanded: 2:3 ratio; medium (and a forced compact split): equal 1:1.
     final leadingFlex = size == ScreenSize.expanded ? 2 : 1;
     final trailingFlex = size == ScreenSize.expanded ? 3 : 1;
 
@@ -145,6 +154,56 @@ class ResponsiveSearchLayout extends StatelessWidget {
     return ResponsiveLayoutWrapper(
       compactBody: searchPanel,
       detailBody: mapPanel,
+    );
+  }
+}
+
+/// Shared master/detail scaffold for the app's two-pane wide layouts.
+///
+/// Delegates to [ResponsiveLayoutWrapper] so the breakpoint, the
+/// foldable-hinge split and the 1:1 (medium) / 2:3 (expanded) ratios all
+/// live in ONE place. Replaces the per-screen hand-rolled `isWideScreen`
+/// checks + literal flex `Row`s in Search / Favorites / Fuel / Trajets.
+///
+/// - On compact screens (< 600dp), shows only [master] full-width — the
+///   detail pane is hidden (unless [forceSplit] is set).
+/// - On medium / expanded screens, shows [master] beside the detail pane
+///   ([detail] when non-null, else [detailPlaceholder]). When both detail
+///   and placeholder are null, [master] stays full-width on every size.
+///
+/// Selection / navigation logic stays with the caller — this widget only
+/// owns the layout container.
+class ResponsiveMasterDetail extends StatelessWidget {
+  /// The primary pane, shown on every screen size.
+  final Widget master;
+
+  /// The active detail pane (e.g. a selected station). Takes precedence
+  /// over [detailPlaceholder] on wide screens.
+  final Widget? detail;
+
+  /// Fallback detail pane shown on wide screens when [detail] is null
+  /// (e.g. an inline map or an empty-selection hint).
+  final Widget? detailPlaceholder;
+
+  /// Forwarded to [ResponsiveLayoutWrapper.forceSplit] — forces the
+  /// side-by-side split even on a compact-width screen (medium 1:1 ratio).
+  /// Used by Favorites to honour its "landscape OR ≥600dp" trigger.
+  final bool forceSplit;
+
+  const ResponsiveMasterDetail({
+    super.key,
+    required this.master,
+    this.detail,
+    this.detailPlaceholder,
+    this.forceSplit = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ResponsiveLayoutWrapper(
+      compactBody: master,
+      detailBody: detail ?? detailPlaceholder,
+      forceSplit: forceSplit,
     );
   }
 }

--- a/lib/features/consumption/presentation/widgets/fuel_tab.dart
+++ b/lib/features/consumption/presentation/widgets/fuel_tab.dart
@@ -103,35 +103,25 @@ class FuelTab extends ConsumerWidget {
     }
 
     // #2018 — landscape / tablet split: left = tank level + stats
-    // header, right = fill-ups list. Mirrors the search-results
-    // wide-screen pattern via `isWideScreen(context)` (≥ 600dp).
+    // header, right = fill-ups list. #2530 — routed through the shared
+    // ResponsiveMasterDetail scaffold so the breakpoint + foldable-hinge +
+    // 1:1 (medium) / 2:3 (expanded) ratios live in ONE place. (`isWideScreen`
+    // == screenSizeOf != compact, so the wide branch only ever hits the
+    // medium/expanded paths of the wrapper.)
     if (isWideScreen(context)) {
-      // 2:3 flex on landscape so the Pleins list (the dense data the
-      // user scrolls) gets more width than the mostly-static stats
-      // header. Prior 1:1 split wasted half the screen on the sparse
-      // left column per the 2026-05-24 screenshots.
-      return Row(
-        children: [
-          Expanded(
-            flex: 2,
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.only(top: 8, bottom: bottomInset),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: headerChildren,
-              ),
-            ),
+      return ResponsiveMasterDetail(
+        master: SingleChildScrollView(
+          padding: const EdgeInsets.only(top: 8, bottom: bottomInset),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: headerChildren,
           ),
-          const VerticalDivider(width: 1),
-          Expanded(
-            flex: 3,
-            child: ListView.builder(
-              padding: const EdgeInsets.only(top: 8, bottom: bottomInset),
-              itemCount: fillUps.length,
-              itemBuilder: (context, index) => buildFillUpRow(index),
-            ),
-          ),
-        ],
+        ),
+        detail: ListView.builder(
+          padding: const EdgeInsets.only(top: 8, bottom: bottomInset),
+          itemCount: fillUps.length,
+          itemBuilder: (context, index) => buildFillUpRow(index),
+        ),
       );
     }
 

--- a/lib/features/consumption/presentation/widgets/trajets_tab.dart
+++ b/lib/features/consumption/presentation/widgets/trajets_tab.dart
@@ -137,30 +137,24 @@ class TrajetsTab extends ConsumerWidget {
     // + maintenance suggestions, right = trajets list. Narrow screens
     // fall back to a single column with the same vertical order.
     // #2374 — the "View all on map" action moved to the AppBar.
+    // #2530 — routed through the shared ResponsiveMasterDetail scaffold so
+    // the breakpoint + foldable-hinge + 1:1 (medium) / 2:3 (expanded)
+    // ratios live in ONE place. (`isWideScreen` == screenSizeOf != compact,
+    // so the wide branch only ever hits the medium/expanded wrapper paths.)
     if (isWideScreen(context)) {
-      return Row(
-        children: [
-          // 2:3 flex on landscape so the trajets list (the dense
-          // data) gets more room than the mostly-static insights
-          // panel. Prior 1:1 split wasted half the screen on the
-          // sparse left side per the 2026-05-24 screenshots.
-          Expanded(
-            flex: 2,
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.only(top: 4, bottom: bottomInset),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  MonthlyInsightsCard(summary: monthlySummary),
-                  const MaintenanceSuggestionList(),
-                  const SharedTripsSection(),
-                ],
-              ),
-            ),
+      return ResponsiveMasterDetail(
+        master: SingleChildScrollView(
+          padding: const EdgeInsets.only(top: 4, bottom: bottomInset),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MonthlyInsightsCard(summary: monthlySummary),
+              const MaintenanceSuggestionList(),
+              const SharedTripsSection(),
+            ],
           ),
-          const VerticalDivider(width: 1),
-          Expanded(flex: 3, child: trajetsList),
-        ],
+        ),
+        detail: trajetsList,
       );
     }
     return Column(

--- a/lib/features/favorites/presentation/screens/favorites_screen.dart
+++ b/lib/features/favorites/presentation/screens/favorites_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import '../../../../app/responsive_search_layout.dart';
 import '../../../../app/shell/settings_app_bar_action.dart';
 import '../../../../core/sharing/widget_share_renderer.dart';
 import '../../../../core/sync/sync_provider.dart';
@@ -119,18 +120,18 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     final isLandscape = media.orientation == Orientation.landscape;
     final isWide = media.size.width >= 600;
     if (isLandscape || isWide) {
-      return Row(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Expanded(
-            child: RepaintBoundary(
-              key: _shareBoundaryKey,
-              child: const FavoritesTab(),
-            ),
-          ),
-          const VerticalDivider(width: 1, thickness: 1),
-          const Expanded(child: AlertsTab()),
-        ],
+      // #2530 — the side-by-side panes go through the shared
+      // ResponsiveMasterDetail scaffold so the foldable-hinge + 1:1/2:3
+      // ratios live in ONE place. Favorites keeps its own broader trigger
+      // (landscape OR ≥600dp) via `forceSplit`, so it still splits on a
+      // sub-600 landscape phone the same way it did before.
+      return ResponsiveMasterDetail(
+        forceSplit: true,
+        master: RepaintBoundary(
+          key: _shareBoundaryKey,
+          child: const FavoritesTab(),
+        ),
+        detail: const AlertsTab(),
       );
     }
     return Column(

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -143,7 +143,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     });
 
     final l10n = AppLocalizations.of(context);
-    final isWide = isWideScreen(context);
     final isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
 
@@ -163,28 +162,30 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         const SettingsAppBarAction(),
       ],
       bodyPadding: EdgeInsets.zero,
-      body: isWide
-          ? _buildWideLayout(context)
-          : _buildSearchContent(context),
+      // #2530 — the shared master/detail scaffold owns the breakpoint +
+      // foldable-hinge + 1:1/2:3 ratios. Compact (< 600dp) renders
+      // `_buildSearchContent` full-width, byte-for-byte unchanged. On wide
+      // screens the detail pane is the selected-station inline view,
+      // falling back to the inline map when nothing is selected. Search
+      // thereby picks up the consistent 2:3 expanded ratio (it was a flat
+      // 1:1 before this consolidation).
+      body: _buildWideLayout(context),
     );
   }
 
   Widget _buildWideLayout(BuildContext context) {
     final selectedId = ref.watch(selectedStationProvider);
 
-    return Row(
-      children: [
-        Expanded(child: _buildSearchContent(context)),
-        const VerticalDivider(width: 1),
-        Expanded(
-          child: selectedId != null
-              ? StationDetailInline(
-                  stationId: selectedId,
-                  onClose: () => ref.read(selectedStationProvider.notifier).clear(),
-                )
-              : const InlineMap(),
-        ),
-      ],
+    return ResponsiveMasterDetail(
+      master: _buildSearchContent(context),
+      detail: selectedId != null
+          ? StationDetailInline(
+              stationId: selectedId,
+              onClose: () =>
+                  ref.read(selectedStationProvider.notifier).clear(),
+            )
+          : null,
+      detailPlaceholder: const InlineMap(),
     );
   }
 

--- a/test/app/responsive_layout_test.dart
+++ b/test/app/responsive_layout_test.dart
@@ -286,6 +286,175 @@ void main() {
     });
   });
 
+  group('ResponsiveMasterDetail', () {
+    // The two flex panes of the wrapper's Row are the only `Expanded`s in
+    // these trees, in master-then-detail order.
+    List<int> paneFlex(WidgetTester tester) => tester
+        .widgetList<Expanded>(find.byType(Expanded))
+        .map((e) => e.flex)
+        .toList();
+
+    testWidgets('shows only master on compact (one pane)', (tester) async {
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(
+              master: Text('Master'),
+              detail: Text('Detail'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Master'), findsOneWidget);
+      expect(find.text('Detail'), findsNothing);
+      expect(find.byType(VerticalDivider), findsNothing);
+    });
+
+    testWidgets('shows two panes (1:1) on medium', (tester) async {
+      tester.view.physicalSize = const Size(768, 1024);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(
+              master: Text('Master'),
+              detail: Text('Detail'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Master'), findsOneWidget);
+      expect(find.text('Detail'), findsOneWidget);
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      expect(paneFlex(tester), [1, 1]);
+    });
+
+    testWidgets('shows two panes with the 2:3 ratio on expanded',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(
+              master: Text('Master'),
+              detail: Text('Detail'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Master'), findsOneWidget);
+      expect(find.text('Detail'), findsOneWidget);
+      // Master flex 2, detail flex 3 — the shared expanded ratio.
+      expect(paneFlex(tester), [2, 3]);
+    });
+
+    testWidgets('falls back to detailPlaceholder when detail is null',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(
+              master: Text('Master'),
+              detailPlaceholder: Text('Placeholder'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Master'), findsOneWidget);
+      expect(find.text('Placeholder'), findsOneWidget);
+    });
+
+    testWidgets('detail takes precedence over detailPlaceholder',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(
+              master: Text('Master'),
+              detail: Text('Detail'),
+              detailPlaceholder: Text('Placeholder'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Detail'), findsOneWidget);
+      expect(find.text('Placeholder'), findsNothing);
+    });
+
+    testWidgets('master full-width when both detail and placeholder are null',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(master: Text('Master')),
+          ),
+        ),
+      );
+
+      expect(find.text('Master'), findsOneWidget);
+      expect(find.byType(VerticalDivider), findsNothing);
+    });
+
+    testWidgets('forceSplit shows two panes (1:1) even on compact',
+        (tester) async {
+      // The Favorites "landscape OR ≥600dp" trigger relies on forceSplit to
+      // keep the side-by-side layout on a sub-600 landscape phone.
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveMasterDetail(
+              forceSplit: true,
+              master: Text('Master'),
+              detail: Text('Detail'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Master'), findsOneWidget);
+      expect(find.text('Detail'), findsOneWidget);
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      expect(paneFlex(tester), [1, 1]);
+    });
+  });
+
   group('displayHingeOf', () {
     testWidgets('returns null when no display features', (tester) async {
       late Rect? result;

--- a/test/features/consumption/presentation/widgets/fuel_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/fuel_tab_test.dart
@@ -128,6 +128,48 @@ void main() {
           'Tapping a correction card must open the bottom-sheet editor.',
     );
   });
+
+  // #2530 — the wide-screen split now goes through the shared
+  // ResponsiveMasterDetail scaffold. Structural pane-count assertions.
+  group('#2530 responsive panes', () {
+    testWidgets('compact width renders a single pane (no VerticalDivider)',
+        (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await pumpApp(
+        tester,
+        FuelTab(fillUps: fillUps, stats: stats, l: null),
+        overrides: overrides(gamification: false),
+      );
+
+      expect(find.byType(VerticalDivider), findsNothing);
+    });
+
+    testWidgets('expanded width renders two panes with the 2:3 ratio',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await pumpApp(
+        tester,
+        FuelTab(fillUps: fillUps, stats: stats, l: null),
+        overrides: overrides(gamification: false),
+      );
+
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      // Master flex 2 (stats header), detail flex 3 (fill-up list).
+      final flexes = tester
+          .widgetList<Expanded>(find.byType(Expanded))
+          .map((e) => e.flex)
+          .toList();
+      expect(flexes, containsAllInOrder(<int>[2, 3]));
+    });
+  });
 }
 
 /// Returns null for the active vehicle so [TankLevelCard] short-circuits

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -873,6 +873,62 @@ void main() {
           reason: 'CTA is disabled while a start is connecting');
     });
   });
+
+  // #2530 — the wide-screen split now goes through the shared
+  // ResponsiveMasterDetail scaffold. Structural pane-count assertions.
+  group('TrajetsTab — #2530 responsive panes', () {
+    final trips = [
+      _entry(
+        id: 'trip-r',
+        vehicleId: 'v1',
+        startedAt: DateTime(2026, 4, 22, 9),
+        distanceKm: 12.0,
+      ),
+    ];
+
+    testWidgets('compact width renders a single pane (no VerticalDivider)',
+        (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await _pumpTab(
+        tester,
+        vehicleId: null,
+        trips: trips,
+        vehicles: [combustionVehicle],
+        activeVehicle: combustionVehicle,
+      );
+
+      expect(find.byType(VerticalDivider), findsNothing);
+      expect(find.byKey(const Key('trajets_list')), findsOneWidget);
+    });
+
+    testWidgets('expanded width renders two panes with the 2:3 ratio',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await _pumpTab(
+        tester,
+        vehicleId: null,
+        trips: trips,
+        vehicles: [combustionVehicle],
+        activeVehicle: combustionVehicle,
+      );
+
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      // Master flex 2 (insights), detail flex 3 (trajets list).
+      final flexes = tester
+          .widgetList<Expanded>(find.byType(Expanded))
+          .map((e) => e.flex)
+          .toList();
+      expect(flexes, containsAllInOrder(<int>[2, 3]));
+    });
+  });
 }
 
 /// A trip stuck in the transient connecting phase (#2274 concern 2) so

--- a/test/features/favorites/presentation/screens/favorites_screen_test.dart
+++ b/test/features/favorites/presentation/screens/favorites_screen_test.dart
@@ -166,6 +166,33 @@ void main() {
       expect(find.byType(VerticalDivider), findsOneWidget);
     });
 
+    testWidgets(
+        '#2530 expanded width picks up the shared 2:3 master/detail ratio',
+        (tester) async {
+      final test = standardTestOverrides(favoriteIds: []);
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      stubAlerts(test.mockStorage);
+
+      await pumpApp(
+        tester,
+        const MediaQuery(
+          // Expanded width (≥840dp): tablet landscape / desktop.
+          data: MediaQueryData(size: Size(1024, 768)),
+          child: FavoritesScreen(),
+        ),
+        overrides: test.overrides,
+      );
+
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      // FavoritesTab (master) flex 2, AlertsTab (detail) flex 3.
+      final flexes = tester
+          .widgetList<Expanded>(find.byType(Expanded))
+          .map((e) => e.flex)
+          .toList();
+      expect(flexes, containsAllInOrder(<int>[2, 3]));
+    });
+
     testWidgets('renders station cards when favorites have data',
         (tester) async {
       final test = standardTestOverrides(

--- a/test/features/search/presentation/screens/search_screen_test.dart
+++ b/test/features/search/presentation/screens/search_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/map/presentation/widgets/inline_map.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/presentation/screens/search_screen.dart';
@@ -248,6 +249,51 @@ void main() {
             'Expected results area to be at least 50% of screen height, got '
             '${resultsBox.height}/$screenHeight',
       );
+    });
+
+    // #2530 — Search now goes through the shared ResponsiveMasterDetail
+    // scaffold. Structural pane-count assertions at the breakpoints.
+    testWidgets('compact width renders a single pane (no VerticalDivider)',
+        (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const SearchScreen(),
+        overrides: [...test.overrides, userPositionNullOverride()],
+      );
+
+      expect(find.byType(VerticalDivider), findsNothing);
+      expect(find.bySemanticsLabel('Search results'), findsOneWidget);
+    });
+
+    testWidgets('wide width renders two panes (VerticalDivider + InlineMap)',
+        (tester) async {
+      tester.view.physicalSize = const Size(1024, 768);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const SearchScreen(),
+        overrides: [...test.overrides, userPositionNullOverride()],
+      );
+
+      // The split scaffold renders the search pane beside the inline map,
+      // separated by the shared VerticalDivider.
+      expect(find.byType(VerticalDivider), findsOneWidget);
+      expect(find.byType(InlineMap), findsOneWidget);
+      expect(find.bySemanticsLabel('Search results'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Closes #2530