### PR TITLE
feat(bg-alerts): Ref-free country-agnostic BG price source + per-country source for the 11 polled countries (#2861, #2862)

### DIFF
--- a/lib/core/background/alert_country_grouping.dart
+++ b/lib/core/background/alert_country_grouping.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../features/alerts/data/models/price_alert.dart';
+import '../../features/alerts/domain/entities/radius_alert.dart';
+import '../services/country_service_registry.dart';
+
+/// The work for ONE country in a background scan (#2861): the per-station
+/// price-alert station ids whose prices must be refreshed, plus the radius
+/// alerts whose centres fall in this country.
+///
+/// Grouping by country is the core ToS safeguard for the multi-country
+/// background scan (Epic #2860): each provider is queried **at most once per
+/// scan** for all of its alerts, never once per alert.
+class CountryAlertGroup {
+  CountryAlertGroup(this.countryCode);
+
+  /// ISO 3166-1 alpha-2 code this group's provider serves.
+  final String countryCode;
+
+  /// Station ids of active per-station price alerts in this country. A set so
+  /// the same station behind two alerts (e.g. E5 + Diesel) is fetched once.
+  final Set<String> stationIds = <String>{};
+
+  /// Active radius alerts whose centre resolves to this country.
+  final List<RadiusAlert> radiusAlerts = <RadiusAlert>[];
+
+  bool get isEmpty => stationIds.isEmpty && radiusAlerts.isEmpty;
+}
+
+/// Groups the active per-station + radius alerts by their **derived** country
+/// (#2861) so a background scan hits each provider at most once.
+///
+/// Country derivation is lazy — neither [PriceAlert] nor [RadiusAlert] stores
+/// a country, so we never migrate Hive:
+///
+///  - per-station: the station-id prefix
+///    ([CountryServiceRegistry.countryForStationId]); when the id carries no
+///    recognised prefix (a raw DE Tankerkönig UUID, an FR numeric id, …) we
+///    fall back to [fallbackCountryCode] (the active country) so legacy
+///    favorites saved before the #753 prefix scheme are still scanned.
+///  - radius: the centre's bounding box
+///    ([CountryServiceRegistry.countryForLatLng]); a centre outside every
+///    registered box is dropped (we have no provider to ask).
+///
+/// Only `isActive` price alerts and `enabled` radius alerts are considered.
+/// The returned map is keyed by country code; iteration order is the insertion
+/// order so a scan is deterministic.
+Map<String, CountryAlertGroup> groupAlertsByCountry({
+  required List<PriceAlert> priceAlerts,
+  required List<RadiusAlert> radiusAlerts,
+  String? fallbackCountryCode,
+}) {
+  final groups = <String, CountryAlertGroup>{};
+
+  CountryAlertGroup groupFor(String code) =>
+      groups.putIfAbsent(code, () => CountryAlertGroup(code));
+
+  for (final alert in priceAlerts) {
+    if (!alert.isActive) continue;
+    final code = CountryServiceRegistry.countryForStationId(alert.stationId) ??
+        fallbackCountryCode;
+    if (code == null) continue;
+    groupFor(code).stationIds.add(alert.stationId);
+  }
+
+  for (final alert in radiusAlerts) {
+    if (!alert.enabled) continue;
+    final code =
+        CountryServiceRegistry.countryForLatLng(alert.centerLat, alert.centerLng);
+    if (code == null) continue;
+    groupFor(code).radiusAlerts.add(alert);
+  }
+
+  return groups;
+}

--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -6,15 +6,12 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import '../../features/alerts/data/repositories/alert_repository.dart';
-import '../../features/station_services/germany/tankerkoenig_batch_price_fetcher.dart';
-import '../../features/station_services/germany/tankerkoenig_station_service.dart';
 import '../../features/widget/data/home_widget_service.dart';
 import '../logging/error_logger.dart';
-import '../services/dio_factory.dart';
 import '../storage/hive_storage.dart';
 import '../telemetry/storage/isolate_error_spool.dart';
 import 'background_price_history_writer.dart';
-import 'background_retry.dart';
+import 'background_price_source.dart';
 import 'background_scan_dedup_store.dart';
 import 'background_scan_runners.dart';
 import 'daily_collection.dart';
@@ -237,22 +234,26 @@ class BackgroundAlertScanCoordinator {
       return;
     }
 
-    // 2. Fetch prices via the shared Tankerkoenig batch fetcher (chunking +
-    //    parsing + retry). #2249 — DioFactory so the BG batch fetch inherits
-    //    the rate-limit + conditional-GET interceptors, not a raw request.
-    final dio = DioFactory.create(
+    // 2. Fetch prices via the registry-driven per-country source (#2862).
+    //    The source groups the mixed-country id set by derived country and
+    //    queries each polled provider at most once, within that provider's
+    //    minInterval; a prefix-less id falls back to the active country (DE
+    //    today). This replaces the hardcoded Tankerkönig batch fetch — DE
+    //    still goes through its Tankerkönig batch service, the other ten
+    //    polled countries now go through their own. Bulk-dataset countries
+    //    (ES/IT/AR/DK) are scanned by child #2863, not here.
+    final activeCountry =
+        storage.getSetting('active_country_code') as String? ?? 'DE';
+    final source = BackgroundPriceSource(
+      storage: storage,
       connectTimeout: bgConnectTimeout,
       receiveTimeout: bgReceiveTimeout,
     );
-    final fetcher = TankerkoenigBatchPriceFetcher(
-      dio: dio,
-      batchSize: tankerkoenigBatchSize,
-      retryConfig: const BackgroundRetryConfig(
-        maxAttempts: maxRetryAttempts,
-        baseDelay: retryBaseDelay,
-      ),
+    final prices = await source.fetchPricesGrouped(
+      stationIds: allStationIds,
+      fallbackCountryCode: activeCountry,
+      apiKey: apiKey,
     );
-    final prices = await fetcher.fetchBatch(ids: allStationIds, apiKey: apiKey);
     debugPrint('BackgroundAlertScanCoordinator: fetched prices for '
         '${prices.length} stations');
 
@@ -275,42 +276,53 @@ class BackgroundAlertScanCoordinator {
     }
 
     await BackgroundScanRunners.runRadiusAlerts(
-        now: now, apiKey: apiKey, templates: templates);
+      now: now,
+      source: source,
+      apiKey: apiKey,
+      templates: templates,
+    );
 
     await HomeWidgetService.updateWidget(
       storage,
       profileStorage: storage,
       settingsStorage: storage,
     );
-    await _refreshNearestWidgetFromSearch(storage);
+    await _refreshNearestWidgetFromSearch(storage, source: source);
   }
 
   /// #609 — nearest-widget refresh from a real search (or legacy fallback).
-  Future<void> _refreshNearestWidgetFromSearch(HiveStorage storage) async {
+  ///
+  /// #2862 — the nearest-widget search now goes through the registry-driven
+  /// [BackgroundPriceSource] for the active country instead of a hardcoded
+  /// Tankerkönig service, so a non-DE user's widget shows nearby stations
+  /// from their own country's provider. A [source] is reused when the scan
+  /// body already built one (so its per-country services are shared); the
+  /// empty-favorites early-return builds a throwaway one.
+  Future<void> _refreshNearestWidgetFromSearch(
+    HiveStorage storage, {
+    BackgroundPriceSource? source,
+  }) async {
     try {
       final apiKey = storage.getApiKey();
-      final hasKey = apiKey != null && apiKey.isNotEmpty;
-      if (hasKey) {
-        // #2249 — rate-limited + conditional-GET Dio (nearest-widget search).
-        final dio = DioFactory.create(
-          baseUrl: 'https://creativecommons.tankerkoenig.de/json',
-          connectTimeout: bgConnectTimeout,
-          receiveTimeout: bgReceiveTimeout,
-        )..options.queryParameters = {'apikey': apiKey};
-        final service = TankerkoenigStationService(dio);
-        await HomeWidgetService.updateNearestWidget(
-          storage,
-          storage,
-          profileStorage: storage,
-          stationService: service,
-        );
-      } else {
-        await HomeWidgetService.updateNearestWidget(
-          storage,
-          storage,
-          profileStorage: storage,
-        );
-      }
+      final activeCountry =
+          storage.getSetting('active_country_code') as String? ?? 'DE';
+      final priceSource = source ??
+          BackgroundPriceSource(
+            storage: storage,
+            connectTimeout: bgConnectTimeout,
+            receiveTimeout: bgReceiveTimeout,
+          );
+      final service =
+          priceSource.serviceFor(activeCountry, apiKey: apiKey);
+      // A null service means the active country is not a polled provider
+      // (e.g. a bulk-dataset country — child #2863) or has no configured key;
+      // fall back to the cache-only nearest-widget path.
+      await HomeWidgetService.updateNearestWidget(
+        storage,
+        storage,
+        profileStorage: storage,
+        stationService: service,
+      );
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
         'where': 'BackgroundAlertScanCoordinator: nearest widget refresh failed'

--- a/lib/core/background/background_price_source.dart
+++ b/lib/core/background/background_price_source.dart
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../features/search/data/models/search_params.dart';
+import '../../features/search/domain/entities/station.dart';
+import '../cache/cache_manager.dart';
+import '../constants/field_names.dart';
+import '../data/storage_repository.dart';
+import '../logging/error_logger.dart';
+import '../services/country_service_registry.dart';
+import '../services/dio_factory.dart';
+import '../services/service_config.dart';
+import '../services/station_service.dart';
+
+/// The 11 polled / realtime providers a background scan may query directly,
+/// reusing the per-country `StationServiceChain` within each provider's
+/// `FuelServicePolicy.minInterval` (Epic #2860, child #2862).
+///
+/// Bulk-dataset countries (ES, IT, AR, DK + the flag-gated FR/GB bulk paths)
+/// are deliberately **excluded** here — they need the download-once +
+/// local-filter flow of child #2863, never a per-alert network hit. Until
+/// then those countries simply are not scanned (no regression vs today, where
+/// only DE was). AU is excluded as a throwing stub (#804).
+const Set<String> kBackgroundPolledCountries = {
+  'DE', 'AT', 'PT', 'GB', 'LU', 'SI', 'GR', 'RO', 'MX', 'KR', 'CL',
+};
+
+/// Builds the right country [StationService] (Riverpod-free, via
+/// [CountryServiceRegistry.buildBackgroundService]) inside the WorkManager /
+/// BGAppRefresh isolate and fetches current prices through it — replacing the
+/// three hardcoded Tankerkönig instantiations (#2862).
+///
+/// This is the *which-service-fetches* seam, grouped per country so each
+/// provider is hit at most once per scan. The price **evaluation** stays as
+/// it is today (euro / e5-e10-diesel); making it country/currency-aware is
+/// child #2864.
+///
+/// Construction is per-country and cheap, but the source caches the built
+/// service per country code so a scan that fetches station prices AND runs a
+/// radius search for the same country reuses one service (and so a test can
+/// assert each provider is built exactly once).
+class BackgroundPriceSource {
+  BackgroundPriceSource({
+    required StorageRepository storage,
+    Duration connectTimeout = const Duration(seconds: 10),
+    Duration receiveTimeout = const Duration(seconds: 15),
+    @visibleForTesting StationService? Function(String code, {String? apiKey})?
+        serviceBuilder,
+  })  : _storage = storage,
+        _connectTimeout = connectTimeout,
+        _receiveTimeout = receiveTimeout,
+        _cache = CacheManager(storage),
+        _serviceBuilder = serviceBuilder;
+
+  final StorageRepository _storage;
+  final CacheStrategy _cache;
+  final Duration _connectTimeout;
+  final Duration _receiveTimeout;
+
+  /// Test seam (#2862): a fake per-country service builder. Production leaves
+  /// this null and goes through [CountryServiceRegistry.buildBackgroundService].
+  /// Called at most once per country (the result is cached), so a test can
+  /// assert each provider is built exactly once per scan.
+  final StationService? Function(String code, {String? apiKey})? _serviceBuilder;
+
+  /// Per-scan service cache so each country's provider is built at most once.
+  final Map<String, StationService> _services = {};
+
+  /// Whether [countryCode] is one of the polled providers this source serves.
+  static bool isPolled(String countryCode) =>
+      kBackgroundPolledCountries.contains(countryCode);
+
+  /// Builds (once per scan) and returns the chained [StationService] for
+  /// [countryCode], or null when the country is not a polled provider.
+  ///
+  /// [apiKey] is the user's key from the shared encrypted Hive box, threaded
+  /// into the isolate. Only DE needs it on the Dio (sent as the `apikey`
+  /// query param, since the isolate has no Dio interceptor); KR/CL read their
+  /// key from [_storage] inside the registry factory.
+  StationService? serviceFor(String countryCode, {String? apiKey}) {
+    if (!isPolled(countryCode)) return null;
+    final cached = _services[countryCode];
+    if (cached != null) return cached;
+    final built = _serviceBuilder != null
+        ? _serviceBuilder(countryCode, apiKey: apiKey)
+        : CountryServiceRegistry.buildBackgroundService(
+            countryCode,
+            storage: _storage,
+            cache: _cache,
+            tankerkoenigDio:
+                countryCode == 'DE' ? _buildTankerkoenigDio(apiKey) : null,
+          );
+    if (built != null) _services[countryCode] = built;
+    return built;
+  }
+
+  /// Tankerkönig Dio for the background isolate: rate-limited + conditional
+  /// GET (via [DioFactory]) with the API key baked into the query parameters,
+  /// since there is no Riverpod interceptor here.
+  Dio _buildTankerkoenigDio(String? apiKey) {
+    final dio = DioFactory.create(
+      baseUrl: ServiceConfigs.tankerkoenig.baseUrl,
+      connectTimeout: _connectTimeout,
+      receiveTimeout: _receiveTimeout,
+    );
+    if (apiKey != null && apiKey.isNotEmpty) {
+      dio.options.queryParameters = {'apikey': apiKey};
+    }
+    return dio;
+  }
+
+  /// Fetch current prices for [stationIds] in [countryCode], returning the
+  /// Tankerkönig-shaped `id → {status, e5, e10, diesel, …}` map the existing
+  /// downstream price-history + alert evaluation consume unchanged.
+  ///
+  /// Batches where the provider supports it (the country service's
+  /// [StationService.getPrices] chunks internally — DE Tankerkönig batch is
+  /// the template); a provider with no batch endpoint returns an empty map
+  /// and per-station alerts for that country simply find no fresh price this
+  /// scan (radius alerts still work via [searchStations]).
+  ///
+  /// Returns an empty map for an unpolled country, no station ids, or any
+  /// fetch error (spooled, never thrown — this runs in an OS-spawned isolate).
+  Future<Map<String, Map<String, dynamic>>> fetchPrices({
+    required String countryCode,
+    required Set<String> stationIds,
+    String? apiKey,
+  }) async {
+    if (stationIds.isEmpty) return const {};
+    final service = serviceFor(countryCode, apiKey: apiKey);
+    if (service == null) return const {};
+    try {
+      final result = await service.getPrices(stationIds.toList());
+      final out = <String, Map<String, dynamic>>{};
+      for (final entry in result.data.entries) {
+        out[entry.key] = _toTankerkoenigShape(entry.value);
+      }
+      return out;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'BackgroundPriceSource.fetchPrices($countryCode)',
+        'ids': stationIds.length,
+      }));
+      return const {};
+    }
+  }
+
+  /// Fetch prices for a mixed-country [stationIds] set, grouping by derived
+  /// country so each polled provider is queried **at most once** (#2862).
+  ///
+  /// Country is derived lazily from each id's prefix
+  /// ([CountryServiceRegistry.countryForStationId]); a prefix-less id (a raw
+  /// DE Tankerkönig UUID, an FR numeric id, …) falls back to
+  /// [fallbackCountryCode] (the active country) so legacy favorites saved
+  /// before the #753 prefix scheme are still refreshed. Ids whose country is
+  /// not a polled provider (e.g. bulk-dataset ES/IT — child #2863) are
+  /// silently skipped this scan.
+  ///
+  /// Returns one merged Tankerkönig-shaped map across all countries, keyed by
+  /// the original (prefixed) station id.
+  Future<Map<String, Map<String, dynamic>>> fetchPricesGrouped({
+    required List<String> stationIds,
+    String? fallbackCountryCode,
+    String? apiKey,
+  }) async {
+    final byCountry = <String, Set<String>>{};
+    for (final id in stationIds) {
+      final code =
+          CountryServiceRegistry.countryForStationId(id) ?? fallbackCountryCode;
+      if (code == null || !isPolled(code)) continue;
+      byCountry.putIfAbsent(code, () => <String>{}).add(id);
+    }
+
+    final merged = <String, Map<String, dynamic>>{};
+    for (final entry in byCountry.entries) {
+      final prices = await fetchPrices(
+        countryCode: entry.key,
+        stationIds: entry.value,
+        apiKey: apiKey,
+      );
+      merged.addAll(prices);
+    }
+    return merged;
+  }
+
+  /// Run a radius search in [countryCode] via its provider — the registry-
+  /// driven replacement for the hardcoded Tankerkönig search the radius-alert
+  /// runner used. Returns the priced stations, or an empty list for an
+  /// unpolled country / a fetch error.
+  Future<List<Station>> searchStations({
+    required String countryCode,
+    required SearchParams params,
+    String? apiKey,
+  }) async {
+    final service = serviceFor(countryCode, apiKey: apiKey);
+    if (service == null) return const [];
+    try {
+      final result = await service.searchStations(params);
+      return result.data;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'BackgroundPriceSource.searchStations($countryCode)',
+      }));
+      return const [];
+    }
+  }
+
+  /// Adapt a country-agnostic [StationPrices] back to the legacy
+  /// Tankerkönig-shaped map the per-station / velocity runners read today.
+  /// Carries every priced fuel so #2864 can widen the evaluation without
+  /// re-touching this seam.
+  static Map<String, dynamic> _toTankerkoenigShape(StationPrices prices) => {
+        TankerkoenigFields.status:
+            prices.isOpen ? TankerkoenigFields.statusOpen : 'closed',
+        TankerkoenigFields.e5: prices.e5,
+        TankerkoenigFields.e10: prices.e10,
+        TankerkoenigFields.diesel: prices.diesel,
+        'e98': prices.e98,
+        'dieselPremium': prices.dieselPremium,
+        'e85': prices.e85,
+        'lpg': prices.lpg,
+        'cng': prices.cng,
+      };
+}

--- a/lib/core/background/background_scan_runners.dart
+++ b/lib/core/background/background_scan_runners.dart
@@ -17,15 +17,15 @@ import '../../features/alerts/domain/radius_alert_evaluator.dart';
 import '../../features/alerts/domain/velocity_alert_detector.dart';
 import '../../features/search/data/models/search_params.dart';
 import '../../features/search/domain/entities/fuel_type.dart';
-import '../../features/station_services/germany/tankerkoenig_station_service.dart';
 import '../constants/field_names.dart';
 import '../logging/error_logger.dart';
 import '../notifications/local_notification_service.dart';
-import '../services/dio_factory.dart';
+import '../services/country_service_registry.dart';
 import '../storage/hive_storage.dart';
 import '../storage/storage_keys.dart';
 import '../telemetry/storage/isolate_error_spool.dart';
 import '../utils/json_extensions.dart';
+import 'background_price_source.dart';
 import 'notification_templates.dart';
 
 /// Alert-evaluation runners invoked by [BackgroundAlertScanCoordinator]
@@ -40,11 +40,6 @@ import 'notification_templates.dart';
 /// VelocityAlertRunner) and never mutates their throttle behaviour.
 class BackgroundScanRunners {
   BackgroundScanRunners._();
-
-  /// Connect / receive timeouts for the BG-isolate Dio client. Mirrors the
-  /// coordinator's so radius/widget searches share one budget.
-  static const bgConnectTimeout = Duration(seconds: 10);
-  static const bgReceiveTimeout = Duration(seconds: 15);
 
   /// Do not re-fire the same per-station price alert within this window.
   static const priceAlertRetriggerCooldown = Duration(hours: 4);
@@ -194,8 +189,18 @@ class BackgroundScanRunners {
   }
 
   /// #578 phase 3 — radius alerts via [RadiusAlertRunner] (reused read-only).
+  ///
+  /// #2862 — each alert's samples now come from the registry-driven
+  /// [BackgroundPriceSource] for the **country its centre falls in**
+  /// (derived via the bounding box), instead of a single hardcoded
+  /// Tankerkönig search, so a radius alert in PT / AT / … is evaluated
+  /// against that country's provider. The source caches its per-country
+  /// services, so all alerts in one country reuse one provider. Centres in a
+  /// non-polled country (e.g. bulk-dataset ES/IT — child #2863) yield no
+  /// samples this scan.
   static Future<void> runRadiusAlerts({
     required DateTime now,
+    required BackgroundPriceSource source,
     required String? apiKey,
     required BackgroundNotificationTemplates templates,
   }) async {
@@ -206,20 +211,8 @@ class BackgroundScanRunners {
         debugPrint('BackgroundScanRunners: no active radius alerts');
         return;
       }
-      if (apiKey == null || apiKey.isEmpty) {
-        debugPrint('BackgroundScanRunners: radius alerts skipped — '
-            'no Tankerkoenig API key');
-        return;
-      }
       final notifier = LocalNotificationService();
       await notifier.initialize();
-      // #2249 — rate-limited + conditional-GET Dio (radius-alert search).
-      final dio = DioFactory.create(
-        baseUrl: 'https://creativecommons.tankerkoenig.de/json',
-        connectTimeout: bgConnectTimeout,
-        receiveTimeout: bgReceiveTimeout,
-      )..options.queryParameters = {'apikey': apiKey};
-      final service = TankerkoenigStationService(dio);
       final runner = RadiusAlertRunner(
         store: store,
         dedup: RadiusAlertDedup(),
@@ -229,24 +222,23 @@ class BackgroundScanRunners {
       final fired = await runner.run(
         now: now,
         samplesFor: (alert) async {
-          try {
-            final result = await service.searchStations(SearchParams(
+          final country = CountryServiceRegistry.countryForLatLng(
+              alert.centerLat, alert.centerLng);
+          if (country == null) return const <StationPriceSample>[];
+          final stations = await source.searchStations(
+            countryCode: country,
+            params: SearchParams(
               lat: alert.centerLat,
               lng: alert.centerLng,
               radiusKm: alert.radiusKm,
-            ));
-            final samples = <StationPriceSample>[];
-            for (final station in result.data) {
-              samples.addAll(StationPriceSample.fromStation(station));
-            }
-            return samples;
-          } catch (e, st) {
-            unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
-              'where':
-                  'BackgroundScanRunners: radius samples for ${alert.id} failed'
-            }));
-            return const <StationPriceSample>[];
+            ),
+            apiKey: apiKey,
+          );
+          final samples = <StationPriceSample>[];
+          for (final station in stations) {
+            samples.addAll(StationPriceSample.fromStation(station));
           }
+          return samples;
         },
       );
       debugPrint('BackgroundScanRunners: ${fired.length} radius alerts fired');

--- a/lib/core/services/country_raw_service_builder.dart
+++ b/lib/core/services/country_raw_service_builder.dart
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+
+import '../../features/station_services/argentina/argentina_station_service.dart';
+import '../../features/station_services/australia/australia_station_service.dart';
+import '../../features/station_services/austria/econtrol_station_service.dart';
+import '../../features/station_services/chile/chile_station_service.dart';
+import '../../features/station_services/denmark/denmark_station_service.dart';
+import '../../features/station_services/france/prix_carburants_flux_station_service.dart';
+import '../../features/station_services/france/prix_carburants_station_service.dart';
+import '../../features/station_services/germany/tankerkoenig_station_service.dart';
+import '../../features/station_services/greece/greece_station_service.dart';
+import '../../features/station_services/italy/mise_station_service.dart';
+import '../../features/station_services/luxembourg/luxembourg_station_service.dart';
+import '../../features/station_services/mexico/mexico_station_service.dart';
+import '../../features/station_services/portugal/portugal_station_service.dart';
+import '../../features/station_services/romania/romania_station_service.dart';
+import '../../features/station_services/slovenia/slovenia_station_service.dart';
+import '../../features/station_services/south_korea/south_korea_station_service.dart';
+import '../../features/station_services/spain/miteco_station_service.dart';
+import '../../features/station_services/uk/uk_cma_bulk_station_service.dart';
+import '../../features/station_services/uk/uk_station_service.dart';
+import '../cache/cache_manager.dart';
+import '../data/storage_repository.dart';
+import 'bulk_migration_flags.dart';
+import 'impl/demo_station_service.dart';
+import 'impl/osm_brand_enricher.dart';
+import 'station_service.dart';
+
+/// The dependencies every per-country raw [StationService] can need,
+/// resolved **once** by whoever builds the service (#2861).
+///
+/// This is the seam that makes country-service construction Riverpod-free:
+/// the foreground reads each field from a `Ref`, the WorkManager / BGTask
+/// background isolate constructs them directly from the isolate's
+/// [HiveStorage], but the per-country wiring in [buildRawCountryService]
+/// is *byte-identical* for both — there is one construction path.
+///
+///  - [storage] backs the API-key gate (DE/KR/CL), the [OsmBrandEnricher]
+///    (FR legacy), and is the [CacheStorage] the bulk datasets persist to.
+///  - [cache] is the shared [CacheStrategy] the bulk-dataset services
+///    (ES/IT/AR/DK + the flag-gated FR/GB bulk paths) read-through.
+///  - [tankerkoenigDio] is the rate-limited, API-key-injecting Dio the DE
+///    Tankerkönig service talks through. Background callers build a plain
+///    rate-limited Dio (the key is sent per-request); the foreground hands
+///    the interceptor-wired `tankerkoenigDioProvider` instance.
+class CountryServiceDependencies {
+  const CountryServiceDependencies({
+    required this.storage,
+    required this.cache,
+    required this.tankerkoenigDio,
+  });
+
+  /// Storage repository (favorites, settings, API keys, cache).
+  final StorageRepository storage;
+
+  /// Shared cache layer the bulk-dataset services persist through.
+  final CacheStrategy cache;
+
+  /// Dio for the DE Tankerkönig service. Only the DE branch reads it; other
+  /// countries build their own Dio internally, so it is allowed to be null
+  /// for non-DE construction.
+  final Dio? tankerkoenigDio;
+}
+
+/// Builds the **raw** (un-chained) [StationService] for [countryCode] from
+/// explicit [deps] — no Riverpod `Ref`, so the same wiring runs in the
+/// WorkManager / BGAppRefresh background isolate that has no provider scope
+/// (#2861).
+///
+/// This is the single source of truth for per-country service construction.
+/// `CountryServiceRegistry`'s foreground `createService(Ref)` factories read
+/// their dependencies from the `Ref` and delegate here, so the foreground
+/// behaviour is unchanged — every country-service / chain / search test stays
+/// green — while the background isolate reuses the identical wiring.
+///
+/// Returns [DemoStationService] for the API-key-gated countries (DE, KR, CL)
+/// when no key is configured, exactly as the foreground factories did, so a
+/// keyless user still sees realistic demo data.
+StationService buildRawCountryService(
+  String countryCode,
+  CountryServiceDependencies deps,
+) {
+  switch (countryCode) {
+    case 'DE':
+      if (!deps.storage.hasApiKey()) {
+        return DemoStationService(countryCode: 'DE');
+      }
+      final dio = deps.tankerkoenigDio;
+      if (dio == null) {
+        // Defensive: a DE caller must supply the Tankerkönig Dio. Without it
+        // we cannot talk to the API, so fall back to demo rather than throw
+        // inside an OS-spawned isolate.
+        return DemoStationService(countryCode: 'DE');
+      }
+      return TankerkoenigStationService(dio);
+    case 'FR':
+      // #2277 staged rollout — bulk *flux instantané* when flagged, else the
+      // legacy per-search OSM-enriched service.
+      if (BulkMigrationFlags.frFluxBulk) {
+        return PrixCarburantsFluxStationService(cache: deps.cache);
+      }
+      return PrixCarburantsStationService(
+        enricher: OsmBrandEnricher(deps.storage),
+      );
+    case 'AT':
+      return EControlStationService();
+    case 'ES':
+      return MitecoStationService(cache: deps.cache);
+    case 'IT':
+      return MiseStationService(cache: deps.cache);
+    case 'DK':
+      return DenmarkStationService(cache: deps.cache);
+    case 'AR':
+      return ArgentinaStationService(cache: deps.cache);
+    case 'PT':
+      return PortugalStationService();
+    case 'GB':
+      // #2277 staged rollout — consolidated CMA bulk file when flagged, else
+      // the legacy per-search retailer fan-out.
+      return BulkMigrationFlags.ukCmaBulk
+          ? UkCmaBulkStationService(cache: deps.cache)
+          : UkStationService();
+    case 'AU':
+      return const AustraliaStationService();
+    case 'MX':
+      return MexicoStationService(cache: deps.cache);
+    case 'LU':
+      return LuxembourgStationService();
+    case 'SI':
+      return SloveniaStationService();
+    case 'KR':
+      final apiKey = deps.storage.getApiKey();
+      if (apiKey == null || apiKey.isEmpty) {
+        return DemoStationService(countryCode: 'KR');
+      }
+      return SouthKoreaStationService(apiKey: apiKey);
+    case 'CL':
+      final apiKey = deps.storage.getApiKey();
+      if (apiKey == null || apiKey.isEmpty) {
+        return DemoStationService(countryCode: 'CL');
+      }
+      return ChileStationService(apiKey: apiKey);
+    case 'GR':
+      return GreeceStationService();
+    case 'RO':
+      return RomaniaStationService();
+    default:
+      return DemoStationService(countryCode: countryCode);
+  }
+}

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -1,38 +1,22 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../cache/cache_manager.dart';
 import '../country/country_bounding_box.dart';
 import '../country/country_config.dart';
+import '../data/storage_repository.dart';
 import '../storage/storage_providers.dart';
 import '../../features/search/domain/entities/fuel_type.dart';
-import '../../features/station_services/argentina/argentina_station_service.dart';
-import '../../features/station_services/australia/australia_station_service.dart';
-import '../../features/station_services/austria/econtrol_station_service.dart';
-import '../../features/station_services/chile/chile_station_service.dart';
-import '../../features/station_services/denmark/denmark_station_service.dart';
-import '../../features/station_services/france/prix_carburants_flux_station_service.dart';
-import '../../features/station_services/france/prix_carburants_station_service.dart';
-import '../../features/station_services/germany/tankerkoenig_station_service.dart';
-import '../../features/station_services/greece/greece_station_service.dart';
-import '../../features/station_services/italy/mise_station_service.dart';
-import '../../features/station_services/luxembourg/luxembourg_station_service.dart';
-import '../../features/station_services/mexico/mexico_station_service.dart';
-import '../../features/station_services/portugal/portugal_station_service.dart';
-import '../../features/station_services/romania/romania_station_service.dart';
-import '../../features/station_services/slovenia/slovenia_station_service.dart';
-import '../../features/station_services/south_korea/south_korea_station_service.dart';
-import '../../features/station_services/spain/miteco_station_service.dart';
-import '../../features/station_services/uk/uk_cma_bulk_station_service.dart';
-import '../../features/station_services/uk/uk_station_service.dart';
 import 'bulk_migration_flags.dart';
+import 'country_raw_service_builder.dart';
+import 'diagnostics/data_access_recorder.dart';
 import 'diagnostics/data_access_recorder_provider.dart';
 import 'fuel_service_policy.dart';
 import 'impl/demo_station_service.dart';
-import 'impl/osm_brand_enricher.dart';
 import 'service_providers.dart';
 import 'service_result.dart';
 import 'station_service.dart';
@@ -56,6 +40,14 @@ import 'station_service_chain.dart';
 /// 2. One [ServiceSource] enum value in `service_result.dart` (mechanical;
 ///    enums naturally cluster on append)
 /// 3. One new entry appended to [CountryServiceRegistry.entries]
+///
+/// The raw [StationService] is no longer a per-entry factory field: the
+/// per-country construction lives in the single, Riverpod-free
+/// [buildRawCountryService] (`country_raw_service_builder.dart`) so the
+/// foreground ([CountryServiceRegistry.buildService]) and the WorkManager /
+/// BGAppRefresh background isolate
+/// ([CountryServiceRegistry.buildBackgroundService]) share one construction
+/// path. Both dispatch on [countryCode].
 ///
 /// The country's [CountryConfig] (display name, flag, postal-code shape,
 /// currency formatting, etc.) is intentionally kept separate in
@@ -97,10 +89,6 @@ class CountryServiceEntry {
   /// TTL cache; the rate limiter reads [FuelServicePolicy.minInterval].
   final FuelServicePolicy policy;
 
-  /// Factory that creates the raw [StationService] for this country.
-  /// Receives a [Ref] for dependency injection.
-  final StationService Function(Ref ref) createService;
-
   const CountryServiceEntry({
     required this.countryCode,
     required this.errorSource,
@@ -108,7 +96,6 @@ class CountryServiceEntry {
     required this.availableFuelTypes,
     required this.policy,
     this.requiresApiKey = false,
-    required this.createService,
   });
 }
 
@@ -436,7 +423,6 @@ class CountryServiceRegistry {
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _ptPolicy,
-      createService: _createPortugal,
     ),
     CountryServiceEntry(
       countryCode: 'GB',
@@ -453,7 +439,6 @@ class CountryServiceRegistry {
         FuelType.electric, FuelType.all,
       ],
       policy: _ukPolicy,
-      createService: _createUk,
     ),
     CountryServiceEntry(
       countryCode: 'DK',
@@ -463,7 +448,6 @@ class CountryServiceRegistry {
       ),
       availableFuelTypes: _defaultFuelTypes,
       policy: _dkPolicy,
-      createService: _createDenmark,
     ),
     CountryServiceEntry(
       countryCode: 'LU',
@@ -480,7 +464,6 @@ class CountryServiceRegistry {
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _luPolicy,
-      createService: _createLuxembourg,
     ),
     CountryServiceEntry(
       countryCode: 'SI',
@@ -501,7 +484,6 @@ class CountryServiceRegistry {
         FuelType.electric, FuelType.all,
       ],
       policy: _siPolicy,
-      createService: _createSlovenia,
     ),
     // ── Continental EU (test order matters for shadow neighbours) ─────
     CountryServiceEntry(
@@ -512,7 +494,6 @@ class CountryServiceRegistry {
       ),
       availableFuelTypes: _defaultFuelTypes,
       policy: _atPolicy,
-      createService: _createEControl,
     ),
     CountryServiceEntry(
       countryCode: 'FR',
@@ -528,7 +509,6 @@ class CountryServiceRegistry {
         FuelType.e85, FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _frPolicy,
-      createService: _createPrixCarburants,
     ),
     CountryServiceEntry(
       countryCode: 'IT',
@@ -542,7 +522,6 @@ class CountryServiceRegistry {
         FuelType.electric, FuelType.all,
       ],
       policy: _itPolicy,
-      createService: _createMise,
     ),
     CountryServiceEntry(
       countryCode: 'ES',
@@ -558,7 +537,6 @@ class CountryServiceRegistry {
         FuelType.all,
       ],
       policy: _esPolicy,
-      createService: _createMiteco,
     ),
     CountryServiceEntry(
       countryCode: 'DE',
@@ -570,7 +548,6 @@ class CountryServiceRegistry {
       // DE: Tankerkönig publishes E5, E10, Diesel.
       availableFuelTypes: _defaultFuelTypes,
       policy: _dePolicy,
-      createService: _createTankerkoenig,
     ),
     // ── Non-EU countries (no overlap concerns) ─────────────────────────
     CountryServiceEntry(
@@ -588,7 +565,6 @@ class CountryServiceRegistry {
         FuelType.electric, FuelType.all,
       ],
       policy: _mxPolicy,
-      createService: _createMexico,
     ),
     // CL before AR: Chile's narrow strip sits inside AR's generous
     // longitude range along the cordillera (#596).
@@ -605,7 +581,6 @@ class CountryServiceRegistry {
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _clPolicy,
-      createService: _createChile,
     ),
     CountryServiceEntry(
       countryCode: 'AR',
@@ -624,7 +599,6 @@ class CountryServiceRegistry {
         FuelType.all,
       ],
       policy: _arPolicy,
-      createService: _createArgentina,
     ),
     CountryServiceEntry(
       countryCode: 'AU',
@@ -643,7 +617,6 @@ class CountryServiceRegistry {
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _auPolicy,
-      createService: _createAustralia,
     ),
     CountryServiceEntry(
       countryCode: 'KR',
@@ -660,7 +633,6 @@ class CountryServiceRegistry {
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _krPolicy,
-      createService: _createSouthKorea,
     ),
     CountryServiceEntry(
       countryCode: 'GR',
@@ -677,7 +649,6 @@ class CountryServiceRegistry {
         FuelType.lpg, FuelType.electric, FuelType.all,
       ],
       policy: _grPolicy,
-      createService: _createGreece,
     ),
     CountryServiceEntry(
       countryCode: 'RO',
@@ -696,7 +667,6 @@ class CountryServiceRegistry {
         FuelType.all,
       ],
       policy: _roPolicy,
-      createService: _createRomania,
     ),
   ];
 
@@ -760,7 +730,14 @@ class CountryServiceRegistry {
     }
   }
 
-  /// Build a [StationService] for [countryCode], wrapped in [StationServiceChain].
+  /// Build a [StationService] for [countryCode], wrapped in
+  /// [StationServiceChain] — the **foreground** path.
+  ///
+  /// Reads its dependencies (storage, the Tankerkönig Dio, the dev-only
+  /// #2824 recorder) from the Riverpod [ref] and delegates the actual
+  /// construction to [buildBackgroundService], so the foreground and the
+  /// WorkManager / BGAppRefresh background isolate share one code path
+  /// (#2861).
   ///
   /// Returns [DemoStationService] if:
   /// - The country has no registered entry
@@ -771,14 +748,59 @@ class CountryServiceRegistry {
     Ref ref,
     CacheStrategy cache,
   ) {
+    return buildBackgroundService(
+      countryCode,
+      storage: ref.read(storageRepositoryProvider),
+      cache: cache,
+      tankerkoenigDio: countryCode == 'DE'
+          ? ref.read(tankerkoenigDioProvider)
+          : null,
+      // #2824 — dev-only data-access tracer; null in production (zero
+      // overhead). Only the foreground has a provider scope to read it from.
+      recorder: ref.read(dataAccessRecorderProvider),
+    );
+  }
+
+  /// Build a [StationService] for [countryCode] **without a Riverpod `Ref`**
+  /// — the background-isolate construction path (#2861).
+  ///
+  /// The WorkManager / BGAppRefresh isolate has no provider scope, but the
+  /// registry's lookups (entries / policies / bounding boxes) are static and
+  /// isolate-safe; the only thing the foreground `Ref` provided was the set
+  /// of resolved dependencies, which this method takes directly:
+  ///
+  ///  - [storage] — the isolate's [HiveStorage] (API-key gate, bulk-dataset
+  ///    cache backing, OSM brand enricher).
+  ///  - [cache] — a [CacheStrategy] (the isolate builds `CacheManager(storage)`).
+  ///  - [tankerkoenigDio] — only the DE branch needs it; a background caller
+  ///    passes a plain rate-limited Dio and sends the key per-request.
+  ///  - [recorder] — the optional #2824 tracer; usually null in the isolate.
+  ///
+  /// Builds the **same** [StationServiceChain] (same primary service, error
+  /// source, policy) the foreground builds, via the single, Riverpod-free
+  /// [buildRawCountryService]. Returns [DemoStationService] when the country
+  /// has no registered entry.
+  static StationService buildBackgroundService(
+    String countryCode, {
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    Dio? tankerkoenigDio,
+    DataAccessRecorder? recorder,
+  }) {
     final entry = _byCode[countryCode];
     if (entry == null) return DemoStationService(countryCode: countryCode);
 
-    // #2824 — dev-only data-access tracer; null in production (zero overhead).
-    final recorder = ref.read(dataAccessRecorderProvider);
     recorder?.notePolicy(countryCode, entry.policy.minInterval);
+    final raw = buildRawCountryService(
+      countryCode,
+      CountryServiceDependencies(
+        storage: storage,
+        cache: cache,
+        tankerkoenigDio: tankerkoenigDio,
+      ),
+    );
     return StationServiceChain(
-      entry.createService(ref),
+      raw,
       cache,
       errorSource: entry.errorSource,
       countryCode: countryCode,
@@ -788,6 +810,20 @@ class CountryServiceRegistry {
       recorder: recorder,
     );
   }
+
+  /// Derive the ISO country code an alert's **station id** belongs to
+  /// (#2861). Neither [PriceAlert] nor any favorite stores a country, so we
+  /// infer it lazily from the id's prefix (the #753 `de-`/`uk-`/… scheme).
+  /// Returns null when the id carries no recognised prefix (e.g. a raw DE
+  /// Tankerkönig UUID) — the caller can then fall back to the active country.
+  static String? countryForStationId(String? stationId) =>
+      Countries.countryCodeForStationId(stationId);
+
+  /// Derive the ISO country code a **radius-alert centre** lies in (#2861)
+  /// via the registry's bounding-box lookup. Returns null when the point is
+  /// outside every registered box.
+  static String? countryForLatLng(double lat, double lng) =>
+      entryByLatLng(lat, lng)?.countryCode;
 
   /// Asserts that every country in [Countries.all] has a registry entry.
   ///
@@ -817,108 +853,3 @@ class CountryServiceRegistry {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Factory functions for each country's raw service
-// ---------------------------------------------------------------------------
-// These are top-level functions (not closures) so they can be used in
-// const CountryServiceEntry constructors.
-
-/// Germany factory. Reads the API-key state from storage and either:
-///  - returns [DemoStationService] when no key is present (so the user sees
-///    realistic-looking data without configuring anything), or
-///  - constructs the real [TankerkoenigStationService] backed by the
-///    rate-limited Dio from [tankerkoenigDioProvider].
-///
-/// This used to live in `service_providers.dart` as a Germany special case;
-/// pulling it into the registry restores the "single source of truth"
-/// invariant the registry promises.
-StationService _createTankerkoenig(Ref ref) {
-  final storage = ref.read(storageRepositoryProvider);
-  if (!storage.hasApiKey()) return DemoStationService(countryCode: 'DE');
-  final dio = ref.read(tankerkoenigDioProvider);
-  return TankerkoenigStationService(dio);
-}
-
-StationService _createPrixCarburants(Ref ref) {
-  // #2277 — staged rollout: the bulk *flux instantané* ZIP service when the
-  // flag is on (persisted whole-country dataset, local-filtered), otherwise
-  // the legacy per-search polling service. The bulk service receives the
-  // shared CacheManager for the disk read-through, like the other bulk
-  // datasets.
-  if (BulkMigrationFlags.frFluxBulk) {
-    return PrixCarburantsFluxStationService(
-      cache: ref.read(cacheManagerProvider),
-    );
-  }
-  final enricher = ref.watch(osmBrandEnricherProvider);
-  return PrixCarburantsStationService(enricher: enricher);
-}
-
-StationService _createEControl(Ref ref) => EControlStationService();
-
-// #2264 — bulk-dataset services receive the shared CacheManager so their
-// parsed national dataset is persisted to Hive (read-through on the next
-// search), surviving cold start + offline. The providers are keepAlive
-// (service_providers.dart) so the in-memory copy also survives rebuilds.
-StationService _createMiteco(Ref ref) =>
-    MitecoStationService(cache: ref.read(cacheManagerProvider));
-StationService _createMise(Ref ref) =>
-    MiseStationService(cache: ref.read(cacheManagerProvider));
-StationService _createDenmark(Ref ref) =>
-    DenmarkStationService(cache: ref.read(cacheManagerProvider));
-StationService _createArgentina(Ref ref) =>
-    ArgentinaStationService(cache: ref.read(cacheManagerProvider));
-StationService _createPortugal(Ref ref) => PortugalStationService();
-// #2277 — staged rollout: the consolidated CMA bulk-file service when the flag
-// is on (persisted whole-country dataset, local-filtered), otherwise the legacy
-// per-search retailer fan-out. The bulk service receives the shared
-// CacheManager for the disk read-through, like the other bulk datasets.
-StationService _createUk(Ref ref) => BulkMigrationFlags.ukCmaBulk
-    ? UkCmaBulkStationService(cache: ref.read(cacheManagerProvider))
-    : UkStationService();
-StationService _createAustralia(Ref ref) => const AustraliaStationService();
-StationService _createMexico(Ref ref) =>
-    MexicoStationService(cache: ref.read(cacheManagerProvider));
-StationService _createLuxembourg(Ref ref) => LuxembourgStationService();
-StationService _createSlovenia(Ref ref) => SloveniaStationService();
-
-/// South Korea factory (#597). Reads the OPINET developer API key from
-/// storage via [storageRepositoryProvider]. When no key is present we
-/// return [DemoStationService] so a Korean user still sees realistic
-/// data until they enter their free KNOC-issued key in Settings →
-/// API keys.
-StationService _createSouthKorea(Ref ref) {
-  final storage = ref.read(storageRepositoryProvider);
-  final apiKey = storage.getApiKey();
-  if (apiKey == null || apiKey.isEmpty) {
-    return DemoStationService(countryCode: 'KR');
-  }
-  return SouthKoreaStationService(apiKey: apiKey);
-}
-
-/// Chile factory (#596). Reads the CNE "Bencina en Línea" developer
-/// API key from storage via [storageRepositoryProvider]. When no key
-/// is present we return [DemoStationService] so a Chilean user still
-/// sees realistic data until they register a free CNE key in
-/// Settings → API keys.
-StationService _createChile(Ref ref) {
-  final storage = ref.read(storageRepositoryProvider);
-  final apiKey = storage.getApiKey();
-  if (apiKey == null || apiKey.isEmpty) {
-    return DemoStationService(countryCode: 'CL');
-  }
-  return ChileStationService(apiKey: apiKey);
-}
-
-/// Greece factory (#576). The Paratiritirio Timon feed is wrapped by
-/// the community [fuelpricesgr](https://github.com/mavroprovato/fuelpricesgr)
-/// FastAPI; it is free and open, so no API key is required. Users get
-/// real prefecture-level data out-of-the-box.
-StationService _createGreece(Ref ref) => GreeceStationService();
-
-/// Romania factory (#577). *Monitorul Prețurilor la Carburanți*
-/// (pretcarburant.ro) is the Competition Council + ANPC observatory,
-/// government-mandated with 15-minute price updates. There is no
-/// documented public API — the parser is fixture-driven so a URL
-/// drift is a one-line fix. No key required.
-StationService _createRomania(Ref ref) => RomaniaStationService();

--- a/test/core/background/alert_country_grouping_test.dart
+++ b/test/core/background/alert_country_grouping_test.dart
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/alert_country_grouping.dart';
+import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
+import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+void main() {
+  PriceAlert priceAlert(String id, String stationId, {bool active = true}) =>
+      PriceAlert(
+        id: id,
+        stationId: stationId,
+        stationName: stationId,
+        fuelType: FuelType.diesel,
+        targetPrice: 1.5,
+        isActive: active,
+        createdAt: DateTime.utc(2026, 6, 4),
+      );
+
+  RadiusAlert radiusAlert(
+    String id,
+    double lat,
+    double lng, {
+    bool enabled = true,
+  }) =>
+      RadiusAlert(
+        id: id,
+        fuelType: 'diesel',
+        threshold: 1.6,
+        centerLat: lat,
+        centerLng: lng,
+        radiusKm: 5,
+        label: id,
+        enabled: enabled,
+        createdAt: DateTime.utc(2026, 6, 4),
+      );
+
+  group('country derivation', () {
+    test('per-station id prefix resolves to its country', () {
+      expect(CountryServiceRegistry.countryForStationId('pt-123'), 'PT');
+      expect(CountryServiceRegistry.countryForStationId('uk-abc'), 'GB');
+      expect(CountryServiceRegistry.countryForStationId('lu-9'), 'LU');
+    });
+
+    test('a prefix-less id (raw DE Tankerkönig UUID) resolves to null', () {
+      expect(
+        CountryServiceRegistry.countryForStationId(
+            '51d4b6a2-a095-1aa0-e100-80009459e03a'),
+        isNull,
+      );
+    });
+
+    test('radius centre resolves via the bounding box', () {
+      // Berlin → DE, Lisbon → PT, Vienna → AT.
+      expect(CountryServiceRegistry.countryForLatLng(52.52, 13.40), 'DE');
+      expect(CountryServiceRegistry.countryForLatLng(38.72, -9.14), 'PT');
+      expect(CountryServiceRegistry.countryForLatLng(48.21, 16.37), 'AT');
+    });
+
+    test('a centre outside every registered box resolves to null', () {
+      // Mid-Atlantic, far from any country box.
+      expect(CountryServiceRegistry.countryForLatLng(0.0, -40.0), isNull);
+    });
+  });
+
+  group('groupAlertsByCountry', () {
+    test('alerts spanning 3 countries group into 3 single-provider buckets',
+        () {
+      final groups = groupAlertsByCountry(
+        priceAlerts: [
+          priceAlert('a1', 'pt-1'),
+          priceAlert('a2', 'pt-2'), // same country, second station
+          priceAlert('a3', 'lu-1'),
+        ],
+        radiusAlerts: [
+          radiusAlert('r1', 48.21, 16.37), // Vienna → AT
+        ],
+      );
+
+      expect(groups.keys.toSet(), {'PT', 'LU', 'AT'});
+      expect(groups['PT']!.stationIds, {'pt-1', 'pt-2'});
+      expect(groups['LU']!.stationIds, {'lu-1'});
+      expect(groups['AT']!.stationIds, isEmpty);
+      expect(groups['AT']!.radiusAlerts.single.id, 'r1');
+    });
+
+    test('two alerts on the SAME station collapse to one fetch id', () {
+      final groups = groupAlertsByCountry(
+        priceAlerts: [
+          priceAlert('a1', 'pt-1'),
+          priceAlert('a2', 'pt-1'), // E5 + Diesel on the same station
+        ],
+        radiusAlerts: const [],
+      );
+      expect(groups['PT']!.stationIds, {'pt-1'});
+    });
+
+    test('inactive price alerts and disabled radius alerts are excluded', () {
+      final groups = groupAlertsByCountry(
+        priceAlerts: [
+          priceAlert('a1', 'pt-1', active: false),
+        ],
+        radiusAlerts: [
+          radiusAlert('r1', 38.72, -9.14, enabled: false), // Lisbon, disabled
+        ],
+      );
+      expect(groups, isEmpty);
+    });
+
+    test('a prefix-less station id falls back to the active country', () {
+      final groups = groupAlertsByCountry(
+        priceAlerts: [
+          priceAlert('a1', '51d4b6a2-a095-1aa0-e100-80009459e03a'),
+        ],
+        radiusAlerts: const [],
+        fallbackCountryCode: 'DE',
+      );
+      expect(groups.keys.toSet(), {'DE'});
+      expect(groups['DE']!.stationIds,
+          {'51d4b6a2-a095-1aa0-e100-80009459e03a'});
+    });
+
+    test('a prefix-less id with NO fallback is dropped (no provider to ask)',
+        () {
+      final groups = groupAlertsByCountry(
+        priceAlerts: [priceAlert('a1', 'rawuuid')],
+        radiusAlerts: const [],
+      );
+      expect(groups, isEmpty);
+    });
+
+    test('a radius centre outside every box is dropped', () {
+      final groups = groupAlertsByCountry(
+        priceAlerts: const [],
+        radiusAlerts: [radiusAlert('r1', 0.0, -40.0)],
+      );
+      expect(groups, isEmpty);
+    });
+  });
+}

--- a/test/core/background/background_price_source_test.dart
+++ b/test/core/background/background_price_source_test.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/background/background_price_source.dart';
@@ -58,6 +60,22 @@ class _RecordingService implements StationService {
     );
   }
 
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+}
+
+/// A [StationService] whose calls all throw — for the #2349 never-throws
+/// fault-injection: the BG isolate must spool, never rethrow, a provider fault.
+class _ThrowingService implements StationService {
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+          List<String> ids) async =>
+      throw const SocketException('injected fault');
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(SearchParams params,
+          {CancelToken? cancelToken}) async =>
+      throw const SocketException('injected fault');
   @override
   Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
       throw UnimplementedError();
@@ -190,6 +208,37 @@ void main() {
         stationIds: List.generate(50, (i) => 'de-$i'),
       );
       expect(services['DE']!.priceCalls, 1);
+    });
+  });
+
+  group('never throws — a provider fault is spooled, not propagated (#2349)', () {
+    BackgroundPriceSource throwingSource() => BackgroundPriceSource(
+          storage: FakeStorageRepository(),
+          serviceBuilder: (code, {String? apiKey}) => _ThrowingService(),
+        );
+
+    test('fetchPricesGrouped completes (spools the fault) when the provider '
+        'throws — never rethrows into the OS-spawned isolate', () async {
+      // The documented never-throws boundary (background_price_source.dart):
+      // a throwing per-country service must be caught + spooled, never bubble.
+      await expectLater(
+        throwingSource().fetchPricesGrouped(stationIds: ['de-1', 'at-1']),
+        completes,
+      );
+      final prices =
+          await throwingSource().fetchPricesGrouped(stationIds: ['de-1']);
+      expect(prices, isEmpty,
+          reason: 'a thrown fetch yields no prices, not a crash');
+    });
+
+    test('searchStations swallows a throwing provider', () {
+      expect(
+        () => throwingSource().searchStations(
+          countryCode: 'DE',
+          params: const SearchParams(lat: 52.5, lng: 13.4, radiusKm: 5),
+        ),
+        returnsNormally,
+      );
     });
   });
 }

--- a/test/core/background/background_price_source_test.dart
+++ b/test/core/background/background_price_source_test.dart
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/background_price_source.dart';
+import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/core/services/fuel_service_policy.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+
+/// A recording fake [StationService] for one country: counts how many times
+/// `getPrices` / `searchStations` are called and returns canned data so the
+/// #2862 source's per-country fan-out + Tankerkönig-shape adaptation can be
+/// asserted without any network.
+class _RecordingService implements StationService {
+  _RecordingService(this.code);
+
+  final String code;
+  int priceCalls = 0;
+  int searchCalls = 0;
+  final List<List<String>> idsSeen = [];
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+      List<String> ids) async {
+    priceCalls++;
+    idsSeen.add(ids);
+    return ServiceResult(
+      data: {
+        for (final id in ids)
+          id: const StationPrices(
+            e5: 1.5,
+            e10: 1.4,
+            diesel: 1.6,
+            status: 'open',
+          ),
+      },
+      source: ServiceSource.tankerkoenigApi,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    searchCalls++;
+    return ServiceResult(
+      data: const [],
+      source: ServiceSource.tankerkoenigApi,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  group('isPolled', () {
+    test('the 11 polled providers are recognised; bulk + stub are not', () {
+      for (final code in ['DE', 'AT', 'PT', 'GB', 'LU', 'SI', 'GR', 'RO',
+        'MX', 'KR', 'CL']) {
+        expect(BackgroundPriceSource.isPolled(code), isTrue,
+            reason: '$code must be polled');
+      }
+      // Bulk-dataset countries (child #2863) + the AU stub are NOT scanned.
+      for (final code in ['ES', 'IT', 'AR', 'DK', 'FR', 'AU', 'ZZ']) {
+        expect(BackgroundPriceSource.isPolled(code), isFalse,
+            reason: '$code must NOT be polled by this source');
+      }
+    });
+  });
+
+  group('fetchPricesGrouped — one provider hit per country', () {
+    late Map<String, _RecordingService> built;
+    late BackgroundPriceSource source;
+
+    setUp(() {
+      built = {};
+      source = BackgroundPriceSource(
+        storage: FakeStorageRepository(),
+        serviceBuilder: (code, {String? apiKey}) {
+          // Each country's service is built lazily; count builds per code.
+          return built.putIfAbsent(code, () => _RecordingService(code));
+        },
+      );
+    });
+
+    test('alerts in DE + AT + PT fetch each via its OWN service, ONCE each',
+        () async {
+      final prices = await source.fetchPricesGrouped(
+        stationIds: [
+          'de-1', 'de-2', // DE — two stations
+          'at-1', // AT
+          'pt-1', 'pt-2', 'pt-3', // PT — three stations
+        ],
+      );
+
+      // Three providers built, each exactly once.
+      expect(built.keys.toSet(), {'DE', 'AT', 'PT'});
+      expect(built['DE']!.priceCalls, 1, reason: 'DE provider hit once');
+      expect(built['AT']!.priceCalls, 1, reason: 'AT provider hit once');
+      expect(built['PT']!.priceCalls, 1, reason: 'PT provider hit once');
+
+      // Each provider received exactly its own country's ids.
+      expect(built['DE']!.idsSeen.single.toSet(), {'de-1', 'de-2'});
+      expect(built['AT']!.idsSeen.single, ['at-1']);
+      expect(built['PT']!.idsSeen.single.toSet(), {'pt-1', 'pt-2', 'pt-3'});
+
+      // The merged result spans all six stations in Tankerkönig shape.
+      expect(prices.keys.toSet(),
+          {'de-1', 'de-2', 'at-1', 'pt-1', 'pt-2', 'pt-3'});
+      expect(prices['pt-1']!['status'], 'open');
+      expect(prices['pt-1']!['e5'], 1.5);
+      expect(prices['pt-1']!['diesel'], 1.6);
+    });
+
+    test('a fetch + a radius search for the same country reuse one service',
+        () async {
+      await source.fetchPricesGrouped(stationIds: ['de-1']);
+      await source.searchStations(
+        countryCode: 'DE',
+        params: const SearchParams(lat: 52.5, lng: 13.4, radiusKm: 5),
+      );
+      // ONE DE service, used for both — not rebuilt for the search.
+      expect(built.keys, ['DE']);
+      expect(built['DE']!.priceCalls, 1);
+      expect(built['DE']!.searchCalls, 1);
+    });
+
+    test('ids for an unpolled (bulk) country are skipped — no service built',
+        () async {
+      final prices = await source.fetchPricesGrouped(
+        stationIds: ['es-1', 'it-1'], // ES + IT are bulk (child #2863)
+      );
+      expect(prices, isEmpty);
+      expect(built, isEmpty, reason: 'no bulk-country provider may be built');
+    });
+
+    test('a prefix-less id falls back to the active country', () async {
+      await source.fetchPricesGrouped(
+        stationIds: ['rawuuid-no-prefix'],
+        fallbackCountryCode: 'DE',
+      );
+      expect(built.keys, ['DE']);
+      expect(built['DE']!.idsSeen.single, ['rawuuid-no-prefix']);
+    });
+
+    test('a prefix-less id with no fallback is dropped', () async {
+      final prices =
+          await source.fetchPricesGrouped(stationIds: ['rawuuid']);
+      expect(prices, isEmpty);
+      expect(built, isEmpty);
+    });
+  });
+
+  group('minInterval is honoured per country (#2862)', () {
+    test('every polled country carries a positive minInterval the chain uses',
+        () {
+      for (final code in kBackgroundPolledCountries) {
+        final policy = CountryServiceRegistry.policyFor(code);
+        expect(policy, isNotNull, reason: '$code must have a policy');
+        expect(policy!.minInterval, greaterThan(Duration.zero),
+            reason: '$code minInterval must throttle the BG scan');
+        expect(policy.model, SourceModel.polledApi,
+            reason: '$code is a polled provider, not bulk');
+      }
+    });
+
+    test('50 DE alerts → ONE provider request per scan (rate bounded by the '
+        'scan cadence, not the alert count)', () async {
+      // The chain/fetcher batches internally, so a scan with many same-country
+      // stations is still a single provider call — the per-provider request
+      // rate cannot breach minInterval just because the user has more alerts.
+      final services = <String, _RecordingService>{};
+      final source = BackgroundPriceSource(
+        storage: FakeStorageRepository(),
+        serviceBuilder: (code, {String? apiKey}) =>
+            services.putIfAbsent(code, () => _RecordingService(code)),
+      );
+      await source.fetchPricesGrouped(
+        stationIds: List.generate(50, (i) => 'de-$i'),
+      );
+      expect(services['DE']!.priceCalls, 1);
+    });
+  });
+}

--- a/test/core/background/background_service_test.dart
+++ b/test/core/background/background_service_test.dart
@@ -480,33 +480,45 @@ void main() {
   // inside top-level isolate entrypoints that can't be exercised without a
   // platform engine.
   group('background isolate Dio construction (#2249)', () {
-    // #2415 — the Dio construction moved into the coordinator with the
-    // scan body. The #2249 invariant (rate-limited factory, never raw Dio)
-    // still applies; the source-scan now reads the coordinator.
-    final source =
+    // #2415 — the Dio construction moved into the coordinator with the scan
+    // body. #2862 — it moved again, into the registry-driven
+    // BackgroundPriceSource (which builds each polled country's Dio). The
+    // #2249 invariant (rate-limited factory, never raw Dio) still applies;
+    // the source-scan now reads the price source + the coordinator, and
+    // neither may hand-roll a Dio.
+    final priceSource =
+        File('lib/core/background/background_price_source.dart')
+            .readAsStringSync();
+    final coordinator =
         File('lib/core/background/background_alert_scan_coordinator.dart')
+            .readAsStringSync();
+    final runners =
+        File('lib/core/background/background_scan_runners.dart')
             .readAsStringSync();
 
     test('routes every Dio through DioFactory', () {
       expect(
-        source.contains("import '../services/dio_factory.dart';"),
+        priceSource.contains("import '../services/dio_factory.dart';"),
         isTrue,
-        reason: 'coordinator must import DioFactory',
+        reason: 'the background price source must import DioFactory',
       );
       expect(
-        source.contains('DioFactory.create('),
+        priceSource.contains('DioFactory.create('),
         isTrue,
-        reason: 'background isolate must build its Dio via DioFactory.create',
+        reason: 'the background isolate must build its Dio via '
+            'DioFactory.create',
       );
     });
 
     test('constructs no raw Dio(BaseOptions(...)) instances', () {
-      expect(
-        source.contains('Dio(BaseOptions('),
-        isFalse,
-        reason: 'raw Dio bypasses the rate-limit + conditional-GET '
-            'interceptors — use DioFactory.create instead',
-      );
+      for (final source in [priceSource, coordinator, runners]) {
+        expect(
+          source.contains('Dio(BaseOptions('),
+          isFalse,
+          reason: 'raw Dio bypasses the rate-limit + conditional-GET '
+              'interceptors — use DioFactory.create instead',
+        );
+      }
     });
   });
 

--- a/test/core/services/build_background_service_test.dart
+++ b/test/core/services/build_background_service_test.dart
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/country_raw_service_builder.dart';
+import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/core/services/impl/demo_station_service.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+import 'package:tankstellen/features/station_services/austria/econtrol_station_service.dart';
+import 'package:tankstellen/features/station_services/germany/tankerkoenig_station_service.dart';
+import 'package:tankstellen/features/station_services/luxembourg/luxembourg_station_service.dart';
+import 'package:tankstellen/features/station_services/portugal/portugal_station_service.dart';
+import 'package:tankstellen/features/station_services/slovenia/slovenia_station_service.dart';
+import 'package:tankstellen/features/station_services/south_korea/south_korea_station_service.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+
+/// #2861 — the Ref-free background construction seam.
+///
+/// `buildBackgroundService` must build the SAME `StationServiceChain` per
+/// country the foreground does (the foreground `createService(Ref)` now
+/// delegates to it), so these tests drive the REAL registry + the real
+/// per-country `buildRawCountryService`, not a fake. The chain's internals
+/// (error source, policy) are private; we assert the public `countryCode`
+/// on the wrapper and use the construction-path function
+/// [buildRawCountryService] for the primary-service-type assertions.
+void main() {
+  CacheManager cache() => CacheManager(FakeStorageRepository());
+
+  CountryServiceDependencies deps({
+    FakeStorageRepository? storage,
+    Dio? dio,
+  }) =>
+      CountryServiceDependencies(
+        storage: storage ?? FakeStorageRepository(),
+        cache: cache(),
+        tankerkoenigDio: dio,
+      );
+
+  group('buildBackgroundService — chain wrapper', () {
+    test('wraps every registered country in a StationServiceChain stamped '
+        'with that country code', () {
+      for (final entry in CountryServiceRegistry.entries) {
+        final service = CountryServiceRegistry.buildBackgroundService(
+          entry.countryCode,
+          storage: FakeStorageRepository(),
+          cache: cache(),
+          tankerkoenigDio: entry.countryCode == 'DE' ? Dio() : null,
+        );
+        expect(service, isA<StationServiceChain>(),
+            reason: '${entry.countryCode} must be chained');
+        expect((service as StationServiceChain).countryCode, entry.countryCode);
+      }
+    });
+
+    test('an unregistered country → bare Demo service (not a chain)', () {
+      final service = CountryServiceRegistry.buildBackgroundService(
+        'ZZ',
+        storage: FakeStorageRepository(),
+        cache: cache(),
+      );
+      expect(service, isA<DemoStationService>());
+      expect(service, isNot(isA<StationServiceChain>()));
+    });
+  });
+
+  group('buildRawCountryService — single construction path', () {
+    test('DE with a key → Tankerkönig; without bundled key → Demo', () async {
+      final withKey = FakeStorageRepository();
+      await withKey.setApiKey('key123');
+      expect(
+        buildRawCountryService('DE', deps(storage: withKey, dio: Dio())),
+        isA<TankerkoenigStationService>(),
+      );
+
+      final noKey = FakeStorageRepository();
+      noKey.inner.hasBundledDefaultKey = false;
+      expect(
+        buildRawCountryService('DE', deps(storage: noKey, dio: Dio())),
+        isA<DemoStationService>(),
+      );
+    });
+
+    test('DE with a key but no Dio → Demo (cannot reach the API)', () async {
+      final withKey = FakeStorageRepository();
+      await withKey.setApiKey('key123');
+      expect(
+        buildRawCountryService('DE', deps(storage: withKey)),
+        isA<DemoStationService>(),
+      );
+    });
+
+    test('AT → E-Control', () {
+      expect(buildRawCountryService('AT', deps()),
+          isA<EControlStationService>());
+    });
+
+    test('PT → Portugal', () {
+      expect(buildRawCountryService('PT', deps()),
+          isA<PortugalStationService>());
+    });
+
+    test('LU → Luxembourg, SI → Slovenia', () {
+      expect(buildRawCountryService('LU', deps()),
+          isA<LuxembourgStationService>());
+      expect(buildRawCountryService('SI', deps()),
+          isA<SloveniaStationService>());
+    });
+
+    test('KR with a key → OPINET; without a key → Demo', () async {
+      final withKey = FakeStorageRepository();
+      await withKey.setApiKey('opinet');
+      expect(buildRawCountryService('KR', deps(storage: withKey)),
+          isA<SouthKoreaStationService>());
+
+      // KR/CL gate on getApiKey() (not hasApiKey), so a null key → Demo
+      // regardless of the bundled-default flag.
+      expect(buildRawCountryService('KR', deps()), isA<DemoStationService>());
+    });
+
+    test('an unregistered country → Demo', () {
+      expect(buildRawCountryService('ZZ', deps()), isA<DemoStationService>());
+    });
+  });
+
+  group('foreground non-regression: same primary types via the raw builder',
+      () {
+    // The foreground buildService(Ref) reads its deps from the Ref and calls
+    // buildBackgroundService → buildRawCountryService. These assertions lock
+    // the per-country primary type the foreground has always produced.
+    final cases = <String, TypeMatcher<StationService>>{
+      'AT': isA<EControlStationService>(),
+      'PT': isA<PortugalStationService>(),
+      'LU': isA<LuxembourgStationService>(),
+      'SI': isA<SloveniaStationService>(),
+    };
+    cases.forEach((code, matcher) {
+      test('$code primary unchanged', () {
+        expect(buildRawCountryService(code, deps()), matcher);
+      });
+    });
+  });
+}

--- a/test/core/services/germany_no_special_case_test.dart
+++ b/test/core/services/germany_no_special_case_test.dart
@@ -16,12 +16,20 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   late String providersSource;
   late String registrySource;
+  // #2861 — the per-country raw service construction (incl. the Germany
+  // API-key gate) moved out of the registry into this single, Riverpod-free
+  // builder so the foreground + background isolate share one path. The #425
+  // "no Germany special case" intent now lives here.
+  late String builderSource;
 
   setUpAll(() {
     providersSource =
         File('lib/core/services/service_providers.dart').readAsStringSync();
     registrySource =
         File('lib/core/services/country_service_registry.dart')
+            .readAsStringSync();
+    builderSource =
+        File('lib/core/services/country_raw_service_builder.dart')
             .readAsStringSync();
   });
 
@@ -61,27 +69,32 @@ void main() {
     });
   });
 
-  group('CountryServiceRegistry now owns the Germany factory', () {
-    test('_createTankerkoenig is no longer an UnsupportedError stub', () {
+  group('the registry / raw builder own the Germany factory', () {
+    test('the Germany branch is no longer an UnsupportedError stub', () {
       // The stub used to throw UnsupportedError because the registry had no
       // way to wire the API-key check. After #425 it returns Demo or the
-      // real Tankerkoenig service depending on the storage state.
+      // real Tankerkoenig service depending on the storage state. (#2861 —
+      // this wiring now lives in country_raw_service_builder.dart.)
       expect(
-        registrySource,
+        builderSource,
         isNot(contains('UnsupportedError')),
-        reason: '_createTankerkoenig should be implemented, not a stub',
+        reason: 'the DE branch should be implemented, not a stub',
       );
     });
 
-    test('Germany factory falls back to DemoStationService when no API key',
+    test('Germany branch falls back to DemoStationService when no API key',
         () {
-      expect(registrySource, contains('hasApiKey()'));
-      expect(registrySource, contains("DemoStationService(countryCode: 'DE')"));
+      expect(builderSource, contains('hasApiKey()'));
+      expect(builderSource, contains("DemoStationService(countryCode: 'DE')"));
     });
 
-    test('Germany factory uses tankerkoenigDioProvider when key present', () {
+    test('Germany branch builds the real Tankerkönig service with the Dio',
+        () {
+      // #2861 — the foreground reads tankerkoenigDioProvider in the registry
+      // and threads it through to the Riverpod-free builder, which constructs
+      // the real service.
       expect(registrySource, contains('tankerkoenigDioProvider'));
-      expect(registrySource, contains('TankerkoenigStationService(dio)'));
+      expect(builderSource, contains('TankerkoenigStationService(dio)'));
     });
 
     test('every supported country still has a registry entry', () {

--- a/test/docs/new_country_guide_test.dart
+++ b/test/docs/new_country_guide_test.dart
@@ -135,6 +135,13 @@ void main() {
         final registryContent = registryFile.existsSync()
             ? registryFile.readAsStringSync()
             : '';
+        // #2861 — the per-country construction switch (and its imports) moved
+        // out of the registry into the single Ref-free builder, so a service
+        // wired there counts too.
+        final builderFile =
+            File('lib/core/services/country_raw_service_builder.dart');
+        final builderContent =
+            builderFile.existsSync() ? builderFile.readAsStringSync() : '';
 
         final serviceFiles = featuresDir
             .listSync(recursive: true)
@@ -150,10 +157,12 @@ void main() {
           // The file must be imported in service_providers.dart or registry.
           expect(
             serviceProviders.contains(fileName) ||
-                registryContent.contains(fileName),
+                registryContent.contains(fileName) ||
+                builderContent.contains(fileName),
             isTrue,
             reason:
-                'service_providers.dart or country_service_registry.dart must import $fileName',
+                'service_providers.dart, country_service_registry.dart, or '
+                'country_raw_service_builder.dart must import $fileName',
           );
         }
       });

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -78,7 +78,13 @@ void main() {
     // these 5 lines are the registry's only data-access wiring and can't move
     // out without re-introducing a Germany-style special case the registry
     // exists to eliminate. Decomposition still tracked by #2187/#2188.
-    'lib/core/services/country_service_registry.dart': 921,
+    // #2861 — shrunk 921 → 852: the 17 per-entry `createService(Ref)` factory
+    // functions + the entry's `createService` field moved into the single,
+    // Riverpod-free `buildRawCountryService` (country_raw_service_builder.dart)
+    // so the foreground (buildService) and the WorkManager background isolate
+    // (buildBackgroundService) share ONE construction path. Snapshot lowered
+    // to keep the debt baseline honest.
+    'lib/core/services/country_service_registry.dart': 852,
     'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
     // #2456 — re-grandfathered 457 → 481: two new pure parsers,


### PR DESCRIPTION
Foundation + first consumer of Epic #2860 (background price alerts for all countries) — the architectural keystone that de-couples the WorkManager / BGAppRefresh alert evaluator from the DE/Tankerkönig-only path.

Closes #2861.
Closes #2862.

## #2861 — Ref-free country-agnostic BG service construction (FOUNDATION)
The registry's lookups are static + isolate-safe, but `createService(Ref)` needed a Riverpod `Ref` the WorkManager isolate lacks. Inverted that into a single, Ref-free construction path:

- **`country_raw_service_builder.dart`** — `buildRawCountryService(code, CountryServiceDependencies)` builds the per-country raw `StationService` from explicit deps (storage, cache, optional Tankerkönig Dio). The 17 per-entry `createService(Ref)` factory functions + the entry's `createService` field collapse into this one switch, so the registry shrinks **921 → 852 lines** (snapshot lowered, debt baseline kept honest).
- **`CountryServiceRegistry.buildBackgroundService(code, {required storage, required cache, Dio? tankerkoenigDio, DataAccessRecorder? recorder})`** — wraps the raw service in the **same** `StationServiceChain` (same primary, error source, policy) the foreground builds. The foreground `buildService(code, Ref, cache)` now reads its deps from the `Ref` and **delegates** to it → one construction path, foreground behaviour byte-identical.
- **Lazy country derivation** (no Hive migration): `countryForStationId` (id prefix) + `countryForLatLng` (bbox).
- **`alert_country_grouping.dart`** — `groupAlertsByCountry` buckets active per-station + radius alerts by derived country so a scan hits each provider at most once.

## #2862 — per-country BackgroundPriceSource (the 11 polled countries)
- **`BackgroundPriceSource`** — builds each country's service Ref-free and fetches current prices through it (batch where supported; DE Tankerkönig batch is the template). `fetchPricesGrouped` groups a mixed-country id set by derived country and queries each polled provider **at most once per scan**, within its `FuelServicePolicy.minInterval`. Results are adapted back to the legacy Tankerkönig-shaped map, so the downstream price-history + per-station / velocity / radius evaluation stays unchanged (currency / fuel widening is child #2864).
- Replaces the **3 hardcoded** Tankerkönig instantiations: coordinator price fetch + nearest-widget search, radius runner search. The per-country station-id prefix (today hardcoded `de-`) is derived per id; prefix-less ids fall back to the active country.
- Wires the **11 polled** countries only (DE, AT, PT, GB-legacy, LU, SI, GR, RO, MX, KR, CL); DE/KR/CL user keys cross into the isolate via the shared encrypted Hive box. Bulk-dataset countries (ES/IT/AR/DK + flag-gated FR/GB bulk) are **not** scanned — child #2863 (no regression vs today, where only DE was scanned). AU stays excluded (throwing stub #804).

## Tests (drive real code paths)
- `buildBackgroundService` chains every registered country; `buildRawCountryService` is the single path (DE key / no-key / no-Dio, KR key gate); foreground non-regression on per-country primary types.
- Derivation + grouping: per-station ids + radius centres resolve to the right countries; a 3-country alert set → 3 single-provider buckets; same-station collapse; inactive/disabled exclusion; prefix-less fallback / drop.
- `BackgroundPriceSource`: DE+AT+PT alerts fetch each via its OWN service ONCE each with its own ids; fetch + radius search reuse one service; bulk-country ids skipped (no provider built); every polled country carries a positive polled `minInterval`; 50 same-country alerts → one provider request per scan.
- The #425 germany-no-special-case + #2249 BG-Dio-via-DioFactory guards follow the wiring into the new files (intent preserved).

`flutter analyze` clean; full background / services / alerts / station-services + lint guards (file_length, no_hardcoded_ui_strings, catch_block_stacktrace, no_silent_catch) green; clean codegen no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
