### PR TITLE
feat(consumption): wire road grade into the GPS-only live fuel estimator (#2654)

### DIFF
--- a/lib/features/consumption/domain/services/gps_live_estimate_folder.dart
+++ b/lib/features/consumption/domain/services/gps_live_estimate_folder.dart
@@ -6,6 +6,7 @@ import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../data/obd2/trip_live_reading.dart';
 import '../driving_coaching.dart'
     show DrivingCoachingHint, gpsCoachingHint, recentSamplesWithin;
+import '../road_grade_calculator.dart';
 import '../trip_recorder.dart' show TripSample;
 import 'gps_live_fuel_estimator.dart';
 
@@ -87,6 +88,20 @@ class GpsLiveEstimateFolder {
   final GpsLiveFuelEstimator _estimator;
   final Duration _coachingWindow;
 
+  /// Road-grade estimator (#2654) — driven IDENTICALLY to
+  /// [BaselineRollingState]: 150 m window, 0.2 exp-smoothing,
+  /// minSamplesInWindow=5 confidence gate. Fed the running horizontal
+  /// distance + each fix's GPS altitude in [fold]; its confident grade is
+  /// passed straight into [GpsLiveFuelEstimator.onSample] so the existing
+  /// `m·g·gradeFraction` term (previously always zeroed because the folder
+  /// never supplied a grade) finally bites on hilly GPS-only trips.
+  final RoadGradeCalculator _gradeCalc = RoadGradeCalculator();
+
+  /// Running horizontal distance (metres) since the first fix — the grade
+  /// calculator's window axis. Accumulated from `speedMps · dt` per fold,
+  /// mirroring the estimator's own internal distance integral.
+  double _cumulativeDistanceM = 0;
+
   /// Previous fix's ground speed (m/s) + timestamp — the finite-diff basis
   /// the estimator needs for acceleration. Null before the first fix.
   double? _prevSpeedMps;
@@ -99,11 +114,13 @@ class GpsLiveEstimateFolder {
 
   /// Fold one GPS-stamped [sample] into the estimate + coaching state and
   /// return the new triplet. The sample's `speedKmh` drives the physics;
-  /// its `timestamp` + `altitudeM` feed the coaching window.
+  /// its `altitudeM` (with the running horizontal distance) drives the
+  /// road-grade term (#2654) and feeds the coaching window alongside its
+  /// `timestamp`.
   ///
   /// The first fold (no previous fix yet) only seeds the finite-diff basis
-  /// and returns null estimate figures, matching the GPS-only pipeline's
-  /// behaviour verbatim.
+  /// (and the grade window's first altitude point) and returns null estimate
+  /// figures, matching the GPS-only pipeline's behaviour verbatim.
   GpsLiveEstimate fold(TripSample sample) {
     final speedMps = sample.speedKmh / 3.6;
     double? instant;
@@ -111,13 +128,27 @@ class GpsLiveEstimateFolder {
     double? litersSoFar;
     final prevSpeed = _prevSpeedMps;
     final prevAt = _prevSampleAt;
-    if (prevSpeed != null && prevAt != null) {
-      final dt =
-          sample.timestamp.difference(prevAt).inMilliseconds / 1000.0;
+    final dt = prevAt == null
+        ? null
+        : sample.timestamp.difference(prevAt).inMilliseconds / 1000.0;
+    // Advance the running horizontal distance, then fold this fix's
+    // altitude in at the new cumulative distance — identical to how
+    // BaselineRollingState drives the calculator (#2654). A null altitude
+    // adds no point, so confidence never rises and the grade term stays
+    // gated off (honest); the first fix seeds the window at distance 0.
+    if (dt != null && dt > 0) _cumulativeDistanceM += speedMps * dt;
+    _gradeCalc.addSample(
+      cumulativeDistanceKm: _cumulativeDistanceM / 1000.0,
+      altitudeM: sample.altitudeM,
+    );
+    final grade = _gradeCalc.current;
+    if (prevSpeed != null && dt != null) {
       instant = _estimator.onSample(
         speedMps: speedMps,
         prevSpeedMps: prevSpeed,
         dtSeconds: dt,
+        gradeFraction: grade.gradeFraction,
+        gradeConfident: grade.confident,
       );
       avg = _estimator.runningAvgLPer100Km;
       final liters = _estimator.litersSoFar;

--- a/test/features/consumption/domain/services/gps_live_estimate_folder_grade_test.dart
+++ b/test/features/consumption/domain/services/gps_live_estimate_folder_grade_test.dart
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+import 'package:tankstellen/features/consumption/domain/services/gps_live_estimate_folder.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart'
+    show TripSample;
+
+/// #2654 — the folder is the single choke point that previously fed the
+/// estimator ONLY speed/prevSpeed/dt, never a grade, so the existing
+/// `m·g·gradeFraction` term in [GpsLiveFuelEstimator] was permanently
+/// zeroed (gradeConfident defaulted false). These tests drive a whole trip
+/// through [GpsLiveEstimateFolder.fold] and assert the wiring now feeds a
+/// confident road grade derived from the per-fix altitude, biasing a
+/// climbing GPS-only estimate UP relative to the identical speed profile on
+/// flat ground — and that a no-altitude trip never gains a grade (and never
+/// crashes).
+
+/// Drive a trip through the folder at a constant [speedMps], one fix per
+/// second, with the altitude at fix `i` produced by [altitudeAt]. Returns
+/// the final fold's running litres (the integral the live "~ estimated"
+/// figure is built from). A null [altitudeAt] (or one returning null) feeds
+/// no altitude at all — the GPS-altitude-absent path.
+GpsLiveEstimate _runTrip({
+  required double speedMps,
+  required int ticks,
+  double? Function(int i)? altitudeAt,
+}) {
+  final folder = GpsLiveEstimateFolder.forVehicle(null, null);
+  final start = DateTime(2026, 6, 2, 8);
+  var last = GpsLiveEstimate.none;
+  for (var i = 0; i < ticks; i++) {
+    last = folder.fold(TripSample(
+      timestamp: start.add(Duration(seconds: i)),
+      speedKmh: speedMps * 3.6,
+      rpm: 0, // GPS-only: no engine data
+      altitudeM: altitudeAt?.call(i),
+    ));
+  }
+  return last;
+}
+
+void main() {
+  group('GpsLiveEstimateFolder — grade wiring (#2654)', () {
+    test('a confident climbing trip burns MORE than the same flat profile',
+        () {
+      // 20 m/s, 1 s fixes → 20 m per fix. Over 30 fixes the trip covers
+      // ~580 m — many full 150 m windows, each with ≥5 dense altitude
+      // samples, so the RoadGradeCalculator reaches confidence well before
+      // the end. The climbing trip rises 1.2 m per fix = 6 % grade; the
+      // flat trip holds a constant altitude (confident grade ≈ 0).
+      const speedMps = 20.0;
+      const ticks = 30;
+
+      // Read the FINAL running-litres integral off the live estimate so we
+      // compare the same whole-trip fuel both pipelines would publish.
+      final climbing = _runTrip(
+        speedMps: speedMps,
+        ticks: ticks,
+        altitudeAt: (i) => 100.0 + i * 1.2, // +6 % climb
+      );
+      final flat = _runTrip(
+        speedMps: speedMps,
+        ticks: ticks,
+        altitudeAt: (i) => 100.0, // dead level
+      );
+
+      expect(climbing.fuelLitersSoFar, isNotNull);
+      expect(flat.fuelLitersSoFar, isNotNull);
+      // BEFORE the fix both reads were identical (grade always zeroed) —
+      // this assertion is RED on master. The climbing extra is first-order
+      // (web: 0→6 % grade well north of +50 % tractive fuel), so a strict
+      // greater-than with margin is safe.
+      expect(
+        climbing.fuelLitersSoFar!,
+        greaterThan(flat.fuelLitersSoFar! * 1.05),
+      );
+      // The instantaneous figure must also be lifted by the live grade.
+      expect(
+        climbing.instantLPer100Km!,
+        greaterThan(flat.instantLPer100Km!),
+      );
+    });
+
+    test('a downhill trip burns no MORE than flat — negative grade is a '
+        'credit, never a penalty', () {
+      // A confident downhill (negative grade) reduces tractive force; the
+      // estimator floors power at 0, so it can only ever read ≤ flat.
+      const speedMps = 20.0;
+      const ticks = 30;
+      final downhill = _runTrip(
+        speedMps: speedMps,
+        ticks: ticks,
+        altitudeAt: (i) => 100.0 - i * 1.2,
+      );
+      final flat = _runTrip(
+        speedMps: speedMps,
+        ticks: ticks,
+        altitudeAt: (i) => 100.0,
+      );
+      expect(downhill.fuelLitersSoFar, isNotNull);
+      expect(
+        downhill.fuelLitersSoFar!,
+        lessThanOrEqualTo(flat.fuelLitersSoFar!),
+      );
+    });
+
+    test('a GPS-altitude-absent trip never gains a grade and never crashes',
+        () {
+      // Every fix carries a null altitude — the calculator adds no points,
+      // confidence stays false, the grade term stays gated off, and the
+      // read must equal the no-grade flat baseline EXACTLY (not merely be
+      // finite). Mirrors the estimator's `gradeConfident: false` test.
+      const speedMps = 20.0;
+      const ticks = 30;
+      final noAltitude = _runTrip(
+        speedMps: speedMps,
+        ticks: ticks,
+        altitudeAt: (i) => null, // platform reports no altitude
+      );
+      // Same speed profile with a CONFIDENT flat (0 %) grade — both must
+      // produce the identical integral because a zero grade contributes
+      // nothing, proving the null path is gated off rather than injecting
+      // garbage.
+      final flat = _runTrip(
+        speedMps: speedMps,
+        ticks: ticks,
+        altitudeAt: (i) => 100.0,
+      );
+      expect(noAltitude.fuelLitersSoFar, isNotNull);
+      expect(
+        noAltitude.fuelLitersSoFar!,
+        closeTo(flat.fuelLitersSoFar!, 1e-9),
+      );
+      expect(noAltitude.instantLPer100Km, isNotNull);
+    });
+
+    test('overlay() carries the same grade wiring as fold()', () {
+      // The OBD2 live path enters through overlay(); assert it folds the
+      // altitude through too (a climbing overlay reads higher than flat).
+      final climber = GpsLiveEstimateFolder.forVehicle(null, null);
+      final flatter = GpsLiveEstimateFolder.forVehicle(null, null);
+      final start = DateTime(2026, 6, 2, 8);
+      const base = TripLiveReading(distanceKmSoFar: 0, elapsed: Duration.zero);
+      var climbInstant = 0.0;
+      var flatInstant = 0.0;
+      for (var i = 0; i < 30; i++) {
+        final climb = climber.overlay(
+          base: base,
+          now: start.add(Duration(seconds: i)),
+          effectiveSpeedKmh: 72, // 20 m/s
+          rpm: null,
+          altitudeM: 100.0 + i * 1.2,
+        );
+        final level = flatter.overlay(
+          base: base,
+          now: start.add(Duration(seconds: i)),
+          effectiveSpeedKmh: 72,
+          rpm: null,
+          altitudeM: 100.0,
+        );
+        climbInstant = climb.reading.gpsEstimatedLPer100Km ?? climbInstant;
+        flatInstant = level.reading.gpsEstimatedLPer100Km ?? flatInstant;
+      }
+      expect(climbInstant, greaterThan(flatInstant));
+    });
+  });
+}


### PR DESCRIPTION
## What & why

The GPS-only live fuel estimator already implements the textbook road-load
model verbatim, **including a road-grade term** —
`gps_live_fuel_estimator.dart` computes `grade = m·g·gradeFraction` and adds
it to the tractive force. But that term was **permanently zeroed**: it is
gated behind `gradeConfident`, which defaults `false`, and the single choke
point that feeds the estimator — `GpsLiveEstimateFolder.fold()` — called
`_estimator.onSample(...)` with **only** `speedMps` / `prevSpeedMps` /
`dtSeconds`. It never instantiated a `RoadGradeCalculator` and never passed
`gradeFraction` / `gradeConfident`, so on a hilly GPS-only trip the estimate
read as if the road were dead flat.

The bias is first-order, not a rounding detail: a 0 → ~5–6 % grade is
**+65–81 % tractive fuel**, dwarfing most driving-style effects. The
calculator already exists, is already tested, and is already driven
**identically** by `BaselineRollingState` (150 m window, 0.2 exp-smoothing,
`minSamplesInWindow = 5` confidence gate). This wires the same calculator
into the folder — supplying the inputs only, with **no change to the
estimator physics**.

## The fix (~10 LoC, one seam)

`gps_live_estimate_folder.dart`:

- add a `RoadGradeCalculator` member + a running horizontal-distance
  accumulator (`speedMps · dt`, mirroring the estimator's own internal
  distance integral);
- in `fold()`, advance the distance, feed `cumulativeDistanceKm` +
  `sample.altitudeM` into the calculator (exactly as `BaselineRollingState`
  does), then pass the resulting `gradeFraction` / `gradeConfident` straight
  into `_estimator.onSample(...)`.

A null GPS altitude adds no point — confidence simply never rises and the
grade term stays gated off, which is the honest behaviour (no fabricated
slope). The OBD2 live path inherits the wiring for free because it enters
through `overlay()` → `fold()`.

This unlocks **GPS-only climbing fuel** today and is the prerequisite for the
future OBD2 climbing-cost bucket (Epic #2647 C6).

## Tests (TDD)

New `gps_live_estimate_folder_grade_test.dart`:

- a **climbing-trip** fixture (rising altitude over distance) asserts the
  running litres + instant figure are **higher** than the same speed profile
  on flat ground — RED on master (grade always zeroed), green with the fix;
- an `overlay()` climbing-vs-flat assertion proving the OBD2 path is wired
  too — also RED on master (climb == flat exactly);
- a **no-altitude** trip asserts the read equals the confident-flat baseline
  exactly (grade stays gated off) and never crashes;
- a downhill trip asserts a negative grade is a credit, never a penalty
  (power floors at 0).

`flutter analyze` clean on the change; `flutter test test/features/consumption
test/lint` green; `file_length ≤ 400` respected (folder is 214 lines).

Closes #2654 (Epic #2647, Fix F / C5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
