### PR TITLE
refactor(analytics): reconcile the 3 divergent accel-event detectors onto one canonical gate (#2667)

### DIFF
--- a/lib/features/consumption/data/driving_insights_analyzer.dart
+++ b/lib/features/consumption/data/driving_insights_analyzer.dart
@@ -17,6 +17,7 @@
 /// throttle, coolant temp, and elevation data.
 library;
 
+import '../domain/accel_event_gate.dart';
 import '../domain/driving_insight.dart';
 import '../domain/trip_recorder.dart';
 import '../presentation/widgets/trip_detail_charts.dart';
@@ -24,8 +25,11 @@ import '../presentation/widgets/trip_detail_charts.dart';
 /// RPM above which a sample counts as "high RPM".
 const double _highRpmThreshold = 3000;
 
-/// Acceleration (m/s²) above which an interval counts as "hard accel".
-const double _hardAccelThresholdMps2 = 3.0;
+// Hard-accel detection now routes through the ONE shared accel-event gate
+// (#2667): `kHardAccelThresholdMps2` (3.0) sustained ≥ 1 s with the
+// accuracy + min-speed gate, so the insight count agrees with the harsh
+// detector, the driving score, and the GPS features. The old raw
+// per-interval `_hardAccelThresholdMps2` constant is gone.
 
 /// Liters wasted per hard-accel event. Documented constant — see
 /// `docs/guides/driving-insights.md`. Order-of-magnitude estimate
@@ -97,13 +101,23 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
       Duration.microsecondsPerSecond;
   if (totalDt <= 0) return const [];
 
+  // Hard-accel EPISODES via the ONE shared gate (#2667) — same count the
+  // harsh detector, the score, and the GPS features report.
+  final accelCounts = countAccelEvents([
+    for (final s in sorted)
+      AccelSamplePoint(
+        timestamp: s.timestamp,
+        speedKmh: s.speedKmh,
+        hAccuracyM: s.hAccuracyM,
+      ),
+  ]);
+  final hardAccelEvents = accelCounts.accelEvents;
+  final hardAccelTotalDt = accelCounts.accelSeconds;
+
   // Accumulators.
   double highRpmSeconds = 0;
   double highRpmWastedLiters = 0;
   bool sawFuelRateInHighRpm = false;
-
-  int hardAccelEvents = 0;
-  double hardAccelTotalDt = 0;
 
   double idleSeconds = 0;
   double idleWastedLiters = 0;
@@ -174,14 +188,8 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
       }
     }
 
-    // Hard-acceleration: derivative of speed across the interval.
-    // Convert km/h → m/s by / 3.6.
-    final dvMps = (cur.speedKmh - prev.speedKmh) / 3.6;
-    final accelMps2 = dvMps / dt;
-    if (accelMps2 >= _hardAccelThresholdMps2) {
-      hardAccelEvents++;
-      hardAccelTotalDt += dt;
-    }
+    // Hard-acceleration is counted ABOVE via the shared gate (#2667), not
+    // per-interval here.
 
     // Idling: engine on (rpm > 0), car stationary (speed == 0) for
     // the whole interval. Use a small tolerance on speed to absorb
@@ -235,7 +243,7 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
         percentOfTrip: pctTime,
         metadata: {
           'eventCount': hardAccelEvents,
-          'thresholdMps2': _hardAccelThresholdMps2,
+          'thresholdMps2': kHardAccelThresholdMps2,
           'pctTime': pctTime,
         },
       ));
@@ -306,13 +314,18 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
   return candidates.sublist(0, _topN);
 }
 
-/// Returns the indices of samples (in the sorted-by-timestamp ordering)
-/// where a hard-acceleration event ended — i.e. where the speed delta
-/// from the previous sample exceeds [_hardAccelThresholdMps2]. Mirrors
-/// the detection logic in [analyzeTrip] so the trip-detail map can
-/// render markers at the matching positions (#1458 phase 1).
+/// Returns one index per hard-acceleration EPISODE (in the
+/// sorted-by-timestamp ordering): the end index of the interval at which
+/// the episode first crossed the canonical [kHardAccelThresholdMps2]
+/// sustained ≥ 1 s, via the ONE shared [countAccelEvents] gate (#2667).
+/// The trip-detail map drops a bolt marker at each (#1458 phase 1).
 ///
-/// Sorting + dt-guard contract identical to [analyzeTrip]:
+/// Reconciled (#2667): markers now come from the same gate the analyzer's
+/// hard-accel count uses, so a single physical hard accel yields ONE
+/// marker — not one per qualifying sample interval as the old raw
+/// per-interval logic produced on a multi-second pull.
+///
+/// Sorting + dt-guard contract (delegated to the gate):
 ///   * input is copied + sorted by timestamp before iteration so an
 ///     out-of-order list never spuriously reports an event;
 ///   * intervals with `dt <= 0` are skipped (duplicate timestamps);
@@ -320,37 +333,19 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
 ///     no previous sample to derive an acceleration from.
 ///
 /// IMPORTANT: the returned indices reference positions in the
-/// INTERNALLY-SORTED list, NOT the caller's input order. Callers that
-/// want to map indices back to coordinates must sort their own samples
-/// by timestamp the same way before indexing. The trip-detail map
-/// already passes timestamp-sorted samples (recorder writes monotonic
-/// timestamps), so it can use the indices directly.
+/// INTERNALLY-SORTED list, NOT the caller's input order. The trip-detail
+/// map already passes timestamp-sorted samples, so it can use them
+/// directly.
 List<int> hardAccelSampleIndices(List<TripDetailSample> samples) {
   if (samples.length < 2) return const <int>[];
-
-  // Copy + sort so out-of-order persistence (#1040 race conditions)
-  // doesn't blow up the integration. Same pattern as [analyzeTrip].
-  final sorted = [...samples]
-    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
-
-  final indices = <int>[];
-  for (var i = 1; i < sorted.length; i++) {
-    final prev = sorted[i - 1];
-    final cur = sorted[i];
-    final dt =
-        cur.timestamp.difference(prev.timestamp).inMicroseconds /
-            Duration.microsecondsPerSecond;
-    if (dt <= 0) continue;
-
-    // Same conversion as [analyzeTrip]: km/h → m/s by / 3.6, then
-    // divide by Δt to get acceleration in m/s².
-    final dvMps = (cur.speedKmh - prev.speedKmh) / 3.6;
-    final accelMps2 = dvMps / dt;
-    if (accelMps2 >= _hardAccelThresholdMps2) {
-      indices.add(i);
-    }
-  }
-  return indices;
+  return countAccelEvents([
+    for (final s in samples)
+      // TripDetailSample carries no horizontal accuracy — pass null
+      // ("unknown, accept") so the gate behaves exactly as before for the
+      // accuracy dimension while still applying the shared sustained-window
+      // + min-speed + canonical-threshold gate.
+      AccelSamplePoint(timestamp: s.timestamp, speedKmh: s.speedKmh),
+  ]).accelStartIndices;
 }
 
 /// Fallback when no fuel-rate samples are available during the

--- a/lib/features/consumption/data/driving_score_accumulators.dart
+++ b/lib/features/consumption/data/driving_score_accumulators.dart
@@ -20,8 +20,6 @@ class _Accumulators {
   double coastSeconds = 0;
   double highSpeedSeconds = 0;
   double lambdaEnrichSeconds = 0;
-  int hardAccelEvents = 0;
-  int hardBrakeEvents = 0;
   int hardShiftSpikes = 0;
   int revWhileStationaryBlips = 0;
   double maxPedalVelocity = 0;
@@ -79,13 +77,10 @@ class _Accumulators {
     // is high-RPM time, not a shift spike).
     if (cur.rpm - prev.rpm >= _hardShiftRpmSpike) hardShiftSpikes++;
 
-    // Hard accel / brake from the speed derivative.
-    final accelMps2 = (cur.speedKmh - prev.speedKmh) / 3.6 / dt;
-    if (accelMps2 >= kHardAccelThresholdMps2) {
-      hardAccelEvents++;
-    } else if (accelMps2 <= -kHardBrakeThresholdMps2) {
-      hardBrakeEvents++;
-    }
+    // Hard accel / brake are NOT counted here anymore (#2667): they come
+    // from the ONE shared `countAccelEvents` episode gate, passed into
+    // [build], so the score agrees with the harsh detector / insights /
+    // GPS features instead of over-counting per interval.
 
     // Speed efficiency: high-speed band.
     if (prev.speedKmh >= kHighSpeedThresholdKmh) highSpeedSeconds += dt;
@@ -108,6 +103,8 @@ class _Accumulators {
   DrivingScore build({
     required double totalDt,
     required double? secondsBelowOptimalGear,
+    required int hardAccelEvents,
+    required int hardBrakeEvents,
   }) {
     final idlingPenalty =
         _clamp(idleSeconds / totalDt * _idlingCap, 0, _idlingCap);

--- a/lib/features/consumption/data/driving_score_calculator.dart
+++ b/lib/features/consumption/data/driving_score_calculator.dart
@@ -43,8 +43,15 @@ library;
 
 import 'dart:math' as math;
 
+import '../domain/accel_event_gate.dart';
 import '../domain/driving_score.dart';
 import '../domain/trip_recorder.dart';
+
+// #2667 — re-export the canonical accel/brake thresholds so existing
+// importers of this file (lessons, tests) keep resolving them, while the
+// SINGLE source of truth is `accel_event_gate.dart`.
+export '../domain/accel_event_gate.dart'
+    show kHardAccelThresholdMps2, kHardBrakeThresholdMps2;
 
 // #2460 — the per-interval accumulator + the inline Welford helper live in
 // a part file so this orchestrator stays under the 400-line guard. They
@@ -52,16 +59,12 @@ import '../domain/trip_recorder.dart';
 part 'driving_score_accumulators.dart';
 
 // ---- Canonical thresholds (shared by analyzer + lessons + score) ----
+//
+// kHardAccelThresholdMps2 / kHardBrakeThresholdMps2 now live in
+// `accel_event_gate.dart` (#2667 — the ONE source) and are imported above.
 
 /// RPM above which a sample counts as "high RPM".
 const double kHighRpmThreshold = 3000;
-
-/// Acceleration (m/s²) at/above which an interval is a hard-accel event.
-const double kHardAccelThresholdMps2 = 3.0;
-
-/// Deceleration (m/s², positive) at/below whose negation an interval is
-/// a hard-brake event. Canonical 3.5 (#2460).
-const double kHardBrakeThresholdMps2 = 3.5;
 
 /// Pedal / throttle percent at/above which a sample counts as "full
 /// throttle".
@@ -150,9 +153,24 @@ DrivingScore computeDrivingScore(
     acc.accumulate(prev: prev, cur: cur, dt: dt);
   }
 
+  // Hard-accel / hard-brake EPISODES via the ONE shared gate (#2667) — so
+  // the score agrees with the harsh detector, the insights, and the GPS
+  // features on what counts as a single physical event (the accumulator no
+  // longer over-counts a multi-interval manoeuvre once per interval).
+  final accelCounts = countAccelEvents([
+    for (final s in sorted)
+      AccelSamplePoint(
+        timestamp: s.timestamp,
+        speedKmh: s.speedKmh,
+        hAccuracyM: s.hAccuracyM,
+      ),
+  ]);
+
   return acc.build(
     totalDt: totalDt,
     secondsBelowOptimalGear: secondsBelowOptimalGear,
+    hardAccelEvents: accelCounts.accelEvents,
+    hardBrakeEvents: accelCounts.brakeEvents,
   );
 }
 

--- a/lib/features/consumption/domain/accel_event_gate.dart
+++ b/lib/features/consumption/domain/accel_event_gate.dart
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// The ONE canonical accel-event gate (#2667, Epic #2647 C3 / Fix D).
+///
+/// Three independent detectors used to disagree on the count for the same
+/// physical event:
+///   * [HarshEventDetector] (3.0/3.5 m/s², a ~0.9 s resample, and — since
+///     #2653 — a sustained-window + accuracy + min-speed + source gate),
+///   * `GpsDrivingFeatures.from` (a *2.0 m/s²* threshold with a ≥ 1 s
+///     window but NO accuracy / min-speed gate),
+///   * `driving_insights_analyzer.dart` (a *raw* `dvMps/dt` at 3.0 m/s²
+///     with NO sustained window at all).
+///
+/// `driving_score_calculator.dart` already canonicalised
+/// [kHardAccelThresholdMps2] / [kHardBrakeThresholdMps2] but the others
+/// did not import them, so a single physical event yielded up to four
+/// different counts.
+///
+/// This file is the single source of truth: the canonical thresholds and
+/// the shared gate constants live here, plus one pure [countAccelEvents]
+/// episode counter that every consumer routes through. The score
+/// calculator re-exports the threshold constants from here, the harsh
+/// detector keys its defaults off them, and the GPS-features / insights
+/// list paths call [countAccelEvents] directly — so a given physical
+/// event yields ONE count across the score, the insights, and the GPS
+/// features.
+///
+/// ## Count semantics — one event per *episode*
+///
+/// An "event" is one sustained threshold-crossing *episode*, not one per
+/// qualifying sample interval. A 4-second hard brake is ONE brake, not
+/// four. The detector arms when the speed derivative first holds at or
+/// beyond the threshold for at least [kAccelEventMinSustainedSec], counts
+/// once, then re-arms only after the derivative drops back below the
+/// threshold. This matches the physical intuition of "how many times did
+/// the driver brake/accelerate hard", and is the semantics the GPS
+/// features already used — it is the harsh detector's old
+/// once-per-resample-interval count that was the outlier.
+library;
+
+/// Acceleration (m/s²) at/above which an interval is a hard-accel event.
+/// Canonical — re-exported by `driving_score_calculator.dart`.
+const double kHardAccelThresholdMps2 = 3.0;
+
+/// Deceleration (m/s², positive) at/below whose negation an interval is a
+/// hard-brake event. Canonical 3.5 (brake harder to trip than accel — the
+/// telematics convention).
+const double kHardBrakeThresholdMps2 = 3.5;
+
+/// Minimum window length (seconds) the derivative must span before a
+/// crossing counts (#2653) — rejects the single sub-1 s phasing spike a
+/// coarse speed staircase produces. Matches the "sustained ≥ 1 s"
+/// convention shared with the GPS features.
+const double kAccelEventMinSustainedSec = 1.0;
+
+/// Minimum mean interval speed (km/h) below which an interval is not
+/// scored (#2653). Dead-reckoning noise at a near-standstill manufactures
+/// phantom events; genuine harsh manoeuvres happen above a walking pace.
+const double kAccelEventMinSpeedKmh = 5.0;
+
+/// Reported horizontal GPS accuracy (metres) above which a sample is
+/// dropped *and* the episode anchor reset, so the derivative is never
+/// taken across a bad fix (#2653) — "a bad fix is worse than no fix". A
+/// null / non-finite accuracy is treated as "unknown, accept" so
+/// OBD-speed-only samples (no GPS) still flow.
+const double kAccelEventAccuracyGateM = 10.0;
+
+/// Upper Δt (seconds) between two samples still treated as a measurement
+/// interval. A longer gap is a dropout/pause, not a window — counting a
+/// derivative across it would fabricate an event.
+const double kAccelEventMaxGapSec = 60.0;
+
+/// One sample fed to [countAccelEvents]. Decoupled from any concrete
+/// sample type so both `TripSample` (with `hAccuracyM`) and the leaner
+/// `TripDetailSample` (no accuracy) can map onto it.
+class AccelSamplePoint {
+  const AccelSamplePoint({
+    required this.timestamp,
+    required this.speedKmh,
+    this.hAccuracyM,
+  });
+
+  final DateTime timestamp;
+  final double speedKmh;
+
+  /// Reported horizontal GPS accuracy (m); null/non-finite = unknown.
+  final double? hAccuracyM;
+}
+
+/// Accel / brake episode counts plus the indices (into the
+/// timestamp-sorted input) at which each accel episode *began* — the
+/// markers the trip-detail map renders (#1458).
+class AccelEventCounts {
+  const AccelEventCounts({
+    required this.accelEvents,
+    required this.brakeEvents,
+    required this.accelSeconds,
+    required this.accelStartIndices,
+  });
+
+  final int accelEvents;
+  final int brakeEvents;
+
+  /// Total seconds spent inside hard-accel episodes (the sum of the
+  /// qualifying intervals' Δt). Used by the insights analyzer for the
+  /// hard-accel cost line's `percentOfTrip`.
+  final double accelSeconds;
+
+  /// Post-sort indices where an accel episode is first *confirmed* — the
+  /// end index of the interval at which the sustained-window floor
+  /// ([kAccelEventMinSustainedSec]) is reached. One index per episode; the
+  /// trip-detail map drops one marker there (#1458).
+  final List<int> accelStartIndices;
+}
+
+/// Count hard-accel / hard-brake *episodes* over [points] using the
+/// canonical thresholds + the shared sustained-window + accuracy +
+/// min-speed gate (#2667).
+///
+/// Pure and synchronous. The input is copied and sorted by timestamp
+/// (so out-of-order persistence cannot fabricate or drop an event); the
+/// caller's list is never mutated. Intervals with `dt <= 0` (duplicate
+/// timestamps) or `dt > kAccelEventMaxGapSec` (a dropout) are skipped and
+/// break the running episode so the derivative is never taken across the
+/// gap.
+///
+/// [suppress] — when true the whole series is unfit for differentiation
+/// (the `virtual` dead-reckoning odometer); counts are zero. Mirrors the
+/// harsh detector's source-aware suppression so the GPS-only / virtual
+/// paths agree on "no events" rather than counting phasing artefacts.
+AccelEventCounts countAccelEvents(
+  List<AccelSamplePoint> points, {
+  bool suppress = false,
+}) {
+  if (suppress || points.length < 2) {
+    return const AccelEventCounts(
+      accelEvents: 0,
+      brakeEvents: 0,
+      accelSeconds: 0,
+      accelStartIndices: <int>[],
+    );
+  }
+
+  final sorted = [...points]
+    ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+  var accelEvents = 0, brakeEvents = 0;
+  var accelSeconds = 0.0;
+  final accelStartIndices = <int>[];
+
+  // Episode state: accumulate the sustained duration above each threshold;
+  // arm once it first reaches the sustained-window floor; re-arm only when
+  // the derivative drops back below the threshold.
+  var accelDur = 0.0, brakeDur = 0.0;
+  var inAccel = false, inBrake = false;
+
+  void breakEpisodes() {
+    accelDur = 0;
+    brakeDur = 0;
+    inAccel = false;
+    inBrake = false;
+  }
+
+  for (var i = 1; i < sorted.length; i++) {
+    final prev = sorted[i - 1];
+    final cur = sorted[i];
+    final dt = cur.timestamp.difference(prev.timestamp).inMicroseconds /
+        Duration.microsecondsPerSecond;
+    if (dt <= 0 || dt > kAccelEventMaxGapSec) {
+      breakEpisodes();
+      continue;
+    }
+
+    // Accuracy gate: a bad fix is worse than no fix — drop it and break
+    // the running episode so no derivative spans it.
+    final pAcc = prev.hAccuracyM, cAcc = cur.hAccuracyM;
+    final badFix = (pAcc != null && pAcc.isFinite && pAcc > kAccelEventAccuracyGateM) ||
+        (cAcc != null && cAcc.isFinite && cAcc > kAccelEventAccuracyGateM);
+    if (badFix) {
+      breakEpisodes();
+      continue;
+    }
+
+    // Min-speed floor: a near-standstill wobble is not a real manoeuvre.
+    final meanSpeedKmh = (prev.speedKmh + cur.speedKmh) / 2.0;
+    if (meanSpeedKmh < kAccelEventMinSpeedKmh) {
+      breakEpisodes();
+      continue;
+    }
+
+    // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
+    final accelMps2 = ((cur.speedKmh - prev.speedKmh) / 3.6) / dt;
+
+    if (accelMps2 >= kHardAccelThresholdMps2) {
+      accelDur += dt;
+      accelSeconds += dt;
+      if (!inAccel && accelDur >= kAccelEventMinSustainedSec) {
+        accelEvents++;
+        // Confirm at the END index of the interval that crossed the
+        // sustained floor — where the hard accel is first certain, the
+        // marker position the trip-detail map has always used (#1458).
+        accelStartIndices.add(i);
+        inAccel = true;
+      }
+    } else {
+      accelDur = 0;
+      inAccel = false;
+    }
+
+    if (accelMps2 <= -kHardBrakeThresholdMps2) {
+      brakeDur += dt;
+      if (!inBrake && brakeDur >= kAccelEventMinSustainedSec) {
+        brakeEvents++;
+        inBrake = true;
+      }
+    } else {
+      brakeDur = 0;
+      inBrake = false;
+    }
+  }
+
+  return AccelEventCounts(
+    accelEvents: accelEvents,
+    brakeEvents: brakeEvents,
+    accelSeconds: accelSeconds,
+    accelStartIndices: accelStartIndices,
+  );
+}

--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -4,6 +4,7 @@
 import 'dart:math' as math;
 
 import '../../../core/utils/geo_utils.dart' as geo;
+import 'accel_event_gate.dart';
 import 'trip_recorder.dart';
 
 /// Lateral-acceleration threshold (m/s²) above which a turn counts as a
@@ -58,12 +59,15 @@ class GpsDrivingFeatures {
   /// don't dominate a long cruise leg.
   final double highSpeedSeconds;
 
-  /// Count of acceleration events: `d(speed)/dt > 2 m/s²` sustained
-  /// for > 1 s. Counted once per event, not per sample.
+  /// Count of acceleration events from the ONE shared accel-event gate
+  /// (#2667): `d(speed)/dt ≥ kHardAccelThresholdMps2` (3.0) sustained for
+  /// ≥ 1 s, accuracy-/min-speed-gated. One per physical episode — agrees
+  /// with the harsh detector, the score, and the insights analyzer.
   final int accelEvents;
 
-  /// Count of deceleration / brake events: `d(speed)/dt < −2 m/s²`
-  /// sustained for > 1 s. Reserved for the 7-coef expansion.
+  /// Count of deceleration / brake events from the same shared gate
+  /// (#2667): `d(speed)/dt ≤ −kHardBrakeThresholdMps2` (−3.5) sustained
+  /// for ≥ 1 s. Reserved for the 7-coef expansion.
   final int brakeEvents;
 
   /// Peak absolute acceleration in g, sample-to-sample. Provides a
@@ -157,26 +161,36 @@ class GpsDrivingFeatures {
   /// both samples carry lat/lng, falling back to `speedKmh × dt`
   /// for segments where either side is GPS-unfixed.
   ///
-  /// Acceleration events: rolling window detects `> 2 m/s²` (or
-  /// `< -2 m/s²`) sustained for ≥ 1 s — the same threshold the
-  /// trip recorder's harsh-event detector uses, so the two numbers
-  /// agree on what counts as "an event".
+  /// Acceleration / brake events come from the ONE shared accel-event
+  /// gate ([countAccelEvents], #2667): the canonical
+  /// [kHardAccelThresholdMps2] / [kHardBrakeThresholdMps2] sustained ≥ 1 s
+  /// with the accuracy + min-speed gate — so this number is identical to
+  /// the harsh detector, the driving score, and the insights analyzer for
+  /// the same physical event. (Pre-#2667 this file used a divergent
+  /// 2.0 m/s² threshold with no accuracy / min-speed gate.)
   static GpsDrivingFeatures? from(Iterable<TripSample> samples) {
     final list = samples.toList();
     if (list.length < 2) return null;
     list.sort((a, b) => a.timestamp.compareTo(b.timestamp));
 
+    // Hard accel / brake EPISODE counts via the shared gate (#2667). The
+    // list is already timestamp-sorted; the gate copies + sorts again
+    // defensively, which is cheap and keeps it the single authority.
+    final accelCounts = countAccelEvents([
+      for (final s in list)
+        AccelSamplePoint(
+          timestamp: s.timestamp,
+          speedKmh: s.speedKmh,
+          hAccuracyM: s.hAccuracyM,
+        ),
+    ]);
+
     double idle = 0, low = 0, cruise = 0, high = 0;
     double distM = 0;
-    int accelEvents = 0, brakeEvents = 0;
     double maxAccelG = 0;
     double climb = 0, descent = 0;
     double cornerLoad = 0;
     int sharpCorners = 0;
-
-    // Acceleration-event detector state.
-    bool inAccelEvent = false, inBrakeEvent = false;
-    double accelEventDur = 0, brakeEventDur = 0;
 
     for (var i = 1; i < list.length; i++) {
       final prev = list[i - 1];
@@ -207,32 +221,12 @@ class GpsDrivingFeatures {
         distM += v / 3.6 * dt;
       }
 
-      // Acceleration in m/s² (signed). speed in km/h → m/s via /3.6.
+      // Peak |acceleration| in g, sample-to-sample (a quick sanity ceiling
+      // for the fit). The accel/brake EVENT counts come from the shared
+      // gate above, not from this per-sample derivative.
       final accelMps2 = (cur.speedKmh - prev.speedKmh) / 3.6 / dt;
       final absG = accelMps2.abs() / 9.81;
       if (absG > maxAccelG) maxAccelG = absG;
-
-      // Sustained > 1 s windowing for accel / brake events.
-      if (accelMps2 > 2.0) {
-        accelEventDur += dt;
-        if (!inAccelEvent && accelEventDur >= 1.0) {
-          accelEvents++;
-          inAccelEvent = true;
-        }
-      } else {
-        accelEventDur = 0;
-        inAccelEvent = false;
-      }
-      if (accelMps2 < -2.0) {
-        brakeEventDur += dt;
-        if (!inBrakeEvent && brakeEventDur >= 1.0) {
-          brakeEvents++;
-          inBrakeEvent = true;
-        }
-      } else {
-        brakeEventDur = 0;
-        inBrakeEvent = false;
-      }
 
       // Altitude delta.
       final pAlt = prev.altitudeM, cAlt = cur.altitudeM;
@@ -279,8 +273,8 @@ class GpsDrivingFeatures {
       lowSpeedSeconds: low,
       cruiseSeconds: cruise,
       highSpeedSeconds: high,
-      accelEvents: accelEvents,
-      brakeEvents: brakeEvents,
+      accelEvents: accelCounts.accelEvents,
+      brakeEvents: accelCounts.brakeEvents,
       maxAccelG: maxAccelG,
       meanSpeedKmh: meanSpeed,
       distanceKm: distKm,

--- a/lib/features/consumption/domain/harsh_event_detector.dart
+++ b/lib/features/consumption/domain/harsh_event_detector.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'accel_event_gate.dart';
 import 'harsh_event.dart';
 
 /// Detects harsh-braking / harsh-acceleration events from a stream of
@@ -57,11 +58,11 @@ import 'harsh_event.dart';
 /// needs to surface "harsh brake at 14:23, 0.45 g while doing 80 km/h".
 class HarshEventDetector {
   HarshEventDetector({
-    this.brakeThresholdMps2 = 3.5,
-    this.accelThresholdMps2 = 3.0,
-    this.minSustainedSec = 1.0,
-    this.minSpeedKmh = 5.0,
-    this.maxHAccuracyM = 10.0,
+    this.brakeThresholdMps2 = kHardBrakeThresholdMps2,
+    this.accelThresholdMps2 = kHardAccelThresholdMps2,
+    this.minSustainedSec = kAccelEventMinSustainedSec,
+    this.minSpeedKmh = kAccelEventMinSpeedKmh,
+    this.maxHAccuracyM = kAccelEventAccuracyGateM,
     this.smoothSpeed = false,
     this.onEvent,
   });
@@ -124,6 +125,15 @@ class HarshEventDetector {
   double? _anchorSpeedKmh;
   DateTime? _anchorAt;
 
+  // Episode latches (#2667). An "event" is one sustained threshold-crossing
+  // episode, not one per evaluated ~1 s interval — a multi-second hard
+  // brake is ONE brake. We count on the transition INTO an episode and
+  // re-arm only when an evaluated interval falls back below the threshold.
+  // This is the count semantics shared with `countAccelEvents`, so the
+  // detector agrees with the score / insights / GPS features.
+  bool _inAccelEpisode = false;
+  bool _inBrakeEpisode = false;
+
   /// Number of harsh-braking events counted so far.
   int get brakes => _events
       .where((e) => e.type == HarshEventType.brake)
@@ -161,11 +171,14 @@ class HarshEventDetector {
     if (suppress) return;
 
     // Accuracy gate: a bad fix is worse than no fix — drop it and break
-    // the anchor so the derivative is never taken across it.
+    // the anchor (and the running episode) so the derivative is never
+    // taken across it.
     if (hAccuracyM != null && hAccuracyM.isFinite && hAccuracyM > maxHAccuracyM) {
       _anchorAt = null;
       _anchorSpeedKmh = null;
       _speedWindow.clear();
+      _inAccelEpisode = false;
+      _inBrakeEpisode = false;
       return;
     }
 
@@ -191,20 +204,40 @@ class HarshEventDetector {
 
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
     final accelMps2 = ((speed - anchorSpeed) / 3.6) / dt;
-    if (scorable && accelMps2 <= -brakeThresholdMps2) {
-      _record(HarshEvent(
-        timestamp: timestamp,
-        magnitudeG: (-accelMps2) / standardGravityMps2,
-        speedKmh: speed,
-        type: HarshEventType.brake,
-      ));
-    } else if (scorable && accelMps2 >= accelThresholdMps2) {
-      _record(HarshEvent(
-        timestamp: timestamp,
-        magnitudeG: accelMps2 / standardGravityMps2,
-        speedKmh: speed,
-        type: HarshEventType.acceleration,
-      ));
+
+    // Episode semantics (#2667): record at most once on entry into a
+    // sustained harsh stretch, and re-arm only when an evaluated interval
+    // drops back below the threshold — so a multi-interval manoeuvre is
+    // ONE event, agreeing with the shared gate.
+    final isBrake = scorable && accelMps2 <= -brakeThresholdMps2;
+    final isAccel = scorable && accelMps2 >= accelThresholdMps2;
+
+    if (isBrake) {
+      if (!_inBrakeEpisode) {
+        _record(HarshEvent(
+          timestamp: timestamp,
+          magnitudeG: (-accelMps2) / standardGravityMps2,
+          speedKmh: speed,
+          type: HarshEventType.brake,
+        ));
+        _inBrakeEpisode = true;
+      }
+    } else {
+      _inBrakeEpisode = false;
+    }
+
+    if (isAccel) {
+      if (!_inAccelEpisode) {
+        _record(HarshEvent(
+          timestamp: timestamp,
+          magnitudeG: accelMps2 / standardGravityMps2,
+          speedKmh: speed,
+          type: HarshEventType.acceleration,
+        ));
+        _inAccelEpisode = true;
+      }
+    } else {
+      _inAccelEpisode = false;
     }
     _anchorAt = timestamp;
     _anchorSpeedKmh = speed;
@@ -237,5 +270,7 @@ class HarshEventDetector {
     _speedWindow.clear();
     _anchorSpeedKmh = null;
     _anchorAt = null;
+    _inAccelEpisode = false;
+    _inBrakeEpisode = false;
   }
 }

--- a/test/features/consumption/domain/accel_event_reconciliation_test.dart
+++ b/test/features/consumption/domain/accel_event_reconciliation_test.dart
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/driving_insights_analyzer.dart';
+import 'package:tankstellen/features/consumption/data/driving_score_calculator.dart';
+import 'package:tankstellen/features/consumption/domain/accel_event_gate.dart';
+import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
+import 'package:tankstellen/features/consumption/domain/harsh_event_detector.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// Reconciliation tests for Fix D / Epic #2647 C3 / #2667.
+///
+/// Before this change THREE independent accel-event detectors disagreed
+/// on the count for the same physical event:
+///   (a) [HarshEventDetector] — canonical 3.0/3.5 m/s² + the #2653
+///       sustained-window + accuracy + min-speed gate.
+///   (b) [GpsDrivingFeatures.from] — a *2.0 m/s²* threshold (no canonical
+///       constant, no accuracy / min-speed gate).
+///   (c) [analyzeTrip] / [hardAccelSampleIndices] — a *raw* dvMps/dt at
+///       3.0 m/s² with NO sustained window at all.
+///
+/// They now route through ONE shared evaluator ([countAccelEvents]) keyed
+/// off the ONE canonical [kHardAccelThresholdMps2] /
+/// [kHardBrakeThresholdMps2], so a given physical event yields the SAME
+/// count across the score, the insights, and the GPS features.
+void main() {
+  final t0 = DateTime.utc(2026, 6, 1, 9);
+
+  /// A speed series (km/h) with KNOWN true accel/brake events at a clean
+  /// ~1 Hz cadence, chosen so every event is a genuine sustained (≥ 1 s),
+  /// above-min-speed crossing of the canonical thresholds — i.e. exactly
+  /// the regime in which all three detectors are designed to agree.
+  ///
+  /// Two distinct hard accelerations and two distinct hard brakes, each
+  /// separated by a calm cruise plateau so the duration-accumulator
+  /// re-arms between them:
+  ///   • t 0→2 s: 0 → 40 km/h  (+5.56 m/s², hard accel #1)
+  ///   • t 2→7 s: cruise 40
+  ///   • t 7→9 s: 40 → 80 km/h (+5.56 m/s², hard accel #2)
+  ///   • t 9→14 s: cruise 80
+  ///   • t 14→16 s: 80 → 40 km/h (-5.56 m/s², hard brake #1)
+  ///   • t 16→21 s: cruise 40
+  ///   • t 21→23 s: 40 → 0 km/h (-5.56 m/s², hard brake #2)
+  List<({DateTime t, double speedKmh})> knownSeries() {
+    final pts = <({DateTime t, double speedKmh})>[];
+    void add(int sec, double v) =>
+        pts.add((t: t0.add(Duration(seconds: sec)), speedKmh: v));
+    // accel #1: 0 → 40 over 2 s, sampled each second.
+    add(0, 0);
+    add(1, 20);
+    add(2, 40);
+    // cruise
+    for (var s = 3; s <= 7; s++) {
+      add(s, 40);
+    }
+    // accel #2: 40 → 80 over 2 s
+    add(8, 60);
+    add(9, 80);
+    // cruise
+    for (var s = 10; s <= 14; s++) {
+      add(s, 80);
+    }
+    // brake #1: 80 → 40 over 2 s
+    add(15, 60);
+    add(16, 40);
+    // cruise
+    for (var s = 17; s <= 21; s++) {
+      add(s, 40);
+    }
+    // brake #2: 40 → 0 over 2 s
+    add(22, 20);
+    add(23, 0);
+    return pts;
+  }
+
+  // -- expected ground truth for the fixture ------------------------------
+  const expectedAccels = 2;
+  const expectedBrakes = 2;
+
+  group('the 3 detectors agree on the count (RED on master) — #2667', () {
+    final series = knownSeries();
+
+    /// Map the fixture to [TripSample]s for the score / insights / harsh
+    /// paths (rpm is irrelevant to the accel detector).
+    List<TripSample> tripSamples() => [
+          for (final p in series)
+            TripSample(timestamp: p.t, speedKmh: p.speedKmh, rpm: 1500),
+        ];
+
+    test('shared evaluator counts the known events', () {
+      final counts = countAccelEvents([
+        for (final p in series)
+          AccelSamplePoint(timestamp: p.t, speedKmh: p.speedKmh),
+      ]);
+      expect(counts.accelEvents, expectedAccels);
+      expect(counts.brakeEvents, expectedBrakes);
+    });
+
+    test('HarshEventDetector path agrees', () {
+      final d = HarshEventDetector();
+      for (final p in series) {
+        d.onSample(p.speedKmh, p.t);
+      }
+      expect(d.accelerations, expectedAccels);
+      expect(d.brakes, expectedBrakes);
+    });
+
+    test('GpsDrivingFeatures path agrees', () {
+      final f = GpsDrivingFeatures.from(tripSamples())!;
+      expect(f.accelEvents, expectedAccels);
+      expect(f.brakeEvents, expectedBrakes);
+    });
+
+    test('driving-insights analyzer path agrees on the accel count', () {
+      final samples = tripSamples();
+      final counts = countAccelEvents([
+        for (final p in series)
+          AccelSamplePoint(timestamp: p.t, speedKmh: p.speedKmh),
+      ]);
+      // The analyzer surfaces its hard-accel count in the insight
+      // metadata; it must equal the shared evaluator's accel count.
+      final insights = analyzeTrip(samples);
+      final hardAccel =
+          insights.where((i) => i.labelKey == 'insightHardAccel').toList();
+      expect(hardAccel, hasLength(1));
+      expect(hardAccel.single.metadata['eventCount'], counts.accelEvents);
+      expect(counts.accelEvents, expectedAccels);
+    });
+
+    test('all three paths report the SAME accel + brake count', () {
+      final samples = tripSamples();
+
+      final d = HarshEventDetector();
+      for (final p in series) {
+        d.onSample(p.speedKmh, p.t);
+      }
+
+      final f = GpsDrivingFeatures.from(samples)!;
+
+      final insights = analyzeTrip(samples);
+      final analyzerAccels = insights
+              .where((i) => i.labelKey == 'insightHardAccel')
+              .map((i) => i.metadata['eventCount'] as int)
+              .fold<int>(0, (a, b) => a + b);
+
+      // accel: harsh-detector == gps-features == analyzer.
+      expect(d.accelerations, f.accelEvents);
+      expect(f.accelEvents, analyzerAccels);
+      // brake: harsh-detector == gps-features (analyzer surfaces accel
+      // only, by its existing contract).
+      expect(d.brakes, f.brakeEvents);
+    });
+  });
+
+  group('canonical constants are the single source — #2667', () {
+    test('the shared gate re-exports the score calculator constants', () {
+      // The accel-event gate and the score calculator MUST be the same
+      // numbers — that is the whole point of the reconciliation.
+      expect(kHardAccelThresholdMps2, 3.0);
+      expect(kHardBrakeThresholdMps2, 3.5);
+    });
+
+    test('a 2.0 m/s² ramp is NOT an event under the canonical 3.0 threshold',
+        () {
+      // The old gps_driving_features fired at 2.0 m/s²; under the
+      // canonical 3.0 it must not. 0 → 36 km/h over 5 s = exactly
+      // 2.0 m/s² — below 3.0.
+      final pts = <AccelSamplePoint>[];
+      for (var i = 0; i <= 5; i++) {
+        pts.add(AccelSamplePoint(
+          timestamp: t0.add(Duration(seconds: i)),
+          speedKmh: i * 36.0 / 5,
+        ));
+      }
+      for (var i = 1; i <= 5; i++) {
+        pts.add(AccelSamplePoint(
+          timestamp: t0.add(Duration(seconds: 5 + i)),
+          speedKmh: 36.0,
+        ));
+      }
+      final counts = countAccelEvents(pts);
+      expect(counts.accelEvents, 0);
+    });
+
+    test('a sub-1 s spike is debounced by the shared sustained window', () {
+      // A single 0.5 s bump must not fire — the sustained-window gate is
+      // shared, so the analyzer no longer counts raw single-interval
+      // spikes the way it used to.
+      final pts = <AccelSamplePoint>[
+        AccelSamplePoint(timestamp: t0, speedKmh: 50),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(milliseconds: 500)),
+            speedKmh: 75),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(milliseconds: 1000)),
+            speedKmh: 50),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 2)), speedKmh: 50),
+      ];
+      final counts = countAccelEvents(pts);
+      expect(counts.accelEvents, 0);
+      expect(counts.brakeEvents, 0);
+    });
+
+    test('a bad-fix (> gate) interval is dropped from the shared count', () {
+      // A jittery 25 m fix in the middle of an otherwise-hard accel must
+      // not contribute — the accuracy gate is shared with the detector.
+      final pts = <AccelSamplePoint>[
+        AccelSamplePoint(timestamp: t0, speedKmh: 0, hAccuracyM: 4),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 1)),
+            speedKmh: 20,
+            hAccuracyM: 4),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 2)),
+            speedKmh: 40,
+            hAccuracyM: 25), // bad fix breaks the anchor
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 3)),
+            speedKmh: 40,
+            hAccuracyM: 4),
+      ];
+      final counts = countAccelEvents(pts);
+      // With the bad fix gated, the only clean ≥1 s accel window is
+      // 0 → 20 km/h over 1 s = 5.56 m/s² — one event.
+      expect(counts.accelEvents, 1);
+    });
+  });
+}

--- a/test/features/consumption/domain/gps_driving_features_test.dart
+++ b/test/features/consumption/domain/gps_driving_features_test.dart
@@ -99,22 +99,42 @@ void main() {
     });
 
     group('accel / brake events', () {
-      test('a sustained > 2 m/s² ramp for ≥ 1s counts once', () {
-        // Speed goes 0 → 36 km/h over 5s → 2 m/s². Sustained, single
-        // event.
-        final samples = <TripSample>[];
-        for (var i = 0; i <= 5; i++) {
-          // 36 km/h = 10 m/s. Linear ramp.
-          samples.add(_s(t0.add(Duration(seconds: i)), i * 36.0 / 5));
-        }
-        // Then 10s of cruise so the integrator has time after the ramp.
+      // #2667 — accel/brake events now route through the ONE shared gate
+      // at the CANONICAL kHardAccelThresholdMps2 (3.0), not the old
+      // divergent 2.0 m/s² this file used. The ramp below is therefore
+      // 3.6 m/s² (0 → 36 km/h over the first 2.78 s — comfortably above
+      // 3.0); a 2.0 m/s² ramp would no longer count an event, which is the
+      // whole point of the reconciliation.
+      test('a sustained ≥ 3 m/s² ramp for ≥ 1s counts once', () {
+        // Speed goes 0 → 50 km/h over 2 s → 6.94 m/s². Sustained, single
+        // event, then cruise.
+        final samples = <TripSample>[
+          _s(t0, 0),
+          _s(t0.add(const Duration(seconds: 1)), 25),
+          _s(t0.add(const Duration(seconds: 2)), 50),
+        ];
         for (var i = 1; i <= 10; i++) {
-          samples.add(_s(t0.add(Duration(seconds: 5 + i)), 36.0));
+          samples.add(_s(t0.add(Duration(seconds: 2 + i)), 50.0));
         }
         final f = GpsDrivingFeatures.from(samples)!;
         expect(f.accelEvents, 1);
         expect(f.brakeEvents, 0);
         expect(f.maxAccelG, greaterThan(0.1));
+      });
+
+      test('a 2.0 m/s² ramp is below the canonical 3.0 threshold (#2667)',
+          () {
+        // The OLD gps_driving_features fired here at its 2.0 m/s²
+        // threshold; reconciled onto the canonical 3.0 it must NOT.
+        final samples = <TripSample>[];
+        for (var i = 0; i <= 5; i++) {
+          samples.add(_s(t0.add(Duration(seconds: i)), i * 36.0 / 5));
+        }
+        for (var i = 1; i <= 10; i++) {
+          samples.add(_s(t0.add(Duration(seconds: 5 + i)), 36.0));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.accelEvents, 0);
       });
 
       test('a hard brake (< -2 m/s² for ≥ 1s) counts as brakeEvent', () {

--- a/test/features/consumption/domain/harsh_event_detector_test.dart
+++ b/test/features/consumption/domain/harsh_event_detector_test.dart
@@ -100,9 +100,17 @@ void main() {
 
     test('harsh counts are independent of emit cadence', () {
       // The same speed profile fed at 1 Hz and at 4 Hz must yield the
-      // same counts — a faster cadence must not manufacture events. The
-      // profile carries genuine harsh accels (0→14, 14→28, 28→40 km/h
-      // in 1 s) and harsh brakes (50→35, 35→20 km/h in 1 s).
+      // same counts — a faster cadence must not manufacture events.
+      //
+      // #2667 — counts are now per *episode* (one sustained crossing),
+      // not one per qualifying ~1 s interval, so a physical event yields
+      // ONE count and the detector agrees with the score / insights / GPS
+      // features. The profile has ONE sustained accel episode (0→14→28→40
+      // km/h, three back-to-back >3.0 m/s² intervals = one hard accel) and
+      // ONE sustained brake episode (50→35→20 km/h, two back-to-back
+      // ≤-3.5 m/s² intervals = one hard brake; the later 20→8→0 is gentler
+      // than the 3.5 brake threshold). The cadence-independence guarantee
+      // is unchanged — both feeds report the same episode counts.
       const profile = <double>[0, 14, 28, 40, 50, 50, 35, 20, 8, 0];
 
       final atOneHz = HarshEventDetector();
@@ -113,8 +121,8 @@ void main() {
       feedStaircase(atFourHz, profile,
           emitInterval: const Duration(milliseconds: 250));
 
-      expect(atOneHz.accelerations, 3);
-      expect(atOneHz.brakes, 2);
+      expect(atOneHz.accelerations, 1);
+      expect(atOneHz.brakes, 1);
       expect(atFourHz.accelerations, atOneHz.accelerations);
       expect(atFourHz.brakes, atOneHz.brakes);
     });
@@ -124,12 +132,17 @@ void main() {
       // An emergency stop: the 1 Hz speed PID drops ~25 km/h between
       // refreshes (~6.9 m/s²). Cadence-independent detection must still
       // register it rather than smoothing it away.
+      //
+      // #2667 — the sustained multi-second stop is now ONE brake episode
+      // (it used to count once per qualifying ~1 s interval). The
+      // guarantee being tested is "the genuine hard brake is not smoothed
+      // away", i.e. it is counted at all.
       feedStaircase(
         detector,
         const <double>[90, 90, 65, 40, 15, 0],
         emitInterval: const Duration(milliseconds: 250),
       );
-      expect(detector.brakes, greaterThanOrEqualTo(3));
+      expect(detector.brakes, greaterThanOrEqualTo(1));
     });
 
     test('a long speed plateau before a sharp drop is not under-counted',


### PR DESCRIPTION
## What & why

Three independent accel/harsh-event detectors disagreed on the count for the **same physical event** — a real data-quality + maintainability defect (Epic #2647 P0 C3, Fix D):

| detector | threshold | gate | count semantics |
|---|---|---|---|
| `harsh_event_detector.dart` | canonical 3.0/3.5 | sustained ≥1 s + accuracy + min-speed + source (#2653) | **once per ~1 s resample interval** |
| `gps_driving_features.dart` | **2.0 m/s²** | ≥1 s window, **no** accuracy/min-speed | once per episode |
| `driving_insights_analyzer.dart` | raw 3.0 | **no window at all** | once per interval |

`driving_score_calculator.dart` already canonicalised `kHardAccelThresholdMps2` / `kHardBrakeThresholdMps2`, but the others didn't import them — and the score's own per-sample accumulator counted per interval, a 4th divergence.

A single hard-accel fixture measured **4 / 2 / 4** across the three paths.

## The reconciliation

One shared gate — `lib/features/consumption/domain/accel_event_gate.dart` — is now the **single source of truth**:

- the canonical thresholds (`kHardAccelThresholdMps2 = 3.0`, `kHardBrakeThresholdMps2 = 3.5`) + the shared gate constants (sustained ≥1 s, min-speed 5 km/h, accuracy 10 m);
- one pure `countAccelEvents(...)` **episode** counter — one event per sustained threshold-crossing (a 4-second hard brake is ONE brake, the physically-correct semantics).

All four consumers route through it:

- **`driving_score_calculator`** re-exports the threshold constants from the gate and feeds its hard-accel/brake counts from `countAccelEvents` (the accumulator no longer over-counts per interval);
- **`harsh_event_detector`** keys its defaults off the canonical constants and now counts per *episode* — live #2663 coaching fires once per event, not once per second of a sustained pull;
- **`gps_driving_features`** + **`driving_insights_analyzer`** (both `analyzeTrip` and `hardAccelSampleIndices`) call the shared evaluator.

`cornerLoadIntegral` (#2655) is deliberately untouched — only the accel-event part of `gps_driving_features` is reconciled.

So a physical event yields **ONE count across the score, the insights, and the GPS features.**

## Tests (TDD)

`test/features/consumption/domain/accel_event_reconciliation_test.dart` drives a known speed series (2 distinct hard accels + 2 distinct hard brakes) through all three paths and asserts they **agree** — RED on master (4 / 2 / 4), GREEN here (2 / 2). Plus a test that the canonical constants are the single source, and that the shared sustained-window / min-speed / accuracy gate fire.

Three pre-existing tests that asserted the **OLD divergent behaviour** are adjusted with documenting comments:
- gps_driving_features "sustained > 2 m/s² ramp" → split into a ≥3.0 positive case + a "2.0 is below canonical 3.0" negative case;
- harsh_event_detector "counts independent of emit cadence" (3/2 → 1/1, episode semantics; the cadence-independence guarantee is unchanged);
- harsh_event_detector "genuine hard brake still counted at 4 Hz" (≥3 → ≥1, one episode).

`flutter analyze` clean. `flutter test test/features/consumption test/lint` green. ARB-free (no `lib/l10n/` diff). file_length ≤400 (new gate file: 229 lines). No `.g.dart`/`.freezed.dart` drift (pure-logic files, no codegen annotations).

Closes #2667 (Epic #2647 C3 / Fix D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
