### PR TITLE
ci(app-store): add workflow_dispatch deliver pipeline for the App Store listing

### DIFF
--- a/.github/workflows/app-store-listing.yml
+++ b/.github/workflows/app-store-listing.yml
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: App Store listing
+
+# Pushes the iOS text metadata under ios/fastlane/metadata/<locale>/ to App
+# Store Connect via `fastlane deliver`, WITHOUT rebuilding or uploading a
+# binary. The mirror of `play-store-listing.yml` for Apple.
+#
+# Triggers: workflow_dispatch ONLY. Unlike Play, Apple listing changes are
+# tied to a specific app version + the review process, so a push-triggered
+# auto-publish is too risky — the maintainer dispatches this manually.
+#
+# Safety: `ios/fastlane/Deliverfile` is configured so `deliver` can only ever
+# stage TEXT metadata — submit_for_review(false), automatic_release(false),
+# skip_binary_upload(true), skip_screenshots(true). This workflow passes the
+# same flags explicitly. `submit_for_review` is only ever set true when the
+# `submit` input is explicitly true; the default is a no-op dry run.
+#
+# PREREQUISITE: `deliver` can only update localized metadata when the app has
+# a version in the "Prepare for Submission" state in App Store Connect. If no
+# such editable version exists, the run fails with a clear App Store Connect
+# error (e.g. "Could not find an editable version"). Create/edit a version in
+# App Store Connect first, then dispatch this workflow. See
+# docs/guides/app-store-listing.md.
+#
+# Secrets required (App Store Connect API key — same as ios-testflight.yml):
+# - APP_STORE_CONNECT_API_KEY_BASE64  base64 of the .p8 key file
+# - APP_STORE_CONNECT_API_KEY_ID      the key's Key ID
+# - APP_STORE_CONNECT_API_ISSUER_ID   the issuer ID
+#
+# Screenshots are intentionally NOT uploaded here: Apple requires exact
+# device-pixel sizes per device class, which we don't yet have (tracked
+# separately). See ios/fastlane/Deliverfile + the guide doc.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry-run (deliver --verify_only — validate metadata, no upload)'
+        type: boolean
+        default: true
+      submit:
+        description: 'Submit for review after upload (DANGER — only when intentional; ignored on a dry run)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: app-store-listing
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # deliver/fastlane is most reliable on macOS, matching the iOS lanes
+    # (ios-testflight.yml also runs on macos-latest).
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build App Store Connect API key JSON
+        env:
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ASC_KEY_BASE64:-}" ] || [ -z "${ASC_KEY_ID:-}" ] || [ -z "${ASC_ISSUER_ID:-}" ]; then
+            echo "::error::App Store Connect API secrets are not all set (APP_STORE_CONNECT_API_KEY_BASE64 / _KEY_ID / _ISSUER_ID)." >&2
+            exit 1
+          fi
+          # Decode the base64 secret to the raw .p8 (same source as
+          # ios-testflight.yml). `deliver --api_key_path` does NOT accept a
+          # raw .p8 + separate key_id/issuer_id flags — it expects fastlane's
+          # App Store Connect API key JSON wrapper, whose `key` field holds
+          # the full PEM contents of the .p8. jq embeds the PEM safely
+          # (newlines escaped as \n).
+          P8_PATH="$RUNNER_TEMP/asc-api-key.p8"
+          KEY_JSON="$RUNNER_TEMP/asc-api-key.json"
+          echo "$ASC_KEY_BASE64" | base64 --decode > "$P8_PATH"
+          jq -n \
+            --arg key_id "$ASC_KEY_ID" \
+            --arg issuer_id "$ASC_ISSUER_ID" \
+            --rawfile key "$P8_PATH" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > "$KEY_JSON"
+          rm -f "$P8_PATH"
+          echo "ASC_API_KEY_JSON=$KEY_JSON" >> "$GITHUB_ENV"
+
+      - name: fastlane deliver (text metadata only)
+        working-directory: ios
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          # `submit` only matters on a real run; on a dry run it is ignored.
+          SUBMIT: ${{ inputs.submit }}
+          FASTLANE_DISABLE_COLORS: '1'
+        run: |
+          set -euo pipefail
+
+          # Common args. The Deliverfile already sets these too, but we pass
+          # them explicitly so the workflow is self-documenting and safe even
+          # if the Deliverfile drifts:
+          #   --api_key_path — fastlane's ASC API key JSON wrapper built above.
+          #   --skip_binary_upload / --skip_screenshots — text metadata only.
+          #   --force true — non-interactive (no HTML-preview confirmation
+          #     prompt, which would hang a CI run forever).
+          #   --precheck_include_in_app_purchases false — we have no IAPs;
+          #     skip the precheck IAP scan.
+          ARGS=(
+            --api_key_path "$ASC_API_KEY_JSON"
+            --skip_binary_upload true
+            --skip_screenshots true
+            --force true
+            --precheck_include_in_app_purchases false
+          )
+
+          if [ "$DRY_RUN" = "true" ]; then
+            # --verify_only validates the metadata against App Store Connect
+            # WITHOUT uploading. submit_for_review is irrelevant here.
+            echo "::notice::Dry run — deliver --verify_only (validate metadata, no upload)."
+            ARGS+=( --verify_only true --submit_for_review false )
+          else
+            # Real upload. submit_for_review is true ONLY when the maintainer
+            # explicitly set the submit input; otherwise metadata is staged
+            # and a human presses Submit for Review in the console.
+            if [ "$SUBMIT" = "true" ]; then
+              echo "::warning::Real run with --submit_for_review TRUE — this will submit the app for review."
+              ARGS+=( --submit_for_review true )
+            else
+              echo "::notice::Real run — staging text metadata only (--submit_for_review false)."
+              ARGS+=( --submit_for_review false )
+            fi
+          fi
+
+          echo "Running: bundle exec fastlane deliver ${ARGS[*]}"
+          # PREREQUISITE: this fails with a clear App Store Connect error if
+          # no app version is in "Prepare for Submission" state. Create/edit
+          # a version in App Store Connect first. See the guide doc.
+          bundle exec fastlane deliver "${ARGS[@]}"
+
+      - name: Clean up decoded API key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/asc-api-key.p8" "$RUNNER_TEMP/asc-api-key.json"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## App Store listing"
+            echo ""
+            echo "- **Bundle ID:** de.tankstellen.tankstellen"
+            echo "- **Dry run:** ${{ inputs.dry_run }}"
+            echo "- **Submit for review:** ${{ inputs.submit }} (ignored on a dry run)"
+            echo "- **Uploaded:** text metadata only (no binary, no screenshots)"
+            echo ""
+            echo "Prerequisite: needs a version in **Prepare for Submission** state in App Store Connect."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ docs/guides/*
 !docs/guides/ios-widget-extension.md
 !docs/guides/feature-flags.md
 !docs/guides/fdroid-submission.md
+!docs/guides/app-store-listing.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/app-store-listing.md
+++ b/docs/guides/app-store-listing.md
@@ -1,0 +1,133 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# App Store listing publish (#2593)
+
+The iOS App Store text metadata lives in the repo under
+`ios/fastlane/metadata/<locale>/` (added in #2560). The
+`.github/workflows/app-store-listing.yml` workflow pushes it to App Store
+Connect via `fastlane deliver` — without rebuilding or uploading a binary.
+This is the Apple mirror of `play-store-listing.yml`; before it existed the
+copy lived in the repo but was never published, exactly like Play was.
+
+## Metadata layout
+
+```
+ios/fastlane/metadata/
+├── copyright.txt
+├── en-US/
+│   ├── name.txt              # App name (max 30 chars)
+│   ├── subtitle.txt          # Subtitle (max 30 chars)
+│   ├── keywords.txt          # ASO keywords, comma-separated (max 100 chars total)
+│   ├── description.txt        # Full description (max 4000 chars)
+│   ├── promotional_text.txt   # Promo text, editable without review (max 170 chars)
+│   └── release_notes.txt      # "What's New" for the next version (max 4000 chars)
+├── de-DE/ …
+├── fr-FR/ …
+├── es-ES/ …
+└── it-IT/ …
+```
+
+`deliver` discovers these automatically relative to `ios/fastlane/Deliverfile`.
+The five locales (en-US, de-DE, fr-FR, es-ES, it-IT) are the launch markets;
+App Store Connect auto-falls-back to en-US for any locale not present.
+
+### ASO / keywords fields
+
+- **`keywords.txt`** is the App Store search-ranking field — comma-separated,
+  100 chars total, no spaces after commas (each space costs a character).
+  Don't repeat words already in `name`/`subtitle`; Apple indexes those too.
+- **`subtitle.txt`** (30 chars) appears under the app name on the product page
+  and is also indexed for search — use it for a high-value keyword phrase.
+- **`promotional_text.txt`** (170 chars) sits above the description and can be
+  changed **any time without a new app version or review** — useful for
+  time-bound messaging.
+- **`description.txt`** is the long-form copy. Not indexed for search ranking;
+  it's for conversion once the user is on the page.
+
+## Secrets
+
+The workflow authenticates with the same App Store Connect API key as
+`ios-testflight.yml`. These already exist in repo Actions secrets — verify
+with `gh secret list`:
+
+| Secret | Purpose |
+|---|---|
+| `APP_STORE_CONNECT_API_KEY_BASE64` | base64 of the `.p8` key file |
+| `APP_STORE_CONNECT_API_KEY_ID`     | the key's Key ID |
+| `APP_STORE_CONNECT_API_ISSUER_ID`  | the issuer ID |
+
+`deliver --api_key_path` does **not** take a raw `.p8` plus separate
+key-id/issuer-id flags (those are not deliver parameters). It expects
+fastlane's *App Store Connect API key JSON* wrapper, whose `key` field holds
+the full PEM contents of the `.p8`. The workflow therefore decodes the
+base64 secret to a temp `.p8`, then `jq`-assembles
+`{key_id, issuer_id, key, in_house:false}` into a temp JSON file and passes
+that. Both temp files live in `$RUNNER_TEMP` and are removed in an `always()`
+cleanup step.
+
+## Safety
+
+`ios/fastlane/Deliverfile` is configured so `deliver` can only ever stage
+**text** metadata — it can never submit the app, release a build, or touch the
+binary or screenshots:
+
+- `submit_for_review(false)`, `automatic_release(false)`
+- `force(false)`, `skip_binary_upload(true)`, `skip_screenshots(true)`
+
+The workflow passes the same flags explicitly (`--skip_binary_upload true
+--skip_screenshots true`, plus `--force true` so CI never hangs on the
+interactive HTML-preview confirmation). `--submit_for_review true` is sent
+**only** when the maintainer explicitly sets the `submit` input; the default
+keeps it `false`, so a human still presses "Submit for Review" in the console.
+
+## How to run
+
+The workflow is **`workflow_dispatch` only** — it never auto-fires on push.
+Apple listing changes are tied to a specific app version + the review process,
+so an auto-publish on every metadata commit (the way Play does) is too risky.
+
+1. **Validate first (dry run).** Dispatch with `dry_run` = **true** (the
+   default). This runs `deliver --verify_only`, which validates the metadata
+   against App Store Connect — checks lengths, locale coverage, forbidden
+   content — **without uploading anything**.
+2. **Real run.** Dispatch with `dry_run` = **false** to upload the text
+   metadata. Leave `submit` = false (the default) so the copy is *staged*
+   for the editable version and a human reviews + submits in the console.
+3. **Submit (optional, rare).** Only set `submit` = true if you intend the
+   run itself to submit the app for review. On a dry run this input is ignored.
+
+```
+gh workflow run app-store-listing.yml -f dry_run=true            # validate
+gh workflow run app-store-listing.yml -f dry_run=false           # stage metadata
+gh workflow run app-store-listing.yml -f dry_run=false -f submit=true   # stage + submit
+```
+
+## Prerequisite — a version in "Prepare for Submission"
+
+`deliver` can only update localized metadata when the app has a version in the
+**"Prepare for Submission"** state in App Store Connect (an *editable* version).
+If no editable version exists, the run fails with a clear error such as
+`Could not find an editable version` / `app version ... not found`.
+
+To create one: App Store Connect → your app → **+ Version** (or open the
+in-flight version), so a version sits in "Prepare for Submission". Then dispatch
+the workflow. The metadata you stage attaches to that version; `release_notes`
+becomes its "What's New".
+
+## Screenshots are NOT included
+
+The workflow passes `--skip_screenshots true` and ships no images. Apple
+requires screenshots at **exact device-pixel sizes** per device class (e.g.
+6.7" iPhone 1290×2796, 6.5" 1242×2688, 12.9" iPad 2048×2732), unlike Play's
+auto-scaling. Producing those is a separate task; until then the listing's
+existing screenshots are left untouched and only text metadata is updated.
+
+## Companion
+
+- `play-store-listing.yml` + `docs/guides/PLAY-STORE-LISTING-REFRESH.md` —
+  the Android equivalent this workflow mirrors.
+- `ios-testflight.yml` — the binary-upload pipeline; the API-key auth pattern
+  here is copied from it.


### PR DESCRIPTION
## What

Adds the App Store listing-publish pipeline — the Apple mirror of the working `play-store-listing.yml`. The iOS text metadata under `ios/fastlane/metadata/<locale>/` (en-US, de-DE, fr-FR, es-ES, it-IT — added in #2560) was never pushed to App Store Connect; this `fastlane deliver` workflow closes that gap.

## `.github/workflows/app-store-listing.yml`

- **`workflow_dispatch` only** — never auto-fires on push. Apple listing changes tie to a specific app version + the review process, so an auto-publish on every metadata commit (the way Play does) is too risky.
- **Auth** reuses the App Store Connect API key pattern from `ios-testflight.yml`: decodes `APP_STORE_CONNECT_API_KEY_BASE64` to a temp `.p8`, then `jq`-assembles fastlane's ASC API key **JSON wrapper** (`{key_id, issuer_id, key:<PEM>, in_house:false}`) that `deliver --api_key_path` requires (it does *not* accept a raw `.p8` + separate key-id/issuer-id flags). Both temp files are removed in an `always()` cleanup.
- **`dry_run`** (default **true**) → `deliver --verify_only true`: validates the metadata against App Store Connect without uploading.
- **Real run** (`dry_run` false) uploads **text metadata only** — `--skip_binary_upload true --skip_screenshots true --force true --precheck_include_in_app_purchases false`, matching the SAFE `Deliverfile`.
- **`submit`** (default false) wires `--submit_for_review true` **only** when explicitly true; ignored on a dry run.
- `runs-on: macos-latest`, `timeout-minutes: 15`, `permissions: contents: read`.

## `docs/guides/app-store-listing.md`

Documents the metadata layout, the three secrets, the dry-run → real-run flow, the ASO/keywords fields, the **Prepare-for-Submission prerequisite** (`deliver` can only update localized metadata when the app has a version in "Prepare for Submission" state — otherwise the run fails with a clear ASC error), and that **screenshots are out of scope** (Apple needs exact device-pixel sizes — separate task).

`.gitignore` gets a one-line negation for the new guide, matching the convention for every existing `docs/guides/*` file.

## Scope / gates

- ARB-free; no Dart/l10n touched. Diff is the workflow + the doc + the `.gitignore` negation needed to track the doc.
- YAML validated (`yaml.safe_load`); deliver flags verified against the fastlane docs and consistent with the `Deliverfile`.
- Docs-only/CI → `ci-docs-stub` covers required checks.

## Not done here (by design)

Actually publishing the listing still needs (a) a version in "Prepare for Submission" in App Store Connect and (b) the maintainer to dispatch the workflow. This PR only wires the pipeline; it runs nothing.

Closes #2593

🤖 Generated with [Claude Code](https://claude.com/claude-code)