### PR TITLE
fix(route): cross-border Best Stops + map/list prices apply per-country profile fuel (#2631)

### DIFF
--- a/lib/features/map/presentation/widgets/route_best_stops_list.dart
+++ b/lib/features/map/presentation/widgets/route_best_stops_list.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../core/utils/station_extensions.dart';
+import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import 'route_station_chip.dart';
 
@@ -14,12 +15,18 @@ class RouteBestStopsList extends StatelessWidget {
   final dynamic selectedFuel;
   final void Function(String stationId) onToggleStation;
 
+  /// #2631 — on a cross-border route, maps a station to ITS country's
+  /// profile fuel so the chip shows the price that station's driver pays
+  /// (Spanish stop → E10) instead of '--'. Null → strict [selectedFuel].
+  final FuelType Function(Station)? fuelResolver;
+
   const RouteBestStopsList({
     super.key,
     required this.stations,
     required this.selectedStationIds,
     required this.selectedFuel,
     required this.onToggleStation,
+    this.fuelResolver,
   });
 
   @override
@@ -36,7 +43,8 @@ class RouteBestStopsList extends StatelessWidget {
         itemBuilder: (context, index) {
           final station = stations[index];
           final isSelected = selectedStationIds.contains(station.id);
-          final price = station.priceFor(selectedFuel);
+          final price = station.priceFor(
+              fuelResolver != null ? fuelResolver!(station) : selectedFuel);
           final stopNumber = index + 1;
           return RouteStationChip(
             key: ValueKey('route-station-${station.id}'),

--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -11,8 +11,11 @@ import '../../../../core/widgets/empty_state.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../itinerary/providers/itinerary_provider.dart';
+import '../../../route_search/data/cross_border_corridor.dart'
+    show fuelForStation;
 import '../../../route_search/domain/entities/route_info.dart';
 import '../../../route_search/providers/route_search_provider.dart';
+import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../search/providers/search_provider.dart';
@@ -76,6 +79,15 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
         : const LatLng(48.8566, 2.3522);
     final zoom = _zoomForRoute(result.route.distanceKm);
 
+    // #2631 — price each station by ITS country's profile fuel (offline,
+    // from lat/lng) so a cross-border Spanish station shows the E10 price
+    // an E85 driver would pay instead of '--'. An empty `profileFuelByCountry`
+    // (single-country search) makes this resolve to the active fuel — the
+    // strict #2510 behaviour, unchanged.
+    final fuelType = widget.selectedFuel as FuelType;
+    FuelType resolveFuel(Station s) =>
+        fuelForStation(s, result.profileFuelByCountry, fuelType);
+
     return Column(
       children: [
         RouteViewModeBar(
@@ -109,6 +121,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             showSearchRadius: false,
             selectedStationIds:
                 _selectedStationIds.isNotEmpty ? _selectedStationIds : null,
+            fuelResolver: resolveFuel,
           ),
         ),
         if (_viewMode == RouteViewMode.bestStops && displayStations.isNotEmpty)
@@ -116,6 +129,7 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             stations: displayStations,
             selectedStationIds: _selectedStationIds,
             selectedFuel: widget.selectedFuel,
+            fuelResolver: resolveFuel,
             onToggleStation: (id) => setState(() {
               if (_selectedStationIds.contains(id)) {
                 _selectedStationIds.remove(id);

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -78,6 +78,14 @@ class StationMapLayers extends StatefulWidget {
   /// EV charging station overlay.
   final List<Widget> extraLayers;
 
+  /// #2631 — on a cross-border route, maps a station to the fuel of ITS
+  /// country's profile (offline, from the station's lat/lng). When set,
+  /// marker price, colour and paint order all use that resolved fuel so a
+  /// Spanish station shows the E10 price an E85 driver would pay instead
+  /// of '--'. Null on a single-country search → strict [selectedFuel]
+  /// behaviour (#2510), unchanged.
+  final FuelType Function(Station)? fuelResolver;
+
   const StationMapLayers({
     super.key,
     required this.mapController,
@@ -93,6 +101,7 @@ class StationMapLayers extends StatefulWidget {
     this.showSearchRadius = true,
     this.selectedStationIds,
     this.extraLayers = const [],
+    this.fuelResolver,
   });
 
   @override
@@ -170,13 +179,17 @@ class StationMapLayers extends StatefulWidget {
   /// relative order of equal-priced stations.
   static List<Station> orderedByPriceForPainting(
     List<Station> stations,
-    FuelType selectedFuel,
-  ) {
+    FuelType selectedFuel, {
+    FuelType Function(Station)? fuelResolver,
+  }) {
     // A null selected-fuel price is treated as the most-expensive bucket
     // (+infinity) so, under a descending sort, it lands first → painted
-    // at the very bottom, beneath every priced marker.
+    // at the very bottom, beneath every priced marker. #2631 — when a
+    // cross-border resolver is set, the key is each station's OWN country
+    // fuel price so the cheapest ES (E10) marker still paints on top.
     double sortKey(Station s) =>
-        priceForFuelType(s, selectedFuel) ?? double.infinity;
+        priceForFuelType(s, fuelResolver != null ? fuelResolver(s) : selectedFuel) ??
+        double.infinity;
     final ordered = List<Station>.of(stations);
     // Descending: highest price first (bottom), lowest last (top).
     mergeSort<Station>(ordered,
@@ -266,8 +279,13 @@ class _StationMapLayersState extends State<StationMapLayers> {
     // #2510 — colour by the SELECTED-fuel price (the same strict
     // resolution the list uses), not a fallback chain. A station without
     // the selected fuel paints grey ("--") instead of being re-coloured
-    // by E10's price.
-    _priceRange = priceRange(widget.stations, widget.selectedFuel);
+    // by E10's price. #2631 — when a cross-border resolver is set, each
+    // station's price is taken for ITS country fuel, so the colour range
+    // is computed over those resolved prices to keep colour ↔ price aligned.
+    final resolver = widget.fuelResolver;
+    _priceRange = resolver == null
+        ? priceRange(widget.stations, widget.selectedFuel)
+        : _resolvedRange(widget.stations, resolver);
     final ids = widget.selectedStationIds;
     final hasSelection = ids != null && ids.isNotEmpty;
 
@@ -290,6 +308,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
     final ordered = StationMapLayers.orderedByPriceForPainting(
       widget.stations,
       widget.selectedFuel,
+      fuelResolver: resolver,
     );
     _markers = ordered.map((station) {
       final isPastel = hasSelection && !ids.contains(station.id);
@@ -301,8 +320,29 @@ class _StationMapLayersState extends State<StationMapLayers> {
         _priceRange.$2,
         pastel: isPastel,
         compact: !emphasized.contains(station.id),
+        fuelResolver: resolver,
       );
     }).toList();
+  }
+
+  /// (min, max) over each station's per-country resolved-fuel price (#2631),
+  /// used to colour cross-border markers consistently with the price each
+  /// one actually shows. Mirrors [priceRange] but resolves the fuel per
+  /// station via [resolver]. Returns `(0, 0)` when none resolve to a price.
+  static (double, double) _resolvedRange(
+    List<Station> stations,
+    FuelType Function(Station) resolver,
+  ) {
+    double minP = double.infinity;
+    double maxP = 0;
+    for (final s in stations) {
+      final p = priceForFuelType(s, resolver(s));
+      if (p != null) {
+        if (p < minP) minP = p;
+        if (p > maxP) maxP = p;
+      }
+    }
+    return minP == double.infinity ? (0, 0) : (minP, maxP);
   }
 
   @override
@@ -326,6 +366,8 @@ class _StationMapLayersState extends State<StationMapLayers> {
     if (stationsChanged ||
         oldWidget.selectedFuel != widget.selectedFuel ||
         oldWidget.sortMode != widget.sortMode ||
+        // #2631 — a changed cross-border resolver re-prices every marker.
+        !identical(oldWidget.fuelResolver, widget.fuelResolver) ||
         !identical(oldWidget.selectedStationIds, widget.selectedStationIds)) {
       _recomputeMarkers();
     }

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -55,6 +55,14 @@ class StationMarkerBuilder {
   /// When [compact] is true, the marker renders as a small coloured dot
   /// (no price text) — used for lower-ranked stations so a bounded result
   /// set stays fully visible without the full bubbles overlapping (#2510).
+  ///
+  /// #2631 — on a cross-border route the caller may pass [fuelResolver],
+  /// which maps a station to the fuel of ITS country's profile (offline,
+  /// from the station's lat/lng). The price is then taken for that
+  /// resolved fuel so a Spanish station shows the E10 price an E85 driver
+  /// would actually pay, instead of '--'. When [fuelResolver] is null the
+  /// strict single-[fuel] behaviour (#2510) is unchanged — a station
+  /// lacking that fuel still shows '--', never a within-country fallback.
   static Marker build(
     BuildContext context,
     Station station,
@@ -63,11 +71,14 @@ class StationMarkerBuilder {
     double maxPrice, {
     bool pastel = false,
     bool compact = false,
+    FuelType Function(Station)? fuelResolver,
   }) {
     // #2510 — strict selected-fuel price, exactly like the list card. No
-    // fallback to another fuel: a station lacking the selected fuel shows
-    // "--", it must never be re-labelled with E10's price.
-    final price = station.priceFor(fuel);
+    // within-country fallback: a station lacking the selected fuel shows
+    // "--", it must never be re-labelled with E10's price. #2631 — when a
+    // cross-border resolver is supplied, the fuel is the station's OWN
+    // country profile fuel; the resolution stays strict for that fuel.
+    final price = station.priceFor(fuelResolver != null ? fuelResolver(station) : fuel);
     final baseColor = priceColor(price, minPrice, maxPrice);
     final color = pastel ? _toPastel(baseColor) : baseColor;
     final brand = truncateBrand(station.displayName, maxLength: _maxBrandLength);

--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../../core/country/country_bounding_box.dart';
+import '../../../core/country/country_config.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/services/country_service_registry.dart';
 import '../../../core/services/service_providers.dart';
@@ -19,6 +19,7 @@ import '../../profile/providers/profile_provider.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
+import '../../search/domain/entities/station.dart';
 import '../domain/entities/route_info.dart';
 import '../domain/route_search_strategy.dart';
 import 'strategies/route_geometry.dart';
@@ -225,18 +226,29 @@ StationQueryFunction buildCorridorQueryFunction(
   };
 }
 
-/// Resolve the fuel to price a station by, from its coordinates.
+/// Resolve the fuel to price a [station] by, from its origin country.
 ///
-/// Offline bbox → profile fuel for that country (from [profileFuels]),
-/// falling back to [fallback] (the incoming search fuel) when the station
-/// sits outside every box or in a country with no profile.
+/// Offline country attribution → profile fuel for that country (from
+/// [profileFuels]), falling back to [fallback] (the incoming search fuel)
+/// when the country has no profile or cannot be resolved.
+///
+/// Country attribution uses [Countries.countryForStation], which checks the
+/// station id PREFIX first (`es-…` → ES) and only then the bounding box.
+/// The id prefix is essential here: FR's continental bbox geographically
+/// CONTAINS all of Catalonia (#2621), so a bbox-only lookup resolves a
+/// Barcelona MITECO station to FR and prices it on FR's E85 (null for ES) —
+/// the very '--' bug this fixes. The `es-` prefix every MITECO row carries
+/// (#753) overrides that shadow and yields ES → E10.
 FuelType fuelForStation(
-  double lat,
-  double lng,
+  Station station,
   Map<String, FuelType> profileFuels,
   FuelType fallback,
 ) {
-  final code = countryCodeFromLatLng(lat, lng)?.toUpperCase();
+  final code = Countries.countryForStation(
+    id: station.id,
+    lat: station.lat,
+    lng: station.lng,
+  )?.code.toUpperCase();
   if (code == null) return fallback;
   return profileFuels[code] ?? fallback;
 }

--- a/lib/features/route_search/data/strategies/balanced_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/balanced_search_strategy.dart
@@ -10,6 +10,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../cross_border_corridor.dart' show fuelForStation;
 import '../helpers/batch_query_helper.dart';
 import 'route_filter_sort_isolate.dart';
 import 'route_geometry.dart';
@@ -70,6 +71,7 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
     required List<SearchResultItem> results,
     required FuelType fuelType,
     required double segmentKm,
+    Map<String, FuelType> profileFuelByCountry = const {},
   }) {
     final segmentBest = <int, (String, double)>{};
 
@@ -91,7 +93,9 @@ class BalancedSearchStrategy implements RouteSearchStrategy {
         }
         final segmentIdx = segmentIndexFor(nearestSampleIdx, segmentKm);
 
-        final price = station.priceFor(fuelType);
+        // #2631 — per-country profile fuel (empty map → fuelType fallback).
+        final price = station.priceFor(
+            fuelForStation(station, profileFuelByCountry, fuelType));
         if (price != null) {
           // Balanced score: price + distance penalty
           final routeDist = minDistanceToPolyline(

--- a/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/cheapest_search_strategy.dart
@@ -10,6 +10,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../cross_border_corridor.dart' show fuelForStation;
 import '../helpers/batch_query_helper.dart';
 import 'route_filter_sort_isolate.dart';
 import 'route_geometry.dart';
@@ -75,6 +76,7 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
     required List<SearchResultItem> results,
     required FuelType fuelType,
     required double segmentKm,
+    Map<String, FuelType> profileFuelByCountry = const {},
   }) {
     // Same segment logic as uniform, but with price-first ordering.
     // #2183 — carry the leader's price in a parallel map so the
@@ -101,7 +103,9 @@ class CheapestSearchStrategy implements RouteSearchStrategy {
         }
         final segmentIdx = segmentIndexFor(nearestSampleIdx, segmentKm);
 
-        final price = station.priceFor(fuelType);
+        // #2631 — per-country profile fuel (empty map → fuelType fallback).
+        final price = station.priceFor(
+            fuelForStation(station, profileFuelByCountry, fuelType));
         if (price != null) {
           final currentBestPrice = segmentCheapestPrice[segmentIdx];
           // Strict < keeps first-occurrence-wins on equal prices,

--- a/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/eco_route_search_strategy.dart
@@ -12,6 +12,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../cross_border_corridor.dart' show fuelForStation;
 import '../helpers/batch_query_helper.dart';
 import 'eco_route_candidate.dart';
 import 'eco_route_scoring.dart';
@@ -219,6 +220,7 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
     required List<SearchResultItem> results,
     required FuelType fuelType,
     required double segmentKm,
+    Map<String, FuelType> profileFuelByCountry = const {},
   }) {
     final segmentCheapest = <int, String>{};
     // #2183 — O(1) leader lookup via a parallel price map (was an
@@ -242,7 +244,9 @@ class EcoRouteSearchStrategy implements RouteSearchStrategy {
           }
         }
         final segmentIdx = segmentIndexFor(nearestSampleIdx, segmentKm);
-        final price = station.priceFor(fuelType);
+        // #2631 — per-country profile fuel (empty map → fuelType fallback).
+        final price = station.priceFor(
+            fuelForStation(station, profileFuelByCountry, fuelType));
         if (price != null) {
           final currentBestPrice = segmentCheapestPrice[segmentIdx];
           // Strict < keeps first-occurrence-wins on equal prices.

--- a/lib/features/route_search/data/strategies/uniform_search_strategy.dart
+++ b/lib/features/route_search/data/strategies/uniform_search_strategy.dart
@@ -12,6 +12,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../domain/entities/route_info.dart';
 import '../../domain/route_search_strategy.dart';
+import '../cross_border_corridor.dart' show fuelForStation;
 import '../helpers/batch_query_helper.dart';
 
 /// Default strategy: samples every ~15 km along the route,
@@ -81,11 +82,16 @@ class UniformSearchStrategy implements RouteSearchStrategy {
     required List<SearchResultItem> results,
     required FuelType fuelType,
     required double segmentKm,
+    Map<String, FuelType> profileFuelByCountry = const {},
   }) {
     final stations = <_StationLite>[];
     for (final item in results) {
       if (item is FuelStationResult) {
-        final price = item.station.priceFor(fuelType);
+        // #2631 — price by the station's OWN country profile fuel so a
+        // cross-border ES station (E10 populated, E85 null) is ranked, not
+        // dropped. Empty map → fallback = fuelType → unchanged single-country.
+        final price = item.station.priceFor(
+            fuelForStation(item.station, profileFuelByCountry, fuelType));
         if (price == null) continue;
         stations.add(_StationLite(
           id: item.id,

--- a/lib/features/route_search/domain/route_search_result.dart
+++ b/lib/features/route_search/domain/route_search_result.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
 import 'entities/route_info.dart';
 import 'route_search_strategy.dart';
@@ -35,6 +36,16 @@ class RouteSearchResult {
   /// the single-country attribution.
   final Set<String> corridorCountryCodes;
 
+  /// #2631 — profile fuel keyed by upper-cased country code (the same map
+  /// `buildCorridorServiceMap` was built from). The map + list display
+  /// resolve each station's price by ITS country's fuel from this map
+  /// (offline, via the station's lat/lng), so a cross-border ES station
+  /// shows the E10 price an E85 driver would actually pay instead of '--'.
+  /// Empty for the single-country path, where the active fuel is used and
+  /// the display is byte-identical to the pre-#2631 strict behaviour
+  /// (#2510 — no within-country fallback).
+  final Map<String, FuelType> profileFuelByCountry;
+
   const RouteSearchResult({
     required this.route,
     required this.stations,
@@ -43,5 +54,6 @@ class RouteSearchResult {
     this.strategyType = RouteSearchStrategyType.uniform,
     this.isPartial = false,
     this.corridorCountryCodes = const {},
+    this.profileFuelByCountry = const {},
   });
 }

--- a/lib/features/route_search/domain/route_search_strategy.dart
+++ b/lib/features/route_search/domain/route_search_strategy.dart
@@ -49,11 +49,21 @@ abstract class RouteSearchStrategy {
   ///
   /// Returns a map of segment index → station ID for the cheapest
   /// station in each segment. Returns null if not applicable.
+  ///
+  /// #2631 — each station is priced by ITS country's profile fuel via
+  /// [profileFuelByCountry] (upper-cased country code → fuel), resolved
+  /// offline from the station's lat/lng. A cross-border E85 driver thus
+  /// sees Spanish stations ranked on the E10 price they'd actually pay,
+  /// instead of being dropped because the single active fuel (E85) is
+  /// null for ~95% of ES stations. When the map is empty (the historical
+  /// single-country path) every station is priced by [fuelType], so the
+  /// result is byte-identical to the pre-#2631 behaviour.
   Map<int, String>? computeBestStops({
     required RouteInfo route,
     required List<SearchResultItem> results,
     required FuelType fuelType,
     required double segmentKm,
+    Map<String, FuelType> profileFuelByCountry = const {},
   });
 }
 

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -113,6 +113,7 @@ class RouteSearchState extends _$RouteSearchState {
               strategyType: strategyType,
               isPartial: true,
               corridorCountryCodes: corridorMap.keys.toSet(),
+              profileFuelByCountry: profileFuels,
             ));
           },
         );
@@ -141,12 +142,7 @@ class RouteSearchState extends _$RouteSearchState {
             // #2595 — price by the station's own country fuel, not the
             // single active-profile fuel, so the global cheapest across
             // a cross-border route compares like-for-like.
-            final fuel = fuelForStation(
-              item.station.lat,
-              item.station.lng,
-              profileFuels,
-              fuelType,
-            );
+            final fuel = fuelForStation(item.station, profileFuels, fuelType);
             final price = item.station.priceFor(fuel);
             if (price != null && (cheapestPrice == null || price < cheapestPrice)) {
               cheapestPrice = price;
@@ -162,6 +158,10 @@ class RouteSearchState extends _$RouteSearchState {
           results: allResults,
           fuelType: fuelType,
           segmentKm: segmentKmValue,
+          // #2631 — price each segment by ITS country's profile fuel so a
+          // cross-border ES station (E10 set, E85 null) is ranked into Best
+          // Stops rather than dropped on a null active-fuel price.
+          profileFuelByCountry: profileFuels,
         );
       }
 
@@ -172,6 +172,9 @@ class RouteSearchState extends _$RouteSearchState {
         cheapestPerSegment: segmentCheapest,
         strategyType: strategyType,
         corridorCountryCodes: corridorMap.keys.toSet(),
+        // #2631 — carried to the map/list so each station prices by its
+        // own country fuel (cross-border ES → E10 instead of '--').
+        profileFuelByCountry: profileFuels,
       ));
     } on DioException catch (e, st) {
       if (e.type == DioExceptionType.cancel) return;
@@ -230,12 +233,7 @@ class RouteSearchState extends _$RouteSearchState {
     double? cheapestPrice;
     for (final item in allResults) {
       if (item is FuelStationResult) {
-        final fuel = fuelForStation(
-          item.station.lat,
-          item.station.lng,
-          profileFuels,
-          fuelType,
-        );
+        final fuel = fuelForStation(item.station, profileFuels, fuelType);
         final price = item.station.priceFor(fuel);
         if (price != null &&
             (cheapestPrice == null || price < cheapestPrice)) {
@@ -253,9 +251,12 @@ class RouteSearchState extends _$RouteSearchState {
         results: allResults,
         fuelType: fuelType,
         segmentKm: 50.0,
+        // #2631 — per-country profile fuel for cross-border Best Stops.
+        profileFuelByCountry: profileFuels,
       ),
       strategyType: strategyType,
       corridorCountryCodes: corridorMap.keys.toSet(),
+      profileFuelByCountry: profileFuels,
     );
   }
 

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'061f71b2aeb5c94c12c8e6c842151699949e46c4';
+String _$routeSearchStateHash() => r'd02ed4be94adbfe023265e9aab82d49aca188143';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -14,6 +14,8 @@ import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../favorites/providers/favorites_provider.dart';
+import '../../../route_search/data/cross_border_corridor.dart'
+    show fuelForStation;
 import '../../../route_search/providers/route_search_provider.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_result_item.dart';
@@ -257,7 +259,15 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
       ),
       child: StationCard(
         station: item.station,
-        selectedFuelType: fuelType,
+        // #2631 — price by the station's OWN country profile fuel (offline,
+        // from lat/lng) so a cross-border Spanish card shows its E10 price
+        // instead of '--'. Empty `profileFuelByCountry` (single-country
+        // search) resolves to the active fuel → strict #2510 behaviour.
+        selectedFuelType: fuelForStation(
+          item.station,
+          result.profileFuelByCountry,
+          fuelType,
+        ),
         isFavorite: ref.watch(isFavoriteProvider(item.id)),
         profileFuelType: ref.watch(activeProfileProvider)?.preferredFuelType,
         onTap: () => context.push('/station/${item.id}'),

--- a/test/features/map/presentation/widgets/station_marker_test.dart
+++ b/test/features/map/presentation/widgets/station_marker_test.dart
@@ -374,6 +374,85 @@ void main() {
     );
   });
 
+  group('StationMarkerBuilder cross-border fuelResolver (#2631)', () {
+    // A Spanish MITECO station: E10 priced, NO E85 grade — the exact shape
+    // that rendered '--' on an E85 search before the per-country fix. The
+    // `es-` id prefix attributes it to ES.
+    const esStation = Station(
+      id: 'es-12345',
+      name: 'Repsol',
+      brand: 'Repsol',
+      street: 'Av. Diagonal',
+      postCode: '08001',
+      place: 'Barcelona',
+      lat: 41.39,
+      lng: 2.17,
+      e10: 1.609,
+      isOpen: true,
+    );
+
+    testWidgets(
+      'with a resolver mapping the ES station to E10, the marker shows the '
+      'E10 price even though the active fuel is E85',
+      (tester) async {
+        final marker = StationMarkerBuilder.build(
+          tester.element(find.byType(Container).first),
+          esStation,
+          FuelType.e85, // active fuel — null on this station…
+          0.50,
+          2.50,
+          // …but the cross-border resolver picks ES → E10.
+          fuelResolver: (_) => FuelType.e10,
+        );
+
+        await pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+
+        // The E10 price (1.609 => "1,609") is shown, NOT the '--' the active
+        // E85 would have produced.
+        expect(find.text('1,609'), findsOneWidget);
+        expect(find.text('--'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'WITHOUT a resolver, the same ES station still shows "--" on an E85 '
+      'search (locks the strict #2510 single-fuel behaviour)',
+      (tester) async {
+        final marker = StationMarkerBuilder.build(
+          tester.element(find.byType(Container).first),
+          esStation,
+          FuelType.e85,
+          0.50,
+          2.50,
+          // No resolver → strict active-fuel price → '--'.
+        );
+
+        await pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+
+        expect(find.text('--'), findsOneWidget);
+        expect(find.text('1,609'), findsNothing);
+      },
+    );
+  });
+
   group('StationMarkerBuilder compact dot (#2510)', () {
     testWidgets('a compact marker is a small price-less dot', (tester) async {
       final marker = StationMarkerBuilder.build(

--- a/test/features/route_search/data/strategies/uniform_search_strategy_test.dart
+++ b/test/features/route_search/data/strategies/uniform_search_strategy_test.dart
@@ -230,6 +230,38 @@ void main() {
 
       expect(bestStops, isEmpty);
     });
+
+    // #2631 — backward-compat: with `profileFuelByCountry` omitted (the
+    // single-country path), each station prices by the active fuel exactly
+    // as before, so the map is byte-identical to the pre-#2631 result.
+    test('omitting profileFuelByCountry yields the identical map (#2631)', () {
+      final results = [
+        FuelStationResult(makeStation(
+            id: 'seg0_cheap', lat: 48.0, lng: 2.0, diesel: 1.65)),
+        FuelStationResult(makeStation(
+            id: 'seg0_exp', lat: 48.02, lng: 2.02, diesel: 1.90)),
+        FuelStationResult(makeStation(
+            id: 'seg1_cheap', lat: 48.2, lng: 2.2, diesel: 1.70)),
+      ];
+
+      final withoutMap = strategy.computeBestStops(
+        route: testRoute,
+        results: results,
+        fuelType: FuelType.diesel,
+        segmentKm: 15.0,
+      );
+      final withEmptyMap = strategy.computeBestStops(
+        route: testRoute,
+        results: results,
+        fuelType: FuelType.diesel,
+        segmentKm: 15.0,
+        profileFuelByCountry: const {},
+      );
+
+      expect(withoutMap, equals(withEmptyMap));
+      expect(withoutMap!.values, contains('seg0_cheap'));
+      expect(withoutMap.values, isNot(contains('seg0_exp')));
+    });
   });
 
   group('isolate filter + sort (#2102)', () {

--- a/test/features/route_search/providers/route_search_cross_border_test.dart
+++ b/test/features/route_search/providers/route_search_cross_border_test.dart
@@ -10,8 +10,10 @@ import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/core/utils/station_extensions.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/route_search/data/cross_border_corridor.dart';
 import 'package:tankstellen/features/route_search/data/strategies/route_geometry.dart';
 import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
 import 'package:tankstellen/features/route_search/providers/route_search_provider.dart';
@@ -84,6 +86,72 @@ class _BrandedStationService implements StationService {
 class _NoKeyStorage implements StorageRepository {
   @override
   bool hasApiKey() => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// #2631 — a [StationService] that only returns a station when the queried
+/// point is INSIDE [minLat]..[maxLat], mirroring a real country source that
+/// has NO coverage abroad (FR Prix-Carburants returns nothing in Spain).
+/// The corridor query function queries every country service at every
+/// sample point, so without this gating a 1.20-priced FR station would be
+/// returned next to Barcelona and win every segment — masking the bug.
+/// Returns a station priced ONLY for the requested fuel (ES → e10 set, e85
+/// null), so the per-country-fuel ranking is what the test exercises.
+class _RegionGatedStationService implements StationService {
+  _RegionGatedStationService(
+    this.brand, {
+    required this.idPrefix,
+    required this.minLat,
+    required this.maxLat,
+    required this.price,
+  });
+
+  final String brand;
+  // #753 — real country services prefix their station ids (`es-`, `fr-`)
+  // so a Catalonian station inside FR's bbox is still attributed to ES by
+  // `Countries.countryForStation` / `fuelForStation` (#2631).
+  final String idPrefix;
+  final double minLat;
+  final double maxLat;
+  final double price;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    if (params.lat < minLat || params.lat > maxLat) {
+      return ServiceResult(
+        data: const [],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime.now(),
+      );
+    }
+    final station = Station(
+      id: '$idPrefix${params.lat.toStringAsFixed(2)}-${params.lng.toStringAsFixed(2)}',
+      name: '$brand station',
+      brand: brand,
+      street: 'Route',
+      postCode: '00000',
+      place: brand,
+      lat: params.lat,
+      lng: params.lng,
+      isOpen: true,
+      // Price only the requested fuel — an ES station has e10 set, e85 null,
+      // so pricing it by the active E85 yields '--' (the bug) until the
+      // per-country fuel (E10) is applied.
+      e85: params.fuelType == FuelType.e85 ? price : null,
+      e10: params.fuelType == FuelType.e10 ? price : null,
+    );
+    return ServiceResult(
+      data: [station],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    );
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>
@@ -220,5 +288,119 @@ void main() {
     expect(corridorCountries(route), containsAll(<String>{'FR', 'ES'}),
         reason: 'ES must be detected even though FR shadows every '
             'Catalonian point in first-match bbox order (#2621)');
+  });
+
+  // #2631 — THE regression. A cross-border Best Stops result must include
+  // the Spanish leg's cheapest station. Before the fix, `computeBestStops`
+  // (and the 4 strategies) priced EVERY station by the single active fuel
+  // (FR E85). A real ES station has e10 set / e85 null, so `priceFor(E85)`
+  // is null → the station is skipped from per-segment ranking → zero
+  // Spanish best stops. With the per-country fuel threaded through, the ES
+  // station is priced on E10 and wins its own segment.
+  test(
+      'cross-border Best Stops include the cheapest Spanish station, '
+      'priced by ES profile fuel E10 (#2631)', () async {
+    // 4 FR sample points (lat ≥ 42 → segment 0) + 1 ES point at Barcelona
+    // (sample index 4 → segment 1 under the 50 km test-seam spacing:
+    // (4 * 15 / 50).floor() == 1). Region-gated services mean only FR
+    // answers in France and only ES answers in Spain — so segment 1's sole
+    // candidate is the Spanish station.
+    const frA = LatLng(43.50, 3.50);
+    const frB = LatLng(43.30, 3.30);
+    const frC = LatLng(43.10, 3.10);
+    const frD = LatLng(42.90, 2.90);
+    const esBarcelona = LatLng(41.39, 2.17);
+    const route = RouteInfo(
+      geometry: [frA, frB, frC, frD, LatLng(42.10, 2.40), esBarcelona],
+      distanceKm: 400,
+      durationMinutes: 240,
+      samplePoints: [frA, frB, frC, frD, esBarcelona],
+    );
+
+    // FR sells (gated to lat ≥ 42) at E85 1.20; ES sells (gated to lat ≤ 42)
+    // at E10 1.60 with no E85 grade — the exact shape that produced '--'.
+    // The `es-` prefix is what lets `fuelForStation` attribute the Barcelona
+    // station to ES even though it sits inside FR's continental bbox (#2631).
+    final frService = _RegionGatedStationService('Total FR',
+        idPrefix: 'fr-', minLat: 42.0, maxLat: 90.0, price: 1.20);
+    final esService = _RegionGatedStationService('Repsol ES',
+        idPrefix: 'es-', minLat: -90.0, maxLat: 42.0, price: 1.60);
+
+    final container = ProviderContainer(
+      overrides: [
+        storageRepositoryProvider.overrideWith((ref) => _NoKeyStorage()),
+        perCountryStationServiceProvider('FR')
+            .overrideWith((ref) => frService),
+        perCountryStationServiceProvider('ES')
+            .overrideWith((ref) => esService),
+        allProfilesProvider.overrideWith((ref) => const [
+              UserProfile(
+                  id: 'fr', name: 'Standard',
+                  countryCode: 'FR', preferredFuelType: FuelType.e85),
+              UserProfile(
+                  id: 'es', name: 'Espagne',
+                  countryCode: 'ES', preferredFuelType: FuelType.e10),
+            ]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(routeSearchStateProvider.notifier);
+    final result = await notifier.searchAlongPrebuiltRouteForTest(
+      route: route,
+      fuelType: FuelType.e85, // active fuel is FR's E85.
+    );
+
+    final esStation = result.stations
+        .whereType<FuelStationResult>()
+        .firstWhere((r) => r.station.brand == 'Repsol ES');
+
+    // The ES station models a real MITECO row: E10 priced, E85 null.
+    expect(esStation.station.e10, isNotNull);
+    expect(esStation.station.e85, isNull);
+
+    // THE assertion: the Spanish station is in Best Stops. On master this
+    // is absent (the E85-priced ranking skipped it).
+    expect(result.cheapestPerSegment, isNotNull);
+    expect(result.cheapestPerSegment!.values, contains(esStation.station.id),
+        reason: 'the cheapest Spanish station must appear in Best Stops, '
+            'priced by ES profile fuel E10 (#2631)');
+
+    // #2631 — and the result carries the per-country fuel map so the
+    // map/list display can price each station the same way.
+    expect(result.profileFuelByCountry['ES'], FuelType.e10);
+  });
+
+  // #2631 — the reused resolver: an ES station priced for E10 is non-null
+  // once `fuelForStation` selects E10 from the ES profile, even though the
+  // active search fuel (E85) is null on it. This is the one-line proof that
+  // the per-country selection — not a within-country fallback — is what
+  // surfaces the price.
+  test('fuelForStation selects the ES profile fuel and yields a price (#2631)',
+      () {
+    // Barcelona (41.39) sits INSIDE FR's continental bbox; the `es-` id
+    // prefix (#753) is what attributes it to ES rather than FR.
+    const esStation = Station(
+      id: 'es-1',
+      name: 'Repsol',
+      brand: 'Repsol',
+      street: 'Calle',
+      postCode: '08001',
+      place: 'Barcelona',
+      lat: 41.39,
+      lng: 2.17,
+      e10: 1.60, // E10 priced…
+      isOpen: true,
+    );
+    final fuel = fuelForStation(
+      esStation,
+      const {'ES': FuelType.e10},
+      FuelType.e85, // …while the active fuel is E85.
+    );
+    expect(fuel, FuelType.e10, reason: 'ES profile fuel wins over the active');
+    expect(esStation.priceFor(fuel), isNotNull,
+        reason: 'priced on E10, so it is no longer dropped as "--"');
+    // And the active-fuel path (the bug) is null → the "--" on master.
+    expect(esStation.priceFor(FuelType.e85), isNull);
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -290,7 +290,14 @@ void main() {
     // `onStationTap` field (the map now takes the full horizontal width on
     // wide/landscape — no side panel), so the marker tap is back to its
     // pre-#2532 `/station/:id` push and the field + its plumbing are gone.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 562,
+    // #2631 — re-grandfathered 562 → 604: the optional cross-border
+    // `fuelResolver` field + its dartdoc, its constructor param + the
+    // `didUpdateWidget` identity guard, the resolver thread-through in
+    // `orderedByPriceForPainting` + `_recomputeMarkers`, and the small
+    // `_resolvedRange` helper that colours cross-border markers by each
+    // station's own country fuel. Lets a Spanish station show its E10 price
+    // instead of '--' on an E85 route. Decomposition tracked by #2187/#2188.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 604,
     // #2382 — +5 for Feature.approachOverlay's three per-feature switch
     // cases (label / description / blocked-enable). Intrinsic per-feature
     // growth in this switch-based section; full decomposition is its own


### PR DESCRIPTION
## Why

Follow-up to #2621/#2626 (which made Spanish stations APPEAR on the map). The cross-border *fetch* and the global-cheapest loop were already per-country, but two consumers still priced **every** station by the single active-profile fuel (FR E85):

- `computeBestStops` + the four per-segment strategies — Spanish MITECO stations carry E10/E5 but ~95% have no E85, so `priceFor(E85)` was `null` → the station was skipped from per-segment ranking → **zero Spanish best stops** even on the Spanish leg.
- the map markers / best-stop chips / list cards — same strict-active-fuel pricing → Spanish stations rendered `--`.

This completes the per-country-fuel work the #2608 agent explicitly deferred ("would require widening the strategy interface across all 4 strategies").

## What

- **Strategy interface + 4 strategies**: added an optional `profileFuelByCountry` (default `const {}`, backward-compatible) to `computeBestStops`; each station is now priced by ITS country's profile fuel via the existing `fuelForStation` resolver.
- **Provider**: passes `profileFuelByCountry: profileFuels` into both `computeBestStops` calls and carries the map onto `RouteSearchResult` (new field, default `const {}`) at every construction.
- **Display**: optional `fuelResolver` threaded into `StationMarkerBuilder.build`, `StationMapLayers` (price + paint-order + colour range), `RouteBestStopsList`, and the route list `StationCard`. `RouteMapView` builds the resolver from `result.profileFuelByCountry`.
- **Root-cause correction**: `fuelForStation` now takes the `Station` and resolves its country via `Countries.countryForStation` — **id-prefix first** (`es-…` → ES), bbox fallback. FR's continental bbox geographically contains all of Catalonia (#2621), so the old bbox-only lookup mis-attributed a Barcelona station to FR and re-priced it on E85 (null) — reproducing the very `--` bug. The `es-` id prefix every MITECO row carries (#753) overrides that shadow.

## Backward-compat (load-bearing)

With an empty `profileFuelByCountry` / no resolver (nearby & single-country search), `fuelForStation` returns the active fuel → **byte-identical** to today. The strict #2510 behaviour is preserved: an FR station lacking E85 still shows `--`; **no** within-country E10→E5 fallback is reintroduced (that was the reverted #2400). Selection is by COUNTRY profile only.

## Tests (TDD — red on master, green here)

- `route_search_cross_border_test`: a region-gated FR/ES corridor over 5 sample points so the ES point lands in its own segment — asserts the cheapest Spanish station is in `cheapestPerSegment` (verified absent → RED on the pre-fix ranking) + `profileFuelByCountry['ES'] == E10`, plus a one-liner proving `fuelForStation` picks ES E10 over the active E85 via the `es-` prefix.
- `station_marker_test`: ES station (E10 set, E85 null) + resolver → shows E10; no resolver → still `--` (locks #2510).
- `uniform_search_strategy_test`: backward-compat — omitting `profileFuelByCountry` yields the identical map.

`flutter analyze` clean. `flutter test test/features/route_search test/features/search test/features/map test/lint` green (1171). ARB-free (zero `lib/l10n/` changes). Clean codegen committed (only the `route_search_provider.g.dart` hash drifted). `file_length` re-grandfathered station_map_layers.dart 562 → 604 with rationale.

Closes #2631

🤖 Generated with [Claude Code](https://claude.com/claude-code)
