### PR TITLE
fix(test): silence IsolateErrorSpool in two integration journeys (#2628)

### DIFF
--- a/test/integration/fill_up_receipt_reconciliation_journey_test.dart
+++ b/test/integration/fill_up_receipt_reconciliation_journey_test.dart
@@ -15,6 +15,8 @@ import 'package:tankstellen/features/consumption/domain/services/reconciler.dart
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
+import '../helpers/silence_error_logger.dart';
+
 /// End-to-end integration coverage for the fill-up + receipt-scan +
 /// trip-vs-pump reconciliation journey (#1633 — epic #1612).
 ///
@@ -33,6 +35,12 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// existing sharded `test` CI job.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  // #2628 — silence the IsolateErrorSpool so a fire-and-forget
+  // `errorLogger.log` from the production code under test can't lazily open
+  // a Hive file under the temp dir and race the recursive-delete teardown
+  // (flaky PathNotFoundException). See silence_error_logger.dart.
+  silenceErrorLoggerSpool();
 
   late Directory tmpDir;
 

--- a/test/integration/trip_recording_journey_test.dart
+++ b/test/integration/trip_recording_journey_test.dart
@@ -14,6 +14,8 @@ import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/providers/trip_history_provider.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 
+import '../helpers/silence_error_logger.dart';
+
 /// End-to-end integration coverage for the OBD2 trip-recording journey
 /// (#1632 — epic #1612).
 ///
@@ -31,6 +33,14 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 /// and runs on every PR inside the existing sharded `test` CI job.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  // #2628 — the production code under test logs via fire-and-forget
+  // `unawaited(errorLogger.log(...))`, which lazily + asynchronously opens
+  // the IsolateErrorSpool Hive box under the temp dir. That async open/close
+  // races the synchronous `tmpDir.deleteSync(recursive: true)` teardown and
+  // throws a flaky PathNotFoundException. Silencing the spool (the canonical
+  // helper) makes the enqueue a no-op so the file is never created.
+  silenceErrorLoggerSpool();
 
   late Directory tmpDir;
 


### PR DESCRIPTION
The required `integration` CI check (`flutter test test/integration/`) flaked **master-wide** with:

```
PathNotFoundException: Cannot delete file, path = '/tmp/.../isolate_error_spool.lock'
```

## Root cause
The production code under test logs via fire-and-forget `unawaited(errorLogger.log(...))`. `IsolateErrorSpool.enqueue` then lazily + asynchronously opens its own Hive box (`isolate_error_spool.{hive,lock}`) under the temp dir. That async open/close races the synchronous `tmpDir.deleteSync(recursive: true)` teardown → the file is enumerated then vanishes mid-delete. Reproduced 2/3 locally; confirmed failing on the latest master run (job step "Run end-to-end integration journeys").

## Fix
Apply the canonical `silenceErrorLoggerSpool()` helper (already used by `fuel_trajet_reconciliation_invariant_test`) to the two journeys that lacked it: `trip_recording_journey_test` + `fill_up_receipt_reconciliation_journey_test`. The override makes the spool enqueue a no-op, so the file is never created and the race is gone. **Test-only — no product change.** Verified deterministic across 4 consecutive full-suite runs (was 1-pass-2-fail before).

Closes #2628

🤖 Generated with [Claude Code](https://claude.com/claude-code)