### PR TITLE
feat(pip): always lead with L/100km + approach radar priced-only + tap-to-navigate (#2601)

### DIFF
--- a/lib/core/services/approach_detector.dart
+++ b/lib/core/services/approach_detector.dart
@@ -275,10 +275,21 @@ class ApproachDetector {
               ))
           .where((p) => p.$2 <= _config.radiusMeters)
           .toList();
-      if (inRadius.isEmpty) {
+      // #2601 — priced-only surface (same rule as the radar #2583): an
+      // unpriced forecourt has no actionable price for the driver, so it
+      // must never trigger ApproachInRadius/Leaving. Filter to stations
+      // that quote a usable price for the effective fuel before ranking;
+      // the cheapest-ranking (#2299) + nearest-lock logic then operate on
+      // the priced subset only.
+      final fuel = FuelType.fromString(_config.fuelTypeApiValue);
+      final priced = inRadius.where((p) {
+        final price = p.$1.priceFor(fuel);
+        return price != null && price > 0;
+      }).toList();
+      if (priced.isEmpty) {
         _onNoStationInRadius(gps);
       } else {
-        _onStationsInRadius(inRadius);
+        _onStationsInRadius(priced);
       }
     } on Object {
       // Network / chain failure — stay in Polling silently. The next

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/services/approach_detector.dart';
+import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -28,9 +29,10 @@ import '../../providers/trip_recording_provider.dart';
 /// On a GPS-only trajet (no OBD2 fuel-rate samples) the big figure is
 /// the live physics estimate rendered as `~X.X L/100 km` once the
 /// estimator has warmed up (#2390 / Epic #2385) — the leading `~` flags
-/// it an estimate per ADR 0012. Before the estimate lands (warm-up /
-/// uncalibrated) the tile gracefully falls back to distance, then
-/// elapsed time, so no information-free placeholder is ever shown.
+/// it an estimate per ADR 0012. Before the estimate lands (warm-up) the
+/// hero stays consumption-FRAMED — a bare `~` under the same "est.
+/// L/100 km" caption (#2601) — so the per-100 km figure always leads;
+/// distance and elapsed are demoted to the secondary row, never the hero.
 ///
 /// The widget is paint-only — it does not own the recording state.
 /// The caller passes in the live [TripRecordingState] and a band
@@ -74,32 +76,27 @@ class TripRecordingPipView extends StatelessWidget {
     return _buildDefaultLayout(context);
   }
 
-  /// Default PiP layout (no approach radius hit) — picks the **most
-  /// informative** metric for the big slot based on what the trajet
-  /// has produced so far (#2094 + #2390). Four branches, priority order:
+  /// Default PiP layout (no approach radius hit) — the hero slot is
+  /// **always consumption** (#2601): measured L/100 km, a live estimate,
+  /// or a warm-up placeholder. The user repeatedly asked for the per-100
+  /// km figure to lead, so elapsed (and distance) never take the hero —
+  /// they live in the secondary row. Three consumption states, in order:
   ///
-  /// 1. **OBD2 live fuel rate available** → huge L/100 km (or L/h on
-  ///    idle). Secondary row: distance + elapsed.
-  /// 2. **GPS-only with a live estimate** (#2390) → huge **`~X.X`** under
-  ///    the dedicated localized **`est. L/100 km`** caption (#2393), which
-  ///    reads distinctly from the OBD2 branch's bare `L/100 km`. The
-  ///    leading `~` (a literal glyph, not translatable) marks it an
-  ///    estimate per ADR 0012, and the figure block carries an
-  ///    approximate-explanation tooltip + accessibility label (#2393).
-  ///    The figure comes from `gpsEstimatedLPer100Km`, non-null only on a
-  ///    moving GPS-only trajet once the estimator has warmed up.
-  ///    Secondary row: distance + elapsed.
-  /// 3. **GPS-only, no estimate yet, distance ≥ 0.1 km** → huge
-  ///    **distance**. The estimator is still warming up (or the matrix
-  ///    isn't calibrated); distance is the most useful real-time number.
-  ///    Secondary row: elapsed.
-  /// 4. **Pre-roll (distance ≈ 0)** → huge **elapsed time**. The user
-  ///    sees the session is recording while the GPS warms up.
-  ///    Secondary row: empty.
+  /// 1. **OBD2 live fuel rate** → huge L/100 km (or L/h on idle).
+  /// 2. **GPS-only live estimate** (#2390) → huge **`~X.X`** under the
+  ///    dedicated localized **`est. L/100 km`** caption (#2393), distinct
+  ///    from the OBD2 branch's bare `L/100 km`. The leading `~` (a literal
+  ///    glyph) marks it an estimate per ADR 0012; the figure block carries
+  ///    the approximate-explanation tooltip + a11y label. The value comes
+  ///    from `gpsEstimatedLPer100Km` (moving GPS-only trajet, warmed up).
+  /// 3. **Warm-up — no rate, estimate not landed** (#2601) → a bare **`~`**
+  ///    placeholder under the same `est. L/100 km` caption (`~` already
+  ///    reads as "modelled" per ADR 0012, so it reuses the estimate
+  ///    tooltip + semantics).
   ///
-  /// The big `~` placeholder that wasted the tile pre-#2094 is gone —
-  /// no branch renders an information-free symbol huge; the `~` here
-  /// always precedes a real estimate.
+  /// All three demote distance (when ≥ 0.1 km) + elapsed to the secondary
+  /// row. A final `else` crash-guard renders a sane fallback if no live
+  /// reading exists at all (shouldn't happen during an active recording).
   Widget _buildDefaultLayout(BuildContext context) {
     final l = AppLocalizations.of(context);
     final live = state.live;
@@ -142,20 +139,19 @@ class TripRecordingPipView extends StatelessWidget {
         if (distance != null) '${distance.toStringAsFixed(1)} km',
         if (elapsed != null) _fmtElapsed(elapsed),
       ];
-    } else if (distance != null && distance >= 0.1) {
-      // Branch 3 — GPS-only mid-trajet, no estimate yet: distance is the
-      // live signal (graceful fallback while the estimator warms up).
-      bigFigure = distance.toStringAsFixed(1);
-      bigCaption = 'km';
+    } else if (live != null && !paused) {
+      // Branch 3 (#2601) — pre-estimate warm-up: no OBD2 rate, GPS
+      // estimate not landed yet. Keep the hero consumption-FRAMED (never
+      // lead with elapsed). Placeholder glyph under the same "est.
+      // L/100 km" caption; demote distance + elapsed to the secondary
+      // row like the measured branches.
+      bigFigure = '~';
+      bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
+      isEstimate = true;
       secondaryRow = [
+        if (distance != null && distance >= 0.1) '${distance.toStringAsFixed(1)} km',
         if (elapsed != null) _fmtElapsed(elapsed),
       ];
-    } else if (elapsed != null) {
-      // Branch 3 — pre-roll: lead with elapsed time so the user
-      // knows the session is recording while GPS warms up.
-      bigFigure = _fmtElapsed(elapsed);
-      bigCaption = l?.tripRecordingPipElapsedCaption ?? 'elapsed';
-      secondaryRow = const <String>[];
     } else {
       // No data at all (shouldn't happen during an active recording,
       // but render a sane fallback rather than crashing).
@@ -288,62 +284,77 @@ class TripRecordingPipView extends StatelessWidget {
         : '—';
     final fuelLabel = fuel.displayName;
 
-    return Material(
-      color: backgroundColor,
-      child: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              FittedBox(
-                fit: BoxFit.scaleDown,
-                child: Text(
-                  priceText,
-                  style: TextStyle(
-                    color: foregroundColor,
-                    fontWeight: FontWeight.w800,
-                    fontSize: 56,
-                    height: 1.0,
-                    fontFeatures: const [FontFeature.tabularFigures()],
+    // #2601 — tap the approach-price tile to navigate to the station in
+    // the user's maps app (reuses NavigationUtils #2546). Only this layout
+    // is tappable; the default L/100 km layout stays non-tappable.
+    final navigateLabel = l?.navigate ?? 'Navigate';
+    return Tooltip(
+      message: navigateLabel,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => NavigationUtils.openInMaps(
+          station.lat,
+          station.lng,
+          label: station.navLabel,
+        ),
+        child: Material(
+          color: backgroundColor,
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      priceText,
+                      style: TextStyle(
+                        color: foregroundColor,
+                        fontWeight: FontWeight.w800,
+                        fontSize: 56,
+                        height: 1.0,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
                   ),
-                ),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                fuelLabel,
-                style: TextStyle(
-                  color: foregroundColor.withValues(alpha: 0.85),
-                  fontWeight: FontWeight.w600,
-                  fontSize: 14,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                station.name.isNotEmpty ? station.name : station.brand,
-                style: TextStyle(
-                  color: foregroundColor.withValues(alpha: 0.95),
-                  fontWeight: FontWeight.w600,
-                  fontSize: 13,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              if (distanceMeters != null) ...[
-                const SizedBox(height: 2),
-                Text(
-                  l?.approachStationDistance(
-                          distanceMeters.toStringAsFixed(0)) ??
-                      '${distanceMeters.toStringAsFixed(0)} m',
-                  style: TextStyle(
-                    color: foregroundColor.withValues(alpha: 0.85),
-                    fontSize: 12,
-                    fontFeatures: const [FontFeature.tabularFigures()],
+                  const SizedBox(height: 2),
+                  Text(
+                    fuelLabel,
+                    style: TextStyle(
+                      color: foregroundColor.withValues(alpha: 0.85),
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                   ),
-                ),
-              ],
-            ],
+                  const SizedBox(height: 4),
+                  Text(
+                    station.name.isNotEmpty ? station.name : station.brand,
+                    style: TextStyle(
+                      color: foregroundColor.withValues(alpha: 0.95),
+                      fontWeight: FontWeight.w600,
+                      fontSize: 13,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (distanceMeters != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      l?.approachStationDistance(
+                              distanceMeters.toStringAsFixed(0)) ??
+                          '${distanceMeters.toStringAsFixed(0)} m',
+                      style: TextStyle(
+                        color: foregroundColor.withValues(alpha: 0.85),
+                        fontSize: 12,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/test/core/services/approach_detector_test.dart
+++ b/test/core/services/approach_detector_test.dart
@@ -268,4 +268,88 @@ void main() {
       });
     });
   });
+
+  // #2601 — priced-only surface: an in-radius station that quotes no
+  // usable price for the effective fuel must NOT trigger
+  // ApproachInRadius (the price would be non-actionable). A priced one
+  // surfaces normally.
+  group('ApproachDetector priced-only surface (#2601)', () {
+    test('an in-radius UNPRICED station never enters InRadius', () {
+      fakeAsync((async) {
+        // Single station inside the radius (≈111 m) with NO e10 price —
+        // it sells diesel only. Requesting e10 must yield no in-radius
+        // emit; the detector stays in Polling.
+        final stations = [
+          _station(id: 'A', lat: 48.001, lng: 2.0, diesel: 1.849),
+        ];
+
+        final gps = StreamController<Position>.broadcast();
+        final det = ApproachDetector(
+          gpsStream: gps.stream,
+          fetchStations: (_, _, _, _) async => stations,
+          config: const ApproachDetectorConfig(
+            radiusMeters: 1000,
+            priceMode: ApproachPriceMode.nearest,
+            minPollSeconds: 5,
+            fuelTypeApiValue: 'e10', // not sold at A
+          ),
+        );
+        final emitted = <ApproachState>[];
+        final sub = det.state.listen(emitted.add);
+
+        gps.add(_pos(48.0, 2.0, speedMps: 25));
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        expect(emitted.whereType<ApproachInRadius>(), isEmpty,
+            reason: 'an unpriced station must not surface a non-actionable '
+                'price — it stays out of InRadius');
+        expect(emitted.last, isA<ApproachPolling>(),
+            reason: 'with no priced station in radius the detector polls');
+
+        sub.cancel();
+        det.dispose();
+        gps.close();
+      });
+    });
+
+    test('a PRICED in-radius station surfaces normally', () {
+      fakeAsync((async) {
+        // Same station but now it quotes the requested e10 price.
+        final stations = [
+          _station(id: 'A', lat: 48.001, lng: 2.0, e10: 1.699),
+        ];
+
+        final gps = StreamController<Position>.broadcast();
+        final det = ApproachDetector(
+          gpsStream: gps.stream,
+          fetchStations: (_, _, _, _) async => stations,
+          config: const ApproachDetectorConfig(
+            radiusMeters: 1000,
+            priceMode: ApproachPriceMode.nearest,
+            minPollSeconds: 5,
+            fuelTypeApiValue: 'e10',
+          ),
+        );
+        final emitted = <ApproachState>[];
+        final sub = det.state.listen(emitted.add);
+
+        gps.add(_pos(48.0, 2.0, speedMps: 25));
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        final inRadius = emitted.whereType<ApproachInRadius>().toList();
+        expect(inRadius, isNotEmpty,
+            reason: 'a station with a price for the effective fuel must '
+                'surface');
+        expect(inRadius.last.station.id, 'A');
+
+        sub.cancel();
+        det.dispose();
+        gps.close();
+      });
+    });
+  });
 }

--- a/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_banner_test.dart
@@ -246,12 +246,13 @@ void main() {
           reason: 'PiP must not render the shell — that is what dragged '
               'the button bar into the tile (#1977)');
       // The compact trip strip is still shown. With distance=4.0 +
-      // no fuel rate, #2094's context-adaptive primary lands the
-      // layout on the GPS-only branch: "4.0" hero figure with "km"
-      // caption. Finding the distance value is enough proof the
-      // tile didn't collapse to nothing.
-      expect(find.textContaining('4.0'), findsOneWidget);
-      expect(find.text('km'), findsOneWidget);
+      // no fuel rate + no estimate, #2601's consumption-framed warm-up
+      // branch leads with the "~" placeholder under the est. L/100 km
+      // caption and demotes the distance ("4.0 km") to the secondary
+      // row. Finding the distance value is enough proof the tile
+      // didn't collapse to nothing.
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('4.0 km'), findsOneWidget);
     });
 
     testWidgets('outside PiP mode the shell child renders as usual',

--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
@@ -202,7 +203,7 @@ void main() {
       expect(find.text('Carrefour Pézenas'), findsNothing);
     });
   });
-  group('TripRecordingPipView (#2094) — context-adaptive primary', () {
+  group('TripRecordingPipView (#2094/#2601) — consumption-framed hero', () {
     Widget buildWith({double? fuelRate, double distance = 12.4}) =>
         _wrap(TripRecordingPipView(
           state: _activeState(
@@ -223,31 +224,43 @@ void main() {
       expect(find.text('elapsed'), findsNothing);
     });
 
-    testWidgets('GPS-only branch — distance ≥ 0.1 km → big distance',
-        (tester) async {
+    testWidgets(
+        '#2601 warm-up — distance ≥ 0.1 km, no estimate → "~" + est caption '
+        '(NOT big distance)', (tester) async {
       await tester.pumpWidget(buildWith(fuelRate: null, distance: 4.0));
-      // Branch 2 — distance is the hero figure.
-      expect(find.text('4.0'), findsOneWidget);
-      expect(find.text('km'), findsOneWidget);
+      // #2601 — the hero stays consumption-framed: a "~" placeholder under
+      // the est. L/100 km caption, never a huge distance.
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('est. L/100 km'), findsOneWidget);
+      // Distance is demoted to the secondary row (km suffix, not a hero).
+      expect(find.text('4.0 km'), findsOneWidget);
       expect(find.text('L/100 km'), findsNothing);
-      // Pre-#2094 the layout rendered "~" huge; assert that's gone.
-      expect(find.text('~'), findsNothing);
+      // No bare "km" caption hero anymore.
+      expect(find.text('km'), findsNothing);
     });
 
-    testWidgets('pre-roll branch — distance ≈ 0 → big elapsed time',
+    testWidgets(
+        '#2601 warm-up — distance ≈ 0 (pre-roll) → "~" + est caption with '
+        'elapsed in the secondary row (NOT big elapsed — THE BUG)',
         (tester) async {
       await tester.pumpWidget(buildWith(fuelRate: null, distance: 0.0));
-      // Branch 3 — elapsed time is the hero figure with "elapsed"
-      // caption. Default helper uses 8m 32s elapsed.
-      expect(find.text('elapsed'), findsOneWidget);
-      expect(find.text('8m 32s'), findsOneWidget);
+      // #2601 — THE BUG fix: pre-roll no longer leads with huge elapsed.
+      // The hero is the consumption-framed "~" placeholder; elapsed is
+      // demoted to the secondary row. Default helper uses 8m 32s elapsed.
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('est. L/100 km'), findsOneWidget);
+      expect(find.text('8m 32s'), findsOneWidget); // secondary row
+      // Elapsed is NOT the hero caption anymore.
+      expect(find.text('elapsed'), findsNothing);
       expect(find.text('km'), findsNothing);
       expect(find.text('L/100 km'), findsNothing);
-      expect(find.text('~'), findsNothing);
     });
 
-    testWidgets('elapsed-time formatter reads as a duration, not a clock',
-        (tester) async {
+    testWidgets(
+        'elapsed-time formatter reads as a duration, not a clock '
+        '(secondary row)', (tester) async {
+      // The formatter shapes still render — now in the warm-up branch's
+      // secondary row rather than as the hero.
       // Hour-plus shape drops seconds.
       await tester.pumpWidget(_wrap(TripRecordingPipView(
         state: _activeState(
@@ -273,15 +286,14 @@ void main() {
     });
 
     testWidgets(
-        'real-trip life-cycle — pre-roll → GPS-only → OBD2 adapts the '
-        'primary slot one transition at a time', (tester) async {
+        'real-trip life-cycle — warm-up → warm-up → OBD2 keeps the hero '
+        'consumption-framed at every step (#2601)', (tester) async {
       // Walks the widget through the natural sequence a real trip
       // produces: start parked (pre-roll, 0 km, no fuel rate), drive a
       // bit on GPS only (distance > 0.1 km, still no fuel rate),
       // adapter finally connects mid-trip (fuel rate becomes
-      // available). The big-slot caption must adapt at each step
-      // without any branch ever rendering the `~` placeholder huge
-      // that #2094 set out to kill.
+      // available). The hero must stay CONSUMPTION-framed at every step —
+      // never a huge elapsed/distance (#2601).
       Future<void> pumpAt({
         double distance = 0,
         double? fuelRate,
@@ -300,28 +312,27 @@ void main() {
       }
 
       // T = 0 — engine on, GPS still warming up, no fuel rate.
-      // Branch 3: elapsed time is the hero.
+      // #2601 warm-up: "~" hero under the est caption, elapsed secondary.
       await pumpAt(distance: 0, fuelRate: null);
-      expect(find.text('elapsed'), findsOneWidget);
-      expect(find.text('km'), findsNothing);
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('est. L/100 km'), findsOneWidget);
+      expect(find.text('42s'), findsOneWidget); // secondary row
+      expect(find.text('elapsed'), findsNothing,
+          reason: '#2601 — the hero must never be elapsed time');
       expect(find.text('L/100 km'), findsNothing);
-      expect(find.text('~'), findsNothing,
-          reason:
-              'the `~` placeholder pre-#2094 wasted the whole tile — '
-              'no branch should render it');
 
       // T = 30 s — moved 0.5 km on GPS, still no OBD2 adapter.
-      // Branch 2: distance is the hero.
+      // Still warm-up: "~" hero, distance demoted to the secondary row.
       await pumpAt(
         distance: 0.5,
         fuelRate: null,
         elapsed: const Duration(seconds: 30),
       );
-      expect(find.text('0.5'), findsOneWidget);
-      expect(find.text('km'), findsOneWidget);
-      expect(find.text('elapsed'), findsNothing);
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('est. L/100 km'), findsOneWidget);
+      expect(find.text('0.5 km'), findsOneWidget); // secondary row
+      expect(find.text('km'), findsNothing);
       expect(find.text('L/100 km'), findsNothing);
-      expect(find.text('~'), findsNothing);
 
       // T = 5 min — adapter connected, fuel-rate sample landed.
       // Branch 1: L/100 km takes the hero slot.
@@ -335,7 +346,8 @@ void main() {
       // still findable, just no longer the hero caption.
       expect(find.textContaining('4.0'), findsOneWidget);
       expect(find.text('elapsed'), findsNothing);
-      expect(find.text('~'), findsNothing);
+      // The measured value carries no "~" / est caption.
+      expect(find.text('est. L/100 km'), findsNothing);
     });
   });
 
@@ -405,31 +417,36 @@ void main() {
     });
 
     testWidgets(
-        'GPS-only warm-up (null estimate) → falls back to distance/elapsed, '
-        'no "~" or blank', (tester) async {
-      // Estimator hasn't warmed up yet: estimate is null. With distance
-      // ≥ 0.1 km the tile gracefully shows distance (no "~", no blank).
+        'GPS-only warm-up (null estimate) → "~" hero + est caption, distance '
+        'demoted (#2601)', (tester) async {
+      // Estimator hasn't warmed up yet: estimate is null. #2601 keeps the
+      // hero consumption-framed — a "~" under the est caption — with
+      // distance demoted to the secondary row (never a huge distance).
       await tester.pumpWidget(
           buildWith(fuelRate: null, gpsEstimate: null, distance: 1.2));
-      expect(find.text('1.2'), findsOneWidget);
-      expect(find.text('km'), findsOneWidget);
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('est. L/100 km'), findsOneWidget);
+      expect(find.text('1.2 km'), findsOneWidget); // secondary row
       expect(find.text('L/100 km'), findsNothing);
-      expect(find.textContaining('~'), findsNothing);
+      expect(find.text('km'), findsNothing);
     });
 
     testWidgets(
-        'GPS-only pre-roll (null estimate, distance ≈ 0) → falls back to '
-        'elapsed, no "~"', (tester) async {
+        'GPS-only pre-roll (null estimate, distance ≈ 0) → "~" hero + est '
+        'caption, elapsed demoted (#2601)', (tester) async {
       await tester.pumpWidget(buildWith(
         fuelRate: null,
         gpsEstimate: null,
         distance: 0.0,
         elapsed: const Duration(minutes: 7, seconds: 7),
       ));
-      expect(find.text('7m 7s'), findsOneWidget);
-      expect(find.text('elapsed'), findsOneWidget);
+      // #2601 — pre-roll keeps the consumption-framed hero; elapsed is
+      // demoted to the secondary row instead of leading the tile.
+      expect(find.text('~'), findsOneWidget);
+      expect(find.text('est. L/100 km'), findsOneWidget);
+      expect(find.text('7m 7s'), findsOneWidget); // secondary row
+      expect(find.text('elapsed'), findsNothing);
       expect(find.text('L/100 km'), findsNothing);
-      expect(find.textContaining('~'), findsNothing);
     });
 
     testWidgets('paused GPS-only trip suppresses the estimate', (tester) async {
@@ -447,6 +464,84 @@ void main() {
       )));
       expect(find.textContaining('~'), findsNothing);
       expect(find.text('L/100 km'), findsNothing);
+    });
+  });
+
+  group('TripRecordingPipView (#2601) — approach tap-to-navigate', () {
+    // #2601 — the approach-price tile is tappable: tapping it opens the
+    // station in the user's maps app via NavigationUtils.openInMaps,
+    // which goes through the url_launcher platform channel. We mock that
+    // channel to capture the launched URL (a geo: URI for the station's
+    // coords) without touching a real OS intent.
+    const channel = MethodChannel('plugins.flutter.io/url_launcher');
+    final launchedUrls = <String>[];
+
+    setUp(() {
+      launchedUrls.clear();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'launch' || call.method == 'launchUrl') {
+          final args = call.arguments;
+          final url = args is Map ? args['url'] as String? : args as String?;
+          if (url != null) launchedUrls.add(url);
+          return true;
+        }
+        if (call.method == 'canLaunch') return true;
+        return null;
+      });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    testWidgets(
+        'tapping the approach-price tile launches the station in maps',
+        (tester) async {
+      await tester.pumpWidget(_wrap(TripRecordingPipView(
+        state: _activeState(),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+        approachState: const ApproachInRadius(
+          station: _stationE10,
+          distanceMeters: 350,
+        ),
+        fuelType: FuelType.e10,
+      )));
+
+      // The tile carries a navigate Tooltip + a GestureDetector with a
+      // live onTap (the seam wired in #2601).
+      final gesture = tester.widget<GestureDetector>(
+        find.descendant(
+          of: find.byType(Tooltip),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      expect(gesture.onTap, isNotNull);
+
+      await tester.tap(find.byType(GestureDetector));
+      await tester.pumpAndSettle();
+
+      // openInMaps fired → a geo: URI for the station coordinates.
+      expect(launchedUrls, isNotEmpty,
+          reason: 'tapping the approach tile must open the maps app');
+      expect(launchedUrls.first, startsWith('geo:'));
+      expect(launchedUrls.first, contains('${_stationE10.lat}'));
+      expect(launchedUrls.first, contains('${_stationE10.lng}'));
+    });
+
+    testWidgets('the default L/100 km layout is NOT tappable (no nav seam)',
+        (tester) async {
+      // Only the approach layout navigates; the default layout keeps its
+      // existing non-tappable behavior (#2601 scope guard).
+      await tester.pumpWidget(_wrap(TripRecordingPipView(
+        state: _activeState(),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+        approachState: const ApproachIdle(),
+      )));
+      expect(find.byType(GestureDetector), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Closes #2601.

## A. PiP always leads with L/100 km (drop pre-roll "elapsed")
`TripRecordingPipView._buildDefaultLayout` previously had four branches, the last two of which led with a huge **distance** (mid-trajet) or a huge **elapsed time** (pre-roll — "6s elapsed", the bug). Those two collapse into ONE consumption-framed warm-up branch: a `~` placeholder under the same `est. L/100 km` caption, with distance + elapsed demoted to the secondary row. The hero slot now ALWAYS means consumption (measured L/100 km → live estimate → warm-up placeholder); elapsed is never the hero again.

- `isEstimate = true` on the warm-up branch reuses the existing #2393 estimate Tooltip + Semantics wrap (`~` already means "modelled" per ADR 0012).
- ARB-free: reuses `tripRecordingPipEstConsumptionCaption`; `~` is the same literal as the GPS-estimate branch.
- Doc comments updated to describe the 3-state consumption-framed hero.

## B. Approach/radar: priced-only + tap-to-navigate
- `approach_detector._poll` filters in-radius stations to those quoting a usable price (`priceFor(fuel) != null && > 0`) for the effective fuel BEFORE the cheapest-ranking (#2299) + nearest-lock run, so `ApproachInRadius`/`ApproachLeaving` always carry a priced, actionable station (same rule as the radar #2583). The ranking/lock logic is untouched — it just receives the priced subset.
- The approach-price PiP layout (`_buildApproachPriceLayout`) is now tappable: tapping opens the targeted station in the user's maps app via `NavigationUtils.openInMaps` (#2546), wrapped in a `navigate` Tooltip (reuses the #2546 key). Only this layout is tappable; the default L/100 km layout is unchanged. The defensive `'—'` price branch stays (simulator can inject unpriced) but is now unreachable in production.

## Tests
- PiP: warm-up (no raw, no estimate) renders the `~` + est caption hero with distance/elapsed in the secondary row; B1 (OBD2) / B2 (GPS estimate) unchanged; approach tap launches a `geo:` URI for the station coords (url_launcher channel mock); default layout asserts no `GestureDetector`.
- approach_detector: an in-radius unpriced station yields no-station-in-radius; a priced one surfaces.
- Updated the `trip_recording_banner_test` PiP-mode test for the new warm-up framing.

ARB-free (zero `lib/l10n/` diff), no `@riverpod`/freezed touched (zero codegen drift, verified via clean `build_runner build`). `flutter analyze` clean (only the known pre-existing `unnecessary_import` info). File-length + no-hardcoded-strings lint gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
