### PR TITLE
feat(opening-hours): common WeeklyOpeningHours model + adapter interface + legacy bridge (Epic #2707 C1)

### DIFF
--- a/lib/core/services/station_service_chain_codec.dart
+++ b/lib/core/services/station_service_chain_codec.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import '../../core/logging/error_logger.dart';
 import '../../features/search/domain/entities/station.dart';
+import '../../features/station_detail/domain/opening_hours.dart';
 import 'station_service.dart';
 
 /// JSON-safe (de)serialization helpers for the [StationServiceChain] cache
@@ -42,6 +43,9 @@ Map<String, dynamic> serializeStationDetail(StationDetail detail) => {
       'overrides': detail.overrides,
       'wholeDay': detail.wholeDay,
       'state': detail.state,
+      // #2708 — round-trip the structured opening hours (null when no
+      // adapter has run yet; the legacy fields above carry the fallback).
+      'openingHours': detail.openingHours?.toJson(),
     };
 
 StationDetail? deserializeStationDetail(Map<String, dynamic> data) {
@@ -50,6 +54,7 @@ StationDetail? deserializeStationDetail(Map<String, dynamic> data) {
     if (stationJson == null) return null;
 
     final otList = data['openingTimes'] as List<dynamic>? ?? [];
+    final ohJson = data['openingHours'];
     return StationDetail(
       station: Station.fromJson(stationJson),
       openingTimes: otList
@@ -58,6 +63,11 @@ StationDetail? deserializeStationDetail(Map<String, dynamic> data) {
       overrides: List<String>.from(data['overrides'] as List? ?? []),
       wholeDay: data['wholeDay'] as bool? ?? false,
       state: data['state'] as String?,
+      // #2708 — older cache entries (pre-field) have no key → null, which
+      // round-trips cleanly to the back-compat legacy fallback.
+      openingHours: ohJson is Map
+          ? WeeklyOpeningHours.fromJson(Map<String, dynamic>.from(ohJson))
+          : null,
     );
     // #2296 — catch Object (TypeError from a bad cast on a corrupt /
     // older-schema entry is an Error, not an Exception) so a corrupt cache

--- a/lib/features/search/domain/entities/station.dart
+++ b/lib/features/search/domain/entities/station.dart
@@ -3,6 +3,7 @@
 
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../../../station_detail/domain/opening_hours.dart';
 import 'station_amenity.dart';
 
 part 'station.freezed.dart';
@@ -79,6 +80,12 @@ abstract class StationDetail with _$StationDetail {
     @Default([]) List<String> overrides,
     @Default(false) bool wholeDay,
     String? state,
+    // Epic C1 (#2708) — structured opening hours from a per-country
+    // [OpeningHoursAdapter]. ADDITIVE: the legacy `Station.is24h` /
+    // `openingHoursText` and this entity's `openingTimes` / `wholeDay` stay
+    // for back-compat; until a country's adapter lands this is null and the
+    // display layer falls back through `legacyOpeningHoursBridge`.
+    WeeklyOpeningHours? openingHours,
   }) = _StationDetail;
 }
 

--- a/lib/features/search/domain/entities/station.freezed.dart
+++ b/lib/features/search/domain/entities/station.freezed.dart
@@ -389,7 +389,12 @@ as Set<StationAmenity>,
 /// @nodoc
 mixin _$StationDetail {
 
- Station get station; List<OpeningTime> get openingTimes; List<String> get overrides; bool get wholeDay; String? get state;
+ Station get station; List<OpeningTime> get openingTimes; List<String> get overrides; bool get wholeDay; String? get state;// Epic C1 (#2708) — structured opening hours from a per-country
+// [OpeningHoursAdapter]. ADDITIVE: the legacy `Station.is24h` /
+// `openingHoursText` and this entity's `openingTimes` / `wholeDay` stay
+// for back-compat; until a country's adapter lands this is null and the
+// display layer falls back through `legacyOpeningHoursBridge`.
+ WeeklyOpeningHours? get openingHours;
 /// Create a copy of StationDetail
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -400,16 +405,16 @@ $StationDetailCopyWith<StationDetail> get copyWith => _$StationDetailCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is StationDetail&&(identical(other.station, station) || other.station == station)&&const DeepCollectionEquality().equals(other.openingTimes, openingTimes)&&const DeepCollectionEquality().equals(other.overrides, overrides)&&(identical(other.wholeDay, wholeDay) || other.wholeDay == wholeDay)&&(identical(other.state, state) || other.state == state));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is StationDetail&&(identical(other.station, station) || other.station == station)&&const DeepCollectionEquality().equals(other.openingTimes, openingTimes)&&const DeepCollectionEquality().equals(other.overrides, overrides)&&(identical(other.wholeDay, wholeDay) || other.wholeDay == wholeDay)&&(identical(other.state, state) || other.state == state)&&(identical(other.openingHours, openingHours) || other.openingHours == openingHours));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,station,const DeepCollectionEquality().hash(openingTimes),const DeepCollectionEquality().hash(overrides),wholeDay,state);
+int get hashCode => Object.hash(runtimeType,station,const DeepCollectionEquality().hash(openingTimes),const DeepCollectionEquality().hash(overrides),wholeDay,state,openingHours);
 
 @override
 String toString() {
-  return 'StationDetail(station: $station, openingTimes: $openingTimes, overrides: $overrides, wholeDay: $wholeDay, state: $state)';
+  return 'StationDetail(station: $station, openingTimes: $openingTimes, overrides: $overrides, wholeDay: $wholeDay, state: $state, openingHours: $openingHours)';
 }
 
 
@@ -420,11 +425,11 @@ abstract mixin class $StationDetailCopyWith<$Res>  {
   factory $StationDetailCopyWith(StationDetail value, $Res Function(StationDetail) _then) = _$StationDetailCopyWithImpl;
 @useResult
 $Res call({
- Station station, List<OpeningTime> openingTimes, List<String> overrides, bool wholeDay, String? state
+ Station station, List<OpeningTime> openingTimes, List<String> overrides, bool wholeDay, String? state, WeeklyOpeningHours? openingHours
 });
 
 
-$StationCopyWith<$Res> get station;
+$StationCopyWith<$Res> get station;$WeeklyOpeningHoursCopyWith<$Res>? get openingHours;
 
 }
 /// @nodoc
@@ -437,14 +442,15 @@ class _$StationDetailCopyWithImpl<$Res>
 
 /// Create a copy of StationDetail
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? station = null,Object? openingTimes = null,Object? overrides = null,Object? wholeDay = null,Object? state = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? station = null,Object? openingTimes = null,Object? overrides = null,Object? wholeDay = null,Object? state = freezed,Object? openingHours = freezed,}) {
   return _then(_self.copyWith(
 station: null == station ? _self.station : station // ignore: cast_nullable_to_non_nullable
 as Station,openingTimes: null == openingTimes ? _self.openingTimes : openingTimes // ignore: cast_nullable_to_non_nullable
 as List<OpeningTime>,overrides: null == overrides ? _self.overrides : overrides // ignore: cast_nullable_to_non_nullable
 as List<String>,wholeDay: null == wholeDay ? _self.wholeDay : wholeDay // ignore: cast_nullable_to_non_nullable
 as bool,state: freezed == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
+as WeeklyOpeningHours?,
   ));
 }
 /// Create a copy of StationDetail
@@ -455,6 +461,18 @@ $StationCopyWith<$Res> get station {
   
   return $StationCopyWith<$Res>(_self.station, (value) {
     return _then(_self.copyWith(station: value));
+  });
+}/// Create a copy of StationDetail
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$WeeklyOpeningHoursCopyWith<$Res>? get openingHours {
+    if (_self.openingHours == null) {
+    return null;
+  }
+
+  return $WeeklyOpeningHoursCopyWith<$Res>(_self.openingHours!, (value) {
+    return _then(_self.copyWith(openingHours: value));
   });
 }
 }
@@ -538,10 +556,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Station station,  List<OpeningTime> openingTimes,  List<String> overrides,  bool wholeDay,  String? state)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Station station,  List<OpeningTime> openingTimes,  List<String> overrides,  bool wholeDay,  String? state,  WeeklyOpeningHours? openingHours)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _StationDetail() when $default != null:
-return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,_that.state);case _:
+return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,_that.state,_that.openingHours);case _:
   return orElse();
 
 }
@@ -559,10 +577,10 @@ return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Station station,  List<OpeningTime> openingTimes,  List<String> overrides,  bool wholeDay,  String? state)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Station station,  List<OpeningTime> openingTimes,  List<String> overrides,  bool wholeDay,  String? state,  WeeklyOpeningHours? openingHours)  $default,) {final _that = this;
 switch (_that) {
 case _StationDetail():
-return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,_that.state);case _:
+return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,_that.state,_that.openingHours);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -579,10 +597,10 @@ return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Station station,  List<OpeningTime> openingTimes,  List<String> overrides,  bool wholeDay,  String? state)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Station station,  List<OpeningTime> openingTimes,  List<String> overrides,  bool wholeDay,  String? state,  WeeklyOpeningHours? openingHours)?  $default,) {final _that = this;
 switch (_that) {
 case _StationDetail() when $default != null:
-return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,_that.state);case _:
+return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,_that.state,_that.openingHours);case _:
   return null;
 
 }
@@ -594,7 +612,7 @@ return $default(_that.station,_that.openingTimes,_that.overrides,_that.wholeDay,
 
 
 class _StationDetail implements StationDetail {
-  const _StationDetail({required this.station, final  List<OpeningTime> openingTimes = const [], final  List<String> overrides = const [], this.wholeDay = false, this.state}): _openingTimes = openingTimes,_overrides = overrides;
+  const _StationDetail({required this.station, final  List<OpeningTime> openingTimes = const [], final  List<String> overrides = const [], this.wholeDay = false, this.state, this.openingHours}): _openingTimes = openingTimes,_overrides = overrides;
   
 
 @override final  Station station;
@@ -614,6 +632,12 @@ class _StationDetail implements StationDetail {
 
 @override@JsonKey() final  bool wholeDay;
 @override final  String? state;
+// Epic C1 (#2708) — structured opening hours from a per-country
+// [OpeningHoursAdapter]. ADDITIVE: the legacy `Station.is24h` /
+// `openingHoursText` and this entity's `openingTimes` / `wholeDay` stay
+// for back-compat; until a country's adapter lands this is null and the
+// display layer falls back through `legacyOpeningHoursBridge`.
+@override final  WeeklyOpeningHours? openingHours;
 
 /// Create a copy of StationDetail
 /// with the given fields replaced by the non-null parameter values.
@@ -625,16 +649,16 @@ _$StationDetailCopyWith<_StationDetail> get copyWith => __$StationDetailCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StationDetail&&(identical(other.station, station) || other.station == station)&&const DeepCollectionEquality().equals(other._openingTimes, _openingTimes)&&const DeepCollectionEquality().equals(other._overrides, _overrides)&&(identical(other.wholeDay, wholeDay) || other.wholeDay == wholeDay)&&(identical(other.state, state) || other.state == state));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _StationDetail&&(identical(other.station, station) || other.station == station)&&const DeepCollectionEquality().equals(other._openingTimes, _openingTimes)&&const DeepCollectionEquality().equals(other._overrides, _overrides)&&(identical(other.wholeDay, wholeDay) || other.wholeDay == wholeDay)&&(identical(other.state, state) || other.state == state)&&(identical(other.openingHours, openingHours) || other.openingHours == openingHours));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,station,const DeepCollectionEquality().hash(_openingTimes),const DeepCollectionEquality().hash(_overrides),wholeDay,state);
+int get hashCode => Object.hash(runtimeType,station,const DeepCollectionEquality().hash(_openingTimes),const DeepCollectionEquality().hash(_overrides),wholeDay,state,openingHours);
 
 @override
 String toString() {
-  return 'StationDetail(station: $station, openingTimes: $openingTimes, overrides: $overrides, wholeDay: $wholeDay, state: $state)';
+  return 'StationDetail(station: $station, openingTimes: $openingTimes, overrides: $overrides, wholeDay: $wholeDay, state: $state, openingHours: $openingHours)';
 }
 
 
@@ -645,11 +669,11 @@ abstract mixin class _$StationDetailCopyWith<$Res> implements $StationDetailCopy
   factory _$StationDetailCopyWith(_StationDetail value, $Res Function(_StationDetail) _then) = __$StationDetailCopyWithImpl;
 @override @useResult
 $Res call({
- Station station, List<OpeningTime> openingTimes, List<String> overrides, bool wholeDay, String? state
+ Station station, List<OpeningTime> openingTimes, List<String> overrides, bool wholeDay, String? state, WeeklyOpeningHours? openingHours
 });
 
 
-@override $StationCopyWith<$Res> get station;
+@override $StationCopyWith<$Res> get station;@override $WeeklyOpeningHoursCopyWith<$Res>? get openingHours;
 
 }
 /// @nodoc
@@ -662,14 +686,15 @@ class __$StationDetailCopyWithImpl<$Res>
 
 /// Create a copy of StationDetail
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? station = null,Object? openingTimes = null,Object? overrides = null,Object? wholeDay = null,Object? state = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? station = null,Object? openingTimes = null,Object? overrides = null,Object? wholeDay = null,Object? state = freezed,Object? openingHours = freezed,}) {
   return _then(_StationDetail(
 station: null == station ? _self.station : station // ignore: cast_nullable_to_non_nullable
 as Station,openingTimes: null == openingTimes ? _self._openingTimes : openingTimes // ignore: cast_nullable_to_non_nullable
 as List<OpeningTime>,overrides: null == overrides ? _self._overrides : overrides // ignore: cast_nullable_to_non_nullable
 as List<String>,wholeDay: null == wholeDay ? _self.wholeDay : wholeDay // ignore: cast_nullable_to_non_nullable
 as bool,state: freezed == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
+as WeeklyOpeningHours?,
   ));
 }
 
@@ -681,6 +706,18 @@ $StationCopyWith<$Res> get station {
   
   return $StationCopyWith<$Res>(_self.station, (value) {
     return _then(_self.copyWith(station: value));
+  });
+}/// Create a copy of StationDetail
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$WeeklyOpeningHoursCopyWith<$Res>? get openingHours {
+    if (_self.openingHours == null) {
+    return null;
+  }
+
+  return $WeeklyOpeningHoursCopyWith<$Res>(_self.openingHours!, (value) {
+    return _then(_self.copyWith(openingHours: value));
   });
 }
 }

--- a/lib/features/station_detail/domain/legacy_opening_hours_bridge.dart
+++ b/lib/features/station_detail/domain/legacy_opening_hours_bridge.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../search/domain/entities/station.dart';
+import 'opening_hours.dart';
+
+/// Synthesises a [WeeklyOpeningHours] from a [StationDetail]'s *legacy*
+/// opening-hours fields (`Station.is24h` + `StationDetail.openingTimes`).
+///
+/// This is the migration bridge (Epic C1): country services that have not
+/// yet shipped a dedicated [opening-hours adapter] keep populating only the
+/// legacy fields, and the display layer (C2) can still render a structured
+/// schedule via this synthesiser — so no country regresses before its
+/// adapter lands.
+///
+/// Mapping, in priority order:
+///   1. If [StationDetail.openingHours] is already populated (an adapter ran)
+///      and is not the no-data sentinel, it is returned unchanged.
+///   2. `Station.is24h == true` → all seven regular weekdays [DayState.open24h]
+///      ([WeeklyOpeningHours.allWeek24h], availability `full`).
+///   3. Non-empty `openingTimes` → each parseable `start`/`end` becomes a
+///      [TimeRange] applied to every regular weekday. The legacy
+///      `OpeningTime.text` label is free-form / localized and not reliably
+///      day-tagged across countries, so the bridge deliberately does **not**
+///      try to map it to specific weekdays — it produces a best-effort
+///      whole-week schedule flagged [OpeningHoursAvailability.partial].
+///   4. Otherwise → [WeeklyOpeningHours.notAvailable].
+///
+/// Pure and total — never throws, never returns `null`.
+WeeklyOpeningHours legacyOpeningHoursBridge(StationDetail detail) {
+  final existing = detail.openingHours;
+  if (existing != null &&
+      existing.availability != OpeningHoursAvailability.notProvided) {
+    return existing;
+  }
+
+  if (detail.station.is24h) {
+    return WeeklyOpeningHours.allWeek24h();
+  }
+
+  final ranges = <TimeRange>[];
+  for (final ot in detail.openingTimes) {
+    final start = _minutesFromClock(ot.start);
+    final end = _minutesFromClock(ot.end);
+    if (start == null || end == null) continue;
+    ranges.add(TimeRange(startMinutes: start, endMinutes: end));
+  }
+
+  if (ranges.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+  return WeeklyOpeningHours(
+    days: [
+      for (final day in kRegularWeekdays)
+        DayHours(day: day, state: DayState.openRanges, ranges: ranges),
+    ],
+    availability: OpeningHoursAvailability.partial,
+  );
+}
+
+/// Parses a legacy `HH:mm` or `HH:mm:ss` clock string into minutes-from
+/// -midnight (0..1439), or `null` when it cannot be parsed. Never throws.
+int? _minutesFromClock(String clock) {
+  final parts = clock.split(':');
+  if (parts.length < 2) return null;
+  final hour = int.tryParse(parts[0]);
+  final minute = int.tryParse(parts[1]);
+  if (hour == null || minute == null) return null;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return hour * 60 + minute;
+}

--- a/lib/features/station_detail/domain/open_now.dart
+++ b/lib/features/station_detail/domain/open_now.dart
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'opening_hours.dart';
+
+part 'open_now.freezed.dart';
+
+/// Whether a station is open right now.
+enum OpenStatus { open, closed, unknown }
+
+/// The result of [computeOpenNow]: the current [status] and — when known —
+/// the next state change.
+///
+/// [nextChangeDay] / [nextChangeMinutes] describe the next transition:
+/// when [status] is [OpenStatus.open] they are the day + minute the station
+/// *closes*; when [OpenStatus.closed] they are when it next *opens*. Both
+/// are `null` when there is no determinable next change (e.g. 24/7, or
+/// [OpenStatus.unknown]).
+@freezed
+abstract class OpenNowStatus with _$OpenNowStatus {
+  const factory OpenNowStatus({
+    required OpenStatus status,
+    OpeningDay? nextChangeDay,
+    int? nextChangeMinutes,
+  }) = _OpenNowStatus;
+
+  /// "Open, no determinable next close" — e.g. a 24/7 station.
+  static const OpenNowStatus open = OpenNowStatus(status: OpenStatus.open);
+
+  /// "We don't know" — the schedule was [DayState.unknown] / not provided.
+  static const OpenNowStatus unknown =
+      OpenNowStatus(status: OpenStatus.unknown);
+}
+
+const int _minutesPerDay = 24 * 60;
+
+/// Computes whether [hours] is open at the wall-clock instant [now].
+///
+/// Pure — pass [now] in (never reads `DateTime.now()`) so it is fully
+/// unit-testable. Handles:
+///   - whole-station / per-day [DayState.open24h] → open;
+///   - multi-interval days;
+///   - intervals that **wrap past midnight** (a `22:00-04:00` range is open
+///     at `02:00` the *next* day — checked via yesterday's wrapping ranges);
+///   - [DayState.unknown] / no-data → [OpenStatus.unknown];
+///   - [TimeRange.isDegenerate] ranges are ignored (FR `01:00-01:00`).
+///
+/// Public holidays are *not* auto-detected here (the model carries no
+/// calendar); a caller that knows today is a holiday can resolve the
+/// `PH` day itself. This uses [now]'s ISO weekday for the regular cycle.
+OpenNowStatus computeOpenNow(WeeklyOpeningHours hours, DateTime now) {
+  if (hours.availability == OpeningHoursAvailability.notProvided &&
+      hours.days.isEmpty) {
+    return OpenNowStatus.unknown;
+  }
+
+  final today = openingDayFromIsoWeekday(now.weekday);
+  final todayHours = hours.dayFor(today);
+  final nowMinutes = now.hour * 60 + now.minute;
+
+  // 1. A range from *yesterday* that wraps past midnight may still cover now.
+  final yesterday = _previousDay(today);
+  final yHours = hours.dayFor(yesterday);
+  if (yHours != null && yHours.state == DayState.openRanges) {
+    for (final r in yHours.ranges) {
+      if (r.isDegenerate) continue;
+      if (r.wrapsPastMidnight && nowMinutes < r.endMinutes) {
+        // Still inside yesterday's overnight interval; closes today at end.
+        return OpenNowStatus(
+          status: OpenStatus.open,
+          nextChangeDay: today,
+          nextChangeMinutes: r.endMinutes,
+        );
+      }
+    }
+  }
+
+  // 2. Today's own state.
+  if (todayHours == null || todayHours.state == DayState.unknown) {
+    // No signal for today, but yesterday's wrap didn't cover us → unknown
+    // only if the whole schedule is unknown; otherwise treat as closed and
+    // search forward for the next opening.
+    if (_allUnknown(hours)) return OpenNowStatus.unknown;
+    return _findNextOpening(hours, today, nowMinutes);
+  }
+
+  switch (todayHours.state) {
+    case DayState.open24h:
+      return OpenNowStatus.open;
+    case DayState.closed:
+      return _findNextOpening(hours, today, nowMinutes);
+    case DayState.unknown:
+      if (_allUnknown(hours)) return OpenNowStatus.unknown;
+      return _findNextOpening(hours, today, nowMinutes);
+    case DayState.openRanges:
+      for (final r in todayHours.ranges) {
+        if (r.isDegenerate) continue;
+        if (r.wrapsPastMidnight) {
+          // Open from start through midnight; if now >= start we're open,
+          // closing on the *next* day at end.
+          if (nowMinutes >= r.startMinutes) {
+            return OpenNowStatus(
+              status: OpenStatus.open,
+              nextChangeDay: _nextDay(today),
+              nextChangeMinutes: r.endMinutes,
+            );
+          }
+        } else if (nowMinutes >= r.startMinutes &&
+            nowMinutes < r.endMinutes) {
+          return OpenNowStatus(
+            status: OpenStatus.open,
+            nextChangeDay: today,
+            nextChangeMinutes: r.endMinutes,
+          );
+        }
+      }
+      // Not inside any of today's ranges → closed; find the next opening.
+      return _findNextOpening(hours, today, nowMinutes);
+  }
+}
+
+/// True when no regular weekday carries a resolved state.
+bool _allUnknown(WeeklyOpeningHours hours) {
+  for (final d in kRegularWeekdays) {
+    final dh = hours.dayFor(d);
+    if (dh != null && dh.state != DayState.unknown) return false;
+  }
+  return true;
+}
+
+/// Searches forward up to 7 days for the next opening transition, returning
+/// an [OpenStatus.closed] result whose next-change points at that opening.
+/// Falls back to a bare closed (no next change) when nothing opens.
+OpenNowStatus _findNextOpening(
+  WeeklyOpeningHours hours,
+  OpeningDay today,
+  int nowMinutes,
+) {
+  for (var offset = 0; offset < kRegularWeekdays.length; offset++) {
+    final day = _dayAfter(today, offset);
+    final dh = hours.dayFor(day);
+    if (dh == null) continue;
+    if (dh.state == DayState.open24h) {
+      // A 24h day in the future: it "opens" at 00:00 of that day. For today
+      // (offset 0) we'd have returned open already, so offset>0 here.
+      return OpenNowStatus(
+        status: OpenStatus.closed,
+        nextChangeDay: day,
+        nextChangeMinutes: 0,
+      );
+    }
+    if (dh.state != DayState.openRanges) continue;
+    final starts = <int>[
+      for (final r in dh.ranges)
+        if (!r.isDegenerate) r.startMinutes,
+    ]..sort();
+    for (final start in starts) {
+      // On today, only future starts count.
+      if (offset == 0 && start <= nowMinutes) continue;
+      return OpenNowStatus(
+        status: OpenStatus.closed,
+        nextChangeDay: day,
+        nextChangeMinutes: start,
+      );
+    }
+  }
+  return const OpenNowStatus(status: OpenStatus.closed);
+}
+
+OpeningDay _previousDay(OpeningDay day) => _dayAfter(day, 6);
+
+OpeningDay _nextDay(OpeningDay day) => _dayAfter(day, 1);
+
+/// [day] advanced by [offset] regular weekdays (wrapping Mon..Sun). Ignores
+/// [OpeningDay.publicHoliday], which is not part of the cyclic week.
+OpeningDay _dayAfter(OpeningDay day, int offset) {
+  final idx = kRegularWeekdays.indexOf(day);
+  if (idx < 0) return day; // publicHoliday — not in the cycle.
+  return kRegularWeekdays[(idx + offset) % kRegularWeekdays.length];
+}
+
+/// Minutes in a day, exported for callers that format a next-change time.
+int get minutesPerDay => _minutesPerDay;

--- a/lib/features/station_detail/domain/open_now.freezed.dart
+++ b/lib/features/station_detail/domain/open_now.freezed.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'open_now.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$OpenNowStatus {
+
+ OpenStatus get status; OpeningDay? get nextChangeDay; int? get nextChangeMinutes;
+/// Create a copy of OpenNowStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$OpenNowStatusCopyWith<OpenNowStatus> get copyWith => _$OpenNowStatusCopyWithImpl<OpenNowStatus>(this as OpenNowStatus, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is OpenNowStatus&&(identical(other.status, status) || other.status == status)&&(identical(other.nextChangeDay, nextChangeDay) || other.nextChangeDay == nextChangeDay)&&(identical(other.nextChangeMinutes, nextChangeMinutes) || other.nextChangeMinutes == nextChangeMinutes));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,nextChangeDay,nextChangeMinutes);
+
+@override
+String toString() {
+  return 'OpenNowStatus(status: $status, nextChangeDay: $nextChangeDay, nextChangeMinutes: $nextChangeMinutes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $OpenNowStatusCopyWith<$Res>  {
+  factory $OpenNowStatusCopyWith(OpenNowStatus value, $Res Function(OpenNowStatus) _then) = _$OpenNowStatusCopyWithImpl;
+@useResult
+$Res call({
+ OpenStatus status, OpeningDay? nextChangeDay, int? nextChangeMinutes
+});
+
+
+
+
+}
+/// @nodoc
+class _$OpenNowStatusCopyWithImpl<$Res>
+    implements $OpenNowStatusCopyWith<$Res> {
+  _$OpenNowStatusCopyWithImpl(this._self, this._then);
+
+  final OpenNowStatus _self;
+  final $Res Function(OpenNowStatus) _then;
+
+/// Create a copy of OpenNowStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? nextChangeDay = freezed,Object? nextChangeMinutes = freezed,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as OpenStatus,nextChangeDay: freezed == nextChangeDay ? _self.nextChangeDay : nextChangeDay // ignore: cast_nullable_to_non_nullable
+as OpeningDay?,nextChangeMinutes: freezed == nextChangeMinutes ? _self.nextChangeMinutes : nextChangeMinutes // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [OpenNowStatus].
+extension OpenNowStatusPatterns on OpenNowStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _OpenNowStatus value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _OpenNowStatus() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _OpenNowStatus value)  $default,){
+final _that = this;
+switch (_that) {
+case _OpenNowStatus():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _OpenNowStatus value)?  $default,){
+final _that = this;
+switch (_that) {
+case _OpenNowStatus() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( OpenStatus status,  OpeningDay? nextChangeDay,  int? nextChangeMinutes)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _OpenNowStatus() when $default != null:
+return $default(_that.status,_that.nextChangeDay,_that.nextChangeMinutes);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( OpenStatus status,  OpeningDay? nextChangeDay,  int? nextChangeMinutes)  $default,) {final _that = this;
+switch (_that) {
+case _OpenNowStatus():
+return $default(_that.status,_that.nextChangeDay,_that.nextChangeMinutes);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( OpenStatus status,  OpeningDay? nextChangeDay,  int? nextChangeMinutes)?  $default,) {final _that = this;
+switch (_that) {
+case _OpenNowStatus() when $default != null:
+return $default(_that.status,_that.nextChangeDay,_that.nextChangeMinutes);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _OpenNowStatus implements OpenNowStatus {
+  const _OpenNowStatus({required this.status, this.nextChangeDay, this.nextChangeMinutes});
+  
+
+@override final  OpenStatus status;
+@override final  OpeningDay? nextChangeDay;
+@override final  int? nextChangeMinutes;
+
+/// Create a copy of OpenNowStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$OpenNowStatusCopyWith<_OpenNowStatus> get copyWith => __$OpenNowStatusCopyWithImpl<_OpenNowStatus>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _OpenNowStatus&&(identical(other.status, status) || other.status == status)&&(identical(other.nextChangeDay, nextChangeDay) || other.nextChangeDay == nextChangeDay)&&(identical(other.nextChangeMinutes, nextChangeMinutes) || other.nextChangeMinutes == nextChangeMinutes));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,nextChangeDay,nextChangeMinutes);
+
+@override
+String toString() {
+  return 'OpenNowStatus(status: $status, nextChangeDay: $nextChangeDay, nextChangeMinutes: $nextChangeMinutes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$OpenNowStatusCopyWith<$Res> implements $OpenNowStatusCopyWith<$Res> {
+  factory _$OpenNowStatusCopyWith(_OpenNowStatus value, $Res Function(_OpenNowStatus) _then) = __$OpenNowStatusCopyWithImpl;
+@override @useResult
+$Res call({
+ OpenStatus status, OpeningDay? nextChangeDay, int? nextChangeMinutes
+});
+
+
+
+
+}
+/// @nodoc
+class __$OpenNowStatusCopyWithImpl<$Res>
+    implements _$OpenNowStatusCopyWith<$Res> {
+  __$OpenNowStatusCopyWithImpl(this._self, this._then);
+
+  final _OpenNowStatus _self;
+  final $Res Function(_OpenNowStatus) _then;
+
+/// Create a copy of OpenNowStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? nextChangeDay = freezed,Object? nextChangeMinutes = freezed,}) {
+  return _then(_OpenNowStatus(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as OpenStatus,nextChangeDay: freezed == nextChangeDay ? _self.nextChangeDay : nextChangeDay // ignore: cast_nullable_to_non_nullable
+as OpeningDay?,nextChangeMinutes: freezed == nextChangeMinutes ? _self.nextChangeMinutes : nextChangeMinutes // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/station_detail/domain/opening_hours.dart
+++ b/lib/features/station_detail/domain/opening_hours.dart
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'opening_hours.freezed.dart';
+part 'opening_hours.g.dart';
+
+/// A day of the week, plus the OSM `PH` (public-holiday) pseudo-day.
+///
+/// The seven weekdays are ordered Monday-first to match ISO 8601 and
+/// `DateTime.weekday` (Mon = 1 … Sun = 7). [publicHoliday] mirrors the OSM
+/// `Key:opening_hours` `PH` token — AT *Feiertag*, PT *Feriado* — and has
+/// no ISO weekday; it is carried separately so a country adapter can model
+/// the common "closed on public holidays" rule without inventing an 8th
+/// weekday in the regular Mon–Sun cycle.
+enum OpeningDay { mon, tue, wed, thu, fri, sat, sun, publicHoliday }
+
+/// Maps a 1..7 ISO weekday (`DateTime.weekday`) onto an [OpeningDay].
+///
+/// Pure helper. Returns [OpeningDay.mon] for an out-of-range value rather
+/// than throwing — it must never be a crash site. Callers that may receive
+/// `PH` should branch on it before calling this.
+OpeningDay openingDayFromIsoWeekday(int isoWeekday) {
+  switch (isoWeekday) {
+    case DateTime.monday:
+      return OpeningDay.mon;
+    case DateTime.tuesday:
+      return OpeningDay.tue;
+    case DateTime.wednesday:
+      return OpeningDay.wed;
+    case DateTime.thursday:
+      return OpeningDay.thu;
+    case DateTime.friday:
+      return OpeningDay.fri;
+    case DateTime.saturday:
+      return OpeningDay.sat;
+    case DateTime.sunday:
+      return OpeningDay.sun;
+    default:
+      return OpeningDay.mon;
+  }
+}
+
+/// The seven regular weekdays in Mon..Sun order, excluding
+/// [OpeningDay.publicHoliday].
+const List<OpeningDay> kRegularWeekdays = [
+  OpeningDay.mon,
+  OpeningDay.tue,
+  OpeningDay.wed,
+  OpeningDay.thu,
+  OpeningDay.fri,
+  OpeningDay.sat,
+  OpeningDay.sun,
+];
+
+/// A single opening interval within one day, in minutes-from-midnight
+/// (local time). Both bounds are 0..1439.
+///
+/// When [endMinutes] is less than or equal to [startMinutes] the interval
+/// *wraps past midnight* into the following day (OSM e.g. `22:00-04:00`).
+/// A range where the two bounds are equal is [isDegenerate] — it carries no
+/// duration. Some providers emit such a sentinel (the FR feed's
+/// `01:00-01:00`) to mean "no real interval"; [isDegenerate] lets callers
+/// filter it out instead of treating it as a 24-hour wrap.
+@freezed
+abstract class TimeRange with _$TimeRange {
+  const TimeRange._();
+
+  const factory TimeRange({
+    required int startMinutes,
+    required int endMinutes,
+  }) = _TimeRange;
+
+  factory TimeRange.fromJson(Map<String, dynamic> json) =>
+      _$TimeRangeFromJson(json);
+
+  /// Convenience: build from local `HH:mm` 24h clock parts.
+  factory TimeRange.fromClock({
+    required int startHour,
+    required int startMinute,
+    required int endHour,
+    required int endMinute,
+  }) =>
+      TimeRange(
+        startMinutes: startHour * 60 + startMinute,
+        endMinutes: endHour * 60 + endMinute,
+      );
+
+  /// True when the two bounds coincide → the range carries no duration and
+  /// should be filtered (the FR `01:00-01:00` no-interval sentinel).
+  bool get isDegenerate => startMinutes == endMinutes;
+
+  /// True when the interval crosses midnight into the next day
+  /// (`endMinutes <= startMinutes`, e.g. `22:00-04:00`). A degenerate range
+  /// is *not* treated as a wrap.
+  bool get wrapsPastMidnight => !isDegenerate && endMinutes <= startMinutes;
+}
+
+/// The shape of a single day's opening information.
+///
+/// - [closed] — explicitly closed all day.
+/// - [open24h] — open the whole day (OSM `24/7` for one day).
+/// - [openRanges] — open during the [DayHours.ranges].
+/// - [unknown] — the provider gave no usable signal for this day.
+enum DayState { closed, open24h, openRanges, unknown }
+
+/// One day's opening hours: which [day], its [state], and — for
+/// [DayState.openRanges] — the list of [ranges] (multiple intervals per day
+/// are allowed, e.g. a lunch break `08:00-12:00, 14:00-18:00`).
+@freezed
+abstract class DayHours with _$DayHours {
+  const factory DayHours({
+    required OpeningDay day,
+    required DayState state,
+    @Default([]) List<TimeRange> ranges,
+  }) = _DayHours;
+
+  factory DayHours.fromJson(Map<String, dynamic> json) =>
+      _$DayHoursFromJson(json);
+
+  /// A whole-day-open ([DayState.open24h]) entry for [day].
+  factory DayHours.allDay(OpeningDay day) =>
+      DayHours(day: day, state: DayState.open24h);
+
+  /// An explicitly-closed entry for [day].
+  factory DayHours.closedDay(OpeningDay day) =>
+      DayHours(day: day, state: DayState.closed);
+}
+
+/// How complete the parsed opening-hours data is.
+///
+/// - [full] — every day the provider covers is resolved (open/closed/24h).
+/// - [partial] — some days resolved, others [DayState.unknown].
+/// - [notProvided] — the provider gave no opening-hours data at all.
+enum OpeningHoursAvailability { full, partial, notProvided }
+
+/// A station's complete weekly opening hours.
+///
+/// [days] holds at most one [DayHours] per [OpeningDay]; a missing day is
+/// implicitly [DayState.unknown]. A whole-station 24/7 station is every
+/// regular weekday as [DayState.open24h]. [availability] flags how much of
+/// the schedule the source actually provided, and [rawSource] keeps the
+/// untouched provider string (OSM `opening_hours` value, etc.) for debugging
+/// / round-tripping. Use [notAvailable] for the graceful no-data state.
+@freezed
+abstract class WeeklyOpeningHours with _$WeeklyOpeningHours {
+  const WeeklyOpeningHours._();
+
+  const factory WeeklyOpeningHours({
+    @Default([]) List<DayHours> days,
+    @Default(OpeningHoursAvailability.notProvided)
+    OpeningHoursAvailability availability,
+    String? rawSource,
+  }) = _WeeklyOpeningHours;
+
+  factory WeeklyOpeningHours.fromJson(Map<String, dynamic> json) =>
+      _$WeeklyOpeningHoursFromJson(json);
+
+  /// The graceful no-data sentinel: no days,
+  /// [OpeningHoursAvailability.notProvided]. Adapters return this on missing
+  /// / unparseable input so the no-data UI path is uniform.
+  static const WeeklyOpeningHours notAvailable = WeeklyOpeningHours();
+
+  /// A whole-station 24/7 schedule: all seven regular weekdays open24h.
+  factory WeeklyOpeningHours.allWeek24h({String? rawSource}) =>
+      WeeklyOpeningHours(
+        days: [for (final d in kRegularWeekdays) DayHours.allDay(d)],
+        availability: OpeningHoursAvailability.full,
+        rawSource: rawSource,
+      );
+
+  /// The [DayHours] for [day], or `null` when the source did not cover it
+  /// (treat a `null` as [DayState.unknown]).
+  DayHours? dayFor(OpeningDay day) {
+    for (final d in days) {
+      if (d.day == day) return d;
+    }
+    return null;
+  }
+}

--- a/lib/features/station_detail/domain/opening_hours.freezed.dart
+++ b/lib/features/station_detail/domain/opening_hours.freezed.dart
@@ -1,0 +1,830 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'opening_hours.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$TimeRange {
+
+ int get startMinutes; int get endMinutes;
+/// Create a copy of TimeRange
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TimeRangeCopyWith<TimeRange> get copyWith => _$TimeRangeCopyWithImpl<TimeRange>(this as TimeRange, _$identity);
+
+  /// Serializes this TimeRange to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TimeRange&&(identical(other.startMinutes, startMinutes) || other.startMinutes == startMinutes)&&(identical(other.endMinutes, endMinutes) || other.endMinutes == endMinutes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,startMinutes,endMinutes);
+
+@override
+String toString() {
+  return 'TimeRange(startMinutes: $startMinutes, endMinutes: $endMinutes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TimeRangeCopyWith<$Res>  {
+  factory $TimeRangeCopyWith(TimeRange value, $Res Function(TimeRange) _then) = _$TimeRangeCopyWithImpl;
+@useResult
+$Res call({
+ int startMinutes, int endMinutes
+});
+
+
+
+
+}
+/// @nodoc
+class _$TimeRangeCopyWithImpl<$Res>
+    implements $TimeRangeCopyWith<$Res> {
+  _$TimeRangeCopyWithImpl(this._self, this._then);
+
+  final TimeRange _self;
+  final $Res Function(TimeRange) _then;
+
+/// Create a copy of TimeRange
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? startMinutes = null,Object? endMinutes = null,}) {
+  return _then(_self.copyWith(
+startMinutes: null == startMinutes ? _self.startMinutes : startMinutes // ignore: cast_nullable_to_non_nullable
+as int,endMinutes: null == endMinutes ? _self.endMinutes : endMinutes // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TimeRange].
+extension TimeRangePatterns on TimeRange {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TimeRange value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TimeRange() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TimeRange value)  $default,){
+final _that = this;
+switch (_that) {
+case _TimeRange():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TimeRange value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TimeRange() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int startMinutes,  int endMinutes)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TimeRange() when $default != null:
+return $default(_that.startMinutes,_that.endMinutes);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int startMinutes,  int endMinutes)  $default,) {final _that = this;
+switch (_that) {
+case _TimeRange():
+return $default(_that.startMinutes,_that.endMinutes);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int startMinutes,  int endMinutes)?  $default,) {final _that = this;
+switch (_that) {
+case _TimeRange() when $default != null:
+return $default(_that.startMinutes,_that.endMinutes);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TimeRange extends TimeRange {
+  const _TimeRange({required this.startMinutes, required this.endMinutes}): super._();
+  factory _TimeRange.fromJson(Map<String, dynamic> json) => _$TimeRangeFromJson(json);
+
+@override final  int startMinutes;
+@override final  int endMinutes;
+
+/// Create a copy of TimeRange
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TimeRangeCopyWith<_TimeRange> get copyWith => __$TimeRangeCopyWithImpl<_TimeRange>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TimeRangeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TimeRange&&(identical(other.startMinutes, startMinutes) || other.startMinutes == startMinutes)&&(identical(other.endMinutes, endMinutes) || other.endMinutes == endMinutes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,startMinutes,endMinutes);
+
+@override
+String toString() {
+  return 'TimeRange(startMinutes: $startMinutes, endMinutes: $endMinutes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TimeRangeCopyWith<$Res> implements $TimeRangeCopyWith<$Res> {
+  factory _$TimeRangeCopyWith(_TimeRange value, $Res Function(_TimeRange) _then) = __$TimeRangeCopyWithImpl;
+@override @useResult
+$Res call({
+ int startMinutes, int endMinutes
+});
+
+
+
+
+}
+/// @nodoc
+class __$TimeRangeCopyWithImpl<$Res>
+    implements _$TimeRangeCopyWith<$Res> {
+  __$TimeRangeCopyWithImpl(this._self, this._then);
+
+  final _TimeRange _self;
+  final $Res Function(_TimeRange) _then;
+
+/// Create a copy of TimeRange
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? startMinutes = null,Object? endMinutes = null,}) {
+  return _then(_TimeRange(
+startMinutes: null == startMinutes ? _self.startMinutes : startMinutes // ignore: cast_nullable_to_non_nullable
+as int,endMinutes: null == endMinutes ? _self.endMinutes : endMinutes // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$DayHours {
+
+ OpeningDay get day; DayState get state; List<TimeRange> get ranges;
+/// Create a copy of DayHours
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DayHoursCopyWith<DayHours> get copyWith => _$DayHoursCopyWithImpl<DayHours>(this as DayHours, _$identity);
+
+  /// Serializes this DayHours to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DayHours&&(identical(other.day, day) || other.day == day)&&(identical(other.state, state) || other.state == state)&&const DeepCollectionEquality().equals(other.ranges, ranges));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,day,state,const DeepCollectionEquality().hash(ranges));
+
+@override
+String toString() {
+  return 'DayHours(day: $day, state: $state, ranges: $ranges)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DayHoursCopyWith<$Res>  {
+  factory $DayHoursCopyWith(DayHours value, $Res Function(DayHours) _then) = _$DayHoursCopyWithImpl;
+@useResult
+$Res call({
+ OpeningDay day, DayState state, List<TimeRange> ranges
+});
+
+
+
+
+}
+/// @nodoc
+class _$DayHoursCopyWithImpl<$Res>
+    implements $DayHoursCopyWith<$Res> {
+  _$DayHoursCopyWithImpl(this._self, this._then);
+
+  final DayHours _self;
+  final $Res Function(DayHours) _then;
+
+/// Create a copy of DayHours
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? day = null,Object? state = null,Object? ranges = null,}) {
+  return _then(_self.copyWith(
+day: null == day ? _self.day : day // ignore: cast_nullable_to_non_nullable
+as OpeningDay,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as DayState,ranges: null == ranges ? _self.ranges : ranges // ignore: cast_nullable_to_non_nullable
+as List<TimeRange>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [DayHours].
+extension DayHoursPatterns on DayHours {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DayHours value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DayHours() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DayHours value)  $default,){
+final _that = this;
+switch (_that) {
+case _DayHours():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DayHours value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DayHours() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( OpeningDay day,  DayState state,  List<TimeRange> ranges)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DayHours() when $default != null:
+return $default(_that.day,_that.state,_that.ranges);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( OpeningDay day,  DayState state,  List<TimeRange> ranges)  $default,) {final _that = this;
+switch (_that) {
+case _DayHours():
+return $default(_that.day,_that.state,_that.ranges);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( OpeningDay day,  DayState state,  List<TimeRange> ranges)?  $default,) {final _that = this;
+switch (_that) {
+case _DayHours() when $default != null:
+return $default(_that.day,_that.state,_that.ranges);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _DayHours implements DayHours {
+  const _DayHours({required this.day, required this.state, final  List<TimeRange> ranges = const []}): _ranges = ranges;
+  factory _DayHours.fromJson(Map<String, dynamic> json) => _$DayHoursFromJson(json);
+
+@override final  OpeningDay day;
+@override final  DayState state;
+ final  List<TimeRange> _ranges;
+@override@JsonKey() List<TimeRange> get ranges {
+  if (_ranges is EqualUnmodifiableListView) return _ranges;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_ranges);
+}
+
+
+/// Create a copy of DayHours
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DayHoursCopyWith<_DayHours> get copyWith => __$DayHoursCopyWithImpl<_DayHours>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DayHoursToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DayHours&&(identical(other.day, day) || other.day == day)&&(identical(other.state, state) || other.state == state)&&const DeepCollectionEquality().equals(other._ranges, _ranges));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,day,state,const DeepCollectionEquality().hash(_ranges));
+
+@override
+String toString() {
+  return 'DayHours(day: $day, state: $state, ranges: $ranges)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DayHoursCopyWith<$Res> implements $DayHoursCopyWith<$Res> {
+  factory _$DayHoursCopyWith(_DayHours value, $Res Function(_DayHours) _then) = __$DayHoursCopyWithImpl;
+@override @useResult
+$Res call({
+ OpeningDay day, DayState state, List<TimeRange> ranges
+});
+
+
+
+
+}
+/// @nodoc
+class __$DayHoursCopyWithImpl<$Res>
+    implements _$DayHoursCopyWith<$Res> {
+  __$DayHoursCopyWithImpl(this._self, this._then);
+
+  final _DayHours _self;
+  final $Res Function(_DayHours) _then;
+
+/// Create a copy of DayHours
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? day = null,Object? state = null,Object? ranges = null,}) {
+  return _then(_DayHours(
+day: null == day ? _self.day : day // ignore: cast_nullable_to_non_nullable
+as OpeningDay,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
+as DayState,ranges: null == ranges ? _self._ranges : ranges // ignore: cast_nullable_to_non_nullable
+as List<TimeRange>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$WeeklyOpeningHours {
+
+ List<DayHours> get days; OpeningHoursAvailability get availability; String? get rawSource;
+/// Create a copy of WeeklyOpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WeeklyOpeningHoursCopyWith<WeeklyOpeningHours> get copyWith => _$WeeklyOpeningHoursCopyWithImpl<WeeklyOpeningHours>(this as WeeklyOpeningHours, _$identity);
+
+  /// Serializes this WeeklyOpeningHours to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WeeklyOpeningHours&&const DeepCollectionEquality().equals(other.days, days)&&(identical(other.availability, availability) || other.availability == availability)&&(identical(other.rawSource, rawSource) || other.rawSource == rawSource));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(days),availability,rawSource);
+
+@override
+String toString() {
+  return 'WeeklyOpeningHours(days: $days, availability: $availability, rawSource: $rawSource)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $WeeklyOpeningHoursCopyWith<$Res>  {
+  factory $WeeklyOpeningHoursCopyWith(WeeklyOpeningHours value, $Res Function(WeeklyOpeningHours) _then) = _$WeeklyOpeningHoursCopyWithImpl;
+@useResult
+$Res call({
+ List<DayHours> days, OpeningHoursAvailability availability, String? rawSource
+});
+
+
+
+
+}
+/// @nodoc
+class _$WeeklyOpeningHoursCopyWithImpl<$Res>
+    implements $WeeklyOpeningHoursCopyWith<$Res> {
+  _$WeeklyOpeningHoursCopyWithImpl(this._self, this._then);
+
+  final WeeklyOpeningHours _self;
+  final $Res Function(WeeklyOpeningHours) _then;
+
+/// Create a copy of WeeklyOpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? days = null,Object? availability = null,Object? rawSource = freezed,}) {
+  return _then(_self.copyWith(
+days: null == days ? _self.days : days // ignore: cast_nullable_to_non_nullable
+as List<DayHours>,availability: null == availability ? _self.availability : availability // ignore: cast_nullable_to_non_nullable
+as OpeningHoursAvailability,rawSource: freezed == rawSource ? _self.rawSource : rawSource // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [WeeklyOpeningHours].
+extension WeeklyOpeningHoursPatterns on WeeklyOpeningHours {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WeeklyOpeningHours value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WeeklyOpeningHours() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WeeklyOpeningHours value)  $default,){
+final _that = this;
+switch (_that) {
+case _WeeklyOpeningHours():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WeeklyOpeningHours value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WeeklyOpeningHours() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<DayHours> days,  OpeningHoursAvailability availability,  String? rawSource)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WeeklyOpeningHours() when $default != null:
+return $default(_that.days,_that.availability,_that.rawSource);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<DayHours> days,  OpeningHoursAvailability availability,  String? rawSource)  $default,) {final _that = this;
+switch (_that) {
+case _WeeklyOpeningHours():
+return $default(_that.days,_that.availability,_that.rawSource);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<DayHours> days,  OpeningHoursAvailability availability,  String? rawSource)?  $default,) {final _that = this;
+switch (_that) {
+case _WeeklyOpeningHours() when $default != null:
+return $default(_that.days,_that.availability,_that.rawSource);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _WeeklyOpeningHours extends WeeklyOpeningHours {
+  const _WeeklyOpeningHours({final  List<DayHours> days = const [], this.availability = OpeningHoursAvailability.notProvided, this.rawSource}): _days = days,super._();
+  factory _WeeklyOpeningHours.fromJson(Map<String, dynamic> json) => _$WeeklyOpeningHoursFromJson(json);
+
+ final  List<DayHours> _days;
+@override@JsonKey() List<DayHours> get days {
+  if (_days is EqualUnmodifiableListView) return _days;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_days);
+}
+
+@override@JsonKey() final  OpeningHoursAvailability availability;
+@override final  String? rawSource;
+
+/// Create a copy of WeeklyOpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$WeeklyOpeningHoursCopyWith<_WeeklyOpeningHours> get copyWith => __$WeeklyOpeningHoursCopyWithImpl<_WeeklyOpeningHours>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$WeeklyOpeningHoursToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WeeklyOpeningHours&&const DeepCollectionEquality().equals(other._days, _days)&&(identical(other.availability, availability) || other.availability == availability)&&(identical(other.rawSource, rawSource) || other.rawSource == rawSource));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_days),availability,rawSource);
+
+@override
+String toString() {
+  return 'WeeklyOpeningHours(days: $days, availability: $availability, rawSource: $rawSource)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$WeeklyOpeningHoursCopyWith<$Res> implements $WeeklyOpeningHoursCopyWith<$Res> {
+  factory _$WeeklyOpeningHoursCopyWith(_WeeklyOpeningHours value, $Res Function(_WeeklyOpeningHours) _then) = __$WeeklyOpeningHoursCopyWithImpl;
+@override @useResult
+$Res call({
+ List<DayHours> days, OpeningHoursAvailability availability, String? rawSource
+});
+
+
+
+
+}
+/// @nodoc
+class __$WeeklyOpeningHoursCopyWithImpl<$Res>
+    implements _$WeeklyOpeningHoursCopyWith<$Res> {
+  __$WeeklyOpeningHoursCopyWithImpl(this._self, this._then);
+
+  final _WeeklyOpeningHours _self;
+  final $Res Function(_WeeklyOpeningHours) _then;
+
+/// Create a copy of WeeklyOpeningHours
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? days = null,Object? availability = null,Object? rawSource = freezed,}) {
+  return _then(_WeeklyOpeningHours(
+days: null == days ? _self._days : days // ignore: cast_nullable_to_non_nullable
+as List<DayHours>,availability: null == availability ? _self.availability : availability // ignore: cast_nullable_to_non_nullable
+as OpeningHoursAvailability,rawSource: freezed == rawSource ? _self.rawSource : rawSource // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/station_detail/domain/opening_hours.g.dart
+++ b/lib/features/station_detail/domain/opening_hours.g.dart
@@ -1,0 +1,81 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'opening_hours.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_TimeRange _$TimeRangeFromJson(Map<String, dynamic> json) => _TimeRange(
+  startMinutes: (json['startMinutes'] as num).toInt(),
+  endMinutes: (json['endMinutes'] as num).toInt(),
+);
+
+Map<String, dynamic> _$TimeRangeToJson(_TimeRange instance) =>
+    <String, dynamic>{
+      'startMinutes': instance.startMinutes,
+      'endMinutes': instance.endMinutes,
+    };
+
+_DayHours _$DayHoursFromJson(Map<String, dynamic> json) => _DayHours(
+  day: $enumDecode(_$OpeningDayEnumMap, json['day']),
+  state: $enumDecode(_$DayStateEnumMap, json['state']),
+  ranges:
+      (json['ranges'] as List<dynamic>?)
+          ?.map((e) => TimeRange.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
+);
+
+Map<String, dynamic> _$DayHoursToJson(_DayHours instance) => <String, dynamic>{
+  'day': _$OpeningDayEnumMap[instance.day]!,
+  'state': _$DayStateEnumMap[instance.state]!,
+  'ranges': instance.ranges.map((e) => e.toJson()).toList(),
+};
+
+const _$OpeningDayEnumMap = {
+  OpeningDay.mon: 'mon',
+  OpeningDay.tue: 'tue',
+  OpeningDay.wed: 'wed',
+  OpeningDay.thu: 'thu',
+  OpeningDay.fri: 'fri',
+  OpeningDay.sat: 'sat',
+  OpeningDay.sun: 'sun',
+  OpeningDay.publicHoliday: 'publicHoliday',
+};
+
+const _$DayStateEnumMap = {
+  DayState.closed: 'closed',
+  DayState.open24h: 'open24h',
+  DayState.openRanges: 'openRanges',
+  DayState.unknown: 'unknown',
+};
+
+_WeeklyOpeningHours _$WeeklyOpeningHoursFromJson(Map<String, dynamic> json) =>
+    _WeeklyOpeningHours(
+      days:
+          (json['days'] as List<dynamic>?)
+              ?.map((e) => DayHours.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      availability:
+          $enumDecodeNullable(
+            _$OpeningHoursAvailabilityEnumMap,
+            json['availability'],
+          ) ??
+          OpeningHoursAvailability.notProvided,
+      rawSource: json['rawSource'] as String?,
+    );
+
+Map<String, dynamic> _$WeeklyOpeningHoursToJson(_WeeklyOpeningHours instance) =>
+    <String, dynamic>{
+      'days': instance.days.map((e) => e.toJson()).toList(),
+      'availability': _$OpeningHoursAvailabilityEnumMap[instance.availability]!,
+      'rawSource': instance.rawSource,
+    };
+
+const _$OpeningHoursAvailabilityEnumMap = {
+  OpeningHoursAvailability.full: 'full',
+  OpeningHoursAvailability.partial: 'partial',
+  OpeningHoursAvailability.notProvided: 'notProvided',
+};

--- a/lib/features/station_services/opening_hours/opening_hours_adapter.dart
+++ b/lib/features/station_services/opening_hours/opening_hours_adapter.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../station_detail/domain/opening_hours.dart';
+
+/// Per-country adapter that normalises a provider's raw opening-hours payload
+/// into the common [WeeklyOpeningHours] model.
+///
+/// ## Contract (every implementation MUST honour it)
+/// - **Pure** — [parse] reads only its argument; no I/O, no clock, no
+///   provider state.
+/// - **Never throws** — a malformed / unexpected `rawProviderData` shape must
+///   be caught internally and reported as no-data, not propagated. The
+///   six country adapters feed user-facing UI; a parse fault must degrade
+///   gracefully, never crash the station-detail screen.
+/// - **Never returns `null`** — on missing or unparseable input return
+///   [WeeklyOpeningHours.notAvailable] so the no-data UI path is uniform
+///   across all countries (no per-call null checks at the call site).
+///
+/// `rawProviderData` is intentionally `dynamic`: each country feeds a
+/// different shape (an OSM `opening_hours` string, a JSON map, a list of
+/// weekday rows). The adapter owns the shape-narrowing and the fault
+/// handling so the contract above holds.
+abstract class OpeningHoursAdapter {
+  const OpeningHoursAdapter();
+
+  /// Normalises [rawProviderData] into a [WeeklyOpeningHours]. Pure, never
+  /// throws, never returns `null` — see the class contract.
+  WeeklyOpeningHours parse(dynamic rawProviderData);
+}

--- a/test/features/station_detail/domain/legacy_opening_hours_bridge_test.dart
+++ b/test/features/station_detail/domain/legacy_opening_hours_bridge_test.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_detail/domain/legacy_opening_hours_bridge.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+
+Station _station({bool is24h = false}) => Station(
+      id: 's1',
+      name: 'S',
+      brand: 'B',
+      street: 'St',
+      postCode: '1',
+      place: 'P',
+      lat: 0,
+      lng: 0,
+      isOpen: true,
+      is24h: is24h,
+    );
+
+void main() {
+  group('legacyOpeningHoursBridge', () {
+    test('returns normally on malformed openingTimes → notAvailable '
+        '(fault injection)', () {
+      final detail = StationDetail(
+        station: _station(),
+        openingTimes: const [
+          OpeningTime(text: 'x', start: 'garbage', end: ''),
+          OpeningTime(text: 'y', start: '99:99', end: '08:00'),
+        ],
+      );
+      expect(() => legacyOpeningHoursBridge(detail), returnsNormally);
+      expect(legacyOpeningHoursBridge(detail), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('is24h → all-week 24h', () {
+      final r =
+          legacyOpeningHoursBridge(StationDetail(station: _station(is24h: true)));
+      expect(r.availability, OpeningHoursAvailability.full);
+      expect(r.dayFor(OpeningDay.mon)!.state, DayState.open24h);
+    });
+
+    test('valid openingTimes → partial whole-week ranges', () {
+      final detail = StationDetail(
+        station: _station(),
+        openingTimes: const [
+          OpeningTime(text: 'Mo-Fr', start: '06:30', end: '19:30'),
+        ],
+      );
+      final r = legacyOpeningHoursBridge(detail);
+      expect(r.availability, OpeningHoursAvailability.partial);
+      final mon = r.dayFor(OpeningDay.mon)!;
+      expect(mon.state, DayState.openRanges);
+      expect(mon.ranges.single.startMinutes, 6 * 60 + 30);
+    });
+
+    test('already-populated openingHours is returned unchanged', () {
+      final w = WeeklyOpeningHours.allWeek24h(rawSource: 'x');
+      final detail = StationDetail(station: _station(), openingHours: w);
+      expect(legacyOpeningHoursBridge(detail), w);
+    });
+
+    test('no legacy data → notAvailable', () {
+      expect(
+        legacyOpeningHoursBridge(StationDetail(station: _station())),
+        WeeklyOpeningHours.notAvailable,
+      );
+    });
+  });
+}

--- a/test/features/station_detail/domain/opening_hours_test.dart
+++ b/test/features/station_detail/domain/opening_hours_test.dart
@@ -57,8 +57,8 @@ void main() {
     });
 
     test('dayFor returns null for an uncovered day', () {
-      final w = WeeklyOpeningHours(
-        days: const [DayHours(day: OpeningDay.mon, state: DayState.open24h)],
+      const w = WeeklyOpeningHours(
+        days: [DayHours(day: OpeningDay.mon, state: DayState.open24h)],
         availability: OpeningHoursAvailability.partial,
       );
       expect(w.dayFor(OpeningDay.tue), isNull);
@@ -172,8 +172,8 @@ void main() {
     });
 
     test('degenerate-only day is not open', () {
-      final w = WeeklyOpeningHours(
-        days: const [
+      const w = WeeklyOpeningHours(
+        days: [
           DayHours(
             day: OpeningDay.mon,
             state: DayState.openRanges,

--- a/test/features/station_detail/domain/opening_hours_test.dart
+++ b/test/features/station_detail/domain/opening_hours_test.dart
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/open_now.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+
+void main() {
+  group('TimeRange', () {
+    test('fromClock maps to minutes-from-midnight', () {
+      final r = TimeRange.fromClock(
+        startHour: 8,
+        startMinute: 30,
+        endHour: 19,
+        endMinute: 30,
+      );
+      expect(r.startMinutes, 8 * 60 + 30);
+      expect(r.endMinutes, 19 * 60 + 30);
+      expect(r.isDegenerate, isFalse);
+      expect(r.wrapsPastMidnight, isFalse);
+    });
+
+    test('degenerate range (FR 01:00-01:00) is flagged, never a wrap', () {
+      const r = TimeRange(startMinutes: 60, endMinutes: 60);
+      expect(r.isDegenerate, isTrue);
+      expect(r.wrapsPastMidnight, isFalse);
+    });
+
+    test('wrapsPastMidnight when end <= start', () {
+      final r = TimeRange.fromClock(
+        startHour: 22,
+        startMinute: 0,
+        endHour: 4,
+        endMinute: 0,
+      );
+      expect(r.wrapsPastMidnight, isTrue);
+    });
+  });
+
+  group('WeeklyOpeningHours', () {
+    test('notAvailable is the empty / notProvided sentinel', () {
+      expect(WeeklyOpeningHours.notAvailable.days, isEmpty);
+      expect(
+        WeeklyOpeningHours.notAvailable.availability,
+        OpeningHoursAvailability.notProvided,
+      );
+    });
+
+    test('allWeek24h covers all seven regular weekdays as open24h', () {
+      final w = WeeklyOpeningHours.allWeek24h();
+      expect(w.days.length, 7);
+      expect(w.availability, OpeningHoursAvailability.full);
+      for (final d in kRegularWeekdays) {
+        expect(w.dayFor(d)!.state, DayState.open24h);
+      }
+      expect(w.dayFor(OpeningDay.publicHoliday), isNull);
+    });
+
+    test('dayFor returns null for an uncovered day', () {
+      final w = WeeklyOpeningHours(
+        days: const [DayHours(day: OpeningDay.mon, state: DayState.open24h)],
+        availability: OpeningHoursAvailability.partial,
+      );
+      expect(w.dayFor(OpeningDay.tue), isNull);
+    });
+
+    test('json round-trips losslessly', () {
+      final w = WeeklyOpeningHours(
+        days: [
+          DayHours(
+            day: OpeningDay.mon,
+            state: DayState.openRanges,
+            ranges: [
+              TimeRange.fromClock(
+                startHour: 6,
+                startMinute: 30,
+                endHour: 19,
+                endMinute: 30,
+              ),
+            ],
+          ),
+        ],
+        availability: OpeningHoursAvailability.partial,
+      );
+      expect(WeeklyOpeningHours.fromJson(w.toJson()), w);
+    });
+  });
+
+  group('openingDayFromIsoWeekday', () {
+    test('maps ISO 1..7 onto Mon..Sun', () {
+      expect(openingDayFromIsoWeekday(DateTime.monday), OpeningDay.mon);
+      expect(openingDayFromIsoWeekday(DateTime.sunday), OpeningDay.sun);
+    });
+  });
+
+  group('computeOpenNow', () {
+    // 2026-06-01 10:00; we derive the weekday rather than assume it.
+    final mid = DateTime(2026, 6, 1, 10, 0);
+    final today = openingDayFromIsoWeekday(mid.weekday);
+
+    DayHours dayRange(OpeningDay d, int sh, int sm, int eh, int em) => DayHours(
+          day: d,
+          state: DayState.openRanges,
+          ranges: [
+            TimeRange.fromClock(
+              startHour: sh,
+              startMinute: sm,
+              endHour: eh,
+              endMinute: em,
+            ),
+          ],
+        );
+
+    test('no data → unknown', () {
+      expect(
+        computeOpenNow(WeeklyOpeningHours.notAvailable, mid).status,
+        OpenStatus.unknown,
+      );
+    });
+
+    test('24/7 → open', () {
+      expect(
+        computeOpenNow(WeeklyOpeningHours.allWeek24h(), mid).status,
+        OpenStatus.open,
+      );
+    });
+
+    test('inside today range → open, closes at the range end', () {
+      final w = WeeklyOpeningHours(
+        days: [dayRange(today, 6, 30, 19, 30)],
+        availability: OpeningHoursAvailability.full,
+      );
+      final r = computeOpenNow(w, mid);
+      expect(r.status, OpenStatus.open);
+      expect(r.nextChangeDay, today);
+      expect(r.nextChangeMinutes, 19 * 60 + 30);
+    });
+
+    test('before today opening → closed, opens today at start', () {
+      final early = DateTime(2026, 6, 1, 5, 0); // before 06:30
+      final t = openingDayFromIsoWeekday(early.weekday);
+      final w = WeeklyOpeningHours(
+        days: [dayRange(t, 6, 30, 19, 30)],
+        availability: OpeningHoursAvailability.full,
+      );
+      final r = computeOpenNow(w, early);
+      expect(r.status, OpenStatus.closed);
+      expect(r.nextChangeDay, t);
+      expect(r.nextChangeMinutes, 6 * 60 + 30);
+    });
+
+    test('one closed day among unknown → closed (not unknown)', () {
+      final w = WeeklyOpeningHours(
+        days: [DayHours.closedDay(today)],
+        availability: OpeningHoursAvailability.partial,
+      );
+      expect(computeOpenNow(w, mid).status, OpenStatus.closed);
+    });
+
+    test('overnight range from yesterday still covers early morning', () {
+      // now = the day AFTER `mid`, at 02:00; yesterday has a 22:00-04:00 wrap.
+      final nextDay = mid.add(const Duration(days: 1));
+      final at0200 = DateTime(nextDay.year, nextDay.month, nextDay.day, 2, 0);
+      final yesterday = openingDayFromIsoWeekday(mid.weekday);
+      final w = WeeklyOpeningHours(
+        days: [dayRange(yesterday, 22, 0, 4, 0)],
+        availability: OpeningHoursAvailability.partial,
+      );
+      final r = computeOpenNow(w, at0200);
+      expect(r.status, OpenStatus.open);
+      expect(r.nextChangeMinutes, 4 * 60);
+    });
+
+    test('degenerate-only day is not open', () {
+      final w = WeeklyOpeningHours(
+        days: const [
+          DayHours(
+            day: OpeningDay.mon,
+            state: DayState.openRanges,
+            ranges: [TimeRange(startMinutes: 60, endMinutes: 60)],
+          ),
+        ],
+        availability: OpeningHoursAvailability.full,
+      );
+      // 01:00-01:00 carries no duration → never reports open.
+      final at0100 = DateTime(2026, 6, 1, 1, 0);
+      expect(computeOpenNow(w, at0100).status, isNot(OpenStatus.open));
+    });
+  });
+}

--- a/test/features/station_services/opening_hours/opening_hours_adapter_test.dart
+++ b/test/features/station_services/opening_hours/opening_hours_adapter_test.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/opening_hours/opening_hours_adapter.dart';
+
+/// A conforming adapter that shape-narrows its raw input and catches any
+/// fault, returning the no-data sentinel — the exact contract the
+/// [OpeningHoursAdapter] interface documents (pure, never throws, never
+/// null). Used to fault-inject the contract (#2349 never-throws boundary).
+class _FaultTolerantAdapter extends OpeningHoursAdapter {
+  const _FaultTolerantAdapter();
+
+  @override
+  WeeklyOpeningHours parse(dynamic rawProviderData) {
+    try {
+      final s = rawProviderData as String; // throws on a non-String shape
+      if (s.isEmpty) return WeeklyOpeningHours.notAvailable;
+      return const WeeklyOpeningHours(
+        availability: OpeningHoursAvailability.full,
+      );
+    } catch (_) {
+      return WeeklyOpeningHours.notAvailable;
+    }
+  }
+}
+
+void main() {
+  group('OpeningHoursAdapter never-throws contract', () {
+    const adapter = _FaultTolerantAdapter();
+
+    test('parse returns normally on a malformed shape (fault injection)', () {
+      // Feed shapes a String parser does not expect → the `as String` cast
+      // throws internally; the contract requires it be caught, not propagated.
+      expect(() => adapter.parse(42), returnsNormally);
+      expect(adapter.parse(42), WeeklyOpeningHours.notAvailable);
+      expect(() => adapter.parse(null), returnsNormally);
+      expect(adapter.parse(null), WeeklyOpeningHours.notAvailable);
+      expect(() => adapter.parse(const {'unexpected': true}), returnsNormally);
+      expect(adapter.parse(const {'unexpected': true}),
+          WeeklyOpeningHours.notAvailable);
+    });
+
+    test('parse never returns null on empty input', () {
+      expect(adapter.parse(''), isNotNull);
+      expect(adapter.parse(''), WeeklyOpeningHours.notAvailable);
+    });
+  });
+}


### PR DESCRIPTION
Foundation for the unified multi-country opening-hours feature (#2707). Pure domain layer, **ARB-free** (all UI strings ship in C2 #2709).

- `WeeklyOpeningHours`/`DayHours`/`TimeRange` — OSM `opening_hours` semantics (multi-interval days, 24/7, midnight-wrap, `isDegenerate` for the FR `01:00-01:00` sentinel) + `OpeningDay` (incl. `publicHoliday`/PH), `DayState`, `OpeningHoursAvailability`; `notAvailable` + `allWeek24h`.
- Pure `computeOpenNow(hours, now)` → `OpenNowStatus` (open/closed/unknown + next-change), handles overnight-wrap.
- `OpeningHoursAdapter` interface — `parse(raw)` never throws / never null (→ `notAvailable`).
- Additive `StationDetail.openingHours` + legacy bridge (no country regresses pre-migration); codec round-trips it.

15 unit tests pass (incl. midnight-wrap + degenerate). Clean codegen committed, zero l10n drift, analyze clean. Unblocks the 6 country adapters (#2710–#2715).

Closes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)