### PR TITLE
feat(recording): persist GPS heading + accuracy on every sample (#2648)

### DIFF
--- a/lib/features/consumption/data/obd2/degraded_gps_emitter.dart
+++ b/lib/features/consumption/data/obd2/degraded_gps_emitter.dart
@@ -68,6 +68,10 @@ class DegradedGpsEmitter {
     required double? latitude,
     required double? longitude,
     required double? altitudeM,
+    // #2648 — most recent GPS horizontal accuracy + bearing, forwarded
+    // into the GPS-only sample so the degraded path stops dropping them.
+    double? hAccuracyM,
+    double? bearingDeg,
     required DateTime? lastGpsFixAt,
     required DateTime? startedAt,
     required double resolverDistanceKm,
@@ -91,6 +95,10 @@ class DegradedGpsEmitter {
         latitude: latitude,
         longitude: longitude,
         altitudeM: altitudeM,
+        // #2648 — carry accuracy + bearing into the degraded GPS-only
+        // sample so they aren't dropped when OBD2 falls away mid-trip.
+        hAccuracyM: hAccuracyM,
+        bearingDeg: bearingDeg,
       );
       _recorder.onSample(sample);
       _onSampleAt(nowTs);

--- a/lib/features/consumption/data/obd2/gps_only_sample_builder.dart
+++ b/lib/features/consumption/data/obd2/gps_only_sample_builder.dart
@@ -27,6 +27,8 @@ class GpsOnlySampleBuilder {
     double? latitude,
     double? longitude,
     double? altitudeM,
+    double? hAccuracyM,
+    double? bearingDeg,
   }) {
     return TripSample(
       timestamp: timestamp,
@@ -35,6 +37,11 @@ class GpsOnlySampleBuilder {
       latitude: latitude,
       longitude: longitude,
       altitudeM: altitudeM,
+      // #2648 — the degraded GPS-only path used to drop horizontal
+      // accuracy + bearing too; stamp them so a trip that degrades to
+      // GPS-only still feeds the cornering analytic + accuracy-gate.
+      hAccuracyM: hAccuracyM,
+      bearingDeg: bearingDeg,
     );
   }
 

--- a/lib/features/consumption/data/obd2/live_sample_snapshot.dart
+++ b/lib/features/consumption/data/obd2/live_sample_snapshot.dart
@@ -116,6 +116,17 @@ class LiveSampleSnapshot {
   // alongside the lat/lon fix. Feeds the road-grade calculator (#1941).
   double? _latestAltitudeM;
 
+  // #2648 — most recent GPS horizontal accuracy (metres) + bearing
+  // (compass degrees), pushed in alongside the lat/lon fix. The
+  // `Position` already carries both, but the OBD2 / degraded recording
+  // paths used to drop them (only the GPS-only pipeline kept them), so
+  // they reached only 0.3 % of samples. Latched here so every emitted
+  // [TripSample] carries them — reviving the cornering analytic
+  // (bearing) and the harsh-event accuracy-gate (accuracy). Null when
+  // the provider hasn't pushed a fix (matching pre-#2648 behaviour).
+  double? _latestHAccuracyM;
+  double? _latestBearingDeg;
+
   // #1615 — most recent exact-litre OEM-PID fuel reading, pushed in by
   // the provider layer (`TripOemFuelLevelController`) when the
   // `experimentalOemPids` flag is on and an OEM-capable adapter resolved
@@ -133,6 +144,9 @@ class LiveSampleSnapshot {
   double? get latestLatitude => _latestLatitude;
   double? get latestLongitude => _latestLongitude;
   double? get latestAltitudeM => _latestAltitudeM;
+  // #2648 — GPS horizontal accuracy + bearing latches (see field doc).
+  double? get latestHAccuracyM => _latestHAccuracyM;
+  double? get latestBearingDeg => _latestBearingDeg;
   double? get latestOemFuelLevelLitres => _latestOemFuelLevelLitres;
 
   // #2456 / #2458 / #2459 — latest-value getters for the signals the
@@ -161,12 +175,20 @@ class LiveSampleSnapshot {
   double? get latestLtft => _latestLtft;
 
   /// Push the most recent GPS fix into the per-tick snapshot
-  /// (#1374 phase 1; altitude added #1935 child A). Pass `null` for a
-  /// field to clear that latch.
-  void updateGpsFix({double? latitude, double? longitude, double? altitudeM}) {
+  /// (#1374 phase 1; altitude added #1935 child A; horizontal accuracy +
+  /// bearing added #2648). Pass `null` for a field to clear that latch.
+  void updateGpsFix({
+    double? latitude,
+    double? longitude,
+    double? altitudeM,
+    double? hAccuracyM,
+    double? bearingDeg,
+  }) {
     _latestLatitude = latitude;
     _latestLongitude = longitude;
     _latestAltitudeM = altitudeM;
+    _latestHAccuracyM = hAccuracyM;
+    _latestBearingDeg = bearingDeg;
   }
 
   /// Push the most recent exact-litre OEM-PID fuel reading into the

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -608,12 +608,20 @@ class TripRecordingController {
     double? latitude,
     double? longitude,
     double? altitudeM,
+    double? hAccuracyM,
+    double? bearingDeg,
     double? speedKmh,
   }) {
     _liveSampleSnapshot.updateGpsFix(
       latitude: latitude,
       longitude: longitude,
       altitudeM: altitudeM,
+      // #2648 — forward GPS horizontal accuracy + bearing so the next
+      // emit stamps them onto the TripSample. The OBD2 / degraded paths
+      // used to drop these (the `Position` carried them but they were
+      // never threaded through), so they reached only 0.3 % of samples.
+      hAccuracyM: hAccuracyM,
+      bearingDeg: bearingDeg,
     );
     // #2506 — latch the GPS ground-speed for the live speed fallback. A
     // null / non-finite / negative speed (cold GPS warm-up) is ignored so
@@ -705,6 +713,14 @@ class TripRecordingController {
   /// [debugLatestLatitude].
   @visibleForTesting
   double? get debugLatestAltitudeM => _liveSampleSnapshot.latestAltitudeM;
+
+  /// Read-only snapshots of the most recent GPS horizontal accuracy
+  /// (metres) + bearing (compass degrees) pushed in via [updateGpsFix]
+  /// (#2648). Same caveats as [debugLatestLatitude].
+  @visibleForTesting
+  double? get debugLatestHAccuracyM => _liveSampleSnapshot.latestHAccuracyM;
+  @visibleForTesting
+  double? get debugLatestBearingDeg => _liveSampleSnapshot.latestBearingDeg;
 
   /// Start polling. Reads the odometer and VIN ONCE to pin trip
   /// identity; subsequent ticks are scheduled per-PID by
@@ -1188,6 +1204,13 @@ class TripRecordingController {
         latitude: snap.latestLatitude,
         longitude: snap.latestLongitude,
         altitudeM: snap.latestAltitudeM,
+        // #2648 — GPS horizontal accuracy + bearing. Both already
+        // round-trip through the codec ('ha' / 'be') and TripSample has
+        // had the fields; the OBD2 path simply dropped them. Stamping
+        // them here revives the cornering analytic (bearing) and the
+        // harsh-event accuracy-gate. Null when no GPS fix has landed.
+        hAccuracyM: snap.latestHAccuracyM,
+        bearingDeg: snap.latestBearingDeg,
         // #2459 — the consumed-but-previously-unstored signals, stamped
         // from the snapshot latest-value getters exactly like throttle.
         // Each stays null on cars that don't expose the PID, so the
@@ -1338,6 +1361,9 @@ class TripRecordingController {
       latitude: snap.latestLatitude,
       longitude: snap.latestLongitude,
       altitudeM: snap.latestAltitudeM,
+      // #2648 — carry accuracy + bearing through the degraded path too.
+      hAccuracyM: snap.latestHAccuracyM,
+      bearingDeg: snap.latestBearingDeg,
       lastGpsFixAt: _gpsEndedAt,
       startedAt: _startedAt,
       resolverDistanceKm: currentDistanceKm,

--- a/lib/features/consumption/providers/trip_gps_stream_controller.dart
+++ b/lib/features/consumption/providers/trip_gps_stream_controller.dart
@@ -90,7 +90,18 @@ class TripGpsStreamController {
             latitude: pos.latitude,
             longitude: pos.longitude,
             // #1935 child A — altitude feeds the road-grade calculator.
-            altitudeM: pos.altitude,
+            // #2648 (Fix B) — drop a NaN / ±∞ altitude (some OS / mock
+            // fixes report garbage) instead of propagating it into the
+            // grade math, mirroring the GPS-only pipeline's isFinite guard.
+            altitudeM: pos.altitude.isFinite ? pos.altitude : null,
+            // #2648 (Fix A) — forward GPS horizontal accuracy + bearing
+            // (both already on `pos`; `pos.heading` is read ~100 lines
+            // down for the glide-coach, then was discarded). The OBD2
+            // path used to drop them, so they reached only 0.3 % of
+            // samples. isFinite-guarded like the GPS-only pipeline
+            // (gps_only_recording_pipeline.dart) so a NaN never persists.
+            hAccuracyM: pos.accuracy.isFinite ? pos.accuracy : null,
+            bearingDeg: pos.heading.isFinite ? pos.heading : null,
             // #2506 — forward GPS ground-speed (m/s → km/h) so the live
             // read-out has a speed source when the OBD2 speed PID (0x0D) is
             // momentarily absent. The controller latches it as a fallback;

--- a/test/features/consumption/data/obd2/gps_only_sample_builder_accuracy_bearing_test.dart
+++ b/test/features/consumption/data/obd2/gps_only_sample_builder_accuracy_bearing_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/degraded_gps_emitter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/gps_only_sample_builder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_sample_buffer.dart';
+import 'package:tankstellen/features/consumption/data/trip_sample_codec.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #2648 — the DEGRADED GPS-only path (OBD2 dropped mid-trip) used to drop
+/// GPS horizontal accuracy + bearing along with the OBD2 path. The builder
+/// + the [DegradedGpsEmitter] that drives it now carry them onto the
+/// [TripSample] so a degraded trip still feeds the cornering analytic +
+/// accuracy-gate.
+void main() {
+  group('#2648 GpsOnlySampleBuilder.build stamps accuracy + bearing', () {
+    test('forwards hAccuracyM + bearingDeg onto the sample (round-trips '
+        'through the codec)', () {
+      final sample = GpsOnlySampleBuilder.build(
+        timestamp: DateTime(2026, 6, 1, 9),
+        speedKmh: 50,
+        latitude: 43.4,
+        longitude: 3.5,
+        altitudeM: 100,
+        hAccuracyM: 6.3,
+        bearingDeg: 271.0,
+      );
+      expect(sample.hAccuracyM, 6.3);
+      expect(sample.bearingDeg, 271.0);
+      // Persisted form keeps them ('ha' / 'be') and decodes clean.
+      final decoded = sampleFromJson(sampleToJson(sample));
+      expect(decoded.hAccuracyM, 6.3);
+      expect(decoded.bearingDeg, 271.0);
+    });
+
+    test('both null when not supplied stay null (legacy-compatible)', () {
+      final sample = GpsOnlySampleBuilder.build(
+        timestamp: DateTime(2026, 6, 1, 9),
+        speedKmh: 50,
+        latitude: 43.4,
+        longitude: 3.5,
+      );
+      expect(sample.hAccuracyM, isNull);
+      expect(sample.bearingDeg, isNull);
+    });
+  });
+
+  group('#2648 DegradedGpsEmitter threads accuracy + bearing to the sample',
+      () {
+    test('the GPS-only sample fed to the buffer carries accuracy + bearing',
+        () {
+      final buffer = TripSampleBuffer();
+      final recorder = TripRecorder();
+      final now = DateTime(2026, 6, 1, 10);
+      final emitter = DegradedGpsEmitter(
+        now: () => now,
+        recorder: recorder,
+        sampleBuffer: buffer,
+        gpsAliveWindow: const Duration(seconds: 5),
+        onEscalate: () {},
+        onSampleAt: (_) {},
+        overlayEstimate: (reading,
+                {required nowTs,
+                required effectiveSpeedKmh,
+                required altitudeM}) =>
+            reading,
+      );
+
+      final reading = emitter.emitTick(
+        latestGpsSpeedKmh: 50,
+        latitude: 43.4,
+        longitude: 3.5,
+        altitudeM: 100,
+        hAccuracyM: 7.7,
+        bearingDeg: 12.5,
+        lastGpsFixAt: now, // within the alive window
+        startedAt: now.subtract(const Duration(minutes: 1)),
+        resolverDistanceKm: 1,
+        odometerStartKm: null,
+        odometerLatestKm: null,
+      );
+
+      expect(reading, isNotNull);
+      expect(buffer.capturedSamples, isNotEmpty);
+      expect(buffer.capturedSamples.last.hAccuracyM, 7.7);
+      expect(buffer.capturedSamples.last.bearingDeg, 12.5);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/live_sample_snapshot_gps_fields_test.dart
+++ b/test/features/consumption/data/obd2/live_sample_snapshot_gps_fields_test.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/live_sample_snapshot.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// #2648 — `LiveSampleSnapshot.updateGpsFix` now latches GPS horizontal
+/// accuracy + bearing alongside lat/lon/altitude, so the OBD2 emit path
+/// stops dropping them (they used to reach only 0.3 % of samples — only
+/// the GPS-only pipeline kept them). These pin the latch + the null-guard.
+class _StubTransport implements Obd2Transport {
+  @override
+  bool get isConnected => true;
+  @override
+  Future<void> connect() async {}
+  @override
+  Future<void> disconnect() async {}
+  @override
+  Future<String> sendCommand(String command) async => 'NO DATA';
+}
+
+LiveSampleSnapshot _snapshot() => LiveSampleSnapshot(
+      service: Obd2Service(_StubTransport()),
+      onHighPriorityParse: (_) {},
+      onSpeedSample: (_) {},
+    );
+
+void main() {
+  group('#2648 LiveSampleSnapshot GPS accuracy + bearing latch', () {
+    test('updateGpsFix latches hAccuracyM + bearingDeg onto the getters', () {
+      final snap = _snapshot();
+      snap.updateGpsFix(
+        latitude: 43.4,
+        longitude: 3.5,
+        altitudeM: 100,
+        hAccuracyM: 4.2,
+        bearingDeg: 217.5,
+      );
+      expect(snap.latestHAccuracyM, 4.2);
+      expect(snap.latestBearingDeg, 217.5);
+      // The pre-existing latches are unchanged by the new params.
+      expect(snap.latestLatitude, 43.4);
+      expect(snap.latestLongitude, 3.5);
+      expect(snap.latestAltitudeM, 100);
+    });
+
+    test('both default null when not supplied (pre-#2648 behaviour)', () {
+      final snap = _snapshot();
+      snap.updateGpsFix(latitude: 43.4, longitude: 3.5);
+      expect(snap.latestHAccuracyM, isNull);
+      expect(snap.latestBearingDeg, isNull);
+    });
+
+    test('a subsequent null-field call clears the latch', () {
+      final snap = _snapshot();
+      snap.updateGpsFix(hAccuracyM: 5, bearingDeg: 90);
+      expect(snap.latestHAccuracyM, 5);
+      expect(snap.latestBearingDeg, 90);
+      // Provider pushes a fix with no accuracy/bearing → latch clears,
+      // same null-guard contract as altitude.
+      snap.updateGpsFix(latitude: 1, longitude: 2);
+      expect(snap.latestHAccuracyM, isNull);
+      expect(snap.latestBearingDeg, isNull);
+    });
+  });
+}

--- a/test/features/consumption/data/obd2/trip_recording_controller_gps_accuracy_bearing_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_gps_accuracy_bearing_test.dart
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/pid_scheduler.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+import 'package:tankstellen/features/consumption/data/trip_sample_codec.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2648 — the OBD2 emit path stamps the GPS horizontal accuracy + bearing
+/// latched via [TripRecordingController.updateGpsFix] onto every
+/// [TripSample] (they used to reach only 0.3 % of samples — the OBD2 path
+/// dropped `pos.accuracy` / `pos.heading`). This pins the controller `_emit`
+/// build + the codec round-trip, so a persisted OBD2 trip carries them.
+class _MutableClock {
+  _MutableClock(this._now);
+  DateTime _now;
+  DateTime call() => _now;
+  void advance(Duration d) => _now = _now.add(d);
+}
+
+/// ELM327 handshake + RPM/speed so an emit builds a real sample.
+Map<String, String> _basicResponses() => const {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '010C': '41 0C 0E A6>', // RPM ~937.5
+      '010D': '41 0D 32>', // 50 km/h
+      '01A6': 'NO DATA>',
+      '0902': 'NO DATA>',
+    };
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('#2648 OBD2 _emit stamps GPS accuracy + bearing onto the sample', () {
+    test(
+        'a sample built after updateGpsFix(hAccuracyM, bearingDeg) carries '
+        'them, and they round-trip through the codec', () async {
+      final clock = _MutableClock(DateTime(2026, 6, 1, 9));
+      final transport = FakeObd2Transport(_basicResponses());
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        now: clock.call,
+        pollInterval: const Duration(minutes: 1), // no auto-tick
+        scheduler: PidScheduler(
+          transport: service.sendCommand,
+          tickRate: const Duration(milliseconds: 20),
+        ),
+      );
+      await ctl.start();
+      // Let the scheduler fill the snapshot with RPM + speed.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      ctl.updateGpsFix(
+        latitude: 43.40,
+        longitude: 3.50,
+        altitudeM: 100,
+        hAccuracyM: 3.8,
+        bearingDeg: 154.0,
+        speedKmh: 50,
+      );
+      clock.advance(const Duration(seconds: 1));
+      ctl.debugEmitNow();
+
+      final samples = ctl.capturedSamples;
+      expect(samples, isNotEmpty,
+          reason: 'an emit with speed/rpm must capture a sample');
+      final sample = samples.last;
+      expect(sample.hAccuracyM, closeTo(3.8, 1e-9),
+          reason: 'the OBD2 path must stamp the latched GPS accuracy '
+              '(enables the harsh-event accuracy-gate)');
+      expect(sample.bearingDeg, closeTo(154.0, 1e-9),
+          reason: 'the OBD2 path must stamp the latched GPS bearing '
+              '(revives the cornering analytic)');
+
+      // Persisted form keeps them ('ha' / 'be') and decodes clean.
+      final decoded = sampleFromJson(sampleToJson(sample));
+      expect(decoded.hAccuracyM, closeTo(3.8, 1e-9));
+      expect(decoded.bearingDeg, closeTo(154.0, 1e-9));
+
+      await ctl.stop();
+    });
+
+    test(
+        'a trip with no GPS fix carries null accuracy + bearing '
+        '(pre-#2648 behaviour, byte-for-byte for non-GPS trips)', () async {
+      final clock = _MutableClock(DateTime(2026, 6, 1, 10));
+      final transport = FakeObd2Transport(_basicResponses());
+      final service = Obd2Service(transport);
+      await service.connect();
+
+      final ctl = TripRecordingController(
+        service: service,
+        now: clock.call,
+        pollInterval: const Duration(minutes: 1),
+        scheduler: PidScheduler(
+          transport: service.sendCommand,
+          tickRate: const Duration(milliseconds: 20),
+        ),
+      );
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      clock.advance(const Duration(seconds: 1));
+      ctl.debugEmitNow();
+
+      final sample = ctl.capturedSamples.last;
+      expect(sample.hAccuracyM, isNull);
+      expect(sample.bearingDeg, isNull);
+
+      await ctl.stop();
+    });
+  });
+}

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -229,6 +229,99 @@ void main() {
       await notifier.stop();
     });
   });
+
+  group('#2648 OBD2 path forwards GPS accuracy + bearing (no longer dropped)',
+      () {
+    test(
+        'flag ON — each fix\'s accuracy (pos.accuracy) + bearing '
+        '(pos.heading) reach the controller latch, not just lat/lon/alt',
+        () async {
+      final fakeGeo = _RecordingGeolocator();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gpsTripPath);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      await Future<void>.delayed(Duration.zero);
+
+      // A real fix carrying a finite accuracy + heading. Before #2648 the
+      // OBD2 stream path threaded only lat/lon/alt + speed and dropped
+      // these two on the floor (heading was even read again ~100 lines
+      // later for the glide-coach, then discarded).
+      fakeGeo.emit(_pos(43.40, 3.50,
+          altitude: 100, accuracy: 4.5, heading: 231.0));
+      await Future<void>.delayed(Duration.zero);
+
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull);
+      expect(ctl!.debugLatestHAccuracyM, closeTo(4.5, 1e-9),
+          reason: 'pos.accuracy must reach the latch (revives the '
+              'harsh-event accuracy-gate)');
+      expect(ctl.debugLatestBearingDeg, closeTo(231.0, 1e-9),
+          reason: 'pos.heading must reach the latch (revives the '
+              'cornering analytic)');
+
+      await notifier.stop();
+    });
+
+    test(
+        'flag ON — a NaN altitude / accuracy / heading is dropped to null '
+        'by the isFinite guards (Fix B), not propagated', () async {
+      final fakeGeo = _RecordingGeolocator();
+      final container = ProviderContainer(overrides: [
+        geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+      ]);
+      addTearDown(container.dispose);
+      addTearDown(fakeGeo.dispose);
+
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.obd2TripRecording);
+      await container
+          .read(featureFlagsProvider.notifier)
+          .enable(Feature.gpsTripPath);
+
+      final service = Obd2Service(FakeObd2Transport(_elmOk()));
+      await service.connect();
+
+      final notifier = container.read(tripRecordingProvider.notifier);
+      await notifier.start(service);
+      await Future<void>.delayed(Duration.zero);
+
+      // Some OS / mock fixes report a garbage (NaN) altitude / accuracy /
+      // heading. The isFinite guards must drop them to null rather than
+      // poison the grade math or the accuracy-gate.
+      fakeGeo.emit(_pos(43.40, 3.50,
+          altitude: double.nan,
+          accuracy: double.nan,
+          heading: double.nan));
+      await Future<void>.delayed(Duration.zero);
+
+      final ctl = notifier.debugController;
+      expect(ctl, isNotNull);
+      expect(ctl!.debugLatestAltitudeM, isNull,
+          reason: 'a NaN altitude must be guarded to null (Fix B)');
+      expect(ctl.debugLatestHAccuracyM, isNull,
+          reason: 'a NaN accuracy must be guarded to null');
+      expect(ctl.debugLatestBearingDeg, isNull,
+          reason: 'a NaN heading must be guarded to null');
+
+      await notifier.stop();
+    });
+  });
 }
 
 Map<String, String> _elmOk() => const {
@@ -240,14 +333,21 @@ Map<String, String> _elmOk() => const {
       '01A6': '41 A6 00 01 6A 2C>',
     };
 
-Position _pos(double lat, double lng, {double altitude = 0}) => Position(
+Position _pos(
+  double lat,
+  double lng, {
+  double altitude = 0,
+  double accuracy = 5,
+  double heading = 0,
+}) =>
+    Position(
       latitude: lat,
       longitude: lng,
       timestamp: DateTime.now(),
-      accuracy: 5,
+      accuracy: accuracy,
       altitude: altitude,
       altitudeAccuracy: 0,
-      heading: 0,
+      heading: heading,
       headingAccuracy: 0,
       speed: 0,
       speedAccuracy: 0,

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -97,7 +97,12 @@ void main() {
     // persists onto each TripSample (#2459), + the bank-2 fold into
     // `_applyTrim`. Each is a one-line `_sub` call carrying its own gate.
     // Decomposition is tracked separately by #2187/#2188.
-    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 652,
+    // #2648 — re-grandfathered 652 → 673: GPS horizontal accuracy +
+    // bearing latches (2 fields + 2 getters + 2 updateGpsFix params, all
+    // null-guarded like altitude) so the OBD2 emit path stops dropping
+    // them (they reached only 0.3 % of samples). Net +21; decomposition
+    // is still tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/live_sample_snapshot.dart': 673,
     // #2379 — re-grandfathered 1457 → 1468: threaded the
     // `logFailureAsError` flag through `connect()` (param + doc + the
     // guarded `if` around the now-conditional connect-failed trace) so a
@@ -180,7 +185,14 @@ void main() {
     // plumbing + the host/state-machine seam that must live on the
     // controller. Decomposition of this god-class stays tracked by
     // #2187/#2188/#2190.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1595,
+    // #2648 — re-grandfathered 1595 → 1621: GPS horizontal accuracy +
+    // bearing now thread through the controller's `updateGpsFix` (2
+    // params + doc) → `_liveSampleSnapshot.updateGpsFix`, are stamped in
+    // `_emit` + the degraded-emit call site, and exposed via two
+    // `@visibleForTesting` debug getters. Net +26; the field plumbing
+    // must live on the controller seam. Decomposition stays tracked by
+    // #2187/#2188/#2190.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1621,
     // #2442 — re-grandfathered 496 → 513: the save flow now raises the
     // guided reconciliation workflow after a plein save (a 7-line
     // await-then-route call into the extracted


### PR DESCRIPTION
## Why

`HAccuracyM` + `BearingDeg` were persisted on only **~0.3%** of samples. The codec already round-trips them (`trip_sample_codec.dart` `ha`/`be`) and `TripSample` already has the fields — but the OBD2 + degraded recording paths **dropped** `pos.accuracy`/`pos.heading` because `LiveSampleSnapshot.updateGpsFix` had no field for them. Only the GPS-only pipeline kept them, which is why only GPS-only trips had them. `pos.heading` was even read ~100 lines later on the same callback for the glide-coach, then discarded.

Reviving persisted **bearing** unblocks the cornering analytic (`cornerLoadIntegral` was hard-zeroed); persisted **accuracy** enables the harsh-event accuracy-gate.

## Fix A — stop dropping them (no model/codec change)

- **`live_sample_snapshot.dart`** — add `_latestHAccuracyM`/`_latestBearingDeg` latches + getters; extend `updateGpsFix` with both (null-guarded like altitude).
- **`trip_recording_controller.dart`** — thread the two params through its `updateGpsFix` → snapshot; stamp them in `_emit` and the degraded-emit call site; expose two `@visibleForTesting` debug getters.
- **`trip_gps_stream_controller.dart`** — pass `hAccuracyM: pos.accuracy`, `bearingDeg: pos.heading` with `isFinite` guards (mirroring `gps_only_recording_pipeline.dart:156-158`).
- **`gps_only_sample_builder.dart` + `degraded_gps_emitter.dart`** — thread both so the degraded GPS-only path also stops dropping them.

## Fix B

Add an `isFinite` guard to the existing `altitudeM: pos.altitude` so a NaN/garbage altitude no longer propagates into the grade math.

## Tests (TDD)

- Snapshot-latch unit test (latch returns values; null-guarded).
- Builder + degraded-emitter test (degraded path carries them; round-trips through the codec).
- Controller `_emit` test (OBD2 path stamps them onto the built `TripSample`; codec round-trip; non-GPS trips stay null).
- OBD2 stream-forwarding test (`pos.accuracy`/`pos.heading` reach the latch) + a NaN-guard test (altitude/accuracy/heading all guarded to null).

`file_length` snapshots bumped for the two grandfathered files (`live_sample_snapshot` 652→673, `trip_recording_controller` 1595→1621) with inline justifications.

## State

- `flutter analyze` clean (one pre-existing unrelated `info` in an untouched test).
- `flutter test test/features/consumption test/lint` green.
- Zero codegen drift (TripSample fields already existed) — verified via a full Flutter-aware clean rebuild. No `lib/l10n/` diff. No ARB.

Closes #2648 (Epic #2647 — P0 foundation, Fix A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
