### PR TITLE
fix(telemetry): de-noise benign 'No active stream to cancel' at global error handler (#2772)

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:home_widget/home_widget.dart';
@@ -767,7 +768,10 @@ class AppInitializer {
     // Capture Flutter framework errors (build, layout, paint).
     FlutterError.onError = (details) {
       FlutterError.presentError(details);
-      if (_isTileFetchNoise(details.exception)) return;
+      if (_isTileFetchNoise(details.exception) ||
+          isBenignStreamCancel(details.exception)) {
+        return;
+      }
       errorLogger.log(
         ErrorLayer.ui,
         details.exception,
@@ -780,7 +784,7 @@ class AppInitializer {
     };
     // Capture async / platform errors that escape the framework.
     PlatformDispatcher.instance.onError = (error, stack) {
-      if (_isTileFetchNoise(error)) return true;
+      if (_isTileFetchNoise(error) || isBenignStreamCancel(error)) return true;
       errorLogger.log(ErrorLayer.other, error, stack);
       return true;
     };
@@ -803,6 +807,18 @@ class AppInitializer {
     if (msg.contains('failed host lookup')) return true;
     return false;
   }
+
+  /// Whether [error] is the benign EventChannel teardown PlatformException
+  /// ("No active stream to cancel") — a lifecycle race when the platform
+  /// broadcast was already cleared. `safeCancel` (event_channel_cancel.dart)
+  /// swallows it at the app's own cancel sites, but a plugin-internal / async
+  /// teardown can still surface it through this global handler; it is never a
+  /// real crash, so it must not pollute the error log (#2772).
+  @visibleForTesting
+  static bool isBenignStreamCancel(Object error) =>
+      error is PlatformException &&
+      (error.message?.toLowerCase().contains('no active stream to cancel') ??
+          false);
 
   static void _launch(
     ProviderContainer container,

--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -808,12 +808,9 @@ class AppInitializer {
     return false;
   }
 
-  /// Whether [error] is the benign EventChannel teardown PlatformException
-  /// ("No active stream to cancel") — a lifecycle race when the platform
-  /// broadcast was already cleared. `safeCancel` (event_channel_cancel.dart)
-  /// swallows it at the app's own cancel sites, but a plugin-internal / async
-  /// teardown can still surface it through this global handler; it is never a
-  /// real crash, so it must not pollute the error log (#2772).
+  /// Benign EventChannel teardown ("No active stream to cancel"), a lifecycle
+  /// race that safeCancel covers at app sites but can escape via plugins —
+  /// never a real crash, must not pollute the error log (#2772).
   @visibleForTesting
   static bool isBenignStreamCancel(Object error) =>
       error is PlatformException &&

--- a/test/app/app_initializer_benign_cancel_test.dart
+++ b/test/app/app_initializer_benign_cancel_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/app_initializer.dart';
+
+/// #2772 — the benign EventChannel teardown PlatformException ("No active
+/// stream to cancel") reaches the global FlutterError.onError handler and was
+/// ERROR-logged; the de-noise predicate must classify it as benign while
+/// leaving every other error loggable.
+void main() {
+  group('AppInitializer.isBenignStreamCancel (#2772)', () {
+    test('the benign EventChannel cancel PlatformException → true', () {
+      expect(
+        AppInitializer.isBenignStreamCancel(
+          PlatformException(code: 'error', message: 'No active stream to cancel'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('case-insensitive on the message', () {
+      expect(
+        AppInitializer.isBenignStreamCancel(
+          PlatformException(code: 'error', message: 'NO ACTIVE STREAM TO CANCEL'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a different PlatformException is NOT benign (still logged)', () {
+      expect(
+        AppInitializer.isBenignStreamCancel(
+          PlatformException(code: 'error', message: 'Bluetooth adapter is off'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('non-PlatformException errors are NOT benign', () {
+      expect(AppInitializer.isBenignStreamCancel(Exception('boom')), isFalse);
+      expect(
+        AppInitializer.isBenignStreamCancel(
+          const FormatException('No active stream to cancel'),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -48,7 +48,9 @@ void main() {
     // block now also runs `ProfileRepository.dedupeCountryProfiles()` to
     // enforce one profile per country for existing duplicate users (a few
     // lines next to the adjacent country/language backfill migration).
-    'lib/app/app_initializer.dart': 957,
+    // #2772 — 957 → 961: the isBenignStreamCancel de-noise helper + its
+    // services import + the two global-handler filter calls. Bootstrap file.
+    'lib/app/app_initializer.dart': 961,
     // #2415 — background_service.dart graduated: the scan body moved into
     // BackgroundAlertScanCoordinator + BackgroundScanRunners +
     // BackgroundPriceHistoryWriter, so the file dropped from 782 to ~246


### PR DESCRIPTION
Error log #16: the benign EventChannel teardown PlatformException reaches FlutterError.onError (escaping safeCancel via a plugin/async path) and is ERROR-logged. Add `isBenignStreamCancel` (mirrors `_isTileFetchNoise`), short-circuit it in both global handlers. Behavioral test + ARB-free. Closes #2772