### PR TITLE
fix(nav): stop search re-opening the form + losing the bottom bar, and trace both (#2810, #2811)

### DIFF
--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/logging/error_logger.dart';
 import '../../features/route_search/providers/route_search_provider.dart';
 import '../../features/search/presentation/screens/search_criteria_screen.dart';
 import '../../features/search/providers/search_provider.dart';
@@ -266,32 +269,42 @@ class ShellBottomBar extends ConsumerWidget {
     void openCriteriaOnSearchBranch() {
       if (i != currentIndex) onTap(i);
       final searchNav = searchBranchNavigatorKey.currentState;
-      if (searchNav != null) {
-        searchNav.push<void>(
-          MaterialPageRoute<void>(
-            builder: (_) => const SearchCriteriaScreen(),
-            fullscreenDialog: true,
-          ),
-        );
-      } else {
-        // Defensive fallback for environments where the branch nav
-        // isn't mounted yet (very early frame, widget tests without
-        // the shell wired). Use the local context's Navigator.
-        // #2553 — if even that Navigator is torn down, degrade to a
-        // branch jump rather than throw uncaught: the FAB must never
-        // crash, only ever open criteria or jump to Search.
-        try {
-          Navigator.of(context).push(
-            MaterialPageRoute<void>(
-              builder: (_) => const SearchCriteriaScreen(),
-              fullscreenDialog: true,
-            ),
-          );
-        } catch (e, st) {
-          debugPrint('shell FAB default fallback: $e\n$st');
-          onTap(i);
-        }
+      if (searchNav == null) {
+        // #2811 — branch nav unmounted (early frame / unwired test). Do NOT
+        // root-push here: from the bar's context `Navigator.of(context)` is the
+        // ROOT navigator, and a fullscreen route there covers the whole shell —
+        // bar included — stranding it until restart if orphaned. Degrade to a
+        // branch jump, and trace it (a missing nav on a user tap is abnormal).
+        unawaited(errorLogger.log(
+          ErrorLayer.ui,
+          'search branch navigator not mounted on FAB tap — degraded to '
+              'branch jump (no root push)',
+          StackTrace.current,
+          context: {'source': 'openCriteriaOnSearchBranch', 'branch': i},
+        ));
+        onTap(i);
+        return;
       }
+      // #2810 — refuse to stack a duplicate criteria modal: the FAB stays
+      // visible while it is open (branch-push keeps the shell mounted), so a
+      // repeat tap would push a second copy ("search just re-opens the same
+      // form again and again"). Bail if it is already current.
+      if (searchCriteriaRouteIsCurrent(searchNav)) {
+        unawaited(errorLogger.log(
+          ErrorLayer.ui,
+          'search criteria re-open suppressed (already current)',
+          StackTrace.current,
+          context: {'source': 'openCriteriaOnSearchBranch', 'branch': i},
+        ));
+        return;
+      }
+      searchNav.push<void>(
+        MaterialPageRoute<void>(
+          builder: (_) => const SearchCriteriaScreen(),
+          fullscreenDialog: true,
+          settings: const RouteSettings(name: kSearchCriteriaRouteName),
+        ),
+      );
     }
 
     void defaultOnTap() {

--- a/lib/app/shell_screen.dart
+++ b/lib/app/shell_screen.dart
@@ -1,9 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../core/logging/error_logger.dart';
 import '../core/storage/storage_providers.dart';
 import '../core/utils/frame_callbacks.dart';
 import '../core/widgets/snackbar_helper.dart';
@@ -150,11 +153,27 @@ class _ShellScreenState extends ConsumerState<ShellScreen>
     // and make the central FAB dead on the tab the user switched to.
     ref.read(searchFabActionControllerProvider.notifier).set(null);
 
-    // Navigate via go_router — this preserves each branch's state
-    widget.navigationShell.goBranch(
-      index,
-      initialLocation: index == widget.navigationShell.currentIndex,
-    );
+    // Navigate via go_router — this preserves each branch's state.
+    // #2811 — guard + trace: a goBranch throw must not silently leave the
+    // shell mid-transition (bar present but no tab highlighted) with nothing
+    // in the error log.
+    try {
+      widget.navigationShell.goBranch(
+        index,
+        initialLocation: index == widget.navigationShell.currentIndex,
+      );
+    } catch (e, st) {
+      unawaited(errorLogger.log(
+        ErrorLayer.ui,
+        e,
+        st,
+        context: {
+          'source': 'ShellScreen.goBranch',
+          'index': index,
+          'currentIndex': widget.navigationShell.currentIndex,
+        },
+      ));
+    }
   }
 
   void _onHorizontalDragEnd(DragEndDetails details) {

--- a/lib/features/search/presentation/screens/search_criteria_screen.dart
+++ b/lib/features/search/presentation/screens/search_criteria_screen.dart
@@ -34,6 +34,25 @@ import '../widgets/search_criteria_form.dart';
 /// Full-screen modal for editing search criteria (mode, location, fuel, radius,
 /// filters, equipment). Pops on submission and delegates to the relevant
 /// state providers.
+/// Stable route name for the search-criteria modal (#2810). The shell's three
+/// push paths tag the route with this so they can detect it is already current
+/// and refuse to stack a duplicate (the "search just re-opens the same form
+/// again and again" bug).
+const String kSearchCriteriaRouteName = 'search-criteria';
+
+/// Whether the [kSearchCriteriaRouteName] modal is the current (top) route on
+/// [nav] (#2810). Every push site calls this and bails when it returns true,
+/// so a repeat tap can never stack a second criteria screen. `popUntil` with an
+/// always-true predicate inspects the top route without popping anything.
+bool searchCriteriaRouteIsCurrent(NavigatorState nav) {
+  var current = false;
+  nav.popUntil((r) {
+    current = r.settings.name == kSearchCriteriaRouteName;
+    return true;
+  });
+  return current;
+}
+
 class SearchCriteriaScreen extends ConsumerStatefulWidget {
   const SearchCriteriaScreen({super.key});
 
@@ -85,6 +104,13 @@ class _SearchCriteriaScreenState extends ConsumerState<SearchCriteriaScreen> {
 
   void _updateFabAction() {
     if (!mounted) return;
+    // #2810 — only the CURRENTLY-displayed criteria screen may own the FAB
+    // action. Without this an offstage instance (the user swiped to another
+    // branch, its dispose hasn't fired) can re-register its action — sometimes
+    // disabled — via this post-frame / ref.listen callback AFTER the shell
+    // cleared the FAB on the branch change, leaving the centre FAB looking
+    // faded/dead on Map/Favoris.
+    if (!(ModalRoute.of(context)?.isCurrent ?? false)) return;
     final l10n = AppLocalizations.of(context);
     final mode = ref.read(activeSearchModeProvider);
     final manifest = ref.read(featureManifestProvider);

--- a/lib/features/search/presentation/widgets/search_summary_bar.dart
+++ b/lib/features/search/presentation/widgets/search_summary_bar.dart
@@ -29,10 +29,16 @@ class SearchSummaryBar extends ConsumerWidget {
   const SearchSummaryBar({super.key});
 
   Future<void> _openCriteria(BuildContext context) async {
-    await Navigator.of(context).push<void>(
+    final nav = Navigator.of(context);
+    // #2810 — don't stack a duplicate criteria modal if one is already on top
+    // (the summary bar stays visible behind the modal). The shared guard +
+    // tagged route name keep every push path consistent.
+    if (searchCriteriaRouteIsCurrent(nav)) return;
+    await nav.push<void>(
       MaterialPageRoute<void>(
         fullscreenDialog: true,
         builder: (_) => const SearchCriteriaScreen(),
+        settings: const RouteSettings(name: kSearchCriteriaRouteName),
       ),
     );
   }

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -11,6 +11,7 @@ import 'package:tankstellen/app/shell/shell_bottom_bar.dart';
 import 'package:tankstellen/app/shell/shell_nav_item.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/presentation/screens/search_criteria_screen.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
 
 import '../../fixtures/stations.dart';
@@ -256,6 +257,36 @@ void main() {
       await tester.pump();
 
       expect(taps, [0, 2]);
+    });
+
+    testWidgets(
+        'no branch nav: the FAB degrades to onTap and never root-pushes a '
+        'fullscreen route over the shell (#2811)', (tester) async {
+      // The branch navigator key is not mounted in this isolated harness
+      // (searchBranchNavigatorKey.currentState == null). The OLD fallback
+      // root-pushed a fullscreen SearchCriteriaScreen onto the local
+      // Navigator — covering the whole shell incl. the bottom bar, which
+      // could strand the bar until an app restart. It must now degrade to a
+      // branch jump instead.
+      final taps = <int>[];
+      await pumpBar(
+        tester,
+        items: items,
+        branchForSlot: const [0, 1, 2],
+        currentIndex: 1, // Search selected → onSearchBranch → opens criteria
+        iconControllers: controllers(3),
+        isLandscape: false,
+        onTap: taps.add,
+      );
+
+      await tester.tap(find.byIcon(Icons.search)); // the centre FAB
+      await tester.pump();
+
+      expect(taps, contains(1),
+          reason: '#2811 — degrades to a branch jump (onTap), not a push');
+      expect(find.byType(SearchCriteriaScreen), findsNothing,
+          reason: '#2811 — must NOT root-push a fullscreen route over the '
+              'shell when the branch nav is unmounted');
     });
   });
 

--- a/test/features/search/presentation/screens/search_criteria_route_guard_test.dart
+++ b/test/features/search/presentation/screens/search_criteria_route_guard_test.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/search/presentation/screens/search_criteria_screen.dart';
+
+/// #2810 — the shared guard every search-criteria push site uses to refuse
+/// stacking a duplicate modal (the "search just re-opens the same form again
+/// and again" bug). Tested against a real [NavigatorState] with a route stack,
+/// so it pins the actual top-route detection without the heavy criteria screen.
+void main() {
+  final navKey = GlobalKey<NavigatorState>();
+
+  Future<void> pumpNav(WidgetTester tester) => tester.pumpWidget(
+        MaterialApp(
+          home: Navigator(
+            key: navKey,
+            onGenerateRoute: (_) => MaterialPageRoute<void>(
+              builder: (_) => const Scaffold(body: Text('root')),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('false when the criteria route is not on top', (tester) async {
+    await pumpNav(tester);
+    expect(searchCriteriaRouteIsCurrent(navKey.currentState!), isFalse);
+
+    // An unrelated (unnamed) route on top is still not the criteria route.
+    unawaited(navKey.currentState!.push(
+      MaterialPageRoute<void>(builder: (_) => const Scaffold()),
+    ));
+    await tester.pumpAndSettle();
+    expect(searchCriteriaRouteIsCurrent(navKey.currentState!), isFalse);
+  });
+
+  testWidgets('true when the criteria route is current — and the guard does '
+      'not pop it', (tester) async {
+    await pumpNav(tester);
+    unawaited(navKey.currentState!.push(
+      MaterialPageRoute<void>(
+        settings: const RouteSettings(name: kSearchCriteriaRouteName),
+        builder: (_) => const Scaffold(body: Text('criteria')),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(searchCriteriaRouteIsCurrent(navKey.currentState!), isTrue);
+    // Inspecting must be non-destructive — the route is still there.
+    expect(searchCriteriaRouteIsCurrent(navKey.currentState!), isTrue);
+    expect(find.text('criteria'), findsOneWidget);
+    expect(navKey.currentState!.canPop(), isTrue);
+  });
+}


### PR DESCRIPTION
Two intermittent navigation bugs, both leaving **zero error-log entries** (every nav hot-path catch logged to `debugPrint`, never `errorLogger`, and the failure modes throw nothing — so the global handlers never fired).

Closes #2810, closes #2811.

## #2810 — search button re-opens the same criteria form repeatedly

**Root cause:** three push paths present `SearchCriteriaScreen` (`shell_bottom_bar.openCriteriaOnSearchBranch`, its fallback, `search_summary_bar._openCriteria`) and **none** checked whether it was already current. The centre FAB stays visible while the modal is open (the #2131 branch-push keeps the shell mounted), so a repeat tap stacked a second copy; popping revealed the next — "search just re-opens the same form again and again". (The earlier `_searchFired` theory was a red herring — it's per-State and resets on every push.)

**Fix:** a stable `RouteSettings(name: 'search-criteria')` + a shared `searchCriteriaRouteIsCurrent(nav)` guard at all three sites; and `SearchCriteriaScreen._updateFabAction` now bails unless `ModalRoute.isCurrent`, so an offstage instance can't re-register its (sometimes disabled) action onto another branch — the faded-FAB variant. Suppressed re-opens are logged (`ErrorLayer.ui`).

## #2811 — bottom nav bar disappears (needs app restart)

**Root cause:** the FAB fallback root-pushed a fullscreen `SearchCriteriaScreen` when the branch nav wasn't mounted. From the bar's context `Navigator.of(context)` resolves to the **root** navigator, so that route covered the whole shell — bar included — stranding it until restart if orphaned (the #2131 failure the branch-push was meant to avoid).

**Fix:** the fallback now **degrades to a branch jump — never a root push** — and logs the abnormal missing-nav condition; `goBranch` is wrapped in a logged try/catch so a branch-switch failure is no longer invisible.

## Tests

- `searchCriteriaRouteIsCurrent` guard (named/unnamed top route, non-destructive inspection).
- No-root-push degradation — **RED on master** (the old root-push throws when the branch nav is unmounted; verified by reverting `shell_bottom_bar`).
- The existing 30+ shell/criteria/FAB tests still pass.
- `flutter analyze` clean; `file_length` pass; clean codegen (no drift). No new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
