### PR TITLE
fix(opening-hours): hours render end-to-end in all 6 countries — codec carries structured field + DE/PT detail fetch (#2776)

### DIFF
--- a/lib/features/search/domain/entities/station.dart
+++ b/lib/features/search/domain/entities/station.dart
@@ -38,7 +38,15 @@ abstract class Station with _$Station {
     // country whose service has no detail endpoint (e.g. AT E-Control)
     // still surfaces structured hours via `StationDetail(station:…)`.
     // ADDITIVE: `openingHoursText` / `is24h` stay for back-compat.
-    @JsonKey(includeFromJson: false, includeToJson: false)
+    //
+    // #2777 — MUST serialize: the search-list cache codec
+    // (serializeStationList/deserializeStationList) and the favorites/widget/
+    // deep-link `station.toJson()` paths all round-trip through JSON. With the
+    // field JSON-excluded, a cache-hit search (the dominant repeat path for the
+    // polled FR/AT/CL sources) rehydrated stations with `openingHours == null`
+    // and the detail fast path rendered empty hours. `WeeklyOpeningHours` has
+    // to/fromJson; older cache entries lack the key → null, the same graceful
+    // back-compat fallback the structured `StationDetail.openingHours` uses.
     WeeklyOpeningHours? openingHours,
     @Default(false) bool is24h,
     @Default([]) List<String> services,

--- a/lib/features/search/domain/entities/station.freezed.dart
+++ b/lib/features/search/domain/entities/station.freezed.dart
@@ -21,7 +21,16 @@ mixin _$Station {
 // country whose service has no detail endpoint (e.g. AT E-Control)
 // still surfaces structured hours via `StationDetail(station:…)`.
 // ADDITIVE: `openingHoursText` / `is24h` stay for back-compat.
-@JsonKey(includeFromJson: false, includeToJson: false) WeeklyOpeningHours? get openingHours; bool get is24h; List<String> get services; List<String> get availableFuels; List<String> get unavailableFuels; String? get stationType;// "R" retail, "A" autoroute
+//
+// #2777 — MUST serialize: the search-list cache codec
+// (serializeStationList/deserializeStationList) and the favorites/widget/
+// deep-link `station.toJson()` paths all round-trip through JSON. With the
+// field JSON-excluded, a cache-hit search (the dominant repeat path for the
+// polled FR/AT/CL sources) rehydrated stations with `openingHours == null`
+// and the detail fast path rendered empty hours. `WeeklyOpeningHours` has
+// to/fromJson; older cache entries lack the key → null, the same graceful
+// back-compat fallback the structured `StationDetail.openingHours` uses.
+ WeeklyOpeningHours? get openingHours; bool get is24h; List<String> get services; List<String> get availableFuels; List<String> get unavailableFuels; String? get stationType;// "R" retail, "A" autoroute
  String? get department; String? get region;@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> get amenities;
 /// Create a copy of Station
 /// with the given fields replaced by the non-null parameter values.
@@ -55,7 +64,7 @@ abstract mixin class $StationCopyWith<$Res>  {
   factory $StationCopyWith(Station value, $Res Function(Station) _then) = _$StationCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText,@JsonKey(includeFromJson: false, includeToJson: false) WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
+ String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText, WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
 });
 
 
@@ -201,7 +210,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false)  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Station() when $default != null:
 return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
@@ -222,7 +231,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false)  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)  $default,) {final _that = this;
 switch (_that) {
 case _Station():
 return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
@@ -242,7 +251,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false)  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String brand,  String street,  String? houseNumber, @JsonKey(fromJson: _postCodeToString)  String postCode,  String place,  double lat,  double lng,  double dist, @JsonKey(fromJson: _priceFromJson)  double? e5, @JsonKey(fromJson: _priceFromJson)  double? e10, @JsonKey(fromJson: _priceFromJson)  double? e98, @JsonKey(fromJson: _priceFromJson)  double? diesel, @JsonKey(fromJson: _priceFromJson)  double? dieselPremium, @JsonKey(fromJson: _priceFromJson)  double? e85, @JsonKey(fromJson: _priceFromJson)  double? lpg, @JsonKey(fromJson: _priceFromJson)  double? cng,  bool isOpen,  String? updatedAt,  String? openingHoursText,  WeeklyOpeningHours? openingHours,  bool is24h,  List<String> services,  List<String> availableFuels,  List<String> unavailableFuels,  String? stationType,  String? department,  String? region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson)  Set<StationAmenity> amenities)?  $default,) {final _that = this;
 switch (_that) {
 case _Station() when $default != null:
 return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_that.postCode,_that.place,_that.lat,_that.lng,_that.dist,_that.e5,_that.e10,_that.e98,_that.diesel,_that.dieselPremium,_that.e85,_that.lpg,_that.cng,_that.isOpen,_that.updatedAt,_that.openingHoursText,_that.openingHours,_that.is24h,_that.services,_that.availableFuels,_that.unavailableFuels,_that.stationType,_that.department,_that.region,_that.amenities);case _:
@@ -257,7 +266,7 @@ return $default(_that.id,_that.name,_that.brand,_that.street,_that.houseNumber,_
 @JsonSerializable()
 
 class _Station implements Station {
-  const _Station({required this.id, required this.name, required this.brand, required this.street, this.houseNumber, @JsonKey(fromJson: _postCodeToString) required this.postCode, required this.place, required this.lat, required this.lng, this.dist = 0, @JsonKey(fromJson: _priceFromJson) this.e5, @JsonKey(fromJson: _priceFromJson) this.e10, @JsonKey(fromJson: _priceFromJson) this.e98, @JsonKey(fromJson: _priceFromJson) this.diesel, @JsonKey(fromJson: _priceFromJson) this.dieselPremium, @JsonKey(fromJson: _priceFromJson) this.e85, @JsonKey(fromJson: _priceFromJson) this.lpg, @JsonKey(fromJson: _priceFromJson) this.cng, required this.isOpen, this.updatedAt, this.openingHoursText, @JsonKey(includeFromJson: false, includeToJson: false) this.openingHours, this.is24h = false, final  List<String> services = const [], final  List<String> availableFuels = const [], final  List<String> unavailableFuels = const [], this.stationType, this.department, this.region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) final  Set<StationAmenity> amenities = const {}}): _services = services,_availableFuels = availableFuels,_unavailableFuels = unavailableFuels,_amenities = amenities;
+  const _Station({required this.id, required this.name, required this.brand, required this.street, this.houseNumber, @JsonKey(fromJson: _postCodeToString) required this.postCode, required this.place, required this.lat, required this.lng, this.dist = 0, @JsonKey(fromJson: _priceFromJson) this.e5, @JsonKey(fromJson: _priceFromJson) this.e10, @JsonKey(fromJson: _priceFromJson) this.e98, @JsonKey(fromJson: _priceFromJson) this.diesel, @JsonKey(fromJson: _priceFromJson) this.dieselPremium, @JsonKey(fromJson: _priceFromJson) this.e85, @JsonKey(fromJson: _priceFromJson) this.lpg, @JsonKey(fromJson: _priceFromJson) this.cng, required this.isOpen, this.updatedAt, this.openingHoursText, this.openingHours, this.is24h = false, final  List<String> services = const [], final  List<String> availableFuels = const [], final  List<String> unavailableFuels = const [], this.stationType, this.department, this.region, @JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) final  Set<StationAmenity> amenities = const {}}): _services = services,_availableFuels = availableFuels,_unavailableFuels = unavailableFuels,_amenities = amenities;
   factory _Station.fromJson(Map<String, dynamic> json) => _$StationFromJson(json);
 
 @override final  String id;
@@ -287,7 +296,16 @@ class _Station implements Station {
 // country whose service has no detail endpoint (e.g. AT E-Control)
 // still surfaces structured hours via `StationDetail(station:…)`.
 // ADDITIVE: `openingHoursText` / `is24h` stay for back-compat.
-@override@JsonKey(includeFromJson: false, includeToJson: false) final  WeeklyOpeningHours? openingHours;
+//
+// #2777 — MUST serialize: the search-list cache codec
+// (serializeStationList/deserializeStationList) and the favorites/widget/
+// deep-link `station.toJson()` paths all round-trip through JSON. With the
+// field JSON-excluded, a cache-hit search (the dominant repeat path for the
+// polled FR/AT/CL sources) rehydrated stations with `openingHours == null`
+// and the detail fast path rendered empty hours. `WeeklyOpeningHours` has
+// to/fromJson; older cache entries lack the key → null, the same graceful
+// back-compat fallback the structured `StationDetail.openingHours` uses.
+@override final  WeeklyOpeningHours? openingHours;
 @override@JsonKey() final  bool is24h;
  final  List<String> _services;
 @override@JsonKey() List<String> get services {
@@ -355,7 +373,7 @@ abstract mixin class _$StationCopyWith<$Res> implements $StationCopyWith<$Res> {
   factory _$StationCopyWith(_Station value, $Res Function(_Station) _then) = __$StationCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText,@JsonKey(includeFromJson: false, includeToJson: false) WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
+ String id, String name, String brand, String street, String? houseNumber,@JsonKey(fromJson: _postCodeToString) String postCode, String place, double lat, double lng, double dist,@JsonKey(fromJson: _priceFromJson) double? e5,@JsonKey(fromJson: _priceFromJson) double? e10,@JsonKey(fromJson: _priceFromJson) double? e98,@JsonKey(fromJson: _priceFromJson) double? diesel,@JsonKey(fromJson: _priceFromJson) double? dieselPremium,@JsonKey(fromJson: _priceFromJson) double? e85,@JsonKey(fromJson: _priceFromJson) double? lpg,@JsonKey(fromJson: _priceFromJson) double? cng, bool isOpen, String? updatedAt, String? openingHoursText, WeeklyOpeningHours? openingHours, bool is24h, List<String> services, List<String> availableFuels, List<String> unavailableFuels, String? stationType, String? department, String? region,@JsonKey(fromJson: _amenitiesFromJson, toJson: _amenitiesToJson) Set<StationAmenity> amenities
 });
 
 

--- a/lib/features/search/domain/entities/station.g.dart
+++ b/lib/features/search/domain/entities/station.g.dart
@@ -28,6 +28,11 @@ _Station _$StationFromJson(Map<String, dynamic> json) => _Station(
   isOpen: json['isOpen'] as bool,
   updatedAt: json['updatedAt'] as String?,
   openingHoursText: json['openingHoursText'] as String?,
+  openingHours: json['openingHours'] == null
+      ? null
+      : WeeklyOpeningHours.fromJson(
+          json['openingHours'] as Map<String, dynamic>,
+        ),
   is24h: json['is24h'] as bool? ?? false,
   services:
       (json['services'] as List<dynamic>?)?.map((e) => e as String).toList() ??
@@ -72,6 +77,7 @@ Map<String, dynamic> _$StationToJson(_Station instance) => <String, dynamic>{
   'isOpen': instance.isOpen,
   'updatedAt': instance.updatedAt,
   'openingHoursText': instance.openingHoursText,
+  'openingHours': instance.openingHours?.toJson(),
   'is24h': instance.is24h,
   'services': instance.services,
   'availableFuels': instance.availableFuels,

--- a/lib/features/station_detail/providers/station_detail_provider.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.dart
@@ -26,6 +26,16 @@ part 'station_detail_provider.g.dart';
 /// path below is untouched — it returns synchronously and never hits this.
 const Duration _fallbackFetchTimeout = Duration(seconds: 12);
 
+/// #2778 — country codes (as returned by [Countries.countryCodeForStationId])
+/// whose opening hours live ONLY on the detail endpoint, never in the search
+/// payload: DE Tankerkönig (`list.php` has no hours, `detail.php` does) and PT
+/// DGEG (`PesquisarPostos` has none, `GetDadosPostoMapa` carries `HorarioPosto`).
+/// For a search tap on these, the fast path below fetches [getStationDetail] to
+/// surface hours instead of serving the hours-less cached station. Every other
+/// provider carries hours in the search result (FR/AT/CL/ES via #2777) or has
+/// none to show, so none of them pays an extra fetch on a search tap.
+const _detailOnlyOpeningHoursCountries = {'DE', 'PT'};
+
 @riverpod
 Future<ServiceResult<StationDetail>> stationDetail(
   Ref ref,
@@ -36,7 +46,27 @@ Future<ServiceResult<StationDetail>> stationDetail(
   // hours. This avoids a re-fetch, preserves the brand name, and — for a
   // route tap (#2763) — short-circuits the network entirely.
   final cached = _cachedDetail(ref, stationId);
-  if (cached != null) return cached;
+
+  // `originCountry` is a pure id-prefix parse (#753) — no provider read, no
+  // Hive — so it is safe to resolve before deciding whether to touch the
+  // country service. We need it for two things: the #2778 detail-only-hours
+  // decision below, and the fallback service resolution further down.
+  final originCountry = Countries.countryCodeForStationId(stationId);
+
+  // #2778 — DE Tankerkönig / PT DGEG carry opening hours ONLY on the detail
+  // endpoint; their search payload has none, so a cached search station has
+  // `openingHours == null`. For those, fall through to fetch the real detail;
+  // every other cached station is served instantly below.
+  final needsDetailHoursFetch = cached != null &&
+      cached.data.openingHours == null &&
+      originCountry != null &&
+      _detailOnlyOpeningHoursCountries.contains(originCountry);
+
+  // Common path: serve the cached station instantly WITHOUT touching the
+  // country service (no `activeCountryProvider` read → no Hive). Covers every
+  // cached tap except the DE/PT hours upgrade — FR/AT/CL/ES carry hours via the
+  // search parse + #2777 codec, route taps short-circuit the network (#2763).
+  if (cached != null && !needsDetailHoursFetch) return cached;
 
   // Fallback: fetch from the country whose id prefix the [stationId]
   // carries (#753) — not the active profile country. Widget rows live
@@ -53,7 +83,6 @@ Future<ServiceResult<StationDetail>> stationDetail(
   // unprefixed legacy ids skip the comparison entirely so existing
   // unit tests that overrode just `stationServiceProvider` keep
   // working without standing up Hive.
-  final originCountry = Countries.countryCodeForStationId(stationId);
   final StationService service;
   if (originCountry == null) {
     service = ref.watch(stationServiceProvider);
@@ -62,6 +91,18 @@ Future<ServiceResult<StationDetail>> stationDetail(
     service = (originCountry == activeCountry)
         ? ref.watch(stationServiceProvider)
         : stationServiceForCountry(ref, originCountry);
+  }
+
+  // #2778 — DE/PT hours upgrade: fetch the real detail to surface hours; on any
+  // failure keep the instant cached result so the screen never regresses.
+  if (cached != null) {
+    try {
+      return await service
+          .getStationDetail(stationId)
+          .timeout(_fallbackFetchTimeout);
+    } on Object {
+      return cached;
+    }
   }
 
   try {

--- a/lib/features/station_detail/providers/station_detail_provider.g.dart
+++ b/lib/features/station_detail/providers/station_detail_provider.g.dart
@@ -66,7 +66,7 @@ final class StationDetailProvider
   }
 }
 
-String _$stationDetailHash() => r'bd9a5c2055b1d71d8a3dd54dd456a9a9a192ca4b';
+String _$stationDetailHash() => r'1086a5966fd53468de72df714a9d59d5ba185ee0';
 
 final class StationDetailFamily extends $Family
     with

--- a/lib/features/station_services/germany/tankerkoenig_station_service.dart
+++ b/lib/features/station_services/germany/tankerkoenig_station_service.dart
@@ -100,6 +100,10 @@ class TankerkoenigStationService with StationServiceHelpers implements StationSe
     }
   }
 
+  // #2778 — Tankerkönig list.php (search) carries no hours; openingTimes live
+  // only on detail.php, parsed below. The station-detail fast path fetches
+  // detail for a DE search tap (see _detailOnlyOpeningHoursCountries in
+  // station_detail_provider.dart) instead of serving the hours-less station.
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
     String stationId,

--- a/lib/features/station_services/portugal/portugal_station_service.dart
+++ b/lib/features/station_services/portugal/portugal_station_service.dart
@@ -279,6 +279,11 @@ class PortugalStationService
   /// coordinates, so [PortugalDetailParser] merges its payload onto the cached
   /// search row (coords + prices) — see that helper for the split-endpoint
   /// rationale.
+  // #2778 — DGEG PesquisarPostos (search) carries no hours; HorarioPosto lives
+  // only on the GetDadosPostoMapa detail endpoint, parsed below. The
+  // station-detail fast path fetches detail for a PT search tap (see
+  // _detailOnlyOpeningHoursCountries in station_detail_provider.dart) instead
+  // of serving the hours-less cached station.
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(
     String stationId,

--- a/test/core/services/station_service_chain_codec_opening_hours_test.dart
+++ b/test/core/services/station_service_chain_codec_opening_hours_test.dart
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2777 (Epic #2776 D1) — the search-list cache codec MUST round-trip the
+// structured Station.openingHours. Before the fix the field was
+// @JsonKey(includeFromJson:false,includeToJson:false), so a cache-HIT search
+// (the dominant repeat path for the polled FR/AT/CL sources) rehydrated
+// stations with openingHours==null and the detail fast path rendered empty
+// hours. This drives the REAL France production parse through the REAL codec —
+// it was RED on master (e4c500bb) and is GREEN after the field serializes.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/france/prix_carburants_parsers.dart';
+
+void main() {
+  // The REAL Esso 34120008 (Pézenas) shape from the live data.economie.gouv.fr
+  // feed: a 24/7 automate plus distinct staffed boutique hours.
+  Map<String, dynamic> essoRecord() => <String, dynamic>{
+        'id': '34120008',
+        'geom': <String, dynamic>{'lat': 43.4607, 'lon': 3.4203},
+        'adresse': '28 faubourg des cordeliers',
+        'ville': 'Pézenas',
+        'cp': '34120',
+        'sp95_prix': 1.899,
+        'gazole_prix': 1.799,
+        'horaires_automate_24_24': 'Oui',
+        'horaires_jour':
+            'Automate-24-24, Lundi07.00-18.30, Mardi07.00-18.30, '
+                'Mercredi07.00-18.30, Jeudi07.00-18.30, Vendredi07.00-18.30, '
+                'Samedi08.00-14.00, Dimanche',
+      };
+
+  group('search-list codec opening-hours round-trip (#2777)', () {
+    test('structured Station.openingHours survives serialize -> deserialize',
+        () {
+      final fresh = parsePrixCarburantsStation(essoRecord(), 43.46, 3.42)!;
+      expect(fresh.openingHours, isNotNull,
+          reason: 'precondition — the fresh FR parse populates structured hours');
+
+      // Simulate StationServiceChain Step 1 (cache HIT): the search list is
+      // persisted via serializeStationList and rehydrated via
+      // deserializeStationList exactly as _executeChain does on a cache hit.
+      final restored = deserializeStationList(serializeStationList([fresh]))!.single;
+
+      expect(restored.openingHours, isNotNull,
+          reason: 'structured weekly hours must survive the cache round-trip — '
+              'the detail fast path serves StationDetail(openingHours: '
+              'station.openingHours)');
+
+      // Not just non-null — the actual schedule must be intact.
+      final oh = restored.openingHours!;
+      expect(oh.automate24h, isTrue);
+      expect(oh.dayFor(OpeningDay.mon)?.state, DayState.openRanges);
+      expect(oh.dayFor(OpeningDay.mon)?.ranges.first.startMinutes, 7 * 60);
+      expect(oh.dayFor(OpeningDay.mon)?.ranges.first.endMinutes, 18 * 60 + 30);
+      expect(oh.dayFor(OpeningDay.sat)?.ranges.first.startMinutes, 8 * 60);
+      expect(oh.dayFor(OpeningDay.sat)?.ranges.first.endMinutes, 14 * 60);
+      expect(oh.dayFor(OpeningDay.sun)?.state, DayState.closed);
+      expect(oh.availability, isNot(OpeningHoursAvailability.notProvided));
+    });
+
+    test('a station with no hours round-trips as null (back-compat, no crash)',
+        () {
+      final noHours = parsePrixCarburantsStation(
+        <String, dynamic>{
+          'id': '99999999',
+          'geom': <String, dynamic>{'lat': 48.0, 'lon': 2.0},
+          'ville': 'Nowhere',
+          'gazole_prix': 1.7,
+        },
+        48.0,
+        2.0,
+      )!;
+      final restored =
+          deserializeStationList(serializeStationList([noHours]))!.single;
+      // Either null or a notProvided availability — never a thrown parse.
+      expect(
+          restored.openingHours == null ||
+              restored.openingHours!.availability ==
+                  OpeningHoursAvailability.notProvided,
+          isTrue);
+    });
+  });
+}

--- a/test/features/station_detail/providers/station_detail_provider_detail_only_hours_test.dart
+++ b/test/features/station_detail/providers/station_detail_provider_detail_only_hours_test.dart
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2778 (Epic #2776 D2) — DE (Tankerkönig) and PT (DGEG) carry opening hours
+// ONLY on the detail endpoint; their SEARCH payload has none, so a cached
+// search station has openingHours==null. The station-detail fast path must
+// fall through to getStationDetail for these countries to surface hours,
+// instead of serving the hours-less cached station synchronously (the bug:
+// the section rendered empty). Every other provider is served from cache with
+// no extra fetch. RED on master (fast path returned cached null hours), GREEN
+// after.
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/country/country_provider.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_detail/providers/station_detail_provider.dart';
+
+import '../../../mocks/mocks.dart';
+
+class _FixedActiveCountry extends ActiveCountry {
+  final CountryConfig _country;
+  _FixedActiveCountry(this._country);
+  @override
+  CountryConfig build() => _country;
+}
+
+class _FakeSearchState extends SearchState {
+  final List<SearchResultItem> items;
+  _FakeSearchState(this.items);
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: items,
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}
+
+void main() {
+  late MockStationService mockStationService;
+
+  setUp(() => mockStationService = MockStationService());
+
+  // A cached search station with NO structured hours — exactly what DE/PT
+  // search parses produce (hours live only on the detail endpoint).
+  Station hoursLess(String id) => Station(
+        id: id,
+        name: 'Test',
+        brand: 'Test',
+        street: 'Str.',
+        postCode: '00000',
+        place: 'Town',
+        lat: 50.0,
+        lng: 10.0,
+        isOpen: true,
+        // openingHours intentionally null.
+      );
+
+  ProviderContainer containerFor(CountryConfig country, Station cached) {
+    final c = ProviderContainer(overrides: [
+      stationServiceProvider.overrideWithValue(mockStationService),
+      searchStateProvider
+          .overrideWith(() => _FakeSearchState([FuelStationResult(cached)])),
+      activeCountryProvider.overrideWith(() => _FixedActiveCountry(country)),
+    ]);
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  StationDetail detailWithHours(Station s) => StationDetail(
+        station: s,
+        openingHours: WeeklyOpeningHours.allWeek24h(),
+      );
+
+  group('detail-only opening hours fast-path fall-through (#2778)', () {
+    test('DE: cached search station with no hours → fetches getStationDetail',
+        () async {
+      final cached = hoursLess('de-123');
+      when(() => mockStationService.getStationDetail('de-123')).thenAnswer(
+        (_) async => ServiceResult(
+          data: detailWithHours(cached),
+          source: ServiceSource.tankerkoenigApi,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+
+      final result = await containerFor(Countries.germany, cached)
+          .read(stationDetailProvider('de-123').future);
+
+      expect(result.data.openingHours, isNotNull,
+          reason: 'DE detail endpoint hours must reach the screen');
+      expect(result.data.openingHours!.availability,
+          isNot(OpeningHoursAvailability.notProvided));
+      verify(() => mockStationService.getStationDetail('de-123')).called(1);
+    });
+
+    test('PT: cached search station with no hours → fetches getStationDetail',
+        () async {
+      final cached = hoursLess('pt-456');
+      when(() => mockStationService.getStationDetail('pt-456')).thenAnswer(
+        (_) async => ServiceResult(
+          data: detailWithHours(cached),
+          source: ServiceSource.tankerkoenigApi,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+
+      final result = await containerFor(Countries.portugal, cached)
+          .read(stationDetailProvider('pt-456').future);
+
+      expect(result.data.openingHours, isNotNull);
+      verify(() => mockStationService.getStationDetail('pt-456')).called(1);
+    });
+
+    test('DE: detail fetch failure keeps the instant cached result (no regress)',
+        () async {
+      final cached = hoursLess('de-789');
+      when(() => mockStationService.getStationDetail('de-789'))
+          .thenThrow(Exception('detail endpoint down'));
+
+      final result = await containerFor(Countries.germany, cached)
+          .read(stationDetailProvider('de-789').future);
+
+      // Falls back to the cached station rather than failing the screen.
+      expect(result.data.station.id, 'de-789');
+      expect(result.source, ServiceSource.cache);
+    });
+
+    test('non-detail-only country (AT): served from cache, NO extra fetch',
+        () async {
+      final cached = hoursLess('at-111');
+      final result = await containerFor(Countries.austria, cached)
+          .read(stationDetailProvider('at-111').future);
+
+      expect(result.source, ServiceSource.cache);
+      verifyNever(() => mockStationService.getStationDetail(any()));
+    });
+  });
+}

--- a/test/features/station_detail/providers/station_detail_provider_detail_only_hours_test.dart
+++ b/test/features/station_detail/providers/station_detail_provider_detail_only_hours_test.dart
@@ -16,7 +16,6 @@ import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/country/country_provider.dart';
 import 'package:tankstellen/core/services/service_providers.dart';
 import 'package:tankstellen/core/services/service_result.dart';
-import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';

--- a/test/features/station_services/austria/econtrol_search_opening_hours_test.dart
+++ b/test/features/station_services/austria/econtrol_search_opening_hours_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2780 (Epic #2776 D4) — Austria is a polled-API source with NO detail
+// endpoint, so the search-result Station is the ONLY carrier of opening hours.
+// This drives the REAL EControlStationService.searchStations through an
+// injected Dio (not the divergent _TestableEControlParser copy) and asserts the
+// production parse populates the structured Station.openingHours AND that it
+// survives the search-list codec round-trip — the cache-hit path that rendered
+// empty hours before #2777.
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
+
+/// Returns a fixed E-Control `by-address` payload (a JSON list of station
+/// records) for every request, so the production search pipeline runs without
+/// a live network call.
+class _FixedAdapter implements HttpClientAdapter {
+  final String body;
+  _FixedAdapter(this.body);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async =>
+      ResponseBody.fromString(body, 200, headers: {
+        'content-type': ['application/json'],
+      });
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  test('AT searchStations populates structured hours + survives the codec (#2780)',
+      () async {
+    // One station with a full structured weekly schedule (06:30-20:30 Mon-Sat,
+    // closed Sunday) — the real E-Control `openingHours[]` shape.
+    final body = jsonEncode([
+      <String, dynamic>{
+        'id': '123',
+        'name': 'OMV Wien Ring',
+        'open': true,
+        'location': <String, dynamic>{
+          'latitude': 48.2,
+          'longitude': 16.37,
+          'address': 'Ringstraße 1',
+          'postalCode': '1010',
+          'city': 'Wien',
+        },
+        'prices': [
+          <String, dynamic>{'amount': 1.59}
+        ],
+        'openingHours': [
+          for (final d in const [
+            ['MO', 'Montag'],
+            ['DI', 'Dienstag'],
+            ['MI', 'Mittwoch'],
+            ['DO', 'Donnerstag'],
+            ['FR', 'Freitag'],
+            ['SA', 'Samstag'],
+          ])
+            <String, dynamic>{
+              'day': d[0],
+              'label': d[1],
+              'from': '06:30',
+              'to': '20:30',
+            },
+        ],
+      }
+    ]);
+
+    final dio = Dio()..httpClientAdapter = _FixedAdapter(body);
+    final service = EControlStationService(dio: dio);
+
+    final result = await service.searchStations(
+      const SearchParams(lat: 48.2, lng: 16.37, radiusKm: 10.0),
+    );
+
+    final s = result.data.firstWhere((st) => st.id == 'at-123');
+    expect(s.openingHours, isNotNull,
+        reason: 'the REAL AT search parse must populate structured hours — '
+            'AT has no detail endpoint, so the search Station is the only carrier');
+
+    final restored =
+        deserializeStationList(serializeStationList([s]))!.single;
+    expect(restored.openingHours, isNotNull,
+        reason: 'structured hours must survive the cache round-trip (#2777)');
+    expect(restored.openingHours!.availability,
+        isNot(OpeningHoursAvailability.notProvided));
+    expect(restored.openingHours!.dayFor(OpeningDay.mon)?.state,
+        DayState.openRanges);
+  });
+}

--- a/test/features/station_services/chile/chile_search_opening_hours_test.dart
+++ b/test/features/station_services/chile/chile_search_opening_hours_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2780 (Epic #2776 D4) — Chile is a polled-API source: a cache-hit search
+// rehydrates the list through the codec. This guards the full path the CI
+// adapter-unit test skipped: the REAL CNE search parse must populate the
+// structured Station.openingHours AND it must survive the search-list codec
+// round-trip (serializeStationList -> deserializeStationList), or a tapped CL
+// station renders empty hours on the dominant repeat path.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/chile/chile_response_parser.dart';
+
+void main() {
+  Map<String, dynamic> cneRow(String horario) => <String, dynamic>{
+        'codigo': '12345',
+        'distribuidor': <String, dynamic>{'nombre': 'Copec'},
+        'nombre_fantasia': 'Copec Centro',
+        'direccion_calle': 'Av. Libertador',
+        'direccion_numero': '100',
+        'nombre_comuna': 'Santiago',
+        'ubicacion': <String, dynamic>{'latitud': -33.45, 'longitud': -70.66},
+        'precios': <String, dynamic>{'gasolina_93': 1290.0, 'diesel': 1150.0},
+        'horario_atencion': horario,
+      };
+
+  test('CL search parse populates structured hours + survives the codec (#2780)',
+      () {
+    final stations = parseChileStationsResponse(
+      <String, dynamic>{
+        'data': [cneRow('24_horas')]
+      },
+      fromLat: -33.45,
+      fromLng: -70.66,
+    );
+    final s = stations.single;
+    expect(s.openingHours, isNotNull,
+        reason: 'the REAL CNE search parse must populate structured hours');
+
+    final restored =
+        deserializeStationList(serializeStationList([s]))!.single;
+    expect(restored.openingHours, isNotNull,
+        reason: 'structured hours must survive the cache round-trip (#2777)');
+    expect(restored.openingHours!.availability,
+        isNot(OpeningHoursAvailability.notProvided));
+    // 24/7 should resolve to an open-24h schedule, not collapse to no-data.
+    expect(
+      restored.openingHours!.days.any((d) => d.state == DayState.open24h),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## What & why

Closes #2777, #2778, #2780 · part of Epic #2776 (#2779 closed as verified-unnecessary).

A 14-agent end-to-end audit + a RED-on-master proof found opening hours **broken in 5 of 6 OH countries** — empty hours on the dominant repeat path. Two root causes, both fixed here:

### D1 — codec drops the structured field (#2777) · restores FR/AT/CL
`Station.openingHours` was `@JsonKey(includeFromJson:false, includeToJson:false)`, so `serializeStationList`/`deserializeStationList` — and the favorites/widget/deep-link `station.toJson()` paths — dropped the structured weekly hours on every JSON round-trip. For the polled FR/AT/CL sources a cache-HIT search (the dominant repeat path within the 2–6h TTL) rehydrated stations with `openingHours == null`, the detail fast path served `StationDetail(openingHours: null)`, and the section was elided.

**Fix:** remove the JSON exclusion so the field serializes everywhere. `WeeklyOpeningHours` already has to/fromJson; older cache entries lack the key → null (the same graceful fallback `StationDetail.openingHours` already uses). One change fixes the cache, favorites, widget, and deep-link paths uniformly.

### D2 — DE/PT hours are detail-only (#2778) · restores DE/PT
Tankerkönig `list.php` and DGEG `PesquisarPostos` (the **search** payloads) carry no hours — they live only on the detail endpoint. The fast path served the cached search station synchronously and never called `getStationDetail`, so hours rendered empty.

**Fix:** when a cached search station has `openingHours == null` and its origin country is a detail-only-hours provider (`{DE, PT}`), fall through to `getStationDetail`; on any failure keep the instant cached result. `originCountry` is a pure id-prefix parse, so the common cached path (FR/AT/CL/ES + route taps #2763) still returns without touching the country service — no extra fetch, no `activeCountryProvider`/Hive read.

### D3 (#2779) — closed, not implemented
Verified every `openingHoursText` setter (FR/ES/AT) also sets structured `openingHours`, so after D1 the bridge's priority-1 structured path always wins. A free-form text parser would add mis-render risk for zero coverage.

### D4 — regression guards (#2780)
The audit's core finding: every per-country OH test was an adapter-unit or parse-fn test — **none exercised the search→cache→render path** a real tap takes (that's how this shipped). Added:
- `station_service_chain_codec_opening_hours_test.dart` — real FR parse → real codec round-trip (the #2777 proof; RED on master).
- `chile_search_opening_hours_test.dart` — real CNE parse → codec round-trip.
- `econtrol_search_opening_hours_test.dart` — real AT `searchStations` via injected Dio → codec round-trip (not the divergent `_TestableEControlParser`).
- `station_detail_provider_detail_only_hours_test.dart` — DE/PT search-tap fetches detail; failure keeps cache; non-detail-only country served from cache with no extra fetch.

ES (the one country that already worked) + retiring the divergent `testParseStation` copies remain a tracked follow-up on #2780 (its `searchStations` is coupled to per-province Hive read-through).

## Verification
- **RED→GREEN proven:** the codec round-trip test was RED on master (`Actual: <null>`), GREEN here.
- Clean codegen from clean (HARD RULE #3) — no `.g.dart`/`.freezed.dart` drift; **no `lib/l10n/` changes** (ARB-free, parallel-safe).
- `flutter analyze`: zero new issues.
- 1884 tests pass (`--exclude-tags=network,flaky`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
