### PR TITLE
fix(route-search): destination autocomplete spinner never stops after selecting (#2753)

### DIFF
--- a/lib/features/route_search/presentation/widgets/city_autocomplete_field.dart
+++ b/lib/features/route_search/presentation/widgets/city_autocomplete_field.dart
@@ -88,7 +88,9 @@ class _CityAutocompleteFieldState extends State<CityAutocompleteField> {
       if (!mounted) return;
       setState(() => _isLoading = true);
       try {
-        final results = await widget.searchService.searchCities(value.trim());
+        final results = await widget.searchService
+            .searchCities(value.trim())
+            .timeout(const Duration(seconds: 8));
         if (mounted) {
           _suggestions = results.take(5).toList();
           _showSuggestions = _suggestions.isNotEmpty;
@@ -111,10 +113,15 @@ class _CityAutocompleteFieldState extends State<CityAutocompleteField> {
   }
 
   void _selectCity(ResolvedLocation city) {
+    // A search may be debounced or in flight (Nominatim is rate-limited) when
+    // the user taps a suggestion — cancel it and clear the spinner so the
+    // suffix progress indicator never lingers after a selection (#2753).
+    _debounce?.cancel();
     widget.controller.text = city.name;
     widget.onCitySelected(city);
     _removeOverlay();
     _focusNode.unfocus();
+    if (_isLoading) setState(() => _isLoading = false);
   }
 
   void _showOverlay() {

--- a/test/features/route_search/presentation/widgets/city_autocomplete_field_test.dart
+++ b/test/features/route_search/presentation/widgets/city_autocomplete_field_test.dart
@@ -102,6 +102,38 @@ void main() {
     expect(find.byIcon(Icons.place), findsOneWidget);
   });
 
+  testWidgets(
+      'selecting a suggestion cancels the pending search + clears the spinner '
+      '(#2753)', (tester) async {
+    service.results = const [berlin];
+    await tester.pumpWidget(_harness(controller: controller, service: service));
+
+    // First search resolves → suggestion shows in the overlay.
+    await tester.enterText(find.byType(TextField), 'Ber');
+    await tester.pump(const Duration(milliseconds: 850));
+    await tester.pump();
+    expect(find.text('Berlin, Germany'), findsOneWidget);
+
+    // User types one more char (schedules a NEW debounce), but taps the
+    // suggestion before it fires. Make that next search HANG so a leaked
+    // search would spin the suffix indicator forever.
+    service.completer = Completer<List<ResolvedLocation>>();
+    await tester.enterText(find.byType(TextField), 'Berl');
+    await tester.tap(find.text('Berlin, Germany'));
+    await tester.pump();
+
+    // Elapse the (now-cancelled) debounce window.
+    await tester.pump(const Duration(milliseconds: 850));
+    await tester.pump();
+
+    // FIX (#2753): selection cancels the debounce and clears `_isLoading`.
+    // On master the debounce fired, the hung search set `_isLoading=true`,
+    // and the suffix CircularProgressIndicator spun indefinitely.
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(service.queries, isNot(contains('Berl')),
+        reason: 'selection must cancel the debounced search');
+  });
+
   testWidgets('debounced search fires after 800ms with the trimmed query',
       (tester) async {
     service.results = const [berlin];


### PR DESCRIPTION
Root cause: `_selectCity` never cancelled the pending/in-flight debounced `searchCities` nor cleared `_isLoading`, so the suffix spinner kept turning after picking a destination. Now cancels the debounce + clears the spinner on select, + an 8s timeout guard. Widget test RED-on-master → GREEN. ARB-free, no codegen.

Closes #2753