### PR TITLE
fix(map/route): frame the full itinerary + hold camera across All/Best toggle (#2755)

### DIFF
--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -49,10 +49,49 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
   RouteViewMode _viewMode = RouteViewMode.allStations;
   final Set<String> _selectedStationIds = {};
 
+  /// #2755 — the camera target: the bounds of the FULL route polyline,
+  /// unioned with every along-route fuel station, computed ONCE from the
+  /// immutable result. Framing these (instead of a ~5 km circle around the
+  /// polyline midpoint) makes the camera show the COMPLETE itinerary; being
+  /// constant across the All/Best toggle, it keeps `StationMapLayers`'
+  /// value-`==` `_lastFitBounds` guard a no-op so the camera holds and never
+  /// re-zooms to the changed station subset.
+  late final LatLngBounds _routeBounds = _computeRouteBounds();
+
+  /// Pre-layout camera fallback used by `MapOptions.initialCenter` /
+  /// `initialZoom` before the first layout pass runs `initialCameraFit`
+  /// (which frames `_routeBounds`). Mirrors `trip_path_map_card.dart`.
+  late final LatLng _initialCenter = _routeBounds.center;
+
   List<Station> get _allFuelStations => widget.routeResult.stations
       .whereType<FuelStationResult>()
       .map((r) => r.station)
       .toList();
+
+  /// Build the route-framing bounds from the polyline geometry unioned
+  /// with the along-route fuel stations. A degenerate single-point set
+  /// gets a tiny epsilon box so `CameraFit.bounds` can't divide-by-zero
+  /// (the same fallback as `trip_path_map_card.dart`).
+  LatLngBounds _computeRouteBounds() {
+    final points = <LatLng>[
+      ...widget.routeResult.route.geometry,
+      for (final s in _allFuelStations) LatLng(s.lat, s.lng),
+    ];
+    if (points.isEmpty) {
+      // No geometry and no stations — fall back to a Paris-centred box.
+      // (The build method renders an EmptyState in this case anyway.)
+      points.add(const LatLng(48.8566, 2.3522));
+    }
+    if (points.length == 1) {
+      final p = points.first;
+      const eps = 0.0005; // ~50 m at the equator; fine for any latitude.
+      return LatLngBounds(
+        LatLng(p.latitude - eps, p.longitude - eps),
+        LatLng(p.latitude + eps, p.longitude + eps),
+      );
+    }
+    return LatLngBounds.fromPoints(points);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -73,11 +112,14 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
         ? _getBestStopStations(allFuelStations, result)
         : allFuelStations;
 
-    final midIdx = result.route.geometry.length ~/ 2;
-    final center = result.route.geometry.isNotEmpty
-        ? result.route.geometry[midIdx]
-        : const LatLng(48.8566, 2.3522);
-    final zoom = _zoomForRoute(result.route.distanceKm);
+    // #2755 — frame the COMPLETE itinerary. `center`/`zoom` are only the
+    // pre-layout fallback (`MapOptions.initialCenter`/`initialZoom`); the
+    // real first-paint viewport is framed by `initialCameraFit` to
+    // `_routeBounds` inside `StationMapLayers`. The recenter button and
+    // the toggle therefore always refit to the SAME route bounds, so the
+    // camera holds across the All/Best toggle (no random re-zoom).
+    final center = _initialCenter;
+    const zoom = 6.0;
 
     // #2631 — price each station by ITS country's profile fuel (offline,
     // from lat/lng) so a cross-border Spanish station shows the E10 price
@@ -116,7 +158,15 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             searchRadiusKm: 5,
             selectedFuel: widget.selectedFuel,
             showRecenterButton: true,
-            onRecenter: () => widget.mapController.move(center, zoom),
+            // #2755 — recenter refits to the same full-route bounds the
+            // camera was framed to, never the (changing) station subset.
+            onRecenter: () => widget.mapController.fitCamera(
+              CameraFit.bounds(
+                bounds: _routeBounds,
+                padding: const EdgeInsets.all(32),
+              ),
+            ),
+            cameraFitBounds: _routeBounds,
             routePolyline: result.route.geometry,
             showSearchRadius: false,
             selectedStationIds:
@@ -269,13 +319,5 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
       }
     }
     return bestIdx;
-  }
-  double _zoomForRoute(double distanceKm) {
-    if (distanceKm <= 50) return 10;
-    if (distanceKm <= 100) return 9;
-    if (distanceKm <= 200) return 8;
-    if (distanceKm <= 500) return 7;
-    if (distanceKm <= 1000) return 6;
-    return 5;
   }
 }

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -70,6 +70,18 @@ class StationMapLayers extends StatefulWidget {
   final List<LatLng>? routePolyline;
   final bool showSearchRadius;
 
+  /// #2755 — when non-null, the camera frames THESE bounds (both the
+  /// first-paint [MapOptions.initialCameraFit] and the post-ready re-fit)
+  /// instead of the [boundsForRadius] circle around [center]. Route mode
+  /// passes the full route-polyline bounds (unioned with the along-route
+  /// stations) so the camera frames the COMPLETE itinerary rather than a
+  /// ~5 km circle around the polyline midpoint, and the bounds stay
+  /// identical across the All/Best toggle so the camera holds.
+  ///
+  /// Null on a nearby/radius search → the [boundsForRadius] path is used,
+  /// byte-identical to the pre-#2755 behaviour (#2399 / #2510 unchanged).
+  final LatLngBounds? cameraFitBounds;
+
   /// When non-null, stations NOT in this set are rendered in pastel.
   /// Stations IN this set use vivid/flashy colors for quick identification.
   final Set<String>? selectedStationIds;
@@ -99,6 +111,7 @@ class StationMapLayers extends StatefulWidget {
     this.onRecenter,
     this.routePolyline,
     this.showSearchRadius = true,
+    this.cameraFitBounds,
     this.selectedStationIds,
     this.extraLayers = const [],
     this.fuelResolver,
@@ -268,9 +281,13 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// so this only handles the stations-arrived / centre-moved transition.
   LatLngBounds? _lastFitBounds;
 
-  /// Bounds of the search circle around the current centre — the camera
-  /// target for both `initialCameraFit` and the post-ready re-fit.
+  /// The camera target for both `initialCameraFit` and the post-ready
+  /// re-fit. #2755 — when an explicit [cameraFitBounds] is supplied (route
+  /// mode), frame exactly those bounds; otherwise (nearby mode) fall back
+  /// to the search circle around the current centre, byte-identical to the
+  /// pre-#2755 behaviour.
   LatLngBounds get _fitBounds =>
+      widget.cameraFitBounds ??
       StationMapLayers.boundsForRadius(widget.center, widget.searchRadiusKm);
 
   /// Recompute the memoised price range + marker list from the current
@@ -413,16 +430,17 @@ class _StationMapLayersState extends State<StationMapLayers> {
           options: MapOptions(
             initialCenter: widget.center,
             initialZoom: widget.zoom,
-            // #2399 — frame the search circle during the FIRST layout
+            // #2399 — frame the camera target during the FIRST layout
             // pass, not via a post-frame `fitCamera`. The old post-frame
             // fit raced the (now-deleted) cold-start reset window and
             // could land on a degenerate viewport. Positioning the
             // camera as part of layout means the very first tile fetch
             // already targets the right viewport — no reset needed.
+            // #2755 — `_fitBounds` is the explicit [cameraFitBounds] (route
+            // mode: the full itinerary) when supplied, else the search
+            // circle (nearby mode, unchanged).
             initialCameraFit: CameraFit.bounds(
-              bounds:
-                  StationMapLayers.boundsForRadius(
-                      widget.center, widget.searchRadiusKm),
+              bounds: _fitBounds,
               padding: const EdgeInsets.all(32),
             ),
             // #2399 — keep the FlutterMap (and its loaded tiles) alive

--- a/test/features/map/presentation/widgets/nearby_map_view_test.dart
+++ b/test/features/map/presentation/widgets/nearby_map_view_test.dart
@@ -12,6 +12,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/features/map/presentation/widgets/nearby_map_view.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
@@ -163,6 +164,45 @@ void main() {
 
         expect(controller.fitCount, baseline,
             reason: 'an unchanged fit target must NOT re-fit the camera');
+      },
+    );
+
+    testWidgets(
+      '#2755 — nearby stays on the boundsForRadius path: StationMapLayers '
+      'receives cameraFitBounds == null and the camera frames the search '
+      'circle (NOT the route-mode bounds), guarding #2399/#2510',
+      (tester) async {
+        final controller = _CountingMapController();
+        addTearDown(controller.dispose);
+
+        await pumpApp(
+          tester,
+          _Rebuildable(
+            controller: controller,
+            viewFor: viewFor,
+            initial: resultFor(parisStations),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The #2755 contract: nearby mode passes NO explicit fit bounds, so
+        // `StationMapLayers._fitBounds` falls back to `boundsForRadius`,
+        // byte-identical to the pre-#2755 behaviour.
+        final layers =
+            tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+        expect(layers.cameraFitBounds, isNull,
+            reason: 'nearby must leave cameraFitBounds null (#2399/#2510)');
+
+        // And the first-paint fit target IS the search circle around the
+        // station centroid at the 19 km radius — not a route bound.
+        final expected = StationMapLayers.boundsForRadius(
+          StationMapLayers.centerOf(parisStations),
+          19,
+        );
+        final flutterMap = tester.widget<FlutterMap>(find.byType(FlutterMap));
+        final fit = flutterMap.options.initialCameraFit as FitBounds;
+        expect(fit.bounds, expected,
+            reason: 'nearby first paint frames boundsForRadius, unchanged');
       },
     );
 

--- a/test/features/map/presentation/widgets/route_map_view_test.dart
+++ b/test/features/map/presentation/widgets/route_map_view_test.dart
@@ -12,6 +12,7 @@ import 'package:tankstellen/features/itinerary/providers/itinerary_provider.dart
 import 'package:tankstellen/features/map/presentation/widgets/route_best_stops_list.dart';
 import 'package:tankstellen/features/map/presentation/widgets/route_info_bar.dart';
 import 'package:tankstellen/features/map/presentation/widgets/route_map_view.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
 import 'package:tankstellen/core/widgets/selectable_pill.dart';
 import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
 import 'package:tankstellen/features/route_search/providers/route_search_provider.dart';
@@ -236,6 +237,203 @@ void main() {
 
         // Two segments → two best stations.
         expect(find.text('2 best'), findsOneWidget);
+      },
+    );
+  });
+
+  // #2755 — route mode must frame the COMPLETE itinerary and hold the
+  // camera across the All/Best toggle (the radius circle around the
+  // polyline midpoint was the bug).
+  group('RouteMapView camera framing (#2755)', () {
+    // An ASYMMETRIC polyline: the midpoint index (geometry[mid] = p1) sits
+    // near the dense start, far from the centroid of the full span — so a
+    // route-bounds fit is provably distinct from the old midpoint centre.
+    final asymmetricRoute = <LatLng>[
+      const LatLng(52.40, 13.20), // p0 — south-west start
+      const LatLng(52.42, 13.25), // p1 — midpoint index (mid = 1)
+      const LatLng(52.80, 13.90), // p2 — far north-east end
+    ];
+
+    // Stations spread along the route, including one beyond the polyline's
+    // own longitude span so the UNION bounds differ from the polyline-only
+    // bounds and we can assert the union is what gets framed.
+    Station stationAt(String id, double lat, double lng) => Station(
+          id: id,
+          name: 'S-$id',
+          brand: 'Brand',
+          street: 'Street',
+          postCode: '00000',
+          place: 'Place',
+          lat: lat,
+          lng: lng,
+          isOpen: true,
+          e10: 1.70,
+        );
+    final routeStations = <Station>[
+      stationAt('a', 52.45, 13.30),
+      stationAt('b', 52.60, 13.55),
+      stationAt('c', 52.78, 13.95), // east of the polyline's max lng
+    ];
+
+    /// Expected camera target: bounds of the polyline UNIONED with every
+    /// station — exactly what `RouteMapView._computeRouteBounds` builds.
+    LatLngBounds unionBounds(List<LatLng> geometry, List<Station> stations) {
+      return LatLngBounds.fromPoints([
+        ...geometry,
+        for (final s in stations) LatLng(s.lat, s.lng),
+      ]);
+    }
+
+    testWidgets(
+      'frames the whole route: visibleBounds contains every polyline point '
+      'and every station; camera centre ≈ union-bounds centre (NOT the '
+      'polyline midpoint)',
+      (tester) async {
+        final controller = MapController();
+        addTearDown(controller.dispose);
+
+        final overrides = standardTestOverrides();
+        when(() => overrides.mockStorage.getActiveProfileId())
+            .thenReturn(null);
+
+        await pumpApp(
+          tester,
+          buildHost(
+            buildResult(stations: routeStations, geometry: asymmetricRoute),
+            controller,
+          ),
+          overrides: overrides.overrides,
+        );
+        await tester.pumpAndSettle();
+
+        final expected = unionBounds(asymmetricRoute, routeStations);
+
+        // The StationMapLayers explicit fit target IS the union bounds —
+        // not a 5 km circle around any midpoint (approach (a) contract).
+        final layers =
+            tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+        expect(layers.cameraFitBounds, expected,
+            reason: 'route mode frames the polyline∪stations bounds');
+
+        // The real camera frames the whole itinerary: every polyline point
+        // and every station is inside the visible viewport.
+        final visible = controller.camera.visibleBounds;
+        for (final p in asymmetricRoute) {
+          expect(visible.contains(p), isTrue,
+              reason: 'polyline point $p must be in view');
+        }
+        for (final s in routeStations) {
+          expect(visible.contains(LatLng(s.lat, s.lng)), isTrue,
+              reason: 'station ${s.id} must be in view');
+        }
+
+        // The camera centre is the union-bounds centre, NOT geometry[mid].
+        final midIdx = asymmetricRoute.length ~/ 2;
+        final mid = asymmetricRoute[midIdx];
+        expect(controller.camera.center.latitude,
+            closeTo(expected.center.latitude, 0.02));
+        expect(controller.camera.center.longitude,
+            closeTo(expected.center.longitude, 0.02));
+        expect(
+          (controller.camera.center.longitude - mid.longitude).abs(),
+          greaterThan(0.1),
+          reason: 'must NOT centre on the polyline midpoint (the #2755 bug)',
+        );
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'STABILITY: after a manual zoom-out, toggling Best ↔ All does NOT '
+      're-zoom — centre/zoom are identical across the two taps (#2755 lock)',
+      (tester) async {
+        final controller = MapController();
+        addTearDown(controller.dispose);
+
+        final overrides = standardTestOverrides();
+        when(() => overrides.mockStorage.getActiveProfileId())
+            .thenReturn(null);
+
+        await pumpApp(
+          tester,
+          buildHost(
+            buildResult(
+              stations: routeStations,
+              geometry: asymmetricRoute,
+              cheapestId: routeStations.first.id,
+            ),
+            controller,
+          ),
+          overrides: overrides.overrides,
+        );
+        await tester.pumpAndSettle();
+
+        // Simulate the user zooming out / panning away from the fitted view.
+        final fitted = controller.camera;
+        controller.move(fitted.center, fitted.zoom - 3);
+        await tester.pumpAndSettle();
+        final movedCenter = controller.camera.center;
+        final movedZoom = controller.camera.zoom;
+
+        // Toggle to Best stops: the marker subset shrinks, but the camera
+        // must stay exactly where the user left it (no random snap).
+        await tester.tap(find.text('Best stops'));
+        await tester.pumpAndSettle();
+        final afterBestCenter = controller.camera.center;
+        final afterBestZoom = controller.camera.zoom;
+
+        // Toggle back to All stations: again, no camera movement.
+        await tester.tap(find.text('All stations'));
+        await tester.pumpAndSettle();
+        final afterAllCenter = controller.camera.center;
+        final afterAllZoom = controller.camera.zoom;
+
+        // The camera held through BOTH toggles — no re-zoom, no snap to a
+        // station/cluster. The two taps produce IDENTICAL camera state.
+        expect(afterBestZoom, movedZoom,
+            reason: 'Best toggle must not re-zoom');
+        expect(afterAllZoom, movedZoom,
+            reason: 'All toggle must not re-zoom');
+        expect(afterAllZoom, afterBestZoom, reason: 'no randomness');
+        expect(afterBestCenter.latitude, closeTo(movedCenter.latitude, 1e-9));
+        expect(afterBestCenter.longitude, closeTo(movedCenter.longitude, 1e-9));
+        expect(afterAllCenter.latitude,
+            closeTo(afterBestCenter.latitude, 1e-9));
+        expect(afterAllCenter.longitude,
+            closeTo(afterBestCenter.longitude, 1e-9));
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'degenerate single-point route → no exception (epsilon box), camera '
+      'centred on the point',
+      (tester) async {
+        final controller = MapController();
+        addTearDown(controller.dispose);
+
+        final overrides = standardTestOverrides();
+        when(() => overrides.mockStorage.getActiveProfileId())
+            .thenReturn(null);
+
+        const point = LatLng(48.8566, 2.3522);
+        await pumpApp(
+          tester,
+          buildHost(
+            buildResult(stations: const [], geometry: const [point]),
+            controller,
+          ),
+          overrides: overrides.overrides,
+        );
+        await tester.pumpAndSettle();
+
+        // No CameraFit divide-by-zero on a single-point polyline.
+        expect(tester.takeException(), isNull);
+        expect(controller.camera.center.latitude, closeTo(point.latitude, 0.01));
+        expect(
+            controller.camera.center.longitude, closeTo(point.longitude, 0.01));
       },
     );
   });

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -354,7 +354,12 @@ void main() {
     // `_resolvedRange` helper that colours cross-border markers by each
     // station's own country fuel. Lets a Spanish station show its E10 price
     // instead of '--' on an E85 route. Decomposition tracked by #2187/#2188.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 604,
+    // #2755 — re-grandfathered 604 → 622: the optional `cameraFitBounds`
+    // field + its dartdoc and constructor param, plus the `_fitBounds`
+    // getter / `initialCameraFit` substitution that frames the explicit
+    // bounds (route mode: the full itinerary) instead of the search circle.
+    // Null path unchanged (nearby mode). Decomposition tracked by #2187/#2188.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 622,
     // #2681 — feature_management_section.dart graduated: the #2681 ordered-
     // category reorg decomposed the 718-line god-class into the
     // widgets/feature_management/ folder (conso_feature_card.dart,


### PR DESCRIPTION
## What
In **route-search** mode the map camera framed `boundsForRadius(polyline-midpoint, 5km)` — a ~5 km circle around the polyline midpoint, never the route — and toggling **"All stations" ↔ "Best stops"** only mutated the marker subset while the `StationMapLayers` `centerChanged` re-fit gate (#2399) never fired, so the camera held its old position while a different subset painted, reading as a **random re-zoom**.

Now route mode frames the **complete itinerary** (full route polyline ∪ along-route stations), fit **once**, **stable** across the toggle. Nearby/radius mode is left byte-identical.

## Approach — (a)
An **optional `cameraFitBounds` param (default null)** on `StationMapLayers`. When non-null it is the target for both `MapOptions.initialCameraFit` and the post-ready re-fit (a single guarded substitution in the `_fitBounds` getter). The #2399 `centerChanged` gate, the `_lastFitBounds` value-`==` guard, and the marker recompute are all unchanged. The **null path (nearby/radius) is byte-identical** to today — chosen over approach (b) because it reuses the existing hardened `initialCameraFit` + `_lastFitBounds` machinery (the toggle becomes a no-op for free via the value-`==` guard) instead of bolting on a second `_didFitRoute` fit path that would fight it.

`RouteMapView` computes `_routeBounds` **once** from `route.geometry ∪ stations` via `LatLngBounds.fromPoints` (epsilon box for a degenerate single-point route so `CameraFit` can't divide-by-zero), passes it as `cameraFitBounds`, derives the pre-layout fallback centre from it, and refits the recenter button to it. Removed the now-dead `_zoomForRoute` + midpoint `center`/`zoom`.

## Files changed
- `lib/features/map/presentation/widgets/station_map_layers.dart` — `cameraFitBounds` field + guarded `_fitBounds`/`initialCameraFit` substitution.
- `lib/features/map/presentation/widgets/route_map_view.dart` — `_routeBounds`, route-bounds fit + recenter, dead-code removal.
- `test/features/map/presentation/widgets/route_map_view_test.dart` — route-framing, toggle-stability, degenerate-safe.
- `test/features/map/presentation/widgets/nearby_map_view_test.dart` — nearby-unaffected (`cameraFitBounds == null`, frames `boundsForRadius`).
- `test/lint/file_length_test.dart` — re-grandfather station_map_layers 604 → 622 (rationale inline).

## Tests (all green)
1. **Route-framing** — asymmetric polyline; `visibleBounds` contains every polyline point AND every station; camera centre ≈ union-bounds centre and provably **NOT** the polyline midpoint.
2. **Toggle-stability (#2755 lock)** — after a manual zoom-out, Best↔All taps leave centre/zoom **identical** (no randomness, no snap); `takeException() == null`.
3. **Degenerate single-point route** — epsilon path, no exception, centred on the point.
4. **Nearby unaffected** — `StationMapLayers.cameraFitBounds == null` and first paint frames `boundsForRadius(centerOf(stations), radius)` (guards #2399/#2510).

`flutter analyze` clean (the 2 remaining infos are pre-existing on master in unrelated consumption test files). ARB-free, no codegen / l10n drift.

Closes #2755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
