### PR TITLE
fix(gps-only): carry altitude/geo through trip-detail converter — un-zeroes climb energy (#2790)

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart
@@ -24,4 +24,12 @@ TripSample tripDetailToTripSample(TripDetailSample s) => TripSample(
       throttlePercent: s.throttlePercent,
       pedalPercent: s.pedalPercent,
       lambda: s.lambda,
+      // #2790 — carry the geo/altitude signals so the recomputed GPS features
+      // are not silently zeroed. Without these the climb-energy block sees no
+      // altitude (→ 0 m/km despite a real climb) and distance falls back to
+      // speed×dt instead of haversine. The forward converter (toDetailSample)
+      // already preserves them; the reverse must too.
+      latitude: s.latitude,
+      longitude: s.longitude,
+      altitudeM: s.altitudeM,
     );

--- a/test/features/consumption/presentation/widgets/trip_detail_to_trip_sample_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_detail_to_trip_sample_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2790 — the trip-detail screen recomputes GPS driving features from
+// `widget.samples.map(tripDetailToTripSample)`. The reverse converter used to
+// drop altitudeM/latitude/longitude, so the recomputed features showed climb
+// energy 0 m/km (and speed×dt distance) even when the altitude track clearly
+// climbed — while the altitude CHART looked right because it uses the other
+// converter (toDetailSample) that keeps altitude. RED before the fix
+// (climbEnergyPerKm == 0), GREEN after.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart';
+
+void main() {
+  test('converter preserves altitude/lat/lng (round-trip)', () {
+    final s = TripDetailSample(
+      timestamp: DateTime(2026, 6, 3, 12),
+      speedKmh: 30,
+      latitude: 43.46,
+      longitude: 3.42,
+      altitudeM: 100.0,
+    );
+    final t = tripDetailToTripSample(s);
+    expect(t.latitude, 43.46);
+    expect(t.longitude, 3.42);
+    expect(t.altitudeM, 100.0);
+  });
+
+  test('recomputed GPS features keep a non-zero climb energy for a climbing '
+      'GPS-only track (#2790)', () {
+    final start = DateTime(2026, 6, 3, 12);
+    final detail = <TripDetailSample>[
+      for (var i = 0; i < 30; i++)
+        TripDetailSample(
+          timestamp: start.add(Duration(seconds: i)),
+          speedKmh: 50, // moving — non-zero distance
+          latitude: 43.46 + i * 0.0002, // ~22 m/step, a real ground track
+          longitude: 3.42,
+          altitudeM: 60.0 + i * 1.5, // climbs ~43 m over the track
+        ),
+    ];
+
+    final features =
+        GpsDrivingFeatures.from(detail.map(tripDetailToTripSample));
+    expect(features, isNotNull);
+    expect(features!.climbEnergyPerKm, greaterThan(0),
+        reason: 'altitude must survive the converter so a real climb is not '
+            'reported as 0 m/km on the trip-detail GPS-efficiency card');
+  });
+}


### PR DESCRIPTION
Closes #2790 (Epic #2789 C1). ARB-free.

The trip-detail GPS-efficiency card showed **Énergie de montée 0 m/km despite a clear ~17 m climb** (your GPS-only screenshots). Root cause: `tripDetailToTripSample` (the reverse converter the screen uses to recompute GPS features) dropped `altitudeM`/`latitude`/`longitude`, so the recomputed features had no altitude (→ climb 0) and fell back to speed×dt distance instead of haversine. The altitude **chart** was fine because it uses the *forward* converter (`toDetailSample`) which keeps altitude.

Fix: carry the three geo/altitude fields through the reverse converter.

**RED→GREEN proven:** a climbing GPS-only track → converter → `GpsDrivingFeatures.from` asserts `climbEnergyPerKm > 0` (RED without the fix). 624 widget/domain tests pass; analyze clean; no codegen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)