### PR TITLE
refactor(core): extract StationServiceChain helpers below the 400-line cap (#2842)

### DIFF
--- a/lib/core/services/station_failure_classifier.dart
+++ b/lib/core/services/station_failure_classifier.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../error/exceptions.dart';
+
+/// Error-classification helpers for [StationServiceChain] (#2842).
+///
+/// Extracted verbatim from the chain so the orchestration file stays under the
+/// 400-line cap. Behaviour is unchanged: the chain still routes transience by
+/// [FailureKind] (#2255) and still preserves the pre-#2255 classification for
+/// exceptions constructed without an explicit kind.
+
+/// Resolve the [FailureKind] for [e], preserving the pre-#2255 classification
+/// for exceptions that predate typed kinds (or were constructed without one).
+/// When [ApiException.kind] is explicitly set (anything but
+/// [FailureKind.unknown]) it wins; otherwise we fall back to the legacy
+/// signals — HTTP status (5xx → network, matching the old transient-5xx
+/// rule) then the Dio-type message prefix stamped by `throwApiException`.
+FailureKind effectiveFailureKind(ApiException e) {
+  if (e.kind != FailureKind.unknown) return e.kind;
+  final code = e.statusCode;
+  if (code != null) {
+    final fromStatus = failureKindFromStatus(code);
+    if (fromStatus != FailureKind.unknown) return fromStatus;
+  }
+  final msg = e.message;
+  if (msg.startsWith('connectionTimeout') ||
+      msg.startsWith('receiveTimeout') ||
+      msg.startsWith('sendTimeout')) {
+    return FailureKind.timeout;
+  }
+  if (msg.startsWith('connectionError')) return FailureKind.network;
+  return FailureKind.unknown;
+}
+
+/// `true` when [e] is a transient failure a single short retry could
+/// plausibly recover from. Routes on [FailureKind] (#2255) instead of
+/// sniffing the English [ApiException.message] prefix:
+/// network / timeout / rateLimited → transient;
+/// auth / notFound / parse / unsupported / unknown → terminal.
+bool isTransientFailure(ApiException e) {
+  switch (effectiveFailureKind(e)) {
+    case FailureKind.network:
+    case FailureKind.timeout:
+    case FailureKind.rateLimited:
+      return true;
+    case FailureKind.auth:
+    case FailureKind.notFound:
+    case FailureKind.parse:
+    case FailureKind.unsupported:
+    case FailureKind.unknown:
+      return false;
+  }
+}

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -13,8 +13,10 @@ import '../error/exceptions.dart';
 import '../logging/error_logger.dart';
 import 'fuel_service_policy.dart';
 import 'service_result.dart';
+import 'station_failure_classifier.dart';
 import 'station_service.dart';
 import 'station_service_chain_codec.dart';
+import 'station_transient_retry.dart';
 
 /// Orchestrates station data retrieval with fallback:
 ///
@@ -158,7 +160,7 @@ class StationServiceChain implements StationService {
     // first-byte triggering Dio's connect timeout). Both recover on a
     // second attempt within a second.
     try {
-      final result = await _callWithTransientRetry(apiCall);
+      final result = await callWithTransientRetry(apiCall);
       await _cache.put(
         cacheKey,
         serialize(result.data),
@@ -178,7 +180,7 @@ class StationServiceChain implements StationService {
         source: _errorSource,
         message: e.toString(),
         statusCode: e is ApiException ? e.statusCode : null,
-        kind: e is ApiException ? _effectiveKind(e) : FailureKind.unknown,
+        kind: e is ApiException ? effectiveFailureKind(e) : FailureKind.unknown,
         retryAfter: e is ApiException ? e.retryAfter : null,
         occurredAt: DateTime.now(),
       ));
@@ -203,92 +205,16 @@ class StationServiceChain implements StationService {
     throw ServiceChainExhaustedException(errors: errors);
   }
 
-  /// Delay between the first and second attempt of [_callWithTransientRetry].
-  /// 500 ms keeps the user-visible latency tight (most browsers stall ≥1 s
-  /// before a user even notices), and is long enough for an overloaded
-  /// upstream to clear a 503 burst. Exposed as `@visibleForTesting` so the
-  /// retry test can run without sleeping a real half-second.
+  /// Delay between the first and second attempt of the in-chain transient
+  /// retry. Re-exports the single source of truth in
+  /// `station_transient_retry.dart` (#2842) so the existing test surface
+  /// (`StationServiceChain.transientRetryDelay = …`) keeps working unchanged.
   @visibleForTesting
-  static Duration transientRetryDelay = const Duration(milliseconds: 500);
+  static Duration get transientRetryDelay => stationTransientRetryDelay;
 
-  /// Wraps a single [apiCall] with one retry on transient remote errors.
-  /// Transience is decided by [FailureKind] (#2255): a network blip, a
-  /// timeout, or a rate-limit response are the kinds a short retry could
-  /// plausibly recover from. One retry only — the goal is to absorb a
-  /// transient blip, not to mask sustained outages from the chain's
-  /// fall-through to stale cache or to the user-visible error dialog.
-  ///
-  /// Returns the second attempt's result on success; rethrows the second
-  /// attempt's exception on failure so the caller observes the same
-  /// `on Exception` semantics as a plain `await apiCall()`. Non-transient
-  /// errors (auth, notFound, parse, unsupported, unknown) skip the retry —
-  /// those are not going to fix themselves in 500 ms.
-  Future<ServiceResult<T>> _callWithTransientRetry<T>(
-    Future<ServiceResult<T>> Function() apiCall,
-  ) async {
-    try {
-      return await apiCall();
-    } on ApiException catch (e, st) {
-      if (!_isTransient(e)) rethrow;
-      // Single retry — dev-console only (no production listener). Stack
-      // included to satisfy `catch_block_stacktrace_coverage` (#1103).
-      debugPrint(
-        'StationServiceChain: retrying after transient error '
-        '(status=${e.statusCode}, kind=${_effectiveKind(e).name})\n$st',
-      );
-      // Honour an upstream Retry-After (#2255) but cap it at
-      // [transientRetryDelay] so a long server hint never stretches the
-      // in-chain retry latency — sustained rate-limits fall through to cache.
-      final delay = e.retryAfter != null && e.retryAfter! < transientRetryDelay
-          ? e.retryAfter!
-          : transientRetryDelay;
-      await Future<void>.delayed(delay);
-      return apiCall();
-    }
-  }
-
-  /// `true` when [e] is a transient failure a single short retry could
-  /// plausibly recover from. Routes on [FailureKind] (#2255) instead of
-  /// sniffing the English [ApiException.message] prefix:
-  /// network / timeout / rateLimited → transient;
-  /// auth / notFound / parse / unsupported / unknown → terminal.
-  static bool _isTransient(ApiException e) {
-    switch (_effectiveKind(e)) {
-      case FailureKind.network:
-      case FailureKind.timeout:
-      case FailureKind.rateLimited:
-        return true;
-      case FailureKind.auth:
-      case FailureKind.notFound:
-      case FailureKind.parse:
-      case FailureKind.unsupported:
-      case FailureKind.unknown:
-        return false;
-    }
-  }
-
-  /// Resolve the [FailureKind] for [e], preserving the pre-#2255 classification
-  /// for exceptions that predate typed kinds (or were constructed without one).
-  /// When [ApiException.kind] is explicitly set (anything but
-  /// [FailureKind.unknown]) it wins; otherwise we fall back to the legacy
-  /// signals — HTTP status (5xx → network, matching the old transient-5xx
-  /// rule) then the Dio-type message prefix stamped by `throwApiException`.
-  static FailureKind _effectiveKind(ApiException e) {
-    if (e.kind != FailureKind.unknown) return e.kind;
-    final code = e.statusCode;
-    if (code != null) {
-      final fromStatus = failureKindFromStatus(code);
-      if (fromStatus != FailureKind.unknown) return fromStatus;
-    }
-    final msg = e.message;
-    if (msg.startsWith('connectionTimeout') ||
-        msg.startsWith('receiveTimeout') ||
-        msg.startsWith('sendTimeout')) {
-      return FailureKind.timeout;
-    }
-    if (msg.startsWith('connectionError')) return FailureKind.network;
-    return FailureKind.unknown;
-  }
+  @visibleForTesting
+  static set transientRetryDelay(Duration value) =>
+      stationTransientRetryDelay = value;
 
   @override
   Future<ServiceResult<List<Station>>> searchStations(
@@ -348,7 +274,7 @@ class StationServiceChain implements StationService {
       }
     }
 
-    final future = _callWithTransientRetry(
+    final future = callWithTransientRetry(
       () => _primary.searchStations(params, cancelToken: cancelToken),
     );
     _inFlight[key] = future;

--- a/lib/core/services/station_transient_retry.dart
+++ b/lib/core/services/station_transient_retry.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+
+import '../error/exceptions.dart';
+import 'service_result.dart';
+import 'station_failure_classifier.dart';
+
+/// Single-shot transient-error retry for [StationServiceChain] (#2842).
+///
+/// Extracted verbatim from the chain so the orchestration file stays under the
+/// 400-line cap. Behaviour is unchanged — the retry decision still routes on
+/// [effectiveFailureKind] (#2255), still honours a capped `Retry-After`
+/// (#2255), and the in-chain delay is still the same tunable static the chain
+/// exposed (re-exported as `StationServiceChain.transientRetryDelay`).
+
+/// Delay between the first and second attempt of [callWithTransientRetry].
+/// 500 ms keeps the user-visible latency tight (most browsers stall ≥1 s
+/// before a user even notices), and is long enough for an overloaded
+/// upstream to clear a 503 burst.
+///
+/// Production code only ever reads this; the single mutating surface is the
+/// `@visibleForTesting StationServiceChain.transientRetryDelay` accessor the
+/// retry tests use to run without sleeping a real half-second (#2842).
+Duration stationTransientRetryDelay = const Duration(milliseconds: 500);
+
+/// Wraps a single [apiCall] with one retry on transient remote errors.
+/// Transience is decided by [FailureKind] (#2255): a network blip, a
+/// timeout, or a rate-limit response are the kinds a short retry could
+/// plausibly recover from. One retry only — the goal is to absorb a
+/// transient blip, not to mask sustained outages from the chain's
+/// fall-through to stale cache or to the user-visible error dialog.
+///
+/// Returns the second attempt's result on success; rethrows the second
+/// attempt's exception on failure so the caller observes the same
+/// `on Exception` semantics as a plain `await apiCall()`. Non-transient
+/// errors (auth, notFound, parse, unsupported, unknown) skip the retry —
+/// those are not going to fix themselves in 500 ms.
+Future<ServiceResult<T>> callWithTransientRetry<T>(
+  Future<ServiceResult<T>> Function() apiCall,
+) async {
+  try {
+    return await apiCall();
+  } on ApiException catch (e, st) {
+    if (!isTransientFailure(e)) rethrow;
+    // Single retry — dev-console only (no production listener). Stack
+    // included to satisfy `catch_block_stacktrace_coverage` (#1103).
+    debugPrint(
+      'StationServiceChain: retrying after transient error '
+      '(status=${e.statusCode}, kind=${effectiveFailureKind(e).name})\n$st',
+    );
+    // Honour an upstream Retry-After (#2255) but cap it at
+    // [stationTransientRetryDelay] so a long server hint never stretches the
+    // in-chain retry latency — sustained rate-limits fall through to cache.
+    final delay =
+        e.retryAfter != null && e.retryAfter! < stationTransientRetryDelay
+            ? e.retryAfter!
+            : stationTransientRetryDelay;
+    await Future<void>.delayed(delay);
+    return apiCall();
+  }
+}


### PR DESCRIPTION
## What

Decomposes `StationServiceChain` below the 400-line file cap so the #2824
data-access tracer tap has room to land. **Pure, behaviour-preserving
refactor** — no ARB, no codegen, no public-API change.

The orchestration file sat at 403 raw / 400 effective lines (right at the
`file_length` cap, with no headroom for the tracer). Two cohesive helpers
were lifted out verbatim:

- **`station_failure_classifier.dart`** — `effectiveFailureKind(ApiException)`
  (the pre-#2255 legacy-signal-preserving classifier: explicit kind →
  HTTP-status → Dio-message-prefix) and `isTransientFailure(ApiException)`,
  both as pure top-level functions.
- **`station_transient_retry.dart`** — `callWithTransientRetry` (the
  single-shot transient retry, capped-`Retry-After` honoured) + the
  `stationTransientRetryDelay` tunable.

The chain drops from 400 → ~326 effective lines.

## Public API preserved

`StationServiceChain.transientRetryDelay` stays a `@visibleForTesting`
static — now a getter/setter delegating to the single source of truth in
`station_transient_retry.dart`. The three tests that set it
(`station_service_chain_transient_retry_test`, `…_failure_kind_test`,
`prix_carburants_transient_empty_test`) need **zero** changes.

## Verification

- `flutter analyze` clean on all three touched files (and no new
  project-wide issues).
- `flutter test test/core/services/` green (all chain tests:
  `_test`, `_new_test`, `_edge_cases_test`, `_failure_kind_test`,
  `_transient_retry_test`, `_bulk_policy_test`, `_codec_opening_hours_test`).
- `test/lint/file_length_test.dart`, `…/catch_block_stacktrace_coverage_test.dart`,
  `…/no_hardcoded_ui_strings_test.dart` green — no grandfather entry added;
  the file is genuinely under the cap.
- Cross-feature chain consumers green (FR transient-empty, ES MITECO,
  cross-border route search).
- The only failure in the run was `api_connectivity_test.dart` — a
  `@Tags(['network'])` live-endpoint test (Argentina CSV connection
  timeout) that does not reference the chain; pre-existing, unrelated.

Closes #2842. Unblocks #2824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
