### PR TITLE
feat(vehicle): add Peugeot 107 to reference catalog (#2758)

### DIFF
--- a/assets/reference_vehicles/vehicles.json
+++ b/assets/reference_vehicles/vehicles.json
@@ -1761,6 +1761,22 @@
   },
   {
     "make": "Peugeot",
+    "model": "107",
+    "generation": "I (2005-2014)",
+    "yearStart": 2005,
+    "yearEnd": 2014,
+    "displacementCc": 998,
+    "fuelType": "petrol",
+    "transmission": "manual",
+    "volumetricEfficiency": 0.85,
+    "odometerPidStrategy": "psaUds",
+    "inductionType": "naturallyAspirated",
+    "directInjection": false,
+    "atkinsonCycle": false,
+    "notes": "1.0 12v city car (PSA/Toyota triplet with C1/Aygo)"
+  },
+  {
+    "make": "Peugeot",
     "model": "108",
     "generation": "I (2014-2021)",
     "yearStart": 2014,


### PR DESCRIPTION
Adds the Peugeot 107 (998cc petrol/manual, physics copied from the C1 gen-I twin). Missing by curation only; clean asset-test add. ARB-free, no codegen. Closes #2758