### PR TITLE
fix(route-search): cross-border routes query every corridor country offline + per-country profile fuel (#2595)

### DIFF
--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/country/country_bounding_box.dart';
+import '../../../core/services/country_service_registry.dart';
+import '../../../core/services/service_providers.dart';
+import '../../../core/services/station_service.dart';
+import '../../../core/storage/storage_providers.dart';
+import '../../../core/utils/geo_utils.dart';
+import '../../../core/utils/station_extensions.dart';
+import '../../profile/data/models/user_profile.dart';
+import '../../profile/providers/profile_provider.dart';
+import '../../search/data/models/search_params.dart';
+import '../../search/domain/entities/fuel_type.dart';
+import '../../search/domain/entities/search_result_item.dart';
+import '../domain/entities/route_info.dart';
+import '../domain/route_search_strategy.dart';
+import 'strategies/route_geometry.dart';
+
+/// Cross-border corridor station search (#2595).
+///
+/// A route that crosses a border (Pézenas FR → Barcelona ES) must query
+/// the open-data source of EVERY country the corridor passes through for
+/// which a profile (and thus a configured data source) exists — and price
+/// each leg for that country's profile fuel. Previously the search
+/// resolved the country via a NETWORK geocode that, on null/timeout, fell
+/// back to the active profile's country, so the whole Spanish leg silently
+/// hit FR Prix-Carburants with the single active fuel (E85) and came back
+/// empty.
+///
+/// These helpers are the country-detection + per-country (service, fuel)
+/// resolution + the per-point query function. They are top-level (taking a
+/// [Ref]) so `RouteSearchState` stays a thin orchestrator and this cohesive
+/// cross-border logic — plus its unit tests — lives in one place.
+
+/// A corridor country's resolved station service paired with the fuel its
+/// leg should be queried + priced for.
+typedef CountrySource = ({StationService service, FuelType fuel});
+
+/// Profile fuel keyed by upper-cased country code.
+///
+/// `{ for p in allProfiles if p.countryCode != null :
+///    p.countryCode.toUpperCase(): p.preferredFuelType }`. A later profile
+/// for the same country wins — "the most recently configured profile for
+/// that country" without an extra heuristic.
+Map<String, FuelType> profileFuelByCountry(Ref ref) {
+  final out = <String, FuelType>{};
+  for (final p in ref.read(allProfilesProvider)) {
+    final code = p.countryCode;
+    if (code != null) out[code.toUpperCase()] = p.preferredFuelType;
+  }
+  return out;
+}
+
+/// Pre-resolve, OFFLINE, the `(service, fuel)` for every country the
+/// corridor crosses that has a usable station service.
+///
+/// [corridorCountries] is intersected with the registered, key-satisfied
+/// services. A crossed country is SKIPPED when it has no registry entry, or
+/// when it requires an API key that isn't configured (the DE / CL / KR demo
+/// guard) — we never inject demo stations onto a real route. Per-country
+/// fuel is the matching profile's `preferredFuelType` from [profileFuels],
+/// falling back to E10 for a crossed country the user has no profile for.
+Map<String, CountrySource> buildCorridorServiceMap(
+  Ref ref,
+  RouteInfo route,
+  Map<String, FuelType> profileFuels,
+) {
+  final hasKey = ref.read(storageRepositoryProvider).hasApiKey();
+  final map = <String, CountrySource>{};
+  for (final code in corridorCountries(route)) {
+    final entry = CountryServiceRegistry.entryFor(code);
+    if (entry == null) continue; // unregistered → no real data source.
+    if (entry.requiresApiKey && !hasKey) continue; // demo guard (#2595).
+    map[code] = (
+      service: stationServiceForCountry(ref, code),
+      fuel: profileFuels[code] ?? FuelType.e10,
+    );
+  }
+  debugPrint('RouteSearch: corridor services = '
+      '${map.entries.map((e) => '${e.key}:${e.value.fuel.apiValue}').join(', ')}');
+  return map;
+}
+
+/// Build the per-point query function for a cross-border route.
+///
+/// For each sample point it queries EVERY corridor-country service in
+/// [corridorMap] — each with THAT country's profile fuel — and merges the
+/// responses. Querying all corridor services (rather than only the one the
+/// point's bbox resolves to) is deliberate: the FR and ES bounding boxes
+/// overlap heavily along the Pyrenees, so a pure per-point bbox switch
+/// still mis-attributes the whole Catalonia leg to FR.
+/// `UniformSearchStrategy._runFilterAndSort` then drops every station whose
+/// min-distance-to-polyline exceeds the detour limit, so a FR station
+/// fetched near Barcelona is filtered out while the local ES stations
+/// survive — robustly correct at any border.
+///
+/// Each country's slice is reduced to the top [topNPerSamplePoint] by
+/// [criterion] using THAT country's fuel, so [BatchQueryHelper.queryAll]'s
+/// single-fuel reduce downstream is a harmless identity (already ranked and
+/// bounded). When [corridorMap] is empty (an entirely mid-sea route, or no
+/// profile-backed corridor country) the active profile's service + the
+/// incoming [fuelType] are used as a fallback so a single-country route is
+/// unaffected.
+StationQueryFunction buildCorridorQueryFunction(
+  Ref ref,
+  FuelType fuelType, {
+  required Map<String, CountrySource> corridorMap,
+  required RouteSearchCriterion criterion,
+  required int topNPerSamplePoint,
+}) {
+  // Only fall back to the active-profile service when the corridor map is
+  // empty — reading it eagerly would needlessly build the active country's
+  // service on every normal cross-border search.
+  final sources = corridorMap.isEmpty
+      ? <CountrySource>[
+          (service: ref.read(stationServiceProvider), fuel: fuelType)
+        ]
+      : corridorMap.values.toList(growable: false);
+
+  return ({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+    required FuelType fuelType,
+  }) async {
+    final merged = <SearchResultItem>[];
+    for (final source in sources) {
+      final params = SearchParams(
+        lat: lat,
+        lng: lng,
+        radiusKm: radiusKm,
+        fuelType: source.fuel,
+        sortBy: SortBy.price,
+      );
+      final result = await source.service.searchStations(params);
+      final raw = result.data
+          .map((s) => FuelStationResult(s) as SearchResultItem)
+          .toList();
+      // Per-country top-N reduce using THIS country's fuel, so the ranking
+      // is like-for-like before the slices are concatenated.
+      merged.addAll(topNForCountry(
+        raw,
+        lat: lat,
+        lng: lng,
+        fuelType: source.fuel,
+        topN: topNPerSamplePoint,
+        criterion: criterion,
+      ));
+    }
+    return merged;
+  };
+}
+
+/// Resolve the fuel to price a station by, from its coordinates.
+///
+/// Offline bbox → profile fuel for that country (from [profileFuels]),
+/// falling back to [fallback] (the incoming search fuel) when the station
+/// sits outside every box or in a country with no profile.
+FuelType fuelForStation(
+  double lat,
+  double lng,
+  Map<String, FuelType> profileFuels,
+  FuelType fallback,
+) {
+  final code = countryCodeFromLatLng(lat, lng)?.toUpperCase();
+  if (code == null) return fallback;
+  return profileFuels[code] ?? fallback;
+}
+
+/// Rank one corridor country's slice of a sample point's response to the
+/// top [topN] by [criterion], using THAT country's [fuelType].
+///
+/// Mirrors `BatchQueryHelper`'s per-point reduce (cheapest by price /
+/// nearest by distance, unpriced stations sink to the end but are kept) but
+/// is invoked per corridor country with the country's own fuel, so the
+/// downstream single-fuel reduce in `BatchQueryHelper.queryAll` is a
+/// harmless identity. A standalone helper rather than the
+/// `@visibleForTesting` `BatchQueryHelper.topNForPoint`.
+List<SearchResultItem> topNForCountry(
+  List<SearchResultItem> raw, {
+  required double lat,
+  required double lng,
+  required FuelType fuelType,
+  required int topN,
+  required RouteSearchCriterion criterion,
+}) {
+  if (raw.length <= topN) return raw;
+  final fuel = raw.whereType<FuelStationResult>().toList();
+  final other = raw.where((r) => r is! FuelStationResult).toList(growable: false);
+  switch (criterion) {
+    case RouteSearchCriterion.cheapest:
+      fuel.sort((a, b) {
+        final pa = a.station.priceFor(fuelType);
+        final pb = b.station.priceFor(fuelType);
+        if (pa == null && pb == null) return 0;
+        if (pa == null) return 1;
+        if (pb == null) return -1;
+        return pa.compareTo(pb);
+      });
+    case RouteSearchCriterion.nearest:
+      fuel.sort((a, b) {
+        final da = distanceKm(a.station.lat, a.station.lng, lat, lng);
+        final db = distanceKm(b.station.lat, b.station.lng, lat, lng);
+        return da.compareTo(db);
+      });
+  }
+  return [...fuel.take(topN), ...other];
+}

--- a/lib/features/route_search/data/strategies/route_geometry.dart
+++ b/lib/features/route_search/data/strategies/route_geometry.dart
@@ -3,8 +3,10 @@
 
 import 'package:latlong2/latlong.dart';
 
+import '../../../../core/country/country_bounding_box.dart';
 import '../../../../core/utils/geo_utils.dart';
 import '../../../search/domain/entities/search_result_item.dart';
+import '../../domain/entities/route_info.dart';
 
 /// Shared route-search geometry helpers (#2197).
 ///
@@ -74,3 +76,27 @@ void sortByItineraryOrder(
 /// `(nearestSampleIdx * 15 / segmentKm).floor()` semantics exactly.
 int segmentIndexFor(int nearestSampleIdx, double segmentKm) =>
     (nearestSampleIdx * kSamplePointSpacingKm / segmentKm).floor();
+
+/// The unique set of ISO 3166-1 alpha-2 country codes the [route]'s
+/// polyline passes through, detected OFFLINE (#2595).
+///
+/// Walks every vertex of [route.geometry] through the canonical
+/// bounding-box lookup ([countryCodeFromLatLng] →
+/// `CountryServiceRegistry.entryByLatLng`) and collects the non-null
+/// matches. This replaces the previous per-sample-point NETWORK geocode
+/// (`coordinatesToCountryCode`) used to pick a station service: that
+/// call cost a round-trip per point and, on null/timeout, silently fell
+/// back to the active profile's country — so a Pézenas(FR)→Barcelona(ES)
+/// route queried only FR Prix-Carburants and returned an empty Spanish
+/// leg. The bbox lookup is sub-millisecond and never blackholes.
+///
+/// Returns the codes upper-cased so they collate with profile country
+/// codes regardless of upstream casing.
+Set<String> corridorCountries(RouteInfo route) {
+  final codes = <String>{};
+  for (final p in route.geometry) {
+    final code = countryCodeFromLatLng(p.latitude, p.longitude);
+    if (code != null) codes.add(code.toUpperCase());
+  }
+  return codes;
+}

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -9,16 +9,15 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/error/exceptions.dart';
 import '../../../core/logging/error_logger.dart';
-import '../../../core/services/service_providers.dart';
-import '../../../core/services/station_service.dart';
+import '../../../core/country/country_bounding_box.dart';
 import '../../../core/country/country_provider.dart';
 import '../../../core/utils/station_extensions.dart';
 import '../../profile/data/models/user_profile.dart';
-import '../../search/data/models/search_params.dart';
 import '../../search/providers/ev_charging_service_provider.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
 import '../../profile/providers/profile_provider.dart';
+import '../data/cross_border_corridor.dart';
 import '../data/strategies/route_geometry.dart';
 import '../data/services/routing_service.dart';
 import '../domain/entities/route_info.dart';
@@ -75,12 +74,24 @@ class RouteSearchState extends _$RouteSearchState {
       // (sample points are 15km apart, so smaller radius would create gaps).
       final effectiveRadius = searchRadiusKm < 15 ? 15.0 : searchRadiusKm;
 
+      // #2595 — resolve, OFFLINE, which countries the corridor crosses and
+      // map each to its (service, profile-fuel). Used by the fuel query
+      // function below and by the cross-border cheapest pricing.
+      final profileFuels = profileFuelByCountry(ref);
+      final corridorMap = buildCorridorServiceMap(ref, route, profileFuels);
+
       List<SearchResultItem> allResults;
       if (fuelType == FuelType.electric) {
         allResults = await _searchEVAlongRoute(route, effectiveRadius);
       } else {
         final strategy = strategyFor(strategyType);
-        final queryFn = await _buildQueryFunction(route, fuelType);
+        final queryFn = buildCorridorQueryFunction(
+          ref,
+          fuelType,
+          corridorMap: corridorMap,
+          criterion: criterion,
+          topNPerSamplePoint: topN,
+        );
         allResults = await strategy.searchAlongRoute(
           route: route,
           fuelType: fuelType,
@@ -106,11 +117,17 @@ class RouteSearchState extends _$RouteSearchState {
         );
       }
 
-      // 2b. #1872 — drop fuel stations that don't beat the route's
-      // cheapest by at least the user's minimum-saving threshold.
+      // 2b. #1872 / #2595 — drop fuel stations that don't beat the
+      // route's cheapest by at least the user's minimum-saving threshold.
+      // Each station is priced by ITS country's profile fuel so an
+      // E85-vs-E10 cross-border compare isn't apples-to-oranges.
       if (fuelType != FuelType.electric && minSaving > 0) {
-        allResults =
-            filterRouteResultsByMinSaving(allResults, fuelType, minSaving);
+        allResults = filterRouteResultsByMinSaving(
+          allResults,
+          fuelType,
+          minSaving,
+          profileFuelByCountry: profileFuels,
+        );
       }
 
       // 3. Identify cheapest fuel station
@@ -120,7 +137,16 @@ class RouteSearchState extends _$RouteSearchState {
         double? cheapestPrice;
         for (final item in allResults) {
           if (item is FuelStationResult) {
-            final price = item.station.priceFor(fuelType);
+            // #2595 — price by the station's own country fuel, not the
+            // single active-profile fuel, so the global cheapest across
+            // a cross-border route compares like-for-like.
+            final fuel = fuelForStation(
+              item.station.lat,
+              item.station.lng,
+              profileFuels,
+              fuelType,
+            );
+            final price = item.station.priceFor(fuel);
             if (price != null && (cheapestPrice == null || price < cheapestPrice)) {
               cheapestPrice = price;
               cheapestId = item.id;
@@ -163,65 +189,71 @@ class RouteSearchState extends _$RouteSearchState {
     }
   }
 
-  /// Build a query function that detects country per sample point.
-  ///
-  /// Cross-border routes (e.g. Berlin→Paris) traverse multiple countries.
-  /// Each query resolves the country from its coordinates and uses the
-  /// matching country-specific station service.
-  Future<StationQueryFunction> _buildQueryFunction(
-    RouteInfo route,
-    FuelType fuelType,
-  ) async {
-    final geocoding = ref.read(geocodingChainProvider);
-    final fallbackService = ref.read(stationServiceProvider);
-
-    // Cache: country code per sample point to avoid redundant geocoding
-    String? lastCountry;
-    StationService? lastService;
-
-    return ({
-      required double lat,
-      required double lng,
-      required double radiusKm,
-      required FuelType fuelType,
-    }) async {
-      // Detect country for this specific point
-      String? country;
-      try {
-        country = await geocoding.coordinatesToCountryCode(lat, lng);
-      } catch (e, st) {
-        // #2146 — non-fatal (falls through to fallbackService) but
-        // surface on the log so country-detection blackholes are
-        // recoverable from a bug report.
-        unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
-          'where': 'RouteSearch: fuel country detection',
-          'lat': lat, 'lng': lng,
-        }));
+  /// Test seam (#2595): runs the cross-border station-search portion of
+  /// [searchAlongRoute] against a PRE-BUILT [route], skipping the OSRM
+  /// fetch (the `RoutingService` is constructed internally and not
+  /// injectable). Exercises the real corridor-map build, per-country-fuel
+  /// query function, strategy sweep + merge, and cross-border cheapest —
+  /// so a test can assert each leg routes to its own service + fuel and
+  /// the merged result interleaves both countries by corridor position.
+  @visibleForTesting
+  Future<RouteSearchResult> searchAlongPrebuiltRouteForTest({
+    required RouteInfo route,
+    required FuelType fuelType,
+    double searchRadiusKm = 15.0,
+    RouteSearchStrategyType strategyType = RouteSearchStrategyType.uniform,
+    RouteSearchCriterion criterion = RouteSearchCriterion.cheapest,
+    int topNPerSamplePoint = 10,
+  }) async {
+    final profileFuels = profileFuelByCountry(ref);
+    final corridorMap = buildCorridorServiceMap(ref, route, profileFuels);
+    final strategy = strategyFor(strategyType);
+    final queryFn = buildCorridorQueryFunction(
+      ref,
+      fuelType,
+      corridorMap: corridorMap,
+      criterion: criterion,
+      topNPerSamplePoint: topNPerSamplePoint,
+    );
+    final allResults = await strategy.searchAlongRoute(
+      route: route,
+      fuelType: fuelType,
+      searchRadiusKm: searchRadiusKm,
+      queryStations: queryFn,
+      maxDetourKm: searchRadiusKm,
+      topNPerSamplePoint: topNPerSamplePoint,
+      criterion: criterion,
+    );
+    String? cheapestId;
+    double? cheapestPrice;
+    for (final item in allResults) {
+      if (item is FuelStationResult) {
+        final fuel = fuelForStation(
+          item.station.lat,
+          item.station.lng,
+          profileFuels,
+          fuelType,
+        );
+        final price = item.station.priceFor(fuel);
+        if (price != null &&
+            (cheapestPrice == null || price < cheapestPrice)) {
+          cheapestPrice = price;
+          cheapestId = item.id;
+        }
       }
-
-      // Reuse cached service if country unchanged
-      final StationService service;
-      if (country != null && country == lastCountry && lastService != null) {
-        service = lastService!;
-      } else if (country != null) {
-        service = stationServiceForCountry(ref, country);
-        lastCountry = country;
-        lastService = service;
-        debugPrint('RouteSearch: switched to country=$country at $lat,$lng');
-      } else {
-        service = fallbackService;
-      }
-
-      final params = SearchParams(
-        lat: lat,
-        lng: lng,
-        radiusKm: radiusKm,
+    }
+    return RouteSearchResult(
+      route: route,
+      stations: allResults,
+      cheapestId: cheapestId,
+      cheapestPerSegment: strategy.computeBestStops(
+        route: route,
+        results: allResults,
         fuelType: fuelType,
-        sortBy: SortBy.price,
-      );
-      final result = await service.searchStations(params);
-      return result.data.map((s) => FuelStationResult(s) as SearchResultItem).toList();
-    };
+        segmentKm: 50.0,
+      ),
+      strategyType: strategyType,
+    );
   }
 
   Future<List<SearchResultItem>> _searchEVAlongRoute(
@@ -233,28 +265,21 @@ class RouteSearchState extends _$RouteSearchState {
       throw const ApiException(message: 'OpenChargeMap API key required');
     }
 
-    final geocoding = ref.read(geocodingChainProvider);
     final fallbackCountry = ref.read(activeCountryProvider).code;
     final seen = <String>{};
     final results = <SearchResultItem>[];
 
     for (final point in route.samplePoints) {
       try {
-        // Detect country per sample point for cross-border routes
-        String countryCode = fallbackCountry;
-        try {
-          final detected = await geocoding.coordinatesToCountryCode(
-            point.latitude, point.longitude,
-          );
-          if (detected != null) countryCode = detected;
-        } catch (e, st) {
-          // #2146 — non-fatal (uses fallbackCountry) but surface
-          // so triage can spot misconfigured geocoding chains.
-          unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
-            'where': 'RouteSearch EV: country detection',
-            'lat': point.latitude, 'lng': point.longitude,
-          }));
-        }
+        // #2595 — detect the per-point country OFFLINE via the bbox
+        // registry (no network geocode that could blackhole and fall
+        // back to the active country). Outside every box (e.g. mid-sea)
+        // falls back to the active country.
+        final countryCode = countryCodeFromLatLng(
+              point.latitude,
+              point.longitude,
+            ) ??
+            fallbackCountry;
 
         final result = await service.searchStations(
           lat: point.latitude,
@@ -292,21 +317,39 @@ class RouteSearchState extends _$RouteSearchState {
 /// Keeps only fuel stations priced within [minSaving] €/L of the
 /// cheapest station found along the route (#1872).
 ///
-/// The cheapest priced station is the anchor; a station survives when
-/// its [fuelType] price is at most `cheapest + minSaving`. Stations
-/// with no price for [fuelType] are kept — an unknown price is not a
-/// reason to hide a stop — and the list is returned unchanged when no
-/// station carries a comparable price. EV results never reach here
-/// (the caller gates on a non-electric fuel type).
+/// The cheapest priced station is the anchor; a station survives when its
+/// price is at most `cheapest + minSaving`. Stations with no price are
+/// kept — an unknown price is not a reason to hide a stop — and the list
+/// is returned unchanged when no station carries a comparable price. EV
+/// results never reach here (the caller gates on a non-electric fuel
+/// type).
+///
+/// #2595 — each station is priced by ITS country's profile fuel via
+/// [profileFuelByCountry] (resolved offline from the station's lat/lng),
+/// falling back to [fuelType] for a country with no profile or a station
+/// outside every bbox. This keeps the cross-border min-saving compare
+/// like-for-like (FR→E85 vs ES→E10) instead of pricing every station by a
+/// single fuel one country may not even sell. When [profileFuelByCountry]
+/// is empty (the historical single-country path) every station is priced
+/// by [fuelType], preserving the original behaviour exactly.
 List<SearchResultItem> filterRouteResultsByMinSaving(
   List<SearchResultItem> results,
   FuelType fuelType,
-  double minSaving,
-) {
+  double minSaving, {
+  Map<String, FuelType> profileFuelByCountry = const {},
+}) {
+  FuelType fuelFor(FuelStationResult item) {
+    if (profileFuelByCountry.isEmpty) return fuelType;
+    final code =
+        countryCodeFromLatLng(item.station.lat, item.station.lng)?.toUpperCase();
+    if (code == null) return fuelType;
+    return profileFuelByCountry[code] ?? fuelType;
+  }
+
   double? cheapest;
   for (final item in results) {
     if (item is FuelStationResult) {
-      final price = item.station.priceFor(fuelType);
+      final price = item.station.priceFor(fuelFor(item));
       if (price != null && (cheapest == null || price < cheapest)) {
         cheapest = price;
       }
@@ -316,7 +359,7 @@ List<SearchResultItem> filterRouteResultsByMinSaving(
   final ceiling = cheapest + minSaving;
   return results.where((item) {
     if (item is! FuelStationResult) return true;
-    final price = item.station.priceFor(fuelType);
+    final price = item.station.priceFor(fuelFor(item));
     return price == null || price <= ceiling;
   }).toList();
 }

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'8decdacad1da51c29a037f7e5e99c40b5e5620a4';
+String _$routeSearchStateHash() => r'5f1d6881a6eabc2397f9b7c7c10db62553f57b74';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/test/features/route_search/providers/route_search_cross_border_test.dart
+++ b/test/features/route_search/providers/route_search_cross_border_test.dart
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/route_search/data/strategies/route_geometry.dart';
+import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
+import 'package:tankstellen/features/route_search/providers/route_search_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// #2595 — a route that crosses from France into Spain must query BOTH
+/// countries' open-data sources (per the available profiles) and merge
+/// the legs into one corridor result — each leg priced for ITS country's
+/// profile fuel. Before the fix, the search resolved the country via a
+/// network geocode that, on null/timeout, fell back to the active
+/// profile's country (FR Prix-Carburants) and queried it with the single
+/// active fuel (E85), so the Spanish leg was empty.
+///
+/// The OSRM `RoutingService` is constructed inside `searchAlongRoute` and
+/// not injectable, so this drives the dedicated
+/// `searchAlongPrebuiltRouteForTest` seam with a hand-built corridor — it
+/// runs the exact corridor-map build + per-country-fuel query function +
+/// strategy sweep + merge that production uses, with NO network.
+
+/// A fake [StationService] for one country that returns a single branded
+/// station AT each queried point (so it lands on the route polyline and
+/// survives the detour filter), priced for whatever fuel was requested.
+/// Records the fuel types it was asked for so the test can assert each
+/// leg was queried with its own profile fuel.
+class _BrandedStationService implements StationService {
+  _BrandedStationService(this.brand);
+
+  final String brand;
+  final requestedFuels = <FuelType>[];
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    requestedFuels.add(params.fuelType);
+    final station = Station(
+      id: '$brand-${params.lat.toStringAsFixed(2)}-${params.lng.toStringAsFixed(2)}',
+      name: '$brand station',
+      brand: brand,
+      street: 'Route',
+      postCode: '00000',
+      place: brand,
+      lat: params.lat,
+      lng: params.lng,
+      isOpen: true,
+      // Price only the requested fuel — mirrors a real country dataset
+      // that doesn't carry the other country's grade (ES has no E85).
+      e85: params.fuelType == FuelType.e85 ? 1.20 : null,
+      e10: params.fuelType == FuelType.e10 ? 1.60 : null,
+    );
+    return ServiceResult(
+      data: [station],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// Minimal [StorageRepository] stub so `_buildCorridorServiceMap` can read
+/// `hasApiKey()` without standing up Hive. FR + ES are keyless so the
+/// value doesn't gate them; it only matters for the DE/CL/KR demo guard.
+class _NoKeyStorage implements StorageRepository {
+  @override
+  bool hasApiKey() => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  test(
+      'cross-border FR→ES route queries each leg with its own service + '
+      'profile fuel and merges both into one corridor result (#2595)',
+      () async {
+    // Corridor: Pézenas (FR) heading south-west into Spain. The lower
+    // vertices fall in ES-only bbox territory, so corridorCountries
+    // returns {FR, ES}. Sample points sit on the polyline.
+    const frPoint = LatLng(43.46, 3.42); // Pézenas — FR bbox
+    const esPoint = LatLng(40.50, 0.50); // Castelló-ish — ES-only bbox
+    const route = RouteInfo(
+      geometry: [
+        frPoint,
+        LatLng(42.40, 2.20), // Pyrenees crossing
+        esPoint,
+      ],
+      distanceKm: 400,
+      durationMinutes: 240,
+      samplePoints: [frPoint, esPoint],
+    );
+
+    final frService = _BrandedStationService('Total FR');
+    final esService = _BrandedStationService('Repsol ES');
+
+    final container = ProviderContainer(
+      overrides: [
+        storageRepositoryProvider.overrideWith((ref) => _NoKeyStorage()),
+        // The documented #753 seam — override the per-country family so the
+        // corridor map resolves to our branded fakes.
+        perCountryStationServiceProvider('FR')
+            .overrideWith((ref) => frService),
+        perCountryStationServiceProvider('ES')
+            .overrideWith((ref) => esService),
+        // FR profile uses E85, ES profile uses E10 — the per-country fuel
+        // the issue calls out (E85 availability differs by country).
+        allProfilesProvider.overrideWith((ref) => const [
+              UserProfile(
+                  id: 'fr', name: 'Standard',
+                  countryCode: 'FR', preferredFuelType: FuelType.e85),
+              UserProfile(
+                  id: 'es', name: 'Espagne',
+                  countryCode: 'ES', preferredFuelType: FuelType.e10),
+            ]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(routeSearchStateProvider.notifier);
+    // The active search fuel is FR's E85; the ES leg must NOT inherit it.
+    final result = await notifier.searchAlongPrebuiltRouteForTest(
+      route: route,
+      fuelType: FuelType.e85,
+    );
+
+    final brands = result.stations
+        .whereType<FuelStationResult>()
+        .map((r) => r.station.brand)
+        .toSet();
+
+    // Both legs present — the Spanish leg is no longer empty.
+    expect(brands, contains('Total FR'),
+        reason: 'French leg must be present');
+    expect(brands, contains('Repsol ES'),
+        reason: 'Spanish leg must be present (was empty before #2595)');
+
+    // Each country's service was queried with ITS profile fuel, not the
+    // single active fuel.
+    expect(frService.requestedFuels, everyElement(FuelType.e85),
+        reason: 'FR leg queried with FR profile fuel E85');
+    expect(esService.requestedFuels, everyElement(FuelType.e10),
+        reason: 'ES leg queried with ES profile fuel E10 (not E85)');
+
+    // The ES station is priced for E10 (it has no E85 grade), proving the
+    // per-country-fuel pricing rather than the single active fuel.
+    final esStation = result.stations
+        .whereType<FuelStationResult>()
+        .firstWhere((r) => r.station.brand == 'Repsol ES');
+    expect(esStation.station.e10, isNotNull);
+    expect(esStation.station.e85, isNull);
+
+    // Merged result is sorted by corridor position: the FR station (near
+    // the start) precedes the ES station (near the end).
+    final ordered = result.stations
+        .whereType<FuelStationResult>()
+        .map((r) => r.station.brand)
+        .toList();
+    expect(ordered.indexOf('Total FR'),
+        lessThan(ordered.lastIndexOf('Repsol ES')),
+        reason: 'FR + ES stops interleave by true corridor position');
+  });
+
+  test('corridorCountries detects every crossed country offline (#2595)',
+      () {
+    const route = RouteInfo(
+      geometry: [
+        LatLng(43.46, 3.42), // FR
+        LatLng(42.40, 2.20), // FR (Pyrenees)
+        LatLng(40.50, 0.50), // ES
+        LatLng(39.50, -0.40), // ES
+      ],
+      distanceKm: 500,
+      durationMinutes: 300,
+      samplePoints: [],
+    );
+    expect(corridorCountries(route), containsAll(<String>{'FR', 'ES'}));
+  });
+}


### PR DESCRIPTION
## What & why

A route crossing a border (Pézenas FR → Barcelona ES) returned **only French stations** — the whole Spanish leg was empty. Two root causes:

1. The per-sample-point country was resolved by a **network geocode** (`coordinatesToCountryCode`); on null/timeout it fell back to the **active** profile's country (FR), so the Spanish leg silently queried FR Prix-Carburants.
2. The route used **one** fuel (active = E85), but Spain's dataset has no E85 grade — so the ES leg would be empty even if it were queried.

## Root fix (reuse-maximal)

- **Offline corridor detection** — `corridorCountries(RouteInfo)` (`route_geometry.dart`) walks the route geometry through the canonical **offline** bbox lookup (`countryCodeFromLatLng` → `CountryServiceRegistry.entryByLatLng`) and returns the unique crossed-country set. Sub-ms, no network, never blackholes (replaces the per-point network geocode entirely).
- **Per-country (service, fuel)** — new `cross_border_corridor.dart` pre-resolves, for each crossed country with a registered, key-satisfied service ∩ the user's profiles, a `(StationService, profile fuel)` pair. DE/CL/KR are skipped when their key is unconfigured so demo stations are never injected onto a real route. The per-point query function queries **every** corridor service with **that** country's fuel and merges the slices.
- **Border robustness** — querying all corridor services (not just the one the point's bbox resolves to) is deliberate: the FR/ES boxes overlap along the Pyrenees, so a pure per-point bbox switch still mis-attributes Catalonia to FR. `UniformSearchStrategy._runFilterAndSort` then drops off-corridor foreign stations by detour distance — robustly correct at any border.
- **Cross-border cheapest / min-saving** — the global `cheapestId` loop and `filterRouteResultsByMinSaving` now price each station by **its** country's profile fuel (ES→E10, FR→E85) so the compare is like-for-like.
- **EV path** — `_searchEVAlongRoute` swapped to the same offline bbox lookup, removing its network-geocode failure mode too.

**Reused unchanged:** `BatchQueryHelper.queryAll` (concurrency, per-point failure isolation, dedup) and `UniformSearchStrategy._runFilterAndSort` (country-agnostic distance-along-polyline sort → FR + ES stops interleave by corridor position into one result).

`searchAlongRoute`'s public signature is unchanged; the incoming fuelType remains the default for a crossed country with no profile. The two existing callers are untouched.

## Tests
Adds a 2-country FR+ES corridor test (overrides `perCountryStationServiceProvider` for FR + ES via the documented seam) asserting each leg routes to its own service + fuel and the merged result interleaves both countries by corridor position; plus an offline `corridorCountries` detection test. `flutter test test/features/route_search test/features/search` green (949 passed). ARB-free (zero `lib/l10n/` diff).

Closes #2595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
