### PR TITLE
fix(recording): de-noise harsh-event detection (sustained-window + accuracy-gate + min-speed + source-aware) — Epic #2647 C2

### DIFF
--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -1229,7 +1229,9 @@ class TripRecordingController {
         stft: captureRaw ? snap.latestStft : null,
         ltft: captureRaw ? snap.latestLtft : null,
       );
-      _recorder.onSample(sample);
+      // #2653 — thread the live distance provenance so the detector
+      // suppresses harsh scoring on the `virtual` dead-reckoning source.
+      _recorder.onSample(sample, distanceSource: distanceSource);
       _lastSampleAt = nowTs;
       // #1925 — ping the opt-in debug recorder so a stretch of silence
       // surfaces as a data-gap event in the exported session log.

--- a/lib/features/consumption/domain/harsh_event_detector.dart
+++ b/lib/features/consumption/domain/harsh_event_detector.dart
@@ -4,7 +4,8 @@
 import 'harsh_event.dart';
 
 /// Detects harsh-braking / harsh-acceleration events from a stream of
-/// speed samples, decoupled from the sample-feed cadence (#1922).
+/// speed samples, decoupled from the sample-feed cadence (#1922) and
+/// de-noised against jittery / dead-reckoning speed signals (#2653).
 ///
 /// Extracted from [TripRecorder]: the recorder is fed a `TripSample`
 /// every 250 ms, but the OBD speed PID (0x0D, integer km/h) refreshes
@@ -14,12 +15,41 @@ import 'harsh_event.dart';
 /// acceleration ~4x: a real device backup showed 428 "harsh brakes"
 /// on a single 157 km motorway drive.
 ///
-/// The fix is to re-sample speed at ~1 Hz before taking the
+/// The first fix (#1922) re-samples speed at ~1 Hz before taking the
 /// derivative: the threshold is evaluated only between samples at
 /// least [_evalIntervalSec] apart, so Δt is always a real ~1 s window.
-/// Genuine hard braking (a large Δspeed within ~1 s) still trips the
-/// threshold; the staircase no longer does; and the count is
-/// independent of how fast samples are fed.
+///
+/// #2653 adds four de-noising gates on top, because the resample alone
+/// still over-detected on the **virtual** (dead-reckoning) distance
+/// source — a real 77-trip backup measured a median of 4.78 and a peak
+/// of 43.4 phantom events/km on virtual trips, versus 1.06/km on
+/// GPS-sourced trips (43.4/km is physically impossible → it is noise
+/// counted as events). The gates:
+///   1. **Sustained-window** — the derivative must be measured over a
+///      window of at least [minSustainedSec] (≈1 s, matching
+///      `gps_driving_features.dart`). A single sub-1 s spike (the
+///      phasing artefact a coarse staircase produces against the
+///      ~0.9 s resample) can no longer fire.
+///   2. **Accuracy gate** — a fix whose reported horizontal accuracy
+///      exceeds [maxHAccuracyM] (~10 m) is dropped *and* breaks the
+///      anchor, so the derivative is never taken across a bad fix
+///      ("a bad fix is worse than no fix"). Possible since #2648/#2650
+///      persist `hAccuracyM`.
+///   3. **Min-speed floor** — intervals whose mean speed is below
+///      [minSpeedKmh] (~5 km/h) are not scored; dead-reckoning noise at
+///      a near-standstill manufactures phantom events.
+///   4. **Source-aware suppression** — when [onSample] is told the
+///      sample came from a suppressed source (the `virtual`
+///      dead-reckoning odometer, and GPS-only trips that also default
+///      to `virtual`), harsh scoring is skipped entirely. A
+///      1 km/h-quantised dead-reckoning speed signal is unfit for
+///      differentiation; suppressing it is honest, where counting its
+///      phasing artefacts is not.
+///
+/// An optional 3-sample moving-average pre-smoothing on speed (the same
+/// low-pass already proven in `gps_live_fuel_estimator.dart`) further
+/// damps quantisation jitter before the derivative; off by default so
+/// the canonical OBD path is unchanged.
 ///
 /// Since #2029 the detector also records a [HarshEvent] per crossing
 /// — the integer counters stay as cheap getters for legacy consumers,
@@ -29,6 +59,10 @@ class HarshEventDetector {
   HarshEventDetector({
     this.brakeThresholdMps2 = 3.5,
     this.accelThresholdMps2 = 3.0,
+    this.minSustainedSec = 1.0,
+    this.minSpeedKmh = 5.0,
+    this.maxHAccuracyM = 10.0,
+    this.smoothSpeed = false,
   });
 
   /// Deceleration magnitude (m/s², positive number) at or above which
@@ -39,13 +73,41 @@ class HarshEventDetector {
   /// harsh acceleration.
   final double accelThresholdMps2;
 
+  /// Minimum window length (seconds) the derivative must span before a
+  /// crossing is counted (#2653). A single sub-[minSustainedSec]
+  /// interval — the phasing artefact a coarse speed staircase produces
+  /// against the [_evalIntervalSec] resample — is rejected, matching the
+  /// "sustained ≥ 1 s" convention in `gps_driving_features.dart`.
+  final double minSustainedSec;
+
+  /// Minimum mean interval speed (km/h) below which an interval is not
+  /// scored (#2653). Dead-reckoning noise at a near-standstill produces
+  /// phantom events; genuine harsh manoeuvres happen above a walking
+  /// pace.
+  final double minSpeedKmh;
+
+  /// Reported horizontal GPS accuracy (metres) above which a sample is
+  /// dropped *and* the anchor reset, so the derivative is never taken
+  /// across a bad fix (#2653). A non-finite or null accuracy is treated
+  /// as "unknown, accept" so OBD-speed-only samples (no GPS) still flow.
+  final double maxHAccuracyM;
+
+  /// When true, speed is passed through a 3-sample moving average before
+  /// differentiation (#2653), damping 1 km/h quantisation jitter. Off by
+  /// default — the canonical OBD path keeps its raw-speed behaviour.
+  final bool smoothSpeed;
+
   /// Minimum spacing (seconds) between two evaluated samples — this is
   /// what re-samples the speed signal at ~1 Hz. 0.9 rather than 1.0 so
   /// a nominally-1 Hz feed with minor jitter still evaluates every
   /// sample instead of skipping to a 2 s window.
   static const double _evalIntervalSec = 0.9;
 
+  /// Window length for the optional speed moving average.
+  static const int _smoothWindow = 3;
+
   final List<HarshEvent> _events = [];
+  final List<double> _speedWindow = [];
 
   // The last sample an evaluation was anchored on. Advances only when
   // an evaluation actually fires, so a burst of sub-second samples
@@ -72,43 +134,90 @@ class HarshEventDetector {
   /// Feed one speed sample. Safe to call at any cadence; samples
   /// closer together than [_evalIntervalSec] are folded into the next
   /// evaluated window rather than each producing a derivative.
-  void onSample(double speedKmh, DateTime timestamp) {
+  ///
+  /// [hAccuracyM] is the sample's reported horizontal GPS accuracy (null
+  /// / non-finite when unknown, e.g. an OBD-speed-only sample); a fix
+  /// worse than [maxHAccuracyM] is dropped and resets the anchor.
+  /// [suppress] is true when the sample's distance source is unfit for
+  /// speed differentiation (the `virtual` dead-reckoning odometer) — the
+  /// detector then ignores the sample entirely (#2653).
+  void onSample(
+    double speedKmh,
+    DateTime timestamp, {
+    double? hAccuracyM,
+    bool suppress = false,
+  }) {
+    // Source-aware suppression: a dead-reckoning speed signal is unfit
+    // for differentiation. Don't even seed the anchor from it.
+    if (suppress) return;
+
+    // Accuracy gate: a bad fix is worse than no fix — drop it and break
+    // the anchor so the derivative is never taken across it.
+    if (hAccuracyM != null && hAccuracyM.isFinite && hAccuracyM > maxHAccuracyM) {
+      _anchorAt = null;
+      _anchorSpeedKmh = null;
+      _speedWindow.clear();
+      return;
+    }
+
+    final speed = smoothSpeed ? _smooth(speedKmh) : speedKmh;
+
     final anchorAt = _anchorAt;
     final anchorSpeed = _anchorSpeedKmh;
     if (anchorAt == null || anchorSpeed == null) {
       _anchorAt = timestamp;
-      _anchorSpeedKmh = speedKmh;
+      _anchorSpeedKmh = speed;
       return;
     }
     final dt = timestamp.difference(anchorAt).inMicroseconds /
         Duration.microsecondsPerSecond;
     if (dt < _evalIntervalSec) return;
 
+    // Sustained-window gate: only count a crossing whose derivative was
+    // measured over a real ≥ minSustainedSec window. A single sub-1 s
+    // spike (the staircase phasing artefact) is rejected here.
+    // Min-speed floor: skip intervals at a near-standstill.
+    final meanSpeedKmh = (speed + anchorSpeed) / 2.0;
+    final scorable = dt >= minSustainedSec && meanSpeedKmh >= minSpeedKmh;
+
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
-    final accelMps2 = ((speedKmh - anchorSpeed) / 3.6) / dt;
-    if (accelMps2 <= -brakeThresholdMps2) {
+    final accelMps2 = ((speed - anchorSpeed) / 3.6) / dt;
+    if (scorable && accelMps2 <= -brakeThresholdMps2) {
       _events.add(HarshEvent(
         timestamp: timestamp,
         magnitudeG: (-accelMps2) / standardGravityMps2,
-        speedKmh: speedKmh,
+        speedKmh: speed,
         type: HarshEventType.brake,
       ));
-    } else if (accelMps2 >= accelThresholdMps2) {
+    } else if (scorable && accelMps2 >= accelThresholdMps2) {
       _events.add(HarshEvent(
         timestamp: timestamp,
         magnitudeG: accelMps2 / standardGravityMps2,
-        speedKmh: speedKmh,
+        speedKmh: speed,
         type: HarshEventType.acceleration,
       ));
     }
     _anchorAt = timestamp;
-    _anchorSpeedKmh = speedKmh;
+    _anchorSpeedKmh = speed;
+  }
+
+  /// Push [raw] into the moving-average window and return the smoothed
+  /// value (mean of the last up-to-[_smoothWindow] samples). Mirrors the
+  /// low-pass in `gps_live_fuel_estimator.dart`.
+  double _smooth(double raw) {
+    _speedWindow.add(raw);
+    if (_speedWindow.length > _smoothWindow) {
+      _speedWindow.removeAt(0);
+    }
+    final sum = _speedWindow.reduce((a, b) => a + b);
+    return sum / _speedWindow.length;
   }
 
   /// Reset the counters and anchor — used before recording a fresh
   /// trip without discarding the detector instance.
   void reset() {
     _events.clear();
+    _speedWindow.clear();
     _anchorSpeedKmh = null;
     _anchorAt = null;
   }

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -3,6 +3,7 @@
 
 import 'dart:math' as math;
 
+import '../data/obd2/trip_distance_source.dart' show kDistanceSourceVirtual;
 import 'harsh_event_detector.dart';
 import 'trip_sample.dart';
 import 'trip_summary.dart';
@@ -78,16 +79,33 @@ class TripRecorder {
 
   /// Feed one sample. Safe to call with arbitrary cadence; the
   /// recorder derives Δt internally.
-  void onSample(TripSample sample) {
+  ///
+  /// [distanceSource] is the trip's live distance provenance
+  /// (`kDistanceSourceReal` / `kDistanceSourceGps` /
+  /// `kDistanceSourceVirtual`, #2653). On a `virtual` (dead-reckoning)
+  /// source the speed signal is unfit for differentiation, so harsh
+  /// scoring is suppressed for that sample. Null leaves harsh scoring
+  /// enabled — the safe default for legacy / test call sites and the
+  /// OBD speed path.
+  void onSample(TripSample sample, {String? distanceSource}) {
     _startedAt ??= sample.timestamp;
     _endedAt = sample.timestamp;
     _maxRpm = math.max(_maxRpm, sample.rpm);
 
     // Harsh brake / accel — delegated to the detector, which
     // re-samples speed at ~1 Hz so the 250 ms emit cadence cannot
-    // inflate the count (#1922). Fed every sample, including the
-    // first, so its anchor is seeded from trip start.
-    _harshDetector.onSample(sample.speedKmh, sample.timestamp);
+    // inflate the count (#1922), then de-noises with a sustained-window
+    // + accuracy + min-speed + source-aware gate (#2653). Fed every
+    // sample, including the first, so its anchor is seeded from trip
+    // start. On the `virtual` dead-reckoning source the detector
+    // suppresses scoring entirely (median 4.78 / peak 43.4 phantom
+    // events/km in the field backup).
+    _harshDetector.onSample(
+      sample.speedKmh,
+      sample.timestamp,
+      hAccuracyM: sample.hAccuracyM,
+      suppress: distanceSource == kDistanceSourceVirtual,
+    );
 
     // Track coolant samples for the cold-start surcharge heuristic
     // (#1262 phase 2). Cars without PID 0x05 carry coolantTempC ==

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -11,6 +11,7 @@ import '../../../core/logging/error_logger.dart';
 import '../../vehicle/domain/entities/gps_calibration_matrix.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
+import '../data/obd2/trip_distance_source.dart' show kDistanceSourceGps;
 import '../data/obd2/trip_live_reading.dart';
 import '../domain/entities/trip_save_stage.dart';
 import '../domain/gps_driving_features.dart';
@@ -158,7 +159,13 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
       bearingDeg: p.heading.isFinite ? p.heading : null,
     );
     _samples.add(sample);
-    recorder.onSample(sample);
+    // #2653 — a GPS-only trip's speed is the device's Doppler ground
+    // speed (genuine ~1 Hz, not 1 km/h-quantised dead reckoning), so it
+    // is differentiable; the detector's accuracy + min-speed +
+    // sustained-window gates de-noise it without the wholesale
+    // suppression the `virtual` source needs. Tag it `gps` so harsh
+    // scoring stays enabled-but-gated rather than suppressed.
+    recorder.onSample(sample, distanceSource: kDistanceSourceGps);
     final summary = recorder.buildSummary();
     // #2389 / #2506 — fold this fix into the SHARED estimate + coaching
     // folder (also used by the OBD2 live path). The folder does its own

--- a/test/features/consumption/domain/harsh_event_detector_test.dart
+++ b/test/features/consumption/domain/harsh_event_detector_test.dart
@@ -169,5 +169,141 @@ void main() {
       lenient.onSample(30, start.add(const Duration(seconds: 2)));
       expect(lenient.brakes, 0);
     });
+
+    // ---- #2653 de-noising gates -----------------------------------------
+
+    group('sustained-window gate (#2653)', () {
+      test('a single sub-1 s spike does NOT fire', () {
+        // 80 → 60 km/h is -6.2 m/s² — harsh by magnitude — but it
+        // happened across only a 0.9 s window. A coarse staircase
+        // sampled against the ~0.9 s resample produces exactly this kind
+        // of one-interval phasing artefact; the sustained gate rejects
+        // it because the derivative did not span ≥ 1 s.
+        detector.onSample(80, start);
+        detector.onSample(
+            60, start.add(const Duration(milliseconds: 900)));
+        expect(detector.brakes, 0);
+        expect(detector.accelerations, 0);
+      });
+
+      test('a ≥1 s sustained event DOES fire', () {
+        // The same -6.2 m/s² magnitude, now measured over a full 1.0 s
+        // window — a genuine hard brake, counted.
+        detector.onSample(90, start);
+        detector.onSample(74, start.add(const Duration(seconds: 1)));
+        expect(detector.brakes, 1);
+      });
+
+      test('minSustainedSec is configurable', () {
+        // Tighten the window to 0.5 s and the 0.9 s spike now counts —
+        // proves the gate is the only thing suppressing it above.
+        final loose = HarshEventDetector(minSustainedSec: 0.5);
+        loose.onSample(80, start);
+        loose.onSample(60, start.add(const Duration(milliseconds: 900)));
+        expect(loose.brakes, 1);
+      });
+    });
+
+    group('accuracy gate (#2653)', () {
+      test('a bad-fix sample (> 10 m) is rejected and breaks the anchor',
+          () {
+        // A jittery urban-canyon fix with 25 m accuracy must not feed the
+        // derivative — "a bad fix is worse than no fix". The anchor at
+        // 80 km/h is dropped, so no brake is computed across it.
+        detector.onSample(80, start, hAccuracyM: 4);
+        detector.onSample(30, start.add(const Duration(seconds: 2)),
+            hAccuracyM: 25);
+        expect(detector.brakes, 0);
+      });
+
+      test('a good-fix sample (≤ 10 m) is scored normally', () {
+        detector.onSample(80, start, hAccuracyM: 4);
+        detector.onSample(30, start.add(const Duration(seconds: 2)),
+            hAccuracyM: 6);
+        expect(detector.brakes, 1);
+      });
+
+      test('a null / unknown accuracy is accepted (OBD-speed-only path)',
+          () {
+        detector.onSample(80, start);
+        detector.onSample(30, start.add(const Duration(seconds: 2)));
+        expect(detector.brakes, 1);
+      });
+    });
+
+    group('min-speed floor (#2653)', () {
+      // A genuine ≥ 3.5 m/s² derivative is physically impossible below a
+      // 5 km/h mean over a ≥ 1 s window (both endpoints < 10 km/h ⇒
+      // Δv < 2.8 m/s²), so the floor is exercised against a *lenient*
+      // threshold that a low-speed dead-reckoning wobble can cross —
+      // proving the floor, not the magnitude threshold.
+      test('a crawl-speed wobble below the floor is not scored', () {
+        final crawl = HarshEventDetector(brakeThresholdMps2: 1.0);
+        crawl.onSample(7, start);
+        // 7 → 0 km/h over 1 s = -1.94 m/s² (≥ 1.0 lenient threshold), but
+        // the mean is 3.5 km/h — below the 5 km/h floor → not scored.
+        crawl.onSample(0, start.add(const Duration(seconds: 1)));
+        expect(crawl.brakes, 0);
+        expect(crawl.accelerations, 0);
+      });
+
+      test('the same wobble above the floor IS scored', () {
+        final fast = HarshEventDetector(brakeThresholdMps2: 1.0);
+        fast.onSample(20, start);
+        // 20 → 13 km/h over 1 s = -1.94 m/s², mean 16.5 km/h ≥ 5 → counts.
+        fast.onSample(13, start.add(const Duration(seconds: 1)));
+        expect(fast.brakes, 1);
+      });
+
+      test('minSpeedKmh is configurable', () {
+        // Drop the floor to 0 and the crawl-speed wobble now counts —
+        // confirming the floor is the only thing suppressing it above.
+        final noFloor =
+            HarshEventDetector(brakeThresholdMps2: 1.0, minSpeedKmh: 0);
+        noFloor.onSample(7, start);
+        noFloor.onSample(0, start.add(const Duration(seconds: 1)));
+        expect(noFloor.brakes, 1);
+      });
+    });
+
+    group('source-aware suppression (#2653)', () {
+      test('a suppressed sample is ignored entirely (anchor not seeded)',
+          () {
+        // Feed a clearly-harsh brake on a suppressed (virtual) source —
+        // it must produce nothing AND not even seed the anchor, so a
+        // following non-suppressed sample starts fresh.
+        detector.onSample(90, start, suppress: true);
+        detector.onSample(40, start.add(const Duration(seconds: 1)),
+            suppress: true);
+        expect(detector.brakes, 0);
+        expect(detector.accelerations, 0);
+      });
+    });
+
+    group('optional speed pre-smoothing (#2653)', () {
+      test('a 3-sample moving average damps a single-step quantisation '
+          'spike', () {
+        // A 1 km/h-quantised signal sits at 50, jumps to 70 for one
+        // sample, then settles at 51. Differentiated raw, the 50→70
+        // step over 1 s is +5.6 m/s² → a phantom harsh accel. The
+        // 3-sample MA blunts the lone spike below the threshold.
+        final smoothed = HarshEventDetector(smoothSpeed: true);
+        smoothed.onSample(50, start);
+        smoothed.onSample(50, start.add(const Duration(seconds: 1)));
+        smoothed.onSample(70, start.add(const Duration(seconds: 2)));
+        smoothed.onSample(51, start.add(const Duration(seconds: 3)));
+        smoothed.onSample(51, start.add(const Duration(seconds: 4)));
+        expect(smoothed.accelerations, 0);
+
+        // The same series WITHOUT smoothing fires the phantom.
+        final raw = HarshEventDetector();
+        raw.onSample(50, start);
+        raw.onSample(50, start.add(const Duration(seconds: 1)));
+        raw.onSample(70, start.add(const Duration(seconds: 2)));
+        raw.onSample(51, start.add(const Duration(seconds: 3)));
+        raw.onSample(51, start.add(const Duration(seconds: 4)));
+        expect(raw.accelerations, greaterThanOrEqualTo(1));
+      });
+    });
   });
 }

--- a/test/features/consumption/domain/trip_recorder_test.dart
+++ b/test/features/consumption/domain/trip_recorder_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_distance_source.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 
 /// Pure-logic tests for the trip recorder (#718).
@@ -499,6 +500,122 @@ void main() {
           rpm: 2000,
         ));
         expect(r.buildSummary().distanceKm, closeTo(60 * 20 / 60, 1e-6));
+      });
+    });
+
+    group('harsh-event de-noising by distance source (#2653)', () {
+      // A backup-like VIRTUAL (dead-reckoning) speed series: the recorder
+      // ticks at 1 Hz, but the 1 km/h-quantised virtual speed only steps
+      // to a new value every 6 s, bouncing ±15 km/h around a 45 km/h
+      // cruise — the classic integrator over/undershoot. The 15 km/h
+      // step compressed into a single ~1 s eval window manufactures a
+      // phantom harsh event at almost every bounce.
+      //
+      // On master (source-blind, no sustained/min-speed gate) this
+      // measured ~13.3 phantom events/km — far above even the field
+      // backup's 4.78 median / 43.4 peak on virtual trips, and orders of
+      // magnitude above the 1.06/km of genuine GPS-sourced trips.
+      const bounce = <double>[45, 60, 45, 30];
+
+      void feedBounce(TripRecorder r, {required String distanceSource}) {
+        final start = DateTime.utc(2026);
+        var latched = bounce[0];
+        var stepIdx = 0;
+        var lastStepSec = 0;
+        for (var i = 0; i < 1200; i++) {
+          if (i - lastStepSec >= 6) {
+            stepIdx++;
+            latched = bounce[stepIdx % bounce.length];
+            lastStepSec = i;
+          }
+          r.onSample(
+            TripSample(
+              timestamp: start.add(Duration(seconds: i)),
+              speedKmh: latched,
+              rpm: 0,
+            ),
+            distanceSource: distanceSource,
+          );
+        }
+      }
+
+      test(
+          'VIRTUAL source: the dead-reckoning staircase yields < 1.5 '
+          'events/km (master ≈ 13.3, suppressed here)', () {
+        final r = TripRecorder();
+        feedBounce(r, distanceSource: kDistanceSourceVirtual);
+        final s = r.buildSummary();
+        final total = s.harshBrakes + s.harshAccelerations;
+        final perKm = total / s.distanceKm;
+        expect(s.distanceKm, greaterThan(10),
+            reason: 'sanity: the series should cover ~15 km');
+        expect(perKm, lessThan(1.5),
+            reason: 'virtual dead-reckoning must not manufacture harsh '
+                'events — master counted ~13.3/km here');
+        expect(total, 0,
+            reason: 'the virtual source is suppressed entirely');
+      });
+
+      test(
+          'GPS source: the SAME staircase is gated, not suppressed, and '
+          'a genuine GPS-fed signal still scores', () {
+        // The 6 s-step staircase is an artefact of a coarse virtual
+        // odometer; a real GPS Doppler signal does not look like this.
+        // We still assert the gps path is NOT wholesale-suppressed by
+        // feeding a genuine, well-spaced hard brake on the gps source
+        // and confirming it counts.
+        final r = TripRecorder();
+        final start = DateTime.utc(2026);
+        r.onSample(
+          TripSample(timestamp: start, speedKmh: 90, rpm: 0, hAccuracyM: 5),
+          distanceSource: kDistanceSourceGps,
+        );
+        r.onSample(
+          TripSample(
+            timestamp: start.add(const Duration(seconds: 2)),
+            speedKmh: 30,
+            rpm: 0,
+            hAccuracyM: 5,
+          ),
+          distanceSource: kDistanceSourceGps,
+        );
+        expect(r.buildSummary().harshBrakes, 1,
+            reason: 'gps source must stay enabled-but-gated');
+      });
+
+      test('a bad-accuracy GPS fix (> 10 m) is rejected end-to-end', () {
+        final r = TripRecorder();
+        final start = DateTime.utc(2026);
+        r.onSample(
+          TripSample(timestamp: start, speedKmh: 90, rpm: 0, hAccuracyM: 4),
+          distanceSource: kDistanceSourceGps,
+        );
+        r.onSample(
+          TripSample(
+            timestamp: start.add(const Duration(seconds: 2)),
+            speedKmh: 30,
+            rpm: 0,
+            hAccuracyM: 30, // jittery urban-canyon fix
+          ),
+          distanceSource: kDistanceSourceGps,
+        );
+        expect(r.buildSummary().harshBrakes, 0,
+            reason: 'a bad fix is worse than no fix — not differentiated');
+      });
+
+      test('no distanceSource keeps harsh scoring enabled (legacy default)',
+          () {
+        // The legacy / OBD-speed call site passes no source — the genuine
+        // hard brake must still count exactly as before #2653.
+        final r = TripRecorder();
+        final start = DateTime.utc(2026);
+        r.onSample(TripSample(timestamp: start, speedKmh: 90, rpm: 3000));
+        r.onSample(TripSample(
+          timestamp: start.add(const Duration(seconds: 2)),
+          speedKmh: 30,
+          rpm: 1500,
+        ));
+        expect(r.buildSummary().harshBrakes, 1);
       });
     });
   });

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -192,7 +192,12 @@ void main() {
     // `@visibleForTesting` debug getters. Net +26; the field plumbing
     // must live on the controller seam. Decomposition stays tracked by
     // #2187/#2188/#2190.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1621,
+    // #2653 — re-grandfathered 1621 → 1623: the `_recorder.onSample`
+    // call now threads the live `distanceSource` (+ a 2-line rationale
+    // comment) so the harsh-event detector suppresses scoring on the
+    // `virtual` dead-reckoning source. Net +2; the wiring must live at the
+    // controller's emit site. Decomposition stays tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1623,
     // #2442 — re-grandfathered 496 → 513: the save flow now raises the
     // guided reconciliation workflow after a plein save (a 7-line
     // await-then-route call into the extracted


### PR DESCRIPTION
## Problem

The harsh-event detector over-detects on the **`virtual`** (dead-reckoning) distance source. A real 77-trip backup measured a **median of 4.78** and a **peak of 43.4 phantom events/km** on virtual trips, versus **1.06/km** on GPS-sourced trips. 43.4 events/km is physically impossible — it is measurement noise counted as events, and it poisons `DrivingStyleScore`, the insights analyzer, and any future style/efficiency feature.

**Root cause:** the detector was source-blind, accuracy-blind, min-speed-blind and had **no sustained-duration gate** — a single qualifying ~0.9 s interval fired. On a coarse 1 km/h-quantised dead-reckoning speed signal the re-emit-vs-step phasing manufactures phantom slopes: a ~15 km/h staircase bounce compressed into a single ~1 s eval window trips the 3.0 / 3.5 m/s² thresholds at almost every step.

## Fix (`harsh_event_detector.dart`; canonical thresholds unchanged)

1. **Sustained-window gate** — the derivative must span ≥ 1 s (matching `gps_driving_features.dart`). A single sub-1 s spike can no longer fire.
2. **Accuracy gate** — a fix with `hAccuracyM > 10 m` is dropped **and** breaks the anchor, so the derivative is never taken across a bad fix ("a bad fix is worse than no fix"). Possible since #2648/#2650 persist `hAccuracyM`.
3. **Min-speed floor** — intervals below a 5 km/h mean are not scored; dead-reckoning noise at a near-standstill manufactures phantom events.
4. **Source-aware suppression** — the `virtual` dead-reckoning source skips harsh scoring entirely (its quantised speed is unfit for differentiation). Threaded via `TripRecorder.onSample(distanceSource:)` from the OBD2 controller's emit site. GPS-only trips pass `gps` so their genuine Doppler speed stays **enabled-but-gated**, not suppressed — that is where speed-derived harsh detection has value.
5. **Optional** 3-sample MA pre-smoothing on speed (off by default; mirrors `gps_live_fuel_estimator.dart`).

## RED → GREEN

A deterministic backup-like virtual series — 1 Hz feed, 1 km/h-quantised speed stepping ±15 km/h every 6 s (the classic integrator over/undershoot) over ~15 km — measures:

| | events/km |
|---|---|
| **master detector logic (RED)** | **13.28** |
| **fixed, `virtual` source (GREEN)** | **0.00** (< 1.5 gate) |

New unit tests cover the sustained-window, accuracy, min-speed, source-suppression and pre-smoothing gates plus an end-to-end `TripRecorder` regression by distance source. The existing cadence-independence + genuine-hard-brake contract is fully preserved (all prior detector/recorder tests stay green).

## Scope

Deliberately does **not** touch `gps_driving_features.dart` / `driving_insights_analyzer.dart` — the 3-detector reconciliation is C3, serialized after this.

`flutter analyze` clean; `test/features/consumption` + `test/lint` green (the controller test file passes standalone; a batch-only timer-ordering flake unrelated to this change does not affect CI's per-file sharding). Clean `build_runner` produced zero `*.g.dart` / `*.freezed.dart` drift; no `lib/l10n/` diff (no ARB). `file_length` re-grandfathered the controller 1621 → 1623 (+2, the `distanceSource` wiring at the emit site).

Closes #2653 (Epic #2647)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
