### PR TITLE
feat(price-prediction): make the fill-up predictor holiday-aware (#2570)

### DIFF
--- a/lib/features/price_history/domain/services/fill_up_guidance_predictor.dart
+++ b/lib/features/price_history/domain/services/fill_up_guidance_predictor.dart
@@ -1,9 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../../../../core/calendar/public_holiday_calendar.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../data/models/price_record.dart';
 import '../entities/fill_up_guidance.dart';
+import 'holiday_premium.dart';
 
 /// Pure, model-free "best time to fill up?" heuristic (#1543).
 ///
@@ -34,7 +36,17 @@ import '../entities/fill_up_guidance.dart';
 ///    [minBucketSamples] and at least [minBucketsForSignal] distinct
 ///    buckets must exist before we trust the cheapest one. The
 ///    day-of-week spread also yields a potential per-litre saving.
-/// 6. **Verdict** —
+/// 6. **Holiday adjustment** (#2570) — when a [countryCode] is supplied
+///    each sample is stamped as on/off a public holiday via
+///    [PublicHolidayCalendar]. If "now" is itself a holiday and the
+///    window carries a trustworthy holiday premium (the shared
+///    [HolidayPremium] maths, ≥ [HolidayPremium.minHolidaySamples]
+///    holiday readings and a non-holiday baseline), the verdict is
+///    nudged conservatively: holidays that historically run **dearer**
+///    lean toward waiting, holidays that run **cheaper** lean toward
+///    filling now. The nudge never fabricates a cheaper window and only
+///    ever shifts the verdict by one step.
+/// 7. **Verdict** —
 ///    - percentile ≤ [cheapPercentile] → [FillUpGuidanceKind.goodTimeNow]
 ///    - percentile ≥ [dearPercentile] **and** a cheaper window exists →
 ///      [FillUpGuidanceKind.waitCheaperWindow]
@@ -73,6 +85,18 @@ class FillUpGuidancePredictor {
   /// "wait for a cheaper day" recommendation (1 ct/L).
   static const double minMeaningfulSavingEur = 0.01;
 
+  /// How far below [dearPercentile] a price may sit and still be
+  /// escalated to "wait" when "now" is a holiday that historically runs
+  /// dearer (#2570). Keeps the holiday nudge to a single conservative
+  /// band rather than overriding a clearly mid-cheap reading.
+  static const int holidayDearPercentileRelief = 15;
+
+  /// How far above [cheapPercentile] a price may sit and still be
+  /// promoted to "fill now" when "now" is a holiday that historically
+  /// runs cheaper (#2570). Symmetric counterpart to
+  /// [holidayDearPercentileRelief].
+  static const int holidayCheapPercentileRelief = 15;
+
   /// Computes a [FillUpGuidance] verdict from [history] as of [now].
   ///
   /// [history] may be in any order; only records inside [windowDays] of
@@ -80,22 +104,39 @@ class FillUpGuidancePredictor {
   /// [FillUpGuidanceKind.insufficientData] verdict (never `null`) when
   /// the data is too thin — callers gate the UI on
   /// [FillUpGuidance.hasGuidance].
+  ///
+  /// [countryCode] is the ISO-3166 alpha-2 code of the station's
+  /// country (e.g. `'DE'`). When supplied it enables the holiday
+  /// adjustment (#2570): samples are stamped on/off public holidays via
+  /// [PublicHolidayCalendar] and, if "now" is a holiday with a
+  /// trustworthy holiday premium, the verdict is nudged. Pass `null`
+  /// (the default) to disable the adjustment entirely — the verdict is
+  /// then identical to the pre-#2570 heuristic.
   FillUpGuidance predict({
     required List<PriceRecord> history,
     required FuelType fuelType,
     required DateTime now,
     int windowDays = 30,
+    String? countryCode,
   }) {
     final cutoff = now.subtract(Duration(days: windowDays));
 
-    // (timestamp, price) pairs inside the window, newest first.
+    // (timestamp, price, isHoliday) triples inside the window, newest
+    // first. The holiday flag is stamped from the shared calendar so
+    // the predictor and the price-prediction provider agree on what a
+    // "holiday reading" is. With no country the flag still catches the
+    // country-agnostic dates (New Year, Christmas).
     final samples = <_Sample>[];
     for (final record in history) {
       if (record.recordedAt.isBefore(cutoff)) continue;
       if (record.recordedAt.isAfter(now)) continue;
       final price = _priceFor(record, fuelType);
       if (price == null) continue;
-      samples.add(_Sample(record.recordedAt, price));
+      samples.add(_Sample(
+        record.recordedAt,
+        price,
+        PublicHolidayCalendar.isPublicHoliday(record.recordedAt, countryCode),
+      ));
     }
     samples.sort((a, b) => b.at.compareTo(a.at)); // newest first
 
@@ -133,10 +174,19 @@ class FillUpGuidancePredictor {
     final hasCheaperWindow =
         cheapestDayOfWeek != null || cheapestDayPart != null;
 
+    // Holiday adjustment (#2570): only relevant when *today* is itself a
+    // public holiday — a holiday premium tells us nothing about a normal
+    // day. We reuse the shared premium maths over this window's samples.
+    final nowIsHoliday =
+        PublicHolidayCalendar.isPublicHoliday(now, countryCode);
+    final holidayBias =
+        nowIsHoliday ? _holidayBias(samples) : _HolidayBias.none;
+
     final kind = _verdict(
       percentile: percentile,
       trend: trend,
       hasCheaperWindow: hasCheaperWindow,
+      holidayBias: holidayBias,
     );
 
     return FillUpGuidance(
@@ -157,17 +207,60 @@ class FillUpGuidancePredictor {
     required int percentile,
     required FillUpTrend trend,
     required bool hasCheaperWindow,
+    _HolidayBias holidayBias = _HolidayBias.none,
   }) {
+    // Cheap-band reading is always a "good time", even on a dearer
+    // holiday — the absolute price already beats the window.
     if (percentile <= cheapPercentile) {
       return FillUpGuidanceKind.goodTimeNow;
     }
+
+    // Holiday-cheaper nudge: a slightly-above-cheap reading on a holiday
+    // that historically runs cheaper is promoted to "fill now". The
+    // relief band keeps this from firing on a genuinely mid/dear price.
+    if (holidayBias == _HolidayBias.cheaper &&
+        percentile <= cheapPercentile + holidayCheapPercentileRelief) {
+      return FillUpGuidanceKind.goodTimeNow;
+    }
+
+    // Standard "wait" gate.
     if (percentile >= dearPercentile && hasCheaperWindow) {
       return FillUpGuidanceKind.waitCheaperWindow;
     }
+
+    // Holiday-dearer nudge: a near-dear reading on a holiday that
+    // historically runs dearer leans toward waiting — but only when a
+    // genuinely cheaper window actually exists to wait for. We never
+    // fabricate a window, so the recommendation stays honest.
+    if (holidayBias == _HolidayBias.dearer &&
+        hasCheaperWindow &&
+        percentile >= dearPercentile - holidayDearPercentileRelief) {
+      return FillUpGuidanceKind.waitCheaperWindow;
+    }
+
     if (trend == FillUpTrend.rising) {
       return FillUpGuidanceKind.fillSoonRising;
     }
     return FillUpGuidanceKind.neutral;
+  }
+
+  /// Resolves the holiday bias for the current window from the shared
+  /// [HolidayPremium] maths (#2570). Returns [_HolidayBias.none] when
+  /// the premium is absent (too few holiday samples / no baseline) or
+  /// below the actionable threshold, so a weak signal never moves the
+  /// verdict.
+  _HolidayBias _holidayBias(List<_Sample> samples) {
+    final holidayPrices = <double>[];
+    final nonHolidayPrices = <double>[];
+    for (final s in samples) {
+      (s.isHoliday ? holidayPrices : nonHolidayPrices).add(s.price);
+    }
+    final premium = HolidayPremium.compute(
+      holidayPrices: holidayPrices,
+      nonHolidayPrices: nonHolidayPrices,
+    );
+    if (!HolidayPremium.isActionable(premium)) return _HolidayBias.none;
+    return premium! > 0 ? _HolidayBias.dearer : _HolidayBias.cheaper;
   }
 
   // --- Statistics helpers (pure) ---
@@ -267,12 +360,20 @@ class FillUpGuidancePredictor {
   }
 }
 
-/// One (timestamp, price) observation used internally by the predictor.
+/// One (timestamp, price, holiday-flag) observation used internally by
+/// the predictor. [isHoliday] is stamped from [PublicHolidayCalendar]
+/// at intake (#2570) so the holiday term needs no second calendar pass.
 class _Sample {
   final DateTime at;
   final double price;
-  const _Sample(this.at, this.price);
+  final bool isHoliday;
+  const _Sample(this.at, this.price, this.isHoliday);
 }
+
+/// Direction of the holiday price bias for the current window (#2570).
+/// [none] means there is no trustworthy / actionable holiday signal, so
+/// the verdict is left exactly as the non-holiday heuristic produced it.
+enum _HolidayBias { none, dearer, cheaper }
 
 /// Result of a cheap-window bucketing pass.
 class _BucketStat {

--- a/lib/features/price_history/domain/services/holiday_premium.dart
+++ b/lib/features/price_history/domain/services/holiday_premium.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../../core/utils/num_extensions.dart';
+
+/// Single source of truth for the public-holiday price-premium maths
+/// shared by the price-prediction provider and the fill-up-guidance
+/// heuristic (#1117 phase 1, #2570).
+///
+/// Both call sites used to (or would have to) re-derive the same
+/// "average EUR/L gap between holiday and non-holiday readings". This
+/// helper extracts that proven calculation once so the two heuristics
+/// can never drift apart. It is pure, side-effect-free, and takes the
+/// two price populations directly so it stays decoupled from whatever
+/// observation type the caller carries (`FeatureVector`, the
+/// predictor's internal sample, …).
+class HolidayPremium {
+  const HolidayPremium._();
+
+  /// Minimum holiday observations required before a premium is trusted.
+  /// Below this the signal is too noisy to be useful (#1117 phase 1).
+  static const int minHolidaySamples = 3;
+
+  /// EUR/L magnitude above which a holiday premium is considered
+  /// actionable — both for the provider's text hint and the predictor's
+  /// verdict nudge. Below 2 cents the difference is not worth acting on.
+  static const double noticeThresholdEur = 0.02;
+
+  /// Average EUR/L delta between [holidayPrices] and [nonHolidayPrices]
+  /// (positive = holidays run dearer, negative = cheaper).
+  ///
+  /// Returns `null` — i.e. "no trustworthy signal" — when there are
+  /// fewer than [minHolidaySamples] holiday observations or no
+  /// non-holiday baseline to compare against. The result is rounded to
+  /// 3 decimals (0.1 ct/L) to match the legacy provider behaviour.
+  static double? compute({
+    required List<double> holidayPrices,
+    required List<double> nonHolidayPrices,
+  }) {
+    if (holidayPrices.length < minHolidaySamples) return null;
+    if (nonHolidayPrices.isEmpty) return null;
+
+    final delta = holidayPrices.average - nonHolidayPrices.average;
+    return double.parse(delta.toStringAsFixed(3));
+  }
+
+  /// Whether [premium] is large enough (in either direction) to act on.
+  /// `null` and sub-threshold premiums are not actionable.
+  static bool isActionable(double? premium) =>
+      premium != null && premium.abs() > noticeThresholdEur;
+}

--- a/lib/features/price_history/providers/fill_up_guidance_provider.dart
+++ b/lib/features/price_history/providers/fill_up_guidance_provider.dart
@@ -3,6 +3,7 @@
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/country/country_config.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
 import '../../feature_management/domain/feature_dependency_graph.dart';
@@ -51,11 +52,18 @@ FillUpGuidance? fillUpGuidance(
   final repo = ref.watch(priceHistoryRepositoryProvider);
   final history = repo.getHistory(stationId, days: 30);
 
+  // Resolve the station's country from its id prefix so the predictor's
+  // holiday adjustment (#2570) can flag the country-specific national
+  // holiday in addition to the country-agnostic dates. Mirrors how
+  // `pricePredictionProvider` feeds country into the feature extractor.
+  final countryCode = Countries.countryCodeForStationId(stationId);
+
   const predictor = FillUpGuidancePredictor();
   final guidance = predictor.predict(
     history: history,
     fuelType: fuelType,
     now: DateTime.now(),
+    countryCode: countryCode,
   );
 
   return guidance.hasGuidance ? guidance : null;

--- a/lib/features/price_history/providers/fill_up_guidance_provider.g.dart
+++ b/lib/features/price_history/providers/fill_up_guidance_provider.g.dart
@@ -116,7 +116,7 @@ final class FillUpGuidanceProvider
   }
 }
 
-String _$fillUpGuidanceHash() => r'd3bd35a190dade11bbd64e59904ba654d25b2e85';
+String _$fillUpGuidanceHash() => r'a1080417bd8854845a36e457966ac5b16f7a7876';
 
 /// On-device "best time to fill up?" guidance for a station + fuel type
 /// (#1543, no-ML heuristic).

--- a/lib/features/price_history/providers/price_prediction_provider.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.dart
@@ -11,6 +11,7 @@ import '../../feature_management/domain/feature_dependency_graph.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../data/models/price_prediction.dart';
 import '../domain/entities/feature_vector.dart';
+import '../domain/services/holiday_premium.dart';
 import '../domain/services/price_feature_extractor.dart';
 import 'price_history_provider.dart';
 import 'tflite_price_predictor_provider.dart';
@@ -27,15 +28,6 @@ const _dayNames = {
   6: 'Saturday',
   7: 'Sunday',
 };
-
-/// Minimum holiday samples required to surface a [PricePrediction.holidayPremium].
-/// Below this, the signal is too noisy to be useful (#1117 phase 1).
-const int _kMinHolidaySamples = 3;
-
-/// Threshold (EUR/L) above which the holiday premium is appended to the
-/// recommendation string. Below 2 cents the difference is not worth
-/// nagging the user about.
-const double _kHolidayPremiumNoticeThreshold = 0.02;
 
 /// Computes "best time to fill" predictions from locally stored price history.
 ///
@@ -185,9 +177,10 @@ double? _maybeModelPredict({
 }
 
 /// Average EUR/L delta between holiday and non-holiday samples in
-/// [vectors]. Returns `null` when fewer than [_kMinHolidaySamples]
-/// holiday observations exist or when no non-holiday baseline is
-/// available.
+/// [vectors], delegating the maths to the shared [HolidayPremium]
+/// helper so this provider and the [FillUpGuidancePredictor] heuristic
+/// share exactly one implementation (#2570). Returns `null` when the
+/// signal is too thin to trust (see [HolidayPremium.compute]).
 double? _computeHolidayPremium(List<FeatureVector> vectors) {
   final holidayPrices = <double>[];
   final nonHolidayPrices = <double>[];
@@ -198,21 +191,17 @@ double? _computeHolidayPremium(List<FeatureVector> vectors) {
       nonHolidayPrices.add(v.priceEur);
     }
   }
-  if (holidayPrices.length < _kMinHolidaySamples) return null;
-  if (nonHolidayPrices.isEmpty) return null;
-
-  final hAvg = holidayPrices.average;
-  final nAvg = nonHolidayPrices.average;
-  final delta = hAvg - nAvg;
-  return double.parse(delta.toStringAsFixed(3));
+  return HolidayPremium.compute(
+    holidayPrices: holidayPrices,
+    nonHolidayPrices: nonHolidayPrices,
+  );
 }
 
 /// Optionally appends a one-sentence holiday hint to [base] when the
 /// computed [holidayPremium] is large enough to be actionable.
 String _maybeAppendHolidayHint(String base, double? holidayPremium) {
-  if (holidayPremium == null) return base;
-  if (holidayPremium.abs() <= _kHolidayPremiumNoticeThreshold) return base;
-  final cents = (holidayPremium.abs() * 100).toStringAsFixed(1);
+  if (!HolidayPremium.isActionable(holidayPremium)) return base;
+  final cents = (holidayPremium!.abs() * 100).toStringAsFixed(1);
   final direction = holidayPremium > 0 ? 'higher' : 'lower';
   return '$base. Holidays trend $cents ct/L $direction';
 }

--- a/test/features/price_history/domain/services/fill_up_guidance_predictor_test.dart
+++ b/test/features/price_history/domain/services/fill_up_guidance_predictor_test.dart
@@ -373,5 +373,197 @@ void main() {
       expect(g.sampleCount, 15);
     });
   });
+
+  group('holiday adjustment (#2570)', () {
+    // All cases below share a fixed window anchored on New Year's Day
+    // 2027 (a country-agnostic public holiday) so "now" is itself a
+    // holiday without needing a country code. The trailing 30-day
+    // window also captures Christmas Day 2026 — the second
+    // country-agnostic date — giving 3+ holiday readings for the
+    // shared premium maths to trust.
+    final newYear = DateTime(2027, 1, 1, 12); // Fri, public holiday
+
+    /// History where holiday readings run *dearer* than the
+    /// non-holiday baseline, with the current (New Year) price sitting
+    /// in the near-dear band (~61st percentile) and a genuine cheaper
+    /// day-of-week / day-part window present. Engineered so the
+    /// baseline (non-holiday) verdict is `fillSoonRising` but a
+    /// dearer-holiday nudge escalates it to `waitCheaperWindow`.
+    List<PriceRecord> dearerHolidayHistory() => <PriceRecord>[
+          rec(newYear, 1.625), // current — New Year, near-dear
+          // 3 dear Christmas readings → holiday avg well above baseline.
+          rec(DateTime(2026, 12, 25, 9), 1.72),
+          rec(DateTime(2026, 12, 25, 14), 1.73),
+          rec(DateTime(2026, 12, 25, 19), 1.71),
+          // Non-holiday baseline spread across weekdays + dayparts so a
+          // cheaper window genuinely exists. Two readings sit above the
+          // current price to keep the percentile below the 75th.
+          rec(DateTime(2026, 12, 14, 9), 1.55),
+          rec(DateTime(2026, 12, 14, 20), 1.58),
+          rec(DateTime(2026, 12, 15, 9), 1.56),
+          rec(DateTime(2026, 12, 15, 20), 1.59),
+          rec(DateTime(2026, 12, 16, 10), 1.57),
+          rec(DateTime(2026, 12, 16, 20), 1.60),
+          rec(DateTime(2026, 12, 17, 10), 1.61),
+          rec(DateTime(2026, 12, 17, 20), 1.62),
+          rec(DateTime(2026, 12, 21, 10), 1.66),
+          rec(DateTime(2026, 12, 22, 10), 1.68),
+        ];
+
+    /// History where holiday readings run *cheaper* than baseline, with
+    /// the current (New Year) price in the slightly-above-cheap band
+    /// (~39th percentile). Baseline verdict is `neutral`; a
+    /// cheaper-holiday nudge promotes it to `goodTimeNow`.
+    List<PriceRecord> cheaperHolidayHistory() => <PriceRecord>[
+          rec(newYear, 1.50), // current — New Year, mid-low
+          rec(DateTime(2026, 12, 25, 9), 1.40),
+          rec(DateTime(2026, 12, 25, 14), 1.41),
+          rec(DateTime(2026, 12, 25, 19), 1.42),
+          rec(DateTime(2026, 12, 14, 9), 1.55),
+          rec(DateTime(2026, 12, 14, 20), 1.60),
+          rec(DateTime(2026, 12, 15, 9), 1.52),
+          rec(DateTime(2026, 12, 15, 20), 1.62),
+          rec(DateTime(2026, 12, 16, 10), 1.48),
+          rec(DateTime(2026, 12, 16, 20), 1.64),
+          rec(DateTime(2026, 12, 17, 10), 1.49),
+          rec(DateTime(2026, 12, 17, 20), 1.66),
+          rec(DateTime(2026, 12, 21, 10), 1.53),
+          rec(DateTime(2026, 12, 22, 10), 1.58),
+        ];
+
+    test('today a holiday + holidays historically dearer → leans wait', () {
+      final g = predictor.predict(
+        history: dearerHolidayHistory(),
+        fuelType: FuelType.e10,
+        now: newYear, // New Year is itself the holiday
+      );
+      // Sanity: the current price is near-dear but below the 75th, so
+      // the standard dear gate would NOT fire on its own.
+      expect(g.currentPercentile, inInclusiveRange(60, 74));
+      expect(g.kind, FillUpGuidanceKind.waitCheaperWindow,
+          reason: 'a dearer holiday nudges a near-dear reading to wait');
+    });
+
+    test('today a holiday + holidays historically cheaper → leans fill', () {
+      final g = predictor.predict(
+        history: cheaperHolidayHistory(),
+        fuelType: FuelType.e10,
+        now: newYear,
+      );
+      // Sanity: the current price is above the cheap band, so the
+      // standard cheap gate would NOT fire on its own.
+      expect(g.currentPercentile, greaterThan(
+          FillUpGuidancePredictor.cheapPercentile));
+      expect(g.kind, FillUpGuidanceKind.goodTimeNow,
+          reason: 'a cheaper holiday nudges a near-cheap reading to fill now');
+    });
+
+    test('same dearer history but today NOT a holiday → verdict unchanged', () {
+      // Anchor "now" one day later (Jan 2 2027 — not a holiday). The
+      // newest sample is still the Jan 1 reading and the 30-day window
+      // is identical, so the only thing that changes vs the case above
+      // is that today is no longer a holiday → no nudge → the baseline
+      // verdict stands. This is the regression-lock for #2570.
+      final notAHoliday = DateTime(2027, 1, 2, 12);
+      final g = predictor.predict(
+        history: dearerHolidayHistory(),
+        fuelType: FuelType.e10,
+        now: notAHoliday,
+      );
+      expect(g.currentPercentile, inInclusiveRange(60, 74));
+      expect(g.kind, FillUpGuidanceKind.fillSoonRising,
+          reason: 'no holiday today → the pre-#2570 verdict is preserved');
+    });
+
+    test('same cheaper history but today NOT a holiday → verdict unchanged', () {
+      final notAHoliday = DateTime(2027, 1, 2, 12);
+      final g = predictor.predict(
+        history: cheaperHolidayHistory(),
+        fuelType: FuelType.e10,
+        now: notAHoliday,
+      );
+      expect(g.kind, FillUpGuidanceKind.neutral,
+          reason: 'no holiday today → the pre-#2570 verdict is preserved');
+    });
+
+    test('no holiday readings in the window → holiday path is inert', () {
+      // A plain rising series on distinct weekdays, none on a holiday.
+      // With zero holiday samples the shared premium is null, so the
+      // holiday term contributes nothing and the verdict must be
+      // identical whether or not a country code is supplied. This is the
+      // regression-lock: the #2570 change is a no-op when there is no
+      // holiday signal.
+      final baseNow = DateTime(2026, 3, 13, 22); // the file's default now
+      final history = <PriceRecord>[
+        for (int i = 0; i < 21; i++)
+          rec(baseNow.subtract(Duration(days: i)), 1.70 - i * 0.02),
+      ];
+      final withoutCountry = predictor.predict(
+        history: history,
+        fuelType: FuelType.e10,
+        now: baseNow,
+      );
+      final withCountry = predictor.predict(
+        history: history,
+        fuelType: FuelType.e10,
+        now: baseNow,
+        countryCode: 'DE',
+      );
+      expect(withoutCountry.trend, FillUpTrend.rising);
+      // No holiday samples → the country code changes nothing.
+      expect(withCountry.kind, withoutCountry.kind);
+      expect(withCountry.currentPercentile, withoutCountry.currentPercentile);
+    });
+
+    test('country-specific holiday only nudges when its countryCode is set',
+        () {
+      // German Unity Day (Oct 3) is a DE-only fixed date — it is NOT a
+      // country-agnostic holiday, so it flags only when countryCode
+      // resolves to 'DE'. We reuse the dearer-history shape but move the
+      // holiday readings and "now" onto Oct 3 2026 so the nudge depends
+      // entirely on the country code. "now" is the evening so all four
+      // Unity-Day readings fall before it (records after `now` are
+      // excluded), giving the 3+ holiday samples the premium needs.
+      final unityDay = DateTime(2026, 10, 3, 22); // Sat evening, DE day
+      List<PriceRecord> deHistory() => <PriceRecord>[
+            rec(DateTime(2026, 10, 3, 18), 1.625), // current — Unity Day
+            // 3 more dear readings, also on Unity Day (distinct hours).
+            rec(DateTime(2026, 10, 3, 7), 1.72),
+            rec(DateTime(2026, 10, 3, 10), 1.73),
+            rec(DateTime(2026, 10, 3, 14), 1.71),
+            // Non-holiday baseline across distinct weekdays / dayparts.
+            rec(DateTime(2026, 9, 14, 9), 1.55),
+            rec(DateTime(2026, 9, 14, 20), 1.58),
+            rec(DateTime(2026, 9, 15, 9), 1.56),
+            rec(DateTime(2026, 9, 15, 20), 1.59),
+            rec(DateTime(2026, 9, 16, 10), 1.57),
+            rec(DateTime(2026, 9, 16, 20), 1.60),
+            rec(DateTime(2026, 9, 17, 10), 1.61),
+            rec(DateTime(2026, 9, 17, 20), 1.62),
+            rec(DateTime(2026, 9, 21, 10), 1.66),
+            rec(DateTime(2026, 9, 22, 10), 1.68),
+          ];
+
+      // Without a country code, Oct 3 is just a normal day → no nudge →
+      // baseline verdict (fillSoonRising for this near-dear rising set).
+      final withoutCountry = predictor.predict(
+        history: deHistory(),
+        fuelType: FuelType.e10,
+        now: unityDay,
+      );
+      expect(withoutCountry.kind, FillUpGuidanceKind.fillSoonRising,
+          reason: 'Oct 3 is not country-agnostic; null country = no nudge');
+
+      // With 'DE', Oct 3 flags as a holiday → dearer nudge → wait.
+      final withCountry = predictor.predict(
+        history: deHistory(),
+        fuelType: FuelType.e10,
+        now: unityDay,
+        countryCode: 'DE',
+      );
+      expect(withCountry.kind, FillUpGuidanceKind.waitCheaperWindow,
+          reason: 'DE country code flags Unity Day → dearer-holiday nudge');
+    });
+  });
 }
 

--- a/test/features/price_history/domain/services/holiday_premium_test.dart
+++ b/test/features/price_history/domain/services/holiday_premium_test.dart
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/price_history/domain/services/holiday_premium.dart';
+
+/// Unit tests for the shared [HolidayPremium] maths (#2570).
+///
+/// This helper is the single source of truth for the holiday-vs-non-
+/// holiday EUR/L premium consumed by both `pricePredictionProvider`
+/// (text hint) and `FillUpGuidancePredictor` (verdict nudge), so its
+/// thresholds and rounding are locked down here.
+void main() {
+  group('compute', () {
+    test('returns null below the minimum holiday-sample count', () {
+      // Two holiday readings is one short of the 3-sample floor.
+      final premium = HolidayPremium.compute(
+        holidayPrices: const [1.80, 1.82],
+        nonHolidayPrices: const [1.60, 1.61, 1.62],
+      );
+      expect(premium, isNull);
+    });
+
+    test('returns null when there is no non-holiday baseline', () {
+      final premium = HolidayPremium.compute(
+        holidayPrices: const [1.80, 1.81, 1.82],
+        nonHolidayPrices: const [],
+      );
+      expect(premium, isNull);
+    });
+
+    test('positive premium when holidays run dearer, rounded to 3 dp', () {
+      // Holiday avg 1.80, non-holiday avg 1.60 → +0.20 EUR/L.
+      final premium = HolidayPremium.compute(
+        holidayPrices: const [1.80, 1.80, 1.80],
+        nonHolidayPrices: const [1.60, 1.60, 1.60],
+      );
+      expect(premium, closeTo(0.20, 1e-9));
+    });
+
+    test('negative premium when holidays run cheaper', () {
+      final premium = HolidayPremium.compute(
+        holidayPrices: const [1.40, 1.41, 1.42],
+        nonHolidayPrices: const [1.60, 1.62, 1.64],
+      );
+      expect(premium, isNotNull);
+      expect(premium, lessThan(0));
+    });
+
+    test('rounds the delta to 3 decimals (0.1 ct/L granularity)', () {
+      // Raw delta 0.0123… → rounded to 0.012.
+      final premium = HolidayPremium.compute(
+        holidayPrices: const [1.6123, 1.6123, 1.6123],
+        nonHolidayPrices: const [1.6000],
+      );
+      expect(premium, 0.012);
+    });
+
+    test('exactly at the minimum sample count is computed', () {
+      final premium = HolidayPremium.compute(
+        holidayPrices: const [1.80, 1.81, 1.82],
+        nonHolidayPrices: const [1.60],
+      );
+      expect(premium, isNotNull);
+    });
+  });
+
+  group('isActionable', () {
+    test('null premium is never actionable', () {
+      expect(HolidayPremium.isActionable(null), isFalse);
+    });
+
+    test('premium exactly at the threshold is NOT actionable', () {
+      // Mirrors the legacy provider's `<=` boundary: 2 ct/L exactly is
+      // below the bar and must not append a hint / fire a nudge.
+      expect(
+        HolidayPremium.isActionable(HolidayPremium.noticeThresholdEur),
+        isFalse,
+      );
+    });
+
+    test('premium just above the threshold is actionable (either sign)', () {
+      expect(
+        HolidayPremium.isActionable(HolidayPremium.noticeThresholdEur + 0.001),
+        isTrue,
+      );
+      expect(
+        HolidayPremium.isActionable(-(HolidayPremium.noticeThresholdEur + 0.001)),
+        isTrue,
+      );
+    });
+
+    test('sub-threshold premium is not actionable', () {
+      expect(HolidayPremium.isActionable(0.005), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Makes the on-device "best time to fill up" predictor holiday-aware by
composing the already-shipped, already-tested ingredients
(`PublicHolidayCalendar` + the proven holiday-premium maths) into the
active `FillUpGuidancePredictor` heuristic. Until now the heuristic had
zero holiday references — holiday data only fed an optional text hint in
`pricePredictionProvider` and the dormant (flag-off) TFLite path.

## How

- **Extracted a shared pure helper, `HolidayPremium`** (price_history
  domain). It is the single source of truth for the
  holiday-vs-non-holiday EUR/L premium: the ≥3-holiday-sample floor, the
  non-holiday-baseline guard, 3-dp rounding, and the >2 ct/L actionable
  threshold. `pricePredictionProvider._computeHolidayPremium` /
  `_maybeAppendHolidayHint` now delegate to it instead of re-deriving the
  arithmetic, so the two call sites can never drift apart. The legacy
  `<=`-threshold boundary semantics are preserved exactly via
  `HolidayPremium.isActionable`'s `>`.
- **Holiday data into the heuristic:** `FillUpGuidancePredictor.predict()`
  takes an optional `countryCode` and stamps each internal sample with an
  `isHoliday` flag via `PublicHolidayCalendar.isPublicHoliday()`. The
  `fillUpGuidance` provider resolves the country from the station-id
  prefix (mirroring `pricePredictionProvider`) and passes it through.
- **Conservative verdict nudge in `_verdict()`:** when *today* is itself a
  public holiday and the window carries a trustworthy premium, a holiday
  that historically runs dearer leans a near-dear reading toward
  `waitCheaperWindow` (only when a genuine cheaper window already exists —
  we never fabricate one), and a holiday that runs cheaper promotes a
  near-cheap reading to `goodTimeNow`. The nudge shifts the verdict by at
  most one step and is fully inert when there is no actionable holiday
  signal, so a null country / non-holiday day reproduces the pre-#2570
  verdict exactly.

## ARB-free, file-disjoint

No new user-facing string and no holiday card badge — logic only.
Existing `FillUpGuidance` / card copy is reused, so this PR stays
parallelizable against other ARB PRs.

## Tests

- `fill_up_guidance_predictor_test`: holiday-dearer → leans wait,
  holiday-cheaper → leans fill, no-holiday-today → unchanged
  (regression-lock on byte-identical data, only the holiday-ness of "now"
  differs), no-holiday-samples → country code is a no-op, and a
  country-specific holiday (DE Unity Day) that nudges only when its
  `countryCode` is supplied.
- `holiday_premium_test`: thresholds, rounding, and the actionable
  boundary for the extracted helper.
- All existing predictor / provider / calendar tests stay green.

Gates: `flutter analyze` clean on touched dirs, `flutter test
test/features/price_history/ test/core/calendar/` (222 passing),
file-length lint passing, codegen clean from a true clean rebuild
(`fill_up_guidance_provider.g.dart` hash committed).

Closes #2570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
