### PR TITLE
fix(obd2): stop PID writes through a disconnected classic channel + de-noise benign error traces (#2671)

### DIFF
--- a/lib/core/telemetry/trace_recorder.dart
+++ b/lib/core/telemetry/trace_recorder.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
@@ -60,6 +63,21 @@ class TraceRecorder {
       effectiveError = error;
     }
 
+    // #2671 — benign offline/cancelled transients are EXPECTED, not errors.
+    // A no-network DNS failure (`SocketException: Failed host lookup …`) and
+    // a user-cancelled request (`DioException [request cancelled]`) reached
+    // the trace store with NO suppression, polluting a signal-rich error
+    // log. Skip them with a breadcrumb only — no store, no upload. Placed in
+    // `record()` (not the classifier) so EVERY caller path (dio interceptor,
+    // `errorLogger.log`, the service chain) is covered, and matched against
+    // the UNWRAPPED [effectiveError] so a ContextualError-wrapped transient
+    // is suppressed too.
+    if (_isBenignTransient(effectiveError)) {
+      debugPrint('TraceRecorder: skipping benign transient (offline/'
+          'cancelled), not persisting (#2671): $effectiveError');
+      return;
+    }
+
     // Build chain snapshot from ServiceChainExhaustedException
     var chain = serviceChainState;
     if (chain == null && effectiveError is ServiceChainExhaustedException) {
@@ -116,6 +134,24 @@ class TraceRecorder {
 
     await _storage.store(trace);
     await _uploader.uploadIfEnabled(trace);
+  }
+
+  /// #2671 — true for an EXPECTED offline/cancelled transient that must not
+  /// be persisted as an error trace:
+  ///   1. a [SocketException] whose message reports a failed host lookup
+  ///      (the device is simply offline — DNS can't resolve the API host);
+  ///   2. a [DioException] of type [DioExceptionType.cancel] (the user
+  ///      navigated away / a newer request superseded this one).
+  /// Narrow by construction: a connection-refused [SocketException] or any
+  /// non-cancel Dio failure is a real error and still persists.
+  static bool _isBenignTransient(Object error) {
+    if (error is SocketException) {
+      return error.message.toUpperCase().contains('FAILED HOST LOOKUP');
+    }
+    if (error is DioException) {
+      return error.type == DioExceptionType.cancel;
+    }
+    return false;
   }
 }
 

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -3,10 +3,13 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+
 import 'classic_method_channel.dart';
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
 import 'obd2_comm_diagnostics.dart';
+import 'obd2_connection_errors.dart';
 import '../../../../core/logging/error_logger.dart';
 
 /// Standard Bluetooth Serial Port Profile UUID (#761). Every
@@ -97,6 +100,14 @@ class ClassicElmChannel implements ElmByteChannel {
         _incoming.add(bytes);
       },
       onError: (Object e, StackTrace st) {
+        // #2671 — a Classic-SPP drop raises a socket ERROR on the reader
+        // stream (not stream `done`), so the `onDone` handler below never
+        // runs. Mirror it here: clear `_open` the instant the link errors so
+        // the very next `write()` short-circuits on the `!_open` guard
+        // instead of dispatching into a dead socket and throwing the raw
+        // `PlatformException(state, not connected)` the PidScheduler then
+        // logged as an ERROR (4× in the field log).
+        _open = false;
         // #2295 — forward the socket error onto the byte stream so the
         // transport's pending `sendCommand` completer fails IMMEDIATELY
         // (via `_failPending`) instead of waiting out the read timeout,
@@ -119,9 +130,31 @@ class ClassicElmChannel implements ElmByteChannel {
   @override
   Future<void> write(List<int> bytes) async {
     if (!_open) {
-      throw StateError('ClassicElmChannel: not open');
+      // #2671 — the channel is not open: either never opened, or a drop
+      // cleared `_open` (the `onError` / `onDone` handlers). Surface the
+      // recoverable [Obd2DisconnectedException] so the drop detector's
+      // `_isTypedDisconnect` routes a post-drop write through pause/reconnect
+      // instead of letting a raw error reach the PidScheduler's error log.
+      throw const Obd2DisconnectedException('ClassicElmChannel: not open');
     }
-    await _plugin.write(bytes);
+    // #2671 — a drop can land AFTER the `_open` guard passed but DURING the
+    // native write (the in-flight-write race): the Kotlin side then throws
+    // `PlatformException(state, not connected)`. Reclassify it as the
+    // recoverable [Obd2DisconnectedException] — matching the #2524 precedent
+    // in [BluetoothObd2Transport._sendRaw] — so the drop detector's
+    // `_isTypedDisconnect` routes it through pause/reconnect instead of the
+    // raw platform error being spooled as an ERROR trace. Also flip `_open`
+    // so the next write short-circuits on the guard.
+    try {
+      await _plugin.write(bytes);
+    } catch (e, st) {
+      _open = false;
+      debugPrint('ClassicElmChannel: write failed — reclassifying as a '
+          'recoverable disconnect (#2671): $e\n$st');
+      throw const Obd2DisconnectedException(
+        'ClassicElmChannel: write failed — adapter not connected',
+      );
+    }
   }
 
   /// Bin a Classic-SPP `open()` throw into a stable, low-cardinality

--- a/lib/features/consumption/data/obd2/dropped_session_host.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_host.dart
@@ -21,6 +21,19 @@ abstract class DroppedSessionHost {
   /// so no further transport chatter happens while we recover.
   void stopScheduler();
 
+  /// #2671 — gate PID dispatch the instant a drop is detected, WITHOUT
+  /// tearing the scheduler down. Belt-and-braces with [stopScheduler]: even
+  /// if the timer is later restarted while the link is still flapping, a
+  /// paused tick will not write into the dead/reconnecting socket (which
+  /// threw `PlatformException(state, not connected)` 4× in the field log).
+  void pauseScheduler();
+
+  /// #2671 — re-open PID dispatch once the link has genuinely recovered.
+  /// Also resets the per-PID failure/backoff streaks + the unresponsive
+  /// diagnostic so the reconnected adapter starts clean. Called only on a
+  /// confirmed reconnect, never while still flapping.
+  void resumeScheduler();
+
   /// Tear down the CURRENT (now-dead) OBD2 service the instant a drop is
   /// detected (#2524). Closes its transport channel and fails any command
   /// stranded in the transport's `_pending` via `_failPending`, so the

--- a/lib/features/consumption/data/obd2/dropped_session_manager.dart
+++ b/lib/features/consumption/data/obd2/dropped_session_manager.dart
@@ -148,6 +148,11 @@ class DroppedSessionManager {
       detail: reason.name,
     );
     _host.stopScheduler();
+    // #2671 — also GATE dispatch (not just cancel the timer): if a later
+    // path restarts the scheduler while the link is still flapping, a paused
+    // tick must not write into the dead socket. Resumed only on a confirmed
+    // reconnect (onScannerReconnect).
+    _host.pauseScheduler();
     // #2524 — tear down the now-dead service so its channel closes + any
     // stranded `_pending` fails (else it later trips the concurrent guard).
     _host.disconnectDroppedService();
@@ -277,6 +282,9 @@ class DroppedSessionManager {
         AutoRecordEventKind.silentReconnectSucceeded,
         mac: _pinnedAdapterMac,
       );
+      // #2671 — link confirmed back: re-open dispatch + reset failure
+      // streaks before the scheduler resumes ticking.
+      _host.resumeScheduler();
       if (!_host.paused && !_host.stopped) _host.startScheduler();
       _host.emitState();
       return;
@@ -299,6 +307,9 @@ class DroppedSessionManager {
         AutoRecordEventKind.silentReconnectSucceeded,
         mac: _pinnedAdapterMac,
       );
+      // #2671 — link confirmed back: re-open dispatch + reset failure
+      // streaks before the scheduler resumes ticking.
+      _host.resumeScheduler();
       // Respect a user pause that landed during the silent window.
       if (!_host.paused && !_host.stopped) _host.startScheduler();
       _host.emitState();

--- a/lib/features/consumption/data/obd2/pid_scheduler.dart
+++ b/lib/features/consumption/data/obd2/pid_scheduler.dart
@@ -8,6 +8,7 @@ import '../../../../core/logging/error_logger.dart';
 import 'obd2_comm_diagnostics.dart';
 import 'pid_bandwidth_governor.dart';
 import 'pid_scheduler_comm_diagnostics.dart';
+import 'pid_subscription.dart';
 import 'scheduled_pid.dart';
 import 'unresponsive_adapter_diagnostic.dart';
 
@@ -110,9 +111,16 @@ class PidScheduler {
   /// [DateTime.now].
   final DateTime Function() _clock;
 
-  final Map<String, _Subscription> _subs = <String, _Subscription>{};
+  final Map<String, PidSubscription> _subs = <String, PidSubscription>{};
   Timer? _timer;
   bool _running = false;
+
+  /// #2671 — true while a connection drop / flapping link recovers. The
+  /// timer may still run, but a paused tick must NOT dispatch — every write
+  /// into the dead Classic-SPP socket threw `PlatformException(not
+  /// connected)`. Set on `dropDetected`, cleared on reconnect.
+  bool _paused = false;
+
   String? _inFlight;
   int _subscriptionCounter = 0;
 
@@ -168,11 +176,12 @@ class PidScheduler {
     ScheduledPid config,
     void Function(String response) onResult,
   ) {
-    _subs[command] = _Subscription(
+    _subs[command] = PidSubscription(
       command: command,
       config: config,
       onResult: onResult,
       order: _subscriptionCounter++,
+      maxConsecutiveFailures: _maxConsecutiveFailures,
     );
     _governor.register(
       command,
@@ -207,6 +216,26 @@ class PidScheduler {
     _timer = null;
   }
 
+  /// Whether dispatch is currently gated by a connection-drop pause (#2671).
+  @visibleForTesting
+  bool get isPaused => _paused;
+
+  /// #2671 — gate PID dispatch while a drop / flapping link recovers, WITHOUT
+  /// tearing the timer down: a paused [_tick] short-circuits before the
+  /// transport, so no write lands on a dead socket. Idempotent.
+  void pause() => _paused = true;
+
+  /// #2671 — re-open dispatch once the link recovers. Also resets the per-PID
+  /// failure/backoff streaks + the unresponsive-episode latch so the
+  /// reconnected adapter starts clean. Idempotent.
+  void resume() {
+    _paused = false;
+    for (final sub in _subs.values) {
+      sub.consecutiveFailures = 0;
+    }
+    _unresponsiveDiagnostic.reset();
+  }
+
   /// Pure selection: given the current subscription state and [now],
   /// return the command that should fire next — or `null` if nothing is
   /// subscribed. Exposed for tests that need to verify the weighted
@@ -222,7 +251,7 @@ class PidScheduler {
     if (_subs.isEmpty) return null;
 
     String? bestCommand;
-    _Subscription? best;
+    PidSubscription? best;
     var bestWeight = double.negativeInfinity;
 
     for (final entry in _subs.entries) {
@@ -237,7 +266,7 @@ class PidScheduler {
     return bestCommand;
   }
 
-  double _weightFor(_Subscription sub, DateTime now) {
+  double _weightFor(PidSubscription sub, DateTime now) {
     final last = sub.config.lastReadAt;
     if (last == null) return double.infinity;
     final elapsedMs = now.difference(last).inMicroseconds / 1000.0;
@@ -255,7 +284,7 @@ class PidScheduler {
   ///     factor, handing the freed budget to the dynamics tier on a slow
   ///     link.
   /// Backoff dominates (a dead PID stays at [_backoffHz] regardless).
-  double _effectiveHz(_Subscription sub) {
+  double _effectiveHz(PidSubscription sub) {
     if (sub.isBackedOff) return _backoffHz;
     final base = sub.config.hz;
     return _governor.isDemoted(sub.command)
@@ -267,9 +296,9 @@ class PidScheduler {
   /// [currentBestWeight]/[currentBest] as the winner so far.
   bool _beats(
     double candidateWeight,
-    _Subscription candidate,
+    PidSubscription candidate,
     double currentBestWeight,
-    _Subscription? currentBest,
+    PidSubscription? currentBest,
   ) {
     if (currentBest == null) return true;
     if (candidateWeight > currentBestWeight) return true;
@@ -286,6 +315,9 @@ class PidScheduler {
 
   Future<void> _tick() async {
     if (!_running) return;
+    // #2671 — paused while a drop recovers: do NOT dispatch into the dead /
+    // reconnecting socket until [resume] re-opens dispatch.
+    if (_paused) return;
     // Tee EVERY tick (fired or skipped) so back-pressure becomes a rate
     // (#2468). Gated: a pure branch-not-taken in prod (debug-mode off).
     final diag = Obd2CommDiagnostics.instance;
@@ -346,7 +378,9 @@ class PidScheduler {
             consecutiveFailures: sub.consecutiveFailures,
             backedOff: sub.isBackedOff);
       }
-      _maybeEmitUnresponsiveDiagnostic(e, st);
+      // Surface a broadly-unresponsive adapter WITHOUT flooding the log
+      // (#2379 / #2524); a typed disconnect is skipped there (#2671).
+      _unresponsiveDiagnostic.onFailure(backedOffCount, e, st);
     } finally {
       _inFlight = null;
       // Re-evaluate the bandwidth budget after every completed read (the
@@ -360,40 +394,5 @@ class PidScheduler {
       }
     }
   }
-
-  /// Surface a broadly-unresponsive adapter WITHOUT flooding the error log
-  /// (#2379 / #2524). Delegates the log-once-per-episode decision to
-  /// [UnresponsiveAdapterDiagnostic]; see that class for the contract.
-  void _maybeEmitUnresponsiveDiagnostic(Object error, StackTrace stack) {
-    _unresponsiveDiagnostic.onFailure(backedOffCount, error, stack);
-  }
 }
 
-class _Subscription {
-  _Subscription({
-    required this.command,
-    required this.config,
-    required this.onResult,
-    required this.order,
-  });
-
-  /// The OBD-II command this subscription polls (e.g. `'010C'`). Kept so
-  /// the governor can address demotions by command without a reverse map.
-  final String command;
-
-  final ScheduledPid config;
-  final void Function(String response) onResult;
-
-  /// Monotonic subscription index used for FIFO tie-breaking.
-  final int order;
-
-  /// Consecutive transport failures since the last successful read. Reset
-  /// to 0 on any success. Drives the [isBackedOff] state (#2379).
-  int consecutiveFailures = 0;
-
-  /// True once this PID has failed [PidScheduler._maxConsecutiveFailures]
-  /// times in a row — it is then selected at the slow backoff rate until
-  /// it next answers.
-  bool get isBackedOff =>
-      consecutiveFailures >= PidScheduler._maxConsecutiveFailures;
-}

--- a/lib/features/consumption/data/obd2/pid_subscription.dart
+++ b/lib/features/consumption/data/obd2/pid_subscription.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'scheduled_pid.dart';
+
+/// One subscribed PID in the [PidScheduler] rotation (#814 / #2379).
+///
+/// Extracted from `pid_scheduler.dart` so the scheduler's selection core
+/// stays under the 400-line cap (#2671), mirroring the
+/// `UnresponsiveAdapterDiagnostic` / `PidSchedulerCommDiagnostics` splits.
+/// Pure data + the [isBackedOff] derivation; the scheduler owns all timing.
+class PidSubscription {
+  PidSubscription({
+    required this.command,
+    required this.config,
+    required this.onResult,
+    required this.order,
+    required this.maxConsecutiveFailures,
+  });
+
+  /// The OBD-II command this subscription polls (e.g. `'010C'`). Kept so
+  /// the governor can address demotions by command without a reverse map.
+  final String command;
+
+  final ScheduledPid config;
+  final void Function(String response) onResult;
+
+  /// Monotonic subscription index used for FIFO tie-breaking.
+  final int order;
+
+  /// Consecutive failures before the PID is considered backed off (#2379).
+  final int maxConsecutiveFailures;
+
+  /// Consecutive transport failures since the last successful read. Reset
+  /// to 0 on any success. Drives the [isBackedOff] state (#2379).
+  int consecutiveFailures = 0;
+
+  /// True once this PID has failed [maxConsecutiveFailures] times in a row —
+  /// it is then selected at the slow backoff rate until it next answers.
+  bool get isBackedOff => consecutiveFailures >= maxConsecutiveFailures;
+}

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -549,6 +549,10 @@ class TripRecordingController {
       // the resume transition.
       unawaited(_droppedSession.stopReconnectScanner());
       _droppedSession.clearPausedTripRow();
+      // #2671 — a drop-pause gated the scheduler's dispatch (pauseScheduler);
+      // the link is back, so re-open it + reset the per-PID failure streaks
+      // before the timer resumes ticking.
+      _scheduler?.resume();
     }
     _paused = false;
     _scheduler?.start();
@@ -1535,6 +1539,12 @@ class _DroppedSessionHostAdapter implements DroppedSessionHost {
 
   @override
   void stopScheduler() => _c._scheduler?.stop();
+
+  @override
+  void pauseScheduler() => _c._scheduler?.pause();
+
+  @override
+  void resumeScheduler() => _c._scheduler?.resume();
 
   @override
   void disconnectDroppedService() {

--- a/lib/features/consumption/data/obd2/unresponsive_adapter_diagnostic.dart
+++ b/lib/features/consumption/data/obd2/unresponsive_adapter_diagnostic.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import 'obd2_connection_errors.dart';
 
 /// Owns the "OBD2 adapter broadly unresponsive" diagnostic decision for
 /// the [PidScheduler] (#2379 / #2524), extracted so the scheduler's
@@ -37,10 +38,31 @@ class UnresponsiveAdapterDiagnostic {
   bool _inEpisode = false;
   DateTime? _lastLoggedAt;
 
+  /// Reset the episode latch + rate-limit window so a fresh outage can log a
+  /// fresh ERROR. Called by [PidScheduler.resume] on reconnect (#2671): the
+  /// pre-drop episode state must not suppress the diagnostic for a genuinely
+  /// new outage on the recovered link.
+  void reset() {
+    _inEpisode = false;
+    _lastLoggedAt = null;
+  }
+
   /// Feed the per-tick failure outcome. [backedOffCount] is how many PIDs
   /// are currently backed off; [error]/[stack] are the failure that
   /// triggered this tick (logged only on a fresh episode transition).
   void onFailure(int backedOffCount, Object error, StackTrace stack) {
+    // #2671 — a typed disconnect / not-connected error IS the drop itself,
+    // not an "adapter unresponsive" episode. On a Classic-SPP flap every
+    // write threw `PlatformException(state, not connected)` (category
+    // `platform`) — exactly the field error. Logging it here spooled that
+    // ERROR per drop. The drop is handled by the pause/reconnect path
+    // (PidScheduler.pause + DroppedSessionManager), so skip it entirely and
+    // do NOT touch the episode latch (a real timeout outage must still log).
+    if (_isRecoverableDisconnect(error)) {
+      debugPrint('UnresponsiveAdapterDiagnostic: skipping a recoverable '
+          'disconnect — handled by the drop/reconnect path (#2671): $error');
+      return;
+    }
     if (backedOffCount < _backoffThreshold) {
       _inEpisode = false; // recovered — re-arm for the next outage
       return;
@@ -63,5 +85,16 @@ class UnresponsiveAdapterDiagnostic {
     _lastLoggedAt = now;
     unawaited(errorLogger.log(ErrorLayer.other, error, stack,
         context: {'where': msg, 'backedOffPids': backedOffCount}));
+  }
+
+  /// True for an error that means "the link dropped" rather than "the
+  /// adapter is broadly unresponsive" — the typed [Obd2DisconnectedException]
+  /// the channels now raise, or a raw not-connected platform/state error
+  /// (matched by message so this stays decoupled from `package:flutter`'s
+  /// services library, mirroring `TripDropDetector._isTypedDisconnect`).
+  static bool _isRecoverableDisconnect(Object error) {
+    if (error is Obd2DisconnectedException) return true;
+    final msg = error.toString().toLowerCase();
+    return msg.contains('not connected') || msg.contains('transport closed');
   }
 }

--- a/test/core/telemetry/trace_recorder_test.dart
+++ b/test/core/telemetry/trace_recorder_test.dart
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -246,6 +249,87 @@ void main() {
       expect(storage.stored.first.category, ErrorCategory.api,
           reason: 'ApiException stays api — layer fallback only fires '
               'when classifier returns unknown');
+    });
+
+    // #2671 — benign offline/cancelled transients are EXPECTED, not errors.
+    // They must NOT be persisted as error traces (no store, no upload) so
+    // the error log stays signal-rich. The filter lives in `record()` so
+    // EVERY caller path (dio interceptor, errorLogger.log, service chain)
+    // is covered.
+    group('benign-transient suppression (#2671)', () {
+      test('a "Failed host lookup" SocketException is NOT persisted',
+          () async {
+        const error =
+            SocketException('Failed host lookup: supabase.co');
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'offline DNS failure must not be stored');
+        expect(uploader.uploadCalled, isFalse,
+            reason: 'offline DNS failure must not be uploaded');
+      });
+
+      test(
+          'a "Failed host lookup" SocketException wrapped in ContextualError '
+          'is NOT persisted (matches on the unwrapped error)', () async {
+        final wrapped = ContextualError(
+          layer: ErrorLayer.services,
+          error: const SocketException('Failed host lookup: supabase.co'),
+          context: null,
+        );
+        await recorder.record(wrapped, StackTrace.current);
+
+        expect(storage.stored, isEmpty);
+        expect(uploader.uploadCalled, isFalse);
+      });
+
+      test('a cancelled DioException is NOT persisted', () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.cancel,
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'user-cancelled request must not be stored');
+        expect(uploader.uploadCalled, isFalse,
+            reason: 'user-cancelled request must not be uploaded');
+      });
+
+      test(
+          'a NON-cancel DioException (genuine failure) IS still persisted',
+          () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.badResponse,
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, hasLength(1),
+            reason: 'a real API failure must still be recorded');
+        expect(uploader.uploadCalled, isTrue);
+      });
+
+      test('a genuine ApiException still persists (filter is narrow)',
+          () async {
+        const error = ApiException(message: 'boom', statusCode: 500);
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, hasLength(1),
+            reason: 'a genuine API error must still be recorded');
+        expect(uploader.uploadCalled, isTrue);
+      });
+
+      test(
+          'a non-host-lookup SocketException (e.g. connection refused) IS '
+          'still persisted', () async {
+        const error = SocketException('Connection refused');
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, hasLength(1),
+            reason: 'only host-lookup (offline DNS) is benign; a refused '
+                'connection is a real failure worth a trace');
+      });
     });
   });
 }

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/features/consumption/data/obd2/'
 import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_adapter.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 
 /// TDD tests for the Bluetooth OBD2 transport (#716).
@@ -289,6 +290,42 @@ void main() {
       expect(reply.trim(), '41 0D 3C',
           reason: 'the reconnected instance starts with _pending == null + '
               'an empty buffer, so the next command succeeds (#2524)');
+    });
+
+    test(
+        '#2671 — a drop landing DURING the native write surfaces as the '
+        'typed Obd2DisconnectedException and clears _pending (no poisoned '
+        'transport)', () async {
+      final channel = _ScriptedChannel();
+      // The classic channel reclassifies a not-connected platform write
+      // throw into a recoverable Obd2DisconnectedException (#2671 fix b).
+      // Model that: the channel's write throws the typed disconnect.
+      channel.scriptWriteThrows(
+        '010C\r',
+        const Obd2DisconnectedException(),
+      );
+      // The recovery command writes fine and gets a normal reply, proving
+      // _pending was cleared on the throwing write.
+      channel.scriptResponse('010D\r', '41 0D 3C >');
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      // 1) The failing command surfaces the typed disconnect to its caller
+      //    — the drop detector's `_isTypedDisconnect` routes this through
+      //    pause/reconnect instead of logging an ERROR trace.
+      await expectLater(
+        transport.sendCommand('010C\r'),
+        throwsA(isA<Obd2DisconnectedException>()),
+      );
+
+      // 2) _pending was cleared on the throw, so the NEXT command does not
+      //    trip the concurrent-sendCommand guard (which itself now throws
+      //    Obd2DisconnectedException). A clean reply proves the transport
+      //    is not poisoned.
+      final reply = await transport.sendCommand('010D\r');
+      expect(reply.trim(), '41 0D 3C',
+          reason: 'transport must recover: _pending cleared on the typed '
+              'disconnect write, so the next command proceeds normally');
     });
 
     test('disconnect closes the channel and flips isConnected to false',

--- a/test/features/consumption/data/obd2/classic_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_test.dart
@@ -4,9 +4,11 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_elm_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_method_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 /// Captured call to [_FakeObd2ClassicMethodChannel.connect].
@@ -208,9 +210,12 @@ void main() {
       expect(errors, hasLength(1));
       expect(errors.single, same(boom));
 
-      // The broadcast controller is NOT closed by a forwarded error, so
-      // the channel stays functional and later good bytes still flow.
-      expect(channel.isOpen, isTrue);
+      // #2671 — a reader-stream error now also clears `_open` (a classic-SPP
+      // drop raises an ERROR, not stream `done`), so the next write
+      // short-circuits instead of dispatching into a dead socket.
+      expect(channel.isOpen, isFalse);
+      // The broadcast controller is NOT closed by a forwarded error, so any
+      // late good bytes the native side already queued still flow through.
       fake.incomingController.add([0x99]);
       await Future<void>.delayed(Duration.zero);
       expect(received, [
@@ -223,19 +228,14 @@ void main() {
   });
 
   group('ClassicElmChannel.write', () {
-    test('throws StateError when channel is not open; no plugin.write call',
-        () async {
+    test(
+        'throws the recoverable Obd2DisconnectedException when not open; '
+        'no plugin.write call (#2671)', () async {
       final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
 
       await expectLater(
         channel.write([0x01, 0x02]),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains('not open'),
-          ),
-        ),
+        throwsA(isA<Obd2DisconnectedException>()),
       );
       expect(fake.writeCalls, isEmpty);
     });
@@ -248,6 +248,69 @@ void main() {
 
       expect(fake.writeCalls, hasLength(1));
       expect(fake.writeCalls.single, [0x41, 0x54, 0x5A, 0x0D]);
+
+      await channel.close();
+    });
+  });
+
+  // #2671 — a Classic-SPP drop raises a socket ERROR on the reader stream
+  // (not stream done). The `onError` handler must clear `_open` so the next
+  // write short-circuits, and a `plugin.write` that throws the raw
+  // `PlatformException(state, not connected)` must surface as the
+  // recoverable `Obd2DisconnectedException` the drop detector routes through
+  // pause/reconnect — never the raw platform error logged as an ERROR trace.
+  group('ClassicElmChannel — disconnect on reader-stream error (#2671)', () {
+    test(
+        'a reader-stream error flips isOpen=false so the next write '
+        'short-circuits as Obd2DisconnectedException (no plugin.write call)',
+        () async {
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await channel.open();
+      expect(channel.isOpen, isTrue);
+
+      // Swallow the forwarded error on the incoming stream so it doesn't
+      // surface as an unhandled zone error during the test.
+      final sub = channel.incoming.listen((_) {}, onError: (_) {});
+
+      // The native classic-SPP socket drop raises an ERROR on the reader
+      // stream, not stream `done`.
+      fake.incomingController.addError(
+        PlatformException(code: 'state', message: 'not connected'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(channel.isOpen, isFalse,
+          reason: 'onError must clear _open just like onDone does');
+
+      // The next write must short-circuit on the guard as a recoverable
+      // typed disconnect — NOT a raw StateError, and NOT reaching the plugin.
+      await expectLater(
+        channel.write([0x01, 0x02]),
+        throwsA(isA<Obd2DisconnectedException>()),
+      );
+      expect(fake.writeCalls, isEmpty,
+          reason: 'a closed channel must not reach plugin.write');
+
+      await sub.cancel();
+      await channel.close();
+    });
+
+    test(
+        'a plugin.write that throws PlatformException(not connected) is '
+        'rethrown as the recoverable Obd2DisconnectedException', () async {
+      // Models the in-flight-write race: the drop lands DURING the native
+      // write, so the guard passed but the plugin write throws raw.
+      fake.writeError =
+          PlatformException(code: 'state', message: 'not connected');
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
+      await channel.open();
+
+      await expectLater(
+        channel.write([0x41, 0x54, 0x5A, 0x0D]),
+        throwsA(isA<Obd2DisconnectedException>()),
+        reason: 'the raw PlatformException must be reclassified as a '
+            'recoverable typed disconnect (matching the #2524 precedent)',
+      );
 
       await channel.close();
     });

--- a/test/features/consumption/data/obd2/dropped_session_manager_test.dart
+++ b/test/features/consumption/data/obd2/dropped_session_manager_test.dart
@@ -84,6 +84,9 @@ void main() {
       expect(mgr.dropReason, TripDropReason.transportError);
       expect(host.stopSchedulerCalls, 1,
           reason: 'the scheduler must be stopped the instant a drop fires');
+      expect(host.pauseSchedulerCalls, 1,
+          reason: '#2671 — dispatch must also be GATED on drop so a later '
+              'tick never writes into the dead/flapping link');
       expect(host.clearErrorWindowCalls, 1);
       expect(host.emitStateCalls, greaterThanOrEqualTo(1));
       final saved = pausedRepo.loadAll();
@@ -296,6 +299,9 @@ void main() {
             reason: 'the user never saw a pause');
         expect(host.startSchedulerCalls, 1,
             reason: 'a silent reconnect must restart the polling loop');
+        expect(host.resumeSchedulerCalls, 1,
+            reason: '#2671 — a confirmed reconnect must re-open dispatch + '
+                'reset failure streaks before the loop resumes ticking');
         expect(host.resetDropDetectorCalls, 1);
         expect(pausedRepo.loadAll(), isEmpty,
             reason: 'a silent reconnect must clear the stranded partial');
@@ -549,6 +555,8 @@ void main() {
 /// be asserted end-to-end.
 class _FakeHost implements DroppedSessionHost {
   int stopSchedulerCalls = 0;
+  int pauseSchedulerCalls = 0;
+  int resumeSchedulerCalls = 0;
   int disconnectDroppedServiceCalls = 0;
   int startSchedulerCalls = 0;
   int resetDropDetectorCalls = 0;
@@ -593,6 +601,12 @@ class _FakeHost implements DroppedSessionHost {
 
   @override
   void stopScheduler() => stopSchedulerCalls++;
+
+  @override
+  void pauseScheduler() => pauseSchedulerCalls++;
+
+  @override
+  void resumeScheduler() => resumeSchedulerCalls++;
 
   @override
   void disconnectDroppedService() => disconnectDroppedServiceCalls++;

--- a/test/features/consumption/data/obd2/pid_scheduler_test.dart
+++ b/test/features/consumption/data/obd2/pid_scheduler_test.dart
@@ -402,6 +402,101 @@ void main() {
     });
   });
 
+  // ── #2671 — drop-awareness: pause gates dispatch, resume re-enables ──
+  //
+  // On a detected drop the DroppedSessionManager pauses the scheduler so it
+  // stops dispatching PIDs into a dead/flapping link (the field bug spammed
+  // PlatformException(not connected) while the adapter flapped). The timer
+  // may still be running, but a paused tick must NOT reach the transport.
+  group('PidScheduler — pause/resume drop-awareness (#2671)', () {
+    test(
+        'a paused scheduler does NOT dispatch even with the timer running '
+        '(no transport call)', () async {
+      final transport = _FakeTransport();
+      final scheduler = PidScheduler(
+        transport: transport.call,
+        tickRate: const Duration(milliseconds: 10),
+      );
+      scheduler.subscribe('010C', ScheduledPid(hz: 5.0), (_) {});
+      scheduler
+        ..start()
+        ..pause();
+
+      // Let many ticks fire while paused.
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(transport.calls, isEmpty,
+          reason: 'a paused tick must short-circuit before dispatch');
+      expect(scheduler.inFlightCommand, isNull);
+
+      scheduler.stop();
+    });
+
+    test('resume() re-enables dispatch after a pause', () async {
+      final transport = _FakeTransport();
+      final scheduler = PidScheduler(
+        transport: transport.call,
+        tickRate: const Duration(milliseconds: 10),
+      );
+      scheduler.subscribe('010C', ScheduledPid(hz: 5.0), (_) {});
+      scheduler
+        ..start()
+        ..pause();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      expect(transport.calls, isEmpty);
+
+      scheduler.resume();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      await Future<void>.delayed(Duration.zero);
+      scheduler.stop();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(transport.calls, isNotEmpty,
+          reason: 'resume() must re-open dispatch');
+    });
+
+    test(
+        'resume() resets failure / backoff counters so a recovered link '
+        'starts clean', () async {
+      var fakeNow = DateTime(2026, 1, 1, 12);
+      var failing = true;
+      Future<String> transport(String command) async {
+        if (failing) throw Exception('timeout');
+        return '41 0C 00>';
+      }
+
+      final scheduler = PidScheduler(
+        transport: transport,
+        tickRate: const Duration(milliseconds: 5),
+        clock: () => fakeNow,
+      );
+      scheduler.subscribe('010C', ScheduledPid(hz: 5.0), (_) {});
+      scheduler.start();
+
+      // Drive the PID into backoff.
+      for (var i = 0; i < 8 && scheduler.backedOffCount == 0; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 8));
+        await Future<void>.delayed(Duration.zero);
+        fakeNow = fakeNow.add(const Duration(milliseconds: 250));
+      }
+      expect(scheduler.backedOffCount, 1,
+          reason: 'consecutive failures must engage backoff first');
+
+      // Drop → pause; reconnect → resume. resume() must wipe the failure
+      // streak so the recovered link does not start already-backed-off.
+      failing = false;
+      scheduler
+        ..pause()
+        ..resume();
+      expect(scheduler.backedOffCount, 0,
+          reason: 'resume() must reset the per-PID failure/backoff state');
+
+      scheduler.stop();
+      await Future<void>.delayed(Duration.zero);
+    });
+  });
+
   // ── #2379 — transient-failure handling ──────────────────────────────
   //
   // These tests bind a capture recorder so they assert on what reached

--- a/test/features/consumption/data/obd2/unresponsive_adapter_diagnostic_test.dart
+++ b/test/features/consumption/data/obd2/unresponsive_adapter_diagnostic_test.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/unresponsive_adapter_diagnostic.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// Captures every `errorLogger.log` call routed through the foreground
+/// recorder seam, without standing up Hive / Riverpod. Mirrors the fake in
+/// `pid_scheduler_test.dart`.
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  late _CaptureRecorder recorder;
+  var fakeNow = DateTime(2026, 1, 1, 12);
+
+  UnresponsiveAdapterDiagnostic build() => UnresponsiveAdapterDiagnostic(
+        backoffThreshold: 3,
+        window: const Duration(seconds: 30),
+        clock: () => fakeNow,
+      );
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CaptureRecorder();
+    errorLogger.testRecorderOverride = recorder;
+    fakeNow = DateTime(2026, 1, 1, 12);
+  });
+
+  tearDown(() {
+    errorLogger.resetForTest();
+    errorLogger.spoolEnqueueOverride = ({
+      required String isolateTaskName,
+      required Object error,
+      StackTrace? stack,
+      Map<String, dynamic>? contextMap,
+      DateTime? timestamp,
+    }) async {};
+  });
+
+  // Let the fire-and-forget `unawaited(errorLogger.log(...))` settle.
+  Future<void> drain() async {
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  group('UnresponsiveAdapterDiagnostic — typed-disconnect suppression (#2671)',
+      () {
+    test(
+        'a genuine timeout episode (threshold reached) STILL logs ONE error '
+        '— guarding the suppression does not break the real diagnostic',
+        () async {
+      final diag = build();
+      diag.onFailure(3, Exception('timeout'), StackTrace.current);
+      await drain();
+
+      expect(recorder.calls, hasLength(1),
+          reason: 'a non-disconnect episode transition logs one ERROR');
+    });
+
+    test(
+        'a typed Obd2DisconnectedException at threshold logs NOTHING — a '
+        'drop episode must never spool the not-connected ERROR', () async {
+      final diag = build();
+      diag.onFailure(
+          3, const Obd2DisconnectedException(), StackTrace.current);
+      await drain();
+
+      expect(recorder.calls, isEmpty,
+          reason: 'a typed disconnect is a recoverable drop, not an '
+              'unresponsive-adapter ERROR');
+    });
+
+    test(
+        'a PlatformException(state, not connected) at threshold logs NOTHING '
+        '— the exact field error must be suppressed', () async {
+      final diag = build();
+      diag.onFailure(
+        3,
+        PlatformException(code: 'state', message: 'not connected'),
+        StackTrace.current,
+      );
+      await drain();
+
+      expect(recorder.calls, isEmpty,
+          reason: 'the not-connected platform error is the drop itself, '
+              'not an adapter-unresponsive episode');
+    });
+
+    test(
+        'after a suppressed disconnect, a later genuine timeout episode '
+        'still logs (the episode latch was not consumed)', () async {
+      final diag = build();
+      // Suppressed: must not arm/consume the episode latch.
+      diag.onFailure(
+          3, const Obd2DisconnectedException(), StackTrace.current);
+      await drain();
+      expect(recorder.calls, isEmpty);
+
+      // A genuine timeout episode now logs exactly once.
+      diag.onFailure(3, Exception('timeout'), StackTrace.current);
+      await drain();
+      expect(recorder.calls, hasLength(1),
+          reason: 'the suppressed disconnect must not have latched the '
+              'episode, so a real timeout still logs');
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -204,7 +204,14 @@ void main() {
     // the existing trip_recorder re-export, no new import); the wiring must
     // live where the controller builds its recorder. Decomposition stays
     // tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1626,
+    // #2671 — re-grandfathered 1626 → 1636: the OBD2 drop-pause fix wires the
+    // scheduler's new pause()/resume() through the DroppedSessionHost adapter
+    // (two thin wrappers mirroring the existing stopScheduler) + a resume()
+    // call on the drop→reconnect transition with a rationale comment, so a
+    // flapping link no longer dispatches PIDs into a dead channel. Net +10;
+    // the wiring must live at the controller's host adapter + resume site.
+    // Decomposition stays tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1636,
     // #2442 — re-grandfathered 496 → 513: the save flow now raises the
     // guided reconciliation workflow after a plein save (a 7-line
     // await-then-route call into the extracted


### PR DESCRIPTION
## What & why

A real-device field log surfaced 4× `PlatformException(state, not connected)` spooled as ERROR traces while a Classic-SPP ELM327 adapter flapped (connectSucceeded → dropDetected → silentReconnect, repeatedly), plus 2× offline-DNS `SocketException` and 1× user-cancelled `DioException` persisted as errors. Three root causes, three fixes — all error-handling only, **no new user-facing strings**.

### Bug 1 — a disconnected classic-SPP write threw a raw `PlatformException`
- `ClassicElmChannel.onError` now clears `_open` (a classic-SPP drop raises a socket **ERROR**, not stream `done`, so the existing `onDone` path never ran) → the next write short-circuits instead of dispatching into a dead socket.
- The `!_open` guard and a throwing `_plugin.write` (the in-flight-write race: a drop landing after the `_connected` recheck but during the native write) now surface the recoverable `Obd2DisconnectedException` — matching the #2524 precedent in `BluetoothObd2Transport._sendRaw`. `TripDropDetector._isTypedDisconnect` already routes that through pause/reconnect instead of an ERROR trace.

### Bug 2 — `PidScheduler` had no drop-awareness (kept dispatching into a dead/flapping link)
- Added `_paused`: `_tick` short-circuits before dispatch when paused. `pause()` gates dispatch (timer untouched); `resume()` re-opens it **and** resets the per-PID failure/backoff streaks + the unresponsive-episode latch so a reconnected adapter starts clean.
- Wired `DroppedSessionManager.handleDrop` → `pauseScheduler` and every confirmed-reconnect path (silent, degraded-GPS, visible resume) → `resumeScheduler` via two new `DroppedSessionHost` seam methods.
- `UnresponsiveAdapterDiagnostic.onFailure` now **skips** a typed-disconnect / not-connected error (the exact field error, category `platform`) so a drop episode never spools that ERROR; latch reset on `resume()`.
- Extracted `PidSubscription` into its own file to keep `pid_scheduler.dart` under the 400-line cap.

### Bug 3 (de-noise) — benign offline/cancelled errors persisted as traces
- `TraceRecorder.record` now early-returns (breadcrumb only, no store/upload) for a `SocketException` whose message reports a failed host lookup (offline DNS) and a `DioException` of type `cancel` (user-cancelled), matched on the **unwrapped** `effectiveError` so a `ContextualError`-wrapped transient is caught too. Placed in `record()` (not the classifier) so every caller path is covered. Genuine `ApiException` / connection-refused / non-cancel Dio still persist.

## TDD (RED-on-master first, then GREEN)
- `classic_elm_channel_test.dart` — after `onError`, `isOpen` is false **and** a subsequent `write()` throws `Obd2DisconnectedException` (not a raw `PlatformException`).
- `bluetooth_obd2_transport_test.dart` — a drop landing during the native write surfaces as a typed disconnect, `_pending` cleared (no poisoned transport).
- `pid_scheduler_test.dart` — a paused `_tick` does NOT dispatch even with the timer running; `resume()` re-enables dispatch + resets failure counters.
- `unresponsive_adapter_diagnostic_test.dart` — `onFailure` does NOT log for a typed-disconnect / not-connected error, while a genuine timeout episode still logs once.
- `trace_recorder_test.dart` — a `Failed host lookup` `SocketException` and a `cancel` `DioException` result in ZERO store + ZERO uploader calls, while a genuine `ApiException` still persists.

## Gates
- `flutter analyze` — 0 new issues in touched files.
- `flutter test test/features/consumption test/core/telemetry` — 4045 passed, 6 skipped, 0 failed.
- `test/lint/file_length_test.dart` — green (PidSubscription extraction).
- Clean `build_runner` — no codegen drift.

Closes #2671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
