### PR TITLE
fix(trip-recording): stop 'Moyenne' per-letter wrap + 'Enr…' title truncation (#2764)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -33,6 +33,7 @@ import '../../providers/wakelock_facade.dart';
 import '../widgets/broken_map_widgets.dart';
 import '../widgets/minimal_drive_summary.dart';
 import '../widgets/obd2_breadcrumb_overlay.dart';
+import '../widgets/recording_app_bar_actions.dart';
 import '../widgets/trip_avg_consumption_card.dart';
 import '../widgets/trip_radar_card.dart';
 import '../widgets/trip_save_progress.dart';
@@ -763,73 +764,23 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
         // recording fires a one-time tooltip pointing at the banner.
         onPressed: _onBackPressed,
       ),
+      // #2764 — the 5 inline IconButtons truncated the title to "Enr…".
+      // Pause + Stop stay primary; Pin / Help / PiP fold into a single
+      // overflow kebab (see [RecordingAppBarActions]).
       actions: stopped != null
           ? null
           : [
-              // #891 — wrap in Semantics so TalkBack announces the
-              // *next* action (Pin / Unpin) in addition to the
-              // tooltip's battery-cost hint. `container: true`
-              // merges the IconButton's tap semantics into the label.
-              Semantics(
-                container: true,
-                button: true,
-                toggled: _pinned,
-                label: _pinned
-                    ? (l?.tripRecordingPinSemanticOn ??
-                        'Unpin recording form')
-                    : (l?.tripRecordingPinSemanticOff ??
-                        'Pin recording form'),
-                child: IconButton(
-                  key: const Key('tripPinButton'),
-                  icon: Icon(
-                    _pinned ? Icons.push_pin : Icons.push_pin_outlined,
-                    color: _pinned
-                        ? Theme.of(context).colorScheme.primary
-                        : null,
-                  ),
-                  tooltip: l?.tripRecordingPinTooltip ??
-                      'Pinning keeps the screen on — uses more battery',
-                  isSelected: _pinned,
-                  onPressed: _togglePin,
-                ),
-              ),
-              // #1273 — `?` icon adjacent to the pin button. Always
-              // visible (no toggle gating); first-launch users need
-              // a path to "what does this button do" without leaving
-              // the recording screen.
-              IconButton(
-                key: const Key('tripPinHelpButton'),
-                icon: const Icon(Icons.help_outline),
-                tooltip: l?.tripRecordingPinHelpTooltip ??
-                    'What does pin do?',
-                onPressed: _showPinHelp,
-              ),
-              // #1884 — minimise the recording into a floating
-              // Picture-in-Picture tile. Android-only; the button is
-              // absent where PiP can't host app UI.
-              if (_pip.isSupported)
-                IconButton(
-                  key: const Key('tripMinimiseButton'),
-                  icon: const Icon(Icons.picture_in_picture_alt),
-                  tooltip: l?.tripRecordingMinimiseTooltip ??
-                      'Minimise to a floating tile',
-                  onPressed: () => _pip.enterPip(),
-                ),
-              IconButton(
-                key: const Key('tripPauseButton'),
-                icon: Icon(state.phase == TripRecordingPhase.paused
-                    ? Icons.play_arrow
-                    : Icons.pause),
-                tooltip: state.phase == TripRecordingPhase.paused
-                    ? (l?.tripResume ?? 'Resume')
-                    : (l?.tripPause ?? 'Pause'),
-                onPressed: state.isActive ? _togglePause : null,
-              ),
-              IconButton(
-                key: const Key('tripStopButton'),
-                icon: const Icon(Icons.stop_circle_outlined),
-                tooltip: l?.tripStop ?? 'Stop recording',
-                onPressed: _stopping || !state.isActive ? null : _onStop,
+              RecordingAppBarActions(
+                pinned: _pinned,
+                pipSupported: _pip.isSupported,
+                isActive: state.isActive,
+                isPaused: state.phase == TripRecordingPhase.paused,
+                stopping: _stopping,
+                onTogglePin: _togglePin,
+                onShowPinHelp: _showPinHelp,
+                onEnterPip: () => _pip.enterPip(),
+                onTogglePause: _togglePause,
+                onStop: _onStop,
               ),
             ],
       bodyPadding: EdgeInsets.zero,
@@ -1112,13 +1063,29 @@ class _MetricCard extends StatelessWidget {
     final theme = Theme.of(context);
     return Card(
       margin: EdgeInsets.zero,
-      child: ListTile(
-        leading: Icon(icon, size: 28),
-        title: Text(label, style: theme.textTheme.bodySmall),
-        trailing: Text(
-          value,
-          style: theme.textTheme.titleLarge
-              ?.copyWith(fontFeatures: const [FontFeature.tabularFigures()]),
+      // #2764 — explicit Row over a ListTile title/trailing split: the
+      // label gets the flexible space and ellipsizes, the value keeps
+      // its intrinsic width (mirrors TripAvgConsumptionCard's fix).
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            Icon(icon, size: 28),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                label,
+                style: theme.textTheme.bodySmall,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              value,
+              style: theme.textTheme.titleLarge?.copyWith(
+                  fontFeatures: const [FontFeature.tabularFigures()]),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/consumption/presentation/widgets/recording_app_bar_actions.dart
+++ b/lib/features/consumption/presentation/widgets/recording_app_bar_actions.dart
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+
+/// Overflow targets the recording kebab dispatches via its single
+/// `onSelected` path (#2764). Each item maps to a callback the host
+/// [TripRecordingScreen] already owns (pin / help / PiP).
+enum _RecordingOverflowAction { pin, help, pip }
+
+/// Trailing app-bar actions for the active trip-recording screen (#2764).
+///
+/// Material 3 caps a top app bar at ~3 trailing actions before the title
+/// starts truncating; the old inline layout emitted 5 (Pin + Help + PiP +
+/// Pause + Stop) which clipped the title to "Enr…". This widget keeps the
+/// two primary controls — **Pause + Stop** — as visible [IconButton]s and
+/// folds **Pin, Help, PiP** into a single `more_vert` overflow kebab so the
+/// title always has room. Mirrors the #2761 consumption-screen pattern.
+///
+/// All behaviour + keys are preserved: the pin item reflects [pinned] (icon
+/// + label flip + a `Semantics(toggled:)` wrapper for TalkBack), the PiP
+/// item only renders when [pipSupported] is true, and Help opens the same
+/// target via [onShowPinHelp].
+class RecordingAppBarActions extends StatelessWidget {
+  const RecordingAppBarActions({
+    super.key,
+    required this.pinned,
+    required this.pipSupported,
+    required this.isActive,
+    required this.isPaused,
+    required this.stopping,
+    required this.onTogglePin,
+    required this.onShowPinHelp,
+    required this.onEnterPip,
+    required this.onTogglePause,
+    required this.onStop,
+  });
+
+  /// Whether the recording form is currently pinned (wake lock held).
+  final bool pinned;
+
+  /// Whether Picture-in-Picture can host app UI on this platform
+  /// (Android-only; the PiP item is absent elsewhere).
+  final bool pipSupported;
+
+  /// Whether the trip is actively recording (gates Pause / Stop).
+  final bool isActive;
+
+  /// Whether the trip is currently paused (drives the Pause↔Resume icon).
+  final bool isPaused;
+
+  /// Whether a stop is already in flight (disables Stop to avoid re-entry).
+  final bool stopping;
+
+  final VoidCallback onTogglePin;
+  final VoidCallback onShowPinHelp;
+  final VoidCallback onEnterPip;
+  final VoidCallback onTogglePause;
+  final VoidCallback onStop;
+
+  void _onSelected(_RecordingOverflowAction action) {
+    switch (action) {
+      case _RecordingOverflowAction.pin:
+        onTogglePin();
+      case _RecordingOverflowAction.help:
+        onShowPinHelp();
+      case _RecordingOverflowAction.pip:
+        onEnterPip();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Pause + Stop stay primary (visible) — the two controls a
+        // driver reaches for mid-trip.
+        IconButton(
+          key: const Key('tripPauseButton'),
+          icon: Icon(isPaused ? Icons.play_arrow : Icons.pause),
+          tooltip: isPaused ? (l?.tripResume ?? 'Resume') : (l?.tripPause ?? 'Pause'),
+          onPressed: isActive ? onTogglePause : null,
+        ),
+        IconButton(
+          key: const Key('tripStopButton'),
+          icon: const Icon(Icons.stop_circle_outlined),
+          tooltip: l?.tripStop ?? 'Stop recording',
+          onPressed: stopping || !isActive ? null : onStop,
+        ),
+        // Pin / Help / PiP collapse into one kebab so the title keeps room.
+        PopupMenuButton<_RecordingOverflowAction>(
+          key: const Key('recording_overflow_menu'),
+          icon: const Icon(Icons.more_vert),
+          tooltip: l?.moreActionsTooltip ?? 'More',
+          onSelected: _onSelected,
+          itemBuilder: (_) => [
+            // #891 — the pin item reflects + toggles `_pinned`. Its
+            // visible label IS the Pin / Unpin action string (so the
+            // menu reads like the action it performs), and a
+            // `Semantics(toggled:)` wrapper keeps the TalkBack on/off
+            // state the old icon-only IconButton exposed. The label is
+            // not duplicated on the wrapper so the merged semantics
+            // stays exactly "Pin recording form" / "Unpin recording
+            // form" (#2764).
+            PopupMenuItem<_RecordingOverflowAction>(
+              key: const Key('tripPinButton'),
+              value: _RecordingOverflowAction.pin,
+              child: Semantics(
+                toggled: pinned,
+                child: _MenuRow(
+                  icon: pinned ? Icons.push_pin : Icons.push_pin_outlined,
+                  iconColor:
+                      pinned ? Theme.of(context).colorScheme.primary : null,
+                  label: pinned
+                      ? (l?.tripRecordingPinSemanticOn ?? 'Unpin recording form')
+                      : (l?.tripRecordingPinSemanticOff ??
+                          'Pin recording form'),
+                ),
+              ),
+            ),
+            // #1273 — "what does pin do?" help, always present.
+            PopupMenuItem<_RecordingOverflowAction>(
+              key: const Key('tripPinHelpButton'),
+              value: _RecordingOverflowAction.help,
+              child: _MenuRow(
+                icon: Icons.help_outline,
+                label: l?.tripRecordingPinHelpTooltip ?? 'What does pin do?',
+              ),
+            ),
+            // #1884 — minimise to PiP; Android-only.
+            if (pipSupported)
+              PopupMenuItem<_RecordingOverflowAction>(
+                key: const Key('tripMinimiseButton'),
+                value: _RecordingOverflowAction.pip,
+                child: _MenuRow(
+                  icon: Icons.picture_in_picture_alt,
+                  label: l?.tripRecordingMinimiseTooltip ??
+                      'Minimise to a floating tile',
+                ),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// A leading-icon + label row for an overflow [PopupMenuItem] (mirrors the
+/// consumption-screen kebab's `_MenuRow`). The label shrinks + ellipsizes
+/// so a long translation (German / the en_XA pseudo-locale) never overflows
+/// the PopupMenuItem's ~256 dp bound.
+class _MenuRow extends StatelessWidget {
+  final IconData icon;
+  final Color? iconColor;
+  final String label;
+
+  const _MenuRow({required this.icon, required this.label, this.iconColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 20, color: iconColor),
+        const SizedBox(width: 12),
+        Flexible(child: Text(label, overflow: TextOverflow.ellipsis)),
+      ],
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/trip_avg_consumption_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_avg_consumption_card.dart
@@ -123,15 +123,30 @@ class TripAvgConsumptionCard extends ConsumerWidget {
     return Card(
       key: const Key('tripAvgConsumptionCard'),
       margin: EdgeInsets.zero,
-      child: ListTile(
-        leading: const Icon(Icons.eco, size: 28),
-        title: Text(
-          l?.tripMetricAvgConsumption ?? 'Avg',
-          style: theme.textTheme.bodySmall,
-        ),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: trailing,
+      // #2764 — an explicit Row (not a ListTile title/trailing split):
+      // ListTile hands the wide trailing Row (tooltip + badge + value)
+      // its full intrinsic width, squeezing the label to ~1 char so it
+      // wrapped one letter per line. The label now lives in an
+      // `Expanded` that ellipsizes, and the trailing keeps its min width.
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            const Icon(Icons.eco, size: 28),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                l?.tripMetricAvgConsumption ?? 'Avg',
+                style: theme.textTheme.bodySmall,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: trailing,
+            ),
+          ],
         ),
       ),
     );

--- a/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
+++ b/test/features/consumption/presentation/screens/active_recording_screen_pin_test.dart
@@ -20,6 +20,12 @@ import '../../../../helpers/pump_app.dart';
 /// - auto-release the lock when the recording stops, even if the user
 ///   never tapped unpin.
 /// - hit the 48dp Material tap-target guideline.
+///
+/// #2764 — Pin now lives inside the trailing overflow kebab
+/// (`recording_overflow_menu`) rather than as a primary AppBar
+/// IconButton, so these tests open the kebab before reaching the pin
+/// item. The item keeps its `tripPinButton` key + the Pin/Unpin
+/// semantics, so the behavioural assertions are unchanged.
 
 class _FakeWakelockFacade implements WakelockFacade {
   int enableCalls = 0;
@@ -92,6 +98,12 @@ Future<void> _pumpRecordingScreen(
   );
 }
 
+/// #2764 — open the trailing overflow kebab so the Pin item is mounted.
+Future<void> _openOverflow(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('recording_overflow_menu')));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -101,6 +113,7 @@ void main() {
         (tester) async {
       final facade = _FakeWakelockFacade();
       await _pumpRecordingScreen(tester, facade: facade);
+      await _openOverflow(tester);
 
       final pinButton = find.byKey(const Key('tripPinButton'));
       expect(pinButton, findsOneWidget);
@@ -121,9 +134,13 @@ void main() {
       final facade = _FakeWakelockFacade();
       await _pumpRecordingScreen(tester, facade: facade);
 
+      await _openOverflow(tester);
       await tester.tap(find.byKey(const Key('tripPinButton')));
       await tester.pumpAndSettle();
 
+      // Selecting the item closes the menu; re-open to read the icon,
+      // which must now be the filled (pinned) variant.
+      await _openOverflow(tester);
       expect(
         find.descendant(
           of: find.byKey(const Key('tripPinButton')),
@@ -141,11 +158,16 @@ void main() {
       await _pumpRecordingScreen(tester, facade: facade);
 
       final pin = find.byKey(const Key('tripPinButton'));
+      await _openOverflow(tester);
       await tester.tap(pin);
       await tester.pumpAndSettle();
+      // Re-open the menu for the second toggle (the first selection
+      // closed it).
+      await _openOverflow(tester);
       await tester.tap(pin);
       await tester.pumpAndSettle();
 
+      await _openOverflow(tester);
       expect(
         find.descendant(
           of: pin,
@@ -162,14 +184,15 @@ void main() {
       final facade = _FakeWakelockFacade();
       await _pumpRecordingScreen(tester, facade: facade);
 
-      // Pin first.
+      // Pin first (via the overflow kebab).
+      await _openOverflow(tester);
       await tester.tap(find.byKey(const Key('tripPinButton')));
       await tester.pumpAndSettle();
       expect(facade.enableCalls, 1);
       expect(facade.disableCalls, 0);
 
-      // Stop the recording — this should auto-release without a
-      // second user gesture on the pin toggle.
+      // Stop the recording (a primary, always-visible action) — this
+      // should auto-release without a second user gesture on the pin.
       await tester.tap(find.byKey(const Key('tripStopButton')));
       await tester.pumpAndSettle();
 
@@ -182,6 +205,7 @@ void main() {
       final facade = _FakeWakelockFacade();
       await _pumpRecordingScreen(tester, facade: facade);
 
+      await _openOverflow(tester);
       await tester.tap(find.byKey(const Key('tripPinButton')));
       await tester.pumpAndSettle();
       expect(facade.disableCalls, 0);
@@ -198,6 +222,8 @@ void main() {
         (tester) async {
       final facade = _FakeWakelockFacade();
       await _pumpRecordingScreen(tester, facade: facade);
+      // Open the kebab so the pin item is on screen and audited.
+      await _openOverflow(tester);
 
       await expectLater(
         tester,
@@ -212,6 +238,7 @@ void main() {
 
       // When unpinned, Semantics label should read "Pin recording form".
       final handle = tester.ensureSemantics();
+      await _openOverflow(tester);
       expect(
         find.bySemanticsLabel('Pin recording form'),
         findsOneWidget,
@@ -221,6 +248,8 @@ void main() {
       await tester.tap(find.byKey(const Key('tripPinButton')));
       await tester.pumpAndSettle();
 
+      // Re-open the kebab; the item must now read "Unpin recording form".
+      await _openOverflow(tester);
       expect(
         find.bySemanticsLabel('Unpin recording form'),
         findsOneWidget,

--- a/test/features/consumption/presentation/screens/trip_recording_screen_auto_pin_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_auto_pin_test.dart
@@ -92,6 +92,13 @@ Future<void> _pump(
   );
 }
 
+/// #2764 — Pin lives inside the trailing overflow kebab now; open it so
+/// the pin item (with its icon) is mounted before asserting the icon.
+Future<void> _openOverflow(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('recording_overflow_menu')));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   silenceErrorLoggerSpool();
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -108,6 +115,7 @@ void main() {
 
       expect(facade.enableCalls, 1,
           reason: 'autoPin must acquire the wake lock without a user tap');
+      await _openOverflow(tester);
       expect(
         find.descendant(
           of: find.byKey(const Key('tripPinButton')),
@@ -129,6 +137,7 @@ void main() {
 
       expect(facade.enableCalls, 0,
           reason: 'default autoPin OFF must not auto-acquire the wake lock');
+      await _openOverflow(tester);
       expect(
         find.descendant(
           of: find.byKey(const Key('tripPinButton')),

--- a/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_page_scaffold_test.dart
@@ -73,13 +73,19 @@ void main() {
       expect(find.text('Recording trip'), findsOneWidget);
     });
 
-    testWidgets('pause / stop / pin action buttons survive the migration',
+    testWidgets('pause / stop primary + pin (via overflow kebab) survive',
         (tester) async {
       await _pumpRecordingScreen(tester);
 
-      expect(find.byKey(const Key('tripPinButton')), findsOneWidget);
+      // Pause + Stop stay primary, visible actions.
       expect(find.byKey(const Key('tripPauseButton')), findsOneWidget);
       expect(find.byKey(const Key('tripStopButton')), findsOneWidget);
+      // #2764 — Pin moved into the trailing overflow kebab; it's reachable
+      // once the kebab is opened (the pin item keeps its key).
+      expect(find.byKey(const Key('recording_overflow_menu')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('recording_overflow_menu')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('tripPinButton')), findsOneWidget);
     });
   });
 }

--- a/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_visual_eco_coach_test.dart
@@ -220,10 +220,12 @@ void main() {
       await tester.pumpAndSettle();
 
       // Pop back to the launcher — disposes the recording screen.
-      Navigator.of(tester.element(find.byKey(const Key('tripPinButton'))))
+      // #2764 — Stop is a primary, always-visible action; use it as the
+      // recording-screen anchor (Pin moved into the overflow kebab).
+      Navigator.of(tester.element(find.byKey(const Key('tripStopButton'))))
           .pop();
       await tester.pumpAndSettle();
-      expect(find.byKey(const Key('tripPinButton')), findsNothing,
+      expect(find.byKey(const Key('tripStopButton')), findsNothing,
           reason: 'recording screen must be off-screen now');
 
       // Emit another event — nothing should show on the launcher
@@ -256,9 +258,12 @@ void main() {
         'copy', (tester) async {
       await _pumpRecordingScreen(tester, coachEventsController: events);
 
+      // #2764 — Help lives in the overflow kebab now; open it first.
+      await tester.tap(find.byKey(const Key('recording_overflow_menu')));
+      await tester.pumpAndSettle();
       final helpButton = find.byKey(const Key('tripPinHelpButton'));
       expect(helpButton, findsOneWidget,
-          reason: 'pin help button must be in the AppBar actions');
+          reason: 'pin help item must be in the overflow kebab');
 
       await tester.tap(helpButton);
       await tester.pumpAndSettle();
@@ -274,15 +279,19 @@ void main() {
       );
     });
 
-    testWidgets('? icon is visible regardless of whether the pin is on or off',
+    testWidgets('help item is present regardless of whether pin is on or off',
         (tester) async {
       await _pumpRecordingScreen(tester, coachEventsController: events);
 
-      // Unpinned: help button visible.
+      // Unpinned: open the kebab → Help item present alongside Pin.
+      await tester.tap(find.byKey(const Key('recording_overflow_menu')));
+      await tester.pumpAndSettle();
       expect(find.byKey(const Key('tripPinHelpButton')), findsOneWidget);
 
-      // Pin → help still visible.
+      // Tap Pin (this closes the menu) → re-open → Help still present.
       await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('recording_overflow_menu')));
       await tester.pumpAndSettle();
       expect(find.byKey(const Key('tripPinHelpButton')), findsOneWidget);
     });

--- a/test/features/consumption/presentation/widgets/recording_app_bar_actions_test.dart
+++ b/test/features/consumption/presentation/widgets/recording_app_bar_actions_test.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/recording_app_bar_actions.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// #2764 — the trip-recording AppBar dropped from 5 inline IconButtons
+/// (which truncated the title to "Enr…") to 2 primary actions
+/// (Pause + Stop) plus a single overflow kebab holding Pin / Help / PiP.
+///
+/// These tests pin the new shape: Pause + Stop visible, the
+/// `recording_overflow_menu` kebab present, and opening it surfaces
+/// Pin / Help / (PiP when supported) — each still firing its callback.
+void main() {
+  /// A captured-callback record so each item can prove it fires.
+  late List<String> fired;
+
+  Widget harness({
+    bool pinned = false,
+    bool pipSupported = true,
+    bool isActive = true,
+    bool isPaused = false,
+    bool stopping = false,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        // A real AppBar with a long title so we can prove the title is
+        // NOT truncated once the actions collapse to 3 trailing items.
+        appBar: AppBar(
+          title: const Text(
+            'Enregistrement du trajet en cours',
+            key: Key('recordingTitle'),
+          ),
+          actions: [
+            RecordingAppBarActions(
+              pinned: pinned,
+              pipSupported: pipSupported,
+              isActive: isActive,
+              isPaused: isPaused,
+              stopping: stopping,
+              onTogglePin: () => fired.add('pin'),
+              onShowPinHelp: () => fired.add('help'),
+              onEnterPip: () => fired.add('pip'),
+              onTogglePause: () => fired.add('pause'),
+              onStop: () => fired.add('stop'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  setUp(() => fired = <String>[]);
+
+  Future<void> openKebab(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('recording_overflow_menu')));
+    await tester.pumpAndSettle();
+  }
+
+  group('RecordingAppBarActions (#2764)', () {
+    testWidgets('Pause + Stop are primary; kebab present; title not truncated',
+        (tester) async {
+      await tester.pumpWidget(harness());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('tripPauseButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripStopButton')), findsOneWidget);
+      expect(find.byKey(const Key('recording_overflow_menu')), findsOneWidget);
+
+      // The full title renders (no clipping to "Enr…"). Reading the
+      // RenderParagraph proves the text wasn't replaced by an ellipsis
+      // run.
+      final para = tester.renderObject<RenderParagraph>(
+        find.descendant(
+          of: find.byKey(const Key('recordingTitle')),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(para.text.toPlainText(),
+          'Enregistrement du trajet en cours');
+      expect(tester.takeException(), isNull,
+          reason: 'no overflow with only 3 trailing actions');
+    });
+
+    testWidgets('Pin / Help / PiP live inside the kebab and each fires',
+        (tester) async {
+      await tester.pumpWidget(harness(pipSupported: true));
+      await tester.pumpAndSettle();
+
+      // Folded away until the kebab opens.
+      expect(find.byKey(const Key('tripPinButton')), findsNothing);
+      expect(find.byKey(const Key('tripPinHelpButton')), findsNothing);
+      expect(find.byKey(const Key('tripMinimiseButton')), findsNothing);
+
+      await openKebab(tester);
+      expect(find.byKey(const Key('tripPinButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripPinHelpButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripMinimiseButton')), findsOneWidget);
+
+      // Pin fires.
+      await tester.tap(find.byKey(const Key('tripPinButton')));
+      await tester.pumpAndSettle();
+      expect(fired, ['pin']);
+
+      // Help fires.
+      await openKebab(tester);
+      await tester.tap(find.byKey(const Key('tripPinHelpButton')));
+      await tester.pumpAndSettle();
+      expect(fired, ['pin', 'help']);
+
+      // PiP fires.
+      await openKebab(tester);
+      await tester.tap(find.byKey(const Key('tripMinimiseButton')));
+      await tester.pumpAndSettle();
+      expect(fired, ['pin', 'help', 'pip']);
+    });
+
+    testWidgets('PiP item is absent when PiP is unsupported', (tester) async {
+      await tester.pumpWidget(harness(pipSupported: false));
+      await tester.pumpAndSettle();
+      await openKebab(tester);
+
+      expect(find.byKey(const Key('tripPinButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripPinHelpButton')), findsOneWidget);
+      expect(find.byKey(const Key('tripMinimiseButton')), findsNothing,
+          reason: 'PiP only renders where the platform can host it');
+    });
+
+    testWidgets('Pause + Stop fire their callbacks', (tester) async {
+      await tester.pumpWidget(harness());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('tripPauseButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('tripStopButton')));
+      await tester.pumpAndSettle();
+      expect(fired, ['pause', 'stop']);
+    });
+
+    testWidgets('Pause + Stop are disabled when the trip is not active',
+        (tester) async {
+      await tester.pumpWidget(harness(isActive: false));
+      await tester.pumpAndSettle();
+
+      final pause =
+          tester.widget<IconButton>(find.byKey(const Key('tripPauseButton')));
+      final stop =
+          tester.widget<IconButton>(find.byKey(const Key('tripStopButton')));
+      expect(pause.onPressed, isNull);
+      expect(stop.onPressed, isNull);
+    });
+
+    testWidgets('pin item reflects the pinned state (filled icon + Unpin '
+        'semantics)', (tester) async {
+      await tester.pumpWidget(harness(pinned: true));
+      await tester.pumpAndSettle();
+
+      final handle = tester.ensureSemantics();
+      await openKebab(tester);
+
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('tripPinButton')),
+          matching: find.byIcon(Icons.push_pin),
+        ),
+        findsOneWidget,
+        reason: 'pinned → filled push-pin icon',
+      );
+      expect(find.bySemanticsLabel('Unpin recording form'), findsOneWidget);
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/trip_avg_consumption_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_avg_consumption_card_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
@@ -30,7 +31,13 @@ void main() {
     required TripLiveReading? live,
     String? brokenMapOverride,
     GpsCalibrationMatrix? matrix,
+    Locale? locale,
+    double? cardWidth,
   }) {
+    final card = TripAvgConsumptionCard(
+      live: live,
+      brokenMapOverride: brokenMapOverride,
+    );
     return ProviderScope(
       overrides: [
         activeVehicleProfileProvider.overrideWith(
@@ -44,12 +51,19 @@ void main() {
         ),
       ],
       child: MaterialApp(
+        locale: locale,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: TripAvgConsumptionCard(
-            live: live,
-            brokenMapOverride: brokenMapOverride,
+          body: Align(
+            alignment: Alignment.topCenter,
+            // #2764 — pin a realistically narrow card width so the wide
+            // trailing Row (tooltip + badge + value) competes with the
+            // label for space, reproducing the per-letter wrap if the
+            // label ever loses its Expanded/ellipsis.
+            child: cardWidth == null
+                ? card
+                : SizedBox(width: cardWidth, child: card),
           ),
         ),
       ),
@@ -190,6 +204,106 @@ void main() {
       ));
       await tester.pumpAndSettle();
       expect(find.text(l.gpsMatrixMaturityConverged), findsOneWidget);
+    });
+  });
+
+  // #2764 — the label must keep its flexible space + ellipsize on a
+  // single line even when the wide trailing Row (tooltip + maturity
+  // badge + value) is present. The old ListTile title/trailing split
+  // gave the trailing its full intrinsic width, squeezing 'Moyenne' to
+  // ~1 char per line. A narrow card width forces the competition.
+  group('label single-line, no per-letter wrap (#2764)', () {
+    // A GPS-estimate reading → the WIDEST trailing (tooltip + badge +
+    // ~value); the worst case for the label's remaining space.
+    const wideTrailingLive = TripLiveReading(
+      elapsed: Duration(minutes: 5),
+      distanceKmSoFar: 10.0,
+      gpsEstimatedAvgLPer100Km: 6.4,
+    );
+
+    Finder labelFinder(String text) => find.descendant(
+          of: find.byKey(const Key('tripAvgConsumptionCard')),
+          matching: find.text(text),
+        );
+
+    // Visual line count of a Text: distinct box `top` offsets over the
+    // full string. A single ellipsized line ⇒ 1; the #2764 per-letter
+    // wrap ⇒ one per character.
+    int renderedLineCount(WidgetTester tester, Finder f, String text) {
+      final para = tester.renderObject<RenderParagraph>(f);
+      final boxes = para.getBoxesForSelection(
+        TextSelection(baseOffset: 0, extentOffset: text.length),
+      );
+      final tops = boxes.map((b) => b.top.round()).toSet();
+      return tops.isEmpty ? 1 : tops.length;
+    }
+
+    // The structural contract that PREVENTS the per-letter wrap: the
+    // label lives inside an Expanded (so it claims the flexible space
+    // rather than being squeezed by the wide trailing) and is single-
+    // line + ellipsizing. This is the direct regression guard — the old
+    // ListTile title/trailing split had neither.
+    void expectLabelIsExpandedSingleLineEllipsis(
+        WidgetTester tester, Finder labelText) {
+      final textWidget = tester.widget<Text>(labelText);
+      expect(textWidget.maxLines, 1,
+          reason: 'label must be capped to a single line (#2764)');
+      expect(textWidget.overflow, TextOverflow.ellipsis,
+          reason: 'label must ellipsize, never wrap per character (#2764)');
+      expect(
+        find.ancestor(of: labelText, matching: find.byType(Expanded)),
+        findsOneWidget,
+        reason: 'label must sit in an Expanded so the wide trailing '
+            "(tooltip + badge + value) can't squeeze it to ~1 char.",
+      );
+    }
+
+    testWidgets('FR "Moyenne" is a single-line, ellipsizing, Expanded label '
+        'beside the full trailing', (tester) async {
+      await tester.pumpWidget(harness(
+        live: wideTrailingLive,
+        matrix: const GpsCalibrationMatrix(),
+        locale: const Locale('fr'),
+        // Bounded but roomy enough that the wide value Text doesn't
+        // overflow — the structural assertions below are what guard the
+        // bug, not a pixel-precise squeeze.
+        cardWidth: 600,
+      ));
+      await tester.pumpAndSettle();
+
+      final label = labelFinder('Moyenne');
+      expect(label, findsOneWidget, reason: 'FR label resolves to "Moyenne".');
+      expectLabelIsExpandedSingleLineEllipsis(tester, label);
+      expect(renderedLineCount(tester, label, 'Moyenne'), 1,
+          reason: 'The label renders on ONE line, not one letter per line.');
+
+      // The value + maturity badge must still be present alongside it.
+      expect(find.byKey(const Key('tripAvgConsumptionValue')), findsOneWidget);
+      expect(valueText(tester).data, '~6.4 L/100 km');
+      expect(find.byType(GpsMatrixMaturityBadge), findsOneWidget);
+    });
+
+    testWidgets('en_XA pseudo-locale (text expansion) keeps the label single '
+        'line', (tester) async {
+      await tester.pumpWidget(harness(
+        live: wideTrailingLive,
+        matrix: const GpsCalibrationMatrix(),
+        // The #1699 expansion pseudo-locale stresses the label width.
+        locale: const Locale('en', 'XA'),
+        cardWidth: 600,
+      ));
+      await tester.pumpAndSettle();
+
+      final l = await AppLocalizations.delegate.load(const Locale('en', 'XA'));
+      final labelText = l.tripMetricAvgConsumption;
+      final label = labelFinder(labelText);
+      expect(label, findsOneWidget);
+      expectLabelIsExpandedSingleLineEllipsis(tester, label);
+      expect(renderedLineCount(tester, label, labelText), 1,
+          reason: 'Even the expanded pseudo-locale label stays on one line '
+              'rather than wrapping per character.');
+      expect(find.byKey(const Key('tripAvgConsumptionValue')), findsOneWidget);
+      expect(find.byType(GpsMatrixMaturityBadge), findsOneWidget);
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -271,8 +271,11 @@ void main() {
     // event→coach→speak wire — keeps the keepAlive listener mounted while
     // the screen is up) plus its import + an explaining comment. Pure
     // wiring; decomposition still tracked under #2187/#2188.
+    // #2764 — shrank 1123 → 1090: the 5 inline app-bar IconButtons moved
+    // into the new RecordingAppBarActions widget (Pause + Stop primary,
+    // Pin/Help/PiP folded into an overflow kebab). Net -33 lines here.
     'lib/features/consumption/presentation/screens/trip_recording_screen.dart':
-        1123,
+        1090,
     'lib/features/consumption/presentation/widgets/broken_map_widgets.dart':
         439,
     'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':


### PR DESCRIPTION
## What

Two overflow bugs on the active trip-recording screen.

**(A) "Moyenne" wrapped one letter per line.** `TripAvgConsumptionCard` (and the `_MetricCard`s) used a `ListTile` title/trailing split. The `ListTile` hands the wide `trailing:` Row (info tooltip + `GpsMatrixMaturityBadge` + value) its full intrinsic width, squeezing the title to ~1 char so it wrapped per-letter. Replaced the `ListTile` with an explicit `Row` whose label lives in an `Expanded` (`maxLines: 1`, `TextOverflow.ellipsis`) and whose trailing keeps its min width. Same restructure applied to `_MetricCard`.

**(B) AppBar title truncated to "Enr…".** The AppBar emitted 5 inline `IconButton`s (Pin, Help, PiP, Pause, Stop), clipping the title. Following the #2761 consumption-screen pattern, **Pause + Stop** stay primary and **Pin / Help / PiP** fold into a single trailing overflow kebab (`recording_overflow_menu`). Extracted a new `RecordingAppBarActions` widget — which also shrinks `trip_recording_screen.dart` from 1123 → 1090 effective lines (snapshot lowered accordingly).

All behaviour + keys preserved: the PiP item is gated `if (pipSupported)`, the pin item reflects/toggles `_pinned` (filled icon + `toggled:` Pin/Unpin semantics), Help opens the same bottom sheet.

## ARB

ARB-free. Reuses existing keys only (`moreActionsTooltip`, `tripStop`, `tripPause`/`tripResume`, `tripRecordingPinHelpTooltip`, `tripRecordingMinimiseTooltip`, `tripRecordingPinSemanticOn/Off`). No new keys, no codegen or l10n fan-out — `git status` clean of `*.g.dart` / `*.freezed.dart` / `lib/l10n/`.

## Tests

- `trip_avg_consumption_card_test.dart`: FR "Moyenne" + en_XA pseudo render the label single-line (Expanded + ellipsis, one visual line) with the value + maturity badge still present.
- `recording_app_bar_actions_test.dart` (new): full title not truncated; Pause + Stop primary; `recording_overflow_menu` kebab present; opening it lists Pin / Help / PiP (PiP absent when unsupported); each action fires its callback.
- Updated the existing pin / auto-pin / page-scaffold / eco-coach screen tests to reach Pin/Help/PiP through the kebab.
- `flutter analyze` clean (only 2 pre-existing, unrelated `unnecessary_import` infos in untouched test files; CI runs `--no-fatal-infos`). Full `test/features/consumption/` + `test/lint/file_length_test.dart` green (3974 passed).

Closes #2764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
