### PR TITLE
fix(obd2): reconnect over the live transport kind — classic-aware direct path de-flaps SPP adapters (#2565)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+part of 'obd2_connection_service.dart';
+
+/// Direct/passive by-MAC connect family for [Obd2ConnectionService],
+/// extracted from the service file as a `part` so it keeps private-member
+/// access while the service stays under the #1680 file-length cap (sanctioned
+/// #2190 decomposition — move-only, behaviour preserved).
+///
+/// These are the NO-SCAN connect paths the in-trip reconnect orchestrator
+/// (#2245) drives: a bounded direct GATT/RFCOMM connect and a long-lived
+/// passive autoConnect GATT wait. Each reuses the shared
+/// [Obd2ConnectionService._openAndInit] sequence so a reconnect produces a
+/// session byte-for-byte identical to the scan path.
+extension Obd2ConnectByMac on Obd2ConnectionService {
+  /// Direct-connect-by-MAC, NO scan (#2242). Addresses the adapter via
+  /// `BluetoothDevice.fromId(mac)` with a bounded ~4 s [timeout],
+  /// skipping the active scan — essential for ELM327 clones that stop
+  /// advertising in standby (a scan never sees them; a direct GATT
+  /// connect still wakes them). Tears down any prior direct channel
+  /// first (Android GATT_ERROR 133 on a stale client), runs the SAME
+  /// service-side init as [connect] via [_openAndInit].
+  ///
+  /// On any failure it falls back to the scan-based [connectByMac], so
+  /// behaviour is never worse than today; returns null when both fail.
+  /// [fallbackToScan] `false` (the #2245 in-trip path, which owns its
+  /// own RSSI-gated scan) returns null immediately on a failed direct
+  /// attempt instead of double-scanning.
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration timeout = const Duration(seconds: 4),
+    bool fallbackToScan = true,
+  }) async {
+    // Tear down a prior direct channel BEFORE reopening (dead-GATT
+    // teardown). LOAD-BEARING on Android — a still-open GATT client for
+    // the same device yields GATT_ERROR 133 on the next connect.
+    await _teardownLastDirectChannel();
+
+    // No scan ⇒ no resolved profile. Use the registry's generic FFF0
+    // BLE profile for the adapter init quirks + display name; its UUIDs
+    // match the channel [channelForDirect] builds.
+    final generic = _genericBleProfile();
+    final channel = bluetooth.channelForDirect(mac, connectTimeout: timeout);
+    _lastDirectChannel = channel;
+    try {
+      return await _openAndInit(
+        channel: channel,
+        adapter: generic.adapter,
+        mac: mac,
+        name: generic.displayName,
+        logFailureAsError: false, // #2379 — recoverable (scan fallback)
+      );
+    } on Object catch (_) {
+      // #2379 — a RECOVERABLE attempt (scan fallback below routinely
+      // succeeds): NOT an error trace. Inner connect already suppressed
+      // its trace; the outcome is owned by the orchestrator + breadcrumbs.
+      await _teardownLastDirectChannel();
+      if (!fallbackToScan) return null;
+      return connectByMac(mac);
+    }
+  }
+
+  /// Direct-connect-by-MAC over Bluetooth **CLASSIC** SPP, NO scan (#2565).
+  /// The transport-correct in-trip reconnect for a Classic adapter (vLinker
+  /// FS et al.): the BLE [connectByMacDirect] above unconditionally builds a
+  /// BLE GATT channel with a 4 s connect timeout, which for a Classic adapter
+  /// can only ever time out (`FlutterBluePlusException | connect | fbp-code:1
+  /// | Timed out after 4s`) — the exact field reconnect-storm signature. This
+  /// path instead resolves the bonded Classic profile + opens an RFCOMM
+  /// channel via [classicBluetooth], and runs the SAME service-side init via
+  /// [_openAndInit] with `linkKind:'classic'`.
+  ///
+  /// Returns null when no Classic facade is wired (tests / BLE-only configs)
+  /// so the caller falls through to its transport-aware scan fallback. NEVER
+  /// touches [bluetooth] / `channelForDirect` — there is no 4 s BLE timeout on
+  /// this path. Tears down any prior direct channel first (mirrors the BLE
+  /// path's dead-transport guard).
+  Future<Obd2Service?> connectByMacClassicDirect(String mac) async {
+    final classic = classicBluetooth;
+    if (classic == null) return null;
+    await _teardownLastDirectChannel();
+
+    // No scan ⇒ no resolved profile. Pick the best-fit Classic profile so
+    // the init quirks + display name match the bonded adapter.
+    final profile = _classicProfileForReconnect();
+    final channel = classic.channelFor(mac);
+    _lastDirectChannel = channel;
+    try {
+      return await _openAndInit(
+        channel: channel,
+        adapter: profile.adapter,
+        mac: mac,
+        name: profile.displayName,
+        linkKind: 'classic',
+        logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
+      );
+    } on Object catch (_) {
+      // #2565 — RECOVERABLE: the scanner owns its transport-aware scan
+      // fallback + re-arm. Inner connect already suppressed its trace.
+      await _teardownLastDirectChannel();
+      return null;
+    }
+  }
+
+  /// Passive autoConnect reconnect (#2261 concern 2). Opens a channel
+  /// with `autoConnect:true` and NO bounded timeout, so the OS holds a
+  /// low-power background GATT request that resolves the instant the
+  /// pinned adapter advertises again — used by the reconnect scanner
+  /// past its active-scan miss ceiling so a parked car stops burning the
+  /// radio. NO scan fallback (the passive wait IS the fallback) and NO
+  /// requestMtu (FBP forbids it with autoConnect). Returns null on any
+  /// failure; runs the SAME service-side init via [_openAndInit].
+  Future<Obd2Service?> connectByMacPassive(String mac) async {
+    await _teardownLastDirectChannel();
+    final generic = _genericBleProfile();
+    final channel = bluetooth.channelForDirect(mac, autoConnect: true);
+    _lastDirectChannel = channel;
+    try {
+      return await _openAndInit(
+        channel: channel,
+        adapter: generic.adapter,
+        mac: mac,
+        name: generic.displayName,
+        logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
+      );
+    } on Object catch (e, st) {
+      // #2379 — OBD2/BLE, not local storage.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'Obd2ConnectionService.connectByMacPassive failed',
+      }));
+      await _teardownLastDirectChannel();
+      return null;
+    }
+  }
+
+  /// Generic FFF0 BLE profile used for direct/passive connect quirks +
+  /// display name when no scan resolved a profile.
+  Obd2AdapterProfile _genericBleProfile() => registry.profiles.firstWhere(
+        (p) => p.id == 'generic-fff0',
+        orElse: () => registry.profiles.firstWhere(
+          (p) => p.transport == BluetoothTransport.ble,
+        ),
+      );
+
+  /// Best Classic profile for an in-trip reconnect (#2565). No scan ran, so
+  /// the MAC is all we have; we can't name-match an RFCOMM socket, so prefer
+  /// the `vlinker-fs-classic` profile (the dominant field adapter + the one
+  /// in the reconnect-storm report) and fall back to the first Classic
+  /// profile. The Classic adapter quirks are a safe superset for ELM327 SPP.
+  Obd2AdapterProfile _classicProfileForReconnect() =>
+      registry.profiles.firstWhere(
+        (p) => p.id == 'vlinker-fs-classic',
+        orElse: () => registry.profiles.firstWhere(
+          (p) => p.transport == BluetoothTransport.classic,
+        ),
+      );
+}

--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -13,146 +13,163 @@ part of 'obd2_connection_service.dart';
 /// passive autoConnect GATT wait. Each reuses the shared
 /// [Obd2ConnectionService._openAndInit] sequence so a reconnect produces a
 /// session byte-for-byte identical to the scan path.
-extension Obd2ConnectByMac on Obd2ConnectionService {
-  /// Direct-connect-by-MAC, NO scan (#2242). Addresses the adapter via
-  /// `BluetoothDevice.fromId(mac)` with a bounded ~4 s [timeout],
-  /// skipping the active scan — essential for ELM327 clones that stop
-  /// advertising in standby (a scan never sees them; a direct GATT
-  /// connect still wakes them). Tears down any prior direct channel
-  /// first (Android GATT_ERROR 133 on a stale client), runs the SAME
-  /// service-side init as [connect] via [_openAndInit].
-  ///
-  /// On any failure it falls back to the scan-based [connectByMac], so
-  /// behaviour is never worse than today; returns null when both fail.
-  /// [fallbackToScan] `false` (the #2245 in-trip path, which owns its
-  /// own RSSI-gated scan) returns null immediately on a failed direct
-  /// attempt instead of double-scanning.
-  Future<Obd2Service?> connectByMacDirect(
-    String mac, {
-    Duration timeout = const Duration(seconds: 4),
-    bool fallbackToScan = true,
-  }) async {
-    // Tear down a prior direct channel BEFORE reopening (dead-GATT
-    // teardown). LOAD-BEARING on Android — a still-open GATT client for
-    // the same device yields GATT_ERROR 133 on the next connect.
-    await _teardownLastDirectChannel();
+///
+/// They are kept as free functions (NOT an `extension`) so the thin instance
+/// methods on [Obd2ConnectionService] that delegate to them stay virtually
+/// dispatchable — test fakes (`_RecordingFakeConnection` etc.) must be able to
+/// `@override` `connectByMacDirect` / `connectByMacClassicDirect` /
+/// `connectByMacPassive`, which extension methods (statically dispatched)
+/// silently forbid. `part`-file privacy is library-level, so these reach the
+/// service's private `_openAndInit` / `_teardownLastDirectChannel` /
+/// `_lastDirectChannel`.
 
-    // No scan ⇒ no resolved profile. Use the registry's generic FFF0
-    // BLE profile for the adapter init quirks + display name; its UUIDs
-    // match the channel [channelForDirect] builds.
-    final generic = _genericBleProfile();
-    final channel = bluetooth.channelForDirect(mac, connectTimeout: timeout);
-    _lastDirectChannel = channel;
-    try {
-      return await _openAndInit(
-        channel: channel,
-        adapter: generic.adapter,
-        mac: mac,
-        name: generic.displayName,
-        logFailureAsError: false, // #2379 — recoverable (scan fallback)
-      );
-    } on Object catch (_) {
-      // #2379 — a RECOVERABLE attempt (scan fallback below routinely
-      // succeeds): NOT an error trace. Inner connect already suppressed
-      // its trace; the outcome is owned by the orchestrator + breadcrumbs.
-      await _teardownLastDirectChannel();
-      if (!fallbackToScan) return null;
-      return connectByMac(mac);
-    }
+/// Body of [Obd2ConnectionService.connectByMacDirect] (#2242). Addresses the
+/// adapter via `BluetoothDevice.fromId(mac)` with a bounded ~4 s [timeout],
+/// skipping the active scan — essential for ELM327 clones that stop
+/// advertising in standby (a scan never sees them; a direct GATT connect
+/// still wakes them). Tears down any prior direct channel first (Android
+/// GATT_ERROR 133 on a stale client), runs the SAME service-side init as
+/// [Obd2ConnectionService.connect] via [Obd2ConnectionService._openAndInit].
+///
+/// On any failure it falls back to the scan-based
+/// [Obd2ConnectionService.connectByMac], so behaviour is never worse than
+/// today; returns null when both fail. [fallbackToScan] `false` (the #2245
+/// in-trip path, which owns its own RSSI-gated scan) returns null immediately
+/// on a failed direct attempt instead of double-scanning.
+Future<Obd2Service?> _connectByMacDirect(
+  Obd2ConnectionService svc,
+  String mac, {
+  Duration timeout = const Duration(seconds: 4),
+  bool fallbackToScan = true,
+}) async {
+  // Tear down a prior direct channel BEFORE reopening (dead-GATT
+  // teardown). LOAD-BEARING on Android — a still-open GATT client for
+  // the same device yields GATT_ERROR 133 on the next connect.
+  await svc._teardownLastDirectChannel();
+
+  // No scan ⇒ no resolved profile. Use the registry's generic FFF0
+  // BLE profile for the adapter init quirks + display name; its UUIDs
+  // match the channel [channelForDirect] builds.
+  final generic = _genericBleProfile(svc);
+  final channel = svc.bluetooth.channelForDirect(mac, connectTimeout: timeout);
+  svc._lastDirectChannel = channel;
+  try {
+    return await svc._openAndInit(
+      channel: channel,
+      adapter: generic.adapter,
+      mac: mac,
+      name: generic.displayName,
+      logFailureAsError: false, // #2379 — recoverable (scan fallback)
+    );
+  } on Object catch (_) {
+    // #2379 — a RECOVERABLE attempt (scan fallback below routinely
+    // succeeds): NOT an error trace. Inner connect already suppressed
+    // its trace; the outcome is owned by the orchestrator + breadcrumbs.
+    await svc._teardownLastDirectChannel();
+    if (!fallbackToScan) return null;
+    return svc.connectByMac(mac);
   }
-
-  /// Direct-connect-by-MAC over Bluetooth **CLASSIC** SPP, NO scan (#2565).
-  /// The transport-correct in-trip reconnect for a Classic adapter (vLinker
-  /// FS et al.): the BLE [connectByMacDirect] above unconditionally builds a
-  /// BLE GATT channel with a 4 s connect timeout, which for a Classic adapter
-  /// can only ever time out (`FlutterBluePlusException | connect | fbp-code:1
-  /// | Timed out after 4s`) — the exact field reconnect-storm signature. This
-  /// path instead resolves the bonded Classic profile + opens an RFCOMM
-  /// channel via [classicBluetooth], and runs the SAME service-side init via
-  /// [_openAndInit] with `linkKind:'classic'`.
-  ///
-  /// Returns null when no Classic facade is wired (tests / BLE-only configs)
-  /// so the caller falls through to its transport-aware scan fallback. NEVER
-  /// touches [bluetooth] / `channelForDirect` — there is no 4 s BLE timeout on
-  /// this path. Tears down any prior direct channel first (mirrors the BLE
-  /// path's dead-transport guard).
-  Future<Obd2Service?> connectByMacClassicDirect(String mac) async {
-    final classic = classicBluetooth;
-    if (classic == null) return null;
-    await _teardownLastDirectChannel();
-
-    // No scan ⇒ no resolved profile. Pick the best-fit Classic profile so
-    // the init quirks + display name match the bonded adapter.
-    final profile = _classicProfileForReconnect();
-    final channel = classic.channelFor(mac);
-    _lastDirectChannel = channel;
-    try {
-      return await _openAndInit(
-        channel: channel,
-        adapter: profile.adapter,
-        mac: mac,
-        name: profile.displayName,
-        linkKind: 'classic',
-        logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
-      );
-    } on Object catch (_) {
-      // #2565 — RECOVERABLE: the scanner owns its transport-aware scan
-      // fallback + re-arm. Inner connect already suppressed its trace.
-      await _teardownLastDirectChannel();
-      return null;
-    }
-  }
-
-  /// Passive autoConnect reconnect (#2261 concern 2). Opens a channel
-  /// with `autoConnect:true` and NO bounded timeout, so the OS holds a
-  /// low-power background GATT request that resolves the instant the
-  /// pinned adapter advertises again — used by the reconnect scanner
-  /// past its active-scan miss ceiling so a parked car stops burning the
-  /// radio. NO scan fallback (the passive wait IS the fallback) and NO
-  /// requestMtu (FBP forbids it with autoConnect). Returns null on any
-  /// failure; runs the SAME service-side init via [_openAndInit].
-  Future<Obd2Service?> connectByMacPassive(String mac) async {
-    await _teardownLastDirectChannel();
-    final generic = _genericBleProfile();
-    final channel = bluetooth.channelForDirect(mac, autoConnect: true);
-    _lastDirectChannel = channel;
-    try {
-      return await _openAndInit(
-        channel: channel,
-        adapter: generic.adapter,
-        mac: mac,
-        name: generic.displayName,
-        logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
-      );
-    } on Object catch (e, st) {
-      // #2379 — OBD2/BLE, not local storage.
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'Obd2ConnectionService.connectByMacPassive failed',
-      }));
-      await _teardownLastDirectChannel();
-      return null;
-    }
-  }
-
-  /// Generic FFF0 BLE profile used for direct/passive connect quirks +
-  /// display name when no scan resolved a profile.
-  Obd2AdapterProfile _genericBleProfile() => registry.profiles.firstWhere(
-        (p) => p.id == 'generic-fff0',
-        orElse: () => registry.profiles.firstWhere(
-          (p) => p.transport == BluetoothTransport.ble,
-        ),
-      );
-
-  /// Best Classic profile for an in-trip reconnect (#2565). No scan ran, so
-  /// the MAC is all we have; we can't name-match an RFCOMM socket, so prefer
-  /// the `vlinker-fs-classic` profile (the dominant field adapter + the one
-  /// in the reconnect-storm report) and fall back to the first Classic
-  /// profile. The Classic adapter quirks are a safe superset for ELM327 SPP.
-  Obd2AdapterProfile _classicProfileForReconnect() =>
-      registry.profiles.firstWhere(
-        (p) => p.id == 'vlinker-fs-classic',
-        orElse: () => registry.profiles.firstWhere(
-          (p) => p.transport == BluetoothTransport.classic,
-        ),
-      );
 }
+
+/// Body of [Obd2ConnectionService.connectByMacClassicDirect] (#2565) — a
+/// direct-connect-by-MAC over Bluetooth **CLASSIC** SPP, NO scan. The
+/// transport-correct in-trip reconnect for a Classic adapter (vLinker FS et
+/// al.): the BLE [_connectByMacDirect] above unconditionally builds a BLE GATT
+/// channel with a 4 s connect timeout, which for a Classic adapter can only
+/// ever time out (`FlutterBluePlusException | connect | fbp-code:1 | Timed out
+/// after 4s`) — the exact field reconnect-storm signature. This path instead
+/// resolves the bonded Classic profile + opens an RFCOMM channel via
+/// [Obd2ConnectionService.classicBluetooth], and runs the SAME service-side
+/// init via [Obd2ConnectionService._openAndInit] with `linkKind:'classic'`.
+///
+/// Returns null when no Classic facade is wired (tests / BLE-only configs)
+/// so the caller falls through to its transport-aware scan fallback. NEVER
+/// touches [Obd2ConnectionService.bluetooth] / `channelForDirect` — there is
+/// no 4 s BLE timeout on this path. Tears down any prior direct channel first
+/// (mirrors the BLE path's dead-transport guard).
+Future<Obd2Service?> _connectByMacClassicDirect(
+  Obd2ConnectionService svc,
+  String mac,
+) async {
+  final classic = svc.classicBluetooth;
+  if (classic == null) return null;
+  await svc._teardownLastDirectChannel();
+
+  // No scan ⇒ no resolved profile. Pick the best-fit Classic profile so
+  // the init quirks + display name match the bonded adapter.
+  final profile = _classicProfileForReconnect(svc);
+  final channel = classic.channelFor(mac);
+  svc._lastDirectChannel = channel;
+  try {
+    return await svc._openAndInit(
+      channel: channel,
+      adapter: profile.adapter,
+      mac: mac,
+      name: profile.displayName,
+      linkKind: 'classic',
+      logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
+    );
+  } on Object catch (_) {
+    // #2565 — RECOVERABLE: the scanner owns its transport-aware scan
+    // fallback + re-arm. Inner connect already suppressed its trace.
+    await svc._teardownLastDirectChannel();
+    return null;
+  }
+}
+
+/// Body of [Obd2ConnectionService.connectByMacPassive] (#2261 concern 2).
+/// Opens a channel with `autoConnect:true` and NO bounded timeout, so the OS
+/// holds a low-power background GATT request that resolves the instant the
+/// pinned adapter advertises again — used by the reconnect scanner past its
+/// active-scan miss ceiling so a parked car stops burning the radio. NO scan
+/// fallback (the passive wait IS the fallback) and NO requestMtu (FBP forbids
+/// it with autoConnect). Returns null on any failure; runs the SAME
+/// service-side init via [Obd2ConnectionService._openAndInit].
+Future<Obd2Service?> _connectByMacPassive(
+  Obd2ConnectionService svc,
+  String mac,
+) async {
+  await svc._teardownLastDirectChannel();
+  final generic = _genericBleProfile(svc);
+  final channel = svc.bluetooth.channelForDirect(mac, autoConnect: true);
+  svc._lastDirectChannel = channel;
+  try {
+    return await svc._openAndInit(
+      channel: channel,
+      adapter: generic.adapter,
+      mac: mac,
+      name: generic.displayName,
+      logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
+    );
+  } on Object catch (e, st) {
+    // #2379 — OBD2/BLE, not local storage.
+    unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+      'where': 'Obd2ConnectionService.connectByMacPassive failed',
+    }));
+    await svc._teardownLastDirectChannel();
+    return null;
+  }
+}
+
+/// Generic FFF0 BLE profile used for direct/passive connect quirks +
+/// display name when no scan resolved a profile.
+Obd2AdapterProfile _genericBleProfile(Obd2ConnectionService svc) =>
+    svc.registry.profiles.firstWhere(
+      (p) => p.id == 'generic-fff0',
+      orElse: () => svc.registry.profiles.firstWhere(
+        (p) => p.transport == BluetoothTransport.ble,
+      ),
+    );
+
+/// Best Classic profile for an in-trip reconnect (#2565). No scan ran, so
+/// the MAC is all we have; we can't name-match an RFCOMM socket, so prefer
+/// the `vlinker-fs-classic` profile (the dominant field adapter + the one
+/// in the reconnect-storm report) and fall back to the first Classic
+/// profile. The Classic adapter quirks are a safe superset for ELM327 SPP.
+Obd2AdapterProfile _classicProfileForReconnect(Obd2ConnectionService svc) =>
+    svc.registry.profiles.firstWhere(
+      (p) => p.id == 'vlinker-fs-classic',
+      orElse: () => svc.registry.profiles.firstWhere(
+        (p) => p.transport == BluetoothTransport.classic,
+      ),
+    );

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -276,6 +276,28 @@ class Obd2ConnectionService {
     return connect(match);
   }
 
+  /// Direct-connect-by-MAC, NO scan (#2242). See [_connectByMacDirect] for the
+  /// full contract. A thin INSTANCE method (not an `extension`) so test fakes
+  /// can `@override` it — the body lives in the `part` file to keep this file
+  /// under the #1680 cap (#2190).
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration timeout = const Duration(seconds: 4),
+    bool fallbackToScan = true,
+  }) =>
+      _connectByMacDirect(this, mac,
+          timeout: timeout, fallbackToScan: fallbackToScan);
+
+  /// Direct-connect-by-MAC over Bluetooth **CLASSIC** SPP, NO scan (#2565).
+  /// See [_connectByMacClassicDirect]. Thin overridable instance method.
+  Future<Obd2Service?> connectByMacClassicDirect(String mac) =>
+      _connectByMacClassicDirect(this, mac);
+
+  /// Passive autoConnect reconnect (#2261 concern 2). See
+  /// [_connectByMacPassive]. Thin overridable instance method.
+  Future<Obd2Service?> connectByMacPassive(String mac) =>
+      _connectByMacPassive(this, mac);
+
   Future<void> _teardownLastDirectChannel() async {
     final prior = _lastDirectChannel;
     _lastDirectChannel = null;

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -22,6 +22,7 @@ import '../../../../core/logging/error_logger.dart';
 import '../../../../core/storage/storage_providers.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 
+part 'obd2_connect_by_mac.dart';
 part 'obd2_connection_service.g.dart';
 
 /// Vehicle identity the supported-PID cache (#811/#2253) refines its
@@ -275,84 +276,6 @@ class Obd2ConnectionService {
     return connect(match);
   }
 
-  /// Direct-connect-by-MAC, NO scan (#2242). Addresses the adapter via
-  /// `BluetoothDevice.fromId(mac)` with a bounded ~4 s [timeout],
-  /// skipping the active scan — essential for ELM327 clones that stop
-  /// advertising in standby (a scan never sees them; a direct GATT
-  /// connect still wakes them). Tears down any prior direct channel
-  /// first (Android GATT_ERROR 133 on a stale client), runs the SAME
-  /// service-side init as [connect] via [_openAndInit].
-  ///
-  /// On any failure it falls back to the scan-based [connectByMac], so
-  /// behaviour is never worse than today; returns null when both fail.
-  /// [fallbackToScan] `false` (the #2245 in-trip path, which owns its
-  /// own RSSI-gated scan) returns null immediately on a failed direct
-  /// attempt instead of double-scanning.
-  Future<Obd2Service?> connectByMacDirect(
-    String mac, {
-    Duration timeout = const Duration(seconds: 4),
-    bool fallbackToScan = true,
-  }) async {
-    // Tear down a prior direct channel BEFORE reopening (dead-GATT
-    // teardown). LOAD-BEARING on Android — a still-open GATT client for
-    // the same device yields GATT_ERROR 133 on the next connect.
-    await _teardownLastDirectChannel();
-
-    // No scan ⇒ no resolved profile. Use the registry's generic FFF0
-    // BLE profile for the adapter init quirks + display name; its UUIDs
-    // match the channel [channelForDirect] builds.
-    final generic = _genericBleProfile();
-    final channel = bluetooth.channelForDirect(mac, connectTimeout: timeout);
-    _lastDirectChannel = channel;
-    try {
-      return await _openAndInit(
-        channel: channel,
-        adapter: generic.adapter,
-        mac: mac,
-        name: generic.displayName,
-        logFailureAsError: false, // #2379 — recoverable (scan fallback)
-      );
-    } on Object catch (_) {
-      // #2379 — a RECOVERABLE attempt (scan fallback below routinely
-      // succeeds): NOT an error trace. Inner connect already suppressed
-      // its trace; the outcome is owned by the orchestrator + breadcrumbs.
-      await _teardownLastDirectChannel();
-      if (!fallbackToScan) return null;
-      return connectByMac(mac);
-    }
-  }
-
-  /// Passive autoConnect reconnect (#2261 concern 2). Opens a channel
-  /// with `autoConnect:true` and NO bounded timeout, so the OS holds a
-  /// low-power background GATT request that resolves the instant the
-  /// pinned adapter advertises again — used by the reconnect scanner
-  /// past its active-scan miss ceiling so a parked car stops burning the
-  /// radio. NO scan fallback (the passive wait IS the fallback) and NO
-  /// requestMtu (FBP forbids it with autoConnect). Returns null on any
-  /// failure; runs the SAME service-side init via [_openAndInit].
-  Future<Obd2Service?> connectByMacPassive(String mac) async {
-    await _teardownLastDirectChannel();
-    final generic = _genericBleProfile();
-    final channel = bluetooth.channelForDirect(mac, autoConnect: true);
-    _lastDirectChannel = channel;
-    try {
-      return await _openAndInit(
-        channel: channel,
-        adapter: generic.adapter,
-        mac: mac,
-        name: generic.displayName,
-        logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
-      );
-    } on Object catch (e, st) {
-      // #2379 — OBD2/BLE, not local storage.
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'Obd2ConnectionService.connectByMacPassive failed',
-      }));
-      await _teardownLastDirectChannel();
-      return null;
-    }
-  }
-
   Future<void> _teardownLastDirectChannel() async {
     final prior = _lastDirectChannel;
     _lastDirectChannel = null;
@@ -366,13 +289,6 @@ class Obd2ConnectionService {
       }));
     }
   }
-
-  Obd2AdapterProfile _genericBleProfile() => registry.profiles.firstWhere(
-        (p) => p.id == 'generic-fff0',
-        orElse: () => registry.profiles.firstWhere(
-          (p) => p.transport == BluetoothTransport.ble,
-        ),
-      );
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/features/consumption/data/obd2/reconnect_connector.dart
+++ b/lib/features/consumption/data/obd2/reconnect_connector.dart
@@ -35,6 +35,15 @@ class ReconnectConnector {
   /// swap its service pointer. Fired exactly once per successful attempt.
   final void Function(Obd2Service service) onConnected;
 
+  /// Transport kind of the link that just dropped — `'ble'` / `'classic'`
+  /// (#2565), read off the (dead-but-typed) live service at handle-drop
+  /// time. Drives WHICH direct-connect path [attempt] / [attemptPassive]
+  /// take: a Classic drop reconnects over RFCOMM (the BLE direct path can
+  /// only ever 4 s-timeout for a Classic adapter — the field reconnect-storm
+  /// signature), while `'ble'` / null keep the existing BLE-direct-first
+  /// behaviour unchanged.
+  final String? transportHint;
+
   ResolvedObd2Candidate? _lastCandidate;
   int? _lastSuccessfulRssi;
   var _consecutiveBatchesSeen = 0;
@@ -42,7 +51,14 @@ class ReconnectConnector {
   ReconnectConnector({
     required this.connection,
     required this.onConnected,
+    this.transportHint,
   });
+
+  /// `true` when the live link that dropped was Bluetooth Classic AND a
+  /// Classic facade is wired (#2565). Drives the transport-correct reconnect
+  /// dispatch: a Classic drop must NOT take the BLE direct path.
+  bool get _isClassicDrop =>
+      transportHint == 'classic' && connection.classicBluetooth != null;
 
   /// Strongest-seen candidate from the scan fallback. Exposed for tests.
   ResolvedObd2Candidate? get lastCandidate => _lastCandidate;
@@ -56,14 +72,16 @@ class ReconnectConnector {
   /// failures are logged and surfaced as `false` so the scanner keeps
   /// its backoff schedule.
   Future<bool> attempt(String mac) async {
-    // 1) DIRECT-CONNECT FIRST — no scan. `fallbackToScan: false` keeps
-    //    the service from running its own (ungated) scan fallback, so we
-    //    never double-scan: the single scan below is ours and is gated.
+    // 1) DIRECT-CONNECT FIRST — no scan, over the LIVE transport kind (#2565).
+    //    A Classic drop reconnects over RFCOMM (`connectByMacClassicDirect`);
+    //    a BLE / unknown drop keeps the BLE direct-GATT path (#2245). The BLE
+    //    `channelForDirect` path can only ever 4 s-timeout for a Classic
+    //    adapter (no `channelForDirect` on the Classic facade), so dispatching
+    //    by transport is what de-flaps SPP adapters.
     try {
-      final direct = await connection.connectByMacDirect(
-        mac,
-        fallbackToScan: false,
-      );
+      final direct = _isClassicDrop
+          ? await connection.connectByMacClassicDirect(mac)
+          : await connection.connectByMacDirect(mac, fallbackToScan: false);
       if (direct != null) {
         // A direct connect carries no RSSI (it never scanned), so the
         // relative-RSSI baseline is left as-is — it is only ever set
@@ -79,7 +97,11 @@ class ReconnectConnector {
 
     // 2) SCAN FALLBACK (ultimate). One scan window: track the strongest
     //    sighting + consecutive-batch count, and only connect when the
-    //    relative-RSSI / two-batch gate passes.
+    //    relative-RSSI / two-batch gate passes. The scan merges BLE +
+    //    Classic, so it is transport-aware: a Classic drop reaches its own
+    //    bonded candidate here even after the (skipped-for-classic) BLE
+    //    direct path. The [transportHint] lets the gate accept a bonded
+    //    Classic sighting on the FIRST batch (#2565).
     try {
       await for (final batch in connection.scan()) {
         final seen = batch.where((c) => c.candidate.deviceId == mac);
@@ -100,6 +122,7 @@ class ReconnectConnector {
           lastSuccessfulRssi: _lastSuccessfulRssi,
           seenRssi: candidate.candidate.rssi,
           consecutiveBatchesSeen: _consecutiveBatchesSeen,
+          transportHint: transportHint,
         )) {
           // Too weak AND not yet seen twice — keep scanning this window;
           // a later batch may strengthen or repeat it.
@@ -123,9 +146,18 @@ class ReconnectConnector {
   /// the scanner hits its active-scan miss ceiling it stops burning the
   /// radio and waits on a low-power autoConnect GATT request instead.
   /// Returns `true` once a session is established. Never throws.
+  ///
+  /// #2565 — the passive path is a BLE autoConnect GATT wait, which is
+  /// meaningless for a Classic adapter (the Classic facade has no
+  /// autoConnect, and a BLE `channelForDirect` would only 4 s-timeout). For
+  /// a Classic drop the cheap "wait" is instead a single bounded
+  /// `connectByMacClassicDirect` retry — same paced cadence the scanner
+  /// drives, but over the transport that can actually reconnect.
   Future<bool> attemptPassive(String mac) async {
     try {
-      final svc = await connection.connectByMacPassive(mac);
+      final svc = _isClassicDrop
+          ? await connection.connectByMacClassicDirect(mac)
+          : await connection.connectByMacPassive(mac);
       if (svc != null) {
         onConnected(svc);
         return true;

--- a/lib/features/consumption/data/obd2/reconnect_rssi_gate.dart
+++ b/lib/features/consumption/data/obd2/reconnect_rssi_gate.dart
@@ -27,13 +27,27 @@
 /// When [lastSuccessfulRssi] is null (no successful connect recorded
 /// yet this session) there is no relative baseline, so the decision
 /// falls back to the consecutive-batches rule alone.
+///
+/// #2565 — Bluetooth **Classic** has no RSSI: a bonded device is reported by
+/// the OS exactly once per scan window with [seenRssi] pinned at the `0`
+/// sentinel (`ClassicBluetoothFacade` sets `rssi: 0`). Intervening BLE
+/// batches reset the consecutive-batch counter, so a bonded Classic adapter
+/// would never reach the two-consecutive-batches rule — the storm signature.
+/// A bonded sighting is, by definition, in range and reachable, so when
+/// [transportHint] is `'classic'` AND the sentinel RSSI is seen, the gate
+/// passes on the FIRST batch. This is scoped to the Classic transport only —
+/// a real BLE adapter never reports a 0 dBm RSSI, so the BLE gate is unchanged.
 bool shouldConnectFromScan({
   required int? lastSuccessfulRssi,
   required int seenRssi,
   required int consecutiveBatchesSeen,
+  String? transportHint,
   int relativeDropDbm = 15,
   int requiredConsecutiveBatches = 2,
 }) {
+  // #2565 — a bonded Classic sighting (no RSSI; the `0` sentinel) is in range
+  // by construction: connect on the first batch, never wait for a second one.
+  if (transportHint == 'classic' && seenRssi == 0) return true;
   final seenEnoughTimes = consecutiveBatchesSeen >= requiredConsecutiveBatches;
   if (lastSuccessfulRssi == null) return seenEnoughTimes;
   final strongEnough = seenRssi >= lastSuccessfulRssi - relativeDropDbm;

--- a/lib/features/consumption/providers/obd2_recording_pipeline.dart
+++ b/lib/features/consumption/providers/obd2_recording_pipeline.dart
@@ -3,17 +3,13 @@
 
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/logging/error_logger.dart';
 import '../../../core/sync/trips_sync_enabled_provider.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
-import '../data/obd2/adapter_reconnect_scanner.dart';
-import '../data/obd2/obd2_connection_service.dart';
 import '../data/obd2/obd2_service.dart';
 import '../data/obd2/obd2_session_context_block.dart';
-import '../data/obd2/reconnect_connector.dart';
 import '../data/obd2/trip_recording_controller.dart';
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/entities/trip_save_stage.dart';
@@ -23,6 +19,7 @@ import '../domain/trip_recorder.dart';
 import 'obd2_breadcrumb_provider.dart';
 import 'obd2_controller_phase_mapper.dart';
 import 'recording_pipeline.dart';
+import 'reconnect_scanner_factory.dart';
 import 'reference_vehicle_match.dart';
 import 'trip_baseline_recorder.dart';
 import 'trip_gps_stream_controller.dart';
@@ -159,7 +156,17 @@ class Obd2RecordingPipeline implements RecordingPipeline {
       automatic: automatic,
       // #2459 — diagnostic capture (Feature.debugMode); default off.
       diagnosticCapture: _readDiagnosticCaptureFlag(),
-      reconnectScannerFactory: _buildReconnectScannerFactory(),
+      reconnectScannerFactory: buildReconnectScannerFactory(
+        ref: _ref,
+        onConnected: (svc) {
+          _service = svc;
+          _controller?.replaceService(svc);
+        },
+        // #2565 — read the live transport kind at handle-drop time so the
+        // reconnect dispatches over the SAME transport that dropped. The
+        // dead-but-typed service is still wired here.
+        readLinkKind: () => _service?.linkKind,
+      ),
       breadcrumbCollector: breadcrumbs,
       gpsEstimateFolder: gpsEstimateFolder,
     );
@@ -357,47 +364,4 @@ class Obd2RecordingPipeline implements RecordingPipeline {
     );
   }
 
-  /// Build the reconnect-scanner factory handed to [TripRecordingController]
-  /// (#797 phase 3). Returns null in tests / environments where
-  /// [obd2ConnectionProvider] can't be resolved — the controller then
-  /// falls back to grace-window-only recovery.
-  AdapterReconnectScanner? Function(
-    String pinnedMac,
-    VoidCallback onReconnect,
-  )? _buildReconnectScannerFactory() {
-    final Obd2ConnectionService connection;
-    try {
-      connection = _ref.read(obd2ConnectionProvider);
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {
-        'where': 'Obd2RecordingPipeline: connection provider unavailable'
-      }));
-      return null;
-    }
-    return (pinnedMac, onReconnect) {
-      // One connector per drop holds the gate bookkeeping across the
-      // scanner's repeated connect cycles. The connect callback prefers a
-      // DIRECT GATT connect (works for clones that stop advertising in
-      // standby) and only falls back to an RSSI-gated scan (#2245).
-      // #2524 — swap the pipeline's pointer (so stop() tears down the LIVE
-      // svc) AND the controller's via `replaceService` (so the loop polls the
-      // reconnected transport, not the closed one). See `replaceService`.
-      final connector = ReconnectConnector(
-        connection: connection,
-        onConnected: (svc) {
-          _service = svc;
-          _controller?.replaceService(svc);
-        },
-      );
-      return AdapterReconnectScanner(
-        pinnedMac: pinnedMac,
-        probe: (mac) async => true,
-        connect: connector.attempt,
-        // #2261 concern 2 — after the active-scan miss ceiling switch to a
-        // passive autoConnect GATT wait for the rest of the 15-min grace.
-        passiveConnect: connector.attemptPassive,
-        onReconnect: onReconnect,
-      );
-    };
-  }
 }

--- a/lib/features/consumption/providers/reconnect_scanner_factory.dart
+++ b/lib/features/consumption/providers/reconnect_scanner_factory.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/logging/error_logger.dart';
+import '../data/obd2/adapter_reconnect_scanner.dart';
+import '../data/obd2/obd2_connection_service.dart';
+import '../data/obd2/obd2_service.dart';
+import '../data/obd2/reconnect_connector.dart';
+
+/// Build the reconnect-scanner factory handed to `TripRecordingController`
+/// (#797 phase 3), extracted out of `Obd2RecordingPipeline` as a free
+/// function so threading the live transport kind through the connector keeps
+/// the pipeline under the #1680 file-length cap (sanctioned #2190
+/// decomposition — move-only, behaviour preserved + the #2565 hint thread).
+///
+/// Returns null in tests / environments where [obd2ConnectionProvider] can't
+/// be resolved — the controller then falls back to grace-window-only
+/// recovery.
+///
+/// [onConnected] is invoked with the freshly-reconnected service so the
+/// pipeline can swap its `_service` pointer AND the controller's via
+/// `replaceService` (#2524). [readLinkKind] reads the (dead-but-typed) live
+/// service's `linkKind` at handle-drop time so the connector dispatches the
+/// reconnect over the SAME transport that just dropped (#2565) — a Classic
+/// adapter reconnects over RFCOMM, not a doomed 4 s BLE GATT timeout.
+AdapterReconnectScanner? Function(
+  String pinnedMac,
+  VoidCallback onReconnect,
+)? buildReconnectScannerFactory({
+  required Ref ref,
+  required void Function(Obd2Service service) onConnected,
+  required String? Function() readLinkKind,
+}) {
+  final Obd2ConnectionService connection;
+  try {
+    connection = ref.read(obd2ConnectionProvider);
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.providers, e, st, context: const {
+      'where': 'Obd2RecordingPipeline: connection provider unavailable'
+    }));
+    return null;
+  }
+  return (pinnedMac, onReconnect) {
+    // One connector per drop holds the gate bookkeeping across the
+    // scanner's repeated connect cycles. The connect callback prefers a
+    // DIRECT connect over the LIVE transport kind (#2565) — Classic goes
+    // straight to RFCOMM, BLE keeps its direct-GATT-first path (#2245) —
+    // and only falls back to a transport-aware RSSI-gated scan.
+    // #2524 — swap the pipeline's pointer (so stop() tears down the LIVE
+    // svc) AND the controller's via `replaceService` (so the loop polls the
+    // reconnected transport, not the closed one).
+    final connector = ReconnectConnector(
+      connection: connection,
+      onConnected: onConnected,
+      // #2565 — the transport kind ('ble'/'classic') of the link that just
+      // dropped, read off the dead service. Null when unknown ⇒ the legacy
+      // BLE-direct-first path (behaviour unchanged for BLE adapters).
+      transportHint: readLinkKind(),
+    );
+    return AdapterReconnectScanner(
+      pinnedMac: pinnedMac,
+      probe: (mac) async => true,
+      connect: connector.attempt,
+      // #2261 concern 2 — after the active-scan miss ceiling switch to a
+      // passive autoConnect GATT wait for the rest of the 15-min grace.
+      passiveConnect: connector.attemptPassive,
+      onReconnect: onReconnect,
+    );
+  };
+}

--- a/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
+++ b/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
@@ -362,5 +362,51 @@ void main() {
         await scanner.stop();
       });
     });
+
+    group('classic-direct reconnect pacing (#2565)', () {
+      test(
+          'repeated classic-direct failures still pace via the existing '
+          'backoff (no flood) and self-stop on success', () async {
+        // The scanner is transport-agnostic: it drives `connect`, which for a
+        // classic drop is `ReconnectConnector.attempt` routing over
+        // `connectByMacClassicDirect`. Repeated failures must NOT flood — the
+        // existing exponential backoff paces them — and a later success must
+        // self-stop the scanner exactly as the BLE path does.
+        var connectCalls = 0;
+        var reconnects = 0;
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'cc:dd',
+          probe: (_) async => true, // always in range
+          connect: (_) async {
+            connectCalls++;
+            // First three classic-direct attempts fail; the fourth lands.
+            return connectCalls >= 4;
+          },
+          onReconnect: () => reconnects++,
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+
+        // The backoff must escalate across the three failures (pacing /
+        // no-flood) before the fourth attempt succeeds.
+        await _waitFor(
+            () => connectCalls >= 2 && scanner.currentBackoff >= _kInitial * 2,
+            timeout: const Duration(seconds: 3));
+        expect(scanner.currentBackoff, greaterThanOrEqualTo(_kInitial * 2),
+            reason: 'repeated classic-direct failures must back off, not '
+                'flood — the same bounded schedule as the BLE path');
+
+        await _waitFor(() => reconnects > 0,
+            timeout: const Duration(seconds: 3));
+        expect(connectCalls, greaterThanOrEqualTo(4));
+        expect(reconnects, 1);
+        expect(scanner.isScanning, isFalse,
+            reason: 'a successful classic-direct reconnect self-stops the '
+                'scanner, exactly like BLE');
+        await scanner.stop();
+      });
+    });
   });
 }

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -543,6 +543,103 @@ void main() {
     });
   });
 
+  group('Obd2ConnectionService.connectByMacClassicDirect (#2565)', () {
+    test(
+        'builds a ClassicElmChannel via the classic facade + runs init with '
+        "linkKind=='classic'; NEVER touches the BLE facade", () async {
+      // The transport-correct in-trip reconnect for a Classic adapter
+      // (vLinker FS): RFCOMM via the classic facade, no BLE GATT 4 s timeout.
+      final classicChannel = _FakeChannel(respondTo: _elmOkResponses());
+      final classicFake = _FakeClassicFacade(
+        batches: const [[]],
+        channel: classicChannel,
+      );
+      final ble = _FakeFacade(
+        // Non-empty batch + a direct channel: if the classic path ever fell
+        // through to BLE scan / direct, it would be observable here.
+        batches: [
+          [
+            Obd2AdapterCandidate(
+              deviceId: 'cc:dd',
+              deviceName: 'vLinker FS 14884',
+              advertisedServiceUuids: const [],
+              rssi: 0,
+            ),
+          ],
+        ],
+        directChannel: _FakeChannel(respondTo: _elmOkResponses()),
+      );
+      final svc = Obd2ConnectionService(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _FakePermissions(Obd2PermissionState.granted),
+        bluetooth: ble,
+        classicBluetooth: classicFake,
+      );
+
+      final ready = await svc.connectByMacClassicDirect('cc:dd');
+
+      expect(ready, isNotNull);
+      expect(ready!.isConnected, isTrue);
+      expect(ready.linkKind, 'classic',
+          reason: 'a classic-direct reconnect stamps the classic link kind');
+      expect(classicFake.channelForCalls, ['cc:dd'],
+          reason: 'the channel must be built via the CLASSIC facade (RFCOMM)');
+      expect(classicChannel.openCalls, 1);
+      // The defect this fixes: a Classic reconnect must NEVER take the BLE
+      // direct path (the 4 s `Timed out after 4s` storm signature).
+      expect(ble.directCalls, 0,
+          reason: 'classic-direct must NOT call the BLE channelForDirect');
+      expect(ble.scanInvoked, isFalse,
+          reason: 'classic-direct does not scan — the caller owns the scan');
+      await ready.disconnect();
+    });
+
+    test('returns null (no throw) when no classic facade is wired', () async {
+      // BLE-only configs / unit harnesses: the caller falls through to its
+      // own transport-aware scan fallback.
+      final ble = _FakeFacade(
+        batches: const [[]],
+        directChannel: _FakeChannel(respondTo: _elmOkResponses()),
+      );
+      final svc = Obd2ConnectionService(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _FakePermissions(Obd2PermissionState.granted),
+        bluetooth: ble,
+        // classicBluetooth: null
+      );
+
+      final ready = await svc.connectByMacClassicDirect('cc:dd');
+      expect(ready, isNull);
+      expect(ble.directCalls, 0,
+          reason: 'a missing classic facade must NOT fall back to BLE direct');
+      expect(ble.scanInvoked, isFalse);
+    });
+
+    test('returns null when the classic init fails — never touches BLE',
+        () async {
+      // Silent channel ⇒ the transport init times out ⇒ the recoverable
+      // attempt returns null (the scanner re-arms), never a BLE fallback.
+      final ble = _FakeFacade(
+        batches: const [[]],
+        directChannel: _FakeChannel(respondTo: _elmOkResponses()),
+      );
+      final svc = Obd2ConnectionService(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _FakePermissions(Obd2PermissionState.granted),
+        bluetooth: ble,
+        classicBluetooth: _FakeClassicFacade(
+          batches: const [[]],
+          channel: _FakeChannel(silent: true),
+        ),
+      );
+
+      final ready = await svc.connectByMacClassicDirect('cc:dd');
+      expect(ready, isNull);
+      expect(ble.directCalls, 0);
+      expect(ble.scanInvoked, isFalse);
+    }, timeout: const Timeout(Duration(seconds: 30)));
+  });
+
   group('Obd2ConnectionService.connectByMacPassive (#2261 concern 2)', () {
     test(
         'opens an autoConnect channel, NO scan, NO bounded timeout, '

--- a/test/features/consumption/data/obd2/reconnect_connector_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_connector_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_bluetooth_facade.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
@@ -151,14 +152,197 @@ void main() {
       expect(connected, isNull);
     });
   });
+
+  group('ReconnectConnector — transport-aware reconnect (#2565)', () {
+    test(
+        "transportHint=='classic' ⇒ attempt() classic-directs FIRST and "
+        'NEVER takes the BLE direct path', () async {
+      // The root cause: a Classic adapter (vLinker FS) was reconnecting over
+      // BLE `channelForDirect` → 4 s timeout storm. The classic-direct path
+      // must run instead, and the BLE direct path must never be touched.
+      final classicChannel = _FakeChannel(respondTo: _elmOk());
+      final classicFake = _FakeClassicFacade(channel: classicChannel);
+      final ble = _FakeFacade(
+        // A non-empty batch + a direct channel: if the classic path ever
+        // fell through to BLE direct / scan it would be observable here.
+        directChannel: _FakeChannel(respondTo: _elmOk()),
+        batches: [
+          [_cand('cc:dd', 0)],
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classicFake),
+        onConnected: (s) => connected = s,
+        transportHint: 'classic',
+      );
+
+      final ok = await connector.attempt('cc:dd');
+
+      expect(ok, isTrue);
+      expect(connected, isNotNull);
+      expect(connected!.linkKind, 'classic');
+      expect(classicFake.channelForCalls, ['cc:dd'],
+          reason: 'reconnect must go over the live (classic) transport');
+      expect(ble.directCalls, 0,
+          reason: 'NEVER the doomed BLE direct path for a classic adapter');
+      expect(ble.scanInvoked, isFalse,
+          reason: 'a successful classic-direct connect must NOT scan');
+      await connected!.disconnect();
+    });
+
+    test(
+        "transportHint=='classic' + classic-direct fails ⇒ goes STRAIGHT to "
+        'the transport-aware scan (no BLE direct attempt)', () async {
+      // Classic-direct init fails (silent channel), so the connector must
+      // fall to the merged BLE+Classic scan. The bonded classic candidate
+      // (rssi==0) passes the gate on the FIRST batch (#2565 RSSI hardening),
+      // and the connect routes through the classic facade. The BLE direct
+      // path must never be attempted.
+      final scanChannel = _FakeChannel(respondTo: _elmOk());
+      final classicFake = _FakeClassicFacade(
+        // First channelFor (direct) is silent → init times out; the scan
+        // path's connect() then builds a fresh channel that answers OK.
+        channels: [
+          _FakeChannel(silent: true), // classic-direct: fails init
+          scanChannel, // scan-path connect: succeeds
+        ],
+        // The bonded classic adapter ('vLinker FS' resolves to the Classic
+        // profile, rssi==0 sentinel) — seen ONCE; the #2565 gate connects it
+        // on the first batch.
+        batches: [
+          [_classicCand('cc:dd')],
+        ],
+      );
+      final ble = _FakeFacade(
+        directChannel: _FakeChannel(respondTo: _elmOk()),
+        batches: const [[]],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classicFake),
+        onConnected: (s) => connected = s,
+        transportHint: 'classic',
+      );
+
+      final ok = await connector.attempt('cc:dd');
+
+      expect(ok, isTrue,
+          reason: 'the merged scan recovers the classic adapter');
+      expect(connected, isNotNull);
+      expect(connected!.linkKind, 'classic');
+      expect(ble.directCalls, 0,
+          reason: 'a failed classic-direct must NOT fall to BLE direct — '
+              'straight to the transport-aware scan');
+      expect(classicFake.scanInvoked, isTrue,
+          reason: 'the fallback is the merged BLE+Classic scan');
+      await connected!.disconnect();
+    }, timeout: const Timeout(Duration(seconds: 30)));
+
+    test(
+        "transportHint=='ble' keeps the existing BLE-direct-first path",
+        () async {
+      // Regression-lock: a BLE drop is unchanged — direct GATT first,
+      // never the classic facade.
+      final classicFake = _FakeClassicFacade(channel: _FakeChannel(silent: true));
+      final ble = _FakeFacade(
+        directChannel: _FakeChannel(respondTo: _elmOk()),
+        batches: [
+          [_cand('aa:bb', -55)],
+        ],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classicFake),
+        onConnected: (s) => connected = s,
+        transportHint: 'ble',
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isTrue);
+      expect(ble.directCalls, 1,
+          reason: 'BLE drop ⇒ BLE direct first (unchanged)');
+      expect(classicFake.channelForCalls, isEmpty,
+          reason: 'a BLE drop never touches the classic facade');
+      expect(ble.scanInvoked, isFalse);
+      await connected!.disconnect();
+    });
+
+    test(
+        'attemptPassive for a classic drop bounded-retries classic-direct, '
+        'never a BLE autoConnect wait (#2565)', () async {
+      final classicFake = _FakeClassicFacade(channel: _FakeChannel(respondTo: _elmOk()));
+      final ble = _FakeFacade(
+        directChannel: _FakeChannel(respondTo: _elmOk()),
+        batches: const [[]],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classicFake),
+        onConnected: (s) => connected = s,
+        transportHint: 'classic',
+      );
+
+      final ok = await connector.attemptPassive('cc:dd');
+
+      expect(ok, isTrue);
+      expect(connected!.linkKind, 'classic');
+      expect(classicFake.channelForCalls, ['cc:dd']);
+      expect(ble.passiveCalls, 0,
+          reason: 'a classic drop must NOT open a BLE autoConnect channel');
+      expect(ble.directCalls, 0);
+      await connected!.disconnect();
+    });
+  });
+}
+
+class _FakeClassicFacade implements ClassicBluetoothFacade {
+  final List<List<Obd2AdapterCandidate>> batches;
+  final ElmByteChannel? channel;
+
+  /// Per-call channel sequence — lets the direct attempt fail (silent) and
+  /// the scan-path connect succeed with a fresh channel.
+  final List<ElmByteChannel>? channels;
+  int _i = 0;
+
+  final List<String> channelForCalls = [];
+  bool scanInvoked = false;
+
+  _FakeClassicFacade({this.batches = const [], this.channel, this.channels});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    scanInvoked = true;
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId) {
+    channelForCalls.add(deviceId);
+    if (channels != null) return channels![_i++];
+    return channel ?? _FakeChannel(silent: true);
+  }
 }
 
 // --- helpers ---------------------------------------------------------
 
-Obd2ConnectionService _build(BluetoothFacade bt) => Obd2ConnectionService(
+Obd2ConnectionService _build(
+  BluetoothFacade bt, {
+  ClassicBluetoothFacade? classic,
+}) =>
+    Obd2ConnectionService(
       registry: Obd2AdapterRegistry.defaults(),
       permissions: _GrantPermissions(),
       bluetooth: bt,
+      classicBluetooth: classic,
     );
 
 Obd2AdapterCandidate _cand(String mac, int rssi) => Obd2AdapterCandidate(
@@ -166,6 +350,16 @@ Obd2AdapterCandidate _cand(String mac, int rssi) => Obd2AdapterCandidate(
       deviceName: 'vLinker FD',
       advertisedServiceUuids: const [],
       rssi: rssi,
+    );
+
+/// A bonded Bluetooth-Classic sighting: the `vLinker FS` name resolves to
+/// the `vlinker-fs-classic` profile, and Classic enumeration carries no
+/// RSSI (the `0` sentinel) (#2565).
+Obd2AdapterCandidate _classicCand(String mac) => Obd2AdapterCandidate(
+      deviceId: mac,
+      deviceName: 'vLinker FS',
+      advertisedServiceUuids: const [],
+      rssi: 0,
     );
 
 Map<String, String> _elmOk() => {

--- a/test/features/consumption/data/obd2/reconnect_rssi_gate_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_rssi_gate_test.dart
@@ -93,6 +93,54 @@ void main() {
       );
     });
 
+    test(
+        'a bonded Classic sighting (rssi==0 sentinel, hint=classic) passes '
+        'on the FIRST batch (#2565)', () {
+      // Bluetooth Classic has no RSSI: the bonded-device enumeration pins
+      // it at the 0 sentinel and surfaces it once per scan window. Without
+      // the hint it would have to wait for a 2nd consecutive batch (which
+      // intervening BLE batches keep resetting) — the storm signature.
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: null,
+          seenRssi: 0, // Classic bonded sentinel
+          consecutiveBatchesSeen: 1, // seen exactly once
+          transportHint: 'classic',
+        ),
+        isTrue,
+        reason: 'a bonded Classic adapter is in range by construction — '
+            'connect on the first sighting, never wait for a second batch',
+      );
+    });
+
+    test(
+        'the Classic first-batch shortcut does NOT leak into the BLE gate '
+        '(#2565)', () {
+      // A BLE adapter never reports a 0 dBm RSSI, but even if seenRssi were
+      // 0 with a BLE / null hint the legacy gate must still apply (no
+      // baseline + seen once ⇒ skip).
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: null,
+          seenRssi: 0,
+          consecutiveBatchesSeen: 1,
+          transportHint: 'ble',
+        ),
+        isFalse,
+        reason: 'the first-batch shortcut is Classic-only — BLE keeps the '
+            'two-consecutive-batches rule',
+      );
+      expect(
+        shouldConnectFromScan(
+          lastSuccessfulRssi: null,
+          seenRssi: 0,
+          consecutiveBatchesSeen: 1,
+          // No transportHint at all — the legacy callers pass none.
+        ),
+        isFalse,
+      );
+    });
+
     test('honours custom thresholds', () {
       // Tighten the window to 5 dBm: a 10 dBm drop now fails the
       // relative gate and, seen once, is skipped.


### PR DESCRIPTION
## Problem (flapping half of #2565 — reconnect storm)

A vLinker FS (Bluetooth **Classic** SPP) auto-record trip ends paused with a
reconnect storm: `connectSucceeded` → `dropDetected` within ~1s, then
`connectFailed: FlutterBluePlusException | connect | fbp-code:1 | Timed out
after 4s`, repeating until `Obd2AdapterUnresponsive`.

## Root cause (adversarially confirmed vs origin/master)

The **initial** connect is transport-correct (scan dispatches on
`candidate.profile.transport` → `classicBluetooth.channelFor` → RFCOMM). But the
**in-trip reconnect** was hard-coded BLE with no transport awareness:
`ReconnectConnector.attempt` → `connectByMacDirect(fallbackToScan:false)`, and
`connectByMac{Direct,Passive}` **unconditionally** built a BLE channel via
`bluetooth.channelForDirect(mac)` with a 4 s timeout. For a Classic adapter that
can only ever time out — the exact field signature. The scan fallback *could*
route Classic but was unreliable: a bonded Classic device yields the MAC once at
`rssi:0`, while the RSSI gate needed it across ≥2 consecutive batches
(intervening BLE batches reset the counter).

## Fix (root, not band-aid)

1. **Thread the live transport kind into reconnect.** The pipeline reads
   `_service.linkKind` ('ble'/'classic') at handle-drop time and passes it as a
   new `transportHint` to `ReconnectConnector`.
2. **Classic direct-by-MAC path** `connectByMacClassicDirect`: resolves the
   Classic profile, opens `classicBluetooth.channelFor(mac)` (RFCOMM), runs the
   SAME `_openAndInit(linkKind:'classic')`. Null when no Classic facade (tests)
   → caller falls through to scan. **Never** calls `bluetooth.channelForDirect`
   (no doomed 4 s BLE timeout).
3. **Dispatch on the hint** in `ReconnectConnector`: a Classic drop
   classic-directs FIRST, then goes STRAIGHT to the transport-aware merged scan
   on failure (skips the impossible BLE direct); `attemptPassive` bounded-retries
   classic-direct instead of a meaningless BLE autoConnect wait. 'ble'/null keep
   the existing BLE-direct-first path unchanged.
4. **Harden the RSSI gate**: a bonded Classic sighting (rssi==0 sentinel,
   hint=='classic') passes on the FIRST batch. Scoped to Classic — the BLE gate
   is untouched.
5. Bounded backoff, miss-ceiling→passive, dead-transport teardown, and drop
   classification are left AS-IS (correct) — the only defect was the
   impossible-BLE reconnect.

## Extractions (sanctioned #2190 decomposition — move-only)

`obd2_connection_service.dart` and `obd2_recording_pipeline.dart` were both at
400/400, so behaviour-preserving extraction was done FIRST to make room (run
green before adding behaviour):
- the by-MAC connect family → new `obd2_connect_by_mac.dart` (a `part`, so it
  keeps private-member access),
- `_buildReconnectScannerFactory` → new `reconnect_scanner_factory.dart` (free
  function taking ref/onConnected/readLinkKind).

Touched-file line counts (effective, cap 400): service **316**, pipeline
**364**, connect-by-mac **155**, scanner-factory **72**, connector **169**,
rssi-gate **52**.

## Tests
- `reconnect_connector_test.dart`: classic drop → classic-directs FIRST, never
  BLE direct; success → onConnected+true; failure → straight to transport-aware
  scan (no BLE direct); 'ble' regression-locked; passive classic-retry.
- `obd2_connection_service_test.dart`: `connectByMacClassicDirect` builds a
  ClassicElmChannel + `linkKind=='classic'`; null facade → null (no throw); never
  touches the BLE facade.
- `reconnect_rssi_gate_test.dart`: bonded Classic sighting passes on the first
  batch; shortcut doesn't leak into the BLE gate.
- `adapter_reconnect_scanner_test.dart`: repeated classic-direct failures still
  pace via the existing backoff (no flood) + self-stop on success.

No user-facing strings added. **Part of #2565** — the GPS-degrade half is a
follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
