### PR TITLE
fix(nav): central search FAB can never become a permanent dead no-op (#2553)

### DIFF
--- a/lib/app/shell/search_fab_action_provider.dart
+++ b/lib/app/shell/search_fab_action_provider.dart
@@ -42,11 +42,29 @@ class SearchFabAction {
 
 @Riverpod(keepAlive: true)
 class SearchFabActionController extends _$SearchFabActionController {
+  /// #2553 — the screen that owns the current action, when it registered
+  /// via [setFor]. Tracking the owner (not the action) lets a screen
+  /// self-clear by identity even if its `dispose` clearer never fires
+  /// (e.g. it was pushed onto a branch the user tabbed away from, leaving
+  /// it mounted-but-offstage in the indexed-stack shell). A LATER owner's
+  /// [setFor] supersedes the token, so a stale earlier owner's [clearFor]
+  /// can never stomp the live registrant.
+  Object? _owner;
+
   @override
   SearchFabAction? build() => null;
 
-  /// Replace the current FAB action. Pass null to clear.
+  /// Replace the current FAB action. Pass null to clear. Clears any
+  /// owner token — use [setFor] when you want owner-scoped self-clearing.
   void set(SearchFabAction? action) {
+    _owner = null;
+    state = action;
+  }
+
+  /// Register [action] on behalf of [owner]. The owner becomes the sole
+  /// holder; a subsequent [setFor] from another owner supersedes it.
+  void setFor(Object owner, SearchFabAction action) {
+    _owner = owner;
     state = action;
   }
 
@@ -56,6 +74,20 @@ class SearchFabActionController extends _$SearchFabActionController {
   /// registered. Comparison is by identity — both `set` and `clearIf`
   /// use the same `SearchFabAction` instance.
   void clearIf(SearchFabAction action) {
-    if (identical(state, action)) state = null;
+    if (identical(state, action)) {
+      _owner = null;
+      state = null;
+    }
+  }
+
+  /// Clears the action only if [owner] is still the current registrant
+  /// (compared by identity). A stale owner whose registration was already
+  /// superseded by a live one is a no-op, so a late dispose/teardown can
+  /// never blank out the FAB the live screen registered.
+  void clearFor(Object owner) {
+    if (identical(_owner, owner)) {
+      _owner = null;
+      state = null;
+    }
   }
 }

--- a/lib/app/shell/search_fab_action_provider.g.dart
+++ b/lib/app/shell/search_fab_action_provider.g.dart
@@ -42,7 +42,7 @@ final class SearchFabActionControllerProvider
 }
 
 String _$searchFabActionControllerHash() =>
-    r'2138e732c10b57351810fa2d7053f3d25033c21e';
+    r'1c1d7c66024a83e47391a5f0799c780fbcd8534d';
 
 abstract class _$SearchFabActionController extends $Notifier<SearchFabAction?> {
   SearchFabAction? build();

--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -249,11 +249,13 @@ class ShellBottomBar extends ConsumerWidget {
     final defaultIcon = selected ? item.filledIcon : item.outlinedIcon;
     final iconData = action?.icon ?? defaultIcon;
     final tooltipLabel = action?.tooltip ?? item.label;
-    // #2131 — disabled override: dim the icon + swallow taps when the
-    // current registrant says the action isn't ready (e.g. route tab
-    // with no destination). Null action ⇒ default branch behaviour,
-    // always enabled.
-    final actionEnabled = action == null || action.enabled;
+    // #2131 — disabled override: dim the icon when the current
+    // registrant says the action isn't ready (e.g. route tab with no
+    // destination). Null action ⇒ default branch behaviour, always
+    // enabled.
+    // #2553 — the dim is contextual *affordance only* now; a disabled
+    // (or stale) action no longer swallows the tap — see [onTapHandler].
+    final actionEnabled = action?.enabled ?? true;
 
     // #2131 — push the criteria modal onto the **Search branch's**
     // nested Navigator (via [searchBranchNavigatorKey]) instead of the
@@ -275,12 +277,20 @@ class ShellBottomBar extends ConsumerWidget {
         // Defensive fallback for environments where the branch nav
         // isn't mounted yet (very early frame, widget tests without
         // the shell wired). Use the local context's Navigator.
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => const SearchCriteriaScreen(),
-            fullscreenDialog: true,
-          ),
-        );
+        // #2553 — if even that Navigator is torn down, degrade to a
+        // branch jump rather than throw uncaught: the FAB must never
+        // crash, only ever open criteria or jump to Search.
+        try {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => const SearchCriteriaScreen(),
+              fullscreenDialog: true,
+            ),
+          );
+        } catch (e, st) {
+          debugPrint('shell FAB default fallback: $e\n$st');
+          onTap(i);
+        }
       }
     }
 
@@ -316,9 +326,13 @@ class ShellBottomBar extends ConsumerWidget {
       }
     }
 
-    final onTapHandler = action != null
-        ? (actionEnabled ? action.onTap : () {})
-        : defaultOnTap;
+    // #2553 — a registered-but-DISABLED (or stale) action must never
+    // produce a dead `() {}` no-op. Only an enabled action overrides the
+    // tap; anything else (null OR disabled OR stale) FALLS BACK to the
+    // default branch behaviour. Worst case the FAB opens criteria / jumps
+    // to Search — it can never become a permanent dead hit-target.
+    final onTapHandler =
+        (action != null && actionEnabled) ? action.onTap : defaultOnTap;
 
     // #2131 — surface + icon both dim when the registered action is
     // disabled, mirroring Material's standard disabled-button look.

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -14,6 +14,7 @@ import '../features/vehicle/presentation/widgets/catalog_reresolve_snackbar_host
 import '../l10n/app_localizations.dart';
 import 'current_shell_branch_provider.dart';
 import 'responsive_search_layout.dart';
+import 'shell/search_fab_action_provider.dart';
 import 'shell/shell_bottom_bar.dart';
 import 'shell/shell_destinations.dart';
 import 'shell/shell_nav_rail.dart';
@@ -142,6 +143,12 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     // tile-viewport nudge, #696) can react without reaching into this
     // widget's private state.
     ref.read(currentShellBranchProvider.notifier).set(index);
+    // #2553 — a contextual FAB override (e.g. the Search-branch criteria
+    // screen) is scoped to ITS branch. Clear it on every branch change so
+    // a Search-only action — especially a disabled one left mounted-but-
+    // offstage in the indexed-stack shell — can never outlive its screen
+    // and make the central FAB dead on the tab the user switched to.
+    ref.read(searchFabActionControllerProvider.notifier).set(null);
 
     // Navigate via go_router — this preserves each branch's state
     widget.navigationShell.goBranch(
@@ -202,6 +209,9 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
         if (routerIndex != _currentIndex) {
           setState(() => _currentIndex = routerIndex);
           ref.read(currentShellBranchProvider.notifier).set(routerIndex);
+          // #2553 — same branch-change FAB reset as _goToPage, for
+          // deep-link / programmatic branch switches that bypass it.
+          ref.read(searchFabActionControllerProvider.notifier).set(null);
         }
       });
     }

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -77,7 +77,7 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       // action that makes the FAB look enabled but no-op.
       Future.microtask(() {
         try {
-          notifier.clearIf(action);
+          notifier.clearFor(this); // #2553 — clear by owner, not action.
         } catch (_) {
           // ProviderContainer torn down (e.g. test teardown) — no-op.
         }
@@ -115,7 +115,8 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
       enabled: enabled,
       onTap: onTap,
     );
-    ref.read(searchFabActionControllerProvider.notifier).set(action);
+    // #2553 — register under this State as owner (self-clears by owner).
+    ref.read(searchFabActionControllerProvider.notifier).setFor(this, action);
     _registeredFabAction = action;
   }
 
@@ -123,8 +124,8 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
   // window before the dispose-microtask fires).
   bool _bailIfStale() {
     if (mounted) return false;
-    final a = _registeredFabAction;
-    if (a != null) _fabNotifier?.clearIf(a);
+    // #2553 — clear by owner identity (see SearchFabActionController).
+    if (_registeredFabAction != null) _fabNotifier?.clearFor(this);
     return true;
   }
 

--- a/test/app/shell/search_fab_action_provider_test.dart
+++ b/test/app/shell/search_fab_action_provider_test.dart
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/shell/search_fab_action_provider.dart';
+
+/// Unit tests for [SearchFabActionController] (#2553).
+///
+/// The owner-token API (`setFor` / `clearFor`) is the third defence
+/// layer against the central-FAB-dead-no-op bug: a screen registers its
+/// action under itself as owner, so even when its dispose clearer never
+/// fires (it was left mounted-but-offstage on a branch the user tabbed
+/// away from), a LATER owner's registration supersedes the token and a
+/// stale `clearFor` can never blank out the live FAB.
+void main() {
+  SearchFabAction action(String tooltip) => SearchFabAction(
+        icon: Icons.search,
+        tooltip: tooltip,
+        onTap: () {},
+      );
+
+  group('SearchFabActionController owner-token API (#2553)', () {
+    test('clearFor with a different owner leaves the action unchanged', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      final ownerA = Object();
+      final ownerB = Object();
+      final a1 = action('A');
+
+      notifier.setFor(ownerA, a1);
+      expect(container.read(searchFabActionControllerProvider), same(a1));
+
+      // A foreign owner cannot clear A's registration.
+      notifier.clearFor(ownerB);
+      expect(container.read(searchFabActionControllerProvider), same(a1),
+          reason: 'a non-owner clearFor must be a no-op.');
+    });
+
+    test('clearFor with the owning token clears the action', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      final ownerA = Object();
+      notifier.setFor(ownerA, action('A'));
+      notifier.clearFor(ownerA);
+      expect(container.read(searchFabActionControllerProvider), isNull);
+    });
+
+    test('a stale owner cannot stomp the live one (the core invariant)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      final ownerA = Object();
+      final ownerB = Object();
+      final a1 = action('A');
+      final a2 = action('B');
+
+      notifier.setFor(ownerA, a1);
+      // B supersedes A as the live registrant.
+      notifier.setFor(ownerB, a2);
+      expect(container.read(searchFabActionControllerProvider), same(a2));
+
+      // A late clearFor from the now-stale owner A must NOT blank the FAB.
+      notifier.clearFor(ownerA);
+      expect(container.read(searchFabActionControllerProvider), same(a2),
+          reason: '#2553 — a stale owner can never clear the live action.');
+    });
+
+    test('clearFor when no owner is set is a harmless no-op', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      notifier.clearFor(Object());
+      expect(container.read(searchFabActionControllerProvider), isNull);
+    });
+  });
+
+  group('SearchFabActionController legacy set / clearIf still work', () {
+    test('set replaces the action; set(null) clears it', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      final a1 = action('A');
+      notifier.set(a1);
+      expect(container.read(searchFabActionControllerProvider), same(a1));
+
+      notifier.set(null);
+      expect(container.read(searchFabActionControllerProvider), isNull);
+    });
+
+    test('clearIf only clears when the held action matches by identity', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      final a1 = action('A');
+      final a2 = action('B');
+      notifier.set(a1);
+
+      // A non-matching action does not clear.
+      notifier.clearIf(a2);
+      expect(container.read(searchFabActionControllerProvider), same(a1));
+
+      // The matching instance clears.
+      notifier.clearIf(a1);
+      expect(container.read(searchFabActionControllerProvider), isNull);
+    });
+
+    test('set(null) drops a prior owner token so clearFor cannot resurrect',
+        () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(searchFabActionControllerProvider.notifier);
+
+      final ownerA = Object();
+      notifier.setFor(ownerA, action('A'));
+      // A branch-change reset goes through set(null) — it must drop the
+      // owner so the prior owner's clearFor is a no-op (#2553 layer 2+3).
+      notifier.set(null);
+      expect(container.read(searchFabActionControllerProvider), isNull);
+
+      // ownerA is no longer the owner; a fresh registration is safe.
+      final ownerB = Object();
+      final b = action('B');
+      notifier.setFor(ownerB, b);
+      notifier.clearFor(ownerA);
+      expect(container.read(searchFabActionControllerProvider), same(b),
+          reason: 'set(null) must have cleared the stale owner token.');
+    });
+  });
+}

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -3,11 +3,32 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/app/shell/notched_bar_border.dart';
 import 'package:tankstellen/app/shell/search_fab_action_provider.dart';
 import 'package:tankstellen/app/shell/shell_bottom_bar.dart';
 import 'package:tankstellen/app/shell/shell_nav_item.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+
+import '../../fixtures/stations.dart';
+
+/// #2553 — a SearchState seeded with one result so the default FAB tap
+/// takes the push-free "other tab WITH results → jump to Search" branch
+/// (proves the disabled-action FALLBACK without building the criteria
+/// modal, which needs Hive boxes the bare test container lacks).
+class _SeededSearchState extends SearchState {
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() {
+    return AsyncValue.data(ServiceResult(
+      data: const [FuelStationResult(testStation)],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026),
+    ));
+  }
+}
 
 /// Widget tests for [ShellBottomBar] after the #1874 redesign.
 ///
@@ -390,9 +411,11 @@ void main() {
     Future<ProviderContainer> pumpBarWithContainer(
       WidgetTester tester, {
       SearchFabAction? initialAction,
+      ValueChanged<int>? onTap,
+      List<Override> overrides = const [],
     }) async {
       final container = ProviderContainer(
-        overrides: const [],
+        overrides: overrides,
       );
       addTearDown(container.dispose);
       if (initialAction != null) {
@@ -413,7 +436,7 @@ void main() {
                   currentIndex: 0,
                   iconControllers: controllers(3),
                   isLandscape: false,
-                  onTap: (_) {},
+                  onTap: onTap ?? (_) {},
                 ),
               ),
             ),
@@ -442,28 +465,46 @@ void main() {
       expect(fired, 1);
     });
 
-    testWidgets('disabled action: tap is a no-op + surface dims',
-        (tester) async {
-      var fired = 0;
+    testWidgets(
+        'disabled action: tap FALLS BACK to default (never a dead no-op) '
+        '+ surface still dims (#2553)', (tester) async {
+      // #2553 — regression: previously a registered-but-disabled action
+      // produced a literal `() {}` dead handler with NO fallback, so the
+      // central FAB became a permanent no-op the moment a disabled action
+      // outlived its screen (offstage criteria modal + no shell reset).
+      // The disabled action's own onTap must NOT fire — but the FAB must
+      // fall back to the default branch behaviour instead of doing
+      // nothing. With Search at slot 1, currentIndex 0 and live results
+      // seeded, the default path jumps to the Search branch (onTap(1)).
+      var registeredFired = 0;
+      final taps = <int>[];
       await pumpBarWithContainer(
         tester,
+        onTap: taps.add,
+        overrides: [searchStateProvider.overrideWith(_SeededSearchState.new)],
         initialAction: SearchFabAction(
           icon: Icons.bolt,
           tooltip: 'Run',
           enabled: false,
-          onTap: () => fired++,
+          onTap: () => registeredFired++,
         ),
       );
 
-      // Tap still hit-tests (the FAB stays mounted) — but the
-      // registered onTap is swallowed.
       await tester.tap(find.byIcon(Icons.bolt));
       await tester.pump();
-      expect(fired, 0,
-          reason: '#2131 — disabled action must not fire onTap.');
 
-      // Dim styling: the button's Material colour is the primary
-      // alpha-reduced (matches the [_centerButton] disabled branch).
+      // The DISABLED action's own onTap is never invoked...
+      expect(registeredFired, 0,
+          reason: '#2131 — a disabled action must not fire its own onTap.');
+      // ...but the FAB is NOT dead: it fell back to the default
+      // branch-switch (onTap(1) → jump to the Search slot).
+      expect(taps, contains(1),
+          reason: '#2553 — a disabled action must FALL BACK to default, '
+              'never become a permanent dead no-op.');
+
+      // KEEP the dim-styling affordance: the button's Material colour is
+      // the primary alpha-reduced (matches the [_centerButton] disabled
+      // branch). Only the tap *behaviour* changed, not the visual.
       final ctx = tester.element(find.byType(ShellBottomBar));
       final primary = Theme.of(ctx).colorScheme.primary;
       final dimmed = primary.withValues(alpha: 0.38);
@@ -476,6 +517,34 @@ void main() {
             .first,
       );
       expect(material.color, dimmed);
+    });
+
+    testWidgets(
+        'a stale/disabled action never yields a dead no-op handler (#2553)',
+        (tester) async {
+      // Belt-and-braces: whatever a registrant left behind, a disabled
+      // action with a do-nothing onTap can never swallow the tap into
+      // nothing — the default always runs (here the seeded-results
+      // branch-jump fallback).
+      final taps = <int>[];
+      await pumpBarWithContainer(
+        tester,
+        onTap: taps.add,
+        overrides: [searchStateProvider.overrideWith(_SeededSearchState.new)],
+        initialAction: SearchFabAction(
+          icon: Icons.bolt,
+          tooltip: 'Stale',
+          enabled: false,
+          onTap: () {},
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.bolt));
+      await tester.pump();
+
+      expect(taps, isNotEmpty,
+          reason: '#2553 — the FAB must always do *something* (default '
+              'branch behaviour); it can never be a permanent no-op.');
     });
   });
 

--- a/test/app/shell_screen_test.dart
+++ b/test/app/shell_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/app/shell/search_fab_action_provider.dart';
 import 'package:tankstellen/app/shell_screen.dart';
 import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/services/service_result.dart';
@@ -367,6 +368,107 @@ void main() {
       expect(find.bySemanticsLabel('Trips'), findsOneWidget);
 
       handle.dispose();
+    });
+
+    testWidgets(
+        'switching branch clears a registered SearchFabAction override '
+        '(#2553 layer 2)', (tester) async {
+      // #2553 — a contextual FAB action registered on the Search branch
+      // (e.g. the criteria screen) must not outlive its branch. When the
+      // user tabs to Map, the shell resets the override so a Search-only
+      // (possibly disabled) action can never make the central FAB dead on
+      // the destination tab. Drive the real ShellScreen's branch switch
+      // and assert the override is cleared.
+      tester.view.physicalSize = const Size(360, 640);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final container = ProviderContainer(overrides: overrides.cast());
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) =>
+                ShellScreen(navigationShell: navigationShell),
+            branches: [
+              StatefulShellBranch(routes: [
+                GoRoute(
+                  path: '/',
+                  builder: (_, _) => const Center(child: Text('SearchScreen')),
+                ),
+              ]),
+              StatefulShellBranch(routes: [
+                GoRoute(
+                  path: '/map',
+                  builder: (_, _) => const Center(child: Text('MapScreen')),
+                ),
+              ]),
+              StatefulShellBranch(routes: [
+                GoRoute(
+                  path: '/favorites',
+                  builder: (_, _) =>
+                      const Center(child: Text('FavoritesScreen')),
+                ),
+              ]),
+              StatefulShellBranch(routes: [
+                GoRoute(
+                  path: '/consumption-tab',
+                  builder: (_, _) =>
+                      const Center(child: Text('ConsumptionScreen')),
+                ),
+              ]),
+              StatefulShellBranch(routes: [
+                GoRoute(
+                  path: '/profile',
+                  builder: (_, _) => const Center(child: Text('ProfileScreen')),
+                ),
+              ]),
+              StatefulShellBranch(routes: [
+                GoRoute(
+                  path: '/trajets-tab',
+                  builder: (_, _) => const Center(child: Text('TrajetsScreen')),
+                ),
+              ]),
+            ],
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pump(const Duration(seconds: 1));
+
+      // Register a (disabled, Search-only) override, mimicking the
+      // criteria screen on the Search branch.
+      container.read(searchFabActionControllerProvider.notifier).set(
+            SearchFabAction(
+              icon: Icons.search,
+              tooltip: 'Run',
+              enabled: false,
+              onTap: () {},
+            ),
+          );
+      expect(container.read(searchFabActionControllerProvider), isNotNull);
+
+      // Tab to the Map branch — _goToPage must reset the override.
+      await tester.tap(find.bySemanticsLabel('Map'));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(container.read(searchFabActionControllerProvider), isNull,
+          reason: '#2553 — a branch switch must clear the FAB override so '
+              'a Search-only action cannot outlive its screen.');
     });
   });
 }


### PR DESCRIPTION
## Problem (#2553)

The central search FAB became a **permanent dead no-op** after navigation. Adversarially root-caused (1 of 17 candidate modes confirmed):

In `shell_bottom_bar.dart`, the tap handler was
`action != null ? (actionEnabled ? action.onTap : () {}) : defaultOnTap` — a registered-but-**disabled** `SearchFabAction` produced a literal `() {}` dead lambda with **no fallback** to `defaultOnTap`.

It was reached deterministically: `SearchCriteriaScreen` in Route mode with an empty destination registers `SearchFabAction(enabled:false)` via the `@Riverpod(keepAlive:true)` controller; that screen is a pushed `fullscreenDialog` on the Search branch's nested navigator, so the user can tab away to Map **without** closing it. `StatefulShellRoute.indexedStack` keeps it mounted-but-offstage, so none of the clearers (dispose microtask, `_bailIfStale`, the `ref.listen` re-registration) fire — the disabled action persists globally and the FAB is dead on **every** tab until restart. There was zero shell-side reset on branch change.

## Fix — defense in depth (4 layers)

1. **(load-bearing)** `shell_bottom_bar.dart` — the handler now falls back to `defaultOnTap` for **any** non-enabled-action case (null OR disabled OR stale). The `() {}` dead lambda is deleted; worst case the FAB opens criteria / jumps to Search. The dimmed disabled **styling is kept** as a contextual affordance — only the tap behaviour changes.
2. `shell_screen.dart` — `_goToPage` and the router-sync postframe reset the override (`set(null)`) on every branch change, so a Search-only action can't outlive its branch (covers deep-link / programmatic switches too).
3. `search_fab_action_provider.dart` gains an owner-token API (`setFor`/`clearFor`); `SearchCriteriaScreen` registers/clears by owner (`this` State) so a stale action self-clears by identity even when its dispose frame is skipped offstage, and a later owner's `setFor` supersedes the token so a stale `clearFor` can never blank the live FAB. Existing `set`/`clearIf` keep working unchanged.
4. **hardening** — `actionEnabled = action?.enabled ?? true` (clearer invariant); the criteria-push default fallback is now wrapped so a torn-down `Navigator` degrades to a branch jump rather than throwing (`catch (e, st)` + `debugPrint`).

## Tests (reproduce-then-prove)

- Flipped the #2131 "disabled action: tap is a no-op" test → now asserts the tap **falls back to default** (never dead) while keeping the dim-styling assertion.
- Added a stale/disabled-action-never-dead test.
- `shell_screen_test.dart`: a branch switch clears a registered override.
- New `search_fab_action_provider_test.dart`: `setFor`/`clearFor` owner validity (a stale owner can't stomp the live one) + legacy `set`/`clearIf` behaviour.

## Gates
- `flutter analyze` — zero new issues (one pre-existing `unnecessary_import` info in `trip_kind_from_samples_test.dart` is on master, not this PR).
- `flutter test test/app/shell/ test/app/shell_screen_test.dart` — green (60 tests).
- `flutter test test/lint/{no_silent_catch,file_length,catch_block_stacktrace_coverage}_test.dart` — green.
- Clean-codegen verified: the `search_fab_action_provider.g.dart` hash drift is committed; a clean rebuild leaves zero further drift.

Closes #2553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
