### PR TITLE
fix(driving-style): debounce harsh accel/brake into discrete events (#2846)

### DIFF
--- a/lib/features/consumption/domain/accel_event_gate.dart
+++ b/lib/features/consumption/domain/accel_event_gate.dart
@@ -26,17 +26,32 @@
 /// event yields ONE count across the score, the insights, and the GPS
 /// features.
 ///
-/// ## Count semantics — one event per *episode*
+/// ## Count semantics — one event per *episode*, with a refractory window
 ///
 /// An "event" is one sustained threshold-crossing *episode*, not one per
 /// qualifying sample interval. A 4-second hard brake is ONE brake, not
 /// four. The detector arms when the speed derivative first holds at or
 /// beyond the threshold for at least [kAccelEventMinSustainedSec], counts
-/// once, then re-arms only after the derivative drops back below the
-/// threshold. This matches the physical intuition of "how many times did
-/// the driver brake/accelerate hard", and is the semantics the GPS
-/// features already used — it is the harsh detector's old
-/// once-per-resample-interval count that was the outlier.
+/// once, then **re-arms only after the derivative has stayed below the
+/// threshold for a continuous [kAccelEventRefractorySec] window** (#2846).
+///
+/// The refractory window is the fix for the ~100× over-count (#2846): on a
+/// real Skoda-diesel OBD2 backup ONE braking manoeuvre logged dozens of
+/// "harsh brakes" because the ~1 Hz integer speed PID arrives as a
+/// staircase — a "drop, hold, drop, hold" series whose derivative dips
+/// below the threshold for a single hold interval and then crosses it
+/// again. The old "re-arm after one sub-threshold interval" latch counted
+/// each pulse of that ONE manoeuvre as a new event (2 734 brakes + 3 882
+/// accels across 33 trips, ~10/km). Requiring the signal to settle below
+/// the threshold for a real ~[kAccelEventRefractorySec] gap before another
+/// same-type event can fire collapses a manoeuvre into ONE event while
+/// still separating two genuinely distinct manoeuvres (which are parted by
+/// a cruise far longer than the refractory window).
+///
+/// This matches the physical intuition of "how many times did the driver
+/// brake/accelerate hard", and is the semantics every consumer routes
+/// through ([HarshEventDetector], [ImuEventDetector], and the GPS-features
+/// / insights / score paths) so a given physical event yields ONE count.
 library;
 
 /// Acceleration (m/s²) at/above which an interval is a hard-accel event.
@@ -58,6 +73,21 @@ const double kAccelEventMinSustainedSec = 1.0;
 /// scored (#2653). Dead-reckoning noise at a near-standstill manufactures
 /// phantom events; genuine harsh manoeuvres happen above a walking pace.
 const double kAccelEventMinSpeedKmh = 5.0;
+
+/// Refractory window (seconds): after a hard-accel / hard-brake event
+/// fires, the derivative must stay BELOW the threshold for at least this
+/// long continuously before another same-type event can fire (#2846).
+///
+/// This debounces one physical manoeuvre into ONE event. A coarse ~1 Hz
+/// integer speed PID arrives as a "drop, hold, drop, hold" staircase whose
+/// derivative dips below the threshold for a single hold interval and then
+/// crosses it again; the old "re-arm after one sub-threshold interval"
+/// latch counted each pulse as a new event (the ~100× over-count). 2.0 s
+/// is longer than the ~1 s hold interval a coarse ~1 Hz speed staircase
+/// inserts inside a single continuous manoeuvre, yet shorter than the
+/// multi-second cruise plateau that separates two genuinely distinct
+/// manoeuvres, so it collapses the former while preserving the latter.
+const double kAccelEventRefractorySec = 2.0;
 
 /// Reported horizontal GPS accuracy (metres) above which a sample is
 /// dropped *and* the episode anchor reset, so the derivative is never
@@ -150,14 +180,20 @@ AccelEventCounts countAccelEvents(
   final accelStartIndices = <int>[];
 
   // Episode state: accumulate the sustained duration above each threshold;
-  // arm once it first reaches the sustained-window floor; re-arm only when
-  // the derivative drops back below the threshold.
+  // arm once it first reaches the sustained-window floor; re-arm only once
+  // the derivative has stayed BELOW the threshold for a continuous
+  // refractory window (#2846), so one manoeuvre's staircase jitter is ONE
+  // event. `belowDur` tracks how long we've been continuously sub-threshold
+  // while latched.
   var accelDur = 0.0, brakeDur = 0.0;
+  var accelBelowDur = 0.0, brakeBelowDur = 0.0;
   var inAccel = false, inBrake = false;
 
   void breakEpisodes() {
     accelDur = 0;
     brakeDur = 0;
+    accelBelowDur = 0;
+    brakeBelowDur = 0;
     inAccel = false;
     inBrake = false;
   }
@@ -195,6 +231,7 @@ AccelEventCounts countAccelEvents(
     if (accelMps2 >= kHardAccelThresholdMps2) {
       accelDur += dt;
       accelSeconds += dt;
+      accelBelowDur = 0;
       if (!inAccel && accelDur >= kAccelEventMinSustainedSec) {
         accelEvents++;
         // Confirm at the END index of the interval that crossed the
@@ -204,19 +241,36 @@ AccelEventCounts countAccelEvents(
         inAccel = true;
       }
     } else {
+      // Sub-threshold: don't re-arm immediately (#2846). While latched,
+      // accumulate the continuous below-threshold time and only re-arm once
+      // it clears the refractory window, so one manoeuvre's hold-jitter
+      // can't fire a second event.
       accelDur = 0;
-      inAccel = false;
+      if (inAccel) {
+        accelBelowDur += dt;
+        if (accelBelowDur >= kAccelEventRefractorySec) {
+          inAccel = false;
+          accelBelowDur = 0;
+        }
+      }
     }
 
     if (accelMps2 <= -kHardBrakeThresholdMps2) {
       brakeDur += dt;
+      brakeBelowDur = 0;
       if (!inBrake && brakeDur >= kAccelEventMinSustainedSec) {
         brakeEvents++;
         inBrake = true;
       }
     } else {
       brakeDur = 0;
-      inBrake = false;
+      if (inBrake) {
+        brakeBelowDur += dt;
+        if (brakeBelowDur >= kAccelEventRefractorySec) {
+          inBrake = false;
+          brakeBelowDur = 0;
+        }
+      }
     }
   }
 

--- a/lib/features/consumption/domain/harsh_event_detector.dart
+++ b/lib/features/consumption/domain/harsh_event_detector.dart
@@ -63,6 +63,7 @@ class HarshEventDetector {
     this.minSustainedSec = kAccelEventMinSustainedSec,
     this.minSpeedKmh = kAccelEventMinSpeedKmh,
     this.maxHAccuracyM = kAccelEventAccuracyGateM,
+    this.refractorySec = kAccelEventRefractorySec,
     this.smoothSpeed = false,
     this.onEvent,
   });
@@ -102,6 +103,12 @@ class HarshEventDetector {
   /// as "unknown, accept" so OBD-speed-only samples (no GPS) still flow.
   final double maxHAccuracyM;
 
+  /// Refractory window (seconds) the derivative must stay continuously
+  /// below the threshold before another same-type event can fire (#2846).
+  /// Debounces one physical manoeuvre's staircase jitter into ONE event;
+  /// shared default with `countAccelEvents` so every path agrees.
+  final double refractorySec;
+
   /// When true, speed is passed through a 3-sample moving average before
   /// differentiation (#2653), damping 1 km/h quantisation jitter. Off by
   /// default — the canonical OBD path keeps its raw-speed behaviour.
@@ -128,11 +135,18 @@ class HarshEventDetector {
   // Episode latches (#2667). An "event" is one sustained threshold-crossing
   // episode, not one per evaluated ~1 s interval — a multi-second hard
   // brake is ONE brake. We count on the transition INTO an episode and
-  // re-arm only when an evaluated interval falls back below the threshold.
-  // This is the count semantics shared with `countAccelEvents`, so the
-  // detector agrees with the score / insights / GPS features.
+  // re-arm only once the signal has stayed below the threshold for a
+  // continuous [minSustainedSec]·-independent refractory window
+  // ([refractorySec], #2846): the staircase a coarse ~1 Hz speed PID
+  // produces dips below the threshold for a single hold interval inside one
+  // manoeuvre, and the old "re-arm after one sub-threshold interval" latch
+  // counted each pulse as a new event (the ~100× over-count). This is the
+  // count semantics shared with `countAccelEvents`, so the detector agrees
+  // with the score / insights / GPS features.
   bool _inAccelEpisode = false;
   bool _inBrakeEpisode = false;
+  double _accelBelowSec = 0;
+  double _brakeBelowSec = 0;
 
   /// Number of harsh-braking events counted so far.
   int get brakes => _events
@@ -179,6 +193,8 @@ class HarshEventDetector {
       _speedWindow.clear();
       _inAccelEpisode = false;
       _inBrakeEpisode = false;
+      _accelBelowSec = 0;
+      _brakeBelowSec = 0;
       return;
     }
 
@@ -205,14 +221,17 @@ class HarshEventDetector {
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
     final accelMps2 = ((speed - anchorSpeed) / 3.6) / dt;
 
-    // Episode semantics (#2667): record at most once on entry into a
-    // sustained harsh stretch, and re-arm only when an evaluated interval
-    // drops back below the threshold — so a multi-interval manoeuvre is
-    // ONE event, agreeing with the shared gate.
+    // Episode semantics (#2667 + #2846): record at most once on entry into
+    // a sustained harsh stretch, and re-arm only once the derivative has
+    // stayed below the threshold for a continuous [refractorySec] window —
+    // so a multi-interval manoeuvre (and the staircase hold-jitter that a
+    // coarse speed PID adds inside it) is ONE event, agreeing with the
+    // shared gate.
     final isBrake = scorable && accelMps2 <= -brakeThresholdMps2;
     final isAccel = scorable && accelMps2 >= accelThresholdMps2;
 
     if (isBrake) {
+      _brakeBelowSec = 0;
       if (!_inBrakeEpisode) {
         _record(HarshEvent(
           timestamp: timestamp,
@@ -222,11 +241,16 @@ class HarshEventDetector {
         ));
         _inBrakeEpisode = true;
       }
-    } else {
-      _inBrakeEpisode = false;
+    } else if (_inBrakeEpisode) {
+      _brakeBelowSec += dt;
+      if (_brakeBelowSec >= refractorySec) {
+        _inBrakeEpisode = false;
+        _brakeBelowSec = 0;
+      }
     }
 
     if (isAccel) {
+      _accelBelowSec = 0;
       if (!_inAccelEpisode) {
         _record(HarshEvent(
           timestamp: timestamp,
@@ -236,8 +260,12 @@ class HarshEventDetector {
         ));
         _inAccelEpisode = true;
       }
-    } else {
-      _inAccelEpisode = false;
+    } else if (_inAccelEpisode) {
+      _accelBelowSec += dt;
+      if (_accelBelowSec >= refractorySec) {
+        _inAccelEpisode = false;
+        _accelBelowSec = 0;
+      }
     }
     _anchorAt = timestamp;
     _anchorSpeedKmh = speed;
@@ -272,5 +300,7 @@ class HarshEventDetector {
     _anchorAt = null;
     _inAccelEpisode = false;
     _inBrakeEpisode = false;
+    _accelBelowSec = 0;
+    _brakeBelowSec = 0;
   }
 }

--- a/lib/features/consumption/domain/services/imu_event_detector.dart
+++ b/lib/features/consumption/domain/services/imu_event_detector.dart
@@ -94,10 +94,14 @@ class ImuEventDetector {
 
   // Episode-latch state, mirroring `countAccelEvents`: accumulate the
   // sustained time above each threshold, count once on first crossing the
-  // sustained floor, and re-arm only when the signal drops back below the
-  // threshold.
+  // sustained floor, and re-arm only once the signal has stayed below the
+  // threshold for a continuous refractory window (#2846) — so one
+  // manoeuvre's transient dips can't fire a second event. `_*BelowDur`
+  // tracks the continuous sub-threshold time while latched.
   double _maneuverDur = 0;
   double _cornerDur = 0;
+  double _accelBelowDur = 0;
+  double _brakeBelowDur = 0;
   bool _inAccel = false;
   bool _inBrake = false;
   bool _inCorner = false;
@@ -167,6 +171,7 @@ class ImuEventDetector {
       constantSpeed: constantSpeed,
     );
     _scoreAccelBrake(
+      dt: dt,
       horizMag: horizMag,
       highYaw: highYaw,
       constantSpeed: constantSpeed,
@@ -201,6 +206,7 @@ class ImuEventDetector {
   }
 
   void _scoreAccelBrake({
+    required double dt,
     required double horizMag,
     required bool highYaw,
     required bool constantSpeed,
@@ -212,9 +218,12 @@ class ImuEventDetector {
     // horizontal accel is centripetal (lateral), not a longitudinal
     // accel/brake — so don't score it as one. When speed IS changing through
     // a bend, the net-speed classification below correctly takes over.
+    // Treat the cornering interval as below-threshold for the refractory
+    // accumulators so it counts toward re-arming rather than re-arming
+    // instantly (#2846).
     if (highYaw && constantSpeed) {
-      _inAccel = false;
-      _inBrake = false;
+      _decayAccelLatch(dt);
+      _decayBrakeLatch(dt);
       return;
     }
 
@@ -229,13 +238,14 @@ class ImuEventDetector {
         horizMag >= kHardAccelThresholdMps2 &&
         netSpeedDeltaKmh > _constantSpeedDeltaKmh;
     if (isAccel) {
+      _accelBelowDur = 0;
       if (!_inAccel) {
         _hardAccelCount++;
         _inAccel = true;
         _emit(HarshEventType.acceleration, horizMag, t, speedKmh);
       }
     } else {
-      _inAccel = false;
+      _decayAccelLatch(dt);
     }
 
     // Hard brake: held while speed FELL, with the harder 3.5 m/s² magnitude
@@ -245,13 +255,35 @@ class ImuEventDetector {
         horizMag >= kHardBrakeThresholdMps2 &&
         netSpeedDeltaKmh < -_constantSpeedDeltaKmh;
     if (isBrake) {
+      _brakeBelowDur = 0;
       if (!_inBrake) {
         _hardBrakeCount++;
         _inBrake = true;
         _emit(HarshEventType.brake, horizMag, t, speedKmh);
       }
     } else {
+      _decayBrakeLatch(dt);
+    }
+  }
+
+  /// Re-arm the accel latch only once the signal has stayed below the
+  /// threshold for a continuous [kAccelEventRefractorySec] window (#2846),
+  /// so one manoeuvre's transient dips don't fire a second event.
+  void _decayAccelLatch(double dt) {
+    if (!_inAccel) return;
+    _accelBelowDur += dt;
+    if (_accelBelowDur >= kAccelEventRefractorySec) {
+      _inAccel = false;
+      _accelBelowDur = 0;
+    }
+  }
+
+  void _decayBrakeLatch(double dt) {
+    if (!_inBrake) return;
+    _brakeBelowDur += dt;
+    if (_brakeBelowDur >= kAccelEventRefractorySec) {
       _inBrake = false;
+      _brakeBelowDur = 0;
     }
   }
 
@@ -272,6 +304,8 @@ class ImuEventDetector {
   void _breakEpisodes() {
     _maneuverDur = 0;
     _cornerDur = 0;
+    _accelBelowDur = 0;
+    _brakeBelowDur = 0;
     _inAccel = false;
     _inBrake = false;
     _inCorner = false;

--- a/test/features/consumption/domain/accel_event_reconciliation_test.dart
+++ b/test/features/consumption/domain/accel_event_reconciliation_test.dart
@@ -153,6 +153,77 @@ void main() {
     });
   });
 
+  group('refractory-window debounce — #2846', () {
+    /// A continuous hard brake delivered as the coarse "drop, hold, drop,
+    /// hold" staircase a ~1 Hz integer speed PID produces. Each 15 km/h
+    /// pulse over 1 s is -4.17 m/s² (harsh); the 1 s hold between pulses
+    /// dips the derivative below the threshold. ONE physical manoeuvre.
+    List<AccelSamplePoint> oneStaircaseBrake() {
+      const speeds = <double>[90, 75, 75, 60, 60, 45, 45, 30, 30, 20];
+      return [
+        for (var i = 0; i < speeds.length; i++)
+          AccelSamplePoint(
+              timestamp: t0.add(Duration(seconds: i)), speedKmh: speeds[i]),
+      ];
+    }
+
+    test('one manoeuvre crossing the threshold N times within the '
+        'refractory window → ONE brake (not N)', () {
+      final counts = countAccelEvents(oneStaircaseBrake());
+      expect(counts.brakeEvents, 1,
+          reason: 'the staircase hold-jitter is debounced into one event');
+      expect(counts.accelEvents, 0);
+    });
+
+    test('a clean steady cruise → zero events', () {
+      final pts = <AccelSamplePoint>[
+        for (var s = 0; s <= 20; s++)
+          AccelSamplePoint(
+              timestamp: t0.add(Duration(seconds: s)), speedKmh: 90),
+      ];
+      final counts = countAccelEvents(pts);
+      expect(counts.brakeEvents, 0);
+      expect(counts.accelEvents, 0);
+    });
+
+    test('two genuinely separate manoeuvres → two', () {
+      final pts = <AccelSamplePoint>[];
+      void add(int s, double v) =>
+          pts.add(AccelSamplePoint(timestamp: t0.add(Duration(seconds: s)), speedKmh: v));
+      // Brake #1: 90 → 50 over 2 s.
+      add(0, 90);
+      add(1, 70);
+      add(2, 50);
+      // Long cruise far beyond the refractory window.
+      for (var s = 3; s <= 12; s++) {
+        add(s, 50);
+      }
+      // Re-accelerate then brake #2: 90 → 50 over 2 s.
+      add(13, 90);
+      for (var s = 14; s <= 18; s++) {
+        add(s, 90);
+      }
+      add(19, 70);
+      add(20, 50);
+      final counts = countAccelEvents(pts);
+      expect(counts.brakeEvents, 2,
+          reason: 'two manoeuvres parted by a long cruise count twice');
+    });
+
+    test('all three detector paths agree on the debounced count', () {
+      // The whole point of #2667 + #2846: the staircase manoeuvre yields
+      // ONE brake across the shared gate AND the HarshEventDetector.
+      final gate = countAccelEvents(oneStaircaseBrake());
+      final d = HarshEventDetector();
+      const speeds = <double>[90, 75, 75, 60, 60, 45, 45, 30, 30, 20];
+      for (var i = 0; i < speeds.length; i++) {
+        d.onSample(speeds[i], t0.add(Duration(seconds: i)));
+      }
+      expect(gate.brakeEvents, 1);
+      expect(d.brakes, gate.brakeEvents);
+    });
+  });
+
   group('canonical constants are the single source — #2667', () {
     test('the shared gate re-exports the score calculator constants', () {
       // The accel-event gate and the score calculator MUST be the same

--- a/test/features/consumption/domain/harsh_event_detector_test.dart
+++ b/test/features/consumption/domain/harsh_event_detector_test.dart
@@ -320,6 +320,85 @@ void main() {
       });
     });
 
+    group('refractory-window debounce (#2846)', () {
+      // Real-data root cause (Skoda-diesel backup): 2 734 harsh brakes +
+      // 3 882 harsh accels across 33 trips (~10/km). The ~1 Hz integer
+      // speed PID arrives as a "drop, hold, drop, hold" staircase whose
+      // derivative dips below the threshold for a single ~1 s hold inside
+      // ONE braking manoeuvre and then crosses it again; the old
+      // "re-arm after one sub-threshold interval" latch counted each pulse
+      // as a separate event. A refractory window of kAccelEventRefractorySec
+      // collapses the manoeuvre into ONE event.
+
+      test('one braking manoeuvre crossing the threshold N times within the '
+          'refractory window → exactly ONE brake', () {
+        // 90 → 20 km/h, one continuous hard brake, but delivered as a
+        // coarse staircase: each 15 km/h pulse over 1 s is -4.17 m/s²
+        // (harsh) with a 1 s "hold" interval between (derivative 0, below
+        // threshold). The old latch fired on every pulse (4×); the
+        // refractory window makes it ONE.
+        const oneBrake = <double>[90, 75, 75, 60, 60, 45, 45, 30, 30, 20];
+        for (var i = 0; i < oneBrake.length; i++) {
+          detector.onSample(oneBrake[i], start.add(Duration(seconds: i)));
+        }
+        expect(detector.brakes, 1,
+            reason: 'a single manoeuvre is ONE event, not N pulses');
+        expect(detector.accelerations, 0);
+      });
+
+      test('a clean steady cruise → ZERO events', () {
+        for (var s = 0; s <= 20; s++) {
+          detector.onSample(90, start.add(Duration(seconds: s)));
+        }
+        expect(detector.brakes, 0);
+        expect(detector.accelerations, 0);
+      });
+
+      test('two genuinely separate braking manoeuvres → TWO', () {
+        // Brake #1 (90 → 50), a long cruise far beyond the refractory
+        // window, then brake #2 (80 → 40). Each must count once.
+        detector.onSample(90, start);
+        detector.onSample(60, start.add(const Duration(seconds: 1)));
+        detector.onSample(50, start.add(const Duration(seconds: 2)));
+        // Cruise plateau (10 s, well past kAccelEventRefractorySec).
+        for (var s = 3; s <= 12; s++) {
+          detector.onSample(50, start.add(Duration(seconds: s)));
+        }
+        // Re-accelerate to 80, then brake #2.
+        detector.onSample(80, start.add(const Duration(seconds: 13)));
+        for (var s = 14; s <= 18; s++) {
+          detector.onSample(80, start.add(Duration(seconds: s)));
+        }
+        detector.onSample(50, start.add(const Duration(seconds: 19)));
+        detector.onSample(40, start.add(const Duration(seconds: 20)));
+        expect(detector.brakes, 2,
+            reason: 'two manoeuvres parted by a long cruise count twice');
+      });
+
+      test('a sub-refractory dip inside one manoeuvre does NOT re-arm', () {
+        // One long hard brake 100 → 30 with a single 1 s hold in the
+        // middle (sub-refractory). The hold must not split it into two.
+        const speeds = <double>[100, 84, 84, 68, 52, 36, 30];
+        for (var i = 0; i < speeds.length; i++) {
+          detector.onSample(speeds[i], start.add(Duration(seconds: i)));
+        }
+        expect(detector.brakes, 1);
+      });
+
+      test('refractorySec is configurable', () {
+        // Drop the refractory window to 0 and the staircase holds re-arm
+        // again — proving the window is the only thing collapsing the
+        // pulses above (and that the default is what debounces them).
+        final eager = HarshEventDetector(refractorySec: 0);
+        const oneBrake = <double>[90, 75, 75, 60, 60, 45, 45, 30, 30, 20];
+        for (var i = 0; i < oneBrake.length; i++) {
+          eager.onSample(oneBrake[i], start.add(Duration(seconds: i)));
+        }
+        expect(eager.brakes, greaterThan(1),
+            reason: 'with no refractory window the holds re-arm per pulse');
+      });
+    });
+
     group('live onEvent callback (#2663)', () {
       test('fires onEvent the instant a de-noised event is detected', () {
         final fired = <HarshEvent>[];

--- a/test/features/consumption/domain/services/imu_event_detector_test.dart
+++ b/test/features/consumption/domain/services/imu_event_detector_test.dart
@@ -121,8 +121,8 @@ void main() {
     expect(det.sharpCornerCount, 0);
   });
 
-  test('two separate 1.5 s accel bursts with a sub-threshold gap → TWO '
-      '(re-arm)', () {
+  test('two separate 1.5 s accel bursts with a calm gap → TWO '
+      '(re-arm past the refractory window)', () {
     final det = ImuEventDetector();
     var t = feed(det,
         start: t0,
@@ -130,10 +130,14 @@ void main() {
         mag: 4.0,
         startSpeedKmh: 30,
         speedStepKmh: 0.5);
-    // A 1 s calm gap (below threshold) re-arms the latch.
+    // A calm gap LONGER than the kAccelEventRefractorySec refractory window
+    // (#2846) re-arms the latch — 60 samples × 50 ms = 3 s of below-threshold
+    // cruise, the multi-second plateau that parts two genuinely distinct
+    // manoeuvres (a sub-refractory ~1 s dip, the staircase hold-jitter inside
+    // ONE manoeuvre, must NOT re-arm — that was the ~100× over-count).
     t = feed(det,
         start: t,
-        count: 20,
+        count: 60,
         mag: 0.2,
         startSpeedKmh: 45,
         speedStepKmh: 0.0);
@@ -144,7 +148,39 @@ void main() {
         startSpeedKmh: 45,
         speedStepKmh: 0.5);
     expect(det.hardAccelCount, 2,
-        reason: 'the calm gap re-arms, so the second burst counts again');
+        reason: 'the multi-second calm gap clears the refractory window, '
+            'so the second burst counts again');
+  });
+
+  test('a 1 s sub-threshold dip INSIDE one manoeuvre → ONE '
+      '(refractory window debounces, #2846)', () {
+    // The smoking gun from the Skoda-diesel backup: ONE continuous hard
+    // accel whose strong-magnitude stretch dips below the threshold for a
+    // single ~1 s hold (the staircase a coarse signal inserts), then crosses
+    // it again. The sub-refractory dip must NOT re-arm → ONE event, not two.
+    final det = ImuEventDetector();
+    var t = feed(det,
+        start: t0,
+        count: 30,
+        mag: 4.0,
+        startSpeedKmh: 30,
+        speedStepKmh: 0.5);
+    // 20 samples × 50 ms = 1 s below threshold — shorter than the 2 s
+    // refractory window — while speed keeps climbing (still one manoeuvre).
+    t = feed(det,
+        start: t,
+        count: 20,
+        mag: 0.2,
+        startSpeedKmh: 45,
+        speedStepKmh: 0.5);
+    feed(det,
+        start: t,
+        count: 30,
+        mag: 4.0,
+        startSpeedKmh: 55,
+        speedStepKmh: 0.5);
+    expect(det.hardAccelCount, 1,
+        reason: 'a sub-refractory dip inside one manoeuvre does not re-arm');
   });
 
   test('one continuous 3 s accel stretch → ONE (latch holds)', () {
@@ -169,10 +205,10 @@ void main() {
         mag: 4.0,
         startSpeedKmh: 30,
         speedStepKmh: 0.5);
-    // Calm gap, then a brake.
+    // Calm gap LONGER than the refractory window (#2846), then a brake.
     t = feed(det,
         start: t,
-        count: 20,
+        count: 60,
         mag: 0.2,
         startSpeedKmh: 45,
         speedStepKmh: 0.0);


### PR DESCRIPTION
## What

Fixes the harsh-event detector over-counting (~100×) by debouncing one physical manoeuvre into ONE discrete event with a refractory window.

Closes #2846 (child of #2789).

## Evidence

A real Skoda-diesel OBD2 backup logged **2,734 harsh brakes + 3,882 harsh accels across 33 trips** (~10/km; one 27 km trip = 165 brakes / 225 accels) on a car with otherwise sane speed/RPM/fuel traces.

## Root cause

The episode latch (#2667) re-armed the instant a **single** sub-threshold interval was seen. A coarse ~1 Hz integer speed PID arrives as a "drop, hold, drop, hold" staircase whose derivative dips below the threshold for one ~1 s hold inside ONE continuous brake and then crosses it again — so every pulse of that ONE manoeuvre re-fired. There was no refractory window between events.

Reproduced: `[90, 75, 75, 60, 60, 45, 45, 30, 30, 20]` (one continuous brake as a staircase) counted **4** brakes before the fix, **1** after.

## Fix

Add a shared `kAccelEventRefractorySec` (2.0 s) refractory window — a same-type event can re-arm only once the derivative has stayed below the threshold for that continuous span. 2.0 s is longer than the ~1 s staircase hold inside a single manoeuvre yet shorter than the multi-second cruise that parts two genuinely distinct manoeuvres.

Applied identically to all three detectors that already share the #2667 episode semantics so they keep agreeing on the count:
- `countAccelEvents` — the canonical gate the score / insights / GPS-features paths route through;
- `HarshEventDetector` — the OBD2 speed-derivative path that produced the backup;
- `ImuEventDetector` — the dongle-less GPS+IMU path.

Harsh accel/brake events key off the **speed derivative**, not raw throttle, so the throttle-floored-at-13.73% diesel is unaffected (throttle only drives the separate full-throttle penalty).

## Tests (CI-provable)

- one braking manoeuvre crossing the threshold N times within the refractory window → exactly ONE brake (not N);
- a clean cruise → zero;
- two genuinely separate manoeuvres → two;
- a sub-refractory dip inside one manoeuvre does NOT re-arm;
- all three detector paths agree on the debounced count.

The two IMU re-arm tests now separate manoeuvres by a gap longer than the refractory window (a 1 s gap is exactly the staircase hold-jitter #2846 debounces). Existing driving-style tests stay green — full `test/features/consumption/` suite (4124 tests) passes; `flutter analyze` clean (only 2 pre-existing `info`-level `unnecessary_import` findings, neither introduced here); `file_length` / `no_hardcoded_ui_strings` / `catch_block_stacktrace_coverage` lints green. No ARB strings added; no codegen-affecting source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
