### PR TITLE
fix(receipt): label-anchored Volume/Prix extraction for fuel receipts (#2848)

### DIFF
--- a/lib/features/consumption/data/receipt_parser.dart
+++ b/lib/features/consumption/data/receipt_parser.dart
@@ -4,10 +4,13 @@
 import '../../search/domain/entities/fuel_type.dart';
 import 'ocr/ocr_trace_recorder.dart';
 import 'ocr/pump_ocr_config.dart';
+import 'ocr/pump_validation_gate.dart';
+import 'ocr/recognized_text_block.dart';
 import 'receipt_override_registry.dart';
 import 'receipt_parser/brand_detection.dart';
 import 'receipt_parser/brand_layouts.dart';
 import 'receipt_parser/receipt_field_extractors.dart';
+import 'receipt_parser/receipt_orchestrator.dart';
 import 'receipt_parser/receipt_parse_result.dart';
 
 // Re-export the result type so every existing caller that does
@@ -91,6 +94,50 @@ class ReceiptParser {
     return reconciled;
   }
 
+  /// Geometry-aware parse for the receipt OCR path (#2848).
+  ///
+  /// When ML Kit's [blocks] (with their boxes) look like a fuel-station
+  /// receipt — pump/volume/price markers plus a per-litre signal — the
+  /// values sit in a right column row-aligned with their left-column
+  /// labels, exactly the geometry the pump-display path already solves.
+  /// We route those to the label-anchored extractor (binding Volume→
+  /// litres, Prix→€/L, TOT TTC→total by row) + the SAME validation gate,
+  /// so a fully-legible FR receipt comes back with all three fields and
+  /// `validated:true`. Everything else falls back to the flat-string
+  /// [parse], byte-for-byte unchanged — strictly additive.
+  ReceiptParseResult parseBlocks(
+    List<RecognizedTextBlock> blocks,
+    String text, {
+    String? stationId,
+    OcrLocaleProfile? profile,
+    PumpValidationGate gate = const PumpValidationGate(),
+    OcrTraceRecorder? trace,
+  }) {
+    if (shouldUseReceiptLabelAnchor(text, blocks)) {
+      final lines = text.split('\n').map((l) => l.trim()).toList();
+      trace?.brand(null, 'fuel_station');
+      final anchored = orchestrateReceiptParse(
+        blocks: blocks,
+        text: text,
+        lines: lines,
+        profile: profile,
+        gate: gate,
+        trace: trace,
+      );
+      // The geometry read found enough → use it. If it read fewer than two
+      // fields (sparse/fused boxes), defer to the flat-string parser so we
+      // never regress a receipt the generic path could still handle.
+      if (anchored.derived.isNotEmpty ||
+          [anchored.liters, anchored.totalCost, anchored.pricePerLiter]
+                  .where((v) => v != null)
+                  .length >=
+              2) {
+        return _applyOverrides(anchored, text, stationId, trace);
+      }
+    }
+    return parse(text, stationId: stationId, profile: profile, trace: trace);
+  }
+
   /// Apply per-station overrides on top of the brand-layout result. Any
   /// non-null field on the matching [OverrideSpec] replaces the default.
   /// If the override's regex doesn't match, the brand layout's value
@@ -160,6 +207,12 @@ class ReceiptParser {
       stationName: stationName,
       fuelType: fuelType,
       brandLayout: result.brandLayout,
+      // #2848 — carry the geometry-aware path's validation metadata through
+      // the override merge so a fuel_station read keeps validated/confidence.
+      confidence: result.confidence,
+      validated: result.validated,
+      validationReason: result.validationReason,
+      derived: result.derived,
     );
   }
 

--- a/lib/features/consumption/data/receipt_parser/receipt_label_anchored_extractor.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_label_anchored_extractor.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:meta/meta.dart';
+
+import '../_pump_display_helpers.dart';
+import '../ocr/recognized_text_block.dart';
+import 'receipt_label_table.dart';
+
+/// A receipt block already classified as a printed label (with its field).
+@immutable
+class _LabelHit {
+  final RecognizedTextBlock block;
+  final PumpField field;
+  const _LabelHit(this.block, this.field);
+}
+
+/// A receipt block already classified as a numeric value.
+@immutable
+class _NumericHit {
+  final RecognizedTextBlock block;
+  final double value;
+  final int decimals;
+  const _NumericHit(this.block, this.value, this.decimals);
+}
+
+/// The geometry-aware read of a fuel-station receipt (#2848).
+///
+/// Carries the three transaction values plus a [derived] set naming any
+/// field the cross-check *computed* rather than read directly.
+@immutable
+class ReceiptAnchoredResult {
+  final double? totalCost;
+  final double? liters;
+  final double? pricePerLiter;
+
+  /// Fields whose value was DERIVED from the other two via
+  /// `total ≈ volume × pricePerLitre`, not read off the receipt.
+  final Set<PumpField> derived;
+
+  const ReceiptAnchoredResult({
+    this.totalCost,
+    this.liters,
+    this.pricePerLiter,
+    this.derived = const {},
+  });
+
+  static const empty = ReceiptAnchoredResult();
+
+  /// Number of the three transaction fields that are bound.
+  int get boundCount =>
+      [totalCost, liters, pricePerLiter].where((v) => v != null).length;
+
+  /// `true` when all three agree on `total ≈ volume × €/L` within a cent.
+  bool get isConsistent {
+    if (totalCost == null || liters == null || pricePerLiter == null) {
+      return false;
+    }
+    return (liters! * pricePerLiter! - totalCost!).abs() <= 0.02;
+  }
+}
+
+/// Reads the three fuel-receipt values by anchoring each printed LABEL to
+/// its row-aligned numeric block, then cross-checking the arithmetic
+/// (#2848).
+///
+/// The receipt cousin of `extractByLabelAnchor` (the #2478 pump-display
+/// path) — it reuses the same geometry technique (a value block binds to
+/// the nearest label block) but for the receipt layout, where the value
+/// sits in a RIGHT column ROW-ALIGNED with its left-column label:
+///
+///  1. **Classify** each block label | numeric | noise (reusing the
+///     7-segment digit normaliser + a tolerant numeric tokenizer that
+///     strips a leading currency glyph and trailing OCR noise like `!`,
+///     `/`, stray punctuation, and reads both `0,819` and `30.96`).
+///  2. **Anchor** each label to the numeric block on the SAME ROW (best
+///     vertical overlap, then nearest to its right), so `Volume` binds to
+///     `30.96`, `Prix` to `0.819`, `TOT TTC` to `25.36`.
+///  3. **Cross-check** `total ≈ volume × €/L`: with exactly two values
+///     read it DERIVES the third (and flags it [derived]).
+ReceiptAnchoredResult extractReceiptByLabelAnchor(
+  List<RecognizedTextBlock> blocks,
+) {
+  if (blocks.isEmpty) return ReceiptAnchoredResult.empty;
+
+  final labels = <_LabelHit>[];
+  final numerics = <_NumericHit>[];
+
+  for (final block in blocks) {
+    final numeric = _asNumeric(block);
+    if (numeric != null) {
+      numerics.add(numeric);
+      continue;
+    }
+    final field = classifyReceiptLabel(block.text);
+    if (field != null) {
+      labels.add(_LabelHit(block, field));
+    }
+    // Everything else (header prose, card-reader plate, IDs) is noise.
+  }
+
+  final bound = <PumpField, double>{};
+  final consumed = <_NumericHit>{};
+
+  // Bind heaviest-weight labels first so the per-litre "Prix" claims its
+  // number before a lighter label could.
+  labels.sort((a, b) =>
+      receiptFieldWeight(b.field).compareTo(receiptFieldWeight(a.field)));
+  for (final label in labels) {
+    if (bound.containsKey(label.field)) continue;
+    final value = _anchorOnRow(label.block, numerics, consumed);
+    if (value != null) {
+      bound[label.field] = value.value;
+      consumed.add(value);
+    }
+  }
+
+  return _crossCheck(
+    total: bound[PumpField.total],
+    volume: bound[PumpField.volume],
+    price: bound[PumpField.pricePerLitre],
+  );
+}
+
+/// Parses [block] as a numeric value when its text — after 7-segment
+/// normalisation, stripping a leading/embedded currency glyph (€, EUR)
+/// and unit (L/litres/€/L), and trimming TRAILING OCR noise (`!`, `/`,
+/// stray punctuation) — is a clean decimal. Reads both comma and dot
+/// decimals (FR `0,819` + `30.96` on the same receipt). A block that
+/// also carries label text never parses.
+_NumericHit? _asNumeric(RecognizedTextBlock block) {
+  final normalised = normaliseDigits(block.text).trim();
+  var cleaned = normalised
+      .replaceAll(RegExp(r'(?:€|EUR|LITRES?|litres?|L|l)\b'), ' ')
+      .replaceAll('€', ' ')
+      .replaceAll('/', ' ')
+      // Trailing OCR noise the receipt printer / ML Kit leaves on a value
+      // ("30.96 !", "€ 0,819/", "25,36 ."): drop any non-numeric tail.
+      .replaceAll(RegExp(r'[!|;:*°"º°\s]+$'), '')
+      .trim();
+  // A leading currency/space residue ("  25,36") is already handled by the
+  // anchored ^...$ match below once trimmed.
+  cleaned = cleaned.replaceAll(RegExp(r'^[^\d]+'), '');
+  final m = RegExp(r'^(\d+[.,]\d{1,3})$').firstMatch(cleaned);
+  if (m == null) return null;
+  final raw = m.group(1)!;
+  final value = parseDecimalFromOcr(raw);
+  if (value == null) return null;
+  final decimals = raw.split(RegExp(r'[.,]')).last.length;
+  return _NumericHit(block, value, decimals);
+}
+
+/// Finds the numeric block ROW-ALIGNED with [label]: prefers a numeric
+/// whose vertical span overlaps the label's row, then — among those — the
+/// nearest to the RIGHT (receipt values sit in a right column). When no
+/// numeric shares the row it falls back to the nearest by centre distance
+/// so a slightly mis-aligned value still binds.
+_NumericHit? _anchorOnRow(
+  RecognizedTextBlock label,
+  List<_NumericHit> numerics,
+  Set<_NumericHit> consumed,
+) {
+  _NumericHit? bestRow;
+  var bestRowScore = double.infinity;
+  _NumericHit? bestAny;
+  var bestAnyScore = double.infinity;
+
+  for (final n in numerics) {
+    if (consumed.contains(n)) continue;
+    final dx = n.block.box.cx - label.box.cx;
+    final dy = n.block.box.cy - label.box.cy;
+    final anyScore = dx * dx + dy * dy;
+    if (anyScore < bestAnyScore) {
+      bestAnyScore = anyScore;
+      bestAny = n;
+    }
+    // Row-aligned: the numeric's vertical span overlaps the label's, and
+    // it lies to the right (or roughly level). Score by horizontal gap so
+    // the closest right-column value on the row wins.
+    final overlapsRow =
+        n.block.box.top < label.box.bottom && label.box.top < n.block.box.bottom;
+    final toRight = n.block.box.cx >= label.box.cx;
+    if (overlapsRow && toRight) {
+      final gap = (n.block.box.left - label.box.right).abs();
+      if (gap < bestRowScore) {
+        bestRowScore = gap;
+        bestRow = n;
+      }
+    }
+  }
+  return bestRow ?? bestAny;
+}
+
+/// Cross-checks `total ≈ volume × €/L`, deriving the missing third when
+/// exactly two are read and flagging it [ReceiptAnchoredResult.derived].
+ReceiptAnchoredResult _crossCheck({
+  double? total,
+  double? volume,
+  double? price,
+}) {
+  final derived = <PumpField>{};
+  final present = [total, volume, price].where((v) => v != null).length;
+
+  if (present == 2) {
+    if (total == null && volume != null && price != null) {
+      total = double.parse((volume * price).toStringAsFixed(2));
+      derived.add(PumpField.total);
+    } else if (volume == null && total != null && price != null && price > 0) {
+      volume = double.parse((total / price).toStringAsFixed(2));
+      derived.add(PumpField.volume);
+    } else if (price == null &&
+        total != null &&
+        volume != null &&
+        volume > 0) {
+      price = double.parse((total / volume).toStringAsFixed(3));
+      derived.add(PumpField.pricePerLitre);
+    }
+  }
+
+  return ReceiptAnchoredResult(
+    totalCost: total,
+    liters: volume,
+    pricePerLiter: price,
+    derived: derived,
+  );
+}

--- a/lib/features/consumption/data/receipt_parser/receipt_label_table.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_label_table.dart
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Printed fuel-RECEIPT label table + classification for the receipt
+/// label-anchored extractor (#2848).
+///
+/// Mirrors `ocr/_pump_label_table.dart` but with the receipt vocabulary,
+/// where the labelling differs from a pump display:
+///
+///  * a fuel receipt prints the per-litre price under a bare **`Prix`**
+///    (or `Prix/L`, `P.U.`) label — NOT the total — while the charged
+///    amount is **`TOT TTC`** / `Total` / `Montant`. On the pump display
+///    the bare `PRIX` is the total, so the two tables must stay distinct.
+///  * volume is **`Volume`** / `Litres` / `Quantité`.
+///
+/// These are DATA values (the words printed on the paper receipt), never
+/// user-facing ARB strings.
+library;
+
+import '../ocr/_pump_label_table.dart';
+
+export '../ocr/_pump_label_table.dart' show PumpField, pumpFieldName;
+
+/// A printed receipt label and the field it denotes, with a [weight] so
+/// the disambiguator prefers the LONGEST / most-specific match per block
+/// ("TOT TTC" outranks a bare "TTC"; "Prix" stays light so a Total label
+/// never loses its row).
+class ReceiptLabelDef {
+  final RegExp pattern;
+  final PumpField field;
+  final int weight;
+  const ReceiptLabelDef(this.pattern, this.field, this.weight);
+}
+
+/// Multi-locale fuel-receipt labels. On a receipt the bare `Prix` is the
+/// per-litre price (the total is `TOT TTC` / `Total` / `Montant`), so it
+/// carries the heaviest weight to claim its row before any lighter label.
+final List<ReceiptLabelDef> kReceiptLabels = <ReceiptLabelDef>[
+  // --- price per litre (most specific) -------------------------------
+  ReceiptLabelDef(RegExp(r'prix\s*du\s*litre', caseSensitive: false),
+      PumpField.pricePerLitre, 34),
+  ReceiptLabelDef(RegExp(r'prix\s*unit', caseSensitive: false),
+      PumpField.pricePerLitre, 34),
+  ReceiptLabelDef(RegExp(r'prezzo\s*(?:unitario|al\s*litro)',
+      caseSensitive: false), PumpField.pricePerLitre, 34),
+  ReceiptLabelDef(RegExp(r'precio\s*por\s*litro', caseSensitive: false),
+      PumpField.pricePerLitre, 34),
+  ReceiptLabelDef(RegExp(r'(?:€|EUR)\s*/\s*l', caseSensitive: false),
+      PumpField.pricePerLitre, 32),
+  ReceiptLabelDef(RegExp(r'\bp\.?\s*u\.?\b', caseSensitive: false),
+      PumpField.pricePerLitre, 32),
+  ReceiptLabelDef(RegExp(r'literpreis', caseSensitive: false),
+      PumpField.pricePerLitre, 32),
+  // On a receipt the bare "Prix" is the per-litre price.
+  ReceiptLabelDef(
+      RegExp(r'\bprix\b', caseSensitive: false), PumpField.pricePerLitre, 30),
+  // --- total amount --------------------------------------------------
+  ReceiptLabelDef(RegExp(r'tot\.?\s*ttc', caseSensitive: false),
+      PumpField.total, 24),
+  ReceiptLabelDef(RegExp(r'total(?:e)?(?:\s*ttc)?', caseSensitive: false),
+      PumpField.total, 22),
+  ReceiptLabelDef(RegExp(r'montant(?:\s*(?:ttc|r[eé]el))?',
+      caseSensitive: false), PumpField.total, 22),
+  ReceiptLabelDef(RegExp(r'importo', caseSensitive: false), PumpField.total, 20),
+  ReceiptLabelDef(RegExp(r'importe', caseSensitive: false), PumpField.total, 20),
+  ReceiptLabelDef(RegExp(r'betra[gq]', caseSensitive: false), PumpField.total, 20),
+  // --- volume --------------------------------------------------------
+  ReceiptLabelDef(RegExp(r'volume', caseSensitive: false), PumpField.volume, 16),
+  ReceiptLabelDef(RegExp(r'quantit[eéà]', caseSensitive: false),
+      PumpField.volume, 16),
+  ReceiptLabelDef(RegExp(r'litres?', caseSensitive: false), PumpField.volume, 14),
+  ReceiptLabelDef(RegExp(r'litri', caseSensitive: false), PumpField.volume, 14),
+  ReceiptLabelDef(RegExp(r'litros', caseSensitive: false), PumpField.volume, 14),
+  ReceiptLabelDef(RegExp(r'menge', caseSensitive: false), PumpField.volume, 14),
+];
+
+/// Classifies [text] as a receipt label, returning the field of the
+/// heaviest matching label so "TOT TTC" outranks a bare "Total" prefix
+/// and the per-litre "Prix" never collides with the total (#2848). Null
+/// when no label matches.
+PumpField? classifyReceiptLabel(String text) {
+  ReceiptLabelDef? best;
+  for (final def in kReceiptLabels) {
+    if (!def.pattern.hasMatch(text)) continue;
+    if (best == null || def.weight > best.weight) best = def;
+  }
+  return best?.field;
+}
+
+/// Receipt-specific binding order weight (heaviest binds first). Mirrors
+/// `pumpFieldWeight` but tuned for the receipt labelling where the bare
+/// "Prix" is the per-litre price.
+int receiptFieldWeight(PumpField field) {
+  switch (field) {
+    case PumpField.pricePerLitre:
+      return 30;
+    case PumpField.total:
+      return 20;
+    case PumpField.volume:
+      return 14;
+  }
+}
+
+/// `true` when [fullText] carries enough fuel-station markers to route a
+/// receipt to the geometry-aware extractor instead of the generic
+/// flat-string parser: a pump/volume/price marker AND a per-litre price
+/// signal (a `€/L`-style token, OR both a `Prix`-family and a
+/// `Volume`-family label so a column-aligned receipt with the units in a
+/// separate block still routes). Deliberately conservative — anything
+/// that doesn't look like a fuel-pump receipt stays on the generic path.
+bool looksLikeFuelStationReceipt(String fullText) {
+  final lower = fullText.toLowerCase();
+  final hasPump =
+      RegExp(r'\bpompe\b|\bpump\b|\bs[aä]ule\b|\bpista\b').hasMatch(lower);
+  final hasVolume =
+      RegExp(r'\bvolume\b|\bquantit|\blitres?\b|\blitri\b').hasMatch(lower);
+  final hasPriceLabel =
+      RegExp(r'\bprix\b|prix\s*unit|\bp\.?\s*u\.?\b|literpreis|prezzo')
+          .hasMatch(lower);
+  final hasPerLitreToken =
+      RegExp(r'(?:€|eur)\s*/\s*l|/\s*l\b|€\s*\d').hasMatch(lower);
+
+  final stationSignal = hasPump || hasVolume || hasPriceLabel;
+  final priceSignal = hasPerLitreToken || (hasPriceLabel && hasVolume);
+  return stationSignal && priceSignal;
+}

--- a/lib/features/consumption/data/receipt_parser/receipt_orchestrator.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_orchestrator.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../ocr/ocr_trace_recorder.dart';
+import '../ocr/pump_ocr_config.dart';
+import '../ocr/pump_validation_gate.dart';
+import '../ocr/recognized_text_block.dart';
+import 'brand_detection.dart';
+import 'receipt_field_extractors.dart';
+import 'receipt_label_anchored_extractor.dart';
+import 'receipt_label_table.dart';
+import 'receipt_parse_result.dart';
+
+/// Orchestrates the #2848 geometry-aware fuel-receipt read.
+///
+/// The receipt cousin of `orchestratePumpDisplayParse`: it runs the
+/// label-anchored extractor over ML Kit's [blocks] (binding Volume→litres,
+/// Prix→€/L, TOT TTC→total by row alignment), scores a confidence, runs
+/// the SAME per-country [PumpValidationGate] (in-range + `litres × €/L ≈
+/// total`), and folds the geometry numbers together with the
+/// date/station/fuel still read from the flat [text]. Returns a
+/// `ReceiptParseResult` with `validated` / `confidence` set.
+ReceiptParseResult orchestrateReceiptParse({
+  required List<RecognizedTextBlock> blocks,
+  required String text,
+  required List<String> lines,
+  OcrLocaleProfile? profile,
+  PumpValidationGate gate = const PumpValidationGate(),
+  OcrTraceRecorder? trace,
+}) {
+  final anchored = extractReceiptByLabelAnchor(blocks);
+
+  // Prose fields the geometry path never produces — read from flat text.
+  final date = extractDate(text);
+  final stationName = extractStationName(lines);
+  final fuelType = extractFuelType(text);
+
+  final confidence = _confidenceFor(anchored);
+  final result = gate.evaluate(
+    total: anchored.totalCost,
+    volume: anchored.liters,
+    pricePerLitre: anchored.pricePerLiter,
+    confidence: confidence,
+    profile: profile,
+    trace: trace,
+  );
+  final derivedNames = anchored.derived.map(pumpFieldName).toSet();
+  trace?.result(
+    totalCost: anchored.totalCost,
+    liters: anchored.liters,
+    pricePerLiter: anchored.pricePerLiter,
+    derived: derivedNames,
+    confidence: confidence,
+    validated: profile != null && result.accepted,
+    validationReason: result.reason,
+  );
+
+  return ReceiptParseResult(
+    liters: anchored.liters,
+    totalCost: anchored.totalCost,
+    pricePerLiter: anchored.pricePerLiter,
+    date: date,
+    stationName: stationName,
+    fuelType: fuelType,
+    brandLayout: 'fuel_station',
+    confidence: confidence,
+    validated: profile != null && result.accepted,
+    validationReason: result.reason,
+    derived: derivedNames,
+  );
+}
+
+/// `true` when [text] / [blocks] look like a fuel-station receipt that
+/// should route to [orchestrateReceiptParse] instead of the generic
+/// flat-string parser. Conservative: needs the fuel-pump markers AND a
+/// per-litre price signal (see [looksLikeFuelStationReceipt]).
+bool shouldUseReceiptLabelAnchor(String text, List<RecognizedTextBlock> blocks) {
+  if (blocks.length < 2) return false;
+  return looksLikeFuelStationReceipt(text);
+}
+
+double _confidenceFor(ReceiptAnchoredResult r) {
+  var score = 0.0;
+  if (r.totalCost != null) score += 0.3;
+  if (r.liters != null) score += 0.3;
+  if (r.pricePerLiter != null) score += 0.3;
+  if (r.isConsistent) score += 0.1;
+  return score.clamp(0.0, 1.0);
+}

--- a/lib/features/consumption/data/receipt_parser/receipt_parse_result.dart
+++ b/lib/features/consumption/data/receipt_parser/receipt_parse_result.dart
@@ -28,10 +28,28 @@ class ReceiptParseResult {
   /// Null when the receipt doesn't name a recognisable product.
   final FuelType? fuelType;
 
-  /// Brand layout the parser used — "super_u", "carrefour", or "generic".
+  /// Brand layout the parser used — "super_u", "carrefour", "generic", or
+  /// "fuel_station" (the #2848 geometry-aware label-anchored read).
   /// Exposed so tests and telemetry can verify dispatch went to the
   /// specialised branch when a well-known receipt layout is scanned.
   final String brandLayout;
+
+  /// Read confidence in [0, 1] (#2848). Only the geometry-aware
+  /// fuel-station path scores this; the flat-string paths leave it 0.
+  final double confidence;
+
+  /// `true` when the geometry-aware read passed the per-country
+  /// validation gate (in-range + `litres × €/L ≈ total`) — #2848. The
+  /// flat-string paths leave it false, exactly as before.
+  final bool validated;
+
+  /// Machine-readable validation reason code (diagnostics, not
+  /// user-facing); null on the flat-string paths.
+  final String? validationReason;
+
+  /// Fields whose value the cross-check DERIVED rather than read directly
+  /// (`'totalCost'` / `'liters'` / `'pricePerLiter'`) — #2848.
+  final Set<String> derived;
 
   const ReceiptParseResult({
     this.liters,
@@ -41,6 +59,10 @@ class ReceiptParseResult {
     this.stationName,
     this.fuelType,
     this.brandLayout = 'generic',
+    this.confidence = 0,
+    this.validated = false,
+    this.validationReason,
+    this.derived = const {},
   });
 
   /// `true` when the parser extracted at least volume or total cost.

--- a/lib/features/consumption/data/receipt_scan_service.dart
+++ b/lib/features/consumption/data/receipt_scan_service.dart
@@ -113,8 +113,8 @@ class ReceiptScanService {
     OcrTraceRecorder? trace,
   }) async {
     trace?.input(country: country, brand: brand);
-    final text = await _recognise(path, trace: trace);
-    if (text == null) {
+    final recognised = await _recognise(path, trace: trace);
+    if (recognised == null) {
       await _tryDelete(path);
       return null;
     }
@@ -123,9 +123,13 @@ class ReceiptScanService {
       await _ocrConfig.load();
       profile = _ocrConfig.profileFor(country);
     }
+    // #2848 — pass ML Kit's block geometry to the parser so a fuel-station
+    // receipt (Volume/Prix/TOT TTC row-aligned with their left-column labels)
+    // routes to the label-anchored extractor; non-fuel receipts fall back.
     return ReceiptScanOutcome(
-      parse: _parser.parse(text, profile: profile, trace: trace),
-      ocrText: text,
+      parse: _parser.parseBlocks(recognised.blocks, recognised.text,
+          profile: profile, trace: trace),
+      ocrText: recognised.text,
       imagePath: path,
     );
   }
@@ -293,7 +297,7 @@ class ReceiptScanService {
   /// #1860 — when [enhanceContrast] is set (the pump-display path) the
   /// temp copy also gets a grayscale + histogram-normalise + contrast
   /// pass so 7-segment LCDs and washed-out displays become readable.
-  Future<String?> _recognise(
+  Future<({String text, List<RecognizedTextBlock> blocks})?> _recognise(
     String path, {
     bool enhanceContrast = false,
     OcrNormalizedRect? roi,
@@ -301,14 +305,14 @@ class ReceiptScanService {
   }) async {
     final recognized =
         await _recogniseRaw(path, enhanceContrast: enhanceContrast, roi: roi);
-    final text = recognized?.text;
-    if (text != null) debugPrint('OCR text (${text.length} chars):\n$text');
-    // #2517 — TRACE ONLY: recover the ML Kit geometry the receipt path
-    // discards (production still reads only the flat [text]).
-    if (trace != null && recognized != null) {
-      trace.blocks(recognized.text, mapRecognizedText(recognized));
-    }
-    return text;
+    if (recognized == null) return null;
+    final text = recognized.text;
+    debugPrint('OCR text (${text.length} chars):\n$text');
+    // #2848 — keep ML Kit's block geometry so the receipt path can route a
+    // fuel-station receipt to the label-anchored extractor (was trace-only).
+    final blocks = mapRecognizedText(recognized);
+    trace?.blocks(text, blocks);
+    return (text: text, blocks: blocks);
   }
 
   /// Runs ML Kit on the pump-display crop and returns BOTH the flat text

--- a/test/features/consumption/data/receipt_parser/receipt_label_anchored_test.dart
+++ b/test/features/consumption/data/receipt_parser/receipt_label_anchored_test.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/ocr/pump_ocr_config.dart';
+import 'package:tankstellen/features/consumption/data/ocr/recognized_text_block.dart';
+import 'package:tankstellen/features/consumption/data/receipt_parser.dart';
+
+/// Label-anchored fuel-RECEIPT extraction — issue #2848.
+///
+/// ## Ground-truth source
+///
+/// A recorded FR fuel-receipt trace (2026-06-04). ML Kit read the receipt
+/// fine, but the parser classified it `layout: generic` and extracted ONLY
+/// `totalCost = 25.36` (no volume, no price, confidence 0, validated
+/// false). The Volume / Prix (€/L) values sit in a RIGHT column,
+/// row-aligned with their left-column labels — exactly the geometry the
+/// pump-display path already solves but the receipt path didn't use.
+///
+/// ML Kit can't run in `flutter test`, so (as with the #2478 pump
+/// fixtures) we hand-build the block list a real photo produced from ONLY
+/// the fuel-relevant blocks in the trace. The card number, transaction /
+/// edition IDs and the raw receipt image are deliberately NOT committed.
+///
+/// Real ML Kit blocks (text @ [left, top, right, bottom]):
+///   "Pompe 2"     @ [34, 787, 306, 852]
+///   "Volume"      @ [36, 856, 266, 909]  → "30.96 !"  @ [730, 823, 1007, 892]
+///   "Prix"        @ [38, 922, 188, 973]  → "€ 0,819/" @ [650, 886, 993, 960]
+///   "TOT TTC"     @ [42,1045, 313,1147]  → "€ 25,36"  @ [772,1011,1027,1153]
+///   "TVA 20.00 %" @ [49,1288, 614,1348]  → "€ 4.2"    @ [788,1267,1029,1340]
+///   "Net"         @ [48,1360, 162,1412]  → "€ 21.13"  @ [748,1338,1031,1404]
+///
+/// 30.96 × 0.819 = 25.36 ✓ — once all three read, the identity gate marks
+/// the read validated.
+void main() {
+  // FR profile mirroring the shipped config (priceMin 0.5 / priceMax 4.0).
+  const frProfile = OcrLocaleProfile(
+    country: 'FR',
+    currency: 'EUR',
+    decimalSeparator: ',',
+    priceMin: 0.5,
+    priceMax: 4.0,
+    volumeMax: 200.0,
+    totalMax: 500.0,
+  );
+
+  RecognizedTextBlock block(
+    String text, {
+    required double l,
+    required double t,
+    required double r,
+    required double b,
+  }) =>
+      RecognizedTextBlock(
+          text: text, box: OcrBox(left: l, top: t, right: r, bottom: b));
+
+  /// The fuel-relevant blocks from the recorded FR trace (sanitised — no
+  /// card number, no transaction / edition IDs, no raw image).
+  List<RecognizedTextBlock> frReceiptBlocks() => <RecognizedTextBlock>[
+        block('Pompe 2', l: 34, t: 787, r: 306, b: 852),
+        block('Volume', l: 36, t: 856, r: 266, b: 909),
+        block('30.96 !', l: 730, t: 823, r: 1007, b: 892),
+        block('Prix', l: 38, t: 922, r: 188, b: 973),
+        block('€ 0,819/', l: 650, t: 886, r: 993, b: 960),
+        block('TOT TTC', l: 42, t: 1045, r: 313, b: 1147),
+        block('€ 25,36', l: 772, t: 1011, r: 1027, b: 1153),
+        block('TVA 20.00 %', l: 49, t: 1288, r: 614, b: 1348),
+        block('€ 4.2', l: 788, t: 1267, r: 1029, b: 1340),
+        block('Net', l: 48, t: 1360, r: 162, b: 1412),
+        block('€ 21.13', l: 748, t: 1338, r: 1031, b: 1404),
+      ];
+
+  /// Flat OCR text the same receipt produces — ML Kit emits a two-column
+  /// receipt COLUMN-GROUPED (the whole left label column, then the whole
+  /// right value column), NOT row-interleaved. That column-grouped order is
+  /// exactly why master's flat-string parse couldn't row-align Volume/Prix
+  /// to their values and read only the total.
+  String frReceiptText() => const [
+        // left column — labels, top to bottom
+        'Pompe 2', 'Volume', 'Prix', 'TOT TTC', 'TVA 20.00 %', 'Net',
+        // right column — values, top to bottom
+        '30.96 !', '€ 0,819/', '€ 25,36', '€ 4.2', '€ 21.13',
+      ].join('\n');
+
+  const parser = ReceiptParser();
+
+  group('#2848 — fuel-station receipt label-anchored read', () {
+    test('reads Volume + Prix + TOT TTC by row alignment, validated', () {
+      final r = parser.parseBlocks(
+        frReceiptBlocks(),
+        frReceiptText(),
+        profile: frProfile,
+      );
+
+      expect(r.liters, closeTo(30.96, 0.001),
+          reason: 'Volume → 30.96 L (trailing "!" OCR noise stripped)');
+      expect(r.pricePerLiter, closeTo(0.819, 0.001),
+          reason: 'Prix → 0.819 €/L (€ prefix + trailing "/" stripped, '
+              'comma decimal)');
+      expect(r.totalCost, closeTo(25.36, 0.001),
+          reason: 'TOT TTC → 25.36 € (comma decimal)');
+      expect(r.validated, isTrue,
+          reason: '30.96 × 0.819 = 25.36 → identity gate accepts');
+      expect(r.brandLayout, 'fuel_station');
+      expect(r.derived, isEmpty,
+          reason: 'all three read directly, nothing derived');
+      expect(r.confidence, greaterThanOrEqualTo(0.9));
+    });
+
+    test('does NOT mistake TVA / Net rows for the transaction values', () {
+      final r = parser.parseBlocks(
+        frReceiptBlocks(),
+        frReceiptText(),
+        profile: frProfile,
+      );
+      // The TVA (4.2) and Net (21.13) rows must not leak into the total.
+      expect(r.totalCost, closeTo(25.36, 0.001));
+      expect(r.liters, closeTo(30.96, 0.001));
+    });
+
+    test('RED-on-master proof: the flat-string parse reads ONLY the total',
+        () {
+      // On master the receipt path runs `parse(text)` (flat string) and
+      // grabs the biggest currency amount as the total but cannot bind
+      // Volume / Prix — the exact #2848 failure this PR fixes.
+      final flat = parser.parse(frReceiptText(), profile: frProfile);
+      expect(flat.totalCost, isNotNull);
+      expect(flat.liters, isNull,
+          reason: 'flat string cannot row-align Volume → no litres');
+      expect(flat.pricePerLiter, isNull,
+          reason: 'flat string cannot row-align Prix → no €/L');
+      expect(flat.validated, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Closes #2848.

Fuel receipts only extracted the **total**. A recorded FR trace showed ML Kit read everything — Volume `30.96 L`, Prix `0,819 €/L`, TOT TTC `25,36 €` (consistent: 30.96×0.819 = 25.36) — but the parser ran the generic flat-string path and got **only** `totalCost=25.36` (no volume, no price, confidence 0, validated false). On a two-column receipt ML Kit emits the label column and the value column **column-grouped**, not row-interleaved, so the flat string cannot row-align Volume/Prix to their right-column values — exactly the geometry the pump-display path (#2478 `label_anchored_extractor`) already solves.

## What changed (strictly additive)

- **`receipt_label_table.dart`** — fuel-receipt label vocabulary. On a *receipt* the bare `Prix` is the per-litre price (the total is `TOT TTC` / `Total` / `Montant`), the opposite of the pump display — so a dedicated table, plus a conservative `looksLikeFuelStationReceipt` detector (pump/volume/price markers + a €/L signal).
- **`receipt_label_anchored_extractor.dart`** — reuses the #2478 anchoring technique but for the receipt layout: binds `Volume→litres`, `Prix→€/L`, `TOT TTC→total` by **row alignment** (value in the right column, same row as its left-column label). Tolerant numeric tokenizing strips a leading currency glyph and **trailing OCR noise (`!`, `/`, stray punctuation)** and reads **both** comma and dot decimals on the same receipt (`0,819` + `30.96`).
- **`receipt_orchestrator.dart`** — runs the **same** per-country validation gate (`in-range` + `litres × €/L ≈ total`) → a consistent receipt returns `validated:true`; folds in date/station/fuel from the flat text.
- **`ReceiptParser.parseBlocks`** routes fuel-station receipts here and **falls back to the flat-string `parse` otherwise** (also defers when <2 geometry fields bind). `ReceiptScanService` now passes ML Kit's block geometry to the parser instead of discarding it.
- **`ReceiptParseResult`** gains `validated` / `confidence` / `validationReason` / `derived` (default `false`/`0`/`null`/`{}` — flat paths unchanged).

## Test (drives the real path)

`test/.../receipt_parser/receipt_label_anchored_test.dart` feeds the recorded FR block list through the **real** receipt path and asserts `litres≈30.96`, `€/L≈0.819`, `total≈25.36`, `validated`. A sibling assertion drives the master flat-string `parse` on the column-grouped text and shows it reads **only the total** — the behaviour this PR fixes.

**Sanitised:** the fixture contains only the fuel-relevant blocks. The card number, transaction/edition IDs and the raw receipt image are **not** committed.

## Checks

- `flutter analyze` clean (the 2 remaining info-level hints are pre-existing in unrelated test files).
- `flutter test test/features/consumption/` green (4117 passing); `file_length` / `catch_block_stacktrace_coverage` / `no_hardcoded_ui_strings` lint tests green. No new ARB. No codegen touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
