### PR TITLE
fix(trip-path): frame camera via initialCameraFit so OSM tiles load (no grey) (#2624)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -13,7 +11,6 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
 import '../../data/driving_insights_analyzer.dart';
 import 'trip_detail_charts.dart';
-import '../../../../core/logging/error_logger.dart';
 
 // ---------------------------------------------------------------------------
 // Phase 3 thresholds (#1374) — fixed defaults.
@@ -62,7 +59,8 @@ enum _SegmentBucket { efficient, borderline, wasteful }
 ///   (see thresholds above).
 /// * Two markers — first and last GPS sample — for trip start and end.
 /// * Legend below the map showing the three buckets + their labels.
-/// * Auto-fits the viewport to the polyline bounds.
+/// * Frames the viewport to the polyline bounds on the first layout pass
+///   via [MapOptions.initialCameraFit] (#2624).
 class TripPathMapCard extends StatelessWidget {
   final List<TripDetailSample> samples;
 
@@ -137,10 +135,9 @@ class TripPathMapCard extends StatelessWidget {
 }
 
 /// Stateful inner map so the [MapController] can survive rebuilds and
-/// the post-frame `fitCamera` callback can target a stable controller
-/// instance. Mirrors the pattern used by [StationMapLayers] — the
-/// outer card stays a [StatelessWidget] so callers don't have to
-/// worry about lifecycle.
+/// remain available for interaction (pinch / drag). Mirrors the pattern
+/// used by [StationMapLayers] — the outer card stays a [StatelessWidget]
+/// so callers don't have to worry about lifecycle.
 class _TripPathMap extends StatefulWidget {
   final List<LatLng> points;
   final List<TripDetailSample> pointSamples;
@@ -157,14 +154,16 @@ class _TripPathMap extends StatefulWidget {
 class _TripPathMapState extends State<_TripPathMap> {
   late final MapController _mapController = MapController();
 
-  /// Pre-computed bounds for the polyline. Single-point polylines fall
-  /// back to a degenerate bounds object centered on the point — the
-  /// `fitCamera` call handles those by centering on the point at a
-  /// sane default zoom rather than throwing.
+  /// Pre-computed bounds for the polyline, fed to
+  /// [MapOptions.initialCameraFit]. Single-point polylines fall back to a
+  /// degenerate bounds box centered on the point (see [_computeBounds]) so
+  /// `CameraFit.bounds` centres on the point at a sane zoom rather than
+  /// dividing by zero.
   late final LatLngBounds _bounds = _computeBounds(widget.points);
 
-  /// Fallback initial camera so the very first frame paints something
-  /// reasonable before the post-frame `fitCamera` callback fires.
+  /// Pre-fit fallback centre used by [MapOptions.initialCenter] for the
+  /// degenerate case where layout hasn't run yet; `initialCameraFit`
+  /// frames the real viewport on the first layout pass.
   late final LatLng _initialCenter = _bounds.center;
 
   static LatLngBounds _computeBounds(List<LatLng> points) {
@@ -179,28 +178,6 @@ class _TripPathMapState extends State<_TripPathMap> {
       );
     }
     return LatLngBounds.fromPoints(points);
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    // Fit the camera to the polyline bounds once the map has laid out.
-    // Mirrors the pattern in `nearby_map_view.dart`: schedule via
-    // `addPostFrameCallback` so the MapController has a real viewport
-    // size by the time `fitCamera` runs.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      try {
-        _mapController.fitCamera(
-          CameraFit.bounds(
-            bounds: _bounds,
-            padding: const EdgeInsets.all(24),
-          ),
-        );
-      } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'TripPathMapCard fitCamera failed'}));
-      }
-    });
   }
 
   @override
@@ -322,6 +299,19 @@ class _TripPathMapState extends State<_TripPathMap> {
       options: MapOptions(
         initialCenter: _initialCenter,
         initialZoom: 13,
+        // #2624 — frame the polyline bounds during the FIRST layout pass
+        // via `initialCameraFit`, not a post-frame `fitCamera`. The old
+        // post-frame fit (now removed) jumped the camera after the first
+        // tile fetch had already targeted the fallback viewport, leaving
+        // grey tiles. Mirrors the main map page's #2398/#2399 fix
+        // (`station_map_layers.dart`): positioning the camera as part of
+        // layout means the first tile fetch already targets the right
+        // viewport. `initialCenter`/`initialZoom` above stay as the
+        // pre-fit fallback for the degenerate no-layout-yet frame.
+        initialCameraFit: CameraFit.bounds(
+          bounds: _bounds,
+          padding: const EdgeInsets.all(32),
+        ),
         // Steady-state pinch / drag stays enabled — the user may want
         // to inspect the path. Rotation is disabled for the same
         // reason `StationMapLayers` does it: trip overlays read more

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -342,4 +342,45 @@ void main() {
       expect(find.text('Wasteful (≥ 10 L/100km)'), findsOneWidget);
     });
   });
+
+  group('TripPathMapCard — camera framing (#2624)', () {
+    testWidgets(
+        'first paint is framed by MapOptions.initialCameraFit, not a '
+        'post-frame fitCamera', (tester) async {
+      // #2624 — the camera is positioned during the FIRST layout pass via
+      // `MapOptions.initialCameraFit`, mirroring the main map page's
+      // #2398/#2399 fix. The OLD post-frame `fitCamera` jumped the camera
+      // after the first tile fetch had already targeted the fallback
+      // viewport, leaving grey tiles. Asserting `initialCameraFit` is
+      // non-null pins the framing mechanism so a regression to the
+      // post-frame fit fails here.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+        _sample(sec: 1, lat: 43.47, lng: 3.44),
+        _sample(sec: 2, lat: 43.48, lng: 3.45),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final flutterMap = tester.widget<FlutterMap>(find.byType(FlutterMap));
+      expect(flutterMap.options.initialCameraFit, isNotNull,
+          reason: 'first paint must be framed via initialCameraFit so the '
+              'first tile fetch targets the right viewport (no grey tiles)');
+    });
+
+    testWidgets('single-sample trip still frames via initialCameraFit',
+        (tester) async {
+      // Degenerate bounds (single fix) must not break the framing path —
+      // `_computeBounds` synthesizes a tiny box so `CameraFit.bounds`
+      // centres on the point rather than dividing by zero.
+      final samples = [
+        _sample(sec: 0, lat: 43.46, lng: 3.43),
+      ];
+
+      await pumpApp(tester, TripPathMapCard(samples: samples));
+
+      final flutterMap = tester.widget<FlutterMap>(find.byType(FlutterMap));
+      expect(flutterMap.options.initialCameraFit, isNotNull);
+    });
+  });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -214,8 +214,11 @@ void main() {
         439,
     'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':
         439,
+    // #2624 — shrank 463 → 450: dropped the post-frame `fitCamera` block
+    // (+ its dart:async / error_logger imports) in favour of
+    // `MapOptions.initialCameraFit`, fixing the grey-tile cold-start race.
     'lib/features/consumption/presentation/widgets/trip_path_map_card.dart':
-        463,
+        450,
     // #2441 — re-grandfathered 879 → 911: split the trip-vs-pump
     // reconciliation into a detect-vs-apply seam. The detector still
     // lives in reconciler.dart; the apply step (`applyReconciliation`)


### PR DESCRIPTION
## Problem

The **Trip-path** map card (Trip history detail, `trip_path_map_card.dart`) rendered **grey OSM tiles** — only the GPS polyline drew. It already routed tiles through `SparkiloTileLayer`, but it still framed the camera with the **old post-frame `fitCamera`** in `initState` (`WidgetsBinding.instance.addPostFrameCallback` → `_mapController.fitCamera(CameraFit.bounds(...))`).

That camera jump fires **after** the first tile fetch has already targeted the fallback `initialCenter`/`initialZoom` viewport, so the tiles for the real (fitted) viewport never get fetched in time → grey. This is the exact cold-start camera-jump race the **main map page fixed in #2398/#2399** by framing in `MapOptions.initialCameraFit` on the first layout pass (`station_map_layers.dart`).

## Fix (mirrors #2398/#2399)

- Add `initialCameraFit: CameraFit.bounds(bounds: _bounds, padding: const EdgeInsets.all(32))` to the trip-path `MapOptions`, so the camera is positioned **as part of the first layout pass** — the first tile fetch already targets the right viewport, no post-frame jump.
- Remove the `initState` post-frame `fitCamera` block (and its try/catch error log). `initState` then only called `super.initState()`, so the override is dropped entirely.
- `initialCenter`/`initialZoom` stay as the pre-fit fallback; `_mapController` stays (still passed to `FlutterMap` as `mapController:` for pinch/drag) + its `dispose()`; `_bounds`/`_initialCenter` are now consumed by the new framing.

## Cleanup

- Removed the now-unused `import 'dart:async';` (was only for `unawaited`) and `import '../../../../core/logging/error_logger.dart';` (was only for the fit-failure log) — both verified to have no other use in the file. `flutter analyze` clean.
- File: 463 → 450 effective lines; lowered the `file_length_test` snapshot per the shrink ratchet.

## Tests

- Existing `trip_path_map_card_test.dart` coverage (render gating, polyline points, heatmap buckets, markers, legend) unchanged and green — none of it asserted the post-frame mechanism.
- Added a `camera framing (#2624)` group asserting `FlutterMap.options.initialCameraFit` is non-null (multi-sample + single-sample), mirroring `nearby_map_view`'s #2399 coverage.
- `flutter analyze` clean; `flutter test` for trip-path / trip-detail / file-length lint all green (67 tests).

No `@riverpod`/`@freezed`/ARB changes → no codegen or l10n fan-out.

Closes #2624

🤖 Generated with [Claude Code](https://claude.com/claude-code)
