### PR TITLE
fix(geocoder): dedupe Nominatim admin-level duplicates in city search (#2639)

### DIFF
--- a/lib/core/services/location_search_service.dart
+++ b/lib/core/services/location_search_service.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
+import 'dart:math' as math;
 import 'package:dio/dio.dart';
 import '../cache/cache_manager.dart';
 import '../country/country_config.dart';
@@ -16,11 +17,31 @@ class ResolvedLocation {
   final double lng;
   final String? postcode;
 
+  /// Raw Nominatim discriminator fields, used to deduplicate the multiple
+  /// admin-level entities Nominatim returns for one place (e.g. the
+  /// "Barcelona" city node vs. its province boundary). All nullable so
+  /// non-Nominatim / legacy-cached entries stay valid (#2639).
+  final int? osmId;
+  final double? importance;
+  final int? placeRank;
+  final String? addressType;
+
+  /// Country of the place, captured from the raw entry's `address.country`
+  /// (or the full display_name's last segment) before [name] is truncated to
+  /// three segments — so the dedup country guard never compares a truncated
+  /// label (#2639).
+  final String? country;
+
   const ResolvedLocation({
     required this.name,
     required this.lat,
     required this.lng,
     this.postcode,
+    this.osmId,
+    this.importance,
+    this.placeRank,
+    this.addressType,
+    this.country,
   });
 }
 
@@ -94,25 +115,40 @@ class LocationSearchService {
           'format': 'json',
           'limit': '8',
           'addressdetails': '1',
+          // Nominatim's own dedupe does NOT merge a city node with its
+          // province boundary; the client-side _dedupe is the real fix
+          // (#2639). Kept explicit for clarity.
+          'dedupe': '1',
         },
         cancelToken: cancelToken,
       );
 
       if (response.data is! List) return [];
 
-      final results = (response.data as List).map((r) {
+      final mapped = (response.data as List).map((r) {
         final addr = r['address'] as Map<String, dynamic>? ?? {};
         final name = r['display_name']?.toString() ?? '';
         final short = name.split(',').take(3).join(',').trim();
+        // Capture the country from the FULL display_name before truncation —
+        // the city node's truncated [name] drops it (#2639).
+        final country = addr['country']?.toString() ??
+            (name.contains(',') ? name.split(',').last.trim() : null);
         return ResolvedLocation(
           name: short,
           lat: double.tryParse(r['lat']?.toString() ?? '') ?? 0,
           lng: double.tryParse(r['lon']?.toString() ?? '') ?? 0,
           postcode: addr['postcode']?.toString(),
+          osmId: (r['osm_id'] as num?)?.toInt(),
+          importance: (r['importance'] as num?)?.toDouble(),
+          placeRank: (r['place_rank'] as num?)?.toInt(),
+          addressType: r['addresstype']?.toString(),
+          country: country,
         );
       }).toList();
 
-      // Cache the results
+      final results = _dedupe(mapped);
+
+      // Cache the deduped results so cached reads dedup-stably too.
       await _cache.put(
         cacheKey,
         _serializeLocations(results),
@@ -133,6 +169,11 @@ class LocationSearchService {
                   'lat': l.lat,
                   'lng': l.lng,
                   'postcode': l.postcode,
+                  'osmId': l.osmId,
+                  'importance': l.importance,
+                  'placeRank': l.placeRank,
+                  'addressType': l.addressType,
+                  'country': l.country,
                 })
             .toList(),
       };
@@ -147,7 +188,119 @@ class LocationSearchService {
         lat: (m['lat'] as num?)?.toDouble() ?? 0,
         lng: (m['lng'] as num?)?.toDouble() ?? 0,
         postcode: m['postcode'] as String?,
+        osmId: (m['osmId'] as num?)?.toInt(),
+        importance: (m['importance'] as num?)?.toDouble(),
+        placeRank: (m['placeRank'] as num?)?.toInt(),
+        addressType: m['addressType'] as String?,
+        country: m['country'] as String?,
       );
     }).toList();
   }
+
+  /// Address types that represent an actual settlement a user means when they
+  /// type a place name — these win over administrative/boundary entities.
+  static const _settlementTypes = {'city', 'town', 'village', 'hamlet'};
+
+  /// Radius within which a same-name, same-country entry is treated as a
+  /// duplicate of the kept one. Wide enough to bind a city node to its
+  /// province boundary (Barcelona: ~44 km) yet far below the separation of
+  /// genuinely distinct same-country same-name places (Springfield IL↔MO:
+  /// ~427 km), so those stay separate (#2639).
+  static const _nearDuplicateKm = 50.0;
+
+  /// Collapse the multiple admin-level entities Nominatim returns for one
+  /// place into a single best entry (#2639).
+  ///
+  /// Two grouping rules:
+  /// - **A — same `osmId`**: exact OSM identity, always one place.
+  /// - **B — near-duplicate**: equal normalized first display-name token AND
+  ///   equal country AND coordinates within [_nearDuplicateKm] of the kept
+  ///   entry. This binds a city node to its province boundary (different
+  ///   osmIds — Barcelona's are ~44 km apart, the boundary's representative
+  ///   point sitting well outside the city centroid) while the distance +
+  ///   country guards keep genuinely distinct same-name places apart
+  ///   (Barcelona ES vs VE; same-country "Springfield"s are 100s of km apart).
+  ///
+  /// Within each group the *best* entry is kept (see [_isBetter]): a
+  /// settlement type beats an administrative one, then higher importance,
+  /// then lower placeRank.
+  List<ResolvedLocation> _dedupe(List<ResolvedLocation> locs) {
+    final kept = <ResolvedLocation>[];
+    for (final loc in locs) {
+      final idx = kept.indexWhere((k) => _sameGroup(k, loc));
+      if (idx == -1) {
+        kept.add(loc);
+      } else if (_isBetter(loc, kept[idx])) {
+        kept[idx] = loc;
+      }
+    }
+    return kept;
+  }
+
+  bool _sameGroup(ResolvedLocation a, ResolvedLocation b) {
+    // Group A — exact OSM identity.
+    if (a.osmId != null && b.osmId != null && a.osmId == b.osmId) return true;
+    // Group B — same first token + same country + within _nearDuplicateKm.
+    if (_normToken(a.name) != _normToken(b.name)) return false;
+    if (_country(a) != _country(b)) return false;
+    return _distanceKm(a.lat, a.lng, b.lat, b.lng) <= _nearDuplicateKm;
+  }
+
+  /// True if [a] should be preferred over [b] within a dedup group.
+  bool _isBetter(ResolvedLocation a, ResolvedLocation b) {
+    final aSettle = _settlementTypes.contains(a.addressType);
+    final bSettle = _settlementTypes.contains(b.addressType);
+    if (aSettle != bSettle) return aSettle;
+    final ai = a.importance ?? 0;
+    final bi = b.importance ?? 0;
+    if (ai != bi) return ai > bi;
+    final ar = a.placeRank ?? 1 << 30;
+    final br = b.placeRank ?? 1 << 30;
+    return ar < br;
+  }
+
+  /// First display-name segment, trimmed, lowercased, diacritics + punctuation
+  /// stripped, so "Barcelonès" and "barcelones" compare equal.
+  String _normToken(String name) {
+    final first = name.split(',').first;
+    final lower = first.trim().toLowerCase();
+    final folded = _foldDiacritics(lower);
+    return folded.replaceAll(RegExp(r'[^a-z0-9]'), '');
+  }
+
+  /// Normalized country of the place (#2639). Uses the captured [country]
+  /// field; falls back to the (possibly truncated) name's last segment for
+  /// legacy-cached entries that predate the field.
+  String _country(ResolvedLocation l) {
+    final raw = l.country ?? l.name.split(',').last;
+    return _foldDiacritics(raw.trim().toLowerCase());
+  }
+
+  static const _diacriticsSrc = 'àáâãäåçèéêëìíîïñòóôõöùúûüýÿ';
+  static const _diacriticsDst = 'aaaaaaceeeeiiiinooooouuuuyy';
+
+  String _foldDiacritics(String input) {
+    final buf = StringBuffer();
+    for (final rune in input.runes) {
+      final ch = String.fromCharCode(rune);
+      final i = _diacriticsSrc.indexOf(ch);
+      buf.write(i == -1 ? ch : _diacriticsDst[i]);
+    }
+    return buf.toString();
+  }
+
+  /// Great-circle distance in km (haversine).
+  double _distanceKm(double lat1, double lng1, double lat2, double lng2) {
+    const earthKm = 6371.0;
+    final dLat = _rad(lat2 - lat1);
+    final dLng = _rad(lng2 - lng1);
+    final a = math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(_rad(lat1)) *
+            math.cos(_rad(lat2)) *
+            math.sin(dLng / 2) *
+            math.sin(dLng / 2);
+    return earthKm * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+  }
+
+  double _rad(double deg) => deg * math.pi / 180.0;
 }

--- a/test/core/services/location_search_service_test.dart
+++ b/test/core/services/location_search_service_test.dart
@@ -11,6 +11,31 @@ import 'package:tankstellen/core/services/service_result.dart';
 
 class MockCacheManager extends Mock implements CacheManager {}
 
+class MockDio extends Mock implements Dio {}
+
+/// One raw Nominatim /search entry, as a JSON map.
+Map<String, dynamic> _raw({
+  required int osmId,
+  required String displayName,
+  required double lat,
+  required double lon,
+  String addressType = 'city',
+  double importance = 0.5,
+  int placeRank = 16,
+  String? postcode,
+}) {
+  return {
+    'osm_id': osmId,
+    'display_name': displayName,
+    'lat': lat.toString(),
+    'lon': lon.toString(),
+    'addresstype': addressType,
+    'importance': importance,
+    'place_rank': placeRank,
+    'address': {'postcode': ?postcode},
+  };
+}
+
 void main() {
   late MockCacheManager mockCache;
   late LocationSearchService service;
@@ -234,6 +259,209 @@ void main() {
         lng: 0.0,
       );
       expect(loc.postcode, isNull);
+    });
+  });
+
+  group('searchCities deduplication', () {
+    late MockDio mockDio;
+    late LocationSearchService dioService;
+
+    setUpAll(() {
+      registerFallbackValue(RequestOptions(path: '/search'));
+      registerFallbackValue(Duration.zero);
+      registerFallbackValue(ServiceSource.nominatimGeocoding);
+    });
+
+    setUp(() {
+      mockDio = MockDio();
+      dioService = LocationSearchService(mockCache, dio: mockDio);
+      // Cache always misses; writes are no-ops.
+      when(() => mockCache.getFresh(any())).thenReturn(null);
+      when(
+        () => mockCache.put(
+          any(),
+          any(),
+          ttl: any(named: 'ttl'),
+          source: any(named: 'source'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    void stubResponse(List<Map<String, dynamic>> raw) {
+      when(
+        () => mockDio.get(
+          any(),
+          queryParameters: any(named: 'queryParameters'),
+          cancelToken: any(named: 'cancelToken'),
+        ),
+      ).thenAnswer(
+        (_) async => Response(
+          data: raw,
+          statusCode: 200,
+          requestOptions: RequestOptions(path: '/search'),
+        ),
+      );
+    }
+
+    test('collapses the city node and its province boundary, keeping the city',
+        () async {
+      // Two real Nominatim entries for "Barcelona" — the city node and the
+      // province boundary share the first display-name token + country and
+      // sit ~42 km apart, but carry DIFFERENT osm_ids.
+      stubResponse([
+        _raw(
+          osmId: 347950,
+          displayName: 'Barcelona, Barcelonès, Barcelona, Catalunya, España',
+          lat: 41.3825,
+          lon: 2.1769,
+          addressType: 'city',
+          importance: 0.804,
+          placeRank: 16,
+        ),
+        _raw(
+          osmId: 349035,
+          displayName: 'Barcelona, Catalunya, España',
+          lat: 41.7646,
+          lon: 2.0357,
+          addressType: 'province',
+          importance: 0.642,
+          placeRank: 12,
+        ),
+      ]);
+
+      final results = await dioService.searchCities('Barcelona');
+
+      expect(results, hasLength(1));
+      expect(results.first.osmId, equals(347950));
+      expect(results.first.addressType, equals('city'));
+      expect(results.first.lat, closeTo(41.3825, 0.0001));
+    });
+
+    test('keeps same-name places in different countries distinct', () async {
+      stubResponse([
+        _raw(
+          osmId: 347950,
+          displayName: 'Barcelona, Catalunya, España',
+          lat: 41.3825,
+          lon: 2.1769,
+          addressType: 'city',
+          importance: 0.804,
+        ),
+        _raw(
+          osmId: 555111,
+          displayName: 'Barcelona, Anzoátegui, Venezuela',
+          lat: 10.1340,
+          lon: -64.6760,
+          addressType: 'city',
+          importance: 0.6,
+        ),
+      ]);
+
+      final results = await dioService.searchCities('Barcelona');
+
+      expect(results, hasLength(2));
+    });
+
+    test('keeps far-apart same-country same-name places distinct', () async {
+      // Two distinct "Springfield" cities in the same country, ~427 km
+      // apart (well beyond the ~50 km near-duplicate guard), with different
+      // osm_ids → must NOT be collapsed.
+      stubResponse([
+        _raw(
+          osmId: 100001,
+          displayName: 'Springfield, Illinois, United States',
+          lat: 39.7817,
+          lon: -89.6501,
+          addressType: 'city',
+          importance: 0.6,
+        ),
+        _raw(
+          osmId: 100002,
+          displayName: 'Springfield, Missouri, United States',
+          lat: 37.2090,
+          lon: -93.2923,
+          addressType: 'city',
+          importance: 0.55,
+        ),
+      ]);
+
+      final results = await dioService.searchCities('Springfield');
+
+      expect(results, hasLength(2));
+    });
+
+    test('collapses entries that share the same osm_id', () async {
+      stubResponse([
+        _raw(
+          osmId: 42,
+          displayName: 'Foo, Bar, Country',
+          lat: 10.0,
+          lon: 10.0,
+          addressType: 'town',
+          importance: 0.5,
+        ),
+        _raw(
+          osmId: 42,
+          displayName: 'Foo, Bar, Country',
+          lat: 10.0,
+          lon: 10.0,
+          addressType: 'administrative',
+          importance: 0.4,
+        ),
+      ]);
+
+      final results = await dioService.searchCities('Foo');
+
+      expect(results, hasLength(1));
+      expect(results.first.osmId, equals(42));
+    });
+
+    test('round-trips discriminator fields through the cache serializer',
+        () async {
+      stubResponse([
+        _raw(
+          osmId: 347950,
+          displayName: 'Barcelona, Catalunya, España',
+          lat: 41.3825,
+          lon: 2.1769,
+          addressType: 'city',
+          importance: 0.804,
+          placeRank: 16,
+          postcode: '08001',
+        ),
+      ]);
+
+      Map<String, dynamic>? captured;
+      when(
+        () => mockCache.put(
+          any(),
+          captureAny(),
+          ttl: any(named: 'ttl'),
+          source: any(named: 'source'),
+        ),
+      ).thenAnswer((inv) async {
+        captured = inv.positionalArguments[1] as Map<String, dynamic>;
+      });
+
+      await dioService.searchCities('Barcelona');
+
+      expect(captured, isNotNull);
+      // Re-deserialize via the cache path and confirm fields survive.
+      when(() => mockCache.getFresh(any())).thenReturn(
+        CacheEntry(
+          payload: captured!,
+          storedAt: DateTime.now(),
+          originalSource: ServiceSource.nominatimGeocoding,
+          ttl: CacheTtl.citySearch,
+        ),
+      );
+      final fromCache = await dioService.searchCities('Barcelona');
+      expect(fromCache, hasLength(1));
+      expect(fromCache.first.osmId, equals(347950));
+      expect(fromCache.first.addressType, equals('city'));
+      expect(fromCache.first.importance, closeTo(0.804, 0.0001));
+      expect(fromCache.first.placeRank, equals(16));
+      expect(fromCache.first.country, equals('España'));
     });
   });
 


### PR DESCRIPTION
## What

Route destination autocomplete showed duplicate place suggestions — e.g. **two "Barcelona"** for one search. This dedupes them in the geocoding service.

## Root cause

Nominatim `/search` returns **multiple admin-level entities for one place**. For "Barcelona" it returns:

- `osm_id 347950` — the **city** (addresstype `city`, importance 0.804, `Barcelona, Barcelonès, Barcelona, Catalunya, España`, 41.38/2.18)
- `osm_id 349035` — the **province boundary** (addresstype `province`, importance 0.642, `Barcelona, Catalunya, España`, 41.76/2.03)

The mapping did `display_name.split(',').take(3).join(',')` → two near-identical labels, and returned the raw list with **no dedup**. The two differ in both `osm_id` AND coordinates (~44 km apart), so neither name-equality alone nor coordinate-rounding alone collapses them. Nominatim's own `dedupe` does **not** merge a city node with its province boundary — the client-side pass is the real fix.

## Fix (geocoding service only — disjoint from cross-border route work)

`lib/core/services/location_search_service.dart`:

1. **`ResolvedLocation`** gains discriminator fields `osmId`, `importance`, `placeRank`, `addressType`, `country` (all nullable; legacy-cached entries stay valid). `country` is captured from the **full** `display_name` / `address.country` *before* `name` is truncated, so the country guard never compares a truncated label. All round-trip through the cache serializer so cached reads dedup-stably.
2. **`_dedupe`** runs between mapping and caching (so deduped results are both cached and returned):
   - **Group A** — collapse entries sharing the same `osmId` (exact OSM identity).
   - **Group B** — collapse entries with equal normalized first display-name token (trim + lowercase + strip diacritics/punctuation) AND equal country AND coordinates within **~50 km** of the kept entry. This binds a city node to its province boundary (~44 km for Barcelona) while staying far below distinct same-country same-name places (Springfield IL↔MO ~427 km), which the distance + country guards keep separate.
   - Within a group keep the **best**: settlement (`city`/`town`/`village`/`hamlet`) beats administrative/boundary, then higher `importance`, then lower `placeRank` — so **Barcelona-the-city wins over Barcelona-the-province**.
3. `dedupe=1` added explicitly to the query (clarity; the client-side pass is the real fix).

## Tests (TDD)

`test/core/services/location_search_service_test.dart` — drives `searchCities` through a mocked Dio with raw Nominatim JSON:

- **Collapses** the two real Barcelona entries → length 1, survivor is the city (osm_id 347950 / addresstype city / lat 41.38).
- **Keeps distinct** by country: Barcelona ES vs Barcelona VE → length 2.
- **Keeps distinct** far-apart same-country: Springfield IL vs MO → length 2.
- **Collapses** same-`osm_id` entries → length 1.
- **Round-trips** all discriminator fields through the cache serializer.

## Verification

- `flutter analyze` — clean on touched files (one pre-existing unrelated info in `trip_kind_from_samples_test.dart`, untouched here).
- `flutter test test/core/services test/features/search test/lint` — green (the one failure, `api_connectivity_test` Argentina, is a live-network test that fails identically on clean master).
- Clean `build_runner build` — **zero** `.g.dart`/`.freezed.dart` drift (ResolvedLocation is a plain class).
- **Zero** `lib/l10n/` diff — no ARB.
- `file_length` ≤400: `location_search_service.dart` at 306 lines.

Closes #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
