### PR TITLE
fix(trip-radar): retain last station during rescan (colour-only) + only priced-for-fuel stations (#2583)

### DIFF
--- a/lib/features/approach/providers/nearest_station_radar_provider.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.dart
@@ -1,10 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:collection/collection.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/services/approach_detector.dart';
 import '../../../core/services/service_providers.dart';
+import '../../../core/utils/station_extensions.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
@@ -28,9 +30,12 @@ part 'nearest_station_radar_provider.g.dart';
 ///   approach state, so the fallback stays out of the way.
 /// - `null` when the state is [ApproachIdle] / null (no GPS fix yet) —
 ///   the card shows its "scanning" placeholder.
-/// - the nearest [Station] (sorted by distance) for an
-///   [ApproachPolling] fix, or `null` when the search chain returns
-///   nothing in range.
+/// - the nearest [Station] **that has a price for the effective fuel**
+///   (the distance-sorted list filtered to `priceFor(fuel) > 0`) for an
+///   [ApproachPolling] fix, or `null` when nothing in range is priced
+///   for the driver's fuel (#2583). Unpriced nearest stations are
+///   skipped so the card only ever surfaces a station the driver can
+///   actually price-compare — never a `--` placeholder price.
 ///
 /// The lookup mirrors the detector's own `fetchStations` callback
 /// ([approachStateProvider]) — same `searchStations` chain, same
@@ -61,7 +66,14 @@ Future<Station?> nearestStationRadar(Ref ref) async {
         sortBy: SortBy.distance,
       ),
     );
-    return result.data.isEmpty ? null : result.data.first;
+    // The list is already distance-sorted; surface the nearest station
+    // that actually carries a price for the effective fuel (a non-null,
+    // positive [priceFor]) so the card never shows a `--` price the
+    // driver can't compare (#2583). `null` when none in range is priced.
+    return result.data.firstWhereOrNull((s) {
+      final price = s.priceFor(fuel);
+      return price != null && price > 0;
+    });
   } on Object {
     // Network / chain failure — treat as "no station nearby". The
     // provider re-runs on the next approach-state tick.

--- a/lib/features/approach/providers/nearest_station_radar_provider.g.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.g.dart
@@ -24,9 +24,12 @@ part of 'nearest_station_radar_provider.dart';
 ///   approach state, so the fallback stays out of the way.
 /// - `null` when the state is [ApproachIdle] / null (no GPS fix yet) —
 ///   the card shows its "scanning" placeholder.
-/// - the nearest [Station] (sorted by distance) for an
-///   [ApproachPolling] fix, or `null` when the search chain returns
-///   nothing in range.
+/// - the nearest [Station] **that has a price for the effective fuel**
+///   (the distance-sorted list filtered to `priceFor(fuel) > 0`) for an
+///   [ApproachPolling] fix, or `null` when nothing in range is priced
+///   for the driver's fuel (#2583). Unpriced nearest stations are
+///   skipped so the card only ever surfaces a station the driver can
+///   actually price-compare — never a `--` placeholder price.
 ///
 /// The lookup mirrors the detector's own `fetchStations` callback
 /// ([approachStateProvider]) — same `searchStations` chain, same
@@ -52,9 +55,12 @@ final nearestStationRadarProvider = NearestStationRadarProvider._();
 ///   approach state, so the fallback stays out of the way.
 /// - `null` when the state is [ApproachIdle] / null (no GPS fix yet) —
 ///   the card shows its "scanning" placeholder.
-/// - the nearest [Station] (sorted by distance) for an
-///   [ApproachPolling] fix, or `null` when the search chain returns
-///   nothing in range.
+/// - the nearest [Station] **that has a price for the effective fuel**
+///   (the distance-sorted list filtered to `priceFor(fuel) > 0`) for an
+///   [ApproachPolling] fix, or `null` when nothing in range is priced
+///   for the driver's fuel (#2583). Unpriced nearest stations are
+///   skipped so the card only ever surfaces a station the driver can
+///   actually price-compare — never a `--` placeholder price.
 ///
 /// The lookup mirrors the detector's own `fetchStations` callback
 /// ([approachStateProvider]) — same `searchStations` chain, same
@@ -81,9 +87,12 @@ final class NearestStationRadarProvider
   ///   approach state, so the fallback stays out of the way.
   /// - `null` when the state is [ApproachIdle] / null (no GPS fix yet) —
   ///   the card shows its "scanning" placeholder.
-  /// - the nearest [Station] (sorted by distance) for an
-  ///   [ApproachPolling] fix, or `null` when the search chain returns
-  ///   nothing in range.
+  /// - the nearest [Station] **that has a price for the effective fuel**
+  ///   (the distance-sorted list filtered to `priceFor(fuel) > 0`) for an
+  ///   [ApproachPolling] fix, or `null` when nothing in range is priced
+  ///   for the driver's fuel (#2583). Unpriced nearest stations are
+  ///   skipped so the card only ever surfaces a station the driver can
+  ///   actually price-compare — never a `--` placeholder price.
   ///
   /// The lookup mirrors the detector's own `fetchStations` callback
   /// ([approachStateProvider]) — same `searchStations` chain, same
@@ -115,4 +124,4 @@ final class NearestStationRadarProvider
 }
 
 String _$nearestStationRadarHash() =>
-    r'9922d973739e0321b79e5ddede5403fa25029a87';
+    r'04dd547eb264fa9dd992356631288e17eb4666fb';

--- a/lib/features/consumption/presentation/widgets/trip_radar_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_radar_card.dart
@@ -80,11 +80,23 @@ class TripRadarCard extends ConsumerWidget {
       );
     }
 
-    // 2. Fallback — nearest station off the live polling GPS.
+    // 2. Fallback — nearest priced station off the live polling GPS.
+    //
+    // `skipLoadingOnReload: true` routes a *re-run* (the provider goes
+    // AsyncLoading carrying its previous value via copyWithPrevious on
+    // every approach-state tick) back through `data:` with the retained
+    // station — so a rescan KEEPS the last station on screen instead of
+    // blanking it to the "Scanning…" placeholder (#2583). A genuine
+    // FIRST load (no prior value) still falls to `loading:`. The active
+    // scan is signalled by a COLOUR-only tint (`scanning`), never text
+    // and never a blanked row.
     final fallback = ref.watch(nearestStationRadarProvider);
+    final scanning = fallback.isLoading;
     return fallback.when(
+      skipLoadingOnReload: true,
       data: (station) {
         if (station == null) {
+          // A load COMPLETED with no priced station in range.
           return _RadarPlaceholder(
             title: l?.tripRadarClosestStation ?? 'Closest station',
             message: l?.tripRadarNoStationNearby ?? 'No station nearby',
@@ -99,8 +111,12 @@ class TripRadarCard extends ConsumerWidget {
           // in-radius layout's "… m away" caption.
           distanceMeters: station.dist > 0 ? station.dist * 1000.0 : null,
           live: false,
+          // Tint the leading icon while a rescan is in flight, keeping
+          // the retained station fully readable underneath (#2583).
+          scanning: scanning,
         );
       },
+      // FIRST load only (no retained value) — the row is genuinely empty.
       loading: () => _RadarPlaceholder(
         title: l?.tripRadarClosestStation ?? 'Closest station',
         message: l?.tripRadarScanning ?? 'Scanning for nearby stations',
@@ -126,12 +142,18 @@ class _RadarCard extends StatelessWidget {
   /// nearest-station fallback) — drives the leading icon emphasis.
   final bool live;
 
+  /// True while the fallback provider is re-running (a rescan). Signalled
+  /// by a COLOUR tint on the leading icon only — the retained station
+  /// stays fully readable, no text and no blanked row (#2583).
+  final bool scanning;
+
   const _RadarCard({
     required this.title,
     required this.station,
     required this.fuel,
     required this.distanceMeters,
     required this.live,
+    this.scanning = false,
   });
 
   @override
@@ -168,10 +190,15 @@ class _RadarCard extends StatelessWidget {
             station.lng,
             label: station.displayName,
           ),
+          // Leading icon doubles as the (colour-only) scan signal: an
+          // in-radius hit is the primary accent; a fallback rescan
+          // (`scanning`) tints the gas-station glyph to the primary
+          // accent too, so the driver sees the refresh without the row
+          // ever blanking or changing text (#2583).
           leading: Icon(
             live ? Icons.my_location : Icons.local_gas_station,
             size: 28,
-            color: live ? theme.colorScheme.primary : null,
+            color: (live || scanning) ? theme.colorScheme.primary : null,
           ),
           // Overline carries the localised card title; the prominent line
           // is the (data, not ARB) station name + the fuel/distance row.

--- a/test/features/approach/providers/nearest_station_radar_provider_test.dart
+++ b/test/features/approach/providers/nearest_station_radar_provider_test.dart
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/services/approach_detector.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/approach/providers/effective_approach_state_provider.dart';
+import 'package:tankstellen/features/approach/providers/nearest_station_radar_provider.dart';
+import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// #2583 — the nearest-station radar fallback must surface only stations
+/// the driver can actually price-compare: the nearest station that carries
+/// a non-null, positive price for the **effective** fuel, skipping any
+/// nearer but unpriced station rather than showing a `--` price.
+
+Position _pos({required double lat, required double lng}) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime(2026, 5, 1, 9),
+      accuracy: 5,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: 12,
+      speedAccuracy: 0,
+    );
+
+Station _station(String id, {double? e10, double? diesel, double dist = 0}) =>
+    Station(
+      id: id,
+      name: 'Station $id',
+      brand: 'Brand',
+      street: '',
+      postCode: '',
+      place: '',
+      lat: 48.0,
+      lng: 2.0,
+      e10: e10,
+      diesel: diesel,
+      dist: dist,
+      isOpen: true,
+    );
+
+/// Minimal [StationService] returning a fixed, distance-sorted result for
+/// `searchStations`. The other interface methods are unused by the radar
+/// provider and throw if hit.
+class _FakeStationService implements StationService {
+  _FakeStationService(this._stations);
+  final List<Station> _stations;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    return ServiceResult<List<Station>>(
+      data: _stations,
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026, 5, 1, 9),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String id) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
+ProviderContainer _container({
+  required List<Station> stations,
+  FuelType fuel = FuelType.e10,
+}) {
+  return ProviderContainer(
+    overrides: [
+      effectiveApproachStateProvider.overrideWithValue(
+        ApproachPolling(
+          gps: _pos(lat: 48.0, lng: 2.0),
+          nextPollIn: const Duration(seconds: 5),
+        ),
+      ),
+      effectiveFuelTypeProvider.overrideWithValue(fuel),
+      stationServiceProvider
+          .overrideWithValue(_FakeStationService(stations)),
+    ],
+  );
+}
+
+void main() {
+  test('skips the nearer UNPRICED station and returns the nearest PRICED one',
+      () async {
+    // The nearest (dist 0) has no e10 price; the next (dist 1.2) does.
+    final container = _container(
+      stations: [
+        _station('NEAR_UNPRICED', dist: 0, diesel: 1.65),
+        _station('FAR_PRICED', dist: 1.2, e10: 1.789),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final out = await container.read(nearestStationRadarProvider.future);
+    expect(out, isNotNull);
+    expect(out!.id, 'FAR_PRICED',
+        reason: 'unpriced nearest is skipped for the nearest priced station');
+  });
+
+  test('returns null when NO station in range is priced for the fuel',
+      () async {
+    final container = _container(
+      stations: [
+        _station('A', dist: 0, diesel: 1.65),
+        _station('B', dist: 2.0, diesel: 1.70),
+      ],
+      fuel: FuelType.e10,
+    );
+    addTearDown(container.dispose);
+
+    final out = await container.read(nearestStationRadarProvider.future);
+    expect(out, isNull,
+        reason: 'none priced for e10 → genuine "no station nearby"');
+  });
+
+  test('treats a non-positive price as unpriced (<= 0 skipped)', () async {
+    final container = _container(
+      stations: [
+        _station('ZERO', dist: 0, e10: 0),
+        _station('REAL', dist: 0.5, e10: 1.5),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final out = await container.read(nearestStationRadarProvider.future);
+    expect(out!.id, 'REAL', reason: 'a <= 0 price counts as no price');
+  });
+
+  test('returns the nearest priced station when the nearest IS priced',
+      () async {
+    final container = _container(
+      stations: [
+        _station('NEAR_PRICED', dist: 0, e10: 1.6),
+        _station('FAR_PRICED', dist: 3.0, e10: 1.5),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final out = await container.read(nearestStationRadarProvider.future);
+    expect(out!.id, 'NEAR_PRICED');
+  });
+
+  test('non-polling approach state → null (fallback stays out of the way)',
+      () async {
+    final container = ProviderContainer(
+      overrides: [
+        effectiveApproachStateProvider.overrideWithValue(null),
+        effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+        stationServiceProvider.overrideWithValue(
+          _FakeStationService([_station('X', e10: 1.5)]),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final out = await container.read(nearestStationRadarProvider.future);
+    expect(out, isNull);
+  });
+}

--- a/test/features/consumption/presentation/widgets/trip_radar_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_radar_card_test.dart
@@ -1,7 +1,10 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
@@ -12,6 +15,7 @@ import 'package:tankstellen/features/consumption/presentation/widgets/trip_radar
 import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
@@ -242,6 +246,145 @@ void main() {
       await tester.tap(find.byType(ListTile));
       await tester.pump();
       expect(fake.launchedUrls, isEmpty);
+    });
+  });
+
+  // --- #2583: retain last station during rescan (colour-only) ----------------
+  group('TripRadarCard — rescan retention + scanning tint (#2583)', () {
+    testWidgets(
+        'a reload KEEPS the last station (no "Scanning…") + shows the '
+        'scanning tint on the leading icon', (tester) async {
+      // Drive a genuine reload via `container.invalidate`: while the widget
+      // still watches it the FutureProvider re-runs, going AsyncLoading
+      // carrying its previous value. Under skipLoadingOnReload that routes
+      // the retained station back through `data:` while `isLoading` flips
+      // true (the colour-only scan signal). A short async gate keeps the
+      // re-run pending across a single pump so the in-flight frame is
+      // observable.
+      final gate = Completer<void>();
+      var firstRun = true;
+      final container = ProviderContainer(
+        overrides: [
+          effectiveApproachStateProvider.overrideWithValue(null),
+          effectiveFuelTypeProvider.overrideWithValue(FuelType.diesel),
+          nearestStationRadarProvider.overrideWith((ref) async {
+            if (firstRun) {
+              firstRun = false;
+              return _pricedStation;
+            }
+            // The reload waits on the gate so the loading frame is visible.
+            await gate.future;
+            return _pricedStation;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TripRadarCard()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // First scan resolved: the station row is up (the diesel price shows).
+      expect(find.text(PriceFormatter.formatPrice(1.659)), findsOneWidget);
+      expect(find.text('Scanning for nearby stations'), findsNothing);
+
+      // Trigger a reload — invalidate so the FutureProvider re-runs
+      // (AsyncLoading carrying the previous value); the gated body keeps it
+      // pending across this pump.
+      container.invalidate(nearestStationRadarProvider);
+      // Force the lazy re-computation to materialise now (the gated body
+      // keeps it pending) so the in-flight loading frame is deterministic.
+      expect(
+        container.read(nearestStationRadarProvider).isLoading,
+        isTrue,
+        reason: 'invalidate puts the provider into a reload (carrying value)',
+      );
+      await tester.pump(); // let the reload propagate (do NOT settle yet)
+
+      // During the in-flight rescan the row STILL shows the last station —
+      // never the "Scanning…" placeholder — and the leading icon is tinted
+      // to the primary "scanning" accent (colour-only signal).
+      expect(find.text('Scanning for nearby stations'), findsNothing);
+      expect(find.text(PriceFormatter.formatPrice(1.659)), findsOneWidget);
+
+      final theme = Theme.of(tester.element(find.byType(ListTile)));
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byType(ListTile),
+          matching: find.byIcon(Icons.local_gas_station),
+        ),
+      );
+      expect(icon.color, theme.colorScheme.primary,
+          reason: 'in-flight rescan tints the leading icon (colour signal)');
+
+      // Let the gated reload complete; the tint clears but the station stays.
+      gate.complete();
+      await tester.pumpAndSettle();
+      final settledIcon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byType(ListTile),
+          matching: find.byIcon(Icons.local_gas_station),
+        ),
+      );
+      expect(settledIcon.color, isNull,
+          reason: 'no tint once the rescan completes');
+      expect(find.text(PriceFormatter.formatPrice(1.659)), findsOneWidget);
+    });
+
+    testWidgets(
+        'first-ever load (no prior value) still shows the "Scanning…" '
+        'placeholder', (tester) async {
+      // A never-completing future keeps the AsyncValue in its FIRST loading
+      // state (no retained value) — the genuine cold start.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            effectiveApproachStateProvider.overrideWithValue(null),
+            effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+            nearestStationRadarProvider.overrideWith(
+              (ref) => Completer<Station?>().future,
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TripRadarCard()),
+          ),
+        ),
+      );
+      await tester.pump(); // single pump — the future never completes
+
+      expect(find.text('Scanning for nearby stations'), findsOneWidget);
+      // The cold-start placeholder is not tappable.
+      final tile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(tile.onTap, isNull);
+    });
+
+    testWidgets(
+        'a completed scan with NO priced station renders "No station '
+        'nearby"', (tester) async {
+      await pumpApp(
+        tester,
+        const TripRadarCard(),
+        overrides: [
+          effectiveApproachStateProvider.overrideWithValue(null),
+          effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+          // Provider already filters to priced-for-fuel; null models "no
+          // priced station in range".
+          nearestStationRadarProvider.overrideWith((ref) async => null),
+        ],
+      );
+
+      expect(find.text('No station nearby'), findsOneWidget);
+      expect(find.text('Scanning for nearby stations'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Problem (recording-screen "Closest station" radar card)

On every approach-state tick the radar fallback re-ran → `AsyncLoading` → the card blanked the previously-found station to a "Scanning for nearby stations" placeholder. It also surfaced the nearest station even when it had **no price for the driver's effective fuel** (the price column showed `--`).

## Fix (ARB-free — colour signal only, reuses existing strings)

**Provider (`nearestStationRadar`)** — return the nearest station that actually carries a price for the effective fuel:
```dart
result.data.firstWhereOrNull((s) {
  final price = s.priceFor(fuel);
  return price != null && price > 0;
});
```
over the already distance-sorted list, or `null` when none in range is priced (a genuine "No station nearby"). The 10 km window, effective fuel, `ApproachPolling` guard and `try/catch → null` are unchanged. A `<= 0` price counts as no price.

**Card (`TripRadarCard`)** — `fallback.when(skipLoadingOnReload: true, …)` so a *reload* routes the retained value back through `data:` → a rescan **keeps** the last station on screen instead of blanking it. The in-flight scan (`fallback.isLoading`) is threaded into `_RadarCard` as `scanning` and signalled **colour-only** by tinting the leading icon to the primary accent — no text, no blanked row. The "Scanning…" placeholder now appears **only** on the genuine first load (no prior value); "No station nearby" only when a load **completes** with `null`.

## Tests

- **Provider**: skips the nearer unpriced station for the nearest priced one; returns `null` when none priced; treats `<= 0` as unpriced; returns the nearest when it IS priced; non-polling state → `null`.
- **Widget**: a reload (`container.invalidate`) keeps the last station (no "Scanning…") and tints the leading icon to the primary accent during the in-flight scan, clearing once it settles; first-ever load (never-completing future) still shows "Scanning…"; a completed scan with no priced station renders "No station nearby".
- `flutter test test/features/consumption/ test/features/approach/` — all green.

## Gates

- `flutter analyze` clean (only the pre-existing `unnecessary_import` info in an untouched file).
- file-length + no-hardcoded-strings lint tests pass.
- Clean codegen (HARD RULE #3): only the expected `nearest_station_radar_provider.g.dart` hash + doc-comment drift, committed.
- **Zero `lib/l10n` diff — ARB-free.**

Closes #2583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
