### PR TITLE
fix(route/telemetry): de-noise UK-feed errors on a southern-France route — corridor over-inclusion + transient/offline + offline widget refresh (#2703)

### DIFF
--- a/lib/core/network/dio_offline.dart
+++ b/lib/core/network/dio_offline.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+
+/// Whether [error] is a connection-LAYER transient — an offline / no-network
+/// / connection-reset failure rather than a real server error (#2703).
+///
+/// Lifted out of `PrixCarburantsStationService._isOffline` (#2524) so the
+/// trace de-noise gate ([TraceRecorder]) and the FR service share ONE
+/// classification that cannot drift. A "Failed host lookup" SocketException
+/// surfaces from Dio either as [DioExceptionType.connectionError] or, on some
+/// platforms, as a [DioExceptionType.unknown] wrapping the raw SocketException;
+/// a slow/refused connection arrives as one of the *timeout types; a low-level
+/// `HttpException` ("Connection closed"/"Software caused connection abort")
+/// is the raw socket layer giving up. All mean "the device has no working
+/// connection right now", which is expected and already handled by returning
+/// empty / skipping — so it must NOT pollute the error spool.
+///
+/// Deliberately NARROW: a [DioExceptionType.badResponse] (a 4xx/5xx the server
+/// actually answered) is a REAL error and returns `false` here, so it still
+/// persists as a trace. This does NOT route through `failureKindFromDio`
+/// (which maps 5xx → network) precisely so a server error is never suppressed.
+bool isOfflineDioException(Object error) {
+  if (error is DioException) {
+    switch (error.type) {
+      case DioExceptionType.connectionError:
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        return true;
+      case DioExceptionType.unknown:
+        // i18n-ignore: matching a platform exception class name, not UI text.
+        return error.error?.runtimeType.toString().contains('SocketException') ??
+            false;
+      case DioExceptionType.badResponse:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.cancel:
+        return false;
+    }
+  }
+  // A bare low-level connection abort/close from the socket layer.
+  if (error is HttpException) return true;
+  return false;
+}

--- a/lib/core/telemetry/trace_recorder.dart
+++ b/lib/core/telemetry/trace_recorder.dart
@@ -3,12 +3,14 @@
 
 import 'dart:io';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
 import '../error/exceptions.dart';
 import '../logging/error_logger.dart';
+import '../network/dio_offline.dart';
 import '../services/service_result.dart';
 import 'collectors/app_state_collector.dart';
 import 'collectors/breadcrumb_collector.dart';
@@ -63,18 +65,27 @@ class TraceRecorder {
       effectiveError = error;
     }
 
-    // #2671 — benign offline/cancelled transients are EXPECTED, not errors.
-    // A no-network DNS failure (`SocketException: Failed host lookup …`) and
-    // a user-cancelled request (`DioException [request cancelled]`) reached
-    // the trace store with NO suppression, polluting a signal-rich error
-    // log. Skip them with a breadcrumb only — no store, no upload. Placed in
-    // `record()` (not the classifier) so EVERY caller path (dio interceptor,
-    // `errorLogger.log`, the service chain) is covered, and matched against
-    // the UNWRAPPED [effectiveError] so a ContextualError-wrapped transient
-    // is suppressed too.
-    if (_isBenignTransient(effectiveError)) {
+    // #2671 / #2703 — benign offline/cancelled/connection transients are
+    // EXPECTED, not errors. A no-network DNS failure, a user-cancelled
+    // request, AND the connection-layer transients that slipped through
+    // (#2703: a `DioException[connectionError]` WRAPPING the host-lookup
+    // SocketException, the *timeout types, an `HttpException` connection
+    // abort) reached the trace store with NO suppression, polluting a
+    // signal-rich error log. Skip them with a breadcrumb only — no store,
+    // no upload. Placed in `record()` (not the classifier) so EVERY caller
+    // path (dio interceptor, `errorLogger.log`, the service chain) is
+    // covered, and matched against the UNWRAPPED [effectiveError] so a
+    // ContextualError-wrapped transient is suppressed too.
+    //
+    // #2703 — read the device online-state UPFRONT so the gate can suppress
+    // any network-category transient while the device is offline. Shape-match
+    // is PRIMARY (it catches online-but-DNS-dead); `isOnline == false` is the
+    // secondary signal for a network failure with no offline-specific shape.
+    final isOnline = await _isDeviceOnline();
+    if (_isBenignTransient(effectiveError, isOnline: isOnline)) {
       debugPrint('TraceRecorder: skipping benign transient (offline/'
-          'cancelled), not persisting (#2671): $effectiveError');
+          'cancelled/connection), not persisting (#2671/#2703): '
+          '$effectiveError');
       return;
     }
 
@@ -136,22 +147,64 @@ class TraceRecorder {
     await _uploader.uploadIfEnabled(trace);
   }
 
-  /// #2671 — true for an EXPECTED offline/cancelled transient that must not
-  /// be persisted as an error trace:
+  /// #2671 / #2703 — true for an EXPECTED offline/cancelled/connection
+  /// transient that must not be persisted as an error trace:
   ///   1. a [SocketException] whose message reports a failed host lookup
   ///      (the device is simply offline — DNS can't resolve the API host);
   ///   2. a [DioException] of type [DioExceptionType.cancel] (the user
-  ///      navigated away / a newer request superseded this one).
-  /// Narrow by construction: a connection-refused [SocketException] or any
-  /// non-cancel Dio failure is a real error and still persists.
-  static bool _isBenignTransient(Object error) {
+  ///      navigated away / a newer request superseded this one);
+  ///   3. (#2703) a connection-LAYER Dio transient or a bare [HttpException]
+  ///      — classified by the shared [isOfflineDioException] util so this
+  ///      and the FR service can't drift (`connectionError` /
+  ///      `connectionTimeout` / `sendTimeout` / `receiveTimeout`, an
+  ///      `unknown` wrapping a SocketException, a connection abort);
+  ///   4. (#2703) when [isOnline] is `false`, any other network-category
+  ///      exception (`SocketException` / `TimeoutException` / `HttpException`)
+  ///      — a doomed call made while the device has no connection.
+  /// Narrow by construction: a [DioExceptionType.badResponse] (a 4xx/5xx the
+  /// server actually answered) and a connection-REFUSED [SocketException]
+  /// while online are real errors and still persist.
+  static bool _isBenignTransient(Object error, {required bool isOnline}) {
     if (error is SocketException) {
-      return error.message.toUpperCase().contains('FAILED HOST LOOKUP');
+      if (error.message.toUpperCase().contains('FAILED HOST LOOKUP')) {
+        return true;
+      }
+      // Any socket failure while the device is offline is expected (#2703);
+      // while online (e.g. connection refused) it stays a real error.
+      return !isOnline;
     }
-    if (error is DioException) {
-      return error.type == DioExceptionType.cancel;
+    if (error is DioException && error.type == DioExceptionType.cancel) {
+      return true;
     }
+    // #2703 — shared connection-layer classification (PRIMARY signal).
+    if (isOfflineDioException(error)) return true;
+    // #2703 — secondary offline signal: a doomed network call while offline.
+    if (!isOnline && _isNetworkCategory(error)) return true;
     return false;
+  }
+
+  /// Whether [error] is a network-category exception by SHAPE — used only as
+  /// the secondary `isOnline == false` signal (#2703). Deliberately EXCLUDES
+  /// [DioException]: a connection-layer Dio failure is already caught as the
+  /// PRIMARY signal by [isOfflineDioException], while a
+  /// [DioExceptionType.badResponse] is a real server answer that must persist
+  /// even if the connectivity probe momentarily reports offline.
+  static bool _isNetworkCategory(Object error) =>
+      error is SocketException ||
+      error is HttpException ||
+      error.runtimeType.toString().contains('TimeoutException');
+
+  /// Read the current device online-state for the de-noise gate (#2703).
+  /// Best-effort: any failure of the connectivity plugin returns `true`
+  /// (assume online) so the gate falls back to pure shape-matching rather
+  /// than wrongly suppressing a real error.
+  static Future<bool> _isDeviceOnline() async {
+    try {
+      final results = await Connectivity().checkConnectivity();
+      return results.isNotEmpty && !results.contains(ConnectivityResult.none);
+    } catch (_) {
+      return true;
+    }
   }
 }
 

--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -98,15 +98,29 @@ Map<String, CountrySource> buildCorridorServiceMap(
   return map;
 }
 
-/// The subset of [profileCountries] whose registered bounding box
-/// INTERSECTS the [route]'s own lat/lng bounding box (#2621).
+/// The subset of [profileCountries] whose registered bounding box actually
+/// CONTAINS at least one route vertex (#2621 / #2703).
 ///
 /// Belt-and-braces for the corridor-detection union: even if per-vertex
 /// detection were to miss a country (e.g. a future shadowing regression),
-/// a profile-backed country whose box overlaps the route's extent is still
-/// queried. Gated on ACTUAL extent intersection — NOT mere profile
-/// existence — so a pure-FR route does not pull in a distant PT/ES profile
-/// the user happens to have configured. Returns upper-cased codes.
+/// a profile-backed country the route genuinely touches is still queried.
+///
+/// #2703 — the over-inclusion fix. The previous gate credited a profile
+/// country whenever its box overlapped the route's single coarse whole-route
+/// AABB. That AABB is the rectangle [minLat..maxLat] × [minLng..maxLng] of
+/// EVERY vertex, so its corners are synthetic points the polyline never
+/// visits: a southern-France route whose extreme NW vertex reaches toward the
+/// Channel makes the AABB's (maxLat, minLng) corner clip GB's box
+/// [49.5+, ≤2.0] even though no actual vertex is in GB — so GB was queried,
+/// wasting requests on the flaky UK feed and spamming the error log.
+///
+/// The fix keeps the AABB as a cheap PRE-FILTER and adds vertex-containment
+/// as the CONFIRM: a profile country is credited only when its box contains
+/// ≥1 real route vertex (the same per-vertex [CountryBoundingBox.contains]
+/// test [corridorCountries] uses). A profile country the polyline truly
+/// touches is therefore still never dropped (preserves the #2621 recovery
+/// intent), but a country merely clipped by a synthetic AABB corner is not.
+/// Returns upper-cased codes.
 Set<String> countriesTouchingRouteExtent(
   RouteInfo route,
   Iterable<String> profileCountries,
@@ -125,12 +139,17 @@ Set<String> countriesTouchingRouteExtent(
     final code = raw.toUpperCase();
     final box = CountryServiceRegistry.boundingBoxFor(code);
     if (box == null) continue;
-    // Axis-aligned bbox intersection (overlap on BOTH lat and lng).
+    // Cheap AABB PRE-FILTER: skip a box that can't possibly hold a vertex.
     final overlaps = box.minLat <= maxLat &&
         box.maxLat >= minLat &&
         box.minLng <= maxLng &&
         box.maxLng >= minLng;
-    if (overlaps) out.add(code);
+    if (!overlaps) continue;
+    // CONFIRM with per-vertex containment — the synthetic AABB corner that
+    // clipped GB on a southern-France route holds no real vertex (#2703).
+    final touches = route.geometry
+        .any((p) => box.contains(p.latitude, p.longitude));
+    if (touches) out.add(code);
   }
   return out;
 }

--- a/lib/features/route_search/data/cross_border_corridor.dart
+++ b/lib/features/route_search/data/cross_border_corridor.dart
@@ -1,13 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/country/country_config.dart';
-import '../../../core/logging/error_logger.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../../core/services/country_service_registry.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/station_service.dart';
@@ -160,8 +158,12 @@ Set<String> countriesTouchingRouteExtent(
 ///
 /// Each per-country `searchStations` is wrapped in a try/catch (#2621): one
 /// country's outage / throw must NOT abort the whole route — the other legs
-/// still resolve, and an empty/failed ES leg is routed to [errorLogger]
-/// (ErrorLayer.services) so it is diagnosable rather than silently dropped.
+/// still resolve. #2703 — a recoverable per-leg failure (the overall corridor
+/// still returns results) records a diagnostic [BreadcrumbCollector]
+/// breadcrumb rather than a top-level ERROR trace, so a flaky feed (the
+/// southern-France UK-feed timeouts) no longer spams the error log; the
+/// orchestrator raises ONE aggregate ERROR only when the merged result is
+/// empty.
 StationQueryFunction buildCorridorQueryFunction(
   Ref ref,
   FuelType fuelType, {
@@ -199,16 +201,24 @@ StationQueryFunction buildCorridorQueryFunction(
         raw = result.data
             .map((s) => FuelStationResult(s) as SearchResultItem)
             .toList();
-      } catch (e, st) {
+      } catch (e, st) { // ignore: unused_catch_stack
         // #2621 — degrade to the other legs rather than aborting the whole
-        // route; never silently swallow (an empty ES leg must be traceable).
-        unawaited(errorLogger.log(ErrorLayer.services, e, st, context: {
-          'where': 'RouteSearch corridor: per-country station query',
-          'country': countryCode,
-          'fuel': source.fuel.apiValue,
-          'lat': lat,
-          'lng': lng,
-        }));
+        // route; never silently swallow. #2703 — a single country's feed
+        // failing in a multi-country corridor where the overall search still
+        // returns results is RECOVERABLE (the chain already retries transient
+        // faults), so it must NOT spam a top-level ERROR trace for every
+        // failed leg (the 5 UK-feed ERRORs from the field log). Record a
+        // diagnostic BREADCRUMB instead — a chronically-failing feed is still
+        // visible in any trace that DOES surface, but a recoverable leg outage
+        // is silent. (The orchestrator raises one aggregate ERROR only when
+        // the final merged corridor result is empty — see
+        // `route_search_provider`.)
+        BreadcrumbCollector.add(
+          'RouteSearch corridor: per-country station query failed',
+          detail: 'country=$countryCode fuel=${source.fuel.apiValue} '
+              'lat=$lat lng=$lng type=${e.runtimeType}',
+        );
+        debugPrint('RouteSearch corridor: $countryCode leg failed ($e)');
         continue;
       }
       // Per-country top-N reduce using THIS country's fuel, so the ranking

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -9,6 +9,7 @@ import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
 import '../../../core/services/impl/osm_brand_enricher.dart';
 import 'prix_carburants_parsers.dart' as parser;
+import '../../../core/network/dio_offline.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/service_result.dart';
@@ -178,24 +179,10 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
   }
 
   /// Whether [e] is an offline / no-network failure rather than a real
-  /// API error (#2524). A "Failed host lookup" / SocketException surfaces
-  /// either as [DioExceptionType.connectionError] or, on some platforms,
-  /// as a [DioExceptionType.unknown] wrapping the raw SocketException — both
-  /// mean "the device has no working connection", which is expected and
-  /// already handled by returning an empty list, so it must not pollute the
-  /// error spool.
-  static bool _isOffline(DioException e) {
-    if (e.type == DioExceptionType.connectionError ||
-        e.type == DioExceptionType.connectionTimeout) {
-      return true;
-    }
-    if (e.type == DioExceptionType.unknown) {
-      // i18n-ignore: matching a platform exception class name, not UI text.
-      return e.error?.runtimeType.toString().contains('SocketException') ??
-          false;
-    }
-    return false;
-  }
+  /// API error (#2524). Delegates to the shared [isOfflineDioException]
+  /// classifier (#2703) so this and the trace-recorder de-noise gate
+  /// classify connection-layer transients identically and can't drift.
+  static bool _isOffline(DioException e) => isOfflineDioException(e);
 
   /// Merge two raw API result lists, deduplicating by station id.
   /// Stations from [primary] win when an id collides.

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/network/connectivity_service.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/storage/storage_providers.dart';
 import '../../price_history/providers/price_prediction_provider.dart';
@@ -76,6 +77,14 @@ class NearestWidgetRefresh extends _$NearestWidgetRefresh {
           pricePredictionProvider(stationId, fuelType),
         ),
       );
+      // #2703 — the nearest-widget refresh hits the network (the active
+      // country's StationService). When the device is offline the call is
+      // doomed and ERROR-logged (the field-log offline home-widget refresh),
+      // so skip it silently — the favorites variant above is a local-only
+      // read and still ran. The existing stale-fallback in
+      // NearestWidgetDataBuilder remains the safety net once we DO refresh.
+      final isOnline = await ref.read(currentConnectivityProvider.future);
+      if (!isOnline) return;
       await HomeWidgetService.updateNearestWidget(
         storage,
         storage,

--- a/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
+++ b/lib/features/widget/providers/nearest_widget_refresh_provider.g.dart
@@ -102,7 +102,7 @@ final class NearestWidgetRefreshProvider
 }
 
 String _$nearestWidgetRefreshHash() =>
-    r'9381374c118f967eb22d7a1a7356bbd59cb03cb1';
+    r'47daafe8b3c4b738fd31735214fd9c195f16f649';
 
 /// Foreground heartbeat that rebuilds the home-screen widget — both the
 /// favorites and the nearest variants — every

--- a/test/core/telemetry/trace_recorder_test.dart
+++ b/test/core/telemetry/trace_recorder_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
@@ -329,6 +330,133 @@ void main() {
         expect(storage.stored, hasLength(1),
             reason: 'only host-lookup (offline DNS) is benign; a refused '
                 'connection is a real failure worth a trace');
+      });
+    });
+
+    // #2703 — the field shapes from the southern-France route corridor that
+    // slipped through the #2671 filter: a DioException[connectionError] that
+    // WRAPS the host-lookup SocketException, a DioException[connectionTimeout]
+    // (the 4 UK-feed timeouts), a DioException[unknown] wrapping a
+    // SocketException, and a bare HttpException connection-abort. These are
+    // expected transients and must NOT persist; a badResponse (4xx/5xx) and a
+    // connection-refused SocketException (while ONLINE) still must.
+    group('connection-layer transient suppression (#2703)', () {
+      test(
+          'a DioException[connectionError] wrapping a host-lookup '
+          'SocketException is NOT persisted', () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.connectionError,
+          error: const SocketException('Failed host lookup: api2.krlmedia.com'),
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'a connectionError wrapping a host lookup is offline');
+        expect(uploader.uploadCalled, isFalse);
+      });
+
+      test('a DioException[connectionTimeout] is NOT persisted', () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.connectionTimeout,
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'a connection timeout is an expected transient (#2703)');
+        expect(uploader.uploadCalled, isFalse);
+      });
+
+      test('a DioException[receiveTimeout] is NOT persisted', () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.receiveTimeout,
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty);
+      });
+
+      test(
+          'a DioException[unknown] wrapping a SocketException is NOT persisted',
+          () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.unknown,
+          error: const SocketException('Connection failed'),
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'an unknown Dio error wrapping a SocketException is '
+                'an offline transient on some platforms (#2703)');
+      });
+
+      test('a bare HttpException (connection abort) is NOT persisted',
+          () async {
+        const error = HttpException('Software caused connection abort');
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'a raw socket-layer connection abort is a transient');
+      });
+
+      test(
+          'a DioException[badResponse] (a real 4xx/5xx) IS still persisted '
+          '— the filter never suppresses a server answer', () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/stations'),
+          type: DioExceptionType.badResponse,
+          response: Response(
+            requestOptions: RequestOptions(path: '/stations'),
+            statusCode: 503,
+          ),
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, hasLength(1),
+            reason: 'a 5xx is a real server error and must persist (#2703)');
+        expect(uploader.uploadCalled, isTrue);
+      });
+    });
+
+    // #2703 — the offline SECONDARY signal: with the connectivity probe
+    // reporting `none`, a network-category transient with NO offline-specific
+    // shape (a generic TimeoutException) is still suppressed. The default
+    // setUp mock reports `wifi` (online); this group re-mocks `none`.
+    group('offline secondary signal (#2703)', () {
+      setUp(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('dev.fluttercommunity.plus/connectivity'),
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'check') {
+              return <String>['none'];
+            }
+            return null;
+          },
+        );
+      });
+
+      test('a generic TimeoutException while offline is NOT persisted',
+          () async {
+        final error = TimeoutException('request timed out');
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'a network call made while offline is a doomed transient');
+        expect(uploader.uploadCalled, isFalse);
+      });
+
+      test(
+          'a connection-refused SocketException while offline is suppressed '
+          '(it would persist while online)', () async {
+        const error = SocketException('Connection refused');
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'offline → any socket failure is an expected transient');
       });
     });
   });

--- a/test/features/route_search/data/cross_border_corridor_extent_test.dart
+++ b/test/features/route_search/data/cross_border_corridor_extent_test.dart
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// #2703 — corridor over-inclusion. `countriesTouchingRouteExtent` credited a
+// user-PROFILE country whenever its bounding box overlapped the route's single
+// coarse whole-route AABB. The AABB's corners are synthetic points the polyline
+// never visits: a southern-France route whose extreme NW vertex reaches toward
+// the Channel makes the AABB's (maxLat, minLng) corner clip GB's box
+// [49.5+, ≤2.0] even with NO actual GB vertex — so the flaky UK feed
+// (api2.krlmedia.com) was queried, producing the field-log timeouts.
+//
+// The fix keeps the AABB as a cheap pre-filter and CONFIRMS with per-vertex
+// containment. RED on master: GB is credited (AABB corner clips it). GREEN:
+// GB is dropped (no vertex inside it). CONTROL: a route with a real GB vertex
+// still includes GB (the #2621 recovery intent is preserved).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/route_search/data/cross_border_corridor.dart';
+import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Minimal [StorageRepository] stub so `buildCorridorServiceMap` can read
+/// `hasApiKey()` without standing up Hive. GB/FR are keyless so the value
+/// doesn't gate them.
+class _NoKeyStorage implements StorageRepository {
+  @override
+  bool hasApiKey() => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  // A southern-France route whose whole-route AABB corner (maxLat 50.5,
+  // minLng -2.0) lands INSIDE GB's box [49.5..61, -9..2] — but NEITHER vertex
+  // is in GB: (50.5, 3.0) has lng 3.0 > 2.0, and (43.44, -2.0) has lat 43.44 <
+  // 49.5. Both vertices ARE in FR's box [41..51.5, -5.5..10]. This is the
+  // Channel-clip over-inclusion shape.
+  const noGbVertexRoute = RouteInfo(
+    geometry: [
+      LatLng(50.5, 3.0), // NE-ish — supplies maxLat
+      LatLng(43.44, -2.0), // SW-ish (southern France) — supplies minLng
+    ],
+    distanceKm: 900,
+    durationMinutes: 540,
+    samplePoints: [],
+  );
+
+  // Same route plus a REAL GB vertex (London) — GB is genuinely on the
+  // polyline and must still be credited.
+  const gbVertexRoute = RouteInfo(
+    geometry: [
+      LatLng(50.5, 3.0),
+      LatLng(43.44, -2.0),
+      LatLng(51.0, -0.1), // London — INSIDE GB's box
+    ],
+    distanceKm: 1100,
+    durationMinutes: 660,
+    samplePoints: [],
+  );
+
+  group('countriesTouchingRouteExtent — vertex-containment confirm (#2703)',
+      () {
+    test(
+        'a GB profile is NOT credited when only the synthetic AABB corner '
+        'clips GB and no vertex is inside it (RED on master)', () {
+      final touched =
+          countriesTouchingRouteExtent(noGbVertexRoute, const ['GB']);
+      expect(touched, isNot(contains('GB')),
+          reason: 'no route vertex is in GB — the AABB corner clip must not '
+              'credit the flaky UK feed (#2703)');
+    });
+
+    test(
+        'a profile country the route genuinely touches IS still credited '
+        '(CONTROL — preserves #2621 recovery)', () {
+      final touched =
+          countriesTouchingRouteExtent(gbVertexRoute, const ['GB']);
+      expect(touched, contains('GB'),
+          reason: 'a real GB vertex (London) must keep GB in the set');
+    });
+
+    test('FR is credited on both routes (every vertex is in FR)', () {
+      expect(countriesTouchingRouteExtent(noGbVertexRoute, const ['FR']),
+          contains('FR'));
+      expect(countriesTouchingRouteExtent(gbVertexRoute, const ['FR']),
+          contains('FR'));
+    });
+  });
+
+  group('buildCorridorServiceMap — GB dropped end-to-end (#2703)', () {
+    test(
+        'a GB profile does NOT enter the corridor service map for a '
+        'southern-France route with no GB vertex (RED on master)', () {
+      final container = ProviderContainer(overrides: [
+        storageRepositoryProvider.overrideWith((ref) => _NoKeyStorage()),
+      ]);
+      addTearDown(container.dispose);
+
+      late Ref capturedRef;
+      final refCapture = Provider<int>((ref) {
+        capturedRef = ref;
+        return 0;
+      });
+      container.read(refCapture);
+
+      final map = buildCorridorServiceMap(
+        capturedRef,
+        noGbVertexRoute,
+        const {'GB': FuelType.e10, 'FR': FuelType.e10},
+      );
+
+      expect(map.keys, isNot(contains('GB')),
+          reason: 'GB must not be queried for a southern-France route whose '
+              'only GB touch is a synthetic AABB corner (#2703)');
+      // FR genuinely touches the route, so it stays.
+      expect(map.keys, contains('FR'),
+          reason: 'FR is on the polyline and must be queried');
+    });
+
+    test(
+        'a GB profile DOES enter the map when the route has a real GB vertex '
+        '(CONTROL)', () {
+      final container = ProviderContainer(overrides: [
+        storageRepositoryProvider.overrideWith((ref) => _NoKeyStorage()),
+      ]);
+      addTearDown(container.dispose);
+
+      late Ref capturedRef;
+      final refCapture = Provider<int>((ref) {
+        capturedRef = ref;
+        return 0;
+      });
+      container.read(refCapture);
+
+      final map = buildCorridorServiceMap(
+        capturedRef,
+        gbVertexRoute,
+        const {'GB': FuelType.e10, 'FR': FuelType.e10},
+      );
+
+      expect(map.keys, contains('GB'),
+          reason: 'a route with a real GB vertex must still query GB');
+    });
+  });
+}

--- a/test/features/route_search/data/cross_border_corridor_query_test.dart
+++ b/test/features/route_search/data/cross_border_corridor_query_test.dart
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// #2703 — a single corridor country's feed failing in a multi-country route
+// where the overall search still returns results is RECOVERABLE: the chain
+// already retries transient faults and the other legs still resolve. It must
+// NOT spam a top-level ERROR trace for every failed leg (the 5 UK-feed ERRORs
+// from the southern-France field log). The catch in `buildCorridorQueryFunction`
+// now records a diagnostic BreadcrumbCollector breadcrumb and drops the
+// `errorLogger.log(ErrorLayer.services, …)` ERROR call.
+//
+// Reuse-fidelity: drives the REAL `buildCorridorQueryFunction` with a real
+// throwing StationService for one country + a real returning one for the other,
+// and asserts (a) the merged result is non-empty (the good leg survives) and
+// (b) NO trace reached the TraceRecorder (no ERROR for the failed leg), while a
+// breadcrumb WAS recorded. RED on master (the failed leg logged an ERROR).
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/storage/trace_storage.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/core/telemetry/upload/trace_uploader.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/route_search/data/cross_border_corridor.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// A country service that always throws — the flaky UK feed.
+class _ThrowingStationService implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    throw const SocketException('Failed host lookup: api2.krlmedia.com');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// A country service that returns one station at the queried point.
+class _OkStationService implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    final station = Station(
+      id: 'fr-${params.lat.toStringAsFixed(2)}-${params.lng.toStringAsFixed(2)}',
+      name: 'Total',
+      brand: 'Total',
+      street: 'Route',
+      postCode: '34120',
+      place: 'Pézenas',
+      lat: params.lat,
+      lng: params.lng,
+      isOpen: true,
+      e10: 1.60,
+    );
+    return ServiceResult(
+      data: [station],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// Captures every trace the recorder is asked to store.
+class _CapturingTraceStorage extends TraceStorage {
+  final stored = <ErrorTrace>[];
+
+  @override
+  Future<void> store(ErrorTrace trace) async => stored.add(trace);
+
+  @override
+  List<ErrorTrace> getAll() => stored;
+
+  @override
+  ErrorTrace? getById(String id) =>
+      stored.where((t) => t.id == id).firstOrNull;
+}
+
+class _NoopUploader extends TraceUploader {
+  _NoopUploader() : super(_NoopSettings());
+  @override
+  Future<void> uploadIfEnabled(ErrorTrace trace) async {}
+}
+
+class _NoopSettings implements SettingsStorage {
+  @override
+  dynamic getSetting(String key) => null;
+  @override
+  Future<void> putSetting(String key, dynamic value) async {}
+  @override
+  bool get isSetupComplete => false;
+  @override
+  bool get isSetupSkipped => false;
+  @override
+  Future<void> skipSetup() async {}
+  @override
+  Future<void> resetSetupSkip() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _CapturingTraceStorage traceStorage;
+  late ProviderContainer container;
+
+  setUp(() {
+    // The recorder reads connectivity upfront (#2703) — mock it online so the
+    // gate's behaviour is irrelevant here (a thrown leg never reaches it).
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('dev.fluttercommunity.plus/connectivity'),
+      (call) async => call.method == 'check' ? <String>['wifi'] : null,
+    );
+
+    traceStorage = _CapturingTraceStorage();
+    container = ProviderContainer();
+
+    late Ref capturedRef;
+    final refCapture = Provider<int>((ref) {
+      capturedRef = ref;
+      return 0;
+    });
+    container.read(refCapture);
+
+    // Route the singleton errorLogger through a real TraceRecorder backed by
+    // the capturing storage, so any ERROR.log lands where we can assert.
+    errorLogger.testRecorderOverride =
+        TraceRecorder(traceStorage, _NoopUploader(), capturedRef);
+    BreadcrumbCollector.clear();
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('dev.fluttercommunity.plus/connectivity'),
+      null,
+    );
+    errorLogger.resetForTest();
+    BreadcrumbCollector.clear();
+    container.dispose();
+  });
+
+  test(
+      'a corridor leg that throws is a breadcrumb, not an ERROR — the other '
+      'leg still returns results (#2703)', () async {
+    late Ref capturedRef;
+    final refCapture = Provider<int>((ref) {
+      capturedRef = ref;
+      return 0;
+    });
+    container.read(refCapture);
+
+    final queryFn = buildCorridorQueryFunction(
+      capturedRef,
+      FuelType.e10,
+      corridorMap: <String, CountrySource>{
+        // The flaky UK feed — throws on every query.
+        'GB': (service: _ThrowingStationService(), fuel: FuelType.e10),
+        // The healthy FR feed — returns a station.
+        'FR': (service: _OkStationService(), fuel: FuelType.e10),
+      },
+      criterion: RouteSearchCriterion.cheapest,
+      topNPerSamplePoint: 10,
+    );
+
+    final result = await queryFn(
+      lat: 43.44,
+      lng: 3.44,
+      radiusKm: 15,
+      fuelType: FuelType.e10,
+    );
+
+    // The good FR leg survives — the route is not aborted by the GB outage.
+    expect(result.whereType<FuelStationResult>(), isNotEmpty,
+        reason: 'the healthy FR leg must still return its station');
+
+    // Let any fire-and-forget error log settle, then assert NONE was raised.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(traceStorage.stored, isEmpty,
+        reason: 'a recoverable per-leg failure must NOT persist an ERROR '
+            'trace (the UK-feed ERROR spam, #2703)');
+
+    // …but the failure is still DIAGNOSABLE via a breadcrumb.
+    final crumbs = BreadcrumbCollector.snapshot();
+    expect(
+      crumbs.any((c) => c.action.contains('per-country station query failed')),
+      isTrue,
+      reason: 'a chronically-failing feed must leave a breadcrumb',
+    );
+    expect(
+      crumbs.any((c) => (c.detail ?? '').contains('country=GB')),
+      isTrue,
+      reason: 'the breadcrumb names the failing country',
+    );
+  });
+}

--- a/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
+++ b/test/features/widget/providers/nearest_widget_refresh_provider_test.dart
@@ -17,11 +17,18 @@
 // the `home_widget` plugin via platform channels; we mock the channel so
 // the call path completes instead of throwing.
 
+import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/network/connectivity_service.dart';
 import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/widget/providers/nearest_widget_refresh_provider.dart';
 import '../../../helpers/silence_error_logger.dart';
 
@@ -119,6 +126,65 @@ void main() {
       expect(container.dispose, returnsNormally);
     });
 
+    // #2703 — the nearest-widget refresh hits the network. When the device
+    // is offline the call is doomed and ERROR-logged (the field-log offline
+    // home-widget refresh). `_tick` must read connectivity and skip the
+    // nearest-widget network refresh while offline, WITHOUT touching the
+    // station service — but the local-only favorites `updateWidget` still
+    // runs (it never errored).
+    group('offline guard (#2703)', () {
+      late _CountingStationService countingService;
+
+      ProviderContainer makeContainer({required bool online}) {
+        countingService = _CountingStationService();
+        // A profile + a known GPS fix so the nearest builder WOULD call
+        // searchStations when online (otherwise the no-GPS path
+        // short-circuits and the test proves nothing).
+        final fake = FakeHiveStorage();
+        fake.putSetting(StorageKeys.userPositionLat, 43.44);
+        fake.putSetting(StorageKeys.userPositionLng, 3.44);
+        fake.saveProfile('p1', const {
+          'id': 'p1',
+          'name': 'Std',
+          'preferredFuelType': 'e10',
+          'defaultSearchRadius': 10.0,
+        });
+        fake.setActiveProfileId('p1');
+        final repo = FakeStorageRepository(inner: fake);
+
+        return ProviderContainer(
+          overrides: [
+            storageRepositoryProvider.overrideWithValue(repo),
+            stationServiceProvider.overrideWithValue(countingService),
+            currentConnectivityProvider.overrideWith((ref) async => online),
+          ],
+        );
+      }
+
+      test('offline tick does NOT call the station service', () async {
+        final c = makeContainer(online: false);
+        addTearDown(c.dispose);
+
+        c.read(nearestWidgetRefreshProvider);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        expect(countingService.searchCalls, 0,
+            reason: 'an offline tick must skip the nearest-widget network '
+                'refresh (the doomed offline call, #2703)');
+      });
+
+      test('online tick DOES call the station service (control)', () async {
+        final c = makeContainer(online: true);
+        addTearDown(c.dispose);
+
+        c.read(nearestWidgetRefreshProvider);
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+
+        expect(countingService.searchCalls, greaterThanOrEqualTo(1),
+            reason: 'when online the nearest-widget refresh still runs');
+      });
+    });
+
     test('a tick whose storage layer throws does not bubble up', () async {
       // Wire a fake whose getSetting throws on every call. The provider's
       // try/catch must swallow it — `unawaited(_tick())` means an
@@ -165,4 +231,27 @@ class _ThrowingFake extends FakeHiveStorage {
   dynamic getSetting(String key) {
     throw StateError('storage exploded');
   }
+}
+
+/// #2703 — counts `searchStations` calls so the offline guard can be proven:
+/// 0 while offline (the nearest refresh is skipped), ≥1 while online.
+class _CountingStationService implements StationService {
+  int searchCalls = 0;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    searchCalls++;
+    return ServiceResult(
+      data: const [],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
Closes #2703.

Field log #12 (southern France, ~Pézenas): a route corridor search queried the UK feed (`api2.krlmedia.com`) → 1 offline host-lookup + 4 8s timeouts, all ERROR-logged, plus an offline home-widget refresh ERROR. Four disjoint fixes, ARB-free (network/telemetry/route — no user-facing strings).

## The four fixes

1. **De-noise offline/transient connection errors** (`core/telemetry/trace_recorder.dart`). The #2671 filter only matched a bare `SocketException` host-lookup + a cancelled Dio. Broadened to suppress connection-LAYER transients via a new shared `isOfflineDioException` util (`core/network/dio_offline.dart`, lifted from `PrixCarburantsStationService._isOffline` and now called by BOTH so the classification can't drift): `connectionError` / `connectionTimeout` / `sendTimeout` / `receiveTimeout`, an `unknown` wrapping a `SocketException`, and a bare `HttpException`. The recorder also reads connectivity upfront so any network-category transient is suppressed while offline (secondary signal; shape-match stays primary). NARROW: a `badResponse` (4xx/5xx) and an online connection-refused still persist; never routed through `failureKindFromDio`.

2. **Corridor per-leg failure → breadcrumb, not ERROR** (`route_search/data/cross_border_corridor.dart`). `buildCorridorQueryFunction` already try/catch + `continue`s per country (#2621), but ERROR-logged every failed leg even when the corridor still returned results — the 5 UK-feed ERROR traces. Now it records a `BreadcrumbCollector` breadcrumb ({country, fuel, lat, lng, type}) and drops the per-leg `errorLogger.log`. A chronically-failing feed stays diagnosable; a recoverable outage is silent.

3. **Skip the home-widget refresh when offline** (`widget/providers/nearest_widget_refresh_provider.dart`). `_tick` fired `updateNearestWidget` (a network fetch) unconditionally. Now it reads `currentConnectivityProvider.future` and returns early when offline; the local-only favorites `updateWidget` still runs, and the `NearestWidgetDataBuilder` stale-fallback remains the online safety net.

## Behavioral note — corridor over-inclusion (the root bug)

4. **Tighten the corridor extent gate** (`countriesTouchingRouteExtent`). It credited a profile country whenever its box overlapped the route's single coarse whole-route AABB. The AABB's corners are synthetic points the polyline never visits: a southern-France route whose NW extreme reaches toward the Channel makes the AABB's (maxLat, minLng) corner clip GB's box [49.5+, ≤2.0] with **no actual GB vertex** — so GB was queried, hammering the flaky UK feed. The AABB stays a cheap pre-filter; per-vertex containment (`CountryBoundingBox.contains`, the same test `corridorCountries` uses) is now the confirm. A profile country the polyline truly touches is never dropped (preserves the #2621 recovery intent); a synthetic-corner clip is. **RED-on-master test verified**: a GB profile + a southern-France route clipping GB's AABB corner with no GB vertex → resolved set / corridor service map does NOT contain GB (fails on master, `Actual: ['FR','ES','GB']`); CONTROL with a real GB vertex (London) still includes GB.

## Gates
- `flutter analyze` clean (2 pre-existing `info` unnecessary_import in untouched consumption tests).
- `flutter test test/core/telemetry test/features/route_search test/features/widget` + FR service + lint + l10n all GREEN.
- ARB-free: zero `lib/l10n/` drift. Clean codegen: zero `*.g.dart`/`*.freezed.dart` drift (the `nearest_widget_refresh_provider.g.dart` hash regen is committed).
- Disjoint from the in-flight #2647/#2698 — parallel-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
