### PR TITLE
fix(cache): guard closed cache.hive box on StationServiceChain.apiCall (#2670)

### DIFF
--- a/lib/core/cache/cache_manager.dart
+++ b/lib/core/cache/cache_manager.dart
@@ -1,10 +1,13 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../data/storage_repository.dart';
+import '../logging/error_logger.dart';
 import '../services/service_result.dart';
 import '../storage/storage_providers.dart';
 import 'cache_eviction_policy.dart';
@@ -51,9 +54,6 @@ class CacheTtl {
   /// search list is dominated by those prices; longer would surface stale
   /// figures, shorter would defeat the cache between back-to-back queries.
   /// Matches [prices] and the Tankerkoenig update cadence on purpose.
-  ///
-  /// Intentionally compile-time (see class-level policy note); a future
-  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration stationSearch = Duration(minutes: 5);
 
   /// TTL for a single station's detail payload (address, hours, brand).
@@ -61,9 +61,6 @@ class CacheTtl {
   /// 15 minutes because detail data is mostly slow-changing metadata
   /// (opening hours, address) rather than live prices, so it tolerates a
   /// longer cache than a search list while still refreshing within a visit.
-  ///
-  /// Intentionally compile-time (see class-level policy note); a future
-  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration stationDetail = Duration(minutes: 15);
 
   /// TTL for a bulk price lookup keyed by station ids.
@@ -71,9 +68,6 @@ class CacheTtl {
   /// 5 minutes to match the Tankerkoenig price-update cadence and rate
   /// limit: refreshing faster cannot yield newer data and risks tripping
   /// the upstream limit, refreshing slower serves stale prices.
-  ///
-  /// Intentionally compile-time (see class-level policy note); a future
-  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration prices = Duration(minutes: 5);
 
   /// TTL for forward/reverse geocode results (ZIP <-> coordinates).
@@ -81,9 +75,6 @@ class CacheTtl {
   /// 24 hours because ZIP-code centroids and place coordinates are
   /// effectively static; caching for a day avoids repeated geocoder calls
   /// for the same query with no meaningful staleness risk.
-  ///
-  /// Intentionally compile-time (see class-level policy note); a future
-  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration geocode = Duration(hours: 24);
 
   /// TTL for a favourited station's cached snapshot (offline view).
@@ -91,9 +82,6 @@ class CacheTtl {
   /// 30 minutes as a middle ground: long enough that opening the favourites
   /// list offline shows a recent snapshot, short enough that a returning
   /// online user re-fetches reasonably fresh prices.
-  ///
-  /// Intentionally compile-time (see class-level policy note); a future
-  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration stationData = Duration(minutes: 30);
 
   /// TTL for city-name autocomplete / lookup results.
@@ -101,9 +89,6 @@ class CacheTtl {
   /// 30 minutes because city-name -> location mappings are stable; caching
   /// avoids re-querying the lookup service for the same typed prefix within
   /// a session without risking stale results.
-  ///
-  /// Intentionally compile-time (see class-level policy note); a future
-  /// `RuntimeConfig`/remote-config could make this tunable.
   static const Duration citySearch = Duration(minutes: 30);
 }
 
@@ -223,6 +208,10 @@ class CacheManager implements CacheStrategy {
   CacheManager(this._storage);
 
   /// Store data in cache with metadata envelope.
+  ///
+  /// #2670 — a [FileSystemException] from a box closed mid-flight degrades to
+  /// "not cached", never a throw on a routine API success (belt-and-braces;
+  /// the store guard already no-ops a closed box).
   @override
   Future<void> put(
     String key,
@@ -230,20 +219,34 @@ class CacheManager implements CacheStrategy {
     required Duration ttl,
     required ServiceSource source,
   }) async {
-    await _storage.cacheData(key, {
-      'payload': data,
-      'storedAt': DateTime.now().millisecondsSinceEpoch,
-      'source': source.index,
-      'ttlMs': ttl.inMilliseconds,
-    });
+    try {
+      await _storage.cacheData(key, {
+        'payload': data,
+        'storedAt': DateTime.now().millisecondsSinceEpoch,
+        'source': source.index,
+        'ttlMs': ttl.inMilliseconds,
+      });
+    } on FileSystemException catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: {'where': 'CacheManager.put (closed box)', 'key': key}));
+    }
   }
 
   /// Retrieve cached data. Returns the entry even if expired —
   /// the caller (fallback chain) decides whether stale data is acceptable.
-  /// Returns null only if the key was never cached.
+  /// Returns null only if the key was never cached (or the box is closed —
+  /// #2670, a closed box reads as a clean miss so the chain falls through to
+  /// the API / stale path instead of throwing).
   @override
   CacheEntry? get(String key) {
-    final raw = _storage.getCachedData(key);
+    final Map<String, dynamic>? raw;
+    try {
+      raw = _storage.getCachedData(key);
+    } on FileSystemException catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: {'where': 'CacheManager.get (closed box)', 'key': key}));
+      return null;
+    }
     if (raw == null) return null;
 
     final payload = raw['payload'];

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -7,6 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import 'hive_isolate_ownership.dart';
+import 'hive_legacy_migration.dart';
+
 /// Thrown by [HiveBoxes.init] when a persistent box cannot be opened —
 /// its file is damaged beyond Hive's own crash recovery (#1686).
 ///
@@ -150,65 +153,11 @@ class HiveBoxes {
     return HiveAesCipher(key);
   }
 
-  /// One-time migration of a pre-encryption plaintext [boxName] into an
-  /// encrypted box (#1686).
-  ///
-  /// A box already written with the cipher opens cleanly — nothing to
-  /// do. When the cipher open fails, a plaintext open is attempted: a
-  /// box that still carries plaintext data is migrated; one that fails
-  /// the plaintext open too is damaged and is **left on disk
-  /// untouched** — corruption is never resolved by deleting user data.
-  /// A box Hive cannot open at all then surfaces in [init]'s Phase 2 as
-  /// a [HiveCorruptionException].
-  static Future<void> _migrateLegacyPlaintextBox(
-      String boxName, HiveAesCipher cipher) async {
-    try {
-      final box = await Hive.openBox(boxName, encryptionCipher: cipher);
-      await box.close();
-      return; // Already encrypted, or a fresh install.
-    } catch (_) {
-      // Fall through — the box may be a pre-encryption plaintext box.
-    }
-
-    Box<dynamic> plain;
-    try {
-      plain = await Hive.openBox(boxName);
-    } catch (e, st) { // ignore: unused_catch_stack
-      debugPrint('Hive: "$boxName" unreadable during the migration probe '
-          '— left on disk for Phase 2 to surface.');
-      return;
-    }
-
-    await _migrateToEncrypted(boxName, plain, cipher);
-  }
-
-  /// Copies an already-open plaintext [plain] box into an encrypted box
-  /// of the same name (#1686).
-  ///
-  /// The plaintext file is deleted only *after* its entries are held in
-  /// memory, so an interruption mid-migration cannot lose data — a
-  /// crash leaves the still-intact plaintext box, never an empty one.
-  static Future<void> _migrateToEncrypted(
-      String boxName, Box<dynamic> plain, HiveAesCipher cipher) async {
-    final entries = Map<dynamic, dynamic>.from(plain.toMap());
-    await plain.close();
-
-    await Hive.deleteBoxFromDisk(boxName);
-    final encryptedBox =
-        await Hive.openBox(boxName, encryptionCipher: cipher);
-    if (entries.isNotEmpty) {
-      await encryptedBox.putAll(entries);
-    }
-    await encryptedBox.close();
-    debugPrint('Hive: migrated "$boxName" to encrypted storage '
-        '(${entries.length} entries)');
-  }
-
-  /// Test hook for [_migrateToEncrypted] (#1686).
+  /// Test hook for [HiveLegacyMigration.migrateToEncrypted] (#1686).
   @visibleForTesting
   static Future<void> migrateToEncryptedForTest(
           String boxName, Box<dynamic> plain, HiveAesCipher cipher) =>
-      _migrateToEncrypted(boxName, plain, cipher);
+      HiveLegacyMigration.migrateToEncrypted(boxName, plain, cipher);
 
   /// Boxes only read by deep OBD2 / trip / badge / snapshot / glide
   /// features — none is needed to paint the landing search screen, so
@@ -245,8 +194,8 @@ class HiveBoxes {
     // Phase 1 — migrate any pre-encryption plaintext boxes. The probes
     // are independent, so they (and any migration) run in parallel.
     await Future.wait<void>(
-      _encryptedBoxes
-          .map((boxName) => _migrateLegacyPlaintextBox(boxName, cipher)),
+      _encryptedBoxes.map((boxName) =>
+          HiveLegacyMigration.migrateLegacyPlaintextBox(boxName, cipher)),
     );
 
     // Phase 2 — open the first-frame-critical boxes in one parallel
@@ -276,6 +225,13 @@ class HiveBoxes {
       throw HiveCorruptionException(
           'a storage box could not be opened (${e.message})');
     }
+
+    // #2670 — the main isolate owns these for the whole app lifetime; a
+    // foreground background scan's closeIsolateBoxes() must never close them.
+    HiveIsolateOwnership.markOwned(const [
+      settings, profiles, favorites, cache, priceHistory, alerts,
+      isolateErrorSpool, featureFlags, appProfile, boxSchema,
+    ]);
 
     // #1686 — stamp the current schema version for any box that lacks
     // one, so a future release can detect and migrate old on-disk data.
@@ -310,7 +266,7 @@ class HiveBoxes {
   /// be sure its box is open without re-running the opens.
   static Future<void> initDeferred() => _deferredInit ??= Future.wait(
         _deferredBoxes.map((name) => Hive.openBox<String>(name)),
-      );
+      ).whenComplete(() => HiveIsolateOwnership.markOwned(_deferredBoxes));
 
   /// Initialize Hive in a background isolate with proper encryption.
   static Future<void> initInIsolate() async {
@@ -331,13 +287,20 @@ class HiveBoxes {
     await Hive.openBox<String>(isolateErrorSpool);
   }
 
-  /// Close all Hive boxes opened by [initInIsolate].
+  /// Close the Hive boxes opened by [initInIsolate] at the end of a
+  /// background task to release file handles.
   ///
-  /// Must be called at the end of every background task to release file
-  /// handles and prevent race conditions with the main isolate.
+  /// #2670 — boxes [HiveIsolateOwnership] records as main-isolate-owned (from
+  /// [init] / [initDeferred] / [initForTest]) are **skipped**: when the scan
+  /// ran inside the foreground isolate these are the live, shared global
+  /// handles the rest of the app still uses, and closing them produced the
+  /// `FileSystemException: File closed, path='…/cache.hive'` field crash. A
+  /// true spawned `dart:isolate` worker never ran [init], so its registry is
+  /// empty and every [initInIsolate] handle is still closed.
   static Future<void> closeIsolateBoxes() async {
     final boxNames = [settings, favorites, alerts, cache, priceHistory, priceSnapshots, isolateErrorSpool];
     for (final name in boxNames) {
+      if (HiveIsolateOwnership.isOwned(name)) continue;
       try {
         if (Hive.isBoxOpen(name)) {
           await Hive.box(name).close();
@@ -370,6 +333,14 @@ class HiveBoxes {
     await Hive.openBox<String>(priceSnapshots);
     // #1686 — schema-version meta box, mirrors the runtime open.
     await Hive.openBox<int>(boxSchema);
+    // #2670 — initForTest stands in for the main isolate's init(): the boxes
+    // it opens are main-isolate-owned, so closeIsolateBoxes() leaves them open
+    // (mirroring the production foreground-isolate scenario).
+    HiveIsolateOwnership.markOwned(const [
+      settings, favorites, cache, profiles, priceHistory, alerts,
+      serviceReminders, obd2PausedTrips, obd2NegotiatedProtocol,
+      obd2ActiveTrip, priceSnapshots, boxSchema,
+    ]);
   }
 
   /// Safely converts any Hive map to a typed map.

--- a/lib/core/storage/hive_isolate_ownership.dart
+++ b/lib/core/storage/hive_isolate_ownership.dart
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+/// Per-isolate registry of Hive boxes the **main isolate** opened and owns
+/// for the whole app lifetime (#2670).
+///
+/// Hive's box registry is a single global per *isolate*, not per logical
+/// "worker". When a background scan runs inside the **foreground** isolate
+/// (the Android home-widget refresh + foreground-service runners — see
+/// `ErrorLayer.background`, "tasks running inside the foreground isolate"),
+/// `HiveBoxes.initInIsolate` / `closeIsolateBoxes` operate on those very same
+/// global handles. Before #2670, `closeIsolateBoxes`'s `finally` therefore
+/// closed the live `cache` box the main `init()` had opened, and the next
+/// foreground `StationServiceChain` cache read hit a closed file
+/// (`FileSystemException: File closed, path='…/cache.hive'`, 43× in field).
+///
+/// The fix: `closeIsolateBoxes` never closes a box recorded here. A box is
+/// recorded only when the main lifecycle opener (`init` / `initDeferred` /
+/// `initForTest`) ran *in this isolate*, so a **true spawned `dart:isolate`**
+/// worker — which never calls `init()` — sees an empty registry and still
+/// closes its own `initInIsolate` handles to release OS file descriptors. The
+/// guard is thus a no-op for the only case it must not touch (the shared
+/// foreground handles) and inert everywhere else.
+class HiveIsolateOwnership {
+  HiveIsolateOwnership._();
+
+  static final Set<String> _owned = <String>{};
+
+  /// Records [names] as main-isolate-owned. Idempotent.
+  static void markOwned(Iterable<String> names) => _owned.addAll(names);
+
+  /// Whether [name] is owned by the main isolate and must survive
+  /// `closeIsolateBoxes`.
+  static bool isOwned(String name) => _owned.contains(name);
+
+  /// Clears the registry (#2670). Test-only hook so a test can simulate a
+  /// **spawned-worker** isolate — where `init()` never ran — and assert
+  /// `closeIsolateBoxes` still closes the `initInIsolate` handles.
+  @visibleForTesting
+  static void resetForTest() => _owned.clear();
+}

--- a/lib/core/storage/hive_legacy_migration.dart
+++ b/lib/core/storage/hive_legacy_migration.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+/// One-time migration of pre-encryption plaintext Hive boxes into their
+/// encrypted equivalents (#1686).
+///
+/// Extracted from `HiveBoxes` (#2670) so the box-lifecycle file stays under
+/// the file-length norm. The behaviour is unchanged: corruption is never
+/// resolved by deleting user data — a box Hive cannot open at all is left on
+/// disk for `HiveBoxes.init`'s Phase 2 to surface as a corruption error.
+class HiveLegacyMigration {
+  HiveLegacyMigration._();
+
+  /// Migrate a pre-encryption plaintext [boxName] into an encrypted box.
+  ///
+  /// A box already written with the cipher opens cleanly — nothing to do.
+  /// When the cipher open fails, a plaintext open is attempted: a box that
+  /// still carries plaintext data is migrated; one that fails the plaintext
+  /// open too is damaged and is **left on disk untouched**. A box Hive cannot
+  /// open at all then surfaces in `init`'s Phase 2 as a corruption error.
+  static Future<void> migrateLegacyPlaintextBox(
+      String boxName, HiveAesCipher cipher) async {
+    try {
+      final box = await Hive.openBox(boxName, encryptionCipher: cipher);
+      await box.close();
+      return; // Already encrypted, or a fresh install.
+    } catch (_) {
+      // Fall through — the box may be a pre-encryption plaintext box.
+    }
+
+    Box<dynamic> plain;
+    try {
+      plain = await Hive.openBox(boxName);
+    } catch (e, st) { // ignore: unused_catch_stack
+      debugPrint('Hive: "$boxName" unreadable during the migration probe '
+          '— left on disk for Phase 2 to surface.');
+      return;
+    }
+
+    await migrateToEncrypted(boxName, plain, cipher);
+  }
+
+  /// Copies an already-open plaintext [plain] box into an encrypted box of
+  /// the same name (#1686).
+  ///
+  /// The plaintext file is deleted only *after* its entries are held in
+  /// memory, so an interruption mid-migration cannot lose data — a crash
+  /// leaves the still-intact plaintext box, never an empty one.
+  static Future<void> migrateToEncrypted(
+      String boxName, Box<dynamic> plain, HiveAesCipher cipher) async {
+    final entries = Map<dynamic, dynamic>.from(plain.toMap());
+    await plain.close();
+
+    await Hive.deleteBoxFromDisk(boxName);
+    final encryptedBox =
+        await Hive.openBox(boxName, encryptionCipher: cipher);
+    if (entries.isNotEmpty) {
+      await encryptedBox.putAll(entries);
+    }
+    await encryptedBox.close();
+    debugPrint('Hive: migrated "$boxName" to encrypted storage '
+        '(${entries.length} entries)');
+  }
+}

--- a/lib/core/storage/stores/cache_hive_store.dart
+++ b/lib/core/storage/stores/cache_hive_store.dart
@@ -1,22 +1,46 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../data/storage_repository.dart';
+import '../../logging/error_logger.dart';
 import '../hive_boxes.dart';
 
 /// Hive-backed implementation of [CacheStorage] and [ItineraryStorage].
 ///
 /// Manages the API response cache and itinerary storage.
 /// The [CacheManager] wraps this for TTL and metadata envelopes.
+///
+/// #2670 — every box access goes through [_boxOrNull], which returns null
+/// when the `cache` box isn't open instead of throwing. A background scan
+/// running in the foreground isolate can close the shared `cache` handle
+/// mid-flight (`closeIsolateBoxes`); without this guard the next routine
+/// `StationServiceChain` cache read threw `FileSystemException: File closed`
+/// (43× in field). A closed box now degrades to a clean cache miss / no-op,
+/// matching the other Hive stores (`RadiusAlertStore`, `PriceSnapshotStore`,
+/// `VelocityAlertCooldown`). The root close-site is fixed in
+/// [HiveBoxes.closeIsolateBoxes]; this is the belt-and-braces reader guard.
 class CacheHiveStore implements CacheStorage, ItineraryStorage {
-  Box get _cache => Hive.box(HiveBoxes.cache);
+  Box? _boxOrNull() {
+    try {
+      if (!Hive.isBoxOpen(HiveBoxes.cache)) return null;
+      return Hive.box(HiveBoxes.cache);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {'where': 'CacheHiveStore: cache box unavailable'}));
+      return null;
+    }
+  }
 
   // Cache
   @override
   Future<void> cacheData(String key, dynamic data) async {
-    await _cache.put(key, {
+    final box = _boxOrNull();
+    if (box == null) return;
+    await box.put(key, {
       'data': data,
       'timestamp': DateTime.now().millisecondsSinceEpoch,
     });
@@ -24,7 +48,9 @@ class CacheHiveStore implements CacheStorage, ItineraryStorage {
 
   @override
   Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) {
-    final cached = _cache.get(key);
+    final box = _boxOrNull();
+    if (box == null) return null;
+    final cached = box.get(key);
     if (cached == null) return null;
 
     final map = HiveBoxes.toStringDynamicMap(cached);
@@ -43,21 +69,29 @@ class CacheHiveStore implements CacheStorage, ItineraryStorage {
   }
 
   @override
-  Future<void> clearCache() => _cache.clear();
+  Future<void> clearCache() async {
+    final box = _boxOrNull();
+    if (box != null) await box.clear();
+  }
 
   @override
-  Iterable<dynamic> get cacheKeys => _cache.keys;
+  Iterable<dynamic> get cacheKeys => _boxOrNull()?.keys ?? const [];
 
   @override
-  Future<void> deleteCacheEntry(String key) => _cache.delete(key);
+  Future<void> deleteCacheEntry(String key) async {
+    final box = _boxOrNull();
+    if (box != null) await box.delete(key);
+  }
 
   @override
-  int get cacheEntryCount => _cache.length;
+  int get cacheEntryCount => _boxOrNull()?.length ?? 0;
 
   // Itineraries (stored in cache box)
   @override
   List<Map<String, dynamic>> getItineraries() {
-    final data = _cache.get('itineraries');
+    final box = _boxOrNull();
+    if (box == null) return [];
+    final data = box.get('itineraries');
     if (data == null) return [];
     return (data as List)
         .map((e) => HiveBoxes.toStringDynamicMap(e))
@@ -66,8 +100,10 @@ class CacheHiveStore implements CacheStorage, ItineraryStorage {
   }
 
   @override
-  Future<void> saveItineraries(List<Map<String, dynamic>> itineraries) =>
-      _cache.put('itineraries', itineraries);
+  Future<void> saveItineraries(List<Map<String, dynamic>> itineraries) async {
+    final box = _boxOrNull();
+    if (box != null) await box.put('itineraries', itineraries);
+  }
 
   @override
   Future<void> addItinerary(Map<String, dynamic> itinerary) async {

--- a/test/core/cache/cache_manager_test.dart
+++ b/test/core/cache/cache_manager_test.dart
@@ -1,10 +1,26 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/cache/cache_manager.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+
+/// No-op recorder so the closed-box tests can drive `errorLogger.log`
+/// without a Hive-backed spool (which would need platform init).
+class _NoopRecorder implements TraceRecorder {
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {}
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
 
 /// In-memory fake implementing [CacheStorage] for testing [CacheManager]
 /// without Hive platform initialization.
@@ -56,6 +72,34 @@ class FakeCacheStorage implements CacheStorage {
 
   @override
   Future<void> deleteCacheEntry(String key) async => _cache.remove(key);
+}
+
+/// A [CacheStorage] whose reads/writes throw [FileSystemException] — exactly
+/// what the real Hive store does when its `cache.hive` box is closed
+/// mid-flight by a foreground background scan (#2670). Drives the
+/// CacheManager-level resilience guard.
+class ClosedBoxCacheStorage implements CacheStorage {
+  static const _closed = FileSystemException(
+      'File closed', '/tmp/cache.hive');
+
+  @override
+  Future<void> cacheData(String key, dynamic data) async => throw _closed;
+
+  @override
+  Map<String, dynamic>? getCachedData(String key, {Duration? maxAge}) =>
+      throw _closed;
+
+  @override
+  Future<void> clearCache() async => throw _closed;
+
+  @override
+  int get cacheEntryCount => throw _closed;
+
+  @override
+  Iterable<dynamic> get cacheKeys => throw _closed;
+
+  @override
+  Future<void> deleteCacheEntry(String key) async => throw _closed;
 }
 
 void main() {
@@ -660,6 +704,43 @@ void main() {
           ttl: const Duration(hours: 1), source: ServiceSource.cache);
       final evicted = await cache.evictBounded();
       expect(evicted, equals(0));
+    });
+  });
+
+  // #2670 — when the underlying Hive box was closed mid-flight a read/write
+  // throws FileSystemException. The CacheManager must treat that as a clean
+  // miss / no-op so StationServiceChain falls through to the API + stale
+  // path instead of surfacing a crash on a routine cached search.
+  group('CacheManager - closed box resilience (#2670)', () {
+    late CacheManager closedCache;
+
+    setUp(() {
+      // Route the defensive errorLogger.log through a no-op recorder so the
+      // unit test doesn't reach the Hive-backed isolate spool.
+      errorLogger.testRecorderOverride = _NoopRecorder();
+      closedCache = CacheManager(ClosedBoxCacheStorage());
+    });
+
+    tearDown(() => errorLogger.resetForTest());
+
+    test('get treats a closed box as a cache miss (returns null, no throw)',
+        () {
+      expect(() => closedCache.get('search:FR:x'), returnsNormally);
+      expect(closedCache.get('search:FR:x'), isNull);
+    });
+
+    test('getFresh treats a closed box as a cache miss', () {
+      expect(() => closedCache.getFresh('search:FR:x'), returnsNormally);
+      expect(closedCache.getFresh('search:FR:x'), isNull);
+    });
+
+    test('put swallows the closed-box write failure (never throws)',
+        () async {
+      await expectLater(
+        closedCache.put('search:FR:x', {'v': 1},
+            ttl: const Duration(minutes: 5), source: ServiceSource.cache),
+        completes,
+      );
     });
   });
 }

--- a/test/core/storage/hive_boxes_test.dart
+++ b/test/core/storage/hive_boxes_test.dart
@@ -197,11 +197,15 @@ void main() {
       });
 
       test('migration logic exists for encrypted boxes', () {
+        // #2670 — the legacy-migration concern moved to its own file so the
+        // box-lifecycle file stays under the file-length norm; the contract
+        // is unchanged.
         final source =
-            File('lib/core/storage/hive_boxes.dart').readAsStringSync();
+            File('lib/core/storage/hive_legacy_migration.dart')
+                .readAsStringSync();
 
         expect(
-          source.contains('_migrateToEncrypted'),
+          source.contains('migrateToEncrypted'),
           isTrue,
           reason: 'Migration method must exist for unencrypted-to-encrypted',
         );

--- a/test/core/storage/hive_storage_test.dart
+++ b/test/core/storage/hive_storage_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_isolate_ownership.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 
 /// HiveStorage tests use real Hive boxes initialized with a temp directory.
@@ -562,41 +563,61 @@ void main() {
   // Isolate Box Lifecycle
   // ---------------------------------------------------------------------------
   group('Isolate Box Lifecycle', () {
-    test('closeIsolateBoxes closes all open boxes without error', () async {
-      // Boxes are already open from setUp via initForTest
+    // #2670 — initForTest stands in for the main isolate's init(): the boxes
+    // it opens are main-isolate-owned, so closeIsolateBoxes() (which runs in
+    // a foreground background scan's finally) must NOT close them. Before the
+    // fix it closed the live `cache` handle and the next StationServiceChain
+    // read threw `FileSystemException: File closed` (43× in field).
+    test('closeIsolateBoxes does NOT close the live cache box the main '
+        'isolate opened (root #2670)', () async {
+      // Boxes are already open from setUp via initForTest.
       await HiveStorage.closeIsolateBoxes();
 
-      // After closing, boxes should not be accessible
-      // Re-open for other tests in tearDown
-      expect(Hive.isBoxOpen('settings'), isFalse);
-      expect(Hive.isBoxOpen('favorites'), isFalse);
-      expect(Hive.isBoxOpen('alerts'), isFalse);
-      expect(Hive.isBoxOpen('cache'), isFalse);
-      expect(Hive.isBoxOpen('price_history'), isFalse);
-
-      // Re-open boxes so tearDown (Hive.close()) works cleanly
-      await HiveStorage.initForTest();
+      expect(Hive.isBoxOpen('cache'), isTrue,
+          reason: 'the main-isolate cache box must stay open for in-flight '
+              'StationServiceChain reads');
+      expect(Hive.isBoxOpen('settings'), isTrue);
+      expect(Hive.isBoxOpen('favorites'), isTrue);
+      expect(Hive.isBoxOpen('alerts'), isTrue);
+      expect(Hive.isBoxOpen('price_history'), isTrue);
     });
 
-    test('closeIsolateBoxes is safe to call when boxes are already closed', () async {
+    test('closeIsolateBoxes is safe to call when boxes are already closed',
+        () async {
+      HiveIsolateOwnership.resetForTest();
       await HiveStorage.closeIsolateBoxes();
 
-      // Calling again should not throw
+      // Calling again should not throw.
       await HiveStorage.closeIsolateBoxes();
 
-      // Re-open for other tests
+      // Re-open for other tests.
       await HiveStorage.initForTest();
     });
 
     test('closeIsolateBoxes does not close profiles box', () async {
-      // profiles box is only opened by main isolate init, not initInIsolate
-      // closeIsolateBoxes should only close the 5 boxes that initInIsolate opens
+      // profiles box is only opened by main isolate init, not initInIsolate.
       await HiveStorage.closeIsolateBoxes();
 
-      // profiles box should still be open (it was opened by initForTest)
       expect(Hive.isBoxOpen('profiles'), isTrue);
+    });
 
-      // Re-open for other tests
+    test('a spawned-worker isolate (init never ran) still closes its '
+        'initInIsolate handles to release file descriptors (#2670)', () async {
+      // Simulate a TRUE separate dart:isolate where init() never marked
+      // ownership: closeIsolateBoxes MUST close the boxes so the OS file
+      // handles a real worker opened are released.
+      HiveIsolateOwnership.resetForTest();
+
+      expect(Hive.isBoxOpen('cache'), isTrue);
+      await HiveStorage.closeIsolateBoxes();
+
+      expect(Hive.isBoxOpen('cache'), isFalse,
+          reason: 'a worker-isolate handle must still be closed');
+      expect(Hive.isBoxOpen('settings'), isFalse);
+      expect(Hive.isBoxOpen('alerts'), isFalse);
+      expect(Hive.isBoxOpen('price_history'), isFalse);
+
+      // Re-open boxes so tearDown (Hive.close()) runs cleanly.
       await HiveStorage.initForTest();
     });
   });

--- a/test/core/storage/stores/cache_hive_store_test.dart
+++ b/test/core/storage/stores/cache_hive_store_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/storage/stores/cache_hive_store.dart';
 
@@ -90,6 +91,63 @@ void main() {
       // crashing.
       await store.cacheData('list', [1, 2, 3]);
       expect(store.getCachedData('list'), isNull);
+    });
+  });
+
+  // #2670 — a foreground background scan can close the shared `cache` box
+  // (closeIsolateBoxes) while the rest of the app still references it. Before
+  // the fix the unguarded `Hive.box(cache)` getter threw
+  // `FileSystemException: File closed` on the next routine read (43× in
+  // field). Every access must degrade to a clean miss / no-op instead.
+  group('CacheHiveStore — closed cache box (#2670)', () {
+    test('getCachedData returns null instead of throwing when the box '
+        'was closed mid-flight', () async {
+      await store.cacheData('k1', {'hello': 'world'});
+      expect(store.getCachedData('k1'), isNotNull);
+
+      // Simulate closeIsolateBoxes() closing the live handle.
+      await Hive.box(HiveBoxes.cache).close();
+
+      expect(() => store.getCachedData('k1'), returnsNormally);
+      expect(store.getCachedData('k1'), isNull);
+
+      // Re-open so tearDown's Hive.close() runs cleanly.
+      await HiveStorage.initForTest();
+    });
+
+    test('getItineraries returns an empty list, not a throw, on a '
+        'closed box', () async {
+      await store.saveItineraries([
+        {'id': 'i1', 'name': 'Trip'},
+      ]);
+      await Hive.box(HiveBoxes.cache).close();
+
+      expect(() => store.getItineraries(), returnsNormally);
+      expect(store.getItineraries(), isEmpty);
+
+      await HiveStorage.initForTest();
+    });
+
+    test('cacheData is a silent no-op on a closed box (never throws)',
+        () async {
+      await Hive.box(HiveBoxes.cache).close();
+
+      await expectLater(store.cacheData('k', {'x': 1}), completes);
+
+      await HiveStorage.initForTest();
+    });
+
+    test('saveItineraries / clearCache / deleteCacheEntry no-op on a '
+        'closed box', () async {
+      await Hive.box(HiveBoxes.cache).close();
+
+      await expectLater(store.saveItineraries(const []), completes);
+      await expectLater(store.clearCache(), completes);
+      await expectLater(store.deleteCacheEntry('k'), completes);
+      expect(store.cacheKeys, isEmpty);
+      expect(store.cacheEntryCount, 0);
+
+      await HiveStorage.initForTest();
     });
   });
 


### PR DESCRIPTION
## Problem (#2670 — the dominant field error)

43 of 50 field traces were `FileSystemException: File closed,
path='…/cache.hive'` with context `where: StationServiceChain.apiCall`. A
routine cached search threw on every cached `apiCall`.

## Root cause

A background price scan running inside the **foreground** isolate (Android
home-widget refresh / foreground-service runner — it logs
`ErrorLayer.background`, "tasks running inside the foreground isolate") ends
its `finally` with `HiveStorage.closeIsolateBoxes()`, whose box list includes
`cache`. Hive's box registry is a single global **per isolate**, so that
close shut the live `cache` handle the main `init()` opened for the whole app
lifetime. The next foreground `StationServiceChain` cache read hit the closed
file and threw — `CacheHiveStore`'s unguarded `Hive.box(cache)` getter had no
open-check, unlike every other store in the repo.

## Fix — two layers (root + belt-and-braces)

**(a) ROOT — isolate ownership tracking.** New `HiveIsolateOwnership` registry
records every box opened by the main-isolate lifecycle (`init` /
`initDeferred` / `initForTest`). `closeIsolateBoxes()` now skips any owned
box, so a foreground scan never closes the shared `cache` handle. A **true
spawned `dart:isolate`** worker never ran `init()`, so its registry is empty
and every `initInIsolate` handle is still closed — the OS file descriptors a
real worker must release are still released.

**(b) GUARD — `CacheHiveStore`** now routes every access through `_boxOrNull()`
(matching `RadiusAlertStore` / `PriceSnapshotStore` / `VelocityAlertCooldown`):
a closed box is a clean cache miss / no-op, never a throw. `CacheManager.get`/`put`
additionally swallow `FileSystemException` so `StationServiceChain` falls
through to the API + stale-cache path.

## Decomposition (file-length norm)

To keep `hive_boxes.dart` and `cache_manager.dart` ≤400 lines, the cohesive
legacy-encryption migration moved to `hive_legacy_migration.dart` and the
ownership registry to its own file; the redundant per-constant
"intentionally compile-time" doc trailers (already stated in the class-level
policy note) were de-duplicated.

## TDD — RED on master, GREEN after

All three layers were proven RED on `origin/master` first, then GREEN:

- `cache_hive_store_test.dart` — closed box threw `HiveError: Box not found`
  (the in-memory-Hive equivalent of the prod `File closed`).
- `cache_manager_test.dart` — threw the exact field error `FileSystemException:
  File closed, path = '/tmp/cache.hive'`.
- `hive_storage_test.dart` — on master `closeIsolateBoxes()` closed the live
  `cache` box (`isBoxOpen('cache')` was false after the call); the fix keeps
  it open, and a separate test confirms a spawned-worker isolate still closes
  its handles.

Error-handling only — no new user-facing strings. `flutter analyze` clean,
zero codegen drift, all non-network tests green.

Closes #2670

🤖 Generated with [Claude Code](https://claude.com/claude-code)
