### PR TITLE
feat(mexico): real Magna/Premium fuel-grade labels (#2717)

### DIFF
--- a/lib/core/utils/station_extensions.dart
+++ b/lib/core/utils/station_extensions.dart
@@ -69,3 +69,25 @@ String shortFuelLabel(FuelType fuel) => switch (fuel) {
       FuelTypeAll() => '', // no label for the wildcard
     };
 
+/// Country-aware pump label for [fuel] (#2717).
+///
+/// Mexico's CRE feed has no European E5/E98 grades — its pumps are
+/// PEMEX **Magna** (~87-oct regular, mapped to the e5 family by #2704)
+/// and **Premium** (~91-92 oct, mapped to e98). The underlying mapping
+/// is physically correct (eco/CO₂ factor, fuel colour and compatibility
+/// family all match), so this only fixes the rendered *string*: for
+/// `countryCode == 'MX'` it returns the real PEMEX grade name, and for
+/// every other country (and `null`) it falls straight through to
+/// [shortFuelLabel] — guaranteeing zero change for FR/DE/etc. Diesel,
+/// e10, lpg, … always use [shortFuelLabel], even in Mexico.
+String fuelDisplayLabel(FuelType fuel, {String? countryCode}) {
+  if (countryCode == 'MX') {
+    return switch (fuel) {
+      FuelTypeE5() => 'Magna', // i18n-ignore: PEMEX fuel-grade proper noun
+      FuelTypeE98() => 'Premium', // i18n-ignore: PEMEX fuel-grade proper noun
+      _ => shortFuelLabel(fuel),
+    };
+  }
+  return shortFuelLabel(fuel);
+}
+

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import '../../../../core/country/country_config.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';
@@ -179,15 +181,27 @@ class AllPricesStationCard extends StatelessWidget {
   List<Widget> _buildFuelBadges(BuildContext context) {
     final badges = <Widget>[];
 
+    // #2717 — resolve the station's country so Mexican (mx-) stations show
+    // PEMEX grade names (Magna/Premium); every other country falls through
+    // to the language-neutral fuel code unchanged.
+    final cc = Countries.countryCodeForStationId(station.id);
+
     final fuelEntries = <(FuelType, double?, String)>[
-      (FuelType.e5, station.e5, 'E5'),
-      (FuelType.e10, station.e10, 'E10'),
-      (FuelType.e98, station.e98, 'E98'),
-      (FuelType.diesel, station.diesel, 'Diesel'),
-      (FuelType.dieselPremium, station.dieselPremium, 'Diesel+'),
-      (FuelType.e85, station.e85, 'E85'),
-      (FuelType.lpg, station.lpg, 'GPL'),
-      (FuelType.cng, station.cng, 'GNV'),
+      (FuelType.e5, station.e5, fuelDisplayLabel(FuelType.e5, countryCode: cc)),
+      (FuelType.e10, station.e10,
+          fuelDisplayLabel(FuelType.e10, countryCode: cc)),
+      (FuelType.e98, station.e98,
+          fuelDisplayLabel(FuelType.e98, countryCode: cc)),
+      (FuelType.diesel, station.diesel,
+          fuelDisplayLabel(FuelType.diesel, countryCode: cc)),
+      (FuelType.dieselPremium, station.dieselPremium,
+          fuelDisplayLabel(FuelType.dieselPremium, countryCode: cc)),
+      (FuelType.e85, station.e85,
+          fuelDisplayLabel(FuelType.e85, countryCode: cc)),
+      (FuelType.lpg, station.lpg,
+          fuelDisplayLabel(FuelType.lpg, countryCode: cc)),
+      (FuelType.cng, station.cng,
+          fuelDisplayLabel(FuelType.cng, countryCode: cc)),
     ];
 
     for (final (fuelType, price, label) in fuelEntries) {

--- a/lib/features/search/presentation/widgets/station_card_price_column.dart
+++ b/lib/features/search/presentation/widgets/station_card_price_column.dart
@@ -54,6 +54,10 @@ class _StationPriceColumn extends StatelessWidget {
     return effective < 0.001 ? 0.001 : effective;
   }
 
+  /// ISO country code inferred from the station id, used to pick the
+  /// right fuel-grade labels (#2717 — `mx-` → PEMEX Magna/Premium).
+  String? get _countryCode => Countries.countryCodeForStationId(station.id);
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -166,20 +170,22 @@ class _StationPriceColumn extends StatelessWidget {
           ),
         if (selectedFuelType == FuelType.all && !isCheapest) ...[
           const SizedBox(height: 2),
+          // #2717 — Mexican (mx-) stations show PEMEX grade names
+          // (Magna/Premium); every other country is unchanged.
           _PriceRow(
-            label: 'E5',
+            label: fuelDisplayLabel(FuelType.e5, countryCode: _countryCode),
             price: station.e5,
             fuelType: FuelType.e5,
             isProfileFuel: profileFuelType is FuelTypeE5,
           ),
           _PriceRow(
-            label: 'E10',
+            label: fuelDisplayLabel(FuelType.e10, countryCode: _countryCode),
             price: station.e10,
             fuelType: FuelType.e10,
             isProfileFuel: profileFuelType is FuelTypeE10,
           ),
           _PriceRow(
-            label: 'Diesel',
+            label: fuelDisplayLabel(FuelType.diesel, countryCode: _countryCode),
             price: station.diesel,
             fuelType: FuelType.diesel,
             isProfileFuel: profileFuelType is FuelTypeDiesel,

--- a/lib/features/station_detail/presentation/widgets/station_prices_section.dart
+++ b/lib/features/station_detail/presentation/widgets/station_prices_section.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/country/country_config.dart';
 import '../../../../core/widgets/section_card.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/profile_provider.dart';
@@ -34,16 +35,34 @@ class StationPricesSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
 
+    // #2717 — Mexican (mx-) stations show PEMEX grade names (Magna for the
+    // e5-family regular, Premium for the e98-family). Every other country
+    // keeps its existing European "Super E5"/"Super 98" labels untouched.
+    final cc = Countries.countryCodeForStationId(station.id);
+    final isMx = cc == 'MX';
+
     return SectionCard(
       title: l10n?.prices ?? 'Prices',
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          PriceTile(label: 'Super E5', price: station.e5, fuelType: FuelType.e5),
+          PriceTile(
+            label: isMx
+                ? fuelDisplayLabel(FuelType.e5, countryCode: cc)
+                : 'Super E5', // i18n-ignore: language-neutral fuel code
+            price: station.e5,
+            fuelType: FuelType.e5,
+          ),
           PriceTile(label: 'Super E10', price: station.e10, fuelType: FuelType.e10),
           PriceTile(label: 'Diesel', price: station.diesel, fuelType: FuelType.diesel),
           if (station.e98 != null)
-            PriceTile(label: 'Super 98', price: station.e98, fuelType: FuelType.e98),
+            PriceTile(
+              label: isMx
+                  ? fuelDisplayLabel(FuelType.e98, countryCode: cc)
+                  : 'Super 98', // i18n-ignore: language-neutral fuel code
+              price: station.e98,
+              fuelType: FuelType.e98,
+            ),
           if (station.e85 != null)
             PriceTile(label: 'E85', price: station.e85, fuelType: FuelType.e85),
           if (station.lpg != null)

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -538,6 +538,66 @@ void main() {
       });
     });
 
+    group('Mexico PEMEX fuel-grade labels (#2717)', () {
+      // A Mexican (mx-) station: CRE regular→e5, premium→e98 (the #2704
+      // mapping). The label seam must render PEMEX grade names — Magna for
+      // the e5-family regular, Premium for the e98-family — instead of the
+      // European E5/E98 codes.
+      const mxStation = Station(
+        id: 'mx-11702',
+        name: 'TRENOGAS SA DE CV',
+        brand: '',
+        street: 'TRENOGAS SA DE CV',
+        postCode: '',
+        place: '',
+        lat: 19.43,
+        lng: -99.13,
+        e5: 22.95,
+        e98: 24.89,
+        diesel: 23.45,
+        isOpen: true,
+      );
+
+      testWidgets('mx- station shows Magna + Premium, never E5/E98', (
+        tester,
+      ) async {
+        await pumpApp(tester, const AllPricesStationCard(station: mxStation));
+
+        expect(find.text('Magna'), findsOneWidget);
+        expect(find.text('Premium'), findsOneWidget);
+        expect(find.text('E5'), findsNothing);
+        expect(find.text('E98'), findsNothing);
+        // Diesel is NOT a PEMEX-renamed grade — its code is unchanged.
+        expect(find.text('Diesel'), findsOneWidget);
+      });
+
+      testWidgets('non-MX (de-) station never shows Magna/Premium', (
+        tester,
+      ) async {
+        const deStation = Station(
+          id: 'de-abc',
+          name: 'Aral',
+          brand: 'ARAL',
+          street: 'Hauptstr. 1',
+          postCode: '10115',
+          place: 'Berlin',
+          lat: 52.52,
+          lng: 13.40,
+          e5: 1.859,
+          e98: 1.989,
+          diesel: 1.659,
+          isOpen: true,
+        );
+
+        await pumpApp(tester, const AllPricesStationCard(station: deStation));
+
+        expect(find.text('Magna'), findsNothing);
+        expect(find.text('Premium'), findsNothing);
+        expect(find.text('E5'), findsOneWidget);
+        expect(find.text('E98'), findsOneWidget);
+      });
+    });
+
     group('StationCardShell composition (#2493)', () {
       testWidgets('built from the shared shell with no accent stripe', (
         tester,

--- a/test/features/station_services/mexico/mexico_fuel_label_test.dart
+++ b/test/features/station_services/mexico/mexico_fuel_label_test.dart
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/utils/station_extensions.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/station_services/mexico/mexico_station_service.dart';
+
+/// #2717 — Mexican CRE stations must render real PEMEX grade NAMES
+/// (Magna / Premium) instead of the European E5 / E98 codes that the
+/// physically-correct #2704 mapping (regular→e5, premium→e98) produces.
+///
+/// Reuse-fidelity: this drives the REAL [MexicoStationService] XML parser
+/// against the real CRE wire shape (`<gas_price type="regular|premium|
+/// diesel">`), then asserts at the [fuelDisplayLabel] layer — never a
+/// request-echoing fake. The underlying e5/e98/diesel slots are exercised
+/// exhaustively by mexico_station_service_test.dart; this file owns only
+/// the label seam.
+
+/// Fake HTTP adapter that maps request URLs to canned XML responses.
+class _FakeCreAdapter implements HttpClientAdapter {
+  _FakeCreAdapter({required this.responses});
+
+  final Map<String, String> responses;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final body = responses[options.uri.toString()];
+    if (body == null) {
+      return ResponseBody.fromString('not mapped', 404);
+    }
+    return ResponseBody.fromString(
+      body,
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/xml; charset=utf-8'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _placesUrl = 'https://fake.cre/publicaciones/places';
+const _pricesUrl = 'https://fake.cre/publicaciones/prices';
+
+MexicoStationService _serviceWith({
+  required String placesXml,
+  required String pricesXml,
+}) {
+  final adapter = _FakeCreAdapter(responses: {
+    _placesUrl: placesXml,
+    _pricesUrl: pricesXml,
+  });
+  final dio = Dio()..httpClientAdapter = adapter;
+  return MexicoStationService(
+    dio: dio,
+    baseUrl: 'https://fake.cre/publicaciones',
+  );
+}
+
+const _cdmxParams = SearchParams(lat: 19.43, lng: -99.13, radiusKm: 10);
+
+void main() {
+  group('fuelDisplayLabel — Mexico PEMEX grade names (#2717)', () {
+    test(
+        'a station parsed by the REAL MexicoStationService renders Magna / '
+        'Premium; diesel + other countries fall through unchanged', () async {
+      // Build the REAL CRE wire shape and parse it with the REAL service.
+      const placesXml = '<?xml version="1.0" encoding="utf-8"?>\n'
+          '<places>'
+          '<place place_id="11702">'
+          '<name>TRENOGAS SA DE CV</name>'
+          '<location><x>-99.13</x><y>19.43</y></location>'
+          '</place>'
+          '</places>';
+      const pricesXml = '<?xml version="1.0" encoding="utf-8"?>\n'
+          '<places>'
+          '<place place_id="11702">'
+          '<gas_price type="regular">22.95</gas_price>'
+          '<gas_price type="premium">24.89</gas_price>'
+          '<gas_price type="diesel">23.45</gas_price>'
+          '</place>'
+          '</places>';
+
+      final result = await _serviceWith(
+        placesXml: placesXml,
+        pricesXml: pricesXml,
+      ).searchStations(_cdmxParams);
+
+      expect(result.data, hasLength(1));
+      final station = result.data.first;
+      // Sanity: the #2704 mapping holds (regular→e5, premium→e98).
+      expect(station.id, 'mx-11702');
+      expect(station.e5, 22.95);
+      expect(station.e98, 24.89);
+      expect(station.diesel, 23.45);
+
+      // Country resolved from the station id exactly as the call sites do.
+      final cc = Countries.countryCodeForStationId(station.id);
+      expect(cc, 'MX');
+
+      // The label seam: e5→Magna, e98→Premium.
+      expect(fuelDisplayLabel(FuelType.e5, countryCode: cc), 'Magna');
+      expect(fuelDisplayLabel(FuelType.e98, countryCode: cc), 'Premium');
+
+      // Diesel is NOT a PEMEX-renamed grade — falls through to the code.
+      expect(
+        fuelDisplayLabel(FuelType.diesel, countryCode: cc),
+        shortFuelLabel(FuelType.diesel),
+      );
+    });
+
+    test('cross-country guard — DE / FR never see Magna or Premium', () {
+      for (final cc in ['DE', 'FR']) {
+        expect(
+          fuelDisplayLabel(FuelType.e5, countryCode: cc),
+          shortFuelLabel(FuelType.e5),
+          reason: '$cc e5 must stay the European code',
+        );
+        expect(
+          fuelDisplayLabel(FuelType.e98, countryCode: cc),
+          shortFuelLabel(FuelType.e98),
+          reason: '$cc e98 must stay the European code',
+        );
+      }
+    });
+
+    test('null-country guard — falls through to shortFuelLabel', () {
+      expect(
+        fuelDisplayLabel(FuelType.e5, countryCode: null),
+        shortFuelLabel(FuelType.e5),
+      );
+      expect(
+        fuelDisplayLabel(FuelType.e98, countryCode: null),
+        shortFuelLabel(FuelType.e98),
+      );
+    });
+
+    test('MX only renames e5/e98 — every other grade keeps its code', () {
+      const cc = 'MX';
+      for (final fuel in [
+        FuelType.e10,
+        FuelType.diesel,
+        FuelType.dieselPremium,
+        FuelType.e85,
+        FuelType.lpg,
+        FuelType.cng,
+        FuelType.hydrogen,
+        FuelType.electric,
+      ]) {
+        expect(
+          fuelDisplayLabel(fuel, countryCode: cc),
+          shortFuelLabel(fuel),
+          reason: '${fuel.apiValue} is not a PEMEX-renamed grade',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Mexican (`mx-`) stations rendered European fuel codes (`E5` / `Super 98`) for their PEMEX CRE grades. This fixes the **rendered string only** via a country-aware display-label seam — **approach B**, NOT new `FuelType` enum members.

## Why approach B (string-only)

The underlying #2704 mapping (CRE `regular→e5`, `premium→e98`, `diesel→diesel`) is **physically correct**: a Magna pump *is* ~87-oct regular (e5-family); Premium *is* ~91-92 oct (e98-family). So eco/CO₂ factor, fuel colour and compatibility family are all already right — only the label was wrong. The enum-cascade alternative would force 5 sealed-switch edits, codegen, count-test churn and a picker leak — explicitly rejected.

## Changes

- New total, pure `fuelDisplayLabel(FuelType, {String? countryCode})` next to `shortFuelLabel` in `station_extensions.dart`: `countryCode == 'MX'` → e5 **Magna**, e98 **Premium**; everything else (diesel, e10, lpg, …, every other country, and `null`) falls straight through to `shortFuelLabel` — zero regression for FR/DE/etc.
- **ARB-free (literal path).** Magna / Premium are PEMEX grade proper nouns, kept as `// i18n-ignore` literals exactly like the existing `E5`/`E10`/`Diesel` fuel-code literals at these sinks. No l10n fan-out, no drift. The `no_hardcoded` lint baseline stays **0** (`label:` is not a scanned sink).
- Wired 3 label surfaces, resolving the country once per build via `Countries.countryCodeForStationId(station.id)`:
  - `all_prices_station_card.dart` (fuel badges)
  - `station_card_price_column.dart` (`FuelType.all` price rows)
  - `station_prices_section.dart` (detail `PriceTile`s — non-MX keep `Super E5`/`Super 98`)

## Out of scope (separable follow-ups)

Profile fuel-picker dropdown, map markers.

## Tests (reuse-fidelity)

- `test/features/station_services/mexico/mexico_fuel_label_test.dart` (new): drives the **real** `MexicoStationService` XML parser over the real CRE wire shape, then asserts at the label layer — `mx-` → Magna/Premium, diesel unchanged; cross-country `DE`/`FR` + `null` guards; MX renames only e5/e98.
- `test/features/search/presentation/widgets/all_prices_station_card_test.dart`: `mx-` card shows Magna + Premium (never E5/E98); `de-` card shows E5/E98 and never Magna/Premium.
- Existing Mexico mapping test unchanged (e5==regular / e98==premium / e10==null anchor still passes).

Targeted suites green: mexico, search, station_detail widgets, lint (baseline 0), price_utils. Zero `*.g.dart`/`*.freezed.dart`/`lib/l10n/` drift. (The one failure in the combined full-`test/core/` run is a pre-existing live-network flake in `api_connectivity_test.dart` — Argentina CSV connection timeout — untouched by this PR.)

Closes #2717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
