### PR TITLE
feat(bg-alerts): CountryAlertStrategy framework + bulk-dataset specialization (#2863)

### DIFF
--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -10,10 +10,14 @@ import '../../features/widget/data/home_widget_service.dart';
 import '../logging/error_logger.dart';
 import '../storage/hive_storage.dart';
 import '../telemetry/storage/isolate_error_spool.dart';
+import '../cache/cache_manager.dart';
+import '../services/country_service_registry.dart';
 import 'background_price_history_writer.dart';
 import 'background_price_source.dart';
 import 'background_scan_dedup_store.dart';
 import 'background_scan_runners.dart';
+import 'bulk_dataset_alert_strategy.dart';
+import 'country_alert_strategy_resolver.dart';
 import 'daily_collection.dart';
 import 'hive_isolate_lock.dart';
 import 'notification_templates.dart';
@@ -254,6 +258,26 @@ class BackgroundAlertScanCoordinator {
       fallbackCountryCode: activeCountry,
       apiKey: apiKey,
     );
+
+    // #2863 — bulk-dataset countries (ES/IT/AR/DK + flag-gated FR/GB) are not
+    // served by the polled [BackgroundPriceSource]; their alert stations flow
+    // through a [BulkDatasetAlertStrategy] resolved per country. The dataset is
+    // downloaded at most once per scan (per its datasetTtl) then local-filtered
+    // — zero per-alert network. Merged into the same Tankerkönig-shaped map the
+    // evaluator consumes, so per-station price alerts in bulk countries now
+    // fire too. (Radius alerts in bulk countries are handled below, in the
+    // strategy-aware [BackgroundScanRunners.runRadiusAlerts].)
+    final resolver = CountryAlertStrategyResolver(
+      storage: storage,
+      cache: CacheManager(storage),
+      apiKey: apiKey,
+    );
+    prices.addAll(await _fetchBulkAlertPrices(
+      alertStationIds: alertStationIds,
+      fallbackCountryCode: activeCountry,
+      resolver: resolver,
+    ));
+
     debugPrint('BackgroundAlertScanCoordinator: fetched prices for '
         '${prices.length} stations');
 
@@ -277,8 +301,7 @@ class BackgroundAlertScanCoordinator {
 
     await BackgroundScanRunners.runRadiusAlerts(
       now: now,
-      source: source,
-      apiKey: apiKey,
+      resolver: resolver,
       templates: templates,
     );
 
@@ -288,6 +311,41 @@ class BackgroundAlertScanCoordinator {
       settingsStorage: storage,
     );
     await _refreshNearestWidgetFromSearch(storage, source: source);
+  }
+
+  /// #2863 — fetch per-station alert prices for **bulk-dataset** countries via
+  /// their [BulkDatasetAlertStrategy] (resolved per country by [resolver]).
+  ///
+  /// Groups the alert station ids by derived country (the same lazy derivation
+  /// the polled grouping uses), keeps only the bulk-policy countries (polled
+  /// ones were already fetched by [BackgroundPriceSource]), and asks each
+  /// country's strategy for its prices. Each bulk strategy answers by local
+  /// geo-filter over its cached whole-country dataset — at most one dataset
+  /// download per country per scan, then zero per-alert network. Each strategy
+  /// swallows + spools its own faults (its documented boundary, fault-tested in
+  /// `country_alert_strategy_test.dart`), so a bulk-country provider fault
+  /// degrades to "no fresh prices this scan" rather than failing the scan.
+  Future<Map<String, Map<String, dynamic>>> _fetchBulkAlertPrices({
+    required Set<String> alertStationIds,
+    required String? fallbackCountryCode,
+    required CountryAlertStrategyResolver resolver,
+  }) async {
+    final byCountry = <String, Set<String>>{};
+    for (final id in alertStationIds) {
+      final code =
+          CountryServiceRegistry.countryForStationId(id) ?? fallbackCountryCode;
+      // Only the bulk-dataset countries; polled ids were already fetched.
+      if (code == null || !BulkDatasetAlertStrategy.isBulk(code)) continue;
+      byCountry.putIfAbsent(code, () => <String>{}).add(id);
+    }
+
+    final merged = <String, Map<String, dynamic>>{};
+    for (final entry in byCountry.entries) {
+      final strategy = resolver.strategyFor(entry.key);
+      if (strategy == null) continue;
+      merged.addAll(await strategy.fetchPrices(entry.value));
+    }
+    return merged;
   }
 
   /// #609 — nearest-widget refresh from a real search (or legacy fallback).

--- a/lib/core/background/background_price_shape.dart
+++ b/lib/core/background/background_price_shape.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../features/search/domain/entities/station.dart';
+import '../constants/field_names.dart';
+import '../services/station_service.dart';
+
+/// Adapters from the country-agnostic price models ([StationPrices], [Station])
+/// back to the legacy Tankerkönig-shaped `id → {status, e5, e10, diesel, …}`
+/// map the per-station / velocity alert runners read today (#2862 / #2863).
+///
+/// Both the polled ([PolledAlertStrategy]) and bulk
+/// ([BulkDatasetAlertStrategy]) strategies emit this one shape so the price
+/// evaluation downstream stays untouched — making it country/currency/fuel-set
+/// aware is child #2864, which can widen this shape without re-touching either
+/// strategy. Every priced fuel is carried, not just E5/E10/diesel, so that
+/// widening needs no upstream change.
+
+/// Adapt a [StationPrices] (the polled `getPrices` result) to the Tankerkönig
+/// shape.
+Map<String, dynamic> stationPricesToTankerkoenigShape(StationPrices prices) => {
+      TankerkoenigFields.status:
+          prices.isOpen ? TankerkoenigFields.statusOpen : 'closed',
+      TankerkoenigFields.e5: prices.e5,
+      TankerkoenigFields.e10: prices.e10,
+      TankerkoenigFields.diesel: prices.diesel,
+      'e98': prices.e98,
+      'dieselPremium': prices.dieselPremium,
+      'e85': prices.e85,
+      'lpg': prices.lpg,
+      'cng': prices.cng,
+    };
+
+/// Adapt a priced [Station] (a bulk-dataset local-filter result) to the
+/// Tankerkönig shape, so a [BulkDatasetAlertStrategy] can answer per-station
+/// price alerts from its cached whole-country dataset — the bulk primaries'
+/// `getPrices` returns empty by design (prices live on the dataset rows the
+/// search emits, not behind a per-station endpoint).
+Map<String, dynamic> stationToTankerkoenigShape(Station station) => {
+      TankerkoenigFields.status:
+          station.isOpen ? TankerkoenigFields.statusOpen : 'closed',
+      TankerkoenigFields.e5: station.e5,
+      TankerkoenigFields.e10: station.e10,
+      TankerkoenigFields.diesel: station.diesel,
+      'e98': station.e98,
+      'dieselPremium': station.dieselPremium,
+      'e85': station.e85,
+      'lpg': station.lpg,
+      'cng': station.cng,
+    };

--- a/lib/core/background/background_price_source.dart
+++ b/lib/core/background/background_price_source.dart
@@ -3,47 +3,38 @@
 
 import 'dart:async';
 
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../features/search/data/models/search_params.dart';
 import '../../features/search/domain/entities/station.dart';
 import '../cache/cache_manager.dart';
-import '../constants/field_names.dart';
 import '../data/storage_repository.dart';
-import '../logging/error_logger.dart';
 import '../services/country_service_registry.dart';
-import '../services/dio_factory.dart';
-import '../services/service_config.dart';
 import '../services/station_service.dart';
+import 'country_alert_strategy.dart';
+import 'polled_alert_strategy.dart';
 
-/// The 11 polled / realtime providers a background scan may query directly,
-/// reusing the per-country `StationServiceChain` within each provider's
-/// `FuelServicePolicy.minInterval` (Epic #2860, child #2862).
-///
-/// Bulk-dataset countries (ES, IT, AR, DK + the flag-gated FR/GB bulk paths)
-/// are deliberately **excluded** here — they need the download-once +
-/// local-filter flow of child #2863, never a per-alert network hit. Until
-/// then those countries simply are not scanned (no regression vs today, where
-/// only DE was). AU is excluded as a throwing stub (#804).
-const Set<String> kBackgroundPolledCountries = {
-  'DE', 'AT', 'PT', 'GB', 'LU', 'SI', 'GR', 'RO', 'MX', 'KR', 'CL',
-};
+// `kBackgroundPolledCountries` now lives in `polled_alert_strategy.dart` (the
+// per-country polled specialization, #2863). Re-exported here so existing
+// imports (`background_price_source.dart`) keep compiling.
+export 'polled_alert_strategy.dart' show kBackgroundPolledCountries;
 
-/// Builds the right country [StationService] (Riverpod-free, via
-/// [CountryServiceRegistry.buildBackgroundService]) inside the WorkManager /
-/// BGAppRefresh isolate and fetches current prices through it — replacing the
-/// three hardcoded Tankerkönig instantiations (#2862).
+/// Multi-country price-fetch orchestrator for a background scan, grouping a
+/// mixed-country station-id set by derived country so each polled provider is
+/// queried **at most once per scan** (Epic #2860, child #2862).
 ///
-/// This is the *which-service-fetches* seam, grouped per country so each
-/// provider is hit at most once per scan. The price **evaluation** stays as
-/// it is today (euro / e5-e10-diesel); making it country/currency-aware is
-/// child #2864.
+/// Since #2863 the per-country work is delegated to a [PolledAlertStrategy] —
+/// the [SourceModel.polledApi] specialization of [CountryAlertStrategy] — built
+/// once per country and cached, so a scan that fetches station prices AND runs
+/// a radius search for the same country reuses one strategy (and one provider
+/// service). Bulk-dataset countries (ES/IT/AR/DK + flag-gated FR/GB) are NOT
+/// handled here; they flow through [BulkDatasetAlertStrategy], resolved by the
+/// scan coordinator via [CountryAlertStrategy.forCountry]. This source remains
+/// the polled-only seam the velocity/per-station price refresh + nearest-widget
+/// search use.
 ///
-/// Construction is per-country and cheap, but the source caches the built
-/// service per country code so a scan that fetches station prices AND runs a
-/// radius search for the same country reuses one service (and so a test can
-/// assert each provider is built exactly once).
+/// The price **evaluation** stays as it is today (euro / e5-e10-diesel); making
+/// it country/currency/fuel-set aware is child #2864.
 class BackgroundPriceSource {
   BackgroundPriceSource({
     required StorageRepository storage,
@@ -52,102 +43,68 @@ class BackgroundPriceSource {
     @visibleForTesting StationService? Function(String code, {String? apiKey})?
         serviceBuilder,
   })  : _storage = storage,
-        _connectTimeout = connectTimeout,
-        _receiveTimeout = receiveTimeout,
         _cache = CacheManager(storage),
-        _serviceBuilder = serviceBuilder;
+        _deps = PolledAlertStrategyDeps(
+          connectTimeout: connectTimeout,
+          receiveTimeout: receiveTimeout,
+          serviceBuilder: serviceBuilder,
+        );
 
   final StorageRepository _storage;
   final CacheStrategy _cache;
-  final Duration _connectTimeout;
-  final Duration _receiveTimeout;
+  final PolledAlertStrategyDeps _deps;
 
-  /// Test seam (#2862): a fake per-country service builder. Production leaves
-  /// this null and goes through [CountryServiceRegistry.buildBackgroundService].
-  /// Called at most once per country (the result is cached), so a test can
-  /// assert each provider is built exactly once per scan.
-  final StationService? Function(String code, {String? apiKey})? _serviceBuilder;
-
-  /// Per-scan service cache so each country's provider is built at most once.
-  final Map<String, StationService> _services = {};
+  /// Per-scan strategy cache so each country's polled provider is built at most
+  /// once. Keyed by country code; a `null` value records a country we already
+  /// determined has no buildable polled strategy this scan.
+  final Map<String, PolledAlertStrategy?> _strategies = {};
 
   /// Whether [countryCode] is one of the polled providers this source serves.
   static bool isPolled(String countryCode) =>
-      kBackgroundPolledCountries.contains(countryCode);
+      PolledAlertStrategy.isPolled(countryCode);
+
+  /// Build (once per scan) and return the [PolledAlertStrategy] for
+  /// [countryCode], or null when the country is not a polled provider / its
+  /// service cannot be built.
+  PolledAlertStrategy? _strategyFor(String countryCode, {String? apiKey}) {
+    if (_strategies.containsKey(countryCode)) return _strategies[countryCode];
+    final strategy = PolledAlertStrategy.forCountry(
+      countryCode,
+      storage: _storage,
+      cache: _cache,
+      apiKey: apiKey,
+      deps: _deps,
+    );
+    _strategies[countryCode] = strategy;
+    return strategy;
+  }
 
   /// Builds (once per scan) and returns the chained [StationService] for
   /// [countryCode], or null when the country is not a polled provider.
   ///
-  /// [apiKey] is the user's key from the shared encrypted Hive box, threaded
-  /// into the isolate. Only DE needs it on the Dio (sent as the `apikey`
-  /// query param, since the isolate has no Dio interceptor); KR/CL read their
-  /// key from [_storage] inside the registry factory.
-  StationService? serviceFor(String countryCode, {String? apiKey}) {
-    if (!isPolled(countryCode)) return null;
-    final cached = _services[countryCode];
-    if (cached != null) return cached;
-    final built = _serviceBuilder != null
-        ? _serviceBuilder(countryCode, apiKey: apiKey)
-        : CountryServiceRegistry.buildBackgroundService(
-            countryCode,
-            storage: _storage,
-            cache: _cache,
-            tankerkoenigDio:
-                countryCode == 'DE' ? _buildTankerkoenigDio(apiKey) : null,
-          );
-    if (built != null) _services[countryCode] = built;
-    return built;
-  }
-
-  /// Tankerkönig Dio for the background isolate: rate-limited + conditional
-  /// GET (via [DioFactory]) with the API key baked into the query parameters,
-  /// since there is no Riverpod interceptor here.
-  Dio _buildTankerkoenigDio(String? apiKey) {
-    final dio = DioFactory.create(
-      baseUrl: ServiceConfigs.tankerkoenig.baseUrl,
-      connectTimeout: _connectTimeout,
-      receiveTimeout: _receiveTimeout,
-    );
-    if (apiKey != null && apiKey.isNotEmpty) {
-      dio.options.queryParameters = {'apikey': apiKey};
-    }
-    return dio;
-  }
+  /// Kept for the nearest-widget search (#609 / #2862), which needs a raw
+  /// [StationService] handle rather than the strategy facade. [apiKey] is the
+  /// user's key threaded into the isolate.
+  StationService? serviceFor(String countryCode, {String? apiKey}) =>
+      _strategyFor(countryCode, apiKey: apiKey)?.service;
 
   /// Fetch current prices for [stationIds] in [countryCode], returning the
   /// Tankerkönig-shaped `id → {status, e5, e10, diesel, …}` map the existing
   /// downstream price-history + alert evaluation consume unchanged.
   ///
-  /// Batches where the provider supports it (the country service's
-  /// [StationService.getPrices] chunks internally — DE Tankerkönig batch is
-  /// the template); a provider with no batch endpoint returns an empty map
-  /// and per-station alerts for that country simply find no fresh price this
-  /// scan (radius alerts still work via [searchStations]).
-  ///
-  /// Returns an empty map for an unpolled country, no station ids, or any
-  /// fetch error (spooled, never thrown — this runs in an OS-spawned isolate).
+  /// Delegates to the country's [PolledAlertStrategy] (which chunks to the
+  /// provider's batch size internally). Returns an empty map for an unpolled
+  /// country, no station ids, or any fetch error (spooled, never thrown — this
+  /// runs in an OS-spawned isolate).
   Future<Map<String, Map<String, dynamic>>> fetchPrices({
     required String countryCode,
     required Set<String> stationIds,
     String? apiKey,
   }) async {
     if (stationIds.isEmpty) return const {};
-    final service = serviceFor(countryCode, apiKey: apiKey);
-    if (service == null) return const {};
-    try {
-      final result = await service.getPrices(stationIds.toList());
-      final out = <String, Map<String, dynamic>>{};
-      for (final entry in result.data.entries) {
-        out[entry.key] = _toTankerkoenigShape(entry.value);
-      }
-      return out;
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
-        'where': 'BackgroundPriceSource.fetchPrices($countryCode)',
-        'ids': stationIds.length,
-      }));
-      return const {};
-    }
+    final strategy = _strategyFor(countryCode, apiKey: apiKey);
+    if (strategy == null) return const {};
+    return strategy.fetchPrices(stationIds);
   }
 
   /// Fetch prices for a mixed-country [stationIds] set, grouping by derived
@@ -159,7 +116,8 @@ class BackgroundPriceSource {
   /// [fallbackCountryCode] (the active country) so legacy favorites saved
   /// before the #753 prefix scheme are still refreshed. Ids whose country is
   /// not a polled provider (e.g. bulk-dataset ES/IT — child #2863) are
-  /// silently skipped this scan.
+  /// silently skipped here (the scan coordinator scans them via
+  /// [BulkDatasetAlertStrategy]).
   ///
   /// Returns one merged Tankerkönig-shaped map across all countries, keyed by
   /// the original (prefixed) station id.
@@ -188,42 +146,17 @@ class BackgroundPriceSource {
     return merged;
   }
 
-  /// Run a radius search in [countryCode] via its provider — the registry-
-  /// driven replacement for the hardcoded Tankerkönig search the radius-alert
-  /// runner used. Returns the priced stations, or an empty list for an
-  /// unpolled country / a fetch error.
+  /// Run a radius search in [countryCode] via its polled provider — the
+  /// registry-driven replacement for the hardcoded Tankerkönig search the
+  /// radius-alert runner used. Returns the priced stations, or an empty list
+  /// for an unpolled country / a fetch error.
   Future<List<Station>> searchStations({
     required String countryCode,
     required SearchParams params,
     String? apiKey,
   }) async {
-    final service = serviceFor(countryCode, apiKey: apiKey);
-    if (service == null) return const [];
-    try {
-      final result = await service.searchStations(params);
-      return result.data;
-    } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
-        'where': 'BackgroundPriceSource.searchStations($countryCode)',
-      }));
-      return const [];
-    }
+    final strategy = _strategyFor(countryCode, apiKey: apiKey);
+    if (strategy == null) return const [];
+    return strategy.searchArea(params);
   }
-
-  /// Adapt a country-agnostic [StationPrices] back to the legacy
-  /// Tankerkönig-shaped map the per-station / velocity runners read today.
-  /// Carries every priced fuel so #2864 can widen the evaluation without
-  /// re-touching this seam.
-  static Map<String, dynamic> _toTankerkoenigShape(StationPrices prices) => {
-        TankerkoenigFields.status:
-            prices.isOpen ? TankerkoenigFields.statusOpen : 'closed',
-        TankerkoenigFields.e5: prices.e5,
-        TankerkoenigFields.e10: prices.e10,
-        TankerkoenigFields.diesel: prices.diesel,
-        'e98': prices.e98,
-        'dieselPremium': prices.dieselPremium,
-        'e85': prices.e85,
-        'lpg': prices.lpg,
-        'cng': prices.cng,
-      };
 }

--- a/lib/core/background/background_scan_runners.dart
+++ b/lib/core/background/background_scan_runners.dart
@@ -25,7 +25,7 @@ import '../storage/hive_storage.dart';
 import '../storage/storage_keys.dart';
 import '../telemetry/storage/isolate_error_spool.dart';
 import '../utils/json_extensions.dart';
-import 'background_price_source.dart';
+import 'country_alert_strategy_resolver.dart';
 import 'notification_templates.dart';
 
 /// Alert-evaluation runners invoked by [BackgroundAlertScanCoordinator]
@@ -190,18 +190,23 @@ class BackgroundScanRunners {
 
   /// #578 phase 3 — radius alerts via [RadiusAlertRunner] (reused read-only).
   ///
-  /// #2862 — each alert's samples now come from the registry-driven
-  /// [BackgroundPriceSource] for the **country its centre falls in**
-  /// (derived via the bounding box), instead of a single hardcoded
-  /// Tankerkönig search, so a radius alert in PT / AT / … is evaluated
-  /// against that country's provider. The source caches its per-country
-  /// services, so all alerts in one country reuse one provider. Centres in a
-  /// non-polled country (e.g. bulk-dataset ES/IT — child #2863) yield no
-  /// samples this scan.
+  /// #2862 — each alert's samples come from the per-country source for the
+  /// **country its centre falls in** (derived via the bounding box), instead
+  /// of a single hardcoded Tankerkönig search, so a radius alert in PT / AT /
+  /// … is evaluated against that country's provider.
+  ///
+  /// #2863 — the country is now resolved to a [CountryAlertStrategy] via the
+  /// per-scan [CountryAlertStrategyResolver], so **both** polled and bulk
+  /// countries flow through one seam: a polled centre searches its provider
+  /// within `minInterval`; a bulk centre (ES/IT/AR/DK + flag-gated FR/GB) is a
+  /// local geo-filter over the cached whole-country dataset — zero per-alert
+  /// network. The resolver caches strategies per country, so all alerts in one
+  /// country reuse one strategy (and, for bulk, one in-memory dataset). A
+  /// centre whose country has no buildable strategy (e.g. the AU stub) yields
+  /// no samples this scan.
   static Future<void> runRadiusAlerts({
     required DateTime now,
-    required BackgroundPriceSource source,
-    required String? apiKey,
+    required CountryAlertStrategyResolver resolver,
     required BackgroundNotificationTemplates templates,
   }) async {
     try {
@@ -225,14 +230,14 @@ class BackgroundScanRunners {
           final country = CountryServiceRegistry.countryForLatLng(
               alert.centerLat, alert.centerLng);
           if (country == null) return const <StationPriceSample>[];
-          final stations = await source.searchStations(
-            countryCode: country,
-            params: SearchParams(
+          final strategy = resolver.strategyFor(country);
+          if (strategy == null) return const <StationPriceSample>[];
+          final stations = await strategy.searchArea(
+            SearchParams(
               lat: alert.centerLat,
               lng: alert.centerLng,
               radiusKm: alert.radiusKm,
             ),
-            apiKey: apiKey,
           );
           final samples = <StationPriceSample>[];
           for (final station in stations) {

--- a/lib/core/background/bulk_dataset_alert_strategy.dart
+++ b/lib/core/background/bulk_dataset_alert_strategy.dart
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../features/search/data/models/search_params.dart';
+import '../../features/search/domain/entities/station.dart';
+import '../cache/cache_manager.dart';
+import '../data/storage_repository.dart';
+import '../logging/error_logger.dart';
+import '../services/country_service_registry.dart';
+import '../services/fuel_service_policy.dart';
+import '../services/station_service.dart';
+import '../utils/json_extensions.dart';
+import 'background_price_shape.dart';
+import 'country_alert_strategy.dart';
+
+/// [CountryAlertStrategy] for a [SourceModel.bulkFile] country (#2863) — ES,
+/// IT, AR, DK, plus the flag-gated GB-bulk / FR-bulk paths.
+///
+/// ## Dataset-once + local-filter, zero per-alert network
+///
+/// Bulk countries publish a whole-country dataset (ES MITECO per-province, IT
+/// MIMIT CSV, AR Secretaría de Energía CSV, DK multi-brand aggregate, GB CMA
+/// consolidated, FR *flux instantané*) rather than a per-search endpoint. The
+/// existing foreground bulk infrastructure already downloads that dataset
+/// once, persists it (`PersistentDataset` / `CacheManager`, shared Hive),
+/// obeys `datasetTtlSoft` / `datasetTtlHard` via [CachedDatasetMixin], parses
+/// heavy CSV in `compute()`, and **local-filters** every search over the
+/// cached dataset. The [StationServiceChain] built for a bulk policy routes
+/// `searchStations` through its bulk path — no per-key cache, answered straight
+/// from the local-filtering primary.
+///
+/// This strategy REUSES exactly that path: it builds the country's
+/// bulk-backed [StationService] via
+/// [CountryServiceRegistry.buildBackgroundService] (the same chain + bulk
+/// primary the foreground search uses) and answers every alert from it:
+///
+///  - [searchArea] — a radius search is a local geo-filter over the cached
+///    dataset. The first search of a scan may download + persist the dataset
+///    (governed by the policy's `datasetTtl`); every search after that — and
+///    every scan within the soft TTL — answers from the cache with ZERO
+///    network. The twice-daily background cadence (Epic #2860) makes the
+///    per-`minInterval` download budget trivially compliant.
+///  - [fetchPrices] — the bulk primaries return an empty `getPrices` by design
+///    (prices live on the dataset rows the search emits, not behind a
+///    per-station endpoint), so per-station price alerts are answered by a
+///    tiny local geo-filter around each alert station's last-known coordinates
+///    and matched by id — again zero per-alert network once the dataset is
+///    cached.
+///
+/// AU is NOT a bulk country and is excluded upstream by
+/// [CountryAlertStrategy.forCountry] (throwing stub #804).
+class BulkDatasetAlertStrategy implements CountryAlertStrategy {
+  BulkDatasetAlertStrategy({
+    required this.countryCode,
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    required FuelServicePolicy policy,
+    @visibleForTesting StationService? service,
+    @visibleForTesting StationCoordsResolver? coordsResolver,
+  })  : _storage = storage,
+        _cache = cache,
+        _policy = policy,
+        _serviceOverride = service,
+        _coordsResolver = coordsResolver ?? _defaultCoordsResolver(storage);
+
+  @override
+  final String countryCode;
+
+  final StorageRepository _storage;
+  final CacheStrategy _cache;
+  final FuelServicePolicy _policy;
+
+  /// Test seam: a pre-built bulk service (a fake dataset). Production leaves
+  /// this null and builds the real bulk chain on first use.
+  final StationService? _serviceOverride;
+
+  /// Resolves an alert station's last-known coordinates so a per-station price
+  /// alert can be answered by a tiny local geo-filter (the bulk dataset has no
+  /// per-station price endpoint). Defaults to reading the shared Hive caches.
+  final StationCoordsResolver _coordsResolver;
+
+  /// The bulk-backed station service, built once per strategy instance so a
+  /// scan that runs a radius search AND a per-station price lookup for the same
+  /// country shares one in-memory dataset (the dataset is downloaded at most
+  /// once per scan, then local-filtered).
+  StationService? _service;
+
+  /// Radius (km) of the tiny local geo-filter used to locate a single alert
+  /// station within the cached dataset. Small enough to be a cheap local scan,
+  /// generous enough to absorb minor coordinate drift between the cached
+  /// favorite/station record and the dataset's own coordinates.
+  static const double _perStationProbeRadiusKm = 1.0;
+
+  /// `true` when [countryCode]'s registry policy is a bulk-file source — the
+  /// discriminator [CountryAlertStrategy.forCountry] branches on (NOT the
+  /// country code, so GB/FR follow [BulkMigrationFlags]).
+  static bool isBulk(String countryCode) =>
+      CountryServiceRegistry.policyFor(countryCode)?.isBulkFile ?? false;
+
+  StationService _bulkService() {
+    return _service ??= _serviceOverride ??
+        CountryServiceRegistry.buildBackgroundService(
+          countryCode,
+          storage: _storage,
+          cache: _cache,
+        );
+  }
+
+  /// Radius search = local geo-filter over the cached whole-country dataset.
+  /// Returns an empty list on any fault (spooled, never thrown).
+  @override
+  Future<List<Station>> searchArea(SearchParams params) async {
+    try {
+      final result = await _bulkService().searchStations(params);
+      return result.data;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'BulkDatasetAlertStrategy.searchArea($countryCode)',
+        'ttlSoftMin': _policy.datasetTtlSoft.inMinutes,
+      }));
+      return const [];
+    }
+  }
+
+  /// Per-station prices by LOCAL geo-filter over the cached dataset — zero
+  /// per-alert network once the dataset is cached.
+  ///
+  /// For each alert station id we resolve its last-known coordinates (from the
+  /// shared station/favorite caches) and run a tiny-radius [searchArea] around
+  /// them, then pick out the row whose id matches. All probes share one
+  /// in-memory dataset, so a country with N per-station alerts triggers at most
+  /// one dataset download per scan, never N. Ids whose coordinates cannot be
+  /// resolved (never cached / never a favorite) are skipped this scan — they
+  /// still get refreshed once they appear in a radius-alert or search result.
+  ///
+  /// Returns an empty map for no ids or any fault.
+  @override
+  Future<Map<String, Map<String, dynamic>>> fetchPrices(
+    Set<String> stationIds,
+  ) async {
+    if (stationIds.isEmpty) return const {};
+    try {
+      final out = <String, Map<String, dynamic>>{};
+      for (final id in stationIds) {
+        final coords = _coordsResolver(id);
+        if (coords == null) continue;
+        final found = await searchArea(SearchParams(
+          lat: coords.lat,
+          lng: coords.lng,
+          radiusKm: _perStationProbeRadiusKm,
+        ));
+        for (final station in found) {
+          if (station.id == id) {
+            out[id] = stationToTankerkoenigShape(station);
+            break;
+          }
+        }
+      }
+      return out;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'BulkDatasetAlertStrategy.fetchPrices($countryCode)',
+        'ids': stationIds.length,
+      }));
+      return const {};
+    }
+  }
+
+  /// Default coordinate resolver: read the alert station's last-known lat/lng
+  /// from the shared favorite-station cache first (permanent, never expires),
+  /// then the generic `station:<id>` cache the scan + velocity runner populate.
+  static StationCoordsResolver _defaultCoordsResolver(
+    StorageRepository storage,
+  ) {
+    return (String stationId) {
+      final fav = storage.getFavoriteStationData(stationId);
+      final favLat = fav?.getDouble('lat');
+      final favLng = fav?.getDouble('lng');
+      if (favLat != null && favLng != null) {
+        return (lat: favLat, lng: favLng);
+      }
+      final cached = storage.getCachedData('station:$stationId');
+      final data = cached?.getMap('data') ?? cached;
+      final lat = data?.getDouble('lat');
+      final lng = data?.getDouble('lng');
+      if (lat != null && lng != null) return (lat: lat, lng: lng);
+      return null;
+    };
+  }
+}
+
+/// Resolves a station id to its last-known coordinates, or null when unknown.
+/// Injected so a [BulkDatasetAlertStrategy] test can seed coordinates without
+/// a real Hive box.
+typedef StationCoordsResolver = ({double lat, double lng})? Function(
+  String stationId,
+);

--- a/lib/core/background/country_alert_strategy.dart
+++ b/lib/core/background/country_alert_strategy.dart
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../features/search/data/models/search_params.dart';
+import '../../features/search/domain/entities/station.dart';
+import '../cache/cache_manager.dart';
+import '../data/storage_repository.dart';
+import '../services/country_service_registry.dart';
+import '../services/fuel_service_policy.dart';
+import 'bulk_dataset_alert_strategy.dart';
+import 'polled_alert_strategy.dart';
+
+/// The per-country **specialization seam** a background alert scan resolves to
+/// (Epic #2860, child #2863).
+///
+/// A scan groups its active alerts by derived country
+/// (`groupAlertsByCountry`), then asks the registry for **one** strategy per
+/// country and fetches once. Where a country's prices come from — and at what
+/// network cost — is the strategy's concern; the price **evaluation** + euro /
+/// fuel-set notification copy is deliberately untouched here (that is child
+/// #2864). A strategy only answers two questions the evaluator already
+/// consumes:
+///
+///  - [fetchPrices] — current prices for a set of station ids in this country,
+///    as the Tankerkönig-shaped `id → {status, e5, e10, diesel, …}` map the
+///    per-station / velocity runners read unchanged.
+///  - [searchArea] — a radius search returning the priced [Station]s the
+///    radius-alert runner turns into samples.
+///
+/// ## Why branch on `FuelServicePolicy.model`, not country code
+///
+/// The split between the two concrete strategies is **how the data is
+/// delivered**, not which flag is on the map. A country is polled or bulk
+/// purely by its [SourceModel]:
+///
+///  - [PolledAlertStrategy] — [SourceModel.polledApi]: build the country's
+///    `StationService` and query it within the provider's `minInterval`
+///    (DE/AT/PT/GB-legacy/LU/SI/GR/RO/MX/KR/CL).
+///  - [BulkDatasetAlertStrategy] — [SourceModel.bulkFile]: refresh a cached
+///    whole-country dataset at most per its `datasetTtl`, then answer EVERY
+///    alert by local geo-filter over that dataset — zero per-alert network
+///    (ES/IT/AR/DK).
+///
+/// GB and FR each flip between the two via [BulkMigrationFlags] — their policy
+/// model is `bulkFile` or `polledApi` depending on the compile-time flag — so
+/// branching on `policy.model` (the resolved truth) moves them between
+/// strategies automatically, where branching on country code would not.
+abstract class CountryAlertStrategy {
+  /// ISO 3166-1 alpha-2 code this strategy serves.
+  String get countryCode;
+
+  /// Fetch current prices for [stationIds] in [countryCode], returning the
+  /// Tankerkönig-shaped `id → {status, e5, e10, diesel, …}` map the existing
+  /// per-station / velocity runners consume unchanged.
+  ///
+  /// Returns an empty map for no ids or any fetch fault (spooled, never
+  /// thrown — this runs in an OS-spawned isolate). The keys are the original
+  /// (prefixed) station ids; only the ids the source can resolve are present.
+  Future<Map<String, Map<String, dynamic>>> fetchPrices(Set<String> stationIds);
+
+  /// Run a radius search in [countryCode], returning the priced stations the
+  /// radius-alert runner converts to samples. Returns an empty list on any
+  /// fetch fault.
+  Future<List<Station>> searchArea(SearchParams params);
+
+  /// Resolve the right [CountryAlertStrategy] for [countryCode] from the
+  /// registry's [FuelServicePolicy.model] — **not** the country code, so
+  /// GB/FR follow [BulkMigrationFlags] (a flag flip moves them between the
+  /// polled and bulk strategies because it flips their resolved `policy.model`).
+  ///
+  /// Returns null when:
+  ///  - the country has no registry entry, or
+  ///  - it is the AU throwing stub (#804 — excluded from background scans), or
+  ///  - it is a polled country [PolledAlertStrategy] cannot serve (its
+  ///    `serviceFor` yields no service this scan).
+  ///
+  /// [apiKey] is the user's key threaded into the isolate (DE needs it on the
+  /// Dio; KR/CL read theirs from [storage] inside the registry factory).
+  static CountryAlertStrategy? forCountry(
+    String countryCode, {
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    String? apiKey,
+    PolledAlertStrategyDeps? polledDeps,
+  }) {
+    // AU is a documented throwing stub (#804) — never scanned in the BG isolate.
+    if (countryCode == 'AU') return null;
+
+    final policy = CountryServiceRegistry.policyFor(countryCode);
+    if (policy == null) return null;
+
+    switch (policy.model) {
+      case SourceModel.bulkFile:
+        return BulkDatasetAlertStrategy(
+          countryCode: countryCode,
+          storage: storage,
+          cache: cache,
+          policy: policy,
+        );
+      case SourceModel.polledApi:
+        return PolledAlertStrategy.forCountry(
+          countryCode,
+          storage: storage,
+          cache: cache,
+          apiKey: apiKey,
+          deps: polledDeps,
+        );
+    }
+  }
+}

--- a/lib/core/background/country_alert_strategy_resolver.dart
+++ b/lib/core/background/country_alert_strategy_resolver.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../cache/cache_manager.dart';
+import '../data/storage_repository.dart';
+import 'country_alert_strategy.dart';
+import 'polled_alert_strategy.dart';
+
+/// Per-scan cache of [CountryAlertStrategy] instances, one per country (Epic
+/// #2860, child #2863).
+///
+/// A background scan groups its alerts by derived country (`alert_country_
+/// grouping.dart`) and then asks this resolver for the strategy that serves
+/// each country. Polled countries get a [PolledAlertStrategy], bulk-dataset
+/// countries a [BulkDatasetAlertStrategy] — the resolver branches on
+/// `FuelServicePolicy.model` inside [CountryAlertStrategy.forCountry], so GB/FR
+/// follow [BulkMigrationFlags] and AU (#804 stub) resolves to null.
+///
+/// Caching per country means a scan that fetches per-station prices AND runs a
+/// radius search for the same country reuses one strategy — and so, for a bulk
+/// country, one in-memory whole-country dataset (downloaded at most once per
+/// scan, then local-filtered). A `null` result is cached too so a country with
+/// no buildable strategy is resolved only once.
+class CountryAlertStrategyResolver {
+  CountryAlertStrategyResolver({
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    String? apiKey,
+    PolledAlertStrategyDeps? polledDeps,
+  })  : _storage = storage,
+        _cache = cache,
+        _apiKey = apiKey,
+        _polledDeps = polledDeps;
+
+  final StorageRepository _storage;
+  final CacheStrategy _cache;
+  final String? _apiKey;
+  final PolledAlertStrategyDeps? _polledDeps;
+
+  final Map<String, CountryAlertStrategy?> _byCountry = {};
+
+  /// The strategy serving [countryCode], built once per scan and cached, or
+  /// null when the country has no buildable strategy (no entry, AU stub, an
+  /// unbuildable polled service).
+  CountryAlertStrategy? strategyFor(String countryCode) {
+    if (_byCountry.containsKey(countryCode)) return _byCountry[countryCode];
+    final strategy = CountryAlertStrategy.forCountry(
+      countryCode,
+      storage: _storage,
+      cache: _cache,
+      apiKey: _apiKey,
+      polledDeps: _polledDeps,
+    );
+    _byCountry[countryCode] = strategy;
+    return strategy;
+  }
+}

--- a/lib/core/background/polled_alert_strategy.dart
+++ b/lib/core/background/polled_alert_strategy.dart
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../features/search/data/models/search_params.dart';
+import '../../features/search/domain/entities/station.dart';
+import '../cache/cache_manager.dart';
+import '../data/storage_repository.dart';
+import '../logging/error_logger.dart';
+import '../services/country_service_registry.dart';
+import '../services/dio_factory.dart';
+import '../services/service_config.dart';
+import '../services/station_service.dart';
+import 'background_price_shape.dart';
+import 'country_alert_strategy.dart';
+
+/// The 11 polled / realtime providers a background scan may query directly,
+/// reusing the per-country `StationServiceChain` within each provider's
+/// `FuelServicePolicy.minInterval` (Epic #2860, children #2862 / #2863).
+///
+/// Bulk-dataset countries (ES, IT, AR, DK + the flag-gated FR/GB bulk paths)
+/// are served by [BulkDatasetAlertStrategy] instead — they download a
+/// whole-country dataset once and local-filter every alert, never a per-alert
+/// network hit. AU is excluded entirely (throwing stub #804).
+const Set<String> kBackgroundPolledCountries = {
+  'DE', 'AT', 'PT', 'GB', 'LU', 'SI', 'GR', 'RO', 'MX', 'KR', 'CL',
+};
+
+/// Resolved dependencies + test seams for the polled strategy / source, kept
+/// in one record so the [BackgroundPriceSource] orchestrator and an individual
+/// [PolledAlertStrategy] thread the same knobs without a wide constructor.
+///
+/// [serviceBuilder] is the #2862 test seam: a fake per-country service builder.
+/// Production leaves it null and goes through
+/// [CountryServiceRegistry.buildBackgroundService].
+class PolledAlertStrategyDeps {
+  const PolledAlertStrategyDeps({
+    this.connectTimeout = const Duration(seconds: 10),
+    this.receiveTimeout = const Duration(seconds: 15),
+    this.serviceBuilder,
+  });
+
+  final Duration connectTimeout;
+  final Duration receiveTimeout;
+
+  @visibleForTesting
+  final StationService? Function(String code, {String? apiKey})? serviceBuilder;
+}
+
+/// [CountryAlertStrategy] for a single [SourceModel.polledApi] country (#2863).
+///
+/// This is the *which-service-fetches* seam, extracted from the #2862 polled
+/// path: build the country's [StationService] once (Riverpod-free, via
+/// [CountryServiceRegistry.buildBackgroundService]) and answer alerts through
+/// it — `getPrices` for per-station alerts (the country service chunks to its
+/// batch size internally), `searchStations` for radius alerts — within the
+/// provider's `minInterval`. The built service is cached so a scan that fetches
+/// prices AND runs a radius search for the same country reuses one service.
+class PolledAlertStrategy implements CountryAlertStrategy {
+  PolledAlertStrategy._(
+    this.countryCode,
+    this._service,
+  );
+
+  @override
+  final String countryCode;
+
+  final StationService _service;
+
+  /// The built country [StationService] backing this strategy. Exposed for the
+  /// nearest-widget search (#609 / #2862), which needs a raw service handle
+  /// rather than the strategy facade.
+  StationService get service => _service;
+
+  /// Whether [countryCode] is one of the polled providers this strategy serves.
+  static bool isPolled(String countryCode) =>
+      kBackgroundPolledCountries.contains(countryCode);
+
+  /// Build the polled strategy for [countryCode], or null when the country is
+  /// not a polled provider / its service cannot be built (no key, etc.).
+  ///
+  /// [apiKey] is the user's key threaded into the isolate. Only DE needs it on
+  /// the Dio (sent as the `apikey` query param — the isolate has no Dio
+  /// interceptor); KR/CL read their key from [storage] inside the registry
+  /// factory.
+  static PolledAlertStrategy? forCountry(
+    String countryCode, {
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    String? apiKey,
+    PolledAlertStrategyDeps? deps,
+  }) {
+    if (!isPolled(countryCode)) return null;
+    final d = deps ?? const PolledAlertStrategyDeps();
+    final service = d.serviceBuilder != null
+        ? d.serviceBuilder!(countryCode, apiKey: apiKey)
+        : CountryServiceRegistry.buildBackgroundService(
+            countryCode,
+            storage: storage,
+            cache: cache,
+            tankerkoenigDio: countryCode == 'DE'
+                ? _buildTankerkoenigDio(apiKey, d)
+                : null,
+          );
+    if (service == null) return null;
+    return PolledAlertStrategy._(countryCode, service);
+  }
+
+  /// Tankerkönig Dio for the background isolate: rate-limited + conditional
+  /// GET (via [DioFactory]) with the API key baked into the query parameters,
+  /// since there is no Riverpod interceptor here.
+  static Dio _buildTankerkoenigDio(String? apiKey, PolledAlertStrategyDeps d) {
+    final dio = DioFactory.create(
+      baseUrl: ServiceConfigs.tankerkoenig.baseUrl,
+      connectTimeout: d.connectTimeout,
+      receiveTimeout: d.receiveTimeout,
+    );
+    if (apiKey != null && apiKey.isNotEmpty) {
+      dio.options.queryParameters = {'apikey': apiKey};
+    }
+    return dio;
+  }
+
+  /// Fetch current prices for [stationIds] via the country service's batch
+  /// `getPrices` (which chunks to the provider's batch size internally), mapped
+  /// to the Tankerkönig-shaped map. A provider with no batch endpoint returns
+  /// an empty map (per-station alerts for it find no fresh price this scan;
+  /// radius alerts still work via [searchArea]).
+  ///
+  /// Returns an empty map for no ids or any fetch fault (spooled, never
+  /// thrown).
+  @override
+  Future<Map<String, Map<String, dynamic>>> fetchPrices(
+    Set<String> stationIds,
+  ) async {
+    if (stationIds.isEmpty) return const {};
+    try {
+      final result = await _service.getPrices(stationIds.toList());
+      final out = <String, Map<String, dynamic>>{};
+      for (final entry in result.data.entries) {
+        out[entry.key] = stationPricesToTankerkoenigShape(entry.value);
+      }
+      return out;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'PolledAlertStrategy.fetchPrices($countryCode)',
+        'ids': stationIds.length,
+      }));
+      return const {};
+    }
+  }
+
+  /// Run a radius search via the country provider. Returns the priced stations,
+  /// or an empty list on a fetch fault.
+  @override
+  Future<List<Station>> searchArea(SearchParams params) async {
+    try {
+      final result = await _service.searchStations(params);
+      return result.data;
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'PolledAlertStrategy.searchArea($countryCode)',
+      }));
+      return const [];
+    }
+  }
+}

--- a/test/core/background/background_service_test.dart
+++ b/test/core/background/background_service_test.dart
@@ -481,11 +481,15 @@ void main() {
   // platform engine.
   group('background isolate Dio construction (#2249)', () {
     // #2415 — the Dio construction moved into the coordinator with the scan
-    // body. #2862 — it moved again, into the registry-driven
-    // BackgroundPriceSource (which builds each polled country's Dio). The
-    // #2249 invariant (rate-limited factory, never raw Dio) still applies;
-    // the source-scan now reads the price source + the coordinator, and
-    // neither may hand-roll a Dio.
+    // body. #2862 — it moved into the registry-driven BackgroundPriceSource.
+    // #2863 — it moved once more, into the polled CountryAlertStrategy
+    // (PolledAlertStrategy builds each polled country's Dio). The #2249
+    // invariant (rate-limited factory, never raw Dio) still applies; the
+    // source-scan now reads the polled strategy + the price source + the
+    // coordinator + the runners, and none may hand-roll a Dio.
+    final polledStrategy =
+        File('lib/core/background/polled_alert_strategy.dart')
+            .readAsStringSync();
     final priceSource =
         File('lib/core/background/background_price_source.dart')
             .readAsStringSync();
@@ -498,12 +502,12 @@ void main() {
 
     test('routes every Dio through DioFactory', () {
       expect(
-        priceSource.contains("import '../services/dio_factory.dart';"),
+        polledStrategy.contains("import '../services/dio_factory.dart';"),
         isTrue,
-        reason: 'the background price source must import DioFactory',
+        reason: 'the polled alert strategy must import DioFactory',
       );
       expect(
-        priceSource.contains('DioFactory.create('),
+        polledStrategy.contains('DioFactory.create('),
         isTrue,
         reason: 'the background isolate must build its Dio via '
             'DioFactory.create',
@@ -511,7 +515,7 @@ void main() {
     });
 
     test('constructs no raw Dio(BaseOptions(...)) instances', () {
-      for (final source in [priceSource, coordinator, runners]) {
+      for (final source in [polledStrategy, priceSource, coordinator, runners]) {
         expect(
           source.contains('Dio(BaseOptions('),
           isFalse,

--- a/test/core/background/bulk_dataset_alert_strategy_test.dart
+++ b/test/core/background/bulk_dataset_alert_strategy_test.dart
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/bulk_dataset_alert_strategy.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/fuel_service_policy.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+
+/// A seeded whole-country bulk dataset behind the [StationService] interface:
+/// holds a fixed list of priced stations and answers every `searchStations`
+/// by LOCAL geo-filter (distance ≤ radius) over that list — exactly what the
+/// real bulk primaries (MITECO / MISE / Argentina / Denmark) do once the
+/// dataset is in memory. It counts network "downloads" so a test can prove the
+/// strategy never re-downloads within the dataset TTL, and its `getPrices`
+/// returns empty (the real bulk primaries do too — prices live on the rows).
+class _SeededBulkDataset implements StationService {
+  _SeededBulkDataset(this.stations);
+
+  final List<Station> stations;
+
+  int searchCalls = 0;
+  int downloads = 0;
+  int priceCalls = 0;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    // The first search loads the whole-country dataset; every later search is
+    // local-only over the in-memory copy — the dataset-once contract.
+    if (searchCalls == 0) downloads++;
+    searchCalls++;
+    final matched = <Station>[];
+    for (final s in stations) {
+      final dist = _planarKm(params.lat, params.lng, s.lat, s.lng);
+      if (dist <= params.radiusKm) matched.add(s.copyWith(dist: dist));
+    }
+    return ServiceResult(
+      data: matched,
+      source: ServiceSource.mitecoApi,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+      List<String> ids) async {
+    priceCalls++; // Bulk primaries return empty — prices live on the rows.
+    return ServiceResult(
+      data: const {},
+      source: ServiceSource.mitecoApi,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+}
+
+double _planarKm(double lat1, double lng1, double lat2, double lng2) {
+  const kmPerDeg = 111.0; // Fine for the small distances under test.
+  final dLat = (lat2 - lat1) * kmPerDeg;
+  final dLng = (lng2 - lng1) * kmPerDeg;
+  return math.sqrt(dLat * dLat + dLng * dLng);
+}
+
+Station _station(String id, double lat, double lng,
+        {double? e5, double? diesel, bool open = true}) =>
+    Station(
+      id: id,
+      name: id,
+      brand: 'Brand',
+      street: 'Street',
+      postCode: '00000',
+      place: 'Town',
+      lat: lat,
+      lng: lng,
+      e5: e5,
+      diesel: diesel,
+      isOpen: open,
+    );
+
+/// A bulk [StationService] whose every call throws — for the #2349
+/// never-throws fault-injection.
+class _ThrowingBulkDataset implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(SearchParams params,
+          {CancelToken? cancelToken}) async =>
+      throw const SocketException('injected bulk fault');
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+          List<String> ids) async =>
+      throw const SocketException('injected bulk fault');
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+}
+
+/// A minimal ES-shaped bulk policy (soft 6 h / hard 24 h) so the strategy under
+/// test has a real bulkFile policy without depending on registry constants.
+const _esBulkPolicy = FuelServicePolicy(
+  model: SourceModel.bulkFile,
+  minInterval: Duration(minutes: 30),
+  datasetTtlSoft: Duration(hours: 6),
+  datasetTtlHard: Duration(hours: 24),
+  searchResultTtl: Duration.zero,
+  attribution: 'Test',
+  license: 'Test',
+  sourceUrl: 'https://example.test/',
+);
+
+void main() {
+  final storage = FakeStorageRepository();
+  final cache = CacheManager(storage);
+
+  group('isBulk — branches on the registry policy.model (#2863)', () {
+    test('bulk-file countries are bulk; polled / stub / unknown are not', () {
+      for (final code in ['ES', 'IT', 'AR', 'DK']) {
+        expect(BulkDatasetAlertStrategy.isBulk(code), isTrue,
+            reason: '$code is a bulkFile policy');
+      }
+      for (final code in ['DE', 'AT', 'PT', 'KR', 'AU', 'ZZ']) {
+        expect(BulkDatasetAlertStrategy.isBulk(code), isFalse,
+            reason: '$code is not a bulkFile policy');
+      }
+    });
+  });
+
+  group('local geo-filter, zero per-alert network', () {
+    late _SeededBulkDataset dataset;
+    late BulkDatasetAlertStrategy strategy;
+
+    // Two ES stations a few hundred metres apart near Madrid, plus one far
+    // away (Barcelona) that must never match a Madrid radius search.
+    final madridA = _station('es-1', 40.4168, -3.7038, e5: 1.50, diesel: 1.40);
+    final madridB = _station('es-2', 40.4180, -3.7050, e5: 1.55, diesel: 1.45);
+    final barcelona = _station('es-9', 41.3874, 2.1686, e5: 1.99, diesel: 1.99);
+
+    setUp(() {
+      dataset = _SeededBulkDataset([madridA, madridB, barcelona]);
+      strategy = BulkDatasetAlertStrategy(
+        countryCode: 'ES',
+        storage: storage,
+        cache: cache,
+        policy: _esBulkPolicy,
+        service: dataset,
+        // Seed the alert station's coordinates directly (no Hive needed).
+        coordsResolver: (id) => switch (id) {
+          'es-1' => (lat: 40.4168, lng: -3.7038),
+          'es-2' => (lat: 40.4180, lng: -3.7050),
+          _ => null,
+        },
+      );
+    });
+
+    test('searchArea returns only stations inside the radius', () async {
+      final found = await strategy.searchArea(
+          const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5));
+      expect(found.map((s) => s.id).toSet(), {'es-1', 'es-2'},
+          reason: 'Barcelona is far outside a 5 km Madrid radius');
+    });
+
+    test('fetchPrices answers the alert stations + prices by local filter',
+        () async {
+      final prices = await strategy.fetchPrices({'es-1', 'es-2'});
+      expect(prices.keys.toSet(), {'es-1', 'es-2'});
+      expect(prices['es-1']!['status'], 'open');
+      expect(prices['es-1']!['e5'], 1.50);
+      expect(prices['es-1']!['diesel'], 1.40);
+      expect(prices['es-2']!['e5'], 1.55);
+    });
+
+    test('a station id with no resolvable coordinates is skipped', () async {
+      final prices = await strategy.fetchPrices({'es-1', 'es-unknown'});
+      expect(prices.keys, {'es-1'},
+          reason: 'es-unknown has no cached coords → skipped this scan');
+    });
+
+    test('the dataset is downloaded once — repeated alerts cost zero extra '
+        'network within the TTL', () async {
+      // A first search loads the dataset (downloads == 1); every later search —
+      // including the two per-station probes in fetchPrices — is a local filter
+      // over the SAME in-memory dataset.
+      await strategy.searchArea(
+          const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5));
+      await strategy.fetchPrices({'es-1', 'es-2'});
+      await strategy.searchArea(
+          const SearchParams(lat: 40.4168, lng: -3.7038, radiusKm: 5));
+
+      expect(dataset.downloads, 1,
+          reason: 'whole-country dataset downloaded at most once');
+      expect(dataset.priceCalls, 0,
+          reason: 'bulk fetchPrices must NOT hit the per-station price '
+              'endpoint — it local-filters the dataset');
+      expect(dataset.searchCalls, greaterThan(1),
+          reason: 'all later answers come from local filtering');
+    });
+  });
+
+  group('never throws — a bulk fault is spooled, not propagated (#2349)', () {
+    // The documented never-throws boundary (bulk_dataset_alert_strategy.dart):
+    // a throwing dataset/service must be caught + spooled, never bubble into
+    // the OS-spawned isolate.
+    BulkDatasetAlertStrategy throwing() => BulkDatasetAlertStrategy(
+          countryCode: 'ES',
+          storage: storage,
+          cache: cache,
+          policy: _esBulkPolicy,
+          service: _ThrowingBulkDataset(),
+          coordsResolver: (id) => (lat: 40.0, lng: -3.0),
+        );
+
+    test('searchArea completes (empty) when the dataset throws', () async {
+      await expectLater(
+        throwing().searchArea(
+            const SearchParams(lat: 40.0, lng: -3.0, radiusKm: 5)),
+        completes,
+      );
+      expect(
+        await throwing().searchArea(
+            const SearchParams(lat: 40.0, lng: -3.0, radiusKm: 5)),
+        isEmpty,
+      );
+    });
+
+    test('fetchPrices completes (empty) when the dataset throws', () async {
+      await expectLater(throwing().fetchPrices({'es-1'}), completes);
+      expect(await throwing().fetchPrices({'es-1'}), isEmpty);
+    });
+  });
+}

--- a/test/core/background/country_alert_strategy_test.dart
+++ b/test/core/background/country_alert_strategy_test.dart
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/bulk_dataset_alert_strategy.dart';
+import 'package:tankstellen/core/background/country_alert_strategy.dart';
+import 'package:tankstellen/core/background/polled_alert_strategy.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+
+void main() {
+  final storage = FakeStorageRepository();
+  final cache = CacheManager(storage);
+
+  group('strategy selection branches on policy.model (#2863)', () {
+    test('polled-API countries resolve to PolledAlertStrategy', () {
+      for (final code in ['DE', 'AT', 'PT', 'LU', 'SI', 'GR', 'RO', 'MX',
+        'KR', 'CL']) {
+        final strategy = CountryAlertStrategy.forCountry(code,
+            storage: storage, cache: cache, apiKey: 'k');
+        expect(strategy, isA<PolledAlertStrategy>(),
+            reason: '$code is polledApi → PolledAlertStrategy');
+      }
+    });
+
+    test('bulk-file countries resolve to BulkDatasetAlertStrategy', () {
+      for (final code in ['ES', 'IT', 'AR', 'DK']) {
+        final strategy = CountryAlertStrategy.forCountry(code,
+            storage: storage, cache: cache);
+        expect(strategy, isA<BulkDatasetAlertStrategy>(),
+            reason: '$code is bulkFile → BulkDatasetAlertStrategy');
+      }
+    });
+
+    test('the AU throwing stub (#804) resolves to NO strategy', () {
+      expect(
+        CountryAlertStrategy.forCountry('AU', storage: storage, cache: cache),
+        isNull,
+      );
+    });
+
+    test('an unregistered country resolves to NO strategy', () {
+      expect(
+        CountryAlertStrategy.forCountry('ZZ', storage: storage, cache: cache),
+        isNull,
+      );
+    });
+
+    test('GB/FR follow their resolved policy.model (BulkMigrationFlags), NOT '
+        'their country code — a flag flip moves them between strategies', () {
+      // The selection reads policy.model (the resolved truth that
+      // BulkMigrationFlags.ukCmaBulk / .frFluxBulk decide), NOT the country
+      // code. So whichever way the flag is set, the resolved strategy class
+      // tracks policy.model: a bulkFile model resolves to
+      // BulkDatasetAlertStrategy, a polledApi model to PolledAlertStrategy
+      // (when the country is in the BG-scanned polled set). Flipping the flag
+      // moves the country between the two with no code change here — exactly
+      // the contract this test pins.
+      for (final code in ['GB', 'FR']) {
+        final strategy = CountryAlertStrategy.forCountry(code,
+            storage: storage, cache: cache, apiKey: 'k');
+        if (BulkDatasetAlertStrategy.isBulk(code)) {
+          expect(strategy, isA<BulkDatasetAlertStrategy>(),
+              reason: '$code policy.model == bulkFile (flag on) → bulk strategy');
+        } else if (PolledAlertStrategy.isPolled(code)) {
+          // Legacy polledApi AND in the BG-scanned polled set (GB).
+          expect(strategy, isA<PolledAlertStrategy>(),
+              reason: '$code polled + scanned → PolledAlertStrategy');
+        } else {
+          // Legacy polledApi but NOT in the BG-scanned set (FR): not scanned
+          // today, so no strategy. Flipping frFluxBulk moves it to the bulk
+          // branch above.
+          expect(strategy, isNull,
+              reason: '$code is polled but not in the BG-scanned set');
+        }
+      }
+    });
+  });
+
+  group('PolledAlertStrategy selection parity (#2862/#2863)', () {
+    test('isPolled recognises the 11 providers, not bulk / stub', () {
+      for (final code in ['DE', 'AT', 'PT', 'GB', 'LU', 'SI', 'GR', 'RO',
+        'MX', 'KR', 'CL']) {
+        expect(PolledAlertStrategy.isPolled(code), isTrue);
+      }
+      for (final code in ['ES', 'IT', 'AR', 'DK', 'AU', 'ZZ']) {
+        expect(PolledAlertStrategy.isPolled(code), isFalse);
+      }
+    });
+
+    test('forCountry returns null for a non-polled (bulk) country', () {
+      expect(
+        PolledAlertStrategy.forCountry('ES', storage: storage, cache: cache),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #2863 (Epic #2860, child 3). Depends on the #2861/#2862 foundation (merged in #2867).

## What

Introduces an explicit OO per-country specialization seam for the background alert scan, resolved by `FuelServicePolicy.model` (NOT country code, so GB/FR flip between strategies via `BulkMigrationFlags`).

### Strategy interface

```dart
abstract class CountryAlertStrategy {
  String get countryCode;
  Future<Map<String, Map<String, dynamic>>> fetchPrices(Set<String> stationIds);
  Future<List<Station>> searchArea(SearchParams params);

  static CountryAlertStrategy? forCountry(String code, {
    required StorageRepository storage,
    required CacheStrategy cache,
    String? apiKey,
    PolledAlertStrategyDeps? polledDeps,
  });
}
```

`fetchPrices` / `searchArea` both return the Tankerkönig-shaped data the evaluator already consumes. `forCountry` branches on `policyFor(code).model` and excludes the AU throwing stub (#804).

### Two concrete strategies

- **`PolledAlertStrategy`** — the `SourceModel.polledApi` specialization (DE/AT/PT/GB-legacy/LU/SI/GR/RO/MX/KR/CL). The existing per-country polled path (build the country `StationService` via `buildBackgroundService`, `getPrices` chunked + `searchStations` within `minInterval`) refactored out of `BackgroundPriceSource`, which now delegates to it — its public API + tests preserved.
- **`BulkDatasetAlertStrategy`** — NEW `SourceModel.bulkFile` specialization (ES/IT/AR/DK + flag-gated GB-bulk/FR-bulk). REUSES the foreground bulk infra (the bulk `StationServiceChain` + `PersistentDataset`/`CacheManager` + `compute()`-parsed CSV) to refresh the cached whole-country dataset at most per its `datasetTtl`, then answers EVERY alert by LOCAL geo-filter over the cache — **zero per-alert network**. Per-station alerts probe the dataset around the alert station's last-known coords (the bulk primaries' `getPrices` is empty by design — prices live on the dataset rows).

### Wiring

The scan coordinator resolves a `CountryAlertStrategy` per grouped country via `CountryAlertStrategyResolver`, so polled AND bulk countries both flow through the strategy: bulk-country per-station price alerts merge into the same shaped map, and `runRadiusAlerts` evaluates a centre against its country's strategy (polled search or bulk local-filter). Price evaluation / euro copy is untouched (that is #2864).

## Files

New: `country_alert_strategy.dart`, `polled_alert_strategy.dart`, `bulk_dataset_alert_strategy.dart`, `country_alert_strategy_resolver.dart`, `background_price_shape.dart` (all under `lib/core/background/`, each < 400 lines).
Refactored: `background_price_source.dart` (delegates to `PolledAlertStrategy`), `background_alert_scan_coordinator.dart`, `background_scan_runners.dart`.

## Tests

- Strategy selection branches on `policy.model`: polled→`PolledAlertStrategy`, bulk→`BulkDatasetAlertStrategy`, AU/unknown→null, GB/FR track `BulkMigrationFlags`.
- A seeded ES dataset proves local geo-filter returns the alert's stations + prices with the dataset downloaded **once** (zero re-download within the TTL, zero per-station-endpoint hits).
- #2349 never-throws fault injection for the bulk boundary (`bulk_dataset_alert_strategy_test.dart`).
- The #2249 `DioFactory` source-scan guard updated to the moved Dio construction.

`flutter analyze` clean; background (160) + services + station-services + alerts + lint guards (file_length / no_hardcoded_ui_strings / catch_block_stacktrace_coverage / never_throws_contract / new_country_guide) all green. No model/freezed/@riverpod changes → no codegen drift. No new user-facing strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
