### PR TITLE
feat(bg-alerts): country/currency-aware notifications + per-country fuel mapping (#2864)

### DIFF
--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -292,11 +292,17 @@ class BackgroundAlertScanCoordinator {
       prices: prices,
       now: now,
       templates: templates,
+      fallbackCountryCode: activeCountry,
     );
 
     if (prices.isNotEmpty) {
       await BackgroundScanRunners.runVelocity(
-          storage: storage, prices: prices, now: now, templates: templates);
+        storage: storage,
+        prices: prices,
+        now: now,
+        templates: templates,
+        fallbackCountryCode: activeCountry,
+      );
     }
 
     await BackgroundScanRunners.runRadiusAlerts(

--- a/lib/core/background/background_price_history_writer.dart
+++ b/lib/core/background/background_price_history_writer.dart
@@ -27,6 +27,21 @@ class BackgroundPriceHistoryWriter {
   /// Keep this much price-history per station; older points are trimmed.
   static const retention = Duration(days: 30);
 
+  /// #2864 — every fuel grade the country-agnostic price map can carry
+  /// (`background_price_shape.dart`). The writer extracts each one so a non-DE
+  /// fuel set (FR E85 / LPG, IT CNG, …) is recorded too. DE stays byte-identical
+  /// — e5/e10/diesel are still read from the same keys.
+  static const _fuelFields = <String>[
+    TankerkoenigFields.e5,
+    TankerkoenigFields.e10,
+    TankerkoenigFields.e98,
+    TankerkoenigFields.diesel,
+    TankerkoenigFields.dieselPremium,
+    TankerkoenigFields.e85,
+    TankerkoenigFields.lpg,
+    TankerkoenigFields.cng,
+  ];
+
   static Future<void> recordHistory(
     HiveStorage storage,
     Map<String, Map<String, dynamic>> prices,
@@ -43,7 +58,12 @@ class BackgroundPriceHistoryWriter {
         recordedAt: now,
         e5: p.getDouble(TankerkoenigFields.e5),
         e10: p.getDouble(TankerkoenigFields.e10),
+        e98: p.getDouble(TankerkoenigFields.e98),
         diesel: p.getDouble(TankerkoenigFields.diesel),
+        dieselPremium: p.getDouble(TankerkoenigFields.dieselPremium),
+        e85: p.getDouble(TankerkoenigFields.e85),
+        lpg: p.getDouble(TankerkoenigFields.lpg),
+        cng: p.getDouble(TankerkoenigFields.cng),
       );
       final existing = storage.getPriceRecords(stationId);
       final lastRecordedAt = existing.isNotEmpty
@@ -79,12 +99,12 @@ class BackgroundPriceHistoryWriter {
       final cachedData = cached?.getMap('data');
       if (cachedData == null) continue;
       final stationData = Map<String, dynamic>.from(cachedData);
-      final e5 = p.getDouble(TankerkoenigFields.e5);
-      final e10 = p.getDouble(TankerkoenigFields.e10);
-      final diesel = p.getDouble(TankerkoenigFields.diesel);
-      if (e5 != null) stationData[TankerkoenigFields.e5] = e5;
-      if (e10 != null) stationData[TankerkoenigFields.e10] = e10;
-      if (diesel != null) stationData[TankerkoenigFields.diesel] = diesel;
+      // #2864 — patch every fuel grade present in the fetched prices, not just
+      // e5/e10/diesel, so a non-DE station's full fuel set stays fresh in cache.
+      for (final field in _fuelFields) {
+        final value = p.getDouble(field);
+        if (value != null) stationData[field] = value;
+      }
       stationData[TankerkoenigFields.isOpen] =
           p[TankerkoenigFields.status] == TankerkoenigFields.statusOpen;
       await storage.cacheData('station:$stationId', stationData);

--- a/lib/core/background/background_price_shape.dart
+++ b/lib/core/background/background_price_shape.dart
@@ -24,11 +24,11 @@ Map<String, dynamic> stationPricesToTankerkoenigShape(StationPrices prices) => {
       TankerkoenigFields.e5: prices.e5,
       TankerkoenigFields.e10: prices.e10,
       TankerkoenigFields.diesel: prices.diesel,
-      'e98': prices.e98,
-      'dieselPremium': prices.dieselPremium,
-      'e85': prices.e85,
-      'lpg': prices.lpg,
-      'cng': prices.cng,
+      TankerkoenigFields.e98: prices.e98,
+      TankerkoenigFields.dieselPremium: prices.dieselPremium,
+      TankerkoenigFields.e85: prices.e85,
+      TankerkoenigFields.lpg: prices.lpg,
+      TankerkoenigFields.cng: prices.cng,
     };
 
 /// Adapt a priced [Station] (a bulk-dataset local-filter result) to the
@@ -42,9 +42,9 @@ Map<String, dynamic> stationToTankerkoenigShape(Station station) => {
       TankerkoenigFields.e5: station.e5,
       TankerkoenigFields.e10: station.e10,
       TankerkoenigFields.diesel: station.diesel,
-      'e98': station.e98,
-      'dieselPremium': station.dieselPremium,
-      'e85': station.e85,
-      'lpg': station.lpg,
-      'cng': station.cng,
+      TankerkoenigFields.e98: station.e98,
+      TankerkoenigFields.dieselPremium: station.dieselPremium,
+      TankerkoenigFields.e85: station.e85,
+      TankerkoenigFields.lpg: station.lpg,
+      TankerkoenigFields.cng: station.cng,
     };

--- a/lib/core/background/background_scan_runners.dart
+++ b/lib/core/background/background_scan_runners.dart
@@ -16,16 +16,17 @@ import '../../features/alerts/data/velocity_alert_runner.dart';
 import '../../features/alerts/domain/radius_alert_evaluator.dart';
 import '../../features/alerts/domain/velocity_alert_detector.dart';
 import '../../features/search/data/models/search_params.dart';
-import '../../features/search/domain/entities/fuel_type.dart';
 import '../constants/field_names.dart';
 import '../logging/error_logger.dart';
 import '../notifications/local_notification_service.dart';
+import '../notifications/notification_service.dart';
 import '../services/country_service_registry.dart';
 import '../storage/hive_storage.dart';
 import '../storage/storage_keys.dart';
 import '../telemetry/storage/isolate_error_spool.dart';
 import '../utils/json_extensions.dart';
 import 'country_alert_strategy_resolver.dart';
+import 'fuel_price_fields.dart';
 import 'notification_templates.dart';
 
 /// Alert-evaluation runners invoked by [BackgroundAlertScanCoordinator]
@@ -44,14 +45,22 @@ class BackgroundScanRunners {
   /// Do not re-fire the same per-station price alert within this window.
   static const priceAlertRetriggerCooldown = Duration(hours: 4);
 
-  /// #2246 — the switch intentionally stays at e5/e10/diesel: those are the
-  /// only fuels Tankerkönig's prices feed exposes.
+  /// #2864 — per-station price-alert evaluation is now country/currency/fuel
+  /// aware. Each alert's country is derived from its station-id prefix
+  /// ([CountryServiceRegistry.countryForStationId], falling back to
+  /// [fallbackCountryCode] for prefix-less legacy ids); the current price is
+  /// read via the per-country fuel mapping ([priceFieldKeyForCountry]) so an
+  /// LPG / CNG / E98 alert in a country whose provider exposes that fuel fires,
+  /// and the notification renders in that country's currency. DE e5/e10/diesel
+  /// resolution + the euro are unchanged.
   static Future<void> runPerStationAlerts({
     required AlertRepository repo,
     required List<PriceAlert> alerts,
     required Map<String, Map<String, dynamic>> prices,
     required DateTime now,
     required BackgroundNotificationTemplates templates,
+    String? fallbackCountryCode,
+    @visibleForTesting NotificationService? notifier,
   }) async {
     final activeAlerts = alerts.where((a) => a.isActive).toList();
     if (activeAlerts.isEmpty || prices.isEmpty) {
@@ -64,8 +73,8 @@ class BackgroundScanRunners {
       return;
     }
 
-    final notifier = LocalNotificationService();
-    await notifier.initialize();
+    final notify = notifier ?? LocalNotificationService();
+    await notify.initialize();
     var notificationCount = 0;
 
     for (final alert in activeAlerts) {
@@ -75,17 +84,14 @@ class BackgroundScanRunners {
               TankerkoenigFields.statusNoPrices) {
         continue;
       }
-      double? currentPrice;
-      switch (alert.fuelType) {
-        case FuelTypeE5():
-          currentPrice = stationPrices.getDouble(TankerkoenigFields.e5);
-        case FuelTypeE10():
-          currentPrice = stationPrices.getDouble(TankerkoenigFields.e10);
-        case FuelTypeDiesel():
-          currentPrice = stationPrices.getDouble(TankerkoenigFields.diesel);
-        default:
-          continue;
-      }
+      final country =
+          CountryServiceRegistry.countryForStationId(alert.stationId) ??
+              fallbackCountryCode;
+      final fuelKey = country == null
+          ? priceFieldKeyFor(alert.fuelType)
+          : priceFieldKeyForCountry(alert.fuelType, country);
+      if (fuelKey == null) continue;
+      final currentPrice = stationPrices.getDouble(fuelKey);
       if (currentPrice == null || currentPrice > alert.targetPrice) continue;
 
       if (alert.lastTriggeredAt != null &&
@@ -97,7 +103,7 @@ class BackgroundScanRunners {
         continue;
       }
 
-      await notifier.showPriceAlert(
+      await notify.showPriceAlert(
         id: alert.stationId.hashCode,
         title: templates.renderPriceAlertTitle(
           station: alert.stationName,
@@ -106,6 +112,7 @@ class BackgroundScanRunners {
         body: templates.renderPriceAlertBody(
           price: currentPrice.toStringAsFixed(3),
           target: alert.targetPrice.toStringAsFixed(3),
+          currency: templates.currencyForCountry(country),
         ),
       );
       notificationCount++;
@@ -115,11 +122,17 @@ class BackgroundScanRunners {
   }
 
   /// #579 — velocity detector across nearby stations.
+  ///
+  /// #2864 — the velocity fuel is now read via the per-country fuel mapping for
+  /// the active country ([fallbackCountryCode]), so the detector runs on the
+  /// fuel the user's country actually exposes (e.g. an LPG velocity alert in FR)
+  /// rather than the DE-only e5/e10/diesel switch.
   static Future<void> runVelocity({
     required HiveStorage storage,
     required Map<String, Map<String, dynamic>> prices,
     required DateTime now,
     required BackgroundNotificationTemplates templates,
+    String? fallbackCountryCode,
   }) async {
     try {
       final notifier = LocalNotificationService();
@@ -131,10 +144,12 @@ class BackgroundScanRunners {
         copyBuilder: (event) => buildVelocityCopy(event, templates),
       );
       final config = await runner.loadConfig();
-      final fuelKey = tankerkoenigKeyFor(config.fuelType);
+      final fuelKey = fallbackCountryCode == null
+          ? priceFieldKeyFor(config.fuelType)
+          : priceFieldKeyForCountry(config.fuelType, fallbackCountryCode);
       if (fuelKey == null) {
         debugPrint('BackgroundScanRunners: velocity skipped — '
-            '${config.fuelType.apiValue} not in Tankerkoenig response');
+            '${config.fuelType.apiValue} not in the active country feed');
         return;
       }
       final observations = <VelocityStationObservation>[];
@@ -222,7 +237,13 @@ class BackgroundScanRunners {
         store: store,
         dedup: RadiusAlertDedup(),
         notifier: notifier,
+        // #2864 — currency comes from the centre's country, so a GB / DK / …
+        // radius alert renders in £ / kr instead of a forced euro.
         copyBuilder: (event) => buildRadiusAlertCopy(event, templates),
+        // #2864 — the deep-link payload country is the centre's country, not a
+        // hardcoded 'de'.
+        countryResolver: (alert) => CountryServiceRegistry.countryForLatLng(
+            alert.centerLat, alert.centerLng),
       );
       final fired = await runner.run(
         now: now,
@@ -260,18 +281,6 @@ class BackgroundScanRunners {
   }
 }
 
-/// Map [FuelType] → Tankerkoenig JSON key. The BG isolate only fetches
-/// E5/E10/diesel today so other fuels return `null` and skip velocity
-/// detection. Top-level + visible-for-testing so the copy/format helpers
-/// stay testable without a coordinator instance.
-@visibleForTesting
-String? tankerkoenigKeyFor(FuelType fuelType) => switch (fuelType) {
-      FuelTypeE5() => TankerkoenigFields.e5,
-      FuelTypeE10() => TankerkoenigFields.e10,
-      FuelTypeDiesel() => TankerkoenigFields.diesel,
-      _ => null,
-    };
-
 /// Build notification copy for a velocity event. #2306 — copy comes from the
 /// localized [BackgroundNotificationTemplates] the main isolate resolved for
 /// the active in-app language.
@@ -292,6 +301,11 @@ VelocityAlertCopy buildVelocityCopy(
 
 /// Build notification copy for a grouped radius alert (#1012 phase 2). #2306
 /// — copy comes from the localized [BackgroundNotificationTemplates].
+///
+/// #2864 — the currency is resolved from the radius centre's country (via the
+/// registry bounding box), so a GB / DK / … radius alert renders in £ / kr
+/// instead of a forced euro. A centre outside every registered box falls back
+/// to the template's default (euro).
 @visibleForTesting
 RadiusAlertCopy buildRadiusAlertCopy(
   RadiusAlertGroupedEvent event,
@@ -299,7 +313,9 @@ RadiusAlertCopy buildRadiusAlertCopy(
 ) {
   final threshold = event.alert.threshold.toStringAsFixed(3);
   final label = event.alert.label;
-  final currency = templates.currencySymbol;
+  final country = CountryServiceRegistry.countryForLatLng(
+      event.alert.centerLat, event.alert.centerLng);
+  final currency = templates.currencyForCountry(country);
   final total = event.matches.length + event.truncatedMoreCount;
   final lines = event.matches
       // #2211 — show the station name, not the raw id. The per-line
@@ -314,6 +330,7 @@ RadiusAlertCopy buildRadiusAlertCopy(
       label: label,
       count: total,
       threshold: threshold,
+      currency: currency,
     ),
     body: lines.join('\n'),
   );

--- a/lib/core/background/fuel_price_fields.dart
+++ b/lib/core/background/fuel_price_fields.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../features/search/domain/entities/fuel_type.dart';
+import '../constants/field_names.dart';
+import '../services/country_service_registry.dart';
+
+/// Maps a [FuelType] to the JSON field key it occupies in the country-agnostic
+/// background price map (`background_price_shape.dart`) — the single source of
+/// truth shared by the per-station / velocity alert evaluators and the
+/// price-history writer (Epic #2860, child #2864).
+///
+/// ## Why a dedicated mapping, not `FuelType.apiValue`
+///
+/// The price-map keys are mostly the [FuelType.apiValue] (`e5`, `e10`,
+/// `diesel`, `e98`, `e85`, `lpg`, `cng`), but **diesel-premium** is carried as
+/// camelCase `dieselPremium` in the map while its `apiValue` is snake_case
+/// `diesel_premium`. Reading the field by `apiValue` would silently miss
+/// diesel-premium, so the key is resolved explicitly here, kept in lock-step
+/// with the keys both `stationPricesToTankerkoenigShape` and
+/// `stationToTankerkoenigShape` emit.
+///
+/// Electric / hydrogen / the `all` wildcard have no price field in the map
+/// (the providers don't publish them through this feed), so they map to null —
+/// an alert on one of those simply finds no fresh price this scan, exactly as
+/// the old `e5/e10/diesel`-only switch returned null for everything else.
+String? priceFieldKeyFor(FuelType fuelType) => switch (fuelType) {
+      FuelTypeE5() => TankerkoenigFields.e5,
+      FuelTypeE10() => TankerkoenigFields.e10,
+      FuelTypeDiesel() => TankerkoenigFields.diesel,
+      FuelTypeE98() => TankerkoenigFields.e98,
+      FuelTypeDieselPremium() => TankerkoenigFields.dieselPremium,
+      FuelTypeE85() => TankerkoenigFields.e85,
+      FuelTypeLpg() => TankerkoenigFields.lpg,
+      FuelTypeCng() => TankerkoenigFields.cng,
+      FuelTypeHydrogen() || FuelTypeElectric() || FuelTypeAll() => null,
+    };
+
+/// Resolve the price-map field key for [fuelType] **only when [countryCode]'s
+/// provider exposes that fuel** (#2864).
+///
+/// Gates [priceFieldKeyFor] by [CountryServiceRegistry.fuelTypesFor] so an
+/// alert evaluates against a country's actual fuel set: a French LPG alert
+/// resolves `lpg`, an Italian CNG alert resolves `cng`, but an LPG alert in a
+/// country whose feed has no LPG returns null (no spurious fire). DE's
+/// e5/e10/diesel resolution is unchanged — those three are in DE's fuel set and
+/// keep their historical keys.
+///
+/// Returns null when the fuel has no price field at all (electric/…), or when
+/// the country's provider does not list the fuel.
+String? priceFieldKeyForCountry(FuelType fuelType, String countryCode) {
+  final key = priceFieldKeyFor(fuelType);
+  if (key == null) return null;
+  if (!CountryServiceRegistry.fuelTypesFor(countryCode).contains(fuelType)) {
+    return null;
+  }
+  return key;
+}

--- a/lib/core/background/notification_templates.dart
+++ b/lib/core/background/notification_templates.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 import 'dart:ui' as ui;
 
 import '../../l10n/app_localizations.dart';
+import '../country/country_config.dart';
 
 /// #2306 — localized notification copy resolved IN THE MAIN ISOLATE and
 /// handed to the WorkManager background isolate.
@@ -45,10 +46,14 @@ class BackgroundNotificationTemplates {
   /// `+ {count} more` — trailing line of the radius body when truncated.
   final String radiusGroupedMore;
 
-  /// Currency symbol for the locale's market. The background isolate only
-  /// queries Tankerkönig (German) stations today, so this is the euro
-  /// sign; kept as a field so a future multi-currency BG path resolves it
-  /// once in the main isolate rather than baking `€` into the isolate.
+  /// Default currency symbol — the euro — used when a render call does not
+  /// supply a per-alert currency (the fallback / legacy path).
+  ///
+  /// #2864 — the BG scan now spans every country, so the currency is no longer
+  /// a single market value: it is resolved **per alert** from the alert's
+  /// country (`CountryConfig.byCode(code).currencySymbol`) and passed to each
+  /// render call. This field stays as the safe default (euro) for when no
+  /// country resolves, so DE / EUR-zone behaviour is byte-identical.
   final String currencySymbol;
 
   const BackgroundNotificationTemplates({
@@ -147,14 +152,22 @@ class BackgroundNotificationTemplates {
   }) =>
       _fill(priceAlertTitle, {'station': station, 'fuelType': fuelType});
 
-  /// Per-station price-alert body: current price + the user's target,
-  /// both with the local currency symbol.
+  /// Per-station price-alert body: current price + the user's target, both
+  /// with the alert's currency symbol.
+  ///
+  /// #2864 — [currency] is the per-alert symbol resolved from the alert's
+  /// country; it defaults to [currencySymbol] (euro) when the caller has no
+  /// country to resolve.
   String renderPriceAlertBody({
     required String price,
     required String target,
+    String? currency,
   }) =>
-      _fill(priceAlertBody,
-          {'price': price, 'currency': currencySymbol, 'target': target});
+      _fill(priceAlertBody, {
+        'price': price,
+        'currency': currency ?? currencySymbol,
+        'target': target,
+      });
 
   /// Velocity-drop title.
   String renderVelocityTitle({required String fuelLabel}) =>
@@ -165,21 +178,37 @@ class BackgroundNotificationTemplates {
       _fill(velocityBody, {'count': '$count', 'cents': '$cents'});
 
   /// Radius-alert grouped title.
+  ///
+  /// #2864 — [currency] is the per-alert symbol resolved from the radius
+  /// centre's country; defaults to [currencySymbol] (euro) when unresolved.
   String renderRadiusTitle({
     required String label,
     required int count,
     required String threshold,
+    String? currency,
   }) =>
       _fill(radiusGroupedTitle, {
         'label': label,
         'count': '$count',
         'threshold': threshold,
-        'currency': currencySymbol,
+        'currency': currency ?? currencySymbol,
       });
 
   /// Trailing `+ N more` line of the radius body.
   String renderRadiusMore({required int count}) =>
       _fill(radiusGroupedMore, {'count': '$count'});
+
+  /// Resolve the currency symbol for [countryCode] from its [CountryConfig]
+  /// (#2864), falling back to this template's default ([currencySymbol], euro)
+  /// when the code is null or unregistered.
+  ///
+  /// This is the one place the BG render paths turn a derived alert country
+  /// into a currency symbol, so a GB radius alert reads `£`, an AR per-station
+  /// alert reads `$`, and a prefix-less DE id stays `€`.
+  String currencyForCountry(String? countryCode) {
+    if (countryCode == null) return currencySymbol;
+    return Countries.byCode(countryCode)?.currencySymbol ?? currencySymbol;
+  }
 
   /// Literal-replace every `{key}` token. ARB placeholders never overlap,
   /// so order does not matter.

--- a/lib/core/constants/field_names.dart
+++ b/lib/core/constants/field_names.dart
@@ -19,6 +19,17 @@ class TankerkoenigFields {
   static const e10 = 'e10';
   static const diesel = 'diesel';
   static const isOpen = 'isOpen';
+
+  // #2864 — extended fuel grades non-DE providers expose. The
+  // country-agnostic price map (background_price_shape.dart) already carries
+  // these keys; naming them here keeps the FuelType→field mapping
+  // (fuel_price_fields.dart) and the price-history writer off string
+  // literals. The status quo for DE stays e5/e10/diesel — these are additive.
+  static const e98 = 'e98';
+  static const dieselPremium = 'dieselPremium';
+  static const e85 = 'e85';
+  static const lpg = 'lpg';
+  static const cng = 'cng';
 }
 
 /// Supabase table and column names for TankSync.

--- a/lib/features/alerts/data/radius_alert_runner.dart
+++ b/lib/features/alerts/data/radius_alert_runner.dart
@@ -68,9 +68,21 @@ class RadiusAlertRunner {
 
   /// 2-letter country code stamped into the deep-link payload so the
   /// tap resolver can disambiguate id collisions across countries
-  /// (#1012 phase 3). Today the BG isolate only wires Tankerkönig, so
-  /// this is `'de'` in production. Tests inject whatever they need.
+  /// (#1012 phase 3).
+  ///
+  /// #2864 — this is the *fallback* country, used only when
+  /// [countryResolver] is null or returns null for an alert. The BG
+  /// scan now derives each radius alert's country from its centre's
+  /// bounding box ([countryResolver]) so a UK / AT / … radius alert
+  /// deep-links into the right country; the fallback stays `'de'` for
+  /// legacy / test callers that pass no resolver.
   final String country;
+
+  /// #2864 — resolves the deep-link country for a given radius alert
+  /// from its centre (the BG path passes
+  /// `CountryServiceRegistry.countryForLatLng`). When null, or when it
+  /// returns null for an alert, the runner falls back to [country].
+  final String? Function(RadiusAlert alert)? countryResolver;
 
   RadiusAlertRunner({
     required this.store,
@@ -78,6 +90,7 @@ class RadiusAlertRunner {
     required this.notifier,
     required this.copyBuilder,
     this.country = 'de',
+    this.countryResolver,
     RadiusAlertEvaluator? evaluator,
   }) : evaluator = evaluator ?? const RadiusAlertEvaluator();
 
@@ -159,7 +172,7 @@ class RadiusAlertRunner {
         final payload = NotificationPayload(
           kind: NotificationPayload.kindRadius,
           stationId: topMatches.first.stationId,
-          country: country,
+          country: countryResolver?.call(alert) ?? country,
         ).encode();
         await notifier.showPriceAlert(
           id: _notificationId(alert.id),

--- a/test/core/background/background_alert_scan_coordinator_test.dart
+++ b/test/core/background/background_alert_scan_coordinator_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/background/background_alert_scan_coordinator.dart';
 import 'package:tankstellen/core/background/background_scan_runners.dart';
+import 'package:tankstellen/core/background/fuel_price_fields.dart';
 import 'package:tankstellen/core/background/notification_templates.dart';
 import 'package:tankstellen/features/alerts/data/radius_alert_runner.dart';
 import 'package:tankstellen/features/alerts/domain/entities/radius_alert.dart';
@@ -58,16 +59,26 @@ void main() {
     });
   });
 
-  group('tankerkoenigKeyFor', () {
-    test('maps the three BG-supported fuels', () {
-      expect(tankerkoenigKeyFor(FuelType.e5), 'e5');
-      expect(tankerkoenigKeyFor(FuelType.e10), 'e10');
-      expect(tankerkoenigKeyFor(FuelType.diesel), 'diesel');
+  group('priceFieldKeyFor (#2864)', () {
+    test('maps the DE-historical fuels to their byte-identical keys', () {
+      expect(priceFieldKeyFor(FuelType.e5), 'e5');
+      expect(priceFieldKeyFor(FuelType.e10), 'e10');
+      expect(priceFieldKeyFor(FuelType.diesel), 'diesel');
     });
 
-    test('returns null for fuels the BG isolate cannot fetch', () {
-      expect(tankerkoenigKeyFor(FuelType.lpg), isNull);
-      expect(tankerkoenigKeyFor(FuelType.electric), isNull);
+    test('maps the widened fuel set to the price-map keys', () {
+      expect(priceFieldKeyFor(FuelType.e98), 'e98');
+      // diesel-premium is camelCase in the map, NOT its snake_case apiValue.
+      expect(priceFieldKeyFor(FuelType.dieselPremium), 'dieselPremium');
+      expect(priceFieldKeyFor(FuelType.e85), 'e85');
+      expect(priceFieldKeyFor(FuelType.lpg), 'lpg');
+      expect(priceFieldKeyFor(FuelType.cng), 'cng');
+    });
+
+    test('returns null for fuels with no price field in the feed', () {
+      expect(priceFieldKeyFor(FuelType.electric), isNull);
+      expect(priceFieldKeyFor(FuelType.hydrogen), isNull);
+      expect(priceFieldKeyFor(FuelType.all), isNull);
     });
   });
 
@@ -135,6 +146,49 @@ void main() {
       // total = visible (1) + truncated (4) = 5
       expect(copy.title, contains('5'));
       expect(copy.body, contains('4'));
+    });
+
+    test('a DE centre renders the euro (byte-identical, #2864)', () {
+      // Berlin (52.5, 13.4) → DE → €.
+      final copy = buildRadiusAlertCopy(
+        RadiusAlertGroupedEvent(
+          alert: alert(),
+          matches: [sample('s1', 1.629)],
+        ),
+        templates,
+      );
+      expect(copy.title, contains('€'));
+      expect(copy.body, contains('€'));
+    });
+
+    test('a GB centre renders £, not a forced euro (#2864)', () {
+      // Manchester (53.48, -2.24) → GB → £ (well north of FR's box, so the
+      // bounding-box derivation is unambiguous).
+      final gbAlert = RadiusAlert(
+        id: 'gb1',
+        fuelType: 'diesel',
+        threshold: 1.459,
+        centerLat: 53.48,
+        centerLng: -2.24,
+        radiusKm: 5,
+        label: 'Manchester diesel',
+        createdAt: DateTime.utc(2026, 5, 30),
+      );
+      const gbSample = StationPriceSample(
+        stationId: 'uk-1',
+        name: 'Shell Manchester',
+        lat: 53.48,
+        lng: -2.24,
+        fuelType: 'diesel',
+        pricePerLiter: 1.439,
+      );
+      final copy = buildRadiusAlertCopy(
+        RadiusAlertGroupedEvent(alert: gbAlert, matches: [gbSample]),
+        templates,
+      );
+      expect(copy.title, contains('£'));
+      expect(copy.title, isNot(contains('€')));
+      expect(copy.body, contains('£'));
     });
   });
 }

--- a/test/core/background/background_price_history_writer_test.dart
+++ b/test/core/background/background_price_history_writer_test.dart
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:tankstellen/core/background/background_price_history_writer.dart';
+import 'package:tankstellen/core/constants/field_names.dart';
+import 'package:tankstellen/core/storage/hive_boxes.dart';
+import 'package:tankstellen/core/storage/hive_storage.dart';
+
+/// #2864 — the BG price-history writer recorded only e5/e10/diesel, so a
+/// non-DE station's extended fuel set (FR E85 / LPG, IT CNG, AR diesel-premium)
+/// was dropped from history. The extraction is now mapping-driven over every
+/// fuel field the country-agnostic price map can carry, while DE's three grades
+/// stay byte-identical.
+void main() {
+  late Directory tempDir;
+  late HiveStorage storage;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_price_hist_writer_');
+    Hive.init(tempDir.path);
+    storage = HiveStorage();
+  });
+
+  setUp(() async {
+    if (Hive.isBoxOpen(HiveBoxes.priceHistory)) {
+      await Hive.box(HiveBoxes.priceHistory).close();
+    }
+    await Hive.openBox(HiveBoxes.priceHistory);
+    await Hive.box(HiveBoxes.priceHistory).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('records a non-DE fuel set (E85 / LPG / E98)', () async {
+    final now = DateTime.utc(2026, 6, 4, 9);
+    await BackgroundPriceHistoryWriter.recordHistory(
+      storage,
+      {
+        'fr-123': {
+          TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+          TankerkoenigFields.e5: 1.859,
+          TankerkoenigFields.e10: 1.799,
+          TankerkoenigFields.diesel: 1.749,
+          TankerkoenigFields.e98: 1.949,
+          TankerkoenigFields.e85: 0.999,
+          TankerkoenigFields.lpg: 0.899,
+        },
+      },
+      now,
+    );
+
+    final records = storage.getPriceRecords('fr-123');
+    expect(records, hasLength(1));
+    final r = records.single;
+    // The widened grades are persisted, not just e5/e10/diesel.
+    expect(r[TankerkoenigFields.e85], 0.999);
+    expect(r[TankerkoenigFields.lpg], 0.899);
+    expect(r[TankerkoenigFields.e98], 1.949);
+    expect(r[TankerkoenigFields.diesel], 1.749);
+    expect(r[TankerkoenigFields.e5], 1.859);
+    expect(r[TankerkoenigFields.e10], 1.799);
+  });
+
+  test('records IT CNG (Metano) and AR diesel-premium', () async {
+    final now = DateTime.utc(2026, 6, 4, 9);
+    await BackgroundPriceHistoryWriter.recordHistory(
+      storage,
+      {
+        'it-9': {
+          TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+          TankerkoenigFields.e5: 1.899,
+          TankerkoenigFields.diesel: 1.799,
+          TankerkoenigFields.cng: 1.499,
+        },
+        'ar-7': {
+          TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+          TankerkoenigFields.diesel: 950.0,
+          TankerkoenigFields.dieselPremium: 1100.0,
+          TankerkoenigFields.cng: 800.0,
+        },
+      },
+      now,
+    );
+
+    final it = storage.getPriceRecords('it-9').single;
+    expect(it[TankerkoenigFields.cng], 1.499);
+
+    final ar = storage.getPriceRecords('ar-7').single;
+    expect(ar[TankerkoenigFields.dieselPremium], 1100.0);
+    expect(ar[TankerkoenigFields.cng], 800.0);
+  });
+
+  test('DE e5/e10/diesel recording is byte-identical', () async {
+    final now = DateTime.utc(2026, 6, 4, 9);
+    await BackgroundPriceHistoryWriter.recordHistory(
+      storage,
+      {
+        'de-1': {
+          TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+          TankerkoenigFields.e5: 1.759,
+          TankerkoenigFields.e10: 1.699,
+          TankerkoenigFields.diesel: 1.649,
+        },
+      },
+      now,
+    );
+
+    final r = storage.getPriceRecords('de-1').single;
+    expect(r[TankerkoenigFields.e5], 1.759);
+    expect(r[TankerkoenigFields.e10], 1.699);
+    expect(r[TankerkoenigFields.diesel], 1.649);
+    // No extended grades present → recorded as null.
+    expect(r[TankerkoenigFields.lpg], isNull);
+    expect(r[TankerkoenigFields.cng], isNull);
+  });
+}

--- a/test/core/background/fuel_price_fields_test.dart
+++ b/test/core/background/fuel_price_fields_test.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/fuel_price_fields.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// #2864 — the background alert evaluator used a DE-only e5/e10/diesel switch
+/// (`tankerkoenigKeyFor`). It is now the per-country [priceFieldKeyForCountry],
+/// gated by each country's published fuel set, so an alert on a fuel a country
+/// actually exposes (FR LPG/E85, IT CNG, AR diesel-premium) resolves to its
+/// price field and can fire — while DE's three grades resolve byte-identically.
+void main() {
+  group('priceFieldKeyFor — raw FuelType → price-map key', () {
+    test('DE-historical grades keep their exact keys', () {
+      expect(priceFieldKeyFor(FuelType.e5), 'e5');
+      expect(priceFieldKeyFor(FuelType.e10), 'e10');
+      expect(priceFieldKeyFor(FuelType.diesel), 'diesel');
+    });
+
+    test('widened grades map to the shape adapter keys', () {
+      expect(priceFieldKeyFor(FuelType.e98), 'e98');
+      // The map carries diesel-premium as camelCase, not its snake_case
+      // apiValue — reading by apiValue would silently miss it.
+      expect(priceFieldKeyFor(FuelType.dieselPremium), 'dieselPremium');
+      expect(priceFieldKeyFor(FuelType.e85), 'e85');
+      expect(priceFieldKeyFor(FuelType.lpg), 'lpg');
+      expect(priceFieldKeyFor(FuelType.cng), 'cng');
+    });
+
+    test('fuels with no feed price field map to null', () {
+      expect(priceFieldKeyFor(FuelType.electric), isNull);
+      expect(priceFieldKeyFor(FuelType.hydrogen), isNull);
+      expect(priceFieldKeyFor(FuelType.all), isNull);
+    });
+  });
+
+  group('priceFieldKeyForCountry — gated by the country fuel set', () {
+    test('DE e5/e10/diesel resolve unchanged', () {
+      expect(priceFieldKeyForCountry(FuelType.e5, 'DE'), 'e5');
+      expect(priceFieldKeyForCountry(FuelType.e10, 'DE'), 'e10');
+      expect(priceFieldKeyForCountry(FuelType.diesel, 'DE'), 'diesel');
+    });
+
+    test('DE does NOT resolve LPG / CNG (not in its feed)', () {
+      // The DE Tankerkönig feed has no LPG/CNG, so a DE-derived LPG alert must
+      // not spuriously match the (absent) lpg field.
+      expect(priceFieldKeyForCountry(FuelType.lpg, 'DE'), isNull);
+      expect(priceFieldKeyForCountry(FuelType.cng, 'DE'), isNull);
+    });
+
+    test('France resolves a non-DE fuel (LPG + E85)', () {
+      // FR's published set includes LPG (GPLc) and E85 — the original gap the
+      // DE-only switch could never fire on.
+      expect(priceFieldKeyForCountry(FuelType.lpg, 'FR'), 'lpg');
+      expect(priceFieldKeyForCountry(FuelType.e85, 'FR'), 'e85');
+      expect(priceFieldKeyForCountry(FuelType.e98, 'FR'), 'e98');
+    });
+
+    test('Italy resolves CNG (Metano)', () {
+      expect(priceFieldKeyForCountry(FuelType.cng, 'IT'), 'cng');
+      // IT's feed has no E85, so an IT E85 alert finds no field.
+      expect(priceFieldKeyForCountry(FuelType.e85, 'IT'), isNull);
+    });
+
+    test('Argentina resolves diesel-premium (Gas Oil premium)', () {
+      expect(
+          priceFieldKeyForCountry(FuelType.dieselPremium, 'AR'),
+          'dieselPremium');
+      expect(priceFieldKeyForCountry(FuelType.cng, 'AR'), 'cng');
+    });
+
+    test('Electric never resolves to a price field, even where supported', () {
+      // FR supports EV in its fuel set, but EV has no price-feed field.
+      expect(priceFieldKeyForCountry(FuelType.electric, 'FR'), isNull);
+    });
+  });
+}

--- a/test/core/background/notification_templates_test.dart
+++ b/test/core/background/notification_templates_test.dart
@@ -70,6 +70,14 @@ void main() {
       );
     });
 
+    test('price-alert body honours a per-alert currency override (#2864)', () {
+      // A GB alert renders the body in £, not a forced euro.
+      expect(
+        t.renderPriceAlertBody(price: '1.459', target: '1.500', currency: '£'),
+        '1.459 £ (target: 1.500 £)',
+      );
+    });
+
     test('velocity body fills count + cents', () {
       expect(
         t.renderVelocityBody(count: 4, cents: 7),
@@ -84,8 +92,32 @@ void main() {
       );
     });
 
+    test('radius title honours a per-alert currency override (#2864)', () {
+      expect(
+        t.renderRadiusTitle(
+            label: 'Home', count: 3, threshold: '1.600', currency: 'kr'),
+        'Home: 3 stations ≤ 1.600 kr',
+      );
+    });
+
     test('radius "+ N more" line fills count', () {
       expect(t.renderRadiusMore(count: 5), '+ 5 more');
+    });
+  });
+
+  group('currencyForCountry (#2864) — derive symbol from country', () {
+    final t = BackgroundNotificationTemplates.resolveForLanguage('en');
+
+    test('resolves the registered currency per country', () {
+      expect(t.currencyForCountry('DE'), '€');
+      expect(t.currencyForCountry('GB'), '£');
+      expect(t.currencyForCountry('DK'), 'kr');
+      expect(t.currencyForCountry('KR'), '₩');
+    });
+
+    test('falls back to the template default (euro) for null / unknown', () {
+      expect(t.currencyForCountry(null), '€');
+      expect(t.currencyForCountry('ZZ'), '€');
     });
   });
 

--- a/test/core/background/per_station_alert_country_test.dart
+++ b/test/core/background/per_station_alert_country_test.dart
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/background_scan_runners.dart';
+import 'package:tankstellen/core/background/notification_templates.dart';
+import 'package:tankstellen/core/constants/field_names.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/notifications/notification_service.dart';
+import 'package:tankstellen/features/alerts/data/models/price_alert.dart';
+import 'package:tankstellen/features/alerts/data/repositories/alert_repository.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// In-memory [AlertStorage] so the per-station alert runner can persist a fired
+/// alert's cooldown without Hive.
+class _FakeAlertStorage implements AlertStorage {
+  List<Map<String, dynamic>> _alerts = [];
+
+  @override
+  List<Map<String, dynamic>> getAlerts() => _alerts;
+
+  @override
+  Future<void> saveAlerts(List<Map<String, dynamic>> alerts) async {
+    _alerts = alerts;
+  }
+
+  @override
+  Future<void> clearAlerts() async => _alerts = [];
+
+  @override
+  int get alertCount => _alerts.length;
+}
+
+/// Captures every notification the runner emits.
+class _FakeNotifier implements NotificationService {
+  final List<({int id, String title, String body, String? payload})>
+      priceAlerts = [];
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> showPriceAlert({
+    required int id,
+    required String title,
+    required String body,
+    String? payload,
+  }) async {
+    priceAlerts.add((id: id, title: title, body: body, payload: payload));
+  }
+
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<bool> areNotificationsEnabled() async => true;
+
+  @override
+  Future<void> showServiceReminder({
+    required int id,
+    required String title,
+    required String body,
+  }) async {}
+
+  @override
+  Future<void> cancelNotification(int id) async {}
+
+  @override
+  Future<void> cancelAll() async {}
+}
+
+void main() {
+  final templates = BackgroundNotificationTemplates.resolveForLanguage('en');
+
+  PriceAlert alert({
+    required String id,
+    required String stationId,
+    required FuelType fuelType,
+    required double target,
+  }) =>
+      PriceAlert(
+        id: id,
+        stationId: stationId,
+        stationName: 'Test Station',
+        fuelType: fuelType,
+        targetPrice: target,
+        createdAt: DateTime.utc(2026, 6, 1),
+      );
+
+  group('runPerStationAlerts — #2864 country/currency/fuel aware', () {
+    test('an FR LPG alert resolves the lpg field, fires, and renders in €',
+        () async {
+      final notifier = _FakeNotifier();
+      final repo = AlertRepository(_FakeAlertStorage());
+      final fr = alert(
+        id: 'a-fr',
+        stationId: 'fr-1',
+        fuelType: FuelType.lpg,
+        target: 1.000,
+      );
+
+      await BackgroundScanRunners.runPerStationAlerts(
+        repo: repo,
+        alerts: [fr],
+        prices: {
+          'fr-1': {
+            TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+            // No e5/e10/diesel match would have fired under the old switch;
+            // the LPG price is below the user's target.
+            TankerkoenigFields.lpg: 0.899,
+          },
+        },
+        now: DateTime.utc(2026, 6, 4, 8),
+        templates: templates,
+        fallbackCountryCode: 'FR',
+        notifier: notifier,
+      );
+
+      expect(notifier.priceAlerts, hasLength(1),
+          reason: 'FR LPG alert must fire — the old e5/e10/diesel-only switch '
+              'could never resolve LPG.');
+      // FR is EUR-zone, so the body renders the euro.
+      expect(notifier.priceAlerts.single.body, contains('€'));
+      expect(notifier.priceAlerts.single.body, contains('0.899'));
+    });
+
+    test('a GB diesel alert renders £, not a forced euro', () async {
+      final notifier = _FakeNotifier();
+      final repo = AlertRepository(_FakeAlertStorage());
+      final gb = alert(
+        id: 'a-gb',
+        stationId: 'uk-1',
+        fuelType: FuelType.diesel,
+        target: 1.500,
+      );
+
+      await BackgroundScanRunners.runPerStationAlerts(
+        repo: repo,
+        alerts: [gb],
+        prices: {
+          'uk-1': {
+            TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+            TankerkoenigFields.diesel: 1.439,
+          },
+        },
+        now: DateTime.utc(2026, 6, 4, 8),
+        templates: templates,
+        fallbackCountryCode: 'GB',
+        notifier: notifier,
+      );
+
+      expect(notifier.priceAlerts, hasLength(1));
+      expect(notifier.priceAlerts.single.body, contains('£'));
+      expect(notifier.priceAlerts.single.body, isNot(contains('€')));
+    });
+
+    test('a DE e5 alert is byte-identical (resolves e5 + €)', () async {
+      final notifier = _FakeNotifier();
+      final repo = AlertRepository(_FakeAlertStorage());
+      final de = alert(
+        id: 'a-de',
+        stationId: 'de-1',
+        fuelType: FuelType.e5,
+        target: 1.800,
+      );
+
+      await BackgroundScanRunners.runPerStationAlerts(
+        repo: repo,
+        alerts: [de],
+        prices: {
+          'de-1': {
+            TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+            TankerkoenigFields.e5: 1.759,
+          },
+        },
+        now: DateTime.utc(2026, 6, 4, 8),
+        templates: templates,
+        fallbackCountryCode: 'DE',
+        notifier: notifier,
+      );
+
+      expect(notifier.priceAlerts, hasLength(1));
+      expect(notifier.priceAlerts.single.body, contains('€'));
+      expect(notifier.priceAlerts.single.body, contains('1.759'));
+    });
+
+    test('a DE LPG alert does NOT fire (LPG absent from the DE feed)',
+        () async {
+      final notifier = _FakeNotifier();
+      final repo = AlertRepository(_FakeAlertStorage());
+      final deLpg = alert(
+        id: 'a-de-lpg',
+        stationId: 'de-2',
+        fuelType: FuelType.lpg,
+        target: 1.000,
+      );
+
+      await BackgroundScanRunners.runPerStationAlerts(
+        repo: repo,
+        alerts: [deLpg],
+        prices: {
+          'de-2': {
+            TankerkoenigFields.status: TankerkoenigFields.statusOpen,
+            // Even if a stray lpg value were present, the per-country gate
+            // refuses it because DE's fuel set has no LPG.
+            TankerkoenigFields.lpg: 0.899,
+          },
+        },
+        now: DateTime.utc(2026, 6, 4, 8),
+        templates: templates,
+        fallbackCountryCode: 'DE',
+        notifier: notifier,
+      );
+
+      expect(notifier.priceAlerts, isEmpty,
+          reason: 'DE has no LPG in its feed — the alert must not fire.');
+    });
+  });
+}

--- a/test/features/alerts/data/radius_alert_runner_test.dart
+++ b/test/features/alerts/data/radius_alert_runner_test.dart
@@ -616,5 +616,63 @@ void main() {
       expect(decoded!.country, 'it');
       expect(decoded.stationId, 'it-001');
     });
+
+    test(
+        '#2864 — countryResolver wins over the fallback country per alert',
+        () async {
+      final store = RadiusAlertStore();
+      final dedup = RadiusAlertDedup();
+      final notifier = _FakeNotifier();
+      // Fallback is 'de', but the resolver derives the centre's country
+      // ('gb' here) so the deep-link payload points at the right country.
+      final runner = RadiusAlertRunner(
+        store: store,
+        dedup: dedup,
+        notifier: notifier,
+        copyBuilder: _copy,
+        country: 'de',
+        countryResolver: (alert) => 'gb',
+      );
+
+      await store.upsert(makeAlert(id: 'r1'));
+
+      await runner.run(
+        now: DateTime.utc(2026, 4, 22, 12),
+        samplesFor: (a) async => [sample(stationId: 'uk-001', price: 1.540)],
+      );
+
+      final decoded = NotificationPayload.tryDecode(
+          notifier.priceAlerts.single.payload);
+      expect(decoded, isNotNull);
+      expect(decoded!.country, 'gb',
+          reason: 'The resolved centre country must win over the fallback.');
+    });
+
+    test(
+        '#2864 — falls back to country when the resolver returns null',
+        () async {
+      final store = RadiusAlertStore();
+      final dedup = RadiusAlertDedup();
+      final notifier = _FakeNotifier();
+      final runner = RadiusAlertRunner(
+        store: store,
+        dedup: dedup,
+        notifier: notifier,
+        copyBuilder: _copy,
+        country: 'de',
+        countryResolver: (alert) => null,
+      );
+
+      await store.upsert(makeAlert(id: 'r1'));
+
+      await runner.run(
+        now: DateTime.utc(2026, 4, 22, 12),
+        samplesFor: (a) async => [sample(stationId: 's1', price: 1.540)],
+      );
+
+      final decoded = NotificationPayload.tryDecode(
+          notifier.priceAlerts.single.payload);
+      expect(decoded!.country, 'de');
+    });
   });
 }


### PR DESCRIPTION
Closes #2864 (Epic #2860, child 4). Builds on the #2861/#2862 foundation
(#2867) + the #2863 `CountryAlertStrategy` framework (#2868).

## What

Makes the background alert scan's notification copy + price evaluation
country/currency/fuel aware, killing the euro hardcode and the DE-only
e5/e10/diesel switch. **Additive** — DE behaviour (euro + e5/e10/diesel)
stays byte-identical.

### 1. Currency — per-alert, not baked
`notification_templates.dart`'s baked `_euro` becomes a per-alert symbol.
New `currencyForCountry(code)` resolves it from
`Countries.byCode(code).currencySymbol`; `renderPriceAlertBody` /
`renderRadiusTitle` take an optional `currency` override (defaulting to the
template's euro). The persisted `currencySymbol` field stays as the safe
fallback when no country resolves.

### 2. Per-country fuel mapping
New `fuel_price_fields.dart` replaces the e5/e10/diesel-only
`tankerkoenigKeyFor` with:
- `priceFieldKeyFor(FuelType)` → the country-agnostic price-map key
  (`e5`/`e10`/`diesel`/`e98`/`dieselPremium`/`e85`/`lpg`/`cng`). Note
  diesel-premium is **camelCase** in the map, not its snake_case
  `apiValue` — reading by `apiValue` would silently miss it.
- `priceFieldKeyForCountry(FuelType, code)` — gates the above by
  `CountryServiceRegistry.fuelTypesFor(code)`.

`runPerStationAlerts` + `runVelocity` now derive each alert's country (id
prefix → fallback active country) and resolve the fuel + currency from it,
so an FR LPG / IT CNG / AR diesel-premium alert fires; a DE LPG alert does
not (LPG absent from DE's feed).

### 3. Radius country
`radius_alert_runner.dart`'s `country='de'` deep-link default gains a
per-alert `countryResolver`. The BG runner threads
`countryForLatLng(centre)` into both the payload country and the rendered
currency, so a GB / DK radius alert deep-links + renders in £ / kr.

### 4. Price-history writer — mapping-driven
`background_price_history_writer.dart` extraction now spans every fuel
field the country-agnostic price map carries, so a non-DE fuel set is
recorded in history + patched into the station cache. DE stays
byte-identical.

## Tests (CI-provable, real paths)
- `fuel_price_fields_test.dart` — DE e5/e10/diesel unchanged; FR LPG/E85/E98,
  IT CNG, AR diesel-premium resolve; DE LPG/CNG + electric/hydrogen → null.
- `per_station_alert_country_test.dart` — FR LPG fires with €, GB diesel
  fires with £ (not euro), DE e5 byte-identical, DE LPG does not fire.
- `notification_templates_test.dart` — per-alert currency override + 
  `currencyForCountry` (DE €, GB £, DK kr, KR ₩; null/unknown → €).
- `background_alert_scan_coordinator_test.dart` — radius copy renders € for
  a DE centre, £ for a GB centre; `priceFieldKeyFor` mapping.
- `radius_alert_runner_test.dart` — `countryResolver` wins over the fallback;
  null resolver falls back.
- `background_price_history_writer_test.dart` — records FR E85/LPG/E98, IT
  CNG, AR diesel-premium; DE byte-identical.

No new ARB keys (currency symbols come from `CountryConfig`).
`flutter analyze` clean; background + alerts suites (446 tests) + lint
guards (file_length / no_hardcoded_ui_strings / catch_block / never_throws /
new_country_guide) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
