### PR TITLE
fix(pip): scale whole PiP stack with FittedBox so secondary row never clips (#2620)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -16,15 +16,10 @@ import '../../providers/trip_recording_provider.dart';
 /// Picture-in-Picture tile (#2068 — replaces the prior dense
 /// one-row layout from #1977 with a single huge L/100 km figure).
 ///
-/// Layout:
-///
-/// ```
-/// ┌──────────────────────┐
-/// │       5.8            │  ← `displayLarge`-sized L/100 km
-/// │     L/100 km         │  ← `labelMedium` unit caption
-/// │  12.4 km · 8:32      │  ← compact distance + duration row
-/// └──────────────────────┘
-/// ```
+/// Layout (top→bottom): huge L/100 km figure, the unit caption, then a
+/// compact `distance · duration` secondary row. The whole stack is scaled
+/// down uniformly by one outer `FittedBox` so it never clips the small
+/// 2:1 tile (#2620).
 ///
 /// On a GPS-only trajet (no OBD2 fuel-rate samples) the big figure is
 /// the live physics estimate rendered as `~X.X L/100 km` once the
@@ -105,11 +100,14 @@ class TripRecordingPipView extends StatelessWidget {
     final elapsed = live?.elapsed;
 
     // Resolve OBD2-derived live L/100 km (or L/h at idle).
-    final raw = (live != null && !paused) ? formatInstantConsumption(live) : null;
+    final raw = (live != null && !paused)
+        ? formatInstantConsumption(live)
+        : null;
     // #2390 — GPS-only live estimate (null on OBD2 trips + during the
     // estimator's warm-up). The OBD2 `raw` figure always wins over it.
-    final gpsEstimate =
-        (live != null && !paused) ? live.gpsEstimatedLPer100Km : null;
+    final gpsEstimate = (live != null && !paused)
+        ? live.gpsEstimatedLPer100Km
+        : null;
 
     final String bigFigure;
     final String bigCaption;
@@ -149,7 +147,8 @@ class TripRecordingPipView extends StatelessWidget {
       bigCaption = l?.tripRecordingPipEstConsumptionCaption ?? 'est. L/100 km';
       isEstimate = true;
       secondaryRow = [
-        if (distance != null && distance >= 0.1) '${distance.toStringAsFixed(1)} km',
+        if (distance != null && distance >= 0.1)
+          '${distance.toStringAsFixed(1)} km',
         if (elapsed != null) _fmtElapsed(elapsed),
       ];
     } else {
@@ -166,23 +165,22 @@ class TripRecordingPipView extends StatelessWidget {
     // no estimate disclaimer).
     final estimateInfo = isEstimate
         ? (l?.tripRecordingEstimatedInfo ??
-            'Estimated value (~) — modelled from GPS speed, not measured.')
+              'Estimated value (~) — modelled from GPS speed, not measured.')
         : null;
     Widget figureBlock = Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        FittedBox(
-          fit: BoxFit.scaleDown,
-          child: Text(
-            bigFigure,
-            style: TextStyle(
-              color: foregroundColor,
-              fontWeight: FontWeight.w800,
-              fontSize: 64,
-              height: 1.0,
-              fontFeatures: const [FontFeature.tabularFigures()],
-            ),
+        // #2620 — plain Text; the outer `_pipStack` FittedBox scales the
+        // WHOLE stack (figure + caption + secondary row) so nothing clips.
+        Text(
+          bigFigure,
+          style: TextStyle(
+            color: foregroundColor,
+            fontWeight: FontWeight.w800,
+            fontSize: 64,
+            height: 1.0,
+            fontFeatures: const [FontFeature.tabularFigures()],
           ),
         ),
         const SizedBox(height: 2),
@@ -203,57 +201,70 @@ class TripRecordingPipView extends StatelessWidget {
       );
     }
 
+    return _pipStack(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          figureBlock,
+          if (secondaryRow.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                for (var i = 0; i < secondaryRow.length; i++) ...[
+                  if (i > 0)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 6),
+                      child: Text(
+                        '·',
+                        style: TextStyle(
+                          color: foregroundColor.withValues(alpha: 0.6),
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                  Text(
+                    secondaryRow[i],
+                    style: TextStyle(
+                      color: foregroundColor.withValues(alpha: 0.9),
+                      fontSize: 12,
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ],
+          if (paused) ...[
+            const SizedBox(height: 4),
+            Text(
+              l?.tripBannerPaused ?? 'Paused',
+              style: TextStyle(
+                color: foregroundColor.withValues(alpha: 0.8),
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Shared PiP host: scales the WHOLE content stack down uniformly so the
+  /// figure + caption + secondary row ALWAYS fit the small 2:1 tile without
+  /// clipping (#2620). The single outer FittedBox(scaleDown) measures the
+  /// column's full intrinsic size and shrinks it on both axes; Center keeps
+  /// it optically centred when it already fits.
+  Widget _pipStack({required Widget child}) {
     return Material(
       color: backgroundColor,
       child: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              figureBlock,
-              if (secondaryRow.isNotEmpty) ...[
-                const SizedBox(height: 6),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    for (var i = 0; i < secondaryRow.length; i++) ...[
-                      if (i > 0)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 6),
-                          child: Text(
-                            '·',
-                            style: TextStyle(
-                              color: foregroundColor.withValues(alpha: 0.6),
-                              fontSize: 12,
-                            ),
-                          ),
-                        ),
-                      Text(
-                        secondaryRow[i],
-                        style: TextStyle(
-                          color: foregroundColor.withValues(alpha: 0.9),
-                          fontSize: 12,
-                          fontFeatures: const [FontFeature.tabularFigures()],
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-              ],
-              if (paused) ...[
-                const SizedBox(height: 4),
-                Text(
-                  l?.tripBannerPaused ?? 'Paused',
-                  style: TextStyle(
-                    color: foregroundColor.withValues(alpha: 0.8),
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
-            ],
+          child: Center(
+            child: FittedBox(fit: BoxFit.scaleDown, child: child),
           ),
         ),
       ),
@@ -274,14 +285,13 @@ class TripRecordingPipView extends StatelessWidget {
     final station = approach is ApproachInRadius
         ? approach.station
         : (approach as ApproachLeaving).lastStation;
-    final distanceMeters =
-        approach is ApproachInRadius ? approach.distanceMeters : null;
+    final distanceMeters = approach is ApproachInRadius
+        ? approach.distanceMeters
+        : null;
     final fuel = fuelType ?? FuelType.e10;
     final price = station.priceFor(fuel);
 
-    final priceText = price != null
-        ? PriceFormatter.formatPrice(price)
-        : '—';
+    final priceText = price != null ? PriceFormatter.formatPrice(price) : '—';
     final fuelLabel = fuel.displayName;
 
     // #2601 — tap the approach-price tile to navigate to the station in
@@ -297,64 +307,58 @@ class TripRecordingPipView extends StatelessWidget {
           station.lng,
           label: station.navLabel,
         ),
-        child: Material(
-          color: backgroundColor,
-          child: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  FittedBox(
-                    fit: BoxFit.scaleDown,
-                    child: Text(
-                      priceText,
-                      style: TextStyle(
-                        color: foregroundColor,
-                        fontWeight: FontWeight.w800,
-                        fontSize: 56,
-                        height: 1.0,
-                        fontFeatures: const [FontFeature.tabularFigures()],
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    fuelLabel,
-                    style: TextStyle(
-                      color: foregroundColor.withValues(alpha: 0.85),
-                      fontWeight: FontWeight.w600,
-                      fontSize: 14,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    station.name.isNotEmpty ? station.name : station.brand,
-                    style: TextStyle(
-                      color: foregroundColor.withValues(alpha: 0.95),
-                      fontWeight: FontWeight.w600,
-                      fontSize: 13,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (distanceMeters != null) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      l?.approachStationDistance(
-                              distanceMeters.toStringAsFixed(0)) ??
-                          '${distanceMeters.toStringAsFixed(0)} m',
-                      style: TextStyle(
-                        color: foregroundColor.withValues(alpha: 0.85),
-                        fontSize: 12,
-                        fontFeatures: const [FontFeature.tabularFigures()],
-                      ),
-                    ),
-                  ],
-                ],
+        child: _pipStack(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // #2620 — plain Text; the outer `_pipStack` FittedBox scales
+              // the whole price stack so the distance line never clips.
+              Text(
+                priceText,
+                style: TextStyle(
+                  color: foregroundColor,
+                  fontWeight: FontWeight.w800,
+                  fontSize: 56,
+                  height: 1.0,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                ),
               ),
-            ),
+              const SizedBox(height: 2),
+              Text(
+                fuelLabel,
+                style: TextStyle(
+                  color: foregroundColor.withValues(alpha: 0.85),
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                station.name.isNotEmpty ? station.name : station.brand,
+                style: TextStyle(
+                  color: foregroundColor.withValues(alpha: 0.95),
+                  fontWeight: FontWeight.w600,
+                  fontSize: 13,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (distanceMeters != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  l?.approachStationDistance(
+                        distanceMeters.toStringAsFixed(0),
+                      ) ??
+                      '${distanceMeters.toStringAsFixed(0)} m',
+                  style: TextStyle(
+                    color: foregroundColor.withValues(alpha: 0.85),
+                    fontSize: 12,
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ],
+            ],
           ),
         ),
       ),
@@ -379,15 +383,11 @@ class TripRecordingPipView extends StatelessWidget {
     return '';
   }
 
-  /// Format an elapsed [Duration] so it reads as a duration, not a
-  /// clock time (#2094). Pre-#2094 returned `"14:12"` which on a PiP
-  /// tile next to the system clock could be mistaken for 14:12 of
-  /// the day. New shapes:
-  ///
-  /// - Under 1 minute → `"42s"`.
-  /// - Under 1 hour → `"14m 12s"`.
-  /// - 1 hour or more → `"1h 14m"` (seconds drop — at hour-plus
-  ///   scale the second precision is noise).
+  /// Format an elapsed [Duration] so it reads as a duration, not a clock
+  /// time (#2094 — `"14:12"` next to the system clock read as a time of
+  /// day). Shapes: `"42s"` under a minute, `"14m 12s"` under an hour,
+  /// `"1h 14m"` at an hour-plus (seconds drop — they're noise at that
+  /// scale).
   static String _fmtElapsed(Duration d) {
     final h = d.inHours;
     final m = d.inMinutes % 60;

--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -41,36 +41,57 @@ TripRecordingState _activeState({
   // trips + during the estimator's warm-up.
   double? gpsEstimatedLPer100Km,
   TripRecordingPhase phase = TripRecordingPhase.recording,
-}) =>
-    TripRecordingState(
-      phase: phase,
-      situation: DrivingSituation.highwayCruise,
-      band: ConsumptionBand.normal,
-      live: TripLiveReading(
-        speedKmh: 70,
-        distanceKmSoFar: distance,
-        elapsed: elapsed,
-        fuelRateLPerHour: fuelRateLPerHour,
-        gpsEstimatedLPer100Km: gpsEstimatedLPer100Km,
-      ),
-    );
+}) => TripRecordingState(
+  phase: phase,
+  situation: DrivingSituation.highwayCruise,
+  band: ConsumptionBand.normal,
+  live: TripLiveReading(
+    speedKmh: 70,
+    distanceKmSoFar: distance,
+    elapsed: elapsed,
+    fuelRateLPerHour: fuelRateLPerHour,
+    gpsEstimatedLPer100Km: gpsEstimatedLPer100Km,
+  ),
+);
 
 Widget _wrap(Widget child) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: child),
+);
+
+/// Constrain the PiP view to the REAL Android 2:1 tile geometry so the
+/// no-clip assertions exercise the same fixed-aspect box production hits
+/// (MainActivity.kt `setAspectRatio(Rational(2,1))`). 320×160 = 2:1. The
+/// tile is pinned to the TOP-LEFT origin so a text's global `getRect()`
+/// can be compared directly against the tile height (0..160).
+Widget _wrapPip(Widget child, {Size size = const Size(320, 160)}) =>
+    MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(body: child),
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(width: size.width, height: size.height, child: child),
+        ),
+      ),
     );
 
 void main() {
   group('TripRecordingPipView (#2084) — approach-radius layout', () {
-    testWidgets('default state renders the L/100 km layout — no approach',
-        (tester) async {
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-        approachState: const ApproachIdle(),
-      )));
+    testWidgets('default state renders the L/100 km layout — no approach', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            approachState: const ApproachIdle(),
+          ),
+        ),
+      );
       // L/100 km unit caption is the canonical default-layout marker.
       expect(find.text('L/100 km'), findsOneWidget);
       // Approach layout would surface the station name; assert absent.
@@ -78,16 +99,20 @@ void main() {
     });
 
     testWidgets('ApproachInRadius flips to huge-price layout', (tester) async {
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-        approachState: const ApproachInRadius(
-          station: _stationE10,
-          distanceMeters: 350,
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            approachState: const ApproachInRadius(
+              station: _stationE10,
+              distanceMeters: 350,
+            ),
+            fuelType: FuelType.e10,
+          ),
         ),
-        fuelType: FuelType.e10,
-      )));
+      );
       // Station name shows.
       expect(find.text('Carrefour Pézenas'), findsOneWidget);
       // The price for the requested fuel type renders.
@@ -97,66 +122,81 @@ void main() {
       expect(find.text('L/100 km'), findsNothing);
     });
 
-    testWidgets('ApproachLeaving keeps the price layout through grace',
-        (tester) async {
+    testWidgets('ApproachLeaving keeps the price layout through grace', (
+      tester,
+    ) async {
       // During the 5 s exit grace the price should stay visible —
       // suppresses UI flicker.
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-        approachState: const ApproachLeaving(lastStation: _stationE10),
-        fuelType: FuelType.e10,
-      )));
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            approachState: const ApproachLeaving(lastStation: _stationE10),
+            fuelType: FuelType.e10,
+          ),
+        ),
+      );
       expect(find.text('Carrefour Pézenas'), findsOneWidget);
       expect(find.text('L/100 km'), findsNothing);
     });
 
-    testWidgets('approachState=null still renders the default layout',
-        (tester) async {
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-      )));
+    testWidgets('approachState=null still renders the default layout', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
+        ),
+      );
       expect(find.text('L/100 km'), findsOneWidget);
     });
 
-    testWidgets('approach with no price for the requested fuel falls back to —',
-        (tester) async {
-      const stationDieselOnly = Station(
-        id: 's-2',
-        name: 'Diesel-only',
-        brand: 'X',
-        street: '',
-        postCode: '',
-        place: '',
-        lat: 0,
-        lng: 0,
-        diesel: 2.0,
-        isOpen: true,
-      );
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-        approachState: const ApproachInRadius(
-          station: stationDieselOnly,
-          distanceMeters: 100,
-        ),
-        fuelType: FuelType.e10, // not sold here
-      )));
-      expect(find.text('—'), findsOneWidget);
-      expect(find.text('Diesel-only'), findsOneWidget);
-    });
+    testWidgets(
+      'approach with no price for the requested fuel falls back to —',
+      (tester) async {
+        const stationDieselOnly = Station(
+          id: 's-2',
+          name: 'Diesel-only',
+          brand: 'X',
+          street: '',
+          postCode: '',
+          place: '',
+          lat: 0,
+          lng: 0,
+          diesel: 2.0,
+          isOpen: true,
+        );
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              approachState: const ApproachInRadius(
+                station: stationDieselOnly,
+                distanceMeters: 100,
+              ),
+              fuelType: FuelType.e10, // not sold here
+            ),
+          ),
+        );
+        expect(find.text('—'), findsOneWidget);
+        expect(find.text('Diesel-only'), findsOneWidget);
+      },
+    );
   });
 
   group('TripRecordingPipView (#2086) — state-machine transitions', () {
     // Integration coverage: simulated trajet passes through a station
     // fixture, asserts overlay flips to big-price on radius entry,
     // holds for the grace, and collapses back to L/100 km on exit.
-    testWidgets(
-        'Idle → Polling → InRadius → Leaving → Polling: layout follows '
+    testWidgets('Idle → Polling → InRadius → Leaving → Polling: layout follows '
         'the state-machine transitions one-to-one', (tester) async {
       // Sweep the widget through the 5 state-machine transitions and
       // assert the layout matches at each step. We do not test the
@@ -164,13 +204,17 @@ void main() {
       // approach_detector_test.dart) — only the widget's response.
 
       Future<void> pumpWithState(ApproachState approach) async {
-        await tester.pumpWidget(_wrap(TripRecordingPipView(
-          state: _activeState(),
-          backgroundColor: Colors.green,
-          foregroundColor: Colors.white,
-          approachState: approach,
-          fuelType: FuelType.e10,
-        )));
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              approachState: approach,
+              fuelType: FuelType.e10,
+            ),
+          ),
+        );
         await tester.pump();
       }
 
@@ -185,10 +229,9 @@ void main() {
       //    state's fields, only that it's NOT InRadius/Leaving).
 
       // 3. InRadius — flips to price view.
-      await pumpWithState(const ApproachInRadius(
-        station: _stationE10,
-        distanceMeters: 350,
-      ));
+      await pumpWithState(
+        const ApproachInRadius(station: _stationE10, distanceMeters: 350),
+      );
       expect(find.text('Carrefour Pézenas'), findsOneWidget);
       expect(find.text('L/100 km'), findsNothing);
 
@@ -204,18 +247,15 @@ void main() {
     });
   });
   group('TripRecordingPipView (#2094/#2601) — consumption-framed hero', () {
-    Widget buildWith({double? fuelRate, double distance = 12.4}) =>
-        _wrap(TripRecordingPipView(
-          state: _activeState(
-            distance: distance,
-            fuelRateLPerHour: fuelRate,
-          ),
-          backgroundColor: Colors.green,
-          foregroundColor: Colors.white,
-        ));
+    Widget buildWith({double? fuelRate, double distance = 12.4}) => _wrap(
+      TripRecordingPipView(
+        state: _activeState(distance: distance, fuelRateLPerHour: fuelRate),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+      ),
+    );
 
-    testWidgets('OBD2 branch — fuel rate live → big L/100 km',
-        (tester) async {
+    testWidgets('OBD2 branch — fuel rate live → big L/100 km', (tester) async {
       await tester.pumpWidget(buildWith(fuelRate: 4.06));
       // Branch 1 active.
       expect(find.text('L/100 km'), findsOneWidget);
@@ -225,130 +265,149 @@ void main() {
     });
 
     testWidgets(
-        '#2601 warm-up — distance ≥ 0.1 km, no estimate → "~" + est caption '
-        '(NOT big distance)', (tester) async {
-      await tester.pumpWidget(buildWith(fuelRate: null, distance: 4.0));
-      // #2601 — the hero stays consumption-framed: a "~" placeholder under
-      // the est. L/100 km caption, never a huge distance.
-      expect(find.text('~'), findsOneWidget);
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      // Distance is demoted to the secondary row (km suffix, not a hero).
-      expect(find.text('4.0 km'), findsOneWidget);
-      expect(find.text('L/100 km'), findsNothing);
-      // No bare "km" caption hero anymore.
-      expect(find.text('km'), findsNothing);
-    });
+      '#2601 warm-up — distance ≥ 0.1 km, no estimate → "~" + est caption '
+      '(NOT big distance)',
+      (tester) async {
+        await tester.pumpWidget(buildWith(fuelRate: null, distance: 4.0));
+        // #2601 — the hero stays consumption-framed: a "~" placeholder under
+        // the est. L/100 km caption, never a huge distance.
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        // Distance is demoted to the secondary row (km suffix, not a hero).
+        expect(find.text('4.0 km'), findsOneWidget);
+        expect(find.text('L/100 km'), findsNothing);
+        // No bare "km" caption hero anymore.
+        expect(find.text('km'), findsNothing);
+      },
+    );
 
     testWidgets(
-        '#2601 warm-up — distance ≈ 0 (pre-roll) → "~" + est caption with '
-        'elapsed in the secondary row (NOT big elapsed — THE BUG)',
-        (tester) async {
-      await tester.pumpWidget(buildWith(fuelRate: null, distance: 0.0));
-      // #2601 — THE BUG fix: pre-roll no longer leads with huge elapsed.
-      // The hero is the consumption-framed "~" placeholder; elapsed is
-      // demoted to the secondary row. Default helper uses 8m 32s elapsed.
-      expect(find.text('~'), findsOneWidget);
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      expect(find.text('8m 32s'), findsOneWidget); // secondary row
-      // Elapsed is NOT the hero caption anymore.
-      expect(find.text('elapsed'), findsNothing);
-      expect(find.text('km'), findsNothing);
-      expect(find.text('L/100 km'), findsNothing);
-    });
+      '#2601 warm-up — distance ≈ 0 (pre-roll) → "~" + est caption with '
+      'elapsed in the secondary row (NOT big elapsed — THE BUG)',
+      (tester) async {
+        await tester.pumpWidget(buildWith(fuelRate: null, distance: 0.0));
+        // #2601 — THE BUG fix: pre-roll no longer leads with huge elapsed.
+        // The hero is the consumption-framed "~" placeholder; elapsed is
+        // demoted to the secondary row. Default helper uses 8m 32s elapsed.
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('8m 32s'), findsOneWidget); // secondary row
+        // Elapsed is NOT the hero caption anymore.
+        expect(find.text('elapsed'), findsNothing);
+        expect(find.text('km'), findsNothing);
+        expect(find.text('L/100 km'), findsNothing);
+      },
+    );
 
-    testWidgets(
-        'elapsed-time formatter reads as a duration, not a clock '
+    testWidgets('elapsed-time formatter reads as a duration, not a clock '
         '(secondary row)', (tester) async {
       // The formatter shapes still render — now in the warm-up branch's
       // secondary row rather than as the hero.
       // Hour-plus shape drops seconds.
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(
-          distance: 0.0,
-          fuelRateLPerHour: null,
-          elapsed: const Duration(hours: 1, minutes: 14, seconds: 12),
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(
+              distance: 0.0,
+              fuelRateLPerHour: null,
+              elapsed: const Duration(hours: 1, minutes: 14, seconds: 12),
+            ),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
         ),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-      )));
+      );
       expect(find.text('1h 14m'), findsOneWidget);
       // Under-1-minute shape uses seconds only.
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(
-          distance: 0.0,
-          fuelRateLPerHour: null,
-          elapsed: const Duration(seconds: 42),
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(
+              distance: 0.0,
+              fuelRateLPerHour: null,
+              elapsed: const Duration(seconds: 42),
+            ),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
         ),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-      )));
+      );
       expect(find.text('42s'), findsOneWidget);
     });
 
     testWidgets(
-        'real-trip life-cycle — warm-up → warm-up → OBD2 keeps the hero '
-        'consumption-framed at every step (#2601)', (tester) async {
-      // Walks the widget through the natural sequence a real trip
-      // produces: start parked (pre-roll, 0 km, no fuel rate), drive a
-      // bit on GPS only (distance > 0.1 km, still no fuel rate),
-      // adapter finally connects mid-trip (fuel rate becomes
-      // available). The hero must stay CONSUMPTION-framed at every step —
-      // never a huge elapsed/distance (#2601).
-      Future<void> pumpAt({
-        double distance = 0,
-        double? fuelRate,
-        Duration elapsed = const Duration(seconds: 42),
-      }) async {
-        await tester.pumpWidget(_wrap(TripRecordingPipView(
-          state: _activeState(
-            distance: distance,
-            fuelRateLPerHour: fuelRate,
-            elapsed: elapsed,
-          ),
-          backgroundColor: Colors.green,
-          foregroundColor: Colors.white,
-        )));
-        await tester.pump();
-      }
+      'real-trip life-cycle — warm-up → warm-up → OBD2 keeps the hero '
+      'consumption-framed at every step (#2601)',
+      (tester) async {
+        // Walks the widget through the natural sequence a real trip
+        // produces: start parked (pre-roll, 0 km, no fuel rate), drive a
+        // bit on GPS only (distance > 0.1 km, still no fuel rate),
+        // adapter finally connects mid-trip (fuel rate becomes
+        // available). The hero must stay CONSUMPTION-framed at every step —
+        // never a huge elapsed/distance (#2601).
+        Future<void> pumpAt({
+          double distance = 0,
+          double? fuelRate,
+          Duration elapsed = const Duration(seconds: 42),
+        }) async {
+          await tester.pumpWidget(
+            _wrap(
+              TripRecordingPipView(
+                state: _activeState(
+                  distance: distance,
+                  fuelRateLPerHour: fuelRate,
+                  elapsed: elapsed,
+                ),
+                backgroundColor: Colors.green,
+                foregroundColor: Colors.white,
+              ),
+            ),
+          );
+          await tester.pump();
+        }
 
-      // T = 0 — engine on, GPS still warming up, no fuel rate.
-      // #2601 warm-up: "~" hero under the est caption, elapsed secondary.
-      await pumpAt(distance: 0, fuelRate: null);
-      expect(find.text('~'), findsOneWidget);
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      expect(find.text('42s'), findsOneWidget); // secondary row
-      expect(find.text('elapsed'), findsNothing,
-          reason: '#2601 — the hero must never be elapsed time');
-      expect(find.text('L/100 km'), findsNothing);
+        // T = 0 — engine on, GPS still warming up, no fuel rate.
+        // #2601 warm-up: "~" hero under the est caption, elapsed secondary.
+        await pumpAt(distance: 0, fuelRate: null);
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('42s'), findsOneWidget); // secondary row
+        expect(
+          find.text('elapsed'),
+          findsNothing,
+          reason: '#2601 — the hero must never be elapsed time',
+        );
+        expect(find.text('L/100 km'), findsNothing);
 
-      // T = 30 s — moved 0.5 km on GPS, still no OBD2 adapter.
-      // Still warm-up: "~" hero, distance demoted to the secondary row.
-      await pumpAt(
-        distance: 0.5,
-        fuelRate: null,
-        elapsed: const Duration(seconds: 30),
-      );
-      expect(find.text('~'), findsOneWidget);
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      expect(find.text('0.5 km'), findsOneWidget); // secondary row
-      expect(find.text('km'), findsNothing);
-      expect(find.text('L/100 km'), findsNothing);
+        // T = 30 s — moved 0.5 km on GPS, still no OBD2 adapter.
+        // Still warm-up: "~" hero, distance demoted to the secondary row.
+        await pumpAt(
+          distance: 0.5,
+          fuelRate: null,
+          elapsed: const Duration(seconds: 30),
+        );
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('0.5 km'), findsOneWidget); // secondary row
+        expect(find.text('km'), findsNothing);
+        expect(find.text('L/100 km'), findsNothing);
 
-      // T = 5 min — adapter connected, fuel-rate sample landed.
-      // Branch 1: L/100 km takes the hero slot.
-      await pumpAt(
-        distance: 4.0,
-        fuelRate: 4.06,
-        elapsed: const Duration(minutes: 5),
-      );
-      expect(find.text('L/100 km'), findsOneWidget);
-      // Distance + elapsed move to the secondary row — they're
-      // still findable, just no longer the hero caption.
-      expect(find.textContaining('4.0'), findsOneWidget);
-      expect(find.text('elapsed'), findsNothing);
-      // The measured value carries no "~" / est caption.
-      expect(find.text('est. L/100 km'), findsNothing);
-    });
+        // T = 5 min — adapter connected, fuel-rate sample landed.
+        // Branch 1: L/100 km takes the hero slot.
+        await pumpAt(
+          distance: 4.0,
+          fuelRate: 4.06,
+          elapsed: const Duration(minutes: 5),
+        );
+        expect(find.text('L/100 km'), findsOneWidget);
+        // Distance + elapsed move to the secondary row — they're
+        // still findable, just no longer the hero caption.
+        expect(find.textContaining('4.0'), findsOneWidget);
+        expect(find.text('elapsed'), findsNothing);
+        // The measured value carries no "~" / est caption.
+        expect(find.text('est. L/100 km'), findsNothing);
+      },
+    );
   });
 
   group('TripRecordingPipView (#2390) — GPS-only live estimate', () {
@@ -357,49 +416,54 @@ void main() {
       double? gpsEstimate,
       double distance = 1.2,
       Duration elapsed = const Duration(minutes: 7, seconds: 7),
-    }) =>
-        _wrap(TripRecordingPipView(
-          state: _activeState(
-            distance: distance,
-            elapsed: elapsed,
-            fuelRateLPerHour: fuelRate,
-            gpsEstimatedLPer100Km: gpsEstimate,
-          ),
-          backgroundColor: Colors.green,
-          foregroundColor: Colors.white,
-        ));
+    }) => _wrap(
+      TripRecordingPipView(
+        state: _activeState(
+          distance: distance,
+          elapsed: elapsed,
+          fuelRateLPerHour: fuelRate,
+          gpsEstimatedLPer100Km: gpsEstimate,
+        ),
+        backgroundColor: Colors.green,
+        foregroundColor: Colors.white,
+      ),
+    );
 
     testWidgets(
-        'GPS-only trip with a live estimate → big "~X.X" + "est. L/100 km", '
-        'not elapsed time', (tester) async {
-      // No OBD2 fuel rate, estimator has produced 6.4 L/100 km. The
-      // estimate becomes the hero with a leading "~" and the dedicated
-      // localized "est. L/100 km" caption (#2393) — the elapsed time is
-      // demoted.
-      await tester.pumpWidget(buildWith(fuelRate: null, gpsEstimate: 6.4));
-      expect(find.text('~6.4'), findsOneWidget);
-      // #2393 — the estimate caption is the dedicated marker, distinct
-      // from the OBD2 branch's bare "L/100 km".
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      expect(find.text('L/100 km'), findsNothing);
-      // The elapsed time is NOT the hero figure (it moves to the
-      // secondary row instead of leading the tile).
-      expect(find.text('7m 7s'), findsOneWidget); // secondary row
-      // Distance also stays in the secondary row.
-      expect(find.text('1.2 km'), findsOneWidget);
-    });
+      'GPS-only trip with a live estimate → big "~X.X" + "est. L/100 km", '
+      'not elapsed time',
+      (tester) async {
+        // No OBD2 fuel rate, estimator has produced 6.4 L/100 km. The
+        // estimate becomes the hero with a leading "~" and the dedicated
+        // localized "est. L/100 km" caption (#2393) — the elapsed time is
+        // demoted.
+        await tester.pumpWidget(buildWith(fuelRate: null, gpsEstimate: 6.4));
+        expect(find.text('~6.4'), findsOneWidget);
+        // #2393 — the estimate caption is the dedicated marker, distinct
+        // from the OBD2 branch's bare "L/100 km".
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('L/100 km'), findsNothing);
+        // The elapsed time is NOT the hero figure (it moves to the
+        // secondary row instead of leading the tile).
+        expect(find.text('7m 7s'), findsOneWidget); // secondary row
+        // Distance also stays in the secondary row.
+        expect(find.text('1.2 km'), findsOneWidget);
+      },
+    );
 
-    testWidgets('GPS-only estimate → approximate tooltip + a11y label (#2393)',
-        (tester) async {
-      await tester.pumpWidget(buildWith(fuelRate: null, gpsEstimate: 6.4));
-      // The figure block is wrapped in a Tooltip carrying the
-      // approximate-explanation message (long-press affordance).
-      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
-      expect(tooltip.message, isNotNull);
-      expect(tooltip.message, contains('GPS'));
-      // The same explanation is exposed as a Semantics label for a11y.
-      expect(find.bySemanticsLabel(RegExp('GPS')), findsOneWidget);
-    });
+    testWidgets(
+      'GPS-only estimate → approximate tooltip + a11y label (#2393)',
+      (tester) async {
+        await tester.pumpWidget(buildWith(fuelRate: null, gpsEstimate: 6.4));
+        // The figure block is wrapped in a Tooltip carrying the
+        // approximate-explanation message (long-press affordance).
+        final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+        expect(tooltip.message, isNotNull);
+        expect(tooltip.message, contains('GPS'));
+        // The same explanation is exposed as a Semantics label for a11y.
+        expect(find.bySemanticsLabel(RegExp('GPS')), findsOneWidget);
+      },
+    );
 
     testWidgets('OBD2 trip → real measured consumption, estimate path NOT '
         'taken (tilde-free, no est. caption, no tooltip)', (tester) async {
@@ -417,51 +481,62 @@ void main() {
     });
 
     testWidgets(
-        'GPS-only warm-up (null estimate) → "~" hero + est caption, distance '
-        'demoted (#2601)', (tester) async {
-      // Estimator hasn't warmed up yet: estimate is null. #2601 keeps the
-      // hero consumption-framed — a "~" under the est caption — with
-      // distance demoted to the secondary row (never a huge distance).
-      await tester.pumpWidget(
-          buildWith(fuelRate: null, gpsEstimate: null, distance: 1.2));
-      expect(find.text('~'), findsOneWidget);
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      expect(find.text('1.2 km'), findsOneWidget); // secondary row
-      expect(find.text('L/100 km'), findsNothing);
-      expect(find.text('km'), findsNothing);
-    });
+      'GPS-only warm-up (null estimate) → "~" hero + est caption, distance '
+      'demoted (#2601)',
+      (tester) async {
+        // Estimator hasn't warmed up yet: estimate is null. #2601 keeps the
+        // hero consumption-framed — a "~" under the est caption — with
+        // distance demoted to the secondary row (never a huge distance).
+        await tester.pumpWidget(
+          buildWith(fuelRate: null, gpsEstimate: null, distance: 1.2),
+        );
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('1.2 km'), findsOneWidget); // secondary row
+        expect(find.text('L/100 km'), findsNothing);
+        expect(find.text('km'), findsNothing);
+      },
+    );
 
     testWidgets(
-        'GPS-only pre-roll (null estimate, distance ≈ 0) → "~" hero + est '
-        'caption, elapsed demoted (#2601)', (tester) async {
-      await tester.pumpWidget(buildWith(
-        fuelRate: null,
-        gpsEstimate: null,
-        distance: 0.0,
-        elapsed: const Duration(minutes: 7, seconds: 7),
-      ));
-      // #2601 — pre-roll keeps the consumption-framed hero; elapsed is
-      // demoted to the secondary row instead of leading the tile.
-      expect(find.text('~'), findsOneWidget);
-      expect(find.text('est. L/100 km'), findsOneWidget);
-      expect(find.text('7m 7s'), findsOneWidget); // secondary row
-      expect(find.text('elapsed'), findsNothing);
-      expect(find.text('L/100 km'), findsNothing);
-    });
+      'GPS-only pre-roll (null estimate, distance ≈ 0) → "~" hero + est '
+      'caption, elapsed demoted (#2601)',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWith(
+            fuelRate: null,
+            gpsEstimate: null,
+            distance: 0.0,
+            elapsed: const Duration(minutes: 7, seconds: 7),
+          ),
+        );
+        // #2601 — pre-roll keeps the consumption-framed hero; elapsed is
+        // demoted to the secondary row instead of leading the tile.
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('7m 7s'), findsOneWidget); // secondary row
+        expect(find.text('elapsed'), findsNothing);
+        expect(find.text('L/100 km'), findsNothing);
+      },
+    );
 
     testWidgets('paused GPS-only trip suppresses the estimate', (tester) async {
       // Paused → the estimate must not show (a stale reading would
       // mislead); the tile shows distance instead.
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(
-          distance: 1.2,
-          fuelRateLPerHour: null,
-          gpsEstimatedLPer100Km: 6.4,
-          phase: TripRecordingPhase.paused,
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(
+              distance: 1.2,
+              fuelRateLPerHour: null,
+              gpsEstimatedLPer100Km: 6.4,
+              phase: TripRecordingPhase.paused,
+            ),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
         ),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-      )));
+      );
       expect(find.textContaining('~'), findsNothing);
       expect(find.text('L/100 km'), findsNothing);
     });
@@ -480,15 +555,17 @@ void main() {
       launchedUrls.clear();
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (call) async {
-        if (call.method == 'launch' || call.method == 'launchUrl') {
-          final args = call.arguments;
-          final url = args is Map ? args['url'] as String? : args as String?;
-          if (url != null) launchedUrls.add(url);
-          return true;
-        }
-        if (call.method == 'canLaunch') return true;
-        return null;
-      });
+            if (call.method == 'launch' || call.method == 'launchUrl') {
+              final args = call.arguments;
+              final url = args is Map
+                  ? args['url'] as String?
+                  : args as String?;
+              if (url != null) launchedUrls.add(url);
+              return true;
+            }
+            if (call.method == 'canLaunch') return true;
+            return null;
+          });
     });
 
     tearDown(() {
@@ -497,51 +574,210 @@ void main() {
     });
 
     testWidgets(
-        'tapping the approach-price tile launches the station in maps',
-        (tester) async {
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-        approachState: const ApproachInRadius(
-          station: _stationE10,
-          distanceMeters: 350,
-        ),
-        fuelType: FuelType.e10,
-      )));
+      'tapping the approach-price tile launches the station in maps',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              approachState: const ApproachInRadius(
+                station: _stationE10,
+                distanceMeters: 350,
+              ),
+              fuelType: FuelType.e10,
+            ),
+          ),
+        );
 
-      // The tile carries a navigate Tooltip + a GestureDetector with a
-      // live onTap (the seam wired in #2601).
-      final gesture = tester.widget<GestureDetector>(
-        find.descendant(
-          of: find.byType(Tooltip),
-          matching: find.byType(GestureDetector),
-        ),
-      );
-      expect(gesture.onTap, isNotNull);
+        // The tile carries a navigate Tooltip + a GestureDetector with a
+        // live onTap (the seam wired in #2601).
+        final gesture = tester.widget<GestureDetector>(
+          find.descendant(
+            of: find.byType(Tooltip),
+            matching: find.byType(GestureDetector),
+          ),
+        );
+        expect(gesture.onTap, isNotNull);
 
-      await tester.tap(find.byType(GestureDetector));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byType(GestureDetector));
+        await tester.pumpAndSettle();
 
-      // openInMaps fired → a geo: URI for the station coordinates.
-      expect(launchedUrls, isNotEmpty,
-          reason: 'tapping the approach tile must open the maps app');
-      expect(launchedUrls.first, startsWith('geo:'));
-      expect(launchedUrls.first, contains('${_stationE10.lat}'));
-      expect(launchedUrls.first, contains('${_stationE10.lng}'));
-    });
+        // openInMaps fired → a geo: URI for the station coordinates.
+        expect(
+          launchedUrls,
+          isNotEmpty,
+          reason: 'tapping the approach tile must open the maps app',
+        );
+        expect(launchedUrls.first, startsWith('geo:'));
+        expect(launchedUrls.first, contains('${_stationE10.lat}'));
+        expect(launchedUrls.first, contains('${_stationE10.lng}'));
+      },
+    );
 
-    testWidgets('the default L/100 km layout is NOT tappable (no nav seam)',
-        (tester) async {
+    testWidgets('the default L/100 km layout is NOT tappable (no nav seam)', (
+      tester,
+    ) async {
       // Only the approach layout navigates; the default layout keeps its
       // existing non-tappable behavior (#2601 scope guard).
-      await tester.pumpWidget(_wrap(TripRecordingPipView(
-        state: _activeState(),
-        backgroundColor: Colors.green,
-        foregroundColor: Colors.white,
-        approachState: const ApproachIdle(),
-      )));
+      await tester.pumpWidget(
+        _wrap(
+          TripRecordingPipView(
+            state: _activeState(),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            approachState: const ApproachIdle(),
+          ),
+        ),
+      );
       expect(find.byType(GestureDetector), findsNothing);
+    });
+  });
+
+  group('TripRecordingPipView (#2620) — no clip in a small PiP viewport', () {
+    // Every state must render its full stack — figure + caption +
+    // secondary row — inside the fixed 2:1 Android tile (320×160) WITHOUT
+    // a RenderFlex overflow and WITHOUT the bottom line bleeding past the
+    // tile. The reported bug clipped the `distance · elapsed` row in the
+    // warm-up state; the outer `FittedBox(scaleDown)` now shrinks the
+    // whole stack so the last line stays on-screen and readable.
+    const tileHeight = 160.0;
+
+    testWidgets(
+      'warm-up (the reported bug) — "~" + est caption + secondary row all '
+      'fit, secondary not clipped',
+      (tester) async {
+        // fuelRate null + gpsEstimate null + distance 0.0 + elapsed 37s — the
+        // exact warm-up branch from the screenshot (`~` / est. L/100 km /
+        // 0.0 km · 37s).
+        await tester.pumpWidget(
+          _wrapPip(
+            TripRecordingPipView(
+              state: _activeState(
+                distance: 0.0,
+                fuelRateLPerHour: null,
+                gpsEstimatedLPer100Km: null,
+                elapsed: const Duration(seconds: 37),
+              ),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+            ),
+          ),
+        );
+        expect(tester.takeException(), isNull);
+        expect(find.text('~'), findsOneWidget);
+        expect(find.text('est. L/100 km'), findsOneWidget);
+        expect(find.text('37s'), findsOneWidget);
+        // The secondary row's bottom must stay within the tile — not clipped.
+        expect(
+          tester.getRect(find.text('37s')).bottom,
+          lessThanOrEqualTo(tileHeight),
+        );
+      },
+    );
+
+    testWidgets('GPS-estimate — "~6.4" + secondary row within bounds', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrapPip(
+          TripRecordingPipView(
+            state: _activeState(
+              distance: 1.2,
+              fuelRateLPerHour: null,
+              gpsEstimatedLPer100Km: 6.4,
+              elapsed: const Duration(minutes: 7, seconds: 7),
+            ),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('~6.4'), findsOneWidget);
+      expect(find.text('7m 7s'), findsOneWidget);
+      expect(
+        tester.getRect(find.text('7m 7s')).bottom,
+        lessThanOrEqualTo(tileHeight),
+      );
+    });
+
+    testWidgets('OBD2 live — L/100 km + secondary row within bounds', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrapPip(
+          TripRecordingPipView(
+            state: _activeState(fuelRateLPerHour: 4.06),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('L/100 km'), findsOneWidget);
+      // Default helper elapsed is 8m 32s — its bottom must stay on-tile.
+      expect(
+        tester.getRect(find.text('8m 32s')).bottom,
+        lessThanOrEqualTo(tileHeight),
+      );
+    });
+
+    testWidgets('approach-price — name + price + distance line within bounds', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrapPip(
+          TripRecordingPipView(
+            state: _activeState(),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+            approachState: const ApproachInRadius(
+              station: _stationE10,
+              distanceMeters: 350,
+            ),
+            fuelType: FuelType.e10,
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('Carrefour Pézenas'), findsOneWidget);
+      // Price for E10 renders (locale-dependent format, integer present).
+      expect(find.textContaining('1'), findsWidgets);
+      // The bottom-most distance line must stay within the tile.
+      expect(
+        tester.getRect(find.textContaining('350')).bottom,
+        lessThanOrEqualTo(tileHeight),
+      );
+    });
+
+    testWidgets('paused — fallback figure + paused label both within bounds', (
+      tester,
+    ) async {
+      // Paused suppresses every live reading (raw + estimate both null),
+      // so the layout hits its fallback figure + the localized paused
+      // label. Both must stay on-tile.
+      await tester.pumpWidget(
+        _wrapPip(
+          TripRecordingPipView(
+            state: _activeState(
+              distance: 4.0,
+              fuelRateLPerHour: 4.06,
+              gpsEstimatedLPer100Km: 6.4,
+              elapsed: const Duration(minutes: 5),
+              phase: TripRecordingPhase.paused,
+            ),
+            backgroundColor: Colors.green,
+            foregroundColor: Colors.white,
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      // The localized paused banner is the bottom-most line.
+      final pausedLine = find.text('Trip paused — tap to resume');
+      expect(pausedLine, findsOneWidget);
+      expect(tester.getRect(pausedLine).bottom, lessThanOrEqualTo(tileHeight));
     });
   });
 }


### PR DESCRIPTION
## Problem

The trip-recording PiP overlay clips its bottom line. In the reported warm-up state the secondary `0.0 km · 37s` row is cut off at the tile's bottom edge (screenshot: big `~`, caption `est. L/100 km`, then the `distance · elapsed` row unreadable).

## Root cause

Each layout wrapped only the single hero figure `Text` in a `FittedBox(scaleDown)`, while the host `Column` had **unconstrained height** inside the FIXED 2:1 Android PiP tile (`MainActivity.kt setAspectRatio(Rational(2,1))`). The column's intrinsic content (hero 64 px + caption + spacers + secondary row) exceeds the tile height, and a center-aligned `Column` paints children centered and lets the bottom bleed past the box.

## Fix (content-only — aspect ratio untouched)

- New shared `_pipStack` host wraps the **whole** content column in one outer `FittedBox(BoxFit.scaleDown)` inside a `Center`, so the full intrinsic stack (figure + caption + secondary row) is scaled down uniformly on both axes and never clips the small tile.
- Both `_buildDefaultLayout` and `_buildApproachPriceLayout` now build through `_pipStack`.
- Dropped both redundant per-figure `FittedBox` wrappers (the outer one scales the whole stack).
- The approach layout's tap-to-navigate `Tooltip → GestureDetector` (#2601) is unchanged.
- No hard-coded strings, no ARB/codegen touched. Production file is 396 effective lines (under the 400 cap).

## Tests

New `#2620` group constrains the view to the real 320×160 (2:1) tile pinned to the top-left origin and asserts, for warm-up / GPS-estimate / OBD2 / approach-price / paused, that there is **no `RenderFlex` overflow** (`takeException() is null`) and the bottom-most line stays within the tile height. All 24 tests in the file pass (19 existing + 5 new). `flutter analyze` clean; `file_length` lint green.

Closes #2620

🤖 Generated with [Claude Code](https://claude.com/claude-code)