### PR TITLE
fix(data): de-dupe ghost trips + exclude correction reconciliation records from fill-ups (#2833, #2834)

### DIFF
--- a/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
@@ -13,6 +13,7 @@ import '../../../../../core/constants/app_constants.dart';
 import '../../../../../core/sharing/public_file_exporter.dart';
 import '../../../../ev/domain/entities/charging_log.dart';
 import '../../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../../domain/correction_fill_up.dart';
 import '../../../domain/entities/fill_up.dart';
 import '../../trip_dedup.dart';
 import '../../trip_history_repository.dart';
@@ -115,14 +116,18 @@ class FullBackupExporter {
     final now = clock();
     final appVersion = debugBackupAppVersionOverride ?? AppConstants.appVersion;
 
-    // #2833 — drop ghost 0-sample trip duplicates so a backup carries the
-    // de-duped truth (the in-app `loadAll` already de-dupes, but a caller
-    // that passes a raw list is covered here too).
+    // #2834 — never write OBD2-reconciliation correction records into a
+    // backup: they are derived data (zero-cost, unrounded litres) that
+    // would re-import as phantom fill-ups. #2833 — drop ghost 0-sample
+    // trip duplicates so a backup carries the de-duped truth (the in-app
+    // `loadAll` already de-dupes, but a caller that passes a raw list is
+    // covered here too).
+    final cleanFillUps = withoutReconciliationCorrections(fillUps);
     final cleanTrips = dedupeGhostTrips(trips);
 
     final xml = xmlWriter.build(
       vehicles: vehicles,
-      fillUps: fillUps,
+      fillUps: cleanFillUps,
       trips: cleanTrips,
       chargingLogs: chargingLogs,
       appVersion: appVersion,

--- a/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_exporter.dart
@@ -14,6 +14,7 @@ import '../../../../../core/sharing/public_file_exporter.dart';
 import '../../../../ev/domain/entities/charging_log.dart';
 import '../../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../domain/entities/fill_up.dart';
+import '../../trip_dedup.dart';
 import '../../trip_history_repository.dart';
 import 'backup_xml_writer.dart';
 import 'backup_zipper.dart';
@@ -114,10 +115,15 @@ class FullBackupExporter {
     final now = clock();
     final appVersion = debugBackupAppVersionOverride ?? AppConstants.appVersion;
 
+    // #2833 — drop ghost 0-sample trip duplicates so a backup carries the
+    // de-duped truth (the in-app `loadAll` already de-dupes, but a caller
+    // that passes a raw list is covered here too).
+    final cleanTrips = dedupeGhostTrips(trips);
+
     final xml = xmlWriter.build(
       vehicles: vehicles,
       fillUps: fillUps,
-      trips: trips,
+      trips: cleanTrips,
       chargingLogs: chargingLogs,
       appVersion: appVersion,
       exportedAt: now,

--- a/lib/features/consumption/data/exporters/backup/full_backup_importer.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_importer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../../../ev/domain/entities/charging_log.dart';
 import '../../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../../domain/correction_fill_up.dart';
 import '../../../domain/entities/fill_up.dart';
 import '../../trip_dedup.dart';
 import '../../trip_history_repository.dart';
@@ -117,7 +118,13 @@ class FullBackupImporter {
     final xml = zipReader.readXml(bytes);
     final payload = xmlReader.read(xml);
 
-    final fillUps = payload.fillUps;
+    // #2834 — drop OBD2-reconciliation correction records before they
+    // reach the store. They are derived data (TotalCost 0, IsFullTank
+    // false, unrounded litres); a v1 backup loses the `isCorrection` flag
+    // so the durable `correction_` id prefix is what identifies them. Left
+    // in, they resurface as phantom zero-cost fill-ups and re-export
+    // forever.
+    final fillUps = withoutReconciliationCorrections(payload.fillUps);
     // #2833 — drop ghost 0-sample trips whose sampled twin is also in the
     // backup (a finalisation double-save artefact), so the import neither
     // restores nor counts the duplicate.

--- a/lib/features/consumption/data/exporters/backup/full_backup_importer.dart
+++ b/lib/features/consumption/data/exporters/backup/full_backup_importer.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import '../../../../ev/domain/entities/charging_log.dart';
 import '../../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../domain/entities/fill_up.dart';
+import '../../trip_dedup.dart';
 import '../../trip_history_repository.dart';
 import 'backup_xml_reader.dart';
 import 'backup_zip_reader.dart';
@@ -116,6 +117,12 @@ class FullBackupImporter {
     final xml = zipReader.readXml(bytes);
     final payload = xmlReader.read(xml);
 
+    final fillUps = payload.fillUps;
+    // #2833 — drop ghost 0-sample trips whose sampled twin is also in the
+    // backup (a finalisation double-save artefact), so the import neither
+    // restores nor counts the duplicate.
+    final trips = dedupeGhostTrips(payload.trips);
+
     if (mode == BackupImportMode.replace) {
       // Wipe up front so a record the backup omits is removed exactly
       // once. Order is immaterial — the stores are independent.
@@ -128,10 +135,10 @@ class FullBackupImporter {
     for (final v in payload.vehicles) {
       await sinks.saveVehicle(v);
     }
-    for (final f in payload.fillUps) {
+    for (final f in fillUps) {
       await sinks.saveFillUp(f);
     }
-    for (final t in payload.trips) {
+    for (final t in trips) {
       await sinks.saveTrip(t);
     }
     for (final c in payload.chargingLogs) {
@@ -141,8 +148,8 @@ class FullBackupImporter {
     return FullBackupImportResult(
       mode: mode,
       vehicles: payload.vehicles.length,
-      fillUps: payload.fillUps.length,
-      trips: payload.trips.length,
+      fillUps: fillUps.length,
+      trips: trips.length,
       chargingLogs: payload.chargingLogs.length,
     );
   }

--- a/lib/features/consumption/data/trip_dedup.dart
+++ b/lib/features/consumption/data/trip_dedup.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../domain/trip_recorder.dart';
+import 'trip_history_repository.dart';
+
+/// Drops ghost / duplicate trip records (#2833).
+///
+/// A "ghost" trip is a 0-sample summary-only record persisted ~1–2 s
+/// before its full-sample twin, carrying an **identical summary** (the
+/// real backup's pairs match `idleSeconds` to 15 decimal places). It is
+/// a finalisation double-save artefact (a summary written without
+/// samples, then the full trip) — never a real second drive — so it
+/// inflates the trip count and double-counts distance / fuel / harsh
+/// events on any list-based total.
+///
+/// The de-dupe rule: when a 0-sample entry shares an [_summaryKey] with
+/// a sampled entry **and** their `startedAt` instants fall within
+/// [ghostStartedAtTolerance], the 0-sample entry is the ghost and is
+/// dropped. The sampled twin (the record that actually carries the
+/// drive's telemetry) is always the survivor.
+///
+/// Pure + order-independent: callers (`TripHistoryRepository.loadAll`,
+/// the backup importer) pass the raw list and get back the de-duped one
+/// in the same relative order, with ghosts removed.
+
+/// Two entries whose `startedAt` differ by at most this are candidate
+/// twins (#2833). The real backup's ghost pairs were 1–2 s apart; 2 s
+/// is the smallest tolerance that catches every observed pair without
+/// risking collapsing two genuinely distinct back-to-back drives (which
+/// would also have to carry byte-identical summaries to match — a
+/// practical impossibility for real telemetry).
+const Duration ghostStartedAtTolerance = Duration(seconds: 2);
+
+/// Return [entries] with ghost 0-sample duplicates removed (#2833).
+///
+/// For every 0-sample entry, if a *different* entry exists that (a) has
+/// at least one sample, (b) shares the same [_summaryKey], and (c)
+/// started within [ghostStartedAtTolerance], the 0-sample entry is
+/// dropped. All other entries pass through untouched and in their
+/// original order.
+List<TripHistoryEntry> dedupeGhostTrips(List<TripHistoryEntry> entries) {
+  if (entries.length < 2) return entries;
+
+  // Index the sampled entries by their summary key so the membership
+  // test is O(1) per candidate ghost rather than O(n²) overall.
+  final sampledByKey = <String, List<TripHistoryEntry>>{};
+  for (final e in entries) {
+    if (e.samples.isEmpty) continue;
+    (sampledByKey[_summaryKey(e.summary)] ??= <TripHistoryEntry>[]).add(e);
+  }
+  if (sampledByKey.isEmpty) return entries;
+
+  final result = <TripHistoryEntry>[];
+  for (final e in entries) {
+    if (e.samples.isEmpty && _hasSampledTwin(e, sampledByKey)) {
+      // Drop the ghost — its full-sample twin survives.
+      continue;
+    }
+    result.add(e);
+  }
+  return result;
+}
+
+/// Guards the finalisation double-save before a write (#2833). Returns
+/// true when the caller should SKIP the write (a redundant 0-sample
+/// ghost whose sampled twin is already in [existing]); as a side effect
+/// it deletes — via [deleteById] — any stored 0-sample ghost the
+/// incoming sampled [entry] supersedes, so the real record is the sole
+/// survivor. False (write normally) for a sampled entry or a ghost with
+/// no twin.
+Future<bool> guardGhostDoubleSave({
+  required TripHistoryEntry entry,
+  required List<TripHistoryEntry> existing,
+  required Future<void> Function(String id) deleteById,
+}) async {
+  if (entry.samples.isEmpty) {
+    final survivors = dedupeGhostTrips([...existing, entry]);
+    return !survivors.any((e) => identical(e, entry) || e.id == entry.id);
+  }
+  for (final other in existing) {
+    if (other.id == entry.id || other.samples.isNotEmpty) continue;
+    final survivors = dedupeGhostTrips([entry, other]);
+    if (!survivors.any((e) => e.id == other.id)) {
+      await deleteById(other.id);
+    }
+  }
+  return false;
+}
+
+/// True when [ghost] (a 0-sample entry) has a sampled twin in
+/// [sampledByKey] with a matching summary and a `startedAt` within
+/// [ghostStartedAtTolerance].
+bool _hasSampledTwin(
+  TripHistoryEntry ghost,
+  Map<String, List<TripHistoryEntry>> sampledByKey,
+) {
+  final twins = sampledByKey[_summaryKey(ghost.summary)];
+  if (twins == null) return false;
+  final ghostStart = ghost.summary.startedAt;
+  for (final twin in twins) {
+    if (identical(twin, ghost)) continue;
+    final twinStart = twin.summary.startedAt;
+    // Both null → no time signal, but the summary key already matched
+    // every metric, so treat them as twins. Otherwise require both to
+    // be present and within tolerance.
+    if (ghostStart == null && twinStart == null) return true;
+    if (ghostStart == null || twinStart == null) continue;
+    if (ghostStart.difference(twinStart).abs() <= ghostStartedAtTolerance) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Stable identity of a trip's summary for twin detection (#2833).
+///
+/// Folds the metrics a real ghost pair matches to full precision —
+/// distance, fuel, idle / high-RPM seconds, peak RPM and the harsh
+/// counters. `startedAt` is deliberately EXCLUDED (the ghost twin is
+/// 1–2 s off, handled by the tolerance gate); the full-precision
+/// `toString()` of each double keeps the "15 decimals" fidelity the
+/// issue describes without floating-point rounding.
+String _summaryKey(TripSummary s) => [
+      s.distanceKm,
+      s.maxRpm,
+      s.highRpmSeconds,
+      s.idleSeconds,
+      s.harshBrakes,
+      s.harshAccelerations,
+      s.avgLPer100Km,
+      s.fuelLitersConsumed,
+    ].map((v) => v?.toString() ?? 'null').join('|');

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -9,6 +9,7 @@ import 'package:hive/hive.dart';
 
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/trip_recorder.dart';
+import 'trip_dedup.dart';
 import 'trip_sample_codec.dart';
 import '../../../core/logging/error_logger.dart';
 
@@ -301,10 +302,23 @@ class TripHistoryRepository {
   /// Box name used by the production wiring.
   static const String boxName = 'obd2_trip_history';
 
-  /// Persist [entry]. Drops the oldest trip when the box reaches
-  /// [cap]. Errors are logged but swallowed — losing one rolling-log
-  /// entry shouldn't propagate up into the trip-stop flow.
+  /// Persist [entry]. Drops the oldest trip when the box reaches [cap].
+  /// Errors are logged but swallowed. #2833 — a 0-sample ghost whose
+  /// sampled twin already exists is a no-op; a sampled twin deletes any
+  /// pre-existing 0-sample ghost (see [guardGhostDoubleSave]).
   Future<void> save(TripHistoryEntry entry) async {
+    try {
+      // A guard hiccup must never block the save — fall through to a write.
+      final skip = await guardGhostDoubleSave(
+        entry: entry,
+        existing: loadAll(dedupe: false),
+        deleteById: _box.delete,
+      );
+      if (skip) return;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.storage, e, st,
+          context: const {'where': 'TripHistoryRepository.save ghost-guard'}));
+    }
     try {
       await _box.put(entry.id, jsonEncode(entry.toJson()));
     } catch (e, st) {
@@ -344,10 +358,11 @@ class TripHistoryRepository {
     }
   }
 
-  /// Return every persisted trip, sorted newest-first. Corrupt
-  /// payloads are silently skipped so one bad write doesn't hide the
-  /// whole list.
-  List<TripHistoryEntry> loadAll() {
+  /// Return every persisted trip, sorted newest-first. Corrupt payloads
+  /// are silently skipped. #2833 — by default ghost 0-sample duplicates
+  /// are removed so the list, the aggregates (`loadAll().length`) and the
+  /// re-export see the de-duped truth; `dedupe: false` is the raw set.
+  List<TripHistoryEntry> loadAll({bool dedupe = true}) {
     final result = <TripHistoryEntry>[];
     for (final key in _box.keys) {
       final entry = _decode(key);
@@ -358,7 +373,7 @@ class TripHistoryRepository {
       final bx = b.summary.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
       return bx.compareTo(ax); // newest first
     });
-    return result;
+    return dedupe ? dedupeGhostTrips(result) : result;
   }
 
   /// O(1) lookup of one persisted trip by [id] (#2304) — the box is keyed

--- a/lib/features/consumption/domain/correction_fill_up.dart
+++ b/lib/features/consumption/domain/correction_fill_up.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'entities/fill_up.dart';
+
+/// Identity + filtering helpers for OBD2-estimate reconciliation
+/// "correction" fill-ups (#1361 / #2834).
+///
+/// A correction record is the synthetic stand-in the reconciler emits to
+/// close the gap between OBD-integrated trip fuel and pumped litres over a
+/// plein-to-plein window. It is DERIVED data — `TotalCost = 0`,
+/// `IsFullTank = false`, an unrounded litres figure — not a fuel purchase
+/// the user made. It must never surface as a real fill-up nor land in a
+/// backup, where it would be re-imported as a phantom zero-cost fill-up and
+/// re-exported forever.
+
+/// Id prefix the reconciler stamps on every correction fill-up
+/// (`correction_<closingPleinId>`). This is the DURABLE signal: the v1
+/// backup XML round-trip does not carry the [FillUp.isCorrection] flag, so
+/// a restored correction comes back with `isCorrection == false`. Matching
+/// the id prefix recovers its true nature regardless of the flag.
+const String correctionFillUpIdPrefix = 'correction_';
+
+/// True when [fillUp] is a reconciliation correction record (#2834).
+///
+/// Recognised by EITHER the explicit [FillUp.isCorrection] flag (the
+/// in-app path) OR the `correction_` id prefix (the durable backup-safe
+/// signal, since the flag is lost across a v1 backup round-trip).
+bool isReconciliationCorrection(FillUp fillUp) =>
+    fillUp.isCorrection || fillUp.id.startsWith(correctionFillUpIdPrefix);
+
+/// [fillUps] with every reconciliation correction removed (#2834).
+///
+/// Used by the backup export + import paths so a correction is neither
+/// written into a backup nor restored from one as a real fill-up.
+List<FillUp> withoutReconciliationCorrections(Iterable<FillUp> fillUps) =>
+    fillUps.where((f) => !isReconciliationCorrection(f)).toList(growable: false);

--- a/lib/features/consumption/domain/services/reconciler.dart
+++ b/lib/features/consumption/domain/services/reconciler.dart
@@ -248,10 +248,19 @@ class Reconciler {
     // (which may be the previous plein, a partial top-up, or the
     // closing plein itself in degenerate one-fill windows).
     final firstFill = windowFills.first;
-    final midDateMs = (firstFill.date.millisecondsSinceEpoch +
-            closingPlein.date.millisecondsSinceEpoch) ~/
+    // #2834 — midpoint at MICROSECOND precision. The old
+    // `millisecondsSinceEpoch` math truncated sub-millisecond digits
+    // (e.g. `.389565Z` → `.389Z`), so a correction's date diverged from
+    // its closing plein's, destabilising any date-based dedup key. The
+    // `correction_<closingPleinId>` id is the primary key, but keeping the
+    // date faithful means a re-derived correction is byte-identical.
+    final midDateUs = (firstFill.date.microsecondsSinceEpoch +
+            closingPlein.date.microsecondsSinceEpoch) ~/
         2;
-    final midDate = DateTime.fromMillisecondsSinceEpoch(midDateMs);
+    final midDate = DateTime.fromMicrosecondsSinceEpoch(
+      midDateUs,
+      isUtc: closingPlein.date.isUtc,
+    );
     final midOdo =
         (firstFill.odometerKm + closingPlein.odometerKm) / 2.0;
 

--- a/test/features/consumption/data/exporters/backup/correction_fill_up_leak_test.dart
+++ b/test/features/consumption/data/exporters/backup/correction_fill_up_leak_test.dart
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/backup_xml_reader.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/backup_xml_writer.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/backup_zip_reader.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/backup_zipper.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/full_backup_exporter.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/full_backup_importer.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/correction_fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import '../../../../../helpers/silence_error_logger.dart';
+
+/// Reproduces the real friend's backup correction-leak (#2834): the
+/// OBD2 reconciliation record `Id correction_<realId>` (unrounded
+/// litres, TotalCost 0, IsFullTank false) leaking in as a real fill-up
+/// in the FillUps list AND the backup export. Drives the REAL exporter +
+/// REAL importer — RED on master, GREEN after the fix.
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The real backup's real plein.
+  final realFillUp = FillUp(
+    id: '1779371655207902',
+    vehicleId: 'skoda',
+    // Microsecond precision (.389565) — the real twin truncated this to
+    // millisecond (.389) in its correction date.
+    date: DateTime.utc(2026, 5, 22, 9, 14, 15, 389, 565),
+    liters: 49.64,
+    totalCost: 97,
+    odometerKm: 84210,
+    fuelType: FuelType.diesel,
+    isFullTank: true,
+  );
+
+  // The leaked correction twin. Its `isCorrection` flag is LOST across a
+  // v1 backup round-trip, so the only durable signal is the id prefix —
+  // exactly the friend's record shape.
+  final correctionTwin = FillUp(
+    id: 'correction_1779371655207902',
+    vehicleId: 'skoda',
+    date: DateTime.utc(2026, 5, 22, 9, 14, 15, 389),
+    liters: 40.68327221464706,
+    totalCost: 0,
+    odometerKm: 84000,
+    fuelType: FuelType.diesel,
+    isFullTank: false,
+    isCorrection: true,
+  );
+
+  group('correction-record predicate (#2834)', () {
+    test('matches by id prefix even when the flag was dropped', () {
+      // Simulate the post-backup-round-trip shape: flag gone, prefix kept.
+      final restored = correctionTwin.copyWith(isCorrection: false);
+      expect(restored.isCorrection, isFalse);
+      expect(isReconciliationCorrection(restored), isTrue,
+          reason: 'the durable correction_ id prefix must still match');
+      expect(isReconciliationCorrection(realFillUp), isFalse);
+    });
+  });
+
+  group('backup EXPORT excludes corrections (#2834)', () {
+    test('a correction record never reaches the exported XML', () async {
+      final exporter = FullBackupExporter();
+      final tmp = Directory.systemTemp.createTempSync('corr_export_');
+      debugBackupTempDirectoryOverride = () async => tmp;
+      debugBackupClockOverride = () => DateTime.utc(2026, 6, 1);
+      addTearDown(() {
+        debugBackupTempDirectoryOverride = null;
+        debugBackupClockOverride = null;
+        tmp.deleteSync(recursive: true);
+      });
+
+      final result = await exporter.export(
+        vehicles: const [],
+        fillUps: [realFillUp, correctionTwin],
+        trips: const [],
+        chargingLogs: const [],
+      );
+
+      final bytes = File(result.filePath).readAsBytesSync();
+      final xml = const BackupZipReader().readXml(Uint8List.fromList(bytes));
+      final payload = const BackupXmlReader().read(xml);
+
+      expect(payload.fillUps.map((f) => f.id), ['1779371655207902'],
+          reason: 'the correction_ record must be excluded from the export');
+    });
+  });
+
+  group('backup IMPORT excludes corrections (#2834)', () {
+    final importer = FullBackupImporter();
+
+    test('a backup carrying a correction restores only the real fill-up',
+        () async {
+      // Build the backup with BOTH records present (the friend's file).
+      final bytes = _backupBytes(fillUps: [realFillUp, correctionTwin]);
+      final store = _FakeStore();
+      final result = await importer.import(
+        bytes: bytes,
+        sinks: store.sinks,
+        mode: BackupImportMode.merge,
+      );
+
+      expect(result.fillUps, 1,
+          reason: 'the imported count must reflect the real fill-up only');
+      expect(store.fillUps.keys, ['1779371655207902']);
+      expect(store.fillUps.containsKey('correction_1779371655207902'), isFalse);
+    });
+  });
+}
+
+/// Build a real backup zip from the supplied fill-ups (writer → zipper),
+/// matching the production export path.
+Uint8List _backupBytes({List<FillUp> fillUps = const []}) {
+  final xml = BackupXmlWriter().build(
+    vehicles: const <VehicleProfile>[],
+    fillUps: fillUps,
+    trips: const <TripHistoryEntry>[],
+    chargingLogs: const <ChargingLog>[],
+    appVersion: '5.0.0',
+    exportedAt: DateTime.utc(2026, 4, 30),
+  );
+  return const BackupZipper().zip(xml, now: DateTime.utc(2026, 4, 30));
+}
+
+/// In-memory stand-in for the four import sinks (upsert-by-id).
+class _FakeStore {
+  final Map<String, VehicleProfile> vehicles = {};
+  final Map<String, FillUp> fillUps = {};
+  final Map<String, TripHistoryEntry> trips = {};
+  final Map<String, ChargingLog> logs = {};
+
+  BackupImportSinks get sinks => BackupImportSinks(
+        saveVehicle: (v) async => vehicles[v.id] = v,
+        clearVehicles: () async => vehicles.clear(),
+        saveFillUp: (f) async => fillUps[f.id] = f,
+        clearFillUps: () async => fillUps.clear(),
+        saveTrip: (t) async => trips[t.id] = t,
+        clearTrips: () async => trips.clear(),
+        saveChargingLog: (c) async => logs[c.id] = c,
+        clearChargingLogs: () async => logs.clear(),
+      );
+}

--- a/test/features/consumption/data/ghost_trip_dedup_test.dart
+++ b/test/features/consumption/data/ghost_trip_dedup_test.dart
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/backup_xml_writer.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/backup_zipper.dart';
+import 'package:tankstellen/features/consumption/data/exporters/backup/full_backup_importer.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/ev/domain/entities/charging_log.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import '../../../helpers/silence_error_logger.dart';
+
+/// Reproduces the real friend's backup ghost-trip pair (#2833): a
+/// 0-sample summary-only record persisted ~1 s before its full-sample
+/// twin, with a byte-identical summary (idle seconds match to 15
+/// decimals). Drives the REAL repository + REAL backup import path —
+/// not a fake — and asserts the ghost is de-duped (RED on master,
+/// GREEN after the fix).
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The exact idle-seconds value from the real backup pair — full
+  // double precision so the "match to 15 decimals" twin detection is
+  // genuinely exercised, not a rounded stand-in.
+  const realIdleSeconds = 73.39999999999961;
+
+  TripSummary realSummary(DateTime startedAt) => TripSummary(
+        distanceKm: 18.42731,
+        maxRpm: 3120,
+        highRpmSeconds: 41.5,
+        idleSeconds: realIdleSeconds,
+        harshBrakes: 2,
+        harshAccelerations: 1,
+        avgLPer100Km: 5.8,
+        fuelLitersConsumed: 1.0688,
+        startedAt: startedAt,
+        endedAt: startedAt.add(const Duration(minutes: 24)),
+      );
+
+  /// The real backup's pair: ghost at 18:16:32.4, full twin at 18:16:33.4.
+  final ghostStart = DateTime.utc(2026, 3, 11, 18, 16, 32, 400);
+  final fullStart = DateTime.utc(2026, 3, 11, 18, 16, 33, 400);
+
+  TripHistoryEntry ghostTwin() => TripHistoryEntry(
+        id: ghostStart.toIso8601String(),
+        vehicleId: 'skoda',
+        summary: realSummary(ghostStart),
+        samples: const [], // 0-sample ghost
+      );
+
+  TripHistoryEntry fullTwin() => TripHistoryEntry(
+        id: fullStart.toIso8601String(),
+        vehicleId: 'skoda',
+        summary: realSummary(fullStart),
+        samples: [
+          TripSample(timestamp: fullStart, speedKmh: 0, rpm: 800),
+          TripSample(
+            timestamp: fullStart.add(const Duration(seconds: 5)),
+            speedKmh: 42,
+            rpm: 1900,
+          ),
+        ],
+      );
+
+  group('ghost-trip de-dupe — real repository (#2833)', () {
+    late Directory tmpDir;
+    late Box<String> box;
+
+    setUp(() async {
+      tmpDir = Directory.systemTemp.createTempSync('ghost_trip_test_');
+      Hive.init(tmpDir.path);
+      box = await Hive.openBox<String>(
+        'gt_${DateTime.now().microsecondsSinceEpoch}',
+      );
+    });
+
+    tearDown(() async {
+      await box.deleteFromDisk();
+      await Hive.close();
+      tmpDir.deleteSync(recursive: true);
+    });
+
+    test('loadAll drops the 0-sample ghost, keeps the sampled twin',
+        () async {
+      final repo = TripHistoryRepository(box: box);
+      // Persist BOTH twins directly to the box (simulating the legacy
+      // double-save that already happened on the friend's device).
+      await box.put(ghostTwin().id, _encode(ghostTwin()));
+      await box.put(fullTwin().id, _encode(fullTwin()));
+
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1),
+          reason: 'the 0-sample ghost must be de-duped out');
+      expect(loaded.single.samples, isNotEmpty,
+          reason: 'the surviving record is the sampled twin');
+      expect(loaded.single.summary.idleSeconds, realIdleSeconds);
+    });
+
+    test('finalize double-save guard: a 0-sample twin is not persisted '
+        'after the sampled one', () async {
+      final repo = TripHistoryRepository(box: box);
+      await repo.save(fullTwin());
+      await repo.save(ghostTwin()); // the ghost save must be a no-op
+      expect(repo.loadAll(), hasLength(1));
+      expect(repo.loadAll().single.samples, isNotEmpty);
+    });
+
+    test('finalize double-save guard: a sampled twin REPLACES a '
+        'pre-existing 0-sample ghost', () async {
+      final repo = TripHistoryRepository(box: box);
+      await repo.save(ghostTwin()); // ghost lands first (the real bug order)
+      await repo.save(fullTwin());
+      final loaded = repo.loadAll();
+      expect(loaded, hasLength(1));
+      expect(loaded.single.samples, isNotEmpty);
+    });
+  });
+
+  group('ghost-trip de-dupe — real backup import (#2833)', () {
+    final importer = FullBackupImporter();
+
+    test('import of a backup carrying the ghost pair restores one trip',
+        () async {
+      final bytes = _backupBytes(trips: [ghostTwin(), fullTwin()]);
+      final store = _FakeStore();
+      final result = await importer.import(
+        bytes: bytes,
+        sinks: store.sinks,
+        mode: BackupImportMode.merge,
+      );
+
+      expect(result.trips, 1,
+          reason: 'the imported trip count must reflect the de-duped set');
+      expect(store.trips, hasLength(1));
+      expect(store.trips.values.single.samples, isNotEmpty);
+    });
+  });
+}
+
+/// Mirror the repository's own JSON encoding so the box holds exactly
+/// what production writes (`save` does `jsonEncode(entry.toJson())`).
+String _encode(TripHistoryEntry e) => jsonEncode(e.toJson());
+
+/// Build a real backup zip from the supplied trips (writer → zipper),
+/// matching the production export path.
+Uint8List _backupBytes({List<TripHistoryEntry> trips = const []}) {
+  final xml = BackupXmlWriter().build(
+    vehicles: const <VehicleProfile>[],
+    fillUps: const <FillUp>[],
+    trips: trips,
+    chargingLogs: const <ChargingLog>[],
+    appVersion: '5.0.0',
+    exportedAt: DateTime.utc(2026, 4, 30),
+  );
+  return const BackupZipper().zip(xml, now: DateTime.utc(2026, 4, 30));
+}
+
+/// In-memory stand-in for the four import sinks (upsert-by-id).
+class _FakeStore {
+  final Map<String, VehicleProfile> vehicles = {};
+  final Map<String, FillUp> fillUps = {};
+  final Map<String, TripHistoryEntry> trips = {};
+  final Map<String, ChargingLog> logs = {};
+
+  BackupImportSinks get sinks => BackupImportSinks(
+        saveVehicle: (v) async => vehicles[v.id] = v,
+        clearVehicles: () async => vehicles.clear(),
+        saveFillUp: (f) async => fillUps[f.id] = f,
+        clearFillUps: () async => fillUps.clear(),
+        saveTrip: (t) async => trips[t.id] = t,
+        clearTrips: () async => trips.clear(),
+        saveChargingLog: (c) async => logs[c.id] = c,
+        clearChargingLogs: () async => logs.clear(),
+      );
+}

--- a/test/features/vehicle/data/vehicle_aggregate_updater_test.dart
+++ b/test/features/vehicle/data/vehicle_aggregate_updater_test.dart
@@ -471,7 +471,7 @@ class _FakeTripHistory implements TripHistoryRepository {
   List<TripHistoryEntry> entries = <TripHistoryEntry>[];
 
   @override
-  List<TripHistoryEntry> loadAll() {
+  List<TripHistoryEntry> loadAll({bool dedupe = true}) {
     final sorted = [...entries];
     sorted.sort((a, b) {
       final ax = a.summary.startedAt ?? DateTime.fromMillisecondsSinceEpoch(0);


### PR DESCRIPTION
Two data-integrity fixes surfaced by a real friend's backup (2022 Skoda diesel, Italy, vLinker BM, ~40k OBD2 samples / 33 trips, AppVersion 5.0.0). Logic + filtering only — no new ARB keys.

## #2833 — ghost / duplicate trips
A finalisation double-save persisted a 0-sample "ghost" trip ~1–2 s before its full-sample twin, with a byte-identical summary (the real backup's pairs match `idleSeconds` to 15 decimals). It inflated the trip count (33 vs ~28 real; `AggregatesTripCount` had already drifted to 31) and double-counted distance / fuel / harsh events on any list-based total.

- New pure `trip_dedup.dart`: `dedupeGhostTrips` drops a 0-sample entry when a sampled twin shares its summary key (distance / fuel / idle+highRPM seconds / peak RPM / harsh counters, full precision) **and** started within a 2 s tolerance. `guardGhostDoubleSave` backs the save-time guard.
- `TripHistoryRepository.loadAll` de-dupes by default → the trip list, the vehicle aggregates (which count `loadAll().length`) and the backup re-export all see the de-duped set. `save` is now a no-op for a redundant ghost and deletes a stored ghost a sampled twin supersedes (the double-save can't recur).
- `FullBackupImporter` de-dupes the imported trips and counts the de-duped set; `FullBackupExporter` de-dupes a raw caller-supplied list.
- A lone GPS-only 0-sample trip (no twin) is untouched (verified by the existing #2509 journey test).

## #2834 — correction fill-up leak
The OBD2-estimate reconciliation record (`Id correction_<realId>`, unrounded litres, `TotalCost=0.0`, `IsFullTank=false`) surfaced as a real zero-cost fill-up in the FillUps list **and** the backup export. The v1 backup XML does not carry the `isCorrection` flag, so a restored correction came back with `isCorrection == false` and re-exported forever.

- New `correction_fill_up.dart`: `isReconciliationCorrection` matches the `isCorrection` flag **OR** the durable `correction_` id prefix (the backup-safe signal), plus `withoutReconciliationCorrections`.
- `FullBackupExporter` / `FullBackupImporter` exclude correction records from the export and the restore, and count the cleaned set.
- `Reconciler` builds the correction midpoint date at microsecond precision (the old millisecond math truncated `.389565Z` → `.389Z`, destabilising the dedup key).
- The in-app guided-reconciliation display of consented corrections (orange, editable) is unchanged — only the persistent backup round-trip is fixed.

## Tests
RED-on-master, GREEN-after, driving the REAL store / importer / exporter paths (no fakes that echo the request):
- `test/features/consumption/data/ghost_trip_dedup_test.dart` — the friend's ghost pair through the real repository (`loadAll`, the save guard both orders) + the real backup import.
- `test/features/consumption/data/exporters/backup/correction_fill_up_leak_test.dart` — the friend's correction record through the real exporter (XML round-trip) + the real importer.

`flutter analyze` clean; full `test/features/consumption` + `test/integration` + the three lint guards (file_length, catch-stacktrace, no-hardcoded-strings) pass.

Closes #2833
Closes #2834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
