### PR TITLE
feat(route-results): slim the route header — drop the route-mode banner + partial-results row (#2630)

### DIFF
--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -209,10 +209,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         // Compact summary bar — top-level entry point for editing criteria.
         const SearchSummaryBar(),
         UserPositionBar(
-          // #2111 — route mode swaps the banner to a corridor-context
-          // label so users read the results as a trajet view.
-          routeMode:
-              ref.watch(activeSearchModeProvider) == SearchMode.route,
           onUpdatePosition: () async {
             final settings = ref.read(settingsStorageProvider);
             if (!LocationConsentDialog.hasConsent(settings)) {

--- a/lib/features/search/presentation/widgets/route_results_view.dart
+++ b/lib/features/search/presentation/widgets/route_results_view.dart
@@ -134,16 +134,6 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // #2140 — non-blocking partial-results banner: shows while
-          // more stations are streaming in. User can still scroll and
-          // tap the partial results below.
-          if (result.isPartial) ...[
-            _PartialResultsBanner(
-              label: l10n?.routeSearchPartialBanner ??
-                  'Searching for more stations…',
-            ),
-            const SizedBox(height: 6),
-          ],
           // #2622 — de-densify: the route summary and the All/Best toggle
           // share ONE row (summary left, pills right) and wrap when narrow.
           // The "Every {km} km" segment row was a verbatim duplicate of the
@@ -326,50 +316,5 @@ class _RouteResultsViewState extends ConsumerState<RouteResultsView> {
     }
     final bestIds = segmentMap.values.toSet();
     return allStations.where((s) => bestIds.contains(s.id)).cast<SearchResultItem>().toList();
-  }
-}
-
-/// #2140 — thin non-blocking banner shown above route results while
-/// more stations are still streaming in. Pairs a small spinner with a
-/// localised label so the user knows data is loading without losing
-/// the ability to interact with what's already on screen.
-class _PartialResultsBanner extends StatelessWidget {
-  final String label;
-  const _PartialResultsBanner({required this.label});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            width: 12,
-            height: 12,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: theme.colorScheme.primary,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Flexible(
-            child: Text(
-              label,
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/features/search/presentation/widgets/user_position_bar.dart
+++ b/lib/features/search/presentation/widgets/user_position_bar.dart
@@ -7,23 +7,12 @@ import '../../../../core/location/user_position_provider.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Shows the user's known position and allows updating it.
-///
-/// #2111 — when [routeMode] is true the bar swaps its label to a
-/// route-context message so the user reads the results screen as a
-/// trajet view, not a point + radius. The position-update affordance
-/// is suppressed in route mode because the user's GPS is not the
-/// search anchor — the route corridor is.
 class UserPositionBar extends ConsumerWidget {
   final VoidCallback onUpdatePosition;
-
-  /// #2111 — flip the bar's content to a route-mode indicator.
-  /// Defaults to false so every existing call site behaves identically.
-  final bool routeMode;
 
   const UserPositionBar({
     super.key,
     required this.onUpdatePosition,
-    this.routeMode = false,
   });
 
   String _formatAge(DateTime updatedAt) {
@@ -44,35 +33,6 @@ class UserPositionBar extends ConsumerWidget {
     final unknownLabel = l10n?.positionUnknown ?? 'Position unknown';
     final distFromSearchLabel =
         l10n?.distancesFromCenter ?? 'Distances from search center';
-
-    // #2111 — in route mode, replace the position readout with a
-    // route-mode label so the user understands the results are
-    // along a corridor, not nearby a point. The route summary chip
-    // (km · min · station-count) lives separately in the results
-    // header — this bar just sets context.
-    if (routeMode) {
-      return Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        color: theme.colorScheme.tertiaryContainer.withValues(alpha: 0.3),
-        child: Row(
-          children: [
-            Icon(Icons.route,
-                size: 16, color: theme.colorScheme.tertiary),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Text(
-                l10n?.routeModeBannerLabel ??
-                    'Route mode — distances are along the corridor',
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurface,
-                ),
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
 
     if (userPos != null) {
       return Container(

--- a/test/features/search/presentation/widgets/route_results_view_test.dart
+++ b/test/features/search/presentation/widgets/route_results_view_test.dart
@@ -15,7 +15,7 @@ import 'package:tankstellen/features/search/providers/ignored_stations_provider.
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 
-RouteSearchResult _resultWithStations(int count) {
+RouteSearchResult _resultWithStations(int count, {bool isPartial = false}) {
   final stations = <SearchResultItem>[
     for (var i = 0; i < count; i++)
       FuelStationResult(Station(
@@ -40,6 +40,7 @@ RouteSearchResult _resultWithStations(int count) {
       samplePoints: [LatLng(43.48, 3.46)],
     ),
     stations: stations,
+    isPartial: isPartial,
   );
 }
 
@@ -154,6 +155,38 @@ void main() {
       // The header no longer carries the straighten/"Every km" duplicate.
       expect(find.byIcon(Icons.straighten), findsNothing);
       expect(find.textContaining('Every'), findsNothing);
+    });
+
+    testWidgets(
+        '#2630 — a partial result no longer renders the "Searching for more '
+        'stations…" row or its spinner; the summary + All/Best toggle stay',
+        (tester) async {
+      final test = standardTestOverrides();
+
+      await pumpApp(
+        tester,
+        const CustomScrollView(slivers: [RouteResultsView()]),
+        overrides: [
+          ...test.overrides,
+          routeSearchStateProvider.overrideWith(
+            () => _FixedRouteSearch(
+              _resultWithStations(3, isPartial: true),
+            ),
+          ),
+          ignoredStationsProvider.overrideWith(() => _NoIgnoredStations()),
+        ],
+      );
+
+      // The removed partial-results banner and its spinner are gone even
+      // though isPartial is true (the OLD code would have shown both).
+      expect(find.text('Searching for more stations…'), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      // The km · min · station-count summary and the All/Best toggle remain.
+      expect(find.textContaining('306 km'), findsOneWidget);
+      expect(find.textContaining('3 stations'), findsOneWidget);
+      expect(find.text('All stations'), findsOneWidget);
+      expect(find.text('Best stops'), findsOneWidget);
     });
   });
 }

--- a/test/features/search/presentation/widgets/user_position_bar_test.dart
+++ b/test/features/search/presentation/widgets/user_position_bar_test.dart
@@ -130,5 +130,26 @@ void main() {
 
       expect(tapped, isTrue);
     });
+
+    testWidgets(
+        '#2630 — the route-mode banner is gone: the bar always renders the '
+        'GPS readout (no route corridor label, no route icon)', (tester) async {
+      await pumpApp(
+        tester,
+        UserPositionBar(onUpdatePosition: () {}),
+        overrides: [
+          userPositionOverride(lat: 48.8566, lng: 2.3522, source: 'GPS'),
+        ],
+      );
+
+      // The removed route-mode branch used Icons.route + the corridor label.
+      expect(find.byIcon(Icons.route), findsNothing);
+      expect(
+        find.textContaining('distances are along the corridor'),
+        findsNothing,
+      );
+      // The normal GPS readout still renders for every mode.
+      expect(find.byIcon(Icons.my_location), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Summary

The route result header (route mode) stacked three redundant progress indicators. This PR keeps the first chip row + the summary and removes the other two.

**KEEP**
- The chip row (fuel chip + "Searching the route…" chip) — rendered by `SearchSummaryBar._secondChip` while `routeState.isLoading || isPartial`, so it remains the sole sufficient progress indicator.
- The "{km} · {min} · {n} stations" summary and the All/Best toggle.

**REMOVE**
1. The full-width "Route mode — distances are along the corridor" banner (`UserPositionBar` route-mode branch).
2. The "Searching for more stations…" partial-results row (`_PartialResultsBanner` in `route_results_view.dart`).

## Changes

- `user_position_bar.dart` — delete the `routeMode` branch in `build()` plus the now-unused `routeMode` field, ctor param, and dartdoc. The bar falls through to the normal GPS-readout branch in every mode (nearby mode unaffected — it never set `routeMode`).
- `search_screen.dart` — drop the `routeMode:` argument at the `UserPositionBar` call site. `activeSearchModeProvider` stays live (still drives the corridor/`isRoute` logic), so no dead import.
- `route_results_view.dart` — remove the `if (result.isPartial)` banner block from `_buildHeader` and the now-orphaned `_PartialResultsBanner` widget (verified single construction site). The summary `Wrap` becomes the header's first child. File length 365 → 320 (≤400).

## Untouched on purpose

- `RouteSearchResult.isPartial` and the `route_search_provider` logic that sets it — they still feed the chip via `SearchSummaryBar`.
- ARB: zero `lib/l10n/` changes. The two orphaned-by-code keys (`routeModeBannerLabel`, `routeSearchPartialBanner`) are left in place; deleting them would force a 23-locale fan-out for no gain, and the coverage gate only fails on locale-keys-missing-from-English.

## Tests (structural, no goldens)

- `route_results_view_test.dart` — a partial result (`isPartial: true`) now renders neither the "Searching for more stations…" row nor any `CircularProgressIndicator`, while the "306 km" / "3 stations" summary and the All/Best toggle still render.
- `user_position_bar_test.dart` — the bar always renders its GPS readout (`Icons.my_location`) with no route-mode banner (`Icons.route` / "distances are along the corridor" gone).

`flutter analyze` clean on touched files; `flutter test test/features/search test/lint` green (837 tests); a11y text-scaling green. Zero codegen/l10n drift verified via a from-clean `build_runner` rebuild.

Closes #2630

🤖 Generated with [Claude Code](https://claude.com/claude-code)