### PR TITLE
fix(obd2): stop transient live-read timeouts from flooding the error log (#2855)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_read_telemetry.dart
+++ b/lib/features/consumption/data/obd2/obd2_read_telemetry.dart
@@ -32,6 +32,17 @@ bool isExpectedObd2ReadTransient(Object error) =>
 /// instead; a GENUINE fault still `errorLogger.log`s at [ErrorLayer.other] so
 /// it stays visible. Shared by the data-layer `readVin` and the onboarding
 /// connector so the two sites can't drift.
+///
+/// #2855 — also backs the high-frequency live-poll reads (`readSpeedKmh`,
+/// `readRpm`, and every `_readDouble`-based PID: throttle / load / fuel-rate
+/// / MAF / MAP / IAT / baro / fuel-trims / …). An engine-off or busy adapter
+/// times the speed/RPM PID out every ~2.5 s poll cycle; a real log showed
+/// 50× `readSpeed failed` ERROR traces in 2 min. Routing those through here
+/// turns each transient into the designed 'no reading this cycle' null +
+/// breadcrumb, so the per-poll flood stops while genuine parse/IO faults
+/// still surface. Persistent non-response is already covered by the
+/// comm-health diagnostics (#2464) + passive-waiting banner (#2767), so no
+/// real signal is lost. Same spirit as the #2379 odometer fix.
 void recordObd2ReadFailure(
   Object error,
   StackTrace stack, {

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -819,7 +819,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.vehicleSpeedCommand);
       return Elm327Protocol.parseVehicleSpeed(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readSpeed failed'}));
+      recordObd2ReadFailure(e, st, where: 'OBD2 readSpeed failed'); // #2855
       return null;
     }
   }
@@ -856,7 +856,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.engineRpmCommand);
       return Elm327Protocol.parseEngineRpm(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readRpm failed'}));
+      recordObd2ReadFailure(e, st, where: 'OBD2 readRpm failed'); // #2855
       return null;
     }
   }
@@ -1285,7 +1285,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(Elm327Protocol.fuelTypeCommand);
       return Elm327Protocol.parseFuelType(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 readFuelType failed'}));
+      recordObd2ReadFailure(e, st, where: 'OBD2 readFuelType failed'); // #2855
       return null;
     }
   }
@@ -1552,7 +1552,7 @@ class Obd2Service implements Obd2RawCommandPort {
       final response = await _send(command);
       return parser(response);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {'where': 'OBD2 read $label failed'}));
+      recordObd2ReadFailure(e, st, where: 'OBD2 read $label failed'); // #2855
       return null;
     }
   }

--- a/test/features/consumption/data/obd2/obd2_service_live_read_logging_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_live_read_logging_test.dart
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+
+/// #2855 — the high-frequency OBD2 live-poll reads (`readSpeedKmh`,
+/// `readRpm`, and the shared `_readDouble`-backed PID reads) already return
+/// null on failure as graceful degradation, but they ERROR-logged EVERY
+/// failure — including the routine `TimeoutException` of an engine-off /
+/// busy adapter. A real log showed 50× `readSpeed failed` traces in 2 min.
+///
+/// This file pins the contract: a transient (TimeoutException) read failure
+/// produces ZERO error traces (the null return IS the signal), while a
+/// GENUINE non-transient failure still logs exactly once. Persistent
+/// non-response is surfaced by comm-health diagnostics (#2464) + the
+/// passive-waiting banner (#2767), so suppressing per-poll timeout traces
+/// loses no real signal. Same spirit as the #2379 odometer fix.
+
+const _initResponses = {
+  'ATZ': 'ELM327 v1.5>',
+  'ATE0': 'OK>',
+  'ATL0': 'OK>',
+  'ATH0': 'OK>',
+  'ATSP0': 'OK>',
+};
+
+/// Live-poll PID commands exercised here: speed (010D), RPM (010C) and a
+/// `_readDouble`-backed read, engine load (0104).
+const _liveReadCommands = {'010D', '010C', '0104'};
+
+/// Transport that connects + inits normally (so connect() is quiet), but
+/// throws a [TimeoutException] for the live-read PIDs — the engine-off /
+/// busy-adapter scenario that produced the real flood.
+class _LiveReadTimingOutTransport implements Obd2Transport {
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    if (_liveReadCommands.contains(cmd)) {
+      throw TimeoutException('ELM327 did not respond within 2.5s');
+    }
+    return _initResponses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+}
+
+/// Transport that connects + inits normally but throws a GENUINE
+/// non-transient fault (a plain [FormatException], standing in for a
+/// parse/IO fault) for the live-read PIDs — this MUST still be logged.
+class _LiveReadGenuineFaultTransport implements Obd2Transport {
+  bool _connected = false;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    if (!_connected) throw StateError('Not connected');
+    final cmd = command.trim();
+    if (_liveReadCommands.contains(cmd)) {
+      throw const FormatException('corrupt OBD2 frame');
+    }
+    return _initResponses[cmd] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+}
+
+class _CaptureRecorder implements TraceRecorder {
+  final calls = <Object>[];
+
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    calls.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _CaptureRecorder recorder;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    recorder = _CaptureRecorder();
+    errorLogger.testRecorderOverride = recorder;
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  group('live-read transient timeouts do NOT flood the error log (#2855)', () {
+    test(
+        'N readSpeedKmh timeouts each return null and log ZERO error traces',
+        () async {
+      final service = Obd2Service(_LiveReadTimingOutTransport());
+      await service.connect();
+      expect(recorder.calls, isEmpty,
+          reason: 'connect() should be quiet for this transport');
+
+      const cycles = 50; // the real flood was 50 traces in ~2 min.
+      for (var i = 0; i < cycles; i++) {
+        expect(await service.readSpeedKmh(), isNull,
+            reason: 'best-effort: a timeout yields null');
+      }
+
+      expect(recorder.calls, isEmpty,
+          reason: 'a transient readSpeed timeout is the no-reply path — '
+              'it must NOT pollute the error log ($cycles cycles = was '
+              '$cycles traces)');
+    });
+
+    test('N readRpm timeouts each return null and log ZERO error traces',
+        () async {
+      final service = Obd2Service(_LiveReadTimingOutTransport());
+      await service.connect();
+      expect(recorder.calls, isEmpty);
+
+      const cycles = 50;
+      for (var i = 0; i < cycles; i++) {
+        expect(await service.readRpm(), isNull);
+      }
+
+      expect(recorder.calls, isEmpty,
+          reason: 'a transient readRpm timeout must NOT pollute the log');
+    });
+
+    test(
+        'N _readDouble (engine load) timeouts each return null and log ZERO '
+        'error traces', () async {
+      final service = Obd2Service(_LiveReadTimingOutTransport());
+      await service.connect();
+      expect(recorder.calls, isEmpty);
+
+      const cycles = 50;
+      for (var i = 0; i < cycles; i++) {
+        expect(await service.readEngineLoad(), isNull);
+      }
+
+      expect(recorder.calls, isEmpty,
+          reason: 'the shared _readDouble live-read path must NOT pollute '
+              'the log on a transient timeout');
+    });
+  });
+
+  group('genuine non-transient read faults still log (#2855)', () {
+    test('readSpeedKmh parse/IO fault returns null AND logs once', () async {
+      final service = Obd2Service(_LiveReadGenuineFaultTransport());
+      await service.connect();
+      expect(recorder.calls, isEmpty,
+          reason: 'connect() should be quiet for this transport');
+
+      expect(await service.readSpeedKmh(), isNull);
+
+      expect(recorder.calls, hasLength(1),
+          reason: 'a genuine (non-transient) read fault must still surface '
+              'as exactly one error trace');
+    });
+
+    test('readEngineLoad parse/IO fault returns null AND logs once', () async {
+      final service = Obd2Service(_LiveReadGenuineFaultTransport());
+      await service.connect();
+      expect(recorder.calls, isEmpty);
+
+      expect(await service.readEngineLoad(), isNull);
+
+      expect(recorder.calls, hasLength(1),
+          reason: 'a genuine _readDouble fault must still surface once');
+    });
+  });
+}


### PR DESCRIPTION
Closes #2855.

## Problem
The high-frequency OBD2 live-poll reads already return `null` on failure as graceful degradation, but their catch ERROR-logged **every** failure — including the routine `TimeoutException` of an engine-off / busy adapter. A real field log (2026-06-04, app 5.0.0) showed **50× `OBD2 readSpeed failed`** traces in ~2 min, one per ~2.5 s poll cycle.

Affected reads:
- `readSpeedKmh()`
- `readRpm()`
- the shared `_readDouble(label)` helper — backs `readThrottlePercent` / `readEngineLoad` / `readFuelRateLPerHour` / `readMaf` / `readManifoldPressure` / `readIntakeAirTemp` / `readBaro` / fuel-trims / …
- `readFuelType()` (one-shot, low-frequency — folded in for consistency)

## Fix (root, centralized — not a per-method band-aid)
Route the four read catches through the **existing #2763** `recordObd2ReadFailure` helper, which:
- breadcrumbs an **expected transient** (`TimeoutException` / `StateError` / expected `Obd2ConnectionError` — the documented flaky-comms contract) and does **not** ERROR-log it, and
- still `errorLogger.log`s a **genuine** non-transient fault (parse / IO).

This reuses the same classifier `readVin` already uses (`isExpectedObd2ReadTransient`), so the read sites can't drift. Read behaviour (`null` on failure), the timeout value, and the polling cadence are **unchanged** — only the error-LOGGING decision moved.

Persistent non-response is already surfaced by the comm-health diagnostics (#2464) and the reconnect/passive-waiting banner (#2767), so suppressing per-poll timeout traces loses no real signal. Same spirit as the #2379 odometer fix.

## File length
`obd2_service.dart` stays **exactly** at its 1603-line snapshot (inline 1:1 swaps, no grandfather entry added); the full rationale lives on the helper's doc comment in `obd2_read_telemetry.dart`.

## Test (CI-provable, no device)
`obd2_service_live_read_logging_test.dart` drives the service with a fake transport that throws `TimeoutException` **N=50×**: `readSpeedKmh` / `readRpm` / `readEngineLoad` each return `null` and produce **ZERO** error traces (was N). A second fake throwing a non-timeout `FormatException` → still logs **once** and returns `null`. Verified RED on the pre-fix code, GREEN with the fix.

- `flutter analyze` clean on changed files
- obd2 service suite + lint guards (`file_length` / `no_hardcoded_ui_strings` / `catch_block_stacktrace_coverage`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
