### PR TITLE
fix(mexico): repair CRE/datos.gob.mx — names, address, prices (dup place_id), fuel grades

### DIFF
--- a/lib/core/country/country_config.dart
+++ b/lib/core/country/country_config.dart
@@ -388,13 +388,13 @@ class Countries {
     apiProvider: 'CRE / datos.gob.mx',
     attribution: 'Datos: Comisión Reguladora de Energía',
     fuelTypes: ['Regular', 'Premium', 'Diesel'],
-    // #2180 — MexicoStationService maps CRE's gas_price types to Station
-    // fields as regular → e5, premium → e10, diesel → diesel. The premium
-    // grade lands in the e10 slot, never e98, so the picker must offer e10
-    // (not e98) to match the data the search selector surfaces.
+    // #2704 — MexicoStationService maps CRE regular→e5, premium→e98 (MX's
+    // high-octane 91–92 grade, NOT the European e10 ethanol blend, absent in
+    // MX), diesel→diesel. The picker must offer e98 (not e10) to match the
+    // data the search selector surfaces.
     supportedFuelTypes: {
       FuelType.e5,
-      FuelType.e10,
+      FuelType.e98,
       FuelType.diesel,
       FuelType.electric,
     },

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -578,7 +578,14 @@ class CountryServiceRegistry {
       boundingBox: CountryBoundingBox(
         minLat: 14.0, maxLat: 33.0, minLng: -119.0, maxLng: -86.0,
       ),
-      availableFuelTypes: _defaultFuelTypes,
+      // MX (#2704): CRE sells Regular (Magna, e5), Premium (91–92, e98) and
+      // Diesel in MXN — premium maps to the high-octane e98 slot, NOT the
+      // European e10 ethanol blend. The picker must offer what the parser
+      // surfaces.
+      availableFuelTypes: [
+        FuelType.e5, FuelType.e98, FuelType.diesel,
+        FuelType.electric, FuelType.all,
+      ],
       policy: _mxPolicy,
       createService: _createMexico,
     ),

--- a/lib/features/station_services/mexico/mexico_station_service.dart
+++ b/lib/features/station_services/mexico/mexico_station_service.dart
@@ -32,14 +32,17 @@ import '../../../core/logging/error_logger.dart';
 ///   returns one `<place>` per station with `<name>`, `<cre_id>`, and
 ///   `<location><x/><y/></location>` (x = longitude, y = latitude).
 /// - `https://publicacionexterna.azurewebsites.net/publicaciones/prices`
-///   returns one `<place>` per station with one or more
-///   `<gas_price type="regular|premium|diesel">` children. Prices
-///   are Mexican pesos per litre.
+///   returns one or more `<place>` per station with
+///   `<gas_price type="regular|premium|diesel">` DIRECT children (verified
+///   #2704: 37 021/37 021 are direct, none nested under `<location>`). MXN/L.
 ///
 /// Both feeds are joined client-side by `place_id` to produce
 /// fully-populated [Station] records. The merged list is cached for
 /// 4 hours — the CRE dataset updates several times daily but rarely
 /// faster than that.
+///
+/// #2704 — grades map regular→e5, premium→e98 (high-octane, not the
+/// non-existent-in-MX e10), diesel→diesel. No brand/address in either feed.
 class MexicoStationService
     with StationServiceHelpers, CachedDatasetMixin
     implements StationService {
@@ -69,7 +72,11 @@ class MexicoStationService
             : PersistentDataset<List<_CreStation>>(
                 cache: cache,
                 countryCode: 'MX',
-                datasetName: 'stations',
+                // #2704 — bumped from 'stations' to 'stations.v2' so warm
+                // devices holding the pre-fix merged cache (truncated names,
+                // premium-in-e10) read-miss and re-pull immediately, instead
+                // of waiting out the 24-hour hard TTL.
+                datasetName: 'stations.v2',
                 source: ServiceSource.mexicoApi,
                 serialize: (stations) =>
                     {'stations': stations.map((s) => s.toJson()).toList()},
@@ -106,18 +113,27 @@ class MexicoStationService
       for (final c in cached) {
         final dist = distanceKm(params.lat, params.lng, c.lat, c.lng);
         if (dist > params.radiusKm) continue;
+        // #2704 — CRE's <name> is the operator's full company name
+        // ("TRENOGAS SA DE CV"), NOT a brand, with no brand/address field.
+        // `name.split(' ').first` used to truncate it to a fragment. Keep
+        // `brand` empty and mirror the full name into name + street so the
+        // card's hasBrand==false branch (station_card_status.dart:57/76, the
+        // #2161 fallback) shows the full name and collapses the empty
+        // postCode/place line — no fragment, no orphan comma. Grade mapping
+        // (option A, ARB-free): regular→e5, premium→e98 (high-octane, not the
+        // non-existent-in-MX e10), diesel→diesel. Labels = follow-up #2717.
         stations.add(Station(
           id: 'mx-${c.id}',
           name: c.name,
-          brand: c.name.split(' ').first,
-          street: '',
+          brand: '',
+          street: c.name,
           postCode: '',
           place: '',
           lat: c.lat,
           lng: c.lng,
           dist: dist,
           e5: c.regular,
-          e10: c.premium,
+          e98: c.premium,
           diesel: c.diesel,
           isOpen: true,
         ));
@@ -229,8 +245,10 @@ class MexicoStationService
     final out = <String, _CrePlace>{};
     for (final node in doc.findAllElements('place')) {
       try {
-        final id = node.getAttribute('place_id');
-        if (id == null) continue;
+        // #2704 — trim the join key on both feeds so a stray space never
+        // breaks the place↔price join.
+        final id = node.getAttribute('place_id')?.trim();
+        if (id == null || id.isEmpty) continue;
         final name =
             node.findElements('name').firstOrNull?.innerText.trim() ?? '';
         final location = node.findElements('location').firstOrNull;
@@ -256,9 +274,19 @@ class MexicoStationService
     final out = <String, _CrePrices>{};
     for (final node in doc.findAllElements('place')) {
       try {
-        final id = node.getAttribute('place_id');
-        if (id == null) continue;
-        double? regular, premium, diesel;
+        // #2704 — trim the join key: the prices feed splits a single
+        // station's grades across MULTIPLE <place> blocks with the SAME
+        // place_id (1 577 of ~14 k stations on the live feed). The previous
+        // `out[id] = _CrePrices(...)` did last-wins, so a station whose
+        // regular was in block A and premium in block B kept only B's grades
+        // and dropped the rest → "--" prices. Accumulate across blocks
+        // instead, keeping whatever each duplicate contributes.
+        final id = node.getAttribute('place_id')?.trim();
+        if (id == null || id.isEmpty) continue;
+        final prev = out[id];
+        double? regular = prev?.regular,
+            premium = prev?.premium,
+            diesel = prev?.diesel;
         for (final gp in node.findElements('gas_price')) {
           final type = gp.getAttribute('type');
           final value = double.tryParse(gp.innerText.trim());

--- a/test/core/country/country_fuel_parity_test.dart
+++ b/test/core/country/country_fuel_parity_test.dart
@@ -119,16 +119,20 @@ void main() {
       }
     });
 
-    test('regression: Mexico offers e10 (premium grade) not e98 (#2180)', () {
-      // MexicoStationService maps CRE "premium" onto Station.e10, never
-      // e98, so the picker offering e98 was a dead, unsearchable option.
-      expect(Countries.mexico.supportedFuelTypes, contains(FuelType.e10));
+    test('regression: Mexico offers e98 (premium grade) not e10 (#2704)', () {
+      // #2704 — MexicoStationService maps CRE "premium" (Mexico's
+      // high-octane 91–92 grade) onto Station.e98, never e10 (a European
+      // ethanol blend that does not exist in Mexico). The picker must offer
+      // e98 and must NOT offer e10, otherwise it surfaces an unsearchable
+      // grade and hides the one premium prices actually populate.
+      expect(Countries.mexico.supportedFuelTypes, contains(FuelType.e98));
       expect(
         Countries.mexico.supportedFuelTypes,
-        isNot(contains(FuelType.e98)),
-        reason: 'MX premium grade lands in the e10 slot, not e98',
+        isNot(contains(FuelType.e10)),
+        reason: 'MX premium grade lands in the e98 slot, not e10',
       );
-      expect(registrySet('MX'), contains(FuelType.e10));
+      expect(registrySet('MX'), contains(FuelType.e98));
+      expect(registrySet('MX'), isNot(contains(FuelType.e10)));
     });
 
     test('regression: Denmark offers e10 in BOTH structures (#2180)', () {

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -39,6 +39,42 @@ void main() {
       expect(find.textContaining('10115'), findsOneWidget);
     });
 
+    testWidgets(
+        'brand-less CRE station shows full name as title and NO orphan '
+        'comma in the address line (#2704)', (tester) async {
+      // #2704 — Mexican CRE stations carry no brand and no address: the
+      // service sets brand:'' and mirrors the full company name into both
+      // name and street, leaving postCode/place empty. The card's
+      // hasBrand==false branch must render the full name as the title and
+      // collapse the address line to blank — never a lone ", ".
+      const mxStation = Station(
+        id: 'mx-11702',
+        name: 'TRENOGAS SA DE CV',
+        brand: '',
+        street: 'TRENOGAS SA DE CV',
+        postCode: '',
+        place: '',
+        lat: 19.43,
+        lng: -99.13,
+        dist: 2.7,
+        e5: 22.95,
+        e98: 24.89,
+        diesel: 23.45,
+        isOpen: true,
+      );
+      await pumpApp(
+        tester,
+        const StationCard(station: mxStation, selectedFuelType: FuelType.e5),
+      );
+
+      expect(find.text('TRENOGAS SA DE CV'), findsOneWidget,
+          reason: 'full company name is the card title');
+      // The address line collapses to '' (postCode + place both empty);
+      // there must be no orphan comma anywhere on the card.
+      expect(find.text(', '), findsNothing);
+      expect(find.text(','), findsNothing);
+    });
+
     testWidgets('renders price for selected fuel type', (tester) async {
       await pumpApp(
         tester,

--- a/test/features/station_services/italy_mexico_persisted_dataset_test.dart
+++ b/test/features/station_services/italy_mexico_persisted_dataset_test.dart
@@ -201,7 +201,8 @@ void main() {
 
       expect(result.data, isNotEmpty);
       expect(result.data.first.e5, 22.95);
-      expect(cache.get(PersistentDataset.datasetKey('MX', 'stations')),
+      // #2704 — datasetName bumped to 'stations.v2' to evict pre-fix caches.
+      expect(cache.get(PersistentDataset.datasetKey('MX', 'stations.v2')),
           isNotNull,
           reason: 'MX dataset must be persisted to the shared cache');
     });
@@ -223,7 +224,9 @@ void main() {
       expect(s.id, 'mx-11702');
       expect(s.name, 'Gasolinera Centro');
       expect(s.e5, 22.95);
-      expect(s.e10, 24.89);
+      // #2704 — CRE premium maps to e98 (high-octane), not e10.
+      expect(s.e98, 24.89);
+      expect(s.e10, isNull);
       expect(s.diesel, 23.45);
     });
 

--- a/test/features/station_services/mexico/mexico_station_service_test.dart
+++ b/test/features/station_services/mexico/mexico_station_service_test.dart
@@ -152,10 +152,17 @@ void main() {
   });
 
   group('searchStations (CRE azure feeds — #505 fix)', () {
-    test('fetches /places and /prices and joins by place_id', () async {
+    test(
+        'fetches /places and /prices and joins by place_id '
+        '(full name, e5/e98/diesel — #2704)', () async {
+      // #2704 — REAL CRE <name> is the operator's full company name with no
+      // brand field; the field bug truncated "TRENOGAS SA DE CV" to a
+      // fragment. Assert the FULL name survives and lands in name + street
+      // (card title fallback), brand stays empty, and CRE
+      // regular/premium/diesel map to e5/e98/diesel — NOT e5/e10.
       final service = _serviceWith(
         placesXml: _placesXml([
-          (id: '11702', name: 'Gasolinera Centro', x: -99.13, y: 19.43),
+          (id: '11702', name: 'TRENOGAS SA DE CV', x: -99.13, y: 19.43),
         ]),
         pricesXml: _pricesXml([
           (id: '11702', regular: 22.95, premium: 24.89, diesel: 23.45),
@@ -167,12 +174,19 @@ void main() {
       expect(result.data, hasLength(1));
       final s = result.data.first;
       expect(s.id, 'mx-11702');
-      expect(s.name, 'Gasolinera Centro');
-      expect(s.brand, 'Gasolinera');
+      expect(s.name, 'TRENOGAS SA DE CV',
+          reason: 'full CRE company name, never the first-token fragment');
+      expect(s.brand, '', reason: 'CRE has no brand field');
+      expect(s.street, 'TRENOGAS SA DE CV',
+          reason: 'name mirrored into street so the card title shows it '
+              'via the hasBrand==false fallback');
+      expect(s.postCode, '');
+      expect(s.place, '');
       expect(s.lat, 19.43);
       expect(s.lng, closeTo(-99.13, 0.0001));
-      expect(s.e5, 22.95);
-      expect(s.e10, 24.89);
+      expect(s.e5, 22.95, reason: 'CRE regular → e5');
+      expect(s.e98, 24.89, reason: 'CRE premium → e98 (high-octane), not e10');
+      expect(s.e10, isNull, reason: 'no European e10 grade in Mexico');
       expect(s.diesel, 23.45);
       expect(s.isOpen, isTrue);
     });
@@ -368,6 +382,91 @@ void main() {
         firstCount,
         reason: 'second search within TTL must NOT hit the network',
       );
+    });
+
+    test(
+        'merges grades split across DUPLICATE place_id blocks — the real '
+        'CRE /prices shape, decisive "no prices" guard (#2704)', () async {
+      // #2704 — the LIVE CRE /prices feed splits a single station's grades
+      // across multiple <place place_id="X"> blocks (1 577 of ~14 k
+      // stations). The old `out[id] = _CrePrices(...)` was last-wins, so a
+      // station whose regular sat in block A and premium in block B kept
+      // only block B and rendered "--" for the rest. This fixture reproduces
+      // that exact shape — regular alone in block 1, premium+diesel in
+      // block 2. On master the merge drops regular (RED: s.e5 == null);
+      // after the accumulate-across-blocks fix all three survive.
+      const splitPrices = '<?xml version="1.0" encoding="utf-8"?>\n'
+          '<places>'
+          '<place place_id="11702">'
+          '<gas_price type="regular">22.95</gas_price>'
+          '</place>'
+          '<place place_id="11702">'
+          '<gas_price type="premium">24.89</gas_price>'
+          '<gas_price type="diesel">23.45</gas_price>'
+          '</place>'
+          '</places>';
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '11702', name: 'TRENOGAS SA DE CV', x: -99.13, y: 19.43),
+        ]),
+        pricesXml: splitPrices,
+      );
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(1));
+      final s = result.data.first;
+      expect(s.e5, 22.95,
+          reason: 'regular from the FIRST duplicate block must survive');
+      expect(s.e98, 24.89, reason: 'premium → e98');
+      expect(s.diesel, 23.45);
+    });
+
+    test('joins on a place_id with surrounding whitespace (#2704)', () async {
+      // Defensive: trim the join key on both feeds so a stray space never
+      // collapses prices to "--".
+      const placesWs = '<?xml version="1.0" encoding="utf-8"?>\n'
+          '<places>'
+          '<place place_id=" 11702 ">'
+          '<name>TRENOGAS SA DE CV</name>'
+          '<location><x>-99.13</x><y>19.43</y></location>'
+          '</place>'
+          '</places>';
+      const pricesWs = '<?xml version="1.0" encoding="utf-8"?>\n'
+          '<places>'
+          '<place place_id="11702">'
+          '<gas_price type="regular">22.95</gas_price>'
+          '</place>'
+          '</places>';
+      final service = _serviceWith(placesXml: placesWs, pricesXml: pricesWs);
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(1));
+      expect(result.data.first.e5, 22.95);
+    });
+
+    test(
+        'distance is computed from the search center, not zero — a station '
+        '~5 km away reports dist ~5 (#2704 "0 m" service-layer guard)',
+        () async {
+      // #2704 — the field "0 m" for every station does NOT originate in this
+      // service: it parses x→lng / y→lat correctly and computes the haversine
+      // from params.lat/lng. This guards that fact — a place ~5 km north of
+      // the search center reports a non-zero ~5 km distance. (The remaining
+      // "0 m" reproduction lives in the search-center wiring, NOT here; see
+      // the PR body.)
+      // 0.045° of latitude ≈ 5.0 km.
+      final service = _serviceWith(
+        placesXml: _placesXml([
+          (id: '1', name: 'NORTE SA DE CV', x: -99.13, y: 19.475),
+        ]),
+        pricesXml: _pricesXml([
+          (id: '1', regular: 22.0, premium: null, diesel: null),
+        ]),
+      );
+      final result = await service.searchStations(_cdmxParams);
+      expect(result.data, hasLength(1));
+      final d = result.data.first.dist;
+      expect(d, greaterThan(0), reason: 'never collapses to 0 m');
+      expect(d, closeTo(5.0, 0.5),
+          reason: 'haversine from the search center, ~5 km north');
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -64,7 +64,12 @@ void main() {
     // refactored to delegate to it. Fixes the FR-shadows-Catalonia bbox bug
     // that left cross-border routes with zero Spanish stations. Decomposition
     // of this registry is tracked separately by #2187/#2188.
-    'lib/core/services/country_service_registry.dart': 909,
+    // #2704 — re-grandfathered 909 → 916: MX's availableFuelTypes was made
+    // explicit ([e5, e98, diesel, electric, all]) instead of _defaultFuelTypes
+    // (which carries the wrong e10), with a 4-line rationale comment. Premium
+    // is MX's high-octane grade, not the European e10 blend. Decomposition of
+    // this registry is tracked separately by #2187/#2188.
+    'lib/core/services/country_service_registry.dart': 916,
     'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
     // #2456 — re-grandfathered 457 → 481: two new pure parsers,


### PR DESCRIPTION
The Mexican list showed fragment names, lone-comma addresses, "0 m", E5/E10 labels, "--" prices. Verified against the **live CRE feeds**:
- **Name**: `name.split(' ').first` truncated the full company name → brand:'' + full name via brand→name→street (#2161).
- **Address**: CRE has no address field → name as title, no orphan comma.
- **Prices "--" (decisive)**: the `/prices` feed splits a station's grades across **multiple `<place place_id="X">` blocks** (1,577 stations); last-wins dropped grades → accumulate across duplicate-id blocks. (The `findAllElements` nesting hypothesis was **false** — 37,021/37,021 `<gas_price>` are direct children.)
- **Fuel grades**: regular→e5, premium→**e98** (not e10), diesel; MX registry/config → {e5,e98,diesel,electric}. Real Magna/Premium labels = follow-up **#2717**.
- **Cache**: datasetName→`stations.v2` so warm devices re-pull.
- **"0 m"**: scoped out (the MX search-center geocoding is a separate subsystem) with an isolating test proving the service computes distance correctly.

ARB-free; verified clean codegen + zero l10n drift; analyze clean. Closes #2704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)