### PR TITLE
fix(opening-hours/FR): carry structured openingHours on search Station for the detail fast path (#2751)

### DIFF
--- a/lib/features/station_services/france/prix_carburants_flux_parser.dart
+++ b/lib/features/station_services/france/prix_carburants_flux_parser.dart
@@ -32,6 +32,7 @@ import 'package:archive/archive.dart';
 import 'package:xml/xml.dart';
 
 import '../../search/domain/entities/station.dart';
+import 'france_opening_hours_adapter.dart';
 import 'prix_carburants_parsers.dart' as parser;
 
 /// Decode the flux ZIP [bytes], locate the inner XML entry, and parse every
@@ -167,6 +168,13 @@ Station? parseFluxPdv(XmlElement pdv) {
     stationType: pop.isEmpty ? null : pop,
     is24h: is24h,
     openingHoursText: openingHoursText,
+    // #2751 — carry the structured schedule on the search Station (the
+    // glued `rawHoraires` is the same shape the adapter parses on the
+    // instantané path) so the detail fast path renders staffed hours.
+    openingHours: const FranceOpeningHoursAdapter().parse(<String, dynamic>{
+      'horaires_jour': rawHoraires,
+      'horaires_automate_24_24': is24h ? 'Oui' : 'Non',
+    }),
   );
 }
 

--- a/lib/features/station_services/france/prix_carburants_parsers.dart
+++ b/lib/features/station_services/france/prix_carburants_parsers.dart
@@ -35,6 +35,7 @@ import '../../search/domain/entities/station.dart';
 import '../../search/domain/entities/station_amenity.dart';
 import '../../../core/utils/geo_utils.dart';
 import '../../../core/logging/error_logger.dart';
+import 'france_opening_hours_adapter.dart';
 
 /// Extract the `results` list from a Prix-Carburants API envelope.
 ///
@@ -115,6 +116,13 @@ Station? parsePrixCarburantsStation(
       updatedAt: parsePrixCarburantsMostRecentUpdate(r),
       is24h: r['horaires_automate_24_24'] == 'Oui',
       openingHoursText: parsePrixCarburantsOpeningHours(r['horaires_jour']),
+      // #2751 — carry the STRUCTURED schedule on the search Station so the
+      // detail provider's search-cache fast path renders the staffed
+      // boutique hours (+ the 24/7-automate badge) directly, instead of
+      // falling through `legacyOpeningHoursBridge` (which collapses an
+      // automate station to "Open 24 hours" and loses the staffed hours).
+      // Same adapter call the cold `getStationDetail` path already uses.
+      openingHours: const FranceOpeningHoursAdapter().parse(r),
       services: parsePrixCarburantsServices(r['services_service']),
       amenities: parseAmenitiesFromServices(
         parsePrixCarburantsServices(r['services_service']),

--- a/test/features/station_services/france/prix_carburants_search_opening_hours_test.dart
+++ b/test/features/station_services/france/prix_carburants_search_opening_hours_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/france/prix_carburants_parsers.dart';
+
+/// #2751 — the search→detail fast path (station_detail_provider) serves
+/// `StationDetail.openingHours = fromSearch.station.openingHours`. So the FR
+/// SEARCH parse MUST carry the structured schedule, or the staffed boutique
+/// hours are lost (an automate station collapses to "Open 24 hours" via the
+/// legacy bridge). RED on master (search Station.openingHours == null),
+/// GREEN after. Reuse-fidelity: the record is the REAL Esso 34120008 (Pézenas)
+/// shape from the live data.economie.gouv.fr feed.
+void main() {
+  Map<String, dynamic> essoRecord() => <String, dynamic>{
+        'id': '34120008',
+        'geom': <String, dynamic>{'lat': 43.4607, 'lon': 3.4203},
+        'adresse': '28 faubourg des cordeliers, route de montpellier',
+        'ville': 'Pézenas',
+        'cp': '34120',
+        'sp95_prix': 1.899,
+        'gazole_prix': 1.799,
+        'horaires_automate_24_24': 'Oui',
+        'horaires_jour':
+            'Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30, '
+                'Mercredi07.00-18.30, Jeudi07.00-18.30, Vendredi07.00-18.30, '
+                'Samedi08.00-14.00, Dimanche',
+      };
+
+  test('FR search parse carries the structured staffed schedule (#2751)', () {
+    final s = parsePrixCarburantsStation(essoRecord(), 43.46, 3.42);
+    expect(s, isNotNull);
+
+    final oh = s!.openingHours;
+    expect(oh, isNotNull,
+        reason: 'search Station must carry structured hours so the detail '
+            'fast path renders them instead of the legacy bridge');
+
+    // 24/7 automate is an orthogonal badge, NOT a replacement for staffed hours.
+    expect(oh!.automate24h, isTrue);
+
+    // Mon–Fri 07:00–18:30 staffed.
+    expect(oh.dayFor(OpeningDay.mon)?.state, DayState.openRanges);
+    expect(oh.dayFor(OpeningDay.mon)?.ranges.first.startMinutes, 7 * 60);
+    expect(oh.dayFor(OpeningDay.mon)?.ranges.first.endMinutes, 18 * 60 + 30);
+    // Sat 08:00–14:00.
+    expect(oh.dayFor(OpeningDay.sat)?.ranges.first.startMinutes, 8 * 60);
+    expect(oh.dayFor(OpeningDay.sat)?.ranges.first.endMinutes, 14 * 60);
+    // Sun closed (bare "Dimanche" with no range → Fermé).
+    expect(oh.dayFor(OpeningDay.sun)?.state, DayState.closed);
+
+    // NOT collapsed to all-week 24h (the bug this fixes).
+    expect(oh.availability, isNot(OpeningHoursAvailability.notProvided));
+    final allOpen24 = kRegularWeekdays
+        .every((d) => oh.dayFor(d)?.state == DayState.open24h);
+    expect(allOpen24, isFalse,
+        reason: 'staffed hours must survive — not collapse to Open 24 hours');
+  });
+
+  test('non-automate FR station still carries its staffed schedule (#2751)',
+      () {
+    final r = essoRecord()
+      ..['horaires_automate_24_24'] = 'Non'
+      ..['horaires_jour'] =
+          'Lundi08.00-12.00 et 14.00-19.00, Mardi08.00-19.00, Dimanche';
+    final s = parsePrixCarburantsStation(r, 43.46, 3.42);
+    final oh = s!.openingHours;
+    expect(oh, isNotNull);
+    expect(oh!.automate24h, isFalse);
+    // Split shift on Monday → two ranges.
+    expect(oh.dayFor(OpeningDay.mon)?.ranges.length, 2);
+    expect(oh.dayFor(OpeningDay.sun)?.state, DayState.closed);
+  });
+}


### PR DESCRIPTION
Fixes the *real* reason FR opening hours are still missing after #2742: the search→detail **fast path** serves `Station.openingHours`, which the FR search parsers never populated → automate stations collapsed to 'Open 24 hours' (staffed hours lost), non-automate → empty.

Now both FR search parsers (instantané + flux) populate `openingHours` via `FranceOpeningHoursAdapter`. **Verified RED-on-master → GREEN** with the real Esso 34120008 record; the parsed schedule renders "24/7 automate · Mon–Fri 07:00–18:30 · Sat 08:00–14:00 · Sun Closed". ARB-free, no codegen drift, 240 FR+detail+lint tests green.

Closes #2751