### PR TITLE
fix(route-search): cross-border map fits to results (#2782) + animated 'Recherche sur l'itinéraire…' chip (#2783)

### DIFF
--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -49,13 +49,16 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
   RouteViewMode _viewMode = RouteViewMode.allStations;
   final Set<String> _selectedStationIds = {};
 
-  /// #2755 — the camera target: the bounds of the FULL route polyline,
-  /// unioned with every along-route fuel station, computed ONCE from the
-  /// immutable result. Framing these (instead of a ~5 km circle around the
-  /// polyline midpoint) makes the camera show the COMPLETE itinerary; being
-  /// constant across the All/Best toggle, it keeps `StationMapLayers`'
-  /// value-`==` `_lastFitBounds` guard a no-op so the camera holds and never
-  /// re-zooms to the changed station subset.
+  /// #2782 — the camera target: the bounds of the along-route fuel STATIONS
+  /// (the search results), computed ONCE from the immutable result. #2755
+  /// originally framed the full route polyline so the camera showed the
+  /// COMPLETE itinerary, but for a cross-border itinerary that polyline spans
+  /// both countries and the camera zooms far out ("shows far too much").
+  /// Framing the results keeps the scope fit to what the user is actually
+  /// looking at. Computed from ALL result stations (not the displayed
+  /// All/Best subset), so it stays constant across the toggle and keeps
+  /// `StationMapLayers`' value-`==` `_lastFitBounds` guard a no-op — the
+  /// camera holds and never re-zooms to the changed subset.
   late final LatLngBounds _routeBounds = _computeRouteBounds();
 
   /// Pre-layout camera fallback used by `MapOptions.initialCenter` /
@@ -68,18 +71,23 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
       .map((r) => r.station)
       .toList();
 
-  /// Build the route-framing bounds from the polyline geometry unioned
-  /// with the along-route fuel stations. A degenerate single-point set
-  /// gets a tiny epsilon box so `CameraFit.bounds` can't divide-by-zero
-  /// (the same fallback as `trip_path_map_card.dart`).
+  /// Build the framing bounds from the along-route fuel STATIONS (the search
+  /// results) so the camera scope fits what was found (#2782). Falls back to
+  /// the full route polyline only when there are no stations (so an empty
+  /// route still frames something), then to a Paris box if there is no
+  /// geometry either. A degenerate single-point set gets a tiny epsilon box so
+  /// `CameraFit.bounds` can't divide-by-zero (as in `trip_path_map_card.dart`).
   LatLngBounds _computeRouteBounds() {
     final points = <LatLng>[
-      ...widget.routeResult.route.geometry,
       for (final s in _allFuelStations) LatLng(s.lat, s.lng),
     ];
     if (points.isEmpty) {
-      // No geometry and no stations — fall back to a Paris-centred box.
-      // (The build method renders an EmptyState in this case anyway.)
+      // No results to frame — fall back to the route geometry so the
+      // itinerary is still visible (the build method renders an EmptyState
+      // in this case anyway), then to a Paris-centred box.
+      points.addAll(widget.routeResult.route.geometry);
+    }
+    if (points.isEmpty) {
       points.add(const LatLng(48.8566, 2.3522));
     }
     if (points.length == 1) {

--- a/lib/features/search/presentation/widgets/search_summary_bar.dart
+++ b/lib/features/search/presentation/widgets/search_summary_bar.dart
@@ -75,8 +75,15 @@ class SearchSummaryBar extends ConsumerWidget {
     final searching =
         routeState.isLoading || routeState.value?.isPartial == true;
     if (searching) {
+      // #2783 — a live spinner (not the static route icon) so a route search
+      // in progress — including the progressive/partial phase where real
+      // cards are already showing — clearly reads as still ongoing.
       return _SummaryChip(
-        icon: const Icon(Icons.route, size: 16),
+        icon: const SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
         label: l10n?.routeSearchingChip ?? 'Searching the route…',
       );
     }

--- a/test/features/map/presentation/widgets/route_map_view_test.dart
+++ b/test/features/map/presentation/widgets/route_map_view_test.dart
@@ -275,19 +275,20 @@ void main() {
       stationAt('c', 52.78, 13.95), // east of the polyline's max lng
     ];
 
-    /// Expected camera target: bounds of the polyline UNIONED with every
-    /// station — exactly what `RouteMapView._computeRouteBounds` builds.
-    LatLngBounds unionBounds(List<LatLng> geometry, List<Station> stations) {
+    /// Expected camera target (#2782): bounds of the STATIONS (the search
+    /// results) only — exactly what `RouteMapView._computeRouteBounds` now
+    /// builds. The polyline geometry is intentionally NOT unioned in, so a
+    /// long cross-border route no longer drags the camera far out.
+    LatLngBounds stationBounds(List<Station> stations) {
       return LatLngBounds.fromPoints([
-        ...geometry,
         for (final s in stations) LatLng(s.lat, s.lng),
       ]);
     }
 
     testWidgets(
-      'frames the whole route: visibleBounds contains every polyline point '
-      'and every station; camera centre ≈ union-bounds centre (NOT the '
-      'polyline midpoint)',
+      'frames the SEARCH RESULTS: fit target is the station bounds, and the '
+      'far polyline start (SW of the station cluster) is NOT framed — the '
+      'cross-border over-zoom fix (#2782)',
       (tester) async {
         final controller = MapController();
         addTearDown(controller.dispose);
@@ -306,39 +307,36 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        final expected = unionBounds(asymmetricRoute, routeStations);
+        final expected = stationBounds(routeStations);
 
-        // The StationMapLayers explicit fit target IS the union bounds —
-        // not a 5 km circle around any midpoint (approach (a) contract).
+        // The StationMapLayers explicit fit target IS the station (results)
+        // bounds — NOT the polyline∪stations union (#2782).
         final layers =
             tester.widget<StationMapLayers>(find.byType(StationMapLayers));
         expect(layers.cameraFitBounds, expected,
-            reason: 'route mode frames the polyline∪stations bounds');
+            reason: 'route mode frames the search-result stations, not the '
+                'full route polyline');
 
-        // The real camera frames the whole itinerary: every polyline point
-        // and every station is inside the visible viewport.
+        // The far polyline START (p0, SW of the station cluster) is OUTSIDE
+        // the fit bounds — this is the whole point of #2782: a long
+        // cross-border route no longer drags the camera out to the geometry.
+        final polylineStart = asymmetricRoute.first; // 52.40, 13.20
+        expect(expected.contains(polylineStart), isFalse,
+            reason: 'the fit target must exclude the far route geometry so a '
+                'cross-border itinerary does not over-zoom');
+
+        // Every station (result) is inside the visible viewport.
         final visible = controller.camera.visibleBounds;
-        for (final p in asymmetricRoute) {
-          expect(visible.contains(p), isTrue,
-              reason: 'polyline point $p must be in view');
-        }
         for (final s in routeStations) {
           expect(visible.contains(LatLng(s.lat, s.lng)), isTrue,
               reason: 'station ${s.id} must be in view');
         }
 
-        // The camera centre is the union-bounds centre, NOT geometry[mid].
-        final midIdx = asymmetricRoute.length ~/ 2;
-        final mid = asymmetricRoute[midIdx];
+        // The camera centre is the station-bounds centre.
         expect(controller.camera.center.latitude,
             closeTo(expected.center.latitude, 0.02));
         expect(controller.camera.center.longitude,
             closeTo(expected.center.longitude, 0.02));
-        expect(
-          (controller.camera.center.longitude - mid.longitude).abs(),
-          greaterThan(0.1),
-          reason: 'must NOT centre on the polyline midpoint (the #2755 bug)',
-        );
 
         expect(tester.takeException(), isNull);
       },

--- a/test/features/search/presentation/widgets/search_summary_bar_test.dart
+++ b/test/features/search/presentation/widgets/search_summary_bar_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
@@ -110,9 +111,14 @@ void main() {
             const AsyncValue<RouteSearchResult?>.loading(),
           ),
         ],
+        // #2783 — the searching chip now carries an indefinite spinner;
+        // pumpAndSettle would hang, so pump a single frame.
+        settle: false,
       );
 
       expect(find.text('Searching the route…'), findsOneWidget);
+      // #2783 — a live spinner signals the search is ongoing.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.text('Within 10 km'), findsNothing);
       expect(find.text('Every 50 km'), findsNothing);
     });
@@ -141,9 +147,12 @@ void main() {
             ),
           ),
         ],
+        // #2783 — spinner animates indefinitely during the partial phase too.
+        settle: false,
       );
 
       expect(find.text('Searching the route…'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.text('Every 50 km'), findsNothing);
     });
 

--- a/test/helpers/pump_app.dart
+++ b/test/helpers/pump_app.dart
@@ -17,6 +17,7 @@ Future<void> pumpApp(
   List<Object>? overrides,
   Locale locale = const Locale('en'),
   TextDirection? textDirection,
+  bool settle = true,
 }) async {
   Widget body = child;
   if (textDirection != null) {
@@ -37,7 +38,14 @@ Future<void> pumpApp(
       ),
     ),
   );
-  await tester.pumpAndSettle();
+  // `settle: false` for screens with an indefinite animation (e.g. a loading
+  // spinner / shimmer) that `pumpAndSettle` would wait on forever — pump a
+  // single frame so the first paint is asserted without hanging.
+  if (settle) {
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump();
+  }
 }
 
 /// Convenience wrapper that pumps a widget with a custom [TextScaler].


### PR DESCRIPTION
Closes #2782, #2783. Two display-only route-search UX fixes — neither touches the route-search result/country-profile logic (confirmed correct).

## #2782 — cross-border itinerary over-zoom
`route_map_view._computeRouteBounds` framed the full route polyline (#2755), so a cross-border itinerary zoomed far out. Now fits the camera to the along-route **stations (search results)**; polyline is the fallback when there are no stations. Bounds stay constant across the All/Best toggle. Test asserts results-fit **and** that the far polyline start is excluded.

## #2783 — ongoing-search animation
The 'Searching the route…' / 'Recherche sur l'itinéraire…' summary chip was static. Now shows a live `CircularProgressIndicator` while `isLoading || isPartial` (covers the progressive phase), matching the existing autocomplete spinner. **ARB-free** (key already in EN+FR). Adds an opt-in `settle: false` to `pumpApp` so animated states don't hang `pumpAndSettle`.

## Verification
- Clean codegen (no drift); **no l10n drift**; file_length green; `flutter analyze` zero new issues.
- 1169 search/map/route tests pass; affected tests updated to the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)