### PR TITLE
feat(consumption): GPS+IMU sensor fusion for dongle-optional driving analytics

### DIFF
--- a/lib/core/sensors/imu_sample.dart
+++ b/lib/core/sensors/imu_sample.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// One fused inertial-measurement-unit sample (#2760): the gravity-removed
+/// linear acceleration on the three device axes plus the yaw-axis angular
+/// rate, stamped with a wall-clock time.
+///
+/// ## In-memory only — never persisted
+///
+/// This is a transient value carried from [ImuSensorSource] to the pure
+/// [ImuEventDetector] and dropped immediately. The dongle-optional GPS+IMU
+/// pipeline (#2760) is bound by a hard "aggregate-only, disk-efficient"
+/// constraint: at ~50 Hz a raw sample list would saturate local disk, so
+/// NOTHING here is ever buffered into a list for persistence or written to
+/// JSON. The detector folds each sample into a handful of in-memory integer
+/// counters in real time; on trip stop only those few scalars survive. There
+/// is deliberately no `toJson` / `fromJson` on this type — adding one would
+/// invite exactly the raw-sample persistence the issue forbids.
+///
+/// The accelerometer axes carry **linear** acceleration with gravity already
+/// removed (sourced from `userAccelerometerEventStream`, not the raw
+/// `accelerometerEventStream`), so a phone resting flat reads ~0 on every
+/// axis. Units: m/s² for the accel axes, rad/s for the yaw rate.
+class ImuSample {
+  const ImuSample({
+    required this.t,
+    required this.axMps2,
+    required this.ayMps2,
+    required this.azMps2,
+    required this.gyroZRadPerSec,
+  });
+
+  /// Wall-clock timestamp the fused sample was assembled at.
+  final DateTime t;
+
+  /// Linear (gravity-removed) acceleration on the device X axis, m/s².
+  final double axMps2;
+
+  /// Linear (gravity-removed) acceleration on the device Y axis, m/s².
+  final double ayMps2;
+
+  /// Linear (gravity-removed) acceleration on the device Z axis, m/s².
+  final double azMps2;
+
+  /// Angular rate about the device Z (yaw) axis, rad/s — the cornering
+  /// signal: a sustained non-zero yaw rate at speed is a turn.
+  final double gyroZRadPerSec;
+}

--- a/lib/core/sensors/imu_sensor_source.dart
+++ b/lib/core/sensors/imu_sensor_source.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:sensors_plus/sensors_plus.dart';
+
+import 'imu_sample.dart';
+
+part 'imu_sensor_source.g.dart';
+
+/// Wraps `sensors_plus` behind a testable, app-lifetime provider (#2760).
+///
+/// ## The single `sensors_plus` import site
+///
+/// This is the ONLY file in the codebase that imports `sensors_plus`, the
+/// loosely-coupled-plugin idiom the project mandates (mirroring
+/// `geolocator_wrapper.dart`): the platform plugin is touched in exactly one
+/// place, never with an inline `if (Platform.isX)`, so the GPS+IMU pipeline
+/// and its tests depend on the plain [ImuSample] value type rather than on
+/// the plugin's event classes. Tests override [imuSensorSourceProvider] with
+/// a fake emitting a fixed synthetic [ImuSample] stream.
+///
+/// `keepAlive` because a trip — and the sensor stream feeding its detector —
+/// outlives widget rebuilds as the driver navigates the app mid-trip, exactly
+/// like the geolocator wrapper.
+@Riverpod(keepAlive: true)
+ImuSensorSource imuSensorSource(Ref ref) {
+  return ImuSensorSource();
+}
+
+class ImuSensorSource {
+  /// A fused ~50 Hz stream of gravity-removed linear acceleration +
+  /// yaw-rate samples.
+  ///
+  /// ## Why `userAccelerometerEventStream`, not `accelerometerEventStream`
+  ///
+  /// `userAccelerometerEventStream` reports **linear** acceleration with the
+  /// gravity vector already removed on-device (Android's `TYPE_LINEAR_
+  /// ACCELERATION` / iOS CoreMotion `userAcceleration`). A phone lying flat
+  /// reads ~0 on every axis, so the harsh-accel / harsh-brake detector sees
+  /// the genuine vehicle longitudinal acceleration directly — no fragile
+  /// per-app low-pass gravity-removal filter, and no orientation bookkeeping
+  /// to subtract a ~9.8 m/s² bias. The raw `accelerometerEventStream` would
+  /// include gravity and is deliberately NOT used.
+  ///
+  /// ## Fusion
+  ///
+  /// The accelerometer drives the cadence: every accel event produces one
+  /// [ImuSample] carrying the most-recent gyroscope Z reading (the yaw rate).
+  /// Both are sampled at [SensorInterval.gameInterval] (~50 Hz). A gyro
+  /// reading that has not arrived yet is carried as 0.0 — the detector's
+  /// cornering gate additionally requires a lateral-accel threshold, so a
+  /// missing yaw rate cannot manufacture a phantom corner.
+  ///
+  /// ## Aggregate-only contract
+  ///
+  /// The returned stream is consumed sample-by-sample by the pure detector
+  /// and never collected into a persisted list — see [ImuSample].
+  Stream<ImuSample> stream() {
+    var lastGyroZ = 0.0;
+    StreamSubscription<GyroscopeEvent>? gyroSub;
+    StreamSubscription<UserAccelerometerEvent>? accelSub;
+
+    // Closed in its own `onCancel` once the consumer detaches (alongside the
+    // two upstream sensor subscriptions), so there is no leak — the analyzer
+    // can't see across the closure, hence the ignore (same idiom as the
+    // shared position source in geolocator_wrapper.dart).
+    // ignore: close_sinks
+    late final StreamController<ImuSample> out;
+    out = StreamController<ImuSample>(
+      onListen: () {
+        // A device without an accelerometer / gyroscope, or a host without
+        // the platform plugin bound (e.g. a unit-test process), makes the
+        // sensor stream throw at subscribe time. Degrade gracefully to a
+        // quiet stream that simply never emits — the GPS+IMU trip then
+        // records off GPS alone rather than crashing. (Tests that exercise
+        // the detector override this provider with a synthetic source.)
+        try {
+          gyroSub = gyroscopeEventStream(
+            samplingPeriod: SensorInterval.gameInterval,
+          ).listen((e) => lastGyroZ = e.z, onError: (Object _) {});
+          accelSub = userAccelerometerEventStream(
+            samplingPeriod: SensorInterval.gameInterval,
+          ).listen(
+            (e) {
+              if (out.isClosed) return;
+              out.add(ImuSample(
+                t: DateTime.now(),
+                axMps2: e.x,
+                ayMps2: e.y,
+                azMps2: e.z,
+                gyroZRadPerSec: lastGyroZ,
+              ));
+            },
+            onError: (Object err, StackTrace st) {
+              if (!out.isClosed) out.addError(err, st);
+            },
+          );
+        } catch (_) {
+          // Sensors unavailable — leave the stream quiet.
+        }
+      },
+      onCancel: () async {
+        try {
+          await accelSub?.cancel();
+          await gyroSub?.cancel();
+        } catch (_) {
+          // A subscription that failed to set up cleanly may also throw on
+          // cancel; nothing to recover.
+        }
+        if (!out.isClosed) await out.close();
+      },
+    );
+    return out.stream;
+  }
+}

--- a/lib/core/sensors/imu_sensor_source.g.dart
+++ b/lib/core/sensors/imu_sensor_source.g.dart
@@ -1,0 +1,98 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'imu_sensor_source.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Wraps `sensors_plus` behind a testable, app-lifetime provider (#2760).
+///
+/// ## The single `sensors_plus` import site
+///
+/// This is the ONLY file in the codebase that imports `sensors_plus`, the
+/// loosely-coupled-plugin idiom the project mandates (mirroring
+/// `geolocator_wrapper.dart`): the platform plugin is touched in exactly one
+/// place, never with an inline `if (Platform.isX)`, so the GPS+IMU pipeline
+/// and its tests depend on the plain [ImuSample] value type rather than on
+/// the plugin's event classes. Tests override [imuSensorSourceProvider] with
+/// a fake emitting a fixed synthetic [ImuSample] stream.
+///
+/// `keepAlive` because a trip — and the sensor stream feeding its detector —
+/// outlives widget rebuilds as the driver navigates the app mid-trip, exactly
+/// like the geolocator wrapper.
+
+@ProviderFor(imuSensorSource)
+final imuSensorSourceProvider = ImuSensorSourceProvider._();
+
+/// Wraps `sensors_plus` behind a testable, app-lifetime provider (#2760).
+///
+/// ## The single `sensors_plus` import site
+///
+/// This is the ONLY file in the codebase that imports `sensors_plus`, the
+/// loosely-coupled-plugin idiom the project mandates (mirroring
+/// `geolocator_wrapper.dart`): the platform plugin is touched in exactly one
+/// place, never with an inline `if (Platform.isX)`, so the GPS+IMU pipeline
+/// and its tests depend on the plain [ImuSample] value type rather than on
+/// the plugin's event classes. Tests override [imuSensorSourceProvider] with
+/// a fake emitting a fixed synthetic [ImuSample] stream.
+///
+/// `keepAlive` because a trip — and the sensor stream feeding its detector —
+/// outlives widget rebuilds as the driver navigates the app mid-trip, exactly
+/// like the geolocator wrapper.
+
+final class ImuSensorSourceProvider
+    extends
+        $FunctionalProvider<ImuSensorSource, ImuSensorSource, ImuSensorSource>
+    with $Provider<ImuSensorSource> {
+  /// Wraps `sensors_plus` behind a testable, app-lifetime provider (#2760).
+  ///
+  /// ## The single `sensors_plus` import site
+  ///
+  /// This is the ONLY file in the codebase that imports `sensors_plus`, the
+  /// loosely-coupled-plugin idiom the project mandates (mirroring
+  /// `geolocator_wrapper.dart`): the platform plugin is touched in exactly one
+  /// place, never with an inline `if (Platform.isX)`, so the GPS+IMU pipeline
+  /// and its tests depend on the plain [ImuSample] value type rather than on
+  /// the plugin's event classes. Tests override [imuSensorSourceProvider] with
+  /// a fake emitting a fixed synthetic [ImuSample] stream.
+  ///
+  /// `keepAlive` because a trip — and the sensor stream feeding its detector —
+  /// outlives widget rebuilds as the driver navigates the app mid-trip, exactly
+  /// like the geolocator wrapper.
+  ImuSensorSourceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'imuSensorSourceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$imuSensorSourceHash();
+
+  @$internal
+  @override
+  $ProviderElement<ImuSensorSource> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  ImuSensorSource create(Ref ref) {
+    return imuSensorSource(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ImuSensorSource value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ImuSensorSource>(value),
+    );
+  }
+}
+
+String _$imuSensorSourceHash() => r'0df5d3689f54a0056b9cd4adf97a0146aa3ee606';

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -205,6 +205,14 @@ Map<String, dynamic> _summaryToJson(TripSummary s) => {
       // Omitted when false (every real trip) so legacy trips round-trip
       // with zero bytes added.
       if (s.isVirtual) 'virt': true,
+      // #2760: IMU-detected aggregate event counts for dongle-less
+      // (GPS+IMU) trips. THREE scalars only — never the raw ~50 Hz sample
+      // stream (the aggregate-only / disk-efficient constraint). Compact
+      // keys 'iha' / 'ihb' / 'sc'; each omitted when 0 so OBD2 trips and
+      // every legacy trip round-trip with zero bytes added.
+      if (s.imuHardAccelCount != 0) 'iha': s.imuHardAccelCount,
+      if (s.imuHardBrakeCount != 0) 'ihb': s.imuHardBrakeCount,
+      if (s.sharpCornerCount != 0) 'sc': s.sharpCornerCount,
     };
 
 TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -252,6 +260,11 @@ TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
       // false so every real trip and every legacy trip deserialises
       // as a normal, fully-counted trajet.
       isVirtual: (j['virt'] as bool?) ?? false,
+      // #2760: IMU aggregate event counts. Missing key → 0 for OBD2 trips
+      // and every legacy trip recorded before IMU fusion landed.
+      imuHardAccelCount: (j['iha'] as num?)?.toInt() ?? 0,
+      imuHardBrakeCount: (j['ihb'] as num?)?.toInt() ?? 0,
+      sharpCornerCount: (j['sc'] as num?)?.toInt() ?? 0,
     );
 
 /// Hive-backed list of finalised trips (#726).

--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -14,6 +14,15 @@ import 'trip_recorder.dart';
 /// band so a brisk-but-controlled bend doesn't trip it.
 const double kSharpCornerThresholdMps2 = 3.5;
 
+/// Minimum yaw rate (rad/s) the gyroscope must report for an IMU-detected
+/// sharp corner (#2760). ≈0.30 rad/s ≈ 17 °/s — a brisk-but-real turn rate;
+/// a steering correction or lane change yaws well below this. Paired with
+/// the [kSharpCornerThresholdMps2] lateral-accel floor and a ~constant-speed
+/// gate so only a genuine sustained bend (not a bump or a straight-line
+/// jolt) trips the IMU corner counter. Lives beside the GPS corner threshold
+/// so the two cornering signals share one source of truth.
+const double kSharpCornerYawRateRadPerSec = 0.30;
+
 /// Horizontal-accuracy ceiling (m) for trusting a fix's bearing in the
 /// corner-load integral. A jittery fix (urban canyon / cold start)
 /// reports a noisy heading that would manufacture a phantom corner, so

--- a/lib/features/consumption/domain/services/imu_event_detector.dart
+++ b/lib/features/consumption/domain/services/imu_event_detector.dart
@@ -1,0 +1,279 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import '../../../../core/sensors/imu_sample.dart';
+import '../accel_event_gate.dart';
+import '../gps_driving_features.dart'
+    show kSharpCornerThresholdMps2, kSharpCornerYawRateRadPerSec;
+import '../harsh_event.dart';
+
+/// Pure, plugin-free harsh-accel / harsh-brake / sharp-corner detector for
+/// the dongle-optional GPS+IMU pipeline (#2760).
+///
+/// ## What it is
+///
+/// Fed one [ImuSample] at a time (~50 Hz) via [onSample], plus the live GPS
+/// ground speed via [currentSpeedKmh], it folds the inertial signal into a
+/// handful of in-memory integer counters: [hardAccelCount], [hardBrakeCount],
+/// [sharpCornerCount]. It NEVER retains the samples — the binding
+/// aggregate-only constraint (#2760). On trip stop the pipeline reads the
+/// three counters and drops the detector.
+///
+/// ## Why it mirrors `accel_event_gate.dart`
+///
+/// The accel/brake event semantics are deliberately identical to the
+/// canonical [countAccelEvents] gate the GPS-speed path uses: the SAME
+/// thresholds ([kHardAccelThresholdMps2] = 3.0, [kHardBrakeThresholdMps2] =
+/// 3.5), the SAME sustained-window floor ([kAccelEventMinSustainedSec] =
+/// 1.0 s), the SAME min-speed gate ([kAccelEventMinSpeedKmh] = 5 km/h), and
+/// the SAME one-event-per-*episode* latch/re-arm — a 4-second hard brake is
+/// ONE brake, not 80 samples. The only difference is the *source* of the
+/// acceleration: a direct inertial reading rather than the noisy
+/// speed-derivative, which is more accurate and is why the dongle becomes
+/// optional.
+///
+/// ## Accel vs brake direction
+///
+/// The accelerometer is orientation-agnostic, so the detector uses the
+/// horizontal linear-accel magnitude `sqrt(ax² + ay²)` as the manoeuvre
+/// strength and the *sign of the GPS-speed change* to classify it: a
+/// strong horizontal acceleration while ground speed is rising is a hard
+/// accel; while falling, a hard brake. A near-constant speed with a strong
+/// horizontal accel and a high yaw rate is a corner instead.
+///
+/// ## Cornering
+///
+/// A sharp corner needs all three: the lateral (horizontal) accel ≥
+/// [kSharpCornerThresholdMps2] (3.5 m/s²), the gyroscope yaw rate |gyroZ| ≥
+/// [kSharpCornerYawRateRadPerSec] (0.30 rad/s), AND a roughly constant GPS
+/// speed (so a hard brake into a bend is counted as a brake, not a corner),
+/// sustained ≥ [_cornerMinSustainedSec] (2.0 s). The yaw-rate gate is what
+/// keeps a straight-line bump or a longitudinal jolt from registering as a
+/// corner.
+class ImuEventDetector {
+  ImuEventDetector({this.onEvent});
+
+  /// Optional live callback, fired the instant a confirmed accel/brake
+  /// episode is detected — matches [HarshEventDetector.onEvent] so the
+  /// GPS+IMU pipeline can feed the SAME `LiveHarshEventBus` the OBD2 /
+  /// GPS-speed paths use, and dongle-less spoken coaching fires (#2760).
+  /// Corners are not [HarshEvent]s (no type), so they do not fire it.
+  void Function(HarshEvent event)? onEvent;
+
+  /// The latest GPS ground speed (km/h), fed by the pipeline from each GPS
+  /// fix. Drives the min-speed gate and the accel-vs-brake direction. A
+  /// near-standstill (< [kAccelEventMinSpeedKmh]) suppresses scoring so
+  /// parked-phone jitter manufactures nothing.
+  double currentSpeedKmh = 0;
+
+  /// Confirmed hard-acceleration episodes so far.
+  int get hardAccelCount => _hardAccelCount;
+
+  /// Confirmed hard-braking episodes so far.
+  int get hardBrakeCount => _hardBrakeCount;
+
+  /// Confirmed sharp-cornering episodes so far.
+  int get sharpCornerCount => _sharpCornerCount;
+
+  int _hardAccelCount = 0;
+  int _hardBrakeCount = 0;
+  int _sharpCornerCount = 0;
+
+  /// Lateral (horizontal) accel must hold above 3.5 m/s² and the yaw rate
+  /// above 0.30 rad/s for at least this long before a corner is confirmed —
+  /// longer than the 1 s accel/brake floor because a bend is a slower,
+  /// sustained manoeuvre and we want to reject transient jolts.
+  static const double _cornerMinSustainedSec = 2.0;
+
+  /// Speed change (km/h) between consecutive samples below which the speed is
+  /// treated as "roughly constant" for the corner gate. Sampled per ~20 ms
+  /// step; a real accel/brake moves speed far faster than this per step.
+  static const double _constantSpeedDeltaKmh = 0.15;
+
+  // Episode-latch state, mirroring `countAccelEvents`: accumulate the
+  // sustained time above each threshold, count once on first crossing the
+  // sustained floor, and re-arm only when the signal drops back below the
+  // threshold.
+  double _maneuverDur = 0;
+  double _cornerDur = 0;
+  bool _inAccel = false;
+  bool _inBrake = false;
+  bool _inCorner = false;
+
+  DateTime? _lastT;
+
+  /// GPS speed (km/h) captured at the instant a strong-longitudinal stretch
+  /// began. Because GPS refreshes ~1 Hz while the IMU runs ~50 Hz, the
+  /// per-sample speed delta is usually 0 — so accel-vs-brake direction is
+  /// decided by the NET speed change since the manoeuvre started, not the
+  /// (near-zero) sample-to-sample delta.
+  double _maneuverStartSpeedKmh = 0;
+
+  /// Fold one inertial sample into the counters. Pure: no I/O, no
+  /// persistence, O(1) work and O(1) memory regardless of trip length.
+  void onSample(ImuSample s) {
+    final lastT = _lastT;
+    final speedKmh = currentSpeedKmh;
+    _lastT = s.t;
+    if (lastT == null) return; // first sample seeds the dt anchor only.
+
+    final dt = s.t.difference(lastT).inMicroseconds /
+        Duration.microsecondsPerSecond;
+    // A non-positive dt (duplicate / out-of-order) or a long gap (a sensor
+    // dropout / paused trip) breaks every running episode so no integral
+    // spans it — the same guard the speed-derivative gate uses.
+    if (dt <= 0 || dt > kAccelEventMaxGapSec) {
+      _breakEpisodes();
+      return;
+    }
+
+    // Min-speed floor: a near-standstill is not a real manoeuvre. Parked /
+    // walking-pace jitter is dropped and resets the latches.
+    if (speedKmh < kAccelEventMinSpeedKmh) {
+      _breakEpisodes();
+      return;
+    }
+
+    // Horizontal linear-accel magnitude — orientation-agnostic manoeuvre
+    // strength. The vertical (Z) axis is dropped so road bumps don't inflate
+    // it. Gravity is already removed upstream (userAccelerometer), so a
+    // steady cruise reads ~0. We use the same magnitude for the longitudinal
+    // (accel/brake) gate and the lateral (corner) gate; the yaw rate + net
+    // speed change disambiguate which manoeuvre it is.
+    final horizMag = math.sqrt(s.axMps2 * s.axMps2 + s.ayMps2 * s.ayMps2);
+    final yawRate = s.gyroZRadPerSec.abs();
+    final highYaw = yawRate >= kSharpCornerYawRateRadPerSec;
+
+    // A strong horizontal stretch is "in progress" while the magnitude holds
+    // at/above the accel threshold (3.0). Capture the GPS speed at its start
+    // so accel-vs-brake direction is decided by the NET speed change over the
+    // stretch (robust to the ~1 Hz GPS vs ~50 Hz IMU rate mismatch).
+    final strong = horizMag >= kHardAccelThresholdMps2;
+    if (strong) {
+      if (_maneuverDur == 0) _maneuverStartSpeedKmh = speedKmh;
+      _maneuverDur += dt;
+    } else {
+      _maneuverDur = 0;
+    }
+    final netSpeedDeltaKmh = speedKmh - _maneuverStartSpeedKmh;
+    final constantSpeed = netSpeedDeltaKmh.abs() <= _constantSpeedDeltaKmh;
+
+    _scoreCorner(
+      dt: dt,
+      horizMag: horizMag,
+      highYaw: highYaw,
+      constantSpeed: constantSpeed,
+    );
+    _scoreAccelBrake(
+      horizMag: horizMag,
+      highYaw: highYaw,
+      constantSpeed: constantSpeed,
+      netSpeedDeltaKmh: netSpeedDeltaKmh,
+      speedKmh: speedKmh,
+      t: s.t,
+    );
+  }
+
+  void _scoreCorner({
+    required double dt,
+    required double horizMag,
+    required bool highYaw,
+    required bool constantSpeed,
+  }) {
+    // A corner is a sustained lateral load: the (centripetal) horizontal
+    // accel ≥ 3.5 m/s², the yaw rate above the gate, and a ~constant speed
+    // (a hard brake INTO a bend is a brake, not a corner). The lateral floor
+    // here is the harsher 3.5, matching the GPS corner threshold.
+    final isCorner =
+        horizMag >= kSharpCornerThresholdMps2 && highYaw && constantSpeed;
+    if (isCorner) {
+      _cornerDur += dt;
+      if (!_inCorner && _cornerDur >= _cornerMinSustainedSec) {
+        _sharpCornerCount++;
+        _inCorner = true;
+      }
+    } else {
+      _cornerDur = 0;
+      _inCorner = false;
+    }
+  }
+
+  void _scoreAccelBrake({
+    required double horizMag,
+    required bool highYaw,
+    required bool constantSpeed,
+    required double netSpeedDeltaKmh,
+    required double speedKmh,
+    required DateTime t,
+  }) {
+    // A high-yaw, constant-speed manoeuvre is cornering geometry: the
+    // horizontal accel is centripetal (lateral), not a longitudinal
+    // accel/brake — so don't score it as one. When speed IS changing through
+    // a bend, the net-speed classification below correctly takes over.
+    if (highYaw && constantSpeed) {
+      _inAccel = false;
+      _inBrake = false;
+      return;
+    }
+
+    // The manoeuvre confirms once the strong-magnitude stretch has held for
+    // the sustained floor. Direction is the sign of the net GPS-speed change
+    // over the stretch: rising → hard accel, falling → hard brake. A purely
+    // lateral jolt with no net speed change and no yaw is ignored.
+    final confirmed = _maneuverDur >= kAccelEventMinSustainedSec;
+
+    // Hard accel: the strong stretch (≥ 3.0 m/s²) held while speed rose.
+    final isAccel = confirmed &&
+        horizMag >= kHardAccelThresholdMps2 &&
+        netSpeedDeltaKmh > _constantSpeedDeltaKmh;
+    if (isAccel) {
+      if (!_inAccel) {
+        _hardAccelCount++;
+        _inAccel = true;
+        _emit(HarshEventType.acceleration, horizMag, t, speedKmh);
+      }
+    } else {
+      _inAccel = false;
+    }
+
+    // Hard brake: held while speed FELL, with the harder 3.5 m/s² magnitude
+    // floor (the telematics convention — brake harder to trip than accel,
+    // shared with the speed-derivative gate's kHardBrakeThresholdMps2).
+    final isBrake = confirmed &&
+        horizMag >= kHardBrakeThresholdMps2 &&
+        netSpeedDeltaKmh < -_constantSpeedDeltaKmh;
+    if (isBrake) {
+      if (!_inBrake) {
+        _hardBrakeCount++;
+        _inBrake = true;
+        _emit(HarshEventType.brake, horizMag, t, speedKmh);
+      }
+    } else {
+      _inBrake = false;
+    }
+  }
+
+  void _emit(
+    HarshEventType type,
+    double magMps2,
+    DateTime t,
+    double speedKmh,
+  ) {
+    onEvent?.call(HarshEvent(
+      timestamp: t,
+      magnitudeG: magMps2 / standardGravityMps2,
+      speedKmh: speedKmh,
+      type: type,
+    ));
+  }
+
+  void _breakEpisodes() {
+    _maneuverDur = 0;
+    _cornerDur = 0;
+    _inAccel = false;
+    _inBrake = false;
+    _inCorner = false;
+  }
+}

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -124,6 +124,27 @@ class TripSummary {
   /// fully-counted trajet.
   final bool isVirtual;
 
+  /// Confirmed hard-acceleration episodes detected from the IMU on a
+  /// GPS-only (dongle-less) trip (#2760), via [ImuEventDetector] — the same
+  /// one-event-per-episode semantics the speed-derivative gate uses, but
+  /// sourced from a direct inertial reading rather than the noisy GPS speed
+  /// derivative. Defaults `0`: OBD2 trips and every legacy trip recorded
+  /// before this field landed carry no IMU signal. When non-zero on a
+  /// GPS-only trip the pipeline prefers these counts for [harshAccelerations]
+  /// (the figure the driving score reads), as they are the more accurate
+  /// dongle-less signal.
+  final int imuHardAccelCount;
+
+  /// Confirmed hard-braking episodes detected from the IMU (#2760). See
+  /// [imuHardAccelCount]; the brake analogue.
+  final int imuHardBrakeCount;
+
+  /// Confirmed sharp-cornering episodes detected from the IMU (#2760):
+  /// lateral accel ≥ 3.5 m/s² AND yaw rate ≥ 0.30 rad/s at roughly constant
+  /// speed, sustained ≥ 2 s. Captured + fed into the score/bus; a dedicated
+  /// UI row is an explicit follow-up. Defaults `0` for OBD2 / legacy trips.
+  final int sharpCornerCount;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -143,7 +164,26 @@ class TripSummary {
     this.kind = TripKind.gpsPlusObd2,
     this.harshEvents = const [],
     this.isVirtual = false,
+    this.imuHardAccelCount = 0,
+    this.imuHardBrakeCount = 0,
+    this.sharpCornerCount = 0,
   });
+
+  /// IMU hard-accel episodes per km (#2760). Derived, not stored — the raw
+  /// count + [distanceKm] are persisted; this is the normalised view so a
+  /// long calm motorway leg with one hard accel doesn't read worse than a
+  /// short aggressive drive. Returns 0 for zero-distance trips.
+  double get imuHardAccelPerKm =>
+      distanceKm > 0 ? imuHardAccelCount / distanceKm : 0.0;
+
+  /// IMU hard-brake episodes per km (#2760). Derived; see [imuHardAccelPerKm].
+  double get imuHardBrakePerKm =>
+      distanceKm > 0 ? imuHardBrakeCount / distanceKm : 0.0;
+
+  /// IMU sharp-corner episodes per km (#2760). Derived; see
+  /// [imuHardAccelPerKm].
+  double get sharpCornersPerKm =>
+      distanceKm > 0 ? sharpCornerCount / distanceKm : 0.0;
 
   /// Returns a copy with the given fields replaced (#1858). Used by the
   /// retroactive η_v recompute to rescale `fuelLitersConsumed` /
@@ -169,6 +209,9 @@ class TripSummary {
     TripKind? kind,
     List<HarshEvent>? harshEvents,
     bool? isVirtual,
+    int? imuHardAccelCount,
+    int? imuHardBrakeCount,
+    int? sharpCornerCount,
   }) =>
       TripSummary(
         distanceKm: distanceKm ?? this.distanceKm,
@@ -191,6 +234,9 @@ class TripSummary {
         kind: kind ?? this.kind,
         harshEvents: harshEvents ?? this.harshEvents,
         isVirtual: isVirtual ?? this.isVirtual,
+        imuHardAccelCount: imuHardAccelCount ?? this.imuHardAccelCount,
+        imuHardBrakeCount: imuHardBrakeCount ?? this.imuHardBrakeCount,
+        sharpCornerCount: sharpCornerCount ?? this.sharpCornerCount,
       );
 }
 

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -8,6 +8,8 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/location/geolocator_wrapper.dart';
 import '../../../core/logging/error_logger.dart';
+import '../../../core/sensors/imu_sample.dart';
+import '../../../core/sensors/imu_sensor_source.dart';
 import '../../driving/providers/live_harsh_event_bus_provider.dart';
 import '../../vehicle/domain/entities/gps_calibration_matrix.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
@@ -18,6 +20,7 @@ import '../domain/entities/trip_save_stage.dart';
 import '../domain/gps_driving_features.dart';
 import '../domain/services/gps_fuel_estimator.dart';
 import '../domain/services/gps_live_estimate_folder.dart';
+import '../domain/services/imu_event_detector.dart';
 import '../domain/trip_recorder.dart';
 import 'recording_pipeline.dart';
 import 'trip_recording_phase.dart';
@@ -79,6 +82,15 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
   StreamSubscription<Position>? _sub;
   final List<TripSample> _samples = [];
   DateTime? _startedAt;
+
+  /// #2760 — IMU sensor-fusion attaches ONLY here, in the dongle-less
+  /// pipeline (the OBD2 path is behaviour-preserving). The detector folds
+  /// the ~50 Hz inertial stream into a handful of in-memory counters — it
+  /// NEVER buffers raw samples (the aggregate-only constraint). Both are
+  /// null between trips; the subscription opens on [start] and is cancelled
+  /// on [stop], mirroring the Geolocator [_sub] lifecycle.
+  StreamSubscription<ImuSample>? _imuSub;
+  ImuEventDetector? _imuDetector;
 
   /// #2389 / #2506 — shared GPS-physics live-estimate + coaching folder.
   /// Turns the same GPS speed stream into a live L/100 km figure (instant
@@ -144,6 +156,27 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
                 }));
           },
         );
+    // #2760 — attach IMU sensor fusion (this dongle-less pipeline ONLY).
+    // The detector feeds confirmed accel/brake episodes onto the SAME live
+    // harsh-event bus the OBD2 / GPS-speed paths use (mirroring the recorder's
+    // onHarshEvent above), so spoken coaching fires without a dongle. Sensor
+    // failure is non-fatal — we log and the trip still records off GPS alone.
+    final imuDetector = ImuEventDetector(
+      onEvent: _ref.read(liveHarshEventBusProvider.notifier).add,
+    );
+    _imuDetector = imuDetector;
+    _imuSub = _ref
+        .read(imuSensorSourceProvider)
+        .stream()
+        .listen(
+          imuDetector.onSample,
+          onError: (Object e, StackTrace st) {
+            unawaited(errorLogger.log(ErrorLayer.providers, e, st,
+                context: const {
+                  'where': 'GpsOnlyRecordingPipeline.start: IMU stream error'
+                }));
+          },
+        );
     // Seed the state so the recording screen renders immediately
     // (the first GPS fix can be 1-3 s away on a cold start).
     _host.state = _host.state.copyWith(
@@ -173,6 +206,10 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
       bearingDeg: p.heading.isFinite ? p.heading : null,
     );
     _samples.add(sample);
+    // #2760 — feed the latest GPS ground speed to the IMU detector so its
+    // min-speed gate and accel-vs-brake direction classification track the
+    // real vehicle speed (the inertial stream alone has no speed).
+    _imuDetector?.currentSpeedKmh = sample.speedKmh;
     // #2653 — a GPS-only trip's speed is the device's Doppler ground
     // speed (genuine ~1 Hz, not 1 km/h-quantised dead reckoning), so it
     // is differentiable; the detector's accuracy + min-speed +
@@ -210,6 +247,12 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     final recorder = _recorder;
     await _sub?.cancel();
     _sub = null;
+    // #2760 — tear down the IMU stream alongside the GPS one so no inertial
+    // subscription survives between trips (the battery / lifecycle bound).
+    await _imuSub?.cancel();
+    _imuSub = null;
+    final imuDetector = _imuDetector;
+    _imuDetector = null;
     if (recorder == null) {
       _host.state = const TripRecordingState();
       return const StoppedTripResult.empty();
@@ -225,8 +268,26 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // hardcoding `gpsOnly`. If [appendObd2Sample] (or any future
     // mid-trip path) injected OBD2 samples into the buffer, the
     // resulting kind correctly flips to `gpsPlusObd2`.
+    final kind = TripKind.fromSamples(samples);
+    // #2760 — stamp the aggregate-only IMU event counts. THREE scalars; the
+    // raw ~50 Hz inertial stream was folded into them in real time and is
+    // never persisted. When the IMU produced events on a dongle-less trip,
+    // PREFER them for the `harshAccelerations` / `harshBrakes` the driving
+    // score reads (`driving_score_calculator.dart`): a direct inertial
+    // reading is a more accurate harsh-manoeuvre signal than the GPS
+    // speed-derivative the recorder's [HarshEventDetector] used. The
+    // speed-derived counts stay the fallback when the IMU saw nothing.
+    final imuAccel = imuDetector?.hardAccelCount ?? 0;
+    final imuBrake = imuDetector?.hardBrakeCount ?? 0;
+    final imuCorners = imuDetector?.sharpCornerCount ?? 0;
+    final preferImu = kind == TripKind.gpsOnly && (imuAccel > 0 || imuBrake > 0);
     var summary = recorder.buildSummary().copyWith(
-          kind: TripKind.fromSamples(samples),
+          kind: kind,
+          imuHardAccelCount: imuAccel,
+          imuHardBrakeCount: imuBrake,
+          sharpCornerCount: imuCorners,
+          harshAccelerations: preferImu ? imuAccel : null,
+          harshBrakes: preferImu ? imuBrake : null,
         );
     // #2080 — for GPS-only / hybrid trips (no OBD2 fuel-rate
     // coverage), feed the sample stream through GpsDrivingFeatures +

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1612,6 +1612,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  sensors_plus:
+    dependency: "direct main"
+    description:
+      name: sensors_plus
+      sha256: "56e8cd4260d9ed8e00ecd8da5d9fdc8a1b2ec12345a750dfa51ff83fcf12e3fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  sensors_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: sensors_plus_platform_interface
+      sha256: "58815d2f5e46c0c41c40fb39375d3f127306f7742efe3b891c0b1c87e2b5cd5d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   sentry:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,12 @@ dependencies:
   latlong2: ^0.9.1
   geolocator: ^14.0.2
   geocoding: ^4.0.0
+  # IMU sensor fusion for dongle-optional driving analytics (#2760).
+  # Pure-platform accelerometer + gyroscope (Android SensorManager /
+  # iOS CoreMotion) — no GMS / Play Services dependency, so it ships on
+  # the F-Droid flavour unchanged (ADR 0003). Only imported by
+  # lib/core/sensors/imu_sensor_source.dart (loosely-coupled plugin idiom).
+  sensors_plus: ^7.0.0
 
   # Routing
   go_router: ^17.2.3

--- a/test/features/approach/providers/gps_only_radar_race_test.dart
+++ b/test/features/approach/providers/gps_only_radar_race_test.dart
@@ -31,6 +31,7 @@ import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+import '../../../helpers/empty_imu_source.dart';
 import '../../../helpers/silence_error_logger.dart';
 
 /// #2646 integration regression — the fuel-station radar + swipe must work in
@@ -250,6 +251,9 @@ void main() {
 
     final container = ProviderContainer(overrides: [
       geolocatorWrapperProvider.overrideWithValue(geo),
+      // #2760 — quiet IMU source so the GPS-only pipeline's new fusion attach
+      // doesn't reach the real sensors_plus platform channel.
+      imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       tripRecordingProvider.overrideWith(_RecordingTrip.new),
       activeProfileProvider.overrideWith(_FixedProfile.new),
       effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),

--- a/test/features/consumption/domain/services/imu_event_detector_test.dart
+++ b/test/features/consumption/domain/services/imu_event_detector_test.dart
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sensors/imu_sample.dart';
+import 'package:tankstellen/features/consumption/domain/harsh_event.dart';
+import 'package:tankstellen/features/consumption/domain/services/imu_event_detector.dart';
+
+/// Reuse-fidelity tests for the pure [ImuEventDetector] (#2760). No
+/// request-echoing fake: we replay a fixed synthetic [ImuSample] stream at a
+/// 50 ms cadence and assert the in-memory episode counters — proving the
+/// debounce (one event per sustained episode, NOT one per sample) the
+/// aggregate-only design depends on.
+void main() {
+  const cadence = Duration(milliseconds: 50);
+  final t0 = DateTime(2026, 6, 1, 8);
+
+  /// Feed [det] a burst: [count] samples 50 ms apart starting at [start],
+  /// each carrying horizontal accel magnitude [mag] (on the X axis) and yaw
+  /// [yaw], with the GPS speed stepped by [speedStepKmh] per sample from
+  /// [startSpeedKmh]. Returns the timestamp just after the last sample.
+  DateTime feed(
+    ImuEventDetector det, {
+    required DateTime start,
+    required int count,
+    required double mag,
+    double yaw = 0.0,
+    required double startSpeedKmh,
+    double speedStepKmh = 0.0,
+  }) {
+    var t = start;
+    var speed = startSpeedKmh;
+    for (var i = 0; i < count; i++) {
+      det.currentSpeedKmh = speed;
+      det.onSample(ImuSample(
+        t: t,
+        axMps2: mag,
+        ayMps2: 0,
+        azMps2: 0,
+        gyroZRadPerSec: yaw,
+      ));
+      t = t.add(cadence);
+      speed += speedStepKmh;
+    }
+    return t;
+  }
+
+  test('a sustained 1.5 s 4.0 m/s² burst with speed rising → ONE hard accel '
+      '(episode debounce, not 30)', () {
+    final det = ImuEventDetector();
+    // 1.5 s at 50 ms = 30 samples. Speed climbs so the direction is "accel".
+    feed(det,
+        start: t0,
+        count: 30,
+        mag: 4.0,
+        startSpeedKmh: 30,
+        speedStepKmh: 0.5);
+    expect(det.hardAccelCount, 1,
+        reason: 'one sustained episode counts once, not per-sample');
+    expect(det.hardBrakeCount, 0);
+    expect(det.sharpCornerCount, 0);
+  });
+
+  test('a 4 s 4.0 m/s² burst with speed falling → ONE hard brake', () {
+    final det = ImuEventDetector();
+    // 4 s = 80 samples; speed falls so the direction is "brake".
+    feed(det,
+        start: t0,
+        count: 80,
+        mag: 4.0,
+        startSpeedKmh: 100,
+        speedStepKmh: -0.5);
+    expect(det.hardBrakeCount, 1);
+    expect(det.hardAccelCount, 0);
+  });
+
+  test('a 2.5 s lateral 4.0 m/s² + yaw 0.4 rad/s at ~constant speed → ONE '
+      'sharp corner', () {
+    final det = ImuEventDetector();
+    // Constant speed (step 0) so the corner gate's constant-speed clause
+    // holds; yaw above the 0.30 gate; 2.5 s > the 2.0 s sustained floor.
+    feed(det,
+        start: t0,
+        count: 50,
+        mag: 4.0,
+        yaw: 0.4,
+        startSpeedKmh: 60,
+        speedStepKmh: 0.0);
+    expect(det.sharpCornerCount, 1);
+    expect(det.hardAccelCount, 0,
+        reason: 'a constant-speed high-yaw bend is a corner, not an accel');
+    expect(det.hardBrakeCount, 0);
+  });
+
+  test('a 0.5 s 4.0 m/s² spike → ZERO (below the 1 s sustained floor)', () {
+    final det = ImuEventDetector();
+    // 0.5 s = 10 samples — under the 1.0 s accel/brake floor.
+    feed(det,
+        start: t0,
+        count: 10,
+        mag: 4.0,
+        startSpeedKmh: 50,
+        speedStepKmh: 0.5);
+    expect(det.hardAccelCount, 0);
+    expect(det.hardBrakeCount, 0);
+  });
+
+  test('standstill (speed < 5 km/h) jitter → ZERO (min-speed gate)', () {
+    final det = ImuEventDetector();
+    // A long, strong inertial burst but at a near-standstill — the parked /
+    // walking-pace gate must drop every sample.
+    feed(det,
+        start: t0,
+        count: 80,
+        mag: 5.0,
+        yaw: 0.5,
+        startSpeedKmh: 2.0,
+        speedStepKmh: 0.0);
+    expect(det.hardAccelCount, 0);
+    expect(det.hardBrakeCount, 0);
+    expect(det.sharpCornerCount, 0);
+  });
+
+  test('two separate 1.5 s accel bursts with a sub-threshold gap → TWO '
+      '(re-arm)', () {
+    final det = ImuEventDetector();
+    var t = feed(det,
+        start: t0,
+        count: 30,
+        mag: 4.0,
+        startSpeedKmh: 30,
+        speedStepKmh: 0.5);
+    // A 1 s calm gap (below threshold) re-arms the latch.
+    t = feed(det,
+        start: t,
+        count: 20,
+        mag: 0.2,
+        startSpeedKmh: 45,
+        speedStepKmh: 0.0);
+    feed(det,
+        start: t,
+        count: 30,
+        mag: 4.0,
+        startSpeedKmh: 45,
+        speedStepKmh: 0.5);
+    expect(det.hardAccelCount, 2,
+        reason: 'the calm gap re-arms, so the second burst counts again');
+  });
+
+  test('one continuous 3 s accel stretch → ONE (latch holds)', () {
+    final det = ImuEventDetector();
+    feed(det,
+        start: t0,
+        count: 60,
+        mag: 4.0,
+        startSpeedKmh: 30,
+        speedStepKmh: 0.4);
+    expect(det.hardAccelCount, 1,
+        reason: 'no sub-threshold gap → the latch holds → one episode');
+  });
+
+  test('onEvent fires once per confirmed accel/brake episode with the right '
+      'type (bus wiring)', () {
+    final fired = <HarshEvent>[];
+    final det = ImuEventDetector(onEvent: fired.add);
+    var t = feed(det,
+        start: t0,
+        count: 30,
+        mag: 4.0,
+        startSpeedKmh: 30,
+        speedStepKmh: 0.5);
+    // Calm gap, then a brake.
+    t = feed(det,
+        start: t,
+        count: 20,
+        mag: 0.2,
+        startSpeedKmh: 45,
+        speedStepKmh: 0.0);
+    feed(det,
+        start: t,
+        count: 40,
+        mag: 4.0,
+        startSpeedKmh: 90,
+        speedStepKmh: -0.5);
+    expect(fired, hasLength(2));
+    expect(fired[0].type, HarshEventType.acceleration);
+    expect(fired[1].type, HarshEventType.brake);
+    // Magnitude is reported in g, derived from the 4.0 m/s² horizontal mag.
+    expect(fired[0].magnitudeG, closeTo(4.0 / standardGravityMps2, 1e-6));
+  });
+}

--- a/test/features/consumption/providers/gps_only_imu_fusion_test.dart
+++ b/test/features/consumption/providers/gps_only_imu_fusion_test.dart
@@ -1,0 +1,414 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
+import 'package:tankstellen/core/sensors/imu_sample.dart';
+import 'package:tankstellen/core/sensors/imu_sensor_source.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
+import 'package:tankstellen/features/consumption/domain/entities/trip_save_stage.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/providers/gps_only_recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/recording_pipeline.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_phase.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_state.dart';
+import 'package:tankstellen/features/driving/providers/live_harsh_event_bus_provider.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+import '../../../helpers/silence_error_logger.dart';
+
+/// #2760 — GPS+IMU sensor-fusion integration tests for the dongle-optional
+/// pipeline. Drives the real [GpsOnlyRecordingPipeline] against a fake
+/// [ImuSensorSource] emitting a fixed synthetic [ImuSample] stream (NOT a
+/// request-echoing fake) and a real [TripHistoryRepository], proving the four
+/// binding behaviours: debounced aggregate counts persist, NO raw IMU samples
+/// reach disk, the inertial subscription opens once / cancels on stop / never
+/// survives between trips, and confirmed episodes reach the live harsh-event
+/// bus.
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late Box<String> box;
+
+  setUp(() async {
+    tmpDir = Directory.systemTemp.createTempSync('gps_imu_test_');
+    Hive.init(tmpDir.path);
+    box = await Hive.openBox<String>(
+      'imu_${DateTime.now().microsecondsSinceEpoch}',
+    );
+  });
+
+  tearDown(() async {
+    await box.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  group('GPS+IMU fusion in GpsOnlyRecordingPipeline (#2760)', () {
+    test('NO-RAW-PERSISTENCE: a recorded trip carries the debounced IMU '
+        'counts AND the JSON holds ONLY the 3 scalar keys (no raw array)',
+        () async {
+      final repo = TripHistoryRepository(box: box);
+      // One sustained 2 s hard-accel burst (speed rising) → exactly ONE
+      // accel episode, NOT one per ~50 Hz sample.
+      final imu = _FakeImuSource(_accelBurst(
+        start: DateTime(2026, 6, 1, 8),
+        seconds: 2.0,
+        mag: 4.0,
+      ));
+      final harness = _Harness(repo: repo, imu: imu);
+      addTearDown(harness.dispose);
+
+      harness.pipeline.start();
+      final t0 = DateTime(2026, 6, 1, 8);
+      // First fix: detector speed = 72 km/h (moving, above the 5 km/h gate).
+      // The burst's start-speed anchor is captured here.
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 20.0, at: t0));
+      await _pump();
+      final half = harness.imu.sampleCount ~/ 2;
+      harness.imu.emitBurst(0, half);
+      await _pump();
+      // Second fix mid-burst: speed rises to 90 km/h → the net speed change
+      // over the strong stretch is +18 km/h, so it classifies as a HARD
+      // ACCEL, not a brake. Non-zero integrated distance too.
+      harness.geo.emit(_pos(43.41, 3.51,
+          speedMps: 25.0, at: t0.add(const Duration(seconds: 1))));
+      await _pump();
+      harness.imu.emitBurst(half);
+      await _pump();
+
+      await harness.pipeline.stop();
+
+      // (a) the round-tripped summary carries the debounced count.
+      final entries = repo.loadAll();
+      expect(entries, hasLength(1));
+      final summary = entries.single.summary;
+      expect(summary.imuHardAccelCount, 1,
+          reason: 'one sustained episode, not ~100 raw samples');
+      expect(summary.imuHardBrakeCount, 0);
+
+      // (b) the persisted JSON holds ONLY the 3 scalar keys — never a raw
+      // per-sample IMU array. The byte cost is O(bytes), not O(seconds×50).
+      final raw = box.get(entries.single.id)!;
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      final summaryJson = decoded['summary'] as Map<String, dynamic>;
+      expect(summaryJson['iha'], 1, reason: 'the one accel count, as a scalar');
+      // No raw-IMU payload of any plausible shape leaked in anywhere.
+      for (final k in ['imu', 'imuSamples', 'samplesImu', 'imuRaw']) {
+        expect(summaryJson.containsKey(k), isFalse,
+            reason: 'no raw IMU key "$k" in the summary');
+        expect(decoded.containsKey(k), isFalse,
+            reason: 'no raw IMU key "$k" at the entry root');
+      }
+      // The persisted size is dominated by the trip's GPS samples + a handful
+      // of scalars — NOT ~100 IMU sample objects. A 2 s 50 Hz raw dump would
+      // be ~100 entries; the encoded payload here is tiny.
+      expect(raw.length, lessThan(4096),
+          reason: 'aggregate-only — no O(seconds×50) raw-IMU payload');
+      // No value anywhere in the JSON is a list of > 50 elements (a smoking
+      // gun for a per-sample dump). The only lists are bounded aggregates.
+      _assertNoLargeArray(decoded);
+    });
+
+    test('LIFECYCLE: exactly one IMU subscription opens on start, is '
+        'cancelled on stop, and none exists between trips', () async {
+      final imu = _FakeImuSource(const []);
+      final harness = _Harness(repo: TripHistoryRepository(box: box), imu: imu);
+      addTearDown(harness.dispose);
+
+      expect(imu.activeListeners, 0, reason: 'none before start');
+
+      harness.pipeline.start();
+      await _pump();
+      expect(imu.activeListeners, 1, reason: 'exactly one opens on start');
+      // Mirror the GPS _sub assertion: the geolocator stream is also open.
+      expect(harness.geo.activeListeners, 1);
+
+      await harness.pipeline.stop();
+      expect(imu.activeListeners, 0, reason: 'cancelled on stop');
+      expect(harness.geo.activeListeners, 0);
+
+      // A second trip re-opens exactly one and tears it down again — none
+      // ever survives between trips.
+      harness.pipeline.start();
+      await _pump();
+      expect(imu.activeListeners, 1);
+      await harness.pipeline.stop();
+      expect(imu.activeListeners, 0);
+      expect(imu.totalSubscriptions, 2, reason: 'one per trip, no leak');
+    });
+
+    test('BUS WIRING: each confirmed IMU accel/brake episode pushes a '
+        'HarshEvent onto LiveHarshEventBus', () async {
+      final imu = _FakeImuSource(_accelBurst(
+        start: DateTime(2026, 6, 1, 9),
+        seconds: 2.0,
+        mag: 4.0,
+      ));
+      final harness = _Harness(repo: TripHistoryRepository(box: box), imu: imu);
+      addTearDown(harness.dispose);
+
+      // Subscribe to the bus before the trip drives any event.
+      final events = <HarshEvent>[];
+      final busSub = harness.container
+          .read(liveHarshEventBusProvider.notifier)
+          .stream
+          .listen(events.add);
+      addTearDown(busSub.cancel);
+
+      harness.pipeline.start();
+      final t0 = DateTime(2026, 6, 1, 9);
+      // Rising GPS speed across the burst so it classifies as a hard accel.
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 15.0, at: t0));
+      await _pump();
+      final half = harness.imu.sampleCount ~/ 2;
+      harness.imu.emitBurst(0, half);
+      await _pump();
+      harness.geo.emit(_pos(43.41, 3.51,
+          speedMps: 25.0, at: t0.add(const Duration(seconds: 1))));
+      await _pump();
+      harness.imu.emitBurst(half);
+      await _pump();
+
+      expect(events, isNotEmpty,
+          reason: 'a confirmed IMU episode must reach the coaching bus');
+      expect(events.first.type, HarshEventType.acceleration);
+
+      await harness.pipeline.stop();
+    });
+  });
+}
+
+/// Builds a 50 ms-cadence accel burst: [seconds] of 4.0 m/s² horizontal
+/// magnitude on the X axis, gravity-removed, no yaw.
+List<ImuSample> _accelBurst({
+  required DateTime start,
+  required double seconds,
+  required double mag,
+}) {
+  final out = <ImuSample>[];
+  final n = (seconds / 0.05).round();
+  var t = start;
+  for (var i = 0; i < n; i++) {
+    out.add(ImuSample(
+      t: t,
+      axMps2: mag,
+      ayMps2: 0,
+      azMps2: 0,
+      gyroZRadPerSec: 0,
+    ));
+    t = t.add(const Duration(milliseconds: 50));
+  }
+  return out;
+}
+
+/// Recursively assert no list deeper in [json] has > 50 elements — a
+/// per-sample IMU dump of a 2 s trip would be ~40-100. Bounded aggregates
+/// (harshEvents, diagnostics) are far smaller.
+void _assertNoLargeArray(Object? node) {
+  if (node is List) {
+    expect(node.length, lessThanOrEqualTo(50),
+        reason: 'a >50-element array smells like a raw per-sample dump');
+    for (final e in node) {
+      _assertNoLargeArray(e);
+    }
+  } else if (node is Map) {
+    for (final v in node.values) {
+      _assertNoLargeArray(v);
+    }
+  }
+}
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+/// A fake [ImuSensorSource] that replays a FIXED synthetic sample list (no
+/// request-echoing) and tracks listener lifecycle so the pipeline's
+/// subscribe-once / cancel-on-stop contract is observable.
+///
+/// The burst is NOT auto-emitted on listen — the test calls [emitBurst] AFTER
+/// it has fed the first GPS fix, so the detector's GPS-fed speed is set before
+/// the inertial burst is classified (the same ordering the live pipeline sees:
+/// GPS fixes and ~50 Hz IMU samples interleave continuously). The held
+/// samples then flow onto the current subscription's controller.
+class _FakeImuSource extends ImuSensorSource {
+  _FakeImuSource(this._samples);
+
+  final List<ImuSample> _samples;
+  int activeListeners = 0;
+  int totalSubscriptions = 0;
+  StreamController<ImuSample>? _ctl;
+
+  @override
+  Stream<ImuSample> stream() {
+    // The consumer (the pipeline) cancels this subscription on stop; the
+    // controller is single-use per trip and dropped with the harness.
+    // ignore: close_sinks
+    final ctl = StreamController<ImuSample>(
+      onListen: () {
+        activeListeners++;
+        totalSubscriptions++;
+      },
+      onCancel: () => activeListeners--,
+    );
+    _ctl = ctl;
+    return ctl.stream;
+  }
+
+  /// Push a slice [from, to) of the fixed synthetic burst onto the live
+  /// subscription. The test interleaves slices with GPS-speed bumps so the
+  /// detector's net-speed-change direction logic sees a rising / falling
+  /// trend across the burst, exactly as the live ~50 Hz IMU vs ~1 Hz GPS
+  /// streams interleave.
+  void emitBurst([int? from, int? to]) {
+    final ctl = _ctl;
+    if (ctl == null || ctl.isClosed) return;
+    final slice = _samples.sublist(from ?? 0, to ?? _samples.length);
+    for (final s in slice) {
+      ctl.add(s);
+    }
+  }
+
+  int get sampleCount => _samples.length;
+}
+
+/// Wires a real [GpsOnlyRecordingPipeline] to a real [TripHistoryRepository]
+/// (via a host that persists) + a fake Geolocator + a fake IMU source.
+class _Harness {
+  _Harness({required TripHistoryRepository repo, required this.imu})
+      : host = _PersistingHost(repo: repo) {
+    container = ProviderContainer(overrides: [
+      geolocatorWrapperProvider.overrideWithValue(geo),
+      imuSensorSourceProvider.overrideWithValue(imu),
+      activeVehicleProfileProvider.overrideWith(_NoActiveVehicle.new),
+    ]);
+    pipeline = container.read(_pipelineProvider(host));
+  }
+
+  final _PersistingHost host;
+  final _FakeImuSource imu;
+  final _RecordingGeolocator geo = _RecordingGeolocator();
+  late final ProviderContainer container;
+  late final GpsOnlyRecordingPipeline pipeline;
+
+  void dispose() {
+    container.dispose();
+    geo.dispose();
+  }
+}
+
+final _pipelineProvider =
+    Provider.family<GpsOnlyRecordingPipeline, RecordingPipelineHost>(
+  (ref, host) => GpsOnlyRecordingPipeline(ref: ref, host: host),
+);
+
+class _NoActiveVehicle extends ActiveVehicleProfile {
+  @override
+  VehicleProfile? build() => null;
+}
+
+/// A host that writes the finished summary to a REAL repository, so the
+/// no-raw-persistence test inspects the actual on-disk JSON.
+class _PersistingHost implements RecordingPipelineHost {
+  _PersistingHost({required this.repo});
+
+  final TripHistoryRepository repo;
+
+  @override
+  TripRecordingState state = const TripRecordingState();
+
+  @override
+  String? lastTripVehicleId;
+
+  @override
+  DateTime? lastTripStartedAt;
+
+  @override
+  String? readActiveVehicleId() => null;
+
+  @override
+  void setSaveStage(TripSaveStage stage) {
+    state = state.copyWith(phase: TripRecordingPhase.saving, saveStage: stage);
+  }
+
+  @override
+  Future<TripPersistOutcome> saveToHistory(
+    TripSummary summary, {
+    bool automatic = false,
+    List<TripSample> samples = const [],
+    List<GpsSampleDiagnostic> gpsSampleDiagnostics = const [],
+    String? vehicleId,
+    String? adapterMac,
+    String? adapterName,
+    String? adapterFirmware,
+    int gpsFixCount = 0,
+  }) async {
+    final start = summary.startedAt ?? lastTripStartedAt ?? DateTime.now();
+    await repo.save(TripHistoryEntry(
+      id: start.toIso8601String(),
+      vehicleId: vehicleId,
+      summary: summary,
+    ));
+    return TripPersistOutcome.saved;
+  }
+}
+
+Position _pos(
+  double lat,
+  double lng, {
+  double speedMps = 0,
+  double altitude = 0,
+  DateTime? at,
+}) =>
+    Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: at ?? DateTime.now(),
+      accuracy: 5,
+      altitude: altitude,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: speedMps,
+      speedAccuracy: 0,
+    );
+
+/// Controllable fake [GeolocatorWrapper] — mirrors the one in
+/// gps_only_recording_pipeline_test.dart, overriding the SHARED source the
+/// pipeline subscribes to.
+class _RecordingGeolocator extends GeolocatorWrapper {
+  int positionStreamCallCount = 0;
+  LocationAccuracy? lastAccuracy;
+  StreamController<Position>? _controller;
+  int activeListeners = 0;
+
+  @override
+  Stream<Position> sharedPositionStream({LocationSettings? locationSettings}) {
+    positionStreamCallCount++;
+    lastAccuracy = locationSettings?.accuracy;
+    final prev = _controller;
+    if (prev != null && !prev.isClosed) prev.close();
+    _controller = StreamController<Position>(
+      onListen: () => activeListeners++,
+      onCancel: () => activeListeners--,
+    );
+    return _controller!.stream;
+  }
+
+  void emit(Position p) => _controller?.add(p);
+
+  Future<void> dispose() async {
+    final c = _controller;
+    if (c != null && !c.isClosed) await c.close();
+  }
+}

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -18,6 +18,7 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_state.
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
 import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 
+import '../../../helpers/empty_imu_source.dart';
 import '../../../helpers/silence_error_logger.dart';
 
 /// Direct unit tests for the #2190 [GpsOnlyRecordingPipeline] strategy,
@@ -287,6 +288,11 @@ class _Harness {
       : host = _FakeHost(activeVehicleId: activeVehicleId) {
     container = ProviderContainer(overrides: [
       geolocatorWrapperProvider.overrideWithValue(geo),
+      // #2760 — the pipeline now attaches IMU fusion in start(); stub it with
+      // an empty source so these GPS-focused tests don't touch the real
+      // sensors_plus platform channel. (Dedicated IMU coverage lives in
+      // gps_only_imu_fusion_test.dart + imu_event_detector_test.dart.)
+      imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       // No active vehicle → the #2080 GPS-fuel imputation branch sees a
       // null profile and leaves avg / litres null, mirroring a fresh
       // install. (Production reads the real provider here.) When

--- a/test/features/consumption/providers/trip_recording_pipeline_selection_test.dart
+++ b/test/features/consumption/providers/trip_recording_pipeline_selection_test.dart
@@ -11,6 +11,7 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
 
+import '../../../helpers/empty_imu_source.dart';
 import '../../../helpers/silence_error_logger.dart';
 
 /// #2190 — pins which recording strategy the [TripRecording] notifier
@@ -27,6 +28,7 @@ void main() {
       final fakeGeo = _FakeGeo();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);
@@ -71,6 +73,7 @@ void main() {
       final fakeGeo = _FakeGeo();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);

--- a/test/features/consumption/providers/trip_recording_provider_gps_test.dart
+++ b/test/features/consumption/providers/trip_recording_provider_gps_test.dart
@@ -13,6 +13,8 @@ import 'package:tankstellen/features/consumption/providers/trip_recording_provid
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 
+import '../../../helpers/empty_imu_source.dart';
+
 /// Verifies the [Feature.gpsTripPath]-gated GPS subscription wiring
 /// inside [TripRecording.start] (#1374 phase 1).
 ///
@@ -40,6 +42,7 @@ void main() {
       final fakeGeo = _RecordingGeolocator();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);
@@ -81,6 +84,7 @@ void main() {
       final fakeGeo = _RecordingGeolocator();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);
@@ -158,6 +162,7 @@ void main() {
       final fakeGeo = _RecordingGeolocator();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);
@@ -202,6 +207,7 @@ void main() {
         ..permission = LocationPermission.denied;
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);
@@ -239,6 +245,7 @@ void main() {
       final fakeGeo = _RecordingGeolocator();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);
@@ -283,6 +290,7 @@ void main() {
       final fakeGeo = _RecordingGeolocator();
       final container = ProviderContainer(overrides: [
         geolocatorWrapperProvider.overrideWithValue(fakeGeo),
+        imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       ]);
       addTearDown(container.dispose);
       addTearDown(fakeGeo.dispose);

--- a/test/helpers/empty_imu_source.dart
+++ b/test/helpers/empty_imu_source.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:tankstellen/core/sensors/imu_sample.dart';
+import 'package:tankstellen/core/sensors/imu_sensor_source.dart';
+
+// Re-export so a test importing this helper can write the override
+// `imuSensorSourceProvider.overrideWithValue(EmptyImuSource())` with this one
+// import.
+export 'package:tankstellen/core/sensors/imu_sensor_source.dart'
+    show imuSensorSourceProvider;
+
+/// A stub [ImuSensorSource] that yields no samples (#2760).
+///
+/// The GPS-only recording pipeline now attaches IMU sensor fusion in
+/// `start()`. Tests that drive the pipeline (directly or via the
+/// `TripRecording` notifier) but are NOT exercising the IMU path override
+/// `imuSensorSourceProvider` with this so they never touch the real
+/// `sensors_plus` platform channel (which has no binding in a unit-test
+/// process). Dedicated IMU coverage lives in
+/// `gps_only_imu_fusion_test.dart` + `imu_event_detector_test.dart`.
+class EmptyImuSource extends ImuSensorSource {
+  @override
+  Stream<ImuSample> stream() => const Stream<ImuSample>.empty();
+}


### PR DESCRIPTION
Closes #2760

## What

Makes the OBD2 dongle truly **optional** by hardening the GPS-only recording pipeline with real IMU sensor fusion — the only free + private + offline + every-brand path. Accelerometer + gyroscope harsh-accel / harsh-brake / sharp-corner detection runs on-device in real time.

## Binding constraint — aggregate-only, disk-efficient

NEVER buffers or persists the raw ~50 Hz IMU sample stream. The pure detector folds each sample into a handful of in-memory integer counters; on stop only 3 scalars survive (`iha` / `ihb` / `sc`, each omitted when 0). `ImuSample` has no `toJson` by design.

## Files

- `lib/core/sensors/imu_sample.dart` — tiny in-memory value type.
- `lib/core/sensors/imu_sensor_source.dart` — the **single** `sensors_plus` import site (loosely-coupled plugin idiom, mirroring `geolocator_wrapper`). Zips `userAccelerometerEventStream` (gravity-removed linear accel — not raw) + gyroscope at `SensorInterval.gameInterval` (~50 Hz). Degrades to a quiet stream on a sensor-less / unbound host.
- `lib/features/consumption/domain/services/imu_event_detector.dart` — pure (no plugin import). Shares `accel_event_gate`'s thresholds (3.0 / 3.5 m/s²), 1.0 s sustained floor, 5 km/h min-speed gate, and one-event-per-episode latch/re-arm. Accel-vs-brake direction comes from the **net GPS-speed change** over the manoeuvre (robust to 1 Hz GPS vs 50 Hz IMU); corner = lateral ≥3.5 m/s² AND |yaw| ≥ `kSharpCornerYawRateRadPerSec` (0.30) at ~constant speed, sustained 2 s. Confirmed accel/brake episodes feed the same `LiveHarshEventBus` (dongle-less coaching).
- `trip_summary.dart` — 3 new `int` fields (default 0) + derived per-km getters (plain class, no codegen).
- `trip_history_repository.dart` — 3 guarded compact scalar keys.
- `gps_only_recording_pipeline.dart` — attaches the detector + IMU subscription in `start()` (**IMU only here** — the OBD2 path is behaviour-preserving), feeds GPS speed, cancels in `stop()` beside the geolocator sub, stamps the counts, and prefers the IMU accel/brake counts for the driving score on GPS-only trips.

## GMS-free (F-Droid)

`sensors_plus` is pure-platform (`SensorManager` / CoreMotion). Its only Android dependency is `kotlin-stdlib` — no `com.google.android.gms` / Firebase / MLKit — so it enters no fdroid runtime classpath (ADR 0003). (The Gradle dependency-graph audit could not run in the build sandbox — no JDK — but the plugin's `build.gradle` was inspected and carries zero Google coordinates.)

## Scope

ARB-free — no new UI row/label (corner-count surfacing is an explicit follow-up). No `lib/l10n/` drift. One new `.g.dart` (`imu_sensor_source.g.dart`); clean codegen committed.

## Tests

- `imu_event_detector_test.dart` — sustained 1.5 s burst → 1 (not 30, proves debounce); 4 s brake → 1; 2.5 s lateral+yaw → 1 corner; 0.5 s spike → 0; standstill jitter → 0; two bursts with a gap → 2 (re-arm); one continuous stretch → 1 (latch); onEvent fires per episode.
- `gps_only_imu_fusion_test.dart` — (1) **no-raw-persistence**: reload from a real repo, only the 3 scalar keys in the JSON, payload < 4 KB, no >50-element array; (2) **lifecycle**: exactly one IMU subscription opens on start, cancels on stop, none survives between trips; (3) **bus wiring**: each confirmed episode pushes a `HarshEvent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
