### PR TITLE
fix(pump-ocr): grayscale retry + salvage garbled unit price so 7-seg LCDs aren't 'nothing recognized' (#2798)

### DIFF
--- a/lib/features/consumption/data/_pump_display_patterns.dart
+++ b/lib/features/consumption/data/_pump_display_patterns.dart
@@ -106,6 +106,16 @@ final List<RegExp> kPricePerLiterPatterns = <RegExp>[
 final RegExp kCentsPerLiterPattern =
     RegExp(r'\bCT\b\s*[:=]?\s*(\d{2,3}[.,]?\d?)', caseSensitive: false);
 
+/// #2798 — a glare-garbled unit price whose 7-segment decimal dot was lost AND
+/// whose leading "1" misread as a 1-lookalike LETTER ("L999"/"l999"/"I999" for
+/// 1,999 €/L). Deliberately requires a LEADING LETTER (not a bare digit) +
+/// exactly three digits, so a separator-less total/volume run of bare digits
+/// (e.g. "1049", "5277") can never match — only the unambiguous "letter then
+/// three digits" garble. The parser still band-checks the recovered value to a
+/// plausible fuel unit price before accepting it.
+final RegExp kGarbledPricePerLiterPattern =
+    RegExp(r'(?:^|\s)([LlIi])(\d{3})(?=\s|€|/|$)');
+
 /// Matches a lone digit 1-9 on a line — the large pump-number glyph
 /// printed on the cabinet.
 final RegExp kLonePumpDigitPattern = RegExp(r'^[1-9]$');

--- a/lib/features/consumption/data/ocr/image_orientation.dart
+++ b/lib/features/consumption/data/ocr/image_orientation.dart
@@ -61,6 +61,7 @@ Uint8List? preprocessPumpDisplayForOcr(
   Uint8List jpegBytes, {
   OcrNormalizedRect? roi,
   OcrImagePreprocessor preprocessor = const OcrImagePreprocessor(),
+  bool binarize = true,
 }) {
   try {
     final decoded = img.decodeJpg(jpegBytes);
@@ -70,6 +71,17 @@ Uint8List? preprocessPumpDisplayForOcr(
         roi != null ? preprocessor.cropToRoi(upright, roi) : upright;
     final gray = preprocessor.toGrayscale(cropped);
     final denoised = preprocessor.denoise(gray);
+    if (!binarize) {
+      // #2798 — contrast-stretched GRAYSCALE (the originally-documented #1860
+      // intent). ML Kit is trained on natural/grayscale images, not 1-bit line
+      // art: the #2275 Sauvola binarization, run with a fixed window against a
+      // large crop, fits inside one fat 7-segment stroke and dissolves the
+      // value digits to background — only the thin printed labels survive. The
+      // pump path retries with this grayscale variant when the binarized pass
+      // recovers nothing.
+      return img.encodeJpg(img.normalize(denoised, min: 0, max: 255),
+          quality: 90);
+    }
     final binary = preprocessor.sauvolaBinarize(denoised);
     final closed = preprocessor.morphologicalClose(binary);
     return img.encodeJpg(closed, quality: 90);

--- a/lib/features/consumption/data/pump_display_parser.dart
+++ b/lib/features/consumption/data/pump_display_parser.dart
@@ -164,6 +164,19 @@ class PumpDisplayParser {
         return ct / 100.0;
       }
     }
+    // #2798 — last-resort salvage of a glare-garbled unit price: a 7-segment
+    // LCD shows €/L as "1.999" but the dot is frequently lost and the leading
+    // "1" reads as a 1-lookalike letter ("L999"). Reconstruct X.XXX and accept
+    // it ONLY inside the plausible fuel unit-price band so a stray token can
+    // never fabricate an out-of-range price. Letter-led by construction (see
+    // kGarbledPricePerLiterPattern), so bare-digit totals/volumes never match.
+    final garbled = kGarbledPricePerLiterPattern.firstMatch(text);
+    if (garbled != null) {
+      final value = parseDecimalFromOcr('1.${garbled.group(2)!}');
+      if (value != null && value >= 0.8 && value <= 3.5) {
+        return value;
+      }
+    }
     return null;
   }
 

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -202,23 +202,39 @@ class ReceiptScanService {
     // block geometry (#2478) — not just the flat string — so the
     // label-anchored extractor can tell which number sits under which
     // label and recover the dropped unit price.
-    final recognised = await _recognisePump(path, roi: roi);
+    var recognised = await _recognisePump(path, roi: roi);
     if (recognised == null) {
       await _tryDelete(path);
       return null;
     }
+    // #2478 PRIMARY label-anchored read (recovers the dropped PRIX DU LITRE),
+    // flat-string fallback, then the gate.
+    PumpDisplayParseResult parseFor(
+            ({String text, List<RecognizedTextBlock> blocks}) r) =>
+        orchestratePumpDisplayParse(
+            blocks: r.blocks,
+            text: r.text,
+            profile: profile,
+            parser: _pumpParser,
+            gate: _pumpGate,
+            trace: trace);
+    var parse = parseFor(recognised);
+
+    // #2798 — the #2275 binarization can dissolve faint 7-seg value digits
+    // (ML Kit returns only labels → nothing derived). When the binarized pass
+    // recovers nothing, retry once with grayscale and keep it only if it reads
+    // more — non-regressive: a usable binarized read is never replaced.
+    if (!parse.hasUsableData) {
+      final gray = await _recognisePump(path, roi: roi, binarize: false);
+      final grayParse = gray == null ? null : parseFor(gray);
+      if (gray != null && grayParse!.hasUsableData) {
+        recognised = gray;
+        parse = grayParse;
+      }
+    }
     trace?.blocks(recognised.text, recognised.blocks);
     return PumpDisplayScanOutcome(
-      // #2478 — PRIMARY label-anchored read (recovers the dropped PRIX DU
-      // LITRE unit price), flat-string parser fallback, then the gate.
-      parse: orchestratePumpDisplayParse(
-        blocks: recognised.blocks,
-        text: recognised.text,
-        profile: profile,
-        parser: _pumpParser,
-        gate: _pumpGate,
-        trace: trace,
-      ),
+      parse: parse,
       ocrText: recognised.text,
       imagePath: path,
     );
@@ -304,8 +320,10 @@ class ReceiptScanService {
   Future<({String text, List<RecognizedTextBlock> blocks})?> _recognisePump(
     String path, {
     OcrNormalizedRect? roi,
+    bool binarize = true,
   }) async {
-    final recognized = await _recogniseRaw(path, enhanceContrast: true, roi: roi);
+    final recognized = await _recogniseRaw(path,
+        enhanceContrast: true, roi: roi, binarize: binarize);
     if (recognized == null) return null;
     final blocks = mapRecognizedText(recognized);
     debugPrint('Pump OCR: ${recognized.text.length} chars, ${blocks.length} blocks');
@@ -321,11 +339,12 @@ class ReceiptScanService {
     String path, {
     bool enhanceContrast = false,
     OcrNormalizedRect? roi,
+    bool binarize = true,
   }) async {
     String? uprightTemp;
     try {
-      uprightTemp =
-          await _writeUprightCopy(path, enhanceContrast: enhanceContrast, roi: roi);
+      uprightTemp = await _writeUprightCopy(path,
+          enhanceContrast: enhanceContrast, roi: roi, binarize: binarize);
       final inputImage = InputImage.fromFilePath(uprightTemp ?? path);
       return await _recognizer.processImage(inputImage);
     } catch (e, st) {
@@ -342,18 +361,22 @@ class ReceiptScanService {
   /// returns that temp path, or null when the image cannot be decoded
   /// (the caller then OCRs the original unchanged).
   ///
-  /// #1860 — with [enhanceContrast] the temp copy is additionally run
-  /// through [preprocessPumpDisplayForOcr] (grayscale + normalise +
-  /// contrast); otherwise it is the plain [bakeImageOrientation] path.
+  /// #1860/#2275/#2798 — with [enhanceContrast] the temp copy is run through
+  /// [preprocessPumpDisplayForOcr]: by default a #2275 Sauvola binarization;
+  /// with [binarize] false a contrast-stretched grayscale (the pump path's
+  /// #2798 retry when binarization erased the faint 7-seg value digits).
+  /// Without [enhanceContrast] it is the plain [bakeImageOrientation] path.
   Future<String?> _writeUprightCopy(
     String path, {
     bool enhanceContrast = false,
     OcrNormalizedRect? roi,
+    bool binarize = true,
   }) async {
     try {
       final bytes = await File(path).readAsBytes();
       final upright = enhanceContrast
-          ? preprocessPumpDisplayForOcr(bytes, roi: roi, preprocessor: _preprocessor)
+          ? preprocessPumpDisplayForOcr(bytes,
+              roi: roi, preprocessor: _preprocessor, binarize: binarize)
           : bakeImageOrientation(bytes);
       if (upright == null) return null;
       final tempPath = '$path.upright.jpg';

--- a/test/features/consumption/data/pump_display_parser_garbled_price_test.dart
+++ b/test/features/consumption/data/pump_display_parser_garbled_price_test.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2798 — salvage a glare-garbled unit price. A 7-segment LCD shows €/L as
+// "1.999" but the decimal dot is frequently lost and the leading "1" misreads
+// as a 1-lookalike letter ("L999"). The real failing trace
+// (LITRES / L999 / PRIDX DU LJTRE / VOLUME / PRIX) derived nothing because
+// "L999" was discarded as noise. The salvage is deliberately narrow: it fires
+// only on a LEADING LETTER + 3 digits and band-checks the result, so a
+// separator-less bare-digit total/volume can never be fabricated into a price.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/pump_display_parser.dart';
+
+void main() {
+  const parser = PumpDisplayParser();
+
+  group('PumpDisplayParser — garbled unit-price salvage (#2798)', () {
+    test('recovers "L999" as 1.999 €/L', () {
+      final r = parser.parse('PRIX DU LITRE L999');
+      expect(r.pricePerLiter, closeTo(1.999, 0.0001));
+    });
+
+    test('recovers the real failing trace flat text', () {
+      // The exact ML Kit flatText from the reported capture.
+      final r = parser.parse('LITRES\nL999\nPRIDX DU LJTRE\nVOLUME\nPRIX');
+      expect(r.pricePerLiter, closeTo(1.999, 0.0001),
+          reason: 'the discarded L999 token is the 1,999 €/L unit price');
+    });
+
+    test('"I999" (capital-i lookalike) also recovers to 1.999', () {
+      expect(parser.parse('I999').pricePerLiter, closeTo(1.999, 0.0001));
+    });
+
+    test('a bare-digit run with NO leading letter is NOT fabricated into a '
+        'price (guards against misreading a total/volume)', () {
+      // "1049" (a 10,49 € total whose dot was lost) and "5277" (52,77 L) must
+      // never be salvaged as a unit price — the salvage requires a letter lead.
+      expect(parser.parse('1049').pricePerLiter, isNull);
+      expect(parser.parse('5277').pricePerLiter, isNull);
+    });
+
+    test('does not clobber a properly-labelled unit price', () {
+      final r = parser.parse('PRIX DU LITRE 1,846 €/L');
+      expect(r.pricePerLiter, closeTo(1.846, 0.0001));
+    });
+  });
+}

--- a/test/features/consumption/data/receipt_scan_service_test.dart
+++ b/test/features/consumption/data/receipt_scan_service_test.dart
@@ -520,6 +520,34 @@ void main() {
               'from the lighter field so a washed-out LCD becomes legible.');
     });
 
+    test('binarize:false keeps a continuous-tone grayscale (#2798 retry — not '
+        'a 1-bit mask, so ML Kit can read the 7-seg digits)', () {
+      // A smooth luminance ramp stands in for the soft gradients of a glary
+      // LCD photo. The default Sauvola pass collapses tone to ink+background;
+      // the grayscale retry must instead preserve the intermediate tones ML
+      // Kit is trained on.
+      final src = img.Image(width: 64, height: 64);
+      for (final p in src) {
+        final v = p.x * 255 ~/ 63;
+        p.setRgb(v, v, v);
+      }
+      int distinctLevels(img.Image im) {
+        final seen = <int>{};
+        for (final p in im) {
+          seen.add(p.r.round());
+        }
+        return seen.length;
+      }
+
+      final gray = preprocessPumpDisplayForOcr(
+          Uint8List.fromList(img.encodeJpg(src)),
+          binarize: false);
+      expect(gray, isNotNull);
+      expect(distinctLevels(img.decodeJpg(gray!)!), greaterThan(16),
+          reason: 'the grayscale retry preserves continuous tone, '
+              'not a two-cluster 1-bit mask');
+    });
+
     test('bakes EXIF orientation upright — dimensions swap, like #1711',
         () {
       // An 80×40 image tagged orientation 6 displays as 40×80; the

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -226,6 +226,12 @@ void main() {
     // the wiring must live at the controller's host adapter + resume site.
     // Decomposition stays tracked by #2187/#2188.
     'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1636,
+    // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR
+    // with a contrast-stretched GRAYSCALE pass when the #2275 binarized pass
+    // recovers nothing (the binarization erased faint 7-seg value digits). The
+    // retry + its parseFor helper + the threaded `binarize` flag push this just
+    // past 400; further compression would hurt readability of a real fix.
+    'lib/features/consumption/data/receipt_scan_service.dart': 408,
     // #2442 — re-grandfathered 496 → 513: the save flow now raises the
     // guided reconciliation workflow after a plein save (a 7-line
     // await-then-route call into the extracted


### PR DESCRIPTION
Closes #2798. ARB-free. A real Tokheim 7-seg LCD (1,999 €/L · 105,49 € · 52,77 L) OCR'd to **nothing**. A 4-auditor analysis of the trace pinned two root causes:

## 1. Recognition — ML Kit was fed a 1-bit image
`preprocessPumpDisplayForOcr` handed ML Kit a **1-bit Sauvola** image. ML Kit is trained on natural/grayscale, not line art — and the fixed Sauvola window on a large crop fits **inside one fat 7-seg stroke**, dissolving the value digits to background while only the thin printed labels survive. That's why only labels came back.

**Fix:** add a contrast-stretched **grayscale** preprocessing variant and **retry** the pump pass with it when the binarized pass recovers nothing usable. **Non-regressive** — a usable binarized read is never replaced, so the tuned #2275 binarization is preserved and grayscale only *adds* coverage.

## 2. Parser — the one read value was discarded
`L999` (= 1,999 €/L, dot lost + leading 1→L) was thrown away. Added a **narrow, band-guarded** salvage: a *leading 1-lookalike letter* + 3 digits → `1.XXX`, accepted only inside a plausible fuel unit-price band — so a separator-less bare-digit total/volume can **never** be fabricated into a price.

Also fixed the #1860/#2275 doc-comment that claimed grayscale while the code binarized.

## Verification
- 5 salvage tests (incl. the **real failing trace text → 1.999**, and bare-digit "1049"/"5277" *not* fabricated); a grayscale-retry preprocessing guard.
- ARB-free; **2200 consumption/data tests pass**; analyze clean; no codegen drift.

## Honest scope note
The grayscale retry's effect on the **total/volume** digits can't be unit-tested (ML Kit is on-device) — please A/B it with the OCR tester (#2518) on real pumps. Deferred follow-ups in #2798: per-field ROI crops, fuzzy label matching, and wiring the geometric 7-seg decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)