### PR TITLE
feat(opening-hours): France adapter — horaires + Automate-24-24 (Epic #2707 C3)

### DIFF
--- a/lib/features/station_services/france/france_opening_hours_adapter.dart
+++ b/lib/features/station_services/france/france_opening_hours_adapter.dart
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../station_detail/domain/opening_hours.dart';
+import '../opening_hours/opening_hours_adapter.dart';
+
+/// Maps the French Prix-Carburants (gouv.fr) opening-hours payload onto the
+/// common [WeeklyOpeningHours] model (Epic #2707 C3, #2710).
+///
+/// ## Input shape
+/// [parse] accepts a `Map` carrying the two raw feed fields:
+///   - `horaires_jour` — the flattened, comma-joined per-day string, e.g.
+///     `"Automate-24-24, Lundi07.00-18.30, Mardi08.00-12.00, Mardi14.00-19.00"`.
+///   - `horaires_automate_24_24` — the 24/7-automate flag, the string `'Oui'`
+///     when the site has a 24-hour unattended pump.
+///
+/// A bare `String` is also accepted as a convenience (treated as the
+/// `horaires_jour` value with no automate flag).
+///
+/// ## Normalisation rules (the four feed quirks this adapter owns)
+/// 1. **`Automate-24-24` prefix** — stripped. When the automate flag is set
+///    the whole week is [WeeklyOpeningHours.allWeek24h] regardless of the
+///    per-day ranges (the unattended pump is open 24/7).
+/// 2. **The missing-space bug** — the feed glues the day name onto the first
+///    clock (`Lundi07.00-18.30`). The legacy `replaceAll(', ', '\n')` flattener
+///    never separated them. Here a single regex captures the day name and the
+///    `HH.MM-HH.MM` range as **separate groups**, so the structural split is
+///    correct by construction.
+/// 3. **The `01:00-01:00` degenerate sentinel** — the feed emits an
+///    open==close range to mean "no real interval". Such a day resolves to
+///    [DayState.unknown] (the literal range is dropped), never a real interval
+///    and never 24h ([TimeRange.isDegenerate]).
+/// 4. **Split shifts** — a lunch break is published as two entries for the
+///    same day (`Mardi08.00-12.00, Mardi14.00-19.00`); both ranges coalesce
+///    into that day's [DayHours.ranges].
+///
+/// A day the feed omits is left out of [WeeklyOpeningHours.days] (implicitly
+/// unknown). Empty / unparseable input returns [WeeklyOpeningHours.notAvailable].
+///
+/// Honours the [OpeningHoursAdapter] contract: pure, never throws, never
+/// returns `null`.
+class FranceOpeningHoursAdapter extends OpeningHoursAdapter {
+  const FranceOpeningHoursAdapter();
+
+  /// The automate flag's truthy value in the gouv.fr feed.
+  // i18n-ignore: gouv.fr feed enum value, not user-facing text
+  static const String _automateYes = 'Oui';
+
+  /// French weekday label → [OpeningDay]. Lower-cased + accent-folded before
+  /// lookup so `Mardi`, `mardi` and a stray accented variant all resolve.
+  static const Map<String, OpeningDay> _dayByLabel = {
+    'lundi': OpeningDay.mon,
+    'mardi': OpeningDay.tue,
+    'mercredi': OpeningDay.wed,
+    'jeudi': OpeningDay.thu,
+    'vendredi': OpeningDay.fri,
+    'samedi': OpeningDay.sat,
+    'dimanche': OpeningDay.sun,
+  };
+
+  /// Captures `<DayName><HH.MM>-<HH.MM>` (the glued feed form) in three
+  /// groups: day label, start clock, end clock. The day label is letters only
+  /// (incl. accents), so the regex cleanly splits `Lundi07.00-18.30` without a
+  /// separating space — the structural fix for the missing-space bug (#2710).
+  static final RegExp _dayRangeRe = RegExp(
+    r'([A-Za-zÀ-ÿ]+)\s*(\d{1,2})[.:](\d{2})\s*-\s*(\d{1,2})[.:](\d{2})',
+  );
+
+  @override
+  WeeklyOpeningHours parse(dynamic rawProviderData) {
+    try {
+      final (raw, automate24h) = _narrow(rawProviderData);
+      if (raw == null) return WeeklyOpeningHours.notAvailable;
+
+      // The 24/7-automate flag wins outright: the unattended pump is open all
+      // week regardless of the staffed per-day ranges.
+      if (automate24h) {
+        return WeeklyOpeningHours.allWeek24h(rawSource: raw);
+      }
+
+      final trimmed = raw.trim();
+      if (trimmed.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+      // Accumulate ranges per day (split shifts coalesce). A day that appears
+      // only as a degenerate `01:00-01:00` sentinel lands here with an empty
+      // range list → resolved to `unknown` below.
+      final ranges = <OpeningDay, List<TimeRange>>{};
+      final seen = <OpeningDay>{};
+      var matchedAny = false;
+
+      for (final m in _dayRangeRe.allMatches(trimmed)) {
+        matchedAny = true;
+        final day = _dayByLabel[_fold(m.group(1)!)];
+        if (day == null) continue;
+        seen.add(day);
+
+        final range = TimeRange.fromClock(
+          startHour: int.parse(m.group(2)!),
+          startMinute: int.parse(m.group(3)!),
+          endHour: int.parse(m.group(4)!),
+          endMinute: int.parse(m.group(5)!),
+        );
+        // Degenerate `01:00-01:00` → no real interval. Drop the range; the day
+        // is recorded as `seen` so it resolves to `unknown`, never 24h.
+        if (range.isDegenerate) continue;
+        (ranges[day] ??= <TimeRange>[]).add(range);
+      }
+
+      if (!matchedAny) return WeeklyOpeningHours.notAvailable;
+
+      final days = <DayHours>[];
+      for (final day in kRegularWeekdays) {
+        if (!seen.contains(day)) continue; // omitted → implicitly unknown
+        final dayRanges = ranges[day];
+        if (dayRanges == null || dayRanges.isEmpty) {
+          // The day appeared but carried only a degenerate sentinel.
+          days.add(DayHours(day: day, state: DayState.unknown));
+        } else {
+          days.add(
+            DayHours(day: day, state: DayState.openRanges, ranges: dayRanges),
+          );
+        }
+      }
+
+      if (days.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+      // `full` when every regular weekday is resolved, else `partial`.
+      final availability = days.length == kRegularWeekdays.length
+          ? OpeningHoursAvailability.full
+          : OpeningHoursAvailability.partial;
+      return WeeklyOpeningHours(
+        days: days,
+        availability: availability,
+        rawSource: raw,
+      );
+    } catch (_) {
+      // Contract: never throw — degrade to no-data.
+      return WeeklyOpeningHours.notAvailable;
+    }
+  }
+
+  /// Narrow [rawProviderData] to `(horairesJour, automate24h)`. Accepts a
+  /// `Map` with the two feed keys, or a bare `String` (the `horaires_jour`
+  /// value with no automate flag). Anything else → `(null, false)`.
+  (String?, bool) _narrow(dynamic raw) {
+    if (raw is String) return (raw, false);
+    if (raw is Map) {
+      final hours = raw['horaires_jour'];
+      final automate = raw['horaires_automate_24_24'];
+      return (
+        hours?.toString(),
+        automate?.toString() == _automateYes,
+      );
+    }
+    return (null, false);
+  }
+
+  /// Lower-case + strip the few accented French day-label letters so the map
+  /// lookup is robust to casing / accent drift in the feed.
+  String _fold(String s) => s
+      .toLowerCase()
+      .replaceAll('à', 'a')
+      .replaceAll('â', 'a')
+      .replaceAll('é', 'e')
+      .replaceAll('è', 'e')
+      .replaceAll('ê', 'e')
+      .replaceAll('î', 'i')
+      .replaceAll('ô', 'o')
+      .replaceAll('û', 'u')
+      .replaceAll('ç', 'c');
+}

--- a/lib/features/station_services/france/prix_carburants_flux_parser.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_parser.dart
@@ -32,6 +32,7 @@ import 'package:archive/archive.dart';
 import 'package:xml/xml.dart';
 
 import '../../search/domain/entities/station.dart';
+import 'prix_carburants_parsers.dart' as parser;
 
 /// Decode the flux ZIP [bytes], locate the inner XML entry, and parse every
 /// point-of-sale into a [Station] (distance 0 — the caller stamps it per
@@ -98,6 +99,17 @@ Station? parseFluxPdv(XmlElement pdv) {
   final adresse = pdv.findElements('adresse').firstOrNull?.innerText.trim() ?? '';
   final ville = pdv.findElements('ville').firstOrNull?.innerText.trim() ?? '';
 
+  // #2710 — the flux XML carries opening hours the legacy JSON feed flattened
+  // into `horaires_jour`. Flatten the `<horaires>/<jour>/<horaire>` tree into
+  // the SAME comma-joined `horaires_jour` form, then run it through the shared
+  // `parsePrixCarburantsOpeningHours` so the Station's legacy `openingHoursText`
+  // reads identically to the polling path (`Lundi 07:00-18:30`). The flux
+  // service rebuilds the structured `WeeklyOpeningHours` from this same text
+  // via [FranceOpeningHoursAdapter] (which tolerates `.`/`:` + any separator).
+  final rawHoraires = _flattenHoraires(pdv);
+  final openingHoursText = parser.parsePrixCarburantsOpeningHours(rawHoraires);
+  final is24h = _isAutomate24h(pdv);
+
   double? e5, e10, e98, diesel, e85, lpg;
   String? mostRecentMaj;
   for (final prix in pdv.findElements('prix')) {
@@ -153,7 +165,46 @@ Station? parseFluxPdv(XmlElement pdv) {
     isOpen: true,
     updatedAt: _formatMaj(mostRecentMaj),
     stationType: pop.isEmpty ? null : pop,
+    is24h: is24h,
+    openingHoursText: openingHoursText,
   );
+}
+
+/// Whether the `<horaires automate-24-24="1">` flag is set on the pdv's
+/// opening-hours element. The gouv.fr flux uses `"1"` for the 24/7 automate.
+bool _isAutomate24h(XmlElement pdv) {
+  final horaires = pdv.findElements('horaires').firstOrNull;
+  if (horaires == null) return false;
+  final flag = horaires.getAttribute('automate-24-24')?.trim();
+  return flag == '1' || flag?.toLowerCase() == 'oui';
+}
+
+/// Flatten the flux `<horaires>/<jour>/<horaire>` tree into the SAME
+/// comma-joined `horaires_jour` string the JSON feed publishes (e.g.
+/// `"Lundi07.00-18.30, Mardi08.00-12.00, Mardi14.00-19.00"`), so the single
+/// [FranceOpeningHoursAdapter] handles both feeds. Each `<jour>` carries its
+/// French `nom` + one or more `<horaire ouverture="HH.MM" fermeture="HH.MM"/>`
+/// children; split shifts become repeated `<jour>` entries. Returns `null`
+/// when the pdv carries no usable opening-hours element.
+String? _flattenHoraires(XmlElement pdv) {
+  final horaires = pdv.findElements('horaires').firstOrNull;
+  if (horaires == null) return null;
+
+  final parts = <String>[];
+  for (final jour in horaires.findElements('jour')) {
+    final nom = jour.getAttribute('nom')?.trim() ?? '';
+    if (nom.isEmpty) continue;
+    for (final h in jour.findElements('horaire')) {
+      final open = h.getAttribute('ouverture')?.trim();
+      final close = h.getAttribute('fermeture')?.trim();
+      if (open == null || close == null || open.isEmpty || close.isEmpty) {
+        continue;
+      }
+      parts.add('$nom$open-$close');
+    }
+  }
+  if (parts.isEmpty) return null;
+  return parts.join(', ');
 }
 
 /// GeoDecimal coordinate → WGS84 degrees (÷ 100000). Tolerates a value that is

--- a/lib/features/station_services/france/prix_carburants_flux_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_station_service.dart
@@ -15,6 +15,7 @@ import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
+import 'france_opening_hours_adapter.dart';
 import 'prix_carburants_flux_parser.dart' as flux;
 
 /// French Prix-Carburants **bulk-file** service (#2277).
@@ -178,8 +179,18 @@ class PrixCarburantsFluxStationService
     if (all != null) {
       for (final s in all) {
         if (s.id == stationId) {
+          // #2710 — build the structured weekly schedule from the SAME FR
+          // adapter the polling path uses, fed the legacy fields the flux
+          // parser flattened onto the Station (`openingHoursText` carries the
+          // `horaires_jour`-shaped string, `is24h` the automate flag). Pure +
+          // total: no hours → `notAvailable`, display falls back to the bridge.
+          const adapter = FranceOpeningHoursAdapter();
+          final openingHours = adapter.parse(<String, dynamic>{
+            'horaires_jour': s.openingHoursText,
+            'horaires_automate_24_24': s.is24h ? 'Oui' : 'Non',
+          });
           return ServiceResult(
-            data: StationDetail(station: s),
+            data: StationDetail(station: s, openingHours: openingHours),
             source: ServiceSource.prixCarburantsApi,
             fetchedAt: DateTime.now(),
           );

--- a/lib/features/station_services/france/prix_carburants_parsers.dart
+++ b/lib/features/station_services/france/prix_carburants_parsers.dart
@@ -157,20 +157,27 @@ String? parsePrixCarburantsMostRecentUpdate(Map<String, dynamic> r) {
   }
 }
 
-/// Clean up the Prix-Carburants opening-hours string.
+/// Clean up the Prix-Carburants opening-hours string (legacy back-compat
+/// text; the structured schedule now comes from [FranceOpeningHoursAdapter]).
 ///
 /// Source format: `"Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30..."`
-/// Output: one day per line, with `HH:MM` instead of `HH.MM`. Returns
-/// `null` for `null` or empty input so the caller can suppress the
-/// row entirely.
+/// Output: one day per line, with `HH:MM` instead of `HH.MM` and — fixing the
+/// missing-space bug (#2710) — a space between the day name and the first
+/// clock (`Lundi 07:00-18:30`, not the old glued `Lundi07:00-18:30`). Returns
+/// `null` for `null` or empty input so the caller can suppress the row.
 String? parsePrixCarburantsOpeningHours(dynamic hoursStr) {
   if (hoursStr == null) return null;
   final s = hoursStr.toString();
   if (s.isEmpty) return null;
   // Format: "Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30..."
-  // Clean up: add spaces around times
+  // Clean up: strip the automate prefix, separate the glued day↔clock,
+  // convert `HH.MM` → `HH:MM`, one day per line.
   return s
       .replaceAll('Automate-24-24, ', '')
+      // #2710 — insert a space between a glued day name and its first clock
+      // (`Lundi07.00` → `Lundi 07.00`) so the legacy text reads correctly too.
+      .replaceAllMapped(RegExp(r'([A-Za-zÀ-ÿ])(\d{1,2}\.\d{2})'),
+          (m) => '${m[1]} ${m[2]}')
       .replaceAllMapped(RegExp(r'(\d{2})\.(\d{2})-(\d{2})\.(\d{2})'),
           (m) => '${m[1]}:${m[2]}-${m[3]}:${m[4]}')
       .replaceAllMapped(RegExp(r'(\d{2})\.(\d{2})'),

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import '../../search/data/models/search_params.dart';
 import '../../search/domain/entities/station.dart';
 import '../../../core/services/impl/osm_brand_enricher.dart';
+import 'france_opening_hours_adapter.dart';
 import 'prix_carburants_parsers.dart' as parser;
 import '../../../core/network/dio_offline.dart';
 import '../../../core/services/dio_factory.dart';
@@ -252,8 +253,20 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
 
     final is24h = r['horaires_automate_24_24'] == 'Oui';
 
+    // #2710 — populate the structured weekly schedule from the FR adapter
+    // (Epic C3). The adapter is pure + total: a missing / unparseable
+    // `horaires_jour` yields `notAvailable`, so the display layer falls back
+    // through `legacyOpeningHoursBridge` exactly as before. Legacy
+    // `Station.is24h` / `openingHoursText` stay populated for back-compat.
+    const openingHoursAdapter = FranceOpeningHoursAdapter();
+    final openingHours = openingHoursAdapter.parse(r);
+
     return ServiceResult(
-      data: StationDetail(station: enriched, wholeDay: is24h),
+      data: StationDetail(
+        station: enriched,
+        wholeDay: is24h,
+        openingHours: openingHours,
+      ),
       source: ServiceSource.prixCarburantsApi,
       fetchedAt: DateTime.now(),
     );

--- a/test/features/station_services/france/france_opening_hours_adapter_test.dart
+++ b/test/features/station_services/france/france_opening_hours_adapter_test.dart
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/france/france_opening_hours_adapter.dart';
+
+/// Reuse-fidelity tests for the real [FranceOpeningHoursAdapter] (#2710),
+/// driven with recorded `horaires_jour` strings from the gouv.fr feed — the
+/// SAME flattened form the live Prix-Carburants endpoint emits. These prove
+/// the four feed quirks the adapter owns:
+///   - the `Automate-24-24` 24/7 flag,
+///   - the missing-space day↔clock glue (`Lundi07.00-18.30`),
+///   - the `01:00-01:00` degenerate "no interval" sentinel,
+///   - split shifts (a lunch break as two same-day entries).
+void main() {
+  const adapter = FranceOpeningHoursAdapter();
+
+  group('FranceOpeningHoursAdapter', () {
+    test('automate flag → all week open24h, availability full', () {
+      final out = adapter.parse({
+        'horaires_jour':
+            'Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30',
+        'horaires_automate_24_24': 'Oui',
+      });
+
+      expect(out.availability, OpeningHoursAvailability.full);
+      expect(out.days, hasLength(kRegularWeekdays.length));
+      for (final day in kRegularWeekdays) {
+        expect(out.dayFor(day)?.state, DayState.open24h);
+      }
+    });
+
+    test(
+        'per-day range parses the day + clock as SEPARATE values '
+        '(no glued string)', () {
+      final out = adapter.parse({
+        'horaires_jour':
+            'Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30',
+        'horaires_automate_24_24': 'Non',
+      });
+
+      final monday = out.dayFor(OpeningDay.mon);
+      expect(monday, isNotNull);
+      expect(monday!.state, DayState.openRanges);
+      expect(monday.ranges, hasLength(1));
+      // 07:00 = 420 min, 18:30 = 1110 min — proves the day name was split off
+      // the clock (the old flattener glued them into `Lundi07.00`).
+      expect(monday.ranges.single.startMinutes, 7 * 60);
+      expect(monday.ranges.single.endMinutes, 18 * 60 + 30);
+
+      final tuesday = out.dayFor(OpeningDay.tue);
+      expect(tuesday?.ranges.single.startMinutes, 7 * 60);
+      expect(tuesday?.ranges.single.endMinutes, 18 * 60 + 30);
+
+      // Only Mon+Tue were provided → partial, never `full`.
+      expect(out.availability, OpeningHoursAvailability.partial);
+      expect(out.days, hasLength(2));
+    });
+
+    test('01:00-01:00 degenerate sentinel → unknown, range dropped', () {
+      final out = adapter.parse({
+        'horaires_jour': 'Lundi01.00-01.00, Mardi08.00-18.00',
+        'horaires_automate_24_24': 'Non',
+      });
+
+      final monday = out.dayFor(OpeningDay.mon);
+      expect(monday, isNotNull);
+      // Not a real interval, not 24h — explicitly unknown with no rendered range.
+      expect(monday!.state, DayState.unknown);
+      expect(monday.ranges, isEmpty);
+
+      final tuesday = out.dayFor(OpeningDay.tue);
+      expect(tuesday?.state, DayState.openRanges);
+      expect(tuesday?.ranges, hasLength(1));
+    });
+
+    test('split shifts coalesce into one day with two ranges', () {
+      final out = adapter.parse({
+        'horaires_jour': 'Mardi08.00-12.00, Mardi14.00-19.00',
+        'horaires_automate_24_24': 'Non',
+      });
+
+      final tuesday = out.dayFor(OpeningDay.tue);
+      expect(tuesday, isNotNull);
+      expect(tuesday!.state, DayState.openRanges);
+      expect(tuesday.ranges, hasLength(2));
+      expect(tuesday.ranges[0].startMinutes, 8 * 60);
+      expect(tuesday.ranges[0].endMinutes, 12 * 60);
+      expect(tuesday.ranges[1].startMinutes, 14 * 60);
+      expect(tuesday.ranges[1].endMinutes, 19 * 60);
+    });
+
+    test('all seven weekdays provided → availability full', () {
+      final out = adapter.parse({
+        'horaires_jour': 'Lundi07.00-20.00, Mardi07.00-20.00, '
+            'Mercredi07.00-20.00, Jeudi07.00-20.00, Vendredi07.00-20.00, '
+            'Samedi08.00-20.00, Dimanche09.00-13.00',
+        'horaires_automate_24_24': 'Non',
+      });
+      expect(out.days, hasLength(7));
+      expect(out.availability, OpeningHoursAvailability.full);
+      expect(out.dayFor(OpeningDay.sun)?.ranges.single.endMinutes, 13 * 60);
+    });
+
+    test('empty / null / unparseable input → notAvailable', () {
+      expect(adapter.parse(''), WeeklyOpeningHours.notAvailable);
+      expect(adapter.parse(null), WeeklyOpeningHours.notAvailable);
+      expect(adapter.parse(42), WeeklyOpeningHours.notAvailable);
+      expect(
+        adapter.parse({'horaires_jour': '', 'horaires_automate_24_24': 'Non'}),
+        WeeklyOpeningHours.notAvailable,
+      );
+      // No recognisable day↔clock token at all → no-data, not a crash.
+      expect(
+        adapter.parse({'horaires_jour': 'garbage payload no clocks'}),
+        WeeklyOpeningHours.notAvailable,
+      );
+    });
+
+    test('bare String is accepted as the horaires_jour value', () {
+      final out = adapter.parse('Lundi06.30-22.00');
+      final monday = out.dayFor(OpeningDay.mon);
+      expect(monday?.state, DayState.openRanges);
+      expect(monday?.ranges.single.startMinutes, 6 * 60 + 30);
+    });
+  });
+}

--- a/test/features/station_services/france/france_opening_hours_adapter_test.dart
+++ b/test/features/station_services/france/france_opening_hours_adapter_test.dart
@@ -124,5 +124,16 @@ void main() {
       expect(monday?.state, DayState.openRanges);
       expect(monday?.ranges.single.startMinutes, 6 * 60 + 30);
     });
+
+    test('never throws on a malformed shape — returns normally (#2349)', () {
+      // Fault injection: feed shapes the parser must shape-narrow + catch,
+      // asserting the call RETURNS NORMALLY (the documented never-throws
+      // contract), not merely that the value is notAvailable.
+      expect(() => adapter.parse(42), returnsNormally);
+      expect(() => adapter.parse(null), returnsNormally);
+      expect(() => adapter.parse(<int>[1, 2, 3]), returnsNormally);
+      expect(() => adapter.parse({'horaires_jour': 12345}), returnsNormally);
+      expect(adapter.parse(<int>[1, 2, 3]), WeeklyOpeningHours.notAvailable);
+    });
   });
 }

--- a/test/features/station_services/france/prix_carburants_flux_test.dart
+++ b/test/features/station_services/france/prix_carburants_flux_test.dart
@@ -35,6 +35,22 @@ String _fluxXml(List<Map<String, dynamic>> pdvs) {
       buf.write('<prix nom="$nom" valeur="$valeur" '
           'maj="2026-05-29T08:00:00+00:00"/>');
     });
+    // #2710 — optional opening-hours block, mirroring the real gouv.fr flux
+    // schema: `<horaires automate-24-24="0"><jour nom="Lundi"><horaire
+    // ouverture="07.00" fermeture="18.30"/></jour>...</horaires>`. `hours` is
+    // `automate?,List<(nom, ouverture, fermeture)>`.
+    if (p['hours'] != null) {
+      final hours = p['hours'] as Map<String, dynamic>;
+      final automate = hours['automate'] as bool? ?? false;
+      buf.write('<horaires automate-24-24="${automate ? '1' : '0'}">');
+      final jours = hours['jours'] as List<dynamic>? ?? const [];
+      for (final j in jours) {
+        final row = j as List<dynamic>;
+        buf.write('<jour nom="${row[0]}"><horaire '
+            'ouverture="${row[1]}" fermeture="${row[2]}"/></jour>');
+      }
+      buf.write('</horaires>');
+    }
     buf.write('</pdv>');
   }
   buf.write('</pdv_liste>');
@@ -194,6 +210,60 @@ void main() {
       final stations = flux.parseFluxZip(zip);
       expect(stations, hasLength(1));
       expect(stations.first.id, 'fr-9');
+    });
+
+    test('omits opening hours when the pdv carries no <horaires> (#2710)', () {
+      final s = flux.parseFluxXml(_fluxXml([
+        _pdv(id: '34200002', lat: 43.45, lng: 3.52),
+      ])).first;
+      expect(s.openingHoursText, isNull);
+      expect(s.is24h, isFalse);
+    });
+
+    test('flattens <horaires> into the legacy openingHoursText (#2710)', () {
+      final s = flux.parseFluxXml(_fluxXml([
+        {
+          'id': '34200002',
+          'lat': 4345000,
+          'lng': 352000,
+          'adresse': '120 RUE LECLERC',
+          'ville': 'CASTELNAU',
+          'cp': '34290',
+          'prices': {'SP95': 1.879},
+          'hours': {
+            'automate': false,
+            'jours': [
+              ['Lundi', '07.00', '18.30'],
+              // split shift: same day, two <jour> rows
+              ['Mardi', '08.00', '12.00'],
+              ['Mardi', '14.00', '19.00'],
+            ],
+          },
+        },
+      ])).first;
+
+      // Legacy text reads like the polling path — day un-glued, `.`→`:`.
+      expect(s.openingHoursText, contains('Lundi 07:00-18:30'));
+      expect(s.openingHoursText, isNot(contains('Lundi07')));
+      expect(s.is24h, isFalse);
+    });
+
+    test('automate-24-24="1" sets is24h on the flux Station (#2710)', () {
+      final s = flux.parseFluxXml(_fluxXml([
+        {
+          'id': '7',
+          'lat': 4345000,
+          'lng': 352000,
+          'prices': {'Gazole': 1.7},
+          'hours': {
+            'automate': true,
+            'jours': [
+              ['Lundi', '07.00', '18.30'],
+            ],
+          },
+        },
+      ])).first;
+      expect(s.is24h, isTrue);
     });
   });
 

--- a/test/features/station_services/france/prix_carburants_parsers_test.dart
+++ b/test/features/station_services/france/prix_carburants_parsers_test.dart
@@ -203,12 +203,16 @@ void main() {
   });
 
   group('parsePrixCarburantsOpeningHours', () {
-    test('formats hours and strips Automate-24-24 prefix', () {
+    test('formats hours, strips Automate-24-24, and un-glues the day↔clock',
+        () {
       final out = parsePrixCarburantsOpeningHours(
         'Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30',
       );
       expect(out, isNotNull);
-      expect(out, contains('Lundi07:00-18:30'));
+      // #2710 — the missing-space bug is fixed: the day name is separated
+      // from its first clock (`Lundi 07:00-18:30`), never glued.
+      expect(out, contains('Lundi 07:00-18:30'));
+      expect(out, isNot(contains('Lundi07:00')));
       expect(out, isNot(contains('Automate-24-24')));
       expect(out, isNot(contains(', ')));
     });

--- a/test/features/station_services/france/prix_carburants_station_service_test.dart
+++ b/test/features/station_services/france/prix_carburants_station_service_test.dart
@@ -12,6 +12,7 @@ import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/brand_registry.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
 import '../../../fakes/fake_storage_repository.dart';
 import '../../../helpers/silence_error_logger.dart';
 
@@ -306,7 +307,9 @@ void main() {
         'Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30',
       );
       expect(hours, isNotNull);
-      expect(hours, contains('Lundi07:00-18:30'));
+      // #2710 — the day name is un-glued from its first clock.
+      expect(hours, contains('Lundi 07:00-18:30'));
+      expect(hours, isNot(contains('Lundi07:00')));
       expect(hours, isNot(contains('Automate-24-24')));
     });
 
@@ -497,6 +500,76 @@ void main() {
 
       // No enricher → falls back to the address heuristic (sentinel here).
       expect(result.data.station.brand, BrandRegistry.independentLabel);
+    });
+  });
+
+  // #2710 (Epic C3) — getStationDetail now populates the structured
+  // StationDetail.openingHours via FranceOpeningHoursAdapter, while the legacy
+  // is24h / openingHoursText stay for back-compat.
+  group('PrixCarburantsStationService getStationDetail opening hours (#2710)',
+      () {
+    test('populates structured openingHours from horaires_jour', () async {
+      final response = {
+        'results': [
+          {
+            'id': '34550043',
+            'adresse': 'ROUTE NATIONALE',
+            'ville': 'BESSAN',
+            'cp': '34550',
+            'geom': {'lat': 43.36, 'lon': 3.43},
+            'gazole_prix': 1.659,
+            'horaires_automate_24_24': 'Non',
+            'horaires_jour':
+                'Lundi07.00-18.30, Mardi08.00-12.00, Mardi14.00-19.00',
+          },
+        ],
+      };
+      final adapter = _TrackingMockAdapter()..addResponse(response);
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio, enricher: null);
+
+      final result = await svc.getStationDetail('fr-34550043');
+      final hours = result.data.openingHours;
+
+      expect(hours, isNotNull);
+      // Monday: a single staffed range, day un-glued from the clock.
+      final monday = hours!.dayFor(OpeningDay.mon);
+      expect(monday?.state, DayState.openRanges);
+      expect(monday?.ranges.single.startMinutes, 7 * 60);
+      // Tuesday: split shift coalesced into two ranges.
+      final tuesday = hours.dayFor(OpeningDay.tue);
+      expect(tuesday?.ranges, hasLength(2));
+      // Legacy back-compat fields preserved.
+      expect(result.data.station.openingHoursText, contains('Lundi 07:00'));
+      expect(result.data.station.is24h, isFalse);
+    });
+
+    test('24/7 automate → all-week open24h structured schedule', () async {
+      final response = {
+        'results': [
+          {
+            'id': '34550044',
+            'adresse': 'AIRE AUTOROUTE',
+            'ville': 'BEZIERS',
+            'cp': '34500',
+            'geom': {'lat': 43.34, 'lon': 3.21},
+            'gazole_prix': 1.7,
+            'horaires_automate_24_24': 'Oui',
+            'horaires_jour': 'Automate-24-24, Lundi07.00-18.30',
+          },
+        ],
+      };
+      final adapter = _TrackingMockAdapter()..addResponse(response);
+      final dio = Dio(BaseOptions(baseUrl: ''))..httpClientAdapter = adapter;
+      final svc = PrixCarburantsStationService(dio: dio, enricher: null);
+
+      final result = await svc.getStationDetail('fr-34550044');
+      final hours = result.data.openingHours;
+
+      expect(hours?.availability, OpeningHoursAvailability.full);
+      expect(hours?.dayFor(OpeningDay.sun)?.state, DayState.open24h);
+      expect(result.data.wholeDay, isTrue);
+      expect(result.data.station.is24h, isTrue);
     });
   });
 
@@ -1489,6 +1562,8 @@ class _TestablePrixCarburantsService {
     if (s.isEmpty) return null;
     return s
         .replaceAll('Automate-24-24, ', '')
+        .replaceAllMapped(RegExp(r'([A-Za-zÀ-ÿ])(\d{1,2}\.\d{2})'),
+            (m) => '${m[1]} ${m[2]}')
         .replaceAllMapped(RegExp(r'(\d{2})\.(\d{2})-(\d{2})\.(\d{2})'),
             (m) => '${m[1]}:${m[2]}-${m[3]}:${m[4]}')
         .replaceAllMapped(RegExp(r'(\d{2})\.(\d{2})'),


### PR DESCRIPTION
## What

Epic #2707 **C3** — `FranceOpeningHoursAdapter` maps the Prix-Carburants
(gouv.fr) opening-hours payload onto the common `WeeklyOpeningHours` model
introduced in C1 (#2708/#2720). Builds on the merged foundation; **ARB-free**
(all opening-hours user-facing strings ship in C2 #2709), so this is disjoint
from the in-flight #2721.

## The four feed quirks the adapter fixes

- **Missing-space bug** — the feed glues the day name onto the first clock
  (`Lundi07.00-18.30`). The old `replaceAll(', ', '\n')` flattener never
  separated them. The adapter captures the day label and the `HH.MM-HH.MM`
  range as **separate regex groups** — the structural fix is capture, not
  string-split. The legacy `parsePrixCarburantsOpeningHours` text is fixed the
  same way (`Lundi 07:00-18:30`).
- **`01:00-01:00` degenerate sentinel** — dropped → `DayState.unknown`
  (`TimeRange.isDegenerate`); never a real interval, never 24h.
- **`Automate-24-24` flag** — `horaires_automate_24_24 == 'Oui'` → whole week
  `open24h` (`WeeklyOpeningHours.allWeek24h`), availability `full`.
- **Split shifts** — repeated same-day ranges coalesce into `DayHours.ranges`.
  Omitted day → implicitly unknown; empty/unparseable → `notAvailable`. Pure +
  total: never throws, never null.

## Wiring (both FR paths)

- `PrixCarburantsStationService.getStationDetail` (polling) populates
  `StationDetail.openingHours`.
- `PrixCarburantsFluxStationService.getStationDetail` (bulk flux) — the flux
  parser now flattens the `<horaires>/<jour>/<horaire>` XML tree onto the
  Station's legacy `openingHoursText`/`is24h`, and the service rebuilds the
  structured schedule via the same adapter.
- Legacy `is24h`/`openingHoursText` kept for back-compat; display still falls
  back through `legacyOpeningHoursBridge` when the adapter yields no data.

## Tests (reuse-fidelity, RED-on-master)

New `france_opening_hours_adapter_test.dart` drives the **real** adapter with
recorded `horaires_jour` strings: 24h-automate, per-day (asserting the day +
range parse with NO glued string), the `01:00-01:00` degenerate (→ unknown,
not rendered), a split-shift day, full week, empty → notAvailable. The
pre-existing `prix_carburants_parsers_test.dart` assertion of the buggy glued
`Lundi07:00-18:30` is **flipped** to the fixed `Lundi 07:00-18:30` — the
RED-on-master proof. Flux tests cover the `<horaires>` flatten + automate flag.

## Gates

- `flutter analyze` clean (2 pre-existing unrelated `info`s in consumption tests).
- `flutter test test/features/station_services/france` + station_detail + lints: 211 green.
- file_length ≤ 400 (largest changed file 359 lines).
- Clean codegen: zero `.g.dart`/`.freezed.dart` drift. Zero `lib/l10n/` drift (ARB-free).

Closes #2710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
