### PR TITLE
test(opening-hours): backfill ES/AT search-path regression coverage + dedupe testParseStation (#2780)

### DIFF
--- a/test/features/station_services/austria/econtrol_search_opening_hours_test.dart
+++ b/test/features/station_services/austria/econtrol_search_opening_hours_test.dart
@@ -3,48 +3,24 @@
 //
 // #2780 (Epic #2776 D4) — Austria is a polled-API source with NO detail
 // endpoint, so the search-result Station is the ONLY carrier of opening hours.
-// This drives the REAL EControlStationService.searchStations through an
-// injected Dio (not the divergent _TestableEControlParser copy) and asserts the
-// production parse populates the structured Station.openingHours AND that it
+// This drives the REAL EControlStationService.searchStations through the shared
+// real-service helper (not a divergent _TestableEControlParser copy) and asserts
+// the production parse populates the structured Station.openingHours AND that it
 // survives the search-list codec round-trip — the cache-hit path that rendered
 // empty hours before #2777.
-import 'dart:convert';
-
-import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/station_service_chain_codec.dart';
-import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
-import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
 
-/// Returns a fixed E-Control `by-address` payload (a JSON list of station
-/// records) for every request, so the production search pipeline runs without
-/// a live network call.
-class _FixedAdapter implements HttpClientAdapter {
-  final String body;
-  _FixedAdapter(this.body);
-
-  @override
-  Future<ResponseBody> fetch(
-    RequestOptions options,
-    Stream<List<int>>? requestStream,
-    Future<void>? cancelFuture,
-  ) async =>
-      ResponseBody.fromString(body, 200, headers: {
-        'content-type': ['application/json'],
-      });
-
-  @override
-  void close({bool force = false}) {}
-}
+import '../support/real_service_search.dart';
 
 void main() {
   test('AT searchStations populates structured hours + survives the codec (#2780)',
       () async {
     // One station with a full structured weekly schedule (06:30-20:30 Mon-Sat,
     // closed Sunday) — the real E-Control `openingHours[]` shape.
-    final body = jsonEncode([
-      <String, dynamic>{
+    final result = await searchEcontrolStations([
+      {
         'id': '123',
         'name': 'OMV Wien Ring',
         'open': true,
@@ -77,20 +53,12 @@ void main() {
       }
     ]);
 
-    final dio = Dio()..httpClientAdapter = _FixedAdapter(body);
-    final service = EControlStationService(dio: dio);
-
-    final result = await service.searchStations(
-      const SearchParams(lat: 48.2, lng: 16.37, radiusKm: 10.0),
-    );
-
-    final s = result.data.firstWhere((st) => st.id == 'at-123');
+    final s = result.firstWhere((st) => st.id == 'at-123');
     expect(s.openingHours, isNotNull,
         reason: 'the REAL AT search parse must populate structured hours — '
             'AT has no detail endpoint, so the search Station is the only carrier');
 
-    final restored =
-        deserializeStationList(serializeStationList([s]))!.single;
+    final restored = deserializeStationList(serializeStationList([s]))!.single;
     expect(restored.openingHours, isNotNull,
         reason: 'structured hours must survive the cache round-trip (#2777)');
     expect(restored.openingHours!.availability,

--- a/test/features/station_services/austria/econtrol_station_service_test.dart
+++ b/test/features/station_services/austria/econtrol_station_service_test.dart
@@ -1,774 +1,258 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
+//
+// #2780 (Epic #2776 D4) — every parse assertion here drives the REAL
+// [EControlStationService.searchStations] through a fixed Dio (see
+// `support/real_service_search.dart`), replacing the `_TestableEControlParser`
+// copy that re-implemented the parse but never set the structured
+// `Station.openingHours` nor the `at-` id prefix — i.e. proved the copy, not the
+// production path (the #2776 false-green lesson).
+//
+// Austria is the worst-case carrier: it polls its API (cache-HIT dominant) AND
+// has NO detail endpoint, so the search-result Station is the ONLY thing that
+// can ever carry opening hours. A cold favorite/widget tap (no live search
+// state) rehydrates that Station from `Station.toJson`/`fromJson`, so that codec
+// MUST preserve the hours — the regression this test backfills.
 
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
-import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
 import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+import '../support/real_service_search.dart';
+
+/// A realistic E-Control `by-address` record: OMV Wien, Mon–Sat 06:30–20:30
+/// (closed Sunday) — the real `openingHours[]` shape.
+Map<String, dynamic> omvWien({
+  String id = '123',
+  num? amount = 1.659,
+  bool open = true,
+  List<Map<String, dynamic>>? openingHours,
+}) =>
+    {
+      'id': id,
+      'name': 'OMV Wien Ring',
+      'open': open,
+      'location': {
+        'latitude': 48.2,
+        'longitude': 16.37,
+        'address': 'Ringstraße 1',
+        'postalCode': '1010',
+        'city': 'Wien',
+      },
+      'prices': [
+        if (amount != null) {'amount': amount},
+      ],
+      'openingHours': openingHours ??
+          [
+            for (final d in const ['MO', 'DI', 'MI', 'DO', 'FR', 'SA'])
+              {'day': d, 'label': d, 'from': '06:30', 'to': '20:30'},
+          ],
+    };
+
 void main() {
-  late EControlStationService service;
+  group('EControlStationService contract', () {
+    final service = EControlStationService();
 
-  setUp(() {
-    service = EControlStationService();
-  });
-
-  group('EControlStationService', () {
     test('implements StationService interface', () {
       expect(service, isA<StationService>());
     });
 
-    group('getStationDetail', () {
-      test('throws ApiException (detail not available)', () {
-        expect(
-          () => service.getStationDetail('at-123'),
-          throwsA(isA<ApiException>()),
-        );
-      });
-
-      test('error message mentions E-Control API', () async {
-        try {
-          await service.getStationDetail('at-test');
-          fail('Should have thrown');
-        } on ApiException catch (e) {
-          expect(e.message, contains('E-Control'));
-        }
-      });
-    });
-
-    group('getPrices', () {
-      test('returns empty map', () async {
-        final result = await service.getPrices(['at-1', 'at-2']);
-        expect(result.data, isEmpty);
-        expect(result.source, ServiceSource.eControlApi);
-      });
-
-      test('returns empty map for empty id list', () async {
-        final result = await service.getPrices([]);
-        expect(result.data, isEmpty);
-      });
-
-      test('result has correct metadata', () async {
-        final result = await service.getPrices(['x']);
-        expect(result.source, ServiceSource.eControlApi);
-        expect(result.fetchedAt, isA<DateTime>());
-        expect(result.isStale, isFalse);
-      });
-    });
-  });
-
-  group('E-Control parsing edge cases', () {
-    late _TestableEControlParser parser;
-
-    setUp(() {
-      parser = _TestableEControlParser();
-    });
-
-    group('parseStation additional cases', () {
-      test('handles multiple prices in prices array (takes last)', () {
-        final data = {
-          'id': 100,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [
-            {'amount': 1.500},
-            {'amount': 1.600},
-          ],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station, isNotNull);
-        expect(station!.diesel, closeTo(1.600, 0.001));
-      });
-
-      test('handles null id gracefully', () {
-        final data = {
-          'name': 'No ID Station',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station, isNotNull);
-        expect(station!.id, '');
-      });
-
-      test('handles null name gracefully', () {
-        final data = {
-          'id': 999,
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station, isNotNull);
-        expect(station!.name, '');
-      });
-
-      test('opening hours with day key instead of label', () {
-        final data = {
-          'id': 100,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': [
-            {'day': 'Monday', 'from': '06:00', 'to': '22:00'},
-          ],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station!.openingHoursText, contains('Monday'));
-      });
-
-      test('empty opening hours results in null openingHoursText', () {
-        final data = {
-          'id': 100,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station!.openingHoursText, isNull);
-      });
-
-      test('non-map items in openingHours are skipped', () {
-        final data = {
-          'id': 100,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': ['not a map', 42],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station!.openingHoursText, isNull);
-      });
-
-      test('non-map items in prices are skipped', () {
-        final data = {
-          'id': 100,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': ['not a map', 42],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station!.diesel, isNull);
-      });
-
-      test('defaults open to true when not specified', () {
-        final data = {
-          'id': 100,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station!.isOpen, isTrue);
-      });
-    });
-
-    group('extractBrand additional cases', () {
-      test('detects Eni brand', () {
-        expect(parser.testExtractBrand('Eni Tankstelle Wien'), 'Eni');
-      });
-
-      test('detects Turmöl brand', () {
-        expect(parser.testExtractBrand('Turmöl Graz'), 'Turmöl');
-      });
-
-      test('detects IQ brand', () {
-        expect(parser.testExtractBrand('IQ Salzburg'), 'IQ');
-      });
-
-      test('detects Avia brand', () {
-        expect(parser.testExtractBrand('Avia Linz'), 'Avia');
-      });
-
-      test('detects Genol brand', () {
-        expect(parser.testExtractBrand('Genol Innsbruck'), 'Genol');
-      });
-
-      test('detects Lagerhaus brand', () {
-        expect(parser.testExtractBrand('Lagerhaus Klagenfurt'), 'Lagerhaus');
-      });
-
-      test('detects SB brand', () {
-        expect(parser.testExtractBrand('SB Tankstelle'), 'SB');
-      });
-
-      test('case insensitive brand detection', () {
-        expect(parser.testExtractBrand('omv Wien'), 'OMV');
-        expect(parser.testExtractBrand('SHELL Austria'), 'Shell');
-        expect(parser.testExtractBrand('bp Graz'), 'BP');
-      });
-    });
-
-    group('merging additional cases', () {
-      test('super-only station gets e5 and e10 set', () {
-        const superStation = Station(
-          id: '200',
-          name: 'Shell',
-          brand: 'Shell',
-          street: 'Str',
-          postCode: '1010',
-          place: 'Wien',
-          lat: 48.2,
-          lng: 16.4,
-          dist: 1.0,
-          e5: 1.549,
-          isOpen: true,
-        );
-
-        // Station only from SUP query, no merge needed
-        final merged = superStation.copyWith(
-          e5: superStation.e5,
-          e10: superStation.e5,
-        );
-
-        expect(merged.e5, closeTo(1.549, 0.001));
-        expect(merged.e10, closeTo(1.549, 0.001));
-        expect(merged.diesel, isNull);
-      });
-    });
-  });
-
-  group('E-Control parsing (via _TestableEControlParser)', () {
-    late _TestableEControlParser parser;
-
-    setUp(() {
-      parser = _TestableEControlParser();
-    });
-
-    group('parseStation', () {
-      test('parses valid diesel station response', () {
-        final data = {
-          'id': 12345,
-          'name': 'OMV Wien Hauptbahnhof',
-          'location': {
-            'latitude': 48.1852,
-            'longitude': 16.3761,
-            'address': 'Wiedner Gürtel 12',
-            'postalCode': '1040',
-            'city': 'Wien',
-          },
-          'distance': 2.3,
-          'open': true,
-          'prices': [
-            {'amount': 1.659},
-          ],
-          'openingHours': [
-            {'label': 'Mo-Fr', 'from': '06:00', 'to': '22:00'},
-            {'label': 'Sa-So', 'from': '07:00', 'to': '21:00'},
-          ],
-        };
-
-        final station = parser.testParseStation(data, 48.2, 16.37, 'DIE');
-        expect(station, isNotNull);
-        expect(station!.id, '12345');
-        expect(station.name, 'OMV Wien Hauptbahnhof');
-        expect(station.street, 'Wiedner Gürtel 12');
-        expect(station.postCode, '1040');
-        expect(station.place, 'Wien');
-        expect(station.lat, closeTo(48.1852, 0.001));
-        expect(station.lng, closeTo(16.3761, 0.001));
-        expect(station.dist, closeTo(2.3, 0.01));
-        expect(station.diesel, closeTo(1.659, 0.001));
-        expect(station.e5, isNull); // DIE query => no e5
-        expect(station.isOpen, isTrue);
-        expect(station.openingHoursText, contains('Mo-Fr'));
-        expect(station.openingHoursText, contains('06:00-22:00'));
-      });
-
-      test('parses valid SUP (Super 95) station response', () {
-        final data = {
-          'id': 67890,
-          'name': 'BP Innsbruck',
-          'location': {
-            'latitude': 47.2692,
-            'longitude': 11.3933,
-            'address': 'Innrain 5',
-            'postalCode': '6020',
-            'city': 'Innsbruck',
-          },
-          'open': false,
-          'prices': [
-            {'amount': 1.549},
-          ],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 47.27, 11.39, 'SUP');
-        expect(station, isNotNull);
-        expect(station!.e5, closeTo(1.549, 0.001));
-        expect(station.e10, closeTo(1.549, 0.001));
-        expect(station.diesel, isNull);
-        expect(station.isOpen, isFalse);
-      });
-
-      test('uses calculated distance when API distance is missing', () {
-        final data = {
-          'id': 111,
-          'name': 'Test',
-          'location': {
-            'latitude': 48.2,
-            'longitude': 16.4,
-          },
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.2, 16.4, 'DIE');
-        expect(station, isNotNull);
-        // Distance should be calculated (very small since coords are similar)
-        expect(station!.dist, isNotNull);
-      });
-
-      test('handles missing price gracefully', () {
-        final data = {
-          'id': 222,
-          'name': 'Test',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'DIE');
-        expect(station, isNotNull);
-        expect(station!.diesel, isNull);
-      });
-
-      test('handles missing location fields gracefully', () {
-        final data = {
-          'id': 333,
-          'name': 'Test',
-          'location': <String, dynamic>{},
-          'prices': [],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 0, 0, 'DIE');
-        expect(station, isNotNull);
-        expect(station!.street, '');
-        expect(station.postCode, '');
-        expect(station.place, '');
-      });
-
-      test('parses GAS (CNG) fuel type to lpg field', () {
-        final data = {
-          'id': 444,
-          'name': 'CNG Station',
-          'location': {'latitude': 48.0, 'longitude': 16.0},
-          'prices': [
-            {'amount': 1.299},
-          ],
-          'openingHours': [],
-        };
-
-        final station = parser.testParseStation(data, 48.0, 16.0, 'GAS');
-        expect(station, isNotNull);
-        expect(station!.lpg, closeTo(1.299, 0.001));
-        expect(station.e5, isNull);
-        expect(station.diesel, isNull);
-      });
-
-      test('returns null for missing location map', () {
-        final data = {
-          'id': 555,
-          'name': 'Bad',
-          'prices': [],
-          'openingHours': [],
-        };
-
-        // Missing 'location' key => uses empty map fallback => lat/lng = 0
-        final station = parser.testParseStation(data, 0, 0, 'DIE');
-        expect(station, isNotNull);
-      });
-    });
-
-    group('extractBrand', () {
-      test('detects OMV brand', () {
-        expect(parser.testExtractBrand('OMV Graz Süd'), 'OMV');
-      });
-
-      test('detects BP brand', () {
-        expect(parser.testExtractBrand('BP Wien Mitte'), 'BP');
-      });
-
-      test('detects Shell brand', () {
-        expect(parser.testExtractBrand('Shell Austria Linz'), 'Shell');
-      });
-
-      test('detects Jet brand', () {
-        expect(parser.testExtractBrand('Jet Tankstelle Villach'), 'Jet');
-      });
-
-      test('detects Avanti brand', () {
-        expect(parser.testExtractBrand('Avanti Wien Nord'), 'Avanti');
-      });
-
-      test('uses first word for unknown brands', () {
-        expect(parser.testExtractBrand('UnknownBrand Station'), 'UnknownBrand');
-      });
-
-      test('handles brand with hyphen separator', () {
-        expect(parser.testExtractBrand('Avanti - Salzburg'), 'Avanti');
-      });
-
-      test('returns full name if single word', () {
-        expect(parser.testExtractBrand('Tankstelle'), 'Tankstelle');
-      });
-
-      test('returns empty string for empty name', () {
-        expect(parser.testExtractBrand(''), '');
-      });
-    });
-
-    group('merging diesel and super queries', () {
-      test('merges e5 from SUP into diesel station', () {
-        const dieselStation = Station(
-          id: '100',
-          name: 'Test',
-          brand: 'OMV',
-          street: 'Str',
-          postCode: '1010',
-          place: 'Wien',
-          lat: 48.2,
-          lng: 16.4,
-          dist: 1.0,
-          diesel: 1.659,
-          isOpen: true,
-        );
-
-        const superStation = Station(
-          id: '100',
-          name: 'Test',
-          brand: 'OMV',
-          street: 'Str',
-          postCode: '1010',
-          place: 'Wien',
-          lat: 48.2,
-          lng: 16.4,
-          dist: 1.0,
-          e5: 1.549,
-          isOpen: true,
-        );
-
-        // Simulate the merge logic
-        final merged = dieselStation.copyWith(
-          e5: superStation.e5,
-          e10: superStation.e5,
-        );
-
-        expect(merged.diesel, closeTo(1.659, 0.001));
-        expect(merged.e5, closeTo(1.549, 0.001));
-        expect(merged.e10, closeTo(1.549, 0.001));
-        expect(merged.id, '100');
-      });
-    });
-  });
-
-  group('EControlStationService searchStations', () {
-    test('searchStations throws ApiException on network failure', () async {
-      const params = SearchParams(
-        lat: 48.2, lng: 16.37, radiusKm: 10.0,
+    test('getStationDetail throws ApiException mentioning E-Control', () async {
+      expect(
+        () => service.getStationDetail('at-123'),
+        throwsA(isA<ApiException>()),
       );
       try {
-        await service.searchStations(params);
+        await service.getStationDetail('at-test');
+        fail('Should have thrown');
       } on ApiException catch (e) {
-        expect(e.message, isNotEmpty);
+        expect(e.message, contains('E-Control'));
       }
     });
 
-    test('searchStations returns valid result type', () async {
-      const params = SearchParams(
-        lat: 48.2, lng: 16.37, radiusKm: 10.0,
-      );
-      try {
-        final result = await service.searchStations(params);
-        expect(result.source, ServiceSource.eControlApi);
-        expect(result.data, isA<List<Station>>());
-      } on ApiException catch (_) {
-        // Expected in test env
-      }
-    });
+    test('getPrices returns an empty map with E-Control metadata', () async {
+      final result = await service.getPrices(['at-1', 'at-2']);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.eControlApi);
+      expect(result.fetchedAt, isA<DateTime>());
+      expect(result.isStale, isFalse);
 
-    test('searchStations with sort by price', () async {
-      const params = SearchParams(
-        lat: 48.2, lng: 16.37, radiusKm: 10.0,
-        sortBy: SortBy.price,
-      );
-      try {
-        final result = await service.searchStations(params);
-        expect(result.source, ServiceSource.eControlApi);
-      } on ApiException catch (_) {
-        // Expected
-      }
+      expect((await service.getPrices([])).data, isEmpty);
     });
   });
 
-  group('E-Control full merge pipeline', () {
-    late _TestableEControlParser parser;
-
-    setUp(() {
-      parser = _TestableEControlParser();
+  // The #2780 headline: AT has no detail endpoint, so the search Station is the
+  // sole hours carrier — across BOTH codecs a tap can travel through.
+  group('AT search-path opening hours (#2780)', () {
+    test('REAL search parse populates structured Station.openingHours',
+        () async {
+      final s = (await searchEcontrolStations([omvWien()]))
+          .firstWhere((s) => s.id == 'at-123');
+      expect(s.openingHours, isNotNull,
+          reason: 'AT has no detail endpoint — the search parse is the only '
+              'chance to carry structured hours');
+      expect(s.openingHours!.availability,
+          isNot(OpeningHoursAvailability.notProvided));
+      expect(s.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.openRanges);
     });
 
-    test('diesel and super queries merge by station ID', () {
-      // Simulate two API responses
-      final dieselResponse = [
-        {
-          'id': 100,
-          'name': 'OMV Wien',
-          'location': {
-            'latitude': 48.2,
-            'longitude': 16.4,
-            'address': 'Hauptstr 1',
-            'postalCode': '1010',
-            'city': 'Wien',
-          },
-          'distance': 1.5,
-          'open': true,
-          'prices': [{'amount': 1.659}],
-          'openingHours': [
-            {'label': 'Mo-Fr', 'from': '06:00', 'to': '22:00'},
-          ],
-        },
-        {
-          'id': 200,
-          'name': 'BP Graz',
-          'location': {
-            'latitude': 47.07,
-            'longitude': 15.44,
-            'address': 'Grazer Str 5',
-            'postalCode': '8010',
-            'city': 'Graz',
-          },
-          'distance': 3.2,
-          'open': false,
-          'prices': [{'amount': 1.699}],
-          'openingHours': [],
-        },
-      ];
-
-      final superResponse = [
-        {
-          'id': 100,
-          'name': 'OMV Wien',
-          'location': {
-            'latitude': 48.2,
-            'longitude': 16.4,
-            'address': 'Hauptstr 1',
-            'postalCode': '1010',
-            'city': 'Wien',
-          },
-          'distance': 1.5,
-          'open': true,
-          'prices': [{'amount': 1.549}],
-          'openingHours': [],
-        },
-        {
-          'id': 300,
-          'name': 'Jet Linz',
-          'location': {
-            'latitude': 48.3,
-            'longitude': 14.3,
-            'address': 'Linzer Str 10',
-            'postalCode': '4020',
-            'city': 'Linz',
-          },
-          'distance': 5.0,
-          'open': true,
-          'prices': [{'amount': 1.519}],
-          'openingHours': [],
-        },
-      ];
-
-      // Parse diesel stations
-      final dieselStations = dieselResponse.map((r) =>
-          parser.testParseStation(r as Map<String, dynamic>, 48.2, 16.37, 'DIE')
-      ).whereType<Station>().toList();
-
-      // Parse super stations
-      final superStations = superResponse.map((r) =>
-          parser.testParseStation(r as Map<String, dynamic>, 48.2, 16.37, 'SUP')
-      ).whereType<Station>().toList();
-
-      expect(dieselStations, hasLength(2));
-      expect(superStations, hasLength(2));
-
-      // Merge like the real service does
-      final merged = <int, Station>{};
-
-      for (final s in dieselStations) {
-        final id = int.tryParse(s.id) ?? 0;
-        merged[id] = s;
-      }
-
-      for (final s in superStations) {
-        final id = int.tryParse(s.id) ?? 0;
-        final existing = merged[id];
-        if (existing != null) {
-          merged[id] = existing.copyWith(
-            e5: s.e5,
-            e10: s.e5,
-          );
-        } else {
-          merged[id] = s.copyWith(
-            e5: s.e5,
-            e10: s.e5,
-          );
-        }
-      }
-
-      expect(merged, hasLength(3));
-
-      // Station 100 should have both diesel and super
-      final omv = merged[100]!;
-      expect(omv.diesel, closeTo(1.659, 0.001));
-      expect(omv.e5, closeTo(1.549, 0.001));
-      expect(omv.e10, closeTo(1.549, 0.001));
-      expect(omv.isOpen, isTrue);
-
-      // Station 200 should have only diesel
-      final bp = merged[200]!;
-      expect(bp.diesel, closeTo(1.699, 0.001));
-      expect(bp.e5, isNull);
-      expect(bp.isOpen, isFalse);
-
-      // Station 300 should have only super
-      final jet = merged[300]!;
-      expect(jet.e5, closeTo(1.519, 0.001));
-      expect(jet.e10, closeTo(1.519, 0.001));
-      expect(jet.diesel, isNull);
+    test('structured hours survive the search-list cache codec round-trip',
+        () async {
+      final fresh = (await searchEcontrolStations([omvWien()]))
+          .firstWhere((s) => s.id == 'at-123');
+      final restored =
+          deserializeStationList(serializeStationList([fresh]))!.single;
+      expect(restored.openingHours, isNotNull,
+          reason: 'cache-HIT rehydration (#2777) must keep the hours');
+      expect(restored.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.openRanges);
     });
 
-    test('merged stations sorted by distance', () {
-      final data1 = {
-        'id': 1,
-        'name': 'Far',
-        'location': {'latitude': 49.0, 'longitude': 16.0},
-        'distance': 5.0,
-        'prices': [{'amount': 1.5}],
-        'openingHours': [],
-      };
-      final data2 = {
-        'id': 2,
-        'name': 'Near',
-        'location': {'latitude': 48.2, 'longitude': 16.37},
-        'distance': 0.5,
-        'prices': [{'amount': 1.6}],
-        'openingHours': [],
-      };
+    test(
+        'AT favorite/widget cold-tap: hours survive the Station.toJson round-trip',
+        () async {
+      // A cold favorite/widget tap has no live search state, and AT has no
+      // detail endpoint, so the ONLY hours source is the persisted Station
+      // rehydrated by FavoriteStations.build via Station.toJson/fromJson. If
+      // that codec drops openingHours, the section renders empty forever — the
+      // exact #2776 bug. RED before the #2777 codec fix, GREEN after.
+      final fresh = (await searchEcontrolStations([omvWien()]))
+          .firstWhere((s) => s.id == 'at-123');
 
-      final stations = [
-        parser.testParseStation(data1, 48.2, 16.37, 'DIE')!,
-        parser.testParseStation(data2, 48.2, 16.37, 'DIE')!,
-      ];
-
-      stations.sort((a, b) => a.dist.compareTo(b.dist));
-      expect(stations[0].name, 'Near');
-      expect(stations[1].name, 'Far');
+      final restored = Station.fromJson(fresh.toJson());
+      expect(restored.openingHours, isNotNull,
+          reason: 'a persisted AT favorite/widget station must keep its hours '
+              'through Station.toJson/fromJson — there is no detail endpoint '
+              'to recover them');
+      expect(restored.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.openRanges);
+      // Sunday is absent from the schedule → not open.
+      expect(restored.openingHours!.dayFor(OpeningDay.sun)?.state,
+          isNot(DayState.openRanges));
     });
 
-    test('merged stations sorted by price', () {
-      final data1 = {
-        'id': 1,
-        'name': 'Expensive',
-        'location': {'latitude': 48.2, 'longitude': 16.4},
-        'prices': [{'amount': 1.899}],
-        'openingHours': [],
-      };
-      final data2 = {
-        'id': 2,
-        'name': 'Cheap',
-        'location': {'latitude': 48.2, 'longitude': 16.4},
-        'prices': [{'amount': 1.499}],
-        'openingHours': [],
-      };
-
-      final stations = [
-        parser.testParseStation(data1, 48.2, 16.37, 'DIE')!,
-        parser.testParseStation(data2, 48.2, 16.37, 'DIE')!,
-      ];
-
-      // Sort by diesel price like sortStations does for SortBy.price
-      stations.sort((a, b) {
-        final pa = a.diesel ?? 999.0;
-        final pb = b.diesel ?? 999.0;
-        return pa.compareTo(pb);
-      });
-      expect(stations[0].name, 'Cheap');
-      expect(stations[1].name, 'Expensive');
-    });
-
-    test('radius filtering with fallback to nearest', () {
-      // All stations far away
-      final farStations = List.generate(25, (i) => Station(
-        id: '$i',
-        name: 'Station $i',
-        brand: 'Brand',
-        street: 'St',
-        postCode: '1010',
-        place: 'Wien',
-        lat: 48.2 + i * 0.1,
-        lng: 16.37,
-        dist: 50.0 + i, // All > 10km radius
-        isOpen: true,
-      ));
-
-      // Simulate filterByRadius
-      final withinRadius = farStations.where((s) => s.dist <= 10.0).toList();
-      expect(withinRadius, isEmpty);
-
-      // Fallback: return nearest 20
-      final sorted = List<Station>.from(farStations)
-        ..sort((a, b) => a.dist.compareTo(b.dist));
-      final fallback = sorted.take(20).toList();
-      expect(fallback, hasLength(20));
-      expect(fallback.first.dist, closeTo(50.0, 0.1));
-    });
-
-    test('GAS fuel type maps to lpg field', () {
-      final data = {
-        'id': 500,
-        'name': 'CNG Wien',
-        'location': {'latitude': 48.2, 'longitude': 16.4},
-        'prices': [{'amount': 1.299}],
-        'openingHours': [],
-      };
-
-      final station = parser.testParseStation(data, 48.2, 16.37, 'GAS');
-      expect(station, isNotNull);
-      expect(station!.lpg, closeTo(1.299, 0.001));
-      expect(station.e5, isNull);
-      expect(station.diesel, isNull);
+    test('empty openingHours[] round-trips as null (back-compat, no crash)',
+        () async {
+      final fresh = (await searchEcontrolStations(
+        [omvWien(openingHours: const [])],
+      ))
+          .firstWhere((s) => s.id == 'at-123');
+      final restored = Station.fromJson(fresh.toJson());
+      expect(
+        restored.openingHours == null ||
+            restored.openingHours!.availability ==
+                OpeningHoursAvailability.notProvided,
+        isTrue,
+      );
     });
   });
 
-  // #2181 — Dio is now injectable; assert a passed Dio is actually used
-  // for outbound requests (the seam that lets request shape be tested).
+  group('E-Control REAL search parse (via the real service + fixed Dio)', () {
+    test('parses a station incl. the at- id prefix + merged DIE/SUP prices',
+        () async {
+      // DIE query → diesel; SUP query → e5/e10. The real service merges by id.
+      final stations = await searchEcontrolStations(
+        [omvWien(amount: 1.659)],
+        superRecords: [omvWien(amount: 1.549)],
+      );
+      final s = stations.firstWhere((s) => s.id == 'at-123');
+
+      // #753 — the real parse prefixes the numeric upstream id with `at-`.
+      expect(s.id, 'at-123');
+      expect(s.name, 'OMV Wien Ring');
+      expect(s.brand, 'OMV');
+      expect(s.street, 'Ringstraße 1');
+      expect(s.postCode, '1010');
+      expect(s.place, 'Wien');
+      expect(s.lat, closeTo(48.2, 0.001));
+      expect(s.lng, closeTo(16.37, 0.001));
+      expect(s.diesel, closeTo(1.659, 0.001));
+      // Austrian "Super 95" maps to both E5 and E10.
+      expect(s.e5, closeTo(1.549, 0.001));
+      expect(s.e10, closeTo(1.549, 0.001));
+      expect(s.isOpen, isTrue);
+    });
+
+    test('respects the open=false flag from the payload', () async {
+      final s = (await searchEcontrolStations([omvWien(open: false)]))
+          .firstWhere((s) => s.id == 'at-123');
+      expect(s.isOpen, isFalse);
+    });
+
+    test('extracts known Austrian brands from the station name', () async {
+      Future<String> brandOf(String name) async {
+        final rec = omvWien(id: '9')..['name'] = name;
+        final s = (await searchEcontrolStations([rec]))
+            .firstWhere((s) => s.id == 'at-9');
+        return s.brand;
+      }
+
+      expect(await brandOf('Shell Austria Linz'), 'Shell');
+      expect(await brandOf('BP Wien Mitte'), 'BP');
+      expect(await brandOf('AVANTI - Salzburg'), 'Avanti');
+      expect(await brandOf('Turmöl Graz'), 'Turmöl');
+      // Unknown brand → first word.
+      expect(await brandOf('UnknownBrand Station'), 'UnknownBrand');
+    });
+
+    test('a station present in only one fuel query still appears once',
+        () async {
+      // DIE has station 200, SUP has station 300 — both must survive the merge.
+      final stations = await searchEcontrolStations(
+        [omvWien(id: '200', amount: 1.699)],
+        superRecords: [omvWien(id: '300', amount: 1.519)],
+      );
+      final ids = stations.map((s) => s.id).toSet();
+      expect(ids, containsAll(<String>['at-200', 'at-300']));
+
+      final dieselOnly = stations.firstWhere((s) => s.id == 'at-200');
+      expect(dieselOnly.diesel, closeTo(1.699, 0.001));
+      expect(dieselOnly.e5, isNull);
+
+      final superOnly = stations.firstWhere((s) => s.id == 'at-300');
+      expect(superOnly.e5, closeTo(1.519, 0.001));
+      expect(superOnly.e10, closeTo(1.519, 0.001));
+      expect(superOnly.diesel, isNull);
+    });
+
+    test('GAS-less payload yields no lpg (only DIE+SUP are queried)', () async {
+      final s = (await searchEcontrolStations([omvWien()]))
+          .firstWhere((s) => s.id == 'at-123');
+      // The real service only queries DIE + SUP, never GAS.
+      expect(s.lpg, isNull);
+    });
+
+    test('search result carries the E-Control source', () async {
+      // Drive the service directly to assert ServiceResult metadata.
+      final dio = Dio()
+        ..httpClientAdapter =
+            FixedJsonAdapter(jsonEncode([omvWien()]));
+      final result = await EControlStationService(dio: dio).searchStations(
+        const SearchParams(lat: 48.2, lng: 16.37, radiusKm: 10.0),
+      );
+      expect(result.source, ServiceSource.eControlApi);
+      expect(result.data, isA<List<Station>>());
+    });
+  });
+
+  // #2181 — Dio is injectable; assert a passed Dio is actually used for
+  // outbound requests (the seam that lets request shape be tested).
   group('Dio injection (#2181)', () {
-    test('routes requests through the injected Dio', () async {
+    test('routes requests through the injected Dio to the e-control endpoint',
+        () async {
       final adapter = _RecordingAdapter();
       final dio = Dio()..httpClientAdapter = adapter;
-      final injected = EControlStationService(dio: dio);
-
-      await injected.searchStations(
+      await EControlStationService(dio: dio).searchStations(
         const SearchParams(lat: 48.2, lng: 16.37, radiusKm: 10.0),
       );
 
@@ -776,16 +260,14 @@ void main() {
       expect(
         adapter.requestUris.every((u) => u.contains('api.e-control.at')),
         isTrue,
-        reason: 'all requests must go through the injected Dio to the '
-            'e-control endpoint',
+        reason: 'all requests must go through the injected Dio',
       );
     });
   });
 }
 
-/// Minimal [HttpClientAdapter] that records request URIs and returns an
-/// empty JSON array, so the injection seam can be asserted without a live
-/// network call.
+/// Minimal [HttpClientAdapter] that records request URIs and returns an empty
+/// JSON array, so the injection seam can be asserted without a live call.
 class _RecordingAdapter implements HttpClientAdapter {
   final List<String> requestUris = [];
 
@@ -807,81 +289,4 @@ class _RecordingAdapter implements HttpClientAdapter {
 
   @override
   void close({bool force = false}) {}
-}
-
-/// Replicates E-Control parsing logic for isolated testing.
-class _TestableEControlParser {
-  Station? testParseStation(
-    Map<String, dynamic> r,
-    double searchLat,
-    double searchLng,
-    String fuelType,
-  ) {
-    try {
-      final location = r['location'] as Map<String, dynamic>? ?? {};
-      final lat = (location['latitude'] as num?)?.toDouble() ?? 0;
-      final lng = (location['longitude'] as num?)?.toDouble() ?? 0;
-
-      final apiDist = (r['distance'] as num?)?.toDouble();
-
-      double? price;
-      final prices = r['prices'] as List<dynamic>? ?? [];
-      for (final p in prices) {
-        if (p is Map<String, dynamic>) {
-          price = (p['amount'] as num?)?.toDouble();
-        }
-      }
-
-      final openingHours = r['openingHours'] as List<dynamic>? ?? [];
-      final hoursText = openingHours.map((oh) {
-        if (oh is Map<String, dynamic>) {
-          return '${oh['label'] ?? oh['day']}: ${oh['from']}-${oh['to']}';
-        }
-        return '';
-      }).where((s) => s.isNotEmpty).join(', ');
-
-      final name = r['name']?.toString() ?? '';
-      final isOpen = r['open'] as bool? ?? true;
-
-      return Station(
-        id: r['id']?.toString() ?? '',
-        name: name,
-        brand: testExtractBrand(name),
-        street: location['address']?.toString() ?? '',
-        postCode: location['postalCode']?.toString() ?? '',
-        place: location['city']?.toString() ?? '',
-        lat: lat,
-        lng: lng,
-        dist: apiDist ?? _roundedDist(searchLat, searchLng, lat, lng),
-        e5: fuelType == 'SUP' ? price : null,
-        e10: fuelType == 'SUP' ? price : null,
-        diesel: fuelType == 'DIE' ? price : null,
-        lpg: fuelType == 'GAS' ? price : null,
-        isOpen: isOpen,
-        openingHoursText: hoursText.isNotEmpty ? hoursText : null,
-      );
-    } on FormatException catch (_) {
-      return null;
-    }
-  }
-
-  String testExtractBrand(String name) {
-    const brands = [
-      'OMV', 'BP', 'Shell', 'Jet', 'Eni', 'Avanti', 'Turmöl',
-      'IQ', 'Avia', 'A1', 'Genol', 'Lagerhaus', 'SB',
-    ];
-    final upper = name.toUpperCase();
-    for (final b in brands) {
-      if (upper.startsWith(b.toUpperCase())) return b;
-    }
-    final firstWord = name.split(RegExp(r'[\s\-]')).first;
-    return firstWord.isNotEmpty ? firstWord : name;
-  }
-
-  double _roundedDist(double lat1, double lng1, double lat2, double lng2) {
-    // Simplified distance for test — real impl uses Haversine
-    final dlat = (lat1 - lat2).abs();
-    final dlng = (lng1 - lng2).abs();
-    return (dlat * dlat + dlng * dlng) * 111; // Rough km approximation
-  }
 }

--- a/test/features/station_services/spain/miteco_station_service_test.dart
+++ b/test/features/station_services/spain/miteco_station_service_test.dart
@@ -1,802 +1,303 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
+//
+// #2780 (Epic #2776 D4) — every parse assertion here drives the REAL
+// [MitecoStationService.searchStations] through a fixed Dio (see
+// `support/real_service_search.dart`). It used to lean on a `_TestableMitecoParser`
+// copy that re-implemented the parse but never set the structured
+// `Station.openingHours` nor the `es-` id prefix — so it proved the *copy*, not
+// the production path a real Spanish search tap takes (the #2776 false-green
+// lesson). The new ES search-path opening-hours group is the regression guard
+// the matrix lacked: Spain "works today" only incidentally, with NO test.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
-import 'package:tankstellen/features/station_services/spain/miteco_station_service.dart';
 import 'package:tankstellen/core/services/service_result.dart';
 import 'package:tankstellen/core/services/station_service.dart';
-import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/core/services/station_service_chain_codec.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
+import 'package:tankstellen/features/station_services/spain/miteco_station_service.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 
+import '../support/real_service_search.dart';
+
+/// A single realistic MITECO `ListaEESSPrecio` row (REPSOL Madrid, full fuel
+/// slate, `L-D: 06:00-22:00` schedule) near the Madrid search centre.
+Map<String, dynamic> repsolMadrid({
+  String id = '1234',
+  String horario = 'L-D: 06:00-22:00',
+}) =>
+    {
+      'IDEESS': id,
+      'Rótulo': 'REPSOL',
+      'Dirección': 'CALLE MAYOR 1',
+      'Localidad': 'MADRID',
+      'C.P.': '28001',
+      'Latitud': '40,416775',
+      'Longitud (WGS84)': '-3,703790',
+      'Precio Gasolina 95 E5': '1,649',
+      'Precio Gasolina 95 E10': '1,599',
+      'Precio Gasolina 98 E5': '1,829',
+      'Precio Gasoleo A': '1,459',
+      'Precio Gasoleo Premium': '1,529',
+      'Precio Gasolina 95 E85': '1,099',
+      'Precio Gases licuados del petróleo': '0,899',
+      'Precio Gas Natural Comprimido': '1,199',
+      'Horario': horario,
+      'Margen': 'D',
+    };
+
 void main() {
-  late MitecoStationService service;
+  group('MitecoStationService contract', () {
+    final service = MitecoStationService();
 
-  setUp(() {
-    service = MitecoStationService();
-  });
-
-  group('MitecoStationService', () {
     test('implements StationService interface', () {
       expect(service, isA<StationService>());
     });
 
-    group('getStationDetail', () {
-      test('throws ApiException (detail not available)', () {
-        expect(
-          () => service.getStationDetail('es-123'),
-          throwsA(isA<ApiException>()),
-        );
-      });
-
-      test('error message mentions MITECO API', () async {
-        try {
-          await service.getStationDetail('es-test');
-          fail('Should have thrown');
-        } on ApiException catch (e) {
-          expect(e.message, contains('MITECO'));
-        }
-      });
+    test('getStationDetail throws ApiException mentioning MITECO', () async {
+      expect(
+        () => service.getStationDetail('es-123'),
+        throwsA(isA<ApiException>()),
+      );
+      try {
+        await service.getStationDetail('es-test');
+        fail('Should have thrown');
+      } on ApiException catch (e) {
+        expect(e.message, contains('MITECO'));
+      }
     });
 
-    group('getPrices', () {
-      test('returns empty map', () async {
-        final result = await service.getPrices(['es-1', 'es-2']);
-        expect(result.data, isEmpty);
-        expect(result.source, ServiceSource.mitecoApi);
-      });
+    test('getPrices returns an empty map with MITECO metadata', () async {
+      final result = await service.getPrices(['es-1', 'es-2']);
+      expect(result.data, isEmpty);
+      expect(result.source, ServiceSource.mitecoApi);
+      expect(result.fetchedAt, isA<DateTime>());
+      expect(result.isStale, isFalse);
 
-      test('returns empty map for empty id list', () async {
-        final result = await service.getPrices([]);
-        expect(result.data, isEmpty);
-      });
-
-      test('result has correct metadata', () async {
-        final result = await service.getPrices(['x']);
-        expect(result.source, ServiceSource.mitecoApi);
-        expect(result.fetchedAt, isA<DateTime>());
-        expect(result.isStale, isFalse);
-      });
+      expect((await service.getPrices([])).data, isEmpty);
     });
   });
 
-  group('MITECO parsing edge cases', () {
-    late _TestableMitecoParser parser;
+  // The headline #2780 coverage: Spain has structured opening hours in its
+  // search payload, but no test ever proved they reach the screen on the
+  // dominant tap. These drive the REAL search parse, then the two codecs a
+  // real tap round-trips through.
+  group('ES search-path opening hours (#2780)', () {
+    test('REAL search parse populates structured Station.openingHours',
+        () async {
+      final stations = await searchMitecoStations(
+        [repsolMadrid(horario: 'L-V: 06:00-22:00; S-D: 08:00-22:00')],
+      );
 
-    setUp(() {
-      parser = _TestableMitecoParser();
+      final s = stations.firstWhere((s) => s.id == 'es-1234');
+      expect(s.openingHours, isNotNull,
+          reason: 'the REAL MITECO parse must build structured weekly hours '
+              'from the Horario string');
+      expect(s.openingHours!.availability,
+          isNot(OpeningHoursAvailability.notProvided));
+      // Mon (a weekday) carries the 06:00-22:00 range.
+      expect(s.openingHours!.dayFor(OpeningDay.mon)?.state, DayState.openRanges);
+      // The legacy string is still carried for back-compat.
+      expect(s.openingHoursText, 'L-V: 06:00-22:00; S-D: 08:00-22:00');
     });
 
-    group('parseCommaDouble additional', () {
-      test('parses zero correctly', () {
-        expect(parser.testParseCommaDouble('0'), closeTo(0.0, 0.001));
-      });
+    test('structured hours survive the search-list cache codec round-trip',
+        () async {
+      // Cache-HIT path: StationServiceChain Step 1 persists the search list via
+      // serializeStationList and rehydrates via deserializeStationList. Before
+      // #2777 this dropped the @JsonKey-excluded openingHours → empty hours.
+      final fresh = (await searchMitecoStations([repsolMadrid()]))
+          .firstWhere((s) => s.id == 'es-1234');
+      expect(fresh.openingHours, isNotNull, reason: 'precondition');
 
-      test('parses large Spanish price', () {
-        expect(parser.testParseCommaDouble('123,456'), closeTo(123.456, 0.001));
-      });
-
-      test('handles multiple commas (only first replaced in tryParse)', () {
-        // "1,234,567" -> "1.234.567" which double.tryParse returns null
-        expect(parser.testParseCommaDouble('1,234,567'), isNull);
-      });
+      final restored =
+          deserializeStationList(serializeStationList([fresh]))!.single;
+      expect(restored.openingHours, isNotNull,
+          reason: 'structured hours must survive the cache round-trip — the '
+              'detail fast path serves StationDetail(openingHours: '
+              'station.openingHours)');
+      expect(restored.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.openRanges);
     });
 
-    group('parseStation additional', () {
-      test('handles station with only E85 price', () {
-        final record = {
-          'IDEESS': '9999',
-          'Rótulo': 'BIOSTATION',
-          'Dirección': 'BIO ROAD 1',
-          'Localidad': 'VALENCIA',
-          'C.P.': '46001',
-          'Latitud': '39,469',
-          'Longitud (WGS84)': '-0,376',
-          'Precio Gasolina 95 E85': '1,099',
-          'Horario': 'L-D: 00:00-24:00',
-        };
+    test(
+        'structured hours survive the favorite/widget Station.toJson round-trip',
+        () async {
+      // Favorites + widget rows persist a Station via `Station.toJson()` and
+      // rehydrate via `Station.fromJson()` (FavoriteStations.build /
+      // saveFavoriteStationData). A cold favorite tap on an ES station with no
+      // search state must still show hours from that round-trip.
+      final fresh = (await searchMitecoStations([repsolMadrid()]))
+          .firstWhere((s) => s.id == 'es-1234');
 
-        final station = parser.testParseStation(record, 39.47, -0.38);
-        expect(station, isNotNull);
-        expect(station!.e85, closeTo(1.099, 0.001));
-        expect(station.e5, isNull);
-      });
+      final restored = Station.fromJson(fresh.toJson());
+      expect(restored.openingHours, isNotNull,
+          reason: 'a cold favorite/widget tap rehydrates the persisted Station '
+              'and must keep its structured hours');
+      expect(restored.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.openRanges);
+    });
 
-      test('handles station with missing IDEESS', () {
-        final record = {
-          'Rótulo': 'Test',
+    test('a Cerrado (fully-closed) schedule survives the codec round-trip',
+        () async {
+      final fresh = (await searchMitecoStations(
+        [repsolMadrid(horario: 'Cerrado')],
+      ))
+          .firstWhere((s) => s.id == 'es-1234');
+      expect(fresh.isOpen, isFalse);
+      // "Cerrado" is full structured data (every day closed), not "no data".
+      expect(fresh.openingHours, isNotNull);
+      expect(fresh.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.closed);
+
+      final restored =
+          deserializeStationList(serializeStationList([fresh]))!.single;
+      expect(restored.openingHours, isNotNull,
+          reason: 'a closed week is real data and must round-trip, not vanish');
+      expect(restored.openingHours!.dayFor(OpeningDay.mon)?.state,
+          DayState.closed);
+    });
+
+    test('a station with no Horario round-trips as null (back-compat)',
+        () async {
+      final fresh = (await searchMitecoStations([
+        {
+          'IDEESS': '88',
+          'Rótulo': 'NOHOURS',
           'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '-3,7',
-          'Horario': 'Open',
-        };
+          'Localidad': 'MADRID',
+          'C.P.': '28001',
+          'Latitud': '40,42',
+          'Longitud (WGS84)': '-3,70',
+          'Precio Gasolina 95 E5': '1,5',
+          'Horario': '',
+        },
+      ]))
+          .firstWhere((s) => s.id == 'es-88');
+      final restored =
+          deserializeStationList(serializeStationList([fresh]))!.single;
+      expect(
+        restored.openingHours == null ||
+            restored.openingHours!.availability ==
+                OpeningHoursAvailability.notProvided,
+        isTrue,
+      );
+    });
+  });
 
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNotNull);
-        expect(station!.id, '');
-      });
+  group('MITECO REAL search parse (via the real service + fixed Dio)', () {
+    test('parses a full station record incl. the es- id prefix (#753)',
+        () async {
+      final stations = await searchMitecoStations([repsolMadrid()]);
+      final s = stations.firstWhere((s) => s.id == 'es-1234');
 
-      test('handles station with all price fields populated', () {
-        final record = {
-          'IDEESS': '5555',
-          'Rótulo': 'FULL',
-          'Dirección': 'Full St',
+      // #753 — the real parse prefixes the bare IDEESS with `es-`; the divergent
+      // copy never did, which is exactly the kind of drift this test catches.
+      expect(s.id, 'es-1234');
+      expect(s.name, 'REPSOL');
+      expect(s.brand, 'REPSOL');
+      expect(s.street, 'CALLE MAYOR 1');
+      expect(s.place, 'MADRID');
+      expect(s.postCode, '28001');
+      expect(s.lat, closeTo(40.416775, 0.001));
+      expect(s.lng, closeTo(-3.703790, 0.001));
+      expect(s.e5, closeTo(1.649, 0.001));
+      expect(s.e10, closeTo(1.599, 0.001));
+      expect(s.e98, closeTo(1.829, 0.001));
+      expect(s.diesel, closeTo(1.459, 0.001));
+      expect(s.dieselPremium, closeTo(1.529, 0.001));
+      expect(s.e85, closeTo(1.099, 0.001));
+      expect(s.lpg, closeTo(0.899, 0.001));
+      expect(s.cng, closeTo(1.199, 0.001));
+      expect(s.isOpen, isTrue);
+      expect(s.openingHoursText, 'L-D: 06:00-22:00');
+      expect(s.stationType, 'D');
+    });
+
+    test('drops records with missing coordinates', () async {
+      final stations = await searchMitecoStations([
+        repsolMadrid(),
+        {
+          'IDEESS': '9',
+          'Rótulo': 'NoLat',
+          'Dirección': 'St',
           'Localidad': 'Madrid',
           'C.P.': '28001',
-          'Latitud': '40,416',
-          'Longitud (WGS84)': '-3,703',
-          'Precio Gasolina 95 E5': '1,649',
-          'Precio Gasolina 95 E10': '1,599',
-          'Precio Gasolina 98 E5': '1,829',
-          'Precio Gasoleo A': '1,459',
-          'Precio Gasoleo Premium': '1,529',
-          'Precio Gasolina 95 E85': '1,099',
-          'Precio Gases licuados del petróleo': '0,899',
-          'Precio Gas Natural Comprimido': '1,199',
-          'Horario': '24H',
-          'Margen': 'I',
-        };
-
-        final station = parser.testParseStation(record, 40.4, -3.7);
-        expect(station, isNotNull);
-        expect(station!.e5, isNotNull);
-        expect(station.e10, isNotNull);
-        expect(station.e98, isNotNull);
-        expect(station.diesel, isNotNull);
-        expect(station.dieselPremium, isNotNull);
-        expect(station.e85, isNotNull);
-        expect(station.lpg, isNotNull);
-        expect(station.cng, isNotNull);
-        expect(station.stationType, 'I');
-        expect(station.isOpen, isTrue);
-      });
-    });
-
-    group('findNearestProvince additional', () {
-      test('returns Valencia for coordinates near Valencia', () {
-        final id = parser.testFindNearestProvince(39.47, -0.38);
-        expect(id, '46'); // Valencia
-      });
-
-      test('returns Vizcaya for Bilbao coordinates', () {
-        final id = parser.testFindNearestProvince(43.26, -2.93);
-        expect(id, '48'); // Vizcaya
-      });
-
-      test('returns Ceuta for Ceuta coordinates', () {
-        final id = parser.testFindNearestProvince(35.89, -5.32);
-        expect(id, '51'); // Ceuta
-      });
-
-      test('returns Melilla for Melilla coordinates', () {
-        final id = parser.testFindNearestProvince(35.29, -2.94);
-        expect(id, '52'); // Melilla
-      });
-
-      test('returns Baleares for Mallorca coordinates', () {
-        final id = parser.testFindNearestProvince(39.57, 2.65);
-        expect(id, '07'); // Baleares
-      });
-    });
-  });
-
-  group('MITECO parsing (via _TestableMitecoParser)', () {
-    late _TestableMitecoParser parser;
-
-    setUp(() {
-      parser = _TestableMitecoParser();
-    });
-
-    group('parseCommaDouble', () {
-      test('parses Spanish comma-separated number', () {
-        expect(parser.testParseCommaDouble('1,817'), closeTo(1.817, 0.001));
-      });
-
-      test('parses number with dot decimal', () {
-        expect(parser.testParseCommaDouble('1.817'), closeTo(1.817, 0.001));
-      });
-
-      test('returns null for empty string', () {
-        expect(parser.testParseCommaDouble(''), isNull);
-      });
-
-      test('returns null for null input', () {
-        expect(parser.testParseCommaDouble(null), isNull);
-      });
-
-      test('returns null for whitespace-only string', () {
-        expect(parser.testParseCommaDouble('   '), isNull);
-      });
-
-      test('returns null for non-numeric string', () {
-        expect(parser.testParseCommaDouble('abc'), isNull);
-      });
-
-      test('handles string with leading/trailing whitespace', () {
-        expect(parser.testParseCommaDouble(' 1,234 '), closeTo(1.234, 0.001));
-      });
-    });
-
-    group('parseStation', () {
-      test('parses valid MITECO station record', () {
-        final record = {
-          'IDEESS': '1234',
-          'Rótulo': 'REPSOL',
-          'Dirección': 'CALLE MAYOR 1',
-          'Localidad': 'MADRID',
-          'C.P.': '28001',
-          'Latitud': '40,416775',
-          'Longitud (WGS84)': '-3,703790',
-          'Precio Gasolina 95 E5': '1,649',
-          'Precio Gasolina 95 E10': '1,599',
-          'Precio Gasolina 98 E5': '1,829',
-          'Precio Gasoleo A': '1,459',
-          'Precio Gasoleo Premium': '1,529',
-          'Precio Gases licuados del petróleo': '0,899',
-          'Precio Gas Natural Comprimido': '1,199',
-          'Horario': 'L-D: 06:00-22:00',
-          'Margen': 'D',
-        };
-
-        final station = parser.testParseStation(record, 40.42, -3.70);
-        expect(station, isNotNull);
-        expect(station!.id, '1234');
-        expect(station.name, 'REPSOL');
-        expect(station.brand, 'REPSOL');
-        expect(station.street, 'CALLE MAYOR 1');
-        expect(station.place, 'MADRID');
-        expect(station.postCode, '28001');
-        expect(station.lat, closeTo(40.416775, 0.001));
-        expect(station.lng, closeTo(-3.703790, 0.001));
-        expect(station.e5, closeTo(1.649, 0.001));
-        expect(station.e10, closeTo(1.599, 0.001));
-        expect(station.e98, closeTo(1.829, 0.001));
-        expect(station.diesel, closeTo(1.459, 0.001));
-        expect(station.dieselPremium, closeTo(1.529, 0.001));
-        expect(station.lpg, closeTo(0.899, 0.001));
-        expect(station.cng, closeTo(1.199, 0.001));
-        expect(station.isOpen, isTrue);
-        expect(station.openingHoursText, 'L-D: 06:00-22:00');
-        expect(station.stationType, 'D');
-      });
-
-      test('returns null when latitude is missing', () {
-        final record = {
-          'IDEESS': '1',
-          'Rótulo': 'Test',
-          'Dirección': 'Test St',
-          'Localidad': 'Test City',
-          'C.P.': '00000',
           'Latitud': '',
           'Longitud (WGS84)': '-3,7',
+          'Horario': '24H',
+        },
+      ]);
+      expect(stations.map((s) => s.id), contains('es-1234'));
+      expect(stations.map((s) => s.id), isNot(contains('es-9')));
+    });
+
+    test('marks station closed when Horario is Cerrado', () async {
+      final stations = await searchMitecoStations(
+        [repsolMadrid(horario: 'Cerrado')],
+      );
+      final s = stations.firstWhere((s) => s.id == 'es-1234');
+      expect(s.isOpen, isFalse);
+      expect(s.openingHoursText, 'Cerrado');
+      // Even a closed station keeps its prices.
+      expect(s.e5, closeTo(1.649, 0.001));
+    });
+
+    test('Spanish comma-decimal prices parse correctly', () async {
+      final stations = await searchMitecoStations([
+        repsolMadrid(),
+        {
+          'IDEESS': '5',
+          'Rótulo': 'BIO',
+          'Dirección': 'BIO ROAD 1',
+          'Localidad': 'MADRID',
+          'C.P.': '28002',
+          'Latitud': '40,42',
+          'Longitud (WGS84)': '-3,70',
+          'Precio Gasolina 95 E85': '1,099',
           'Horario': 'L-D: 00:00-24:00',
-        };
+        },
+      ]);
+      final bio = stations.firstWhere((s) => s.id == 'es-5');
+      expect(bio.e85, closeTo(1.099, 0.001));
+      expect(bio.e5, isNull);
+    });
 
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNull);
-      });
-
-      test('returns null when longitude is missing', () {
-        final record = {
-          'IDEESS': '1',
-          'Rótulo': 'Test',
-          'Dirección': 'Test St',
-          'Localidad': 'Test City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '',
-          'Horario': 'L-D: 00:00-24:00',
-        };
-
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNull);
-      });
-
-      test('marks station as closed when horario is Cerrado', () {
-        final record = {
-          'IDEESS': '1',
-          'Rótulo': 'Test',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '-3,7',
-          'Horario': 'Cerrado',
-        };
-
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNotNull);
-        expect(station!.isOpen, isFalse);
-      });
-
-      test('marks station as closed when horario is empty', () {
-        final record = {
-          'IDEESS': '1',
-          'Rótulo': 'Test',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '-3,7',
-          'Horario': '',
-        };
-
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNotNull);
-        expect(station!.isOpen, isFalse);
-      });
-
-      test('uses address as name when brand is empty', () {
-        final record = {
-          'IDEESS': '1',
+    test('uses address as name when brand is empty', () async {
+      final stations = await searchMitecoStations([
+        {
+          'IDEESS': '7',
           'Rótulo': '',
           'Dirección': 'CALLE MAYOR',
-          'Localidad': 'City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '-3,7',
+          'Localidad': 'MADRID',
+          'C.P.': '28001',
+          'Latitud': '40,42',
+          'Longitud (WGS84)': '-3,70',
           'Horario': 'L-V: 08:00-20:00',
-        };
-
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNotNull);
-        expect(station!.name, 'CALLE MAYOR');
-      });
-
-      test('handles null price fields without crashing', () {
-        final record = {
-          'IDEESS': '1',
-          'Rótulo': 'Test',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '-3,7',
-          'Horario': 'L-D: 00:00-24:00',
-          'Precio Gasolina 95 E5': null,
-          'Precio Gasoleo A': null,
-        };
-
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNotNull);
-        expect(station!.e5, isNull);
-        expect(station.diesel, isNull);
-      });
-
-      test('sets openingHoursText to null when horario is empty', () {
-        final record = {
-          'IDEESS': '1',
-          'Rótulo': 'Test',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '00000',
-          'Latitud': '40,4',
-          'Longitud (WGS84)': '-3,7',
-          'Horario': '',
-        };
-
-        final station = parser.testParseStation(record, 40.0, -3.0);
-        expect(station, isNotNull);
-        expect(station!.openingHoursText, isNull);
-      });
+        },
+      ]);
+      expect(stations.single.name, 'CALLE MAYOR');
     });
 
-    group('findNearestProvince', () {
-      test('returns Madrid for coordinates in center of Spain', () {
-        final id = parser.testFindNearestProvince(40.4168, -3.7038);
-        expect(id, '28'); // Madrid
-      });
-
-      test('returns Barcelona for coordinates near Barcelona', () {
-        final id = parser.testFindNearestProvince(41.39, 2.17);
-        expect(id, '08'); // Barcelona
-      });
-
-      test('returns Sevilla for coordinates near Seville', () {
-        final id = parser.testFindNearestProvince(37.39, -5.98);
-        expect(id, '41'); // Sevilla
-      });
-
-      test('returns Las Palmas for Canary Islands coordinates', () {
-        final id = parser.testFindNearestProvince(28.1, -15.4);
-        expect(id, '35'); // Las Palmas
-      });
-
-      test('returns a valid province ID for any coordinate', () {
-        final id = parser.testFindNearestProvince(0, 0);
-        expect(id, isNotEmpty);
-        // Should still return something reasonable (likely a southern province)
-      });
-    });
-  });
-
-  group('MitecoStationService searchStations', () {
-    test('searchStations throws ApiException on network failure', () async {
-      const params = SearchParams(
-        lat: 40.42, lng: -3.70, radiusKm: 10.0,
-      );
-      try {
-        await service.searchStations(params);
-      } on ApiException catch (e) {
-        expect(e.message, isNotEmpty);
-      }
-    });
-
-    test('searchStations returns valid result type', () async {
-      const params = SearchParams(
-        lat: 40.42, lng: -3.70, radiusKm: 10.0,
-      );
-      try {
-        final result = await service.searchStations(params);
-        expect(result.source, ServiceSource.mitecoApi);
-        expect(result.data, isA<List<Station>>());
-      } on ApiException catch (_) {
-        // Expected in test env
-      }
-    });
-
-    test('searchStations with sort by distance', () async {
-      const params = SearchParams(
-        lat: 40.42, lng: -3.70, radiusKm: 10.0,
-        sortBy: SortBy.distance,
-      );
-      try {
-        final result = await service.searchStations(params);
-        expect(result.source, ServiceSource.mitecoApi);
-      } on ApiException catch (_) {
-        // Expected
-      }
-    });
-  });
-
-  group('MITECO full station-building pipeline', () {
-    late _TestableMitecoParser parser;
-
-    setUp(() {
-      parser = _TestableMitecoParser();
-    });
-
-    test('parseStation and distance filtering pipeline', () {
-      // Simulate API response records (ListaEESSPrecio)
-      final records = [
-        {
-          'IDEESS': '1001',
-          'Rótulo': 'REPSOL',
-          'Dirección': 'CALLE MAYOR 1',
+    test('search limits to the nearest 50 stations', () async {
+      // 60 distinct stations spread just north of Madrid — all within radius.
+      final records = List.generate(60, (i) {
+        final lat = 40.42 + i * 0.001;
+        return {
+          'IDEESS': '$i',
+          'Rótulo': 'Station $i',
+          'Dirección': 'St $i',
           'Localidad': 'MADRID',
           'C.P.': '28001',
-          'Latitud': '40,416',
-          'Longitud (WGS84)': '-3,703',
+          'Latitud': lat.toStringAsFixed(6).replaceAll('.', ','),
+          'Longitud (WGS84)': '-3,700000',
           'Precio Gasolina 95 E5': '1,649',
-          'Precio Gasoleo A': '1,459',
-          'Horario': 'L-D: 06:00-22:00',
-          'Margen': 'D',
-        },
-        {
-          'IDEESS': '1002',
-          'Rótulo': 'CEPSA',
-          'Dirección': 'AV. CASTELLANA 100',
-          'Localidad': 'MADRID',
-          'C.P.': '28046',
-          'Latitud': '40,462',
-          'Longitud (WGS84)': '-3,691',
-          'Precio Gasolina 95 E5': '1,679',
-          'Precio Gasoleo A': '1,489',
           'Horario': '24H',
-          'Margen': 'I',
-        },
-        {
-          'IDEESS': '1003',
-          'Rótulo': 'BP',
-          'Dirección': 'N-401 KM 5',
-          'Localidad': 'TOLEDO',
-          'C.P.': '45001',
-          'Latitud': '39,862',
-          'Longitud (WGS84)': '-4,027',
-          'Precio Gasolina 95 E5': '1,619',
-          'Precio Gasoleo A': '1,429',
-          'Horario': 'L-D: 07:00-21:00',
-          'Margen': 'D',
-        },
-      ];
-
-      // Parse all stations
-      const searchLat = 40.42;
-      const searchLng = -3.70;
-      final allStations = <Station>[];
-      for (final r in records) {
-        final station = parser.testParseStation(r, searchLat, searchLng);
-        if (station != null) allStations.add(station);
-      }
-
-      expect(allStations, hasLength(3));
-
-      // Verify correct parsing
-      expect(allStations[0].name, 'REPSOL');
-      expect(allStations[0].brand, 'REPSOL');
-      expect(allStations[0].e5, closeTo(1.649, 0.001));
-      expect(allStations[0].diesel, closeTo(1.459, 0.001));
-      expect(allStations[0].stationType, 'D');
-
-      expect(allStations[1].name, 'CEPSA');
-      expect(allStations[1].stationType, 'I');
-
-      // Filter by radius (10km around Madrid center)
-      final withinRadius = allStations.where((s) => s.dist <= 10.0).toList();
-      // Madrid stations should be within 10km, Toledo (~60km away) should not
-      expect(withinRadius.length, lessThanOrEqualTo(allStations.length));
-    });
-
-    test('province lookup for various Spanish cities', () {
-      // Verify that the province finder returns correct IDs for known cities
-      expect(parser.testFindNearestProvince(40.42, -3.70), '28'); // Madrid
-      expect(parser.testFindNearestProvince(41.39, 2.17), '08'); // Barcelona
-      expect(parser.testFindNearestProvince(37.39, -5.98), '41'); // Sevilla
-      expect(parser.testFindNearestProvince(39.47, -0.38), '46'); // Valencia
-      expect(parser.testFindNearestProvince(43.26, -2.93), '48'); // Vizcaya
-    });
-
-    test('stations sorted by price', () {
-      final records = [
-        {
-          'IDEESS': '1',
-          'Rótulo': 'Expensive',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '28001',
-          'Latitud': '40,42',
-          'Longitud (WGS84)': '-3,70',
-          'Precio Gasolina 95 E5': '1,899',
-          'Horario': '24H',
-        },
-        {
-          'IDEESS': '2',
-          'Rótulo': 'Cheap',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '28001',
-          'Latitud': '40,42',
-          'Longitud (WGS84)': '-3,70',
-          'Precio Gasolina 95 E5': '1,499',
-          'Horario': '24H',
-        },
-        {
-          'IDEESS': '3',
-          'Rótulo': 'NoPrice',
-          'Dirección': 'St',
-          'Localidad': 'City',
-          'C.P.': '28001',
-          'Latitud': '40,42',
-          'Longitud (WGS84)': '-3,70',
-          'Horario': '24H',
-        },
-      ];
-
-      final stations = records
-          .map((r) => parser.testParseStation(r, 40.42, -3.70))
-          .whereType<Station>()
-          .toList();
-
-      // Sort by e5 price (stations without price go to bottom)
-      stations.sort((a, b) {
-        final pa = a.e5 ?? 999.0;
-        final pb = b.e5 ?? 999.0;
-        return pa.compareTo(pb);
+        };
       });
-
-      expect(stations[0].name, 'Cheap');
-      expect(stations[1].name, 'Expensive');
-      expect(stations[2].name, 'NoPrice');
-    });
-
-    test('limit to 50 stations', () {
-      // Generate 60 station records
-      final records = List.generate(60, (i) => {
-        'IDEESS': '$i',
-        'Rótulo': 'Station $i',
-        'Dirección': 'St $i',
-        'Localidad': 'Madrid',
-        'C.P.': '28001',
-        'Latitud': '40,${400 + i}',
-        'Longitud (WGS84)': '-3,700',
-        'Precio Gasolina 95 E5': '1,${600 + i}',
-        'Horario': '24H',
-      });
-
-      final stations = records
-          .map((r) => parser.testParseStation(r, 40.42, -3.70))
-          .whereType<Station>()
-          .toList();
-
-      expect(stations.length, 60);
-
-      // Simulate wrapStations limit
-      final limited = stations.length > 50 ? stations.take(50).toList() : stations;
-      expect(limited, hasLength(50));
-    });
-
-    test('handles Cerrado stations correctly in pipeline', () {
-      final record = {
-        'IDEESS': '9999',
-        'Rótulo': 'CLOSED',
-        'Dirección': 'Closed St',
-        'Localidad': 'Madrid',
-        'C.P.': '28001',
-        'Latitud': '40,42',
-        'Longitud (WGS84)': '-3,70',
-        'Precio Gasolina 95 E5': '1,649',
-        'Horario': 'Cerrado',
-      };
-
-      final station = parser.testParseStation(record, 40.42, -3.70);
-      expect(station, isNotNull);
-      expect(station!.isOpen, isFalse);
-      expect(station.openingHoursText, 'Cerrado');
-      // Even closed stations have prices
-      expect(station.e5, closeTo(1.649, 0.001));
-    });
-
-    test('station with all fuel types in pipeline', () {
-      final record = {
-        'IDEESS': '5000',
-        'Rótulo': 'FULL SERVICE',
-        'Dirección': 'Gran Vía 1',
-        'Localidad': 'MADRID',
-        'C.P.': '28013',
-        'Latitud': '40,420',
-        'Longitud (WGS84)': '-3,702',
-        'Precio Gasolina 95 E5': '1,649',
-        'Precio Gasolina 95 E10': '1,599',
-        'Precio Gasolina 98 E5': '1,829',
-        'Precio Gasoleo A': '1,459',
-        'Precio Gasoleo Premium': '1,529',
-        'Precio Gasolina 95 E85': '1,099',
-        'Precio Gases licuados del petróleo': '0,899',
-        'Precio Gas Natural Comprimido': '1,199',
-        'Horario': 'L-D: 00:00-24:00',
-        'Margen': 'D',
-      };
-
-      final station = parser.testParseStation(record, 40.42, -3.70);
-      expect(station, isNotNull);
-      expect(station!.e5, closeTo(1.649, 0.001));
-      expect(station.e10, closeTo(1.599, 0.001));
-      expect(station.e98, closeTo(1.829, 0.001));
-      expect(station.diesel, closeTo(1.459, 0.001));
-      expect(station.dieselPremium, closeTo(1.529, 0.001));
-      expect(station.e85, closeTo(1.099, 0.001));
-      expect(station.lpg, closeTo(0.899, 0.001));
-      expect(station.cng, closeTo(1.199, 0.001));
+      final stations = await searchMitecoStations(records);
+      expect(stations.length, 50);
     });
   });
-}
-
-/// Replicates MITECO parsing logic for isolated testing.
-class _TestableMitecoParser {
-  double? testParseCommaDouble(String? value) {
-    if (value == null || value.trim().isEmpty) return null;
-    return double.tryParse(value.replaceAll(',', '.'));
-  }
-
-  Station? testParseStation(
-    Map<String, dynamic> r,
-    double searchLat,
-    double searchLng,
-  ) {
-    try {
-      final lat = testParseCommaDouble(r['Latitud']?.toString());
-      final lng = testParseCommaDouble(r['Longitud (WGS84)']?.toString());
-      if (lat == null || lng == null) return null;
-
-      final brand = r['Rótulo']?.toString() ?? '';
-      final address = r['Dirección']?.toString() ?? '';
-      final city = r['Localidad']?.toString() ?? '';
-      final postalCode = r['C.P.']?.toString() ?? '';
-      final horario = r['Horario']?.toString() ?? '';
-
-      final isOpen = horario.isNotEmpty && horario != 'Cerrado';
-
-      return Station(
-        id: r['IDEESS']?.toString() ?? '',
-        name: brand.isNotEmpty ? brand : address,
-        brand: brand,
-        street: address,
-        postCode: postalCode,
-        place: city,
-        lat: lat,
-        lng: lng,
-        dist: 0,
-        e5: testParseCommaDouble(r['Precio Gasolina 95 E5']?.toString()),
-        e10: testParseCommaDouble(r['Precio Gasolina 95 E10']?.toString()),
-        e98: testParseCommaDouble(r['Precio Gasolina 98 E5']?.toString()),
-        diesel: testParseCommaDouble(r['Precio Gasoleo A']?.toString()),
-        dieselPremium:
-            testParseCommaDouble(r['Precio Gasoleo Premium']?.toString()),
-        e85: testParseCommaDouble(r['Precio Gasolina 95 E85']?.toString()),
-        lpg: testParseCommaDouble(
-            r['Precio Gases licuados del petróleo']?.toString()),
-        cng: testParseCommaDouble(
-            r['Precio Gas Natural Comprimido']?.toString()),
-        isOpen: isOpen,
-        openingHoursText: horario.isNotEmpty ? horario : null,
-        stationType: r['Margen']?.toString(),
-      );
-    } on FormatException catch (_) {
-      return null;
-    }
-  }
-
-  String testFindNearestProvince(double lat, double lng) {
-    const provinceCenters = {
-      '01': (42.8467, -2.6727),
-      '02': (38.9943, -1.8585),
-      '03': (38.3452, -0.4810),
-      '04': (36.8340, -2.4637),
-      '05': (40.6565, -4.6818),
-      '06': (38.8794, -6.9707),
-      '07': (39.5696, 2.6502),
-      '08': (41.3851, 2.1734),
-      '09': (42.3440, -3.6970),
-      '10': (39.4753, -6.3724),
-      '11': (36.5271, -6.2886),
-      '12': (39.9864, -0.0513),
-      '13': (38.9860, -3.9273),
-      '14': (37.8882, -4.7794),
-      '15': (43.3623, -8.4115),
-      '16': (40.0704, -2.1374),
-      '17': (41.9794, 2.8214),
-      '18': (37.1773, -3.5986),
-      '19': (40.6337, -3.1660),
-      '20': (43.3183, -1.9812),
-      '21': (37.2614, -6.9447),
-      '22': (42.1318, -0.4078),
-      '23': (37.7796, -3.7849),
-      '24': (42.5987, -5.5671),
-      '25': (41.6176, 0.6200),
-      '26': (42.4650, -2.4500),
-      '27': (43.0099, -7.5562),
-      '28': (40.4168, -3.7038),
-      '29': (36.7213, -4.4214),
-      '30': (37.9922, -1.1307),
-      '31': (42.8125, -1.6458),
-      '32': (42.3358, -7.8639),
-      '33': (43.3619, -5.8494),
-      '34': (42.0097, -4.5288),
-      '35': (28.1235, -15.4363),
-      '36': (42.4310, -8.6446),
-      '37': (40.9701, -5.6635),
-      '38': (28.4636, -16.2518),
-      '39': (43.4623, -3.8100),
-      '40': (40.9429, -4.1088),
-      '41': (37.3891, -5.9845),
-      '42': (41.7636, -2.4649),
-      '43': (41.1189, 1.2445),
-      '44': (40.3456, -1.1065),
-      '45': (39.8628, -4.0273),
-      '46': (39.4699, -0.3763),
-      '47': (41.6523, -4.7245),
-      '48': (43.2630, -2.9350),
-      '49': (41.5033, -5.7446),
-      '50': (41.6488, -0.8891),
-      '51': (35.8894, -5.3213),
-      '52': (35.2923, -2.9381),
-    };
-
-    String bestId = '28';
-    double bestDist = double.infinity;
-
-    for (final entry in provinceCenters.entries) {
-      final dlat = lat - entry.value.$1;
-      final dlng = lng - entry.value.$2;
-      final d = dlat * dlat + dlng * dlng; // Squared distance is fine for comparison
-      if (d < bestDist) {
-        bestDist = d;
-        bestId = entry.key;
-      }
-    }
-
-    return bestId;
-  }
 }

--- a/test/features/station_services/support/real_service_search.dart
+++ b/test/features/station_services/support/real_service_search.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+//
+// #2780 (Epic #2776 D4) — ONE shared test helper that drives the REAL country
+// `searchStations` pipeline through an injected Dio, replacing the per-file
+// divergent `_TestableMitecoParser` / `_TestableEControlParser` copies.
+//
+// Why this exists: those copies re-implemented the production parse but quietly
+// diverged from it — they never set the structured `Station.openingHours`, nor
+// the `es-`/`at-` id prefix. So every assertion they powered was false-green:
+// it proved the *copy* worked, not the production code a real tap exercises
+// (the #2776 lesson — drive the REAL search→codec path, not an adapter unit
+// that echoes the request). Routing every parsing test through the real
+// service + a fixed Dio means a JsonKey-drop / prefix / OH-adapter regression
+// is actually caught.
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
+import 'package:tankstellen/features/station_services/spain/miteco_station_service.dart';
+
+/// A [HttpClientAdapter] that returns one fixed JSON [body] for every request,
+/// regardless of path or query, with no live network call. The body is the raw
+/// upstream payload shape (NOT a parsed Station), so the REAL service parse runs
+/// over it.
+class FixedJsonAdapter implements HttpClientAdapter {
+  final String body;
+  FixedJsonAdapter(this.body);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async =>
+      ResponseBody.fromString(body, 200, headers: {
+        'content-type': ['application/json'],
+      });
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// A [HttpClientAdapter] that picks a response body from [bodyFor] using the
+/// request's `fuelType` query parameter — used for E-Control, which queries the
+/// same endpoint twice (DIE, then SUP) and merges by station id.
+class FuelTypeAdapter implements HttpClientAdapter {
+  final String Function(String fuelType) bodyFor;
+  FuelTypeAdapter(this.bodyFor);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final fuelType = options.uri.queryParameters['fuelType'] ?? '';
+    return ResponseBody.fromString(bodyFor(fuelType), 200, headers: {
+      'content-type': ['application/json'],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// Wrap a list of MITECO `ListaEESSPrecio` raw rows in the upstream
+/// `FiltroProvincia` envelope the real [MitecoStationService] expects.
+String mitecoEnvelope(List<Map<String, dynamic>> records) => jsonEncode({
+      'ResultadoConsulta': 'OK',
+      'ListaEESSPrecio': records,
+    });
+
+/// Drive the REAL [MitecoStationService.searchStations] over [records] (raw
+/// `ListaEESSPrecio` rows) through a fixed Dio. The `cache` is omitted, so there
+/// is no Hive read-through — the service hits the injected adapter directly.
+///
+/// [lat]/[lng] are the search centre; pick coordinates inside Spain so the
+/// per-province request actually fires (the adapter answers every province).
+Future<List<Station>> searchMitecoStations(
+  List<Map<String, dynamic>> records, {
+  double lat = 40.42,
+  double lng = -3.70,
+  double radiusKm = 50.0,
+}) async {
+  final dio = Dio()..httpClientAdapter = FixedJsonAdapter(mitecoEnvelope(records));
+  final service = MitecoStationService(dio: dio);
+  final result = await service.searchStations(
+    SearchParams(lat: lat, lng: lng, radiusKm: radiusKm),
+  );
+  return result.data;
+}
+
+/// Drive the REAL [EControlStationService.searchStations] through a fixed Dio.
+/// E-Control queries DIE then SUP; [dieselRecords] answers the DIE query and
+/// [superRecords] the SUP query (defaults to [dieselRecords] when omitted, so a
+/// single station list carries both prices like a typical OMV).
+Future<List<Station>> searchEcontrolStations(
+  List<Map<String, dynamic>> dieselRecords, {
+  List<Map<String, dynamic>>? superRecords,
+  double lat = 48.2,
+  double lng = 16.37,
+  double radiusKm = 10.0,
+}) async {
+  final dieselBody = jsonEncode(dieselRecords);
+  final superBody = jsonEncode(superRecords ?? dieselRecords);
+  final dio = Dio()
+    ..httpClientAdapter = FuelTypeAdapter(
+      (fuelType) => fuelType == 'SUP' ? superBody : dieselBody,
+    );
+  final service = EControlStationService(dio: dio);
+  final result = await service.searchStations(
+    SearchParams(lat: lat, lng: lng, radiusKm: radiusKm),
+  );
+  return result.data;
+}


### PR DESCRIPTION
## What

Backfills the search-path opening-hours regression tests CI lacked for **Spain (MITECO)** and adds an **AT favorite/widget cold-tap** guard, and consolidates the divergent per-file parser copies into **one shared helper**.

This is the remaining scope of Epic #2776 **D4** — the AT + CL + FR codec round-trips already shipped in #2781. Test-only: **no production code, no ARB, no codegen.**

## Why

The #2776 bug class: structured `Station.openingHours` was `@JsonKey`-excluded from the JSON codec, so it dropped on every cache / favorites / widget round-trip. This was invisible to CI because every per-country test was either an adapter unit or a parser-fn copy (`_TestableMitecoParser` / `_TestableEControlParser`) that **never set `openingHours` nor the `es-`/`at-` id prefix** — i.e. they proved the copy, not the production path a real tap takes (the #2776 false-green lesson).

## Changes

- **New shared helper** `test/features/station_services/support/real_service_search.dart` drives the **REAL** `MitecoStationService` / `EControlStationService` `searchStations` through a fixed Dio (no Hive, no live network), replacing **both** divergent `testParseStation` copies.
- **Spain** — new ES search-path OH group: the REAL parse populates structured hours, and they survive **both** the search-list cache codec (`serialize`/`deserializeStationList`) **and** the favorite/widget `Station.toJson`/`fromJson` round-trip; plus `Cerrado`/no-`Horario` back-compat.
- **Austria** (no detail endpoint → the search Station is the *sole* hours carrier): new AT favorite/widget cold-tap test round-trips through `Station.toJson`/`fromJson`. Verified RED with the pre-#2777 JsonKey exclusion simulated (`Expected: not null, Actual: <null>`), GREEN with the fix in place.
- Both service tests now assert the `es-`/`at-` id prefix the copies omitted.
- `econtrol_search_opening_hours_test` reuses the shared helper (drops its duplicate `_FixedAdapter`).

The `miteco`/`econtrol` test files shrank **802/887 → 303/292** lines.

## Verification

- `flutter test test/features/station_services/` — all green (incl. the codec + detail-only-provider OH tests).
- `flutter analyze test/features/station_services/` — no issues.
- `file_length` + `catch_block_stacktrace_coverage` lint gates — pass.
- RED-on-(pre-fix) discipline proven by temporarily reinstating the JsonKey exclusion.

Closes #2780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
