### PR TITLE
feat(ui): map side-panel detail (selectedStationProvider) + EV station-detail two-column on wide (#2532)

### DIFF
--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -7,8 +7,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../app/current_shell_branch_provider.dart';
+import '../../../../app/responsive_search_layout.dart';
 import '../../../../app/shell/settings_app_bar_action.dart';
 import '../../../../core/sharing/widget_share_renderer.dart';
+import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../ev/presentation/widgets/ev_filter_chips.dart';
@@ -16,7 +18,10 @@ import '../../../ev/presentation/widgets/ev_map_overlay.dart';
 import '../../../ev/providers/ev_providers.dart';
 import '../../../route_search/providers/route_search_provider.dart';
 import '../../../search/providers/search_provider.dart';
+import '../../../search/providers/selected_station_provider.dart';
+import '../../../station_detail/presentation/widgets/station_detail_inline.dart';
 import '../widgets/nearby_map_view.dart';
+import '../widgets/price_legend.dart';
 import '../widgets/route_map_view.dart';
 import '../../../../core/logging/error_logger.dart';
 
@@ -151,6 +156,16 @@ class _MapScreenState extends ConsumerState<MapScreen>
         ref.watch(currentShellBranchProvider) == _mapBranchIndex;
     final showEv = ref.watch(evShowOnMapProvider);
 
+    // #2532 — on a wide screen a marker tap selects the station into the
+    // side panel rather than pushing the full route; on compact the marker
+    // keeps its default `/station/:id` push (passing null leaves the
+    // StationMarkerBuilder default untouched). The detail then renders in a
+    // sibling pane beside the still-full-bleed map (see body below).
+    final isWide = screenSizeOf(context) != ScreenSize.compact;
+    final void Function(String)? onStationTap = isWide
+        ? (id) => ref.read(selectedStationProvider.notifier).select(id)
+        : null;
+
     final Widget body;
     if (!isVisibleBranch) {
       // Offstage: render nothing heavy. When the branch becomes visible
@@ -167,14 +182,42 @@ class _MapScreenState extends ConsumerState<MapScreen>
               routeResult: routeState.value!,
               selectedFuel: selectedFuel,
               mapController: _mapController,
+              onStationTap: onStationTap,
             )
           : NearbyMapView(
               searchState: searchState,
               selectedFuel: selectedFuel,
               searchRadiusKm: searchRadius,
               mapController: _mapController,
+              onStationTap: onStationTap,
             );
     }
+
+    // The master pane — the EV filter chips + the (gated) map body, wrapped
+    // in the #1959 share boundary so the Share action still renders ONLY the
+    // map to a PNG (the detail pane is a sibling, outside the boundary).
+    final Widget mapPane = RepaintBoundary(
+      key: _shareBoundaryKey,
+      child: Column(
+        children: [
+          if (isVisibleBranch && showEv) const EvFilterChips(),
+          Expanded(child: body),
+        ],
+      ),
+    );
+
+    // #2532 — on wide, the selected station (if any) shows its inline detail
+    // in the side pane; otherwise the pane is the empty-state legend. On
+    // compact `ResponsiveMasterDetail` hides the detail entirely, so the map
+    // stays byte-for-byte full-bleed and the marker tap pushes the route.
+    final selectedStationId = ref.watch(selectedStationProvider);
+    final Widget detailPane = selectedStationId != null
+        ? StationDetailInline(
+            stationId: selectedStationId,
+            onClose: () =>
+                ref.read(selectedStationProvider.notifier).clear(),
+          )
+        : const _MapDetailPlaceholder();
 
     return PageScaffold(
       title: l10n?.map ?? 'Map',
@@ -197,15 +240,40 @@ class _MapScreenState extends ConsumerState<MapScreen>
         const SettingsAppBarAction(),
       ],
       bodyPadding: EdgeInsets.zero,
-      body: RepaintBoundary(
-        key: _shareBoundaryKey,
-        child: Column(
-          children: [
-            if (isVisibleBranch && showEv) const EvFilterChips(),
-            Expanded(child: body),
-          ],
-        ),
+      body: ResponsiveMasterDetail(
+        master: mapPane,
+        detail: detailPane,
       ),
+    );
+  }
+}
+
+/// Empty-state side pane shown on a wide map screen when no station is
+/// selected (#2532). A simple hint plus the [PriceLegend] so the colour
+/// ramp is explained even before the user has tapped a marker. Uses only
+/// existing ARB keys — no new strings.
+class _MapDetailPlaceholder extends StatelessWidget {
+  const _MapDetailPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Expanded(
+          child: EmptyState(
+            icon: Icons.touch_app_outlined,
+            title: l10n?.startSearch ??
+                'Search for stations to see them on the map',
+            iconSize: 64,
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(bottom: 16),
+          child: PriceLegend(),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -31,12 +31,19 @@ class NearbyMapView extends ConsumerStatefulWidget {
   final double searchRadiusKm;
   final MapController mapController;
 
+  /// Overrides the station-marker tap (#2532). When null markers push the
+  /// full `/station/:id` route (compact phone behaviour); on a wide screen
+  /// [MapScreen] supplies a callback that selects the station into the
+  /// side-panel detail instead.
+  final void Function(String stationId)? onStationTap;
+
   const NearbyMapView({
     super.key,
     required this.searchState,
     required this.selectedFuel,
     required this.searchRadiusKm,
     required this.mapController,
+    this.onStationTap,
   });
 
   @override
@@ -149,6 +156,7 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
                       ),
                     ),
                     extraLayers: extraLayers,
+                    onStationTap: widget.onStationTap,
                   ),
                 ),
                 _buildInfoBar(context, l10n, stations, result),

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -32,11 +32,18 @@ class RouteMapView extends ConsumerStatefulWidget {
   final dynamic selectedFuel;
   final MapController mapController;
 
+  /// Overrides the station-marker tap (#2532). When null markers push the
+  /// full `/station/:id` route (compact phone behaviour); on a wide screen
+  /// [MapScreen] supplies a callback that selects the station into the
+  /// side-panel detail instead.
+  final void Function(String stationId)? onStationTap;
+
   const RouteMapView({
     super.key,
     required this.routeResult,
     required this.selectedFuel,
     required this.mapController,
+    this.onStationTap,
   });
 
   @override
@@ -109,6 +116,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             showSearchRadius: false,
             selectedStationIds:
                 _selectedStationIds.isNotEmpty ? _selectedStationIds : null,
+            onStationTap: widget.onStationTap,
           ),
         ),
         if (_viewMode == RouteViewMode.bestStops && displayStations.isNotEmpty)

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -78,6 +78,13 @@ class StationMapLayers extends StatefulWidget {
   /// EV charging station overlay.
   final List<Widget> extraLayers;
 
+  /// Overrides what a station marker tap does (#2532). When null the marker
+  /// pushes the full `/station/:id` route (the compact phone behaviour,
+  /// unchanged). On a wide screen [MapScreen] supplies a callback that
+  /// selects the station into the side-panel detail via
+  /// `selectedStationProvider` instead of navigating away.
+  final void Function(String stationId)? onStationTap;
+
   const StationMapLayers({
     super.key,
     required this.mapController,
@@ -93,6 +100,7 @@ class StationMapLayers extends StatefulWidget {
     this.showSearchRadius = true,
     this.selectedStationIds,
     this.extraLayers = const [],
+    this.onStationTap,
   });
 
   @override
@@ -301,6 +309,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
         _priceRange.$2,
         pastel: isPastel,
         compact: !emphasized.contains(station.id),
+        onStationTap: widget.onStationTap,
       );
     }).toList();
   }
@@ -326,7 +335,10 @@ class _StationMapLayersState extends State<StationMapLayers> {
     if (stationsChanged ||
         oldWidget.selectedFuel != widget.selectedFuel ||
         oldWidget.sortMode != widget.sortMode ||
-        !identical(oldWidget.selectedStationIds, widget.selectedStationIds)) {
+        !identical(oldWidget.selectedStationIds, widget.selectedStationIds) ||
+        // #2532 — the tap handler is baked into each marker, so a changed
+        // callback identity (e.g. compact→wide swap) must rebuild them.
+        !identical(oldWidget.onStationTap, widget.onStationTap)) {
       _recomputeMarkers();
     }
 

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -55,6 +55,13 @@ class StationMarkerBuilder {
   /// When [compact] is true, the marker renders as a small coloured dot
   /// (no price text) — used for lower-ranked stations so a bounded result
   /// set stays fully visible without the full bubbles overlapping (#2510).
+  ///
+  /// [onStationTap] overrides the default tap behaviour (#2532). When null
+  /// the marker pushes the full `/station/:id` detail route (the compact
+  /// phone behaviour, unchanged). On a wide screen the map screen supplies a
+  /// callback that instead selects the station into the side panel via
+  /// `selectedStationProvider` — no route change, the detail renders in the
+  /// detail pane beside the still-full-bleed map.
   static Marker build(
     BuildContext context,
     Station station,
@@ -63,6 +70,7 @@ class StationMarkerBuilder {
     double maxPrice, {
     bool pastel = false,
     bool compact = false,
+    void Function(String stationId)? onStationTap,
   }) {
     // #2510 — strict selected-fuel price, exactly like the list card. No
     // fallback to another fuel: a station lacking the selected fuel shows
@@ -99,7 +107,9 @@ class StationMarkerBuilder {
           label: semanticLabel,
           button: true,
           child: GestureDetector(
-            onTap: () => GoRouter.of(context).push('/station/${station.id}'),
+            onTap: () => onStationTap != null
+                ? onStationTap(station.id)
+                : GoRouter.of(context).push('/station/${station.id}'),
             child: Tooltip(
               message: brand,
               waitDuration: const Duration(milliseconds: 300),

--- a/lib/features/search/presentation/screens/ev_station_detail_screen.dart
+++ b/lib/features/search/presentation/screens/ev_station_detail_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../app/responsive_search_layout.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../../core/theme/fuel_colors.dart';
@@ -161,78 +162,155 @@ class _EVStationDetailScreenState extends ConsumerState<EVStationDetailScreen> {
           onPressed: _navigateToStation,
         ),
       ],
-      body: ListView(
-        padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom + 24),
-        children: [
-          EVStationHeaderCard(station: station, evColor: evColor),
-          const SizedBox(height: 8),
-          EVAddressCard(station: station),
-          const SizedBox(height: 8),
-          EVConnectorsCard(station: station, evColor: evColor),
-          const SizedBox(height: 8),
-          EVPricingCard(station: station, evColor: evColor),
-          const SizedBox(height: 8),
-          EVLastUpdatedCard(station: station),
-          const SizedBox(height: 8),
-
-          // Rating
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(l10n?.yourRating ?? 'Your rating',
-                      style: theme.textTheme.titleMedium),
-                  const SizedBox(height: 8),
-                  Consumer(builder: (context, ref, _) {
-                    final rating = ref.watch(stationRatingProvider(station.id));
-                    return Row(
-                      children: [
-                        StarRating(
-                          rating: rating,
-                          onRatingChanged: (stars) {
-                            ref.read(stationRatingsProvider.notifier).rate(station.id, stars);
-                          },
-                        ),
-                        if (rating != null) ...[
-                          const SizedBox(width: 12),
-                          Text('$rating/5', style: theme.textTheme.bodyMedium),
-                        ],
-                      ],
-                    );
-                  }),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 8),
-
-          // Log-charging button — primary wheel-lens action (#582 phase 3).
-          FilledButton.icon(
-            key: const Key('ev_log_charging_button'),
-            onPressed: _logCharging,
-            icon: const Icon(Icons.ev_station),
-            label: Text(l10n?.chargingLogButtonLabel ?? 'Log charging'),
-            style: FilledButton.styleFrom(
-              minimumSize: const Size.fromHeight(48),
-              backgroundColor: evColor,
-            ),
-          ),
-          const SizedBox(height: 8),
-
-          // Navigate button
-          FilledButton.icon(
-            onPressed: _navigateToStation,
-            icon: const Icon(Icons.navigation),
-            label: Text(l10n?.evNavigateToStation ?? 'Navigate to station'),
-            style: FilledButton.styleFrom(
-              minimumSize: const Size.fromHeight(48),
-              backgroundColor: evColor.withValues(alpha: 0.85),
-            ),
-          ),
-        ],
-      ),
+      // #2532 — on medium / expanded screens the single column just stretches
+      // the portrait layout, wasting the width. The two-pane Row puts the
+      // header + address on the LEFT and the connectors / pricing / rating /
+      // actions on the RIGHT, each pane self-scrolling. Compact is unchanged.
+      body: screenSizeOf(context) != ScreenSize.compact
+          ? _wideBody(context, theme, l10n, station, evColor)
+          : _compactBody(context, theme, l10n, station, evColor),
     );
+  }
+
+  /// The portrait single-column body — byte-for-byte the pre-#2532 layout.
+  Widget _compactBody(
+    BuildContext context,
+    ThemeData theme,
+    AppLocalizations? l10n,
+    ChargingStation station,
+    Color evColor,
+  ) {
+    return ListView(
+      padding: EdgeInsets.fromLTRB(
+          16, 16, 16, 16 + MediaQuery.of(context).viewPadding.bottom + 24),
+      children: [
+        ..._headerSections(station, evColor),
+        const SizedBox(height: 8),
+        ..._detailSections(context, theme, l10n, station, evColor),
+      ],
+    );
+  }
+
+  /// The medium / expanded two-pane body (#2532). LEFT (flex 2) = the header
+  /// + address cards; RIGHT (flex 3) = connectors, pricing, last-updated,
+  /// rating and the log / navigate actions. The SAME section widgets are
+  /// reused — only the container changes (mirrors the #2531 fuel pattern).
+  Widget _wideBody(
+    BuildContext context,
+    ThemeData theme,
+    AppLocalizations? l10n,
+    ChargingStation station,
+    Color evColor,
+  ) {
+    final bottomPadding = MediaQuery.of(context).viewPadding.bottom;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          flex: 2,
+          child: ListView(
+            padding: EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding),
+            children: _headerSections(station, evColor),
+          ),
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(
+          flex: 3,
+          child: ListView(
+            padding:
+                EdgeInsets.fromLTRB(16, 16, 16, 16 + bottomPadding + 24),
+            children: _detailSections(context, theme, l10n, station, evColor),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// LEFT-pane sections — the station header + address. Shared by both
+  /// layouts.
+  List<Widget> _headerSections(ChargingStation station, Color evColor) {
+    return [
+      EVStationHeaderCard(station: station, evColor: evColor),
+      const SizedBox(height: 8),
+      EVAddressCard(station: station),
+    ];
+  }
+
+  /// RIGHT-pane sections — connectors, pricing, last-updated, the rating
+  /// card and the log / navigate action buttons. Shared by both layouts.
+  List<Widget> _detailSections(
+    BuildContext context,
+    ThemeData theme,
+    AppLocalizations? l10n,
+    ChargingStation station,
+    Color evColor,
+  ) {
+    return [
+      EVConnectorsCard(station: station, evColor: evColor),
+      const SizedBox(height: 8),
+      EVPricingCard(station: station, evColor: evColor),
+      const SizedBox(height: 8),
+      EVLastUpdatedCard(station: station),
+      const SizedBox(height: 8),
+
+      // Rating
+      Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(l10n?.yourRating ?? 'Your rating',
+                  style: theme.textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Consumer(builder: (context, ref, _) {
+                final rating = ref.watch(stationRatingProvider(station.id));
+                return Row(
+                  children: [
+                    StarRating(
+                      rating: rating,
+                      onRatingChanged: (stars) {
+                        ref
+                            .read(stationRatingsProvider.notifier)
+                            .rate(station.id, stars);
+                      },
+                    ),
+                    if (rating != null) ...[
+                      const SizedBox(width: 12),
+                      Text('$rating/5', style: theme.textTheme.bodyMedium),
+                    ],
+                  ],
+                );
+              }),
+            ],
+          ),
+        ),
+      ),
+      const SizedBox(height: 8),
+
+      // Log-charging button — primary wheel-lens action (#582 phase 3).
+      FilledButton.icon(
+        key: const Key('ev_log_charging_button'),
+        onPressed: _logCharging,
+        icon: const Icon(Icons.ev_station),
+        label: Text(l10n?.chargingLogButtonLabel ?? 'Log charging'),
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(48),
+          backgroundColor: evColor,
+        ),
+      ),
+      const SizedBox(height: 8),
+
+      // Navigate button
+      FilledButton.icon(
+        onPressed: _navigateToStation,
+        icon: const Icon(Icons.navigation),
+        label: Text(l10n?.evNavigateToStation ?? 'Navigate to station'),
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(48),
+          backgroundColor: evColor.withValues(alpha: 0.85),
+        ),
+      ),
+    ];
   }
 }

--- a/test/features/map/presentation/screens/map_side_panel_test.dart
+++ b/test/features/map/presentation/screens/map_side_panel_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/app/current_shell_branch_provider.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/map/presentation/screens/map_screen.dart';
+import 'package:tankstellen/features/map/presentation/widgets/nearby_map_view.dart';
+import 'package:tankstellen/features/map/presentation/widgets/price_legend.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/selected_station_provider.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_detail_inline.dart';
+import 'package:tankstellen/features/station_detail/providers/station_detail_provider.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// Branch index of the Carte tab in the bottom-nav `IndexedStack`.
+const int _mapBranchIndex = 1;
+
+/// A [SelectedStation] notifier pre-seeded with a selection so the wide map
+/// renders the side-panel detail without a tap gesture in the test.
+class _SelectedStation extends SelectedStation {
+  final String? _initial;
+  _SelectedStation(this._initial);
+
+  @override
+  String? build() => _initial;
+}
+
+ProviderContainer _containerOf(WidgetTester tester) =>
+    ProviderScope.containerOf(tester.element(find.byType(MapScreen)));
+
+Future<void> _goBranch(WidgetTester tester, int index) async {
+  _containerOf(tester).read(currentShellBranchProvider.notifier).set(index);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  const stationId = '51d4b477-a095-1aa0-e100-80009459e03a';
+
+  /// Pumps the MapScreen at [size], optionally with a pre-selected station,
+  /// and brings the Carte tab onstage (the #1605 viewport gate only builds
+  /// the map subtree once Carte is the visible branch).
+  Future<void> pumpMap(
+    WidgetTester tester, {
+    required Size size,
+    String? selected,
+  }) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    // The inline detail mounts a PriceHistorySection + rating section that
+    // read price records / ratings off storage — stub them so the detail
+    // pane builds without a provider-error throw.
+    when(() => test.mockStorage.getPriceRecords(any())).thenReturn([]);
+    when(() => test.mockStorage.getPriceHistoryKeys()).thenReturn([]);
+    when(() => test.mockStorage.savePriceRecords(any(), any()))
+        .thenAnswer((_) async {});
+    when(() => test.mockStorage.getRatings()).thenReturn({});
+    when(() => test.mockStorage.getRating(any())).thenReturn(null);
+
+    final detailResult = ServiceResult(
+      data: const StationDetail(station: testStation),
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026, 3, 27, 10),
+    );
+
+    await pumpApp(
+      tester,
+      const MapScreen(),
+      overrides: [
+        ...test.overrides,
+        userPositionNullOverride(),
+        selectedStationProvider.overrideWith(() => _SelectedStation(selected)),
+        stationDetailProvider(stationId).overrideWith((_) async => detailResult),
+      ],
+    );
+    await _goBranch(tester, _mapBranchIndex);
+  }
+
+  group('MapScreen side-panel detail (#2532)', () {
+    testWidgets(
+      'wide (900x600) with a selected station renders the inline detail '
+      'pane beside the map (a VerticalDivider splits the two panes)',
+      (tester) async {
+        await pumpMap(tester, size: const Size(900, 600), selected: stationId);
+
+        // The detail pane is the inline station detail.
+        expect(find.byType(StationDetailInline), findsOneWidget);
+        // The two-pane split is identified by the master/detail divider.
+        expect(find.byType(VerticalDivider), findsOneWidget);
+        // The map (master pane) is still built full-bleed beside it.
+        expect(find.byType(NearbyMapView), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'wide (900x600) with NO selection renders the empty-state legend '
+      'placeholder, not a detail pane',
+      (tester) async {
+        await pumpMap(tester, size: const Size(900, 600), selected: null);
+
+        // No station selected → the placeholder, not the inline detail.
+        expect(find.byType(StationDetailInline), findsNothing);
+        // The empty-state placeholder carries the price legend.
+        expect(find.byType(PriceLegend), findsWidgets);
+        // The split container is still present on a wide screen.
+        expect(find.byType(VerticalDivider), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'compact (400x800) stays full-bleed — no detail pane, no divider, '
+      'even when a station is selected',
+      (tester) async {
+        await pumpMap(tester, size: const Size(400, 800), selected: stationId);
+
+        // On compact the map is full-bleed: ResponsiveMasterDetail hides the
+        // detail entirely, so neither the inline detail nor the master/detail
+        // divider is mounted. The marker tap keeps its `/station/:id` push.
+        expect(find.byType(StationDetailInline), findsNothing);
+        expect(find.byType(VerticalDivider), findsNothing);
+        expect(find.byType(NearbyMapView), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/features/search/presentation/screens/ev_station_detail_screen_test.dart
+++ b/test/features/search/presentation/screens/ev_station_detail_screen_test.dart
@@ -7,6 +7,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
 import 'package:tankstellen/features/search/presentation/screens/ev_station_detail_screen.dart';
+import 'package:tankstellen/features/search/presentation/widgets/ev_station_header_card.dart';
+import 'package:tankstellen/features/search/presentation/widgets/ev_station_info_cards.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
     show ConnectorType;
 
@@ -124,5 +126,78 @@ void main() {
 
       expect(find.text('0.39 EUR/kWh'), findsOneWidget);
     });
+  });
+
+  /// Structural responsive-layout coverage for the EV detail screen (#2532,
+  /// Epic #2525). NO macOS goldens — the adaptive branch is pinned by
+  /// finding (or not finding) the two-pane [VerticalDivider] while the SAME
+  /// section cards render in both layouts.
+  group('EVStationDetailScreen responsive layout (#2532)', () {
+    late MockHiveStorage mockStorage;
+    late List<Object> overrides;
+
+    setUp(() {
+      mockStorage = MockHiveStorage();
+      when(() => mockStorage.hasApiKey()).thenReturn(false);
+      when(() => mockStorage.getFavoriteIds()).thenReturn([]);
+      when(() => mockStorage.getRatings()).thenReturn({});
+      when(() => mockStorage.getRating(any())).thenReturn(null);
+      when(() => mockStorage.getEvApiKey()).thenReturn(null);
+      overrides = [
+        hiveStorageProvider.overrideWithValue(mockStorage),
+        favoritesOverride([]),
+        isFavoriteOverride('ocm-12345', false),
+      ];
+    });
+
+    Future<void> pumpAt(WidgetTester tester, Size size) async {
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await pumpApp(
+        tester,
+        const EVStationDetailScreen(station: _testEvStation),
+        overrides: overrides,
+      );
+    }
+
+    testWidgets(
+      'wide (900x600) renders two panes (a VerticalDivider) with the header '
+      'and connector cards both mounted',
+      (tester) async {
+        await pumpAt(tester, const Size(900, 600));
+
+        // The two-pane layout is identified by its divider.
+        expect(find.byType(VerticalDivider), findsOneWidget);
+
+        // BOTH the LEFT-pane header and the RIGHT-pane connector card render
+        // simultaneously (the portrait single column also mounts both, but
+        // the divider proves the two-pane split is active here).
+        expect(find.byType(EVStationHeaderCard), findsOneWidget);
+        expect(find.byType(EVConnectorsCard), findsOneWidget);
+
+        // A normal AppBar — there is no expanding SliverAppBar in this screen.
+        expect(find.byType(AppBar), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'compact (590x900) keeps a single column — no VerticalDivider',
+      (tester) async {
+        // 590dp is below the 600dp split breakpoint (still compact) yet wide
+        // enough that the pre-existing connector-tile Row does not overflow —
+        // this test isolates the layout BRANCH, not that widget's intrinsic
+        // sizing.
+        await pumpAt(tester, const Size(590, 900));
+
+        // No two-pane split on compact.
+        expect(find.byType(VerticalDivider), findsNothing);
+
+        // The section cards still render in the single column.
+        expect(find.byType(EVStationHeaderCard), findsOneWidget);
+        expect(find.byType(EVConnectorsCard), findsOneWidget);
+      },
+    );
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -231,7 +231,13 @@ void main() {
     // a plain MarkerLayer with the top-ranked stations emphasized; only a
     // huge/zoomed-far set falls back to clustering). Net +18 is the helper,
     // the constants and their dartdoc. Decomposition tracked by #2187/#2188.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 562,
+    // #2532 — re-grandfathered 562 → 574: the optional `onStationTap` field
+    // (so a wide-screen marker tap selects into the side panel instead of
+    // pushing the route) + its dartdoc, its constructor param, its pass-down
+    // in `_recomputeMarkers`, and the `didUpdateWidget` identity guard that
+    // rebuilds markers on a changed callback. Decomposition tracked by
+    // #2187/#2188.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 574,
     // #2382 — +5 for Feature.approachOverlay's three per-feature switch
     // cases (label / description / blocked-enable). Intrinsic per-feature
     // growth in this switch-based section; full decomposition is its own


### PR DESCRIPTION
Closes #2532