### PR TITLE
fix(radar): unify GPS-only recorder + ApproachDetector on a shared position stream (#2646)

### DIFF
--- a/lib/core/location/geolocator_wrapper.dart
+++ b/lib/core/location/geolocator_wrapper.dart
@@ -1,8 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../features/consumption/data/obd2/event_channel_cancel.dart';
 
 part 'geolocator_wrapper.g.dart';
 
@@ -94,12 +98,151 @@ class GeolocatorWrapper {
 
   /// Returns a stream of position updates for continuous location tracking.
   ///
-  /// Used by movement detection in driving mode.
+  /// Used by movement detection in driving mode. This is the bare
+  /// per-call stream: every listener opens its OWN underlying
+  /// `Geolocator.getPositionStream()` subscription. Non-trip callers
+  /// (movement detection) want exactly that — they never run concurrently
+  /// with a trip-recording consumer. Trip consumers must use
+  /// [sharedPositionStream] instead (#2646).
   Stream<Position> getPositionStream({
     LocationSettings? locationSettings,
   }) {
     return Geolocator.getPositionStream(
       locationSettings: _withForcedLocationManager(locationSettings),
     );
+  }
+
+  /// #2646 — a single, refcounted, broadcast position source shared by all
+  /// *trip* consumers (the GPS-only recorder and the live [ApproachDetector]).
+  ///
+  /// ## Why this exists
+  ///
+  /// `Geolocator.getPositionStream()` is backed by a single platform
+  /// EventChannel (`flutter.baseflow.com/geolocator_updates_android`, see
+  /// movement_detection_provider.dart). Two independent listeners contend on
+  /// that one channel's onListen / onCancel lifecycle, and in GPS-only
+  /// recording the recorder + the detector each opened a fresh
+  /// [getPositionStream] in the SAME frame — the recorder won the channel and
+  /// the detector was starved of fixes, so it never left `ApproachIdle`, the
+  /// radar candidate list stayed empty, and swipe was a no-op.
+  ///
+  /// Routing both trip consumers through ONE underlying subscription,
+  /// multiplexed via a broadcast controller, removes the race: every
+  /// listener receives every fix the others receive.
+  ///
+  /// ## Lifecycle (refcounted)
+  ///
+  /// The underlying platform subscription opens lazily on the FIRST listener
+  /// and is cancelled on the LAST — so the app only requests fixes while at
+  /// least one trip consumer is active, preserving the battery cost-bound the
+  /// per-consumer path had. The latest fix is replayed to late joiners so a
+  /// detector that subscribes a frame after the recorder still leaves
+  /// `ApproachIdle` on the most recent fix instead of waiting for the next.
+  ///
+  /// [locationSettings] is read only the first time the underlying stream is
+  /// opened (all trip consumers request `LocationAccuracy.high`); subsequent
+  /// listeners join the existing stream regardless of the settings they pass.
+  Stream<Position> sharedPositionStream({
+    LocationSettings? locationSettings,
+  }) {
+    final source = _shared ??= _SharedPositionSource(
+      // Route through [getPositionStream] (not Geolocator directly) so the
+      // single override seam tests already use stays intact and the
+      // forceLocationManager wrapping (#2574) is applied in exactly one place.
+      open: () => getPositionStream(locationSettings: locationSettings),
+    );
+    return source.subscribe();
+  }
+
+  _SharedPositionSource? _shared;
+}
+
+/// Refcounted broadcast multiplexer over a single underlying position
+/// stream (#2646). Owns the one platform subscription: opens it on the first
+/// listener, cancels it on the last, and replays the latest fix to late
+/// joiners. Constructed lazily by [GeolocatorWrapper.sharedPositionStream].
+class _SharedPositionSource {
+  _SharedPositionSource({required Stream<Position> Function() open})
+      : _open = open;
+
+  final Stream<Position> Function() _open;
+  // The shared bus lives for the wrapper's (keepAlive, app-lifetime)
+  // lifetime — it is reused across trips so the underlying platform
+  // subscription can re-open on the next first-listener without rebuilding
+  // the multiplexer. The underlying subscription it forwards IS torn down on
+  // the last listener (refcount → 0); the controller itself never needs
+  // closing.
+  // ignore: close_sinks
+  final StreamController<Position> _out = StreamController<Position>.broadcast();
+  // The single underlying platform subscription. Cancelled in [_release]
+  // when the last consumer leaves (refcount → 0).
+  // ignore: cancel_subscriptions
+  StreamSubscription<Position>? _upstream;
+  Position? _last;
+  int _refCount = 0;
+
+  /// Hand a consumer a stream that seeds the latest fix (if any) then
+  /// forwards every subsequent fix from the shared broadcast. Opening the
+  /// underlying subscription on the first consumer and cancelling on the last
+  /// is driven off the refcount kept here rather than the broadcast
+  /// controller's own onListen / onCancel, so the seeded late-join replay
+  /// does not perturb the refcount.
+  Stream<Position> subscribe() {
+    // Per-consumer controller. Closed in its own `onCancel` once the
+    // consumer detaches, so there is no leak.
+    // ignore: close_sinks
+    late final StreamController<Position> ctl;
+    StreamSubscription<Position>? relay;
+    ctl = StreamController<Position>(
+      onListen: () {
+        _retain();
+        // Replay the most recent fix so a late joiner (e.g. the detector
+        // subscribing a frame after the recorder) acts on it immediately.
+        final last = _last;
+        if (last != null && !ctl.isClosed) ctl.add(last);
+        relay = _out.stream.listen(
+          (p) {
+            if (!ctl.isClosed) ctl.add(p);
+          },
+          onError: (Object e, StackTrace st) {
+            if (!ctl.isClosed) ctl.addError(e, st);
+          },
+        );
+      },
+      onCancel: () async {
+        await relay?.cancel();
+        relay = null;
+        await _release();
+        if (!ctl.isClosed) await ctl.close();
+      },
+    );
+    return ctl.stream;
+  }
+
+  void _retain() {
+    _refCount++;
+    if (_refCount == 1) {
+      // Cancelled in [_release] when the refcount falls back to 0.
+      _upstream = _open().listen(
+        (p) {
+          _last = p;
+          if (!_out.isClosed) _out.add(p);
+        },
+        onError: (Object e, StackTrace st) {
+          if (!_out.isClosed) _out.addError(e, st);
+        },
+      );
+    }
+  }
+
+  Future<void> _release() async {
+    if (_refCount == 0) return;
+    _refCount--;
+    if (_refCount == 0) {
+      final up = _upstream;
+      _upstream = null;
+      _last = null;
+      await up?.safeCancel();
+    }
   }
 }

--- a/lib/features/approach/providers/approach_state_provider.dart
+++ b/lib/features/approach/providers/approach_state_provider.dart
@@ -69,7 +69,14 @@ Stream<ApproachState> approachState(Ref ref) {
   );
 
   final detector = ApproachDetector(
-    gpsStream: geo.getPositionStream(
+    // #2646 — consume the SHARED, refcounted broadcast position source so the
+    // detector receives the SAME fixes as the GPS-only recorder. Before this,
+    // both opened their own `getPositionStream`; geolocator's single platform
+    // EventChannel let the recorder starve the detector in GPS-only mode, so
+    // it never left ApproachIdle and the radar / swipe stayed dead. The
+    // detector already treats its input as a hot/late-join stream — the shared
+    // source replays the latest fix to late joiners, so no detector change.
+    gpsStream: geo.sharedPositionStream(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.high,
       ),

--- a/lib/features/approach/providers/approach_state_provider.g.dart
+++ b/lib/features/approach/providers/approach_state_provider.g.dart
@@ -116,4 +116,4 @@ final class ApproachStateProvider
   }
 }
 
-String _$approachStateHash() => r'65cc7b55def7d6213d818cd779520c3f0bd09ad6';
+String _$approachStateHash() => r'f52e878832ee20a86c94a924541ab83226f1d55b';

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -113,9 +113,17 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // precision. Permission failure is non-fatal: the stream errors
     // and we log; the user sees an unmoving recording until they
     // grant permission or stop.
+    // #2646 — subscribe to the SHARED, refcounted broadcast position source
+    // rather than a fresh per-call `getPositionStream`. The live
+    // ApproachDetector subscribes to the same source the instant the trip
+    // flips active (approach_state_provider.dart); two independent
+    // `getPositionStream` listeners contend on geolocator's single platform
+    // EventChannel and starve one of them, which broke the fuel-station radar
+    // + swipe in GPS-only recording. One underlying subscription, multiplexed,
+    // feeds every fix to both consumers.
     final geo = _ref.read(geolocatorWrapperProvider);
     _sub = geo
-        .getPositionStream(
+        .sharedPositionStream(
           locationSettings: const LocationSettings(
             accuracy: LocationAccuracy.high,
           ),

--- a/test/core/location/shared_position_stream_test.dart
+++ b/test/core/location/shared_position_stream_test.dart
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
+
+/// Unit guards for the #2646 shared, refcounted broadcast position source.
+///
+/// The defect: `GpsOnlyRecordingPipeline` and the live `ApproachDetector`
+/// each opened their OWN `Geolocator.getPositionStream()` in the same frame.
+/// That single platform EventChannel can only feed one listener, so the
+/// recorder starved the detector — it never left `ApproachIdle`, the radar
+/// candidate list stayed empty, and swipe was a no-op.
+///
+/// The fix routes every *trip* consumer through one underlying subscription,
+/// multiplexed via a broadcast controller, so they all receive every fix.
+/// These tests pin:
+///   - two consumers on the shared source both receive the same Position
+///     (the race regression guard);
+///   - the underlying platform subscription opens on the first listener and
+///     closes on the last (battery cost-bound preserved);
+///   - the latest fix is replayed to a late joiner;
+///   - the per-call `getPositionStream` (movement detection) is UNCHANGED —
+///     each call still opens its own independent subscription.
+Position _pos(double lat, double lng, {double speed = 10}) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime(2026, 6, 1, 9),
+      accuracy: 5,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: speed,
+      speedAccuracy: 0,
+    );
+
+/// Fake wrapper that counts how many distinct underlying [getPositionStream]
+/// subscriptions are opened, and lets the test push fixes into the most
+/// recently opened one. Each `getPositionStream` call returns an independent
+/// single-subscription controller — exactly the single-channel model the
+/// production EventChannel exposes (a second concurrent listener does NOT
+/// share the first's fixes).
+class _CountingGeolocator extends GeolocatorWrapper {
+  int openCount = 0;
+  int liveSubscriptions = 0;
+  final List<StreamController<Position>> _controllers = [];
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
+    openCount++;
+    late final StreamController<Position> ctl;
+    ctl = StreamController<Position>(
+      onListen: () => liveSubscriptions++,
+      onCancel: () {
+        liveSubscriptions--;
+        _controllers.remove(ctl);
+      },
+    );
+    _controllers.add(ctl);
+    return ctl.stream;
+  }
+
+  /// Push a fix into every currently-open underlying controller.
+  void emit(Position p) {
+    for (final c in List.of(_controllers)) {
+      if (!c.isClosed) c.add(p);
+    }
+  }
+
+  Future<void> dispose() async {
+    for (final c in List.of(_controllers)) {
+      if (!c.isClosed) await c.close();
+    }
+  }
+}
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('GeolocatorWrapper.sharedPositionStream (#2646)', () {
+    late _CountingGeolocator geo;
+
+    setUp(() => geo = _CountingGeolocator());
+    tearDown(() => geo.dispose());
+
+    test(
+        'two consumers both receive the SAME fix over ONE underlying '
+        'subscription (the race regression guard)', () async {
+      const settings = LocationSettings(accuracy: LocationAccuracy.high);
+
+      final a = <Position>[];
+      final b = <Position>[];
+      // Model the production seam: the recorder subscribes, then the
+      // detector subscribes a frame later — both off the shared source.
+      final subA = geo.sharedPositionStream(locationSettings: settings).listen(
+            a.add,
+          );
+      await _pump();
+      final subB = geo.sharedPositionStream(locationSettings: settings).listen(
+            b.add,
+          );
+      await _pump();
+
+      // Exactly ONE underlying platform subscription backs both consumers.
+      expect(geo.openCount, 1,
+          reason: 'both trip consumers must multiplex onto ONE channel');
+      expect(geo.liveSubscriptions, 1);
+
+      geo.emit(_pos(52.5, 13.4));
+      await _pump();
+
+      // BOTH consumers see the fix. On the pre-#2646 two-raw-streams design
+      // the second consumer would be starved here.
+      expect(a, hasLength(1), reason: 'recorder receives the fix');
+      expect(b, hasLength(1),
+          reason: 'detector must receive the SAME fix, not be starved');
+      expect(a.single.latitude, 52.5);
+      expect(b.single.latitude, 52.5);
+
+      await subA.cancel();
+      await subB.cancel();
+    });
+
+    test('underlying subscription opens on first listener, closes on last',
+        () async {
+      final s = geo.sharedPositionStream();
+      // Lazy: no platform subscription until someone listens.
+      expect(geo.openCount, 0);
+      expect(geo.liveSubscriptions, 0);
+
+      final sub1 = s.listen((_) {});
+      await _pump();
+      expect(geo.openCount, 1, reason: 'first listener opens the channel');
+      expect(geo.liveSubscriptions, 1);
+
+      final sub2 = geo.sharedPositionStream().listen((_) {});
+      await _pump();
+      expect(geo.openCount, 1, reason: 'second listener reuses the channel');
+      expect(geo.liveSubscriptions, 1);
+
+      await sub1.cancel();
+      await _pump();
+      expect(geo.liveSubscriptions, 1,
+          reason: 'one consumer left — channel stays open');
+
+      await sub2.cancel();
+      await _pump();
+      expect(geo.liveSubscriptions, 0,
+          reason: 'last listener gone → underlying subscription cancelled '
+              '(battery cost-bound preserved between trips)');
+    });
+
+    test('a late joiner is replayed the most recent fix', () async {
+      final first = <Position>[];
+      final sub1 =
+          geo.sharedPositionStream().listen(first.add);
+      await _pump();
+
+      geo.emit(_pos(48.1, 11.6, speed: 20));
+      await _pump();
+      expect(first, hasLength(1));
+
+      // A consumer that joins AFTER the first fix must still receive it so
+      // the detector leaves ApproachIdle immediately rather than waiting for
+      // the next sample.
+      final late = <Position>[];
+      final sub2 = geo.sharedPositionStream().listen(late.add);
+      await _pump();
+
+      expect(late, hasLength(1),
+          reason: 'late joiner must be seeded the latest fix');
+      expect(late.single.latitude, 48.1);
+
+      await sub1.cancel();
+      await sub2.cancel();
+    });
+
+    test(
+        'the channel re-opens for a new trip after the last consumer left '
+        '(no stale closed bus)', () async {
+      final sub1 = geo.sharedPositionStream().listen((_) {});
+      await _pump();
+      await sub1.cancel();
+      await _pump();
+      expect(geo.liveSubscriptions, 0);
+
+      // A second trip later: a fresh consumer must re-open the underlying
+      // subscription off the SAME multiplexer (the broadcast bus is reused).
+      final got = <Position>[];
+      final sub2 = geo.sharedPositionStream().listen(got.add);
+      await _pump();
+      expect(geo.openCount, 2, reason: 'a new trip re-opens the channel');
+      geo.emit(_pos(50.9, 6.9));
+      await _pump();
+      expect(got, hasLength(1));
+
+      await sub2.cancel();
+    });
+
+    test(
+        'the per-call getPositionStream (movement detection) is UNCHANGED — '
+        'each call opens its OWN independent subscription', () async {
+      // Non-trip callers must keep the bare per-call behaviour: two listeners
+      // = two underlying subscriptions, not a shared one.
+      final sub1 = geo.getPositionStream().listen((_) {});
+      final sub2 = geo.getPositionStream().listen((_) {});
+      await _pump();
+
+      expect(geo.openCount, 2,
+          reason: 'per-call stream must NOT be multiplexed — movement '
+              'detection keeps its own subscription');
+      expect(geo.liveSubscriptions, 2);
+
+      await sub1.cancel();
+      await sub2.cancel();
+    });
+  });
+}

--- a/test/features/approach/providers/gps_only_radar_race_test.dart
+++ b/test/features/approach/providers/gps_only_radar_race_test.dart
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
+import 'package:tankstellen/core/services/approach_detector.dart';
+import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
+import 'package:tankstellen/core/services/radar/jit_price_cache.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/approach/providers/approach_state_provider.dart';
+import 'package:tankstellen/features/approach/providers/effective_approach_state_provider.dart';
+import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
+import 'package:tankstellen/features/approach/providers/radar_candidate_list_provider.dart';
+import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/gps_only_recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/approach_overlay_enabled_provider.dart';
+import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #2646 integration regression — the fuel-station radar + swipe must work in
+/// GPS-only recording, not just OBD2.
+///
+/// ## What broke
+///
+/// In GPS-only recording two consumers subscribe to GPS in the same frame:
+/// the [GpsOnlyRecordingPipeline] (synchronous, unconditional) and the live
+/// [ApproachDetector] (the moment `tripState.isActive` flips true). Each
+/// opened its OWN `getPositionStream`; geolocator's single platform
+/// EventChannel feeds only one listener, so the recorder starved the detector.
+/// The detector never left `ApproachIdle`, so `radarCandidateListProvider`'s
+/// `is! ApproachPolling → const []` gate returned an empty list, the radar
+/// card showed its placeholder, and swipe — only built on the non-empty data
+/// branch — was a literal no-op.
+///
+/// ## This test
+///
+/// Drives the REAL pipeline AND the real `approachStateProvider` against ONE
+/// fake geolocator that faithfully models the single-channel contention: each
+/// `getPositionStream` call returns its own single-subscription controller,
+/// and a fix is delivered only to the FIRST-opened controller (the channel
+/// "winner"). It then asserts the detector receives the fix → reaches
+/// `ApproachPolling` → `radarCandidateListProvider` is non-empty (the radar /
+/// swipe path is reachable).
+///
+/// On master (two raw streams) the detector is starved and this is RED. With
+/// the shared, refcounted broadcast source both consumers multiplex onto one
+/// underlying subscription, so the detector gets every fix and it is GREEN.
+
+Position _pos({required double lat, required double lng, double speed = 12}) =>
+    Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime(2026, 6, 1, 9),
+      accuracy: 5,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: speed,
+      speedAccuracy: 0,
+    );
+
+/// Geolocator fake that models geolocator's single platform EventChannel:
+/// every `getPositionStream` call returns its own Dart-level controller, but
+/// they all share ONE platform channel that delivers fixes to only the
+/// **most-recently-attached** listener (the platform's onListen replaces the
+/// active sink). Two independent raw `getPositionStream` listeners therefore
+/// do NOT both receive fixes — the later subscriber wins and the earlier one
+/// is starved, exactly the production race.
+///
+/// In this test the live detector subscribes first (its stream provider
+/// builds when the trip flips active), then the recorder subscribes in
+/// `pipeline.start()` — so on the pre-#2646 two-raw-streams design the
+/// recorder wins and the detector is starved (RED). The `sharedPositionStream`
+/// multiplexer collapses both trip consumers onto a SINGLE `getPositionStream`
+/// call (one platform listener), so there is exactly one winner and the
+/// multiplexer fans every fix out to both (GREEN).
+class _ContendingGeolocator extends GeolocatorWrapper {
+  final List<StreamController<Position>> _attached = [];
+
+  @override
+  Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
+    late final StreamController<Position> ctl;
+    ctl = StreamController<Position>(
+      // Last attach wins the single platform channel.
+      onListen: () => _attached.add(ctl),
+      onCancel: () => _attached.remove(ctl),
+    );
+    return ctl.stream;
+  }
+
+  /// Deliver a fix to the channel winner — the most-recently-attached, still
+  /// open listener.
+  void emit(Position p) {
+    // The controllers are owned by [_attached] and closed in [dispose].
+    // ignore: close_sinks
+    final winner = _attached.lastOrNull;
+    if (winner != null && !winner.isClosed) winner.add(p);
+  }
+
+  Future<void> dispose() async {
+    for (final c in List.of(_attached)) {
+      if (!c.isClosed) await c.close();
+    }
+  }
+}
+
+/// Trip-recording notifier stub reporting a fixed phase so the live detector
+/// gate (`tripState.isActive`) passes.
+class _RecordingTrip extends TripRecording {
+  @override
+  TripRecordingState build() =>
+      const TripRecordingState(phase: TripRecordingPhase.recording);
+}
+
+class _FixedProfile extends ActiveProfile {
+  @override
+  UserProfile? build() => const UserProfile(
+        id: 'p1',
+        name: 'Driver',
+        approachRadiusKm: 10.0,
+        approachMinPollSeconds: 1,
+      );
+}
+
+/// Radar whose `fetchStations` returns a fixed priced set without network.
+class _FakeRadar extends FuelStationRadar {
+  _FakeRadar(this.stations)
+      : super(
+          corridorCache: CorridorLocationCache(
+            fetchCorridor: (_, _, _) async => const <Station>[],
+          ),
+          priceCache: JitPriceCache(fetchPrice: (s) async => s),
+          isBulkSource: true,
+        );
+  final List<Station> stations;
+
+  @override
+  Future<List<Station>> fetchStations(
+    double lat,
+    double lng,
+    double radiusKm,
+    String fuelTypeApiValue, {
+    double? headingDegrees,
+  }) async =>
+      stations;
+}
+
+/// Station service backing `radarCandidateListProvider`'s search.
+class _FakeStationService implements StationService {
+  _FakeStationService(this._stations);
+  final List<Station> _stations;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async =>
+      ServiceResult<List<Station>>(
+        data: _stations,
+        source: ServiceSource.cache,
+        fetchedAt: DateTime(2026, 6, 1, 9),
+      );
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String id) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
+const _station = Station(
+  id: 's-1',
+  name: 'Nearby Station',
+  brand: 'STAR',
+  street: 'Main St',
+  postCode: '10115',
+  place: 'Berlin',
+  lat: 52.5,
+  lng: 13.4,
+  e10: 1.799,
+  dist: 0.3,
+  isOpen: true,
+);
+
+/// Minimal host so the real pipeline can run without the notifier.
+class _Host implements RecordingPipelineHost {
+  @override
+  TripRecordingState state = const TripRecordingState();
+  @override
+  String? lastTripVehicleId;
+  @override
+  DateTime? lastTripStartedAt;
+
+  @override
+  String? readActiveVehicleId() => null;
+  @override
+  void setSaveStage(TripSaveStage stage) {}
+  @override
+  Future<TripPersistOutcome> saveToHistory(
+    TripSummary summary, {
+    bool automatic = false,
+    List<TripSample> samples = const [],
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
+    String? vehicleId,
+    String? adapterMac,
+    String? adapterName,
+    String? adapterFirmware,
+    int gpsFixCount = 0,
+  }) async =>
+      TripPersistOutcome.saved;
+}
+
+final _pipelineProvider =
+    Provider.family<GpsOnlyRecordingPipeline, RecordingPipelineHost>(
+  (ref, host) => GpsOnlyRecordingPipeline(ref: ref, host: host),
+);
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  test(
+      'GPS-only recording: the recorder + the live ApproachDetector both '
+      'consume the shared GPS source, so the detector reaches ApproachPolling '
+      'and the radar candidate list is non-empty (#2646)', () async {
+    final geo = _ContendingGeolocator();
+    addTearDown(geo.dispose);
+
+    final container = ProviderContainer(overrides: [
+      geolocatorWrapperProvider.overrideWithValue(geo),
+      tripRecordingProvider.overrideWith(_RecordingTrip.new),
+      activeProfileProvider.overrideWith(_FixedProfile.new),
+      effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+      approachOverlayEnabledProvider.overrideWithValue(true),
+      fuelStationRadarProvider.overrideWithValue(_FakeRadar(const [_station])),
+      stationServiceProvider
+          .overrideWithValue(_FakeStationService(const [_station])),
+    ]);
+    addTearDown(container.dispose);
+
+    // Keep the live approach detector alive (it subscribes to GPS the moment
+    // it builds, because the trip reports `recording`).
+    final approachSub = container.listen(approachStateProvider, (_, _) {});
+    addTearDown(approachSub.close);
+    container.listen(effectiveApproachStateProvider, (_, _) {});
+
+    // The recorder opens its (shared) GPS subscription synchronously — this is
+    // the consumer that "wins" the channel in the contention model.
+    final pipeline = container.read(_pipelineProvider(_Host()));
+    pipeline.start();
+    addTearDown(() => pipeline.stop());
+
+    // Let the detector's stream provider build + subscribe.
+    await _pump();
+    await _pump();
+
+    // One GPS fix: delivered to the channel winner. On the pre-#2646 design
+    // the detector is on a SECOND, starved stream and never sees this.
+    geo.emit(_pos(lat: 52.5, lng: 13.4));
+    await _pump();
+    await _pump();
+
+    final approach = container.read(approachStateProvider).value;
+    expect(approach, isA<ApproachPolling>(),
+        reason: 'the detector must receive the recorder\'s fix and leave '
+            'ApproachIdle — on master it is starved and stays Idle');
+
+    final candidates =
+        await container.read(radarCandidateListProvider.future);
+    expect(candidates, isNotEmpty,
+        reason: 'ApproachPolling → radarCandidateListProvider returns the '
+            'ranked priced list, so the radar card / swipe path is reachable '
+            '(empty on master because the detector never polled)');
+    expect(candidates.first.id, _station.id);
+  });
+}


### PR DESCRIPTION
## The bug

In **GPS-only** recording the fuel-station radar showed nothing and swipe was a literal no-op. In OBD2 recording both work fine.

## Root cause — two streams, one channel

`geolocator`'s `getPositionStream()` is backed by a **single platform EventChannel**. In GPS-only mode two consumers open their own subscription on it **in the same frame**:

- `GpsOnlyRecordingPipeline.start()` opens the recording subscription synchronously, and
- the live `ApproachDetector` opens a **second** `getPositionStream` the instant `tripState.isActive` flips true (which the pipeline start does).

The two listeners contend on the one channel; the recorder wins (GPS distance/speed keep updating on screen) and the detector is **starved of fixes**. With no fix it never leaves `ApproachIdle` → never emits `ApproachPolling`, so:

- `radarCandidateListProvider` hits its `is! ApproachPolling → const []` gate and returns empty,
- `TripRadarCard` renders the placeholder instead of a station card, and
- the `Dismissible` (built only on the non-empty data branch) never exists → **swipe is a no-op**.

OBD2 "works by timing": its recording stream is `Feature.gpsTripPath` + permission gated + async, so it opens **after** the detector and the race resolves the other way.

## The fix — one shared, refcounted broadcast source

Both trip consumers now multiplex onto a single underlying subscription:

- **`geolocator_wrapper.dart`** — new `sharedPositionStream()`: one underlying `getPositionStream` subscription fanned out via a broadcast controller, **opening on the first listener and closing on the last** (battery cost-bound preserved between trips), **replaying the latest fix to late joiners** so the detector leaves `ApproachIdle` immediately. The bare per-call `getPositionStream` is **unchanged** for non-trip callers (movement detection).
- **`gps_only_recording_pipeline.dart`** + **`approach_state_provider.dart`** — both point at `sharedPositionStream` instead of a fresh `getPositionStream`. **No detector change** — it already handles a hot/late-join broadcast stream.

Now both listeners attach to **one** platform subscription; the detector receives every fix the recorder does → reaches `ApproachPolling` → the radar candidate list is non-empty → swipe works, identically to OBD2.

**Scope guard:** the OBD2 recording stream (`trip_gps_stream_controller.dart`) is left on its own subscription in this PR to stay disjoint from in-flight #2648, and OBD2 already works. Folding it onto the same shared source (keeping its `Feature.gpsTripPath` + permission gate) is a noted follow-up.

## Tests (RED → GREEN)

- `test/core/location/shared_position_stream_test.dart` — two consumers both receive the **same** fix over **one** underlying subscription (the race regression guard); refcount **open-on-first / close-on-last**; late-join replay; per-call `getPositionStream` **unchanged** (movement detection keeps its own subscription).
- `test/features/approach/providers/gps_only_radar_race_test.dart` — integration regression driving the **real** pipeline + `approachStateProvider` against one geolocator that models the single-channel contention. **RED on master** (detector starved, stays Idle, empty candidate list); **GREEN** with the shared source (reaches `ApproachPolling`, non-empty list). The RED→GREEN was verified by temporarily reverting both consumers to `getPositionStream`.

## Verification

- `flutter analyze` clean on all changed files.
- `flutter test test/features/approach test/features/consumption test/core/services test/core/location test/lint --exclude-tags network` → **all pass** (the only failure in the full run is the pre-existing live-network `api_connectivity` Argentina endpoint timeout, `@Tags(['network'])`, unrelated).
- No `lib/l10n/` diff; codegen clean (committed the `approach_state_provider.g.dart` hash drift).

Closes #2646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
