### PR TITLE
feat(gps-only): DrivingLesson polarity — positive praise renders green, not error-red (#2791)

### DIFF
--- a/lib/features/consumption/data/lessons/rules/smooth_driving_rule.dart
+++ b/lib/features/consumption/data/lessons/rules/smooth_driving_rule.dart
@@ -65,6 +65,8 @@ class SmoothDrivingRule implements DrivingLessonRule {
       metricValue: 0,
       title: l.lessonSmoothDrivingTitle,
       advice: l.lessonAdviceSmoothDriving,
+      // #2791 — praise, not waste: render green, not the error-red (i) icon.
+      polarity: LessonPolarity.positive,
     );
   }
 }

--- a/lib/features/consumption/domain/lessons/driving_lesson.dart
+++ b/lib/features/consumption/domain/lessons/driving_lesson.dart
@@ -29,6 +29,13 @@ import 'package:meta/meta.dart';
 /// the same lessons. The registry/strategy split (#2251) means a new
 /// lesson is one new [DrivingLessonRule] file + a registry entry — no
 /// edits to the calculator or the card.
+/// The tone of a [DrivingLesson] — drives the trip-detail card's icon + colour
+/// (#2791). Before this, the card hard-coded `colorScheme.error` for every
+/// tile, so a positive praise line ("Conduite souple — bien joué !") rendered
+/// with a red error (i) icon. Most lessons flag waste ([negative], the default);
+/// praise is [positive]; neutral facts are [info].
+enum LessonPolarity { negative, info, positive }
+
 @immutable
 class DrivingLesson {
   /// Stable, non-localized identifier. Doubles as the GPX
@@ -77,6 +84,12 @@ class DrivingLesson {
   /// written to the GPX.
   final String? trailing;
 
+  /// Tone of this lesson (#2791) — waste vs praise vs neutral. Defaults to
+  /// [LessonPolarity.negative] so every existing waste lesson is unchanged;
+  /// positive rules (e.g. smooth-driving praise) opt into [positive] so the
+  /// card stops painting them error-red.
+  final LessonPolarity polarity;
+
   const DrivingLesson({
     required this.id,
     required this.impact,
@@ -85,6 +98,7 @@ class DrivingLesson {
     this.advice = '',
     this.subtitle,
     this.trailing,
+    this.polarity = LessonPolarity.negative,
   });
 
   @override
@@ -97,12 +111,13 @@ class DrivingLesson {
         other.title == title &&
         other.advice == advice &&
         other.subtitle == subtitle &&
-        other.trailing == trailing;
+        other.trailing == trailing &&
+        other.polarity == polarity;
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, impact, metricValue, title, advice, subtitle, trailing);
+  int get hashCode => Object.hash(
+      id, impact, metricValue, title, advice, subtitle, trailing, polarity);
 
   @override
   String toString() => 'DrivingLesson('

--- a/lib/features/consumption/presentation/widgets/driving_insights_card.dart
+++ b/lib/features/consumption/presentation/widgets/driving_insights_card.dart
@@ -91,8 +91,8 @@ class _LessonTile extends StatelessWidget {
       key: ValueKey('insight_tile_${lesson.id}'),
       contentPadding: EdgeInsets.zero,
       leading: Icon(
-        _iconFor(lesson.id),
-        color: theme.colorScheme.error,
+        _iconFor(lesson),
+        color: _colorFor(lesson.polarity, theme),
       ),
       title: Text(lesson.title),
       subtitle: subtitle == null
@@ -108,15 +108,15 @@ class _LessonTile extends StatelessWidget {
           : Text(
               trailing,
               style: theme.textTheme.titleSmall?.copyWith(
-                color: theme.colorScheme.error,
+                color: _colorFor(lesson.polarity, theme),
                 fontFeatures: const [FontFeature.tabularFigures()],
               ),
             ),
     );
   }
 
-  IconData _iconFor(String lessonId) {
-    switch (lessonId) {
+  IconData _iconFor(DrivingLesson lesson) {
+    switch (lesson.id) {
       case highRpmLessonId:
         return Icons.speed;
       case hardAccelLessonId:
@@ -126,7 +126,24 @@ class _LessonTile extends StatelessWidget {
       case lowGearLessonId:
         return Icons.swap_vert;
       default:
-        return Icons.info_outline;
+        // #2791 — a positive lesson with no dedicated icon reads as praise
+        // (the eco leaf), not a neutral info glyph.
+        return lesson.polarity == LessonPolarity.positive
+            ? Icons.eco
+            : Icons.info_outline;
+    }
+  }
+
+  /// #2791 — tile tint by tone: praise green (primary), neutral muted, waste
+  /// the error red the card used to hard-code for every lesson.
+  Color _colorFor(LessonPolarity polarity, ThemeData theme) {
+    switch (polarity) {
+      case LessonPolarity.positive:
+        return theme.colorScheme.primary;
+      case LessonPolarity.info:
+        return theme.colorScheme.onSurfaceVariant;
+      case LessonPolarity.negative:
+        return theme.colorScheme.error;
     }
   }
 }

--- a/test/features/consumption/presentation/widgets/driving_insights_card_test.dart
+++ b/test/features/consumption/presentation/widgets/driving_insights_card_test.dart
@@ -178,4 +178,49 @@ void main() {
       expect((tiles[1].title as Text).data, contains('hard accelerations'));
     });
   });
+
+  group('DrivingInsightsCard — polarity (#2791)', () {
+    testWidgets('a positive lesson renders green (eco icon, primary colour) — '
+        'NOT the error-red used for waste', (tester) async {
+      await pumpApp(
+        tester,
+        const DrivingInsightsCard(lessons: [
+          DrivingLesson(
+            id: 'smoothDriving',
+            impact: 1,
+            metricValue: 0,
+            title: 'Smooth driving — well done!',
+            polarity: LessonPolarity.positive,
+          ),
+          DrivingLesson(
+            id: 'highRpm',
+            impact: 0.6,
+            metricValue: 0.6,
+            title: 'Engine over 3000 RPM',
+            trailing: '+0.6 L',
+          ),
+        ]),
+      );
+
+      final theme = Theme.of(tester.element(find.byType(DrivingInsightsCard)));
+
+      final positiveIcon = tester.widget<Icon>(find.descendant(
+        of: find.byKey(const ValueKey('insight_tile_smoothDriving')),
+        matching: find.byType(Icon),
+      ));
+      expect(positiveIcon.icon, Icons.eco,
+          reason: 'praise uses the eco leaf, not the info glyph');
+      expect(positiveIcon.color, theme.colorScheme.primary,
+          reason: 'praise renders green');
+      expect(positiveIcon.color, isNot(theme.colorScheme.error),
+          reason: 'the #2791 bug: praise must NOT be error-red');
+
+      final wasteIcon = tester.widget<Icon>(find.descendant(
+        of: find.byKey(const ValueKey('insight_tile_highRpm')),
+        matching: find.byType(Icon),
+      ));
+      expect(wasteIcon.color, theme.colorScheme.error,
+          reason: 'waste lessons stay error-red (default polarity unchanged)');
+    });
+  });
 }


### PR DESCRIPTION
Closes #2791 (Epic #2789 C2). ARB-free.

The trip-detail Insights card hard-coded `colorScheme.error` for **every** tile, so the positive **'Conduite souple — bien joué !'** praise rendered with a **red error (i) icon** (your GPS-only screenshot). `DrivingLesson` had no tone field.

**Fix:** add `LessonPolarity {negative, info, positive}` (default negative → every existing waste lesson unchanged). `SmoothDrivingRule` opts into positive. The card tints by polarity: positive → green (primary) + eco leaf; info → muted; negative → error-red. Prerequisite for the positive GPS coaching lines in C4/C7.

**Verified:** regression test asserts a positive lesson renders the eco icon in primary (NOT error-red) and waste stays red; 51 lesson/card/gpx tests pass; analyze clean; no codegen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)