### PR TITLE
ci(ios): external TestFlight distribution — beta-review info + auto-publish + durable testers (#2611 #2612 #2613)

### DIFF
--- a/.github/workflows/ios-beta-review.yml
+++ b/.github/workflows/ios-beta-review.yml
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+name: iOS Beta App Review Info
+
+# Push the localized Beta App Review test info (App-Review contact block plus
+# the per-locale feedback email + beta-app description) to App Store Connect
+# ahead of an external TestFlight build, so the FIRST 'extern' build clears
+# Beta App Review without manual data entry. No build, no upload, no Xcode —
+# a pure App Store Connect API mutation, so it runs on the cheap ubuntu-latest
+# runner. `workflow_dispatch` ONLY: this is an outward-facing live ASC mutation
+# triggered by hand (or the orchestrator), never automatically.
+#
+# Auth reuses the App Store Connect API key exactly like `ios-testers.yml`:
+# the base64 secret is decoded to a temp .p8 and exported as
+# ASC_API_KEY_FILEPATH, which the Fastfile's `asc_api_key` helper picks up.
+#
+# BLOCKER: the App-Review contact phone is mandatory and never fabricated —
+# set the BETA_CONTACT_PHONE repository secret before running this workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      contact_first:
+        description: 'App-Review contact first name (optional — overrides BETA_CONTACT_FIRST secret / Florian default)'
+        required: false
+        type: string
+        default: ''
+      contact_last:
+        description: 'App-Review contact last name (optional — overrides BETA_CONTACT_LAST secret / Dittgen default)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-beta-review
+  cancel-in-progress: false
+
+jobs:
+  configure-beta-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Decode App Store Connect API key
+        # Copied verbatim from ios-testers.yml: decode the base64 secret to a
+        # temp .p8 and export ASC_API_KEY_FILEPATH so the Fastfile's
+        # `asc_api_key` helper consumes the on-disk key.
+        env:
+          ASC_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          if [ -z "$ASC_KEY_BASE64" ]; then
+            echo "::error::APP_STORE_CONNECT_API_KEY_BASE64 secret is not set." >&2
+            exit 1
+          fi
+          KEY_PATH="$RUNNER_TEMP/asc-api-key.p8"
+          echo "$ASC_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "ASC_API_KEY_FILEPATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: fastlane configure_beta_review
+        working-directory: ios
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          # ASC_API_KEY_FILEPATH was exported by the decode step above.
+          # The App-Review contact phone is MANDATORY — the lane bails clearly
+          # (and never fabricates one) when this secret is unset.
+          BETA_CONTACT_PHONE: ${{ secrets.BETA_CONTACT_PHONE }}
+          # Workflow-dispatch inputs (if given) override the secrets / defaults.
+          BETA_CONTACT_FIRST: ${{ inputs.contact_first != '' && inputs.contact_first || secrets.BETA_CONTACT_FIRST || '' }}
+          BETA_CONTACT_LAST: ${{ inputs.contact_last != '' && inputs.contact_last || secrets.BETA_CONTACT_LAST || '' }}
+          FASTLANE_DISABLE_COLORS: '1'
+        run: bundle exec fastlane configure_beta_review
+
+      - name: Clean up decoded API key
+        if: always()
+        run: rm -f "$ASC_API_KEY_FILEPATH"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## iOS Beta App Review Info"
+            echo ""
+            echo "- **Bundle ID:** de.tankstellen.tankstellen"
+            echo "- **Locales:** en-US, fr-FR, de-DE, es-ES, it-IT, pt-PT"
+            echo "- **Trigger:** ${{ github.event_name }}"
+            echo ""
+            echo "> Sets the App-Review contact block + per-locale feedback email"
+            echo "> and beta-app description so the first external build clears"
+            echo "> Beta App Review with no manual data entry."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ios-testers.yml
+++ b/.github/workflows/ios-testers.yml
@@ -22,10 +22,10 @@ on:
   workflow_dispatch:
     inputs:
       email:
-        description: 'Tester email to enroll (an invite email is sent to them)'
+        description: 'Tester email(s) to enroll — a single address or a comma-separated list (an invite email is sent to each)'
         required: true
         type: string
-        default: 'florian.dittgen@trelleborg.com'
+        default: 'fdittgen@gmail.com,florian.dittgen@trelleborg.com'
       groups:
         description: 'Comma-separated beta group names. Empty = ALL external groups, or the internal group(s) when the app has no external group.'
         required: false

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -6,9 +6,12 @@ name: iOS TestFlight Build
 # Build a signed iOS IPA on a macOS runner and upload it to TestFlight via the
 # App Store Connect API. Mirror of `daily-beta.yml` but for iOS.
 #
-# Build numbers are date+hour-based (YYYYMMDDHH) computed at build time, so
-# there's no commit pushed back to master and re-runs on the same day get
-# distinct, monotonically-increasing CFBundleVersions.
+# Build numbers come from a monotonic run-counter (see the build-number step),
+# computed at build time, so there's no commit pushed back to master and every
+# run gets a distinct, strictly-increasing CFBundleVersion.
+#
+# Scheduled runs (and manual runs with distribute:true) push the build to the
+# external 'extern' TestFlight group; plain manual runs stay internal-only.
 
 on:
   workflow_dispatch:
@@ -18,11 +21,16 @@ on:
         required: false
         type: string
         default: 'Daily build.'
-  # Schedule trigger intentionally left commented until we've confirmed two
-  # consecutive manual runs land in TestFlight cleanly. Then uncomment to
-  # mirror Android's nightly cadence.
-  # schedule:
-  #   - cron: '0 16 * * *'
+      distribute:
+        description: 'Distribute to external "extern" testers (submits for Beta App Review). Scheduled runs always distribute.'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # 04:30 Europe/Paris is intentionally distinct from the other daily crons:
+    # daily-beta.yml runs at 16:00 and daily-github-release.yml at 21:00, so the
+    # iOS nightly external build never collides with them.
+    - cron: '30 4 * * *'
 
 concurrency:
   group: ios-testflight
@@ -35,12 +43,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Compute date-based build number
+      - name: Compute monotonic build number
         id: bn
+        # Monotonic run-counter rather than a date stamp: a 2026060000 base
+        # offset (above every prior YYYYMMDDHH number) plus the run number and
+        # attempt guarantees a strictly-increasing, never-colliding
+        # CFBundleVersion across re-runs and re-attempts.
         run: |
-          BN=$(TZ=Europe/Paris date +%Y%m%d%H)
+          BN=$(( 2026060000 + ${{ github.run_number }} * 10 + ${{ github.run_attempt }} ))
           echo "build_number=$BN" >> "$GITHUB_OUTPUT"
-          echo "Daily build number: $BN"
+          echo "Build number: $BN"
 
       - name: Select Xcode 26+
         # macos-latest selects Xcode 16.4 (iOS 18.5 SDK) by default. Apple
@@ -125,9 +137,18 @@ jobs:
           # Fastfile's `asc_api_key` helper picks up the on-disk .p8.
           IOS_BUILD_NUMBER: ${{ steps.bn.outputs.build_number }}
           TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.release_notes || 'Daily build.' }}
+          # Scheduled runs always distribute externally; manual runs only when
+          # the distribute input is checked.
+          DISTRIBUTE: ${{ github.event_name == 'schedule' || inputs.distribute }}
+          # Beta App Review contact block carried inline on an external build
+          # (the Fastfile omits it gracefully when BETA_CONTACT_PHONE is unset).
+          BETA_CONTACT_PHONE: ${{ secrets.BETA_CONTACT_PHONE }}
+          BETA_CONTACT_FIRST: ${{ secrets.BETA_CONTACT_FIRST || '' }}
+          BETA_CONTACT_LAST: ${{ secrets.BETA_CONTACT_LAST || '' }}
+          BETA_FEEDBACK_EMAIL: ${{ secrets.BETA_FEEDBACK_EMAIL || '' }}
           FASTLANE_DISABLE_COLORS: '1'
           FASTLANE_HIDE_CHANGELOG: '1'
-        run: bundle exec fastlane release_testflight build_number:"${IOS_BUILD_NUMBER}" changelog:"${TESTFLIGHT_CHANGELOG}"
+        run: bundle exec fastlane release_testflight build_number:"${IOS_BUILD_NUMBER}" changelog:"${TESTFLIGHT_CHANGELOG}" distribute_external:"${DISTRIBUTE}"
 
       - name: Clean up decoded API key
         if: always()

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -24,6 +24,53 @@ def asc_api_key
   )
 end
 
+# ---------------------------------------------------------------------------
+# Beta App Review test-info — single source of truth (#2611 / #2612)
+# ---------------------------------------------------------------------------
+# The localized Beta App Review descriptions and the App-Review contact block
+# are consumed by BOTH `configure_beta_review` (the no-build lane that pushes
+# the test info ahead of time, #2611) and `upload_testflight` (which can carry
+# the same info inline when distributing an external build, #2612). Defining
+# them once here keeps the two paths from drifting apart.
+
+# Localized "Beta App Description" shown to TestFlight reviewers and external
+# testers, keyed by ASC locale. Each string is well under the 4000-char limit.
+BETA_APP_DESCRIPTIONS = {
+  "en-US" => "Stop overpaying at the pump. Sparkilo compares real-time fuel prices and EV charging across 17 countries and points you to the cheapest station near you — for petrol, diesel, LPG, CNG, E85 and electric. Free, ad-free, no account, open-source (MIT).",
+  "fr-FR" => "Arrêtez de payer trop cher à la pompe. Sparkilo compare les prix carburant en temps réel et vous guide vers la station la moins chère près de vous — essence, gazole, GPL, GNV, E85 et recharge de voiture électrique. Dans 17 pays, gratuit, sans pub, sans compte, open source (MIT).",
+  "de-DE" => "Schluss mit zu teuer tanken. Sparkilo vergleicht Spritpreise in Echtzeit und führt dich zur günstigsten Tankstelle in der Nähe — für Benzin, Diesel, LPG, CNG, E85 und zum E-Auto laden. In 17 Ländern, kostenlos, werbefrei, ohne Konto, Open Source (MIT).",
+  "es-ES" => "Deja de pagar de más en el surtidor. Sparkilo compara los precios del combustible en tiempo real y te lleva a la gasolinera más barata cerca de ti — gasolina, diésel, GLP, GNC, E85 y recarga de coche eléctrico. En 17 países, gratis, sin anuncios, sin cuenta, de código abierto (MIT).",
+  "it-IT" => "Basta pagare troppo al distributore. Sparkilo confronta i prezzi del carburante in tempo reale e ti porta al distributore più economico vicino a te — benzina, diesel, GPL, metano, E85 e ricarica per auto elettrica. In 17 paesi, gratis, senza pubblicità, senza account, open source (MIT).",
+  "pt-PT" => "Pare de pagar a mais na bomba. O Sparkilo compara os preços dos combustíveis em tempo real e leva-o ao posto mais barato perto de si — gasolina, gasóleo, GPL, GNC, E85 e carregamento de carro elétrico. Em 17 países, grátis, sem publicidade, sem conta, de código aberto (MIT).",
+}.freeze
+
+# Feedback email shown to beta testers (overridable via BETA_FEEDBACK_EMAIL).
+def beta_feedback_email
+  ENV.fetch("BETA_FEEDBACK_EMAIL", "fdittgen@gmail.com")
+end
+
+# Notes shown to the App Review team — explains there is no sign-in to demo.
+BETA_REVIEW_NOTES = "App uses anonymous auth on launch — no sign-in or account needed to use any feature. Free, ad-free, open-source (MIT). Fuel + EV charging price comparison.".freeze
+
+# App-Review contact block in *snake_case* — the casing pilot's
+# `beta_app_review_info` option expects (pilot/lib/pilot/options.rb). Returns
+# nil when BETA_CONTACT_PHONE is unset so a plain upload doesn't crash; the
+# phone is mandatory for the App-Review submission and must come from the
+# BETA_CONTACT_PHONE repo secret (never fabricated).
+def beta_review_contact_info_snake
+  phone = ENV["BETA_CONTACT_PHONE"]
+  return nil if phone.nil? || phone.strip.empty?
+
+  {
+    contact_first_name: ENV.fetch("BETA_CONTACT_FIRST", "Florian"),
+    contact_last_name: ENV.fetch("BETA_CONTACT_LAST", "Dittgen"),
+    contact_phone: phone,
+    contact_email: beta_feedback_email,
+    demo_account_required: false,
+    notes: BETA_REVIEW_NOTES,
+  }
+end
+
 platform :ios do
   # On CI, create + unlock a dedicated temporary keychain and set it as
   # default before any signing-related action runs. Without this, fastlane
@@ -302,6 +349,63 @@ platform :ios do
     ext_summary = external_targets.empty? ? "(none)" : external_targets.map(&:name).join(", ")
     int_summary = internal_targets.empty? ? "(none)" : internal_targets.map(&:name).join(", ")
     UI.success("Done. External enrollment: #{ext_summary}. Internal target(s): #{int_summary}.")
+  end
+
+  desc "Push the localized Beta App Review test info ahead of a build (#2611)."
+  desc "No build, no upload — sets the App-Review contact block plus the"
+  desc "per-locale feedback email + beta-app description so the FIRST external"
+  desc "'extern' build sails through Beta App Review without manual data entry."
+  desc "An App-Manager-scoped API key suffices. Requires the BETA_CONTACT_PHONE"
+  desc "repo secret (the App-Review contact phone is mandatory and is never"
+  desc "fabricated). Auth = the same App Store Connect API key as upload_testflight."
+  lane :configure_beta_review do
+    # Reuse the proven ConnectAPI login path (manage_testers / pilot's Manager).
+    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from(hash: asc_api_key)
+
+    app = Spaceship::ConnectAPI::App.find("de.tankstellen.tankstellen")
+    UI.user_error!("Could not find app de.tankstellen.tankstellen on App Store Connect.") if app.nil?
+
+    # ---- App-Review contact block. The phone is mandatory — bail clearly
+    # rather than fabricate one. (snake-case helper returns nil when unset.)
+    if ENV["BETA_CONTACT_PHONE"].nil? || ENV["BETA_CONTACT_PHONE"].strip.empty?
+      UI.user_error!(
+        "BETA_CONTACT_PHONE is required for the Beta App Review contact info. " \
+        "Set the BETA_CONTACT_PHONE repository secret (a real reachable phone " \
+        "number) and re-run — this lane will not invent one.",
+      )
+    end
+
+    Spaceship::ConnectAPI.patch_beta_app_review_detail(
+      app_id: app.id,
+      attributes: {
+        contactFirstName: ENV.fetch("BETA_CONTACT_FIRST", "Florian"),
+        contactLastName: ENV.fetch("BETA_CONTACT_LAST", "Dittgen"),
+        contactPhone: ENV.fetch("BETA_CONTACT_PHONE"),
+        contactEmail: beta_feedback_email,
+        demoAccountRequired: false,
+        notes: BETA_REVIEW_NOTES,
+      },
+    )
+    UI.success("Beta App Review contact info updated for #{app.name}.")
+
+    # ---- Per-locale Beta App Localizations (feedbackEmail + description).
+    # Fetch existing localizations into a {locale => model} map, then patch the
+    # ones that already exist and post the ones that don't.
+    existing = app.get_beta_app_localizations
+    by_locale = existing.each_with_object({}) { |loc, acc| acc[loc.locale] = loc }
+
+    BETA_APP_DESCRIPTIONS.each do |locale, description|
+      attributes = { feedbackEmail: beta_feedback_email, description: description }
+      if (loc = by_locale[locale])
+        Spaceship::ConnectAPI.patch_beta_app_localizations(localization_id: loc.id, attributes: attributes)
+        UI.success("Updated Beta App Localization for #{locale}.")
+      else
+        Spaceship::ConnectAPI.post_beta_app_localizations(app_id: app.id, attributes: attributes.merge(locale: locale))
+        UI.success("Created Beta App Localization for #{locale}.")
+      end
+    end
+
+    UI.success("Done. Beta App Review test info is staged for #{app.name} (#{BETA_APP_DESCRIPTIONS.keys.join(', ')}).")
   end
 
   desc "Stage App Store text metadata (name/subtitle/keywords/description/etc.)."

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -245,17 +245,19 @@ platform :ios do
     )
   end
 
-  desc "Add an external TestFlight tester to the app's beta group(s)."
-  desc "Inputs (lane options or ENV): email (required), groups (optional"
-  desc "comma list — when omitted, the tester is added to EVERY external"
-  desc "beta group so they receive all current and future builds), and an"
-  desc "optional first_name / last_name. Idempotent: re-adding an existing"
-  desc "tester is a no-op, not a failure. Auth = the same App Store Connect"
-  desc "API key as upload_testflight (asc_api_key)."
+  desc "Add external TestFlight tester(s) to the app's beta group(s)."
+  desc "Inputs (lane options or ENV): email (required — a single address or a"
+  desc "comma-separated list), groups (optional comma list — when omitted, each"
+  desc "tester is added to EVERY external beta group so they receive all current"
+  desc "and future builds), and an optional first_name / last_name. Idempotent:"
+  desc "re-adding an existing tester is a no-op, not a failure, AND an address"
+  desc "that already exists in another group is still joined to the target group"
+  desc "(verified by re-fetch). Auth = the same App Store Connect API key as"
+  desc "upload_testflight (asc_api_key)."
   lane :manage_testers do |options|
-    email = options[:email] || ENV["TESTFLIGHT_TESTER_EMAIL"]
-    UI.user_error!("manage_testers requires an `email` (lane option or TESTFLIGHT_TESTER_EMAIL).") if email.nil? || email.strip.empty?
-    email = email.strip
+    raw_email = options[:email] || ENV["TESTFLIGHT_TESTER_EMAIL"]
+    emails = raw_email.to_s.split(",").map(&:strip).reject(&:empty?)
+    UI.user_error!("manage_testers requires an `email` (lane option or TESTFLIGHT_TESTER_EMAIL) — a single address or a comma-separated list.") if emails.empty?
 
     first_name = options[:first_name] || ENV["TESTFLIGHT_TESTER_FIRST_NAME"]
     last_name = options[:last_name] || ENV["TESTFLIGHT_TESTER_LAST_NAME"]
@@ -328,83 +330,147 @@ platform :ios do
     external_targets = target_groups.reject(&:is_internal_group)
     internal_targets = target_groups.select(&:is_internal_group)
 
-    tester = { email: email, firstName: first_name, lastName: last_name }
+    # Re-fetch a tester by email with their group memberships hydrated. Returns
+    # the BetaTester model or nil. Used to add an EXISTING tester to a group and
+    # to VERIFY membership after the fact.
+    fetch_tester = lambda do |addr|
+      app.get_beta_testers(filter: { email: addr }, includes: "betaGroups").first
+    end
 
-    # A duplicate / already-present assignment surfaces as an already-exists
-    # error from ASC — treat it as success so the lane is idempotent.
-    assign_to = lambda do |group, kind|
+    in_group = lambda do |betatester, group|
+      return false if betatester.nil?
+      (betatester.beta_groups || []).any? { |g| g.id == group.id }
+    end
+
+    # Add `addr` to `group` and PROVE it landed. The previous implementation
+    # treated an "already exists" error from the bulk CREATE as success — but
+    # when the address already exists in ANOTHER group (e.g. an internal group),
+    # the bulk-CREATE is rejected as a duplicate and the tester is NEVER added to
+    # the target group, yet we reported success (observed: testers "added" to
+    # 'extern' that never appeared there). The fix: after the create attempt
+    # (whether it succeeds or duplicates), look up the existing tester and add it
+    # to this group via the relationship endpoint (add_beta_testers — the call
+    # for EXISTING testers, distinct from create), then re-fetch and assert the
+    # tester is actually a member before claiming success.
+    assign_to = lambda do |addr, info, group, kind|
+      # 1) Try the bulk create — the happy path for a brand-new tester. A
+      #    duplicate here is expected and NOT terminal; the relationship add
+      #    below handles the existing-tester case.
       begin
-        group.post_bulk_beta_tester_assignments(beta_testers: [tester])
-        UI.success("Added #{email} to #{kind} beta group '#{group.name}'.")
+        group.post_bulk_beta_tester_assignments(beta_testers: [info])
       rescue => ex
         message = ex.message.to_s
-        if message =~ /already|exist|duplicat/i
-          UI.success("#{email} is already in '#{group.name}' — nothing to do.")
-        else
-          UI.error("Failed to add #{email} to '#{group.name}': #{message}")
+        unless message =~ /already|exist|duplicat/i
+          UI.error("Failed to create #{addr} in '#{group.name}': #{message}")
           raise ex
         end
       end
+
+      # 2) Whatever happened above, ensure the EXISTING tester is attached to
+      #    this group via the relationship call (idempotent — adding a tester
+      #    already in the group is a no-op).
+      betatester = fetch_tester.call(addr)
+      unless in_group.call(betatester, group)
+        if betatester.nil?
+          UI.error("#{addr} could not be found as a beta tester after assignment — cannot add to '#{group.name}'.")
+          return false
+        end
+        begin
+          group.add_beta_testers(beta_tester_ids: [betatester.id])
+        rescue => ex
+          message = ex.message.to_s
+          unless message =~ /already|exist|duplicat/i
+            UI.error("Failed to add existing #{addr} to '#{group.name}': #{message}")
+            return false
+          end
+        end
+      end
+
+      # 3) VERIFY by re-fetching the tester's group memberships. Only claim
+      #    success when the email is genuinely present in the target group.
+      verified = fetch_tester.call(addr)
+      if in_group.call(verified, group)
+        UI.success("#{addr} is in #{kind} beta group '#{group.name}'.")
+        true
+      else
+        UI.error("#{addr} is STILL NOT in '#{group.name}' after assignment — " \
+                 "membership could not be verified. Check the App Store Connect " \
+                 "API key permissions and the group configuration.")
+        false
+      end
     end
 
-    # ---- External groups: a plain email assignment (no ASC account needed).
-    external_targets.each { |group| assign_to.call(group, "external") }
+    emails.each do |email|
+      info = { email: email, firstName: first_name, lastName: last_name }
+      failures = []
 
-    # ---- Internal groups: internal testers must be App Store Connect *users*
-    # first. Ensure the user exists (invite — scoped to this app — if not),
-    # then assign to the internal group(s). The invite is accepted out-of-band
-    # by the tester via email, so assigning a freshly-invited (not-yet-
-    # accepted) user is deferred to a later re-run and reported clearly.
-    unless internal_targets.empty?
-      begin
-        existing_user = Spaceship::ConnectAPI::User.all.find { |u| u.email.to_s.casecmp?(email) }
-        pending_invite = Spaceship::ConnectAPI::UserInvitation.all.find { |i| i.email.to_s.casecmp?(email) }
+      # ---- External groups: a plain email assignment (no ASC account needed).
+      external_targets.each do |group|
+        failures << group.name unless assign_to.call(email, info, group, "external")
+      end
 
-        if !existing_user.nil?
-          # Accepted team user → assign to the internal group(s) now.
-          internal_targets.each { |group| assign_to.call(group, "internal") }
-        elsif !pending_invite.nil?
-          UI.important("#{email} already has a PENDING App Store Connect invitation. " \
-                       "Ask them to accept it, then re-run this workflow to complete the " \
-                       "internal-group assignment for: #{internal_targets.map(&:name).join(', ')}.")
-        else
-          UI.message("#{email} is not yet an App Store Connect user — sending a " \
-                     "Users-and-Access invitation (role #{role}, scoped to #{app.name} only).")
-          Spaceship::ConnectAPI::UserInvitation.create(
-            email: email,
-            first_name: (first_name && !first_name.empty?) ? first_name : email.split("@").first,
-            last_name: (last_name && !last_name.empty?) ? last_name : "Tester",
-            roles: [role],
-            provisioning_allowed: false,
-            all_apps_visible: false,
-            visible_app_ids: [app.id],
-          )
-          UI.success("Invitation sent to #{email}. Once they accept the email and become a " \
-                     "team user, re-run this workflow to place them in: " \
-                     "#{internal_targets.map(&:name).join(', ')}.")
+      # ---- Internal groups: internal testers must be App Store Connect *users*
+      # first. Ensure the user exists (invite — scoped to this app — if not),
+      # then assign to the internal group(s). The invite is accepted out-of-band
+      # by the tester via email, so assigning a freshly-invited (not-yet-
+      # accepted) user is deferred to a later re-run and reported clearly.
+      unless internal_targets.empty?
+        begin
+          existing_user = Spaceship::ConnectAPI::User.all.find { |u| u.email.to_s.casecmp?(email) }
+          pending_invite = Spaceship::ConnectAPI::UserInvitation.all.find { |i| i.email.to_s.casecmp?(email) }
+
+          if !existing_user.nil?
+            # Accepted team user → assign to the internal group(s) now (verified).
+            internal_targets.each do |group|
+              failures << group.name unless assign_to.call(email, info, group, "internal")
+            end
+          elsif !pending_invite.nil?
+            UI.important("#{email} already has a PENDING App Store Connect invitation. " \
+                         "Ask them to accept it, then re-run this workflow to complete the " \
+                         "internal-group assignment for: #{internal_targets.map(&:name).join(', ')}.")
+          else
+            UI.message("#{email} is not yet an App Store Connect user — sending a " \
+                       "Users-and-Access invitation (role #{role}, scoped to #{app.name} only).")
+            Spaceship::ConnectAPI::UserInvitation.create(
+              email: email,
+              first_name: (first_name && !first_name.empty?) ? first_name : email.split("@").first,
+              last_name: (last_name && !last_name.empty?) ? last_name : "Tester",
+              roles: [role],
+              provisioning_allowed: false,
+              all_apps_visible: false,
+              visible_app_ids: [app.id],
+            )
+            UI.success("Invitation sent to #{email}. Once they accept the email and become a " \
+                       "team user, re-run this workflow to place them in: " \
+                       "#{internal_targets.map(&:name).join(', ')}.")
+          end
+        rescue => ex
+          # The ASC *API key* itself carries a role. Inviting / listing users is
+          # a Users-and-Access (Admin) capability — an App-Manager-scoped key
+          # gets FORBIDDEN here. Surface that as an actionable message instead of
+          # a raw stack trace.
+          message = ex.message.to_s
+          if message =~ /forbid|permission|not.*(allowed|permitted)|403|unauthor/i
+            UI.user_error!(
+              "The App Store Connect API key lacks permission to manage Users and " \
+              "Access (needed to invite an INTERNAL tester). Re-issue the API key with " \
+              "the Admin role, or add #{email} as an internal tester manually in App " \
+              "Store Connect → Users and Access. (#{message})",
+            )
+          else
+            raise ex
+          end
         end
-      rescue => ex
-        # The ASC *API key* itself carries a role. Inviting / listing users is
-        # a Users-and-Access (Admin) capability — an App-Manager-scoped key
-        # gets FORBIDDEN here. Surface that as an actionable message instead of
-        # a raw stack trace.
-        message = ex.message.to_s
-        if message =~ /forbid|permission|not.*(allowed|permitted)|403|unauthor/i
-          UI.user_error!(
-            "The App Store Connect API key lacks permission to manage Users and " \
-            "Access (needed to invite an INTERNAL tester). Re-issue the API key with " \
-            "the Admin role, or add #{email} as an internal tester manually in App " \
-            "Store Connect → Users and Access. (#{message})",
-          )
-        else
-          raise ex
-        end
+      end
+
+      unless failures.empty?
+        UI.user_error!("#{email}: could not verify membership in group(s): #{failures.uniq.join(', ')}.")
       end
     end
 
     ext_summary = external_targets.empty? ? "(none)" : external_targets.map(&:name).join(", ")
     int_summary = internal_targets.empty? ? "(none)" : internal_targets.map(&:name).join(", ")
-    UI.success("Done. External enrollment: #{ext_summary}. Internal target(s): #{int_summary}.")
+    UI.success("Done. Tester(s): #{emails.join(', ')}. External group(s): #{ext_summary}. Internal target(s): #{int_summary}.")
   end
 
   desc "Push the localized Beta App Review test info ahead of a build (#2611)."

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -44,9 +44,17 @@ BETA_APP_DESCRIPTIONS = {
   "pt-PT" => "Pare de pagar a mais na bomba. O Sparkilo compara os preços dos combustíveis em tempo real e leva-o ao posto mais barato perto de si — gasolina, gasóleo, GPL, GNC, E85 e carregamento de carro elétrico. Em 17 países, grátis, sem publicidade, sem conta, de código aberto (MIT).",
 }.freeze
 
+# Read an env var, falling back to `default` when it is unset OR empty. CI
+# passes optional secrets through as "" (the `|| ''` fallback), which plain
+# ENV.fetch would NOT replace — so an empty value must be treated as absent.
+def beta_env(name, default)
+  value = ENV[name]
+  (value.nil? || value.strip.empty?) ? default : value.strip
+end
+
 # Feedback email shown to beta testers (overridable via BETA_FEEDBACK_EMAIL).
 def beta_feedback_email
-  ENV.fetch("BETA_FEEDBACK_EMAIL", "fdittgen@gmail.com")
+  beta_env("BETA_FEEDBACK_EMAIL", "fdittgen@gmail.com")
 end
 
 # Notes shown to the App Review team — explains there is no sign-in to demo.
@@ -62,9 +70,9 @@ def beta_review_contact_info_snake
   return nil if phone.nil? || phone.strip.empty?
 
   {
-    contact_first_name: ENV.fetch("BETA_CONTACT_FIRST", "Florian"),
-    contact_last_name: ENV.fetch("BETA_CONTACT_LAST", "Dittgen"),
-    contact_phone: phone,
+    contact_first_name: beta_env("BETA_CONTACT_FIRST", "Florian"),
+    contact_last_name: beta_env("BETA_CONTACT_LAST", "Dittgen"),
+    contact_phone: phone.strip,
     contact_email: beta_feedback_email,
     demo_account_required: false,
     notes: BETA_REVIEW_NOTES,
@@ -163,30 +171,78 @@ platform :ios do
   end
 
   desc "Upload the IPA at build/ios/ipa/Runner.ipa to TestFlight (no review submission)."
+  desc "Pass distribute_external:true to push the build to the external 'extern'"
+  desc "group (submits it for Beta App Review). Defaults to false → internal only."
   lane :upload_testflight do |options|
     changelog = options[:changelog] || ENV["TESTFLIGHT_CHANGELOG"] || "Daily build."
-    # Explicit app/team IDs — without them pilot tries to enumerate apps
-    # from the ASC API key alone and on the very first build hit:
+    # Coerce to a strict boolean: release_testflight may forward an explicit nil
+    # (the key is present), and the workflow passes the string "true"/"false".
+    raw_distribute = options.fetch(:distribute_external, false)
+    distribute_external = [true, "true", "1"].include?(raw_distribute)
+
+    # Base pilot args. Explicit app/team IDs — without them pilot tries to
+    # enumerate apps from the ASC API key alone and on the very first build hit:
     #   Couldn't find app 'de.tankstellen.tankstellen' on the account of ''
     # Passing the IDs skips the lookup and points pilot directly at the
     # app entry. Numeric Apple ID and team ID are stable for the lifetime
     # of the app, so hard-coding here is safe.
-    pilot(
+    pilot_args = {
       api_key: asc_api_key,
       app_identifier: "de.tankstellen.tankstellen",
       apple_id: "6766543414",
       team_id: "C4Y5RDF8P9",
       ipa: "../build/ios/ipa/Runner.ipa",
-      skip_waiting_for_build_processing: true,
       changelog: changelog,
-    )
+      distribute_external: distribute_external,
+    }
+
+    if distribute_external
+      # External distribution: the build must finish processing before pilot can
+      # attach it to the external group and submit it for Beta App Review, so we
+      # canNOT skip waiting here. Target the 'extern' group; don't email testers
+      # automatically (Apple still gates the build behind Beta App Review).
+      pilot_args[:skip_waiting_for_build_processing] = false
+      pilot_args[:groups] = ["extern"]
+      pilot_args[:notify_external_testers] = false
+
+      # Carry the localized test info + contact block inline (shared source of
+      # truth with configure_beta_review, #2611), so even a fresh app has its
+      # Beta App Review data filled. snake_case keys are what pilot expects.
+      pilot_args[:beta_app_description] = BETA_APP_DESCRIPTIONS["en-US"]
+      pilot_args[:localized_app_info] = BETA_APP_DESCRIPTIONS.each_with_object({}) do |(locale, description), acc|
+        acc[locale] = { feedback_email: beta_feedback_email, description: description }
+      end
+
+      # Only attach the App-Review contact block when BETA_CONTACT_PHONE is set
+      # — the phone is mandatory and never fabricated. Omitting it gracefully
+      # keeps a plain upload from crashing while still distributing the build.
+      contact = beta_review_contact_info_snake
+      if contact
+        pilot_args[:beta_app_review_info] = contact
+      else
+        UI.important("BETA_CONTACT_PHONE unset — distributing externally WITHOUT the " \
+                     "App-Review contact block. Run configure_beta_review (with the " \
+                     "BETA_CONTACT_PHONE secret) first so Beta App Review can clear.")
+      end
+    else
+      # Internal-only upload: nothing to review, so skip the processing wait to
+      # keep the job fast (the historical default).
+      pilot_args[:skip_waiting_for_build_processing] = true
+    end
+
+    pilot(pilot_args)
   end
 
   desc "End-to-end CI release: fetch certs, build, and upload to TestFlight."
+  desc "Pass distribute_external:true to also push the build to the external"
+  desc "'extern' group (forwarded to upload_testflight)."
   lane :release_testflight do |options|
     match(type: "appstore", api_key: asc_api_key)
     build_appstore(build_number: options[:build_number])
-    upload_testflight(changelog: options[:changelog])
+    upload_testflight(
+      changelog: options[:changelog],
+      distribute_external: options[:distribute_external],
+    )
   end
 
   desc "Add an external TestFlight tester to the app's beta group(s)."
@@ -378,9 +434,9 @@ platform :ios do
     Spaceship::ConnectAPI.patch_beta_app_review_detail(
       app_id: app.id,
       attributes: {
-        contactFirstName: ENV.fetch("BETA_CONTACT_FIRST", "Florian"),
-        contactLastName: ENV.fetch("BETA_CONTACT_LAST", "Dittgen"),
-        contactPhone: ENV.fetch("BETA_CONTACT_PHONE"),
+        contactFirstName: beta_env("BETA_CONTACT_FIRST", "Florian"),
+        contactLastName: beta_env("BETA_CONTACT_LAST", "Dittgen"),
+        contactPhone: ENV.fetch("BETA_CONTACT_PHONE").strip,
         contactEmail: beta_feedback_email,
         demoAccountRequired: false,
         notes: BETA_REVIEW_NOTES,


### PR DESCRIPTION
Implements Epic #2614 (iOS external TestFlight distribution) as one bundled PR, one commit per child issue. Touches only `ios/fastlane/Fastfile` + `.github/workflows/*.yml` (Ruby + YAML) — no Dart/ARB/codegen.

## Commits

**1. `configure_beta_review` lane — localized Beta App Review test info (#2611)**
New no-build lane (App-Manager key suffices) that pushes the Beta App Review test info to App Store Connect ahead of the first external build, so it clears review with no manual data entry:
- `patch_beta_app_review_detail` with the contact block (first/last/phone/email, `demoAccountRequired:false`, anonymous-auth notes); bails clearly if `BETA_CONTACT_PHONE` is unset rather than fabricating a number.
- Per-locale `BetaAppLocalization` (feedbackEmail + description) for en-US/fr-FR/de-DE/es-ES/it-IT/pt-PT — patches existing, posts missing.
- New `ios-beta-review.yml` workflow (workflow_dispatch only, ubuntu-latest, decode→run→cleanup→summary, cloned from `ios-testers.yml`), with optional `contact_first`/`contact_last` inputs that override the secrets/defaults.

**2. Auto-publish on schedule + distribute to external 'extern' (#2612)**
- `upload_testflight` gains `distribute_external` (default false): waits for processing, targets the `extern` group, `notify_external_testers:false`, and carries the localized test info + contact block inline — sharing one source of truth (file-level constants/helpers) with #2611. The contact block is omitted gracefully when `BETA_CONTACT_PHONE` is unset so a plain upload never crashes.
- `release_testflight` forwards `distribute_external`.
- `ios-testflight.yml`: daily `schedule: '30 4 * * *'` (distinct from daily-beta 16:00 / daily-github-release 21:00); build number switched to a monotonic run-counter `2026060000 + run_number*10 + run_attempt`; `distribute` boolean dispatch input; `DISTRIBUTE = schedule || inputs.distribute`; BETA_* secrets threaded in.

**3. Multi-email external testers + fix existing-tester group join (#2613)**
- `manage_testers` `email` now accepts a comma-separated list (`emails.each`); `ios-testers.yml` default → `fdittgen@gmail.com,florian.dittgen@trelleborg.com`.
- **Bug fix:** the old "already exists → success" rescue never actually joined the target group when the address pre-existed in another group (the bulk CREATE was rejected as duplicate). New per-(group,email) logic: attempt create → re-fetch the existing tester and add it to the group via the relationship endpoint (`group.add_beta_testers`) → **verify** by re-fetching the tester's `betaGroups` and asserting membership before reporting success; otherwise fail with the real reason. Idempotent.

## ⚠️ BLOCKER
Set the repo secret **`BETA_CONTACT_PHONE`** (a real, reachable App-Review contact phone) before the first external run — the lanes refuse to fabricate one. External testers can only install **after the first `extern` build passes Beta App Review** (first external submission per app is human-reviewed by Apple). Optional secrets: `BETA_CONTACT_FIRST`, `BETA_CONTACT_LAST`, `BETA_FEEDBACK_EMAIL`.

Closes #2611, closes #2612, closes #2613. Part of Epic #2614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
