### PR TITLE
fix(radar): merge a tight near fetch into the polled corridor so "Closest station" isn't a far one (#2813)

### DIFF
--- a/lib/features/approach/providers/fuel_station_radar_provider.dart
+++ b/lib/features/approach/providers/fuel_station_radar_provider.dart
@@ -15,6 +15,16 @@ import '../../search/domain/entities/station.dart';
 
 part 'fuel_station_radar_provider.g.dart';
 
+/// Tight near-radius (km) the polled corridor fetch ALSO queries and merges
+/// into the wide corridor (#2813). The wide corridor is row-capped with no
+/// distance ordering (e.g. FR `within_distance(60km)` + `limit:50`), so in a
+/// sparse/suburban area — exactly where few near stations are easily truncated
+/// by far-area density — the genuinely-nearest forecourts drop out and the
+/// "Closest station" card shows a far one. A sparse near-radius fetch isn't
+/// hit by the cap, so it reliably carries the nearest stations back. 15 km
+/// comfortably covers the default 10 km search radius.
+const double kCorridorNearMergeRadiusKm = 15.0;
+
 /// Fuel Station Radar data layer (#2283) — the two-tier source that backs the
 /// approach detector while a trip is recording.
 ///
@@ -126,7 +136,36 @@ FuelStationRadar fuelStationRadar(Ref ref) {
             sortBy: SortBy.distance,
           ),
         );
-        return result.data;
+        // #2813 — a polled source returns the wide corridor under a hard row
+        // cap with no distance ordering (e.g. FR `within_distance(60km)` +
+        // `limit:50`), so in a dense area the genuinely-NEAREST forecourts can
+        // be truncated out — leaving the recording "Closest station" card and
+        // the approach detector showing a far station the in-radius search
+        // would never pick. Merge a tight near-radius fetch (sparse → not row-
+        // capped) by id so the cached corridor always contains the nearest
+        // stations. Bulk-file sources read the full local dataset (no cap), so
+        // the wide fetch is already complete and the merge is skipped.
+        if (isBulk || radiusKm <= kCorridorNearMergeRadiusKm) {
+          return result.data;
+        }
+        final byId = {for (final s in result.data) s.id: s};
+        try {
+          final near = await svc.searchStations(
+            SearchParams(
+              lat: lat,
+              lng: lng,
+              radiusKm: kCorridorNearMergeRadiusKm,
+              fuelType: FuelType.all,
+              sortBy: SortBy.distance,
+            ),
+          );
+          for (final s in near.data) {
+            byId[s.id] = s;
+          }
+        } on Object {
+          // Wide-corridor-only on a near-fetch failure (offline / rate limit).
+        }
+        return byId.values.toList(growable: false);
       } on Object {
         return const <Station>[];
       }

--- a/lib/features/approach/providers/fuel_station_radar_provider.g.dart
+++ b/lib/features/approach/providers/fuel_station_radar_provider.g.dart
@@ -66,4 +66,4 @@ final class FuelStationRadarProvider
   }
 }
 
-String _$fuelStationRadarHash() => r'f571f5d00dff05eeccb12bd475b880971dd1fbf8';
+String _$fuelStationRadarHash() => r'13ce43fe339f6bcf1e6df8c475f0e72236875a69';

--- a/test/features/approach/providers/fuel_station_radar_near_merge_test.dart
+++ b/test/features/approach/providers/fuel_station_radar_near_merge_test.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/country/country_config.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../helpers/mock_providers.dart';
+
+/// #2813 — the polled corridor fetch is row-capped with no distance ordering
+/// (FR `within_distance(60km)` + `limit:50`), so in a sparse area the nearest
+/// forecourts get truncated out of the wide slice and the recording "Closest
+/// station" card shows a far one. The real `fuelStationRadarProvider` closure
+/// must merge a tight near-radius fetch (not row-capped) so the nearest survive.
+///
+/// Driven through the REAL provider + a radius-keyed service (NOT an echoing
+/// fake): the wide (60 km) query returns ONLY the far station — modelling the
+/// cap truncating the near ones — while the tight ([kCorridorNearMergeRadiusKm])
+/// query returns the near one, exactly as a sparse real fetch would.
+Station _station(String id, double lat, double lng, {double? e10}) => Station(
+      id: id,
+      name: 'Station $id',
+      brand: 'TEST',
+      street: '',
+      postCode: '',
+      place: '',
+      lat: lat,
+      lng: lng,
+      e10: e10,
+      isOpen: true,
+    );
+
+class _RadiusKeyedService implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    // Wide corridor (> near radius): the cap dropped the near station — only a
+    // far one survives. Tight near fetch: returns the genuinely-nearest.
+    final wide = params.radiusKm > kCorridorNearMergeRadiusKm;
+    return ServiceResult(
+      data: wide
+          ? [_station('FAR', 48.5, 2.0, e10: 1.80)] // ~55 km
+          : [_station('NEAR', 48.01, 2.0, e10: 1.60)], // ~1.1 km
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  test('polled corridor merges the tight near set so the nearest is not '
+      'truncated by the row cap (#2813)', () async {
+    final container = ProviderContainer(
+      overrides: [
+        // FR = polled (within_distance + limit:50), so the near-merge runs.
+        activeCountryOverride(Countries.byCode('FR')!),
+        stationServiceProvider.overrideWithValue(_RadiusKeyedService()),
+      ].cast(),
+    );
+    addTearDown(container.dispose);
+
+    final radar = container.read(fuelStationRadarProvider);
+    final out = await radar.fetchStations(48.0, 2.0, 1.5, 'e10');
+    final ids = out.map((s) => s.id).toSet();
+
+    // RED on master: wide-only → {FAR}, the NEAR station truncated.
+    // GREEN after the merge: the tight near fetch carries NEAR back.
+    expect(ids, containsAll(<String>{'NEAR', 'FAR'}),
+        reason: '#2813 — the nearest forecourt survives the wide row cap');
+  });
+}


### PR DESCRIPTION
## Symptom

The recording-screen **"Closest station"** card shows a far station (~13 km, *Avenue du Général de Gaulle*) while a normal search from the same spot finds stations at **~2.4 km** (Total/Pézenas). Same class of bug as #2806 but a *different, untouched* path (the approach detector, not the on-search radar).

Closes #2813.

## Root cause

`nearestStationRadarProvider` + `radarCandidateListProvider` read the cache-first corridor via `FuelStationRadar.fetchStations` → `CorridorLocationCache` (60 km). For **polled** countries that corridor is one `within_distance(60km)` + `limit:50` query with **no distance ordering** (`prix_carburants_station_service._queryByGeo`). In a **sparse/suburban** area — exactly where a handful of near stations are easily truncated by far-area density — the genuinely-nearest forecourts drop out of the arbitrary 50-row slice; a far one survives and becomes "closest" after the local sort. #2806/#2807 fixed only the on-search radar.

## Fix (corridor-level — heals both paths at the source)

The polled `fetchCorridor` closure now **also** issues a tight `kCorridorNearMergeRadiusKm` (15 km) fetch — sparse, so it isn't hit by the row cap — and merges it by id into the wide corridor, so the cached corridor always carries the nearest stations. Bulk-file sources read the full local dataset (no cap), so the merge is skipped for them. **No risky FR API-ordering change.**

Note: this is a *mitigation targeted at the reported (sparse-area) failure*, where the bug actually bites; a truly dense near-zone exceeding the cap would still need server-side distance ordering, which requires live-API verification (a recorded fixture) — tracked as a follow-up if it ever surfaces.

## Tests

- Drives the **real** `fuelStationRadarProvider` with a radius-keyed service (wide = far-only, modelling the cap truncating the near ones; near = the nearest) — **RED on master** (corridor returns `{FAR}` only; verified by reverting the provider) → **GREEN** after (`{NEAR, FAR}`).
- Existing `fuel_station_radar` / `nearest_station_radar` / `radar_candidate_list` tests still pass.
- `flutter analyze` clean; clean codegen committed (regenerated provider hash). No new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
