### PR TITLE
fix(radar): PiP closeness indicator — full-width, two-colour, live distance (#2808)

### DIFF
--- a/lib/core/theme/dark_mode_colors.dart
+++ b/lib/core/theme/dark_mode_colors.dart
@@ -63,6 +63,16 @@ class DarkModeColors {
           ? Theme.of(context).colorScheme.primary // #69A16B on dark
           : const Color(0xFF2E7D32); // icon brand green on light
 
+  /// Blue-violet accent that pairs with [brandGreen] for the Fuel Station
+  /// Radar proximity fill (#2808). The fill is a green→accent gradient so the
+  /// "getting close" bar reads as two colours and its leading edge shifts hue
+  /// as it fills. Indigo reads as "purple-like-blue" against both the green
+  /// and the fuel-hued PiP tiles, and clears contrast on light + dark.
+  static Color proximityAccent(BuildContext context) =>
+      Theme.of(context).brightness == Brightness.dark
+          ? const Color(0xFF7C84E8) // indigo.shade300-ish — bright on dark
+          : const Color(0xFF3F51B5); // indigo.shade600 on light
+
   // ---------------------------------------------------------------------------
   // Muted / secondary text
   // ---------------------------------------------------------------------------

--- a/lib/features/approach/providers/nearest_station_radar_provider.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.dart
@@ -87,10 +87,24 @@ Future<Station?> nearestStationRadar(Ref ref) async {
           .compareTo(
             geo.distanceMeters(gps.latitude, gps.longitude, b.lat, b.lng),
           ));
-    return sorted.firstWhereOrNull((s) {
+    final nearest = sorted.firstWhereOrNull((s) {
       final price = s.priceFor(fuel);
       return price != null && price > 0;
     });
+    if (nearest == null) return null;
+    // #2808 — re-stamp the LIVE distance (km) from the current fix. The
+    // corridor station carries a `dist` frozen at the corridor-fetch centre
+    // (stamped once at parse time), so without this the PiP proximity bar +
+    // distance caption never move as the driver approaches. Mirrors the
+    // on-search radar (radar_search_provider.dart).
+    final distKm = geo.distanceMeters(
+          gps.latitude,
+          gps.longitude,
+          nearest.lat,
+          nearest.lng,
+        ) /
+        1000.0;
+    return nearest.copyWith(dist: distKm);
   } on Object {
     // Radar / chain failure — treat as "no station nearby". The provider
     // re-runs on the next approach-state tick.

--- a/lib/features/approach/providers/nearest_station_radar_provider.g.dart
+++ b/lib/features/approach/providers/nearest_station_radar_provider.g.dart
@@ -151,4 +151,4 @@ final class NearestStationRadarProvider
 }
 
 String _$nearestStationRadarHash() =>
-    r'db89908c8f773bb6ade53920cde57bebc6689f08';
+    r'ef42198fcc6ac6493b83d4148eaa21a3f97b0ed1';

--- a/lib/features/approach/providers/radar_candidate_list_provider.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.dart
@@ -82,7 +82,7 @@ Future<List<Station>> radarCandidateList(Ref ref) async {
     // by distance from the live fix, then keep only stations the driver can
     // actually price-compare (a non-null, positive [priceFor] for the
     // effective fuel) so a swipe never lands on a `--` price row (#2583).
-    return (stations
+    final priced = stations
         .where((s) {
           final price = s.priceFor(fuel);
           return price != null && price > 0;
@@ -92,7 +92,23 @@ Future<List<Station>> radarCandidateList(Ref ref) async {
           .distanceMeters(gps.latitude, gps.longitude, a.lat, a.lng)
           .compareTo(
             geo.distanceMeters(gps.latitude, gps.longitude, b.lat, b.lng),
-          )));
+          ));
+    // #2808 — re-stamp each row's LIVE distance (km) from the current fix.
+    // The corridor stations carry a `dist` frozen at the corridor-fetch
+    // centre, so without this the swipe-card proximity bar + caption never
+    // move as the driver approaches. Mirrors the on-search radar.
+    return [
+      for (final s in priced)
+        s.copyWith(
+          dist: geo.distanceMeters(
+                gps.latitude,
+                gps.longitude,
+                s.lat,
+                s.lng,
+              ) /
+              1000.0,
+        ),
+    ];
   } on Object {
     // Radar / chain failure — treat as "no stations nearby". The provider
     // re-runs on the next approach-state tick.

--- a/lib/features/approach/providers/radar_candidate_list_provider.g.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.g.dart
@@ -165,4 +165,4 @@ final class RadarCandidateListProvider
 }
 
 String _$radarCandidateListHash() =>
-    r'1d6dbe2341ea09cb25004f189ddd76ce95629173';
+    r'7b5f774e01d1aae94503d074103c6853067bb955';

--- a/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
+++ b/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
@@ -19,9 +19,11 @@ import '../../../../l10n/app_localizations.dart';
 /// 100% (full) at the station, 0% (empty) at / beyond the radar radius edge.
 /// The fill grows as the driver nears — a glanceable "battery charging"
 /// metaphor — and animates over ~300 ms so the change is visible rather than
-/// snapping. The fill is ALWAYS the corporate brand green
-/// ([DarkModeColors.brandGreen]) even when the host tile wears a fuel hue, so
-/// the proximity signal reads consistently as "charge / getting close".
+/// snapping. The fill is a green→blue-violet gradient
+/// ([DarkModeColors.brandGreen] → [DarkModeColors.proximityAccent], #2808) so
+/// it reads as two colours with its leading edge in the accent hue — kept
+/// consistent even when the host tile wears a fuel hue, so the proximity
+/// signal always reads as "getting close".
 ///
 /// Paint-only: distance + radius come in as params (the PiP is paint-only and
 /// the card threads them from `activeProfileProvider`). When [radiusMeters]
@@ -66,6 +68,7 @@ class ProximityFillBar extends StatelessWidget {
     final l = AppLocalizations.of(context);
     final fill = fillFor(distanceMeters, radius);
     final green = DarkModeColors.brandGreen(context);
+    final accent = DarkModeColors.proximityAccent(context);
     final track = (onColor ?? Theme.of(context).colorScheme.onSurface)
         .withValues(alpha: 0.2);
     final percent = (fill * 100).round();
@@ -87,7 +90,7 @@ class ProximityFillBar extends StatelessWidget {
               widthFactor: value,
               child: DecoratedBox(
                 decoration: BoxDecoration(
-                  color: green,
+                  gradient: LinearGradient(colors: [green, accent]),
                   borderRadius: AppRadius.sm,
                 ),
               ),

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
@@ -119,26 +119,29 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
             ),
           ),
         ],
-        // #2661 — corporate-green battery-style proximity bar: fills as the
-        // driver nears (100% at the station, 0% at the radar radius edge).
-        if (distance != null && radiusMeters != null) ...[
-          const SizedBox(height: 4),
-          SizedBox(
-            width: 120,
-            child: ProximityFillBar(
-              distanceMeters: distance,
-              radiusMeters: radiusMeters,
-              height: 5,
-              onColor: foregroundColor,
-            ),
-          ),
-        ],
       ],
     );
 
+    // #2808 — the proximity bar is a full-bleed band at the BOTTOM of the
+    // tile, OUTSIDE the scaleDown so it isn't shrunk to a hairline. It spans
+    // the complete PiP width (`width: infinity`, bounded by the tile) and is
+    // taller (10 pt) so the "getting close" signal is glanceable.
+    final Widget? proximityBand = (distance != null && radiusMeters != null)
+        ? SizedBox(
+            width: double.infinity,
+            child: ProximityFillBar(
+              distanceMeters: distance,
+              radiusMeters: radiusMeters,
+              height: 10,
+              onColor: foregroundColor,
+            ),
+          )
+        : null;
+
     // #2601 — tap to navigate to the station in the user's maps app. #2620 —
-    // one outer FittedBox(scaleDown) shrinks the whole stack so the bottom
-    // line + fill bar never bleed past the small 2:1 tile.
+    // one outer FittedBox(scaleDown) shrinks the price stack so it never
+    // bleeds past the small 2:1 tile; the proximity band sits below it at the
+    // tile's full width (#2808).
     return Tooltip(
       message: l?.navigate ?? 'Navigate',
       child: GestureDetector(
@@ -151,11 +154,20 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
         child: Material(
           color: backgroundColor,
           child: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              child: Center(
-                child: FittedBox(fit: BoxFit.scaleDown, child: content),
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    child: Center(
+                      child: FittedBox(fit: BoxFit.scaleDown, child: content),
+                    ),
+                  ),
+                ),
+                ?proximityBand,
+              ],
             ),
           ),
         ),

--- a/test/features/approach/providers/nearest_station_radar_provider_test.dart
+++ b/test/features/approach/providers/nearest_station_radar_provider_test.dart
@@ -255,6 +255,28 @@ void main() {
     });
   });
 
+  group('live distance re-stamp (#2808 — PiP proximity bar)', () {
+    test('re-stamps dist from the live fix, not the frozen corridor dist',
+        () async {
+      // ~1.11 km from the fix (48.0,2.0), but carrying a STALE `dist` (99 km)
+      // baked in at corridor-fetch time. The PiP proximity bar reads
+      // `station.dist`, so the provider must overwrite it with the LIVE
+      // distance or the bar never moves as the driver approaches.
+      final stale =
+          _station('S', lat: 48.01, lng: 2.0, e10: 1.5).copyWith(dist: 99.0);
+      final radar = _CapturingRadar([stale]);
+      final container = _container(radar: radar);
+      addTearDown(container.dispose);
+
+      final out = await container.read(nearestStationRadarProvider.future);
+      expect(out, isNotNull);
+      // RED on master (passes the frozen 99 km through); GREEN after the
+      // re-stamp. 0.01° lat ≈ 1.11 km.
+      expect(out!.dist, closeTo(1.11, 0.1),
+          reason: '#2808 — live distance re-stamped, not the frozen 99 km');
+    });
+  });
+
   test('non-polling approach state → null (fallback stays out of the way)',
       () async {
     final radar = _CapturingRadar([_station('X', e10: 1.5)]);

--- a/test/features/approach/providers/radar_candidate_list_provider_test.dart
+++ b/test/features/approach/providers/radar_candidate_list_provider_test.dart
@@ -224,6 +224,26 @@ void main() {
       final out = await container.read(radarCandidateListProvider.future);
       expect(out, isEmpty);
     });
+
+    test('re-stamps each row\'s dist from the live fix (#2808)', () async {
+      // Both carry a STALE `dist` (99 km) from corridor-fetch time; the
+      // swipe-card proximity bar reads `station.dist`, so each row must be
+      // re-stamped with the LIVE distance or the bar never moves.
+      final radar = _CapturingRadar([
+        _station('NEAR', lat: 48.0, lng: 2.0, e10: 1.6).copyWith(dist: 99.0),
+        _station('MID', lat: 48.01, lng: 2.0, e10: 1.5).copyWith(dist: 99.0),
+      ]);
+      final container = _container(radar: radar);
+      addTearDown(container.dispose);
+
+      final out = await container.read(radarCandidateListProvider.future);
+      expect(out.map((s) => s.id), ['NEAR', 'MID']);
+      // RED on master (frozen 99 km passes through); GREEN after the re-stamp.
+      expect(out[0].dist, closeTo(0.0, 0.05),
+          reason: '#2808 — NEAR at the fix re-stamped to ~0 km, not 99');
+      expect(out[1].dist, closeTo(1.11, 0.1),
+          reason: '#2808 — MID re-stamped to its live ~1.11 km, not 99');
+    });
   });
 
   test('non-polling approach state → const [] (page-set stays out of the way)',

--- a/test/features/consumption/presentation/widgets/proximity_fill_bar_test.dart
+++ b/test/features/consumption/presentation/widgets/proximity_fill_bar_test.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: Center(child: child)),
+    );
+
+void main() {
+  testWidgets('fill is a two-colour green→accent gradient (#2808)',
+      (tester) async {
+    await tester.pumpWidget(
+      _host(
+        const SizedBox(
+          width: 200,
+          child: ProximityFillBar(distanceMeters: 200, radiusMeters: 1000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final context = tester.element(find.byType(ProximityFillBar));
+    final green = DarkModeColors.brandGreen(context);
+    final accent = DarkModeColors.proximityAccent(context);
+
+    final decorated = tester
+        .widgetList<DecoratedBox>(find.byType(DecoratedBox))
+        .map((d) => d.decoration)
+        .whereType<BoxDecoration>()
+        .firstWhere((d) => d.gradient != null);
+    final gradient = decorated.gradient! as LinearGradient;
+
+    expect(gradient.colors, [green, accent],
+        reason: 'two distinct colours — brand green and the blue-violet accent');
+    expect(green, isNot(accent));
+  });
+
+  testWidgets('collapses when radius is null/non-positive', (tester) async {
+    await tester.pumpWidget(
+      _host(const ProximityFillBar(distanceMeters: 100, radiusMeters: null)),
+    );
+    expect(find.byType(DecoratedBox), findsNothing);
+  });
+}


### PR DESCRIPTION
## Symptom

On the floating PiP window the proximity/closeness indicator is barely visible and **does not move** as the driver approaches the station. (On the full recording screen it looks fine.)

Closes #2808.

## Root causes (verified vs master)

1. **No-update (the core bug).** `nearestStationRadarProvider` + `radarCandidateListProvider` compute the live distance only to *sort* the corridor set, then return each station with its **frozen `Station.dist`** — stamped once at the corridor-fetch centre. The PiP reads `station.dist`, so the bar sits still. (The on-search radar already re-stamps via `copyWith(dist:)`; the recording path didn't.)
2. **Barely visible.** The PiP wrapped the bar in `SizedBox(width:120, height:5)` *inside* a `FittedBox(scaleDown)` → shrunk to a hairline.
3. **Single colour.** The fill was one brand-green block.

## Fix (shared by GPS-only + OBD2 — one `ProximityFillBar`, one approach detector)

- Re-stamp the **live** distance in both providers before returning.
- Lift the bar out of the `FittedBox`; render it as a **full-bleed band** at the bottom of the tile, full width, 10 pt tall.
- Make the fill a **green→blue-violet gradient** (`brandGreen` → new `DarkModeColors.proximityAccent`).

## Tests

- Live-distance re-stamp in `nearestStationRadarProvider` + `radarCandidateListProvider` — **RED on master** (the frozen 99 km passed straight through; verified by reverting the two providers).
- Two-colour gradient + collapse-when-no-radius on `ProximityFillBar`.
- `flutter analyze` clean on all changed files; clean codegen committed (regenerated provider hashes).

No new user-facing strings (Semantics + distance captions already in ARB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
