### PR TITLE
fix(ocr-tester): bake EXIF orientation so the preview isn't flipped + the overlay aligns (#2821)

### DIFF
--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_screen.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_screen.dart
@@ -6,6 +6,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'dart:ui' show instantiateImageCodec;
 
 import 'package:flutter/material.dart';
@@ -72,6 +73,10 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
   bool _running = false;
   OcrTracePackage? _package;
   Size? _imageSize;
+  // #2821 — the EXIF-baked image bytes for the preview, so the displayed
+  // pixels, the measured [_imageSize], and the ML Kit block overlay (which
+  // ran on the baked upright copy) all share one coordinate space.
+  Uint8List? _bakedImageBytes;
   int? _selectedBlock;
 
   late final ReceiptScanService _service =
@@ -227,7 +232,6 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
     AppLocalizations? l,
     OcrTracePackage package,
   ) {
-    final path = _imagePath;
     return [
       SectionHeader(
         leadingIcon: Icons.grid_on_outlined,
@@ -235,9 +239,9 @@ class _PumpOcrTesterScreenState extends ConsumerState<PumpOcrTesterScreen> {
         padding: EdgeInsets.zero,
       ),
       const SizedBox(height: 8),
-      if (path != null && _imageSize != null)
+      if (_bakedImageBytes != null && _imageSize != null)
         _OverlayView(
-          imagePath: path,
+          imageBytes: _bakedImageBytes!,
           imageSize: _imageSize!,
           package: package,
           selectedIndex: _selectedBlock,

--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
@@ -31,14 +31,17 @@ class _RunningRow extends StatelessWidget {
 
 /// The source image + classified-block overlay inside an InteractiveViewer.
 class _OverlayView extends StatelessWidget {
-  final String imagePath;
+  /// #2821 — the EXIF-baked image bytes (NOT the raw file): rendered via
+  /// [Image.memory] so the displayed pixels match [imageSize] and the block
+  /// overlay, which all live in baked-pixel space.
+  final Uint8List imageBytes;
   final Size imageSize;
   final OcrTracePackage package;
   final int? selectedIndex;
   final ValueChanged<int?> onTapBlock;
 
   const _OverlayView({
-    required this.imagePath,
+    required this.imageBytes,
     required this.imageSize,
     required this.package,
     required this.selectedIndex,
@@ -71,7 +74,7 @@ class _OverlayView extends StatelessWidget {
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
-                    Image.file(File(imagePath), fit: BoxFit.fill),
+                    Image.memory(imageBytes, fit: BoxFit.fill),
                     CustomPaint(
                       key: const Key('ocr_block_overlay'),
                       painter: painter,
@@ -192,6 +195,7 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
       _imagePath = result.path;
       _roi = result.roi;
       _package = null;
+      _bakedImageBytes = null;
     });
   }
 
@@ -207,6 +211,7 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
       _imagePath = shot.path;
       _roi = null;
       _package = null;
+      _bakedImageBytes = null;
     });
   }
 
@@ -217,6 +222,7 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
       _imagePath = shot.path;
       _roi = null;
       _package = null;
+      _bakedImageBytes = null;
     });
   }
 
@@ -254,11 +260,12 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
       debugPrint('PumpOcrTester: pipeline run failed — $e\n$st');
     }
     if (!mounted) return;
-    final size = await _decodeImageSize(path);
+    final decoded = await _decodeBaked(path);
     if (!mounted) return;
     _rebuild(() {
       _package = trace.build();
-      _imageSize = size;
+      _imageSize = decoded?.size;
+      _bakedImageBytes = decoded?.bytes;
       _running = false;
     });
   }
@@ -287,14 +294,23 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
     }
   }
 
-  Future<Size?> _decodeImageSize(String path) async {
+  /// #2821 — read the capture, BAKE its EXIF orientation, and measure the
+  /// baked pixels. Returns the baked bytes + their size so the preview
+  /// ([Image.memory]) and the overlay scale ([imageSize]) share the same
+  /// baked space the ML Kit blocks were produced in — otherwise an EXIF tag
+  /// makes the preview appear flipped/rotated against the boxes.
+  Future<({Uint8List bytes, Size size})?> _decodeBaked(String path) async {
     try {
-      final bytes = await File(path).readAsBytes();
-      final codec = await instantiateImageCodec(bytes);
+      final raw = await File(path).readAsBytes();
+      final baked = bakeImageOrientation(raw) ?? raw;
+      final codec = await instantiateImageCodec(baked);
       final frame = await codec.getNextFrame();
-      return Size(
-        frame.image.width.toDouble(),
-        frame.image.height.toDouble(),
+      return (
+        bytes: baked,
+        size: Size(
+          frame.image.width.toDouble(),
+          frame.image.height.toDouble(),
+        ),
       );
     } catch (_) {
       return null;


### PR DESCRIPTION
The dev pump-OCR tester rendered the captured photo **vertically flipped** (bottom-top) with the ML Kit block overlay misaligned. Three consumers disagreed on orientation: the preview used `Image.file` (Flutter applies the EXIF tag), `_decodeImageSize` measured via `instantiateImageCodec` (ignores EXIF), and the trace blocks live in baked-pixel space (ML Kit ran on the `bakeOrientation`'d upright copy).

The tester now **bakes the EXIF orientation once** (`bakeImageOrientation`, already re-exported) and uses the baked bytes for **both** the measured size and the preview (`Image.memory`) — so the displayed pixels, `_imageSize`, and the overlay boxes share one coordinate space.

**Tester-only / cosmetic** — production OCR already bakes orientation before ML Kit, so it was never affected. Closes #2821.

Existing OCR-tester tests pass; `flutter analyze` clean; no ARB, no codegen. (The scanning-accuracy half of the report is tracked separately as an Epic — wiring the dormant 7-seg recogniser needs on-device A/B.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)