### PR TITLE
fix(dev): Export analysis trace saves a file to Downloads only — drop the share sheet (#2817)

### DIFF
--- a/lib/features/consumption/data/analysis/driving_analysis_trace_export.dart
+++ b/lib/features/consumption/data/analysis/driving_analysis_trace_export.dart
@@ -2,88 +2,39 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/sharing/public_file_exporter.dart';
 import 'driving_analysis_trace.dart';
 
-/// Test-only override for the driving-trace share-sheet handoff, mirroring
-/// `OcrTesterExport.debugOcrPackageShareSinkOverride` (#2804). Widget tests
-/// substitute a fake to capture the outgoing payload without launching the
-/// real OS share sheet.
-typedef DrivingTraceShareSink = Future<void> Function(ShareParams params);
-
-/// See [DrivingTraceShareSink].
-@visibleForTesting
-DrivingTraceShareSink? debugDrivingTraceShareSinkOverride;
-
-/// Test-only override for the temp-directory lookup used by the share path
-/// (#2804).
-@visibleForTesting
-Future<Directory> Function()? debugDrivingTraceTempDirectoryOverride;
-
 /// Local-only export of a [DrivingAnalysisTrace] for the dev-gated trip-detail
-/// calibration tool (#2804, Epic #2789 C6). No paid services, no network: the
-/// JSON lands in the device Downloads folder via [PublicFileExporter] AND is
-/// handed to the OS share sheet so the maintainer can send the annotated trace
-/// straight back. Mirrors the #2518 OCR export, but its share sink defaults to
-/// the real [SharePlus] (production sharing is the whole point) rather than a
-/// no-op.
+/// calibration tool (#2804). Writes the JSON as a FILE into the device's
+/// public Downloads folder via [PublicFileExporter] — no share sheet (#2817),
+/// matching the app's files-only export stance (#2014). The maintainer fills
+/// in the `comment` field and sends the file from the file manager. No paid
+/// services, no network.
 class DrivingAnalysisTraceExport {
   DrivingAnalysisTraceExport._();
 
-  /// Writes the trace JSON to Downloads and opens the share sheet. Returns
-  /// `true` when the Downloads write succeeded (the share sheet is best-effort
-  /// — its failure is logged but does not flip the result).
+  /// Writes the trace JSON to the Downloads folder. Returns `true` when the
+  /// write succeeded, `false` (logged) otherwise.
   static Future<bool> export(DrivingAnalysisTrace trace) async {
     final json = formatDrivingAnalysisTraceJson(trace);
     final stamp =
         trace.capturedAt.toIso8601String().replaceAll(RegExp(r'[:.]'), '-');
     final fileName = 'tankstellen-driving-$stamp.json';
-
-    var ok = false;
     try {
       await PublicFileExporter.saveTextToDownloads(
         text: json,
         fileName: fileName,
         mimeType: 'application/json',
       );
-      ok = true;
+      return true;
     } on Object catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
         'where': 'DrivingAnalysisTraceExport.export: json write',
       }));
+      return false;
     }
-
-    // Hand the file to the share sheet so the maintainer can send it back.
-    // Best-effort — a share failure must not mask a successful Downloads write.
-    try {
-      await _shareAsFile(json, fileName);
-    } on Object catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'DrivingAnalysisTraceExport.export: share',
-      }));
-    }
-    return ok;
-  }
-
-  static Future<void> _shareAsFile(String json, String fileName) async {
-    final tempDirProvider =
-        debugDrivingTraceTempDirectoryOverride ?? getTemporaryDirectory;
-    final tempDir = await tempDirProvider();
-    final filePath = '${tempDir.path}/$fileName';
-    await File(filePath).writeAsString(json, flush: true);
-    final params = ShareParams(
-      files: [XFile(filePath, mimeType: 'application/json')],
-      subject: fileName,
-    );
-    final sink = debugDrivingTraceShareSinkOverride ??
-        (ShareParams p) => SharePlus.instance.share(p).then((_) {});
-    await sink(params);
   }
 }

--- a/test/features/consumption/data/analysis/driving_analysis_trace_export_test.dart
+++ b/test/features/consumption/data/analysis/driving_analysis_trace_export_test.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:tankstellen/core/sharing/public_file_exporter.dart';
 import 'package:tankstellen/features/consumption/data/analysis/driving_analysis_trace.dart';
 import 'package:tankstellen/features/consumption/data/analysis/driving_analysis_trace_export.dart';
@@ -40,14 +39,10 @@ DrivingAnalysisTrace _trace() => DrivingAnalysisTrace(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late Directory tempDir;
   late List<({String fileName, String mimeType, Uint8List bytes})> writes;
-  late List<ShareParams> shares;
 
-  setUp(() async {
-    tempDir = await Directory.systemTemp.createTemp('driving-trace-export');
+  setUp(() {
     writes = [];
-    shares = [];
     debugPublicFileExporterOverride = ({
       required bytes,
       required fileName,
@@ -56,21 +51,18 @@ void main() {
       writes.add((fileName: fileName, mimeType: mimeType, bytes: bytes));
       return 'content://downloads/$fileName';
     };
-    debugDrivingTraceTempDirectoryOverride = () async => tempDir;
-    debugDrivingTraceShareSinkOverride = (params) async => shares.add(params);
   });
 
-  tearDown(() async {
+  tearDown(() {
     debugPublicFileExporterOverride = null;
-    debugDrivingTraceTempDirectoryOverride = null;
-    debugDrivingTraceShareSinkOverride = null;
-    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
   });
 
-  test('writes a stamped JSON to Downloads and returns true', () async {
+  test('#2817 — writes a stamped JSON FILE to Downloads and returns true',
+      () async {
     final ok = await DrivingAnalysisTraceExport.export(_trace());
 
     expect(ok, isTrue);
+    // Exactly one Downloads write — no share-sheet detour.
     expect(writes, hasLength(1));
     final write = writes.single;
     // Stamp derives from capturedAt with `:`/`.` swapped for `-`.
@@ -82,22 +74,7 @@ void main() {
     expect(decoded['comment'], kDrivingAnalysisCommentPrompt);
   });
 
-  test('hands a .json XFile to the share sheet so it can be sent back',
-      () async {
-    await DrivingAnalysisTraceExport.export(_trace());
-
-    expect(shares, hasLength(1));
-    final params = shares.single;
-    expect(params.files, hasLength(1));
-    final file = params.files!.single;
-    expect(file.path, endsWith('.json'));
-    expect(file.mimeType, 'application/json');
-    // The temp file was actually written before sharing.
-    expect(File(file.path).existsSync(), isTrue);
-  });
-
-  test('a Downloads-write failure still returns false but does not throw',
-      () async {
+  test('a Downloads-write failure returns false and does not throw', () async {
     debugPublicFileExporterOverride = ({
       required bytes,
       required fileName,
@@ -106,9 +83,6 @@ void main() {
         throw const FileSystemException('no Downloads access');
 
     final ok = await DrivingAnalysisTraceExport.export(_trace());
-
     expect(ok, isFalse);
-    // The share handoff is independent of the Downloads write.
-    expect(shares, hasLength(1));
   });
 }


### PR DESCRIPTION
The dev **Export analysis trace** (#2804) wrote the JSON to Downloads **and** opened the OS share sheet. The app's standing export stance is files-only-to-Downloads (#2014: "files only download, do not suggest sharing") — the extra share sheet was confusing.

`DrivingAnalysisTraceExport.export` now writes **only** the JSON file to the public Downloads folder via `PublicFileExporter` (matching the backup / OCR exports). Removed the share-sheet path + its share_plus/path_provider/dart:io imports + the share/temp-dir test seams.

Closes #2817.

## Tests
- Writes exactly one Downloads write (no share detour), correct stamped filename + JSON.
- Downloads-write failure returns false without throwing.
- Existing card-gating tests pass. `flutter analyze` clean; no codegen drift; no ARB change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)