### PR TITLE
ci(ios): fix beta-review locale (it) + reliable tester add (#2611 #2613)

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -315,7 +315,7 @@ platform :ios do
           UI.message("No external groups exist — targeting ALL internal beta groups (internal-tester flow).")
           internal_groups
         else
-          UI.message("No `groups` given — adding #{email} to ALL external beta groups.")
+          UI.message("No `groups` given — adding #{emails.join(', ')} to ALL external beta groups.")
           external_groups
         end
       else
@@ -336,11 +336,19 @@ platform :ios do
     external_targets = target_groups.reject(&:is_internal_group)
     internal_targets = target_groups.select(&:is_internal_group)
 
-    # Re-fetch a tester by email with their group memberships hydrated. Returns
-    # the BetaTester model or nil. Used to add an EXISTING tester to a group and
-    # to VERIFY membership after the fact.
-    fetch_tester = lambda do |addr|
-      app.get_beta_testers(filter: { email: addr }, includes: "betaGroups").first
+    # Find a tester by email with their group memberships hydrated, returning the
+    # BetaTester model or nil. We use the ACCOUNT-SCOPED finder
+    # `Spaceship::ConnectAPI::BetaTester.find(email:)` (spaceship .../models/
+    # beta_tester.rb → global GET /v1/betaTesters?filter[email]=…) rather than
+    # the APP-SCOPED `app.get_beta_testers(filter: {email:})` that the previous
+    # implementation used. App#get_beta_testers injects `filter[:apps] = app.id`
+    # (spaceship .../models/app.rb), so a tester who exists on the account but
+    # is not yet indexed against THIS app returns nil — which is exactly why the
+    # live run could not find fdittgen@gmail.com after assignment and never
+    # landed the tester in 'extern' (#2613). The account-scoped find sees the
+    # tester regardless of app association.
+    find_tester = lambda do |addr|
+      Spaceship::ConnectAPI::BetaTester.find(email: addr, includes: "betaGroups")
     end
 
     in_group = lambda do |betatester, group|
@@ -348,54 +356,75 @@ platform :ios do
       (betatester.beta_groups || []).any? { |g| g.id == group.id }
     end
 
-    # Add `addr` to `group` and PROVE it landed. The previous implementation
-    # treated an "already exists" error from the bulk CREATE as success — but
-    # when the address already exists in ANOTHER group (e.g. an internal group),
-    # the bulk-CREATE is rejected as a duplicate and the tester is NEVER added to
-    # the target group, yet we reported success (observed: testers "added" to
-    # 'extern' that never appeared there). The fix: after the create attempt
-    # (whether it succeeds or duplicates), look up the existing tester and add it
-    # to this group via the relationship endpoint (add_beta_testers — the call
-    # for EXISTING testers, distinct from create), then re-fetch and assert the
-    # tester is actually a member before claiming success.
+    # Add `addr` to `group` and PROVE it landed, mirroring pilot's own working
+    # tester flow (pilot/lib/pilot/tester_manager.rb#add_tester) but split into
+    # the create-new vs add-existing branches and followed by a verification:
+    #
+    #   * find by email   → Spaceship::ConnectAPI::BetaTester.find(email:)
+    #   * EXISTING tester → group.add_beta_testers(beta_tester_ids: [tester.id])
+    #                       (spaceship BetaGroup#add_beta_testers →
+    #                        POST /v1/betaGroups/{id}/relationships/betaTesters)
+    #   * NEW tester      → Spaceship::ConnectAPI.post_beta_tester_assignment(
+    #                        beta_group_ids: [group.id], attributes: {...})
+    #                       (spaceship testflight.rb → POST /v1/betaTesters with
+    #                        the betaGroups relationship — creates the tester
+    #                        already attached to the target group)
+    #
+    # The previous code only ever called the bulk-assignment endpoint and then
+    # an app-scoped find; when the address already existed in ANOTHER group the
+    # bulk endpoint returns 200 with a per-tester error (it does NOT raise), so
+    # nothing was added and the find found nothing either — reported as the live
+    # "could not be found as a beta tester after assignment" failure (#2613).
     assign_to = lambda do |addr, info, group, kind|
-      # 1) Try the bulk create — the happy path for a brand-new tester. A
-      #    duplicate here is expected and NOT terminal; the relationship add
-      #    below handles the existing-tester case.
+      existing = find_tester.call(addr)
+      UI.message("[manage_testers] find(#{addr}) → " \
+                 "#{existing ? "tester id #{existing.id}" : 'nil (not yet a tester)'}; " \
+                 "target #{kind} group '#{group.name}' (#{group.id}).")
+
+      if existing && in_group.call(existing, group)
+        # Truly already a member of the target group → idempotent no-op.
+        UI.success("#{addr} is already in #{kind} beta group '#{group.name}' — nothing to do.")
+        return true
+      end
+
       begin
-        group.post_bulk_beta_tester_assignments(beta_testers: [info])
+        if existing
+          # EXISTING tester (possibly only in another group) → attach to this
+          # group via the relationship endpoint.
+          UI.message("[manage_testers] path=add-existing — attaching tester #{existing.id} to '#{group.name}'.")
+          group.add_beta_testers(beta_tester_ids: [existing.id])
+        else
+          # NEW tester → create it already attached to the target group.
+          UI.message("[manage_testers] path=create-new — creating #{addr} attached to '#{group.name}'.")
+          Spaceship::ConnectAPI.post_beta_tester_assignment(
+            beta_group_ids: [group.id],
+            attributes: {
+              email: addr,
+              firstName: info[:firstName],
+              lastName: info[:lastName],
+            },
+          )
+        end
       rescue => ex
         message = ex.message.to_s
-        unless message =~ /already|exist|duplicat/i
-          UI.error("Failed to create #{addr} in '#{group.name}': #{message}")
-          raise ex
-        end
-      end
-
-      # 2) Whatever happened above, ensure the EXISTING tester is attached to
-      #    this group via the relationship call (idempotent — adding a tester
-      #    already in the group is a no-op).
-      betatester = fetch_tester.call(addr)
-      unless in_group.call(betatester, group)
-        if betatester.nil?
-          UI.error("#{addr} could not be found as a beta tester after assignment — cannot add to '#{group.name}'.")
+        if message =~ /already|exist|duplicat/i
+          # Concurrent / prior partial run already attached it — fine; the
+          # verification below confirms the real state.
+          UI.message("[manage_testers] add reported already-exists for #{addr} in '#{group.name}'; verifying.")
+        else
+          UI.error("Failed to add #{addr} to '#{group.name}': #{message}")
           return false
         end
-        begin
-          group.add_beta_testers(beta_tester_ids: [betatester.id])
-        rescue => ex
-          message = ex.message.to_s
-          unless message =~ /already|exist|duplicat/i
-            UI.error("Failed to add existing #{addr} to '#{group.name}': #{message}")
-            return false
-          end
-        end
       end
 
-      # 3) VERIFY by re-fetching the tester's group memberships. Only claim
-      #    success when the email is genuinely present in the target group.
-      verified = fetch_tester.call(addr)
-      if in_group.call(verified, group)
+      # VERIFY by re-fetching (account-scoped) and asserting target-group
+      # membership. Only claim success when the email is genuinely present.
+      verified = find_tester.call(addr)
+      member = in_group.call(verified, group)
+      UI.message("[manage_testers] post-verify #{addr} → groups: " \
+                 "#{verified ? (verified.beta_groups || []).map(&:name).join(', ') : '(tester not found)'}; " \
+                 "in '#{group.name}'? #{member}.")
+      if member
         UI.success("#{addr} is in #{kind} beta group '#{group.name}'.")
         true
       else

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -40,7 +40,13 @@ BETA_APP_DESCRIPTIONS = {
   "fr-FR" => "Arrêtez de payer trop cher à la pompe. Sparkilo compare les prix carburant en temps réel et vous guide vers la station la moins chère près de vous — essence, gazole, GPL, GNV, E85 et recharge de voiture électrique. Dans 17 pays, gratuit, sans pub, sans compte, open source (MIT).",
   "de-DE" => "Schluss mit zu teuer tanken. Sparkilo vergleicht Spritpreise in Echtzeit und führt dich zur günstigsten Tankstelle in der Nähe — für Benzin, Diesel, LPG, CNG, E85 und zum E-Auto laden. In 17 Ländern, kostenlos, werbefrei, ohne Konto, Open Source (MIT).",
   "es-ES" => "Deja de pagar de más en el surtidor. Sparkilo compara los precios del combustible en tiempo real y te lleva a la gasolinera más barata cerca de ti — gasolina, diésel, GLP, GNC, E85 y recarga de coche eléctrico. En 17 países, gratis, sin anuncios, sin cuenta, de código abierto (MIT).",
-  "it-IT" => "Basta pagare troppo al distributore. Sparkilo confronta i prezzi del carburante in tempo reale e ti porta al distributore più economico vicino a te — benzina, diesel, GPL, metano, E85 e ricarica per auto elettrica. In 17 paesi, gratis, senza pubblicità, senza account, open source (MIT).",
+  # App Store Connect's locale code for Italian is "it", NOT "it-IT" (see
+  # fastlane's own supported-locale list, deliver/lib/deliver/languages.rb:
+  # ar-SA ca cs da de-DE … en-US es-ES … fr-FR … it … pt-PT …). All other keys
+  # here (en-US, fr-FR, de-DE, es-ES, pt-PT) appear in that list verbatim. Using
+  # "it-IT" made App Store Connect reject the 5th localization with
+  #   "The 'locale' value is invalid. - /data/attributes/locale" (#2611).
+  "it" => "Basta pagare troppo al distributore. Sparkilo confronta i prezzi del carburante in tempo reale e ti porta al distributore più economico vicino a te — benzina, diesel, GPL, metano, E85 e ricarica per auto elettrica. In 17 paesi, gratis, senza pubblicità, senza account, open source (MIT).",
   "pt-PT" => "Pare de pagar a mais na bomba. O Sparkilo compara os preços dos combustíveis em tempo real e leva-o ao posto mais barato perto de si — gasolina, gasóleo, GPL, GNC, E85 e carregamento de carro elétrico. Em 17 países, grátis, sem publicidade, sem conta, de código aberto (MIT).",
 }.freeze
 
@@ -512,22 +518,45 @@ platform :ios do
 
     # ---- Per-locale Beta App Localizations (feedbackEmail + description).
     # Fetch existing localizations into a {locale => model} map, then patch the
-    # ones that already exist and post the ones that don't.
+    # ones that already exist and post the ones that don't — so a re-run after a
+    # partial failure PATCHes the already-created locales rather than POSTing a
+    # duplicate (the live #2611 run had created en-US/fr-FR/de-DE/es-ES before it
+    # aborted, and they must re-apply as PATCHes on the retry).
     existing = app.get_beta_app_localizations
     by_locale = existing.each_with_object({}) { |loc, acc| acc[loc.locale] = loc }
 
+    # Each locale is patched/posted inside its own begin/rescue so a SINGLE bad
+    # locale (an invalid/unsupported App Store Connect code — the failure mode
+    # that aborted the live #2611 run on the 5th locale) is logged and skipped
+    # while the remaining locales still apply. Future Apple-side locale quirks
+    # thus degrade gracefully instead of taking the whole lane down.
+    failed_locales = []
     BETA_APP_DESCRIPTIONS.each do |locale, description|
       attributes = { feedbackEmail: beta_feedback_email, description: description }
-      if (loc = by_locale[locale])
-        Spaceship::ConnectAPI.patch_beta_app_localizations(localization_id: loc.id, attributes: attributes)
-        UI.success("Updated Beta App Localization for #{locale}.")
-      else
-        Spaceship::ConnectAPI.post_beta_app_localizations(app_id: app.id, attributes: attributes.merge(locale: locale))
-        UI.success("Created Beta App Localization for #{locale}.")
+      begin
+        if (loc = by_locale[locale])
+          Spaceship::ConnectAPI.patch_beta_app_localizations(localization_id: loc.id, attributes: attributes)
+          UI.success("Updated Beta App Localization for #{locale}.")
+        else
+          Spaceship::ConnectAPI.post_beta_app_localizations(app_id: app.id, attributes: attributes.merge(locale: locale))
+          UI.success("Created Beta App Localization for #{locale}.")
+        end
+      rescue => ex
+        failed_locales << locale
+        UI.error("Failed to stage Beta App Localization for #{locale}: #{ex.message}")
+        UI.important("Skipping #{locale} and continuing with the remaining locales.")
       end
     end
 
-    UI.success("Done. Beta App Review test info is staged for #{app.name} (#{BETA_APP_DESCRIPTIONS.keys.join(', ')}).")
+    if failed_locales.empty?
+      UI.success("Done. Beta App Review test info is staged for #{app.name} (#{BETA_APP_DESCRIPTIONS.keys.join(', ')}).")
+    else
+      applied = BETA_APP_DESCRIPTIONS.keys - failed_locales
+      UI.important("Beta App Review test info staged for #{app.name} with " \
+                   "#{applied.join(', ')}; SKIPPED (invalid/rejected locale): " \
+                   "#{failed_locales.join(', ')}. The contact block and the other " \
+                   "locales were applied.")
+    end
   end
 
   desc "Stage App Store text metadata (name/subtitle/keywords/description/etc.)."


### PR DESCRIPTION
Two live App Store Connect runtime bugs in the iOS fastlane lanes shipped in #2615 (Epic #2614). Touches `ios/fastlane/Fastfile` only — no Dart/ARB/codegen.

## Bug 1 — invalid beta-localization locale `it-IT` (#2611)

`configure_beta_review` aborted live on the 5th locale with:

> The 'locale' value is invalid. - /data/attributes/locale

after successfully creating `en-US`, `fr-FR`, `de-DE`, `es-ES`. App Store Connect's locale code for Italian is **`it`**, not `it-IT` — confirmed against fastlane's own supported-locale list (`deliver/lib/deliver/languages.rb` `ALL_LANGUAGES` contains `it` and has no `it-IT`; the other five keys `en-US`/`fr-FR`/`de-DE`/`es-ES`/`pt-PT` all appear there verbatim).

- Renamed the `BETA_APP_DESCRIPTIONS` key `it-IT` → `it` (Italian text unchanged). As the single source of truth, this also corrects the locale fed into `upload_testflight`'s `localized_app_info` `pilot()` call.
- Made `configure_beta_review` **resilient**: each per-locale patch/post now runs in its own `begin/rescue`, so a single invalid/unsupported locale is logged (`UI.error`/`UI.important`) and skipped while the contact block and the remaining locales still apply — future Apple locale quirks degrade gracefully instead of taking down the whole lane.
- Idempotency preserved: the lane still fetches existing localizations and PATCHes already-created locales on re-run (the failed run had created `en-US`/`fr-FR`/`de-DE`/`es-ES`) rather than POSTing duplicates.

## Bug 2 — `manage_testers` never lands the tester in the group (#2613)

Failed live with:

> fdittgen@gmail.com could not be found as a beta tester after assignment — cannot add to 'extern'
>
> could not verify membership in group(s): extern

The post-add verification correctly blocked a false success, but the add/find logic never enrolled the tester.

**Root cause:** the lane located testers with the **app-scoped** `app.get_beta_testers(filter: {email:})`, and `App#get_beta_testers` injects `filter[:apps] = app.id` (spaceship `connect_api/models/app.rb`). A tester present on the account but not yet indexed against *this app* returns `nil`, so the relationship-add path was never reached. The bulk-assignment endpoint also returns HTTP 200 with a *per-tester* error (rather than raising) when the address already exists in another group, so the old "rescue already-exists → success" path silently no-opped.

Rewrote the per-(group,email) add to mirror pilot's working flow (`pilot/lib/pilot/tester_manager.rb#add_tester`) using the authoritative gem calls:

- **find by email** (account-scoped, no app filter): `Spaceship::ConnectAPI::BetaTester.find(email:, includes:)` — `spaceship/.../models/beta_tester.rb:73`.
- **existing tester** → `group.add_beta_testers(beta_tester_ids: [id])` (`BetaGroup#add_beta_testers` → `POST /v1/betaGroups/{id}/relationships/betaTesters`, `beta_group.rb:45` + `testflight.rb:325`).
- **new tester** → `Spaceship::ConnectAPI.post_beta_tester_assignment(beta_group_ids: [group.id], attributes: {email:, firstName:, lastName:})` — creates the tester already attached to the target group (`testflight.rb:304`).

Then re-fetch (account-scoped) and assert target-group membership; `UI.success` only on confirmed membership, else `UI.error` with the real reason.

- **Verbose diagnostics**: logs what `find` returned (nil vs tester id), which path was taken (create vs add-existing), and post-verify group membership — a failing run is now debuggable.
- **Idempotency kept**: a tester truly already in the target group is a success no-op; the multi-email comma-split loop is unchanged.
- Also fixed a **latent NameError**: the "no groups given" external-path log referenced the removed singular `email` var → now `emails.join`.

Re-run targets `fdittgen@gmail.com, florian.dittgen@trelleborg.com` → group `extern` (handles both already-exist and not-yet-exist).

Part of Epic #2614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
