### PR TITLE
feat(opening-hours): Spain adapter — MITECO Horario string (Epic C6)

### DIFF
--- a/lib/features/station_services/spain/miteco_station_service.dart
+++ b/lib/features/station_services/spain/miteco_station_service.dart
@@ -14,6 +14,8 @@ import '../../../core/services/persistent_dataset.dart';
 import '../../../core/services/service_result.dart';
 import '../../../core/services/station_service.dart';
 import '../../../core/logging/error_logger.dart';
+import '../../station_detail/domain/opening_hours.dart';
+import 'spain_opening_hours_adapter.dart';
 import 'spain_provinces.dart';
 
 /// Spanish fuel prices from Geoportal Gasolineras (MITECO).
@@ -194,6 +196,13 @@ class MitecoStationService with StationServiceHelpers implements StationService 
       // Determine if open based on schedule (simplistic: assume open if horario is not empty)
       final isOpen = horario.isNotEmpty && horario != 'Cerrado';
 
+      // #2713 — parse the MITECO `Horario` string (e.g. `L-D: 24H`,
+      // `L-V: 06:00-23:00; S-D: 08:00-23:00`) into the common
+      // [WeeklyOpeningHours]. The legacy `openingHoursText` / `isOpen` stay
+      // for back-compat; the structured `weeklyHours` is the canonical
+      // signal the #2706 detail-fallback threads into the detail screen.
+      final weeklyHours = const SpainOpeningHoursAdapter().parse(horario);
+
       // #753 — `es-` prefix so a MITECO `IDEESS` (bare numeric) cannot
       // collide with another country's numeric id space.
       final rawId = r['IDEESS']?.toString() ?? '';
@@ -219,6 +228,10 @@ class MitecoStationService with StationServiceHelpers implements StationService 
         cng: _parseCommaDouble(r['Precio Gas Natural Comprimido']?.toString()),
         isOpen: isOpen,
         openingHoursText: horario.isNotEmpty ? horario : null,
+        openingHours: weeklyHours.availability ==
+                OpeningHoursAvailability.notProvided
+            ? null
+            : weeklyHours,
         stationType: r['Margen']?.toString(),
       );
     } on FormatException catch (e, st) {

--- a/lib/features/station_services/spain/spain_opening_hours_adapter.dart
+++ b/lib/features/station_services/spain/spain_opening_hours_adapter.dart
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../station_detail/domain/opening_hours.dart';
+import '../opening_hours/opening_hours_adapter.dart';
+
+/// Normalises the Spanish MITECO (geoportalgasolineras) `Horario` string into
+/// the common [WeeklyOpeningHours] model (Epic #2707 C6, #2713).
+///
+/// ## Input shape (verified against live geoportalgasolineras station pages)
+/// MITECO publishes opening hours as a single `Horario` **string**, not a
+/// structured array. Each `;`-separated segment is `<days>: <hours>`, where
+/// `<days>` is a Spanish day token or an inclusive range and `<hours>` is one
+/// of `24H`, `Cerrado`, or one `HH:MM-HH:MM` clock range. Confirmed live forms:
+///   - `'L-D: 24H'` — open all week, 24h.
+///   - `'L-V: 06:00-23:00; S-D: 08:00-23:00'` — weekday + weekend ranges.
+///   - `'L-V: 05:30-23:00; S: 06:30-22:30; D: 07:30-21:00'` — single-day
+///     segments mixed with a range.
+///   - `'Cerrado'` / a `…: Cerrado` segment — closed.
+///
+/// ## Spanish day tokens
+/// `L`=lunes(mon), `M`=martes(tue), `X`=miércoles(wed), `J`=jueves(thu),
+/// `V`=viernes(fri), `S`=sábado(sat), `D`=domingo(sun). A `A-B` token is the
+/// inclusive Mon-first run from `A` to `B` (`L-V` → mon..fri, `S-D` → sat,sun,
+/// `L-D` → the whole week). A backwards range (`B` before `A`) is ignored.
+///
+/// ## Hours semantics
+///   - `24H` (any case) → [DayState.open24h].
+///   - `Cerrado` (any case) → [DayState.closed].
+///   - `HH:MM-HH:MM` → [DayState.openRanges] with one [TimeRange]; `24:00` is
+///     accepted as the end-of-day marker. A degenerate equal-bounds range is
+///     dropped (the day resolves to [DayState.unknown]), never a 24h wrap.
+///   - Multiple segments touching the same day coalesce their ranges; the
+///     first explicit 24h / closed marker for a day wins.
+///
+/// ## Contract
+/// Pure, total, never throws, never returns `null` — empty / unparseable input
+/// degrades to [WeeklyOpeningHours.notAvailable] (the [OpeningHoursAdapter]
+/// contract). The adapter feeds the station-detail UI, so a malformed
+/// `Horario` must degrade gracefully, never crash the screen.
+class SpainOpeningHoursAdapter extends OpeningHoursAdapter {
+  const SpainOpeningHoursAdapter();
+
+  /// Single Spanish day token → [OpeningDay]. Lower-cased before lookup.
+  static const Map<String, OpeningDay> _dayByToken = {
+    'l': OpeningDay.mon,
+    'm': OpeningDay.tue,
+    'x': OpeningDay.wed,
+    'j': OpeningDay.thu,
+    'v': OpeningDay.fri,
+    's': OpeningDay.sat,
+    'd': OpeningDay.sun,
+  };
+
+  /// The whole-day open marker (any case).
+  // i18n-ignore: MITECO feed enum token, not user-facing text
+  static const String _open24hToken = '24h';
+
+  /// The closed marker (any case).
+  // i18n-ignore: MITECO feed enum token, not user-facing text
+  static const String _closedToken = 'cerrado';
+
+  @override
+  WeeklyOpeningHours parse(dynamic rawProviderData) {
+    try {
+      if (rawProviderData is! String) return WeeklyOpeningHours.notAvailable;
+      final raw = rawProviderData;
+      final trimmed = raw.trim();
+      if (trimmed.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+      // A bare `Cerrado` (no day prefix) means the whole week is closed.
+      if (trimmed.toLowerCase() == _closedToken) {
+        return WeeklyOpeningHours(
+          days: [for (final d in kRegularWeekdays) DayHours.closedDay(d)],
+          availability: OpeningHoursAvailability.full,
+          rawSource: raw,
+        );
+      }
+
+      // A bare `24H` (no day prefix) means open all week.
+      if (trimmed.toLowerCase() == _open24hToken) {
+        return WeeklyOpeningHours.allWeek24h(rawSource: raw);
+      }
+
+      final states = <OpeningDay, DayState>{};
+      final ranges = <OpeningDay, List<TimeRange>>{};
+      var matchedAny = false;
+
+      for (final segment in trimmed.split(';')) {
+        if (!_applySegment(segment, states, ranges)) continue;
+        matchedAny = true;
+      }
+
+      if (!matchedAny) return WeeklyOpeningHours.notAvailable;
+
+      final days = <DayHours>[];
+      for (final day in kRegularWeekdays) {
+        final state = states[day];
+        if (state == null) continue; // not covered → implicitly unknown
+        if (state == DayState.openRanges) {
+          final dayRanges = ranges[day] ?? const <TimeRange>[];
+          // The day appeared only as a degenerate range → unknown.
+          days.add(dayRanges.isEmpty
+              ? DayHours(day: day, state: DayState.unknown)
+              : DayHours(
+                  day: day, state: DayState.openRanges, ranges: dayRanges));
+        } else {
+          days.add(DayHours(day: day, state: state));
+        }
+      }
+
+      if (days.isEmpty) return WeeklyOpeningHours.notAvailable;
+
+      final availability = days.length == kRegularWeekdays.length
+          ? OpeningHoursAvailability.full
+          : OpeningHoursAvailability.partial;
+      return WeeklyOpeningHours(
+        days: days,
+        availability: availability,
+        rawSource: raw,
+      );
+    } catch (e, st) {
+      // Contract: the adapter must never propagate a fault to the
+      // station-detail UI — degrade to no-data.
+      assert(() {
+        // ignore: avoid_print
+        print('SpainOpeningHoursAdapter.parse failed: $e\n$st');
+        return true;
+      }());
+      return WeeklyOpeningHours.notAvailable;
+    }
+  }
+
+  /// Applies one `<days>: <hours>` segment to [states] / [ranges]. Returns
+  /// `true` when the segment yielded at least one recognised day, else
+  /// `false` (the caller tracks whether anything matched at all).
+  bool _applySegment(
+    String segment,
+    Map<OpeningDay, DayState> states,
+    Map<OpeningDay, List<TimeRange>> ranges,
+  ) {
+    final colon = segment.indexOf(':');
+    if (colon < 0) return false;
+    final daysPart = segment.substring(0, colon).trim();
+    final hoursPart = segment.substring(colon + 1).trim();
+    if (daysPart.isEmpty || hoursPart.isEmpty) return false;
+
+    final days = _expandDays(daysPart);
+    if (days.isEmpty) return false;
+
+    final hoursLower = hoursPart.toLowerCase();
+    var applied = false;
+
+    if (hoursLower == _open24hToken) {
+      for (final d in days) {
+        states.putIfAbsent(d, () => DayState.open24h);
+        applied = true;
+      }
+      return applied;
+    }
+    if (hoursLower == _closedToken) {
+      for (final d in days) {
+        states.putIfAbsent(d, () => DayState.closed);
+        applied = true;
+      }
+      return applied;
+    }
+
+    final range = _parseRange(hoursPart);
+    if (range == null) return false;
+    for (final d in days) {
+      states.putIfAbsent(d, () => DayState.openRanges);
+      // Only coalesce ranges onto a day that is still range-typed (an earlier
+      // explicit 24h / closed marker wins).
+      if (states[d] != DayState.openRanges) continue;
+      if (range.isDegenerate) {
+        // No real interval: keep the day range-typed with no range so it
+        // resolves to `unknown`, never a 24h wrap.
+        ranges.putIfAbsent(d, () => <TimeRange>[]);
+      } else {
+        (ranges[d] ??= <TimeRange>[]).add(range);
+      }
+      applied = true;
+    }
+    return applied;
+  }
+
+  /// Expands a `<days>` token into the [OpeningDay]s it covers. A single token
+  /// (`L`) → one day; an inclusive `A-B` range (`L-V`, `S-D`, `L-D`) → the
+  /// Mon-first run from `A` to `B`. Unknown tokens / backwards ranges → empty.
+  List<OpeningDay> _expandDays(String token) {
+    final t = token.toLowerCase();
+    final dash = t.indexOf('-');
+    if (dash < 0) {
+      final day = _dayByToken[t];
+      return day == null ? const [] : [day];
+    }
+    final start = _dayByToken[t.substring(0, dash).trim()];
+    final end = _dayByToken[t.substring(dash + 1).trim()];
+    if (start == null || end == null) return const [];
+    final from = kRegularWeekdays.indexOf(start);
+    final to = kRegularWeekdays.indexOf(end);
+    if (from < 0 || to < 0 || to < from) return const []; // backwards → ignore
+    return kRegularWeekdays.sublist(from, to + 1);
+  }
+
+  /// Parses an `HH:MM-HH:MM` clock range, or `null` when malformed. `24:00`
+  /// is accepted as the end-of-day marker (→ minute 1440).
+  TimeRange? _parseRange(String hours) {
+    final dash = hours.indexOf('-');
+    if (dash < 0) return null;
+    final start = _minutesFromClock(hours.substring(0, dash).trim());
+    final end = _minutesFromClock(hours.substring(dash + 1).trim());
+    if (start == null || end == null) return null;
+    return TimeRange(startMinutes: start, endMinutes: end);
+  }
+
+  /// `HH:MM` → minutes-from-midnight (0..1440; `24:00` → 1440), or `null`.
+  int? _minutesFromClock(String clock) {
+    final parts = clock.split(':');
+    if (parts.length < 2) return null;
+    final hour = int.tryParse(parts[0]);
+    final minute = int.tryParse(parts[1]);
+    if (hour == null || minute == null) return null;
+    if (hour == 24 && minute == 0) return 1440;
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+    return hour * 60 + minute;
+  }
+}

--- a/test/features/station_services/spain/spain_opening_hours_adapter_test.dart
+++ b/test/features/station_services/spain/spain_opening_hours_adapter_test.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/opening_hours/opening_hours_adapter.dart';
+import 'package:tankstellen/features/station_services/spain/spain_opening_hours_adapter.dart';
+
+/// Recorded MITECO `Horario` strings, verified literally against live
+/// geoportalgasolineras station pages (Epic C6, #2713):
+///   - `'L-D: 24H'` — open all week, 24h (the common form).
+///   - `'L-V: 06:00-23:00; S-D: 08:00-23:00'` — weekday + weekend ranges
+///     (repsol-avenida-peinador-49).
+///   - `'L-V: 05:30-23:00; S: 06:30-22:30; D: 07:30-21:00'` — single-day
+///     segments mixed with a range (cepsa-poligono-campollano-55).
+const _horario24h = 'L-D: 24H';
+const _horarioWeekdayWeekend = 'L-V: 06:00-23:00; S-D: 08:00-23:00';
+const _horarioPerDay = 'L-V: 05:30-23:00; S: 06:30-22:30; D: 07:30-21:00';
+
+void main() {
+  const adapter = SpainOpeningHoursAdapter();
+
+  test('is an OpeningHoursAdapter', () {
+    expect(adapter, isA<OpeningHoursAdapter>());
+  });
+
+  group('L-D: 24H → open all week', () {
+    late WeeklyOpeningHours result;
+    setUp(() => result = adapter.parse(_horario24h));
+
+    test('every regular weekday is open24h', () {
+      for (final d in kRegularWeekdays) {
+        expect(result.dayFor(d)?.state, DayState.open24h,
+            reason: '$d should be open24h');
+      }
+    });
+
+    test('availability is full', () {
+      expect(result.availability, OpeningHoursAvailability.full);
+    });
+
+    test('keeps the raw Horario string', () {
+      expect(result.rawSource, _horario24h);
+    });
+  });
+
+  group('L-V / S-D day-range mapping', () {
+    late WeeklyOpeningHours result;
+    setUp(() => result = adapter.parse(_horarioWeekdayWeekend));
+
+    test('L-V expands to Mon–Fri with the 06:00-23:00 range', () {
+      for (final d in const [
+        OpeningDay.mon,
+        OpeningDay.tue,
+        OpeningDay.wed,
+        OpeningDay.thu,
+        OpeningDay.fri,
+      ]) {
+        final day = result.dayFor(d);
+        expect(day?.state, DayState.openRanges, reason: '$d');
+        expect(day!.ranges.single.startMinutes, 6 * 60, reason: '$d');
+        expect(day.ranges.single.endMinutes, 23 * 60, reason: '$d');
+      }
+    });
+
+    test('S-D expands to Sat+Sun with the 08:00-23:00 range', () {
+      for (final d in const [OpeningDay.sat, OpeningDay.sun]) {
+        final day = result.dayFor(d);
+        expect(day?.state, DayState.openRanges, reason: '$d');
+        expect(day!.ranges.single.startMinutes, 8 * 60, reason: '$d');
+        expect(day.ranges.single.endMinutes, 23 * 60, reason: '$d');
+      }
+    });
+
+    test('availability is full (whole week covered)', () {
+      expect(result.availability, OpeningHoursAvailability.full);
+    });
+  });
+
+  group('single-day segments mixed with a range', () {
+    late WeeklyOpeningHours result;
+    setUp(() => result = adapter.parse(_horarioPerDay));
+
+    test('Saturday gets its distinct 06:30-22:30 range', () {
+      final sat = result.dayFor(OpeningDay.sat);
+      expect(sat!.ranges.single.startMinutes, 6 * 60 + 30);
+      expect(sat.ranges.single.endMinutes, 22 * 60 + 30);
+    });
+
+    test('Sunday gets its distinct 07:30-21:00 range', () {
+      final sun = result.dayFor(OpeningDay.sun);
+      expect(sun!.ranges.single.startMinutes, 7 * 60 + 30);
+      expect(sun.ranges.single.endMinutes, 21 * 60);
+    });
+
+    test('Mon–Fri keep the 05:30-23:00 range', () {
+      final mon = result.dayFor(OpeningDay.mon);
+      expect(mon!.ranges.single.startMinutes, 5 * 60 + 30);
+      expect(mon.ranges.single.endMinutes, 23 * 60);
+    });
+  });
+
+  group('Cerrado → closed', () {
+    test('bare "Cerrado" closes the whole week', () {
+      final result = adapter.parse('Cerrado');
+      for (final d in kRegularWeekdays) {
+        expect(result.dayFor(d)?.state, DayState.closed, reason: '$d');
+      }
+      expect(result.availability, OpeningHoursAvailability.full);
+    });
+
+    test('a per-day "…: Cerrado" segment closes just that day', () {
+      final result = adapter.parse('L-S: 06:00-22:00; D: Cerrado');
+      expect(result.dayFor(OpeningDay.sat)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.sun)?.state, DayState.closed);
+    });
+  });
+
+  group('partial coverage', () {
+    test('a subset of days → partial availability', () {
+      final result = adapter.parse('L-V: 08:00-20:00');
+      expect(result.availability, OpeningHoursAvailability.partial);
+      expect(result.dayFor(OpeningDay.mon)?.state, DayState.openRanges);
+      expect(result.dayFor(OpeningDay.sat), isNull);
+    });
+  });
+
+  group('24:00 end marker', () {
+    test('00:00-24:00 is the whole-day end marker (1440 minutes)', () {
+      final result = adapter.parse('L-D: 00:00-24:00');
+      final mon = result.dayFor(OpeningDay.mon);
+      expect(mon!.ranges.single.startMinutes, 0);
+      expect(mon.ranges.single.endMinutes, 1440);
+    });
+  });
+
+  group('graceful no-data (never throws, never null)', () {
+    test('empty string → notAvailable', () {
+      expect(adapter.parse(''), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('whitespace-only → notAvailable', () {
+      expect(adapter.parse('   '), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('null → notAvailable', () {
+      expect(adapter.parse(null), WeeklyOpeningHours.notAvailable);
+    });
+
+    test('a segment with only unknown day tokens → notAvailable', () {
+      expect(adapter.parse('Z-Q: 06:00-22:00'), WeeklyOpeningHours.notAvailable);
+    });
+
+    // Fault-injection for `never_throws_contract_test` (#2349): the adapter
+    // documents "never throws", so a non-String / structurally-broken input
+    // must return normally with the no-data sentinel, never propagate.
+    test('non-String / broken inputs return normally → notAvailable', () {
+      expect(() => adapter.parse(42), returnsNormally);
+      expect(() => adapter.parse(<int>[1, 2, 3]), returnsNormally);
+      expect(() => adapter.parse(const {'unexpected': true}), returnsNormally);
+      expect(() => adapter.parse(null), returnsNormally);
+      expect(adapter.parse(42), WeeklyOpeningHours.notAvailable);
+      expect(adapter.parse(<int>[1, 2, 3]), WeeklyOpeningHours.notAvailable);
+      expect(
+        adapter.parse(const {'unexpected': true}),
+        WeeklyOpeningHours.notAvailable,
+      );
+    });
+
+    test('malformed clock segments are dropped, do not throw', () {
+      expect(() => adapter.parse('L-V: 99:99-aa:bb'), returnsNormally);
+      expect(
+        adapter.parse('L-V: 99:99-aa:bb'),
+        WeeklyOpeningHours.notAvailable,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Epic #2707 C6 — #2713

`SpainOpeningHoursAdapter` normalises the Spanish **MITECO**
(geoportalgasolineras) `Horario` string into the common
`WeeklyOpeningHours` model, following the merged FR (#2710) / AT (#2711)
adapter pattern off the #2708 foundation.

### Real `Horario` shape — verified against live station pages
Confirmed against live geoportalgasolineras pages (not the single assumed
form):

| Form | Meaning |
| --- | --- |
| `L-D: 24H` | open all week, 24h |
| `L-V: 06:00-23:00; S-D: 08:00-23:00` | weekday + weekend day-ranges |
| `L-V: 05:30-23:00; S: 06:30-22:30; D: 07:30-21:00` | single-day segments mixed with a range |
| `Cerrado` / `…: Cerrado` | closed |

Day tokens `L`=mon `M`=tue `X`=wed `J`=thu `V`=fri `S`=sat `D`=sun;
inclusive `A-B` ranges expand Mon-first; `;`-separated segments; `24:00`
end marker; a degenerate equal-bounds range is dropped to `unknown`
(never a 24h wrap).

### Wiring
`MitecoStationService._parseStation` parses the row's `Horario` and
populates `Station.openingHours` (null only when `notProvided`). The
#2706 bulk-cache detail-fallback already threads `Station.openingHours`
into the detail screen — no provider re-edit. Legacy `openingHoursText` /
`isOpen` kept for back-compat.

### Contract & gates
- Pure, never throws (internal `catch (e, st)` → `notAvailable`), never null.
- **Never-throws fault-injection test** (`returnsNormally` on int / list /
  map / malformed-clock → `notAvailable`) for `never_throws_contract_test`
  (#2349).
- ARB-free (0 `lib/l10n/` drift). No codegen (no annotated models touched).
  `file_length` ≤400 (229 / 310). `flutter analyze` clean;
  `test/features/station_services/spain` + `never_throws_contract_test`
  green.

Closes #2713

🤖 Generated with [Claude Code](https://claude.com/claude-code)
