### PR TITLE
fix(station-detail): hydrate full station (brand) on cold notification deep-link, not just from the search cache (#2599)

### DIFF
--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -245,10 +245,28 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
     final station = parser.parsePrixCarburantsStation(r, 0, 0);
     if (station == null) throw Exception('Failed to parse station');
 
+    // #2599 — apply the SAME OSM brand enrichment the search path uses
+    // (`searchStations` above). The Prix-Carburants feed publishes no
+    // `brand` column, so a single-station re-fetch only carries the
+    // address-heuristic brand (often the "independent" sentinel). Without
+    // this, a cold notification deep-link (search cache empty → provider
+    // falls back to this re-fetch) opened a brand-less station: the detail
+    // header dropped to the street + "Independent station", while the same
+    // station opened from search results showed its real brand (e.g.
+    // "Intermarché"). Enriching here makes the deep-link path render
+    // identically — and reuses the enricher's persisted `brand_<id>` cache,
+    // so a station the user already saw in search resolves instantly (and
+    // offline). Best-effort: a null enricher or a failed lookup leaves the
+    // heuristic brand untouched, so the sentinel still shows ONLY when the
+    // brand is genuinely absent in the source data.
+    final enriched = _enricher != null
+        ? (await _enricher.enrich([station])).first
+        : station;
+
     final is24h = r['horaires_automate_24_24'] == 'Oui';
 
     return ServiceResult(
-      data: StationDetail(station: station, wholeDay: is24h),
+      data: StationDetail(station: enriched, wholeDay: is24h),
       source: ServiceSource.prixCarburantsApi,
       fetchedAt: DateTime.now(),
     );

--- a/test/features/station_detail/providers/station_detail_provider_test.dart
+++ b/test/features/station_detail/providers/station_detail_provider_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -9,7 +10,9 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/station_brand_header.dart';
 import 'package:tankstellen/features/station_detail/providers/station_detail_provider.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../../../mocks/mocks.dart';
 
@@ -194,6 +197,148 @@ void main() {
       expect(result.source, ServiceSource.tankerkoenigApi);
       verify(() => mockStationService.getStationDetail('shared-id'))
           .called(1);
+    });
+  });
+
+  // #2599 — the cold notification deep-link bug. Tapping a price-alert
+  // notification opens `/station/:id` on a cold launch: the in-memory search
+  // cache is empty, so the provider falls back to the country station
+  // service's `getStationDetail`. That re-fetch must carry the FULL station
+  // (brand + address) so the detail header renders IDENTICALLY to the
+  // search-results path — not the degraded "street + Independent station"
+  // header from the original report. The fix enriches the re-fetched station
+  // (PrixCarburants service); here we assert the provider→header contract:
+  // a branded fallback survives the provider and renders as the brand.
+  group('cold notification deep-link hydration (#2599)', () {
+    // The exact station from the bug screenshots: brand "Intermarché",
+    // address "Route St Thibéry, 34550 Bessan". This is what the enriched
+    // re-fetch now returns on a cache miss. A bare (unprefixed) id keeps the
+    // provider on its `stationServiceProvider` branch (no `activeCountry` /
+    // Hive lookup) so the test stays a focused, Hive-free assertion of the
+    // hydration contract — the brand survives the fallback re-fetch — exactly
+    // like the other fallback tests above.
+    const refetchId = 'st-2599';
+    const brandedFromRefetch = Station(
+      id: refetchId,
+      name: 'ROUTE ST THIBERY', // raw feed name = the street
+      brand: 'Intermarché', // OSM-enriched by getStationDetail (#2599)
+      street: 'Route St Thibéry',
+      postCode: '34550',
+      place: 'Bessan',
+      lat: 43.36,
+      lng: 3.40,
+      isOpen: true,
+    );
+
+    testWidgets(
+        'cold cache resolves a station WITH its brand and the header renders '
+        'the brand, not the street', (tester) async {
+      when(() => mockStationService.getStationDetail(refetchId))
+          .thenAnswer((_) async => ServiceResult(
+                data: const StationDetail(station: brandedFromRefetch),
+                source: ServiceSource.prixCarburantsApi,
+                fetchedAt: DateTime(2026, 6, 1),
+              ));
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            stationServiceProvider.overrideWithValue(mockStationService),
+            // COLD: search cache empty (no FuelStationResult for this id).
+            searchStateProvider.overrideWith(() => _FakeSearchState(const [])),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  final async = ref.watch(stationDetailProvider(refetchId));
+                  return async.when(
+                    data: (r) => StationBrandHeader(station: r.data.station),
+                    loading: () => const SizedBox.shrink(),
+                    error: (e, _) => Text('error: $e'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The brand is the headline — NOT the street, NOT "Independent station".
+      expect(find.text('Intermarché'), findsOneWidget,
+          reason: 'the cold deep-link must hydrate the brand (#2599)');
+      expect(find.text('Independent station'), findsNothing,
+          reason: 'the sentinel must NOT appear for a branded station');
+      // The full address still surfaces as the subtitle (identical to search).
+      expect(find.textContaining('Route St Thibéry'), findsAtLeast(1));
+      expect(find.textContaining('34550'), findsAtLeast(1));
+      verify(() => mockStationService.getStationDetail(refetchId)).called(1);
+    });
+
+    test('cold cache fallback preserves the re-fetched brand on the provider',
+        () async {
+      when(() => mockStationService.getStationDetail(refetchId))
+          .thenAnswer((_) async => ServiceResult(
+                data: const StationDetail(station: brandedFromRefetch),
+                source: ServiceSource.prixCarburantsApi,
+                fetchedAt: DateTime(2026, 6, 1),
+              ));
+
+      final container = createContainer(
+        searchState: () => _FakeSearchState(const []),
+      );
+
+      final result =
+          await container.read(stationDetailProvider(refetchId).future);
+
+      expect(result.data.station.brand, 'Intermarché');
+      expect(result.source, ServiceSource.prixCarburantsApi);
+      verify(() => mockStationService.getStationDetail(refetchId)).called(1);
+    });
+
+    testWidgets(
+        'in-app (search-results) path still renders the brand — unchanged',
+        (tester) async {
+      // The search cache HAS the branded station: the provider returns it
+      // from cache WITHOUT a re-fetch. This path was always correct; assert
+      // the fix did not regress it.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            stationServiceProvider.overrideWithValue(mockStationService),
+            searchStateProvider.overrideWith(
+              () => _FakeSearchState(const [
+                FuelStationResult(brandedFromRefetch),
+              ]),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  final async = ref.watch(stationDetailProvider(refetchId));
+                  return async.when(
+                    data: (r) => StationBrandHeader(station: r.data.station),
+                    loading: () => const SizedBox.shrink(),
+                    error: (e, _) => Text('error: $e'),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Intermarché'), findsOneWidget);
+      expect(find.text('Independent station'), findsNothing);
+      // No re-fetch on the in-app path — it resolves from the search cache.
+      verifyNever(() => mockStationService.getStationDetail(any()));
     });
   });
 }

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -6,10 +6,13 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/station_services/france/prix_carburants_station_service.dart';
+import 'package:tankstellen/core/services/impl/osm_brand_enricher.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import '../../../fakes/fake_storage_repository.dart';
 import '../../../helpers/silence_error_logger.dart';
 
 void main() {
@@ -418,6 +421,82 @@ void main() {
       } catch (e) {
         expect(e, isA<Exception>());
       }
+    });
+  });
+
+  // #2599 — a single-station re-fetch (the cold notification deep-link path)
+  // must apply the SAME OSM brand enrichment the search path uses. The
+  // Prix-Carburants feed has no `brand` column, so without enrichment the
+  // re-fetched station carried only the address-heuristic brand (the
+  // "independent" sentinel) → the detail header dropped to the street +
+  // "Independent station", whereas the same station from search showed its
+  // real brand. Enriching here makes the deep-link render identically.
+  group('PrixCarburantsStationService getStationDetail enrichment (#2599)', () {
+    Map<String, dynamic> singleStationResponse() => {
+          'results': [
+            {
+              'id': '34550042',
+              // Address heuristic alone cannot detect "Intermarché" here:
+              // the feed publishes the street, not the chain.
+              'adresse': 'ROUTE ST THIBERY',
+              'ville': 'BESSAN',
+              'cp': '34550',
+              'geom': {'lat': 43.36, 'lon': 3.43},
+              'sp95_prix': 1.879,
+              'gazole_prix': 1.659,
+            },
+          ],
+        };
+
+    test('applies the OSM enricher so the re-fetched station carries its brand',
+        () async {
+      final adapter = _TrackingMockAdapter()..addResponse(singleStationResponse());
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      // Enricher resolves the real chain brand (as OSM would for the search
+      // path) instead of the address-only sentinel.
+      final enricher = _FakeBrandEnricher(brand: 'Intermarché');
+      final svc = PrixCarburantsStationService(dio: dio, enricher: enricher);
+
+      final result = await svc.getStationDetail('fr-34550042');
+
+      expect(result.data.station.brand, 'Intermarché',
+          reason: 'the re-fetch must carry the OSM-enriched brand (#2599)');
+      // Address fields are untouched — same subtitle the search path shows.
+      expect(result.data.station.street, 'ROUTE ST THIBERY');
+      expect(result.data.station.postCode, '34550');
+      expect(result.data.station.place, 'BESSAN');
+      expect(enricher.enrichCalls, 1,
+          reason: 'getStationDetail must route through the enricher');
+    });
+
+    test(
+        'leaves the heuristic sentinel when enrichment finds no brand '
+        '(genuinely independent)', () async {
+      final adapter = _TrackingMockAdapter()..addResponse(singleStationResponse());
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      // Enricher returns the station unchanged (no POI match / cache miss),
+      // mirroring a genuinely brand-less station.
+      final enricher = _FakeBrandEnricher(brand: null);
+      final svc = PrixCarburantsStationService(dio: dio, enricher: enricher);
+
+      final result = await svc.getStationDetail('fr-34550042');
+
+      // The address heuristic could not detect a brand either → the
+      // independent sentinel is preserved. "Independent station" should show
+      // ONLY here, when the brand is genuinely absent in the source data.
+      expect(result.data.station.brand, BrandRegistry.independentLabel);
+    });
+
+    test('a null enricher leaves the heuristic brand untouched (best-effort)',
+        () async {
+      final adapter = _TrackingMockAdapter()..addResponse(singleStationResponse());
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio, enricher: null);
+
+      final result = await svc.getStationDetail('fr-34550042');
+
+      // No enricher → falls back to the address heuristic (sentinel here).
+      expect(result.data.station.brand, BrandRegistry.independentLabel);
     });
   });
 
@@ -1256,6 +1335,30 @@ void main() {
       expect(adapter.lastRequestUri, startsWith('https://data.economie.gouv.fr'));
     });
   });
+}
+
+/// Test [OsmBrandEnricher] that resolves a fixed [brand] for every station
+/// without touching the network or storage (#2599). When [brand] is null the
+/// station is returned unchanged, mirroring a POI/cache miss (genuinely
+/// brand-less). Counts calls so the test can assert the re-fetch path routes
+/// through it. The base constructor needs a [SettingsStorage]; the fake
+/// repository satisfies it and is never read because [enrich] is overridden.
+class _FakeBrandEnricher extends OsmBrandEnricher {
+  final String? brand;
+  int enrichCalls = 0;
+
+  _FakeBrandEnricher({required this.brand}) : super(FakeStorageRepository());
+
+  @override
+  Future<List<Station>> enrich(
+    List<Station> stations, {
+    CancelToken? cancelToken,
+  }) async {
+    enrichCalls++;
+    final resolved = brand;
+    if (resolved == null) return stations;
+    return stations.map((s) => s.copyWith(brand: resolved)).toList();
+  }
 }
 
 /// Mock Dio adapter that tracks requests and returns canned responses.


### PR DESCRIPTION
## Bug (#2599)

Tapping a price-alert **notification** opened the correct station but **incomplete**: the detail title fell back to the **street** ("Route St Thibéry") + an "Independent station" label — the **brand was missing**. Opening the **same** station from **search results** showed it correctly: title "**Intermarché**", subtitle "Route St Thibéry, 34550 Bessan".

## Root cause (the precise miss path)

A notification tap deep-links to `/station/:id` → `StationDetailScreen(stationId)` → `stationDetailProvider(stationId)`.

- **In-app (search-results) path:** the full `Station` lives in the in-memory search cache, so the provider returns it complete. The search path runs **OSM brand enrichment** (`PrixCarburantsStationService.searchStations` → `_enricher.enrich(...)`), which resolves the real chain brand "Intermarché".
- **Cold notification deep-link:** the search cache is empty, so the provider falls back to the country service's `getStationDetail`. For France, that re-fetch parsed the single record with **only the address-heuristic** `detectPrixCarburantsBrand` (the Prix-Carburants feed publishes no `brand` column) and **never applied the OSM enricher**. The heuristic can't detect "Intermarché" from the street, so it returned the **independent sentinel** + `name = street`. `stationDisplayHeading` then dropped to the street and `StationBrandHeader` showed "Independent station".

So the degraded header was caused by the cold re-fetch skipping the enrichment the search path always runs — not by the brand being genuinely absent.

## Fix (root, not band-aid)

Apply the **same** OSM brand enrichment in `PrixCarburantsStationService.getStationDetail` that `searchStations` already uses, so the single-station re-fetch carries the full station (brand + address). The deep-link path now renders **identically** to the search-results path.

- Reuses the enricher's persisted `brand_<id>` cache, so a station the user already saw in search resolves instantly — and offline.
- "Independent station" now appears **only** when the brand is genuinely absent in the source data (no POI match / cache miss / null enricher), never because the cold path failed to load it.
- Best-effort: a null enricher or failed lookup leaves the heuristic brand untouched.
- In-app (search-cache) path **unchanged**. Backward-compatible. **ARB-free** (zero `lib/l10n/` diff).

## Tests

- **Service layer** (`getStationDetail` #2599): the re-fetch routes through the enricher and carries the brand; preserves the sentinel when enrichment finds nothing; a null enricher leaves the heuristic brand untouched.
- **Provider + widget** (cold deep-link): a COLD cache (empty search) resolves a station **with** its brand, and `StationBrandHeader` renders the brand — not the street, no "Independent station".
- **Regression:** the in-app (search-results) path still renders the brand from cache with **no** re-fetch.

`flutter test test/features/station_detail/ test/features/alerts/` → 329 passing. France service suite → 66 passing. Lint suites (`no_hardcoded_ui_strings`, `file_length`) green. `flutter analyze lib test` → only the pre-existing unrelated `unnecessary_import` info. Clean `build_runner` → zero codegen drift.

Closes #2599

🤖 Generated with [Claude Code](https://claude.com/claude-code)
