### PR TITLE
feat(analytics): revive cornering load from persisted heading (#2655)

### DIFF
--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -1,8 +1,24 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:math' as math;
+
 import '../../../core/utils/geo_utils.dart' as geo;
 import 'trip_recorder.dart';
+
+/// Lateral-acceleration threshold (m/s²) above which a turn counts as a
+/// "sharp corner" event. 3.5 m/s² ≈ 0.36 g — the telematics convention
+/// for a harsh-cornering event (Digital Matter 3.5 m/s²; Verizon 0.4 g
+/// sustained; Geotab ~0.47 g). We sit at the conservative end of that
+/// band so a brisk-but-controlled bend doesn't trip it.
+const double kSharpCornerThresholdMps2 = 3.5;
+
+/// Horizontal-accuracy ceiling (m) for trusting a fix's bearing in the
+/// corner-load integral. A jittery fix (urban canyon / cold start)
+/// reports a noisy heading that would manufacture a phantom corner, so
+/// fixes worse than this are skipped — "a bad fix is worse than no fix"
+/// (HDOP > 2.5–3.0 / accuracy > 10 m, per the GNSS telematics guidance).
+const double kCornerAccuracyGateM = 10.0;
 
 /// Driving-style aggregate derived from a stream of [TripSample]s
 /// **without** any OBD2 telemetry — the lean feature set the GPS
@@ -76,9 +92,18 @@ class GpsDrivingFeatures {
   /// deltas summed). Reserved.
   final double gradeDescentMeters;
 
-  /// Heading-rate × speed² integral — a proxy for lateral g-load over
-  /// the trajet. Higher = more aggressive cornering. Reserved.
+  /// Lateral-acceleration integral over the trajet (m/s² · s), a proxy
+  /// for cumulative cornering g-load. Computed from the persisted
+  /// `bearingDeg` (#2650): per segment `a_lat ≈ v · (dBearing/dt)`
+  /// (yaw-rate × speed), accumulated as `|a_lat| · dt`. Higher = more
+  /// aggressive cornering. Stays `0` on legacy trips that predate the
+  /// persisted heading (#2655) and on fixes the accuracy gate rejects.
   final double cornerLoadIntegral;
+
+  /// Count of sharp-corner events: segments whose lateral acceleration
+  /// `|a_lat|` exceeds [kSharpCornerThresholdMps2] (#2655). Counted once
+  /// per qualifying segment; `0` when heading is absent (legacy trips).
+  final int sharpCornerEvents;
 
   const GpsDrivingFeatures({
     required this.idleSeconds,
@@ -94,6 +119,7 @@ class GpsDrivingFeatures {
     required this.gradeClimbMeters,
     required this.gradeDescentMeters,
     required this.cornerLoadIntegral,
+    this.sharpCornerEvents = 0,
   });
 
   /// Idle share of the trajet (0.0–1.0). Used by the matrix's
@@ -111,6 +137,13 @@ class GpsDrivingFeatures {
   /// `accelEventCost` term. Returns 0 for zero-distance trajets.
   double get accelEventsPerKm =>
       distanceKm > 0 ? accelEvents / distanceKm : 0.0;
+
+  /// Sharp-corner events per km (#2655) — the cornering analogue of
+  /// [accelEventsPerKm], normalised so a long calm motorway leg with one
+  /// brisk exit ramp doesn't read worse than a short twisty drive.
+  /// Returns 0 for zero-distance trajets.
+  double get sharpCornersPerKm =>
+      distanceKm > 0 ? sharpCornerEvents / distanceKm : 0.0;
 
   /// Derives the feature aggregate from [samples]. Returns `null`
   /// when the stream is empty or carries fewer than 2 samples (one
@@ -139,6 +172,7 @@ class GpsDrivingFeatures {
     double maxAccelG = 0;
     double climb = 0, descent = 0;
     double cornerLoad = 0;
+    int sharpCorners = 0;
 
     // Acceleration-event detector state.
     bool inAccelEvent = false, inBrakeEvent = false;
@@ -211,12 +245,28 @@ class GpsDrivingFeatures {
         }
       }
 
-      // Corner-load integral: |Δheading| ≈ atan2(crossTrack) — we don't
-      // have heading directly, so approximate via successive bearings
-      // when 3 GPS-fixed samples are available. For v1 we keep this
-      // term at zero unless extended in #G; the 4-coef lean fit
-      // doesn't read it. Field stays present for the future expansion.
-      cornerLoad += 0;
+      // Corner-load integral (#2655). Now that #2650 persists `bearingDeg`
+      // on every sample, lateral acceleration follows from yaw-rate ×
+      // speed:  a_lat ≈ v · (dBearing/dt). The heading is null on legacy
+      // (pre-#2650) samples and on cars/paths that never reported one, so
+      // the term gracefully stays 0 for old data. Jittery fixes are gated
+      // out (a noisy bearing manufactures phantom corners — a bad fix is
+      // worse than no fix).
+      final pBear = prev.bearingDeg, cBear = cur.bearingDeg;
+      final pAcc = prev.hAccuracyM, cAcc = cur.hAccuracyM;
+      final accurate = (pAcc == null || pAcc <= kCornerAccuracyGateM) &&
+          (cAcc == null || cAcc <= kCornerAccuracyGateM);
+      if (pBear != null && cBear != null && accurate) {
+        // Signed minimal angular delta — handles the 0/360 wrap so a
+        // 350°→10° step is +20°, not −340° ((d+540) mod 360) − 180.
+        final dBearingDeg = ((cBear - pBear + 540.0) % 360.0) - 180.0;
+        final yawRateRadPerSec = dBearingDeg * math.pi / 180.0 / dt;
+        // v in m/s (speed in km/h ÷ 3.6) on the leading sample.
+        final aLat = (v / 3.6) * yawRateRadPerSec;
+        final absLat = aLat.abs();
+        cornerLoad += absLat * dt;
+        if (absLat > kSharpCornerThresholdMps2) sharpCorners++;
+      }
     }
 
     final total = idle + low + cruise + high;
@@ -238,6 +288,7 @@ class GpsDrivingFeatures {
       gradeClimbMeters: climb,
       gradeDescentMeters: descent,
       cornerLoadIntegral: cornerLoad,
+      sharpCornerEvents: sharpCorners,
     );
   }
 

--- a/test/features/consumption/domain/gps_driving_features_test.dart
+++ b/test/features/consumption/domain/gps_driving_features_test.dart
@@ -11,6 +11,8 @@ TripSample _s(
   double? lat,
   double? lng,
   double? altM,
+  double? bearingDeg,
+  double? hAccuracyM,
 }) =>
     TripSample(
       timestamp: t,
@@ -19,6 +21,8 @@ TripSample _s(
       latitude: lat,
       longitude: lng,
       altitudeM: altM,
+      bearingDeg: bearingDeg,
+      hAccuracyM: hAccuracyM,
     );
 
 Iterable<TripSample> _constantSpeed({
@@ -195,6 +199,111 @@ void main() {
         )!;
         expect(f.gradeClimbMeters, 0);
         expect(f.gradeDescentMeters, 0);
+      });
+    });
+
+    group('cornering load (#2655 — revived from persisted bearing)', () {
+      test('a curvy track accumulates cornerLoadIntegral + a sharp-corner '
+          'event', () {
+        // 80 km/h ≈ 22.2 m/s. Sweep the bearing through a tight turn:
+        // 90° → 130° over 1 s = 40°/s ≈ 0.698 rad/s yaw-rate.
+        // a_lat ≈ v · ω = 22.2 · 0.698 ≈ 15.5 m/s² — well past the
+        // ~3.5 m/s² sharp-corner threshold, so it fires an event.
+        final samples = <TripSample>[];
+        var bearing = 90.0;
+        for (var i = 0; i <= 6; i++) {
+          samples.add(_s(
+            t0.add(Duration(seconds: i)),
+            80,
+            lat: 45,
+            lng: 5 + i * 0.0002,
+            bearingDeg: bearing,
+            hAccuracyM: 4,
+          ));
+          bearing += 40; // 40°/s sweep
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.cornerLoadIntegral, greaterThan(0));
+        expect(f.sharpCornerEvents, greaterThanOrEqualTo(1));
+      });
+
+      test('a straight track (constant bearing) has ~0 corner load', () {
+        final samples = <TripSample>[];
+        for (var i = 0; i <= 30; i++) {
+          samples.add(_s(
+            t0.add(Duration(seconds: i)),
+            80,
+            lat: 45,
+            lng: 5 + i * 0.0002,
+            bearingDeg: 90, // dead straight
+            hAccuracyM: 4,
+          ));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.cornerLoadIntegral, closeTo(0.0, 0.001));
+        expect(f.sharpCornerEvents, 0);
+      });
+
+      test('bearing wrap-around 350° → 10° is a +20° delta, not −340°', () {
+        // Crossing true-north: at low yaw the wrap must NOT manufacture a
+        // huge phantom corner. 350 → 10 over 1 s = +20°/s ≈ 0.349 rad/s.
+        // At 36 km/h (10 m/s) a_lat ≈ 3.49 m/s² — just under threshold,
+        // so it contributes to the integral but stays a gentle bend, and
+        // the integral must be small (it would be ~17× larger if the
+        // delta were mis-computed as 340°).
+        final samples = <TripSample>[
+          _s(t0, 36, lat: 45, lng: 5, bearingDeg: 350, hAccuracyM: 4),
+          _s(t0.add(const Duration(seconds: 1)), 36,
+              lat: 45, lng: 5.0002, bearingDeg: 10, hAccuracyM: 4),
+          _s(t0.add(const Duration(seconds: 2)), 36,
+              lat: 45, lng: 5.0004, bearingDeg: 10, hAccuracyM: 4),
+        ];
+        final f = GpsDrivingFeatures.from(samples)!;
+        // a_lat·dt for the +20° step = 10 m/s · 0.349 rad/s · 1 s ≈ 3.49.
+        // A −340° mis-read would give ≈ 59.3 — assert we are in the small
+        // regime, proving the signed-minimal-delta wrap handling.
+        expect(f.cornerLoadIntegral, closeTo(3.49, 0.3));
+        expect(f.sharpCornerEvents, 0);
+      });
+
+      test('legacy samples without bearing stay at 0 (no crash)', () {
+        // Pre-#2650 trips carry bearingDeg == null on every sample. The
+        // term must gracefully degrade to the historical hard-zero.
+        final samples = <TripSample>[];
+        for (var i = 0; i <= 30; i++) {
+          samples.add(_s(
+            t0.add(Duration(seconds: i)),
+            80,
+            lat: 45,
+            lng: 5 + i * 0.0002,
+            // bearingDeg omitted → null
+          ));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.cornerLoadIntegral, 0);
+        expect(f.sharpCornerEvents, 0);
+      });
+
+      test('a low-accuracy fix is gated out of the corner integral', () {
+        // Same tight 40°/s sweep as the curvy test, but every fix is
+        // jittery (hAccuracyM = 40 m). The accuracy gate must reject it
+        // so a bad fix doesn't manufacture a phantom corner.
+        final samples = <TripSample>[];
+        var bearing = 90.0;
+        for (var i = 0; i <= 6; i++) {
+          samples.add(_s(
+            t0.add(Duration(seconds: i)),
+            80,
+            lat: 45,
+            lng: 5 + i * 0.0002,
+            bearingDeg: bearing,
+            hAccuracyM: 40, // jittery — beyond the gate
+          ));
+          bearing += 40;
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.cornerLoadIntegral, 0);
+        expect(f.sharpCornerEvents, 0);
       });
     });
 


### PR DESCRIPTION
## Root cause — `cornerLoadIntegral` was designed but DEAD

`gps_driving_features.dart` declared `cornerLoadIntegral` (a lateral-g-load
proxy for the GPS calibration matrix's 7-coef expansion), but the recorder
loop computed it as literally `cornerLoad += 0` with the comment *"we don't
have heading directly … keep this term at zero."* The field was wired all
the way through but the value was always 0.

## The heading-based revival

#2650 now persists `bearingDeg` on every sample, so the term can finally be
computed. Per segment, lateral acceleration follows from **yaw-rate × speed**:

```
a_lat ≈ v · (dBearing/dt)          // v in m/s, dBearing/dt in rad/s
dBearing = ((cBear − pBear + 540) mod 360) − 180   // signed minimal delta
```

- **Wrap-around at 0/360** — the signed-minimal-delta formula makes a 350°→10°
  step read as **+20°**, not −340° (which would manufacture a ~17× phantom
  corner across true-north).
- **Integral** accumulates `|a_lat| · dt` over the trip.
- **Sharp-corner events** are counted when `|a_lat| > 3.5 m/s²` (≈ 0.36 g) —
  the telematics harsh-cornering convention (Digital Matter 3.5 m/s²;
  Verizon 0.4 g sustained; Geotab ~0.47 g). Threshold const
  `kSharpCornerThresholdMps2`.
- **GPS-accuracy gate** — a fix worse than 10 m horizontal accuracy is skipped
  (a jittery bearing manufactures phantom corners; "a bad fix is worse than no
  fix"). Const `kCornerAccuracyGateM`.
- **Graceful legacy degradation** — `bearingDeg` is null on pre-#2650 samples,
  so the whole term stays the historical hard-zero with no crash.

Surfaced via a new `sharpCornerEvents` field + a `sharpCornersPerKm` getter
mirroring the existing `accelEventsPerKm`, and the revived `cornerLoadIntegral`
value is now non-zero for the matrix's 7-coef expansion path.

## RED → GREEN (TDD)

New tests in `gps_driving_features_test.dart` (all RED on master, where the
term is hard-zeroed → 0):

- **curvy track** (40°/s bearing sweep at 80 km/h) → `cornerLoadIntegral > 0`
  and `sharpCornerEvents ≥ 1`
- **straight track** (constant bearing) → `cornerLoadIntegral ≈ 0`, events = 0
- **wrap-around** 350°→10° → integral in the small +20° regime (~3.49), not the
  −340° phantom, proving the signed-delta handling
- **legacy no-bearing** track → 0, no crash
- **low-accuracy** track (hAccuracyM = 40 m) → gated out to 0

## Scope / safety

- Touches **only** `gps_driving_features.dart` (+ its test) — disjoint from the
  harsh-event detector (C2) and driving-insights reconciliation (C3).
- No ARB / no `lib/l10n` diff. No `.g.dart` / `.freezed.dart` drift.
- `flutter analyze` clean; `flutter test test/features/consumption test/lint`
  green. file_length = 304 (≤ 400).
- `sharpCornerEvents` defaults to 0, so the matrix-reconciler / fuel-estimator
  test fixtures that construct `GpsDrivingFeatures` directly stay unchanged.

Closes #2655 (Epic #2647 C7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)