### PR TITLE
feat(fill-up): e-receipt text parser + GMS-free Android share-intent prefill (#2838, #2735)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,11 @@
 *.pro text eol=lf
 *.toml text eol=lf
 
+# #2838 — e-receipt text fixtures must keep their on-disk bytes verbatim:
+# one fixture deliberately carries CRLF line endings + NBSP to exercise the
+# parser's normalisation, so they must NOT be EOL-normalised on checkout.
+test/features/consumption/data/ereceipt/fixtures/*.txt -text
+
 # Generated files — collapse in GitHub PR diffs
 *.g.dart linguist-generated=true
 *.freezed.dart linguist-generated=true

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -108,21 +108,23 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-            <!-- #2735 — inbound OS share-intent receiver (Epic #2687).
-                 When the user shares a receipt image (or, once #2737
-                 lands, a PDF) from another app, Android offers Sparkilo
-                 in the share sheet; the share_handler plugin reads the
-                 SEND / SEND_MULTIPLE intent on this singleTop activity
-                 (via the onNewIntent + setIntent already overridden in
-                 MainActivity.kt) and hands the attachment path to the
-                 Dart ShareReceiptListener. image/* flows through receipt
-                 OCR; application/pdf currently shows the graceful
-                 "unsupported format — coming soon" message (#2737). -->
+            <!-- #2735 — GMS-free inbound OS share-intent receiver (Epic #2687).
+                 When the user shares a receipt from another app, Android
+                 offers Sparkilo in the share sheet. The in-repo
+                 ShareIntentChannel (registered on this singleTop activity in
+                 MainActivity.kt, via configureFlutterEngine for cold launch +
+                 onNewIntent for warm) decodes the SEND / SEND_MULTIPLE intent
+                 and hands the payload to the Dart ShareReceiptListener — no
+                 third-party plugin, so the F-Droid dex stays GMS-free.
+                 image/* flows through receipt OCR; application/pdf is
+                 rasterised then OCR'd (#2737); text/plain is parsed by the
+                 pure-Dart e-receipt text parser (#2838). -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <data android:mimeType="image/*"/>
                 <data android:mimeType="application/pdf"/>
+                <data android:mimeType="text/plain"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND_MULTIPLE"/>

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
@@ -56,6 +56,18 @@ class MainActivity : FlutterActivity() {
         // app-private save target was invisible.
         PublicFileExporterChannel.registerWith(flutterEngine, applicationContext)
 
+        // GMS-free inbound share-intent receiver (#2735). Same app-internal
+        // channel pattern as the bridges above — replaces the third-party
+        // share_handler plugin so the F-Droid build pulls no extra share
+        // dependency that could drag in Play Services. Register BEFORE
+        // replaying the launch intent below so a cold-launch SEND is cached
+        // for the Dart getInitialShare probe.
+        ShareIntentChannel.registerWith(flutterEngine, applicationContext)
+        // Replay the intent that launched this activity — a cold-launch SEND
+        // (the user picked Sparkilo from another app's share sheet) arrives
+        // as the launch intent, not via onNewIntent.
+        ShareIntentChannel.handleIntent(intent)
+
         // Picture-in-Picture bridge (#1884).
         val pip = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
@@ -133,6 +145,13 @@ class MainActivity : FlutterActivity() {
      */
     override fun onNewIntent(intent: Intent) {
         setIntent(intent)
+        // #2735 — a warm-share SEND (app already running, the user picked
+        // Sparkilo from another app's share sheet) arrives here on this
+        // singleTop activity. Forward it to the GMS-free receiver, which
+        // emits it on the EventChannel the Dart ShareReceiptListener
+        // subscribes to. A non-SEND intent (widget deep-link, etc.) is a
+        // no-op for the receiver and falls through unchanged.
+        ShareIntentChannel.handleIntent(intent)
         super.onNewIntent(intent)
     }
 

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/ShareIntentChannel.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/ShareIntentChannel.kt
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.util.Locale
+
+/**
+ * GMS-free inbound OS share receiver (#2735, Epic #2687).
+ *
+ * Replaces the third-party `share_handler` plugin, which was dropped to keep
+ * the F-Droid build free of any Play-Services risk. This is the SAME
+ * app-internal channel pattern as [Obd2ClassicPlugin] /
+ * [PublicFileExporterChannel]: it uses only the Android framework + Flutter —
+ * NO `com.google.android.gms` / `com.google.mlkit` — so nothing it adds can
+ * leak into the fdroid dex.
+ *
+ * Two channels, mirroring the others:
+ *  - `tankstellen/share_intent/methods` (MethodChannel):
+ *       getInitialShare() -> Map?   the ACTION_SEND payload that cold-launched
+ *                                   the activity, consumed once (or null)
+ *  - `tankstellen/share_intent/events` (EventChannel):
+ *       Stream<Map>  one decoded share per warm ACTION_SEND
+ *
+ * Payload shape (matches `SharedReceiptIntent.fromPlatform` on the Dart side):
+ *   {
+ *     "items": [ {"kind":"image"|"pdf"|"text"|"file", "path":..., "text":...} ],
+ *     "country": "DE"   // ISO 3166-1 alpha-2 from the device locale, or absent
+ *   }
+ *
+ * Lifecycle. [MainActivity] forwards `onCreate`'s launch intent and every
+ * `onNewIntent` here. A SEND that arrives before Dart has subscribed (cold
+ * launch) is cached and replayed by [getInitialShare]; a SEND while Dart is
+ * subscribed (warm) is emitted on the EventChannel immediately.
+ */
+object ShareIntentChannel {
+    private const val TAG = "ShareIntent"
+    private const val METHOD_CHANNEL = "tankstellen/share_intent/methods"
+    private const val EVENT_CHANNEL = "tankstellen/share_intent/events"
+
+    @Volatile
+    private var eventSink: EventChannel.EventSink? = null
+
+    /** A SEND seen before Dart subscribed (cold launch); drained by getInitialShare. */
+    @Volatile
+    private var pendingInitial: Map<String, Any?>? = null
+
+    fun registerWith(flutterEngine: FlutterEngine, context: Context) {
+        val appContext = context.applicationContext
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getInitialShare" -> {
+                        val payload = pendingInitial
+                        pendingInitial = null
+                        result.success(payload)
+                    }
+                    else -> result.notImplemented()
+                }
+            }
+
+        EventChannel(flutterEngine.dartExecutor.binaryMessenger, EVENT_CHANNEL)
+            .setStreamHandler(object : EventChannel.StreamHandler {
+                override fun onListen(args: Any?, sink: EventChannel.EventSink?) {
+                    eventSink = sink
+                }
+
+                override fun onCancel(args: Any?) {
+                    eventSink = null
+                }
+            })
+
+        // appContext is captured so a SEND that arrives via onNewIntent can
+        // copy content:// streams into the cache without re-plumbing context.
+        cachedContext = appContext
+    }
+
+    @Volatile
+    private var cachedContext: Context? = null
+
+    /**
+     * Handle an inbound intent. A non-SEND intent (LAUNCHER tap, widget
+     * deep-link, …) is ignored. A SEND that decodes to at least one item is
+     * either emitted to a live Dart subscriber (warm) or cached for
+     * [getInitialShare] (cold). Wrapped so a malformed share can never crash
+     * the activity's intent handling.
+     *
+     * Returns true when the intent was a share this receiver consumed, so the
+     * caller can skip any non-share fallback handling.
+     */
+    fun handleIntent(intent: Intent?): Boolean {
+        if (intent == null) return false
+        val action = intent.action
+        if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) {
+            return false
+        }
+        return try {
+            val payload = decode(intent) ?: return false
+            val sink = eventSink
+            if (sink != null) {
+                sink.success(payload)
+            } else {
+                pendingInitial = payload
+            }
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "share intent decode failed", e)
+            false
+        }
+    }
+
+    /** Decodes a SEND / SEND_MULTIPLE intent into the Dart payload map, or null. */
+    private fun decode(intent: Intent): Map<String, Any?>? {
+        val items = ArrayList<Map<String, Any?>>()
+
+        // EXTRA_TEXT (a shared text body — e-receipt e-mail / SMS) (#2838).
+        val sharedText = intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
+        if (!sharedText.isNullOrBlank()) {
+            items.add(mapOf("kind" to "text", "text" to sharedText))
+        }
+
+        // EXTRA_STREAM content URIs (images / PDFs / other files).
+        val uris: List<Uri> = when (intent.action) {
+            Intent.ACTION_SEND -> {
+                @Suppress("DEPRECATION")
+                val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+                if (uri != null) listOf(uri) else emptyList()
+            }
+            Intent.ACTION_SEND_MULTIPLE -> {
+                @Suppress("DEPRECATION")
+                intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+                    ?: emptyList()
+            }
+            else -> emptyList()
+        }
+        for (uri in uris) {
+            val item = decodeUri(uri, intent.type) ?: continue
+            items.add(item)
+        }
+
+        if (items.isEmpty()) return null
+        return mapOf(
+            "items" to items,
+            "country" to deviceCountry(),
+        )
+    }
+
+    /**
+     * Copies a shared content [uri] into the app cache and classifies it by
+     * MIME / extension. Copying is required: the sharing app grants only a
+     * transient read permission on the original URI, which is gone by the
+     * time the Dart OCR / rasterise path runs.
+     */
+    private fun decodeUri(uri: Uri, intentType: String?): Map<String, Any?>? {
+        val context = cachedContext ?: return null
+        val resolver = context.contentResolver
+        val mime = resolver.getType(uri) ?: intentType ?: ""
+        val kind = when {
+            mime.startsWith("image/") -> "image"
+            mime == "application/pdf" -> "pdf"
+            mime.startsWith("text/") -> "text"
+            else -> "file"
+        }
+
+        // For a text/* stream, read the body directly rather than caching a file.
+        if (kind == "text") {
+            val text = try {
+                resolver.openInputStream(uri)?.use { it.readBytes().toString(Charsets.UTF_8) }
+            } catch (e: Exception) {
+                Log.w(TAG, "text stream read failed", e)
+                null
+            }
+            if (text.isNullOrBlank()) return null
+            return mapOf("kind" to "text", "text" to text)
+        }
+
+        val ext = when (kind) {
+            "image" -> if (mime == "image/png") "png" else "jpg"
+            "pdf" -> "pdf"
+            else -> "bin"
+        }
+        val cacheFile = File(
+            context.cacheDir,
+            "shared_receipt_${System.currentTimeMillis()}_${items_seq++}.$ext",
+        )
+        return try {
+            resolver.openInputStream(uri)?.use { input ->
+                cacheFile.outputStream().use { output -> input.copyTo(output) }
+            } ?: return null
+            mapOf("kind" to kind, "path" to cacheFile.absolutePath)
+        } catch (e: Exception) {
+            Log.w(TAG, "stream copy failed for $uri", e)
+            null
+        }
+    }
+
+    /** Monotonic suffix so two streams shared in the same millisecond differ. */
+    @Volatile
+    private var items_seq = 0
+
+    /** ISO 3166-1 alpha-2 region of the device locale, or null. */
+    private fun deviceCountry(): String? {
+        val country = Locale.getDefault().country
+        return if (country.isNullOrBlank()) null else country.uppercase(Locale.ROOT)
+    }
+}

--- a/lib/features/consumption/data/ereceipt/ereceipt_locale_profiles.dart
+++ b/lib/features/consumption/data/ereceipt/ereceipt_locale_profiles.dart
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../ocr/pump_ocr_config.dart';
+
+/// Pure-Dart country → [OcrLocaleProfile] lookup for the e-receipt **text**
+/// parser (#2838 / Epic #2687).
+///
+/// The pump-display / camera OCR path threads its profile from the bundled
+/// `assets/ocr_config/index.json` (loaded by [PumpOcrConfig]). The e-receipt
+/// text parser is deliberately **pure-Dart with no asset I/O** — it parses a
+/// string a user pasted or another app shared, so it must run synchronously
+/// in a unit test (and in the share-intent handler) without a Flutter binding
+/// or an `AssetBundle`. These `const` profiles mirror the JSON bands for the
+/// markets the e-receipt path covers so the currency-aware extractors
+/// (`extractTotalCost` / `extractPricePerLiter`) read amounts in the right
+/// currency without loading anything.
+///
+/// The numbers intentionally match the shipped `index.json` rows (EUR markets
+/// share the FR/DE band, GBP uses the GB band). Adding a market here is a
+/// data-only change; the parser is otherwise currency-blind.
+class EReceiptLocaleProfiles {
+  EReceiptLocaleProfiles._();
+
+  /// Returns the [OcrLocaleProfile] for an ISO 3166-1 alpha-2 [countryCode]
+  /// (case-insensitive), or `null` when the market isn't mapped — the parser
+  /// then falls back to its EUR default, unchanged from passing no profile.
+  static OcrLocaleProfile? forCountry(String? countryCode) {
+    if (countryCode == null) return null;
+    return _byCountry[countryCode.toUpperCase()];
+  }
+
+  // EUR markets share one band (mirrors the FR/DE index.json rows); GBP uses
+  // the GB row. `decimalSeparator` is informational here — the extractors
+  // accept both `.` and `,` regardless — so it carries the country's printed
+  // convention.
+  static const OcrLocaleProfile _eur = OcrLocaleProfile(
+    country: 'EUR',
+    currency: 'EUR',
+    decimalSeparator: ',',
+    priceMin: 0.5,
+    priceMax: 4.0,
+    volumeMax: 200.0,
+    totalMax: 500.0,
+  );
+
+  static const Map<String, OcrLocaleProfile> _byCountry = {
+    'IT': OcrLocaleProfile(
+      country: 'IT',
+      currency: 'EUR',
+      decimalSeparator: ',',
+      priceMin: 0.5,
+      priceMax: 4.0,
+      volumeMax: 200.0,
+      totalMax: 500.0,
+    ),
+    'DE': OcrLocaleProfile(
+      country: 'DE',
+      currency: 'EUR',
+      decimalSeparator: ',',
+      priceMin: 0.5,
+      priceMax: 4.0,
+      volumeMax: 200.0,
+      totalMax: 500.0,
+    ),
+    'FR': OcrLocaleProfile(
+      country: 'FR',
+      currency: 'EUR',
+      decimalSeparator: ',',
+      priceMin: 0.5,
+      priceMax: 4.0,
+      volumeMax: 200.0,
+      totalMax: 500.0,
+    ),
+    'AT': _eur,
+    'ES': _eur,
+    'PT': _eur,
+    'SI': _eur,
+    'LU': _eur,
+    'GR': _eur,
+    'GB': OcrLocaleProfile(
+      country: 'GB',
+      currency: 'GBP',
+      decimalSeparator: '.',
+      priceMin: 0.8,
+      priceMax: 3.0,
+      volumeMax: 200.0,
+      totalMax: 500.0,
+    ),
+  };
+}

--- a/lib/features/consumption/data/ereceipt/ereceipt_text_parser.dart
+++ b/lib/features/consumption/data/ereceipt/ereceipt_text_parser.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../receipt_parser.dart';
+import 'ereceipt_locale_profiles.dart';
+
+/// Pure-Dart parser for **digital fuel receipt text** — the body of a
+/// forwarded e-receipt e-mail, a copied SMS confirmation, or the text layer
+/// extracted from a shared PDF (#2838, phase 1 of Epic #2687).
+///
+/// This is a thin, focused entry point over the shipped [ReceiptParser]: it
+/// reuses every receipt primitive (brand detection, the per-brand layouts,
+/// the currency-aware field extractors, and cross-field reconciliation) so an
+/// e-receipt and a camera-OCR'd photo extract the SAME five fields — litres,
+/// price-per-litre, fuel grade, total, and station/brand — with one parsing
+/// implementation. The difference is purely the input shape:
+///
+///   * **No camera / no asset I/O.** The text arrives as a `String`, so this
+///     parser is synchronous and runs in a plain unit test (and in the
+///     share-intent handler) without a Flutter binding or an `AssetBundle`.
+///     The country → currency profile is resolved from the pure-Dart
+///     [EReceiptLocaleProfiles] table, not the bundled OCR-config JSON.
+///   * **Cleaner text → light normalisation.** Digital receipt text comes
+///     with CRLF / CR line endings, no-break spaces (` `, common in
+///     EUR-formatted amounts), and zero-width characters from HTML e-mail
+///     bodies. [_normalise] folds those to the `\n` + ASCII-space shape the
+///     line-oriented [ReceiptParser] already expects, so its regexes match
+///     without per-source special-casing.
+///
+/// The result is always non-null; callers check [ReceiptParseResult.hasData]
+/// to know whether anything actionable was extracted, exactly as with the
+/// camera path. Feeds the inbound share-intent prefill (#2735).
+class EReceiptTextParser {
+  final ReceiptParser _parser;
+
+  /// [parser] defaults to a plain [ReceiptParser] (no override registry — an
+  /// e-receipt has no `stationId` to key per-station overrides on). Inject a
+  /// configured parser only in tests that want to assert delegation.
+  const EReceiptTextParser({ReceiptParser parser = const ReceiptParser()})
+      : _parser = parser;
+
+  /// Parse the [text] of a shared / pasted e-receipt into the fuel field set.
+  ///
+  /// [countryCode] is an optional ISO 3166-1 alpha-2 code (`IT`, `DE`, `GB`,
+  /// …). When supplied and mapped in [EReceiptLocaleProfiles], the
+  /// currency-aware extractors read totals / prices in that market's currency
+  /// and per-litre band; otherwise the parser defaults to EUR — unchanged
+  /// from passing no profile. Returns an empty (`hasData == false`) result
+  /// for blank input rather than throwing, so the share-intent handler can
+  /// treat "nothing parseable" and "no text shared" identically.
+  ReceiptParseResult parse(String text, {String? countryCode}) {
+    final normalised = _normalise(text);
+    if (normalised.isEmpty) return const ReceiptParseResult();
+    return _parser.parse(
+      normalised,
+      profile: EReceiptLocaleProfiles.forCountry(countryCode),
+    );
+  }
+
+  /// `true` when [text] looks like a fuel receipt worth routing to the
+  /// prefill form — it parsed at least a volume or a total. A convenience
+  /// over `parse(text).hasData` for the share-intent gate.
+  bool looksLikeReceipt(String text, {String? countryCode}) =>
+      parse(text, countryCode: countryCode).hasData;
+
+  /// Folds digital-text quirks down to the `\n` + ASCII-space layout the
+  /// line-oriented [ReceiptParser] expects:
+  ///
+  ///   * CRLF / lone-CR line endings → `\n` (Windows mail clients, PDF text
+  ///     layers);
+  ///   * no-break / narrow-no-break / thin spaces (` ` ` `
+  ///     ` `) → a regular space — EUR amounts are routinely printed as
+  ///     `1 234,56 €` with a NBSP that otherwise splits the number;
+  ///   * zero-width / BOM characters (`​`-`‍`, `﻿`) stripped —
+  ///     they leak in from HTML e-mail bodies and break `\b` word boundaries.
+  ///
+  /// Pure + side-effect-free so it can be unit-tested in isolation.
+  static String _normalise(String text) {
+    return text
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n')
+        .replaceAll(RegExp(r'[   ]'), ' ')
+        .replaceAll(RegExp(r'[​-‍﻿]'), '')
+        .trim();
+  }
+}

--- a/lib/features/consumption/data/receipt_parser/brand_detection.dart
+++ b/lib/features/consumption/data/receipt_parser/brand_detection.dart
@@ -27,6 +27,14 @@ String? detectBrand(List<String> lines, String fullText) {
   if (haystack.contains('shell')) return 'shell';
   if (haystack.contains('esso')) return 'esso';
   if (haystack.contains('aral')) return 'aral';
+  // #2838 — Italian retailers (e-receipt phase 1). enilive is Eni's
+  // forecourt brand; check it before the broader "eni" token so the more
+  // specific name wins. Q8 / IP / Tamoil / Api round out the IT majors.
+  if (haystack.contains('enilive')) return 'enilive';
+  if (RegExp(r'\beni\b').hasMatch(haystack)) return 'eni';
+  if (RegExp(r'\bq8\b').hasMatch(haystack)) return 'q8';
+  if (RegExp(r'\bip\b').hasMatch(haystack)) return 'ip';
+  if (haystack.contains('tamoil')) return 'tamoil';
   return null;
 }
 
@@ -37,6 +45,8 @@ String? extractStationName(List<String> lines) {
     'avia', 'jet', 'elf', 'agip', 'q8', 'omv', 'mol', 'orlen',
     'intermarché', 'intermarche', 'leclerc', 'carrefour', 'auchan',
     'super u', 'système u', 'systeme u', 'casino',
+    // #2838 — Italian retailers (e-receipt phase 1).
+    'enilive', 'eni', 'ip', 'tamoil', 'api',
   ];
 
   for (final line in lines.take(5)) {

--- a/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_field_extractors.dart
@@ -45,18 +45,29 @@ FuelType? extractFuelType(String text) {
   if (RegExp(r'\be98\b|sp98|super\s*98').hasMatch(lower)) {
     return FuelType.e98;
   }
-  if (RegExp(r'diesel\s*premium|premium\s*diesel|gazole\s*premium')
+  if (RegExp(r'diesel\s*premium|premium\s*diesel|gazole\s*premium|'
+          r'gasolio\s*premium|hi\s*-?\s*q\s*diesel|excellium\s*diesel|'
+          r'v[- ]?power\s*diesel')
       .hasMatch(lower)) {
     return FuelType.dieselPremium;
   }
-  if (RegExp(r'\bdiesel\b|\bgazole\b|\bb7\b').hasMatch(lower)) {
+  // #2838 — Italian e-receipts label diesel "Gasolio" (compound forms like
+  // "Gasolio Auto", "Diesel+", "Blu Diesel" common on Eni/IP receipts).
+  if (RegExp(r'\bdiesel\b|\bgazole\b|\bb7\b|\bgasolio\b').hasMatch(lower)) {
     return FuelType.diesel;
   }
   if (RegExp(r'\bgpl\b|\blpg\b').hasMatch(lower)) {
     return FuelType.lpg;
   }
-  if (RegExp(r'\bgnv\b|\bcng\b').hasMatch(lower)) {
+  if (RegExp(r'\bgnv\b|\bcng\b|\bmetano\b').hasMatch(lower)) {
     return FuelType.cng;
+  }
+  // #2838 — Italian petrol is "Benzina" (E10 wasn't rolled out in IT for a
+  // long time, so an unqualified "Benzina" is E5). A qualified "Benzina E10"
+  // already matched the \be10\b branch above, so this only catches the bare
+  // petrol label — kept LAST so the specific E5/E10/E85/E98 codes win first.
+  if (RegExp(r'\bbenzina\b').hasMatch(lower)) {
+    return FuelType.e5;
   }
   return null;
 }
@@ -99,9 +110,10 @@ double? extractLiters(String text) {
     // the bottom of this function prunes the remaining false positives
     // (TVA percentages stay outside range).
     RegExp(r'(\d{1,3}[.,]\d{2,3})(?!\d)\s*[?|itjP1](?![A-Za-z0-9.,])'),
-    // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27"
+    // "VOLUME : 42.35" / "Volume: 42,35" / "Quantité = 5.27" / "Litri 38,42"
+    // (#2838 — Italian e-receipts label the volume "Litri" / "Quantità").
     RegExp(
-      r'(?:volume|quantit[eé])\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',
+      r'(?:volume|quantit[eéà]|litri)\s*[:=]?\s*(\d{1,3}[.,]\d{1,3})',
       caseSensitive: false,
     ),
     // "5,00 x SP95E5" / "42,50 X GAZOLE" / "10,00 × SP98" — French
@@ -141,11 +153,15 @@ double? extractTotalCost(String text, {OcrLocaleProfile? profile}) {
   final sym = currency.majorUnitPattern;
 
   final labelled = matchFirst(text, [
-    // TOTAL / TOT TTC / MONTANT[ REEL / TTC] / TTC / German labels.
+    // TOTAL / TOT TTC / MONTANT[ REEL / TTC] / TTC / German + Italian labels.
     // Accept ":" or "=" between label and amount, optional currency sym.
+    // #2838 — Italian e-receipts label the charged amount "Importo" or
+    // "Totale" (matched by the leading `total` alt). "Importo" is the
+    // line-item value, "Totale"/"Totale documento" the document total.
     RegExp(
-      r'(?:total|tot\s*ttc|montant(?:\s*(?:ttc|reel|r[eé]el))?|ttc|'
-      r'betrag|summe|gesamt)'
+      r'(?:totale(?:\s*documento)?|total|tot\s*ttc|'
+      r'montant(?:\s*(?:ttc|reel|r[eé]el))?|ttc|'
+      r'betrag|summe|gesamt|importo)'
       '\\s*[:=]?\\s*(?:$sym)?\\s*(\\d+[.,]\\d+)',
       caseSensitive: false,
     ),
@@ -219,11 +235,14 @@ double? extractPricePerLiter(String text, {OcrLocaleProfile? profile}) {
     // "€ 1.999/L" / "£ 1.429/L" — currency symbol before the number.
     RegExp('(?:$sym)\\s*(\\d+[.,]\\d{2,3})\\s*/\\s*[lLℓ]', caseSensitive: false),
     // Labels: PRIX/L, PU, Preis/L, Literpreis, Prix unit(.), Preis je
-    // Liter, plus generic English "Unit price" / "Price/L". Also accepts
-    // `ℓ` in place of `l` in the slash-L forms.
+    // Liter, plus generic English "Unit price" / "Price/L". #2838 — Italian
+    // e-receipts label the per-litre price "Prezzo unitario", "Prezzo/Litro"
+    // or "Prezzo al litro". Also accepts `ℓ` in place of `l` in the
+    // slash-L forms.
     RegExp(
       r'(?:prix\s*/\s*[lℓ]|prix\s*unit\.?|pu|preis\s*/\s*[lℓ]|'
-      r'preis\s*je\s*liter|literpreis|unit\s*price|price\s*/\s*[lℓ])'
+      r'preis\s*je\s*liter|literpreis|unit\s*price|price\s*/\s*[lℓ]|'
+      r'prezzo\s*(?:unitario|/\s*litro|al\s*litro))'
       '\\s*[:=]?\\s*(?:$sym)?\\s*(\\d+[.,]\\d{2,3})',
       caseSensitive: false,
     ),

--- a/lib/features/consumption/data/share/share_intent_channel.dart
+++ b/lib/features/consumption/data/share/share_intent_channel.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart';
+
+import 'shared_receipt_intent.dart';
+
+/// GMS-free bridge to the native inbound-share receiver (#2735).
+///
+/// Replaces the `share_handler` plugin, which was dropped because pulling a
+/// third-party share plugin risked dragging Google Play Services into the
+/// F-Droid build. This talks to an in-repo `ShareIntentChannel.kt` registered
+/// on `MainActivity` — the SAME app-internal channel pattern as
+/// `Obd2ClassicPlugin` / `BackgroundAdapterChannel` / `PublicFileExporterChannel`,
+/// so there is no external Gradle artefact and nothing to audit out of the
+/// fdroid dex.
+///
+/// Two channels, mirroring the others:
+///   * `tankstellen/share_intent/methods` — `getInitialShare()` returns the
+///     `ACTION_SEND` payload that cold-launched the activity (or `null`);
+///   * `tankstellen/share_intent/events` — a `Stream` that emits one decoded
+///     [SharedReceiptIntent] per warm share (app already running).
+///
+/// The class is abstract with a default platform-backed [instance] so the
+/// listener can be unit-tested by injecting a fake — the same test seam the
+/// old `ShareHandlerPlatform` offered, minus the plugin.
+abstract class ShareIntentChannel {
+  /// The cold-launch share the OS handed the freshly-started activity, or
+  /// `null` when the app wasn't launched from a share. Consumed once.
+  Future<SharedReceiptIntent?> getInitialShare();
+
+  /// Warm shares delivered while the app is already running.
+  Stream<SharedReceiptIntent> get shareStream;
+
+  /// The production, platform-channel-backed implementation.
+  static final ShareIntentChannel instance = _PlatformShareIntentChannel();
+}
+
+class _PlatformShareIntentChannel implements ShareIntentChannel {
+  static const _methods = MethodChannel('tankstellen/share_intent/methods');
+  static const _events = EventChannel('tankstellen/share_intent/events');
+
+  @override
+  Future<SharedReceiptIntent?> getInitialShare() async {
+    final raw = await _methods.invokeMethod<Object?>('getInitialShare');
+    return SharedReceiptIntent.fromPlatform(raw);
+  }
+
+  @override
+  Stream<SharedReceiptIntent> get shareStream => _events
+      .receiveBroadcastStream()
+      .map(SharedReceiptIntent.fromPlatform)
+      .where((intent) => intent != null)
+      .cast<SharedReceiptIntent>();
+}

--- a/lib/features/consumption/data/share/shared_receipt_intent.dart
+++ b/lib/features/consumption/data/share/shared_receipt_intent.dart
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+/// What kind of payload an inbound OS share carried (#2735, GMS-free
+/// rewrite). The native [ShareIntentChannel] classifies each `EXTRA_STREAM`
+/// item by MIME / extension and `EXTRA_TEXT` as text, so the Dart handler
+/// never re-sniffs file types.
+enum SharedReceiptItemKind {
+  /// A bitmap (`image/*`) copied into the app cache — routed through receipt
+  /// photo OCR.
+  image,
+
+  /// A PDF (`application/pdf`) copied into the app cache — rasterised, then
+  /// routed through the same OCR path as an image (#2737).
+  pdf,
+
+  /// Plain text (`EXTRA_TEXT`, or a shared `text/*` stream) — routed through
+  /// the pure-Dart e-receipt text parser (#2838).
+  text,
+
+  /// Anything else (video / arbitrary file) — genuinely unsupported.
+  file,
+}
+
+/// One attachment from an inbound share. Exactly one of [path] / [text] is
+/// populated, keyed by [kind]: file-backed items ([image]/[pdf]/[file]) carry
+/// a cache [path]; a [text] item carries the shared [text] body.
+@immutable
+class SharedReceiptItem {
+  final SharedReceiptItemKind kind;
+
+  /// Cache path for a file-backed item (image / pdf / file), else `null`.
+  final String? path;
+
+  /// Shared body for a [SharedReceiptItemKind.text] item, else `null`.
+  final String? text;
+
+  const SharedReceiptItem({required this.kind, this.path, this.text});
+
+  const SharedReceiptItem.image(String this.path)
+      : kind = SharedReceiptItemKind.image,
+        text = null;
+
+  const SharedReceiptItem.pdf(String this.path)
+      : kind = SharedReceiptItemKind.pdf,
+        text = null;
+
+  const SharedReceiptItem.text(String this.text)
+      : kind = SharedReceiptItemKind.text,
+        path = null;
+
+  const SharedReceiptItem.file(String this.path)
+      : kind = SharedReceiptItemKind.file,
+        text = null;
+
+  /// Decodes one item from the platform-channel map. Returns `null` for a
+  /// malformed entry so a single bad attachment never sinks the whole share.
+  static SharedReceiptItem? fromMap(Object? raw) {
+    if (raw is! Map) return null;
+    final kindStr = raw['kind'];
+    final path = raw['path'];
+    final text = raw['text'];
+    switch (kindStr) {
+      case 'image':
+        return path is String && path.isNotEmpty
+            ? SharedReceiptItem.image(path)
+            : null;
+      case 'pdf':
+        return path is String && path.isNotEmpty
+            ? SharedReceiptItem.pdf(path)
+            : null;
+      case 'text':
+        return text is String && text.isNotEmpty
+            ? SharedReceiptItem.text(text)
+            : null;
+      case 'file':
+        return path is String && path.isNotEmpty
+            ? SharedReceiptItem.file(path)
+            : null;
+      default:
+        return null;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is SharedReceiptItem &&
+      other.kind == kind &&
+      other.path == path &&
+      other.text == text;
+
+  @override
+  int get hashCode => Object.hash(kind, path, text);
+}
+
+/// A decoded inbound OS share — the GMS-free in-repo analogue of
+/// `share_handler`'s `SharedMedia`. Carries the attachments the native
+/// receiver resolved from an `ACTION_SEND` / `ACTION_SEND_MULTIPLE` intent.
+///
+/// Optionally carries the device's [countryCode] (resolved natively from the
+/// active locale) so the text parser reads amounts in the right currency
+/// without a Dart-side lookup. `null` when unavailable — the parser then
+/// defaults to EUR.
+@immutable
+class SharedReceiptIntent {
+  final List<SharedReceiptItem> items;
+  final String? countryCode;
+
+  const SharedReceiptIntent({required this.items, this.countryCode});
+
+  bool get isEmpty => items.isEmpty;
+
+  /// Decodes the platform-channel payload (a `{items: [...], country: "..."}`
+  /// map). Returns `null` for a null / non-map payload; drops malformed
+  /// items individually.
+  static SharedReceiptIntent? fromPlatform(Object? raw) {
+    if (raw is! Map) return null;
+    final rawItems = raw['items'];
+    if (rawItems is! List) return null;
+    final items = rawItems
+        .map(SharedReceiptItem.fromMap)
+        .whereType<SharedReceiptItem>()
+        .toList(growable: false);
+    if (items.isEmpty) return null;
+    final country = raw['country'];
+    return SharedReceiptIntent(
+      items: items,
+      countryCode: country is String && country.isNotEmpty ? country : null,
+    );
+  }
+}

--- a/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
+++ b/lib/features/consumption/presentation/screens/add_fill_up_screen.dart
@@ -160,10 +160,10 @@ class _AddFillUpScreenState extends ConsumerState<AddFillUpScreen> {
     // value without spinning up the trip-recording graph.
     _fuelLevelBeforeL =
         widget.initialFuelLevelBeforeL ?? _readObd2FuelLevelLitres();
-    // #2735 — when an OS share intent routed the user here with a receipt
-    // image, OCR + prefill it after the first frame (helper lives in
-    // `fill_up_share_scan_handlers.dart` to keep this file lean, #1680).
-    scheduleSharedReceiptScanIfPending(
+    // #2735/#2838 — when an OS share intent routed the user here, prefill
+    // from it after the first frame: image/PDF OCR'd, e-receipt text applied
+    // (one helper drains both stashes; lives in the widgets file, #1680).
+    scheduleSharedReceiptPrefillIfPending(
       ref,
       context,
       _buildScanHostState,

--- a/lib/features/consumption/presentation/widgets/fill_up_share_scan_handlers.dart
+++ b/lib/features/consumption/presentation/widgets/fill_up_share_scan_handlers.dart
@@ -9,8 +9,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../data/receipt_parser.dart';
 import '../../data/receipt_scan_service.dart';
 import '../../providers/pending_shared_receipt_provider.dart';
+import '../../providers/pending_shared_receipt_text_provider.dart';
 import 'fill_up_scan_handlers.dart';
 
 /// Shared receipt-prefill body + the path-fed share-scan sibling
@@ -145,11 +147,27 @@ Future<void> runSharedReceiptScan(
   }
 }
 
+/// #2735/#2838 — single `initState` entry point that drains BOTH inbound-share
+/// stashes the screen can be routed with: an image / PDF receipt path (OCR'd)
+/// and a parsed e-receipt text result (applied directly). Keeping it one call
+/// keeps `AddFillUpScreen` at its grandfathered size (#1680). Both branches
+/// are no-ops when their stash is empty, so the common manual-open case does
+/// nothing.
+void scheduleSharedReceiptPrefillIfPending(
+  WidgetRef ref,
+  BuildContext context,
+  FillUpScanHostState Function() buildHost,
+  bool Function() isMounted,
+) {
+  scheduleSharedReceiptScanIfPending(ref, context, buildHost, isMounted);
+  scheduleSharedReceiptTextIfPending(ref, context, buildHost, isMounted);
+}
+
 /// #2735 — drains the inbound-share receipt path stashed by
 /// `ShareReceiptHandler` and runs [runSharedReceiptScan] on the next
 /// frame, prefilling the host form from the shared receipt's OCR. Called
-/// from `AddFillUpScreen.initState`; a no-op when nothing was shared (the
-/// common case of opening the form manually).
+/// via [scheduleSharedReceiptPrefillIfPending]; a no-op when nothing was
+/// shared (the common case of opening the form manually).
 ///
 /// Lives here, not on the screen, so the screen file stays close to its
 /// grandfathered size (#1680). [ref] reads the stash via `consumeDeferred`
@@ -180,5 +198,56 @@ void scheduleSharedReceiptScanIfPending(
   WidgetsBinding.instance.addPostFrameCallback((_) {
     if (!isMounted()) return;
     unawaited(runSharedReceiptScan(context, buildHost(), sharedPath));
+  });
+}
+
+/// #2838 — drains the inbound-share e-receipt TEXT result stashed by
+/// `ShareReceiptHandler` (already parsed by the pure-Dart `EReceiptTextParser`
+/// at receive time — there is no file to OCR) and prefills the host form on
+/// the next frame through the SAME [applyReceiptOutcome] body the camera /
+/// image-share paths use. Called from `AddFillUpScreen.initState`; a no-op
+/// when nothing text-shaped was shared.
+///
+/// The parsed [ReceiptParseResult] is wrapped in a synthetic
+/// [ReceiptScanOutcome] (empty `imagePath` — there is no photo to report) so
+/// it flows through the identical prefill body, guaranteeing zero drift
+/// between a text e-receipt and a scanned photo. [consumeDeferred] is used
+/// for the same `initState`-is-Riverpod-locked reason as the path sibling.
+void scheduleSharedReceiptTextIfPending(
+  WidgetRef ref,
+  BuildContext context,
+  FillUpScanHostState Function() buildHost,
+  bool Function() isMounted,
+) {
+  ReceiptParseResult? result;
+  try {
+    result =
+        ref.read(pendingSharedReceiptTextProvider.notifier).consumeDeferred();
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+      'where': 'AddFillUp: pending shared-receipt text read failed',
+    }));
+    return;
+  }
+  if (result == null || !result.hasData) return;
+  final parsed = result;
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (!isMounted()) return;
+    try {
+      final outcome = ReceiptScanOutcome(
+        parse: parsed,
+        ocrText: '',
+        imagePath: '',
+      );
+      applyReceiptOutcome(buildHost(), outcome);
+      final l = AppLocalizations.of(context);
+      if (isMounted() && context.mounted) {
+        SnackBarHelper.show(context, receiptScanSuccessMessage(l, outcome));
+      }
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
+        'where': 'AddFillUp: shared-receipt text prefill failed',
+      }));
+    }
   });
 }

--- a/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_handler.dart
@@ -3,10 +3,8 @@
 
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:share_handler/share_handler.dart';
 
 import '../../../../app/router.dart';
 import '../../../../core/logging/error_logger.dart';
@@ -15,88 +13,102 @@ import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/feature.dart';
+import '../../data/ereceipt/ereceipt_text_parser.dart';
 import '../../data/ocr/receipt_pdf_rasterizer.dart';
+import '../../data/share/shared_receipt_intent.dart';
 import '../../providers/pending_shared_receipt_provider.dart';
+import '../../providers/pending_shared_receipt_text_provider.dart';
 
 part 'share_receipt_handler.g.dart';
 
-/// Routes an inbound OS share ([SharedMedia]) onto the live app: an
-/// image attachment is stashed in [pendingSharedReceiptProvider] and the
-/// router is pushed to `/consumption/add`, where the Add-fill-up screen
-/// consumes the stash and OCRs the receipt via `runSharedReceiptScan`
-/// (#2734).
+/// Routes an inbound OS share ([SharedReceiptIntent]) onto the live app
+/// (#2735, GMS-free rewrite — the `share_handler` plugin was dropped to keep
+/// the F-Droid build free of any Play-Services risk; the share now arrives
+/// via the in-repo [ShareIntentChannel]).
 ///
-/// A shared **PDF** (#2737) is first rasterised on-device to a JPEG via
-/// [ReceiptPdfRasterizer] and then takes the EXACT same stash + route +
-/// OCR path as an image — `parseReceiptImage` never knows the bitmap came
-/// from a PDF. When rasterisation fails (corrupt PDF, or the native
-/// renderer is unavailable) it shows the graceful #2735 `shareReceipt
-/// Failed` message. Any other attachment type (video / arbitrary file)
-/// still shows `shareReceiptUnsupportedFormat`.
+/// Three input shapes, one prefill destination — the Add-fill-up form:
 ///
-/// Split out from [ShareReceiptListener] so the routing + gating logic is
-/// unit-testable without pumping the full widget tree — the same shape
-/// (and debugging history) as [NotificationLaunchHandler] /
-/// [WidgetLaunchHandler]. Reading the router from the provider (not
-/// `GoRouter.of(context)`) sidesteps the `InheritedGoRouter`-above-the-
-/// builder trap those classes documented.
+///   * **image** (`image/*`): stashed in [pendingSharedReceiptProvider] and
+///     the router pushed to `/consumption/add`, where the screen consumes the
+///     stash and OCRs the receipt via `runSharedReceiptScan` (#2734).
+///   * **PDF** (`application/pdf`, #2737): rasterised on-device to a JPEG via
+///     [ReceiptPdfRasterizer] and then taking the EXACT same stash + route +
+///     OCR path as an image — `parseReceiptImage` never knows the bitmap came
+///     from a PDF. A failed rasterisation shows the graceful
+///     `shareReceiptFailed` message.
+///   * **text** (`EXTRA_TEXT` / `text/*`, #2838): parsed at receive time by
+///     the pure-Dart [EReceiptTextParser] (no OCR, no file). The parsed
+///     result is stashed in [pendingSharedReceiptTextProvider] and the screen
+///     prefills the form through the SAME `applyReceiptOutcome` body — so a
+///     text e-receipt fills the form with zero drift from a photo scan.
+///
+/// Any other attachment type (video / arbitrary file) shows
+/// `shareReceiptUnsupportedFormat`.
+///
+/// Split out from `ShareReceiptListener` so the routing + gating logic is
+/// unit-testable without pumping the full widget tree — the same shape as
+/// [NotificationLaunchHandler]. Reading the router from the provider (not
+/// `GoRouter.of(context)`) sidesteps the `InheritedGoRouter`-above-the-builder
+/// trap.
 ///
 /// **Never throws** (#2349): every public entry is wrapped so a decode /
-/// push / snackbar failure routes through [errorLogger] and the user is
-/// never crashed back to the launcher by a malformed share. The sibling
-/// `share_receipt_handler_test.dart` pins this with fault injection.
+/// push / snackbar / parse failure routes through [errorLogger] and the user
+/// is never crashed back to the launcher by a malformed share.
 class ShareReceiptHandler {
   final Ref _ref;
   final ReceiptPdfRasterizer _pdfRasterizer;
+  final EReceiptTextParser _textParser;
 
-  ShareReceiptHandler(this._ref, {ReceiptPdfRasterizer? pdfRasterizer})
-      : _pdfRasterizer = pdfRasterizer ?? const ReceiptPdfRasterizer();
+  ShareReceiptHandler(
+    this._ref, {
+    ReceiptPdfRasterizer? pdfRasterizer,
+    EReceiptTextParser textParser = const EReceiptTextParser(),
+  })  : _pdfRasterizer = pdfRasterizer ?? const ReceiptPdfRasterizer(),
+        _textParser = textParser;
 
-  /// Handle one inbound [media]. No-op for a null media, an empty
-  /// attachment list, or — defensively — when the feature is gated off.
+  /// Handle one inbound [intent]. No-op for a null intent, an empty item
+  /// list, or — defensively — when the feature is gated off.
   ///
-  /// Returns normally on any failure (#2349): a thrown error from the
-  /// router push or a missing localized context must not propagate out
-  /// of the platform stream callback.
-  void handle(SharedMedia? media) {
+  /// Returns normally on any failure (#2349): a thrown error from the router
+  /// push, the text parser, or a missing localized context must not propagate
+  /// out of the platform stream callback.
+  void handle(SharedReceiptIntent? intent) {
     try {
-      if (media == null) return;
-      // The share-intent receiver is opt-in (#2735) — when the user has
-      // not enabled it, silently drop the share rather than navigating.
-      // Gated here (not only at the listener) so a direct handler call
-      // from a test or a future caller honours the same flag.
+      if (intent == null || intent.isEmpty) return;
+      // The share-intent receiver is opt-in (#2735) — when the user has not
+      // enabled it, silently drop the share rather than navigating. Gated
+      // here (not only at the listener) so a direct handler call from a test
+      // or a future caller honours the same flag.
       if (!_featureEnabled()) return;
 
-      final attachments = media.attachments
-              ?.whereType<SharedAttachment>()
-              .toList() ??
-          const <SharedAttachment>[];
-      if (attachments.isEmpty) return;
+      final items = intent.items;
 
       // First image wins — receipts are single photos in practice; a
-      // SEND_MULTIPLE batch still prefills from the first image and the
-      // user can re-share the rest.
-      final image = attachments
-          .where((a) => a.type == SharedAttachmentType.image)
+      // SEND_MULTIPLE batch still prefills from the first image.
+      final image = items
+          .where((i) => i.kind == SharedReceiptItemKind.image)
           .firstOrNull;
-      if (image != null) {
-        _stashAndRoute(image.path);
+      if (image?.path != null) {
+        _stashAndRoute(image!.path!);
         return;
       }
 
       // No image — a shared PDF (#2737) is rasterised to a bitmap and then
-      // takes the same path. `share_handler` carries PDFs as `file`
-      // attachments (it has no `pdf` type and no MIME on the attachment),
-      // so we recognise them by extension. The render is async, so the
-      // outcome is handled in [_rasterizeAndRoute]; `handle` stays
+      // takes the same path. The render is async, so `handle` stays
       // synchronous + never-throws by fire-and-forgetting it.
-      final pdf = attachments
-          .where((a) =>
-              a.type == SharedAttachmentType.file &&
-              a.path.toLowerCase().endsWith('.pdf'))
-          .firstOrNull;
-      if (pdf != null) {
-        unawaited(_rasterizeAndRoute(pdf.path));
+      final pdf =
+          items.where((i) => i.kind == SharedReceiptItemKind.pdf).firstOrNull;
+      if (pdf?.path != null) {
+        unawaited(_rasterizeAndRoute(pdf!.path!));
+        return;
+      }
+
+      // No image / PDF — a shared text e-receipt (#2838) is parsed on the
+      // spot and the result stashed for the form to apply.
+      final text =
+          items.where((i) => i.kind == SharedReceiptItemKind.text).firstOrNull;
+      if (text?.text != null) {
+        _parseTextAndRoute(text!.text!, intent.countryCode);
         return;
       }
 
@@ -111,21 +123,16 @@ class ShareReceiptHandler {
 
   /// Stashes the receipt-image [path] and routes to the Add-fill-up form,
   /// where the screen consumes the stash and OCRs it via
-  /// `runSharedReceiptScan` (#2734). Shared by the image and PDF paths —
-  /// a rasterised PDF page is just a JPEG by the time it reaches here.
+  /// `runSharedReceiptScan` (#2734). Shared by the image and PDF paths.
   void _stashAndRoute(String path) {
     _ref.read(pendingSharedReceiptProvider.notifier).set(path);
-    debugPrint('ShareReceiptHandler.handle stashed $path');
+    debugPrint('ShareReceiptHandler.handle stashed image $path');
     _push('/consumption/add');
   }
 
-  /// Rasterises the shared PDF at [path] to a JPEG (off the UI thread via
-  /// the native renderer) and, on success, takes the SAME stash + route +
-  /// OCR path as an image share. On failure ([ReceiptPdfRasterizer]
-  /// returns null — corrupt PDF, or no native renderer) it shows the
-  /// graceful #2735 `shareReceiptFailed` message. Never throws (#2349):
-  /// the rasteriser already swallows its own faults, and this wrapper
-  /// catches anything the route push could raise.
+  /// Rasterises the shared PDF at [path] to a JPEG and, on success, takes the
+  /// SAME stash + route + OCR path as an image share. On failure shows the
+  /// graceful `shareReceiptFailed` message. Never throws (#2349).
   Future<void> _rasterizeAndRoute(String path) async {
     try {
       final jpegPath = await _pdfRasterizer.rasterize(path);
@@ -140,6 +147,23 @@ class ShareReceiptHandler {
       }));
       _showReadFailed();
     }
+  }
+
+  /// Parses a shared e-receipt [text] body with the pure-Dart
+  /// [EReceiptTextParser] (#2838) and, when it yielded fuel data, stashes the
+  /// result in [pendingSharedReceiptTextProvider] and routes to the form.
+  /// When nothing parseable was found it shows the graceful
+  /// `shareReceiptFailed` message rather than routing to a blank form.
+  void _parseTextAndRoute(String text, String? countryCode) {
+    final result = _textParser.parse(text, countryCode: countryCode);
+    if (!result.hasData) {
+      debugPrint('ShareReceiptHandler: shared text had no parseable receipt');
+      _showReadFailed();
+      return;
+    }
+    _ref.read(pendingSharedReceiptTextProvider.notifier).set(result);
+    debugPrint('ShareReceiptHandler.handle stashed parsed text result');
+    _push('/consumption/add');
   }
 
   bool _featureEnabled() {
@@ -165,10 +189,9 @@ class ShareReceiptHandler {
     }
   }
 
-  /// Surfaces the localized "unsupported format" snackbar for a shared
-  /// PDF / non-image attachment. Reaches a navigator-bearing context via
-  /// the root navigator key so the message shows even though the share
-  /// arrived from above the navigator. No-op when no context is mounted.
+  /// Surfaces the localized "unsupported format" snackbar for a non-image /
+  /// non-PDF / non-text attachment. Reaches a navigator-bearing context via
+  /// the root navigator key. No-op when no context is mounted.
   void _showUnsupportedFormat() {
     final context = rootNavigatorKey.currentContext;
     if (context == null || !context.mounted) return;
@@ -181,11 +204,10 @@ class ShareReceiptHandler {
     );
   }
 
-  /// Surfaces the localized "couldn't read the receipt" snackbar for a
-  /// PDF that could not be rasterised (#2737), reusing the #2735
-  /// `shareReceiptFailed` key — the file type IS supported, the read just
-  /// failed, so the message asks the user to retry rather than implying
-  /// the format is rejected.
+  /// Surfaces the localized "couldn't read the receipt" snackbar for a PDF
+  /// that could not be rasterised (#2737) or a shared text body with no
+  /// parseable fuel data (#2838), reusing the `shareReceiptFailed` key — the
+  /// format IS supported, the read just failed.
   void _showReadFailed() {
     final context = rootNavigatorKey.currentContext;
     if (context == null || !context.mounted) return;
@@ -199,12 +221,9 @@ class ShareReceiptHandler {
   }
 }
 
-/// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs
-/// through (#2737). Exposed as its own provider so a test can override it
-/// with a fake — the native PdfRenderer is unavailable under `flutter
-/// test`, so the PDF branch is unit-tested by injecting a fake that
-/// returns a known JPEG path (success) or null (graceful fallback),
-/// asserting it routes to the SAME stash+OCR path as an image.
+/// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs through
+/// (#2737). Exposed as its own provider so a test can override it with a fake
+/// — the native PdfRenderer is unavailable under `flutter test`.
 @riverpod
 ReceiptPdfRasterizer receiptPdfRasterizer(Ref ref) =>
     const ReceiptPdfRasterizer();

--- a/lib/features/consumption/presentation/widgets/share_receipt_handler.g.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_handler.g.dart
@@ -8,22 +8,16 @@ part of 'share_receipt_handler.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs
-/// through (#2737). Exposed as its own provider so a test can override it
-/// with a fake — the native PdfRenderer is unavailable under `flutter
-/// test`, so the PDF branch is unit-tested by injecting a fake that
-/// returns a known JPEG path (success) or null (graceful fallback),
-/// asserting it routes to the SAME stash+OCR path as an image.
+/// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs through
+/// (#2737). Exposed as its own provider so a test can override it with a fake
+/// — the native PdfRenderer is unavailable under `flutter test`.
 
 @ProviderFor(receiptPdfRasterizer)
 final receiptPdfRasterizerProvider = ReceiptPdfRasterizerProvider._();
 
-/// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs
-/// through (#2737). Exposed as its own provider so a test can override it
-/// with a fake — the native PdfRenderer is unavailable under `flutter
-/// test`, so the PDF branch is unit-tested by injecting a fake that
-/// returns a known JPEG path (success) or null (graceful fallback),
-/// asserting it routes to the SAME stash+OCR path as an image.
+/// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs through
+/// (#2737). Exposed as its own provider so a test can override it with a fake
+/// — the native PdfRenderer is unavailable under `flutter test`.
 
 final class ReceiptPdfRasterizerProvider
     extends
@@ -33,12 +27,9 @@ final class ReceiptPdfRasterizerProvider
           ReceiptPdfRasterizer
         >
     with $Provider<ReceiptPdfRasterizer> {
-  /// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs
-  /// through (#2737). Exposed as its own provider so a test can override it
-  /// with a fake — the native PdfRenderer is unavailable under `flutter
-  /// test`, so the PDF branch is unit-tested by injecting a fake that
-  /// returns a known JPEG path (success) or null (graceful fallback),
-  /// asserting it routes to the SAME stash+OCR path as an image.
+  /// The on-device PDF→bitmap rasteriser the handler feeds shared PDFs through
+  /// (#2737). Exposed as its own provider so a test can override it with a fake
+  /// — the native PdfRenderer is unavailable under `flutter test`.
   ReceiptPdfRasterizerProvider._()
     : super(
         from: null,

--- a/lib/features/consumption/presentation/widgets/share_receipt_listener.dart
+++ b/lib/features/consumption/presentation/widgets/share_receipt_listener.dart
@@ -5,48 +5,50 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:share_handler/share_handler.dart';
 
 import '../../../../core/logging/error_logger.dart';
+import '../../data/share/share_intent_channel.dart';
+import '../../data/share/shared_receipt_intent.dart';
 import 'share_receipt_handler.dart';
 
-/// Listens for an inbound OS share intent and routes the shared receipt
-/// image to the Add-fill-up form (#2735 / Epic #2687).
+/// Listens for an inbound OS share intent and routes the shared receipt to
+/// the Add-fill-up form (#2735 / Epic #2687).
+///
+/// GMS-free: reads from the in-repo [ShareIntentChannel] (an app-internal
+/// MethodChannel/EventChannel on `MainActivity`) rather than the dropped
+/// `share_handler` plugin, so the F-Droid build pulls no extra share
+/// dependency that could drag in Play Services.
 ///
 /// Two code paths — mirrors [NotificationLaunchListener] exactly:
 ///
-/// 1. **Cold start** — the user shared a receipt while Sparkilo was
-///    killed. [ShareHandlerPlatform.getInitialSharedMedia] surfaces the
-///    media the OS handed the freshly-launched activity. The router may
-///    not have attached its Navigator yet, so the dispatch is deferred
-///    to `addPostFrameCallback` (same race the home-widget cold-launch
-///    stash fixed at #widget-deeplink).
-/// 2. **Warm share** — the app is already running. The plugin's
-///    [ShareHandlerPlatform.sharedMediaStream] emits the media and we
-///    dispatch immediately.
+/// 1. **Cold start** — the user shared a receipt while Sparkilo was killed.
+///    [ShareIntentChannel.getInitialShare] surfaces the share the OS handed
+///    the freshly-launched activity. The router may not have attached its
+///    Navigator yet, so the dispatch is deferred to `addPostFrameCallback`
+///    (same race the home-widget cold-launch stash fixed at #widget-deeplink).
+/// 2. **Warm share** — the app is already running. [ShareIntentChannel.shareStream]
+///    emits the share and we dispatch immediately.
 ///
 /// Both paths funnel through [ShareReceiptHandler] so the routing /
 /// feature-gating logic has a single, tested entry point.
 ///
 /// **Never throws** (#2349): the cold-launch probe and the stream
-/// subscription are each wrapped so a platform-channel fault or a
-/// throwing downstream handler routes through [errorLogger] instead of
-/// crashing the app. The sibling `share_receipt_listener_test.dart`
-/// pins this with a failing stream + a throwing handler.
+/// subscription are each wrapped so a platform-channel fault or a throwing
+/// downstream handler routes through [errorLogger] instead of crashing.
 class ShareReceiptListener extends ConsumerStatefulWidget {
   final Widget child;
 
-  /// Test seam — supplies the platform plugin the listener reads cold /
-  /// warm shares from. Production passes `null` and the listener uses
-  /// [ShareHandlerPlatform.instance]; widget tests inject a fake whose
-  /// stream + initial media they control (and whose stream can be made
-  /// to throw, for the #2349 fault-injection contract).
-  final ShareHandlerPlatform? shareHandler;
+  /// Test seam — supplies the channel the listener reads cold / warm shares
+  /// from. Production passes `null` and the listener uses
+  /// [ShareIntentChannel.instance]; widget tests inject a fake whose stream +
+  /// initial share they control (and whose stream can be made to throw, for
+  /// the #2349 fault-injection contract).
+  final ShareIntentChannel? shareChannel;
 
   const ShareReceiptListener({
     super.key,
     required this.child,
-    this.shareHandler,
+    this.shareChannel,
   });
 
   @override
@@ -55,10 +57,10 @@ class ShareReceiptListener extends ConsumerStatefulWidget {
 }
 
 class _ShareReceiptListenerState extends ConsumerState<ShareReceiptListener> {
-  StreamSubscription<SharedMedia>? _subscription;
+  StreamSubscription<SharedReceiptIntent>? _subscription;
 
-  ShareHandlerPlatform get _handler =>
-      widget.shareHandler ?? ShareHandlerPlatform.instance;
+  ShareIntentChannel get _channel =>
+      widget.shareChannel ?? ShareIntentChannel.instance;
 
   @override
   void initState() {
@@ -73,13 +75,13 @@ class _ShareReceiptListenerState extends ConsumerState<ShareReceiptListener> {
     super.dispose();
   }
 
-  /// Reads the share the OS delivered on cold launch (if any) and
-  /// dispatches it after the first frame so the router's Navigator is
-  /// attached. A null / empty initial media is a no-op.
+  /// Reads the share the OS delivered on cold launch (if any) and dispatches
+  /// it after the first frame so the router's Navigator is attached. A null
+  /// initial share is a no-op.
   Future<void> _handleColdShare() async {
     try {
-      final media = await _handler.getInitialSharedMedia();
-      WidgetsBinding.instance.addPostFrameCallback((_) => _dispatch(media));
+      final intent = await _channel.getInitialShare();
+      WidgetsBinding.instance.addPostFrameCallback((_) => _dispatch(intent));
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
         'where': 'ShareReceiptListener: cold-share probe failed',
@@ -92,7 +94,7 @@ class _ShareReceiptListenerState extends ConsumerState<ShareReceiptListener> {
   /// (#2349) — it is logged and the subscription keeps listening.
   void _listenWarmShares() {
     try {
-      _subscription = _handler.sharedMediaStream.listen(
+      _subscription = _channel.shareStream.listen(
         _dispatch,
         onError: (Object e, StackTrace st) {
           unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
@@ -107,13 +109,13 @@ class _ShareReceiptListenerState extends ConsumerState<ShareReceiptListener> {
     }
   }
 
-  void _dispatch(SharedMedia? media) {
+  void _dispatch(SharedReceiptIntent? intent) {
     if (!mounted) return;
-    if (media == null) return;
-    // The handler is itself never-throws, but guard the provider read
-    // too so a disposed container during teardown can't surface an error.
+    if (intent == null) return;
+    // The handler is itself never-throws, but guard the provider read too so
+    // a disposed container during teardown can't surface an error.
     try {
-      ref.read(shareReceiptHandlerProvider).handle(media);
+      ref.read(shareReceiptHandlerProvider).handle(intent);
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.ui, e, st, context: const {
         'where': 'ShareReceiptListener._dispatch',

--- a/lib/features/consumption/providers/pending_shared_receipt_text_provider.dart
+++ b/lib/features/consumption/providers/pending_shared_receipt_text_provider.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../data/receipt_parser.dart';
+
+part 'pending_shared_receipt_text_provider.g.dart';
+
+/// One-shot stash for the [ReceiptParseResult] of an e-receipt **text** an
+/// external app shared into Sparkilo (#2735 + #2838 / Epic #2687).
+///
+/// The text sibling of [pendingSharedReceiptProvider]. An image / PDF share
+/// stashes a file PATH that the Add-fill-up screen OCRs on open; a shared
+/// text body, by contrast, is parsed by the pure-Dart [EReceiptTextParser]
+/// in the share handler at receive time — there is no file to OCR — so the
+/// already-parsed result is what gets stashed here. The Add-fill-up screen
+/// consumes it on open and prefills the form through the SAME
+/// `applyReceiptOutcome` body the camera / image-share paths use, so a text
+/// receipt fills the form with zero prefill drift.
+///
+/// **Lifecycle** mirrors the path stash: `set(result)` writes;
+/// `consumeDeferred()` returns the value and clears via a microtask so it is
+/// safe to call from the screen's `initState` (a Riverpod-locked phase).
+@Riverpod(keepAlive: true)
+class PendingSharedReceiptText extends _$PendingSharedReceiptText {
+  @override
+  ReceiptParseResult? build() => null;
+
+  /// Stores [result] (or clears the stash when [result] is `null`).
+  void set(ReceiptParseResult? result) {
+    state = result;
+  }
+
+  /// Returns the pending result and clears the stash via a microtask so the
+  /// caller can invoke it from inside a widget build / `initState` without
+  /// tripping Riverpod's build-phase state-write assert.
+  ReceiptParseResult? consumeDeferred() {
+    final pending = state;
+    if (pending != null) {
+      Future.microtask(() => state = null);
+    }
+    return pending;
+  }
+}

--- a/lib/features/consumption/providers/pending_shared_receipt_text_provider.g.dart
+++ b/lib/features/consumption/providers/pending_shared_receipt_text_provider.g.dart
@@ -1,0 +1,125 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_shared_receipt_text_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// One-shot stash for the [ReceiptParseResult] of an e-receipt **text** an
+/// external app shared into Sparkilo (#2735 + #2838 / Epic #2687).
+///
+/// The text sibling of [pendingSharedReceiptProvider]. An image / PDF share
+/// stashes a file PATH that the Add-fill-up screen OCRs on open; a shared
+/// text body, by contrast, is parsed by the pure-Dart [EReceiptTextParser]
+/// in the share handler at receive time — there is no file to OCR — so the
+/// already-parsed result is what gets stashed here. The Add-fill-up screen
+/// consumes it on open and prefills the form through the SAME
+/// `applyReceiptOutcome` body the camera / image-share paths use, so a text
+/// receipt fills the form with zero prefill drift.
+///
+/// **Lifecycle** mirrors the path stash: `set(result)` writes;
+/// `consumeDeferred()` returns the value and clears via a microtask so it is
+/// safe to call from the screen's `initState` (a Riverpod-locked phase).
+
+@ProviderFor(PendingSharedReceiptText)
+final pendingSharedReceiptTextProvider = PendingSharedReceiptTextProvider._();
+
+/// One-shot stash for the [ReceiptParseResult] of an e-receipt **text** an
+/// external app shared into Sparkilo (#2735 + #2838 / Epic #2687).
+///
+/// The text sibling of [pendingSharedReceiptProvider]. An image / PDF share
+/// stashes a file PATH that the Add-fill-up screen OCRs on open; a shared
+/// text body, by contrast, is parsed by the pure-Dart [EReceiptTextParser]
+/// in the share handler at receive time — there is no file to OCR — so the
+/// already-parsed result is what gets stashed here. The Add-fill-up screen
+/// consumes it on open and prefills the form through the SAME
+/// `applyReceiptOutcome` body the camera / image-share paths use, so a text
+/// receipt fills the form with zero prefill drift.
+///
+/// **Lifecycle** mirrors the path stash: `set(result)` writes;
+/// `consumeDeferred()` returns the value and clears via a microtask so it is
+/// safe to call from the screen's `initState` (a Riverpod-locked phase).
+final class PendingSharedReceiptTextProvider
+    extends $NotifierProvider<PendingSharedReceiptText, ReceiptParseResult?> {
+  /// One-shot stash for the [ReceiptParseResult] of an e-receipt **text** an
+  /// external app shared into Sparkilo (#2735 + #2838 / Epic #2687).
+  ///
+  /// The text sibling of [pendingSharedReceiptProvider]. An image / PDF share
+  /// stashes a file PATH that the Add-fill-up screen OCRs on open; a shared
+  /// text body, by contrast, is parsed by the pure-Dart [EReceiptTextParser]
+  /// in the share handler at receive time — there is no file to OCR — so the
+  /// already-parsed result is what gets stashed here. The Add-fill-up screen
+  /// consumes it on open and prefills the form through the SAME
+  /// `applyReceiptOutcome` body the camera / image-share paths use, so a text
+  /// receipt fills the form with zero prefill drift.
+  ///
+  /// **Lifecycle** mirrors the path stash: `set(result)` writes;
+  /// `consumeDeferred()` returns the value and clears via a microtask so it is
+  /// safe to call from the screen's `initState` (a Riverpod-locked phase).
+  PendingSharedReceiptTextProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'pendingSharedReceiptTextProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$pendingSharedReceiptTextHash();
+
+  @$internal
+  @override
+  PendingSharedReceiptText create() => PendingSharedReceiptText();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ReceiptParseResult? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ReceiptParseResult?>(value),
+    );
+  }
+}
+
+String _$pendingSharedReceiptTextHash() =>
+    r'b8e66951cc26c0ca44d1bd4624bc500a3127d212';
+
+/// One-shot stash for the [ReceiptParseResult] of an e-receipt **text** an
+/// external app shared into Sparkilo (#2735 + #2838 / Epic #2687).
+///
+/// The text sibling of [pendingSharedReceiptProvider]. An image / PDF share
+/// stashes a file PATH that the Add-fill-up screen OCRs on open; a shared
+/// text body, by contrast, is parsed by the pure-Dart [EReceiptTextParser]
+/// in the share handler at receive time — there is no file to OCR — so the
+/// already-parsed result is what gets stashed here. The Add-fill-up screen
+/// consumes it on open and prefills the form through the SAME
+/// `applyReceiptOutcome` body the camera / image-share paths use, so a text
+/// receipt fills the form with zero prefill drift.
+///
+/// **Lifecycle** mirrors the path stash: `set(result)` writes;
+/// `consumeDeferred()` returns the value and clears via a microtask so it is
+/// safe to call from the screen's `initState` (a Riverpod-locked phase).
+
+abstract class _$PendingSharedReceiptText
+    extends $Notifier<ReceiptParseResult?> {
+  ReceiptParseResult? build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final ref = this.ref as $Ref<ReceiptParseResult?, ReceiptParseResult?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<ReceiptParseResult?, ReceiptParseResult?>,
+              ReceiptParseResult?,
+              Object?,
+              Object?
+            >;
+    element.handleCreate(ref, build);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1644,38 +1644,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.21.0"
-  share_handler:
-    dependency: "direct main"
-    description:
-      name: share_handler
-      sha256: "0a6d007f0e44fbee27164adcd159ecbc88238864313f4e5c58161cae2180328d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.25"
-  share_handler_android:
-    dependency: transitive
-    description:
-      name: share_handler_android
-      sha256: caf555b933dc72783aa37fef75688c7b86bd6f7bc17d80fbf585bc42f123cc8d
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.11"
-  share_handler_ios:
-    dependency: transitive
-    description:
-      name: share_handler_ios
-      sha256: cdc21f88f336a944157a8e9ceb191525cee3b082d6eb6c2082488e4f09dc3ece
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.15"
-  share_handler_platform_interface:
-    dependency: transitive
-    description:
-      name: share_handler_platform_interface
-      sha256: "7a4df95a87b326b2f07458d937f2281874567c364b7b7ebe4e7d50efaae5f106"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.6"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,14 +90,12 @@ dependencies:
   # Pinned to 12.x — share_plus 13.x is a major bump; deferred to its
   # own migration pass (#1684).
   share_plus: ^12.0.2
-  # Inbound OS share-intent receiver (#2735 / Epic #2687) — a receipt
-  # image shared from another app lands in Sparkilo and prefills the
-  # Add fill-up form. OS-native + GMS-free (no Play Services / ML Kit),
-  # MIT-licensed. Android intent-filters are declared in
-  # AndroidManifest.xml; the iOS Share Extension target + App Group are
-  # deferred to #2736, so on iOS the share path simply receives nothing
-  # until that target ships — the package still builds without it.
-  share_handler: ^0.0.25
+  # Inbound OS share-intent receiver (#2735 / Epic #2687) is now served by
+  # the in-repo, GMS-free ShareIntentChannel (Android MethodChannel/
+  # EventChannel on MainActivity, declared via AndroidManifest intent-filters)
+  # — the third-party share_handler plugin was removed so the F-Droid build
+  # carries no extra share dependency that could drag in Play Services. iOS is
+  # deferred to #2736.
   # On-device PDF e-receipt rasteriser (#2737 / Epic #2687) — a shared PDF
   # receipt is rendered to a bitmap so it flows through the SAME ML Kit OCR
   # path as image shares. MIT-licensed and GMS-FREE: its Android renderer is

--- a/test/features/consumption/data/ereceipt/ereceipt_text_parser_test.dart
+++ b/test/features/consumption/data/ereceipt/ereceipt_text_parser_test.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/ereceipt/ereceipt_text_parser.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// #2838 — the pure-Dart e-receipt TEXT parser. Drives the REAL parsing
+/// stack (`EReceiptTextParser` → `ReceiptParser` → field extractors +
+/// currency profiles + reconciliation) against realistic Italian and German
+/// e-receipt text fixtures — the email-body / PDF-text-layer shape, NOT
+/// camera OCR. No email infra, no Flutter binding, no asset I/O.
+void main() {
+  const parser = EReceiptTextParser();
+
+  String fixture(String name) => File(
+        'test/features/consumption/data/ereceipt/fixtures/$name',
+      ).readAsStringSync();
+
+  group('EReceiptTextParser — Italian e-receipt fixtures', () {
+    test(
+        'Eni Milano: extracts litres / price-per-litre / grade / total / '
+        'station from a Gasolio document', () {
+      final result = parser.parse(fixture('eni_milano_2026-05-12.txt'),
+          countryCode: 'IT');
+
+      expect(result.liters, closeTo(42.18, 0.01));
+      expect(result.pricePerLiter, closeTo(1.789, 0.001));
+      expect(result.totalCost, closeTo(75.46, 0.01));
+      expect(result.fuelType, FuelType.diesel,
+          reason: '"Gasolio" is Italian for diesel');
+      expect(result.stationName, contains('Eni'));
+      expect(result.date, DateTime(2026, 5, 12));
+      expect(result.hasData, isTrue);
+    });
+
+    test(
+        'IP Roma: parses a Benzina HTML-email receipt despite CRLF + NBSP + '
+        'en-dash noise (exercises normalisation)', () {
+      final raw = fixture('ip_roma_2026-06-03.txt');
+      // Guard the fixture actually carries the digital-text quirks the
+      // normaliser exists to fold — otherwise this test would pass for the
+      // wrong reason if the fixture were ever rewritten as clean text.
+      expect(raw.contains('\r\n'), isTrue, reason: 'fixture must carry CRLF');
+      expect(raw.contains(' '), isTrue, reason: 'fixture must carry NBSP');
+
+      final result = parser.parse(raw, countryCode: 'IT');
+
+      expect(result.liters, closeTo(27.54, 0.01));
+      expect(result.pricePerLiter, closeTo(1.879, 0.001));
+      expect(result.totalCost, closeTo(51.75, 0.01));
+      expect(result.fuelType, FuelType.e5,
+          reason: '"Benzina" with no E10 qualifier is E5 in Italy');
+      expect(result.stationName, contains('IP'));
+      expect(result.date, DateTime(2026, 6, 3));
+    });
+  });
+
+  group('EReceiptTextParser — German e-receipt fixtures', () {
+    test(
+        'Shell Berlin: extracts the five fields from a digital "Quittung" with '
+        'V-Power Diesel', () {
+      final result = parser.parse(fixture('shell_berlin_2026-05-20.txt'),
+          countryCode: 'DE');
+
+      expect(result.liters, closeTo(51.72, 0.01));
+      expect(result.pricePerLiter, closeTo(1.929, 0.001));
+      expect(result.totalCost, closeTo(99.77, 0.01));
+      expect(result.fuelType, FuelType.dieselPremium,
+          reason: '"V-Power Diesel" is a premium diesel grade');
+      expect(result.stationName, contains('Shell'));
+      expect(result.date, DateTime(2026, 5, 20));
+    });
+
+    test('Aral Köln: e-mail Super E10 receipt with BETRAG / Literpreis labels',
+        () {
+      final result = parser.parse(fixture('aral_koeln_2026-05-28.txt'),
+          countryCode: 'DE');
+
+      expect(result.liters, closeTo(44.07, 0.01));
+      expect(result.pricePerLiter, closeTo(1.759, 0.001));
+      expect(result.totalCost, closeTo(77.52, 0.01),
+          reason: 'BETRAG is the charged total, not the Netto line');
+      expect(result.fuelType, FuelType.e10);
+      expect(result.stationName, contains('ARAL'));
+      expect(result.date, DateTime(2026, 5, 28));
+    });
+  });
+
+  group('EReceiptTextParser — reconciliation reuse', () {
+    test('derives the missing total from litres × price-per-litre', () {
+      // No "Importo"/"Totale" line at all — reconcile() must fill it in.
+      const text = 'Eni Station\n'
+          'Gasolio\n'
+          'Litri 30,00\n'
+          'Prezzo unitario 1,800 EUR/L\n';
+      final result = parser.parse(text, countryCode: 'IT');
+
+      expect(result.liters, closeTo(30.00, 0.01));
+      expect(result.pricePerLiter, closeTo(1.800, 0.001));
+      expect(result.totalCost, closeTo(54.00, 0.01),
+          reason: 'total = 30.00 × 1.800, derived by the shared reconcile()');
+    });
+  });
+
+  group('EReceiptTextParser — empty / non-receipt input', () {
+    test('blank input returns an empty result rather than throwing', () {
+      final result = parser.parse('   \n\n  ');
+      expect(result.hasData, isFalse);
+      expect(result.liters, isNull);
+      expect(result.totalCost, isNull);
+    });
+
+    test('an unrelated text body parses no fuel fields', () {
+      final result = parser.parse(
+        'Hi! Thanks for your order. Your package ships tomorrow.',
+        countryCode: 'DE',
+      );
+      expect(result.hasData, isFalse);
+    });
+
+    test('looksLikeReceipt gates on extractable fuel data', () {
+      expect(
+        parser.looksLikeReceipt(fixture('eni_milano_2026-05-12.txt'),
+            countryCode: 'IT'),
+        isTrue,
+      );
+      expect(parser.looksLikeReceipt('just a note', countryCode: 'IT'), isFalse);
+    });
+  });
+
+  group('EReceiptTextParser — currency profile threading', () {
+    test('a GB receipt reads pence-per-litre via the GB profile', () {
+      // 142.9 p/L folds to £1.429/L; the GB band (0.8–3.0) accepts it,
+      // proving the country → OcrLocaleProfile lookup reached the currency
+      // extractors. Under the default EUR profile this would be rejected.
+      const text = 'Shell\n'
+          'Unleaded\n'
+          'Volume 40.00 L\n'
+          '142.9p/L\n'
+          'TOTAL £57.16\n';
+      final result = parser.parse(text, countryCode: 'GB');
+
+      expect(result.pricePerLiter, closeTo(1.429, 0.001));
+      expect(result.totalCost, closeTo(57.16, 0.01));
+    });
+
+    test('an unknown country code falls back to EUR without throwing', () {
+      final result = parser.parse(
+        fixture('eni_milano_2026-05-12.txt'),
+        countryCode: 'ZZ',
+      );
+      // EUR default still parses an EUR receipt fine.
+      expect(result.liters, closeTo(42.18, 0.01));
+      expect(result.totalCost, closeTo(75.46, 0.01));
+    });
+  });
+}

--- a/test/features/consumption/data/ereceipt/fixtures/aral_koeln_2026-05-28.txt
+++ b/test/features/consumption/data/ereceipt/fixtures/aral_koeln_2026-05-28.txt
@@ -1,0 +1,18 @@
+ARAL Tankstelle
+Aachener Straße 220
+50931 Köln
+Steuernummer: 217/5703/0455
+
+Quittung (E-Mail)
+Datum 28.05.2026 07:31
+
+Zapfsaeule 3
+Kraftstoff: Super E10
+Menge                  44,07 L
+Literpreis             1,759 EUR/L
+BETRAG                 77,52 EUR
+
+Netto                  65,14 EUR
+MwSt 19,00 %           12,38 EUR
+
+Diese Quittung wurde elektronisch erstellt.

--- a/test/features/consumption/data/ereceipt/fixtures/eni_milano_2026-05-12.txt
+++ b/test/features/consumption/data/ereceipt/fixtures/eni_milano_2026-05-12.txt
@@ -1,0 +1,19 @@
+Eni Station
+Via Melchiorre Gioia 45
+20124 Milano (MI)
+P.IVA 00905811006
+
+DOCUMENTO COMMERCIALE
+di vendita o prestazione
+
+Data 12/05/2026 18:42
+Pompa 4                Gasolio
+
+Litri                  42,18
+Prezzo unitario        1,789 EUR/L
+Importo                75,46 EUR
+
+Totale documento       75,46 EUR
+Pagamento contante     75,46 EUR
+
+Arrivederci e grazie

--- a/test/features/consumption/data/ereceipt/fixtures/ip_roma_2026-06-03.txt
+++ b/test/features/consumption/data/ereceipt/fixtures/ip_roma_2026-06-03.txt
@@ -1,0 +1,15 @@
+IP Gruppo api
+Stazione di Servizio
+Viale Lazio 8
+00198 Roma (RM)
+
+Ricevuta digitale
+Data: 03/06/2026 09:17
+Erogatore 2 – Benzina
+
+Litri      27,540
+Prezzo al litro   1,879 €/L
+Importo      51,75 €
+
+Totale      51,75 €
+Grazie per averci scelto

--- a/test/features/consumption/data/ereceipt/fixtures/shell_berlin_2026-05-20.txt
+++ b/test/features/consumption/data/ereceipt/fixtures/shell_berlin_2026-05-20.txt
@@ -1,0 +1,19 @@
+Shell Deutschland
+Station 1234
+Holzmarktstraße 19
+10243 Berlin
+
+Ihre digitale Quittung
+
+Datum: 20.05.2026 14:08 Uhr
+Beleg-Nr. 0042-115
+
+Produkt: Shell V-Power Diesel
+Menge: 51,72 L
+Literpreis: 1,929 EUR/L
+Gesamtbetrag: 99,77 EUR
+
+Zahlung: girocard
+MwSt 19,00 % enthalten
+
+Vielen Dank für Ihren Einkauf

--- a/test/features/consumption/data/share/shared_receipt_intent_test.dart
+++ b/test/features/consumption/data/share/shared_receipt_intent_test.dart
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/share/'
+    'shared_receipt_intent.dart';
+
+/// #2735 — the platform-channel decode boundary. The GMS-free
+/// `ShareIntentChannel.kt` emits exactly the `{items:[...], country:"..."}`
+/// map shape these tests drive, so this pins that the Dart side decodes the
+/// real native payload (and drops malformed entries) rather than echoing a
+/// hand-built object — the data-shape contract between Kotlin and Dart.
+void main() {
+  group('SharedReceiptItem.fromMap', () {
+    test('decodes each kind to the matching field', () {
+      expect(
+        SharedReceiptItem.fromMap({'kind': 'image', 'path': '/c/a.jpg'}),
+        const SharedReceiptItem.image('/c/a.jpg'),
+      );
+      expect(
+        SharedReceiptItem.fromMap({'kind': 'pdf', 'path': '/c/a.pdf'}),
+        const SharedReceiptItem.pdf('/c/a.pdf'),
+      );
+      expect(
+        SharedReceiptItem.fromMap({'kind': 'text', 'text': 'Litri 30,00'}),
+        const SharedReceiptItem.text('Litri 30,00'),
+      );
+      expect(
+        SharedReceiptItem.fromMap({'kind': 'file', 'path': '/c/a.bin'}),
+        const SharedReceiptItem.file('/c/a.bin'),
+      );
+    });
+
+    test('returns null for a malformed / mismatched entry', () {
+      expect(SharedReceiptItem.fromMap(null), isNull);
+      expect(SharedReceiptItem.fromMap('not a map'), isNull);
+      expect(SharedReceiptItem.fromMap({'kind': 'image'}), isNull,
+          reason: 'an image item with no path is malformed');
+      expect(SharedReceiptItem.fromMap({'kind': 'text', 'text': ''}), isNull,
+          reason: 'an empty text body carries nothing actionable');
+      expect(SharedReceiptItem.fromMap({'kind': 'video', 'path': '/x'}), isNull,
+          reason: 'an unknown kind is rejected');
+    });
+  });
+
+  group('SharedReceiptIntent.fromPlatform', () {
+    test('decodes the items list and the country code', () {
+      final intent = SharedReceiptIntent.fromPlatform({
+        'items': [
+          {'kind': 'image', 'path': '/c/a.jpg'},
+          {'kind': 'text', 'text': 'Gasolio'},
+        ],
+        'country': 'IT',
+      });
+      expect(intent, isNotNull);
+      expect(intent!.items, hasLength(2));
+      expect(intent.countryCode, 'IT');
+      expect(intent.isEmpty, isFalse);
+    });
+
+    test('drops malformed items individually but keeps the good ones', () {
+      final intent = SharedReceiptIntent.fromPlatform({
+        'items': [
+          {'kind': 'image', 'path': '/c/a.jpg'},
+          {'kind': 'image'}, // malformed — dropped
+          'garbage', // not a map — dropped
+        ],
+      });
+      expect(intent, isNotNull);
+      expect(intent!.items, hasLength(1));
+      expect(intent.items.single, const SharedReceiptItem.image('/c/a.jpg'));
+      expect(intent.countryCode, isNull);
+    });
+
+    test('returns null for a null / non-map / itemless payload', () {
+      expect(SharedReceiptIntent.fromPlatform(null), isNull);
+      expect(SharedReceiptIntent.fromPlatform('x'), isNull);
+      expect(SharedReceiptIntent.fromPlatform({'country': 'IT'}), isNull,
+          reason: 'no items → nothing to route');
+      expect(
+        SharedReceiptIntent.fromPlatform({
+          'items': [
+            {'kind': 'image'},
+          ],
+        }),
+        isNull,
+        reason: 'all items malformed → null, not an empty intent',
+      );
+    });
+
+    test('an empty / blank country code decodes to null', () {
+      final intent = SharedReceiptIntent.fromPlatform({
+        'items': [
+          {'kind': 'text', 'text': 'Diesel'},
+        ],
+        'country': '',
+      });
+      expect(intent, isNotNull);
+      expect(intent!.countryCode, isNull);
+    });
+  });
+}

--- a/test/features/consumption/presentation/screens/add_fill_up_screen_share_receipt_test.dart
+++ b/test/features/consumption/presentation/screens/add_fill_up_screen_share_receipt_test.dart
@@ -9,11 +9,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:tankstellen/features/consumption/data/ereceipt/ereceipt_text_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
 import 'package:tankstellen/features/consumption/data/receipt_scan_service.dart';
 import 'package:tankstellen/features/consumption/presentation/screens/add_fill_up_screen.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/fill_up_numeric_field.dart';
 import 'package:tankstellen/features/consumption/providers/pending_shared_receipt_provider.dart';
+import 'package:tankstellen/features/consumption/providers/pending_shared_receipt_text_provider.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
@@ -164,6 +166,59 @@ void main() {
     });
   });
 
+  testWidgets(
+      'a stashed shared-receipt TEXT result prefills the form via the real '
+      'e-receipt parser (#2838)', (tester) async {
+    // The share handler parses shared text at receive time; the screen
+    // applies the stashed result through the same prefill body. Seed the
+    // stash with the REAL EReceiptTextParser's output for a German e-receipt
+    // fixture so this drives the actual parse→apply path end to end.
+    final parsed = const EReceiptTextParser().parse(
+      File('test/features/consumption/data/ereceipt/fixtures/'
+              'aral_koeln_2026-05-28.txt')
+          .readAsStringSync(),
+      countryCode: 'DE',
+    );
+    expect(parsed.hasData, isTrue, reason: 'fixture must parse');
+
+    final router = GoRouter(
+      initialLocation: '/add',
+      routes: [
+        GoRoute(
+          path: '/add',
+          builder: (context, state) => const AddFillUpScreen(),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vehicleProfileListProvider.overrideWith(() => _StubVehicleList()),
+          featureFlagsProvider.overrideWith(() => _ShareIntentEnabled()),
+          pendingSharedReceiptTextProvider.overrideWith(
+            () => _SeededPendingSharedReceiptText(parsed),
+          ),
+        ],
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The Aral Köln fixture parses to 44.07 L / €77.52 — the apply body
+    // formats them to 2 decimals into the controllers.
+    expect(_valueOf(tester, 'Liters'), '44.07',
+        reason: 'the shared text result prefilled litres');
+    expect(_valueOf(tester, 'Total cost'), '77.52',
+        reason: 'the shared text result prefilled the total');
+  });
+
   testWidgets('no stashed path → the form opens blank (manual entry)',
       (tester) async {
     final router = GoRouter(
@@ -207,4 +262,15 @@ class _SeededPendingSharedReceipt extends PendingSharedReceipt {
 
   @override
   String? build() => _path;
+}
+
+/// Seeds [pendingSharedReceiptTextProvider] with a parsed result at build so
+/// the screen applies it on open, simulating the share handler having parsed
+/// shared e-receipt text before routing to `/consumption/add` (#2838).
+class _SeededPendingSharedReceiptText extends PendingSharedReceiptText {
+  _SeededPendingSharedReceiptText(this._result);
+  final ReceiptParseResult _result;
+
+  @override
+  ReceiptParseResult? build() => _result;
 }

--- a/test/features/consumption/presentation/widgets/share_receipt_handler_test.dart
+++ b/test/features/consumption/presentation/widgets/share_receipt_handler_test.dart
@@ -1,27 +1,32 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:share_handler/share_handler.dart';
 import 'package:tankstellen/app/router.dart';
 import 'package:tankstellen/features/consumption/data/ocr/'
     'receipt_pdf_rasterizer.dart';
+import 'package:tankstellen/features/consumption/data/share/'
+    'shared_receipt_intent.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/'
     'share_receipt_handler.dart';
 import 'package:tankstellen/features/consumption/providers/'
     'pending_shared_receipt_provider.dart';
+import 'package:tankstellen/features/consumption/providers/'
+    'pending_shared_receipt_text_provider.dart';
 import 'package:tankstellen/features/feature_management/application/'
     'feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
-/// A real [GoRouter] with `/` and `/consumption/add` routes so the
-/// handler's `push` resolves exactly as production does and the landed
-/// route can be asserted (the same fake-router-by-real-route pattern as
-/// `notification_launch_listener_test.dart`).
+/// A real [GoRouter] with `/` and `/consumption/add` routes so the handler's
+/// `push` resolves exactly as production does (the same fake-router-by-real-
+/// route pattern as `notification_launch_listener_test.dart`).
 GoRouter _router({String? Function()? onAdd}) {
   return GoRouter(
     initialLocation: '/',
@@ -38,36 +43,27 @@ GoRouter _router({String? Function()? onAdd}) {
   );
 }
 
-SharedMedia _imageMedia(String path) => SharedMedia(
-      attachments: [
-        SharedAttachment(path: path, type: SharedAttachmentType.image),
-      ],
-    );
+SharedReceiptIntent _imageIntent(String path) =>
+    SharedReceiptIntent(items: [SharedReceiptItem.image(path)]);
 
-/// A shared PDF arrives via `share_handler` as a `file` attachment (the
-/// package has no `pdf` type and carries no MIME) — the handler keys off
-/// the `.pdf` extension.
-SharedMedia _pdfMedia(String path) => SharedMedia(
-      attachments: [
-        SharedAttachment(path: path, type: SharedAttachmentType.file),
-      ],
-    );
+SharedReceiptIntent _pdfIntent(String path) =>
+    SharedReceiptIntent(items: [SharedReceiptItem.pdf(path)]);
 
-/// A genuinely-unsupported share (video, or a non-PDF arbitrary file).
-SharedMedia _fileMedia(String path) => SharedMedia(
-      attachments: [
-        SharedAttachment(path: path, type: SharedAttachmentType.file),
-      ],
+SharedReceiptIntent _fileIntent(String path) =>
+    SharedReceiptIntent(items: [SharedReceiptItem.file(path)]);
+
+SharedReceiptIntent _textIntent(String text, {String? country}) =>
+    SharedReceiptIntent(
+      items: [SharedReceiptItem.text(text)],
+      countryCode: country,
     );
 
 /// Test double for the on-device PDF rasteriser (#2737) — the native
 /// PdfRenderer is unavailable under `flutter test`, so the PDF branch is
-/// driven with an injected fake that records the path it was asked to
-/// rasterise and returns a canned result.
+/// driven with an injected fake that records the path and returns a canned
+/// result.
 class _FakeRasterizer extends ReceiptPdfRasterizer {
   _FakeRasterizer(this._result);
-
-  /// The JPEG path the rasteriser "produced", or null to model failure.
   final String? _result;
   String? receivedPdfPath;
 
@@ -77,6 +73,10 @@ class _FakeRasterizer extends ReceiptPdfRasterizer {
     return _result;
   }
 }
+
+String _fixture(String name) => File(
+      'test/features/consumption/data/ereceipt/fixtures/$name',
+    ).readAsStringSync();
 
 void main() {
   silenceErrorLoggerSpool();
@@ -107,7 +107,7 @@ void main() {
     return container;
   }
 
-  group('ShareReceiptHandler.handle', () {
+  group('ShareReceiptHandler.handle — image', () {
     testWidgets('stashes a shared image path and routes to /consumption/add',
         (tester) async {
       final router = _router();
@@ -115,7 +115,7 @@ void main() {
 
       container
           .read(shareReceiptHandlerProvider)
-          .handle(_imageMedia('/tmp/receipt.jpg'));
+          .handle(_imageIntent('/tmp/receipt.jpg'));
       await tester.pumpAndSettle();
 
       expect(container.read(pendingSharedReceiptProvider), '/tmp/receipt.jpg',
@@ -131,17 +131,19 @@ void main() {
 
       container
           .read(shareReceiptHandlerProvider)
-          .handle(_imageMedia('/tmp/receipt.jpg'));
+          .handle(_imageIntent('/tmp/receipt.jpg'));
       await tester.pumpAndSettle();
 
       expect(container.read(pendingSharedReceiptProvider), isNull,
           reason: 'a disabled feature must never stash or route');
       expect(find.text('home'), findsOneWidget);
     });
+  });
 
+  group('ShareReceiptHandler.handle — PDF (#2737)', () {
     testWidgets(
-        'a shared PDF is rasterised, then takes the SAME stash+route '
-        'path as an image (#2737)', (tester) async {
+        'a shared PDF is rasterised, then takes the SAME stash+route path '
+        'as an image', (tester) async {
       final router = _router();
       final fake = _FakeRasterizer('/tmp/receipt.pdf.page1.jpg');
       final container = await pump(tester,
@@ -149,40 +151,90 @@ void main() {
 
       container
           .read(shareReceiptHandlerProvider)
-          .handle(_pdfMedia('/tmp/receipt.pdf'));
+          .handle(_pdfIntent('/tmp/receipt.pdf'));
       await tester.pumpAndSettle();
 
-      expect(fake.receivedPdfPath, '/tmp/receipt.pdf',
-          reason: 'the PDF path must be handed to the rasteriser');
+      expect(fake.receivedPdfPath, '/tmp/receipt.pdf');
       expect(container.read(pendingSharedReceiptProvider),
           '/tmp/receipt.pdf.page1.jpg',
-          reason: 'the rasterised JPEG must be stashed for the SAME OCR path '
-              'an image share uses (#2737)');
-      expect(find.text('add-fill-up'), findsOneWidget,
-          reason: 'a rasterised PDF routes the user to the Add-fill-up form');
+          reason: 'the rasterised JPEG must be stashed for the SAME OCR path');
+      expect(find.text('add-fill-up'), findsOneWidget);
     });
 
-    testWidgets(
-        'a PDF whose rasterisation fails does NOT stash or route '
-        '(graceful fallback)', (tester) async {
+    testWidgets('a PDF whose rasterisation fails does NOT stash or route',
+        (tester) async {
       final router = _router();
-      // A null result models a corrupt PDF / absent native renderer.
       final fake = _FakeRasterizer(null);
       final container = await pump(tester,
           router: router, enabled: featureOn, rasterizer: fake);
 
       container
           .read(shareReceiptHandlerProvider)
-          .handle(_pdfMedia('/tmp/corrupt.pdf'));
+          .handle(_pdfIntent('/tmp/corrupt.pdf'));
       await tester.pumpAndSettle();
 
       expect(fake.receivedPdfPath, '/tmp/corrupt.pdf');
       expect(container.read(pendingSharedReceiptProvider), isNull,
-          reason: 'a failed rasterisation must fall back gracefully, not '
-              'stash a non-existent bitmap');
+          reason: 'a failed rasterisation must fall back gracefully');
+      expect(find.text('home'), findsOneWidget);
+    });
+  });
+
+  group('ShareReceiptHandler.handle — text (#2838)', () {
+    testWidgets(
+        'a shared e-receipt text body is parsed by the REAL parser and the '
+        'result stashed + routed', (tester) async {
+      final router = _router();
+      final container = await pump(tester, router: router, enabled: featureOn);
+
+      container.read(shareReceiptHandlerProvider).handle(
+            _textIntent(_fixture('eni_milano_2026-05-12.txt'), country: 'IT'),
+          );
+      await tester.pumpAndSettle();
+
+      final result = container.read(pendingSharedReceiptTextProvider);
+      expect(result, isNotNull,
+          reason: 'the parsed text result must be stashed for the form');
+      expect(result!.liters, closeTo(42.18, 0.01));
+      expect(result.totalCost, closeTo(75.46, 0.01));
+      expect(result.fuelType, FuelType.diesel);
+      // The path stash stays empty — a text share has no file to OCR.
+      expect(container.read(pendingSharedReceiptProvider), isNull);
+      expect(find.text('add-fill-up'), findsOneWidget,
+          reason: 'a parseable text receipt routes to the Add-fill-up form');
+    });
+
+    testWidgets('a text body with no parseable receipt does NOT stash or route',
+        (tester) async {
+      final router = _router();
+      final container = await pump(tester, router: router, enabled: featureOn);
+
+      container
+          .read(shareReceiptHandlerProvider)
+          .handle(_textIntent('Hi! Your order ships tomorrow.', country: 'DE'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(pendingSharedReceiptTextProvider), isNull,
+          reason: 'non-receipt text must not route to a blank form');
       expect(find.text('home'), findsOneWidget);
     });
 
+    testWidgets('text share is also gated by the opt-in feature flag',
+        (tester) async {
+      final router = _router();
+      final container = await pump(tester, router: router, enabled: const {});
+
+      container.read(shareReceiptHandlerProvider).handle(
+            _textIntent(_fixture('eni_milano_2026-05-12.txt'), country: 'IT'),
+          );
+      await tester.pumpAndSettle();
+
+      expect(container.read(pendingSharedReceiptTextProvider), isNull);
+      expect(find.text('home'), findsOneWidget);
+    });
+  });
+
+  group('ShareReceiptHandler.handle — unsupported / empty', () {
     testWidgets('a non-PDF file is never sent to the rasteriser (unsupported)',
         (tester) async {
       final router = _router();
@@ -192,27 +244,26 @@ void main() {
 
       container
           .read(shareReceiptHandlerProvider)
-          .handle(_fileMedia('/tmp/statement.docx'));
+          .handle(_fileIntent('/tmp/statement.docx'));
       await tester.pumpAndSettle();
 
-      expect(fake.receivedPdfPath, isNull,
-          reason: 'only .pdf files are rasterised; other files are '
-              'unsupported');
+      expect(fake.receivedPdfPath, isNull);
       expect(container.read(pendingSharedReceiptProvider), isNull);
       expect(find.text('home'), findsOneWidget);
     });
 
-    testWidgets('null / empty media is a no-op', (tester) async {
+    testWidgets('null / empty intent is a no-op', (tester) async {
       final router = _router();
       final container = await pump(tester, router: router, enabled: featureOn);
 
       container.read(shareReceiptHandlerProvider).handle(null);
       container
           .read(shareReceiptHandlerProvider)
-          .handle(SharedMedia(attachments: const []));
+          .handle(const SharedReceiptIntent(items: []));
       await tester.pumpAndSettle();
 
       expect(container.read(pendingSharedReceiptProvider), isNull);
+      expect(container.read(pendingSharedReceiptTextProvider), isNull);
       expect(find.text('home'), findsOneWidget);
     });
   });
@@ -220,10 +271,6 @@ void main() {
   group('ShareReceiptHandler — never throws (#2349 fault injection)', () {
     testWidgets('returns normally when a downstream read throws',
         (tester) async {
-      // Inject a feature-flags read that throws — the handler's gate
-      // read is the first downstream dependency, and the #2349 contract
-      // says a thrown dependency must be caught + logged, never
-      // propagated out of the platform stream callback.
       final router = _router();
       final container = ProviderContainer(
         overrides: [
@@ -243,12 +290,11 @@ void main() {
       expect(
         () => container
             .read(shareReceiptHandlerProvider)
-            .handle(_imageMedia('/tmp/receipt.jpg')),
+            .handle(_imageIntent('/tmp/receipt.jpg')),
         returnsNormally,
         reason: 'a thrown downstream dependency must be caught + logged, '
             'never propagated (#2349)',
       );
-      // A failed gate read defaults to "disabled" → no stash, no route.
       expect(container.read(pendingSharedReceiptProvider), isNull);
       expect(find.text('home'), findsOneWidget);
     });

--- a/test/features/consumption/presentation/widgets/share_receipt_listener_test.dart
+++ b/test/features/consumption/presentation/widgets/share_receipt_listener_test.dart
@@ -7,9 +7,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:share_handler/share_handler.dart';
 import 'package:tankstellen/app/router.dart';
+import 'package:tankstellen/features/consumption/data/share/'
+    'share_intent_channel.dart';
+import 'package:tankstellen/features/consumption/data/share/'
+    'shared_receipt_intent.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/'
     'share_receipt_listener.dart';
 import 'package:tankstellen/features/consumption/providers/'
@@ -19,33 +21,33 @@ import 'package:tankstellen/features/feature_management/application/'
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
-/// Fake [ShareHandlerPlatform] whose cold-launch media + warm stream the
-/// test drives. `initialThrows` forces `getInitialSharedMedia` to throw,
-/// and `addError` on [controller] simulates a platform-channel stream
-/// fault — both #2349 fault-injection seams.
-class _FakeShareHandler extends ShareHandlerPlatform
-    with MockPlatformInterfaceMixin {
-  _FakeShareHandler({this.initial, this.initialThrows = false});
+/// Fake [ShareIntentChannel] whose cold-launch share + warm stream the test
+/// drives. `initialThrows` forces `getInitialShare` to throw, and `addError`
+/// on [controller] simulates a platform-channel stream fault — both #2349
+/// fault-injection seams. Replaces the old `ShareHandlerPlatform` fake now
+/// that the GMS-free in-repo channel owns the share path.
+class _FakeShareChannel implements ShareIntentChannel {
+  _FakeShareChannel({this.initial, this.initialThrows = false});
 
-  final SharedMedia? initial;
+  final SharedReceiptIntent? initial;
   final bool initialThrows;
   // Closed by the test's addTearDown — the linter can't trace it there.
   // ignore: close_sinks
-  final controller = StreamController<SharedMedia>.broadcast();
+  final controller = StreamController<SharedReceiptIntent>.broadcast();
 
   @override
-  Future<SharedMedia?> getInitialSharedMedia() async {
-    if (initialThrows) throw StateError('initial-media probe barfed');
+  Future<SharedReceiptIntent?> getInitialShare() async {
+    if (initialThrows) throw StateError('initial-share probe barfed');
     return initial;
   }
 
   @override
-  Stream<SharedMedia> get sharedMediaStream => controller.stream;
+  Stream<SharedReceiptIntent> get shareStream => controller.stream;
 }
 
-/// A real [GoRouter] with `/` + `/consumption/add` so a routed share can
-/// be asserted via the landed route (GoRouter is a factory — it cannot
-/// be subclassed, so we drive a real one, same as the notification test).
+/// A real [GoRouter] with `/` + `/consumption/add` so a routed share can be
+/// asserted via the landed route (GoRouter is a factory — it cannot be
+/// subclassed, so we drive a real one, same as the notification test).
 GoRouter _router() => GoRouter(
       initialLocation: '/',
       routes: [
@@ -57,20 +59,17 @@ GoRouter _router() => GoRouter(
       ],
     );
 
-SharedMedia _imageMedia(String path) => SharedMedia(
-      attachments: [
-        SharedAttachment(path: path, type: SharedAttachmentType.image),
-      ],
-    );
+SharedReceiptIntent _imageIntent(String path) =>
+    SharedReceiptIntent(items: [SharedReceiptItem.image(path)]);
 
 Future<ProviderContainer> _pumpListener(
   WidgetTester tester, {
-  required _FakeShareHandler handler,
+  required _FakeShareChannel channel,
   required GoRouter router,
   Set<Feature> enabled = const {Feature.addFillUpShareIntentReceipt},
   bool gateThrows = false,
 }) async {
-  addTearDown(() => handler.controller.close());
+  addTearDown(() => channel.controller.close());
   final container = ProviderContainer(
     overrides: [
       if (gateThrows)
@@ -88,7 +87,7 @@ Future<ProviderContainer> _pumpListener(
       child: MaterialApp.router(
         routerConfig: router,
         builder: (context, child) => ShareReceiptListener(
-          shareHandler: handler,
+          shareChannel: channel,
           child: child ?? const SizedBox(),
         ),
       ),
@@ -103,14 +102,14 @@ void main() {
   group('ShareReceiptListener — warm share', () {
     testWidgets('a streamed image share is routed through the handler',
         (tester) async {
-      final handler = _FakeShareHandler();
+      final channel = _FakeShareChannel();
       final container = await _pumpListener(
         tester,
-        handler: handler,
+        channel: channel,
         router: _router(),
       );
 
-      handler.controller.add(_imageMedia('/tmp/warm.jpg'));
+      channel.controller.add(_imageIntent('/tmp/warm.jpg'));
       await tester.pumpAndSettle();
 
       expect(container.read(pendingSharedReceiptProvider), '/tmp/warm.jpg');
@@ -119,17 +118,17 @@ void main() {
   });
 
   group('ShareReceiptListener — cold share', () {
-    testWidgets('the initial shared media is dispatched after first frame',
+    testWidgets('the initial shared intent is dispatched after first frame',
         (tester) async {
-      final handler = _FakeShareHandler(initial: _imageMedia('/tmp/cold.jpg'));
+      final channel = _FakeShareChannel(initial: _imageIntent('/tmp/cold.jpg'));
       final container = await _pumpListener(
         tester,
-        handler: handler,
+        channel: channel,
         router: _router(),
       );
 
-      // getInitialSharedMedia resolves async, then a post-frame callback
-      // dispatches it — settle to drain both.
+      // getInitialShare resolves async, then a post-frame callback dispatches
+      // it — settle to drain both.
       await tester.pumpAndSettle();
 
       expect(container.read(pendingSharedReceiptProvider), '/tmp/cold.jpg');
@@ -141,24 +140,20 @@ void main() {
     testWidgets(
         'a failing initial probe + a stream error + a throwing downstream '
         'still pump normally', (tester) async {
-      // Cold probe throws, the gate read throws (handler downstream
-      // fault), and the warm stream emits a raw error event — all three
-      // surfaces the listener funnels. None may escape as an unhandled
-      // async error or fail the pump.
-      final handler = _FakeShareHandler(initialThrows: true);
+      final channel = _FakeShareChannel(initialThrows: true);
       await _pumpListener(
         tester,
-        handler: handler,
+        channel: channel,
         router: _router(),
         gateThrows: true,
       );
       await tester.pumpAndSettle();
 
       // A warm image share whose downstream gate read throws — emitting it
-      // must return normally (the dispatch is synchronous; the throw is
-      // caught inside the handler, never propagated out of the callback).
+      // must return normally (the throw is caught inside the handler, never
+      // propagated out of the callback).
       expect(
-        () => handler.controller.add(_imageMedia('/tmp/boom.jpg')),
+        () => channel.controller.add(_imageIntent('/tmp/boom.jpg')),
         returnsNormally,
         reason: 'a thrown downstream must be swallowed, not propagated '
             'out of the stream callback (#2349)',
@@ -167,13 +162,13 @@ void main() {
 
       // A raw stream error event — caught by the listener's onError.
       expect(
-        () => handler.controller.addError(StateError('platform channel error')),
+        () => channel.controller.addError(StateError('platform channel error')),
         returnsNormally,
       );
       await tester.pump();
 
-      // No exception bubbled out of the pumps — the listener is alive,
-      // still showing home (nothing was routed because the gate threw).
+      // No exception bubbled out of the pumps — the listener is alive, still
+      // showing home (nothing routed because the gate threw).
       expect(find.text('home'), findsOneWidget);
     });
   });

--- a/test/features/consumption/providers/pending_shared_receipt_text_provider_test.dart
+++ b/test/features/consumption/providers/pending_shared_receipt_text_provider_test.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
+import 'package:tankstellen/features/consumption/providers/'
+    'pending_shared_receipt_text_provider.dart';
+
+/// #2838 — the one-shot stash for a parsed e-receipt TEXT result the share
+/// handler writes and the AddFillUpScreen reads. Mirrors the path-stash
+/// lifecycle test, focusing on the build-phase-safe `consumeDeferred`.
+void main() {
+  group('PendingSharedReceiptText', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+      addTearDown(container.dispose);
+    });
+
+    const result = ReceiptParseResult(liters: 30, totalCost: 54);
+
+    test('starts empty (null)', () {
+      expect(container.read(pendingSharedReceiptTextProvider), isNull);
+    });
+
+    test('set(result) stores it; subsequent read returns it', () {
+      container.read(pendingSharedReceiptTextProvider.notifier).set(result);
+      expect(container.read(pendingSharedReceiptTextProvider), same(result));
+    });
+
+    test('consumeDeferred() returns the result now, clears on a microtask',
+        () async {
+      container.read(pendingSharedReceiptTextProvider.notifier).set(result);
+      final returned = container
+          .read(pendingSharedReceiptTextProvider.notifier)
+          .consumeDeferred();
+      expect(returned, same(result),
+          reason: 'the result is returned synchronously for the screen to '
+              'apply in the same frame');
+      expect(container.read(pendingSharedReceiptTextProvider), same(result),
+          reason: 'the clear is deferred to avoid the build-phase write assert');
+      await Future<void>.value();
+      expect(container.read(pendingSharedReceiptTextProvider), isNull,
+          reason: 'the microtask clears the stash');
+    });
+
+    test('consumeDeferred() on an empty stash is a no-op (returns null)', () {
+      final returned = container
+          .read(pendingSharedReceiptTextProvider.notifier)
+          .consumeDeferred();
+      expect(returned, isNull);
+      expect(container.read(pendingSharedReceiptTextProvider), isNull);
+    });
+
+    test('set(null) clears an existing stash', () {
+      container.read(pendingSharedReceiptTextProvider.notifier).set(result);
+      container.read(pendingSharedReceiptTextProvider.notifier).set(null);
+      expect(container.read(pendingSharedReceiptTextProvider), isNull);
+    });
+  });
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -251,8 +251,14 @@ void main() {
     // `fill_up_share_scan_handlers.dart`, NOT here, to keep this file's
     // growth to the call site + dartdoc). Decomposition stays tracked under
     // #2187/#2188/#2190.
+    // #2838 — realign 537 → 539: the actual file already stood at 539 on
+    // master (#2840/#2841 grew it +2 without bumping this snapshot). The
+    // share-intent text-prefill wiring here is net-zero on the file (the
+    // single existing `scheduleSharedReceiptScanIfPending` call site was
+    // renamed in place to `scheduleSharedReceiptPrefillIfPending`, which
+    // drains both stashes), so this only corrects the snapshot to reality.
     'lib/features/consumption/presentation/screens/add_fill_up_screen.dart':
-        537,
+        539,
     // #2380 — +5: closest-station radar card at the top of the
     // recording column + a SingleChildScrollView wrap so the longer
     // column (radar + 5 metric cards + coaching card) scrolls instead


### PR DESCRIPTION
## Summary

Two commits, both children of Epic #2687.

### #2838 — pure-Dart e-receipt **text** parser
A focused, pure-Dart parser for digital fuel-receipt TEXT (forwarded
e-receipt e-mail body, copied SMS confirmation, shared PDF text layer). It
**reuses** the shipped receipt primitives end-to-end — brand detection,
per-brand layouts, currency-aware field extractors, cross-field
reconciliation — so an e-receipt and a camera-OCR'd photo extract the same
five fields (litres, price-per-litre, fuel grade, total, station/brand)
through one implementation.

- `EReceiptTextParser` wraps `ReceiptParser` with light normalisation
  (CRLF/CR → `\n`, NBSP/narrow-NBSP/thin-space → space, zero-width/BOM
  stripped) so HTML-email + PDF-text-layer input matches without
  per-source special-casing. Synchronous, no Flutter binding, no asset I/O.
- `EReceiptLocaleProfiles` maps a country code → `const OcrLocaleProfile`
  (pure-Dart, mirrors the shipped `index.json` bands).
- Italian coverage added to the shared extractors (additive, data-only):
  Gasolio/Benzina/Metano + premium-diesel fuel labels, the Litri/Quantità
  volume label, Importo/Totale total label, Prezzo unitario/al litro
  per-litre label, and Eni/enilive/IP/Q8/Tamoil/Api brand detection.
- Unit-tested with realistic **Italian** (Eni Milano Gasolio, IP Roma
  Benzina with CRLF+NBSP+en-dash noise) and **German** (Shell Berlin
  V-Power Diesel, Aral Köln Super E10) e-receipt text fixtures — no email
  infra. The IP fixture's raw CRLF/NBSP bytes are pinned via
  `.gitattributes` so EOL normalisation can't silently defeat the test.

### #2735 — GMS-free Android share-intent → fill-up prefill
Replaces the third-party `share_handler` plugin (dropped to keep the
F-Droid build free of any Play-Services risk) with an in-repo, GMS-free
share receiver, and routes shared **text** through the #2838 parser.

- **Native** `ShareIntentChannel.kt` — the SAME app-internal
  MethodChannel/EventChannel pattern as `Obd2ClassicPlugin` /
  `PublicFileExporterChannel` (only the Android framework + Flutter; **no**
  `com.google.android.gms` / `com.google.mlkit`). Decodes ACTION_SEND /
  ACTION_SEND_MULTIPLE: `EXTRA_TEXT` → a text item, `EXTRA_STREAM` content
  URIs copied to the app cache + classified (image / pdf / text / file),
  plus the device-locale country. Registered on `MainActivity`; cold-launch
  SEND replayed from `configureFlutterEngine`, warm SEND from the existing
  `onNewIntent` on the singleTop activity.
- AndroidManifest SEND filter gains `text/plain`; `pubspec` drops
  `share_handler` (+ its 3 transitive packages).
- **Dart** `SharedReceiptIntent` / `SharedReceiptItem` model (tested
  `fromPlatform` decode boundary) + `ShareIntentChannel` (abstract +
  platform-backed default, injectable test seam). `ShareReceiptListener` /
  `ShareReceiptHandler` rewritten onto it, preserving the never-throws
  (#2349) cold/warm contract. Image stashes a path (OCR'd on the form), PDF
  rasterises then takes the image path (#2737), TEXT is parsed on the spot
  and stashed in the new `PendingSharedReceiptText` provider.
- `AddFillUpScreen` applies the text result through the SAME
  `applyReceiptOutcome` body the camera / image-share paths use — zero
  prefill drift.
- Opt-in via the existing `Feature.addFillUpShareIntentReceipt`; ARB keys
  for the share strings + feature label/description already ship on master,
  so no new ARB keys were introduced.

## F-Droid / GMS

The new receiver is OS-native + Flutter-only. `ShareIntentChannel.kt`
references no GMS/ML Kit type; removing `share_handler` strictly **reduces**
the dependency graph, so the fdroid runtime classpath cannot regress.

## Tests

All drive the real paths (no request-echoing fakes):
- e-receipt parser: 10 cases over IT + DE text fixtures + normalisation +
  reconciliation + GB pence-per-litre profile threading;
- handler: image / pdf / text / unsupported + opt-in gate + #2349 fault
  injection;
- listener: cold / warm / fault on a fake `ShareIntentChannel`;
- `SharedReceiptIntent.fromPlatform` data-shape decode;
- `PendingSharedReceiptText` stash lifecycle;
- screen widget test prefilling from the REAL `EReceiptTextParser`.

`flutter analyze lib` clean; the receipt-parser + share + lint suites green.
The `add_fill_up_screen` file_length snapshot is realigned 537 → 539 (the
file already stood at 539 on master; this change is net-zero on it).

Closes #2838.
Closes #2735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
