### PR TITLE
feat(trip-recording): finer GPS cadence during active recording (#2766)

### DIFF
--- a/lib/core/location/geolocator_wrapper.dart
+++ b/lib/core/location/geolocator_wrapper.dart
@@ -139,19 +139,29 @@ class GeolocatorWrapper {
   /// detector that subscribes a frame after the recorder still leaves
   /// `ApproachIdle` on the most recent fix instead of waiting for the next.
   ///
-  /// [locationSettings] is read only the first time the underlying stream is
-  /// opened (all trip consumers request `LocationAccuracy.high`); subsequent
-  /// listeners join the existing stream regardless of the settings they pass.
+  /// [recording] marks the caller as the trip recorder, whose fine,
+  /// foreground-service-promoted [locationSettings] must win the cadence on
+  /// the shared upstream (#2766). The underlying platform stream is opened
+  /// with the most recent recording subscriber's settings if one is present,
+  /// regardless of subscription order — so even when the live
+  /// [ApproachDetector] opens the channel first with its coarse settings,
+  /// the recorder's join re-opens the upstream at the fine ~1 s cadence.
+  /// Non-recording consumers (the detector) join with whatever settings the
+  /// upstream is already running.
   Stream<Position> sharedPositionStream({
     LocationSettings? locationSettings,
+    bool recording = false,
   }) {
     final source = _shared ??= _SharedPositionSource(
       // Route through [getPositionStream] (not Geolocator directly) so the
       // single override seam tests already use stays intact and the
       // forceLocationManager wrapping (#2574) is applied in exactly one place.
-      open: () => getPositionStream(locationSettings: locationSettings),
+      open: (settings) => getPositionStream(locationSettings: settings),
     );
-    return source.subscribe();
+    return source.subscribe(
+      locationSettings: locationSettings,
+      recording: recording,
+    );
   }
 
   _SharedPositionSource? _shared;
@@ -162,10 +172,11 @@ class GeolocatorWrapper {
 /// listener, cancels it on the last, and replays the latest fix to late
 /// joiners. Constructed lazily by [GeolocatorWrapper.sharedPositionStream].
 class _SharedPositionSource {
-  _SharedPositionSource({required Stream<Position> Function() open})
-      : _open = open;
+  _SharedPositionSource({
+    required Stream<Position> Function(LocationSettings? settings) open,
+  }) : _open = open;
 
-  final Stream<Position> Function() _open;
+  final Stream<Position> Function(LocationSettings? settings) _open;
   // The shared bus lives for the wrapper's (keepAlive, app-lifetime)
   // lifetime — it is reused across trips so the underlying platform
   // subscription can re-open on the next first-listener without rebuilding
@@ -180,6 +191,14 @@ class _SharedPositionSource {
   StreamSubscription<Position>? _upstream;
   Position? _last;
   int _refCount = 0;
+  // The settings the live [_upstream] was opened with, and the recorder's
+  // fine settings to prefer (#2766). The recorder marks itself `recording`,
+  // and we always (re)open the upstream with `_recordingSettings` when one is
+  // present — so the fine ~1 s cadence wins regardless of who opened the
+  // channel first.
+  LocationSettings? _activeSettings;
+  LocationSettings? _recordingSettings;
+  int _recordingRefCount = 0;
 
   /// Hand a consumer a stream that seeds the latest fix (if any) then
   /// forwards every subsequent fix from the shared broadcast. Opening the
@@ -187,7 +206,10 @@ class _SharedPositionSource {
   /// is driven off the refcount kept here rather than the broadcast
   /// controller's own onListen / onCancel, so the seeded late-join replay
   /// does not perturb the refcount.
-  Stream<Position> subscribe() {
+  Stream<Position> subscribe({
+    LocationSettings? locationSettings,
+    bool recording = false,
+  }) {
     // Per-consumer controller. Closed in its own `onCancel` once the
     // consumer detaches, so there is no leak.
     // ignore: close_sinks
@@ -195,7 +217,7 @@ class _SharedPositionSource {
     StreamSubscription<Position>? relay;
     ctl = StreamController<Position>(
       onListen: () {
-        _retain();
+        _retain(locationSettings: locationSettings, recording: recording);
         // Replay the most recent fix so a late joiner (e.g. the detector
         // subscribing a frame after the recorder) acts on it immediately.
         final last = _last;
@@ -212,36 +234,76 @@ class _SharedPositionSource {
       onCancel: () async {
         await relay?.cancel();
         relay = null;
-        await _release();
+        await _release(recording: recording);
         if (!ctl.isClosed) await ctl.close();
       },
     );
     return ctl.stream;
   }
 
-  void _retain() {
+  void _retain({
+    required LocationSettings? locationSettings,
+    required bool recording,
+  }) {
     _refCount++;
+    if (recording) {
+      _recordingRefCount++;
+      _recordingSettings = locationSettings;
+    }
+    // The effective settings: the recorder's fine settings always win while a
+    // recording consumer is present; otherwise the joining consumer's.
+    final wanted = _recordingRefCount > 0 ? _recordingSettings : locationSettings;
     if (_refCount == 1) {
-      // Cancelled in [_release] when the refcount falls back to 0.
-      _upstream = _open().listen(
-        (p) {
-          _last = p;
-          if (!_out.isClosed) _out.add(p);
-        },
-        onError: (Object e, StackTrace st) {
-          if (!_out.isClosed) _out.addError(e, st);
-        },
-      );
+      _openUpstream(wanted);
+      return;
+    }
+    // Already open. If a recording consumer just joined a channel that was
+    // opened with coarser (non-recording) settings, re-open it at the fine
+    // cadence so the recorder's cadence wins even when the detector opened
+    // first (#2766). Identity compare is enough: the same settings object is
+    // never re-passed, and re-opening on every coarse join is harmless but
+    // unwanted, so we gate strictly on the recorder arriving.
+    if (recording && !identical(_activeSettings, wanted)) {
+      _reopenUpstream(wanted);
     }
   }
 
-  Future<void> _release() async {
+  void _openUpstream(LocationSettings? settings) {
+    _activeSettings = settings;
+    // Cancelled in [_release] when the refcount falls back to 0, or replaced
+    // by [_reopenUpstream] when the recorder upgrades the cadence.
+    _upstream = _open(settings).listen(
+      (p) {
+        _last = p;
+        if (!_out.isClosed) _out.add(p);
+      },
+      onError: (Object e, StackTrace st) {
+        if (!_out.isClosed) _out.addError(e, st);
+      },
+    );
+  }
+
+  void _reopenUpstream(LocationSettings? settings) {
+    final old = _upstream;
+    _upstream = null;
+    _openUpstream(settings);
+    // Cancel the superseded coarse subscription after the fine one is live so
+    // there is no gap in fixes; the broadcast bus + `_last` replay bridge it.
+    unawaited(old?.safeCancel());
+  }
+
+  Future<void> _release({required bool recording}) async {
     if (_refCount == 0) return;
     _refCount--;
+    if (recording && _recordingRefCount > 0) {
+      _recordingRefCount--;
+      if (_recordingRefCount == 0) _recordingSettings = null;
+    }
     if (_refCount == 0) {
       final up = _upstream;
       _upstream = null;
       _last = null;
+      _activeSettings = null;
       await up?.safeCancel();
     }
   }

--- a/lib/core/location/recording_location_settings.dart
+++ b/lib/core/location/recording_location_settings.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../language/language_provider.dart';
+
+/// #2766 — the platform-specific [LocationSettings] used while a trip is
+/// **actively recording**, so the GPS trace stays fine-grained (~1 s) instead
+/// of the ~5 s the OS batches a backgrounded `getPositionStream` down to.
+///
+/// ## Why a bare `LocationSettings` throttles
+///
+/// `LocationSettings(accuracy: high)` carries no interval, no distance filter,
+/// and — on Android — does **not** promote geolocator to a foreground service.
+/// Once the recording screen is backgrounded (driving, screen off) Android
+/// batches fixes to a ~5000 ms median, coarsening the polyline + every
+/// distance / fuel analytic derived from it.
+///
+/// ## The un-throttle levers (per platform, via the plugin pattern)
+///
+///   * **Android** — an [AndroidSettings] with `intervalDuration: 1 s`,
+///     `distanceFilter: 0`, and a [ForegroundNotificationConfig]. The
+///     foreground service is the actual lever: it raises geolocator_android's
+///     priority so the OS stops the ~5 s batching while the persistent
+///     notification is showing. `enableWakeLock` keeps the CPU awake for the
+///     fixes. Title/text come from the already-localized ARB keys.
+///   * **iOS** — an [AppleSettings] with `activityType:
+///     automotiveNavigation` (CLLocationManager tunes accuracy/cadence for a
+///     car), `allowBackgroundLocationUpdates: true`, and
+///     `pauseLocationUpdatesAutomatically: false` so iOS does not auto-pause
+///     updates when it thinks the user stopped moving.
+///
+/// ## Platform selection (no inline `Platform.isX` in business logic)
+///
+/// Selection is on [defaultTargetPlatform] — the same idiom
+/// `auto_record_orchestrator_factories.dart` and `pip_controller.dart` use —
+/// so tests drive it with `debugDefaultTargetPlatform`. An explicit
+/// [platform] override is also accepted for direct unit testing.
+///
+/// ## Battery bound
+///
+/// This is the fine, foreground-service-promoted profile. It is requested
+/// ONLY by the recording pipeline, and the shared position source is
+/// refcounted to the trip lifecycle (opens on the first trip listener,
+/// cancels on the last), so the wakelock + 1 s cadence apply only while a
+/// trip is actively recording. The interval is a self-bounded 1000 ms with
+/// `distanceFilter: 0` — never geolocator's unbounded "fastest".
+LocationSettings recordingLocationSettings({
+  required AppLocalizations l10n,
+  TargetPlatform? platform,
+}) {
+  final target = platform ?? defaultTargetPlatform;
+  switch (target) {
+    case TargetPlatform.android:
+      return AndroidSettings(
+        accuracy: LocationAccuracy.high,
+        // Self-bounded fine cadence: ask for a fix every second and let
+        // every one through (no distance gate) so the trace stays dense
+        // even at a standstill / in stop-and-go traffic.
+        intervalDuration: const Duration(seconds: 1),
+        distanceFilter: 0,
+        // The un-throttle lever: promote geolocator to a foreground service
+        // so the OS stops the ~5 s background batching for the duration of
+        // the trip. Title/text are the already-merged ARB keys (#2766).
+        foregroundNotificationConfig: ForegroundNotificationConfig(
+          notificationTitle: l10n.tripRecordingGpsNotificationTitle,
+          notificationText: l10n.tripRecordingGpsNotificationText,
+          enableWakeLock: true,
+          setOngoing: true,
+        ),
+      );
+    case TargetPlatform.iOS:
+      return AppleSettings(
+        accuracy: LocationAccuracy.high,
+        // Car-tuned Core Location profile — best cadence/accuracy for a
+        // vehicle and lets iOS deliver updates with the screen off.
+        activityType: ActivityType.automotiveNavigation,
+        allowBackgroundLocationUpdates: true,
+        // Do not let iOS auto-pause when it heuristically decides the user
+        // stopped — a fuel-stop or a red light must not end the trace.
+        pauseLocationUpdatesAutomatically: false,
+      );
+    default:
+      // Desktop / web / fuchsia: no platform-specific foreground service
+      // lever exists, so the cross-platform high-accuracy settings are all
+      // there is to give. Recording is a phone feature in practice.
+      return const LocationSettings(accuracy: LocationAccuracy.high);
+  }
+}
+
+/// #2766 — [recordingLocationSettings] with the active in-app language
+/// resolved off [ref] (no `BuildContext`, since the recorder runs from a
+/// notifier / service context). `lookupAppLocalizations` is a pure
+/// synchronous constructor. Both the language read and the lookup are
+/// guarded so a harness (or any context) without the active-profile /
+/// storage graph wired degrades to English notification copy rather than
+/// crashing the trip start — in production the graph is always wired.
+LocationSettings recordingLocationSettingsForRef(
+  Ref ref, {
+  TargetPlatform? platform,
+}) {
+  String code;
+  try {
+    code = ref.read(activeLanguageProvider).code;
+  } catch (_) {
+    code = 'en';
+  }
+  AppLocalizations l10n;
+  try {
+    l10n = lookupAppLocalizations(ui.Locale(code));
+  } catch (_) {
+    l10n = lookupAppLocalizations(const ui.Locale('en'));
+  }
+  return recordingLocationSettings(l10n: l10n, platform: platform);
+}

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -7,6 +7,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/location/geolocator_wrapper.dart';
+import '../../../core/location/recording_location_settings.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/sensors/imu_sample.dart';
 import '../../../core/sensors/imu_sensor_source.dart';
@@ -140,12 +141,20 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     // EventChannel and starve one of them, which broke the fuel-station radar
     // + swipe in GPS-only recording. One underlying subscription, multiplexed,
     // feeds every fix to both consumers.
+    // #2766 — open the SHARED source with the fine, foreground-service
+    // promoted recording settings (Android ~1 s + foreground service;
+    // iOS automotiveNavigation + background updates) so the OS stops the
+    // ~5 s background batching that coarsened the trace + analytics. Marked
+    // `recording: true` so these settings WIN the cadence on the shared
+    // upstream even if the ApproachDetector opened the channel first with its
+    // coarse settings. The notification copy comes from the already-merged
+    // ARB keys, resolved for the active in-app language without a
+    // BuildContext (this runs from the notifier, not a widget).
     final geo = _ref.read(geolocatorWrapperProvider);
     _sub = geo
         .sharedPositionStream(
-          locationSettings: const LocationSettings(
-            accuracy: LocationAccuracy.high,
-          ),
+          recording: true,
+          locationSettings: recordingLocationSettingsForRef(_ref),
         )
         .listen(
           _onPosition,

--- a/test/core/location/recording_location_settings_test.dart
+++ b/test/core/location/recording_location_settings_test.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/location/recording_location_settings.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+/// #2766 — the recording GPS settings builder.
+///
+/// Pins the platform-specific un-throttle levers:
+///   - Android → an [AndroidSettings] with a 1 s interval, distanceFilter 0,
+///     and a [ForegroundNotificationConfig] carrying the ARB title/text +
+///     wakelock (the foreground service is what stops the ~5 s background
+///     batching);
+///   - iOS → an [AppleSettings] with automotiveNavigation +
+///     allowBackgroundLocationUpdates + no auto-pause;
+///   - selection is on the target platform (here via the explicit override),
+///     mirroring the `debugDefaultTargetPlatform` seam tests would otherwise
+///     use — no inline `Platform.isX`.
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  group('recordingLocationSettings (#2766)', () {
+    test('Android → AndroidSettings: 1 s interval, foreground service w/ ARB',
+        () {
+      final settings = recordingLocationSettings(
+        l10n: l10n,
+        platform: TargetPlatform.android,
+      );
+
+      expect(settings, isA<AndroidSettings>());
+      final android = settings as AndroidSettings;
+      expect(android.accuracy, LocationAccuracy.high);
+      expect(android.intervalDuration, const Duration(seconds: 1),
+          reason: 'fine ~1 s cadence, not the ~5 s background default');
+      expect(android.distanceFilter, 0,
+          reason: 'every fix through — dense trace even at a standstill');
+
+      final fg = android.foregroundNotificationConfig;
+      expect(fg, isNotNull,
+          reason: 'the foreground service is the un-throttle lever');
+      expect(fg!.notificationTitle, l10n.tripRecordingGpsNotificationTitle);
+      expect(fg.notificationText, l10n.tripRecordingGpsNotificationText);
+      expect(fg.enableWakeLock, isTrue);
+    });
+
+    test('iOS → AppleSettings: automotiveNavigation + background updates', () {
+      final settings = recordingLocationSettings(
+        l10n: l10n,
+        platform: TargetPlatform.iOS,
+      );
+
+      expect(settings, isA<AppleSettings>());
+      final apple = settings as AppleSettings;
+      expect(apple.accuracy, LocationAccuracy.high);
+      expect(apple.activityType, ActivityType.automotiveNavigation);
+      expect(apple.allowBackgroundLocationUpdates, isTrue);
+      expect(apple.pauseLocationUpdatesAutomatically, isFalse,
+          reason: 'a red light / fuel stop must not auto-end the trace');
+    });
+
+    test('selection follows debugDefaultTargetPlatformOverride when no override',
+        () {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(recordingLocationSettings(l10n: l10n), isA<AndroidSettings>());
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(recordingLocationSettings(l10n: l10n), isA<AppleSettings>());
+    });
+
+    test('desktop/web → plain high-accuracy LocationSettings (no fg lever)',
+        () {
+      final settings = recordingLocationSettings(
+        l10n: l10n,
+        platform: TargetPlatform.macOS,
+      );
+      expect(settings, isA<LocationSettings>());
+      expect(settings, isNot(isA<AndroidSettings>()));
+      expect(settings, isNot(isA<AppleSettings>()));
+      expect(settings.accuracy, LocationAccuracy.high);
+    });
+  });
+}

--- a/test/core/location/shared_position_stream_test.dart
+++ b/test/core/location/shared_position_stream_test.dart
@@ -48,10 +48,14 @@ class _CountingGeolocator extends GeolocatorWrapper {
   int openCount = 0;
   int liveSubscriptions = 0;
   final List<StreamController<Position>> _controllers = [];
+  // Every distinct underlying open's settings, in order (#2766 — lets a test
+  // assert the recorder's fine settings reach the shared upstream).
+  final List<LocationSettings?> openedSettings = [];
 
   @override
   Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
     openCount++;
+    openedSettings.add(locationSettings);
     late final StreamController<Position> ctl;
     ctl = StreamController<Position>(
       onListen: () => liveSubscriptions++,
@@ -217,6 +221,93 @@ void main() {
 
       await sub1.cancel();
       await sub2.cancel();
+    });
+  });
+
+  // #2766 — the recorder's fine, foreground-service-promoted settings must
+  // WIN the cadence on the shared upstream regardless of subscription order.
+  group('GeolocatorWrapper.sharedPositionStream recording cadence (#2766)', () {
+    late _CountingGeolocator geo;
+    setUp(() => geo = _CountingGeolocator());
+    tearDown(() => geo.dispose());
+
+    // The fine recording settings the recorder passes; identity-distinct from
+    // the detector's coarse settings so the source can tell them apart.
+    final fine = AndroidSettings(
+      accuracy: LocationAccuracy.high,
+      intervalDuration: const Duration(seconds: 1),
+      distanceFilter: 0,
+    );
+    const coarse = LocationSettings(accuracy: LocationAccuracy.high);
+
+    test('recorder first → upstream opens with the fine recording settings',
+        () async {
+      final sub = geo
+          .sharedPositionStream(locationSettings: fine, recording: true)
+          .listen((_) {});
+      await _pump();
+
+      expect(geo.openCount, 1);
+      expect(geo.openedSettings.single, same(fine),
+          reason: "recorder's fine settings open the upstream");
+
+      await sub.cancel();
+    });
+
+    test(
+        'detector first (coarse) THEN recorder joins → upstream RE-OPENS at '
+        'the fine cadence, so the recording cadence wins', () async {
+      // The detector opens the channel first with coarse settings.
+      final subDetector = geo
+          .sharedPositionStream(locationSettings: coarse)
+          .listen((_) {});
+      await _pump();
+      expect(geo.openCount, 1);
+      expect(geo.openedSettings.single, same(coarse));
+
+      // The recorder joins a frame later, marked recording: the upstream must
+      // re-open with the FINE settings so the trace stays ~1 s, not ~5 s.
+      final got = <Position>[];
+      final subRecorder = geo
+          .sharedPositionStream(locationSettings: fine, recording: true)
+          .listen(got.add);
+      await _pump();
+
+      expect(geo.openCount, 2, reason: 'recorder forces a re-open');
+      expect(geo.openedSettings.last, same(fine),
+          reason: 'the re-opened upstream carries the fine recording settings');
+      // Only the fine subscription is live now (the coarse one was cancelled).
+      expect(geo.liveSubscriptions, 1);
+
+      // Both consumers keep receiving fixes off the re-opened upstream.
+      geo.emit(_pos(52.5, 13.4));
+      await _pump();
+      expect(got, hasLength(1), reason: 'recorder still receives fixes');
+
+      await subDetector.cancel();
+      await subRecorder.cancel();
+    });
+
+    test('a coarse late joiner does NOT downgrade an already-fine upstream',
+        () async {
+      final subRecorder = geo
+          .sharedPositionStream(locationSettings: fine, recording: true)
+          .listen((_) {});
+      await _pump();
+      expect(geo.openCount, 1);
+
+      // The detector joins later with coarse settings — it must NOT re-open
+      // the upstream (the recorder's fine cadence stays authoritative).
+      final subDetector = geo
+          .sharedPositionStream(locationSettings: coarse)
+          .listen((_) {});
+      await _pump();
+
+      expect(geo.openCount, 1, reason: 'no re-open for a coarse joiner');
+      expect(geo.openedSettings.single, same(fine));
+
+      await subRecorder.cancel();
+      await subDetector.cancel();
     });
   });
 }

--- a/test/features/approach/providers/gps_only_radar_race_test.dart
+++ b/test/features/approach/providers/gps_only_radar_race_test.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
 import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
@@ -140,6 +141,13 @@ class _FixedProfile extends ActiveProfile {
       );
 }
 
+/// #2766 — pins the active language so the pipeline's recording-notification
+/// ARB lookup resolves without the storage / profile graph.
+class _FixedActiveLanguage extends ActiveLanguage {
+  @override
+  AppLanguage build() => const AppLanguage('en', 'English', 'English');
+}
+
 /// Radar whose `fetchStations` returns a fixed priced set without network.
 class _FakeRadar extends FuelStationRadar {
   _FakeRadar(this.stations)
@@ -256,6 +264,9 @@ void main() {
       imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
       tripRecordingProvider.overrideWith(_RecordingTrip.new),
       activeProfileProvider.overrideWith(_FixedProfile.new),
+      // #2766 — the GPS-only pipeline's start() resolves the recording
+      // notification copy; pin the language off the storage graph.
+      activeLanguageProvider.overrideWith(_FixedActiveLanguage.new),
       effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
       approachOverlayEnabledProvider.overrideWithValue(true),
       fuelStationRadarProvider.overrideWithValue(_FakeRadar(const [_station])),

--- a/test/features/consumption/providers/gps_only_imu_fusion_test.dart
+++ b/test/features/consumption/providers/gps_only_imu_fusion_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:hive/hive.dart';
+import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/core/sensors/imu_sample.dart';
 import 'package:tankstellen/core/sensors/imu_sensor_source.dart';
@@ -291,6 +292,9 @@ class _Harness {
       geolocatorWrapperProvider.overrideWithValue(geo),
       imuSensorSourceProvider.overrideWithValue(imu),
       activeVehicleProfileProvider.overrideWith(_NoActiveVehicle.new),
+      // #2766 — start() resolves AppLocalizations for the recording
+      // notification; pin the language so it stays off the storage graph.
+      activeLanguageProvider.overrideWith(_FixedActiveLanguage.new),
     ]);
     pipeline = container.read(_pipelineProvider(host));
   }
@@ -315,6 +319,13 @@ final _pipelineProvider =
 class _NoActiveVehicle extends ActiveVehicleProfile {
   @override
   VehicleProfile? build() => null;
+}
+
+/// #2766 — pins the active language so `start()`'s recording-notification
+/// ARB lookup resolves without the storage / profile graph.
+class _FixedActiveLanguage extends ActiveLanguage {
+  @override
+  AppLanguage build() => const AppLanguage('en', 'English', 'English');
 }
 
 /// A host that writes the finished summary to a REAL repository, so the
@@ -393,7 +404,10 @@ class _RecordingGeolocator extends GeolocatorWrapper {
   int activeListeners = 0;
 
   @override
-  Stream<Position> sharedPositionStream({LocationSettings? locationSettings}) {
+  Stream<Position> sharedPositionStream({
+    LocationSettings? locationSettings,
+    bool recording = false,
+  }) {
     positionStreamCallCount++;
     lastAccuracy = locationSettings?.accuracy;
     final prev = _controller;

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -3,9 +3,11 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/features/consumption/domain/entities/gps_sample_diagnostic.dart';
 import 'package:tankstellen/features/consumption/domain/entities/trip_save_stage.dart';
@@ -54,6 +56,36 @@ void main() {
       // Identity bookkeeping is delegated back to the host.
       expect(harness.host.lastTripVehicleId, 'veh-42');
       expect(harness.host.lastTripStartedAt, isNotNull);
+    });
+
+    test(
+        '#2766 — start() opens the SHARED source with the fine recording '
+        'settings: Android foreground service + ~1 s interval reach the '
+        'upstream so the OS stops the ~5 s background throttle', () {
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+
+      harness.pipeline.start();
+
+      // The recorder is the first (only) trip subscriber here, so the shared
+      // upstream opens with its settings — and they must be the fine Android
+      // recording settings, not a bare LocationSettings.
+      final opened = harness.geo.lastSettings;
+      expect(opened, isA<AndroidSettings>(),
+          reason: 'recording opens with platform-specific Android settings');
+      final android = opened! as AndroidSettings;
+      expect(android.intervalDuration, const Duration(seconds: 1));
+      expect(android.distanceFilter, 0);
+      expect(android.foregroundNotificationConfig, isNotNull,
+          reason: 'the foreground service is the un-throttle lever');
+      expect(
+        android.foregroundNotificationConfig!.notificationTitle,
+        isNotEmpty,
+        reason: 'ARB notification title carried into the config',
+      );
     });
 
     test('each position fix is synthesised into a GPS sample (rpm 0, '
@@ -293,6 +325,10 @@ class _Harness {
       // sensors_plus platform channel. (Dedicated IMU coverage lives in
       // gps_only_imu_fusion_test.dart + imu_event_detector_test.dart.)
       imuSensorSourceProvider.overrideWithValue(EmptyImuSource()),
+      // #2766 — start() resolves AppLocalizations for the active language to
+      // build the recording-notification copy; pin it to English so the test
+      // doesn't pull in the Hive-backed storage / profile graph.
+      activeLanguageProvider.overrideWith(_FixedActiveLanguage.new),
       // No active vehicle → the #2080 GPS-fuel imputation branch sees a
       // null profile and leaves avg / litres null, mirroring a fresh
       // install. (Production reads the real provider here.) When
@@ -324,6 +360,14 @@ final _pipelineProvider =
     Provider.family<GpsOnlyRecordingPipeline, RecordingPipelineHost>(
   (ref, host) => GpsOnlyRecordingPipeline(ref: ref, host: host),
 );
+
+/// #2766 — pins the active language to English so `start()`'s ARB lookup for
+/// the recording-notification copy resolves without the storage / profile
+/// graph. Mirrors the `_FixedActiveLanguage` idiom in app_test.dart.
+class _FixedActiveLanguage extends ActiveLanguage {
+  @override
+  AppLanguage build() => const AppLanguage('en', 'English', 'English');
+}
 
 class _NoActiveVehicle extends ActiveVehicleProfile {
   @override
@@ -429,6 +473,10 @@ Position _pos(
 class _RecordingGeolocator extends GeolocatorWrapper {
   int positionStreamCallCount = 0;
   LocationAccuracy? lastAccuracy;
+  // #2766 — the settings the SHARED source opened the underlying stream with,
+  // so a test can assert the recorder's fine (foreground-service) settings
+  // reached the upstream.
+  LocationSettings? lastSettings;
   StreamController<Position>? _controller;
   int activeListeners = 0;
 
@@ -436,6 +484,7 @@ class _RecordingGeolocator extends GeolocatorWrapper {
   Stream<Position> getPositionStream({LocationSettings? locationSettings}) {
     positionStreamCallCount++;
     lastAccuracy = locationSettings?.accuracy;
+    lastSettings = locationSettings;
     final prev = _controller;
     if (prev != null && !prev.isClosed) prev.close();
     _controller = StreamController<Position>(


### PR DESCRIPTION
Closes #2766

## Problem
The GPS-only recorder opened the shared position stream with a bare `LocationSettings(accuracy: high)` — no interval, no distance filter, no Android foreground-service config — so Android background-throttled fixes to a ~5000 ms median, coarsening the trace + every distance / fuel analytic derived from it.

## Fix
New `lib/core/location/recording_location_settings.dart` builds the platform-specific settings used **only while a trip is actively recording**:

- **Android** — `AndroidSettings(intervalDuration: 1s, distanceFilter: 0, foregroundNotificationConfig: ...)`. The foreground service is the actual un-throttle lever: it raises geolocator_android's priority so the OS stops the ~5 s batching. Title/text reuse the already-merged ARB keys `tripRecordingGpsNotification{Title,Text}`; `enableWakeLock: true`.
- **iOS** — `AppleSettings(activityType: automotiveNavigation, allowBackgroundLocationUpdates: true, pauseLocationUpdatesAutomatically: false)`.

Platform selection is on `defaultTargetPlatform` (the repo idiom in `auto_record_orchestrator_factories` / `pip_controller`) — **no inline `Platform.isX`** in business logic.

### Fine cadence wins on the shared, refcounted stream
`_SharedPositionSource` captured `locationSettings` only on the FIRST open, so if the live `ApproachDetector` opened the channel first with its coarse settings, the recorder's fine settings never applied. The recorder's subscription is now marked `recording: true`, and the source always (re)opens the upstream with the recording settings while a recording consumer is present — so the fine ~1 s cadence wins **regardless of subscription order**. A coarse late joiner never downgrades an already-fine upstream.

### Battery bound
The fine interval + foreground wakelock are requested only by the recorder, and the shared source stays refcounted to the trip lifecycle (opens on the first trip listener, cancels on the last), so they apply only while a trip is actively recording. `distanceFilter: 0, intervalDuration: 1000` is self-bounded, never "fastest". Accel/brake detection (the #2769 IMU fusion) is untouched.

## Tests
- `recording_location_settings_test.dart` — Android → `AndroidSettings` with `intervalDuration == 1s` + `foregroundNotificationConfig` carrying the ARB title/text + wakelock; iOS → `AppleSettings` with automotiveNavigation + background updates; selection via `debugDefaultTargetPlatformOverride`.
- `shared_position_stream_test.dart` — recorder-first opens with the fine settings; detector-first (coarse) THEN recorder-joins re-opens at the fine cadence (recording wins); a coarse late joiner does not downgrade.
- `gps_only_recording_pipeline_test.dart` — `start()` opens the shared source with the fine Android recording settings (foreground service + ~1 s).

`flutter analyze` clean (only 2 pre-existing unrelated `info`s in untouched test files); the three suites + new tests green (4120 passed, 6 skipped). ARB-free — no `lib/l10n/` drift. Clean codegen — no `.g.dart` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
