### PR TITLE
fix(gps-recording): stream foreground-only while FGS permission is removed + de-noise empty-stop discard (#2787)

### DIFF
--- a/lib/core/location/recording_location_settings.dart
+++ b/lib/core/location/recording_location_settings.dart
@@ -10,6 +10,28 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../../l10n/app_localizations.dart';
 import '../language/language_provider.dart';
 
+/// #2787/#1498 — whether the GPS-recording foreground service may be requested.
+///
+/// #2766 promotes the recording GPS stream to an Android foreground service to
+/// beat the OS's ~5 s background batching. But the `FOREGROUND_SERVICE`
+/// permission is `tools:node="remove"`'d from AndroidManifest.xml for the Open
+/// Testing release (#1498 — ship without triggering Google Play's "Foreground
+/// Service Use" form). With the permission gone, geolocator's `startForeground`
+/// throws `Permission Denial: startForeground … requires FOREGROUND_SERVICE`
+/// and the GPS stream never starts — the trip captures zero fixes and is
+/// discarded as "no movement" (error log #17).
+///
+/// While this is `false` the recorder streams **foreground-only**, which is
+/// reliable because the recording screen pins itself (screen-on by default,
+/// #2785). Flip to `true` **together with** re-adding the manifest
+/// `FOREGROUND_SERVICE` permission once #1498's Play form is approved.
+///
+/// Deliberately `final` (not `const`): a non-const flag keeps the analyzer
+/// from marking the gated `ForegroundNotificationConfig` branch as dead code
+/// while the flag is `false`, so the restore path stays compiled + visible.
+// ignore: prefer_const_declarations
+final bool kGpsRecordingForegroundServiceEnabled = false;
+
 /// #2766 — the platform-specific [LocationSettings] used while a trip is
 /// **actively recording**, so the GPS trace stays fine-grained (~1 s) instead
 /// of the ~5 s the OS batches a backgrounded `getPositionStream` down to.
@@ -65,15 +87,20 @@ LocationSettings recordingLocationSettings({
         // even at a standstill / in stop-and-go traffic.
         intervalDuration: const Duration(seconds: 1),
         distanceFilter: 0,
-        // The un-throttle lever: promote geolocator to a foreground service
-        // so the OS stops the ~5 s background batching for the duration of
-        // the trip. Title/text are the already-merged ARB keys (#2766).
-        foregroundNotificationConfig: ForegroundNotificationConfig(
-          notificationTitle: l10n.tripRecordingGpsNotificationTitle,
-          notificationText: l10n.tripRecordingGpsNotificationText,
-          enableWakeLock: true,
-          setOngoing: true,
-        ),
+        // The un-throttle lever: promote geolocator to a foreground service so
+        // the OS stops the ~5 s background batching for the trip. Gated by
+        // [kGpsRecordingForegroundServiceEnabled] — OFF while the manifest
+        // FOREGROUND_SERVICE permission is removed (#1498), so we pass `null`
+        // and stream foreground-only rather than crash on startForeground
+        // (error log #17 / #2787). Title/text are the already-merged ARB keys.
+        foregroundNotificationConfig: kGpsRecordingForegroundServiceEnabled
+            ? ForegroundNotificationConfig(
+                notificationTitle: l10n.tripRecordingGpsNotificationTitle,
+                notificationText: l10n.tripRecordingGpsNotificationText,
+                enableWakeLock: true,
+                setOngoing: true,
+              )
+            : null,
       );
     case TargetPlatform.iOS:
       return AppleSettings(

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -966,20 +966,31 @@ class TripRecording extends _$TripRecording {
       // No silent discard (#2509): record WHY so a regression of the
       // silent-data-loss bug surfaces in the error log, and let the caller
       // surface a "no movement detected" notice to the user.
-      unawaited(errorLogger.log(
-        ErrorLayer.providers,
-        StateError('trip discarded — no movement detected'),
-        StackTrace.current,
-        context: {
-          'where': 'TripRecording._saveToHistory discard',
-          'reason': 'no-movement',
-          'distanceKm': summary.distanceKm.toStringAsFixed(4),
-          'distanceSource': summary.distanceSource,
-          'sampleCount': samples.length.toString(),
-          'gpsFixCount': gpsFixCount.toString(),
-          'hadStartedAt': (summary.startedAt != null).toString(),
-        },
-      ));
+      //
+      // #2787 — but only error-log when captured SIGNAL is actually being
+      // dropped (the silent-data-loss regression this guard exists to catch).
+      // A genuinely empty stop — no samples AND no GPS fixes, e.g. the user
+      // stopped without moving, or the foreground GPS stream never started
+      // (the #2766 FGS-permission case, error log #17) — has no data to lose,
+      // so logging it as an error trace is pure noise. The user-facing "no
+      // movement detected" notice (the returned outcome) is unchanged.
+      final droppedCapturedSignal = samples.isNotEmpty || gpsFixCount > 0;
+      if (droppedCapturedSignal) {
+        unawaited(errorLogger.log(
+          ErrorLayer.providers,
+          StateError('trip discarded — no movement detected'),
+          StackTrace.current,
+          context: {
+            'where': 'TripRecording._saveToHistory discard',
+            'reason': 'no-movement',
+            'distanceKm': summary.distanceKm.toStringAsFixed(4),
+            'distanceSource': summary.distanceSource,
+            'sampleCount': samples.length.toString(),
+            'gpsFixCount': gpsFixCount.toString(),
+            'hadStartedAt': (summary.startedAt != null).toString(),
+          },
+        ));
+      }
       return TripPersistOutcome.discardedNoMovement;
     }
     try {

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'8d850a48026bdb6556ad0956b706c89a400fb4f2';
+String _$tripRecordingHash() => r'17c301334b0a6c620436c071009441bf2e1e464c';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/core/location/recording_location_settings_test.dart
+++ b/test/core/location/recording_location_settings_test.dart
@@ -25,7 +25,7 @@ void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
 
   group('recordingLocationSettings (#2766)', () {
-    test('Android → AndroidSettings: 1 s interval, foreground service w/ ARB',
+    test('Android → AndroidSettings: 1 s interval, foreground-only (#2787)',
         () {
       final settings = recordingLocationSettings(
         l10n: l10n,
@@ -40,12 +40,15 @@ void main() {
       expect(android.distanceFilter, 0,
           reason: 'every fix through — dense trace even at a standstill');
 
-      final fg = android.foregroundNotificationConfig;
-      expect(fg, isNotNull,
-          reason: 'the foreground service is the un-throttle lever');
-      expect(fg!.notificationTitle, l10n.tripRecordingGpsNotificationTitle);
-      expect(fg.notificationText, l10n.tripRecordingGpsNotificationText);
-      expect(fg.enableWakeLock, isTrue);
+      // #2787 — the foreground service is gated OFF while the manifest
+      // FOREGROUND_SERVICE permission is removed (#1498); requesting it threw
+      // a startForeground Permission Denial that killed the GPS stream (error
+      // log #17). Foreground-only until the flag + manifest permission return.
+      expect(kGpsRecordingForegroundServiceEnabled, isFalse,
+          reason: 'guards against re-enabling the FGS without the manifest '
+              'permission — flip both together when #1498 lands');
+      expect(android.foregroundNotificationConfig, isNull,
+          reason: 'no startForeground while FOREGROUND_SERVICE is removed');
     });
 
     test('iOS → AppleSettings: automotiveNavigation + background updates', () {

--- a/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
+++ b/test/features/consumption/providers/gps_only_recording_pipeline_test.dart
@@ -79,13 +79,13 @@ void main() {
       final android = opened! as AndroidSettings;
       expect(android.intervalDuration, const Duration(seconds: 1));
       expect(android.distanceFilter, 0);
-      expect(android.foregroundNotificationConfig, isNotNull,
-          reason: 'the foreground service is the un-throttle lever');
-      expect(
-        android.foregroundNotificationConfig!.notificationTitle,
-        isNotEmpty,
-        reason: 'ARB notification title carried into the config',
-      );
+      // #2787 — the foreground service is gated OFF while the manifest
+      // FOREGROUND_SERVICE permission is removed (#1498); requesting it threw a
+      // startForeground Permission Denial that killed the GPS stream (error
+      // log #17). The fine 1 s / distanceFilter-0 cadence still applies; the
+      // recorder streams foreground-only (the screen is pinned, #2785).
+      expect(android.foregroundNotificationConfig, isNull,
+          reason: 'no startForeground while FOREGROUND_SERVICE is removed');
     });
 
     test('each position fix is synthesised into a GPS sample (rpm 0, '

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -336,7 +336,10 @@ void main() {
     // switch gained the `degradedGpsOnly` case (mapped to 'recording' — a
     // degraded trip is still actively recording) + its rationale comment.
     // Pure mapping; decomposition still tracked by #2187/#2188/#2190.
-    'lib/features/consumption/providers/trip_recording_provider.dart': 1240,
+    // #2787 — 1240 → 1246: the no-movement discard now only error-logs when
+    // captured signal is actually dropped (the droppedCapturedSignal guard +
+    // its comment), so an empty stop no longer spams the error log.
+    'lib/features/consumption/providers/trip_recording_provider.dart': 1246,
     'lib/features/feature_management/data/legacy_toggle_migrator.dart': 647,
     // #2510 — re-grandfathered 544 → 562: the nearby-search map no longer
     // hides results behind count-clusters. Adds the `rankForEmphasis`


### PR DESCRIPTION
Closes #2787. Error log #17 — two linked GPS-only recording bugs, both ARB-free.

## Root cause — `startForeground … requires FOREGROUND_SERVICE` (×2)
#2766 promoted the recording GPS stream to an Android **foreground service**, but `FOREGROUND_SERVICE` is `tools:node="remove"`'d from the manifest for the Open Testing release (#1498 — avoid the Play 'Foreground Service Use' form). geolocator's `startForeground` was denied → the GPS stream never started → **0 fixes**.

**Fix:** gate the FGS config behind `kGpsRecordingForegroundServiceEnabled` (false while the manifest permission is removed). The recorder streams **foreground-only** — reliable because the recording screen is pinned (screen-on by default, #2785). Fine 1 s / distanceFilter-0 cadence unchanged. Flip the flag **and** re-add the manifest permission together when #1498's Play form lands.

## Consequence — `StateError: trip discarded — no movement detected` (×2)
With 0 GPS fixes the no-movement guard discards the trip (correct). But it was error-logged unconditionally; the #2509 intent was to catch **silent data loss** (real signal dropped). An empty stop (no samples AND no fixes) has nothing to lose → noise.

**Fix:** only error-log the discard when captured signal is actually dropped (`samples>0 || gpsFixCount>0`). The user-facing 'no movement detected' notice is unchanged.

## Verification
- Clean codegen (only the riverpod hash for the edited notifier); **no `lib/l10n` changes**; `flutter analyze` zero new issues.
- Affected suites pass (location + consumption providers, 386 tests); settings + pipeline tests updated to assert the gated-null FGS config with the 1 s cadence intact; existing discard-outcome tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)