### PR TITLE
fix(spain): MITECO station detail falls back to cached bulk station (no detail endpoint)

### DIFF
--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -238,7 +238,45 @@ class MitecoStationService with StationServiceHelpers implements StationService 
   Future<ServiceResult<StationDetail>> getStationDetail(
     String stationId,
   ) async {
+    // #2706 — MITECO is a BULK feed: there is no per-station detail endpoint.
+    // A search already cached every province's full rows in [_byProvince],
+    // and each row carries name/brand/street/prices/coords. So a detail tap
+    // that falls through the provider's in-search fast path (widget rows,
+    // deep links, favorites) is resolved from that cache rather than throwing.
+    final rawId = stationId.startsWith('es-')
+        ? stationId.substring(3) // inverse of the `es-` prefixing at _parseStation
+        : stationId;
+    final row = _findCachedRow(rawId);
+    if (row != null) {
+      final lat = _parseCommaDouble(row['Latitud']?.toString()) ?? 0;
+      final lng = _parseCommaDouble(row['Longitud (WGS84)']?.toString()) ?? 0;
+      // Reuse the search parser; `dist` is irrelevant on the detail screen so
+      // the station's own coords double as the (no-op) search centre.
+      final station = _parseStation(row, lat, lng);
+      if (station != null) {
+        return ServiceResult<StationDetail>(
+          data: StationDetail(station: station),
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        );
+      }
+    }
+    // Cold cache (no prior search) — IDEESS does not encode its province, so a
+    // cold re-fetch is impossible here; preserve today's behaviour and let the
+    // provider's error/retry branch handle it. Cold-resolution is a follow-up.
     throwDetailUnavailable('MITECO API');
+  }
+
+  /// Linear scan of every cached province for the raw `IDEESS` row matching
+  /// [rawId] (#2706). A per-detail-tap scan is cheap and deliberately does NOT
+  /// restructure [_byProvince] (that would collide with the #2713 OH adapter).
+  Map<String, dynamic>? _findCachedRow(String rawId) {
+    for (final province in _byProvince.values) {
+      for (final row in province.rows) {
+        if (row['IDEESS']?.toString() == rawId) return row;
+      }
+    }
+    return null;
   }
 
   @override

--- a/test/features/station_services/spain/miteco_station_detail_test.dart
+++ b/test/features/station_services/spain/miteco_station_detail_test.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_services/spain/miteco_station_service.dart';
+import 'package:tankstellen/features/station_services/spain/spain_provinces.dart';
+
+/// #2706 — MITECO is a BULK feed with no per-station detail endpoint, so
+/// `getStationDetail` used to unconditionally throw "Detail not available".
+/// That bit every out-of-search-cache tap (widget rows, deep links,
+/// favorites) for ES. The fix resolves the detail from the rows a prior
+/// search already cached in `_byProvince`; only a genuinely-cold cache throws.
+
+/// Serves one richly-populated station per province so the test can assert the
+/// real name + prices survive the search→cache→detail round-trip.
+class _PerProvinceAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<void>? cancelFuture) async {
+    final id = options.uri.path.split('/').last;
+    final center = spainProvinceCenters[id]!;
+    final body = {
+      'ResultadoConsulta': 'OK',
+      'ListaEESSPrecio': [
+        {
+          'IDEESS': 'p$id',
+          'Rótulo': 'Repsol-$id',
+          'Dirección': 'Calle $id',
+          'Localidad': 'City-$id',
+          'C.P.': '00000',
+          'Latitud': center.$1.toString().replaceAll('.', ','),
+          'Longitud (WGS84)': center.$2.toString().replaceAll('.', ','),
+          'Precio Gasolina 95 E5': '1,599',
+          'Precio Gasoleo A': '1,499',
+          'Horario': '24H',
+          'Margen': 'D',
+        },
+      ],
+    };
+    return ResponseBody.fromBytes(utf8.encode(jsonEncode(body)), 200, headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+MitecoStationService _service() {
+  final dio = Dio()..httpClientAdapter = _PerProvinceAdapter();
+  return MitecoStationService(dio: dio);
+}
+
+void main() {
+  group('MITECO getStationDetail bulk-feed fallback (#2706)', () {
+    test('resolves a detail from the warmed search cache instead of throwing',
+        () async {
+      final service = _service();
+
+      // Warm `_byProvince` with a real search (Madrid = province 28).
+      final search = await service.searchStations(
+        const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5),
+      );
+      expect(search.data.map((s) => s.id), contains('es-p28'),
+          reason: 'precondition: the bulk search must cache the station');
+
+      // The out-of-search-cache path: ask for the detail by its `es-` id.
+      final detail = await service.getStationDetail('es-p28');
+
+      expect(detail.data, isA<StationDetail>());
+      final station = detail.data.station;
+      expect(station.id, 'es-p28');
+      expect(station.name, 'Repsol-28',
+          reason: 'the real bulk-row name must survive to the detail screen');
+      expect(station.e5, 1.599);
+      expect(station.diesel, 1.499);
+      expect(detail.source, ServiceSource.cache);
+    });
+
+    test('an unknown / cold-cache id still throws (fallback preserved)',
+        () async {
+      final service = _service();
+      // No prior search → cold cache → genuinely unresolvable.
+      expect(
+        () => service.getStationDetail('es-p99'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('an absent id after a warm search throws (not a wrong-station hit)',
+        () async {
+      final service = _service();
+      await service.searchStations(
+        const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5),
+      );
+      expect(
+        () => service.getStationDetail('es-does-not-exist'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('the returned detail round-trips through the chain cache codec',
+        () async {
+      final service = _service();
+      await service.searchStations(
+        const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5),
+      );
+
+      final detail = await service.getStationDetail('es-p28');
+      // It will now be cached under detail:es-p28, so it must survive the
+      // serialize/deserialize the chain applies on write/read.
+      final restored =
+          deserializeStationDetail(serializeStationDetail(detail.data));
+
+      expect(restored, isNotNull);
+      expect(restored!.station.id, 'es-p28');
+      expect(restored.station.name, 'Repsol-28');
+      expect(restored.station.e5, 1.599);
+    });
+  });
+}


### PR DESCRIPTION
MITECO is a bulk feed with no per-station detail endpoint, so `getStationDetail` threw `ApiException: Detail not available from MITECO API` — breaking the Spanish station detail screen for any out-of-search-cache tap (widget rows, deep links, favorites). Fix: cache-lookup over the in-memory `_byProvince` bulk (strip `es-`, scan by IDEESS, reuse `_parseStation`), return `StationDetail(station:)`; throw only on a genuinely-absent cold cache.

RED→GREEN verified (56 spain tests pass; the two resolve-tests fail on master with the exact ApiException, the two cold-fallback tests stay green). ARB-free, zero codegen/l10n drift. Lands before #2713 (shared `miteco_station_service.dart`).

Closes #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)