### PR TITLE
fix(voice): speak TTS announcement in the app's selected locale (#2762)

### DIFF
--- a/lib/core/services/impl/flutter_tts_announcement_service.dart
+++ b/lib/core/services/impl/flutter_tts_announcement_service.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:ui' show Locale;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../voice_announcement_service.dart';
 
 /// Platform TTS implementation using [FlutterTts].
@@ -17,6 +20,10 @@ class FlutterTtsAnnouncementService implements VoiceAnnouncementService {
   final FlutterTts _tts;
   bool _initialized = false;
 
+  /// App language code the spoken text + native voice are bound to (#2762).
+  /// Defaults to English until [setAppLocale] is wired from the provider.
+  String _languageCode = 'en';
+
   @override
   Future<void> initialize() async {
     if (_initialized) return;
@@ -24,6 +31,9 @@ class FlutterTtsAnnouncementService implements VoiceAnnouncementService {
     await _tts.setSpeechRate(0.5);
     await _tts.setVolume(1.0);
     await _tts.setPitch(1.0);
+    // Push the selected locale's voice to the native engine so the first
+    // line isn't spoken with the device-default (usually English) voice.
+    await _applyTtsLanguage(_languageCode);
     _initialized = true;
   }
 
@@ -62,18 +72,82 @@ class FlutterTtsAnnouncementService implements VoiceAnnouncementService {
     await _tts.setLanguage(languageCode);
   }
 
-  /// Build the spoken text for a candidate.
+  @override
+  Future<void> setAppLocale(String languageCode) async {
+    _languageCode = languageCode;
+    // Re-apply to the native engine immediately when it's already up; on a
+    // cold start [initialize] applies it. A no-op before init is fine — the
+    // stored code is used at init time.
+    if (_initialized) {
+      await _applyTtsLanguage(languageCode);
+    }
+  }
+
+  /// Push the BCP-47 voice for [languageCode] to the native engine,
+  /// falling back gracefully if that locale's voice is unavailable so a
+  /// missing voice never crashes an announcement (#2762).
+  Future<void> _applyTtsLanguage(String languageCode) async {
+    try {
+      await setLanguage(_ttsLocaleFor(languageCode));
+    } catch (e, st) {
+      debugPrint('VoiceAnnouncement: setLanguage failed, keeping default: $e');
+      debugPrintStack(stackTrace: st);
+    }
+  }
+
+  /// Map an app language code to a TTS BCP-47 tag. Covers the explicit
+  /// region cases users notice most; anything else falls back to
+  /// `<code>-<CODE>` (e.g. `it` -> `it-IT`), which the native engines
+  /// resolve for every shipped locale.
+  String _ttsLocaleFor(String languageCode) {
+    const explicit = <String, String>{
+      'en': 'en-US',
+      'de': 'de-DE',
+      'fr': 'fr-FR',
+      'pt': 'pt-PT',
+      'nb': 'nb-NO',
+      'el': 'el-GR',
+      'cs': 'cs-CZ',
+      'sv': 'sv-SE',
+      'da': 'da-DK',
+    };
+    final code = languageCode.toLowerCase();
+    return explicit[code] ?? '$code-${code.toUpperCase()}';
+  }
+
+  /// Resolve [AppLocalizations] for the app's SELECTED locale.
   ///
-  /// Format: "Shell, 1.2 kilometers ahead, Diesel 1 euro 42"
-  /// This is a plain English fallback; localised formatting happens in
-  /// the [AnnouncementEngine] which calls this service.
+  /// This fires from a background / approach announcement context, not a
+  /// widget tree, so there is no `BuildContext` to read — [lookupAppLocalizations]
+  /// returns the bindings for an arbitrary [Locale]. Falls back to English
+  /// if the code is somehow unsupported.
+  AppLocalizations _localizations() {
+    try {
+      return lookupAppLocalizations(Locale(_languageCode));
+    } catch (_) {
+      return lookupAppLocalizations(const Locale('en'));
+    }
+  }
+
+  /// Build the spoken text for a candidate in the SELECTED locale (#2762).
+  ///
+  /// The numeric formatting (distance to one decimal place, the
+  /// whole-euro/cents split) stays here; the WORDS ("kilometers ahead",
+  /// "euros") come from the [AppLocalizations.voiceStationAnnouncement] ARB
+  /// key resolved for the app's selected locale, so a French user hears the
+  /// sentence in French.
   String _formatAnnouncement(AnnouncementCandidate candidate) {
     final name = candidate.station.brand.isNotEmpty
         ? candidate.station.brand
         : candidate.station.name;
     final dist = candidate.distanceKm.toStringAsFixed(1);
     final priceParts = candidate.price.toStringAsFixed(2).split('.');
-    return '$name, $dist kilometers ahead, '
-        '${candidate.fuelType} ${priceParts[0]} euro ${priceParts[1]}';
+    return _localizations().voiceStationAnnouncement(
+      name,
+      dist,
+      candidate.fuelType,
+      priceParts[0],
+      priceParts[1],
+    );
   }
 }

--- a/lib/core/services/voice_announcement_providers.dart
+++ b/lib/core/services/voice_announcement_providers.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../language/language_provider.dart';
 import 'announcement_engine.dart';
 import 'impl/flutter_tts_announcement_service.dart';
 import 'voice_announcement_service.dart';
@@ -12,9 +15,26 @@ part 'voice_announcement_providers.g.dart';
 /// Provides the platform TTS service singleton.
 ///
 /// Kept alive for the app lifetime so the TTS engine is initialized once.
+///
+/// Binds the service to the app's SELECTED locale (#2762): the initial
+/// language is read from [activeLanguageProvider] (the persisted/profile
+/// language the rest of the app uses), and a [Ref.listen] re-applies it
+/// whenever the user changes language — so both the native TTS voice and
+/// the spoken sentence follow the app language rather than the device
+/// default voice + hardcoded English words.
 @Riverpod(keepAlive: true)
 VoiceAnnouncementService voiceAnnouncementService(Ref ref) {
   final service = FlutterTtsAnnouncementService();
+
+  // Initial selected locale.
+  unawaited(service.setAppLocale(ref.read(activeLanguageProvider).code));
+
+  // Re-apply on every language change without recreating the singleton.
+  ref.listen<AppLanguage>(
+    activeLanguageProvider,
+    (_, next) => unawaited(service.setAppLocale(next.code)),
+  );
+
   ref.onDispose(() => service.dispose());
   return service;
 }

--- a/lib/core/services/voice_announcement_providers.dart
+++ b/lib/core/services/voice_announcement_providers.dart
@@ -22,17 +22,35 @@ part 'voice_announcement_providers.g.dart';
 /// whenever the user changes language — so both the native TTS voice and
 /// the spoken sentence follow the app language rather than the device
 /// default voice + hardcoded English words.
+///
+/// The locale binding is best-effort by design: this is an app-lifetime
+/// singleton, so it MUST NOT make every transitive consumer (e.g. the active
+/// driving screen) depend on the Hive-backed profile store being open. During
+/// early startup — and in widget tests that don't open the profile box —
+/// [activeLanguageProvider] (which watches the profile) may still be in error
+/// state; reading it would otherwise poison this provider and every consumer.
+/// We therefore read defensively and start on the device-default voice, then
+/// let the [Ref.listen] below snap the locale to the app language the instant
+/// the profile resolves (and on every later language change).
 @Riverpod(keepAlive: true)
 VoiceAnnouncementService voiceAnnouncementService(Ref ref) {
   final service = FlutterTtsAnnouncementService();
 
-  // Initial selected locale.
-  unawaited(service.setAppLocale(ref.read(activeLanguageProvider).code));
+  // Initial selected locale — defensively, see doc comment above.
+  try {
+    unawaited(service.setAppLocale(ref.read(activeLanguageProvider).code));
+  } catch (_) {
+    // Profile store not ready yet; keep the device-default voice until the
+    // listener below fires once the language resolves.
+  }
 
-  // Re-apply on every language change without recreating the singleton.
+  // Re-apply on every language change without recreating the singleton. The
+  // onError handler keeps a not-yet-ready profile from surfacing as an
+  // unhandled provider error while the box is still opening.
   ref.listen<AppLanguage>(
     activeLanguageProvider,
     (_, next) => unawaited(service.setAppLocale(next.code)),
+    onError: (_, _) {},
   );
 
   ref.onDispose(() => service.dispose());

--- a/lib/core/services/voice_announcement_providers.g.dart
+++ b/lib/core/services/voice_announcement_providers.g.dart
@@ -11,6 +11,13 @@ part of 'voice_announcement_providers.dart';
 /// Provides the platform TTS service singleton.
 ///
 /// Kept alive for the app lifetime so the TTS engine is initialized once.
+///
+/// Binds the service to the app's SELECTED locale (#2762): the initial
+/// language is read from [activeLanguageProvider] (the persisted/profile
+/// language the rest of the app uses), and a [Ref.listen] re-applies it
+/// whenever the user changes language — so both the native TTS voice and
+/// the spoken sentence follow the app language rather than the device
+/// default voice + hardcoded English words.
 
 @ProviderFor(voiceAnnouncementService)
 final voiceAnnouncementServiceProvider = VoiceAnnouncementServiceProvider._();
@@ -18,6 +25,13 @@ final voiceAnnouncementServiceProvider = VoiceAnnouncementServiceProvider._();
 /// Provides the platform TTS service singleton.
 ///
 /// Kept alive for the app lifetime so the TTS engine is initialized once.
+///
+/// Binds the service to the app's SELECTED locale (#2762): the initial
+/// language is read from [activeLanguageProvider] (the persisted/profile
+/// language the rest of the app uses), and a [Ref.listen] re-applies it
+/// whenever the user changes language — so both the native TTS voice and
+/// the spoken sentence follow the app language rather than the device
+/// default voice + hardcoded English words.
 
 final class VoiceAnnouncementServiceProvider
     extends
@@ -30,6 +44,13 @@ final class VoiceAnnouncementServiceProvider
   /// Provides the platform TTS service singleton.
   ///
   /// Kept alive for the app lifetime so the TTS engine is initialized once.
+  ///
+  /// Binds the service to the app's SELECTED locale (#2762): the initial
+  /// language is read from [activeLanguageProvider] (the persisted/profile
+  /// language the rest of the app uses), and a [Ref.listen] re-applies it
+  /// whenever the user changes language — so both the native TTS voice and
+  /// the spoken sentence follow the app language rather than the device
+  /// default voice + hardcoded English words.
   VoiceAnnouncementServiceProvider._()
     : super(
         from: null,
@@ -65,7 +86,7 @@ final class VoiceAnnouncementServiceProvider
 }
 
 String _$voiceAnnouncementServiceHash() =>
-    r'3b79a24d1173eb979132dd6be801e98ba462dd3c';
+    r'63837cec11699ecb41ee0563b8bfb0b0900283a5';
 
 /// Provides the announcement engine that evaluates nearby stations.
 ///

--- a/lib/core/services/voice_announcement_providers.g.dart
+++ b/lib/core/services/voice_announcement_providers.g.dart
@@ -18,6 +18,16 @@ part of 'voice_announcement_providers.dart';
 /// whenever the user changes language — so both the native TTS voice and
 /// the spoken sentence follow the app language rather than the device
 /// default voice + hardcoded English words.
+///
+/// The locale binding is best-effort by design: this is an app-lifetime
+/// singleton, so it MUST NOT make every transitive consumer (e.g. the active
+/// driving screen) depend on the Hive-backed profile store being open. During
+/// early startup — and in widget tests that don't open the profile box —
+/// [activeLanguageProvider] (which watches the profile) may still be in error
+/// state; reading it would otherwise poison this provider and every consumer.
+/// We therefore read defensively and start on the device-default voice, then
+/// let the [Ref.listen] below snap the locale to the app language the instant
+/// the profile resolves (and on every later language change).
 
 @ProviderFor(voiceAnnouncementService)
 final voiceAnnouncementServiceProvider = VoiceAnnouncementServiceProvider._();
@@ -32,6 +42,16 @@ final voiceAnnouncementServiceProvider = VoiceAnnouncementServiceProvider._();
 /// whenever the user changes language — so both the native TTS voice and
 /// the spoken sentence follow the app language rather than the device
 /// default voice + hardcoded English words.
+///
+/// The locale binding is best-effort by design: this is an app-lifetime
+/// singleton, so it MUST NOT make every transitive consumer (e.g. the active
+/// driving screen) depend on the Hive-backed profile store being open. During
+/// early startup — and in widget tests that don't open the profile box —
+/// [activeLanguageProvider] (which watches the profile) may still be in error
+/// state; reading it would otherwise poison this provider and every consumer.
+/// We therefore read defensively and start on the device-default voice, then
+/// let the [Ref.listen] below snap the locale to the app language the instant
+/// the profile resolves (and on every later language change).
 
 final class VoiceAnnouncementServiceProvider
     extends
@@ -51,6 +71,16 @@ final class VoiceAnnouncementServiceProvider
   /// whenever the user changes language — so both the native TTS voice and
   /// the spoken sentence follow the app language rather than the device
   /// default voice + hardcoded English words.
+  ///
+  /// The locale binding is best-effort by design: this is an app-lifetime
+  /// singleton, so it MUST NOT make every transitive consumer (e.g. the active
+  /// driving screen) depend on the Hive-backed profile store being open. During
+  /// early startup — and in widget tests that don't open the profile box —
+  /// [activeLanguageProvider] (which watches the profile) may still be in error
+  /// state; reading it would otherwise poison this provider and every consumer.
+  /// We therefore read defensively and start on the device-default voice, then
+  /// let the [Ref.listen] below snap the locale to the app language the instant
+  /// the profile resolves (and on every later language change).
   VoiceAnnouncementServiceProvider._()
     : super(
         from: null,
@@ -86,7 +116,7 @@ final class VoiceAnnouncementServiceProvider
 }
 
 String _$voiceAnnouncementServiceHash() =>
-    r'63837cec11699ecb41ee0563b8bfb0b0900283a5';
+    r'da1d9950c472a9074975e98d2951bd8b62ac3347';
 
 /// Provides the announcement engine that evaluates nearby stations.
 ///

--- a/lib/core/services/voice_announcement_providers.g.dart
+++ b/lib/core/services/voice_announcement_providers.g.dart
@@ -116,7 +116,7 @@ final class VoiceAnnouncementServiceProvider
 }
 
 String _$voiceAnnouncementServiceHash() =>
-    r'da1d9950c472a9074975e98d2951bd8b62ac3347';
+    r'c6a125849af265ba60002e3921c64a47c66f9833';
 
 /// Provides the announcement engine that evaluates nearby stations.
 ///

--- a/lib/core/services/voice_announcement_service.dart
+++ b/lib/core/services/voice_announcement_service.dart
@@ -47,4 +47,15 @@ abstract class VoiceAnnouncementService {
 
   /// Set the language for announcements (BCP-47 code, e.g. "de-DE").
   Future<void> setLanguage(String languageCode);
+
+  /// Bind the service to the app's currently SELECTED locale (#2762).
+  ///
+  /// [languageCode] is the app two-letter language code (e.g. `fr`, `de`,
+  /// `en`). This both (a) drives the native TTS voice — the code is mapped
+  /// to a BCP-47 tag and pushed via [setLanguage] so a French user hears a
+  /// French voice instead of the device default — and (b) selects which
+  /// [AppLocalizations] the spoken sentence in [announce] is resolved
+  /// against. Safe to call repeatedly when the user changes language; an
+  /// unavailable native locale is swallowed so the engine keeps working.
+  Future<void> setAppLocale(String languageCode);
 }

--- a/lib/l10n/_fragments/voice_announcement_de.arb
+++ b/lib/l10n/_fragments/voice_announcement_de.arb
@@ -1,0 +1,3 @@
+{
+  "voiceStationAnnouncement": "{name}, in {distanceKm} Kilometern, {fuelType} {euros} Euro {cents}"
+}

--- a/lib/l10n/_fragments/voice_announcement_en.arb
+++ b/lib/l10n/_fragments/voice_announcement_en.arb
@@ -1,0 +1,28 @@
+{
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "description": "Spoken text-to-speech announcement for a nearby cheap fuel station while in driving/approach mode (#2762). Resolved for the app's SELECTED locale (not the widget tree) and spoken by FlutterTtsAnnouncementService. name is the station brand or name; distanceKm is pre-formatted to one decimal place; fuelType is the fuel grade; euros/cents are the whole-euro and two-digit cents halves of the price. Keep this idiomatic for a driver hearing it aloud.",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
+  }
+}

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -3249,6 +3249,7 @@
   "vehicleDetectedFromVinBadge": "(erkannt)",
   "vehicleDetectedFromVinSnackbar": "Aus VIN erkannt: {summary}. Übernehmen?",
   "vehicleDetectedFromVinApply": "Übernehmen",
+  "voiceStationAnnouncement": "{name}, in {distanceKm} Kilometern, {fuelType} {euros} Euro {cents}",
   "widgetHelpSectionTitle": "Homescreen-Widget",
   "widgetHelpIntro": "Füge das SparKilo-Widget zu deinem Startbildschirm hinzu, um Sprit- und Ladepreise auf einen Blick zu sehen.",
   "widgetHelpAdd": "Füge es über die Widget-Auswahl deines Launchers hinzu — halte einen leeren Bereich des Startbildschirms gedrückt, wähle „Widgets“ und suche SparKilo.",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6603,6 +6603,32 @@
   "@vehicleDetectedFromVinApply": {
     "description": "Snackbar action button label — confirm applying the VIN-decoded values to the vehicle profile (#1399)."
   },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "description": "Spoken text-to-speech announcement for a nearby cheap fuel station while in driving/approach mode (#2762). Resolved for the app's SELECTED locale (not the widget tree) and spoken by FlutterTtsAnnouncementService. name is the station brand or name; distanceKm is pre-formatted to one decimal place; fuelType is the fuel grade; euros/cents are the whole-euro and two-digit cents halves of the price. Keep this idiomatic for a driver hearing it aloud.",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
+  },
   "widgetHelpSectionTitle": "Home-screen widget",
   "@widgetHelpSectionTitle": {
     "description": "Title of the home-screen widget help section in Settings (#1806)."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -2062,6 +2062,7 @@
   "vehicleDetectedFromVinBadge": "⟦(đéŧéçŧéđ) ····⟧",
   "vehicleDetectedFromVinSnackbar": "⟦Đéŧéçŧéđ ƒřóɱ ṼÎÑ: {summary}. Áƥƥłý? ·········⟧",
   "vehicleDetectedFromVinApply": "⟦Áƥƥłý ··⟧",
+  "voiceStationAnnouncement": "⟦{name}, {distanceKm} ķîłóɱéŧéřš áĥéáđ, {fuelType} {euros} éúřóš {cents} ·········⟧",
   "widgetHelpSectionTitle": "⟦Ĥóɱé-šçřééñ ŵîđǧéŧ ·······⟧",
   "widgetHelpIntro": "⟦Áđđ ŧĥé ŠƥářĶîłó ŵîđǧéŧ ŧó ýóúř ĥóɱé šçřééñ ŧó šéé ƒúéł áñđ çĥářǧîñǧ ƥřîçéš áŧ á ǧłáñçé. ································⟧",
   "widgetHelpAdd": "⟦Áđđ îŧ ƒřóɱ ýóúř łáúñçĥéř'š ŵîđǧéŧ ƥîçķéř — łóñǧ-ƥřéšš áñ éɱƥŧý ářéá óƒ ŧĥé ĥóɱé šçřééñ, çĥóóšé Ŵîđǧéŧš, áñđ ƒîñđ ŠƥářĶîłó. ············································⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4226,5 +4226,31 @@
   "tripRecordingGpsNotificationText": "Suivi GPS de votre itinéraire",
   "@tripRecordingGpsNotificationText": {
     "description": "Body text of the Android GPS foreground-service notification shown while a trip is recording (#2766)."
+  },
+  "voiceStationAnnouncement": "{name}, à {distanceKm} kilomètres, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "description": "Spoken text-to-speech announcement for a nearby cheap fuel station while in driving/approach mode (#2762), spoken in French. distanceKm is pre-formatted to one decimal place; euros/cents are the price halves.",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12583,6 +12583,18 @@ abstract class AppLocalizations {
   /// **'Apply'**
   String get vehicleDetectedFromVinApply;
 
+  /// Spoken text-to-speech announcement for a nearby cheap fuel station while in driving/approach mode (#2762). Resolved for the app's SELECTED locale (not the widget tree) and spoken by FlutterTtsAnnouncementService. name is the station brand or name; distanceKm is pre-formatted to one decimal place; fuelType is the fuel grade; euros/cents are the whole-euro and two-digit cents halves of the price. Keep this idiomatic for a driver hearing it aloud.
+  ///
+  /// In en, this message translates to:
+  /// **'{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}'**
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  );
+
   /// Title of the home-screen widget help section in Settings (#1806).
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7222,6 +7222,17 @@ class AppLocalizationsBg extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Приложи';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Джаджа на начален екран';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7177,6 +7177,17 @@ class AppLocalizationsCs extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Použít';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget domovské obrazovky';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7167,6 +7167,17 @@ class AppLocalizationsDa extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Anvend';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Startskærm-widget';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7215,6 +7215,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Übernehmen';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, in $distanceKm Kilometern, $fuelType $euros Euro $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Homescreen-Widget';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7228,6 +7228,17 @@ class AppLocalizationsEl extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Εφαρμογή';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget αρχικής οθόνης';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7137,6 +7137,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Apply';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Home-screen widget';
 
   @override
@@ -14517,6 +14528,17 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get vehicleDetectedFromVinApply => '⟦Áƥƥłý ··⟧';
+
+  @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '⟦$name, $distanceKm ķîłóɱéŧéřš áĥéáđ, $fuelType $euros éúřóš $cents ·········⟧';
+  }
 
   @override
   String get widgetHelpSectionTitle => '⟦Ĥóɱé-šçřééñ ŵîđǧéŧ ·······⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7219,6 +7219,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Aplicar';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget de pantalla de inicio';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7158,6 +7158,17 @@ class AppLocalizationsEt extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Rakenda';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Avaekraani vidin';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7165,6 +7165,17 @@ class AppLocalizationsFi extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Sovella';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Aloitusnäytön widget';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7238,6 +7238,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Appliquer';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, à $distanceKm kilomètres, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget d\'écran d\'accueil';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7191,6 +7191,17 @@ class AppLocalizationsHr extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Primijeni';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget na početnom zaslonu';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7213,6 +7213,17 @@ class AppLocalizationsHu extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Alkalmazás';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Kezdőképernyő-widget';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7201,6 +7201,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Applica';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget schermata Home';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7202,6 +7202,17 @@ class AppLocalizationsLt extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Taikyti';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Pradinio ekrano valdiklis';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7206,6 +7206,17 @@ class AppLocalizationsLv extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Lietot';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Sākuma ekrāna logrīks';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7164,6 +7164,17 @@ class AppLocalizationsNb extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Bruk';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Startskjerm-widget';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7189,6 +7189,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Toepassen';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget voor startscherm';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7198,6 +7198,17 @@ class AppLocalizationsPl extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Zastosuj';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget ekranu głównego';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7215,6 +7215,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Aplicar';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget no ecrã inicial';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7214,6 +7214,17 @@ class AppLocalizationsRo extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Aplicați';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget ecran principal';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7195,6 +7195,17 @@ class AppLocalizationsSk extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Použiť';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Widget na domovskej obrazovke';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7175,6 +7175,17 @@ class AppLocalizationsSl extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Uporabi';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Pripomoček za domači zaslon';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7165,6 +7165,17 @@ class AppLocalizationsSv extends AppLocalizations {
   String get vehicleDetectedFromVinApply => 'Tillämpa';
 
   @override
+  String voiceStationAnnouncement(
+    String name,
+    String distanceKm,
+    String fuelType,
+    String euros,
+    String cents,
+  ) {
+    return '$name, $distanceKm kilometers ahead, $fuelType $euros euros $cents';
+  }
+
+  @override
   String get widgetHelpSectionTitle => 'Hemskärmswidget';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4162,5 +4162,32 @@
   "@tripRecordingGpsNotificationText": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceStationAnnouncement": "{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}",
+  "@voiceStationAnnouncement": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Shell"
+      },
+      "distanceKm": {
+        "type": "String",
+        "example": "1.2"
+      },
+      "fuelType": {
+        "type": "String",
+        "example": "Diesel"
+      },
+      "euros": {
+        "type": "String",
+        "example": "1"
+      },
+      "cents": {
+        "type": "String",
+        "example": "42"
+      }
+    }
   }
 }

--- a/test/core/services/announcement_engine_test.dart
+++ b/test/core/services/announcement_engine_test.dart
@@ -42,6 +42,10 @@ class _FakeVoiceAnnouncementService implements VoiceAnnouncementService {
   @override
   Future<void> setLanguage(String languageCode) async =>
       language = languageCode;
+
+  @override
+  Future<void> setAppLocale(String languageCode) async =>
+      language = languageCode;
 }
 
 // ---------------------------------------------------------------------------

--- a/test/core/services/impl/flutter_tts_announcement_service_test.dart
+++ b/test/core/services/impl/flutter_tts_announcement_service_test.dart
@@ -74,6 +74,25 @@ void main() {
       verify(() => tts.setPitch(1.0)).called(1);
     });
 
+    test('pushes a BCP-47 voice for the bound locale on init (#2762)',
+        () async {
+      // Default locale is English until setAppLocale wires the real one.
+      await service.initialize();
+
+      verify(() => tts.setLanguage('en-US')).called(1);
+    });
+
+    test('uses the selected app locale for the native voice on init (#2762)',
+        () async {
+      // The provider calls setAppLocale BEFORE the engine warms up; the
+      // stored code must drive the native voice at init time.
+      await service.setAppLocale('fr');
+
+      await service.initialize();
+
+      verify(() => tts.setLanguage('fr-FR')).called(1);
+    });
+
     test('subsequent calls are no-ops (idempotent)', () async {
       await service.initialize();
       clearInteractions(tts);
@@ -87,6 +106,33 @@ void main() {
     });
   });
 
+  group('setAppLocale() (#2762)', () {
+    test('re-applies the native voice immediately when already initialized',
+        () async {
+      await service.initialize();
+      clearInteractions(tts);
+
+      await service.setAppLocale('de');
+
+      verify(() => tts.setLanguage('de-DE')).called(1);
+    });
+
+    test('does not crash when the native locale is unavailable (fallback)',
+        () async {
+      // Simulate an engine that rejects an unavailable voice.
+      when(() => tts.setLanguage(any())).thenThrow(Exception('no voice'));
+
+      // initialize() applies the locale; the failure must be swallowed so
+      // the service still comes up and can speak with the default voice.
+      await expectLater(service.initialize(), completes);
+
+      await service.setAppLocale('fr');
+      // A localized announce must still work despite the voice failure.
+      when(() => tts.speak(any())).thenAnswer((_) async => 1);
+      await expectLater(service.announce(_candidate()), completes);
+    });
+  });
+
   group('announce()', () {
     test('skips speak when not initialized', () async {
       await service.announce(_candidate());
@@ -94,7 +140,7 @@ void main() {
       verifyNever(() => tts.speak(any()));
     });
 
-    test('speaks formatted text after initialize', () async {
+    test('speaks the localized (English) text after initialize', () async {
       await service.initialize();
 
       await service.announce(_candidate(
@@ -104,8 +150,28 @@ void main() {
       ));
 
       // testStation has brand "STAR" and price 1.42 splits to "1" / "42".
-      verify(() => tts.speak('STAR, 1.2 kilometers ahead, Diesel 1 euro 42'))
+      // Words now come from the ARB key voiceStationAnnouncement (en).
+      verify(() => tts.speak('STAR, 1.2 kilometers ahead, Diesel 1 euros 42'))
           .called(1);
+    });
+
+    test('speaks the FRENCH sentence when bound to the fr locale (#2762)',
+        () async {
+      await service.setAppLocale('fr');
+      await service.initialize();
+
+      await service.announce(_candidate(
+        fuelType: 'Diesel',
+        price: 1.42,
+        distanceKm: 1.2,
+      ));
+
+      // FR ARB value: "{name}, à {distanceKm} kilomètres, {fuelType} ...".
+      verify(() => tts.speak('STAR, à 1.2 kilomètres, Diesel 1 euros 42'))
+          .called(1);
+      // And NOT the hardcoded English wording.
+      verifyNever(
+          () => tts.speak(any(that: contains('kilometers ahead'))));
     });
 
     test('uses brand when brand is non-empty', () async {
@@ -131,7 +197,7 @@ void main() {
         distanceKm: 0.5,
       ));
 
-      verify(() => tts.speak('Shell, 0.5 kilometers ahead, E10 1 euro 79'))
+      verify(() => tts.speak('Shell, 0.5 kilometers ahead, E10 1 euros 79'))
           .called(1);
     });
 
@@ -159,7 +225,7 @@ void main() {
       ));
 
       verify(() => tts.speak(
-              'Independent Garage, 0.5 kilometers ahead, Diesel 1 euro 50'))
+              'Independent Garage, 0.5 kilometers ahead, Diesel 1 euros 50'))
           .called(1);
     });
 
@@ -191,8 +257,8 @@ void main() {
 
       await service.announce(_candidate(price: 1.05));
 
-      // 1.05 -> "1 euro 05" (zero-padded cents from toStringAsFixed(2)).
-      verify(() => tts.speak(any(that: endsWith('1 euro 05')))).called(1);
+      // 1.05 -> "1 euros 05" (zero-padded cents from toStringAsFixed(2)).
+      verify(() => tts.speak(any(that: endsWith('1 euros 05')))).called(1);
     });
   });
 

--- a/test/features/driving/providers/driving_coach_voice_listener_provider_test.dart
+++ b/test/features/driving/providers/driving_coach_voice_listener_provider_test.dart
@@ -51,6 +51,9 @@ class _FakeVoiceAnnouncementService implements VoiceAnnouncementService {
 
   @override
   Future<void> setLanguage(String languageCode) async {}
+
+  @override
+  Future<void> setAppLocale(String languageCode) async {}
 }
 
 /// Toggle stub returning a fixed enabled value (default-ON or forced OFF)

--- a/test/features/driving/providers/voice_announcement_listener_provider_test.dart
+++ b/test/features/driving/providers/voice_announcement_listener_provider_test.dart
@@ -50,6 +50,9 @@ class _FakeVoiceAnnouncementService implements VoiceAnnouncementService {
 
   @override
   Future<void> setLanguage(String languageCode) async {}
+
+  @override
+  Future<void> setAppLocale(String languageCode) async {}
 }
 
 /// Settings notifier stub returning a fixed [AnnouncementConfig].


### PR DESCRIPTION
## Bug
The radar/approach voice announcement ("station ahead, price") was spoken in **English even when the app language was French**.

## Root causes (`lib/core/services/impl/flutter_tts_announcement_service.dart`)
1. **TTS language never set** — `initialize()` configured shared-instance/rate/volume/pitch but never called `setLanguage()`, so flutter_tts used the device-default (usually English) voice. `setLanguage` existed but had no caller in `lib/`.
2. **Spoken text hardcoded English** — `_formatAnnouncement` returned a literal `"… kilometers ahead, … euro …"` (HARD RULE #1 violation), so even a French voice spoke English words/units.

## Fix
- **Bind to the SELECTED locale.** New `setAppLocale(languageCode)` on the service maps the app language code to a BCP-47 tag (`_ttsLocaleFor`: `fr`→`fr-FR`, `de`→`de-DE`, `en`→`en-US`, plus a `<code>-<CODE>` fallback) and pushes it via `setLanguage` at init and on every change. An unavailable native voice is caught and swallowed (graceful fallback to default) so it never crashes an announcement.
- **Wire it in `voice_announcement_providers.dart`.** The keep-alive singleton reads the initial locale from `activeLanguageProvider` (the same source the rest of the app localises from) and a `ref.listen` re-applies it on language change — no service recreation.
- **Localize the spoken text.** New ARB key `voiceStationAnnouncement(name, distanceKm, fuelType, euros, cents)`. Numeric formatting (distance 1-dp, euro/cent split) stays in Dart; the WORDS come from ARB, resolved for the selected locale via `lookupAppLocalizations` (no `BuildContext` — fires from a background announcement context).

## Selected-locale source
`activeLanguageProvider` (`lib/core/language/language_provider.dart`) — the persisted/profile language the whole app already localises against.

## ARB (HARD RULES #1/#4)
- New en+de `_fragments/voice_announcement_{en,de}.arb` → `build_arb` → `gen_pseudo_arb` → `gen-l10n`.
- **Full 23-locale + `en_XA` fan-out committed**; `autofill --check` idempotent; `test/l10n/` all locales at 100%.
- Real FR value shipped (no `x-mt`): `"{name}, à {distanceKm} kilomètres, {fuelType} {euros} euros {cents}"`. EN: `"{name}, {distanceKm} kilometers ahead, {fuelType} {euros} euros {cents}"`. DE: `"{name}, in {distanceKm} Kilometern, {fuelType} {euros} Euro {cents}"`.

## Tests (`test/core/services/impl/flutter_tts_announcement_service_test.dart`)
- `setLanguage('fr-FR')` applied on init when bound to `fr` (and re-applied on locale change → `de-DE`).
- The announced text is the French ARB sentence (`"STAR, à 1.2 kilomètres, Diesel 1 euros 42"`), and **not** `"kilometers ahead"`.
- An unavailable TTS locale (`setLanguage` throws) does not crash `announce`.

## HARD RULES
- #3 clean codegen: `voice_announcement_providers.g.dart` drift committed; a second clean `build_runner build` produced **zero** further drift.
- #4 l10n fan-out committed.
- `file_length` 153 ≤ 400. `no_hardcoded_ui_strings` baseline unchanged (string now via ARB).
- `flutter analyze` clean (2 pre-existing infos in unrelated consumption tests); `test/core/services/`, `test/l10n/`, `test/lint/` + new tests green.

Closes #2762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
