### PR TITLE
feat(fill-up): persist scanned price/L + confirm grade from receipt OCR (e-receipt Phase 1)

### DIFF
--- a/lib/features/consumption/domain/entities/fill_up.dart
+++ b/lib/features/consumption/domain/entities/fill_up.dart
@@ -74,6 +74,18 @@ abstract class FillUp with _$FillUp {
     /// [fuelLevelBeforeL]. Existing fill-ups deserialise with null so
     /// historical data keeps working.
     double? fuelLevelAfterL,
+
+    /// Unit price per litre as printed on the scanned receipt / pump
+    /// display (#2689, e-receipt Phase 1). When the OCR parser reads a
+    /// `pricePerLiter` off the receipt it is persisted verbatim here,
+    /// preserving the exact quoted price (e.g. `1.999`) rather than the
+    /// `totalCost / liters` quotient — which rounds differently and can
+    /// drift when either field was hand-corrected after the scan. Null
+    /// when the fill-up was entered manually or the scan didn't read a
+    /// price; the [FillUpX.pricePerLiter] getter then falls back to the
+    /// computed quotient. Existing fill-ups deserialise with null so
+    /// historical data keeps working.
+    double? scannedPricePerLiter,
   }) = _FillUp;
 
   factory FillUp.fromJson(Map<String, dynamic> json) => _$FillUpFromJson(json);
@@ -82,7 +94,13 @@ abstract class FillUp with _$FillUp {
 /// Convenience getters for an individual fill-up.
 extension FillUpX on FillUp {
   /// Price per liter in the store currency (e.g. EUR/L).
-  double get pricePerLiter => liters > 0 ? totalCost / liters : 0;
+  ///
+  /// Prefers the receipt-scanned [FillUp.scannedPricePerLiter] when one
+  /// was captured (#2689) so the exact quoted unit price is shown; falls
+  /// back to the `totalCost / liters` quotient for manually-entered
+  /// fill-ups (and a 0 guard when no litres were recorded).
+  double get pricePerLiter =>
+      scannedPricePerLiter ?? (liters > 0 ? totalCost / liters : 0);
 
   /// Estimated CO2 emissions for this fill-up, in kilograms.
   ///

--- a/lib/features/consumption/domain/entities/fill_up.freezed.dart
+++ b/lib/features/consumption/domain/entities/fill_up.freezed.dart
@@ -53,7 +53,17 @@ mixin _$FillUp {
 /// volume. Null when not captured for the same reasons as
 /// [fuelLevelBeforeL]. Existing fill-ups deserialise with null so
 /// historical data keeps working.
- double? get fuelLevelAfterL;
+ double? get fuelLevelAfterL;/// Unit price per litre as printed on the scanned receipt / pump
+/// display (#2689, e-receipt Phase 1). When the OCR parser reads a
+/// `pricePerLiter` off the receipt it is persisted verbatim here,
+/// preserving the exact quoted price (e.g. `1.999`) rather than the
+/// `totalCost / liters` quotient — which rounds differently and can
+/// drift when either field was hand-corrected after the scan. Null
+/// when the fill-up was entered manually or the scan didn't read a
+/// price; the [FillUpX.pricePerLiter] getter then falls back to the
+/// computed quotient. Existing fill-ups deserialise with null so
+/// historical data keeps working.
+ double? get scannedPricePerLiter;
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -66,16 +76,16 @@ $FillUpCopyWith<FillUp> get copyWith => _$FillUpCopyWithImpl<FillUp>(this as Fil
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other.linkedTripIds, linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank)&&(identical(other.isCorrection, isCorrection) || other.isCorrection == isCorrection)&&(identical(other.fuelLevelBeforeL, fuelLevelBeforeL) || other.fuelLevelBeforeL == fuelLevelBeforeL)&&(identical(other.fuelLevelAfterL, fuelLevelAfterL) || other.fuelLevelAfterL == fuelLevelAfterL));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other.linkedTripIds, linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank)&&(identical(other.isCorrection, isCorrection) || other.isCorrection == isCorrection)&&(identical(other.fuelLevelBeforeL, fuelLevelBeforeL) || other.fuelLevelBeforeL == fuelLevelBeforeL)&&(identical(other.fuelLevelAfterL, fuelLevelAfterL) || other.fuelLevelAfterL == fuelLevelAfterL)&&(identical(other.scannedPricePerLiter, scannedPricePerLiter) || other.scannedPricePerLiter == scannedPricePerLiter));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(linkedTripIds),isFullTank,isCorrection,fuelLevelBeforeL,fuelLevelAfterL);
+int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(linkedTripIds),isFullTank,isCorrection,fuelLevelBeforeL,fuelLevelAfterL,scannedPricePerLiter);
 
 @override
 String toString() {
-  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank, isCorrection: $isCorrection, fuelLevelBeforeL: $fuelLevelBeforeL, fuelLevelAfterL: $fuelLevelAfterL)';
+  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank, isCorrection: $isCorrection, fuelLevelBeforeL: $fuelLevelBeforeL, fuelLevelAfterL: $fuelLevelAfterL, scannedPricePerLiter: $scannedPricePerLiter)';
 }
 
 
@@ -86,7 +96,7 @@ abstract mixin class $FillUpCopyWith<$Res>  {
   factory $FillUpCopyWith(FillUp value, $Res Function(FillUp) _then) = _$FillUpCopyWithImpl;
 @useResult
 $Res call({
- String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank, bool isCorrection, double? fuelLevelBeforeL, double? fuelLevelAfterL
+ String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank, bool isCorrection, double? fuelLevelBeforeL, double? fuelLevelAfterL, double? scannedPricePerLiter
 });
 
 
@@ -103,7 +113,7 @@ class _$FillUpCopyWithImpl<$Res>
 
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,Object? isCorrection = null,Object? fuelLevelBeforeL = freezed,Object? fuelLevelAfterL = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,Object? isCorrection = null,Object? fuelLevelBeforeL = freezed,Object? fuelLevelAfterL = freezed,Object? scannedPricePerLiter = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
@@ -120,6 +130,7 @@ as List<String>,isFullTank: null == isFullTank ? _self.isFullTank : isFullTank /
 as bool,isCorrection: null == isCorrection ? _self.isCorrection : isCorrection // ignore: cast_nullable_to_non_nullable
 as bool,fuelLevelBeforeL: freezed == fuelLevelBeforeL ? _self.fuelLevelBeforeL : fuelLevelBeforeL // ignore: cast_nullable_to_non_nullable
 as double?,fuelLevelAfterL: freezed == fuelLevelAfterL ? _self.fuelLevelAfterL : fuelLevelAfterL // ignore: cast_nullable_to_non_nullable
+as double?,scannedPricePerLiter: freezed == scannedPricePerLiter ? _self.scannedPricePerLiter : scannedPricePerLiter // ignore: cast_nullable_to_non_nullable
 as double?,
   ));
 }
@@ -205,10 +216,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection,  double? fuelLevelBeforeL,  double? fuelLevelAfterL)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection,  double? fuelLevelBeforeL,  double? fuelLevelAfterL,  double? scannedPricePerLiter)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _FillUp() when $default != null:
-return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection,_that.fuelLevelBeforeL,_that.fuelLevelAfterL);case _:
+return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection,_that.fuelLevelBeforeL,_that.fuelLevelAfterL,_that.scannedPricePerLiter);case _:
   return orElse();
 
 }
@@ -226,10 +237,10 @@ return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerK
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection,  double? fuelLevelBeforeL,  double? fuelLevelAfterL)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection,  double? fuelLevelBeforeL,  double? fuelLevelAfterL,  double? scannedPricePerLiter)  $default,) {final _that = this;
 switch (_that) {
 case _FillUp():
-return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection,_that.fuelLevelBeforeL,_that.fuelLevelAfterL);case _:
+return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection,_that.fuelLevelBeforeL,_that.fuelLevelAfterL,_that.scannedPricePerLiter);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -246,10 +257,10 @@ return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerK
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection,  double? fuelLevelBeforeL,  double? fuelLevelAfterL)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  DateTime date,  double liters,  double totalCost,  double odometerKm, @FuelTypeJsonConverter()  FuelType fuelType,  String? stationId,  String? stationName,  String? notes,  String? vehicleId,  List<String> linkedTripIds,  bool isFullTank,  bool isCorrection,  double? fuelLevelBeforeL,  double? fuelLevelAfterL,  double? scannedPricePerLiter)?  $default,) {final _that = this;
 switch (_that) {
 case _FillUp() when $default != null:
-return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection,_that.fuelLevelBeforeL,_that.fuelLevelAfterL);case _:
+return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerKm,_that.fuelType,_that.stationId,_that.stationName,_that.notes,_that.vehicleId,_that.linkedTripIds,_that.isFullTank,_that.isCorrection,_that.fuelLevelBeforeL,_that.fuelLevelAfterL,_that.scannedPricePerLiter);case _:
   return null;
 
 }
@@ -261,7 +272,7 @@ return $default(_that.id,_that.date,_that.liters,_that.totalCost,_that.odometerK
 @JsonSerializable()
 
 class _FillUp implements FillUp {
-  const _FillUp({required this.id, required this.date, required this.liters, required this.totalCost, required this.odometerKm, @FuelTypeJsonConverter() required this.fuelType, this.stationId, this.stationName, this.notes, this.vehicleId, final  List<String> linkedTripIds = const <String>[], this.isFullTank = true, this.isCorrection = false, this.fuelLevelBeforeL, this.fuelLevelAfterL}): _linkedTripIds = linkedTripIds;
+  const _FillUp({required this.id, required this.date, required this.liters, required this.totalCost, required this.odometerKm, @FuelTypeJsonConverter() required this.fuelType, this.stationId, this.stationName, this.notes, this.vehicleId, final  List<String> linkedTripIds = const <String>[], this.isFullTank = true, this.isCorrection = false, this.fuelLevelBeforeL, this.fuelLevelAfterL, this.scannedPricePerLiter}): _linkedTripIds = linkedTripIds;
   factory _FillUp.fromJson(Map<String, dynamic> json) => _$FillUpFromJson(json);
 
 @override final  String id;
@@ -330,6 +341,17 @@ class _FillUp implements FillUp {
 /// [fuelLevelBeforeL]. Existing fill-ups deserialise with null so
 /// historical data keeps working.
 @override final  double? fuelLevelAfterL;
+/// Unit price per litre as printed on the scanned receipt / pump
+/// display (#2689, e-receipt Phase 1). When the OCR parser reads a
+/// `pricePerLiter` off the receipt it is persisted verbatim here,
+/// preserving the exact quoted price (e.g. `1.999`) rather than the
+/// `totalCost / liters` quotient — which rounds differently and can
+/// drift when either field was hand-corrected after the scan. Null
+/// when the fill-up was entered manually or the scan didn't read a
+/// price; the [FillUpX.pricePerLiter] getter then falls back to the
+/// computed quotient. Existing fill-ups deserialise with null so
+/// historical data keeps working.
+@override final  double? scannedPricePerLiter;
 
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
@@ -344,16 +366,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other._linkedTripIds, _linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank)&&(identical(other.isCorrection, isCorrection) || other.isCorrection == isCorrection)&&(identical(other.fuelLevelBeforeL, fuelLevelBeforeL) || other.fuelLevelBeforeL == fuelLevelBeforeL)&&(identical(other.fuelLevelAfterL, fuelLevelAfterL) || other.fuelLevelAfterL == fuelLevelAfterL));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FillUp&&(identical(other.id, id) || other.id == id)&&(identical(other.date, date) || other.date == date)&&(identical(other.liters, liters) || other.liters == liters)&&(identical(other.totalCost, totalCost) || other.totalCost == totalCost)&&(identical(other.odometerKm, odometerKm) || other.odometerKm == odometerKm)&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.stationId, stationId) || other.stationId == stationId)&&(identical(other.stationName, stationName) || other.stationName == stationName)&&(identical(other.notes, notes) || other.notes == notes)&&(identical(other.vehicleId, vehicleId) || other.vehicleId == vehicleId)&&const DeepCollectionEquality().equals(other._linkedTripIds, _linkedTripIds)&&(identical(other.isFullTank, isFullTank) || other.isFullTank == isFullTank)&&(identical(other.isCorrection, isCorrection) || other.isCorrection == isCorrection)&&(identical(other.fuelLevelBeforeL, fuelLevelBeforeL) || other.fuelLevelBeforeL == fuelLevelBeforeL)&&(identical(other.fuelLevelAfterL, fuelLevelAfterL) || other.fuelLevelAfterL == fuelLevelAfterL)&&(identical(other.scannedPricePerLiter, scannedPricePerLiter) || other.scannedPricePerLiter == scannedPricePerLiter));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(_linkedTripIds),isFullTank,isCorrection,fuelLevelBeforeL,fuelLevelAfterL);
+int get hashCode => Object.hash(runtimeType,id,date,liters,totalCost,odometerKm,fuelType,stationId,stationName,notes,vehicleId,const DeepCollectionEquality().hash(_linkedTripIds),isFullTank,isCorrection,fuelLevelBeforeL,fuelLevelAfterL,scannedPricePerLiter);
 
 @override
 String toString() {
-  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank, isCorrection: $isCorrection, fuelLevelBeforeL: $fuelLevelBeforeL, fuelLevelAfterL: $fuelLevelAfterL)';
+  return 'FillUp(id: $id, date: $date, liters: $liters, totalCost: $totalCost, odometerKm: $odometerKm, fuelType: $fuelType, stationId: $stationId, stationName: $stationName, notes: $notes, vehicleId: $vehicleId, linkedTripIds: $linkedTripIds, isFullTank: $isFullTank, isCorrection: $isCorrection, fuelLevelBeforeL: $fuelLevelBeforeL, fuelLevelAfterL: $fuelLevelAfterL, scannedPricePerLiter: $scannedPricePerLiter)';
 }
 
 
@@ -364,7 +386,7 @@ abstract mixin class _$FillUpCopyWith<$Res> implements $FillUpCopyWith<$Res> {
   factory _$FillUpCopyWith(_FillUp value, $Res Function(_FillUp) _then) = __$FillUpCopyWithImpl;
 @override @useResult
 $Res call({
- String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank, bool isCorrection, double? fuelLevelBeforeL, double? fuelLevelAfterL
+ String id, DateTime date, double liters, double totalCost, double odometerKm,@FuelTypeJsonConverter() FuelType fuelType, String? stationId, String? stationName, String? notes, String? vehicleId, List<String> linkedTripIds, bool isFullTank, bool isCorrection, double? fuelLevelBeforeL, double? fuelLevelAfterL, double? scannedPricePerLiter
 });
 
 
@@ -381,7 +403,7 @@ class __$FillUpCopyWithImpl<$Res>
 
 /// Create a copy of FillUp
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,Object? isCorrection = null,Object? fuelLevelBeforeL = freezed,Object? fuelLevelAfterL = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? date = null,Object? liters = null,Object? totalCost = null,Object? odometerKm = null,Object? fuelType = null,Object? stationId = freezed,Object? stationName = freezed,Object? notes = freezed,Object? vehicleId = freezed,Object? linkedTripIds = null,Object? isFullTank = null,Object? isCorrection = null,Object? fuelLevelBeforeL = freezed,Object? fuelLevelAfterL = freezed,Object? scannedPricePerLiter = freezed,}) {
   return _then(_FillUp(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,date: null == date ? _self.date : date // ignore: cast_nullable_to_non_nullable
@@ -398,6 +420,7 @@ as List<String>,isFullTank: null == isFullTank ? _self.isFullTank : isFullTank /
 as bool,isCorrection: null == isCorrection ? _self.isCorrection : isCorrection // ignore: cast_nullable_to_non_nullable
 as bool,fuelLevelBeforeL: freezed == fuelLevelBeforeL ? _self.fuelLevelBeforeL : fuelLevelBeforeL // ignore: cast_nullable_to_non_nullable
 as double?,fuelLevelAfterL: freezed == fuelLevelAfterL ? _self.fuelLevelAfterL : fuelLevelAfterL // ignore: cast_nullable_to_non_nullable
+as double?,scannedPricePerLiter: freezed == scannedPricePerLiter ? _self.scannedPricePerLiter : scannedPricePerLiter // ignore: cast_nullable_to_non_nullable
 as double?,
   ));
 }

--- a/lib/features/consumption/domain/entities/fill_up.g.dart
+++ b/lib/features/consumption/domain/entities/fill_up.g.dart
@@ -26,6 +26,7 @@ _FillUp _$FillUpFromJson(Map<String, dynamic> json) => _FillUp(
   isCorrection: json['isCorrection'] as bool? ?? false,
   fuelLevelBeforeL: (json['fuelLevelBeforeL'] as num?)?.toDouble(),
   fuelLevelAfterL: (json['fuelLevelAfterL'] as num?)?.toDouble(),
+  scannedPricePerLiter: (json['scannedPricePerLiter'] as num?)?.toDouble(),
 );
 
 Map<String, dynamic> _$FillUpToJson(_FillUp instance) => <String, dynamic>{
@@ -44,4 +45,5 @@ Map<String, dynamic> _$FillUpToJson(_FillUp instance) => <String, dynamic>{
   'isCorrection': instance.isCorrection,
   'fuelLevelBeforeL': instance.fuelLevelBeforeL,
   'fuelLevelAfterL': instance.fuelLevelAfterL,
+  'scannedPricePerLiter': instance.scannedPricePerLiter,
 };

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -121,6 +121,13 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
   ReceiptScanOutcome? _lastScan;
   FillUpAutoCostCalculator? _autoCostCalc;
 
+  /// Unit price per litre read off the last receipt scan (#2689). Set by
+  /// the scan handler when the OCR parser extracts a `pricePerLiter`, and
+  /// persisted into the saved [FillUp.scannedPricePerLiter] so the exact
+  /// quoted price survives instead of the `totalCost / liters` quotient.
+  /// Null until a scan reads a price; manual entries leave it null.
+  double? _scannedPricePerLiter;
+
   /// Adapter-captured tank level (litres) snapshotted at form-open
   /// (#1434). Closes the producer-wiring gap from #1401 — paired with
   /// [_fuelLevelAfterL] (captured at save) so the persisted [FillUp]
@@ -250,6 +257,8 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
         setScanningPump: (v) => setState(() => _scanningPump = v),
         setDate: (d) => setState(() => _date = d),
         setFuelType: (f) => setState(() => _fuelType = f),
+        setScannedPricePerLiter: (p) =>
+            setState(() => _scannedPricePerLiter = p),
         setLastScan: (o) => setState(() => _lastScan = o),
         isMounted: () => mounted,
         capturePumpImage: widget.pumpImageCapture ?? _capturePumpImage,
@@ -349,6 +358,10 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
       isFullTank: _isFullTank,
       fuelLevelBeforeL: _fuelLevelBeforeL,
       fuelLevelAfterL: afterL,
+      // #2689 — persist the receipt-scanned unit price verbatim when one
+      // was read; null for manual entries falls back to the computed
+      // pricePerLiter getter.
+      scannedPricePerLiter: _scannedPricePerLiter,
     );
 
     // #1401 phase 7b — when both adapter fuel-level captures are

--- a/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_scan_handlers.dart
@@ -49,6 +49,11 @@ class FillUpScanHostState {
   final void Function(bool) setScanningPump;
   final void Function(DateTime) setDate;
   final void Function(FuelType) setFuelType;
+
+  /// Stores the receipt-scanned unit price per litre on the host so the
+  /// saved [FillUp] carries the exact quoted price (#2689) instead of
+  /// only the `totalCost / liters` quotient.
+  final void Function(double) setScannedPricePerLiter;
   final void Function(ReceiptScanOutcome) setLastScan;
 
   /// `mounted` predicate from the host state — checked after every
@@ -81,6 +86,7 @@ class FillUpScanHostState {
     required this.setScanningPump,
     required this.setDate,
     required this.setFuelType,
+    required this.setScannedPricePerLiter,
     required this.setLastScan,
     required this.isMounted,
     required this.capturePumpImage,
@@ -133,6 +139,12 @@ Future<void> runReceiptScan(
     }
     if (result.date != null) {
       state.setDate(result.date!);
+    }
+    // #2689 — keep the exact scanned unit price so the saved FillUp
+    // preserves it verbatim rather than re-deriving totalCost / liters
+    // (which rounds differently and drifts if either field is edited).
+    if (result.pricePerLiter != null) {
+      state.setScannedPricePerLiter(result.pricePerLiter!);
     }
     // Only pre-select the fuel when there is no vehicle bound — the
     // vehicle's configured fuel always wins (#698 single source of

--- a/test/features/consumption/data/receipt_parser/fixtures/aral_hamburg_2026-04-25.txt
+++ b/test/features/consumption/data/receipt_parser/fixtures/aral_hamburg_2026-04-25.txt
@@ -1,0 +1,14 @@
+ARAL Tankstelle
+Bahrenfelder Chaussee 12
+22761 HAMBURG
+Tel 040 89 70 12
+
+QUITTUNG               KARTENZAHLUNG
+Datum 25.04.2026 08:14:37
+Zapfsaeule 2           Super E10
+Menge                  38,50 L
+Literpreis             1,799 EUR/L
+BETRAG                 69,26 EUR
+
+MwSt 19,00 %           11,06 EUR
+Netto                  58,20 EUR

--- a/test/features/consumption/data/receipt_parser_test.dart
+++ b/test/features/consumption/data/receipt_parser_test.dart
@@ -523,5 +523,38 @@ Date Heure  Num Ticket
         },
       );
     });
+
+    // -------------------------------------------------------------------
+    // #2689 — German-format receipt fixture (e-receipt Phase 1). DE
+    // receipts use comma decimals and the `BETRAG` / `Literpreis` labels.
+    // This locks in that the parser populates the four fields the
+    // fill-up scan now persists — liters + pricePerLiter + fuelType +
+    // stationName — so the discard→persist plumbing in the screen always
+    // has real values to thread through.
+    // -------------------------------------------------------------------
+    group('Aral DE-format receipt fixture (#2689)', () {
+      test(
+        'populates liters + pricePerLiter + fuelType + stationName from '
+        'comma-decimal BETRAG / Literpreis layout',
+        () {
+          final receipt = File(
+            'test/features/consumption/data/receipt_parser/'
+            'fixtures/aral_hamburg_2026-04-25.txt',
+          ).readAsStringSync();
+          final result = parser.parse(receipt);
+          expect(result.liters, closeTo(38.50, 0.01));
+          expect(result.totalCost, closeTo(69.26, 0.01));
+          expect(
+            result.pricePerLiter,
+            closeTo(1.799, 0.001),
+            reason: 'the scanned unit price the screen now persists',
+          );
+          expect(result.fuelType, FuelType.e10);
+          expect(result.stationName, contains('ARAL'));
+          expect(result.date, DateTime(2026, 4, 25));
+          expect(result.hasData, isTrue);
+        },
+      );
+    });
   });
 }

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_scanned_price_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_scanned_price_test.dart
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:tankstellen/features/consumption/data/ocr/ocr_trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
+import 'package:tankstellen/features/consumption/data/receipt_scan_service.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/add_fill_up_screen.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_numeric_field.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// Seam test for #2689 — e-receipt Phase 1.
+///
+/// The receipt parser already extracts `pricePerLiter`, but before
+/// #2689 the scan→save path *discarded* it and `FillUp` only ever
+/// *computed* price/L from `totalCost / liters`. This test drives the
+/// real screen through the real `runReceiptScan` handler with a fake
+/// [ReceiptScanService] that returns a canned [ReceiptParseResult] (the
+/// exact `1.999 €/L` the OCR would read), then taps Save and asserts the
+/// persisted [FillUp.scannedPricePerLiter] is the verbatim scanned price.
+///
+/// RED on master (the field doesn't exist + the value is discarded);
+/// GREEN once the plumbing threads `result.pricePerLiter` through to the
+/// saved FillUp. Structural — no goldens.
+
+const _stubVehicle = VehicleProfile(
+  id: 'stub-vehicle',
+  name: 'Stub Car',
+  type: VehicleType.combustion,
+);
+
+class _StubVehicleList extends VehicleProfileList {
+  @override
+  List<VehicleProfile> build() => const [_stubVehicle];
+}
+
+/// Captures every fill-up handed to `add` so the test can inspect the
+/// persisted `scannedPricePerLiter`. Bypasses the production `add`
+/// pipeline (repo, calibration, link-window) — those have their own
+/// coverage; this pins only the screen-side scan→persist contract.
+class _CapturingFillUpList extends FillUpList {
+  final List<FillUp> captured = [];
+
+  @override
+  List<FillUp> build() => const [];
+
+  @override
+  Future<void> add(FillUp fillUp) async {
+    captured.add(fillUp);
+  }
+}
+
+/// Minimal fake [TextRecognizer] / [ImagePicker] so the real
+/// [ReceiptScanService] constructor doesn't reach for the ML Kit native
+/// handle — never called because the fake short-circuits `scanReceipt`.
+class _NoopRecognizer extends TextRecognizer {
+  _NoopRecognizer();
+
+  @override
+  Future<RecognizedText> processImage(InputImage input) async =>
+      RecognizedText(text: '', blocks: const []);
+
+  @override
+  Future<void> close() async {}
+}
+
+class _NoopPicker extends ImagePicker {}
+
+/// Fake [ReceiptScanService] that bypasses the camera + ML Kit and
+/// returns a pre-canned [ReceiptScanOutcome] for `scanReceipt`. The
+/// canned parse carries the four fields the scan now persists — a
+/// verbatim `1.999` unit price, E10 grade, 5.24 L and a total.
+class _FakeReceiptScanService extends ReceiptScanService {
+  _FakeReceiptScanService(this._result)
+      : super(
+          picker: _NoopPicker(),
+          recognizer: _NoopRecognizer(),
+          parser: const ReceiptParser(),
+        );
+
+  final ReceiptParseResult _result;
+  int disposeCalls = 0;
+
+  @override
+  Future<ReceiptScanOutcome?> scanReceipt({
+    String? country,
+    String? brand,
+    OcrTraceRecorder? trace,
+  }) async {
+    return ReceiptScanOutcome(
+      parse: _result,
+      ocrText: 'fixture',
+      imagePath: '/tmp/fake-receipt.jpg',
+    );
+  }
+
+  @override
+  void dispose() {
+    // No-op — the test owns this fake's lifecycle.
+    disposeCalls++;
+  }
+}
+
+/// `Feature.addFillUpOcrReceipt` is default-on, but force-enable it so
+/// the receipt button renders regardless of the env default.
+class _ReceiptOcrEnabled extends FeatureFlags {
+  @override
+  Set<Feature> build() => {Feature.addFillUpOcrReceipt};
+}
+
+Future<void> _pumpScreenInRouter(
+  WidgetTester tester, {
+  required List<Object> overrides,
+  required AddFillUpScreen screen,
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(
+          body: Center(
+            child: Builder(
+              builder: (ctx) => ElevatedButton(
+                onPressed: () => ctx.push('/add'),
+                child: const Text('open-form'),
+              ),
+            ),
+          ),
+        ),
+      ),
+      GoRoute(path: '/add', builder: (context, state) => screen),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides.cast(),
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('en'),
+        routerConfig: router,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('open-form'));
+  await tester.pumpAndSettle();
+}
+
+Finder _fieldByLabel(String label) => find.ancestor(
+      of: find.text(label),
+      matching: find.byType(FillUpNumericField),
+    );
+
+void _typeInto(WidgetTester tester, String label, String value) {
+  final field = tester.widget<TextField>(
+    find.descendant(
+      of: _fieldByLabel(label),
+      matching: find.byType(TextField),
+    ),
+  );
+  field.controller!.text = value;
+}
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('AddFillUpScreen — scanned price persistence (#2689)', () {
+    testWidgets(
+        'a receipt scan reading 1.999 €/L persists '
+        'FillUp.scannedPricePerLiter == 1.999', (tester) async {
+      final fillUpList = _CapturingFillUpList();
+      final fake = _FakeReceiptScanService(
+        const ReceiptParseResult(
+          liters: 5.24,
+          totalCost: 10.47,
+          pricePerLiter: 1.999,
+          fuelType: FuelType.e10,
+        ),
+      );
+
+      await _pumpScreenInRouter(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _StubVehicleList()),
+          fillUpListProvider.overrideWith(() => fillUpList),
+          featureFlagsProvider.overrideWith(() => _ReceiptOcrEnabled()),
+        ],
+        screen: AddFillUpScreen(scanService: fake),
+      );
+
+      // Run the real scan handler — it pre-fills liters/cost/date/grade
+      // AND (post-#2689) captures the scanned unit price.
+      await tester.tap(find.byKey(const Key('import_receipt_button')));
+      await tester.pumpAndSettle();
+
+      // The scan fills liters + total; the odometer is the only field
+      // the user must still type before a valid save.
+      _typeInto(tester, 'Odometer (km)', '12345');
+      await tester.pump();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(fillUpList.captured, hasLength(1));
+      final saved = fillUpList.captured.single;
+      // The load-bearing assertion: the exact scanned price is stored,
+      // not re-derived from totalCost / liters.
+      expect(saved.scannedPricePerLiter, closeTo(1.999, 0.0001));
+      // The computed getter prefers the scanned value over the quotient.
+      expect(saved.pricePerLiter, closeTo(1.999, 0.0001));
+      // The other scanned fields still flow (no regression).
+      expect(saved.liters, closeTo(5.24, 0.001));
+      expect(saved.totalCost, closeTo(10.47, 0.001));
+      expect(saved.fuelType, FuelType.e10);
+    });
+
+    testWidgets(
+        'a manual entry (no scan) leaves scannedPricePerLiter null and '
+        'falls back to the computed quotient', (tester) async {
+      final fillUpList = _CapturingFillUpList();
+
+      await _pumpScreenInRouter(
+        tester,
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _StubVehicleList()),
+          fillUpListProvider.overrideWith(() => fillUpList),
+          featureFlagsProvider.overrideWith(() => _ReceiptOcrEnabled()),
+        ],
+        screen: const AddFillUpScreen(),
+      );
+
+      _typeInto(tester, 'Liters', '40');
+      _typeInto(tester, 'Total cost', '70');
+      _typeInto(tester, 'Odometer (km)', '12345');
+      await tester.pump();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(fillUpList.captured, hasLength(1));
+      final saved = fillUpList.captured.single;
+      expect(saved.scannedPricePerLiter, isNull);
+      // 70 / 40 = 1.75 — the computed fallback.
+      expect(saved.pricePerLiter, closeTo(1.75, 0.0001));
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -219,8 +219,14 @@ void main() {
     // comment). The workflow + apply logic itself lives in the extracted
     // launcher/widget; only the trigger call stays on the screen.
     // Decomposition of this god-class is tracked under #2187/#2188/#2190.
+    // #2689 — re-grandfathered 513 → 526: the e-receipt Phase 1 plumbing
+    // adds the `_scannedPricePerLiter` state field (+ dartdoc), its
+    // `setScannedPricePerLiter` wiring in `_buildScanHostState`, and the
+    // `scannedPricePerLiter:` arg on the saved `FillUp` (+ rationale) so the
+    // exact receipt-scanned unit price is persisted instead of discarded.
+    // Pure field plumbing; decomposition stays tracked under #2187/#2188/#2190.
     'lib/features/consumption/presentation/screens/add_fill_up_screen.dart':
-        513,
+        526,
     // #2380 — +5: closest-station radar card at the top of the
     // recording column + a SingleChildScrollView wrap so the longer
     // column (radar + 5 metric cards + coaching card) scrolls instead


### PR DESCRIPTION
## What

e-receipt **Phase 1** of #2687. The receipt parser **already** extracts every
fuel field (`liters`, `totalCost`, `pricePerLiter`, `date`, `stationName`,
`fuelType`), but the scan→save path **discarded** `result.pricePerLiter`, and
`FillUp` only ever **computed** price/L from `totalCost / liters` — so the exact
quoted unit price (e.g. `1.999`) was never stored, and it drifted when either
field was hand-corrected after the scan.

This is pure **store-only plumbing**, **zero new ARB keys** (ARB-free, runs in
parallel with the ARB-lane PR).

## Changes

- **`FillUp`** gains a nullable `scannedPricePerLiter` (backward-compatible
  deserialise, mirroring the optional `fuelLevelBeforeL`). The computed
  `pricePerLiter` getter now **prefers the scanned value** and falls back to the
  `totalCost / liters` quotient for manually-entered fill-ups. freezed/`.g.dart`
  regenerated **from clean** (HARD RULE #3).
- **`runReceiptScan`** threads `result.pricePerLiter` through a new
  `FillUpScanHostState.setScannedPricePerLiter` setter → a `_scannedPricePerLiter`
  state field on `_AddFillUpScreenState` → written into the `FillUp` built at
  save. Litres/total/station/date/grade still flow unchanged.
- **No editable price/L controller** is added (that would need a new ARB hint
  key) — the store-only minimal path keeps this PR ARB-free.

No new ML-Kit / `TextRecognizer` dependency, so the **fdroid** flavor (which
already excludes photo-OCR) is unaffected — this only stores an extra field.

## Tests

- **Parser layer** — new DE-format fixture (`aral_hamburg_2026-04-25.txt`,
  comma-decimal `BETRAG` / `Literpreis`) asserts `liters` + `pricePerLiter` +
  `fuelType` + `stationName` populate.
- **Seam layer (RED on master)** — a screen-level test drives the real
  `runReceiptScan` with a fake `ReceiptScanService` returning
  `pricePerLiter:1.999` / `fuelType:e10` / `liters:5.24` and asserts the persisted
  `FillUp.scannedPricePerLiter == 1.999`. **RED today** (field didn't exist +
  value discarded — verified: compile error on master), **GREEN after**. Plus a
  manual-entry guard that `scannedPricePerLiter` stays null and the quotient
  fallback applies. Structural, no goldens.

`flutter analyze` clean, `flutter test test/features/consumption` green (3876
pass), file_length snapshot bumped 513 → 526 for the field plumbing, **zero
`lib/l10n/` drift**.

Closes #2689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
