### PR TITLE
ci: fix pre-push toolchain (#2651) + route store-metadata PRs through the docs-stub (#2568)

### DIFF
--- a/.github/workflows/ci-docs-stub.yml
+++ b/.github/workflows/ci-docs-stub.yml
@@ -4,13 +4,19 @@
 name: CI
 
 # Docs-only "stub" workflow. `ci.yml` carries `paths-ignore` for
-# `**/*.md`, `docs/**`, `LICENSE`, `.gitignore`, so on a docs-only PR
-# the real CI workflow never runs — which means none of its required
-# status-check contexts are ever reported, and branch protection would
-# pin the PR at `mergeStateStatus: BLOCKED` forever. This workflow is
-# the mirror image: it triggers ONLY on those same paths and re-emits
-# every required-check context as a trivial pass, so docs-only PRs
-# satisfy branch protection and keep auto-merge autonomy.
+# `**/*.md`, `docs/**`, `LICENSE`, `.gitignore` (and, since #2568, the
+# store-metadata paths `ios/fastlane/**`, `fastlane/metadata/**`), so on a
+# change touching ONLY those paths the real CI workflow never runs — which
+# means none of its required status-check contexts are ever reported, and
+# branch protection would pin the PR at `mergeStateStatus: BLOCKED`
+# forever. This workflow is the mirror image: it triggers ONLY on those
+# same paths and re-emits every required-check context as a trivial pass,
+# so docs-only / metadata-only PRs satisfy branch protection and keep
+# auto-merge autonomy.
+#
+# IMPORTANT: this `paths` set MUST stay the exact complement of `ci.yml`'s
+# `paths-ignore` — every path ignored there has to be triggered here, or a
+# PR touching only that path has no producer for the required contexts.
 #
 # CONTRACT (keep in lock-step with branch protection's
 # required_status_checks): every required context MUST have a job here
@@ -31,6 +37,10 @@ on:
       - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
+      # #2568 — store-metadata paths ci.yml now path-ignores. The stub must
+      # produce the required contexts so metadata-only PRs aren't BLOCKED.
+      - 'ios/fastlane/**'
+      - 'fastlane/metadata/**'
   pull_request:
     branches: [master]
     paths:
@@ -38,6 +48,9 @@ on:
       - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
+      # #2568 — see the push trigger above; complement of ci.yml paths-ignore.
+      - 'ios/fastlane/**'
+      - 'fastlane/metadata/**'
 
 jobs:
   analyze:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
       - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
+      # #2568 — store-metadata-only changes never affect the Dart/Android
+      # build, so skip the heavy matrix. ci-docs-stub.yml triggers on these
+      # same paths and re-emits every required context so auto-merge fires.
+      - 'ios/fastlane/**'
+      - 'fastlane/metadata/**'
   pull_request:
     branches: [master]
     paths-ignore:
@@ -19,6 +24,9 @@ on:
       - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
+      # #2568 — see the push trigger above; mirrored by ci-docs-stub.yml.
+      - 'ios/fastlane/**'
+      - 'fastlane/metadata/**'
   schedule:
     - cron: '0 6 * * 0'
   # #2128 — manual hatch so maintainers can re-fire CI on the active

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -79,14 +79,27 @@ echo "pre-push: running local gates (bypass with SKIP_PREPUSH=1)..."
 # --- 1. Clean codegen (HARD RULE #3) -------------------------------------
 # Clean, not incremental: incremental builds keep stale hashes that CI's
 # clean run catches (see feedback_codegen_drift_local_gate memory).
+#
+# Route every pub/build_runner invocation through the FLUTTER toolchain
+# (#2651). This project is Flutter-SDK-pinned, so a bare `dart pub`/`dart
+# run` cannot resolve Flutter-pinned transitive deps (e.g.
+# url_launcher_platform_interface — it errors with "Flutter users should
+# use `flutter pub`"). That bare-dart failure made step 1 always abort in
+# worktrees, so everyone bypassed the whole gate with SKIP_PREPUSH=1 and
+# the local codegen/l10n drift gate never ran. Resolve deps with
+# `flutter pub get` first, then drive build_runner via `flutter pub run`.
 echo "pre-push [1/5]: regenerating code (build_runner clean && build)..."
-if ! dart run build_runner clean >/dev/null 2>&1; then
-  fail "build_runner clean failed" \
-       "Run 'dart run build_runner clean' and read the error."
+if ! flutter pub get; then
+  fail "flutter pub get failed" \
+       "Run 'flutter pub get' and read the error."
 fi
-if ! dart run build_runner build --delete-conflicting-outputs; then
+if ! flutter pub run build_runner clean >/dev/null 2>&1; then
+  fail "build_runner clean failed" \
+       "Run 'flutter pub run build_runner clean' and read the error."
+fi
+if ! flutter pub run build_runner build --delete-conflicting-outputs; then
   fail "build_runner build failed" \
-       "Run 'dart run build_runner build --delete-conflicting-outputs' and fix the error."
+       "Run 'flutter pub run build_runner build --delete-conflicting-outputs' and fix the error."
 fi
 
 # --- 2. No codegen drift -------------------------------------------------
@@ -99,11 +112,14 @@ fi
 # --- 3. No l10n fan-out drift (HARD RULE #4) -----------------------------
 # Every new en key must fan out to all locales via the autofill pipeline.
 echo "pre-push [3/5]: regenerating l10n and checking for drift..."
-if ! dart run tool/build_arb.dart; then
-  fail "tool/build_arb.dart failed" "Run 'dart run tool/build_arb.dart' and fix the error."
+# Route through `flutter pub run` for the same Flutter-pinned-deps reason
+# as step 1 (#2651): a bare `dart run` can't resolve this project's
+# Flutter-pinned package config and aborts the gate.
+if ! flutter pub run tool/build_arb.dart; then
+  fail "tool/build_arb.dart failed" "Run 'flutter pub run tool/build_arb.dart' and fix the error."
 fi
-if ! dart tool/gen_pseudo_arb.dart; then
-  fail "tool/gen_pseudo_arb.dart failed" "Run 'dart tool/gen_pseudo_arb.dart' and fix the error."
+if ! flutter pub run tool/gen_pseudo_arb.dart; then
+  fail "tool/gen_pseudo_arb.dart failed" "Run 'flutter pub run tool/gen_pseudo_arb.dart' and fix the error."
 fi
 if ! flutter gen-l10n; then
   fail "flutter gen-l10n failed" "Run 'flutter gen-l10n' and fix the error."


### PR DESCRIPTION
Two disjoint CI/infra fixes, one commit each — no Dart, no ARB, no codegen/l10n drift.

## #2651 — pre-push clean-codegen forced SKIP_PREPUSH
The pre-push hook ran clean-codegen via bare `dart run build_runner clean`/`build` and the l10n pipeline via bare `dart run tool/*.dart`. On this Flutter-SDK-pinned project a bare `dart pub`/`dart run` can't resolve the Flutter-pinned transitive deps (e.g. `url_launcher_platform_interface` — "Flutter users should use `flutter pub`"), so the hook aborted at step 1 in fresh worktrees and everyone bypassed the whole gate with `SKIP_PREPUSH=1`. The local codegen/l10n drift gate therefore never ran — drift only got caught by CI's ~13-min round-trip.

Routed every pub/build_runner invocation through the Flutter toolchain: `flutter pub get` first, then `flutter pub run build_runner clean/build` and `flutter pub run tool/build_arb.dart` / `tool/gen_pseudo_arb.dart`; bindings still via `flutter gen-l10n`. Only HOW the gate invokes the toolchain changed — WHAT it checks is unchanged, and the `SKIP_PREPUSH=1` emergency bypass stays intact.

Verified end-to-end locally: the fixed hook completes clean-codegen + l10n-drift **without** the resolution error and **without** SKIP_PREPUSH (build_runner wrote 398 outputs, zero `*.g.dart`/`*.freezed.dart` and zero `lib/l10n/` drift; it then blocked on 2 pre-existing `unnecessary_import` analyzer infos already on master — the gate working as designed).

## #2568 — store-metadata-only PRs no longer trigger the heavy build
A PR touching ONLY `ios/fastlane/**` or `fastlane/metadata/**` changes zero Dart/Android code yet triggered the full heavy `ci.yml` matrix (and a flaky `build-android` there has blocked an autonomous metadata merge).

Added both paths to `ci.yml` `paths-ignore` (push + pull_request) and to `ci-docs-stub.yml` `paths` (push + pull_request). The stub's `paths` is now the exact complement of `ci.yml`'s `paths-ignore`, so every ignored path keeps a producer for the required contexts.

**Auto-merge contract preserved:** the stub re-emits all 10 required contexts (analyze, build-android, codegen-drift, integration, l10n-gate, startup-budget, test (0..3)) — `test (0..3)` via its own matrix, never a job-level skip — so `gh pr merge --auto` still fires on a metadata-only PR.

Closes #2651
Closes #2568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
