### PR TITLE
feat(opening-hours): Austria E-Control adapter — German days + Feiertag (Epic C4)

### DIFF
--- a/lib/features/search/domain/entities/station.dart
+++ b/lib/features/search/domain/entities/station.dart
@@ -33,6 +33,13 @@ abstract class Station with _$Station {
     required bool isOpen,
     String? updatedAt,
     String? openingHoursText,  // "Lun 07:00-18:30, Mar 07:00-18:30..."
+    // Epic C4 — structured weekly hours from a per-country
+    // [OpeningHoursAdapter], carried on the search-result station so a
+    // country whose service has no detail endpoint (e.g. AT E-Control)
+    // still surfaces structured hours via `StationDetail(station:…)`.
+    // ADDITIVE: `openingHoursText` / `is24h` stay for back-compat.
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    WeeklyOpeningHours? openingHours,
     @Default(false) bool is24h,
     @Default([]) List<String> services,
     @Default([]) List<String> availableFuels,

--- a/lib/features/search/domain/entities/station.freezed.dart
+++ b/lib/features/search/domain/entities/station.freezed.dart
@@ -16,7 +16,12 @@ T _$identity<T>(T value) => value;
 mixin _$Station {
 
  String get id; String get name; String get brand; String get street; String? get houseNumber;@JsonKey(fromJson: _postCodeToString) String get postCode; String get place; double get lat; double get lng; double get dist;@JsonKey(fromJson: _priceFromJson) double? get e5;@JsonKey(fromJson: _priceFromJson) double? get e10;@JsonKey(fromJson: _priceFromJson) double? get e98;@JsonKey(fromJson: _priceFromJson) double? get diesel;@JsonKey(fromJson: _priceFromJson) double? get dieselPremium;@JsonKey(fromJson: _priceFromJson) double? get e85;@JsonKey(fromJson: _priceFromJson) double? get lpg;@JsonKey(fromJson: _priceFromJson) double? get cng; bool get isOpen; String? get updatedAt; String? get openingHoursText;// "Lun 07:00-18:30, Mar 07:00-18:30..."
- bool get is24h; List<String> get services; List<String> get availableFuels; List<String> get unavailableFuels; String? get stationType;// "R" retail, "A" autoroute
+// Epic C4 — structured weekly hours from a per-country
+// [OpeningHoursAdapter], carried on the search-result station so a
+// country whose service has no detail endpoint (e.g. AT E-Control)
+// still surfaces structured hours via `StationDetail(station:…)`.
+// ADDITIVE: `openingHoursText` / `is24h` stay for back-compat.
+@JsonKey(includeFromJson: false, includeToJson: false) WeeklyOpeningHours? get openingHours; bool get is24h; List<String> get services; List<String> get availableFuels; List<String> get unavailableFuels; String? get stationType;// "R" retail, "A" autoroute
  String? get department; String? get region;@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> get amenities;
 /// Create a copy of Station
 /// with the given fields replaced by the non-null parameter values.
@@ -30,16 +35,16 @@ $StationCopyWith<Station> get copyWith => _$StationCopyWithImpl<Station>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Station&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.brand, brand) || other.brand == brand)&&(identical(other.street, street) || other.street == street)&&(identical(other.houseNumber, houseNumber) || other.houseNumber == houseNumber)&&(identical(other.postCode, postCode) || other.postCode == postCode)&&(identical(other.place, place) || other.place == place)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng)&&(identical(other.dist, dist) || other.dist == dist)&&(identical(other.e5, e5) || other.e5 == e5)&&(identical(other.e10, e10) || other.e10 == e10)&&(identical(other.e98, e98) || other.e98 == e98)&&(identical(other.diesel, diesel) || other.diesel == diesel)&&(identical(other.dieselPremium, dieselPremium) || other.dieselPremium == dieselPremium)&&(identical(other.e85, e85) || other.e85 == e85)&&(identical(other.lpg, lpg) || other.lpg == lpg)&&(identical(other.cng, cng) || other.cng == cng)&&(identical(other.isOpen, isOpen) || other.isOpen == isOpen)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.openingHoursText, openingHoursText) || other.openingHoursText == openingHoursText)&&(identical(other.is24h, is24h) || other.is24h == is24h)&&const DeepCollectionEquality().equals(other.services, services)&&const DeepCollectionEquality().equals(other.availableFuels, availableFuels)&&const DeepCollectionEquality().equals(other.unavailableFuels, unavailableFuels)&&(identical(other.stationType, stationType) || other.stationType == stationType)&&(identical(other.department, department) || other.department == department)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other.amenities, amenities));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Station&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.brand, brand) || other.brand == brand)&&(identical(other.street, street) || other.street == street)&&(identical(other.houseNumber, houseNumber) || other.houseNumber == houseNumber)&&(identical(other.postCode, postCode) || other.postCode == postCode)&&(identical(other.place, place) || other.place == place)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng)&&(identical(other.dist, dist) || other.dist == dist)&&(identical(other.e5, e5) || other.e5 == e5)&&(identical(other.e10, e10) || other.e10 == e10)&&(identical(other.e98, e98) || other.e98 == e98)&&(identical(other.diesel, diesel) || other.diesel == diesel)&&(identical(other.dieselPremium, dieselPremium) || other.dieselPremium == dieselPremium)&&(identical(other.e85, e85) || other.e85 == e85)&&(identical(other.lpg, lpg) || other.lpg == lpg)&&(identical(other.cng, cng) || other.cng == cng)&&(identical(other.isOpen, isOpen) || other.isOpen == isOpen)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.openingHoursText, openingHoursText) || other.openingHoursText == openingHoursText)&&(identical(other.openingHours, openingHours) || other.openingHours == openingHours)&&(identical(other.is24h, is24h) || other.is24h == is24h)&&const DeepCollectionEquality().equals(other.services, services)&&const DeepCollectionEquality().equals(other.availableFuels, availableFuels)&&const DeepCollectionEquality().equals(other.unavailableFuels, unavailableFuels)&&(identical(other.stationType, stationType) || other.stationType == stationType)&&(identical(other.department, department) || other.department == department)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other.amenities, amenities));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,brand,street,houseNumber,postCode,place,lat,lng,dist,e5,e10,e98,diesel,dieselPremium,e85,lpg,cng,isOpen,updatedAt,openingHoursText,is24h,const DeepCollectionEquality().hash(services),const DeepCollectionEquality().hash(availableFuels),const DeepCollectionEquality().hash(unavailableFuels),stationType,department,region,const DeepCollectionEquality().hash(amenities)]);
+int get hashCode => Object.hashAll([runtimeType,id,name,brand,street,houseNumber,postCode,place,lat,lng,dist,e5,e10,e98,diesel,dieselPremium,e85,lpg,cng,isOpen,updatedAt,openingHoursText,openingHours,is24h,const DeepCollectionEquality().hash(services),const DeepCollectionEquality().hash(availableFuels),const DeepCollectionEquality().hash(unavailableFuels),stationType,department,region,const DeepCollectionEquality().hash(amenities)]);
 
 @override
 String toString() {
-  return 'Station(id: $id, name: $name, brand: $brand, street: $street, houseNumber: $houseNumber, postCode: $postCode, place: $place, lat: $lat, lng: $lng, dist: $dist, e5: $e5, e10: $e10, e98: $e98, diesel: $diesel, dieselPremium: $dieselPremium, e85: $e85, lpg: $lpg, cng: $cng, isOpen: $isOpen, updatedAt: $updatedAt, openingHoursText: $openingHoursText, is24h: $is24h, services: $services, availableFuels: $availableFuels, unavailableFuels: $unavailableFuels, stationType: $stationType, department: $department, region: $region, amenities: $amenities)';
+  return 'Station(id: $id, name: $name, brand: $brand, street: $street, houseNumber: $houseNumber, postCode: $postCode, place: $place, lat: $lat, lng: $lng, dist: $dist, e5: $e5, e10: $e10, e98: $e98, diesel: $diesel, dieselPremium: $dieselPremium, e85: $e85, lpg: $lpg, cng: $cng, isOpen: $isOpen, updatedAt: $updatedAt, openingHoursText: $openingHoursText, openingHours: $openingHours, is24h: $is24h, services: $services, availableFuels: $availableFuels, unavailableFuels: $unavailableFuels, stationType: $stationType, department: $department, region: $region, amenities: $amenities)';
 }
 
 
@@ -50,11 +55,11 @@ abstract mixin class $StationCopyWith<$Res>  {
   factory $StationCopyWith(Station value, $Res Function(Station) _then) = _$StationCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
+ String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText,@JsonKey(includeFromJson: false, includeToJson: false) WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
 });
 
 
-
+$WeeklyOpeningHoursCopyWith<$Res>? get openingHours;
 
 }
 /// @nodoc
@@ -67,7 +72,7 @@ class _$StationCopyWithImpl<$Res>
 
 /// Create a copy of Station
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = null,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = null,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? openingHours = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -90,7 +95,8 @@ as double?,cng: freezed == cng ? _self.cng : cng // ignore: cast_nullable_to_non
 as double?,isOpen: null == isOpen ? _self.isOpen : isOpen // ignore: cast_nullable_to_non_nullable
 as bool,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as String?,openingHoursText: freezed == openingHoursText ? _self.openingHoursText : openingHoursText // ignore: cast_nullable_to_non_nullable
-as String?,is24h: null == is24h ? _self.is24h : is24h // ignore: cast_nullable_to_non_nullable
+as String?,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
+as WeeklyOpeningHours?,is24h: null == is24h ? _self.is24h : is24h // ignore: cast_nullable_to_non_nullable
 as bool,services: null == services ? _self.services : services // ignore: cast_nullable_to_non_nullable
 as List<String>,availableFuels: null == availableFuels ? _self.availableFuels : availableFuels // ignore: cast_nullable_to_non_nullable
 as List<String>,unavailableFuels: null == unavailableFuels ? _self.unavailableFuels : unavailableFuels // ignore: cast_nullable_to_non_nullable
@@ -101,7 +107,19 @@ as String?,amenities: null == amenities ? _self.amenities : amenities // ignore:
 as Set<StationAmenity>,
   ));
 }
+/// Create a copy of Station
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$WeeklyOpeningHoursCopyWith<$Res>? get openingHours {
+    if (_self.openingHours == null) {
+    return null;
+  }
 
+  return $WeeklyOpeningHoursCopyWith<$Res>(_self.openingHours!, (value) {
+    return _then(_self.copyWith(openingHours: value));
+  });
+}
 }
 
 
@@ -183,10 +201,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false)  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Station() when $default != null:
-return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
+return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
   return orElse();
 
 }
@@ -204,10 +222,10 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false)  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)  $default,) {final _that = this;
 switch (_that) {
 case _Station():
-return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
+return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -224,10 +242,10 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false)  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,) {final _that = this;
 switch (_that) {
 case _Station() when $default != null:
-return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
+return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
   return null;
 
 }
@@ -239,7 +257,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 @JsonSerializable()
 
 class _Station implements Station {
-  const _Station({required this.id, required this.name, required this.brand, required this.street, this.houseNumber, @JsonKey(fromJson: _postCodeToString) required this.postCode, required this.place, required this.lat, required this.lng, this.dist = 0, @JsonKey(fromJson: _priceFromJson) this.e5, @JsonKey(fromJson: _priceFromJson) this.e10, @JsonKey(fromJson: _priceFromJson) this.e98, @JsonKey(fromJson: _priceFromJson) this.diesel, @JsonKey(fromJson: _priceFromJson) this.dieselPremium, @JsonKey(fromJson: _priceFromJson) this.e85, @JsonKey(fromJson: _priceFromJson) this.lpg, @JsonKey(fromJson: _priceFromJson) this.cng, required this.isOpen, this.updatedAt, this.openingHoursText, this.is24h = false, final  List<String> services = const [], final  List<String> availableFuels = const [], final  List<String> unavailableFuels = const [], this.stationType, this.department, this.region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) final  Set<StationAmenity> amenities = const {}}): _services = services,_availableFuels = availableFuels,_unavailableFuels = unavailableFuels,_amenities = amenities;
+  const _Station({required this.id, required this.name, required this.brand, required this.street, this.houseNumber, @JsonKey(fromJson: _postCodeToString) required this.postCode, required this.place, required this.lat, required this.lng, this.dist = 0, @JsonKey(fromJson: _priceFromJson) this.e5, @JsonKey(fromJson: _priceFromJson) this.e10, @JsonKey(fromJson: _priceFromJson) this.e98, @JsonKey(fromJson: _priceFromJson) this.diesel, @JsonKey(fromJson: _priceFromJson) this.dieselPremium, @JsonKey(fromJson: _priceFromJson) this.e85, @JsonKey(fromJson: _priceFromJson) this.lpg, @JsonKey(fromJson: _priceFromJson) this.cng, required this.isOpen, this.updatedAt, this.openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false) this.openingHours, this.is24h = false, final  List<String> services = const [], final  List<String> availableFuels = const [], final  List<String> unavailableFuels = const [], this.stationType, this.department, this.region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) final  Set<StationAmenity> amenities = const {}}): _services = services,_availableFuels = availableFuels,_unavailableFuels = unavailableFuels,_amenities = amenities;
   factory _Station.fromJson(Map<String, dynamic> json) => _$StationFromJson(json);
 
 @override final  String id;
@@ -264,6 +282,12 @@ class _Station implements Station {
 @override final  String? updatedAt;
 @override final  String? openingHoursText;
 // "Lun 07:00-18:30, Mar 07:00-18:30..."
+// Epic C4 — structured weekly hours from a per-country
+// [OpeningHoursAdapter], carried on the search-result station so a
+// country whose service has no detail endpoint (e.g. AT E-Control)
+// still surfaces structured hours via `StationDetail(station:…)`.
+// ADDITIVE: `openingHoursText` / `is24h` stay for back-compat.
+@override@JsonKey(includeFromJson: false, includeToJson: false) final  WeeklyOpeningHours? openingHours;
 @override@JsonKey() final  bool is24h;
  final  List<String> _services;
 @override@JsonKey() List<String> get services {
@@ -311,16 +335,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Station&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.brand, brand) || other.brand == brand)&&(identical(other.street, street) || other.street == street)&&(identical(other.houseNumber, houseNumber) || other.houseNumber == houseNumber)&&(identical(other.postCode, postCode) || other.postCode == postCode)&&(identical(other.place, place) || other.place == place)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng)&&(identical(other.dist, dist) || other.dist == dist)&&(identical(other.e5, e5) || other.e5 == e5)&&(identical(other.e10, e10) || other.e10 == e10)&&(identical(other.e98, e98) || other.e98 == e98)&&(identical(other.diesel, diesel) || other.diesel == diesel)&&(identical(other.dieselPremium, dieselPremium) || other.dieselPremium == dieselPremium)&&(identical(other.e85, e85) || other.e85 == e85)&&(identical(other.lpg, lpg) || other.lpg == lpg)&&(identical(other.cng, cng) || other.cng == cng)&&(identical(other.isOpen, isOpen) || other.isOpen == isOpen)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.openingHoursText, openingHoursText) || other.openingHoursText == openingHoursText)&&(identical(other.is24h, is24h) || other.is24h == is24h)&&const DeepCollectionEquality().equals(other._services, _services)&&const DeepCollectionEquality().equals(other._availableFuels, _availableFuels)&&const DeepCollectionEquality().equals(other._unavailableFuels, _unavailableFuels)&&(identical(other.stationType, stationType) || other.stationType == stationType)&&(identical(other.department, department) || other.department == department)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other._amenities, _amenities));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Station&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.brand, brand) || other.brand == brand)&&(identical(other.street, street) || other.street == street)&&(identical(other.houseNumber, houseNumber) || other.houseNumber == houseNumber)&&(identical(other.postCode, postCode) || other.postCode == postCode)&&(identical(other.place, place) || other.place == place)&&(identical(other.lat, lat) || other.lat == lat)&&(identical(other.lng, lng) || other.lng == lng)&&(identical(other.dist, dist) || other.dist == dist)&&(identical(other.e5, e5) || other.e5 == e5)&&(identical(other.e10, e10) || other.e10 == e10)&&(identical(other.e98, e98) || other.e98 == e98)&&(identical(other.diesel, diesel) || other.diesel == diesel)&&(identical(other.dieselPremium, dieselPremium) || other.dieselPremium == dieselPremium)&&(identical(other.e85, e85) || other.e85 == e85)&&(identical(other.lpg, lpg) || other.lpg == lpg)&&(identical(other.cng, cng) || other.cng == cng)&&(identical(other.isOpen, isOpen) || other.isOpen == isOpen)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.openingHoursText, openingHoursText) || other.openingHoursText == openingHoursText)&&(identical(other.openingHours, openingHours) || other.openingHours == openingHours)&&(identical(other.is24h, is24h) || other.is24h == is24h)&&const DeepCollectionEquality().equals(other._services, _services)&&const DeepCollectionEquality().equals(other._availableFuels, _availableFuels)&&const DeepCollectionEquality().equals(other._unavailableFuels, _unavailableFuels)&&(identical(other.stationType, stationType) || other.stationType == stationType)&&(identical(other.department, department) || other.department == department)&&(identical(other.region, region) || other.region == region)&&const DeepCollectionEquality().equals(other._amenities, _amenities));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,brand,street,houseNumber,postCode,place,lat,lng,dist,e5,e10,e98,diesel,dieselPremium,e85,lpg,cng,isOpen,updatedAt,openingHoursText,is24h,const DeepCollectionEquality().hash(_services),const DeepCollectionEquality().hash(_availableFuels),const DeepCollectionEquality().hash(_unavailableFuels),stationType,department,region,const DeepCollectionEquality().hash(_amenities)]);
+int get hashCode => Object.hashAll([runtimeType,id,name,brand,street,houseNumber,postCode,place,lat,lng,dist,e5,e10,e98,diesel,dieselPremium,e85,lpg,cng,isOpen,updatedAt,openingHoursText,openingHours,is24h,const DeepCollectionEquality().hash(_services),const DeepCollectionEquality().hash(_availableFuels),const DeepCollectionEquality().hash(_unavailableFuels),stationType,department,region,const DeepCollectionEquality().hash(_amenities)]);
 
 @override
 String toString() {
-  return 'Station(id: $id, name: $name, brand: $brand, street: $street, houseNumber: $houseNumber, postCode: $postCode, place: $place, lat: $lat, lng: $lng, dist: $dist, e5: $e5, e10: $e10, e98: $e98, diesel: $diesel, dieselPremium: $dieselPremium, e85: $e85, lpg: $lpg, cng: $cng, isOpen: $isOpen, updatedAt: $updatedAt, openingHoursText: $openingHoursText, is24h: $is24h, services: $services, availableFuels: $availableFuels, unavailableFuels: $unavailableFuels, stationType: $stationType, department: $department, region: $region, amenities: $amenities)';
+  return 'Station(id: $id, name: $name, brand: $brand, street: $street, houseNumber: $houseNumber, postCode: $postCode, place: $place, lat: $lat, lng: $lng, dist: $dist, e5: $e5, e10: $e10, e98: $e98, diesel: $diesel, dieselPremium: $dieselPremium, e85: $e85, lpg: $lpg, cng: $cng, isOpen: $isOpen, updatedAt: $updatedAt, openingHoursText: $openingHoursText, openingHours: $openingHours, is24h: $is24h, services: $services, availableFuels: $availableFuels, unavailableFuels: $unavailableFuels, stationType: $stationType, department: $department, region: $region, amenities: $amenities)';
 }
 
 
@@ -331,11 +355,11 @@ abstract mixin class _$StationCopyWith<$Res> implements $StationCopyWith<$Res> {
   factory _$StationCopyWith(_Station value, $Res Function(_Station) _then) = __$StationCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
+ String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText,@JsonKey(includeFromJson: false, includeToJson: false) WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
 });
 
 
-
+@override $WeeklyOpeningHoursCopyWith<$Res>? get openingHours;
 
 }
 /// @nodoc
@@ -348,7 +372,7 @@ class __$StationCopyWithImpl<$Res>
 
 /// Create a copy of Station
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = null,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? brand = null,Object? street = null,Object? houseNumber = freezed,Object? postCode = null,Object? place = null,Object? lat = null,Object? lng = null,Object? dist = null,Object? e5 = freezed,Object? e10 = freezed,Object? e98 = freezed,Object? diesel = freezed,Object? dieselPremium = freezed,Object? e85 = freezed,Object? lpg = freezed,Object? cng = freezed,Object? isOpen = null,Object? updatedAt = freezed,Object? openingHoursText = freezed,Object? openingHours = freezed,Object? is24h = null,Object? services = null,Object? availableFuels = null,Object? unavailableFuels = null,Object? stationType = freezed,Object? department = freezed,Object? region = freezed,Object? amenities = null,}) {
   return _then(_Station(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -371,7 +395,8 @@ as double?,cng: freezed == cng ? _self.cng : cng // ignore: cast_nullable_to_non
 as double?,isOpen: null == isOpen ? _self.isOpen : isOpen // ignore: cast_nullable_to_non_nullable
 as bool,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as String?,openingHoursText: freezed == openingHoursText ? _self.openingHoursText : openingHoursText // ignore: cast_nullable_to_non_nullable
-as String?,is24h: null == is24h ? _self.is24h : is24h // ignore: cast_nullable_to_non_nullable
+as String?,openingHours: freezed == openingHours ? _self.openingHours : openingHours // ignore: cast_nullable_to_non_nullable
+as WeeklyOpeningHours?,is24h: null == is24h ? _self.is24h : is24h // ignore: cast_nullable_to_non_nullable
 as bool,services: null == services ? _self._services : services // ignore: cast_nullable_to_non_nullable
 as List<String>,availableFuels: null == availableFuels ? _self._availableFuels : availableFuels // ignore: cast_nullable_to_non_nullable
 as List<String>,unavailableFuels: null == unavailableFuels ? _self._unavailableFuels : unavailableFuels // ignore: cast_nullable_to_non_nullable
@@ -383,7 +408,19 @@ as Set<StationAmenity>,
   ));
 }
 
+/// Create a copy of Station
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$WeeklyOpeningHoursCopyWith<$Res>? get openingHours {
+    if (_self.openingHours == null) {
+    return null;
+  }
 
+  return $WeeklyOpeningHoursCopyWith<$Res>(_self.openingHours!, (value) {
+    return _then(_self.copyWith(openingHours: value));
+  });
+}
 }
 
 /// @nodoc

--- a/lib/features/station_detail/providers/station_detail_provider.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.dart
@@ -46,8 +46,15 @@ Future<ServiceResult<StationDetail>> stationDetail(
         .where((r) => r.station.id == stationId)
         .firstOrNull;
     if (fromSearch != null) {
+      // Carry any structured weekly hours the search-result station already
+      // holds (Epic C4 — e.g. AT E-Control, which has no detail endpoint)
+      // into `StationDetail.openingHours` so the display layer renders them
+      // directly instead of falling through `legacyOpeningHoursBridge`.
       return ServiceResult(
-        data: StationDetail(station: fromSearch.station),
+        data: StationDetail(
+          station: fromSearch.station,
+          openingHours: fromSearch.station.openingHours,
+        ),
         source: ServiceSource.cache,
         fetchedAt: DateTime.now(),
       );

--- a/lib/features/station_detail/providers/station_detail_provider.g.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.g.dart
@@ -66,7 +66,7 @@ final class StationDetailProvider
   }
 }
 
-String _$stationDetailHash() => r'706b857351c827cb726f540735d92268fffa80ab';
+String _$stationDetailHash() => r'fb765ac559f25d8397acfacce331e6fe58e62534';
 
 final class StationDetailFamily extends $Family
     with

--- a/lib/features/station_services/austria/austria_opening_hours_adapter.dart
+++ b/lib/features/station_services/austria/austria_opening_hours_adapter.dart
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../station_detail/domain/opening_hours.dart';
+import '../opening_hours/opening_hours_adapter.dart';
+
+/// Normalises the Austrian E-Control (Spritpreisrechner) opening-hours feed
+/// into the common [WeeklyOpeningHours] model (Epic C4, #2711).
+///
+/// ## Accepted input shapes
+/// E-Control emits one row per day in an `openingHours[]` array; each row is
+/// a map `{day, label, order, from, to}` where `label` is the full German
+/// day name (`Montag` … `Sonntag`, plus `Feiertag` for public holidays),
+/// `day` is the two-letter code (`MO,DI,MI,DO,FR,SA,SO,FE`), and `from`/`to`
+/// are `HH:MM` 24-hour clock strings. This adapter accepts:
+///   - the **structured** `List` of day rows (preferred), or its enclosing
+///     `Map` (`{'openingHours': [...]}`), and
+///   - the **joined German paragraph** the service historically produced
+///     (`"Montag: 06:30-20:30, Dienstag: …, Feiertag: 06:30-20:30"`) as a
+///     `String` fallback.
+///
+/// ## Time-range semantics (grounded on the live feed, not the issue text)
+///   - `00:00-24:00` → [DayState.open24h] (the feed's whole-day marker).
+///   - `00:00-00:00` → [DayState.closed]. The live feed uses an equal-bounds
+///     pair to mean "not open that day" (verified against eni Floragasse's
+///     Sunday/holiday rows), so a degenerate range is **closed**, never a
+///     24-hour wrap. (#feedback_fake_services_false_green — honour the real
+///     API, not the requested shape.)
+///   - any other `HH:MM-HH:MM` → [DayState.openRanges] with one [TimeRange].
+///   - a `geschlossen` / `closed` token → [DayState.closed].
+///
+/// ## Contract
+/// Pure, total, never throws, never returns `null` — unparseable / empty
+/// input degrades to [WeeklyOpeningHours.notAvailable] (the
+/// [OpeningHoursAdapter] contract).
+class AustriaOpeningHoursAdapter extends OpeningHoursAdapter {
+  const AustriaOpeningHoursAdapter();
+
+  /// Full German day labels → [OpeningDay]. `Feiertag` is the OSM `PH`
+  /// public-holiday pseudo-day.
+  static const Map<String, OpeningDay> _germanDayLabels = {
+    'montag': OpeningDay.mon,
+    'dienstag': OpeningDay.tue,
+    'mittwoch': OpeningDay.wed,
+    'donnerstag': OpeningDay.thu,
+    'freitag': OpeningDay.fri,
+    'samstag': OpeningDay.sat,
+    'sonntag': OpeningDay.sun,
+    'feiertag': OpeningDay.publicHoliday,
+  };
+
+  /// E-Control two-letter `day` codes → [OpeningDay] (secondary path when a
+  /// row carries the code but no usable `label`).
+  static const Map<String, OpeningDay> _germanDayCodes = {
+    'mo': OpeningDay.mon,
+    'di': OpeningDay.tue,
+    'mi': OpeningDay.wed,
+    'do': OpeningDay.thu,
+    'fr': OpeningDay.fri,
+    'sa': OpeningDay.sat,
+    'so': OpeningDay.sun,
+    'fe': OpeningDay.publicHoliday,
+  };
+
+  @override
+  WeeklyOpeningHours parse(dynamic rawProviderData) {
+    try {
+      final rows = _extractRows(rawProviderData);
+      if (rows == null || rows.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+      final byDay = <OpeningDay, DayHours>{};
+      for (final row in rows) {
+        final parsed = _parseRow(row);
+        if (parsed == null) continue;
+        // First occurrence of a day wins (the feed is one row per day).
+        byDay.putIfAbsent(parsed.day, () => parsed);
+      }
+
+      if (byDay.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+      final coversAllWeekdays =
+          kRegularWeekdays.every(byDay.containsKey);
+      return WeeklyOpeningHours(
+        days: byDay.values.toList(),
+        availability: coversAllWeekdays
+            ? OpeningHoursAvailability.full
+            : OpeningHoursAvailability.partial,
+        rawSource: rawProviderData is String ? rawProviderData : null,
+      );
+    } catch (e, st) {
+      // The adapter must never propagate a fault to the station-detail UI.
+      assert(() {
+        // ignore: avoid_print
+        print('AustriaOpeningHoursAdapter.parse failed: $e\n$st');
+        return true;
+      }());
+      return WeeklyOpeningHours.notAvailable;
+    }
+  }
+
+  /// Narrows [raw] to the list of per-day rows, or `null` when there is no
+  /// usable shape. Accepts a `List`, a wrapping `Map`, or a joined String.
+  List<Map<String, String>>? _extractRows(dynamic raw) {
+    if (raw is List) return _rowsFromList(raw);
+    if (raw is Map) {
+      final inner = raw['openingHours'];
+      if (inner is List) return _rowsFromList(inner);
+      return null;
+    }
+    if (raw is String) return _rowsFromJoinedString(raw);
+    return null;
+  }
+
+  /// Maps a structured E-Control `openingHours[]` list into normalised
+  /// `{day,from,to}` string rows. Non-map / empty entries are skipped.
+  List<Map<String, String>> _rowsFromList(List<dynamic> list) {
+    final rows = <Map<String, String>>[];
+    for (final entry in list) {
+      if (entry is! Map) continue;
+      final label = (entry['label'] ?? entry['day'])?.toString().trim() ?? '';
+      final from = entry['from']?.toString().trim() ?? '';
+      final to = entry['to']?.toString().trim() ?? '';
+      if (label.isEmpty) continue;
+      rows.add({'day': label, 'from': from, 'to': to});
+    }
+    return rows;
+  }
+
+  /// Parses the joined German paragraph
+  /// (`"Montag: 06:30-20:30, Dienstag: …, Feiertag: …"`) into `{day,from,to}`
+  /// rows. Each `,`-separated segment is `"<Label>: <from>-<to>"`.
+  List<Map<String, String>> _rowsFromJoinedString(String raw) {
+    final rows = <Map<String, String>>[];
+    for (final segment in raw.split(',')) {
+      final colon = segment.indexOf(':');
+      if (colon < 0) continue;
+      final label = segment.substring(0, colon).trim();
+      final value = segment.substring(colon + 1).trim();
+      if (label.isEmpty) continue;
+      final dash = value.indexOf('-');
+      if (dash < 0) {
+        // No range marker → carry the token (e.g. "geschlossen") as `from`.
+        rows.add({'day': label, 'from': value, 'to': ''});
+        continue;
+      }
+      rows.add({
+        'day': label,
+        'from': value.substring(0, dash).trim(),
+        'to': value.substring(dash + 1).trim(),
+      });
+    }
+    return rows;
+  }
+
+  /// Resolves one normalised row into a [DayHours], or `null` when its day
+  /// label is unrecognised.
+  DayHours? _parseRow(Map<String, String> row) {
+    final day = _dayFromLabel(row['day'] ?? '');
+    if (day == null) return null;
+
+    final from = row['from'] ?? '';
+    final to = row['to'] ?? '';
+
+    if (_isClosedToken(from) || _isClosedToken(to)) {
+      return DayHours.closedDay(day);
+    }
+
+    final start = _minutesFromClock(from);
+    final end = _minutesFromClock(to);
+    if (start == null || end == null) {
+      // No usable clock pair → no signal for this day; omit it (treated as
+      // unknown by the model) rather than inventing a state.
+      return null;
+    }
+
+    // 00:00-24:00 (end == 1440) → whole-day open.
+    if (start == 0 && end == 1440) return DayHours.allDay(day);
+    // 00:00-00:00 (equal bounds) → closed, per the live feed's convention.
+    if (start == end) return DayHours.closedDay(day);
+
+    return DayHours(
+      day: day,
+      state: DayState.openRanges,
+      ranges: [TimeRange(startMinutes: start, endMinutes: end)],
+    );
+  }
+
+  OpeningDay? _dayFromLabel(String label) {
+    final key = label.toLowerCase().trim();
+    return _germanDayLabels[key] ?? _germanDayCodes[key];
+  }
+
+  bool _isClosedToken(String value) {
+    final v = value.toLowerCase().trim();
+    return v == 'geschlossen' || v == 'closed';
+  }
+
+  /// `HH:MM` → minutes-from-midnight (0..1440; 24:00 → 1440), or `null`.
+  /// `24:00` is accepted as the feed's whole-day end marker.
+  int? _minutesFromClock(String clock) {
+    final parts = clock.split(':');
+    if (parts.length < 2) return null;
+    final hour = int.tryParse(parts[0]);
+    final minute = int.tryParse(parts[1]);
+    if (hour == null || minute == null) return null;
+    if (hour == 24 && minute == 0) return 1440;
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+    return hour * 60 + minute;
+  }
+}

--- a/lib/features/station_services/austria/econtrol_station_service.dart
+++ b/lib/features/station_services/austria/econtrol_station_service.dart
@@ -11,6 +11,8 @@ import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/logging/error_logger.dart';
+import '../../station_detail/domain/opening_hours.dart';
+import 'austria_opening_hours_adapter.dart';
 
 /// Austrian fuel prices from E-Control Spritpreisrechner.
 /// Free, no API key, no registration.
@@ -131,8 +133,13 @@ class EControlStationService with StationServiceHelpers implements StationServic
         }
       }
 
-      // Opening hours text
+      // Opening hours — parse the structured E-Control `openingHours[]`
+      // rows into the common [WeeklyOpeningHours] (Epic C4, #2711) instead of
+      // the legacy German paragraph. The structured `weeklyHours` is the
+      // canonical signal; `openingHoursText` is kept (best-effort) for
+      // back-compat with any consumer still reading the legacy string.
       final openingHours = r['openingHours'] as List<dynamic>? ?? [];
+      final weeklyHours = const AustriaOpeningHoursAdapter().parse(openingHours);
       final hoursText = openingHours.map((oh) {
         if (oh is Map<String, dynamic>) {
           return '${oh['label'] ?? oh['day']}: ${oh['from']}-${oh['to']}';
@@ -165,6 +172,10 @@ class EControlStationService with StationServiceHelpers implements StationServic
         lpg: fuelType == 'GAS' ? price : null,
         isOpen: isOpen,
         openingHoursText: hoursText.isNotEmpty ? hoursText : null,
+        openingHours: weeklyHours.availability ==
+                OpeningHoursAvailability.notProvided
+            ? null
+            : weeklyHours,
       );
     } on FormatException catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'E-Control station parse failed'}));

--- a/test/features/station_services/austria/austria_opening_hours_adapter_test.dart
+++ b/test/features/station_services/austria/austria_opening_hours_adapter_test.dart
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/austria/austria_opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/opening_hours/opening_hours_adapter.dart';
+
+/// A recorded E-Control `openingHours[]` payload (live-feed shape verified
+/// against `api.e-control.at/sprit/1.0`): one row per day, German full
+/// `label` + two-letter `day` code + `order` + `HH:MM` `from`/`to`. Mon–Fri
+/// 06:30-20:30, Sat 08:00-20:30, Sun closed (00:00-00:00), Feiertag a real
+/// range — exercises the German-day mapping, Feiertag→publicHoliday and the
+/// closed-day convention in one fixture.
+final List<Map<String, dynamic>> _eControlFullWeekFixture = [
+  {'day': 'MO', 'label': 'Montag', 'order': 1, 'from': '06:30', 'to': '20:30'},
+  {'day': 'DI', 'label': 'Dienstag', 'order': 2, 'from': '06:30', 'to': '20:30'},
+  {'day': 'MI', 'label': 'Mittwoch', 'order': 3, 'from': '06:30', 'to': '20:30'},
+  {
+    'day': 'DO',
+    'label': 'Donnerstag',
+    'order': 4,
+    'from': '06:30',
+    'to': '20:30',
+  },
+  {'day': 'FR', 'label': 'Freitag', 'order': 5, 'from': '06:30', 'to': '20:30'},
+  {'day': 'SA', 'label': 'Samstag', 'order': 6, 'from': '08:00', 'to': '20:30'},
+  {'day': 'SO', 'label': 'Sonntag', 'order': 7, 'from': '00:00', 'to': '00:00'},
+  {
+    'day': 'FE',
+    'label': 'Feiertag',
+    'order': 8,
+    'from': '08:00',
+    'to': '13:00',
+  },
+];
+
+/// A 24/7 station: every day `00:00-24:00`, the live feed's whole-day marker.
+final List<Map<String, dynamic>> _eControl24hFixture = [
+  for (final label in const [
+    'Montag',
+    'Dienstag',
+    'Mittwoch',
+    'Donnerstag',
+    'Freitag',
+    'Samstag',
+    'Sonntag',
+    'Feiertag',
+  ])
+    {'label': label, 'from': '00:00', 'to': '24:00'},
+];
+
+void main() {
+  const adapter = AustriaOpeningHoursAdapter();
+
+  test('is an OpeningHoursAdapter', () {
+    expect(adapter, isA<OpeningHoursAdapter>());
+  });
+
+  group('structured openingHours[] — full Mon–Sun + Feiertag', () {
+    late WeeklyOpeningHours result;
+
+    setUp(() => result = adapter.parse(_eControlFullWeekFixture));
+
+    test('maps every German weekday label to the right OpeningDay', () {
+      expect(result.dayFor(OpeningDay.mon)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.tue)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.wed)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.thu)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.fri)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.sat)?.state, DayState.openRanges);
+    });
+
+    test('Montag → mon with the right 06:30-20:30 range', () {
+      final mon = result.dayFor(OpeningDay.mon);
+      expect(mon, isNotNull);
+      expect(mon!.state, DayState.openRanges);
+      expect(mon.ranges, hasLength(1));
+      expect(mon.ranges.single.startMinutes, 6 * 60 + 30);
+      expect(mon.ranges.single.endMinutes, 20 * 60 + 30);
+    });
+
+    test('Samstag → sat with its distinct 08:00-20:30 range', () {
+      final sat = result.dayFor(OpeningDay.sat);
+      expect(sat!.ranges.single.startMinutes, 8 * 60);
+      expect(sat.ranges.single.endMinutes, 20 * 60 + 30);
+    });
+
+    test('Sonntag 00:00-00:00 → closed', () {
+      final sun = result.dayFor(OpeningDay.sun);
+      expect(sun, isNotNull);
+      expect(sun!.state, DayState.closed);
+      expect(sun.ranges, isEmpty);
+    });
+
+    test('Feiertag → publicHoliday (OSM PH) with its own range', () {
+      final ph = result.dayFor(OpeningDay.publicHoliday);
+      expect(ph, isNotNull);
+      expect(ph!.day, OpeningDay.publicHoliday);
+      expect(ph.state, DayState.openRanges);
+      expect(ph.ranges.single.startMinutes, 8 * 60);
+      expect(ph.ranges.single.endMinutes, 13 * 60);
+    });
+
+    test('availability is full (all seven regular weekdays covered)', () {
+      expect(result.availability, OpeningHoursAvailability.full);
+    });
+  });
+
+  group('24h detection', () {
+    test('00:00-24:00 on every day → all days open24h', () {
+      final result = adapter.parse(_eControl24hFixture);
+      for (final d in kRegularWeekdays) {
+        expect(result.dayFor(d)?.state, DayState.open24h,
+            reason: '$d should be open24h');
+      }
+      expect(result.dayFor(OpeningDay.publicHoliday)?.state, DayState.open24h);
+      expect(result.availability, OpeningHoursAvailability.full);
+    });
+  });
+
+  group('joined German string fallback', () {
+    test('parses the legacy "Montag: 06:30-20:30, …, Feiertag: …" paragraph',
+        () {
+      const joined = 'Montag: 06:30-20:30, Dienstag: 06:30-20:30, '
+          'Mittwoch: 06:30-20:30, Donnerstag: 06:30-20:30, '
+          'Freitag: 06:30-20:30, Samstag: 08:00-20:30, '
+          'Sonntag: 00:00-00:00, Feiertag: 08:00-13:00';
+      final result = adapter.parse(joined);
+
+      expect(result.dayFor(OpeningDay.mon)?.ranges.single.startMinutes,
+          6 * 60 + 30);
+      expect(result.dayFor(OpeningDay.sun)?.state, DayState.closed);
+      expect(result.dayFor(OpeningDay.publicHoliday)?.state,
+          DayState.openRanges);
+      expect(result.availability, OpeningHoursAvailability.full);
+      expect(result.rawSource, joined);
+    });
+
+    test('"geschlossen" token → closed day', () {
+      final result = adapter.parse('Sonntag: geschlossen');
+      expect(result.dayFor(OpeningDay.sun)?.state, DayState.closed);
+    });
+  });
+
+  group('graceful no-data (never throws, never null)', () {
+    test('empty list → notAvailable', () {
+      expect(adapter.parse(const <dynamic>[]), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('empty string → notAvailable', () {
+      expect(adapter.parse(''), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('null → notAvailable', () {
+      expect(adapter.parse(null), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('unrecognised shape → notAvailable, returns normally', () {
+      expect(() => adapter.parse(42), returnsNormally);
+      expect(adapter.parse(42), WeeklyOpeningHours.notAvailable);
+      expect(adapter.parse(const {'unexpected': true}),
+          WeeklyOpeningHours.notAvailable);
+    });
+
+    test('rows with only unrecognised day labels → notAvailable', () {
+      final result = adapter.parse([
+        {'label': 'Funday', 'from': '06:00', 'to': '22:00'},
+      ]);
+      expect(result, WeeklyOpeningHours.notAvailable);
+    });
+
+    test('partial coverage (subset of weekdays) → partial availability', () {
+      final result = adapter.parse([
+        {'label': 'Montag', 'from': '06:00', 'to': '22:00'},
+        {'label': 'Dienstag', 'from': '06:00', 'to': '22:00'},
+      ]);
+      expect(result.availability, OpeningHoursAvailability.partial);
+      expect(result.dayFor(OpeningDay.mon)?.state, DayState.openRanges);
+    });
+  });
+
+  group('enclosing map shape', () {
+    test('{"openingHours": [...]} is unwrapped and parsed', () {
+      final result =
+          adapter.parse({'openingHours': _eControlFullWeekFixture});
+      expect(result.dayFor(OpeningDay.publicHoliday)?.state,
+          DayState.openRanges);
+    });
+  });
+}


### PR DESCRIPTION
## What

Epic #2707 C4 — the **Austria** opening-hours adapter. Adds
`AustriaOpeningHoursAdapter` that normalises the E-Control
(Spritpreisrechner) opening-hours feed into the foundation's
`WeeklyOpeningHours` model (#2708), and wires it into
`EControlStationService`.

## Mapping

- German day labels **Montag→mon, Dienstag→tue, Mittwoch→wed,
  Donnerstag→thu, Freitag→fri, Samstag→sat, Sonntag→sun, Feiertag→publicHoliday**
  (OSM `PH`), with the two-letter `day` codes (`MO/DI/MI/DO/FR/SA/SO/FE`)
  as a secondary path.
- `00:00-24:00` → `open24h`; real `HH:MM-HH:MM` → `openRanges`;
  `00:00-00:00` and the `geschlossen`/`closed` token → `closed`.
- Accepts the **structured** `openingHours[]` list (or its wrapping map);
  falls back to parsing the **joined German paragraph** string.
- Pure, total, never throws, never null → `notAvailable`.

## Real-feed fidelity (not the issue's parenthetical)

The issue text suggested `00:00-00:00` = full-day. The **live**
`api.e-control.at` feed uses `00:00-24:00` for whole-day and
`00:00-00:00` to mean **closed** (verified against eni Floragasse's
Sunday/holiday rows). The adapter honours the real API, per the
"fake-services-false-green" lesson.

## Wiring

`EControlStationService` parses the structured `openingHours[]` via the
adapter (replacing the `.join(', ')` German paragraph as the canonical
signal). It rides on a new **JSON-excluded** `Station.openingHours` field;
the station-detail provider threads it into `StationDetail.openingHours`
(E-Control has no detail endpoint, so the detail is built from the
search-result station). `openingHoursText` / `is24h` stay for back-compat.

## Tests (reuse-fidelity, RED-on-master)

Drive the **real** adapter with a recorded live-feed-shaped fixture:
full Mon–Sun + **Feiertag** (→ publicHoliday), a 24h station, a closed
day, empty/null/garbage → `notAvailable`, plus the joined-string fallback
and the wrapping-map shape. Asserts the German-day mapping,
Feiertag→publicHoliday, and 24h detection.

## Gates

- **ARB-free** — zero `lib/l10n/` drift.
- `flutter analyze` clean; `flutter test` GREEN (Austria dir 66, plus
  opening-hours/station-detail/search dirs 915 — no regressions).
- file_length ≤400 (adapter 210, test 191, service 221).
- HARD RULE #3 clean-codegen committed (`station.freezed.dart` +
  `station_detail_provider.g.dart`).

Closes #2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
