### PR TITLE
fix(ui): dock the central search FAB into a concave bottom-bar notch (#2552)

### DIFF
--- a/lib/app/shell/notched_bar_border.dart
+++ b/lib/app/shell/notched_bar_border.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+/// A [ShapeBorder] that carves a concave half-circle notch into the top
+/// edge of the bottom bar so the central FAB docks into it (#2552).
+///
+/// The notch is a [CircularNotchedRectangle] scallop whose guest circle is
+/// centred on the bar's TOP edge, cutting a smooth concave half-circle the
+/// FAB nests into. When [notchRadius] is `<= 0` the border degenerates to a
+/// plain rectangle (landscape, where the bar stays flat).
+///
+/// Hosted on a [Material]: the host both clips the notch and casts a shadow
+/// that follows the notched silhouette (it derives its elevation shadow
+/// from this border's path), so the border itself paints nothing.
+class NotchedBarBorder extends ShapeBorder {
+  final double notchRadius;
+  final double notchMargin;
+
+  const NotchedBarBorder({
+    required this.notchRadius,
+    required this.notchMargin,
+  });
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
+    if (notchRadius <= 0) return Path()..addRect(rect);
+    final guest = Rect.fromCircle(
+      center: Offset(rect.center.dx, rect.top),
+      radius: notchRadius,
+    );
+    return const CircularNotchedRectangle().getOuterPath(rect, guest);
+  }
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>
+      getOuterPath(rect, textDirection: textDirection);
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {}
+
+  @override
+  ShapeBorder scale(double t) => NotchedBarBorder(
+        notchRadius: notchRadius * t,
+        notchMargin: notchMargin * t,
+      );
+}

--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -8,6 +8,7 @@ import '../../features/route_search/providers/route_search_provider.dart';
 import '../../features/search/presentation/screens/search_criteria_screen.dart';
 import '../../features/search/providers/search_provider.dart';
 import '../routes/shell_branches.dart';
+import 'notched_bar_border.dart';
 import 'search_fab_action_provider.dart';
 import 'shell_nav_item.dart';
 
@@ -52,51 +53,66 @@ class ShellBottomBar extends ConsumerWidget {
     // #2113 — context-aware override registered by criteria / results
     // screens. Null means "default branch-switch behaviour".
     final fabAction = ref.watch(searchFabActionControllerProvider);
-    // Portrait: the centre button rises into a bar-coloured cradle (see
-    // _centerButton, #1885). Landscape keeps the bar flat — no head-room.
+    // Portrait: the centre button docks into a concave notch carved into
+    // the bar's top edge (see _centerButton, #2552). Landscape keeps the
+    // bar flat — no head-room.
     final rise = isLandscape ? 0.0 : 24.0;
 
     final primaryIndex = items.indexWhere((i) => i.isPrimary);
 
-    final bar = Container(
-      height: barHeight,
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        boxShadow: [
-          BoxShadow(
-            color: theme.brightness == Brightness.dark
-                ? Colors.black.withValues(alpha: 0.3)
-                : Colors.black.withValues(alpha: 0.08),
-            blurRadius: 8,
-            offset: const Offset(0, -2),
-          ),
-        ],
+    // #2552 — the FAB docks into a true concave notch (a
+    // CircularNotchedRectangle scallop) cut into the bar's top edge. The
+    // guest circle's radius is the FAB radius plus a small margin so the
+    // bar surface curves up and embraces the button. Landscape stays flat:
+    // notchRadius 0 → the border degenerates to a plain rectangle.
+    const notchMargin = 6.0;
+    final diameter = isLandscape ? 40.0 : 56.0;
+    final notchRadius = isLandscape ? 0.0 : diameter / 2 + notchMargin;
+
+    // Material both CLIPS the notch and casts a shadow that follows the
+    // notched silhouette automatically (it derives its elevation shadow
+    // from the ShapeBorder path), so no separate upward shadow painter is
+    // needed.
+    final bar = Material(
+      color: theme.colorScheme.surfaceContainerHighest,
+      elevation: theme.brightness == Brightness.dark ? 3 : 1,
+      shadowColor: theme.brightness == Brightness.dark
+          ? Colors.black.withValues(alpha: 0.3)
+          : Colors.black.withValues(alpha: 0.12),
+      shape: NotchedBarBorder(
+        notchRadius: notchRadius,
+        notchMargin: notchMargin,
       ),
-      child: Row(
-        children: [
-          // Flat tabs left of the centre button.
-          Expanded(
-            child: Row(
-              children: [
-                for (var i = 0; i < items.length; i++)
-                  if (i < primaryIndex)
-                    Expanded(child: _flatTab(context, i)),
-              ],
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        height: barHeight,
+        child: Row(
+          children: [
+            // Flat tabs left of the centre button.
+            Expanded(
+              child: Row(
+                children: [
+                  for (var i = 0; i < items.length; i++)
+                    if (i < primaryIndex)
+                      Expanded(child: _flatTab(context, i)),
+                ],
+              ),
             ),
-          ),
-          // Reserved gap the raised button straddles.
-          const SizedBox(width: 76),
-          // Flat tabs right of the centre button.
-          Expanded(
-            child: Row(
-              children: [
-                for (var i = 0; i < items.length; i++)
-                  if (i > primaryIndex)
-                    Expanded(child: _flatTab(context, i)),
-              ],
+            // Reserved gap the docked button straddles (≥ 2·notchRadius so
+            // the tabs clear the notch walls).
+            const SizedBox(width: 76),
+            // Flat tabs right of the centre button.
+            Expanded(
+              child: Row(
+                children: [
+                  for (var i = 0; i < items.length; i++)
+                    if (i > primaryIndex)
+                      Expanded(child: _flatTab(context, i)),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
 
@@ -111,7 +127,8 @@ class ShellBottomBar extends ConsumerWidget {
           child: Stack(
             children: [
               // Coloured bar pinned to the bottom. The top `rise` strip
-              // is where the centre button's cradle protrudes (#1885).
+              // is where the docked centre button protrudes above the
+              // notch carved into the bar's top edge (#2552).
               Positioned(
                 left: 0,
                 right: 0,
@@ -199,12 +216,12 @@ class ShellBottomBar extends ConsumerWidget {
 
   /// The raised, primary-tinted centre button for the core action.
   ///
-  /// Portrait (#1885): the button is seated in a circular *cradle* in
-  /// the bar's own surface colour. The cradle's lower half overlaps the
-  /// flat bar — same colour, so the seam vanishes — and its upper half
-  /// protrudes into the `rise` strip, so the bar appears to rise up and
-  /// embrace the button rather than the button floating on top of it.
-  /// Landscape has no head-room, so the button stays flat in the bar.
+  /// Portrait (#2552): the button docks into a concave notch carved into
+  /// the bar's top edge (a CircularNotchedRectangle scallop, painted by
+  /// the bar's [NotchedBarBorder] shape). The notch IS the seat — the bar
+  /// surface curves up and embraces the button instead of a flat disc
+  /// sitting behind it. Landscape has no head-room, so the button stays
+  /// flat in the bar.
   Widget _centerButton(
       BuildContext context, int i, SearchFabAction? action, WidgetRef ref) {
     final theme = Theme.of(context);
@@ -347,35 +364,11 @@ class ShellBottomBar extends ConsumerWidget {
       button: true,
       selected: selected,
       excludeSemantics: true,
+      // #2552 — the notch in the bar (the [NotchedBarBorder] shape) is
+      // the seat now, for both orientations; no separate cradle disc.
       child: Tooltip(
         message: tooltipLabel,
-        child: isLandscape
-            ? button
-            : Stack(
-                alignment: Alignment.center,
-                children: [
-                  // Bar-coloured cradle — blends into the bar where it
-                  // overlaps, protrudes as a soft bump above it.
-                  Container(
-                    width: diameter + 20,
-                    height: diameter + 20,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: theme.colorScheme.surfaceContainerHighest,
-                      boxShadow: [
-                        BoxShadow(
-                          color: theme.brightness == Brightness.dark
-                              ? Colors.black.withValues(alpha: 0.4)
-                              : Colors.black.withValues(alpha: 0.12),
-                          blurRadius: 10,
-                          offset: const Offset(0, 1),
-                        ),
-                      ],
-                    ),
-                  ),
-                  button,
-                ],
-              ),
+        child: button,
       ),
     );
   }

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/shell/notched_bar_border.dart';
 import 'package:tankstellen/app/shell/search_fab_action_provider.dart';
 import 'package:tankstellen/app/shell/shell_bottom_bar.dart';
 import 'package:tankstellen/app/shell/shell_nav_item.dart';
@@ -167,20 +168,16 @@ void main() {
       expect(material.elevation, greaterThan(0));
     });
 
-    /// Returns the circular cradle Containers (#1885) — circular boxes
-    /// in the bar's own surface colour.
-    Iterable<Container> cradles(WidgetTester tester) {
-      final ctx = tester.element(find.byType(ShellBottomBar));
-      final barColor = Theme.of(ctx).colorScheme.surfaceContainerHighest;
-      return tester.widgetList<Container>(find.byType(Container)).where((c) {
-        final d = c.decoration;
-        return d is BoxDecoration &&
-            d.shape == BoxShape.circle &&
-            d.color == barColor;
-      });
+    /// The bar's host [Material] — the one whose `shape` is the
+    /// [NotchedBarBorder] (#2552), as opposed to the circular FAB Material.
+    NotchedBarBorder barBorder(WidgetTester tester) {
+      final material = tester
+          .widgetList<Material>(find.byType(Material))
+          .firstWhere((m) => m.shape is NotchedBarBorder);
+      return material.shape as NotchedBarBorder;
     }
 
-    testWidgets('portrait — the button is seated in a bar-coloured cradle',
+    testWidgets('portrait — the button docks into a notched bar (#2552)',
         (tester) async {
       await pumpBar(
         tester,
@@ -191,13 +188,14 @@ void main() {
         isLandscape: false,
         onTap: (_) {},
       );
-      expect(cradles(tester), isNotEmpty,
-          reason: '#1885 — the centre button sits in a circular cradle '
-              'in the bar surface colour.');
+      // #2552 — the bar Material carries a concave notch the FAB docks
+      // into: notchRadius = 56/2 + 6 = 34.
+      expect(barBorder(tester).notchRadius, 34.0,
+          reason: '#2552 — portrait carves a 34dp concave notch into the '
+              'bar top edge for the FAB to dock into.');
     });
 
-    testWidgets('landscape — no cradle (the bar is flat, no head-room)',
-        (tester) async {
+    testWidgets('landscape — flat bar, no notch (#2552)', (tester) async {
       await pumpBar(
         tester,
         items: items,
@@ -207,7 +205,9 @@ void main() {
         isLandscape: true,
         onTap: (_) {},
       );
-      expect(cradles(tester), isEmpty);
+      // Landscape stays flat: notchRadius 0 → the border degenerates to a
+      // plain rectangle.
+      expect(barBorder(tester).notchRadius, 0.0);
     });
   });
 
@@ -239,7 +239,21 @@ void main() {
   });
 
   group('ShellBottomBar layout: portrait vs landscape', () {
-    testWidgets('portrait: flat-tab labels rendered, bar Container is 64',
+    /// The bar's height comes from the [SizedBox] under the notched-bar
+    /// [Material] (#2552 — the bar is no longer a Container).
+    double barHeight(WidgetTester tester) {
+      final barMaterial = find.byWidgetPredicate(
+        (w) => w is Material && w.shape is NotchedBarBorder,
+      );
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .descendant(of: barMaterial, matching: find.byType(SizedBox))
+            .first,
+      );
+      return sizedBox.height!;
+    }
+
+    testWidgets('portrait: flat-tab labels rendered, bar is 64 tall',
         (tester) async {
       await pumpBar(
         tester,
@@ -254,13 +268,10 @@ void main() {
       expect(find.text('Map'), findsOneWidget);
       expect(find.text('Favorites'), findsOneWidget);
 
-      final barContainer =
-          tester.widget<Container>(find.byType(Container).first);
-      expect(barContainer.constraints?.maxHeight, 64.0);
+      expect(barHeight(tester), 64.0);
     });
 
-    testWidgets('landscape: labels hidden, bar Container is 48',
-        (tester) async {
+    testWidgets('landscape: labels hidden, bar is 48 tall', (tester) async {
       await pumpBar(
         tester,
         items: items,
@@ -274,9 +285,7 @@ void main() {
       for (final item in items) {
         expect(find.text(item.label), findsNothing);
       }
-      final barContainer =
-          tester.widget<Container>(find.byType(Container).first);
-      expect(barContainer.constraints?.maxHeight, 48.0);
+      expect(barHeight(tester), 48.0);
     });
   });
 
@@ -556,6 +565,111 @@ void main() {
       expect(wired, {ctrls[0], ctrls[2], ctrls[4]});
       expect(wired, isNot(contains(ctrls[1])));
       expect(wired, isNot(contains(ctrls[3])));
+    });
+  });
+
+  group('ShellBottomBar notch (#2552)', () {
+    /// The bar's host [Material] — the one whose `shape` is the
+    /// [NotchedBarBorder], as opposed to the circular FAB Material.
+    Material barMaterial(WidgetTester tester) => tester
+        .widgetList<Material>(find.byType(Material))
+        .firstWhere((m) => m.shape is NotchedBarBorder);
+
+    /// The circular FAB [Material] wrapping the centre button.
+    Material fabMaterial(WidgetTester tester, IconData icon) =>
+        tester.widget<Material>(
+          find
+              .ancestor(of: find.byIcon(icon), matching: find.byType(Material))
+              .first,
+        );
+
+    testWidgets('portrait paints a notched shape with the FAB centred',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: controllers(3),
+        isLandscape: false,
+        onTap: (_) {},
+      );
+
+      // The bar carries a concave notch (FAB radius 28 + 6 margin = 34).
+      final border = barMaterial(tester).shape as NotchedBarBorder;
+      expect(border.notchRadius, 34.0);
+
+      // The FAB is still a raised circle, centred over the notch.
+      final fab = fabMaterial(tester, Icons.search_outlined);
+      expect(fab.shape, isA<CircleBorder>());
+      expect(fab.elevation, greaterThan(0));
+
+      final fabCentre =
+          tester.getCenter(find.byIcon(Icons.search_outlined)).dx;
+      final barCentre =
+          tester.getCenter(find.byType(ShellBottomBar)).dx;
+      expect((fabCentre - barCentre).abs(), lessThan(1.0),
+          reason: 'the FAB docks in the centre of the notch.');
+    });
+
+    testWidgets('portrait — the notch clip does not eat the FAB hit-test',
+        (tester) async {
+      // Reuse the SearchFabAction harness: register an action, tap the
+      // FAB, assert it fired once — proves the antialias clip on the bar
+      // Material did not swallow the centred FAB's tap.
+      var fired = 0;
+      final container = ProviderContainer(overrides: const []);
+      addTearDown(container.dispose);
+      container.read(searchFabActionControllerProvider.notifier).set(
+            SearchFabAction(
+              icon: Icons.bolt,
+              tooltip: 'Run',
+              onTap: () => fired++,
+            ),
+          );
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.bottomCenter,
+                child: ShellBottomBar(
+                  items: items,
+                  branchForSlot: const [0, 1, 2],
+                  currentIndex: 0,
+                  iconControllers: controllers(3),
+                  isLandscape: false,
+                  onTap: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.bolt));
+      await tester.pump();
+      expect(fired, 1);
+    });
+
+    testWidgets('landscape — flat bar (notchRadius 0), FAB still present',
+        (tester) async {
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 0,
+        iconControllers: controllers(3),
+        isLandscape: true,
+        onTap: (_) {},
+      );
+
+      final border = barMaterial(tester).shape as NotchedBarBorder;
+      expect(border.notchRadius, 0.0);
+
+      final fab = fabMaterial(tester, Icons.search_outlined);
+      expect(fab.shape, isA<CircleBorder>());
     });
   });
 }


### PR DESCRIPTION
## What & why

The central search FAB previously sat on a flat bar with an opaque disc
stacked behind it (the #1885 "cradle") — a flat halo that read as clunky.
This replaces it with a **true concave notch** carved into the bar's top
edge, the way a polished app docks its central FAB: the bar surface curves
up and embraces the button.

## How

- New `NotchedBarBorder` (a `ShapeBorder`) cuts a `CircularNotchedRectangle`
  scallop whose guest circle is centred on the bar's top edge → a smooth
  concave half-circle the FAB nests into. Lives in its own sibling file
  `lib/app/shell/notched_bar_border.dart` so `shell_bottom_bar.dart` stays
  under the 400-line cap.
- The bar is now a `Material` carrying that shape with `clipBehavior:
  Clip.antiAlias`. The Material both clips the notch **and** casts a shadow
  that follows the notched silhouette automatically (elevation shadow is
  derived from the border path) — so the old explicit upward `BoxShadow`
  is replaced by Material elevation.
- The portrait disc-halo `Stack` in `_centerButton` is deleted; the notch
  is the seat now, for both orientations.

## Preserved

- **Landscape stays flat & pixel-identical**: `notchRadius` 0 degenerates
  the border to a plain rectangle, bar 48dp, FAB 40dp, no dip.
- #2113 context-aware FAB action, #2131 disabled dim + tap-swallow, the
  `defaultOnTap` branch routing, Semantics, Tooltip, `ShellBounceIcon`,
  the #2117 inactive-label hide, #1697 clamped text scaling, the
  `SafeArea` + `Stack` layout, the 76dp reserved tab gap (≥ 2·34).

## Tests

- Retargeted the cradle tests to assert the notch (`notchRadius == 34`
  portrait / `0` landscape) and the height assertions to the bar
  Material's child `SizedBox`.
- New `ShellBottomBar notch (#2552)` group: portrait paints a notched
  shape with the FAB centred over it; the antialias clip does not eat the
  FAB hit-test (registered action fires on tap); landscape stays flat.

All 22 widget tests + `file_length` + `no_inline_border_radius` +
`no_hardcoded_ui_strings` lint gates green; `flutter analyze` clean
(no new issues).

Closes #2552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
