### PR TITLE
refactor(gps-only): score against the pipeline's IMU-preferred harsh counts (#2794)

### DIFF
--- a/lib/features/consumption/data/driving_score_calculator.dart
+++ b/lib/features/consumption/data/driving_score_calculator.dart
@@ -135,6 +135,8 @@ const double _smoothnessPedalVarSaturation = 900.0;
 DrivingScore computeDrivingScore(
   List<TripSample> samples, {
   double? secondsBelowOptimalGear,
+  int? hardAccelEventsOverride,
+  int? hardBrakeEventsOverride,
 }) {
   if (samples.length < 2) return DrivingScore.perfect;
 
@@ -172,11 +174,18 @@ DrivingScore computeDrivingScore(
   // trips have a real rpm on at least one sample and score unchanged.
   final gpsOnly = sorted.every((s) => s.rpm == null);
 
+  // #2794 — prefer the caller's resolved accel/brake episode counts when
+  // provided. A GPS-only trip threads in summary.harshAccelerations/harshBrakes,
+  // which the recording pipeline already set to the IMU-detected episodes when
+  // the phone's inertial sensor was the better dongle-less signal — more
+  // accurate than re-deriving from the noisy GPS speed derivative, and it makes
+  // the displayed score match the figure the recorder intended. OBD2 trips pass
+  // null and score from the sample-derived events exactly as before.
   return acc.build(
     totalDt: totalDt,
     secondsBelowOptimalGear: secondsBelowOptimalGear,
-    hardAccelEvents: accelCounts.accelEvents,
-    hardBrakeEvents: accelCounts.brakeEvents,
+    hardAccelEvents: hardAccelEventsOverride ?? accelCounts.accelEvents,
+    hardBrakeEvents: hardBrakeEventsOverride ?? accelCounts.brakeEvents,
     gpsOnly: gpsOnly,
   );
 }

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -134,12 +134,21 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     final tripSamples = widget.samples.map(tripDetailToTripSample).toList(
           growable: false,
         );
+    final summary = widget.entry.summary;
     // #2460 — thread the trip-end lugging metric stored on the summary
     // into the canonical score so the over-rev/shift family includes it
     // (the calculator can't recompute gear inference from samples alone).
+    //
+    // #2794 — for a GPS-only trip, score against the pipeline's RESOLVED harsh
+    // counts (IMU-preferred when the inertial sensor was the better dongle-less
+    // signal) instead of re-deriving from the noisy GPS speed derivative, so
+    // the displayed score matches the figure the recorder intended.
+    final gpsOnly = summary.kind == TripKind.gpsOnly;
     return computeDrivingScore(
       tripSamples,
-      secondsBelowOptimalGear: widget.entry.summary.secondsBelowOptimalGear,
+      secondsBelowOptimalGear: summary.secondsBelowOptimalGear,
+      hardAccelEventsOverride: gpsOnly ? summary.harshAccelerations : null,
+      hardBrakeEventsOverride: gpsOnly ? summary.harshBrakes : null,
     );
   }
 

--- a/test/features/consumption/data/driving_score_calculator_test.dart
+++ b/test/features/consumption/data/driving_score_calculator_test.dart
@@ -756,4 +756,41 @@ void main() {
       expect(score.idlingPenalty, greaterThan(0));
     });
   });
+
+  group('harsh-event overrides (#2794 — GPS-only IMU-preferred routing)', () {
+    final start = DateTime(2026, 6, 3, 12);
+    // A short GPS-only run (rpm null) with a gentle speed ramp.
+    final samples = <TripSample>[
+      for (var i = 0; i < 20; i++)
+        TripSample(
+            timestamp: start.add(Duration(seconds: i)), speedKmh: 30.0 + i),
+    ];
+
+    test('the accel/brake event overrides drive the penalty, not the '
+        'GPS-derived count', () {
+      final overridden = computeDrivingScore(samples,
+          hardAccelEventsOverride: 4, hardBrakeEventsOverride: 0);
+      final zeroed = computeDrivingScore(samples,
+          hardAccelEventsOverride: 0, hardBrakeEventsOverride: 0);
+
+      expect(overridden.hardAccelPenalty, greaterThan(0),
+          reason: '4 IMU-detected hard accels produce a real penalty');
+      expect(zeroed.hardAccelPenalty, 0,
+          reason: 'a 0 override yields no accel penalty regardless of GPS '
+              'speed-derivative jitter');
+      expect(
+          overridden.hardAccelPenalty, greaterThan(zeroed.hardAccelPenalty));
+    });
+
+    test('a brake override drives the brake penalty', () {
+      final braked = computeDrivingScore(samples,
+          hardAccelEventsOverride: 0, hardBrakeEventsOverride: 3);
+      expect(braked.hardBrakePenalty, greaterThan(0));
+    });
+
+    test('no override → unchanged (GPS-derived events, deterministic)', () {
+      expect(computeDrivingScore(samples),
+          equals(computeDrivingScore(samples)));
+    });
+  });
 }


### PR DESCRIPTION
Closes #2794 (Epic #2789 C5). ARB-free.

The GPS-only driving score **re-derived** hard-accel/brake events from the noisy GPS speed derivative, ignoring the pipeline's `preferImu` work that already wrote the **more-accurate IMU counts** to `summary.harshAccelerations`/`harshBrakes` — so the displayed score could disagree with the recorder's intent.

**Fix (surgical):** add `hardAccelEventsOverride`/`hardBrakeEventsOverride` to `computeDrivingScore`; the trip-detail body passes the summary's resolved counts for GPS-only trips. Only the accel/brake event *source* changes — the idle/high-RPM/lugging model + the GPS-only engine-penalty re-weight are untouched. OBD2 trips pass null (unchanged). The pipeline resolved IMU-vs-GPS at record time (with sensor-availability knowledge), so trusting `summary.harsh*` needs no screen-side availability flag.

**Verified:** override-drives-penalty / 0-override-no-penalty / no-override-unchanged tests; 63 score + trip-detail-body tests pass; analyze clean; no codegen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)