### PR TITLE
fix(alerts): wire Station-alert add via station picker + real FR translations (#2857)

### DIFF
--- a/lib/features/alerts/presentation/screens/alerts_screen.dart
+++ b/lib/features/alerts/presentation/screens/alerts_screen.dart
@@ -17,6 +17,7 @@ import '../../domain/entities/price_alert.dart';
 import '../../domain/entities/radius_alert.dart';
 import '../../providers/alert_provider.dart';
 import '../../providers/radius_alerts_provider.dart';
+import '../widgets/alert_station_picker_sheet.dart';
 import '../widgets/alert_statistics_card.dart';
 import '../widgets/radius_alert_create_sheet.dart';
 
@@ -85,11 +86,11 @@ class _AlertsBody extends ConsumerWidget {
           title: l10n?.alertsStationSectionTitle ?? 'Station alerts',
           count: alerts.length,
           addTooltip: l10n?.alertsStationAdd ?? 'Add a station alert',
-          onAdd: () => SnackBarHelper.show(
-            context,
-            l10n?.noPriceAlertsHint ??
-                'Create an alert from a station\'s detail page.',
-          ),
+          // #2857 — the "+" used to be a dead-end that only re-showed the
+          // "create from a station's detail page" hint. It now opens the
+          // favorite-station picker and, on selection, the same
+          // [CreateAlertDialog] the station-detail app bar uses.
+          onAdd: () => AlertStationPickerSheet.addStationAlert(context, ref),
         ),
         if (alerts.isEmpty)
           _SectionEmpty(

--- a/lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart
+++ b/lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/logging/error_logger.dart';
+import '../../../../core/storage/storage_providers.dart';
+import '../../../../core/widgets/snackbar_helper.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../domain/entities/price_alert.dart';
+import '../../providers/alert_provider.dart';
+import 'create_alert_dialog.dart';
+
+/// Bottom sheet that lets the user pick one of their favorite stations to
+/// attach a price alert to (#2857).
+///
+/// Before this, the Station-alerts "+" on the redesigned alerts screen was a
+/// dead-end: it only re-showed the "create from a station's detail page" hint.
+/// Station alerts are created via [CreateAlertDialog], which needs a station —
+/// previously only reachable from the station-detail app bar. This picker
+/// reuses the same favorites-backed list as the consumption fill-up picker
+/// ([PickStationForFillUpScreen]) and the existing `pickStation*` strings, but
+/// — unlike that screen, which `pushReplacement`s into the fill-up form —
+/// RETURNS the chosen [Station] via `Navigator.pop`, so the caller can hand it
+/// straight to [CreateAlertDialog].
+///
+/// When the user has no favorites yet, the sheet shows the empty hint plus a
+/// "Search" CTA that closes the sheet and navigates to the Search tab — the
+/// sanctioned fallback so the user can reach a station's detail page (where
+/// the create-alert action also lives).
+class AlertStationPickerSheet extends ConsumerWidget {
+  const AlertStationPickerSheet({super.key});
+
+  /// Opens the picker and resolves to the selected [Station], or `null` if
+  /// the user dismissed the sheet (or tapped the Search fallback, which
+  /// pops + navigates away).
+  static Future<Station?> show(BuildContext context) {
+    return showModalBottomSheet<Station>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => const AlertStationPickerSheet(),
+    );
+  }
+
+  /// The full Station-alert add flow (#2857): pick a favorite station, run the
+  /// same [CreateAlertDialog] the station-detail app bar uses, and persist the
+  /// result via [AlertNotifier.addAlert]. Mirrors
+  /// `StationDetailAppBarActions._showCreateAlertDialog` so an alert created
+  /// from the alerts screen is byte-identical to one created from detail.
+  static Future<void> addStationAlert(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final station = await show(context);
+    if (station == null || !context.mounted) return;
+
+    final alert = await showDialog<PriceAlert>(
+      context: context,
+      builder: (_) => CreateAlertDialog(
+        stationId: station.id,
+        stationName: _stationLabel(station),
+        currentPrice: station.diesel ?? station.e10 ?? station.e5,
+      ),
+    );
+    if (alert == null || !context.mounted) return;
+
+    await ref.read(alertProvider.notifier).addAlert(alert);
+    if (!context.mounted) return;
+    final l10n = AppLocalizations.of(context);
+    SnackBarHelper.showSuccess(
+      context,
+      l10n?.alertCreated ?? 'Price alert created',
+    );
+  }
+
+  /// Brand → name → street fallback for the dialog title (#2161): French
+  /// `prix-carburants` stations often carry no brand but a populated name.
+  static String _stationLabel(Station s) {
+    if (s.brand.isNotEmpty && s.brand != 'Station') return s.brand;
+    final name = s.name.trim();
+    if (name.isNotEmpty) return name;
+    return s.street.isNotEmpty ? s.street : s.id;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final storage = ref.watch(storageRepositoryProvider);
+
+    final stations = <Station>[];
+    for (final id in storage.getFavoriteIds()) {
+      final raw = storage.getFavoriteStationData(id);
+      if (raw == null) continue;
+      try {
+        stations.add(Station.fromJson(raw));
+      } catch (e, st) {
+        unawaited(errorLogger.log(
+          ErrorLayer.ui,
+          e,
+          st,
+          context: {'where': 'AlertStationPicker: skipping malformed fav $id'},
+        ));
+      }
+    }
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              l10n?.pickStationTitle ?? 'Pick a station',
+              style: theme.textTheme.titleLarge,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              l10n?.pickStationHelper ??
+                  'Start the fill-up from a known station so prices, brand '
+                      'and fuel type fill themselves in.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          if (stations.isEmpty)
+            _PickerEmptyState(
+              message: l10n?.pickStationEmpty ??
+                  'No favorite stations yet — add some from Search or '
+                      'Favorites, or skip and fill in manually.',
+              searchLabel: l10n?.search ?? 'Search',
+              onSearch: () {
+                Navigator.of(context).pop();
+                context.go('/');
+              },
+            )
+          else
+            Flexible(
+              child: ListView.separated(
+                shrinkWrap: true,
+                itemCount: stations.length,
+                separatorBuilder: (_, _) =>
+                    const Divider(height: 1, indent: 72),
+                itemBuilder: (context, index) {
+                  final station = stations[index];
+                  final title = station.brand.isNotEmpty
+                      ? station.brand
+                      : station.name;
+                  final parts = <String>[];
+                  if (station.street.isNotEmpty) parts.add(station.street);
+                  if (station.place.isNotEmpty) parts.add(station.place);
+                  return ListTile(
+                    key: Key('alert_pick_station_tile_${station.id}'),
+                    leading: const Icon(Icons.local_gas_station),
+                    title: Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: Text(
+                      parts.join(' • '),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () => Navigator.of(context).pop(station),
+                  );
+                },
+              ),
+            ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+/// Empty state shown inside the picker when the user has no favorites yet —
+/// surfaces the hint plus a CTA that jumps to Search so they can reach a
+/// station's detail page (the other create-alert entry point).
+class _PickerEmptyState extends StatelessWidget {
+  const _PickerEmptyState({
+    required this.message,
+    required this.searchLabel,
+    required this.onSearch,
+  });
+
+  final String message;
+  final String searchLabel;
+  final VoidCallback onSearch;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.star_border,
+            size: 48,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          FilledButton.tonalIcon(
+            key: const Key('alert_pick_station_search'),
+            onPressed: onSearch,
+            icon: const Icon(Icons.search),
+            label: Text(searchLabel),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4411,16 +4411,8 @@
       }
     }
   },
-  "alertsStationSectionTitle": "Station alerts",
-  "@alertsStationSectionTitle": {
-    "x-mt": "needs-native-review",
-    "description": "MT — needs native review"
-  },
-  "alertsStationAdd": "Add a station alert",
-  "@alertsStationAdd": {
-    "x-mt": "needs-native-review",
-    "description": "MT — needs native review"
-  },
+  "alertsStationSectionTitle": "Alertes de station",
+  "alertsStationAdd": "Ajouter une alerte de station",
   "scanPumpInconsistent": "The scanned values don't add up — please enter them manually.",
   "@scanPumpInconsistent": {
     "x-mt": "needs-native-review",

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3439,10 +3439,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Cela supprimera le rendement volumétrique appris (η_v) et restaurera la valeur par défaut (0,85). Les estimations de débit de carburant par trajet retomberont sur la constante du constructeur jusqu\'à ce que le calibrateur collecte de nouveaux échantillons lors des prochains trajets.';
 
   @override
-  String get alertsStationSectionTitle => 'Station alerts';
+  String get alertsStationSectionTitle => 'Alertes de station';
 
   @override
-  String get alertsStationAdd => 'Add a station alert';
+  String get alertsStationAdd => 'Ajouter une alerte de station';
 
   @override
   String get alertsRadiusSectionTitle => 'Alertes de zone';

--- a/test/features/alerts/presentation/screens/alerts_screen_test.dart
+++ b/test/features/alerts/presentation/screens/alerts_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/services/widgets/service_status_banner.dart';
 import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
 import 'package:tankstellen/features/alerts/presentation/screens/alerts_screen.dart';
+import 'package:tankstellen/features/alerts/presentation/widgets/create_alert_dialog.dart';
 import 'package:tankstellen/features/alerts/providers/alert_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 
@@ -135,6 +136,108 @@ void main() {
       );
 
       expect(find.byType(ServiceChainErrorWidget), findsOneWidget);
+    });
+  });
+
+  // #2857 — the Station-alerts "+" must reach a real add flow, not re-show
+  // the "create from a station's detail page" snackbar.
+  group('AlertsScreen — Station "+" add flow (#2857)', () {
+    Map<String, dynamic> stationJson(String id, String brand) => {
+          'id': id,
+          'name': brand,
+          'brand': brand,
+          'street': 'Hauptstr. 1',
+          'postCode': '10115',
+          'place': 'Berlin',
+          'lat': 52.5,
+          'lng': 13.4,
+          'isOpen': true,
+          'diesel': 1.55,
+        };
+
+    testWidgets('tapping the Station "+" opens the station picker, not a '
+        'snackbar', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+      when(() => test.mockStorage.getFavoriteIds()).thenReturn(['fav-1']);
+      when(() => test.mockStorage.getFavoriteStationData('fav-1'))
+          .thenReturn(stationJson('fav-1', 'Shell Berlin'));
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+        ],
+      );
+
+      // The Station section "+" is the first add button (Zone "+" is second).
+      await tester.tap(find.byIcon(Icons.add).first);
+      await tester.pumpAndSettle();
+
+      // The picker is shown with the favorite station — NOT the dead-end
+      // snackbar from the old implementation.
+      expect(find.text('Pick a station'), findsOneWidget);
+      expect(find.text('Shell Berlin'), findsOneWidget);
+      expect(
+        find.byKey(const Key('alert_pick_station_tile_fav-1')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('selecting a station opens CreateAlertDialog', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+      when(() => test.mockStorage.getFavoriteIds()).thenReturn(['fav-1']);
+      when(() => test.mockStorage.getFavoriteStationData('fav-1'))
+          .thenReturn(stationJson('fav-1', 'Shell Berlin'));
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+        ],
+      );
+
+      await tester.tap(find.byIcon(Icons.add).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('alert_pick_station_tile_fav-1')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CreateAlertDialog), findsOneWidget);
+    });
+
+    testWidgets('with no favorites the picker offers a Search fallback, not a '
+        'dead-end', (tester) async {
+      final test = standardTestOverrides();
+      when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+      when(() => test.mockStorage.getAlerts()).thenReturn([]);
+      when(() => test.mockStorage.getFavoriteIds()).thenReturn(<String>[]);
+
+      await pumpApp(
+        tester,
+        const AlertsScreen(),
+        overrides: [
+          ...test.overrides,
+          alertProvider.overrideWith(() => _EmptyAlerts()),
+        ],
+      );
+
+      await tester.tap(find.byIcon(Icons.add).first);
+      await tester.pumpAndSettle();
+
+      // Picker is shown with the empty hint + a real Search CTA — the user
+      // can still reach a station's detail page from here.
+      expect(find.text('Pick a station'), findsOneWidget);
+      expect(
+        find.byKey(const Key('alert_pick_station_search')),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/test/l10n/localization_completeness_test.dart
+++ b/test/l10n/localization_completeness_test.dart
@@ -199,6 +199,29 @@ void main() {
         print(buffer.toString());
       }
     });
+
+    // #2857 — the redesigned alerts screen's "Station alerts" header shipped
+    // as English-equal autofill placeholders in French (a primary locale).
+    // The presence-based coverage gates above can't catch this (the keys ARE
+    // present, just holding the English value), so assert value-distinctness
+    // for the alerts-screen section labels a French user reads.
+    test('French alerts-section labels are real translations, not English '
+        'placeholders (#2857)', () {
+      final frFile = arbFiles.firstWhere((f) => f.path.endsWith('app_fr.arb'));
+      final fr = jsonDecode(frFile.readAsStringSync()) as Map<String, dynamic>;
+
+      for (final key in const [
+        'alertsStationSectionTitle',
+        'alertsStationAdd',
+      ]) {
+        expect(fr[key], isNotNull,
+            reason: 'app_fr.arb must contain $key');
+        expect(fr[key], isNot(equals(referenceArb[key])),
+            reason: 'French $key still equals the English value — it is an '
+                'untranslated autofill placeholder. Provide a real French '
+                'string in app_fr.arb (#2857).');
+      }
+    });
   });
 }
 


### PR DESCRIPTION
## What & why

From a real FR screenshot of the redesigned Price Alerts screen (#2820), two bugs (#2857):

### Bug 1 — Station-alert "+" was a dead-end (primary complaint: "can't add alert for a station")
The "Station alerts" section "+" only re-showed the `noPriceAlertsHint` snackbar ("Create an alert from a station's detail page.") — the user could never actually add a station alert from the alerts screen. (The Zone "+" worked; the Station "+" did not.)

**Fix:** a new `AlertStationPickerSheet` (`lib/features/alerts/presentation/widgets/alert_station_picker_sheet.dart`):
- Reuses the **same favorites-backed station list** + the existing `pickStation*` ARB strings as the consumption fill-up picker (`PickStationForFillUpScreen`), but — unlike that screen, which `pushReplacement`s into the fill-up form — it **returns the chosen `Station`** via `Navigator.pop`, so it composes cleanly with the alerts flow.
- On selection it runs the **same `CreateAlertDialog`** the station-detail app bar uses, and persists via `AlertNotifier.addAlert` — so an alert created here is byte-identical to one created from station detail.
- **Fallback** (per the issue): when the user has no favorites, the picker shows the hint plus a **Search CTA** that jumps to the Search tab so they can still reach a station's detail page (where the create-alert action also lives).

The empty-state hint on the alerts screen itself is unchanged.

### Bug 2 — "Station alerts" header was English on FR (a primary locale)
`alertsStationSectionTitle` / `alertsStationAdd` shipped as English-equal autofill **MT placeholders** (DE had real values).

**Mechanism used:** `tool/autofill_locales.dart` only machine-fills keys a locale is **missing** and **never overwrites an existing entry** ("existing human translations are never overwritten"). So I set the real French value in `app_fr.arb` and dropped the `x-mt`/MT-description metadata, turning them into human translations the pipeline preserves:
- `alertsStationSectionTitle` → **Alertes de station**
- `alertsStationAdd` → **Ajouter une alerte de station**

Ran the full pipeline (`dart run tool/build_arb.dart` → `dart tool/gen_pseudo_arb.dart` → `flutter gen-l10n`) and **verified idempotence** — `build_arb` run twice, FR survives both passes (`0 key(s) machine-filled`), and `app_localizations_fr.dart` now returns the real French. Only `app_fr.arb` + its generated binding changed.

## Follow-up gap (NOT fixed here)
This PR translates only the two header keys. The broader gap remains: **~353 keys in `app_fr.arb`** still hold English autofill placeholders (`x-mt: needs-native-review`), and each of the 20 long-tail locales carries ~401. These are recently-added keys that were never natively reviewed. Worth a dedicated FR-review epic (the `kFrenchRequiredPrefixes` gate in `test/l10n/` is the place to harden core surfaces as they're translated).

## Tests
- **Widget (Bug 1):** tapping the Station "+" opens the picker (not a snackbar); tapping a station tile opens `CreateAlertDialog`; with no favorites the picker shows the Search fallback.
- **l10n (Bug 2):** asserts `alertsStationSectionTitle` / `alertsStationAdd` FR != EN — the presence-based coverage gate can't catch English-equal placeholders, so this is a value-distinctness guard.
- `flutter analyze` clean; full `test/features/alerts/` + `test/l10n/` green; `file_length`, `no_hardcoded_ui_strings`, `catch_block_stacktrace_coverage` guards green.

Closes #2857

🤖 Generated with [Claude Code](https://claude.com/claude-code)
