### PR TITLE
feat(ev-map): replace OpenChargeMapService demo stub with a real OCM fetch (#2634)

### DIFF
--- a/lib/features/ev/data/services/ocm_poi_parser.dart
+++ b/lib/features/ev/data/services/ocm_poi_parser.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../../../core/logging/error_logger.dart';
+import '../../../../core/utils/geo_utils.dart';
+import '../../domain/entities/charging_station.dart';
+
+/// Shared OpenChargeMap POI-list parser.
+///
+/// Single source of truth for turning a raw OCM `/poi/` JSON array into
+/// [ChargingStation] entities — including the `UsageType` access-cost
+/// signal (#2618). Extracted (#2634) so the map-side
+/// `OpenChargeMapService` and the search-side `EVChargingService` parse
+/// the *identical* shape rather than each re-implementing it. Every
+/// malformed record is logged + skipped, never crashes the batch.
+class OcmPoiParser {
+  const OcmPoiParser._();
+
+  /// Parse a raw OCM `/poi/` response [items] list into stations, each
+  /// stamped with its haversine distance from [searchLat]/[searchLng].
+  /// Non-map / malformed entries are dropped.
+  static List<ChargingStation> parsePoiList(
+    List<dynamic> items,
+    double searchLat,
+    double searchLng,
+  ) {
+    final stations = <ChargingStation>[];
+    for (final item in items) {
+      if (item is! Map<String, dynamic>) continue;
+      final parsed = parseStation(item, searchLat, searchLng);
+      if (parsed != null) stations.add(parsed);
+    }
+    return stations;
+  }
+
+  /// Parse a single OCM POI [item]. Returns `null` (and logs) when the
+  /// record is malformed or missing coordinates.
+  static ChargingStation? parseStation(
+    Map<String, dynamic> item,
+    double searchLat,
+    double searchLng,
+  ) {
+    try {
+      final addr = item['AddressInfo'] as Map<String, dynamic>?;
+      if (addr == null) return null;
+
+      final lat = (addr['Latitude'] as num?)?.toDouble();
+      final lng = (addr['Longitude'] as num?)?.toDouble();
+      if (lat == null || lng == null) return null;
+
+      final dist = _roundedDistance(searchLat, searchLng, lat, lng);
+
+      final stationId = 'ocm-${item['ID']}';
+
+      final connections = item['Connections'] as List<dynamic>? ?? [];
+      final connectors = <EvConnector>[];
+      for (var i = 0; i < connections.length; i++) {
+        final conn = connections[i] as Map<String, dynamic>;
+        final rawLabel = _mapConnectionType(conn['ConnectionTypeID'] as int?);
+        final statusLabel = _mapStatusType(conn['StatusTypeID'] as int?);
+        connectors.add(EvConnector(
+          id: '$stationId-c$i',
+          type: connectorTypeFromLabel(rawLabel),
+          rawType: rawLabel,
+          maxPowerKw: (conn['PowerKW'] as num?)?.toDouble() ?? 0,
+          quantity: (conn['Quantity'] as int?) ?? 1,
+          currentType: _mapCurrentType(conn['CurrentTypeID'] as int?),
+          status: statusLabel == null
+              ? ConnectorStatus.unknown
+              : ConnectorStatus.fromLabel(statusLabel),
+          statusLabel: statusLabel,
+        ));
+      }
+
+      final operatorInfo = item['OperatorInfo'] as Map<String, dynamic>?;
+      final operatorName = operatorInfo?['Title']?.toString() ?? '';
+
+      final statusType = item['StatusType'] as Map<String, dynamic>?;
+      final isOperational = statusType?['IsOperational'] as bool? ?? true;
+
+      // OCM already returns this structured object; surface its flags +
+      // title so the UI can render a free/paid/membership badge with zero
+      // extra network (#2618).
+      final usageType = item['UsageType'] as Map<String, dynamic>?;
+
+      return ChargingStation(
+        id: stationId,
+        name: addr['Title']?.toString() ?? operatorName,
+        operator: operatorName,
+        latitude: lat,
+        longitude: lng,
+        dist: dist,
+        address: addr['AddressLine1']?.toString() ?? '',
+        postCode: addr['Postcode']?.toString() ?? '',
+        place: addr['Town']?.toString() ?? '',
+        connectors: connectors,
+        totalPoints: (item['NumberOfPoints'] as int?) ?? connectors.length,
+        isOperational: isOperational,
+        usageCost: item['UsageCost']?.toString(),
+        usageTypeId: (usageType?['ID'] as num?)?.toInt(),
+        usageTypeTitle: usageType?['Title']?.toString(),
+        isPayAtLocation: usageType?['IsPayAtLocation'] as bool?,
+        isMembershipRequired: usageType?['IsMembershipRequired'] as bool?,
+        updatedAt: _formatDate(item['DateLastStatusUpdate']?.toString()),
+        countryCode: addr['Country']?['ISOCode']?.toString(),
+      );
+    } catch (e, st) {
+      // #2146 — silent parse failures used to never reach the exportable
+      // log; route via errorLogger so a malformed OCM record is
+      // recoverable from a bug report.
+      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: const {
+        'where': 'OcmPoiParser: station parse',
+      }));
+      return null;
+    }
+  }
+
+  static double _roundedDistance(
+    double lat1,
+    double lng1,
+    double lat2,
+    double lng2,
+  ) =>
+      double.parse(distanceKm(lat1, lng1, lat2, lng2).toStringAsFixed(1));
+
+  /// Map OpenChargeMap ConnectionTypeID to human-readable name.
+  static String _mapConnectionType(int? typeId) => switch (typeId) {
+        1 => 'Type 1',
+        2 => 'CHAdeMO',
+        25 => 'Type 2',
+        27 => 'Tesla Supercharger',
+        32 => 'CCS Type 1',
+        33 => 'CCS Type 2',
+        1036 => 'Type 2',
+        _ => 'Unknown',
+      };
+
+  /// Map OpenChargeMap StatusTypeID to human-readable status.
+  static String? _mapStatusType(int? statusId) => switch (statusId) {
+        0 => 'Unknown',
+        10 => 'Currently Available',
+        20 => 'In Use',
+        30 => 'Temporarily Unavailable',
+        50 => 'Operational',
+        75 => 'Partly Operational',
+        100 => 'Not Operational',
+        150 => 'Planned',
+        200 => 'Removed',
+        _ => null,
+      };
+
+  /// Map OpenChargeMap CurrentTypeID.
+  static String? _mapCurrentType(int? currentId) => switch (currentId) {
+        10 => 'AC',
+        20 => 'DC',
+        30 => 'AC/DC',
+        _ => null,
+      };
+
+  static String? _formatDate(String? iso) {
+    if (iso == null) return null;
+    try {
+      final dt = DateTime.parse(iso);
+      return '${dt.day.toString().padLeft(2, '0')}/'
+          '${dt.month.toString().padLeft(2, '0')}/${dt.year}';
+    } catch (e, st) {
+      // #2146 — route to the exportable log; date drift surfaces as a
+      // broken EV station detail otherwise.
+      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
+        'where': 'OcmPoiParser: date parse',
+        'iso': iso,
+      }));
+      return null;
+    }
+  }
+}

--- a/lib/features/ev/data/services/open_charge_map_service.dart
+++ b/lib/features/ev/data/services/open_charge_map_service.dart
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../../../core/services/dio_factory.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart'
     show ConnectorType;
 import '../../domain/entities/charging_station.dart';
+import 'ocm_poi_parser.dart';
 
 /// Abstract contract for an EV charging station backend.
 ///
@@ -24,22 +27,34 @@ abstract class EvStationService {
 
 /// Open Charge Map-backed [EvStationService].
 ///
-/// Currently a stub: if no API key is configured, it transparently falls
-/// back to [DemoEvStationService]. The real HTTP integration is tracked
-/// separately so this PR can ship the client end-to-end without coupling
-/// to network flakiness.
-///
-/// TODO(#177-followup): implement real https://api.openchargemap.io/v3
-/// REST call using Dio with a Bearer API key, cache TTL, and full
-/// connector/tariff mapping.
+/// Performs a live OCM `/poi/` query around the viewport centre and
+/// parses each result via the shared [OcmPoiParser] — the *same* logic
+/// (including the `UsageType` access-cost signal, #2618) the search-side
+/// `EVChargingService` uses (#2634). [DemoEvStationService] remains the
+/// safety net: no API key, a network/parse error, or tests/offline all
+/// transparently fall back to the deterministic demo dataset, so map
+/// markers degrade gracefully instead of vanishing.
 class OpenChargeMapService implements EvStationService {
   final String? apiKey;
   final EvStationService _fallback;
+  final Dio _dio;
+
+  /// Default Dio — separate so tests can inject a capturing/recorded Dio
+  /// without re-implementing the BaseOptions (mirrors EVChargingService).
+  static Dio _defaultDio() => DioFactory.create(
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 15),
+      );
 
   OpenChargeMapService({
     this.apiKey,
     EvStationService? fallback,
-  }) : _fallback = fallback ?? const DemoEvStationService();
+    Dio? dio,
+  })  : _fallback = fallback ?? const DemoEvStationService(),
+        _dio = dio ?? _defaultDio();
+
+  /// Same OCM POI endpoint the search-side service hits.
+  static const _baseUrl = 'https://api.openchargemap.io/v3/poi/';
 
   @override
   Future<List<ChargingStation>> fetchStations({
@@ -47,21 +62,54 @@ class OpenChargeMapService implements EvStationService {
     required double centerLng,
     required double radiusKm,
   }) async {
-    if (apiKey == null || apiKey!.trim().isEmpty) {
+    final key = apiKey?.trim();
+    if (key == null || key.isEmpty) {
       debugPrint('OpenChargeMapService: no API key, using demo data');
-      return _fallback.fetchStations(
+      return _demo(centerLat, centerLng, radiusKm);
+    }
+
+    try {
+      final response = await _dio.get<dynamic>(
+        _baseUrl,
+        queryParameters: {
+          'output': 'json',
+          'latitude': centerLat,
+          'longitude': centerLng,
+          'distance': radiusKm,
+          'distanceunit': 'KM',
+          'maxresults': 100,
+          'compact': true,
+          'verbose': false,
+          // 'countrycode' intentionally omitted — OCM's strict country
+          // filter drops legitimate border-region chargers (#697); the
+          // lat/lng + distance bbox is the geographic constraint we need.
+          'key': key,
+        },
+      );
+
+      final data = response.data;
+      if (data is! List) {
+        return _demo(centerLat, centerLng, radiusKm);
+      }
+      return OcmPoiParser.parsePoiList(data, centerLat, centerLng);
+    } on DioException catch (e, st) {
+      // Network error / non-2xx / cancel — degrade to demo so the map
+      // overlay still renders something rather than throwing (#2634).
+      debugPrint('OpenChargeMapService: OCM fetch failed ($e); using demo. $st');
+      return _demo(centerLat, centerLng, radiusKm);
+    }
+  }
+
+  Future<List<ChargingStation>> _demo(
+    double centerLat,
+    double centerLng,
+    double radiusKm,
+  ) =>
+      _fallback.fetchStations(
         centerLat: centerLat,
         centerLng: centerLng,
         radiusKm: radiusKm,
       );
-    }
-    // Real call intentionally unimplemented — see class docs.
-    return _fallback.fetchStations(
-      centerLat: centerLat,
-      centerLng: centerLng,
-      radiusKm: radiusKm,
-    );
-  }
 }
 
 /// Deterministic demo dataset used when no API key is configured.

--- a/lib/features/search/data/services/ev_charging_service.dart
+++ b/lib/features/search/data/services/ev_charging_service.dart
@@ -1,14 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:dio/dio.dart';
 
-import '../../../../core/logging/error_logger.dart';
 import '../../../../core/services/dio_factory.dart';
 import '../../../../core/services/mixins/station_service_helpers.dart';
 import '../../../../core/services/service_result.dart';
+import '../../../ev/data/services/ocm_poi_parser.dart';
 import '../../../ev/domain/entities/charging_station.dart';
 
 /// OpenChargeMap API client for EV charging station search.
@@ -78,11 +76,8 @@ class EVChargingService with StationServiceHelpers {
         );
       }
 
-      final stations = <ChargingStation>[];
-      for (final item in response.data as List) {
-        final parsed = _parseStation(item, lat, lng);
-        if (parsed != null) stations.add(parsed);
-      }
+      final stations =
+          OcmPoiParser.parsePoiList(response.data as List, lat, lng);
 
       // Sort by distance
       stations.sort((a, b) => a.dist.compareTo(b.dist));
@@ -94,135 +89,6 @@ class EVChargingService with StationServiceHelpers {
       );
     } on DioException catch (e, st) {
       throwApiException(e, defaultMessage: 'EV charging search failed', stackTrace: st);
-    }
-  }
-
-  ChargingStation? _parseStation(Map<String, dynamic> item, double searchLat, double searchLng) {
-    try {
-      final addr = item['AddressInfo'] as Map<String, dynamic>?;
-      if (addr == null) return null;
-
-      final lat = (addr['Latitude'] as num?)?.toDouble();
-      final lng = (addr['Longitude'] as num?)?.toDouble();
-      if (lat == null || lng == null) return null;
-
-      final dist = roundedDistance(searchLat, searchLng, lat, lng);
-
-      final stationId = 'ocm-${item['ID']}';
-
-      // Parse connectors
-      final connections = item['Connections'] as List<dynamic>? ?? [];
-      final connectors = <EvConnector>[];
-      for (var i = 0; i < connections.length; i++) {
-        final conn = connections[i] as Map<String, dynamic>;
-        final rawLabel = _mapConnectionType(conn['ConnectionTypeID'] as int?);
-        final statusLabel = _mapStatusType(conn['StatusTypeID'] as int?);
-        connectors.add(EvConnector(
-          id: '$stationId-c$i',
-          type: connectorTypeFromLabel(rawLabel),
-          rawType: rawLabel,
-          maxPowerKw: (conn['PowerKW'] as num?)?.toDouble() ?? 0,
-          quantity: (conn['Quantity'] as int?) ?? 1,
-          currentType: _mapCurrentType(conn['CurrentTypeID'] as int?),
-          status: statusLabel == null
-              ? ConnectorStatus.unknown
-              : ConnectorStatus.fromLabel(statusLabel),
-          statusLabel: statusLabel,
-        ));
-      }
-
-      // Parse operator
-      final operatorInfo = item['OperatorInfo'] as Map<String, dynamic>?;
-      final operatorName = operatorInfo?['Title']?.toString() ?? '';
-
-      // Parse status
-      final statusType = item['StatusType'] as Map<String, dynamic>?;
-      final isOperational = statusType?['IsOperational'] as bool? ?? true;
-
-      // Parse the access-cost signal (#2618). OCM already returns this
-      // structured object; we surface its flags + title so the UI can
-      // render a free/paid/membership badge with zero extra network.
-      final usageType = item['UsageType'] as Map<String, dynamic>?;
-
-      return ChargingStation(
-        id: stationId,
-        name: addr['Title']?.toString() ?? operatorName,
-        operator: operatorName,
-        latitude: lat,
-        longitude: lng,
-        dist: dist,
-        address: addr['AddressLine1']?.toString() ?? '',
-        postCode: addr['Postcode']?.toString() ?? '',
-        place: addr['Town']?.toString() ?? '',
-        connectors: connectors,
-        totalPoints: (item['NumberOfPoints'] as int?) ?? connectors.length,
-        isOperational: isOperational,
-        usageCost: item['UsageCost']?.toString(),
-        usageTypeId: (usageType?['ID'] as num?)?.toInt(),
-        usageTypeTitle: usageType?['Title']?.toString(),
-        isPayAtLocation: usageType?['IsPayAtLocation'] as bool?,
-        isMembershipRequired: usageType?['IsMembershipRequired'] as bool?,
-        updatedAt: _formatDate(item['DateLastStatusUpdate']?.toString()),
-        countryCode: addr['Country']?['ISOCode']?.toString(),
-      );
-    } catch (e, st) {
-      // #2146 — silent parse failures used to never reach the
-      // exportable log; route via errorLogger so a malformed OCM
-      // record is recoverable from a bug report.
-      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: const {
-        'where': 'EvChargingService: station parse',
-      }));
-      return null;
-    }
-  }
-
-  /// Map OpenChargeMap ConnectionTypeID to human-readable name.
-  String _mapConnectionType(int? typeId) => switch (typeId) {
-    1 => 'Type 1',
-    2 => 'CHAdeMO',
-    25 => 'Type 2',
-    27 => 'Tesla Supercharger',
-    32 => 'CCS Type 1',
-    33 => 'CCS Type 2',
-    1036 => 'Type 2',
-    _ => 'Unknown',
-  };
-
-  /// Map OpenChargeMap StatusTypeID to human-readable status.
-  String? _mapStatusType(int? statusId) => switch (statusId) {
-    0 => 'Unknown',
-    10 => 'Currently Available',
-    20 => 'In Use',
-    30 => 'Temporarily Unavailable',
-    50 => 'Operational',
-    75 => 'Partly Operational',
-    100 => 'Not Operational',
-    150 => 'Planned',
-    200 => 'Removed',
-    _ => null,
-  };
-
-  /// Map OpenChargeMap CurrentTypeID.
-  String? _mapCurrentType(int? currentId) => switch (currentId) {
-    10 => 'AC',
-    20 => 'DC',
-    30 => 'AC/DC',
-    _ => null,
-  };
-
-  String? _formatDate(String? iso) {
-    if (iso == null) return null;
-    try {
-      final dt = DateTime.parse(iso);
-      return '${dt.day.toString().padLeft(2, '0')}/${dt.month.toString().padLeft(2, '0')}/${dt.year}';
-    } catch (e, st) {
-      // #2146 — route to the exportable log; date drift surfaces
-      // as a broken EV station detail otherwise.
-      unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
-        'where': 'EvChargingService: date parse',
-        'iso': iso,
-      }));
-      return null;
     }
   }
 }

--- a/test/features/ev/data/services/open_charge_map_service_test.dart
+++ b/test/features/ev/data/services/open_charge_map_service_test.dart
@@ -1,11 +1,19 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/features/ev/data/services/open_charge_map_service.dart';
 import 'package:tankstellen/features/ev/domain/entities/charging_station.dart';
+import 'package:tankstellen/features/ev/domain/entities/ev_access_cost.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart'
     show ConnectorType;
+
+class _MockDio extends Mock implements Dio {}
 
 /// Recording fake that captures every fetchStations call so the test can
 /// assert the wrapping [OpenChargeMapService] forwards parameters
@@ -25,6 +33,22 @@ class _RecordingFallback implements EvStationService {
     calls.add((lat: centerLat, lng: centerLng, radius: radiusKm));
     return response;
   }
+}
+
+/// Dio whose `get` replays the recorded OCM `/poi/` fixture verbatim.
+_MockDio _fixtureDio() {
+  final raw = File('test/fixtures/ocm_poi_response.json').readAsStringSync();
+  final data = jsonDecode(raw) as List<dynamic>;
+  final dio = _MockDio();
+  when(() => dio.get<dynamic>(
+        any(),
+        queryParameters: any(named: 'queryParameters'),
+      )).thenAnswer((_) async => Response<dynamic>(
+        requestOptions: RequestOptions(path: '/poi/'),
+        statusCode: 200,
+        data: data,
+      ));
+  return dio;
 }
 
 void main() {
@@ -114,25 +138,111 @@ void main() {
     });
 
     test(
-        'non-empty apiKey still delegates to fallback (real call '
-        'unimplemented)', () async {
+        'with a key + recorded OCM fixture, returns REAL parsed stations '
+        '(carrying UsageType), NOT demo data', () async {
+      // RED on master: the stub ignored the key/Dio and always returned
+      // the 4 demo stations. GREEN after #2634: it parses the fixture.
       final fallback = _RecordingFallback(response: [marker]);
       final service = OpenChargeMapService(
         apiKey: 'real-looking-key',
         fallback: fallback,
+        dio: _fixtureDio(),
       );
 
       final out = await service.fetchStations(
-        centerLat: 51.5,
-        centerLng: -0.1,
-        radiusKm: 12,
+        centerLat: 47.0,
+        centerLng: 4.85,
+        radiusKm: 25,
+      );
+
+      // Fallback never touched — real fetch path served the result.
+      expect(fallback.calls, isEmpty);
+
+      // Two real OCM POIs from the fixture, not the demo dataset.
+      expect(out, hasLength(2));
+      expect(out.map((s) => s.id), containsAll(['ocm-12345', 'ocm-22222']));
+      expect(out.every((s) => s.id.startsWith('ocm-')), isTrue);
+
+      final ionity = out.firstWhere((s) => s.id == 'ocm-12345');
+      // UsageType parsed → paid access badge.
+      expect(ionity.usageTypeId, 4);
+      expect(ionity.usageTypeTitle, 'Public - Pay At Location');
+      expect(ionity.isPayAtLocation, isTrue);
+      expect(ionity.isMembershipRequired, isFalse);
+      expect(ionity.accessCost.kind, EvAccessCostKind.paid);
+      expect(ionity.name, 'Ionity Aire de Beaune');
+      expect(ionity.countryCode, 'FR');
+      // CCS Type 2 @ 350 kW from the recorded Connections block.
+      expect(ionity.connectors, isNotEmpty);
+      expect(ionity.maxPowerKw, 350);
+      expect(
+        ionity.connectors.map((c) => c.type),
+        contains(ConnectorType.ccs),
+      );
+
+      final free = out.firstWhere((s) => s.id == 'ocm-22222');
+      // Free UsageType resolves to a free access badge.
+      expect(free.usageTypeId, 1);
+      expect(free.accessCost.kind, EvAccessCostKind.free);
+    });
+
+    test('with a key but a network error, falls back to demo data',
+        () async {
+      final dio = _MockDio();
+      when(() => dio.get<dynamic>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenThrow(DioException(
+        requestOptions: RequestOptions(path: '/poi/'),
+        type: DioExceptionType.connectionError,
+      ));
+      final fallback = _RecordingFallback(response: [marker]);
+      final service = OpenChargeMapService(
+        apiKey: 'real-looking-key',
+        fallback: fallback,
+        dio: dio,
+      );
+
+      final out = await service.fetchStations(
+        centerLat: 1.0,
+        centerLng: 2.0,
+        radiusKm: 5,
+      );
+
+      // Network failure → demo fallback served, with the original args.
+      expect(out, [marker]);
+      expect(fallback.calls, hasLength(1));
+      expect(fallback.calls.single.lat, 1.0);
+      expect(fallback.calls.single.lng, 2.0);
+      expect(fallback.calls.single.radius, 5);
+    });
+
+    test('with a key but a non-list response body, falls back to demo',
+        () async {
+      final dio = _MockDio();
+      when(() => dio.get<dynamic>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => Response<dynamic>(
+            requestOptions: RequestOptions(path: '/poi/'),
+            statusCode: 200,
+            data: <String, dynamic>{'error': 'bad request'},
+          ));
+      final fallback = _RecordingFallback(response: [marker]);
+      final service = OpenChargeMapService(
+        apiKey: 'real-looking-key',
+        fallback: fallback,
+        dio: dio,
+      );
+
+      final out = await service.fetchStations(
+        centerLat: 5.0,
+        centerLng: 6.0,
+        radiusKm: 3,
       );
 
       expect(out, [marker]);
       expect(fallback.calls, hasLength(1));
-      expect(fallback.calls.single.lat, 51.5);
-      expect(fallback.calls.single.lng, -0.1);
-      expect(fallback.calls.single.radius, 12);
     });
 
     test('forwards arguments unchanged on every call', () async {

--- a/test/fixtures/ocm_poi_response.json
+++ b/test/fixtures/ocm_poi_response.json
@@ -1,0 +1,96 @@
+[
+  {
+    "ID": 12345,
+    "UUID": "F0B0E0D0-0000-0000-0000-000000000001",
+    "DataProviderID": 1,
+    "OperatorID": 23,
+    "UsageTypeID": 4,
+    "UsageType": {
+      "IsPayAtLocation": true,
+      "IsMembershipRequired": false,
+      "IsAccessKeyRequired": false,
+      "ID": 4,
+      "Title": "Public - Pay At Location"
+    },
+    "UsageCost": "0.59 EUR/kWh",
+    "AddressInfo": {
+      "ID": 67890,
+      "Title": "Ionity Aire de Beaune",
+      "AddressLine1": "A6 Aire de Beaune-Merceuil",
+      "Town": "Merceuil",
+      "Postcode": "21190",
+      "Latitude": 47.0024,
+      "Longitude": 4.8421,
+      "Country": {
+        "ISOCode": "FR",
+        "Title": "France"
+      }
+    },
+    "Connections": [
+      {
+        "ID": 1,
+        "ConnectionTypeID": 33,
+        "StatusTypeID": 50,
+        "CurrentTypeID": 20,
+        "PowerKW": 350.0,
+        "Quantity": 4
+      },
+      {
+        "ID": 2,
+        "ConnectionTypeID": 2,
+        "StatusTypeID": 30,
+        "CurrentTypeID": 20,
+        "PowerKW": 50.0,
+        "Quantity": 1
+      }
+    ],
+    "NumberOfPoints": 6,
+    "StatusType": {
+      "IsOperational": true,
+      "ID": 50,
+      "Title": "Operational"
+    },
+    "DateLastStatusUpdate": "2026-04-12T09:30:00Z"
+  },
+  {
+    "ID": 22222,
+    "UUID": "F0B0E0D0-0000-0000-0000-000000000002",
+    "UsageTypeID": 1,
+    "UsageType": {
+      "IsPayAtLocation": false,
+      "IsMembershipRequired": false,
+      "ID": 1,
+      "Title": "Public - Free"
+    },
+    "AddressInfo": {
+      "ID": 33333,
+      "Title": "Mairie - Borne Gratuite",
+      "AddressLine1": "Place de la Mairie",
+      "Town": "Nuits-Saint-Georges",
+      "Postcode": "21700",
+      "Latitude": 47.1389,
+      "Longitude": 4.9497,
+      "Country": {
+        "ISOCode": "FR",
+        "Title": "France"
+      }
+    },
+    "Connections": [
+      {
+        "ID": 3,
+        "ConnectionTypeID": 25,
+        "StatusTypeID": 10,
+        "CurrentTypeID": 10,
+        "PowerKW": 22.0,
+        "Quantity": 2
+      }
+    ],
+    "NumberOfPoints": 2,
+    "StatusType": {
+      "IsOperational": true,
+      "ID": 50,
+      "Title": "Operational"
+    },
+    "DateLastStatusUpdate": "2026-03-01T14:00:00Z"
+  }
+]


### PR DESCRIPTION
## What

`OpenChargeMapService.fetchStations` was a **stub** that always returned `DemoEvStationService` data and never made a live OpenChargeMap call. So the EV map markers (`ev_map_overlay`) only ever showed demo stations and carried **no real OCM `UsageType`/IRVE access signal** — the #2632 viewport enrich and the `EVPricingCard` badge could not work on the map.

It now performs a **real OCM `/poi/` query** around the viewport centre/radius and parses each result via a new shared `OcmPoiParser`.

## Reuse (not reinvent)

The OCM parse logic — `_parseStation` + the connection/status/current maps + date formatting, including the `UsageType` access-cost block (#2618) — was **extracted from the search-side `EVChargingService` into a shared `OcmPoiParser`**. Both services now parse the *identical* OCM shape instead of duplicating it:

- `OpenChargeMapService` (map source) makes the real Dio call + parses via `OcmPoiParser`.
- `EVChargingService` (search source) now **delegates** to the same parser — its public behaviour is unchanged (all its existing `#2618`/`#697` tests stay green).

Same base URL, key param, query shape, and an injectable `Dio? dio` seam mirroring `EVChargingService`/`FrIrvePriceService`.

## Demo fallback (safety net preserved)

`DemoEvStationService` remains the fallback for every degraded path:
- **No API key** configured (null / empty / whitespace-only).
- **`DioException`** — network error, non-2xx, cancel.
- **Non-list response body**.
- **tests / offline**.

So real markers flow end-to-end while the demo path stays the safety net and markers degrade gracefully rather than vanishing.

## Test (reuse-fidelity, no request-echoing fake)

A recorded **real-shape OCM JSON fixture** (`test/fixtures/ocm_poi_response.json` — real `Connections` / `UsageType` / `AddressInfo` field names) drives the **real** `OpenChargeMapService` through its injectable Dio seam:
- with a key + the fixture client → returns parsed `ocm-*` stations **carrying `UsageType`** (paid + free access badges asserted).
- with no key / an injected `DioException` / a non-list body → **falls back to demo**.

### RED → GREEN
- **RED on master**: with a real key the stub returns `[demo-1, demo-2, demo-3, demo-4]` — a test asserting real `ocm-*` fixture stations is red.
- **GREEN after**: the same call returns the 2 parsed fixture stations with `UsageType` populated.

## Gates
- `flutter analyze` clean on touched files (2 remaining `info` are pre-existing, unrelated consumption test imports).
- `flutter test test/features/ev` + search EV service tests + lint baseline (`no_silent_catch`, `catch_block_stacktrace`, `file_length`) — all green (214 + lint).
- Zero `*.g.dart` / `*.freezed.dart` / `lib/l10n/` drift — the new `dio` param is optional/defaulted, no `@riverpod` provider behaviour changed.
- No ARB strings (pure data layer).

Closes #2634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
