### PR TITLE
ci(ios): TestFlight tester-management lane + workflow_dispatch (add external testers)

### DIFF
--- a/.github/workflows/ios-testers.yml
+++ b/.github/workflows/ios-testers.yml
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: iOS TestFlight Testers
+
+# Add an external iOS tester to the app's TestFlight beta group(s) via the
+# App Store Connect API. `workflow_dispatch` ONLY — this is an outward-facing
+# live ASC mutation (it sends an invite email to the tester), so it must never
+# run automatically. The maintainer (or the orchestrator) triggers it by hand.
+#
+# Auth reuses the App Store Connect API key exactly like `ios-testflight.yml`:
+# the base64 secret is decoded to a temp .p8 and exported as
+# ASC_API_KEY_FILEPATH, which the Fastfile's `asc_api_key` helper picks up.
+#
+# This is an API-only operation (no build, no match, no Xcode), so it runs on
+# ubuntu-latest — much cheaper than a macOS runner.
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'Tester email to enroll (an invite email is sent to them)'
+        required: true
+        type: string
+        default: 'florian.dittgen@trelleborg.com'
+      groups:
+        description: 'Comma-separated beta group names. Leave empty to add the tester to ALL external groups.'
+        required: false
+        type: string
+        default: ''
+      first_name:
+        description: 'Tester first name (optional)'
+        required: false
+        type: string
+        default: ''
+      last_name:
+        description: 'Tester last name (optional)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-testers
+  cancel-in-progress: false
+
+jobs:
+  add-tester:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Decode App Store Connect API key
+        # Copied verbatim from ios-testflight.yml: decode the base64 secret to
+        # a temp .p8 and export ASC_API_KEY_FILEPATH so the Fastfile's
+        # `asc_api_key` helper consumes the on-disk key.
+        env:
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          if [ -z "$ASC_KEY_BASE64" ]; then
+            echo "::error::APP_STORE_CONNECT_API_KEY_BASE64 secret is not set." >&2
+            exit 1
+          fi
+          KEY_PATH="$RUNNER_TEMP/asc-api-key.p8"
+          echo "$ASC_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "ASC_API_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: fastlane manage_testers
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          # ASC_API_KEY_FILEPATH was exported by the decode step above.
+          FASTLANE_DISABLE_COLORS: '1'
+        run: |
+          bundle exec fastlane manage_testers \
+            email:"${{ inputs.email }}" \
+            groups:"${{ inputs.groups }}" \
+            first_name:"${{ inputs.first_name }}" \
+            last_name:"${{ inputs.last_name }}"
+
+      - name: Clean up decoded API key
+        if: always()
+        run: rm -f "$ASC_API_KEY_FILEPATH"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## iOS TestFlight Tester"
+            echo ""
+            echo "- **Email:** ${{ inputs.email }}"
+            echo "- **Groups:** ${{ inputs.groups != '' && inputs.groups || 'ALL external groups' }}"
+            echo "- **Bundle ID:** de.tankstellen.tankstellen"
+            echo "- **Trigger:** ${{ github.event_name }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ docs/guides/*
 !docs/guides/feature-flags.md
 !docs/guides/fdroid-submission.md
 !docs/guides/app-store-listing.md
+!docs/guides/ios-testflight-testers.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/ios-testflight-testers.md
+++ b/docs/guides/ios-testflight-testers.md
@@ -1,0 +1,70 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# Add an external TestFlight tester
+
+Enroll an external iOS tester into the app's TestFlight beta group(s) so they
+receive **all current and future** builds for that group — without logging
+into App Store Connect by hand.
+
+## How to run
+
+GitHub → **Actions** → **iOS TestFlight Testers** → **Run workflow**
+(`workflow_dispatch`). Or from the CLI:
+
+```bash
+# Add the default tester (florian.dittgen@trelleborg.com) to ALL external groups
+gh workflow run ios-testers.yml
+
+# Add a specific tester, optionally to specific group(s)
+gh workflow run ios-testers.yml \
+  -f email="someone@example.com" \
+  -f groups="External Testers" \
+  -f first_name="Some" \
+  -f last_name="One"
+```
+
+### Inputs
+
+| Input        | Required | Default                          | Meaning                                                                 |
+| ------------ | -------- | -------------------------------- | ----------------------------------------------------------------------- |
+| `email`      | yes      | `florian.dittgen@trelleborg.com` | Tester email. An invite email is sent to this address.                  |
+| `groups`     | no       | _(empty)_                        | Comma-separated group names. **Empty → add to every external group.**   |
+| `first_name` | no       | _(empty)_                        | Tester first name.                                                      |
+| `last_name`  | no       | _(empty)_                        | Tester last name.                                                       |
+
+When `groups` is omitted the workflow enumerates the app's external beta
+groups and adds the tester to **each** of them, so "all current and future
+tests" is covered regardless of how the group is named. The run log prints the
+discovered group names (internal and external) so you can see exactly which
+group the tester landed in.
+
+## Prerequisites
+
+- The app (`de.tankstellen.tankstellen`) must already have a **TestFlight
+  build** and **at least one external beta group** in App Store Connect.
+  Create the group under App Store Connect → TestFlight first; the workflow
+  adds testers to existing groups, it does not create them. If no external
+  group exists (and no matching `groups` name is passed) the lane fails with a
+  clear message.
+- The App Store Connect API key secrets must be configured (they already are
+  for the TestFlight build workflow): `APP_STORE_CONNECT_API_KEY_BASE64`,
+  `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`.
+
+## What happens
+
+- The tester receives a TestFlight **invite email**. They accept it, install
+  TestFlight, and from then on get every build distributed to that group.
+- The operation is **idempotent**: re-running it for an already-enrolled
+  tester is a no-op, not an error.
+
+## Why `workflow_dispatch` only
+
+This is an outward-facing, live App Store Connect mutation that emails a real
+person. It must never run automatically, so the workflow has no `push` /
+`schedule` triggers — the maintainer (or the orchestrator) dispatches it by
+hand. Under the hood it reuses the same App Store Connect API key and decode
+step as `ios-testflight.yml`, and the `manage_testers` lane in
+`ios/fastlane/Fastfile`.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -142,6 +142,93 @@ platform :ios do
     upload_testflight(changelog: options[:changelog])
   end
 
+  desc "Add an external TestFlight tester to the app's beta group(s)."
+  desc "Inputs (lane options or ENV): email (required), groups (optional"
+  desc "comma list — when omitted, the tester is added to EVERY external"
+  desc "beta group so they receive all current and future builds), and an"
+  desc "optional first_name / last_name. Idempotent: re-adding an existing"
+  desc "tester is a no-op, not a failure. Auth = the same App Store Connect"
+  desc "API key as upload_testflight (asc_api_key)."
+  lane :manage_testers do |options|
+    email = options[:email] || ENV["TESTFLIGHT_TESTER_EMAIL"]
+    UI.user_error!("manage_testers requires an `email` (lane option or TESTFLIGHT_TESTER_EMAIL).") if email.nil? || email.strip.empty?
+    email = email.strip
+
+    first_name = options[:first_name] || ENV["TESTFLIGHT_TESTER_FIRST_NAME"]
+    last_name = options[:last_name] || ENV["TESTFLIGHT_TESTER_LAST_NAME"]
+
+    # `groups` may arrive as a comma list (workflow input) or be empty.
+    raw_groups = options[:groups] || ENV["TESTFLIGHT_TESTER_GROUPS"] || ""
+    requested_groups = raw_groups.to_s.split(",").map(&:strip).reject(&:empty?)
+
+    # Authenticate Spaceship's ConnectAPI directly with the same key the
+    # upload lane uses. `asc_api_key` returns the `app_store_connect_api_key`
+    # hash; `Token.from(hash:)` is exactly how pilot's own Manager logs in
+    # (pilot/lib/pilot/manager.rb), so we reuse the proven path and then
+    # drive the BetaGroup/BetaTester models for full control over the
+    # "all external groups" enumeration and idempotency.
+    api_token = Spaceship::ConnectAPI::Token.from(hash: asc_api_key)
+    Spaceship::ConnectAPI.token = api_token
+
+    # Explicit app lookup by bundle id — mirrors upload_testflight's reasoning
+    # for passing the IDs explicitly rather than letting the API enumerate
+    # apps from the key alone.
+    app = Spaceship::ConnectAPI::App.find("de.tankstellen.tankstellen")
+    UI.user_error!("Could not find app de.tankstellen.tankstellen on App Store Connect.") if app.nil?
+
+    all_groups = app.get_beta_groups
+    external_groups = all_groups.reject(&:is_internal_group)
+
+    UI.message("TestFlight beta groups for #{app.name}:")
+    all_groups.each do |g|
+      kind = g.is_internal_group ? "internal" : "external"
+      UI.message("  - #{g.name} (#{kind})")
+    end
+
+    target_groups =
+      if requested_groups.empty?
+        # No groups given → add to EVERY external group so the tester gets
+        # all current and future builds regardless of the group's name.
+        UI.message("No `groups` given — adding #{email} to ALL external beta groups.")
+        external_groups
+      else
+        matched = all_groups.select { |g| requested_groups.include?(g.name) }
+        missing = requested_groups - matched.map(&:name)
+        UI.important("Requested group(s) not found and skipped: #{missing.join(', ')}") unless missing.empty?
+        matched
+      end
+
+    if target_groups.empty?
+      UI.user_error!(
+        "No target beta group(s) to add the tester to. " \
+        "The app needs at least one external beta group in App Store Connect " \
+        "(create one under TestFlight first), or pass an existing `groups` name.",
+      )
+    end
+
+    tester = { email: email, firstName: first_name, lastName: last_name }
+
+    target_groups.each do |group|
+      begin
+        group.post_bulk_beta_tester_assignments(beta_testers: [tester])
+        UI.success("Added #{email} to external beta group '#{group.name}'.")
+      rescue => ex
+        # Re-adding an already-present tester surfaces as a duplicate /
+        # already-exists error from ASC. Treat that as success so the lane
+        # is idempotent; re-raise anything else.
+        message = ex.message.to_s
+        if message =~ /already|exist|duplicat/i
+          UI.success("#{email} is already in '#{group.name}' — nothing to do.")
+        else
+          UI.error("Failed to add #{email} to '#{group.name}': #{message}")
+          raise ex
+        end
+      end
+    end
+
+    UI.success("Done. #{email} is enrolled in: #{target_groups.map(&:name).join(', ')}.")
+  end
+
   desc "Stage App Store text metadata (name/subtitle/keywords/description/etc.)."
   desc "Run manually on a maintainer workstation — never on CI, never auto-submit."
   desc "Reads metadata/<locale>/ and the safe flags in Deliverfile; a human"


### PR DESCRIPTION
## What

Self-service path to enroll an external iOS tester into the app's TestFlight
beta group(s) so they receive **all current and future** builds — no manual
App Store Connect session.

## Changes

- **`ios/fastlane/Fastfile`** — new `manage_testers` lane.
  - Inputs (lane options / ENV): `email` (required), `groups` (optional comma
    list), `first_name` / `last_name` (optional).
  - `groups` given → adds to those group(s). `groups` omitted → enumerates the
    app's **external** beta groups and adds the tester to **each**, so "all
    current and future tests" is covered regardless of group name. Logs the
    discovered group names (internal + external) to the run output.
  - **Idempotent** — re-adding an existing tester is a no-op, not a failure.
  - Auth + app/apple/team scoping reuse the proven `asc_api_key` path;
    Spaceship `ConnectAPI` is driven directly (same login as pilot's Manager).
- **`.github/workflows/ios-testers.yml`** — `workflow_dispatch` **ONLY**
  (`email` default `florian.dittgen@trelleborg.com`, optional `groups` /
  names). Decodes the ASC key **verbatim** from `ios-testflight.yml` (base64
  secret → temp `.p8` → `ASC_API_KEY_FILEPATH`), runs the lane on
  `ubuntu-latest` (API-only — no build/match/Xcode), always cleans up the key.
  `permissions: contents: read`.
- **`docs/guides/ios-testflight-testers.md`** — how to run, the
  all-external-groups behaviour, prerequisites (a TestFlight build + at least
  one external beta group must already exist), and that an invite email is
  sent. `.gitignore` negation so the new guide is tracked (the dir is
  allowlisted per-file).

## Notes

- **No Dart / ARB.** Reuses existing secrets
  `APP_STORE_CONNECT_API_KEY_BASE64` / `_KEY_ID` / `_ISSUER_ID` (all present).
- The workflow is an outward-facing **live ASC mutation** (emails a real
  tester), so it's `workflow_dispatch`-only and was **not** triggered here —
  the maintainer/orchestrator dispatches it after merge.
- This PR touches `ios/fastlane/` + a workflow (not pure docs/md), so the full
  `ci.yml` runs rather than the `ci-docs-stub`. It's non-Dart, so `analyze`
  passes and the gated heavy jobs run/pass unchanged.

Closes #2604
