### PR TITLE
feat(search): Fuel Station Radar on the search results screen (Epic #2659)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -13,6 +13,8 @@ import '../../../profile/providers/effective_fuel_type_provider.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
+import '../../../search/providers/radar_search_provider.dart';
+import '../../../search/providers/search_filters_provider.dart';
 import '../../domain/driving_coaching.dart';
 import '../../domain/situation_classifier.dart';
 import '../../providers/obd2_connection_state_provider.dart';
@@ -23,6 +25,7 @@ import 'obd2_pause_banner.dart';
 import 'obd2_status_dot.dart';
 import 'trip_recording_banner_content.dart';
 import 'trip_recording_banner_palette.dart';
+import 'trip_recording_pip_price_layout.dart';
 import 'trip_recording_pip_view.dart';
 
 /// Persistent indicator of an active OBD2 trip (#726 + #768).
@@ -64,6 +67,22 @@ class TripRecordingBanner extends ConsumerWidget {
         final p = ref.watch(activeProfileProvider);
         if (p != null) radiusMeters = p.approachRadiusKm * 1000.0;
       } on Object { /* no radius */ }
+      // #2677 — guarded fallback for the on-search Fuel Station Radar PiP
+      // (no trip required): when the trip radar found nothing AND the
+      // on-search radar is active, feed its nearest priced station into the
+      // SAME price layout (the search radius is the proximity bar's radius).
+      // Reuses TripRecordingPipPriceLayout + fuelStationRadarPalette unchanged
+      // — no parallel PiP host.
+      var searchRadarActive = false;
+      if (radarStation == null) {
+        try {
+          if (ref.watch(radarSearchProvider).active) {
+            searchRadarActive = true;
+            radarStation = ref.watch(radarSearchNearestProvider);
+            radiusMeters = ref.watch(searchRadiusProvider) * 1000.0;
+          }
+        } on Object { /* no on-search radar */ }
+      }
       return _pipView(
         context,
         state,
@@ -71,6 +90,7 @@ class TripRecordingBanner extends ConsumerWidget {
         fuelType: fuel,
         radarStation: radarStation,
         radiusMeters: radiusMeters,
+        searchRadarActive: searchRadarActive,
       );
     }
 
@@ -164,8 +184,28 @@ class TripRecordingBanner extends ConsumerWidget {
     required FuelType fuelType,
     required Station? radarStation,
     required double? radiusMeters,
+    bool searchRadarActive = false,
   }) {
     if (!state.isActive) {
+      // #2677 — the on-search Fuel Station Radar runs WITHOUT a trip. When it
+      // owns the PiP tile and has a nearest priced station, render the SAME
+      // price layout (no trip state needed — the layout is paint-only) instead
+      // of the neutral panel. Reuses TripRecordingPipPriceLayout +
+      // fuelStationRadarPalette unchanged.
+      if (searchRadarActive && radarStation != null) {
+        final palette = fuelStationRadarPalette(fuelType);
+        return TripRecordingPipPriceLayout(
+          station: radarStation,
+          fuel: fuelType,
+          backgroundColor: palette.background,
+          foregroundColor: palette.foreground,
+          distanceMeters: radarStation.dist > 0
+              ? radarStation.dist * 1000.0
+              : null,
+          kmCaption: true,
+          radiusMeters: radiusMeters,
+        );
+      }
       // A trip ended while the app sat in PiP — the OS restores the
       // full window momentarily; a neutral panel avoids flashing the
       // shell (and its nav bar) back into the tile in the meantime.

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../app/responsive_search_layout.dart';
 import '../../../../app/shell/settings_app_bar_action.dart';
@@ -16,6 +17,9 @@ import '../../../../core/utils/frame_callbacks.dart';
 import '../../../../core/widgets/page_scaffold.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/data/pip_controller.dart';
+import '../../../consumption/providers/pip_mode_provider.dart';
+import '../../../consumption/providers/wakelock_facade.dart';
 import '../../../map/presentation/widgets/inline_map.dart';
 import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
@@ -23,6 +27,7 @@ import '../../../route_search/providers/route_search_provider.dart';
 import '../../../station_detail/presentation/widgets/station_detail_inline.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_mode.dart';
+import '../../providers/radar_search_provider.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import '../../providers/selected_station_provider.dart';
@@ -46,9 +51,25 @@ class SearchScreen extends ConsumerStatefulWidget {
 class _SearchScreenState extends ConsumerState<SearchScreen> {
   bool _autoSearchAttempted = false;
 
+  /// #2677 — ephemeral pin state for the on-search radar, mirroring the
+  /// trip-recording screen's pin (#891): keeps the screen on + hides system
+  /// bars so the radar result stays readable on a dashboard mount. Not
+  /// persisted — the user opts back in each scan. Android-only affordance.
+  bool _pinned = false;
+
+  /// Cached facade so [dispose] can release the wake lock without touching
+  /// `ref` after the widget has been deactivated.
+  WakelockFacade? _cachedFacade;
+
+  /// #2677 — the single app-wide PiP controller (`pipControllerProvider`).
+  /// Never construct a second one: the `tankstellen/pip` channel admits one
+  /// handler. Drives the minimise button + (#2678) the auto-PiP opt-in.
+  late final PipController _pip;
+
   @override
   void initState() {
     super.initState();
+    _pip = ref.read(pipControllerProvider);
     safePostFrame(() {
       if (_autoSearchAttempted) return;
       _autoSearchAttempted = true;
@@ -122,6 +143,56 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   }
 
   // ---------------------------------------------------------------------------
+  // #2677 — radar pin + reduce-to-PiP (Android-only via PipController.isSupported)
+  // ---------------------------------------------------------------------------
+
+  /// Toggle the radar pin (wake lock + immersive bars). Copied from the
+  /// trip-recording screen so the pinned state is identical.
+  Future<void> _togglePin() async {
+    final nextPinned = !_pinned;
+    setState(() => _pinned = nextPinned);
+    if (nextPinned) {
+      await _enablePin();
+    } else {
+      await _disablePin();
+    }
+  }
+
+  Future<void> _enablePin() async {
+    final facade = ref.read(wakelockFacadeProvider);
+    _cachedFacade = facade;
+    await facade.enable();
+    await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+  }
+
+  Future<void> _disablePin() async {
+    final facade = ref.read(wakelockFacadeProvider);
+    _cachedFacade = facade;
+    await facade.disable();
+    await SystemChrome.setEnabledSystemUIMode(
+      SystemUiMode.manual,
+      overlays: SystemUiOverlay.values,
+    );
+  }
+
+  @override
+  void dispose() {
+    // Release the wake lock + restore system UI if the user leaves while
+    // pinned. Best-effort + fire-and-forget — `dispose` must stay sync.
+    if (_pinned) {
+      final facade = _cachedFacade;
+      if (facade != null) unawaited(facade.disable());
+      unawaited(
+        SystemChrome.setEnabledSystemUIMode(
+          SystemUiMode.manual,
+          overlays: SystemUiOverlay.values,
+        ),
+      );
+    }
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
   // Build
   // ---------------------------------------------------------------------------
 
@@ -147,6 +218,12 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     final isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
 
+    // #2677 — while the on-search radar owns the results, surface the same
+    // pin + reduce-to-PiP controls the trip-recording screen carries. Both
+    // are Android-only (the minimise button hides where PiP can't host app
+    // UI); iOS shows neither — gated on the radar being active.
+    final radarActive = ref.watch(radarSearchProvider).active;
+
     return PageScaffold(
       title: l10n?.appTitle ?? 'Fuel Prices',
       toolbarHeight: isLandscape ? 40 : null,
@@ -160,6 +237,38 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
           },
           tooltip: l10n?.refreshPrices ?? 'Refresh prices',
         ),
+        if (radarActive) ...[
+          // Pin — wake lock + immersive bars (copied from the trip screen).
+          Semantics(
+            container: true,
+            button: true,
+            toggled: _pinned,
+            label: _pinned
+                ? (l10n?.tripRecordingPinSemanticOn ?? 'Unpin recording form')
+                : (l10n?.tripRecordingPinSemanticOff ?? 'Pin recording form'),
+            child: IconButton(
+              key: const Key('radarPinButton'),
+              icon: Icon(
+                _pinned ? Icons.push_pin : Icons.push_pin_outlined,
+                color:
+                    _pinned ? Theme.of(context).colorScheme.primary : null,
+              ),
+              tooltip: l10n?.tripRecordingPinTooltip ??
+                  'Pinning keeps the screen on — uses more battery',
+              isSelected: _pinned,
+              onPressed: _togglePin,
+            ),
+          ),
+          // Minimise to a PiP tile — Android-only.
+          if (_pip.isSupported)
+            IconButton(
+              key: const Key('radarMinimiseButton'),
+              icon: const Icon(Icons.picture_in_picture_alt),
+              tooltip: l10n?.tripRecordingMinimiseTooltip ??
+                  'Minimise to a floating tile',
+              onPressed: () => _pip.enterPip(),
+            ),
+        ],
         const SettingsAppBarAction(),
       ],
       bodyPadding: EdgeInsets.zero,

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -66,6 +66,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
   /// handler. Drives the minimise button + (#2678) the auto-PiP opt-in.
   late final PipController _pip;
 
+  /// #2678 — last value pushed to [PipController.setAutoEnterEnabled], so the
+  /// build only crosses the channel when the radar opt-in actually changes.
+  bool? _radarAutoPipRequested;
+
   @override
   void initState() {
     super.initState();
@@ -189,6 +193,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
         ),
       );
     }
+    // #2678 — drop the auto-PiP opt-in so leaving the app from an unrelated
+    // screen never shrinks the search UI into a tile. The controller itself
+    // is owned by `pipControllerProvider`, not disposed here.
+    unawaited(_pip.setAutoEnterEnabled(false));
     super.dispose();
   }
 
@@ -223,6 +231,17 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
     // are Android-only (the minimise button hides where PiP can't host app
     // UI); iOS shows neither — gated on the radar being active.
     final radarActive = ref.watch(radarSearchProvider).active;
+
+    // #2678 — arm the native auto-PiP opt-in while the radar is active, so the
+    // app shrinks into the tile (onUserLeaveHint) when the user leaves to
+    // Maps mid-scan — mirroring the trip-recording arming. The global OS
+    // observer (TankstellenApp) is unchanged; only this per-screen flag is
+    // new. Disarmed on dismiss (radar inactive) + in dispose. Android-only:
+    // `setAutoEnterEnabled` is an inert no-op where PiP can't host app UI.
+    if (radarActive != _radarAutoPipRequested) {
+      _radarAutoPipRequested = radarActive;
+      unawaited(_pip.setAutoEnterEnabled(radarActive));
+    }
 
     return PageScaffold(
       title: l10n?.appTitle ?? 'Fuel Prices',

--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -4,12 +4,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/services/service_result.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
 import '../../../../core/widgets/shimmer_placeholder.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/domain/entities/user_profile.dart';
 import '../../../profile/providers/profile_provider.dart';
 import '../../domain/entities/search_mode.dart';
+import '../../domain/entities/search_result_item.dart';
+import '../../providers/radar_search_provider.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import 'nearest_shortcut_card.dart';
@@ -42,6 +45,27 @@ class SearchResultsContent extends ConsumerWidget {
     if (searchMode == SearchMode.route) {
       return const CustomScrollView(
         slivers: [RouteResultsView()],
+      );
+    }
+
+    // #2675 — when the on-search Fuel Station Radar is active it OWNS the
+    // results list (mirrors the route early-return above): its
+    // distance-sorted, priced stations are wrapped as FuelStationResult into
+    // a cache-sourced ServiceResult and handed to the same SearchResultsList,
+    // so the polymorphic switch renders them as ordinary fuel cards. The
+    // regular searchStateProvider is left untouched — dismissing the radar
+    // hands the list straight back to it.
+    final radar = ref.watch(radarSearchProvider);
+    if (radar.active) {
+      final stations = radar.stations.value ?? const [];
+      final radarResult = ServiceResult<List<SearchResultItem>>(
+        data: [for (final s in stations) FuelStationResult(s)],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime.now(),
+      );
+      return SearchResultsList(
+        result: radarResult,
+        onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
       );
     }
 

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -25,6 +25,7 @@ import '../../domain/entities/station.dart';
 import '../../providers/selected_station_provider.dart';
 import '../../providers/ignored_stations_provider.dart';
 import '../../providers/search_provider.dart';
+import '../../providers/radar_search_provider.dart';
 import '../../providers/brand_filter_provider.dart';
 import '../../providers/search_screen_ui_provider.dart';
 import '../../providers/station_rating_provider.dart';
@@ -136,6 +137,12 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
                   ),
                 ),
               ),
+              const SizedBox(width: 4),
+              // #2675 — Fuel Station Radar: a one-shot, cache-first scan
+              // around the user's persisted position whose stations render in
+              // this same list like a regular search. Extracted to the parts
+              // file to keep this file under the length cap.
+              const _RadarSearchButton(),
               const SizedBox(width: 4),
               // #1613 — gated entry point for the fuel-cost Calculator.
               // The /calculator route exists but had no navigation entry

--- a/lib/features/search/presentation/widgets/search_results_list_parts.dart
+++ b/lib/features/search/presentation/widgets/search_results_list_parts.dart
@@ -126,6 +126,38 @@ class _CollapsibleBrandFilters extends ConsumerWidget {
   }
 }
 
+/// #2675 — header affordance that runs the on-search Fuel Station Radar: a
+/// one-shot, cache-first scan around the user's persisted position whose
+/// stations render in this same list (the polymorphic switch builds them as
+/// fuel cards). Mirrors the map button's Semantics + Tooltip + InkWell pair.
+class _RadarSearchButton extends ConsumerWidget {
+  const _RadarSearchButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final label = l10n?.fuelStationRadarButtonTooltip ??
+        'Search with Fuel Station Radar';
+    return Semantics(
+      label: label,
+      button: true,
+      child: Tooltip(
+        message: label,
+        child: InkWell(
+          key: const Key('radarSearchButton'),
+          onTap: () => ref.read(radarSearchProvider.notifier).runRadar(),
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            child: Icon(Icons.radar,
+                size: 18, color: Theme.of(context).colorScheme.primary),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Toggle button to switch between compact card view and all-prices detail view.
 class _ViewToggleButton extends ConsumerWidget {
   @override

--- a/lib/features/search/presentation/widgets/search_summary_bar.dart
+++ b/lib/features/search/presentation/widgets/search_summary_bar.dart
@@ -12,6 +12,7 @@ import '../../../route_search/providers/route_search_params_provider.dart';
 import '../../../route_search/providers/route_search_provider.dart';
 import '../../domain/entities/fuel_type.dart';
 import '../../domain/entities/search_mode.dart';
+import '../../providers/radar_search_provider.dart';
 import '../../providers/search_mode_provider.dart';
 import '../../providers/search_provider.dart';
 import '../screens/search_criteria_screen.dart';
@@ -53,6 +54,16 @@ class SearchSummaryBar extends ConsumerWidget {
     AppLocalizations? l10n,
     SearchMode mode,
   ) {
+    // #2676 — while the on-search Fuel Station Radar owns the results, the
+    // radius chip is meaningless (the radar scans its own cached corridor);
+    // replace it with a "radar result" badge so the grey bar signals the
+    // list is a radar scan, not a regular search.
+    if (ref.watch(radarSearchProvider).active) {
+      return _SummaryChip(
+        icon: const Icon(Icons.radar, size: 16),
+        label: l10n?.fuelStationRadarResultBadge ?? 'Fuel Station Radar result',
+      );
+    }
     if (mode != SearchMode.route) {
       final kmText = ref.watch(searchRadiusProvider).round().toString();
       return _SummaryChip(

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/location/user_position_provider.dart';
+import '../../../core/utils/geo_utils.dart' as geo;
+import '../../../core/utils/station_extensions.dart';
+import '../../approach/providers/fuel_station_radar_provider.dart';
+import '../domain/entities/station.dart';
+import 'search_filters_provider.dart';
+
+part 'radar_search_provider.g.dart';
+
+/// State of the on-search Fuel Station Radar (#2659 / #2674).
+///
+/// Holds whether the radar is the active result source ([active]) plus the
+/// `AsyncValue` of the distance-sorted, priced station list it produced.
+class RadarSearchState {
+  const RadarSearchState({
+    required this.active,
+    required this.stations,
+  });
+
+  /// `true` once a radar run has resolved and the results list should render
+  /// the radar stations instead of the regular `searchStateProvider` results.
+  final bool active;
+
+  /// The radar's distance-sorted, priced station list (loading/data/error).
+  final AsyncValue<List<Station>> stations;
+
+  static const RadarSearchState idle = RadarSearchState(
+    active: false,
+    stations: AsyncData<List<Station>>(<Station>[]),
+  );
+
+  RadarSearchState copyWith({
+    bool? active,
+    AsyncValue<List<Station>>? stations,
+  }) =>
+      RadarSearchState(
+        active: active ?? this.active,
+        stations: stations ?? this.stations,
+      );
+}
+
+/// The on-search Fuel Station Radar (#2659).
+///
+/// A one-shot, cache-first radar fetch around the user's persisted position
+/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
+/// the search results list like a regular search. It reuses the #2661 radar
+/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
+/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
+/// zero network.
+///
+/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
+/// approach detector: those only fire while a trip records (gated on
+/// `ApproachPolling`). This provider runs on demand from the search screen, with
+/// no geofence polling and no second `ApproachDetector` / `PipController`.
+@riverpod
+class RadarSearch extends _$RadarSearch {
+  @override
+  RadarSearchState build() => RadarSearchState.idle;
+
+  /// Run the radar around the user's persisted position. No-op (leaves the
+  /// radar inactive) when no position is known yet — the user must search /
+  /// locate at least once so we have somewhere to scan around.
+  Future<void> runRadar() async {
+    final pos = ref.read(userPositionProvider);
+    if (pos == null) {
+      state = RadarSearchState.idle;
+      return;
+    }
+
+    final radiusKm = ref.read(searchRadiusProvider);
+    final fuel = ref.read(selectedFuelTypeProvider);
+
+    state = state.copyWith(
+      active: true,
+      stations: const AsyncLoading<List<Station>>(),
+    );
+
+    try {
+      final radar = ref.read(fuelStationRadarProvider);
+      final raw = await radar.fetchStations(
+        pos.lat,
+        pos.lng,
+        radiusKm,
+        fuel.apiValue,
+      );
+
+      // Stamp each station's distance (km) from the user, distance-sort, then
+      // drop rows with no usable price for the selected fuel — the radar
+      // surfaces priced stations only, like the regular search list.
+      final priced = <Station>[];
+      for (final s in raw) {
+        final distKm =
+            geo.distanceMeters(pos.lat, pos.lng, s.lat, s.lng) / 1000.0;
+        final withDist = s.copyWith(dist: distKm);
+        final price = withDist.priceFor(fuel);
+        if (price == null || price <= 0) continue;
+        priced.add(withDist);
+      }
+      priced.sort((a, b) => a.dist.compareTo(b.dist));
+
+      state = state.copyWith(
+        active: true,
+        stations: AsyncData<List<Station>>(priced),
+      );
+    } catch (e, st) {
+      state = state.copyWith(
+        active: true,
+        stations: AsyncError<List<Station>>(e, st),
+      );
+    }
+  }
+
+  /// Dismiss the radar result and hand the results list back to the regular
+  /// `searchStateProvider`.
+  void dismiss() {
+    state = RadarSearchState.idle;
+  }
+}
+
+/// The nearest priced radar station, or null. Feeds the small-window PiP tile
+/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+@riverpod
+Station? radarSearchNearest(Ref ref) {
+  final radar = ref.watch(radarSearchProvider);
+  if (!radar.active) return null;
+  final list = radar.stations.value;
+  if (list == null || list.isEmpty) return null;
+  return list.first;
+}

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -1,0 +1,165 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'radar_search_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The on-search Fuel Station Radar (#2659).
+///
+/// A one-shot, cache-first radar fetch around the user's persisted position
+/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
+/// the search results list like a regular search. It reuses the #2661 radar
+/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
+/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
+/// zero network.
+///
+/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
+/// approach detector: those only fire while a trip records (gated on
+/// `ApproachPolling`). This provider runs on demand from the search screen, with
+/// no geofence polling and no second `ApproachDetector` / `PipController`.
+
+@ProviderFor(RadarSearch)
+final radarSearchProvider = RadarSearchProvider._();
+
+/// The on-search Fuel Station Radar (#2659).
+///
+/// A one-shot, cache-first radar fetch around the user's persisted position
+/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
+/// the search results list like a regular search. It reuses the #2661 radar
+/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
+/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
+/// zero network.
+///
+/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
+/// approach detector: those only fire while a trip records (gated on
+/// `ApproachPolling`). This provider runs on demand from the search screen, with
+/// no geofence polling and no second `ApproachDetector` / `PipController`.
+final class RadarSearchProvider
+    extends $NotifierProvider<RadarSearch, RadarSearchState> {
+  /// The on-search Fuel Station Radar (#2659).
+  ///
+  /// A one-shot, cache-first radar fetch around the user's persisted position
+  /// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
+  /// the search results list like a regular search. It reuses the #2661 radar
+  /// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
+  /// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
+  /// zero network.
+  ///
+  /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
+  /// approach detector: those only fire while a trip records (gated on
+  /// `ApproachPolling`). This provider runs on demand from the search screen, with
+  /// no geofence polling and no second `ApproachDetector` / `PipController`.
+  RadarSearchProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'radarSearchProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$radarSearchHash();
+
+  @$internal
+  @override
+  RadarSearch create() => RadarSearch();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(RadarSearchState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<RadarSearchState>(value),
+    );
+  }
+}
+
+String _$radarSearchHash() => r'17dd6df0b132ba4d0e25ba88cbf293769ccf71a7';
+
+/// The on-search Fuel Station Radar (#2659).
+///
+/// A one-shot, cache-first radar fetch around the user's persisted position
+/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
+/// the search results list like a regular search. It reuses the #2661 radar
+/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
+/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
+/// zero network.
+///
+/// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
+/// approach detector: those only fire while a trip records (gated on
+/// `ApproachPolling`). This provider runs on demand from the search screen, with
+/// no geofence polling and no second `ApproachDetector` / `PipController`.
+
+abstract class _$RadarSearch extends $Notifier<RadarSearchState> {
+  RadarSearchState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<RadarSearchState, RadarSearchState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<RadarSearchState, RadarSearchState>,
+              RadarSearchState,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}
+
+/// The nearest priced radar station, or null. Feeds the small-window PiP tile
+/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+
+@ProviderFor(radarSearchNearest)
+final radarSearchNearestProvider = RadarSearchNearestProvider._();
+
+/// The nearest priced radar station, or null. Feeds the small-window PiP tile
+/// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+
+final class RadarSearchNearestProvider
+    extends $FunctionalProvider<Station?, Station?, Station?>
+    with $Provider<Station?> {
+  /// The nearest priced radar station, or null. Feeds the small-window PiP tile
+  /// (#2677) the same way `nearestStationRadarProvider` feeds the trip PiP.
+  RadarSearchNearestProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'radarSearchNearestProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$radarSearchNearestHash();
+
+  @$internal
+  @override
+  $ProviderElement<Station?> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  Station? create(Ref ref) {
+    return radarSearchNearest(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(Station? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<Station?>(value),
+    );
+  }
+}
+
+String _$radarSearchNearestHash() =>
+    r'b69ac244695db9325ceb5fe03c40a565082317a3';

--- a/lib/l10n/_fragments/trip_radar_de.arb
+++ b/lib/l10n/_fragments/trip_radar_de.arb
@@ -18,5 +18,9 @@
   "fuelStationRadarFarther": "Weiter entfernte Tankstelle",
   "@fuelStationRadarFarther": {
     "description": "Swipe-right hint / screen-reader action on the Fuel Station Radar card: page to the next-farther station in the distance-ranked list (#2661)."
+  },
+  "fuelStationRadarButtonTooltip": "Mit Tankstellen-Radar suchen",
+  "@fuelStationRadarButtonTooltip": {
+    "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
   }
 }

--- a/lib/l10n/_fragments/trip_radar_de.arb
+++ b/lib/l10n/_fragments/trip_radar_de.arb
@@ -22,5 +22,9 @@
   "fuelStationRadarButtonTooltip": "Mit Tankstellen-Radar suchen",
   "@fuelStationRadarButtonTooltip": {
     "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
+  },
+  "fuelStationRadarResultBadge": "Tankstellen-Radar-Ergebnis",
+  "@fuelStationRadarResultBadge": {
+    "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
   }
 }

--- a/lib/l10n/_fragments/trip_radar_en.arb
+++ b/lib/l10n/_fragments/trip_radar_en.arb
@@ -18,5 +18,9 @@
   "fuelStationRadarFarther": "Farther station",
   "@fuelStationRadarFarther": {
     "description": "Swipe-right hint / screen-reader action on the Fuel Station Radar card: page to the next-farther station in the distance-ranked list (#2661)."
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
   }
 }

--- a/lib/l10n/_fragments/trip_radar_en.arb
+++ b/lib/l10n/_fragments/trip_radar_en.arb
@@ -22,5 +22,9 @@
   "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
   "@fuelStationRadarButtonTooltip": {
     "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2995,6 +2995,10 @@
   "@fuelStationRadarFarther": {
     "description": "Swipe-right hint / screen-reader action on the Fuel Station Radar card: page to the next-farther station in the distance-ranked list (#2661)."
   },
+  "fuelStationRadarButtonTooltip": "Mit Tankstellen-Radar suchen",
+  "@fuelStationRadarButtonTooltip": {
+    "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
+  },
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -2999,6 +2999,10 @@
   "@fuelStationRadarButtonTooltip": {
     "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
   },
+  "fuelStationRadarResultBadge": "Tankstellen-Radar-Ergebnis",
+  "@fuelStationRadarResultBadge": {
+    "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
+  },
   "tripRecordingPinTooltip": "Anpinnen hält den Bildschirm an — verbraucht mehr Akku",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5872,6 +5872,10 @@
   "@fuelStationRadarFarther": {
     "description": "Swipe-right hint / screen-reader action on the Fuel Station Radar card: page to the next-farther station in the distance-ranked list (#2661)."
   },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5876,6 +5876,10 @@
   "@fuelStationRadarButtonTooltip": {
     "description": "Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675)."
   },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."
+  },
   "tripRecordingPinTooltip": "Pinning keeps the screen on — uses more battery",
   "@tripRecordingPinTooltip": {
     "description": "Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1901,6 +1901,7 @@
   "fuelStationRadarNearer": "⟦Ñéářéř šŧáŧîóñ ······⟧",
   "fuelStationRadarFarther": "⟦Ƒářŧĥéř šŧáŧîóñ ······⟧",
   "fuelStationRadarButtonTooltip": "⟦Šéářçĥ ŵîŧĥ Ƒúéł Šŧáŧîóñ Řáđář ············⟧",
+  "fuelStationRadarResultBadge": "⟦Ƒúéł Šŧáŧîóñ Řáđář řéšúłŧ ··········⟧",
   "tripRecordingPinTooltip": "⟦Ƥîññîñǧ ķééƥš ŧĥé šçřééñ óñ — úšéš ɱóřé ƀáŧŧéřý ·················⟧",
   "tripRecordingPinSemanticOn": "⟦Úñƥîñ řéçóřđîñǧ ƒóřɱ ········⟧",
   "tripRecordingPinSemanticOff": "⟦Ƥîñ řéçóřđîñǧ ƒóřɱ ·······⟧",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1900,6 +1900,7 @@
   "tripRadarNoStationNearby": "⟦Ñó šŧáŧîóñ ñéářƀý ·······⟧",
   "fuelStationRadarNearer": "⟦Ñéářéř šŧáŧîóñ ······⟧",
   "fuelStationRadarFarther": "⟦Ƒářŧĥéř šŧáŧîóñ ······⟧",
+  "fuelStationRadarButtonTooltip": "⟦Šéářçĥ ŵîŧĥ Ƒúéł Šŧáŧîóñ Řáđář ············⟧",
   "tripRecordingPinTooltip": "⟦Ƥîññîñǧ ķééƥš ŧĥé šçřééñ óñ — úšéš ɱóřé ƀáŧŧéřý ·················⟧",
   "tripRecordingPinSemanticOn": "⟦Úñƥîñ řéçóřđîñǧ ƒóřɱ ········⟧",
   "tripRecordingPinSemanticOff": "⟦Ƥîñ řéçóřđîñǧ ƒóřɱ ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3773,5 +3773,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -3778,5 +3778,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11613,6 +11613,12 @@ abstract class AppLocalizations {
   /// **'Search with Fuel Station Radar'**
   String get fuelStationRadarButtonTooltip;
 
+  /// Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676).
+  ///
+  /// In en, this message translates to:
+  /// **'Fuel Station Radar result'**
+  String get fuelStationRadarResultBadge;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11607,6 +11607,12 @@ abstract class AppLocalizations {
   /// **'Farther station'**
   String get fuelStationRadarFarther;
 
+  /// Tooltip / accessibility label on the radar button in the search-results header that runs a cache-first radar scan around the user and shows the nearby stations in the results list (#2675).
+  ///
+  /// In en, this message translates to:
+  /// **'Search with Fuel Station Radar'**
+  String get fuelStationRadarButtonTooltip;
+
   /// Tooltip on the pin toggle in the trip-recording AppBar (#891). Warns the user that enabling pin keeps the screen awake at a battery cost.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6660,6 +6660,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Закачането задържа екрана включен — изразходва повече батерия';
 

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6663,6 +6663,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Закачането задържа екрана включен — изразходва повече батерия';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6615,6 +6615,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Připnutí udržuje obrazovku zapnutou — spotřebuje více baterie';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6618,6 +6618,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Připnutí udržuje obrazovku zapnutou — spotřebuje více baterie';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6609,6 +6609,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fastgørelse holder skærmen tændt — bruger mere batteri';
 

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6606,6 +6606,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fastgørelse holder skærmen tændt — bruger mere batteri';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6650,6 +6650,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fuelStationRadarFarther => 'Weiter entfernte Tankstelle';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Mit Tankstellen-Radar suchen';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6653,6 +6653,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Mit Tankstellen-Radar suchen';
 
   @override
+  String get fuelStationRadarResultBadge => 'Tankstellen-Radar-Ergebnis';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Anpinnen hält den Bildschirm an — verbraucht mehr Akku';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -6667,6 +6667,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Η καρφίτσωση κρατά την οθόνη αναμμένη — χρησιμοποιεί περισσότερη μπαταρία';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -6664,6 +6664,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Η καρφίτσωση κρατά την οθόνη αναμμένη — χρησιμοποιεί περισσότερη μπαταρία';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6581,6 +6581,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 
@@ -13667,6 +13670,10 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   @override
   String get fuelStationRadarButtonTooltip =>
       '⟦Šéářçĥ ŵîŧĥ Ƒúéł Šŧáŧîóñ Řáđář ············⟧';
+
+  @override
+  String get fuelStationRadarResultBadge =>
+      '⟦Ƒúéł Šŧáŧîóñ Řáđář řéšúłŧ ··········⟧';
 
   @override
   String get tripRecordingPinTooltip =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6578,6 +6578,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pinning keeps the screen on — uses more battery';
 
@@ -13660,6 +13663,10 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get fuelStationRadarFarther => '⟦Ƒářŧĥéř šŧáŧîóñ ······⟧';
+
+  @override
+  String get fuelStationRadarButtonTooltip =>
+      '⟦Šéářçĥ ŵîŧĥ Ƒúéł Šŧáŧîóñ Řáđář ············⟧';
 
   @override
   String get tripRecordingPinTooltip =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6655,6 +6655,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fijar mantiene la pantalla encendida: consume más batería';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6658,6 +6658,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fijar mantiene la pantalla encendida: consume más batería';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -6598,6 +6598,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kinnitamine hoiab ekraani peal — kasutab rohkem akut';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -6601,6 +6601,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kinnitamine hoiab ekraani peal — kasutab rohkem akut';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -6606,6 +6606,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kiinnittäminen pitää näytön päällä — kuluttaa enemmän akkua';
 

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -6609,6 +6609,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Kiinnittäminen pitää näytön päällä — kuluttaa enemmän akkua';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6673,6 +6673,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'L\'épinglage garde l\'écran allumé — consomme plus de batterie';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6676,6 +6676,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'L\'épinglage garde l\'écran allumé — consomme plus de batterie';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6628,6 +6628,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prikačivanje drži ekran uključenim — troši više baterije';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6631,6 +6631,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prikačivanje drži ekran uključenim — troši više baterije';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -6650,6 +6650,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'A rögzítés bekapcsolva tartja a képernyőt — több akkumulátort használ';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -6653,6 +6653,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'A rögzítés bekapcsolva tartja a képernyőt — több akkumulátort használ';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6644,6 +6644,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fissare mantiene lo schermo acceso — consuma più batteria';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6641,6 +6641,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fissare mantiene lo schermo acceso — consuma più batteria';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -6640,6 +6640,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prisegimas palaiko ekraną įjungtą — naudoja daugiau baterijos';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -6643,6 +6643,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Prisegimas palaiko ekraną įjungtą — naudoja daugiau baterijos';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -6644,6 +6644,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Piespraušana patur ekrānu ieslēgtu — patērē vairāk akumulatora';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -6647,6 +6647,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Piespraušana patur ekrānu ieslēgtu — patērē vairāk akumulatora';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -6604,6 +6604,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Festing holder skjermen på – bruker mer batteri';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -6607,6 +6607,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Festing holder skjermen på – bruker mer batteri';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6628,6 +6628,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Vastpinnen houdt het scherm aan — verbruikt meer batterij';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6631,6 +6631,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Vastpinnen houdt het scherm aan — verbruikt meer batterij';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6633,6 +6633,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Przypięcie utrzymuje ekran włączony — zużywa więcej baterii';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6636,6 +6636,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Przypięcie utrzymuje ekran włączony — zużywa więcej baterii';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6655,6 +6655,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixar mantém o ecrã ligado — usa mais bateria';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6652,6 +6652,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixar mantém o ecrã ligado — usa mais bateria';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6653,6 +6653,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixarea menține ecranul aprins — consumă mai multă baterie';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6650,6 +6650,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Fixarea menține ecranul aprins — consumă mai multă baterie';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -6637,6 +6637,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pripnutie udržuje obrazovku zapnutú — vyčerpáva viac batérie';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -6634,6 +6634,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Pripnutie udržuje obrazovku zapnutú — vyčerpáva viac batérie';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -6615,6 +6615,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Priklepanje ohranja zaslon vklopljen — porablja več baterije';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -6618,6 +6618,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Priklepanje ohranja zaslon vklopljen — porablja več baterije';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6604,6 +6604,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fuelStationRadarFarther => 'Farther station';
 
   @override
+  String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Nålning håller skärmen på – förbrukar mer batteri';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6607,6 +6607,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fuelStationRadarButtonTooltip => 'Search with Fuel Station Radar';
 
   @override
+  String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
+
+  @override
   String get tripRecordingPinTooltip =>
       'Nålning håller skärmen på – förbrukar mer batteri';
 

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -3687,5 +3687,10 @@
   "@fuelStationRadarFarther": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarButtonTooltip": "Search with Fuel Station Radar",
+  "@fuelStationRadarButtonTooltip": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -3692,5 +3692,10 @@
   "@fuelStationRadarButtonTooltip": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "fuelStationRadarResultBadge": "Fuel Station Radar result",
+  "@fuelStationRadarResultBadge": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/features/search/presentation/screens/radar_search_auto_pip_test.dart
+++ b/test/features/search/presentation/screens/radar_search_auto_pip_test.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/consumption/data/pip_controller.dart';
+import 'package:tankstellen/features/consumption/providers/pip_mode_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/screens/search_screen.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #2678 — while the on-search Fuel Station Radar owns the search results, the
+/// native auto-PiP opt-in is ARMED so the app shrinks into the tile when the
+/// user leaves to Maps mid-scan; dismissing the radar disarms it. Android-only
+/// — the controller is a no-op elsewhere, so force the Android code path.
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+  @override
+  Future<void> disable() async {}
+}
+
+Station _station() => const Station(
+      id: 'NEAR',
+      name: 'Station NEAR',
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '00000',
+      place: 'Test',
+      lat: 48.0,
+      lng: 2.0,
+      dist: 1.0,
+      e10: 1.5,
+      isOpen: true,
+    );
+
+/// Toggleable radar so the test can flip active → inactive at runtime.
+class _ToggleRadar extends RadarSearch {
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>([_station()]),
+      );
+
+  void deactivate() => state = RadarSearchState.idle;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('tankstellen/pip');
+
+  testWidgets(
+      'radar active arms auto-PiP once; dismiss disarms it', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final autoEnterCalls = <bool>[];
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'setAutoEnter') {
+        autoEnterCalls.add(call.arguments == true);
+      }
+      return null;
+    });
+
+    final pip = PipController();
+    addTearDown(pip.dispose);
+    final radar = _ToggleRadar();
+
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+    when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+    await pumpApp(
+      tester,
+      const SearchScreen(),
+      overrides: [
+        ...test.overrides,
+        userPositionNullOverride(),
+        wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+        pipControllerProvider.overrideWithValue(pip),
+        pipModeProvider.overrideWith(() => _NeverPip()),
+        radarSearchProvider.overrideWith(() => radar),
+      ],
+    );
+    await tester.pump();
+
+    expect(autoEnterCalls.contains(true), isTrue,
+        reason: 'auto-PiP must be armed while the radar owns the results');
+
+    // Dismiss the radar → the opt-in disarms.
+    autoEnterCalls.clear();
+    radar.deactivate();
+    await tester.pumpAndSettle();
+
+    expect(autoEnterCalls.contains(false), isTrue,
+        reason: 'dismissing the radar must disarm auto-PiP');
+
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+}
+
+class _NeverPip extends PipMode {
+  @override
+  bool build() => false;
+}

--- a/test/features/search/presentation/screens/radar_search_pip_controls_test.dart
+++ b/test/features/search/presentation/screens/radar_search_pip_controls_test.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/consumption/data/pip_controller.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_banner.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart';
+import 'package:tankstellen/features/consumption/providers/pip_mode_provider.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/screens/search_screen.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #2677 — the on-search Fuel Station Radar carries the same pin +
+/// reduce-to-PiP controls the trip-recording screen has, and the PiP small
+/// window reuses the trip price layout. Android-only — the controller is a
+/// no-op on every other platform, so the test forces the Android code path.
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+  @override
+  Future<void> disable() async {}
+}
+
+Station _station(String id) => Station(
+      id: id,
+      name: 'Station $id',
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '00000',
+      place: 'Test',
+      lat: 48.0,
+      lng: 2.0,
+      dist: 1.2,
+      e10: 1.659,
+      isOpen: true,
+    );
+
+class _ActiveRadar extends RadarSearch {
+  _ActiveRadar(this._stations);
+  final List<Station> _stations;
+
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(_stations),
+      );
+}
+
+class _IdleTrip extends TripRecording {
+  @override
+  TripRecordingState build() => const TripRecordingState();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('tankstellen/pip');
+
+  testWidgets(
+      'radar active → pin + minimise buttons in the AppBar; minimise taps '
+      'enterPip', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final calls = <String>[];
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      calls.add(call.method);
+      if (call.method == 'enterPip') return true;
+      return null;
+    });
+
+    final pip = PipController();
+    addTearDown(pip.dispose);
+
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+    when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+    await pumpApp(
+      tester,
+      const SearchScreen(),
+      overrides: [
+        ...test.overrides,
+        userPositionNullOverride(),
+        wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+        pipControllerProvider.overrideWithValue(pip),
+        radarSearchProvider.overrideWith(
+          () => _ActiveRadar([_station('NEAR')]),
+        ),
+      ],
+    );
+
+    expect(find.byKey(const Key('radarPinButton')), findsOneWidget);
+    expect(find.byKey(const Key('radarMinimiseButton')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('radarMinimiseButton')));
+    await tester.pumpAndSettle();
+
+    expect(calls, contains('enterPip'),
+        reason: 'minimise must request a PiP transition over the channel');
+
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
+      'PiP small window with on-search radar active + a nearest station '
+      'renders the trip price layout (no trip needed)', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+    await pumpApp(
+      tester,
+      const TripRecordingBanner(child: SizedBox.shrink()),
+      overrides: [
+        ...test.overrides,
+        // OS has shrunk the app into the PiP tile …
+        pipModeProvider.overrideWith(() => _AlwaysPip()),
+        // … with no trip recording …
+        tripRecordingProvider.overrideWith(_IdleTrip.new),
+        // … but the on-search radar is active with a nearest station.
+        radarSearchProvider.overrideWith(
+          () => _ActiveRadar([_station('NEAR')]),
+        ),
+      ],
+    );
+
+    expect(find.byType(TripRecordingPipPriceLayout), findsOneWidget);
+    // The nearest radar station's name leads the tile (price + km layout).
+    expect(find.text('Station NEAR'), findsOneWidget);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+}
+
+class _AlwaysPip extends PipMode {
+  @override
+  bool build() => true;
+}

--- a/test/features/search/presentation/widgets/radar_search_button_test.dart
+++ b/test/features/search/presentation/widgets/radar_search_button_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
+import 'package:tankstellen/core/services/radar/jit_price_cache.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_list.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+
+import '../../../../fixtures/stations.dart';
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #2675 — the radar button on the search-results header runs the on-search
+/// radar and the SAME results list re-renders the radar stations as ordinary
+/// fuel cards, without touching `searchStateProvider`.
+
+Station _station(String id, double lat, double lng, {double e10 = 1.5}) =>
+    Station(
+      id: id,
+      name: 'Station $id',
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '00000',
+      place: 'Test',
+      lat: lat,
+      lng: lng,
+      e10: e10,
+      isOpen: true,
+    );
+
+class _FixedUserPosition extends UserPosition {
+  @override
+  UserPositionData? build() => UserPositionData(
+        lat: 48.0,
+        lng: 2.0,
+        updatedAt: DateTime.now(),
+        source: 'test',
+      );
+}
+
+FuelStationRadar _recordedRadar(List<Station> corridor) => FuelStationRadar(
+      isBulkSource: true,
+      corridorCache: CorridorLocationCache(
+        isBulk: true,
+        corridorRadiusKm: 60,
+        tileStepDegrees: 0.5,
+        fetchCorridor: (lat, lng, r) async => corridor,
+      ),
+      priceCache: JitPriceCache(fetchPrice: (s) async => s),
+    );
+
+void main() {
+  Future<void> noopRetry() async {}
+
+  testWidgets(
+      'tapping the radar button runs the radar and the list re-renders the '
+      'radar stations as fuel cards — searchStateProvider untouched',
+      (tester) async {
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+    when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+    await pumpApp(
+      tester,
+      SearchResultsContent(onGpsRetry: noopRetry),
+      overrides: [
+        ...test.overrides,
+        userPositionProvider.overrideWith(_FixedUserPosition.new),
+        fuelStationRadarProvider.overrideWithValue(
+          _recordedRadar([_station('RADAR-NEAR', 48.0, 2.0)]),
+        ),
+        // A regular search result the radar must SUPPLANT, not mutate.
+        searchStateProvider.overrideWith(() => _LoadedSearchState([testStation])),
+      ].cast(),
+    );
+
+    // Before the radar runs the regular search result is on screen.
+    expect(find.byKey(ValueKey('station-${testStation.id}')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('radarSearchButton')));
+    await tester.pumpAndSettle();
+
+    // The list now renders the radar station as a fuel card …
+    expect(find.byKey(const ValueKey('station-RADAR-NEAR')), findsOneWidget);
+    // … and the original search result is gone from the list.
+    expect(find.byKey(ValueKey('station-${testStation.id}')), findsNothing);
+    // The SearchResultsList host is still the renderer.
+    expect(find.byType(SearchResultsList), findsOneWidget);
+  });
+
+  testWidgets('an active radar state renders its stations via the same list',
+      (tester) async {
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+    when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+    await pumpApp(
+      tester,
+      SearchResultsContent(onGpsRetry: noopRetry),
+      overrides: [
+        ...test.overrides,
+        radarSearchProvider.overrideWith(
+          () => _ActiveRadar([_station('PRESET', 48.0, 2.0)]),
+        ),
+      ].cast(),
+    );
+
+    expect(find.byKey(const ValueKey('station-PRESET')), findsOneWidget);
+    expect(find.byType(SearchResultsList), findsOneWidget);
+  });
+}
+
+class _LoadedSearchState extends SearchState {
+  _LoadedSearchState(this._stations);
+  final List<Station> _stations;
+
+  @override
+  build() => AsyncData(
+        ServiceResult(
+          data: [for (final s in _stations) FuelStationResult(s)],
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}
+
+class _ActiveRadar extends RadarSearch {
+  _ActiveRadar(this._stations);
+  final List<Station> _stations;
+
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(_stations),
+      );
+}

--- a/test/features/search/presentation/widgets/search_summary_bar_test.dart
+++ b/test/features/search/presentation/widgets/search_summary_bar_test.dart
@@ -9,8 +9,10 @@ import 'package:tankstellen/features/route_search/domain/entities/route_info.dar
 import 'package:tankstellen/features/route_search/domain/route_search_result.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/search_mode.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/screens/search_criteria_screen.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_summary_bar.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
 
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
@@ -171,5 +173,55 @@ void main() {
       expect(find.text('Searching the route…'), findsNothing);
       expect(find.text('Within 10 km'), findsNothing);
     });
+
+    // #2676 — while the on-search Fuel Station Radar owns the results, the
+    // grey bar's second chip becomes a "radar result" badge instead of the
+    // (now meaningless) radius chip.
+    testWidgets('radar active replaces the radius chip with the radar badge',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const SearchSummaryBar(),
+        overrides: [
+          ...test.overrides,
+          selectedFuelTypeOverride(FuelType.e10),
+          searchRadiusOverride(10),
+          radarSearchProvider.overrideWith(_ActiveRadar.new),
+        ],
+      );
+
+      expect(find.text('Fuel Station Radar result'), findsOneWidget);
+      expect(find.text('Within 10 km'), findsNothing);
+    });
+
+    testWidgets('radar inactive keeps the radius chip (badge absent)',
+        (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+
+      await pumpApp(
+        tester,
+        const SearchSummaryBar(),
+        overrides: [
+          ...test.overrides,
+          selectedFuelTypeOverride(FuelType.e10),
+          searchRadiusOverride(10),
+        ],
+      );
+
+      expect(find.text('Within 10 km'), findsOneWidget);
+      expect(find.text('Fuel Station Radar result'), findsNothing);
+    });
   });
+}
+
+class _ActiveRadar extends RadarSearch {
+  @override
+  RadarSearchState build() => const RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(<Station>[]),
+      );
 }

--- a/test/features/search/radar_search_provider_test.dart
+++ b/test/features/search/radar_search_provider_test.dart
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tankstellen/core/location/user_position_provider.dart';
+import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
+import 'package:tankstellen/core/services/radar/jit_price_cache.dart';
+import 'package:tankstellen/core/utils/station_extensions.dart';
+import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+import 'package:tankstellen/features/search/providers/search_filters_provider.dart';
+
+/// #2674 — the on-search radar drives the REAL `FuelStationRadar.fetchStations`
+/// through a recorded corridor-cache fixture (a bulk slice that already carries
+/// prices, like ES/IT do), NOT a request-echoing fake. This pins the
+/// data-shape contract the regular fetch + the provider's distance-sort +
+/// priced-filter actually deliver — see the false-green-fakes memory.
+
+/// Real-shaped corridor station. `e10` null/<=0 models an unpriced forecourt
+/// the radar must drop.
+Station _station(
+  String id,
+  double lat,
+  double lng, {
+  double? e10,
+}) =>
+    Station(
+      id: id,
+      name: 'Station $id',
+      brand: 'TEST',
+      street: 'Teststr.',
+      postCode: '00000',
+      place: 'Test',
+      lat: lat,
+      lng: lng,
+      e10: e10,
+      isOpen: true,
+    );
+
+/// Builds a REAL [FuelStationRadar] over a recorded corridor slice. Bulk
+/// source → the slice already carries prices, so no JIT round-trip fires
+/// (mirrors `fuel_station_radar_provider.dart`'s ES/IT branch).
+FuelStationRadar _recordedRadar(List<Station> corridor) => FuelStationRadar(
+      isBulkSource: true,
+      corridorCache: CorridorLocationCache(
+        isBulk: true,
+        corridorRadiusKm: 60,
+        tileStepDegrees: 0.5,
+        fetchCorridor: (lat, lng, r) async => corridor,
+      ),
+      priceCache: JitPriceCache(fetchPrice: (s) async => s),
+    );
+
+class _FixedUserPosition extends UserPosition {
+  _FixedUserPosition(this._lat, this._lng);
+  final double _lat;
+  final double _lng;
+
+  @override
+  UserPositionData? build() => UserPositionData(
+        lat: _lat,
+        lng: _lng,
+        updatedAt: DateTime.now(),
+        source: 'test',
+      );
+}
+
+class _NullUserPosition extends UserPosition {
+  @override
+  UserPositionData? build() => null;
+}
+
+class _FixedFuelType extends SelectedFuelType {
+  _FixedFuelType(this._type);
+  final FuelType _type;
+  @override
+  FuelType build() => _type;
+}
+
+class _FixedRadius extends SearchRadius {
+  _FixedRadius(this._km);
+  final double _km;
+  @override
+  double build() => _km;
+}
+
+ProviderContainer _container({
+  required ({double lat, double lng})? position,
+  required List<Station> corridor,
+  FuelType fuel = FuelType.e10,
+  double radiusKm = 10.0,
+}) =>
+    ProviderContainer(
+      overrides: [
+        userPositionProvider.overrideWith(
+          () => position == null
+              ? _NullUserPosition()
+              : _FixedUserPosition(position.lat, position.lng),
+        ),
+        selectedFuelTypeProvider.overrideWith(() => _FixedFuelType(fuel)),
+        searchRadiusProvider.overrideWith(() => _FixedRadius(radiusKm)),
+        fuelStationRadarProvider.overrideWithValue(_recordedRadar(corridor)),
+      ],
+    );
+
+void main() {
+  group('RadarSearch — on-search radar over the real fetch', () {
+    test('runRadar flips active and surfaces a distance-sorted priced list',
+        () async {
+      // Three priced stations + one unpriced, scattered around the user. The
+      // user sits at (48.0, 2.0); FAR is ~3.3 km N, NEAR is ~0 m, MID ~1.1 km.
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [
+          _station('FAR', 48.03, 2.0, e10: 1.799),
+          _station('NEAR', 48.0, 2.0, e10: 1.659),
+          _station('MID', 48.01, 2.0, e10: 1.729),
+          _station('UNPRICED', 48.005, 2.0, e10: null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(radarSearchProvider).active, isFalse);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      final state = container.read(radarSearchProvider);
+      expect(state.active, isTrue, reason: 'radar flips active after a run');
+
+      final list = state.stations.value!;
+      // UNPRICED dropped; the three priced ones survive.
+      expect(list.map((s) => s.id), ['NEAR', 'MID', 'FAR'],
+          reason: 'priced rows only, sorted by ascending distance');
+      expect(list.every((s) => (s.priceFor(FuelType.e10) ?? 0) > 0), isTrue);
+      // Distance stamped (km) from the user — drives the PiP tile + sort.
+      expect(list.first.dist, lessThan(0.1));
+      expect(list.last.dist, greaterThan(2.0));
+
+      // The derived nearest provider points at the closest priced station.
+      expect(container.read(radarSearchNearestProvider)?.id, 'NEAR');
+    });
+
+    test('drops every row when nothing in the corridor has a usable price',
+        () async {
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [
+          _station('A', 48.0, 2.0, e10: null),
+          _station('B', 48.01, 2.0, e10: 0.0),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      final state = container.read(radarSearchProvider);
+      expect(state.active, isTrue);
+      expect(state.stations.value, isEmpty);
+      expect(container.read(radarSearchNearestProvider), isNull);
+    });
+
+    test('no-ops with active=false when the user position is unknown',
+        () async {
+      final container = _container(
+        position: null,
+        corridor: [_station('NEAR', 48.0, 2.0, e10: 1.5)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      expect(container.read(radarSearchProvider).active, isFalse,
+          reason: 'no position → nothing to scan around');
+      expect(container.read(radarSearchNearestProvider), isNull);
+    });
+
+    test('dismiss flips active back to false', () async {
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [_station('NEAR', 48.0, 2.0, e10: 1.5)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+      expect(container.read(radarSearchProvider).active, isTrue);
+
+      container.read(radarSearchProvider.notifier).dismiss();
+      expect(container.read(radarSearchProvider).active, isFalse);
+      expect(container.read(radarSearchNearestProvider), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Epic #2659 — Fuel Station Radar on Search

A "Fuel Station Radar" button on the SEARCH RESULTS screen that runs a cache-first radar search around the user and shows the stations in the results list like a regular search, with a grey-bar "radar result" indicator, always-on-top (pin) + reduce-to-PiP title controls (Android), and auto-PiP on background — reusing the #2661 trip-radar + trip-recording PiP machinery. Zero new widgets; two new providers + a copied button + one guarded data-source fallback.

### Children
- **#2674** `radarSearchProvider` — cache-first, one-shot radar fetch around `userPositionProvider`, reusing the #2661 `fuelStationRadarProvider` data layer (corridor cache + JIT price cache). Distance-sorts + priced-filters. Derived `radarSearchNearestProvider`.
- **#2675** radar `IconButton` in the results header + content-level injection — when active, the radar stations render in the same `SearchResultsList` as ordinary fuel cards via a `ServiceResult` wrap. `searchStateProvider` is never mutated.
- **#2676** grey-bar relabel — `SearchSummaryBar._secondChip()` swaps the radius chip for a "radar result" badge while active.
- **#2677** pin + reduce-to-PiP title controls + small-window content — the search screen gains the trip screen's pin + minimise controls; `TripRecordingBanner._pipView` gains a guarded fallback so the on-search radar's nearest station renders in `TripRecordingPipPriceLayout` with no trip.
- **#2678** auto-PiP on background — the native auto-PiP opt-in is armed while the radar is active, disarmed on dismiss + dispose.

### Reuse-fidelity test (#2674)
The provider test drives the REAL `FuelStationRadar.fetchStations` through a recorded corridor-cache fixture (a bulk slice that already carries prices), not a request-echoing fake — pinning the active-flip, distance-sort, priced-filter, null-position no-op, and dismiss contracts. RED-on-master when the priced-filter is removed.

### Notes
- Two ARB keys (`fuelStationRadarButtonTooltip`, `fuelStationRadarResultBadge`) fanned out to all 23 locales + the en_XA pseudo-locale.
- PiP/pin are Android-only via `PipController.isSupported` (iOS shows neither) — no inline `Platform` check.
- Zero codegen drift, zero l10n drift, all touched central files under the 400-line cap (the radar button was extracted to `search_results_list_parts.dart` to keep `search_results_list.dart` comfortably under cap).

Closes #2659
Closes #2674
Closes #2675
Closes #2676
Closes #2677
Closes #2678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
