### PR TITLE
fix(telemetry): de-noise offline/transient + expected-OBD2 conditions logged as ERROR (error-log #14)

### DIFF
--- a/lib/core/network/dio_offline.dart
+++ b/lib/core/network/dio_offline.dart
@@ -45,3 +45,71 @@ bool isOfflineDioException(Object error) {
   if (error is HttpException) return true;
   return false;
 }
+
+/// Whether [error] is an OFFLINE / no-network / host-lookup transient — a
+/// SUPERSET of [isOfflineDioException] that also recognises the offline
+/// shapes which arrive WITHOUT a Dio wrapper (#2745):
+///
+///  - a [SocketException] (or a Dio one) whose message reports a failed
+///    host lookup / unreachable network — the device simply has no DNS;
+///  - the supabase_flutter `AuthRetryableFetchException`, which wraps a
+///    `SocketException` ("Failed host lookup" / "No address associated with
+///    hostname") when the device is offline (#2745 traces #2–4);
+///  - a `PlatformException(IO_ERROR / UNAVAILABLE)` from the on-device
+///    geocoder, which the OS raises when the geocoding backend can't be
+///    reached offline (#2745 trace #7).
+///
+/// Used by the [TraceRecorder] de-noise gate and the offline-tolerant
+/// fallback sites (Nominatim / native geocoder) so a genuinely offline
+/// device does not spool an ERROR for a call it was always going to lose.
+///
+/// Deliberately NARROW by shape + message, NOT by exception family: a
+/// `PlatformException` that is NOT an offline IO error, an
+/// `AuthRetryableFetchException` whose cause is a real 5xx (no offline
+/// substring), and any non-offline failure return `false` so a GENUINE
+/// failure still ERROR-logs. The match is the broadest offline signal that
+/// stays free of false positives — it never inspects HTTP status codes.
+bool isOfflineError(Object error) {
+  if (isOfflineDioException(error)) return true;
+  // A `DioException[unknown]` can wrap a raw [HttpException] connection-abort
+  // (the FR feed field trace #1) — `isOfflineDioException` only inspects a
+  // wrapped SocketException for the `unknown` type, so unwrap + re-classify
+  // the inner error here (#2745).
+  if (error is DioException) {
+    final inner = error.error;
+    if (inner != null && inner != error && isOfflineError(inner)) return true;
+  }
+  if (error is SocketException) return _looksOffline(error.toString());
+  final typeName = error.runtimeType.toString();
+  // The supabase_flutter retryable-fetch wrapper carries the underlying
+  // socket message in its `toString()` (#2745). Match by type name + the
+  // offline substring so a retryable fetch caused by a real server blip
+  // (no offline substring) still persists.
+  // i18n-ignore: matching a platform/library exception class name, not UI.
+  if (typeName.contains('AuthRetryableFetchException')) {
+    return _looksOffline(error.toString());
+  }
+  // On-device geocoder offline: `PlatformException(IO_ERROR, …UNAVAILABLE…)`
+  // / a no-network platform-channel IO error (#2745 trace #7).
+  // i18n-ignore: matching a platform exception class name, not UI text.
+  if (typeName.contains('PlatformException')) {
+    final msg = error.toString().toUpperCase();
+    return msg.contains('UNAVAILABLE') ||
+        (msg.contains('IO_ERROR') && msg.contains('NETWORK'));
+  }
+  return false;
+}
+
+/// True when [message] carries one of the offline / no-network / failed
+/// host-lookup substrings. Matched case-insensitively. Kept in sync with
+/// `friendlyAuthError`'s network-family substrings (#2745).
+bool _looksOffline(String message) {
+  final m = message.toUpperCase();
+  return m.contains('FAILED HOST LOOKUP') ||
+      m.contains('NO ADDRESS ASSOCIATED WITH HOSTNAME') ||
+      m.contains('NETWORK IS UNREACHABLE') ||
+      m.contains('SOFTWARE CAUSED CONNECTION ABORT') ||
+      m.contains('CONNECTION CLOSED') ||
+      m.contains('CONNECTION RESET') ||
+      m.contains('ERRNO = 7');
+}

--- a/lib/core/services/impl/native_geocoding_provider.dart
+++ b/lib/core/services/impl/native_geocoding_provider.dart
@@ -9,6 +9,8 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:geocoding/geocoding.dart' as geo;
 import '../../error/exceptions.dart';
+import '../../network/dio_offline.dart';
+import '../../telemetry/collectors/breadcrumb_collector.dart';
 import '../geocoding_provider.dart';
 import '../service_result.dart';
 import '../../../core/logging/error_logger.dart';
@@ -66,6 +68,18 @@ class NativeGeocodingProvider implements GeocodingProvider {
       if (placemarks.isEmpty) return null;
       return placemarks.first.isoCountryCode;
     } on Exception catch (e, st) {
+      // #2745 — the on-device geocoder raises `PlatformException(IO_ERROR,
+      // …UNAVAILABLE…)` when its backend can't be reached offline (field
+      // trace #7). This already falls back to Nominatim, so drop the
+      // expected offline failure to a breadcrumb rather than an ERROR trace.
+      // A genuine native-geocoder fault still ERROR-logs.
+      if (isOfflineError(e)) {
+        BreadcrumbCollector.add(
+          'Native country detection skipped — offline',
+          detail: 'lat=$lat lng=$lng type=${e.runtimeType}',
+        );
+        return null;
+      }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Native country detection failed'}));
       return null;
     }
@@ -84,6 +98,16 @@ class NativeGeocodingProvider implements GeocodingProvider {
           .where((s) => s != null && s.isNotEmpty)
           .join(' ');
     } on Exception catch (e, st) {
+      // #2745 — see [coordinatesToCountryCode]: an offline platform-geocoder
+      // failure is expected (falls back to "lat, lng"), so breadcrumb it
+      // rather than ERROR-log. A genuine fault still persists.
+      if (isOfflineError(e)) {
+        BreadcrumbCollector.add(
+          'Native reverse geocoding skipped — offline',
+          detail: 'lat=$lat lng=$lng type=${e.runtimeType}',
+        );
+        return '$lat, $lng';
+      }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Native reverse geocoding failed'}));
       return '$lat, $lng';
     }

--- a/lib/core/services/impl/nominatim_geocoding_provider.dart
+++ b/lib/core/services/impl/nominatim_geocoding_provider.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import '../../error/exceptions.dart';
+import '../../network/dio_offline.dart';
+import '../../telemetry/collectors/breadcrumb_collector.dart';
 import '../dio_factory.dart';
 import '../geocoding_provider.dart';
 import '../service_config.dart';
@@ -130,6 +132,17 @@ class NominatimGeocodingProvider implements GeocodingProvider {
           .where((s) => s != null && s.toString().isNotEmpty)
           .join(' ');
     } on DioException catch (e, st) {
+      // #2745 — an offline host-lookup failure to nominatim.openstreetmap.org
+      // is expected (the method already falls back to "lat, lng"), so drop it
+      // to a breadcrumb rather than an ERROR trace (field traces #8/#9). A
+      // genuine API error (4xx/5xx, parse) still ERROR-logs.
+      if (isOfflineError(e)) {
+        BreadcrumbCollector.add(
+          'Nominatim reverse geocoding skipped — offline',
+          detail: 'lat=$lat lng=$lng type=${e.type}',
+        );
+        return '$lat, $lng';
+      }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Nominatim reverse geocoding failed'}));
       return '$lat, $lng';
     }
@@ -155,6 +168,16 @@ class NominatimGeocodingProvider implements GeocodingProvider {
       final code = address?['country_code'] as String?;
       return code?.toUpperCase();
     } on DioException catch (e, st) {
+      // #2745 — offline host-lookup failure is expected (the geocoding chain
+      // already falls back to the next provider / null), so breadcrumb it
+      // rather than ERROR-log (field traces #8/#9). Genuine errors persist.
+      if (isOfflineError(e)) {
+        BreadcrumbCollector.add(
+          'Nominatim country detection skipped — offline',
+          detail: 'lat=$lat lng=$lng type=${e.type}',
+        );
+        return null;
+      }
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Nominatim country detection failed'}));
       return null;
     }

--- a/lib/core/telemetry/trace_recorder.dart
+++ b/lib/core/telemetry/trace_recorder.dart
@@ -153,11 +153,13 @@ class TraceRecorder {
   ///      (the device is simply offline — DNS can't resolve the API host);
   ///   2. a [DioException] of type [DioExceptionType.cancel] (the user
   ///      navigated away / a newer request superseded this one);
-  ///   3. (#2703) a connection-LAYER Dio transient or a bare [HttpException]
-  ///      — classified by the shared [isOfflineDioException] util so this
-  ///      and the FR service can't drift (`connectionError` /
-  ///      `connectionTimeout` / `sendTimeout` / `receiveTimeout`, an
-  ///      `unknown` wrapping a SocketException, a connection abort);
+  ///   3. (#2703/#2745) a connection-LAYER Dio transient, a bare
+  ///      [HttpException], OR an offline host-lookup shape that arrives
+  ///      without a Dio wrapper (a supabase `AuthRetryableFetchException`
+  ///      wrapping a host-lookup SocketException, an on-device geocoder
+  ///      `PlatformException(IO_ERROR/UNAVAILABLE)`) — classified by the
+  ///      shared [isOfflineError] superset so this and the offline-tolerant
+  ///      service sites can't drift;
   ///   4. (#2703) when [isOnline] is `false`, any other network-category
   ///      exception (`SocketException` / `TimeoutException` / `HttpException`)
   ///      — a doomed call made while the device has no connection.
@@ -177,7 +179,14 @@ class TraceRecorder {
       return true;
     }
     // #2703 — shared connection-layer classification (PRIMARY signal).
-    if (isOfflineDioException(error)) return true;
+    // #2745 — broadened to the offline SUPERSET so the host-lookup shapes
+    // that arrive WITHOUT a Dio wrapper are suppressed too: the supabase
+    // `AuthRetryableFetchException(SocketException: Failed host lookup …)`
+    // (traces #2–4) and the on-device geocoder's `PlatformException(IO_ERROR,
+    // …UNAVAILABLE…)` (trace #7). Still NARROW — `isOfflineError` matches by
+    // shape + offline substring, never by HTTP status, so a real 5xx /
+    // non-offline `PlatformException` / non-offline retryable fetch persists.
+    if (isOfflineError(error)) return true;
     // #2703 — secondary offline signal: a doomed network call while offline.
     if (!isOnline && _isNetworkCategory(error)) return true;
     return false;

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -78,10 +78,14 @@ class ClassicElmChannel implements ElmByteChannel {
       if (diag.enabled) {
         diag.noteConnectionEvent(failureReason: 'rfcomm-open-fail');
       }
-      throw StateError(
-        'ClassicElmChannel: failed to open RFCOMM socket to $address '
-        '(plugin returned false). Adapter may not be bonded or is out '
-        'of range.',
+      // #2745 — this was a raw `StateError`, which the connect flow logged as
+      // an `[unknown]` ERROR trace (field trace #6) even though it is an
+      // EXPECTED, user-surfaced "adapter not reachable" condition (the dongle
+      // is unbonded or out of range). Raise the TYPED [Obd2AdapterUnresponsive]
+      // instead so the connect flow treats it as the breadcrumb-level user
+      // condition it already handles for the BLE init path — not an ERROR.
+      throw const Obd2AdapterUnresponsive(
+        'Adapter did not answer — turn the ignition on and retry',
       );
     }
     if (connectSw != null) {

--- a/lib/features/consumption/data/obd2/obd2_connection_errors.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_errors.dart
@@ -13,6 +13,26 @@ sealed class Obd2ConnectionError implements Exception {
 
   @override
   String toString() => '$runtimeType: $message';
+
+  /// #2745 — whether this is an EXPECTED, already-user-surfaced connect
+  /// condition that the UI handles with a localized snackbar + a fall-through
+  /// to the picker, and so must NOT also spool an ERROR trace (the field
+  /// trace #5 was an `[ui] Obd2AdapterUnresponsive` ERROR for exactly this).
+  ///
+  /// `true` for the "adapter off / out of range / ignition off / not bonded"
+  /// family ([Obd2AdapterUnresponsive], [Obd2ScanTimeout], [Obd2BluetoothOff],
+  /// [Obd2DisconnectedException]) — all of which the user can act on directly.
+  /// `false` for [Obd2PermissionDenied] (needs a settings deep-link) and
+  /// [Obd2ProtocolInitFailed] (a counterfeit-clone diagnostic worth keeping),
+  /// which still ERROR-log so a genuine, actionable fault stays visible.
+  bool get isExpectedUserCondition => switch (this) {
+        Obd2AdapterUnresponsive() => true,
+        Obd2ScanTimeout() => true,
+        Obd2BluetoothOff() => true,
+        Obd2DisconnectedException() => true,
+        Obd2PermissionDenied() => false,
+        Obd2ProtocolInitFailed() => false,
+      };
 }
 
 /// User refused to grant BLUETOOTH_SCAN / BLUETOOTH_CONNECT on

--- a/lib/features/consumption/presentation/obd2_connect_telemetry.dart
+++ b/lib/features/consumption/presentation/obd2_connect_telemetry.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import '../../../core/logging/error_logger.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../data/obd2/obd2_connection_errors.dart';
+
+/// #2745 — route an OBD2 connect-flow failure to the right telemetry level.
+///
+/// Error-log #14 trace #5 was an `[ui] Obd2AdapterUnresponsive` ERROR spooled
+/// for a connect failure that the UI already surfaces to the user (a localized
+/// snackbar + a fall-through to the picker). An EXPECTED, user-actionable
+/// condition ([Obd2ConnectionError.isExpectedUserCondition]) records a
+/// diagnostic [BreadcrumbCollector] breadcrumb instead — NOT an ERROR trace.
+/// A GENUINE fault (permission denied, counterfeit-clone init string, or any
+/// non-OBD2 exception) still `errorLogger.log`s at [ErrorLayer.ui] so it stays
+/// visible. Shared by the pinned-connect picker path and the live-trip
+/// recording-start path so the two can't drift.
+void recordObd2ConnectFailure(
+  Object error,
+  StackTrace stack, {
+  required String where,
+}) {
+  if (error is Obd2ConnectionError && error.isExpectedUserCondition) {
+    BreadcrumbCollector.add(
+      'OBD2 connect failed — expected user condition',
+      detail: '$where: ${error.runtimeType}',
+    );
+    return;
+  }
+  unawaited(errorLogger.log(ErrorLayer.ui, error, stack,
+      context: {'where': where}));
+}

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -16,6 +16,7 @@ import '../../data/obd2/obd2_connection_errors.dart';
 import '../../data/obd2/obd2_connection_service.dart';
 import '../../data/obd2/obd2_service.dart';
 import '../obd2_connection_error_l10n.dart';
+import '../obd2_connect_telemetry.dart';
 import '../../../../core/logging/error_logger.dart';
 
 /// Modal bottom sheet that drives the full scan → pick → connect flow
@@ -49,14 +50,13 @@ Future<Obd2Service?> showObd2AdapterPicker(
     final container = ProviderScope.containerOf(context, listen: false);
     Obd2Service? service;
     try {
-      service = await container.read(obd2ConnectionProvider).connectByMac(
-            pinnedMac,
-          );
+      service =
+          await container.read(obd2ConnectionProvider).connectByMac(pinnedMac);
     } on Obd2ConnectionError catch (e, st) {
-      // Real connect failure (permission denied, init timeout). Drop
-      // through to the sheet so the user can pick another adapter;
-      // the snackbar surfaces the mishap.
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {'where': 'showObd2AdapterPicker pinned connect failed'}));
+      // Drop through to the sheet so the user can pick another adapter; the
+      // fall-through snackbar surfaces it. #2745 — an expected, user-surfaced
+      // condition is a breadcrumb, a genuine fault still ERROR-logs.
+      recordObd2ConnectFailure(e, st, where: 'pinned connect failed');
     }
     if (service != null) {
       return service;

--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -11,6 +11,7 @@ import '../../../feature_management/domain/feature.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/obd2_connection_service.dart';
 import '../../data/obd2/obd2_service.dart';
+import '../obd2_connect_telemetry.dart';
 import '../../providers/trip_recording_provider.dart';
 
 /// Owns the #2274 recording-start orchestration that the trajets tab
@@ -136,8 +137,10 @@ class RecordingStartCoordinator {
     } catch (e, st) {
       notifier.cancelConnecting();
       onConnectionError(e);
-      unawaited(errorLogger.log(ErrorLayer.ui, e, st,
-          context: const {'where': 'RecordingStart connectAndStart'}));
+      // #2745 — the `onConnectionError` snackbar already surfaced this, so an
+      // EXPECTED OBD2 connect condition is a breadcrumb, not an ERROR trace
+      // (field trace #5); a genuine fault still ERROR-logs.
+      recordObd2ConnectFailure(e, st, where: 'RecordingStart connectAndStart');
     }
   }
 

--- a/lib/features/station_services/france/prix_carburants_station_service.dart
+++ b/lib/features/station_services/france/prix_carburants_station_service.dart
@@ -11,6 +11,7 @@ import '../../../core/services/impl/osm_brand_enricher.dart';
 import 'france_opening_hours_adapter.dart';
 import 'prix_carburants_parsers.dart' as parser;
 import '../../../core/network/dio_offline.dart';
+import '../../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../../core/services/dio_factory.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/service_result.dart';
@@ -171,6 +172,15 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
       // #2524 — see [_queryByPostalCode]: an offline failure is expected and
       // swallowed (returns []); only a real API error gets an ERROR trace.
       if (_isOffline(e)) {
+        // #2745 — the field trace #1 was a `DioException[unknown]` wrapping
+        // an `HttpException('Software caused connection abort')` from
+        // data.economie.gouv.fr while the device was offline. Drop it to a
+        // diagnostic breadcrumb (still triageable from any surviving trace)
+        // instead of an ERROR — it is an expected no-network condition.
+        BreadcrumbCollector.add(
+          'Prix-Carburants geo fetch skipped — offline',
+          detail: 'lat=$lat lng=$lng type=${e.type}',
+        );
         debugPrint('Prix-Carburants geo fetch skipped — offline ($e)');
         return [];
       }
@@ -180,10 +190,13 @@ class PrixCarburantsStationService with StationServiceHelpers implements Station
   }
 
   /// Whether [e] is an offline / no-network failure rather than a real
-  /// API error (#2524). Delegates to the shared [isOfflineDioException]
-  /// classifier (#2703) so this and the trace-recorder de-noise gate
-  /// classify connection-layer transients identically and can't drift.
-  static bool _isOffline(DioException e) => isOfflineDioException(e);
+  /// API error (#2524). Delegates to the shared [isOfflineError] classifier
+  /// (#2703/#2745) so this and the trace-recorder de-noise gate classify
+  /// offline transients identically and can't drift. #2745 broadened from
+  /// [isOfflineDioException] to [isOfflineError] so a `DioException[unknown]`
+  /// wrapping an `HttpException` connection-abort (the field trace #1) is
+  /// recognised as offline at the call site too.
+  static bool _isOffline(DioException e) => isOfflineError(e);
 
   /// Merge two raw API result lists, deduplicating by station id.
   /// Stations from [primary] win when an id collides.

--- a/test/core/network/dio_offline_test.dart
+++ b/test/core/network/dio_offline_test.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show AuthRetryableFetchException;
+import 'package:tankstellen/core/network/dio_offline.dart';
+
+/// #2745 — `isOfflineError` is the OFFLINE SUPERSET used by the telemetry
+/// de-noise gate + the offline-tolerant fallback sites. These tests feed the
+/// EXACT exception shapes captured in error-log #14 and assert each offline
+/// shape is recognised while a GENUINE (non-offline) counterpart is NOT — the
+/// guard that keeps real failures ERROR-logging.
+void main() {
+  group('isOfflineError — offline shapes are recognised (#2745)', () {
+    test('a "Failed host lookup" SocketException', () {
+      expect(
+        isOfflineError(
+          const SocketException('Failed host lookup: data.economie.gouv.fr'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a "No address associated with hostname" SocketException', () {
+      expect(
+        isOfflineError(
+          const SocketException(
+            'Failed host lookup: xyz.supabase.co '
+            '(OS Error: No address associated with hostname, errno = 7)',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'a DioException[unknown] wrapping an HttpException connection-abort '
+        '(FR trace #1)', () {
+      final e = DioException(
+        requestOptions: RequestOptions(path: '/records'),
+        type: DioExceptionType.unknown,
+        error: const HttpException('Software caused connection abort'),
+      );
+      expect(isOfflineError(e), isTrue,
+          reason: 'the FR feed connection-abort while offline is transient');
+    });
+
+    test('a DioException[connectionError] (offline DNS)', () {
+      final e = DioException(
+        requestOptions: RequestOptions(path: '/reverse'),
+        type: DioExceptionType.connectionError,
+        error: const SocketException('Failed host lookup: nominatim.org'),
+      );
+      expect(isOfflineError(e), isTrue);
+    });
+
+    test(
+        'an AuthRetryableFetchException whose message reports a host lookup '
+        'failure (Supabase traces #2–4)', () {
+      final e = AuthRetryableFetchException(
+        message: 'SocketException: Failed host lookup: '
+            'abc.supabase.co (OS Error: No address associated with hostname)',
+      );
+      expect(isOfflineError(e), isTrue,
+          reason: 'an offline supabase retryable fetch is a transient');
+    });
+
+    test(
+        'a PlatformException(IO_ERROR, …UNAVAILABLE…) from the on-device '
+        'geocoder (native trace #7)', () {
+      final e = PlatformException(
+        code: 'IO_ERROR',
+        message: 'grpc failed: UNAVAILABLE: Unable to resolve host',
+      );
+      expect(isOfflineError(e), isTrue,
+          reason: 'the on-device geocoder offline IO error is transient');
+    });
+  });
+
+  group('isOfflineError — genuine failures are NOT swallowed (the guard)', () {
+    test('a DioException[badResponse] (a real 5xx) is NOT offline', () {
+      final e = DioException(
+        requestOptions: RequestOptions(path: '/records'),
+        type: DioExceptionType.badResponse,
+        response: Response(
+          requestOptions: RequestOptions(path: '/records'),
+          statusCode: 503,
+        ),
+      );
+      expect(isOfflineError(e), isFalse,
+          reason: 'a server 5xx must still ERROR-log');
+    });
+
+    test('a connection-refused SocketException (online) is NOT offline', () {
+      // No host-lookup / unreachable substring → a real failure.
+      expect(
+        isOfflineError(const SocketException('Connection refused')),
+        isFalse,
+      );
+    });
+
+    test(
+        'an AuthRetryableFetchException caused by a real server blip '
+        '(no offline substring) is NOT offline', () {
+      final e = AuthRetryableFetchException(
+        message: 'Internal Server Error',
+        statusCode: '500',
+      );
+      expect(isOfflineError(e), isFalse,
+          reason: 'a non-offline retryable fetch must still ERROR-log');
+    });
+
+    test(
+        'a non-offline PlatformException (e.g. a real plugin bug) is NOT '
+        'offline', () {
+      final e = PlatformException(
+        code: 'PARSE_ERROR',
+        message: 'malformed placemark payload',
+      );
+      expect(isOfflineError(e), isFalse);
+    });
+
+    test('a plain Exception is NOT offline', () {
+      expect(isOfflineError(Exception('parse failed')), isFalse);
+    });
+  });
+}

--- a/test/core/services/nominatim_denoise_test.dart
+++ b/test/core/services/nominatim_denoise_test.dart
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/services/impl/nominatim_geocoding_provider.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+
+/// #2745 — error-log #14 traces #8/#9: `NominatimGeocodingProvider`'s reverse
+/// geocoding + country detection ERROR-logged a `DioException` host-lookup
+/// failure to nominatim.openstreetmap.org while the device was offline. Both
+/// methods already fall back (to "lat, lng" / the next provider), so the trace
+/// must be a breadcrumb, NOT an ERROR. Guard: a genuine 5xx still ERROR-logs.
+
+class _CapturingRecorder implements TraceRecorder {
+  final calls = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ThrowingAdapter implements HttpClientAdapter {
+  _ThrowingAdapter(this.error);
+  final DioException Function(RequestOptions o) error;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<void>? cancelFuture) async {
+    throw error(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+NominatimGeocodingProvider _providerThrowing(
+    DioException Function(RequestOptions o) error) {
+  final dio = Dio(BaseOptions(baseUrl: 'https://nominatim.openstreetmap.org'));
+  dio.httpClientAdapter = _ThrowingAdapter(error);
+  return NominatimGeocodingProvider(countryCode: 'FR', dio: dio);
+}
+
+DioException _offlineHostLookup(RequestOptions o) => DioException(
+      requestOptions: o,
+      type: DioExceptionType.connectionError,
+      error: const SocketException(
+          'Failed host lookup: nominatim.openstreetmap.org'),
+    );
+
+DioException _genuine5xx(RequestOptions o) => DioException(
+      requestOptions: o,
+      type: DioExceptionType.badResponse,
+      response: Response(requestOptions: o, statusCode: 503),
+    );
+
+void main() {
+  late _CapturingRecorder recorder;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CapturingRecorder();
+    errorLogger.testRecorderOverride = recorder;
+    BreadcrumbCollector.clear();
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  group('Nominatim offline de-noise (#2745)', () {
+    test(
+        'coordinatesToAddress offline host-lookup is a breadcrumb, NOT ERROR '
+        '(trace #8)', () async {
+      final provider = _providerThrowing(_offlineHostLookup);
+      final result = await provider.coordinatesToAddress(48.85, 2.35);
+
+      expect(result, '48.85, 2.35', reason: 'falls back to lat, lng');
+      expect(recorder.calls, isEmpty,
+          reason: 'an offline host-lookup must NOT ERROR-log');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('Nominatim reverse geocoding skipped — offline'),
+      );
+    });
+
+    test(
+        'coordinatesToCountryCode offline host-lookup is a breadcrumb, NOT '
+        'ERROR (trace #9)', () async {
+      final provider = _providerThrowing(_offlineHostLookup);
+      final code = await provider.coordinatesToCountryCode(48.85, 2.35);
+
+      expect(code, isNull, reason: 'falls back to the next provider');
+      expect(recorder.calls, isEmpty);
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('Nominatim country detection skipped — offline'),
+      );
+    });
+
+    test('coordinatesToAddress GENUINE 5xx STILL ERROR-logs (the guard)',
+        () async {
+      final provider = _providerThrowing(_genuine5xx);
+      final result = await provider.coordinatesToAddress(48.85, 2.35);
+
+      expect(result, '48.85, 2.35');
+      expect(recorder.calls, hasLength(1),
+          reason: 'a real 5xx must persist as an ERROR trace');
+      expect(recorder.calls.single.toString(),
+          contains('Nominatim reverse geocoding failed'));
+    });
+
+    test('coordinatesToCountryCode GENUINE 5xx STILL ERROR-logs (the guard)',
+        () async {
+      final provider = _providerThrowing(_genuine5xx);
+      await provider.coordinatesToCountryCode(48.85, 2.35);
+
+      expect(recorder.calls, hasLength(1));
+      expect(recorder.calls.single.toString(),
+          contains('Nominatim country detection failed'));
+    });
+  });
+}

--- a/test/core/telemetry/trace_recorder_test.dart
+++ b/test/core/telemetry/trace_recorder_test.dart
@@ -59,6 +59,28 @@ class _FakeSettingsStorage implements SettingsStorage {
   Future<void> resetSetupSkip() async {}
 }
 
+/// #2745 — a stand-in for the supabase `AuthRetryableFetchException`. The
+/// de-noise gate classifies it by RUNTIME-TYPE NAME + offline substring (so
+/// the core telemetry layer carries no supabase import), hence the class
+/// name literally matches the real one and its `toString()` carries the
+/// wrapped socket message. (A separate fidelity test in
+/// `test/core/network/dio_offline_test.dart` drives the REAL supabase class.)
+class _FakeAuthRetryableFetchException implements Exception {
+  final String _message;
+  const _FakeAuthRetryableFetchException(this._message);
+
+  @override
+  Type get runtimeType => AuthRetryableFetchException;
+
+  @override
+  String toString() =>
+      'AuthRetryableFetchException(message: $_message, statusCode: null)';
+}
+
+/// Marker type whose NAME the de-noise gate matches on (`runtimeType
+/// .toString()`). Declaring it here keeps the telemetry test supabase-free.
+class AuthRetryableFetchException {}
+
 /// Fake TraceUploader that does nothing.
 class _FakeTraceUploader extends TraceUploader {
   bool uploadCalled = false;
@@ -418,6 +440,85 @@ void main() {
         expect(storage.stored, hasLength(1),
             reason: 'a 5xx is a real server error and must persist (#2703)');
         expect(uploader.uploadCalled, isTrue);
+      });
+    });
+
+    // #2745 — error-log #14: offline host-lookup shapes that arrive WITHOUT a
+    // Dio wrapper slipped through the #2703 gate and ERROR-logged. The central
+    // de-noise gate now suppresses them via the broadened `isOfflineError`
+    // superset: a supabase `AuthRetryableFetchException(host lookup)` (traces
+    // #2–4), an on-device geocoder `PlatformException(IO_ERROR/UNAVAILABLE)`
+    // (trace #7), and a `DioException[unknown]` wrapping an `HttpException`
+    // connection-abort (FR trace #1). The guard: a GENUINE failure persists.
+    group('offline-without-Dio-wrapper suppression (#2745)', () {
+      test(
+          'a supabase AuthRetryableFetchException wrapping a host lookup is '
+          'NOT persisted (traces #2–4)', () async {
+        const error = SocketException(
+          'Failed host lookup: abc.supabase.co '
+          '(OS Error: No address associated with hostname, errno = 7)',
+        );
+        // The supabase client surfaces this as an AuthRetryableFetchException
+        // carrying the socket message; match the field shape via toString.
+        final wrapped = _FakeAuthRetryableFetchException(error.toString());
+        await recorder.record(wrapped, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'an offline supabase retryable fetch is a transient');
+        expect(uploader.uploadCalled, isFalse);
+      });
+
+      test(
+          'an on-device geocoder PlatformException(IO_ERROR, UNAVAILABLE) is '
+          'NOT persisted (trace #7)', () async {
+        final error = PlatformException(
+          code: 'IO_ERROR',
+          message: 'grpc failed: UNAVAILABLE: Unable to resolve host',
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'the offline native geocoder IO error is a transient');
+      });
+
+      test(
+          'a DioException[unknown] wrapping an HttpException connection-abort '
+          'is NOT persisted (FR trace #1)', () async {
+        final error = DioException(
+          requestOptions: RequestOptions(path: '/records'),
+          type: DioExceptionType.unknown,
+          error: const HttpException('Software caused connection abort'),
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, isEmpty,
+            reason: 'an unknown Dio error wrapping a connection-abort is '
+                'offline (the FR feed dropped the socket)');
+      });
+
+      test(
+          'a GENUINE AuthRetryableFetchException (real 5xx, no offline '
+          'substring) IS still persisted', () async {
+        const error =
+            _FakeAuthRetryableFetchException('Internal Server Error (500)');
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, hasLength(1),
+            reason: 'a non-offline retryable fetch is a real failure');
+        expect(uploader.uploadCalled, isTrue);
+      });
+
+      test(
+          'a GENUINE PlatformException (not an offline IO error) IS still '
+          'persisted', () async {
+        final error = PlatformException(
+          code: 'PARSE_ERROR',
+          message: 'malformed placemark payload',
+        );
+        await recorder.record(error, StackTrace.current);
+
+        expect(storage.stored, hasLength(1),
+            reason: 'a real platform fault must still ERROR-log');
       });
     });
 

--- a/test/features/consumption/data/obd2/classic_elm_channel_diagnostics_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_diagnostics_test.dart
@@ -10,6 +10,7 @@ import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_elm_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/classic_method_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_comm_diagnostics.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 
 /// Captures every `errorLogger.log` call routed through the foreground
 /// recorder seam, retaining the [ContextualError] so the test can assert
@@ -117,7 +118,11 @@ void main() {
       fake.connectResult = false;
 
       final channel = ClassicElmChannel(address: 'AA:BB', plugin: fake);
-      await expectLater(channel.open(), throwsA(isA<StateError>()));
+      // #2745 — connect→false now raises the typed Obd2AdapterUnresponsive
+      // (was a raw StateError) so the connect flow treats it as an expected,
+      // breadcrumb-level user condition. The diagnostics binning is unchanged.
+      await expectLater(
+          channel.open(), throwsA(isA<Obd2AdapterUnresponsive>()));
 
       final conn = Obd2CommDiagnostics.instance.snapshot().connection;
       expect(conn.attempts, 1);

--- a/test/features/consumption/data/obd2/classic_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_test.dart
@@ -130,8 +130,11 @@ void main() {
     });
 
     test(
-        'throws StateError when plugin.connect returns false; isOpen stays '
-        'false and no subscription is installed', () async {
+        'throws the typed Obd2AdapterUnresponsive when plugin.connect returns '
+        'false; isOpen stays false and no subscription is installed (#2745)',
+        () async {
+      // #2745 — was a raw StateError (field trace #6, ERROR-logged as
+      // `[unknown]`). Now a typed, expected, user-surfaced connect condition.
       fake.connectResult = false;
       final channel = ClassicElmChannel(
         address: 'AA:BB:CC:DD:EE:99',
@@ -140,16 +143,7 @@ void main() {
 
       await expectLater(
         channel.open(),
-        throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            allOf(
-              contains('failed to open'),
-              contains('AA:BB:CC:DD:EE:99'),
-            ),
-          ),
-        ),
+        throwsA(isA<Obd2AdapterUnresponsive>()),
       );
       expect(channel.isOpen, isFalse);
 

--- a/test/features/consumption/data/obd2/obd2_connection_errors_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_errors_test.dart
@@ -39,4 +39,26 @@ void main() {
       expect(const Obd2ProtocolInitFailed('x'), isA<Exception>());
     });
   });
+
+  group('isExpectedUserCondition — telemetry de-noise gate (#2745)', () {
+    test(
+        'the "adapter off / out of range / ignition off" family is an '
+        'expected user condition (breadcrumb, not ERROR)', () {
+      expect(const Obd2AdapterUnresponsive().isExpectedUserCondition, isTrue);
+      expect(const Obd2ScanTimeout().isExpectedUserCondition, isTrue);
+      expect(const Obd2BluetoothOff().isExpectedUserCondition, isTrue);
+      expect(
+          const Obd2DisconnectedException().isExpectedUserCondition, isTrue);
+    });
+
+    test(
+        'permission-denied + protocol-init-failed stay ERROR-worthy (the '
+        'guard)', () {
+      expect(const Obd2PermissionDenied().isExpectedUserCondition, isFalse,
+          reason: 'permission denial needs a settings deep-link diagnostic');
+      expect(const Obd2ProtocolInitFailed('GARBAGE>').isExpectedUserCondition,
+          isFalse,
+          reason: 'a counterfeit-clone init string is worth keeping');
+    });
+  });
 }

--- a/test/features/consumption/presentation/obd2_connect_telemetry_test.dart
+++ b/test/features/consumption/presentation/obd2_connect_telemetry_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/presentation/obd2_connect_telemetry.dart';
+
+/// #2745 — error-log #14 trace #5: `recordObd2ConnectFailure` is the shared
+/// connect-flow telemetry router for the pinned-connect picker AND the
+/// live-trip recording-start path. An EXPECTED, already-user-surfaced
+/// condition → breadcrumb; a genuine fault → ERROR.
+class _CapturingRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    errors.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _CapturingRecorder rec;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    rec = _CapturingRecorder();
+    errorLogger.testRecorderOverride = rec;
+    BreadcrumbCollector.clear();
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  group('recordObd2ConnectFailure (#2745)', () {
+    test('an expected Obd2AdapterUnresponsive is a breadcrumb, NOT an ERROR',
+        () async {
+      recordObd2ConnectFailure(const Obd2AdapterUnresponsive(),
+          StackTrace.current,
+          where: 'pinned connect');
+
+      // Allow the fire-and-forget log path (if any) to settle.
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, isEmpty);
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected user condition'),
+      );
+    });
+
+    test('an expected Obd2ScanTimeout is a breadcrumb, NOT an ERROR',
+        () async {
+      recordObd2ConnectFailure(const Obd2ScanTimeout(), StackTrace.current,
+          where: 'pinned connect');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, isEmpty);
+      expect(BreadcrumbCollector.snapshot(), isNotEmpty);
+    });
+
+    test('a genuine Obd2PermissionDenied STILL ERROR-logs (the guard)',
+        () async {
+      recordObd2ConnectFailure(const Obd2PermissionDenied(), StackTrace.current,
+          where: 'pinned connect');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, hasLength(1));
+      expect(rec.errors.single.toString(), contains('pinned connect'));
+      expect(BreadcrumbCollector.snapshot(), isEmpty);
+    });
+
+    test('a non-OBD2 exception STILL ERROR-logs (the guard)', () async {
+      recordObd2ConnectFailure(Exception('unexpected'), StackTrace.current,
+          where: 'connectAndStart');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, hasLength(1));
+      expect(rec.errors.single.toString(), contains('connectAndStart'));
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -6,9 +6,14 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
@@ -235,6 +240,89 @@ void main() {
       await completer.future;
     });
   });
+
+  // #2745 — error-log #14 trace #5: an `[ui] Obd2AdapterUnresponsive` ERROR
+  // was spooled for the pinned-connect failure even though the same condition
+  // is already surfaced to the user (the fall-through sheet + snackbar). The
+  // EXPECTED, user-actionable connect conditions must be a breadcrumb, NOT an
+  // ERROR trace; a GENUINE fault (permission denied) must still ERROR-log.
+  group('pinned-connect telemetry de-noise (#2745)', () {
+    late _CaptureRecorder rec;
+
+    setUp(() {
+      rec = _CaptureRecorder();
+      errorLogger.testRecorderOverride = rec;
+      BreadcrumbCollector.clear();
+    });
+
+    Future<void> pumpAndOpen(WidgetTester tester, Object thrown) async {
+      final svc = _RecordingFakeConnection(connectByMacError: thrown);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (ctx) => ElevatedButton(
+                  onPressed: () => showObd2AdapterPicker(ctx,
+                      pinnedMac: 'AA:BB:CC:DD:EE:FF',
+                      pinnedAdapterName: 'vLinker FS'),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    testWidgets(
+        'an expected Obd2AdapterUnresponsive is a breadcrumb, NOT an ERROR',
+        (tester) async {
+      await pumpAndOpen(tester, const Obd2AdapterUnresponsive());
+
+      expect(rec.errors, isEmpty,
+          reason: 'an already-user-surfaced condition must NOT ERROR-log');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected user condition'),
+      );
+
+      Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a genuine Obd2PermissionDenied STILL ERROR-logs (the guard)',
+        (tester) async {
+      await pumpAndOpen(tester, const Obd2PermissionDenied());
+
+      expect(rec.errors, hasLength(1),
+          reason: 'permission denial is a genuine, diagnostic-worthy fault');
+      expect(rec.errors.single.toString(), contains('pinned connect failed'));
+
+      Navigator.of(tester.element(find.text('Pick an OBD2 adapter'))).pop();
+      await tester.pumpAndSettle();
+    });
+  });
+}
+
+/// Captures every `errorLogger.log` -> `record` call so the de-noise tests
+/// can assert an expected condition was NOT ERROR-logged.
+class _CaptureRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    errors.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 /// Recording fake for [Obd2ConnectionService] that lets the pinned-MAC
@@ -245,7 +333,7 @@ void main() {
 /// indefinitely, which is exactly what the tests need to assert
 /// "the sheet IS rendered" without chasing further state transitions.
 class _RecordingFakeConnection extends Obd2ConnectionService {
-  _RecordingFakeConnection({this.connectByMacResult})
+  _RecordingFakeConnection({this.connectByMacResult, this.connectByMacError})
       : super(
           registry: Obd2AdapterRegistry.defaults(),
           permissions: _FakePermissions(Obd2PermissionState.granted),
@@ -255,6 +343,7 @@ class _RecordingFakeConnection extends Obd2ConnectionService {
       _RecordingFakeConnection(connectByMacResult: _NoopObd2Service());
 
   final Obd2Service? connectByMacResult;
+  final Object? connectByMacError;
   final List<String> connectByMacCalls = [];
 
   @override
@@ -263,6 +352,7 @@ class _RecordingFakeConnection extends Obd2ConnectionService {
     Duration timeout = const Duration(seconds: 5),
   }) async {
     connectByMacCalls.add(mac);
+    if (connectByMacError != null) throw connectByMacError!;
     return connectByMacResult;
   }
 

--- a/test/features/station_services/france/prix_carburants_denoise_test.dart
+++ b/test/features/station_services/france/prix_carburants_denoise_test.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_services/france/prix_carburants_station_service.dart';
+
+/// #2745 — error-log #14 trace #1: `PrixCarburantsStationService._queryByGeo`
+/// ERROR-logged a `DioException` carrying an `HttpException('Software caused
+/// connection abort')` from data.economie.gouv.fr while the device was
+/// offline. The geo query already swallows offline failures (returns []), so
+/// the trace must be a breadcrumb, NOT an ERROR. Guard: a genuine API error
+/// (5xx) still ERROR-logs.
+
+/// Captures every `errorLogger.log` -> `record` call so a test can assert an
+/// offline failure was NOT ERROR-logged while a genuine one was.
+class _CapturingRecorder implements TraceRecorder {
+  final calls = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A Dio adapter that throws a per-test [DioException] on every fetch.
+class _ThrowingAdapter implements HttpClientAdapter {
+  _ThrowingAdapter(this.error);
+  final DioException Function(RequestOptions o) error;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<void>? cancelFuture) async {
+    throw error(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+PrixCarburantsStationService _serviceThrowing(
+    DioException Function(RequestOptions o) error) {
+  final dio = Dio(BaseOptions(baseUrl: 'https://data.economie.gouv.fr'));
+  dio.httpClientAdapter = _ThrowingAdapter(error);
+  return PrixCarburantsStationService(dio: dio);
+}
+
+const _geoParams = SearchParams(lat: 43.45, lng: 3.42, radiusKm: 5);
+
+void main() {
+  late _CapturingRecorder recorder;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CapturingRecorder();
+    errorLogger.testRecorderOverride = recorder;
+    BreadcrumbCollector.clear();
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  group('PrixCarburants geo offline de-noise (#2745)', () {
+    test(
+        'a DioException[unknown] wrapping an HttpException connection-abort '
+        '(field trace #1) is a breadcrumb, NOT an ERROR', () async {
+      final svc = _serviceThrowing((o) => DioException(
+            requestOptions: o,
+            type: DioExceptionType.unknown,
+            error: const HttpException('Software caused connection abort'),
+          ));
+
+      final result = await svc.searchStations(_geoParams);
+
+      expect(result.data, isEmpty, reason: 'offline failure swallowed');
+      expect(recorder.calls, isEmpty,
+          reason: 'an offline connection-abort must NOT ERROR-log (#2745)');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('Prix-Carburants geo fetch skipped — offline'),
+      );
+    });
+
+    test('a connectionError wrapping a host-lookup is a breadcrumb, NOT ERROR',
+        () async {
+      final svc = _serviceThrowing((o) => DioException(
+            requestOptions: o,
+            type: DioExceptionType.connectionError,
+            error: const SocketException(
+                'Failed host lookup: data.economie.gouv.fr'),
+          ));
+
+      await svc.searchStations(_geoParams);
+
+      expect(recorder.calls, isEmpty);
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('Prix-Carburants geo fetch skipped — offline'),
+      );
+    });
+
+    test('a GENUINE API error (5xx) STILL ERROR-logs (the guard)', () async {
+      final svc = _serviceThrowing((o) => DioException(
+            requestOptions: o,
+            type: DioExceptionType.badResponse,
+            response: Response(requestOptions: o, statusCode: 503),
+          ));
+
+      await svc.searchStations(_geoParams);
+
+      expect(recorder.calls, hasLength(1),
+          reason: 'a real 5xx is a genuine failure and must persist');
+      expect(recorder.calls.single.toString(),
+          contains('Prix-Carburants geo fetch failed'));
+    });
+  });
+}


### PR DESCRIPTION
Closes #2745.

Error-log #14 captured 9 ERROR traces that are all transient/offline/expected conditions — no crashes, no data bugs. This is a telemetry **DE-NOISING** pass: downgrade them to a `BreadcrumbCollector` breadcrumb / debug while keeping GENUINE (non-offline) failures as ERROR. No behaviour change beyond logging level. Mirrors the #2703 pattern — ONE shared offline classifier that can't drift, strictly gated.

## Offline network → breadcrumb (gated by `isOfflineError`)
- **New `isOfflineError`** SUPERSET of `isOfflineDioException` (`core/network/dio_offline.dart`): recognises the offline host-lookup shapes that arrive WITHOUT a Dio wrapper — a supabase `AuthRetryableFetchException(host lookup)`, an on-device geocoder `PlatformException(IO_ERROR/UNAVAILABLE)`, and a `DioException[unknown]` wrapping an `HttpException` connection-abort. Matches by shape + offline substring, **never** by HTTP status, so a real 5xx still persists.
- **`TraceRecorder`** central gate now uses `isOfflineError` → covers Supabase traces **#2–4** + native-geocode **#7** (the #2703 gate missed them: they aren't network-category by shape).
- **FR `_queryByGeo`** (#1): `_isOffline` → `isOfflineError` so the unknown-wrapped `HttpException` "Software caused connection abort" is recognised offline at the call site → breadcrumb.
- **Nominatim** `coordinatesTo{Address,CountryCode}` (#8/#9) + **native geocoder** (#7): offline → breadcrumb (both already fall back); genuine error still ERROR-logs.

## Expected OBD2 conditions → typed + breadcrumb
- **`ClassicElmChannel.open`** (#6): the raw `StateError("failed to open RFCOMM socket … not bonded or out of range")` is now the typed **`Obd2AdapterUnresponsive`**, which the connect flow already treats as an expected, breadcrumb-level user condition.
- **New `Obd2ConnectionError.isExpectedUserCondition`** + a shared `recordObd2ConnectFailure` router: the already-user-surfaced family (`Obd2AdapterUnresponsive` / `ScanTimeout` / `BluetoothOff` / `Disconnected`) is a breadcrumb at the picker + recording-start sites (#5); a genuine fault (permission denied, counterfeit-clone init) still ERROR-logs.

## The guard (verified by tests)
A real 5xx, a non-offline `PlatformException`, a non-offline retryable fetch, `Obd2PermissionDenied`, and any unexpected exception all **STILL ERROR-log**.

## Tests
83 new/updated assertions across:
- `test/core/network/dio_offline_test.dart` (new) — the predicate with the exact log shapes incl. the **real** supabase `AuthRetryableFetchException`.
- `test/core/telemetry/trace_recorder_test.dart` — #2745 central-gate group.
- `prix_carburants_denoise_test.dart` (new) + `nominatim_denoise_test.dart` (new) — site-level breadcrumb-vs-ERROR via injected throwing Dio.
- `obd2_connection_errors_test.dart`, `classic_elm_channel{,_diagnostics}_test.dart`, `obd2_connect_telemetry_test.dart` (new), `obd2_adapter_picker_test.dart`.

ARB-free. No codegen drift. `flutter analyze` clean (the 2 residual `info` `unnecessary_import` are pre-existing in untouched test files). file_length cap respected.

### Note for separate review (not this PR)
Per the issue: the Supabase dependency should be confirmed local-first-compatible per the no-paid-service rule. This PR changed only its **logging level**, not its behaviour. Usage is a self-hosted/Supabase TankSync sync layer (`core/sync/*`, `core/data/impl/supabase_*`); whether the chosen backend is paid/free is a maintainer decision left out of this de-noising PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
