### PR TITLE
fix(ocr-tester): copy trace JSON without the image to avoid clipboard TransactionTooLargeException (#2853)

### DIFF
--- a/lib/features/consumption/data/ocr/ocr_trace_package.dart
+++ b/lib/features/consumption/data/ocr/ocr_trace_package.dart
@@ -102,7 +102,12 @@ class OcrTracePackage {
     this.image,
   });
 
-  Map<String, dynamic> toJson() => {
+  /// Serialises the trace. The capture [image] is ~5 MB of base64 and is
+  /// only meaningful as a sibling file, so callers headed for a size-bounded
+  /// sink (the clipboard — #2853, Android's Binder limit is ~1 MB) pass
+  /// `includeImage: false` to elide it; the file/fixture export keeps the
+  /// default so the source frame still rides alongside the JSON.
+  Map<String, dynamic> toJson({bool includeImage = true}) => {
         'schema': schema,
         'kind': kind.name,
         'capturedAt': capturedAt.toIso8601String(),
@@ -123,7 +128,7 @@ class OcrTracePackage {
         if (receipt != null) 'receipt': receipt!.toJson(),
         if (result != null) 'result': result!.toJson(),
         if (expected != null) 'expected': expected!.toJson(),
-        if (image != null) 'image': image!.toJson(),
+        if (includeImage && image != null) 'image': image!.toJson(),
       };
 }
 

--- a/lib/features/consumption/data/ocr/ocr_trace_serializer.dart
+++ b/lib/features/consumption/data/ocr/ocr_trace_serializer.dart
@@ -30,7 +30,15 @@ import 'ocr_trace_package.dart';
 ///   "result": { "totalCost": 18.59, "derived": [], ... }
 /// }
 /// ```
-String formatOcrTracePackageJson(OcrTracePackage package) {
+///
+/// [includeImage] defaults to `true` (the file / fixture export carries the
+/// base64 capture). Pass `false` for size-bounded sinks like the clipboard
+/// (#2853) — the ~5 MB base64 blob is meaningless as pasted text and trips
+/// Android's ~1 MB Binder limit.
+String formatOcrTracePackageJson(
+  OcrTracePackage package, {
+  bool includeImage = true,
+}) {
   const encoder = JsonEncoder.withIndent('  ');
-  return encoder.convert(package.toJson());
+  return encoder.convert(package.toJson(includeImage: includeImage));
 }

--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_export.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_export.dart
@@ -35,6 +35,14 @@ Future<Directory> Function()? debugOcrPackageTempDirectoryOverride;
 /// some clipboard managers silently drop large payloads.
 const int kOcrPackageClipboardThresholdBytes = 64 * 1024;
 
+/// Hard upper bound (UTF-8 bytes) on what [OcrTesterExport.copyAsJson] will
+/// hand to the system clipboard (#2853). Android marshals clipboard data
+/// over a Binder transaction capped near 1 MB; well above this and
+/// `Clipboard.setData` throws `TransactionTooLargeException`. The
+/// image-elided trace is normally a few KB, so this is a defensive ceiling
+/// that routes any pathological payload to the file export instead.
+const int kOcrPackageClipboardMaxBytes = 256 * 1024;
+
 /// Local-only export of a built [OcrTracePackage] for the gated OCR tester
 /// (#2518, Epic #2516 Child 2). No paid services, no network — the JSON
 /// (and, when present, the capture image) lands in the device's Downloads
@@ -44,12 +52,23 @@ const int kOcrPackageClipboardThresholdBytes = 64 * 1024;
 class OcrTesterExport {
   OcrTesterExport._();
 
-  /// Copies the pretty-printed trace JSON to the clipboard. Returns the
-  /// JSON so the caller can size / log it.
-  static Future<String> copyAsJson(OcrTracePackage package) async {
-    final json = formatOcrTracePackageJson(package);
+  /// Copies the pretty-printed trace JSON to the clipboard, WITHOUT the
+  /// base64 capture image (#2853): the image is ~5 MB and meaningless as
+  /// pasted text, and the full payload tripped Android's ~1 MB Binder limit
+  /// (`TransactionTooLargeException`). The capture still rides alongside the
+  /// JSON via [exportPackage] / [saveAsFixture], which keep the image.
+  ///
+  /// Returns `true` when the JSON reached the clipboard, `false` when even
+  /// the image-elided document exceeds [kOcrPackageClipboardMaxBytes] — in
+  /// which case nothing is written and the caller should fall back to the
+  /// file export.
+  static Future<bool> copyAsJson(OcrTracePackage package) async {
+    final json = formatOcrTracePackageJson(package, includeImage: false);
+    if (utf8.encode(json).length > kOcrPackageClipboardMaxBytes) {
+      return false;
+    }
     await Clipboard.setData(ClipboardData(text: json));
-    return json;
+    return true;
   }
 
   /// Writes the trace JSON (and the sibling capture image, when the

--- a/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
+++ b/lib/features/profile/presentation/screens/developer_tools/pump_ocr_tester_widgets.dart
@@ -320,9 +320,15 @@ extension _PumpOcrTesterActions on _PumpOcrTesterScreenState {
   // --- Export --------------------------------------------------------------
 
   Future<void> _copyAsJson(OcrTracePackage package) async {
-    await OcrTesterExport.copyAsJson(package);
+    final copied = await OcrTesterExport.copyAsJson(package);
     if (!mounted) return;
     final l = AppLocalizations.of(context);
+    if (!copied) {
+      // The image-elided trace is still too large for the clipboard (#2853)
+      // — route it to the Downloads / share-sheet export instead.
+      await _exportPackage(package);
+      return;
+    }
     SnackBarHelper.showSuccess(
       context,
       l?.ocrTesterCopied ?? 'OCR trace copied to clipboard.',

--- a/test/features/consumption/data/ocr/ocr_trace_serializer_test.dart
+++ b/test/features/consumption/data/ocr/ocr_trace_serializer_test.dart
@@ -128,4 +128,49 @@ void main() {
     expect(decoded['schema'], 1);
     expect(decoded['crossCheck'], isA<Map>());
   });
+
+  group('includeImage (#2853 — clipboard TransactionTooLargeException)', () {
+    // A recorder run plus a ~5 MB base64 capture image — the same shape that
+    // tripped Android's ~1 MB Binder limit when the clipboard carried it.
+    OcrTracePackage withLargeImage() {
+      // 4 MB of bytes → ~5.3 MB base64, mirroring the real crash payload.
+      final bytes = List<int>.filled(4 * 1024 * 1024, 7);
+      final recorder = runPump()
+        ..image(fileName: 'capture.jpg', base64: base64Encode(bytes));
+      return recorder.build();
+    }
+
+    test('default serialisation (file export) STILL carries the image', () {
+      final json = formatOcrTracePackageJson(withLargeImage());
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+      expect(decoded.containsKey('image'), isTrue);
+      expect((decoded['image'] as Map)['base64'], isNotEmpty);
+      // The file payload is necessarily huge (it embeds the capture).
+      expect(utf8.encode(json).length, greaterThan(5 * 1024 * 1024));
+    });
+
+    test('includeImage:false omits the base64 blob entirely', () {
+      final pkg = withLargeImage();
+      final clip = formatOcrTracePackageJson(pkg, includeImage: false);
+
+      // The base64 bytes must not appear anywhere in the clipboard JSON.
+      expect(clip.contains(pkg.image!.base64), isFalse);
+      expect((jsonDecode(clip) as Map).containsKey('image'), isFalse);
+      // And the document is now far under the ~1 MB Binder transaction cap.
+      expect(utf8.encode(clip).length, lessThan(64 * 1024));
+
+      // Eliding the image leaves the rest of the reasoning chain intact.
+      final decoded = jsonDecode(clip) as Map<String, dynamic>;
+      expect(decoded['kind'], 'pump');
+      expect((decoded['result'] as Map)['totalCost'], closeTo(18.59, 0.001));
+    });
+
+    test('an image-less trace serialises identically either way', () {
+      final pkg = runPump().build();
+      expect(
+        formatOcrTracePackageJson(pkg, includeImage: false),
+        formatOcrTracePackageJson(pkg),
+      );
+    });
+  });
 }

--- a/test/features/profile/presentation/screens/developer_tools/pump_ocr_tester_screen_test.dart
+++ b/test/features/profile/presentation/screens/developer_tools/pump_ocr_tester_screen_test.dart
@@ -282,24 +282,53 @@ void main() {
     });
   });
 
-  group('OcrTesterExport', () {
-    test('copyAsJson serialises the package to the clipboard', () async {
+  group('OcrTesterExport.copyAsJson (#2853)', () {
+    /// Captures the `Clipboard.setData` text via the platform-channel mock,
+    /// returning a getter so the test reads the latest captured value.
+    String? Function() interceptClipboard() {
       TestWidgetsFlutterBinding.ensureInitialized();
-      String? copied;
+      final captured = <String?>[null];
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, (call) async {
         if (call.method == 'Clipboard.setData') {
-          copied = (call.arguments as Map)['text'] as String?;
+          captured[0] = (call.arguments as Map)['text'] as String?;
         }
         return null;
       });
+      addTearDown(() => TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+      return () => captured[0];
+    }
+
+    test('copies the image-elided trace to the clipboard', () async {
+      final clipboard = interceptClipboard();
       final pkg = seededPumpTrace();
-      final json = await OcrTesterExport.copyAsJson(pkg);
-      expect(json, contains('"kind": "pump"'));
+      expect(await OcrTesterExport.copyAsJson(pkg), isTrue);
+      expect(clipboard(), isNotNull);
+      expect(clipboard(), contains('"kind": "pump"'));
+      // No image on this trace, so it equals the image-elided serialisation.
+      expect(clipboard(),
+          equals(formatOcrTracePackageJson(pkg, includeImage: false)));
+    });
+
+    test('does NOT put the base64 capture image on the clipboard', () async {
+      final clipboard = interceptClipboard();
+      // A real-shaped ~5 MB base64 capture — what tripped the Binder limit.
+      final trace = OcrTraceRecorder(kind: OcrTraceKind.pump)
+        ..result(totalCost: 18.59)
+        ..image(
+          fileName: 'capture.jpg',
+          base64: base64Encode(List<int>.filled(4 * 1024 * 1024, 7)),
+        );
+      final pkg = trace.build();
+
+      expect(await OcrTesterExport.copyAsJson(pkg), isTrue);
+      final copied = clipboard();
       expect(copied, isNotNull);
-      expect(copied, equals(formatOcrTracePackageJson(pkg)));
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(SystemChannels.platform, null);
+      // The clipboard string omits the base64 bytes and stays tiny.
+      expect(copied!.contains(pkg.image!.base64), isFalse);
+      expect(utf8.encode(copied).length, lessThan(64 * 1024));
     });
   });
 }


### PR DESCRIPTION
## Problem

The gated OCR tester's **Copy as JSON** action crashed with
`android.os.TransactionTooLargeException`. `copyAsJson` serialized the *whole*
`OcrTracePackage` — including the ~5.3 MB base64 capture image — and handed it
to `Clipboard.setData`. Android marshals clipboard data over a Binder
transaction capped near 1 MB, so the copy blew the limit and threw.

Trace from the real error log:
`Clipboard.setData` ← `OcrTesterExport.copyAsJson` (`pump_ocr_tester_export.dart:51`)
← `_PumpOcrTesterActions._copyAsJson` (`pump_ocr_tester_widgets.dart:307`).

## Fix

The base64 image is meaningless as pasted text — it is only useful as a sibling
file, which the **Export package** / **Save as fixture** paths already write.

- `OcrTracePackage.toJson` / `formatOcrTracePackageJson` gain an `includeImage`
  flag (defaults to `true`, so the file/fixture export is **unchanged** and
  still embeds the capture).
- `copyAsJson` now serializes with `includeImage: false` and returns a `bool`.
  A defensive 256 KB ceiling (`kOcrPackageClipboardMaxBytes`) means any
  pathological payload is *never* handed to `Clipboard.setData` oversized —
  instead the caller falls back to the file export.
- The screen's `_copyAsJson` routes the too-large case to `_exportPackage`,
  reusing the existing `ocrTesterExported` snackbar — **no new ARB key**.
- The **Export package** / file-export path is verified UNCHANGED: it still
  writes the JSON with the image plus the sibling `.jpg`.

## Tests (CI-provable, no platform channel)

- Serializer: a package WITH a ~5 MB image — `includeImage: false` produces
  JSON containing **none** of the base64 bytes and well under the Binder limit;
  the default serialization **still** embeds the image (file payload > 5 MB).
- Export: `copyAsJson` on a ~5 MB-image package puts a payload on the clipboard
  that omits the base64 bytes and stays tiny.

`flutter analyze` clean; serializer + screen tests and the `file_length`,
`no_hardcoded_ui_strings`, `catch_block_stacktrace_coverage` lint guards green.

Closes #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)
