### PR TITLE
fix(radar): refresh GPS + include the in-radius search so the radar is a superset (#2806)

### DIFF
--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -4,9 +4,12 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/location/user_position_provider.dart';
+import '../../../core/services/service_providers.dart';
 import '../../../core/utils/geo_utils.dart' as geo;
 import '../../../core/utils/station_extensions.dart';
 import '../../approach/providers/fuel_station_radar_provider.dart';
+import '../data/models/search_params.dart';
+import '../domain/entities/fuel_type.dart';
 import '../domain/entities/station.dart';
 import 'search_filters_provider.dart';
 
@@ -46,12 +49,14 @@ class RadarSearchState {
 
 /// The on-search Fuel Station Radar (#2659).
 ///
-/// A one-shot, cache-first radar fetch around the user's persisted position
-/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
-/// the search results list like a regular search. It reuses the #2661 radar
-/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
-/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
-/// zero network.
+/// A one-shot radar fetch around the user's CURRENT position
+/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
+/// the trip-only shared GPS stream), surfaced in the search results list like
+/// a regular search. It reuses the #2661 radar data layer
+/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
+/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
+/// in-radius fetch so the result is always a superset of the regular search
+/// (#2806).
 ///
 /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
 /// approach detector: those only fire while a trip records (gated on
@@ -62,10 +67,23 @@ class RadarSearch extends _$RadarSearch {
   @override
   RadarSearchState build() => RadarSearchState.idle;
 
-  /// Run the radar around the user's persisted position. No-op (leaves the
-  /// radar inactive) when no position is known yet — the user must search /
-  /// locate at least once so we have somewhere to scan around.
+  /// Run the radar around the user's CURRENT position. No-op (leaves the radar
+  /// inactive) when no position is known yet — the user must search / locate at
+  /// least once so we have somewhere to scan around.
   Future<void> runRadar() async {
+    // #2806 — refresh the live GPS fix first, exactly as the regular search
+    // does (search_provider_orchestration.dart). The radar used to reuse the
+    // PERSISTED [userPositionProvider] with no refresh, so after any movement
+    // it scanned a location minutes behind the user — surfacing a far-away
+    // band and dropping the nearby stations the in-radius search shows.
+    // Best-effort: keep the persisted position if the fix is denied / times
+    // out, so an offline / permission-less run still scans the last spot.
+    try {
+      await ref.read(userPositionProvider.notifier).updateFromGps();
+    } on Object {
+      // Fall back to whatever position was already persisted.
+    }
+
     final pos = ref.read(userPositionProvider);
     if (pos == null) {
       state = RadarSearchState.idle;
@@ -89,19 +107,30 @@ class RadarSearch extends _$RadarSearch {
         fuel.apiValue,
       );
 
-      // Stamp each station's distance (km) from the user, distance-sort, then
-      // drop rows with no usable price for the selected fuel — the radar
-      // surfaces priced stations only, like the regular search list.
-      final priced = <Station>[];
-      for (final s in raw) {
+      // #2806 — the wide corridor is fetched with a hard row cap (60 km /
+      // limit 50, un-distance-ordered), so in a dense area its returned slice
+      // can MISS the closest forecourts, leaving the radar excluding stations
+      // the regular search shows. Merge a direct in-radius fetch so the radar
+      // is always a SUPERSET of the in-radius search around the same position
+      // (the user's stated expectation). Best-effort: corridor-only if the
+      // in-radius fetch fails.
+      final nearby = await _inRadiusStations(pos, radiusKm, fuel);
+
+      // Dedup by id (the in-radius row wins — it carries the freshest per-fuel
+      // price), stamp each station's distance (km) from the user, drop rows
+      // with no usable price for the selected fuel, then distance-sort — the
+      // radar surfaces priced stations only, like the regular search list.
+      final byId = <String, Station>{};
+      for (final s in [...raw, ...nearby]) {
         final distKm =
             geo.distanceMeters(pos.lat, pos.lng, s.lat, s.lng) / 1000.0;
         final withDist = s.copyWith(dist: distKm);
         final price = withDist.priceFor(fuel);
         if (price == null || price <= 0) continue;
-        priced.add(withDist);
+        byId[withDist.id] = withDist;
       }
-      priced.sort((a, b) => a.dist.compareTo(b.dist));
+      final priced = byId.values.toList()
+        ..sort((a, b) => a.dist.compareTo(b.dist));
 
       state = state.copyWith(
         active: true,
@@ -112,6 +141,31 @@ class RadarSearch extends _$RadarSearch {
         active: true,
         stations: AsyncError<List<Station>>(e, st),
       );
+    }
+  }
+
+  /// A direct in-radius station fetch around [pos], mirroring the regular
+  /// search, so [runRadar] can guarantee the radar list is a superset of it
+  /// (#2806). Returns `[]` on any failure so the radar degrades to its cached
+  /// corridor rather than erroring.
+  Future<List<Station>> _inRadiusStations(
+    UserPositionData pos,
+    double radiusKm,
+    FuelType fuel,
+  ) async {
+    try {
+      final result = await ref.read(stationServiceProvider).searchStations(
+            SearchParams(
+              lat: pos.lat,
+              lng: pos.lng,
+              radiusKm: radiusKm,
+              fuelType: fuel,
+              sortBy: SortBy.distance,
+            ),
+          );
+      return result.data;
+    } on Object {
+      return const <Station>[];
     }
   }
 

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -10,12 +10,14 @@ part of 'radar_search_provider.dart';
 // ignore_for_file: type=lint, type=warning
 /// The on-search Fuel Station Radar (#2659).
 ///
-/// A one-shot, cache-first radar fetch around the user's persisted position
-/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
-/// the search results list like a regular search. It reuses the #2661 radar
-/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
-/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
-/// zero network.
+/// A one-shot radar fetch around the user's CURRENT position
+/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
+/// the trip-only shared GPS stream), surfaced in the search results list like
+/// a regular search. It reuses the #2661 radar data layer
+/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
+/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
+/// in-radius fetch so the result is always a superset of the regular search
+/// (#2806).
 ///
 /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
 /// approach detector: those only fire while a trip records (gated on
@@ -27,12 +29,14 @@ final radarSearchProvider = RadarSearchProvider._();
 
 /// The on-search Fuel Station Radar (#2659).
 ///
-/// A one-shot, cache-first radar fetch around the user's persisted position
-/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
-/// the search results list like a regular search. It reuses the #2661 radar
-/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
-/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
-/// zero network.
+/// A one-shot radar fetch around the user's CURRENT position
+/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
+/// the trip-only shared GPS stream), surfaced in the search results list like
+/// a regular search. It reuses the #2661 radar data layer
+/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
+/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
+/// in-radius fetch so the result is always a superset of the regular search
+/// (#2806).
 ///
 /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
 /// approach detector: those only fire while a trip records (gated on
@@ -42,12 +46,14 @@ final class RadarSearchProvider
     extends $NotifierProvider<RadarSearch, RadarSearchState> {
   /// The on-search Fuel Station Radar (#2659).
   ///
-  /// A one-shot, cache-first radar fetch around the user's persisted position
-  /// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
-  /// the search results list like a regular search. It reuses the #2661 radar
-  /// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
-  /// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
-  /// zero network.
+  /// A one-shot radar fetch around the user's CURRENT position
+  /// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
+  /// the trip-only shared GPS stream), surfaced in the search results list like
+  /// a regular search. It reuses the #2661 radar data layer
+  /// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
+  /// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
+  /// in-radius fetch so the result is always a superset of the regular search
+  /// (#2806).
   ///
   /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
   /// approach detector: those only fire while a trip records (gated on
@@ -80,16 +86,18 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'17dd6df0b132ba4d0e25ba88cbf293769ccf71a7';
+String _$radarSearchHash() => r'4f901087ffd4a6848b0616e88e0d3b71e2b623bf';
 
 /// The on-search Fuel Station Radar (#2659).
 ///
-/// A one-shot, cache-first radar fetch around the user's persisted position
-/// ([userPositionProvider], NOT the trip-only shared GPS stream), surfaced in
-/// the search results list like a regular search. It reuses the #2661 radar
-/// data layer ([fuelStationRadarProvider]) — the tier-1 corridor location
-/// cache (1 h) + tier-3 JIT price cache (5 min) — so a repeat run nearby costs
-/// zero network.
+/// A one-shot radar fetch around the user's CURRENT position
+/// ([userPositionProvider], refreshed from live GPS on each run — #2806 — NOT
+/// the trip-only shared GPS stream), surfaced in the search results list like
+/// a regular search. It reuses the #2661 radar data layer
+/// ([fuelStationRadarProvider]) — the tier-1 corridor location cache (1 h) +
+/// tier-3 JIT price cache (5 min) — for the wide net, and merges a direct
+/// in-radius fetch so the result is always a superset of the regular search
+/// (#2806).
 ///
 /// Deliberately distinct from the trip-gated `nearestStationRadarProvider` /
 /// approach detector: those only fire while a trip records (gated on

--- a/test/features/search/presentation/widgets/radar_search_button_test.dart
+++ b/test/features/search/presentation/widgets/radar_search_button_test.dart
@@ -5,11 +5,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:dio/dio.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
 import 'package:tankstellen/core/services/radar/jit_price_cache.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/radar_search_fab.dart';
@@ -52,6 +56,37 @@ class _FixedUserPosition extends UserPosition {
         updatedAt: DateTime.now(),
         source: 'test',
       );
+
+  // #2806 — runRadar now refreshes the live fix first; keep the fixed point
+  // (and off the geolocator method channel) in the widget test.
+  @override
+  Future<void> updateFromGps() async {}
+}
+
+/// #2806 — runRadar now merges a direct in-radius fetch; this empty service
+/// keeps that merge deterministic (and off the network) so the recorded
+/// corridor remains the only source under test.
+class _EmptyStationService implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async =>
+      ServiceResult(
+        data: const <Station>[],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime.now(),
+      );
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
 }
 
 FuelStationRadar _recordedRadar(List<Station> corridor) => FuelStationRadar(
@@ -113,6 +148,7 @@ void main() {
           fuelStationRadarProvider.overrideWithValue(
             _recordedRadar([_station('RADAR-NEAR', 48.0, 2.0)]),
           ),
+          stationServiceProvider.overrideWithValue(_EmptyStationService()),
           // A regular search result the radar must SUPPLANT, not mutate.
           searchStateProvider
               .overrideWith(() => _LoadedSearchState([testStation])),

--- a/test/features/search/radar_search_provider_test.dart
+++ b/test/features/search/radar_search_provider_test.dart
@@ -1,13 +1,18 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
 import 'package:tankstellen/core/services/radar/jit_price_cache.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/core/utils/station_extensions.dart';
 import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
@@ -55,9 +60,15 @@ FuelStationRadar _recordedRadar(List<Station> corridor) => FuelStationRadar(
     );
 
 class _FixedUserPosition extends UserPosition {
-  _FixedUserPosition(this._lat, this._lng);
+  _FixedUserPosition(this._lat, this._lng, {({double lat, double lng})? refreshTo})
+      : _refreshTo = refreshTo;
   final double _lat;
   final double _lng;
+
+  /// When set, [updateFromGps] moves the position here — models the #2806 live
+  /// refresh. When null it is a no-op (keeps the persisted point), which also
+  /// keeps the unit test off the geolocator method channel.
+  final ({double lat, double lng})? _refreshTo;
 
   @override
   UserPositionData? build() => UserPositionData(
@@ -66,6 +77,18 @@ class _FixedUserPosition extends UserPosition {
         updatedAt: DateTime.now(),
         source: 'test',
       );
+
+  @override
+  Future<void> updateFromGps() async {
+    final r = _refreshTo;
+    if (r == null) return;
+    state = UserPositionData(
+      lat: r.lat,
+      lng: r.lng,
+      updatedAt: DateTime.now(),
+      source: 'gps',
+    );
+  }
 }
 
 class _NullUserPosition extends UserPosition {
@@ -87,9 +110,45 @@ class _FixedRadius extends SearchRadius {
   double build() => _km;
 }
 
+/// A minimal [StationService] that returns a fixed in-radius slice — the
+/// #2806 seam the radar now merges so its list is a superset of the regular
+/// search. Set [throws] to model an in-radius fetch failure (radar must then
+/// degrade to its cached corridor, not error).
+class _FakeStationService implements StationService {
+  _FakeStationService(this._inRadius, {this.throws = false});
+  final List<Station> _inRadius;
+  final bool throws;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    if (throws) throw StateError('in-radius fetch failed');
+    return ServiceResult(
+      data: _inRadius,
+      source: ServiceSource.cache,
+      fetchedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
 ProviderContainer _container({
   required ({double lat, double lng})? position,
   required List<Station> corridor,
+  List<Station> inRadius = const [],
+  bool inRadiusThrows = false,
+  ({double lat, double lng})? refreshTo,
   FuelType fuel = FuelType.e10,
   double radiusKm = 10.0,
 }) =>
@@ -98,11 +157,15 @@ ProviderContainer _container({
         userPositionProvider.overrideWith(
           () => position == null
               ? _NullUserPosition()
-              : _FixedUserPosition(position.lat, position.lng),
+              : _FixedUserPosition(position.lat, position.lng,
+                  refreshTo: refreshTo),
         ),
         selectedFuelTypeProvider.overrideWith(() => _FixedFuelType(fuel)),
         searchRadiusProvider.overrideWith(() => _FixedRadius(radiusKm)),
         fuelStationRadarProvider.overrideWithValue(_recordedRadar(corridor)),
+        stationServiceProvider.overrideWithValue(
+          _FakeStationService(inRadius, throws: inRadiusThrows),
+        ),
       ],
     );
 
@@ -190,6 +253,90 @@ void main() {
       container.read(radarSearchProvider.notifier).dismiss();
       expect(container.read(radarSearchProvider).active, isFalse);
       expect(container.read(radarSearchNearestProvider), isNull);
+    });
+  });
+
+  group('RadarSearch — superset of the in-radius search (#2806)', () {
+    // User at (48.0, 2.0); 0.01° lat ≈ 1.11 km. The wide corridor (capped at
+    // 50, un-distance-ordered) returns only FAR stations — the field bug where
+    // the radar showed a 13–19 km band and excluded the close stations the
+    // 10 km search found.
+    Station far1() => _station('FAR1', 48.12, 2.0, e10: 1.799); // ≈13.3 km
+    Station far2() => _station('FAR2', 48.16, 2.0, e10: 1.829); // ≈17.8 km
+    Station near() => _station('NEAR', 48.0, 2.0, e10: 1.659); //  ≈0 km
+    Station mid() => _station('MID', 48.03, 2.0, e10: 1.729); //  ≈3.3 km
+
+    test('merges the in-radius near stations the corridor missed', () async {
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [far1(), far2()], // corridor missed the near zone
+        inRadius: [near(), mid()], // the regular 10 km search keeps them
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      final list = container.read(radarSearchProvider).stations.value!;
+      // RED on master (corridor-only → [FAR1, FAR2]); the radar must now be a
+      // superset of the in-radius search, distance-sorted from the user.
+      expect(list.map((s) => s.id), ['NEAR', 'MID', 'FAR1', 'FAR2']);
+      expect(container.read(radarSearchNearestProvider)?.id, 'NEAR');
+    });
+
+    test('dedups a station present in both corridor and in-radius', () async {
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        // Same id in both; the in-radius row carries the fresher price.
+        corridor: [_station('DUP', 48.0, 2.0, e10: 1.999)],
+        inRadius: [_station('DUP', 48.0, 2.0, e10: 1.659)],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      final list = container.read(radarSearchProvider).stations.value!;
+      expect(list, hasLength(1));
+      expect(list.single.priceFor(FuelType.e10), 1.659,
+          reason: 'in-radius row wins the dedup (freshest price)');
+    });
+
+    test('degrades to the cached corridor when the in-radius fetch fails',
+        () async {
+      final container = _container(
+        position: (lat: 48.0, lng: 2.0),
+        corridor: [far1(), far2()],
+        inRadiusThrows: true,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      final state = container.read(radarSearchProvider);
+      // No error surfaced; the radar still shows the corridor it had.
+      expect(state.stations.hasError, isFalse);
+      expect(state.stations.value!.map((s) => s.id), ['FAR1', 'FAR2']);
+    });
+
+    test('refreshes live GPS, so it scans the user\'s current position',
+        () async {
+      // Persisted point is stale (49.0, 3.0 — ~130 km away); the live fix is
+      // (48.0, 2.0). The corridor + in-radius are around the LIVE point.
+      final container = _container(
+        position: (lat: 49.0, lng: 3.0),
+        refreshTo: (lat: 48.0, lng: 2.0),
+        corridor: [far1()],
+        inRadius: [near()],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(radarSearchProvider.notifier).runRadar();
+
+      final list = container.read(radarSearchProvider).stations.value!;
+      // Distances are stamped from the REFRESHED (live) point: NEAR ≈ 0 km.
+      // On master (no refresh) they'd be stamped from the stale (49,3) point,
+      // where NEAR is ~130 km away and would sort after FAR1.
+      expect(list.first.id, 'NEAR');
+      expect(list.first.dist, lessThan(0.1));
     });
   });
 }


### PR DESCRIPTION
## Symptom

Same E85 fuel, near Pézenas (FR): the normal search ("Dans un rayon de 10 km") finds 3 close stations (2,5 / 6,2 / 8,4 km); the **radar** finds 28 but the nearest is **13,2 km** — it excludes all 3 close ones and shows a far band (Mèze/Agde/Sète). The user expects the radar to *include* the search results.

Closes #2806.

## Root cause (verified against master — two compounding defects)

1. **Stale center.** The normal search refreshes GPS first (`userPositionProvider.notifier.updateFromGps()`, `search_provider_orchestration.dart:34`). `RadarSearch.runRadar()` read the **persisted** position with no refresh, so after any movement it scanned a location minutes behind the user (the "GPS (4 min)" vs "GPS (2 min)" badge gap).
2. **`limit:50` on a 60 km corridor, no distance ordering.** `fetchStations` returns the whole `CorridorLocationCache` slice; the FR fetch is `within_distance(60km)` + `limit:50` with no `order_by` (`prix_carburants_station_service._queryByGeo`). In a dense area the 50 rows are arbitrary, so the truly-nearest are dropped. The regular search uses the same query at 10 km, where 50 doesn't cap the sparse near set — which is exactly why it keeps the 3 close stations and the radar didn't.

The green "épinglage" pin is unrelated (wake-lock / immersive only; the recent default-ON change didn't cause this).

## Fix (confined to the on-search radar)

`runRadar` now:
- **(a)** refreshes the live GPS fix first, mirroring the regular search (best-effort — falls back to the persisted point if denied/offline);
- **(b)** merges a direct in-radius fetch so the radar list is always a **superset** of the regular search around the same position (dedupe by id, the in-radius row winning for the freshest price, then distance-sort).

The trip-detector data layer (`fetchStations` / corridor cache / FR query) is **untouched**, so the geofence's wide cached net is unchanged.

## Tests

- 4 new `RadarSearch` tests: superset merge, dedup, in-radius-failure degradation, live-GPS refresh — **3 are RED on master** (verified by reverting only the provider).
- Updated `radar_search_button` widget test to control the two new deps.
- Full `test/features/search` + `test/features/approach` sweep green; `flutter analyze` clean; clean codegen committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
