### PR TITLE
fix(route): cross-border route returns zero Spanish stations — bbox first-match shadowing (#2621)

### DIFF
--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -723,11 +723,33 @@ class CountryServiceRegistry {
   /// null when no box matches. Walks [entries] in declared order — the
   /// list is intentionally ordered so tighter boxes are tested before
   /// the larger boxes that incidentally overlap them.
+  ///
+  /// First-match: used for single-country attribution (#516) where one
+  /// answer is wanted. For corridor detection — where a point inside a
+  /// larger box that SHADOWS a smaller declared-later box must still
+  /// surface the shadowed country — use [entriesByLatLng] (#2621).
   static CountryServiceEntry? entryByLatLng(double lat, double lng) {
-    for (final entry in entries) {
-      if (entry.boundingBox.contains(lat, lng)) return entry;
+    for (final entry in entriesByLatLng(lat, lng)) {
+      return entry;
     }
     return null;
+  }
+
+  /// Every entry whose bounding box contains the given point, in declared
+  /// order — NOT just the first match (#2621).
+  ///
+  /// Continental bounding boxes overlap: FR's box (lat 41.0–51.5,
+  /// lng −5.5–10.0) geographically contains all of Catalonia, yet ES is
+  /// declared later, so [entryByLatLng] resolves every Catalonian point to
+  /// FR and never reaches ES. A Pézenas→Barcelona corridor then queried
+  /// only FR and returned zero Spanish stations. Corridor detection unions
+  /// these so the shadowed country (ES) is never dropped — over-collecting
+  /// is safe because the route detour filter drops off-corridor stations.
+  static Iterable<CountryServiceEntry> entriesByLatLng(
+      double lat, double lng) sync* {
+    for (final entry in entries) {
+      if (entry.boundingBox.contains(lat, lng)) yield entry;
+    }
   }
 
   /// Build a [StationService] for [countryCode], wrapped in [StationServiceChain].

--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/country/country_bounding_box.dart';
+import '../../../core/logging/error_logger.dart';
 import '../../../core/services/country_service_registry.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
@@ -58,20 +61,31 @@ Map<String, FuelType> profileFuelByCountry(Ref ref) {
 /// Pre-resolve, OFFLINE, the `(service, fuel)` for every country the
 /// corridor crosses that has a usable station service.
 ///
-/// [corridorCountries] is intersected with the registered, key-satisfied
-/// services. A crossed country is SKIPPED when it has no registry entry, or
-/// when it requires an API key that isn't configured (the DE / CL / KR demo
-/// guard) — we never inject demo stations onto a real route. Per-country
-/// fuel is the matching profile's `preferredFuelType` from [profileFuels],
-/// falling back to E10 for a crossed country the user has no profile for.
+/// The country set is [corridorCountries] (every box a route vertex falls
+/// inside, order-independent — #2621) UNIONED with the user's PROFILE
+/// countries whose bounding box INTERSECTS the route's lat/lng extent
+/// (#2621 belt-and-braces, see [countriesTouchingRouteExtent]). The union
+/// guarantees a profile-backed country touching the corridor is never
+/// silently dropped even if a future detection gap re-shadows it — while
+/// the route-extent gate keeps a pure-FR route from pulling in a distant
+/// profile country (e.g. PT).
+///
+/// The set is intersected with the registered, key-satisfied services. A
+/// country is SKIPPED when it has no registry entry, or when it requires an
+/// API key that isn't configured (the DE / CL / KR demo guard) — we never
+/// inject demo stations onto a real route. Per-country fuel is the matching
+/// profile's `preferredFuelType` from [profileFuels], falling back to E10
+/// for a crossed country the user has no profile for.
 Map<String, CountrySource> buildCorridorServiceMap(
   Ref ref,
   RouteInfo route,
   Map<String, FuelType> profileFuels,
 ) {
   final hasKey = ref.read(storageRepositoryProvider).hasApiKey();
+  final codes = corridorCountries(route)
+    ..addAll(countriesTouchingRouteExtent(route, profileFuels.keys));
   final map = <String, CountrySource>{};
-  for (final code in corridorCountries(route)) {
+  for (final code in codes) {
     final entry = CountryServiceRegistry.entryFor(code);
     if (entry == null) continue; // unregistered → no real data source.
     if (entry.requiresApiKey && !hasKey) continue; // demo guard (#2595).
@@ -83,6 +97,43 @@ Map<String, CountrySource> buildCorridorServiceMap(
   debugPrint('RouteSearch: corridor services = '
       '${map.entries.map((e) => '${e.key}:${e.value.fuel.apiValue}').join(', ')}');
   return map;
+}
+
+/// The subset of [profileCountries] whose registered bounding box
+/// INTERSECTS the [route]'s own lat/lng bounding box (#2621).
+///
+/// Belt-and-braces for the corridor-detection union: even if per-vertex
+/// detection were to miss a country (e.g. a future shadowing regression),
+/// a profile-backed country whose box overlaps the route's extent is still
+/// queried. Gated on ACTUAL extent intersection — NOT mere profile
+/// existence — so a pure-FR route does not pull in a distant PT/ES profile
+/// the user happens to have configured. Returns upper-cased codes.
+Set<String> countriesTouchingRouteExtent(
+  RouteInfo route,
+  Iterable<String> profileCountries,
+) {
+  if (route.geometry.isEmpty) return const {};
+  var minLat = double.infinity, maxLat = double.negativeInfinity;
+  var minLng = double.infinity, maxLng = double.negativeInfinity;
+  for (final p in route.geometry) {
+    if (p.latitude < minLat) minLat = p.latitude;
+    if (p.latitude > maxLat) maxLat = p.latitude;
+    if (p.longitude < minLng) minLng = p.longitude;
+    if (p.longitude > maxLng) maxLng = p.longitude;
+  }
+  final out = <String>{};
+  for (final raw in profileCountries) {
+    final code = raw.toUpperCase();
+    final box = CountryServiceRegistry.boundingBoxFor(code);
+    if (box == null) continue;
+    // Axis-aligned bbox intersection (overlap on BOTH lat and lng).
+    final overlaps = box.minLat <= maxLat &&
+        box.maxLat >= minLat &&
+        box.minLng <= maxLng &&
+        box.maxLng >= minLng;
+    if (overlaps) out.add(code);
+  }
+  return out;
 }
 
 /// Build the per-point query function for a cross-border route.
@@ -105,6 +156,11 @@ Map<String, CountrySource> buildCorridorServiceMap(
 /// profile-backed corridor country) the active profile's service + the
 /// incoming [fuelType] are used as a fallback so a single-country route is
 /// unaffected.
+///
+/// Each per-country `searchStations` is wrapped in a try/catch (#2621): one
+/// country's outage / throw must NOT abort the whole route — the other legs
+/// still resolve, and an empty/failed ES leg is routed to [errorLogger]
+/// (ErrorLayer.services) so it is diagnosable rather than silently dropped.
 StationQueryFunction buildCorridorQueryFunction(
   Ref ref,
   FuelType fuelType, {
@@ -116,10 +172,10 @@ StationQueryFunction buildCorridorQueryFunction(
   // empty — reading it eagerly would needlessly build the active country's
   // service on every normal cross-border search.
   final sources = corridorMap.isEmpty
-      ? <CountrySource>[
-          (service: ref.read(stationServiceProvider), fuel: fuelType)
-        ]
-      : corridorMap.values.toList(growable: false);
+      ? <String, CountrySource>{
+          '*': (service: ref.read(stationServiceProvider), fuel: fuelType)
+        }
+      : corridorMap;
 
   return ({
     required double lat,
@@ -128,7 +184,7 @@ StationQueryFunction buildCorridorQueryFunction(
     required FuelType fuelType,
   }) async {
     final merged = <SearchResultItem>[];
-    for (final source in sources) {
+    for (final MapEntry(key: countryCode, value: source) in sources.entries) {
       final params = SearchParams(
         lat: lat,
         lng: lng,
@@ -136,10 +192,24 @@ StationQueryFunction buildCorridorQueryFunction(
         fuelType: source.fuel,
         sortBy: SortBy.price,
       );
-      final result = await source.service.searchStations(params);
-      final raw = result.data
-          .map((s) => FuelStationResult(s) as SearchResultItem)
-          .toList();
+      final List<SearchResultItem> raw;
+      try {
+        final result = await source.service.searchStations(params);
+        raw = result.data
+            .map((s) => FuelStationResult(s) as SearchResultItem)
+            .toList();
+      } catch (e, st) {
+        // #2621 — degrade to the other legs rather than aborting the whole
+        // route; never silently swallow (an empty ES leg must be traceable).
+        unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+          'where': 'RouteSearch corridor: per-country station query',
+          'country': countryCode,
+          'fuel': source.fuel.apiValue,
+          'lat': lat,
+          'lng': lng,
+        }));
+        continue;
+      }
       // Per-country top-N reduce using THIS country's fuel, so the ranking
       // is like-for-like before the slices are concatenated.
       merged.addAll(topNForCountry(

--- a/lib/features/route_search/data/strategies/route_geometry.dart
+++ b/lib/features/route_search/data/strategies/route_geometry.dart
@@ -3,7 +3,7 @@
 
 import 'package:latlong2/latlong.dart';
 
-import '../../../../core/country/country_bounding_box.dart';
+import '../../../../core/services/country_service_registry.dart';
 import '../../../../core/utils/geo_utils.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
@@ -80,23 +80,33 @@ int segmentIndexFor(int nearestSampleIdx, double segmentKm) =>
 /// The unique set of ISO 3166-1 alpha-2 country codes the [route]'s
 /// polyline passes through, detected OFFLINE (#2595).
 ///
-/// Walks every vertex of [route.geometry] through the canonical
-/// bounding-box lookup ([countryCodeFromLatLng] →
-/// `CountryServiceRegistry.entryByLatLng`) and collects the non-null
-/// matches. This replaces the previous per-sample-point NETWORK geocode
-/// (`coordinatesToCountryCode`) used to pick a station service: that
-/// call cost a round-trip per point and, on null/timeout, silently fell
-/// back to the active profile's country — so a Pézenas(FR)→Barcelona(ES)
-/// route queried only FR Prix-Carburants and returned an empty Spanish
-/// leg. The bbox lookup is sub-millisecond and never blackholes.
+/// Walks every vertex of [route.geometry] and collects EVERY registered
+/// country whose bounding box contains that vertex, via the
+/// order-independent [CountryServiceRegistry.entriesByLatLng] (#2621) —
+/// NOT the first-match `countryCodeFromLatLng`. Continental boxes overlap:
+/// FR's box (lat 41.0–51.5, lng −5.5–10.0) geographically contains all of
+/// Catalonia, and ES is declared after FR, so a first-match lookup
+/// resolves every Catalonian vertex to FR and silently drops the whole
+/// Spanish leg — a Pézenas→Barcelona route then queried only FR and came
+/// back with zero Spanish stations (#2621). Unioning all matches lets the
+/// shadowed ES through; over-collecting is safe because
+/// `UniformSearchStrategy._runFilterAndSort` drops every station whose
+/// detour from the corridor exceeds the budget, so a FR station fetched
+/// near Barcelona is filtered out while the local ES stations survive.
+///
+/// (This already replaced the original per-sample-point NETWORK geocode
+/// that, on null/timeout, fell back to the active profile's country — the
+/// bbox lookup is sub-millisecond and never blackholes.)
 ///
 /// Returns the codes upper-cased so they collate with profile country
 /// codes regardless of upstream casing.
 Set<String> corridorCountries(RouteInfo route) {
   final codes = <String>{};
   for (final p in route.geometry) {
-    final code = countryCodeFromLatLng(p.latitude, p.longitude);
-    if (code != null) codes.add(code.toUpperCase());
+    for (final entry
+        in CountryServiceRegistry.entriesByLatLng(p.latitude, p.longitude)) {
+      codes.add(entry.countryCode.toUpperCase());
+    }
   }
   return codes;
 }

--- a/test/core/services/country_service_registry_test.dart
+++ b/test/core/services/country_service_registry_test.dart
@@ -382,6 +382,40 @@ void main() {
       test('entryByLatLng returns null for the Atlantic', () {
         expect(CountryServiceRegistry.entryByLatLng(0.0, -30.0), isNull);
       });
+
+      // #2621 — first-match shadowing guard. The FR box (lat 41.0–51.5,
+      // lng −5.5–10.0) geographically CONTAINS all of Catalonia, and FR is
+      // declared BEFORE ES, so the first-match `entryByLatLng` resolves
+      // every Catalonian point to FR and never reaches ES. The
+      // order-independent `entriesByLatLng` must yield BOTH — so corridor
+      // detection can union ES in even though FR shadows it.
+      test('entriesByLatLng yields BOTH FR and ES for a Barcelona point', () {
+        const barcelonaLat = 41.39;
+        const barcelonaLng = 2.17;
+        // Sanity: the point is genuinely inside both declared boxes.
+        expect(
+            CountryServiceRegistry.boundingBoxFor('FR')!
+                .contains(barcelonaLat, barcelonaLng),
+            isTrue,
+            reason: 'FR box must geographically contain Barcelona');
+        expect(
+            CountryServiceRegistry.boundingBoxFor('ES')!
+                .contains(barcelonaLat, barcelonaLng),
+            isTrue,
+            reason: 'ES box must contain Barcelona');
+
+        final codes = CountryServiceRegistry.entriesByLatLng(
+                barcelonaLat, barcelonaLng)
+            .map((e) => e.countryCode)
+            .toSet();
+        expect(codes, containsAll(<String>{'FR', 'ES'}),
+            reason: 'order-independent lookup must surface the shadowed ES, '
+                'not just the first-declared FR');
+      });
+
+      test('entriesByLatLng yields nothing for the Atlantic', () {
+        expect(CountryServiceRegistry.entriesByLatLng(0.0, -30.0), isEmpty);
+      });
     });
 
     group('availableFuelTypes (#1111)', () {

--- a/test/features/route_search/providers/route_search_cross_border_test.dart
+++ b/test/features/route_search/providers/route_search_cross_border_test.dart
@@ -95,15 +95,19 @@ void main() {
       'cross-border FR→ES route queries each leg with its own service + '
       'profile fuel and merges both into one corridor result (#2595)',
       () async {
-    // Corridor: Pézenas (FR) heading south-west into Spain. The lower
-    // vertices fall in ES-only bbox territory, so corridorCountries
-    // returns {FR, ES}. Sample points sit on the polyline.
+    // Corridor: Pézenas (FR) → Barcelona (ES) — the EXACT route from the
+    // bug report. #2621 — the Catalonian sample point (Barcelona, 41.39)
+    // sits INSIDE FR's bbox (lat 41.0–51.5), so the first-match
+    // `entryByLatLng` resolved it to FR and the whole Spanish leg was
+    // silently dropped. Using a real sub-Pyrenees Spanish point (not the
+    // earlier hand-picked lat<41.0 one) exercises the production shadow.
     const frPoint = LatLng(43.46, 3.42); // Pézenas — FR bbox
-    const esPoint = LatLng(40.50, 0.50); // Castelló-ish — ES-only bbox
+    const esPoint = LatLng(41.39, 2.17); // Barcelona — INSIDE FR's box too
     const route = RouteInfo(
       geometry: [
         frPoint,
         LatLng(42.40, 2.20), // Pyrenees crossing
+        LatLng(41.98, 2.82), // Girona — Catalonia (ES), INSIDE FR's box
         esPoint,
       ],
       distanceKm: 400,
@@ -155,6 +159,12 @@ void main() {
     expect(brands, contains('Repsol ES'),
         reason: 'Spanish leg must be present (was empty before #2595)');
 
+    // #2621 — the ES service must ACTUALLY have been queried. An empty
+    // `everyElement` matcher passes vacuously, so assert the call happened
+    // (the regression: ES was never queried because FR shadowed it).
+    expect(esService.requestedFuels, isNotEmpty,
+        reason: 'ES service must be queried for a Barcelona corridor (#2621)');
+
     // Each country's service was queried with ITS profile fuel, not the
     // single active fuel.
     expect(frService.requestedFuels, everyElement(FuelType.e85),
@@ -181,19 +191,29 @@ void main() {
         reason: 'FR + ES stops interleave by true corridor position');
   });
 
-  test('corridorCountries detects every crossed country offline (#2595)',
+  // #2621 — REAL Catalonian vertices. The previous version of this test
+  // hand-picked ES points at lat 40.50 / 39.50, BELOW FR's minLat (41.0),
+  // so they fell outside the FR box and were attributed to ES even by the
+  // first-match `entryByLatLng`. A genuine Pézenas→Barcelona route never
+  // drops below 41.0 — Girona (41.98) and Barcelona (41.39) both sit INSIDE
+  // the FR box (lat 41.0–51.5, lng −5.5–10.0), so first-match resolves them
+  // to FR and the whole Spanish leg was silently dropped. With real coords
+  // this test exercises the actual bbox shadow.
+  test('corridorCountries detects every crossed country offline (#2595/#2621)',
       () {
     const route = RouteInfo(
       geometry: [
-        LatLng(43.46, 3.42), // FR
-        LatLng(42.40, 2.20), // FR (Pyrenees)
-        LatLng(40.50, 0.50), // ES
-        LatLng(39.50, -0.40), // ES
+        LatLng(43.46, 3.42), // Pézenas — FR
+        LatLng(42.40, 2.20), // Pyrenees crossing — FR
+        LatLng(41.98, 2.82), // Girona — Catalonia (ES), INSIDE FR's box
+        LatLng(41.39, 2.17), // Barcelona — Catalonia (ES), INSIDE FR's box
       ],
       distanceKm: 500,
       durationMinutes: 300,
       samplePoints: [],
     );
-    expect(corridorCountries(route), containsAll(<String>{'FR', 'ES'}));
+    expect(corridorCountries(route), containsAll(<String>{'FR', 'ES'}),
+        reason: 'ES must be detected even though FR shadows every '
+            'Catalonian point in first-match bbox order (#2621)');
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -58,7 +58,13 @@ void main() {
     // #2373 — re-grandfathered 868 → 887: one required `sourceUrl` field
     // added to every per-country FuelServicePolicy row (19 data lines) so
     // the country-service header can link the upstream data source.
-    'lib/core/services/country_service_registry.dart': 887,
+    // #2621 — re-grandfathered 887 → 909: the order-independent
+    // `entriesByLatLng` (a `sync*` yielding EVERY box that contains a point,
+    // not just the first declared) + its dartdoc, plus `entryByLatLng`
+    // refactored to delegate to it. Fixes the FR-shadows-Catalonia bbox bug
+    // that left cross-border routes with zero Spanish stations. Decomposition
+    // of this registry is tracked separately by #2187/#2188.
+    'lib/core/services/country_service_registry.dart': 909,
     'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
     // #2456 — re-grandfathered 457 → 481: two new pure parsers,


### PR DESCRIPTION
## Root cause — bbox first-match shadowing (recurring)

A Pézenas→Barcelona route returned **zero** Spanish stations even with an (inactive) 🇪🇸 Espagne profile, because the Spanish service was **never queried**.

`CountryServiceRegistry.entryByLatLng` returns the **first** bbox in *declared order* containing a point. FR is declared before ES, and FR's box (lat 41.0–51.5, lng −5.5–10.0) **geographically contains all of Catalonia** — Barcelona (41.39, 2.17), Girona (41.98, 2.82), Tarragona (41.12, 1.25) all have lat ≥ 41.0 **and** lng ≤ 10.0. ES is declared later (lat 27.0–44.0, lng −19.0–5.0), so first-match resolved **every** Catalonian point to FR and never reached ES.

Chain of consequence:
- `corridorCountries(route)` returned `{FR}` only.
- `buildCorridorServiceMap` never added ES.
- **MITECO** (the real, free, no-key, ~12k-station Spanish service) was never queried → empty Spanish leg, FR-only data-source header.

Spain **has** a real data source — it was simply never queried.

### Why #2608's test missed it
The earlier `corridorCountries` test hand-picked ES vertices at **lat 40.50 / 39.50**, **below FR's minLat (41.0)** — so those points fell *outside* the FR box and were attributed to ES even by first-match. A genuine Barcelona route never drops below 41.0, so the real shadow was never exercised.

## The fix (3 parts, no band-aid — the root)

**1A — order-independent detection (the source).** New `CountryServiceRegistry.entriesByLatLng` (`sync*` yielding **every** containing box, not just the first). `entryByLatLng` now delegates to it (single-country attribution #516 unchanged — still first match). `corridorCountries` unions **all** matches per vertex → a Barcelona corridor yields `{FR, ES}`. Over-collecting is safe: the detour filter drops off-corridor stations.

**1B — profile-extent union (belt-and-braces).** `buildCorridorServiceMap` also unions in PROFILE countries whose bbox **intersects the route's lat/lng extent** (`countriesTouchingRouteExtent`) — gated on actual extent intersection, not mere profile existence, so a pure-FR route doesn't pull in PT/ES. Guarantees a profile-backed country touching the corridor is never silently dropped even on a future detection regression.

**2 — per-source resilience.** Each per-country `searchStations` in `buildCorridorQueryFunction` is wrapped in try/catch and logged (`errorLogger`, `ErrorLayer.services`, with country/fuel/coords). One country's outage now degrades to the other legs instead of aborting the whole route; an empty/failed ES leg is diagnosable, never silently swallowed.

The FR/ES boxes are **not** shrunk — Catalonia is genuinely inside any reasonable FR latitude box, and shrinking would regress #516 single-country attribution.

## Tests (TDD — all failed on master pre-fix)
- `corridorCountries` unit test rewritten with **real Catalonian vertices** (Girona/Barcelona, lat > 41) → `containsAll({FR, ES})`.
- Production-seam integration test (`searchAlongPrebuiltRouteForTest`, FR-E85 active + ES-E10 profiles, Barcelona corridor) asserts the ES service was **actually queried** (`requestedFuels` non-empty, no longer vacuous) and an ES station appears.
- Registry guard: `entriesByLatLng` yields **both** FR and ES for a Barcelona point — locks out future first-match shadowing.

## Verification
- `flutter analyze` — clean (only a pre-existing unrelated `info` in `trip_kind_from_samples_test.dart`).
- `flutter test test/features/route_search test/core/services` — green (the one network-tagged Argentina timeout is CI-excluded).
- Clean `build_runner build` — **zero** `*.g.dart` / `*.freezed.dart` drift.
- **Zero** `lib/l10n` / `.arb` changes (multi-source attribution + UX is the separate #2622).

Closes #2621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
