### PR TITLE
test(opening-hours): graceful no-data state for the 11 deferred countries (Epic #2707 Cx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ docs/guides/*
 !docs/guides/fdroid-submission.md
 !docs/guides/app-store-listing.md
 !docs/guides/ios-testflight-testers.md
+!docs/guides/opening-hours.md
 
 # Development-only assets (screenshots, mockups)
 assets_dev/

--- a/docs/guides/opening-hours.md
+++ b/docs/guides/opening-hours.md
@@ -1,0 +1,77 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# Opening Hours
+
+Tankstellen renders a Google-/Apple-Maps-grade weekly opening-hours block on
+the station-detail screen (Epic #2707). This guide records how a country's
+hours flow from its provider to the UI, and — importantly — the deferral
+status of the countries that do **not** expose opening hours yet.
+
+## Pipeline
+
+```
+provider payload
+  → per-country OpeningHoursAdapter.parse(...)        (lib/features/station_services/<c>/<c>_opening_hours_adapter.dart)
+  → StationDetail.openingHours : WeeklyOpeningHours   (the common model)
+  → OpeningHoursView(hours: detail.openingHours ?? legacyOpeningHoursBridge(detail))
+```
+
+- The common model is `WeeklyOpeningHours`
+  (`lib/features/station_detail/domain/opening_hours.dart`).
+- Every adapter implements `OpeningHoursAdapter`
+  (`lib/features/station_services/opening_hours/opening_hours_adapter.dart`):
+  **pure, never throws, never returns `null`** — on missing/unparseable input
+  it returns `WeeklyOpeningHours.notAvailable`.
+- Countries with no adapter yet keep `StationDetail.openingHours == null`.
+  The display layer resolves them through
+  `legacyOpeningHoursBridge(detail)`
+  (`lib/features/station_detail/domain/legacy_opening_hours_bridge.dart`),
+  which maps the legacy `Station.is24h` / `StationDetail.openingTimes` fields
+  to a schedule, or — when those are empty too — to
+  `WeeklyOpeningHours.notAvailable`.
+- `WeeklyOpeningHours.notAvailable` renders as a single muted "Opening hours
+  not available" line (the `openingHoursNotAvailable` ARB key) and is elided
+  entirely from the station-detail section (`station_info_section.dart`).
+  Never a fabricated table or status hero.
+
+## Country coverage
+
+### Adapter shipped (structured hours)
+
+| Country | Code | Source |
+| --- | --- | --- |
+| France | FR | Prix Carburants `opening_hours` |
+| Austria | AT | E-Control |
+| Germany | DE | Tankerkönig `openingTimes` |
+| Spain | ES | MITECO `Horario` |
+| Chile | CL | CNE `horario_atencion` |
+| Portugal | PT | DGEG (#2714) |
+
+### Deferred — no opening-hours data today (11 countries, #2716)
+
+These providers do **not** expose opening hours in the feed we consume, so
+their stations route through `legacyOpeningHoursBridge` → `notAvailable` and
+gracefully show "Opening hours not available". This is verified end-to-end by
+`test/features/station_detail/presentation/widgets/opening_hours_no_data_test.dart`.
+
+| Country | Code | When to revisit |
+| --- | --- | --- |
+| United Kingdom | GB | **Needs a direct fuel-finder API recheck** — the public price-transparency feed did not confirm an `opening_hours` field. Re-evaluate against a brand/fuel-finder API. |
+| Italy | IT | Revisit when the MISE feed exposes hours. |
+| Denmark | DK | Revisit when the provider exposes hours. |
+| Greece | GR | Revisit when the provider exposes hours. |
+| Romania | RO | Revisit when the provider exposes hours. |
+| Slovenia | SI | Revisit when the provider exposes hours. |
+| Luxembourg | LU | Revisit when the provider exposes hours. |
+| Australia | AU | Revisit when the provider exposes hours. |
+| Mexico | MX | Revisit when the CRE feed exposes hours. |
+| Argentina | AR | Revisit when the provider exposes hours. |
+| South Korea | KR | Revisit when the Opinet feed exposes hours. |
+
+**Revisit trigger:** add an `OpeningHoursAdapter` (and the matching adapter
+test) for a country only once its provider actually exposes a usable
+opening-hours field. Until then the bridge keeps the no-data state graceful —
+there is nothing to fix, and nothing should fabricate hours.

--- a/lib/features/station_detail/domain/legacy_opening_hours_bridge.dart
+++ b/lib/features/station_detail/domain/legacy_opening_hours_bridge.dart
@@ -13,6 +13,13 @@ import 'opening_hours.dart';
 /// schedule via this synthesiser — so no country regresses before its
 /// adapter lands.
 ///
+/// The 11 countries with no opening-hours data today (GB, IT, DK, GR, RO,
+/// SI, LU, AU, MX, AR, KR) carry none of these legacy fields either, so they
+/// fall through to [WeeklyOpeningHours.notAvailable] and render the graceful
+/// "Opening hours not available" line. That no-data path is locked by
+/// `opening_hours_no_data_test.dart`; see `docs/guides/opening-hours.md` for
+/// the per-country deferral list and when to revisit each one (#2716).
+///
 /// Mapping, in priority order:
 ///   1. If [StationDetail.openingHours] is already populated (an adapter ran)
 ///      and is not the no-data sentinel, it is returned unchanged.

--- a/test/features/station_detail/presentation/widgets/opening_hours_no_data_test.dart
+++ b/test/features/station_detail/presentation/widgets/opening_hours_no_data_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_detail/domain/legacy_opening_hours_bridge.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_detail/presentation/widgets/opening_hours_view.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// Regression guard for the graceful no-data state of the 11 countries that
+/// ship **without** an [OpeningHoursAdapter] today (Epic #2707 Cx, #2716):
+///
+///   GB, IT, DK, GR, RO, SI, LU, AU, MX, AR, KR.
+///
+/// Their station services populate neither `StationDetail.openingHours` nor
+/// the legacy `Station.is24h` / `StationDetail.openingTimes` fields, so the
+/// display layer resolves their schedule through
+/// `legacyOpeningHoursBridge(detail)`. This test locks that path end-to-end:
+/// the bridge yields [WeeklyOpeningHours.notAvailable], and pumping
+/// [OpeningHoursView] with it renders the localized
+/// `openingHoursNotAvailable` line — never a fabricated table or status
+/// hero. See `docs/guides/opening-hours.md` for the deferral rationale and
+/// when to revisit each country.
+void main() {
+  // A Wednesday — fixed `now` keeps the status line / today-emphasis
+  // deterministic. Irrelevant on the no-data path (the view returns early),
+  // but passed for parity with the real call site.
+  final wednesday = DateTime(2026, 6, 3, 10, 0);
+
+  /// A bare [StationDetail] for a deferred country: no adapter-populated
+  /// `openingHours`, no legacy `is24h`, no `openingTimes`. Exactly the shape
+  /// every GB/IT/DK/GR/RO/SI/LU/AU/MX/AR/KR station detail has today.
+  StationDetail deferredCountryDetail() => const StationDetail(
+        station: Station(
+          id: 's1',
+          name: 'Deferred-country station',
+          brand: 'B',
+          street: 'St',
+          postCode: '1',
+          place: 'P',
+          lat: 0,
+          lng: 0,
+          isOpen: true,
+          // is24h defaults to false — the deferred services never set it.
+        ),
+        // openingTimes defaults to const [] — no legacy schedule either.
+        // openingHours is null — no adapter ran.
+      );
+
+  group('opening-hours no-data — deferred countries (#2716)', () {
+    test('bridge maps a no-OH StationDetail to notAvailable', () {
+      final detail = deferredCountryDetail();
+
+      // Preconditions: this really is the deferred-country shape.
+      expect(detail.openingHours, isNull);
+      expect(detail.station.is24h, isFalse);
+      expect(detail.openingTimes, isEmpty);
+
+      final resolved = legacyOpeningHoursBridge(detail);
+      expect(resolved, WeeklyOpeningHours.notAvailable);
+      expect(resolved.availability, OpeningHoursAvailability.notProvided);
+      expect(resolved.days, isEmpty);
+    });
+
+    testWidgets(
+        'view renders the localized no-data line, not a fake table/status',
+        (tester) async {
+      // Mirror the real call site exactly:
+      //   detail.openingHours ?? legacyOpeningHoursBridge(detail)
+      final detail = deferredCountryDetail();
+      final WeeklyOpeningHours resolved =
+          detail.openingHours ?? legacyOpeningHoursBridge(detail);
+
+      await pumpApp(
+        tester,
+        SingleChildScrollView(
+          child: OpeningHoursView(hours: resolved, now: wednesday),
+        ),
+      );
+
+      // The muted, localized no-data line is shown.
+      expect(find.byKey(const ValueKey('opening-hours-not-available')),
+          findsOneWidget);
+      expect(find.text('Opening hours not available'), findsOneWidget);
+
+      // ...and NOT a fabricated schedule: no status hero, no 24h row, no
+      // collapsed-week expand affordance, no holiday row.
+      expect(find.byKey(const ValueKey('opening-hours-status-line')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('opening-hours-24h-row')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('opening-hours-expand-toggle')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('opening-hours-holiday-row')),
+          findsNothing);
+    });
+
+    test('passing the notAvailable sentinel through the bridge is stable', () {
+      // A country whose (future) adapter explicitly returned the no-data
+      // sentinel must not be "upgraded" by the bridge into a fake schedule.
+      final detail = StationDetail(
+        station: deferredCountryDetail().station,
+        openingHours: WeeklyOpeningHours.notAvailable,
+      );
+      expect(legacyOpeningHoursBridge(detail), WeeklyOpeningHours.notAvailable);
+    });
+  });
+}


### PR DESCRIPTION
## What

Closes #2716. Verifies and locks the **graceful no-data state** for the 11
countries that ship without an `OpeningHoursAdapter` today, and documents the
deferral. This is the last child of Epic #2707 — **all adapters + display +
no-data state are now shipped.**

The behavior already exists via `legacyOpeningHoursBridge`; this PR guards it
with a regression test and a doc rather than re-implementing it.

## Pipeline (already in place)

FR/AT/DE/ES/CL adapters populate `StationDetail.openingHours`. The 11
deferred countries (**GB, IT, DK, GR, RO, SI, LU, AU, MX, AR, KR**) carry no
OH data, so they fall through:

```
StationDetail(openingHours: null, is24h: false, openingTimes: [])
  → legacyOpeningHoursBridge(detail)
  → WeeklyOpeningHours.notAvailable
  → OpeningHoursView → muted "Opening hours not available" (openingHoursNotAvailable)
```

## Changes

- **Regression test** — `opening_hours_no_data_test.dart` asserts the no-data
  path end-to-end: the bridge yields `notAvailable`, and pumping
  `OpeningHoursView` renders the localized string and **not** a fabricated
  table / status hero / 24h row / holiday row.
- **Deferral doc** — `docs/guides/opening-hours.md` with the pipeline and the
  11-country table + a per-country revisit trigger. **GB explicitly needs a
  direct fuel-finder API recheck** (the public price-transparency feed didn't
  confirm `opening_hours`).
- **Dartdoc pointer** on `legacyOpeningHoursBridge` to the doc + test.

## Gates

- ARB-free — reuses the merged `openingHoursNotAvailable` key, **0 `lib/l10n/`
  drift** → disjoint from #2731, parallel-safe.
- `flutter analyze` clean; `flutter test test/features/station_detail` green
  (107 tests, incl. the 3 new); hardcoded-strings lint green.
- Clean codegen → **0 `*.g.dart` / `*.freezed.dart` drift**.
- All files ≤ 400 lines.
- Confirmed (not changed): none of the 11 deferred services populate
  `openingHours` or throw — all route through the bridge to no-data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
