### PR TITLE
fix(route): credit only contributing countries in source-attribution banner

### DIFF
--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -252,6 +252,57 @@ StationQueryFunction buildCorridorQueryFunction(
 /// ES station carrying E10 stays on E10); only an E5-only real Spanish station
 /// resolves to E5. This lives only in the corridor/route resolver — the
 /// nearby/single-country strict `station.priceFor` path stays strict (#2510).
+/// #2680 — the upper-cased ISO codes of the countries that ACTUALLY produced
+/// a *displayable* fuel station in [stations] — a SUBSET of the corridor's
+/// queried codes (`RouteSearchResult.corridorCountryCodes`).
+///
+/// The corridor query (#2622) credits every country it *geographically*
+/// crossed. But a cross-border search for a fuel a country doesn't sell
+/// (E85 in Spain — #2641: every Spanish MITECO row carries an EMPTY
+/// `Precio Bioetanol`) brings back stations with NO price for the displayed
+/// grade, shown as "--". Crediting that country's data source in the
+/// attribution banner is misleading — it produced nothing the user can act
+/// on. This narrows the set to the countries that produced ≥1 station with a
+/// resolvable, non-null price.
+///
+/// "Displayable" mirrors the list/map exactly: a station's grade comes from
+/// [fuelForStation] (its OWN country's [profileFuels] grade, with the #2641
+/// E5↔E10 95-octane sibling fallback), and the station counts only when
+/// `priceFor(thatGrade) != null`. So a Spanish E5-only station priced for an
+/// E10 driver still counts (sibling fallback → E5 price), but the same
+/// station for an E85 driver does NOT (no E85, no E85 sibling) — exactly the
+/// field case where ES must drop off the banner.
+///
+/// Country attribution uses the SAME [Countries.countryForStation] resolver as
+/// [fuelForStation] (id prefix first, then bounding box — #753/#2631), so a
+/// Catalonian MITECO station sitting inside FR's continental bbox is still
+/// attributed to ES. Only [FuelStationResult]s are considered: EV attribution
+/// is not a per-country open-data policy and the banner never credits it. A
+/// station whose country cannot be resolved is dropped (no policy to credit).
+///
+/// Derived from the full found set (`RouteSearchResult.stations`, NOT the
+/// Best-Stops display subset) so the banner is stable across the All / Best
+/// toggle.
+Set<String> contributingCountryCodesFor(
+  Iterable<SearchResultItem> stations,
+  Map<String, FuelType> profileFuels,
+  FuelType fallback,
+) {
+  final out = <String>{};
+  for (final item in stations.whereType<FuelStationResult>()) {
+    final code = Countries.countryForStation(
+      id: item.station.id,
+      lat: item.station.lat,
+      lng: item.station.lng,
+    )?.code.toUpperCase();
+    if (code == null || out.contains(code)) continue;
+    // Displayable only — the same grade the list/map prices this station by.
+    final grade = fuelForStation(item.station, profileFuels, fallback);
+    if (item.station.priceFor(grade) != null) out.add(code);
+  }
+  return out;
+}
+
 FuelType fuelForStation(
   Station station,
   Map<String, FuelType> profileFuels,

--- a/lib/features/route_search/domain/route_search_result.dart
+++ b/lib/features/route_search/domain/route_search_result.dart
@@ -3,6 +3,7 @@
 
 import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/search_result_item.dart';
+import '../data/cross_border_corridor.dart' show contributingCountryCodesFor;
 import 'entities/route_info.dart';
 import 'route_search_strategy.dart';
 
@@ -35,6 +36,24 @@ class RouteSearchResult {
   /// empty (an entirely mid-sea route), in which case the UI falls back to
   /// the single-country attribution.
   final Set<String> corridorCountryCodes;
+
+  /// #2680 — the upper-cased ISO codes of the countries that ACTUALLY produced
+  /// a *displayable* fuel station in [stations], a SUBSET of
+  /// [corridorCountryCodes].
+  ///
+  /// The attribution banner consumes THIS (not [corridorCountryCodes]) so a
+  /// cross-border search for a fuel a country doesn't sell (E85 in Spain —
+  /// every MITECO row's `Precio Bioetanol` is empty) credits only the data
+  /// sources that produced a priced station, never a leg shown entirely as
+  /// "--". Each station's displayed grade is resolved exactly as the list/map
+  /// resolve it — [contributingCountryCodesFor] runs [fuelForStation] with
+  /// THIS result's [profileFuelByCountry] and the caller's active [fuelType]
+  /// fallback. Derived from the full found set [stations] (not the Best-Stops
+  /// display subset), so the banner is stable across the All / Best toggle.
+  /// [corridorCountryCodes] is retained for diagnostics (it records the full
+  /// geographic span the search queried).
+  Set<String> contributingCountryCodes(FuelType fuelType) =>
+      contributingCountryCodesFor(stations, profileFuelByCountry, fuelType);
 
   /// #2631 — profile fuel keyed by upper-cased country code (the same map
   /// `buildCorridorServiceMap` was built from). The map + list display

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -324,10 +324,17 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
 
     // #2622 — in route mode, surface the corridor's multi-country data
     // sources (#2626) so a cross-border result credits every provider, not
-    // just the active country. Empty for nearby mode / single-country routes.
+    // just the active country. #2680 — credit only the countries that
+    // actually PRODUCED a station (contributingCountryCodes), not every
+    // country the corridor geographically crossed, so a leg that returned
+    // nothing (E85 in Spain) is dropped from the banner. Empty for nearby
+    // mode / single-country routes.
     final isRoute = ref.watch(activeSearchModeProvider) == SearchMode.route;
     final corridorCodes = isRoute
-        ? (ref.watch(routeSearchStateProvider).value?.corridorCountryCodes ??
+        ? (ref
+                .watch(routeSearchStateProvider)
+                .value
+                ?.contributingCountryCodes(ref.watch(selectedFuelTypeProvider)) ??
             const <String>{})
         : const <String>{};
 

--- a/test/features/route_search/providers/route_search_cross_border_test.dart
+++ b/test/features/route_search/providers/route_search_cross_border_test.dart
@@ -587,4 +587,117 @@ void main() {
         reason: 'the cheapest Spanish station must appear in Best Stops, '
             'priced by its E5 grade via the sibling fallback (#2641)');
   });
+
+  // #2680 — THE attribution-banner bug. On a cross-border E85 route the top
+  // source-attribution banner credited EVERY country the corridor queried
+  // (`corridorCountryCodes` = corridor span), not the countries that actually
+  // produced a displayable station. Spain sells NO E85 — every MITECO row's
+  // `Precio Bioetanol` is empty (and there is no E85 sibling fallback, unlike
+  // E5↔E10) — so an E85 search returns Spanish stations that all show "--".
+  // The banner must therefore drop "España — MITECO" and credit France only.
+  //
+  // Reuse-fidelity (HARD rule, no request-echoing fakes): drives the REAL
+  // MitecoStationService + the production ES StationServiceChain against the
+  // recorded province-08 fixture (the same seam #2641 uses), so the ES leg's
+  // empty-E85 shape is the genuine field data, not a fake that echoes E85.
+  // RED on master: `corridorCountryCodes` feeds the banner → {FR, ES}.
+  // GREEN: `contributingCountryCodes(E85)` → {FR}, while `corridorCountryCodes`
+  // still carries ES (the contributing-vs-corridor distinction).
+  test(
+      'cross-border E85 banner credits FR only — ES produced no E85 station '
+      'so contributingCountryCodes is {FR} while corridorCountryCodes ⊇ {ES} '
+      '(#2680)', () async {
+    final fixture =
+        File('test/fixtures/miteco_barcelona_08.json').readAsStringSync();
+
+    // Pézenas (FR) → Barcelona (ES) — the bug-report corridor. 4 FR sample
+    // points (lat ≥ 42) + Barcelona at index 4 hit province 08 → the fixture.
+    const frA = LatLng(43.50, 3.50);
+    const frB = LatLng(43.30, 3.30);
+    const frC = LatLng(43.10, 3.10);
+    const frD = LatLng(42.90, 2.90);
+    const esPoint = LatLng(41.39, 2.17); // Barcelona — INSIDE FR's bbox too
+    const route = RouteInfo(
+      geometry: [frA, frB, frC, frD, LatLng(42.10, 2.40), esPoint],
+      distanceKm: 400,
+      durationMinutes: 240,
+      samplePoints: [frA, frB, frC, frD, esPoint],
+    );
+
+    // REAL ES service: a genuine MitecoStationService whose Dio adapter serves
+    // the recorded fixture, wrapped in the production StationServiceChain as
+    // `_createMiteco` → `buildService` builds it for ES.
+    final mitecoDio = Dio()
+      ..httpClientAdapter = _MitecoFixtureAdapter(fixture);
+    final esChain = StationServiceChain(
+      MitecoStationService(dio: mitecoDio),
+      _MemoryCache(),
+      errorSource: ServiceSource.mitecoApi,
+      countryCode: 'ES',
+      policy: _esBulkPolicy,
+    );
+
+    // FR sells E85 (region-gated to lat ≥ 42 so it never bleeds into Spain),
+    // so France genuinely contributes a priced E85 station.
+    final frService = _RegionGatedStationService('Total FR',
+        idPrefix: 'fr-', minLat: 42.0, maxLat: 90.0, price: 1.20);
+
+    final container = ProviderContainer(
+      overrides: [
+        storageRepositoryProvider.overrideWith((ref) => _NoKeyStorage()),
+        perCountryStationServiceProvider('FR')
+            .overrideWith((ref) => frService),
+        perCountryStationServiceProvider('ES')
+            .overrideWith((ref) => esChain),
+        // The field case: an E85 driver crossing FR→ES. BOTH profiles use
+        // E85 — so the ES leg is queried + priced for E85, which Spain lacks.
+        allProfilesProvider.overrideWith((ref) => const [
+              UserProfile(
+                  id: 'fr', name: 'Standard',
+                  countryCode: 'FR', preferredFuelType: FuelType.e85),
+              UserProfile(
+                  id: 'es', name: 'Espagne',
+                  countryCode: 'ES', preferredFuelType: FuelType.e85),
+            ]),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(routeSearchStateProvider.notifier);
+    final result = await notifier.searchAlongPrebuiltRouteForTest(
+      route: route,
+      fuelType: FuelType.e85, // active fuel is E85.
+    );
+
+    // Sanity: the corridor DID query Spain — real MITECO rows arrived (id
+    // `es-…`), they just carry no E85 price. This is what makes the bug real:
+    // ES stations ARE in the found set, only unpriced for the chosen fuel.
+    final esRows = result.stations
+        .whereType<FuelStationResult>()
+        .where((r) => r.station.id.startsWith('es-'))
+        .toList();
+    expect(esRows, isNotEmpty,
+        reason: 'real MITECO rows must arrive in the corridor result');
+    expect(esRows.every((r) => r.station.e85 == null), isTrue,
+        reason: 'Spain sells no E85 — every fixture row Bioetanol is empty');
+
+    // FR genuinely contributed a priced E85 station.
+    expect(
+        result.stations
+            .whereType<FuelStationResult>()
+            .any((r) => r.station.brand == 'Total FR'),
+        isTrue,
+        reason: 'the French leg produced a priced E85 station');
+
+    // THE distinction: the corridor queried BOTH countries…
+    expect(result.corridorCountryCodes, containsAll(<String>{'FR', 'ES'}),
+        reason: 'corridorCountryCodes records the full queried span (#2622)');
+
+    // …but only France produced a DISPLAYABLE (priced) E85 station, so the
+    // attribution banner credits France ONLY. RED on master (no
+    // contributingCountryCodes → banner shows both); GREEN after.
+    expect(result.contributingCountryCodes(FuelType.e85), <String>{'FR'},
+        reason: 'ES produced no E85-priced station → dropped from the banner '
+            '(#2680)');
+  });
 }


### PR DESCRIPTION
## Problem

On a cross-border route the top source-attribution banner credited **every** country the corridor *queried* (its geographic span), not the countries that actually produced a displayable station.

Field case (#2680): an **E85** Spain→France search shows only French stations — Spain sells no E85 (every MITECO row's `Precio Bioetanol` is empty, and unlike E5↔E10 there is no E85 sibling fallback) — yet `España — Geoportal Gasolineras (MITECO)` was still credited.

## Root cause

The banner consumed `RouteSearchResult.corridorCountryCodes` (= `corridorMap.keys.toSet()`), which is **never** narrowed by whether a country returned a priced station — it records only the corridor's geographic span.

## Fix — the contributing-vs-corridor distinction

- **New `contributingCountryCodesFor` helper** next to `fuelForStation`, resolving each found `FuelStationResult` to its country via the SAME `Countries.countryForStation` resolver (id-prefix then bbox), and crediting a country only when ≥1 of its stations has a non-null price for the grade the list/map actually display it by (`fuelForStation`, incl. the #2641 E5↔E10 sibling fallback). A Spanish E5-only station thus counts for an E10 driver but **not** for an E85 driver — exactly the field case.
- **`RouteSearchResult.contributingCountryCodes(fuelType)`** returns this subset. `corridorCountryCodes` is kept untouched for diagnostics (full queried span) — the provider assignments are unchanged.
- The **search screen** passes `contributingCountryCodes(selectedFuelType)` to the banner; the `length > 1` gate then collapses to the single-country header automatically.

Derived from the full found set (`stations`, not the Best-Stops display subset) so the banner is **stable across the All / Best toggle**. EV results are skipped (EV attribution is not a per-country open-data policy). **No new ARB keys** — the existing `routeDataSourceMulti` passthrough and brand-exempt attributions are reused.

## Edge cases

- Single-country route → one segment, unchanged.
- Zero results → empty set → falls through to the single-country header (no empty multi-bar).
- EV route → `whereType` filter skips `EVStationResult`, EV attribution unaffected.
- Null-resolving country (no registered policy) → dropped.

## Test (reuse-fidelity, no request-echoing fakes)

A new scenario in `route_search_cross_border_test.dart` drives the **real** `MitecoStationService` + production ES `StationServiceChain` against the recorded `miteco_barcelona_08.json` fixture (Pézenas FR → Barcelona ES, both profiles E85). The ES leg returns real MITECO rows that all lack E85 →
- `result.contributingCountryCodes(E85) == {FR}`
- `result.corridorCountryCodes ⊇ {FR, ES}`

**RED on master** (price-agnostic resolution → `{FR, ES}`); **GREEN** after.

Closes #2680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
