### PR TITLE
fix+feat(widget): refresh in place (no app launch) + redesign rows for price/name/distance priority (#2600)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/FuelPriceWidgetProvider.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/FuelPriceWidgetProvider.kt
@@ -39,27 +39,48 @@ class FuelPriceWidgetProvider : AppWidgetProvider() {
 
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
-        // #1801 — the refresh icon is now an Activity PendingIntent
-        // (see StationWidgetRenderer), not a broadcast: a
-        // BroadcastReceiver cannot reliably `startActivity` on
-        // Android 10+, so the old ACTION_REFRESH broadcast silently
-        // no-op'd. Only the mode toggle stays a broadcast — it merely
-        // re-renders, which is allowed from onReceive.
-        if (intent.action == StationWidgetRenderer.ACTION_TOGGLE_MODE) {
-            val id = intent.getIntExtra(
-                StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
-                AppWidgetManager.INVALID_APPWIDGET_ID,
-            )
-            if (id != AppWidgetManager.INVALID_APPWIDGET_ID) {
-                StationWidgetRenderer.toggleMode(
-                    context,
-                    id,
-                    StationWidgetRenderer.MODE_FAVORITES,
+        when (intent.action) {
+            // The mode toggle is a broadcast — it merely re-renders, which
+            // is allowed from onReceive.
+            StationWidgetRenderer.ACTION_TOGGLE_MODE -> {
+                val id = intent.getIntExtra(
+                    StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
+                    AppWidgetManager.INVALID_APPWIDGET_ID,
                 )
-                renderAndCommit(
+                if (id != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                    StationWidgetRenderer.toggleMode(
+                        context,
+                        id,
+                        StationWidgetRenderer.MODE_FAVORITES,
+                    )
+                    renderAndCommit(
+                        context,
+                        AppWidgetManager.getInstance(context),
+                        id,
+                    )
+                }
+            }
+            // #2600 — refresh-in-place. The refresh icon is now a broadcast
+            // (not an Activity PendingIntent), so a tap NEVER launches the
+            // app. We dim the glyph for immediate feedback, then enqueue the
+            // SAME on-device `widgetRefreshScan` WorkManager task that the
+            // periodic onUpdate wake uses (#2412): the Dart
+            // `BackgroundService.widgetRefreshScanTask` re-fetches prices and
+            // calls back into HomeWidget to re-render every placed widget.
+            // The coordinator's cross-trigger cooldown (#2415) dedups this
+            // against a concurrent periodic scan, so a rapid tap is cheap.
+            StationWidgetRenderer.ACTION_REFRESH -> {
+                val id = intent.getIntExtra(
+                    StationWidgetRenderer.EXTRA_APP_WIDGET_ID,
+                    AppWidgetManager.INVALID_APPWIDGET_ID,
+                )
+                if (id != AppWidgetManager.INVALID_APPWIDGET_ID) {
+                    StationWidgetRenderer.setRefreshing(context, id)
+                }
+                BackgroundScanEnqueuer.enqueue(
                     context,
-                    AppWidgetManager.getInstance(context),
-                    id,
+                    dartTask = WIDGET_SCAN_TASK,
+                    uniqueName = WIDGET_SCAN_UNIQUE_NAME,
                 )
             }
         }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
@@ -399,11 +399,37 @@ object StationWidgetRenderer {
         }
         row.setTextViewText(R.id.station_main_label, label)
         row.setTextViewText(R.id.station_main_price, priceText)
+        // #2600 — colour-code the price (the redesign's primary anchor).
+        // The Dart builder flags the cheapest priced row in the rendered
+        // set with `isCheapest` (sorted by distance, so the cheapest is
+        // not necessarily first). Cheapest → green; every other priced row
+        // → the high-contrast default. Both `@color` resources have a
+        // values-night/ variant so the hue stays legible on dark launchers.
+        val isCheapest = station.optBoolean("isCheapest", false)
+        val priceColorRes =
+            if (isCheapest) R.color.widget_price_cheap
+            else R.color.widget_price_default
+        row.setTextColor(
+            R.id.station_main_price,
+            getColorCompat(context, priceColorRes),
+        )
 
         val isOpen = station.optBoolean("isOpen", false)
         row.setTextViewText(
             R.id.station_status,
             if (isOpen) "● Open" else "○ Closed",
+        )
+        // #2600 — the status pill carried no explicit colour, so it
+        // inherited the launcher theme's default text colour, which could
+        // be near-invisible on the dark-navy widget background. Pin it:
+        // open → the cheap green, closed → the dim secondary.
+        row.setTextColor(
+            R.id.station_status,
+            getColorCompat(
+                context,
+                if (isOpen) R.color.widget_price_cheap
+                else R.color.widget_text_secondary,
+            ),
         )
 
         // #1121 — predictive nudge line. Render only when the user selected
@@ -473,6 +499,15 @@ object StationWidgetRenderer {
 
         return row
     }
+
+    /**
+     * #2600 — resolve a `@color` resource to an ARGB int for
+     * [RemoteViews.setTextColor]. Goes through [ContextCompat] so the
+     * correct values/ vs values-night/ variant is picked up from the
+     * launcher's current UI mode.
+     */
+    private fun getColorCompat(context: Context, colorRes: Int): Int =
+        ContextCompat.getColor(context, colorRes)
 
     private fun buildBroadcast(
         context: Context,

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/StationWidgetRenderer.kt
@@ -4,11 +4,13 @@
 package de.tankstellen.tankstellen
 
 import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.view.View
 import android.widget.RemoteViews
+import androidx.core.content.ContextCompat
 import es.antonborri.home_widget.HomeWidgetLaunchIntent
 import org.json.JSONArray
 import org.json.JSONObject
@@ -54,9 +56,14 @@ object StationWidgetRenderer {
 
     const val ACTION_TOGGLE_MODE = "de.tankstellen.fuelprices.TOGGLE_MODE"
     const val ACTION_OPEN_APP = "de.tankstellen.fuelprices.OPEN_APP"
-    // #1801 — ACTION_REFRESH removed: the refresh icon is now an
-    // Activity PendingIntent (a broadcast can't reliably startActivity
-    // on Android 10+), so there is no refresh broadcast to name.
+    // #2600 — ACTION_REFRESH re-introduced as a BROADCAST to the
+    // provider (NOT an Activity PendingIntent). Tapping the refresh icon
+    // must not launch the app: the provider's onReceive enqueues the
+    // existing `widgetRefreshScan` WorkManager task (#2412) which
+    // re-fetches prices and re-renders the widget in place. The old #1801
+    // rationale (a broadcast can't `startActivity` on Android 10+) is
+    // moot — refresh deliberately does not start an activity at all.
+    const val ACTION_REFRESH = "de.tankstellen.fuelprices.REFRESH"
 
     const val EXTRA_APP_WIDGET_ID = "appWidgetId"
 
@@ -209,21 +216,28 @@ object StationWidgetRenderer {
             ),
         )
 
-        // Refresh icon (#1801 / #1803 / #1961) — an Activity PendingIntent
-        // that opens the app carrying the `tankstellenwidget://refresh`
-        // marker URI. The Flutter side recognises that URI and runs an
-        // explicit widget rebuild (price re-fetch + re-render) instead of
-        // relying on the resume heartbeat alone — so a tap deterministically
-        // refreshes. A bare launch (uri = null) used to leave the refresh
-        // racing the resume tick.
+        // Refresh icon (#2600) — a BROADCAST to this provider's
+        // ACTION_REFRESH. onReceive enqueues the existing on-device
+        // `widgetRefreshScan` WorkManager task (#2412) which re-fetches
+        // prices and re-renders the widget in place. NO app launch: the
+        // old #1801 / #1961 Activity PendingIntent + `tankstellenwidget://
+        // refresh` marker URI cold-launched the app to refresh, which the
+        // user reported as a bug. The provider dims the glyph (alpha) while
+        // the scan is in flight; the next render restores it to full alpha.
         views.setOnClickPendingIntent(
             R.id.widget_refresh,
-            buildActivity(
+            buildBroadcast(
                 context,
-                uri = Uri.parse("tankstellenwidget://refresh"),
+                providerClass,
+                ACTION_REFRESH,
                 requestCode = appWidgetId * 10 + 2,
+                extraAppWidgetId = appWidgetId,
             ),
         )
+        // Restore the refresh glyph to full opacity on every fresh render —
+        // the transient "refreshing…" dim set by onReceive is cleared once
+        // the scan posts new data and the widget re-renders.
+        views.setInt(R.id.widget_refresh, "setImageAlpha", 255)
 
         // Tapping the widget chrome (not a row) opens the app with no
         // station context so the user lands on whatever their usual
@@ -294,6 +308,31 @@ object StationWidgetRenderer {
         }
 
         return views
+    }
+
+    /**
+     * #2600 — transient "refreshing…" affordance. Dims the refresh glyph
+     * to ~40% opacity via a lightweight `partiallyUpdateAppWidget` so the
+     * user gets immediate feedback that the in-place refresh broadcast was
+     * received, without rebuilding the whole RemoteViews tree (which would
+     * need a fresh data read). The dim is cleared on the next full [render]
+     * (it always resets the alpha to 255) once the scan posts new prices.
+     *
+     * A partial update that targets only `widget_refresh` is safe even
+     * when the layout was last committed by a different render pass — the
+     * RemoteViews here only carries the one alpha mutation.
+     */
+    fun setRefreshing(context: Context, appWidgetId: Int) {
+        try {
+            val views = RemoteViews(context.packageName, R.layout.station_widget_layout)
+            views.setInt(R.id.widget_refresh, "setImageAlpha", 100)
+            AppWidgetManager.getInstance(context)
+                .partiallyUpdateAppWidget(appWidgetId, views)
+        } catch (e: Exception) {
+            // Best-effort visual only — never let the affordance block the
+            // scan enqueue that actually refreshes the data.
+            android.util.Log.d("TankstellenWidget", "setRefreshing failed: $e")
+        }
     }
 
     private fun buildRow(

--- a/android/app/src/main/res/layout/widget_station_row.xml
+++ b/android/app/src/main/res/layout/widget_station_row.xml
@@ -4,18 +4,34 @@
   SPDX-License-Identifier: MIT
 -->
 
+<!--
+  #2600 — row redesign. Visual hierarchy is price ≫ name ≈ distance ≫
+  address, so the glanceable data dominates:
+
+    Row 1 (identity):  name (bold) ........... distance (bold, right)
+    Row 2 (anchor):    PRICE (large, bold, colour-coded) [fuel] .. status
+    Row 3 (secondary): address (small, dim, single-line ellipsised)
+    Row 4 (#1121):     predictive nudge (GONE unless predictive variant)
+
+  All view ids are unchanged from the pre-#2600 layout so the
+  StationWidgetRenderer.buildRow bindings keep working untouched; only the
+  ordering, sizes, weights and colours changed. Colours come from
+  values/ + values-night/ tokens so every scheme + night variant stays
+  legible (address dim-grey passes contrast, cheapest price pops green).
+  Sizes use sp for text, dp for spacing throughout.
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/station_row_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingTop="4dp"
-    android:paddingBottom="4dp"
+    android:paddingTop="5dp"
+    android:paddingBottom="5dp"
     android:clickable="true"
     android:focusable="true"
     android:background="?android:attr/selectableItemBackground">
 
-    <!-- Row 1: brand + distance -->
+    <!-- Row 1: name (prominent, bold) + distance (prominent, bold, right). -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -27,7 +43,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="13sp"
+            android:textSize="14sp"
             android:textStyle="bold"
             android:textColor="@color/widget_text_primary"
             android:maxLines="1"
@@ -37,54 +53,62 @@
             android:id="@+id/station_distance"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="11sp"
-            android:textColor="@color/widget_text_secondary"
-            android:paddingStart="6dp"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            android:textColor="@color/widget_text_primary"
+            android:paddingStart="8dp"
             android:visibility="gone" />
     </LinearLayout>
 
-    <!-- Row 2: address -->
-    <TextView
-        android:id="@+id/station_address"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="10sp"
-        android:textColor="@color/widget_text_secondary"
-        android:maxLines="1"
-        android:ellipsize="end" />
-
-    <!-- Row 3: main fuel price + status -->
+    <!-- Row 2: the PRICE anchor. Largest, bold, colour-coded by the
+         renderer (cheapest → green, else high-contrast primary). The small
+         fuel-type label sits just after it; the open/closed status pill is
+         right-aligned. -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:paddingTop="2dp">
-
-        <TextView
-            android:id="@+id/station_main_label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="10sp"
-            android:textColor="@color/widget_text_secondary"
-            android:paddingEnd="4dp" />
+        android:gravity="bottom"
+        android:paddingTop="1dp">
 
         <TextView
             android:id="@+id/station_main_price"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="@color/widget_price_default" />
+
+        <TextView
+            android:id="@+id/station_main_label"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="13sp"
-            android:textStyle="bold"
-            android:textColor="#1B5E20" />
+            android:textSize="10sp"
+            android:textColor="@color/widget_text_secondary"
+            android:paddingStart="5dp"
+            android:paddingBottom="2dp"
+            android:gravity="bottom" />
 
         <TextView
             android:id="@+id/station_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="10sp"
-            android:paddingStart="6dp" />
+            android:paddingStart="6dp"
+            android:paddingBottom="2dp"
+            android:gravity="bottom" />
     </LinearLayout>
+
+    <!-- Row 3: address — secondary, small + dim, single line ellipsised. -->
+    <TextView
+        android:id="@+id/station_address"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="10sp"
+        android:textColor="@color/widget_text_tertiary"
+        android:maxLines="1"
+        android:ellipsize="end" />
 
     <!-- Row 4 (#1121): predictive nudge — "now €1.84/L · best Tue eve ~€1.79/L".
          Visibility is GONE by default; the renderer flips it to VISIBLE only

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -8,4 +8,11 @@
     <color name="widget_text_primary">#E6E1E5</color>
     <color name="widget_text_secondary">#CAC4D0</color>
     <color name="widget_icon_tint">#CAC4D0</color>
+    <!-- #2600 — dark-launcher price colours. Brighter green pops on the
+         dark-navy widget background; the default price matches the light
+         primary text; the address dim-grey stays above the ~4.5:1 contrast
+         floor against #1E1E1E / dark accent backgrounds. -->
+    <color name="widget_price_cheap">#5CD27A</color>
+    <color name="widget_price_default">#E6E1E5</color>
+    <color name="widget_text_tertiary">#A6A1AC</color>
 </resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -13,4 +13,16 @@
     <color name="widget_text_primary">#1C1B1F</color>
     <color name="widget_text_secondary">#49454F</color>
     <color name="widget_icon_tint">#49454F</color>
+    <!-- #2600 — row price colours. The redesign makes the price the most
+         prominent element. `widget_price_cheap` highlights the cheapest
+         station in the rendered set (green); every other priced row uses
+         `widget_price_default` (same high-contrast primary as the name so
+         the price reads as the anchor without a distracting hue). The
+         address uses the dimmer `widget_text_tertiary`. These are the
+         light-theme values; values-night/ carries the dark-launcher
+         variants (brighter green + lighter dim-grey for contrast on the
+         dark-navy widget background in the screenshot). -->
+    <color name="widget_price_cheap">#1B7F36</color>
+    <color name="widget_price_default">#1C1B1F</color>
+    <color name="widget_text_tertiary">#6E6A75</color>
 </resources>

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -51,7 +51,6 @@ import '../features/vehicle/data/repositories/vehicle_profile_repository.dart';
 import '../features/vehicle/data/vehicle_profile_migrator.dart';
 import '../features/vehicle/providers/vehicle_aggregate_updater_provider.dart';
 import '../features/widget/data/home_widget_service.dart';
-import '../features/widget/presentation/widget_uri_parser.dart';
 import '../features/widget/providers/nearest_widget_refresh_provider.dart';
 import '../features/widget/providers/pending_widget_uri_provider.dart';
 import 'router.dart';
@@ -595,18 +594,10 @@ class AppInitializer {
       final uri = await HomeWidget.initiallyLaunchedFromHomeWidget()
           .timeout(const Duration(milliseconds: 200));
       if (uri == null) return;
-      // #2159 — the refresh-button URI is `tankstellenwidget://refresh`,
-      // which `widgetUriToPath` returns `null` for. If we stashed it,
-      // the router redirect would consume it (clear the stash) and
-      // navigate nowhere, leaving the user on the default landing
-      // screen and the widget unrefreshed. Dispatch directly to the
-      // refresh notifier instead — it's a side effect, not a route.
-      if (isWidgetRefreshUri(uri)) {
-        unawaited(
-          container.read(nearestWidgetRefreshProvider.notifier).refresh(),
-        );
-        return;
-      }
+      // #2600 — the only widget launch URI is a station deep-link now.
+      // The refresh button no longer launches the app (it is a native
+      // broadcast handled in place), so the former #2159 refresh-marker
+      // discrimination was removed: every launch URI is a route to stash.
       container.read(pendingWidgetUriProvider.notifier).set(uri);
     } on TimeoutException {
       debugPrint(

--- a/lib/features/widget/data/nearest_widget_data_builder.dart
+++ b/lib/features/widget/data/nearest_widget_data_builder.dart
@@ -204,6 +204,13 @@ class NearestWidgetDataBuilder {
           .map((s) => _stationToRow(s, userLat: lat, userLng: lng, fuel: fuelType))
           .toList(growable: false);
 
+      // #2600 — flag the cheapest row(s) so the redesigned native widget
+      // can colour the price green. Rows are ordered by distance, so the
+      // cheapest is not necessarily first; mark every row whose preferred
+      // fuel price equals the minimum across the rendered set. Rows with no
+      // price are never the cheapest.
+      _flagCheapest(rows);
+
       final payload = NearestWidgetPayload(
         stations: rows,
         updatedAt: DateTime.now(),
@@ -322,6 +329,26 @@ class NearestWidgetDataBuilder {
       'diesel': station.diesel,
       if (predictive != null) ...predictive,
     };
+  }
+
+  /// #2600 — mark the cheapest priced row(s) with `isCheapest: true` so the
+  /// native widget colours their price green. Operates in place on the
+  /// already-built [rows]. Rows with a null/absent `preferred_fuel_price`
+  /// are ignored (never the cheapest). When two rows tie at the minimum,
+  /// both are flagged — honest, and a rare edge anyway.
+  static void _flagCheapest(List<Map<String, dynamic>> rows) {
+    double? minPrice;
+    for (final row in rows) {
+      final p = (row['preferred_fuel_price'] as num?)?.toDouble();
+      if (p == null) continue;
+      if (minPrice == null || p < minPrice) minPrice = p;
+    }
+    // Always write the key (false when no row is priced) so the field is a
+    // predictable bool the native renderer reads with a `false` default.
+    for (final row in rows) {
+      final p = (row['preferred_fuel_price'] as num?)?.toDouble();
+      row['isCheapest'] = minPrice != null && p != null && p == minPrice;
+    }
   }
 
   Future<void> _persist(

--- a/lib/features/widget/presentation/widget_click_listener.dart
+++ b/lib/features/widget/presentation/widget_click_listener.dart
@@ -11,11 +11,10 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../app/router.dart';
 import '../../consumption/data/obd2/event_channel_cancel.dart';
-import '../providers/nearest_widget_refresh_provider.dart';
 import 'widget_uri_parser.dart';
 import '../../../core/logging/error_logger.dart';
 
-export 'widget_uri_parser.dart' show isWidgetRefreshUri, widgetUriToPath;
+export 'widget_uri_parser.dart' show widgetUriToPath;
 
 part 'widget_click_listener.g.dart';
 
@@ -28,24 +27,17 @@ part 'widget_click_listener.g.dart';
 /// sits **above** the `InheritedGoRouter` the router widget inserts.
 /// This is the class that the `homeWidget.widgetClicked` stream and
 /// the cold-start launch probe both drive.
+///
+/// #2600 — the ONLY widget launch URI is the station deep-link now. The
+/// refresh button is a broadcast handled natively in place (it never
+/// launches the app), so the former refresh-marker branch + `_onRefresh`
+/// callback were removed.
 class WidgetLaunchHandler {
   final GoRouter _router;
 
-  /// Invoked when the launch URI is the [isWidgetRefreshUri] marker —
-  /// rebuilds the home-screen widget instead of navigating (#1961).
-  final VoidCallback _onRefresh;
-
-  WidgetLaunchHandler(this._router, this._onRefresh);
+  WidgetLaunchHandler(this._router);
 
   void handle(Uri? uri) {
-    // #1961 — the refresh button launches the app with a `refresh`
-    // marker URI rather than a station route. Rebuild the widget and
-    // stay on whatever screen the user is on; never navigate.
-    if (isWidgetRefreshUri(uri)) {
-      debugPrint('WidgetLaunchHandler.handle uri=$uri outcome=refresh');
-      _onRefresh();
-      return;
-    }
     final path = widgetUriToPath(uri);
     // #753 diagnostic — prints every widget launch so the user can
     // diff what Kotlin bound to the row (see StationWidgetRenderer
@@ -65,12 +57,7 @@ class WidgetLaunchHandler {
 
 @riverpod
 WidgetLaunchHandler widgetLaunchHandler(Ref ref) {
-  return WidgetLaunchHandler(
-    ref.watch(routerProvider),
-    // Lazily triggered — only a refresh-marker tap reads (and so starts)
-    // the keep-alive refresh provider; an ordinary row tap never does.
-    () => ref.read(nearestWidgetRefreshProvider.notifier).refresh(),
-  );
+  return WidgetLaunchHandler(ref.watch(routerProvider));
 }
 
 /// Listens for taps on a home-screen widget row and navigates the app

--- a/lib/features/widget/presentation/widget_click_listener.g.dart
+++ b/lib/features/widget/presentation/widget_click_listener.g.dart
@@ -55,4 +55,4 @@ final class WidgetLaunchHandlerProvider
 }
 
 String _$widgetLaunchHandlerHash() =>
-    r'a5f58e4a6884fcb4915435691fbb75ab1fa23082';
+    r'259f9b333bd7222fdc6f1ca6fafd5841f6314dfb';

--- a/lib/features/widget/presentation/widget_uri_parser.dart
+++ b/lib/features/widget/presentation/widget_uri_parser.dart
@@ -11,6 +11,13 @@
 /// Returns `null` for any URI that isn't a valid widget launch — the
 /// caller must treat that as a no-op.
 ///
+/// #2600 — the only widget launch URI is now the station deep-link. The
+/// refresh button no longer launches the app at all: it is a broadcast
+/// (`StationWidgetRenderer.ACTION_REFRESH`) the provider handles in place
+/// by enqueuing the on-device price scan, so the old
+/// `tankstellenwidget://refresh` marker URI (#1801 / #1961) and its
+/// `isWidgetRefreshUri` discriminator were removed.
+///
 /// Lives in its own file (rather than next to the listener) so the
 /// router's redirect chain can call it without the listener's
 /// `routerProvider` import re-importing router.dart and creating a
@@ -24,16 +31,3 @@ String? widgetUriToPath(Uri? uri) {
   if (id == null || id.isEmpty) return null;
   return id.startsWith('ocm-') ? '/ev-station/$id' : '/station/$id';
 }
-
-/// Whether [uri] is the home-widget **refresh** marker
-/// (`tankstellenwidget://refresh`), set by the widget's refresh button
-/// (`StationWidgetRenderer`, #1961).
-///
-/// It is not a navigation target — the caller treats it as "rebuild the
-/// widget" rather than a route to push. [widgetUriToPath] returns `null`
-/// for it (host is `refresh`, not `station`), so the two helpers are
-/// mutually exclusive.
-bool isWidgetRefreshUri(Uri? uri) =>
-    uri != null &&
-    uri.scheme == 'tankstellenwidget' &&
-    uri.host == 'refresh';

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -24,9 +24,12 @@ part 'nearest_widget_refresh_provider.g.dart';
 /// provider adds a foreground 2-minute tick that kicks the builder while
 /// the app is running.
 ///
-/// #1803 — the resume hook is what makes the widget's refresh button
-/// work: that button opens the app (#1801), and the app reaching the
-/// foreground triggers a tick that rebuilds both widget variants.
+/// #1803 — the resume hook keeps the widget fresh whenever the app
+/// returns to the foreground. #2600 — the widget's own refresh button no
+/// longer launches the app: it is a native broadcast that re-fetches
+/// prices in place (`FuelPriceWidgetProvider.ACTION_REFRESH` → the
+/// `widgetRefreshScan` WorkManager task), so the former explicit
+/// `refresh()` entry point this provider exposed was removed.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
@@ -56,13 +59,6 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
     // session as soon as the user opens the app (don't wait two minutes).
     unawaited(_tick());
   }
-
-  /// Force an immediate widget rebuild — both variants — outside the
-  /// timer/resume cadence. Driven by the home-widget refresh button
-  /// (#1961): a tap launches the app with the `refresh` marker URI, and
-  /// `WidgetLaunchHandler` calls this so the rebuild is deterministic
-  /// rather than racing the resume heartbeat.
-  Future<void> refresh() => _tick();
 
   Future<void> _tick() async {
     try {

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -18,9 +18,12 @@ part of 'nearest_widget_refresh_provider.dart';
 /// provider adds a foreground 2-minute tick that kicks the builder while
 /// the app is running.
 ///
-/// #1803 — the resume hook is what makes the widget's refresh button
-/// work: that button opens the app (#1801), and the app reaching the
-/// foreground triggers a tick that rebuilds both widget variants.
+/// #1803 — the resume hook keeps the widget fresh whenever the app
+/// returns to the foreground. #2600 — the widget's own refresh button no
+/// longer launches the app: it is a native broadcast that re-fetches
+/// prices in place (`FuelPriceWidgetProvider.ACTION_REFRESH` → the
+/// `widgetRefreshScan` WorkManager task), so the former explicit
+/// `refresh()` entry point this provider exposed was removed.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
@@ -39,9 +42,12 @@ final nearestWidgetRefreshProvider = NearestWidgetRefreshProvider._();
 /// provider adds a foreground 2-minute tick that kicks the builder while
 /// the app is running.
 ///
-/// #1803 — the resume hook is what makes the widget's refresh button
-/// work: that button opens the app (#1801), and the app reaching the
-/// foreground triggers a tick that rebuilds both widget variants.
+/// #1803 — the resume hook keeps the widget fresh whenever the app
+/// returns to the foreground. #2600 — the widget's own refresh button no
+/// longer launches the app: it is a native broadcast that re-fetches
+/// prices in place (`FuelPriceWidgetProvider.ACTION_REFRESH` → the
+/// `widgetRefreshScan` WorkManager task), so the former explicit
+/// `refresh()` entry point this provider exposed was removed.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and
@@ -58,9 +64,12 @@ final class NearestWidgetRefreshProvider
   /// provider adds a foreground 2-minute tick that kicks the builder while
   /// the app is running.
   ///
-  /// #1803 — the resume hook is what makes the widget's refresh button
-  /// work: that button opens the app (#1801), and the app reaching the
-  /// foreground triggers a tick that rebuilds both widget variants.
+  /// #1803 — the resume hook keeps the widget fresh whenever the app
+  /// returns to the foreground. #2600 — the widget's own refresh button no
+  /// longer launches the app: it is a native broadcast that re-fetches
+  /// prices in place (`FuelPriceWidgetProvider.ACTION_REFRESH` → the
+  /// `widgetRefreshScan` WorkManager task), so the former explicit
+  /// `refresh()` entry point this provider exposed was removed.
   ///
   /// Reading the provider once (e.g. from the app's root widget) starts
   /// the tick; the provider owns its Timer + [AppLifecycleListener] and
@@ -93,7 +102,7 @@ final class NearestWidgetRefreshProvider
 }
 
 String _$nearestWidgetRefreshHash() =>
-    r'a9ac6b47255890ba9de4e86a9e3c05346eb8087d';
+    r'9381374c118f967eb22d7a1a7356bbd59cb03cb1';
 
 /// Foreground heartbeat that rebuilds the home-screen widget — both the
 /// favorites and the nearest variants — every
@@ -105,9 +114,12 @@ String _$nearestWidgetRefreshHash() =>
 /// provider adds a foreground 2-minute tick that kicks the builder while
 /// the app is running.
 ///
-/// #1803 — the resume hook is what makes the widget's refresh button
-/// work: that button opens the app (#1801), and the app reaching the
-/// foreground triggers a tick that rebuilds both widget variants.
+/// #1803 — the resume hook keeps the widget fresh whenever the app
+/// returns to the foreground. #2600 — the widget's own refresh button no
+/// longer launches the app: it is a native broadcast that re-fetches
+/// prices in place (`FuelPriceWidgetProvider.ACTION_REFRESH` → the
+/// `widgetRefreshScan` WorkManager task), so the former explicit
+/// `refresh()` entry point this provider exposed was removed.
 ///
 /// Reading the provider once (e.g. from the app's root widget) starts
 /// the tick; the provider owns its Timer + [AppLifecycleListener] and

--- a/test/app/app_initializer_test.dart
+++ b/test/app/app_initializer_test.dart
@@ -337,43 +337,30 @@ void main() {
     });
   });
 
-  group('Widget cold-launch URI dispatch (#2159)', () {
+  group('Widget cold-launch URI dispatch (#2600)', () {
     test(
-        '_stashWidgetLaunchUri intercepts refresh URIs before stashing',
-        () {
-      // #2159 — the refresh-button URI `tankstellenwidget://refresh`
-      // is NOT a route. If we let it flow into pendingWidgetUriProvider
-      // the router redirect consumes it (clears the stash) and
-      // widgetUriToPath returns null, so the user lands on the default
-      // landing screen and the widget never refreshes. The fix is to
-      // discriminate refresh URIs and call the refresh notifier
-      // directly, BEFORE the pending-URI stash.
+        '_stashWidgetLaunchUri stashes the launch URI with no refresh '
+        'discrimination', () {
+      // #2600 — the refresh button is now a native broadcast handled in
+      // place; it never launches the app. The former #2159 refresh-marker
+      // interception (`isWidgetRefreshUri` → `nearestWidgetRefreshProvider`
+      // before the stash) was therefore removed: every cold-launch URI is
+      // a station deep-link to stash for the router redirect.
       final body = _extractMethodBody(
           initSource, 'static Future<void> _stashWidgetLaunchUri');
       expect(body, isNotNull,
           reason: '_stashWidgetLaunchUri must exist');
 
-      final refreshCheck = body!.indexOf('isWidgetRefreshUri(uri)');
-      final refreshDispatch =
-          body.indexOf('nearestWidgetRefreshProvider.notifier');
-      final stash = body.indexOf('pendingWidgetUriProvider.notifier');
-
-      expect(refreshCheck, isNonNegative,
-          reason: 'must check isWidgetRefreshUri before stashing');
-      expect(refreshDispatch, isNonNegative,
-          reason: 'must dispatch refresh URIs to the refresh notifier');
-      expect(stash, isNonNegative,
-          reason: 'station URIs must still flow through the pending stash');
-
-      expect(refreshCheck, lessThan(stash),
+      expect(body, contains('pendingWidgetUriProvider.notifier'),
+          reason: 'launch URIs must flow through the pending stash');
+      expect(body, isNot(contains('isWidgetRefreshUri')),
           reason:
-              'the refresh discriminator must run BEFORE the stash, '
-              'otherwise refresh URIs are consumed by the router redirect '
-              'and silently dropped');
-      expect(refreshDispatch, lessThan(stash),
+              'the refresh-marker discriminator is gone — refresh no '
+              'longer launches the app (#2600)');
+      expect(body, isNot(contains('nearestWidgetRefreshProvider')),
           reason:
-              'the refresh dispatch must run BEFORE the stash for the '
-              'same reason');
+              'the cold-launch path must not dispatch to the refresh '
+              'notifier any more (#2600)');
     });
   });
 }

--- a/test/features/widget/data/nearest_widget_data_builder_test.dart
+++ b/test/features/widget/data/nearest_widget_data_builder_test.dart
@@ -339,6 +339,90 @@ void main() {
       expect(d0, lessThanOrEqualTo(d1));
     });
 
+    test('#2600 — flags the cheapest priced row(s) with isCheapest so the '
+        'redesigned widget can colour the price green', () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.5200);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.4050);
+
+      // Cheapest is NOT the nearest: rows are sorted by distance, so the
+      // isCheapest flag must track price, not position.
+      stationService.stationsToReturn = [
+        _stationFixture(
+          id: 'de-near-expensive',
+          brand: 'Aral',
+          street: 'Str0',
+          place: 'Berlin',
+          lat: 52.5201,
+          lng: 13.4051,
+          e10: 1.899,
+          dist: 0.2,
+        ),
+        _stationFixture(
+          id: 'de-far-cheapest',
+          brand: 'JET',
+          street: 'Str1',
+          place: 'Berlin',
+          lat: 52.55,
+          lng: 13.44,
+          e10: 1.749,
+          dist: 3.0,
+        ),
+        _stationFixture(
+          id: 'de-mid',
+          brand: 'Shell',
+          street: 'Str2',
+          place: 'Berlin',
+          lat: 52.53,
+          lng: 13.42,
+          e10: 1.819,
+          dist: 1.5,
+        ),
+      ];
+
+      final result = await builder.build();
+
+      final byId = {for (final s in result.stations) s['id']: s};
+      expect(byId['de-far-cheapest']!['isCheapest'], isTrue,
+          reason: 'the lowest-price row must be flagged regardless of '
+              'its distance rank');
+      expect(byId['de-near-expensive']!['isCheapest'], isFalse);
+      expect(byId['de-mid']!['isCheapest'], isFalse);
+      // Exactly one cheapest in this set (no ties).
+      expect(
+        result.stations.where((s) => s['isCheapest'] == true).length,
+        1,
+      );
+    });
+
+    test('#2600 — when no row has a price, none is flagged cheapest',
+        () async {
+      await settings.putSetting(StorageKeys.userPositionLat, 52.5200);
+      await settings.putSetting(StorageKeys.userPositionLng, 13.4050);
+      profiles.activeProfileJson = {
+        'id': 'p1',
+        'name': 'EV',
+        'preferredFuelType': 'electric',
+        'defaultSearchRadius': 10.0,
+      };
+      // Electric profile → Station.priceFor returns null → no priced rows.
+      stationService.stationsToReturn = [
+        _stationFixture(
+          id: 'de-0',
+          brand: 'Shell',
+          street: 'Str0',
+          place: 'Berlin',
+          lat: 52.52,
+          lng: 13.40,
+          e10: 1.799,
+        ),
+      ];
+
+      final result = await builder.build();
+
+      expect(result.stations, hasLength(1));
+      expect(result.stations.first['isCheapest'], isFalse);
+    });
+
     test('uses the active profile radius and fuel type (not hardcoded)',
         () async {
       await settings.putSetting(StorageKeys.userPositionLat, 52.5200);

--- a/test/features/widget/presentation/widget_click_listener_test.dart
+++ b/test/features/widget/presentation/widget_click_listener_test.dart
@@ -138,55 +138,27 @@ void main() {
     });
   });
 
-  group('isWidgetRefreshUri (#1961 — refresh marker)', () {
-    test('tankstellenwidget://refresh → true', () {
-      expect(
-        isWidgetRefreshUri(Uri.parse('tankstellenwidget://refresh')),
-        isTrue,
-      );
-    });
-
-    test('a station deep-link → false', () {
-      expect(
-        isWidgetRefreshUri(
-          Uri.parse('tankstellenwidget://station?id=abc'),
-        ),
-        isFalse,
-      );
-    });
-
-    test('null / wrong scheme → false', () {
-      expect(isWidgetRefreshUri(null), isFalse);
-      expect(isWidgetRefreshUri(Uri.parse('https://refresh')), isFalse);
-    });
-
-    test('the refresh marker is not also a navigation target', () {
-      // The two parsers must stay mutually exclusive — a refresh tap
-      // must never resolve to a route to push.
-      final refresh = Uri.parse('tankstellenwidget://refresh');
-      expect(isWidgetRefreshUri(refresh), isTrue);
-      expect(widgetUriToPath(refresh), isNull);
-    });
-  });
-
-  group('WidgetLaunchHandler — refresh marker (#1961)', () {
-    GoRouter buildRouter() => GoRouter(
-          initialLocation: '/',
-          routes: [
-            GoRoute(path: '/', builder: (_, _) => const Text('home')),
-            GoRoute(
-              path: '/station/:id',
-              builder: (_, state) =>
-                  Text('station ${state.pathParameters['id']}'),
-            ),
-          ],
-        );
-
-    testWidgets('a refresh URI runs onRefresh and does not navigate',
+  group('WidgetLaunchHandler — refresh URI removed (#2600)', () {
+    // #2600 — the refresh button is now a native broadcast handled in
+    // place; it never launches the app. The old refresh-marker URI is
+    // therefore no longer a navigation seam at all. A
+    // `tankstellenwidget://refresh` URI (host != station) resolves to no
+    // path and is a harmless no-op should one ever still arrive.
+    testWidgets(
+        'a (legacy) refresh URI resolves to no path and never navigates',
         (tester) async {
-      final router = buildRouter();
-      var refreshCount = 0;
-      final handler = WidgetLaunchHandler(router, () => refreshCount++);
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const Text('home')),
+          GoRoute(
+            path: '/station/:id',
+            builder: (_, state) =>
+                Text('station ${state.pathParameters['id']}'),
+          ),
+        ],
+      );
+      final handler = WidgetLaunchHandler(router);
 
       await tester.pumpWidget(MaterialApp.router(routerConfig: router));
       expect(find.text('home'), findsOneWidget);
@@ -194,23 +166,10 @@ void main() {
       handler.handle(Uri.parse('tankstellenwidget://refresh'));
       await tester.pumpAndSettle();
 
-      expect(refreshCount, 1);
       expect(find.text('home'), findsOneWidget,
-          reason: 'a refresh tap must rebuild the widget, never navigate');
-    });
-
-    testWidgets('a station URI navigates and does NOT run onRefresh',
-        (tester) async {
-      final router = buildRouter();
-      var refreshCount = 0;
-      final handler = WidgetLaunchHandler(router, () => refreshCount++);
-
-      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
-      handler.handle(Uri.parse('tankstellenwidget://station?id=abc'));
-      await tester.pumpAndSettle();
-
-      expect(refreshCount, 0);
-      expect(find.text('station abc'), findsOneWidget);
+          reason: 'host != station → widgetUriToPath null → no navigation');
+      expect(widgetUriToPath(Uri.parse('tankstellenwidget://refresh')),
+          isNull);
     });
   });
 


### PR DESCRIPTION
Closes #2600.

## Part 1 — Refresh in place (no app launch)
The widget refresh (↻) icon was an Activity PendingIntent carrying the
`tankstellenwidget://refresh` marker URI (#1801/#1961), so a tap cold-launched
the app instead of refreshing.

- Re-introduced `ACTION_REFRESH` as a **broadcast** to `FuelPriceWidgetProvider`
  (mirroring `ACTION_TOGGLE_MODE`). The refresh icon's `setOnClickPendingIntent`
  is now `PendingIntent.getBroadcast(...)` targeting the provider with the
  appWidgetId extra + `FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE`.
- `onReceive` handles `ACTION_REFRESH` by enqueuing the existing
  `widgetRefreshScan` WorkManager task via `BackgroundScanEnqueuer` — the same
  #2412 path the periodic `onUpdate` wake uses. The Dart
  `BackgroundService.widgetRefreshScanTask` re-fetches prices and re-renders
  every placed widget. **No activity launch.**
- Transient "refreshing…" affordance: the refresh glyph is dimmed via
  `partiallyUpdateAppWidget` → `setImageAlpha`; the next full render restores it.
- Removed the dead refresh-via-URI app-launch path on the Flutter side:
  `isWidgetRefreshUri`, the `WidgetLaunchHandler` `_onRefresh` branch,
  `NearestWidgetRefresh.refresh()`, and the #2159 cold-launch discrimination in
  `AppInitializer._stashWidgetLaunchUri`.
- Tapping a station ROW still opens the app (`ACTION_OPEN_APP`) unchanged.

## Part 2 — Row redesign (price ≫ name ≈ distance ≫ address)
- **Price**: primary anchor — 18sp bold, colour-coded. The cheapest priced row
  in the rendered set is flagged `isCheapest` by `NearestWidgetDataBuilder`
  (rows are distance-sorted, so cheapest ≠ first) → green; others use a
  high-contrast default. New `widget_price_cheap`/`widget_price_default` tokens
  with values/ + values-night/ variants.
- **Name**: bold 14sp, ellipsised, top row.
- **Distance**: bold, right-aligned, top row.
- **Address**: secondary — 10sp, dim (`widget_text_tertiary`), single-line
  ellipsised.
- **Open/Closed status pill** kept, now with an explicit pinned colour (green
  open / dim secondary closed) so it stays legible on the dark-navy background
  where it previously inherited a near-invisible default.
- All view ids preserved → `buildRow` bindings untouched; only ordering, sizes,
  weights, colours changed.

## Verification
- Built `flutter build apk --debug --flavor fdroid` locally — Kotlin +
  RemoteViews XML compile cleanly (`assembleFdroidDebug` ✓).
- `flutter test test/features/widget/` + app/router tests green (134 tests),
  incl. new cheapest-flag unit tests + updated refresh/cold-launch tests.
- `flutter analyze`: zero new (only the known pre-existing `unnecessary_import`
  info).
- `test/lint/file_length_test.dart` + `no_hardcoded_ui_strings_test.dart` green.
- ARB-free: zero `lib/l10n/` diff.
- Clean codegen verified: zero `*.g.dart`/`*.freezed.dart` drift.

On-device visual verification (contrast across the 4 schemes + night variants)
is the maintainer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
