### PR TITLE
fix(radar): redesign radar stop FAB — "Stop radar" + stop_circle icon (was "✕ Étape")

### DIFF
--- a/lib/features/search/presentation/widgets/radar_search_fab.dart
+++ b/lib/features/search/presentation/widgets/radar_search_fab.dart
@@ -31,7 +31,7 @@ class RadarSearchFab extends ConsumerWidget {
     final active = ref.watch(radarSearchProvider).active;
 
     final label = active
-        ? (l10n?.stop ?? 'Stop')
+        ? (l10n?.stopRadar ?? 'Stop radar')
         : (l10n?.fuelStationRadarStart ?? 'Start fuel station radar');
 
     return FloatingActionButton.extended(
@@ -46,7 +46,7 @@ class RadarSearchFab extends ConsumerWidget {
           notifier.runRadar();
         }
       },
-      icon: Icon(active ? Icons.close : Icons.radar),
+      icon: Icon(active ? Icons.stop_circle : Icons.radar),
       label: Text(label),
     );
   }

--- a/lib/l10n/_fragments/trip_radar_de.arb
+++ b/lib/l10n/_fragments/trip_radar_de.arb
@@ -23,6 +23,10 @@
   "@fuelStationRadarStart": {
     "description": "Label on the extended floating-action button (styled like the trip 'Start recording' pill) that launches a cache-first Fuel Station Radar scan around the user and shows the nearby stations in the search-results list (#2682)."
   },
+  "stopRadar": "Tankstellen-Radar stoppen",
+  "@stopRadar": {
+    "description": "Label on the extended floating-action button when the Fuel Station Radar is active: tapping it ends the radar session and hands the results list back to the regular search. Replaces the ambiguous shared 'stop' key (FR 'Étape') that read as a route-waypoint label, not a radar-off affordance (#2744)."
+  },
   "fuelStationRadarResultBadge": "Tankstellen-Radar-Ergebnis",
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."

--- a/lib/l10n/_fragments/trip_radar_en.arb
+++ b/lib/l10n/_fragments/trip_radar_en.arb
@@ -23,6 +23,10 @@
   "@fuelStationRadarStart": {
     "description": "Label on the extended floating-action button (styled like the trip 'Start recording' pill) that launches a cache-first Fuel Station Radar scan around the user and shows the nearby stations in the search-results list (#2682)."
   },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "description": "Label on the extended floating-action button when the Fuel Station Radar is active: tapping it ends the radar session and hands the results list back to the regular search. Replaces the ambiguous shared 'stop' key (FR 'Étape') that read as a route-waypoint label, not a radar-off affordance (#2744)."
+  },
   "fuelStationRadarResultBadge": "Fuel Station Radar result",
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3068,6 +3068,10 @@
   "@fuelStationRadarStart": {
     "description": "Label on the extended floating-action button (styled like the trip 'Start recording' pill) that launches a cache-first Fuel Station Radar scan around the user and shows the nearby stations in the search-results list (#2682)."
   },
+  "stopRadar": "Tankstellen-Radar stoppen",
+  "@stopRadar": {
+    "description": "Label on the extended floating-action button when the Fuel Station Radar is active: tapping it ends the radar session and hands the results list back to the regular search. Replaces the ambiguous shared 'stop' key (FR 'Étape') that read as a route-waypoint label, not a radar-off affordance (#2744)."
+  },
   "fuelStationRadarResultBadge": "Tankstellen-Radar-Ergebnis",
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6207,6 +6207,10 @@
   "@fuelStationRadarStart": {
     "description": "Label on the extended floating-action button (styled like the trip 'Start recording' pill) that launches a cache-first Fuel Station Radar scan around the user and shows the nearby stations in the search-results list (#2682)."
   },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "description": "Label on the extended floating-action button when the Fuel Station Radar is active: tapping it ends the radar session and hands the results list back to the regular search. Replaces the ambiguous shared 'stop' key (FR 'Étape') that read as a route-waypoint label, not a radar-off affordance (#2744)."
+  },
   "fuelStationRadarResultBadge": "Fuel Station Radar result",
   "@fuelStationRadarResultBadge": {
     "description": "Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676)."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1970,6 +1970,7 @@
   "fuelStationRadarNearer": "⟦Ñéářéř šŧáŧîóñ ······⟧",
   "fuelStationRadarFarther": "⟦Ƒářŧĥéř šŧáŧîóñ ······⟧",
   "fuelStationRadarStart": "⟦Šŧářŧ ƒúéł šŧáŧîóñ řáđář ·········⟧",
+  "stopRadar": "⟦Šŧóƥ řáđář ····⟧",
   "fuelStationRadarResultBadge": "⟦Ƒúéł Šŧáŧîóñ Řáđář řéšúłŧ ··········⟧",
   "tripRecordingPinTooltip": "⟦Ƥîññîñǧ ķééƥš ŧĥé šçřééñ óñ — úšéš ɱóřé ƀáŧŧéřý ·················⟧",
   "tripRecordingPinSemanticOn": "⟦Úñƥîñ řéçóřđîñǧ ƒóřɱ ········⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4183,5 +4183,9 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Arrêter le radar",
+  "@stopRadar": {
+    "description": "Label on the extended floating-action button when the Fuel Station Radar is active: tapping it ends the radar session and hands the results list back to the regular search. Replaces the ambiguous shared 'stop' key (FR 'Étape') that read as a route-waypoint label, not a radar-off affordance (#2744)."
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12031,6 +12031,12 @@ abstract class AppLocalizations {
   /// **'Start fuel station radar'**
   String get fuelStationRadarStart;
 
+  /// Label on the extended floating-action button when the Fuel Station Radar is active: tapping it ends the radar session and hands the results list back to the regular search. Replaces the ambiguous shared 'stop' key (FR 'Étape') that read as a route-waypoint label, not a radar-off affordance (#2744).
+  ///
+  /// In en, this message translates to:
+  /// **'Stop radar'**
+  String get stopRadar;
+
   /// Label of the grey summary-bar chip shown above the results list while the on-search Fuel Station Radar owns the results, replacing the radius chip to signal the list is a radar scan rather than a regular search (#2676).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -6901,6 +6901,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -6856,6 +6856,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -6847,6 +6847,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -6895,6 +6895,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get fuelStationRadarStart => 'Tankstellen-Radar starten';
 
   @override
+  String get stopRadar => 'Tankstellen-Radar stoppen';
+
+  @override
   String get fuelStationRadarResultBadge => 'Tankstellen-Radar-Ergebnis';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -6905,6 +6905,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6819,6 +6819,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override
@@ -14151,6 +14154,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get fuelStationRadarStart => '⟦Šŧářŧ ƒúéł šŧáŧîóñ řáđář ·········⟧';
+
+  @override
+  String get stopRadar => '⟦Šŧóƥ řáđář ····⟧';
 
   @override
   String get fuelStationRadarResultBadge =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -6896,6 +6896,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -6839,6 +6839,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -6847,6 +6847,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -6914,6 +6914,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Arrêter le radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -6869,6 +6869,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -6891,6 +6891,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -6882,6 +6882,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -6881,6 +6881,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -6885,6 +6885,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -6845,6 +6845,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -6869,6 +6869,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -6874,6 +6874,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -6893,6 +6893,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -6891,6 +6891,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -6875,6 +6875,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -6856,6 +6856,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -6845,6 +6845,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get fuelStationRadarStart => 'Start fuel station radar';
 
   @override
+  String get stopRadar => 'Stop radar';
+
+  @override
   String get fuelStationRadarResultBadge => 'Fuel Station Radar result';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4097,5 +4097,10 @@
   "@openingHoursAutomate24h": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "stopRadar": "Stop radar",
+  "@stopRadar": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/features/search/presentation/widgets/radar_search_button_test.dart
+++ b/test/features/search/presentation/widgets/radar_search_button_test.dart
@@ -151,11 +151,16 @@ void main() {
         ].cast(),
       );
 
-      // Active → stop label + close icon, not the start label.
-      expect(find.text('Stop'), findsOneWidget);
+      // Active → a clear "Stop radar" label + a meaningful stop_circle icon
+      // (#2744 — not the ambiguous "Étape"/close treatment), not the start
+      // label.
+      expect(find.text('Stop radar'), findsOneWidget);
+      expect(find.text('Stop'), findsNothing);
       expect(find.text('Start fuel station radar'), findsNothing);
-      expect(find.widgetWithIcon(FloatingActionButton, Icons.close),
+      expect(find.widgetWithIcon(FloatingActionButton, Icons.stop_circle),
           findsOneWidget);
+      expect(
+          find.widgetWithIcon(FloatingActionButton, Icons.close), findsNothing);
 
       // Tapping it dismisses the radar (flips back to the start treatment).
       await tester.tap(find.byKey(const Key('radarSearchButton')));


### PR DESCRIPTION
## What

On the Fuel Station Radar result view the floating action button that **stops** the radar showed **"✕ Étape"** in French — an X icon plus "Stage".

### Root cause
The active/stop state of `RadarSearchFab` reused the generic `stop` ARB key for its label. That key is the route-waypoint label "Stop {n}" (FR **"Étape"**), shared with `route_input.dart`. So in French the radar-off button rendered the route-stage word, and the icon was a bare `Icons.close` — together conveying neither "stop" nor "radar".

### Fix
- New dedicated `stopRadar` ARB key:
  - en **"Stop radar"**, de **"Tankstellen-Radar stoppen"** (matches the existing `fuelStationRadarStart` = "Tankstellen-Radar starten"), fr **"Arrêter le radar"**.
  - Fanned out to all 23 locales + the `en_XA` pseudo-locale (100% coverage).
- Icon: bare `Icons.close` → `Icons.stop_circle` (clear "end the radar session" affordance). Idle state still `Icons.radar`.
- The shared `stop` key is **untouched** — it is still the genuine route-stage waypoint label in `route_input.dart`, where "Étape" is correct.

### Files
- `lib/features/search/presentation/widgets/radar_search_fab.dart` — label + icon.
- `lib/l10n/_fragments/trip_radar_{en,de}.arb` + full l10n fan-out.
- `test/features/search/presentation/widgets/radar_search_button_test.dart` — active state asserts "Stop radar" + `stop_circle`, and absence of old "Stop"/`close`.

## Tests
`flutter analyze` clean; `flutter test test/features/{approach,search,consumption} test/l10n test/lint` all green (4856 passed, 6 skipped). No `.g.dart`/`.freezed.dart` codegen touched.

Closes #2744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
