### PR TITLE
feat(bg-alerts): twice-daily cadence + per-provider budget + tracer compliance gate (#2866)

### DIFF
--- a/lib/core/background/android_background_price_fetcher.dart
+++ b/lib/core/background/android_background_price_fetcher.dart
@@ -8,12 +8,14 @@ import 'background_service.dart';
 
 /// Android implementation of [BackgroundPriceFetcher] using WorkManager.
 ///
-/// Registers two periodic tasks with different constraints for
-/// adaptive battery-aware scheduling:
-/// - Standard task: every 1h, skipped when battery is low
-/// - Charging task: every 30min, only when device is plugged in
+/// Registers ONE periodic alert/price-scan task at the twice-daily cadence
+/// (~every 12h, [BackgroundService.refreshInterval]) — the Epic #2860 EXIT
+/// GATE (#2866) rate-limit / ToS safeguard for the now-multi-country scan.
+/// The task is skipped when the battery is low ([requiresBatteryNotLow]).
+/// The old 30-min charging task was removed: it would have let a multi-country
+/// scan hit a provider more than twice a day, breaching the cadence guarantee.
 ///
-/// #2413 — both tasks carry a `NetworkType.connected` constraint so a wake
+/// #2413 — the task carries a `NetworkType.connected` constraint so a wake
 /// without connectivity is deferred by WorkManager instead of firing a dead
 /// request. The schedule is re-established after a reboot by [BootReceiver]
 /// (Android) re-running [BackgroundService.init] via the `bootReregister`
@@ -31,14 +33,13 @@ class AndroidBackgroundPriceFetcher implements BackgroundPriceFetcher {
   Future<void> init() async {
     await _workmanager.initialize(callbackDispatcher);
 
-    // #2300 — register both tasks with ExistingPeriodicWorkPolicy.update so a
-    // repeated init() (every app launch) is idempotent: it refreshes the
-    // existing chain instead of stacking duplicate periodic work that could
-    // fire two refresh isolates in the same window. Concurrent-access safety
-    // between the two cadences is still backstopped by HiveIsolateLock's
-    // exclusive lock.
+    // #2300 — register with ExistingPeriodicWorkPolicy.update so a repeated
+    // init() (every app launch) is idempotent: it refreshes the existing task
+    // instead of stacking duplicate periodic work that could fire two refresh
+    // isolates in the same window. Concurrent-access safety is still
+    // backstopped by HiveIsolateLock's exclusive lock.
 
-    // Standard task: runs every 1h when battery is not low.
+    // Twice-daily task (#2866): runs ~every 12h when battery is not low.
     // Skipped automatically by Android when battery drops below ~15%.
     await _workmanager.registerPeriodicTask(
       BackgroundService.priceRefreshTask,
@@ -48,19 +49,6 @@ class AndroidBackgroundPriceFetcher implements BackgroundPriceFetcher {
       constraints: Constraints(
         networkType: NetworkType.connected,
         requiresBatteryNotLow: true,
-      ),
-    );
-
-    // Charging task: runs every 30min when device is plugged in.
-    // Gives fresher prices at no battery cost.
-    await _workmanager.registerPeriodicTask(
-      BackgroundService.priceRefreshChargingTask,
-      BackgroundService.priceRefreshChargingTask,
-      frequency: BackgroundService.chargingRefreshInterval,
-      existingWorkPolicy: ExistingPeriodicWorkPolicy.update,
-      constraints: Constraints(
-        networkType: NetworkType.connected,
-        requiresCharging: true,
       ),
     );
   }

--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -11,13 +11,12 @@ import '../logging/error_logger.dart';
 import '../storage/hive_storage.dart';
 import '../telemetry/storage/isolate_error_spool.dart';
 import '../cache/cache_manager.dart';
-import '../services/country_service_registry.dart';
 import 'background_price_history_writer.dart';
 import 'background_price_source.dart';
 import 'background_scan_dedup_store.dart';
 import 'background_scan_runners.dart';
 import 'background_scan_tracer.dart';
-import 'bulk_dataset_alert_strategy.dart';
+import 'bulk_alert_price_merge.dart';
 import 'country_alert_strategy_resolver.dart';
 import 'daily_collection.dart';
 import 'hive_isolate_lock.dart';
@@ -278,7 +277,7 @@ class BackgroundAlertScanCoordinator {
       recorder: tracer.recorder,
       budget: budget,
     );
-    prices.addAll(await _fetchBulkAlertPrices(
+    prices.addAll(await fetchBulkAlertPrices(
       alertStationIds: alertStationIds,
       fallbackCountryCode: activeCountry,
       resolver: resolver,
@@ -321,41 +320,6 @@ class BackgroundAlertScanCoordinator {
     // #2866 — dev-gated: snapshot + export this scan's data-access trace so the
     // maintainer reads `aggregates().compliant` per provider (no-op otherwise).
     await tracer.exportIfEnabled();
-  }
-
-  /// #2863 — fetch per-station alert prices for **bulk-dataset** countries via
-  /// their [BulkDatasetAlertStrategy] (resolved per country by [resolver]).
-  ///
-  /// Groups the alert station ids by derived country (the same lazy derivation
-  /// the polled grouping uses), keeps only the bulk-policy countries (polled
-  /// ones were already fetched by [BackgroundPriceSource]), and asks each
-  /// country's strategy for its prices — answered by local geo-filter over the
-  /// cached whole-country dataset (≤1 dataset download per country per scan,
-  /// then zero per-alert network). Each strategy swallows + spools its own
-  /// faults (its documented boundary, fault-tested in
-  /// `country_alert_strategy_test.dart`), so a bulk-country fault degrades to
-  /// "no fresh prices this scan" rather than failing the scan.
-  Future<Map<String, Map<String, dynamic>>> _fetchBulkAlertPrices({
-    required Set<String> alertStationIds,
-    required String? fallbackCountryCode,
-    required CountryAlertStrategyResolver resolver,
-  }) async {
-    final byCountry = <String, Set<String>>{};
-    for (final id in alertStationIds) {
-      final code =
-          CountryServiceRegistry.countryForStationId(id) ?? fallbackCountryCode;
-      // Only the bulk-dataset countries; polled ids were already fetched.
-      if (code == null || !BulkDatasetAlertStrategy.isBulk(code)) continue;
-      byCountry.putIfAbsent(code, () => <String>{}).add(id);
-    }
-
-    final merged = <String, Map<String, dynamic>>{};
-    for (final entry in byCountry.entries) {
-      final strategy = resolver.strategyFor(entry.key);
-      if (strategy == null) continue;
-      merged.addAll(await strategy.fetchPrices(entry.value));
-    }
-    return merged;
   }
 
   /// #609 — nearest-widget refresh from a real search (or legacy fallback).

--- a/lib/core/background/background_alert_scan_coordinator.dart
+++ b/lib/core/background/background_alert_scan_coordinator.dart
@@ -16,22 +16,22 @@ import 'background_price_history_writer.dart';
 import 'background_price_source.dart';
 import 'background_scan_dedup_store.dart';
 import 'background_scan_runners.dart';
+import 'background_scan_tracer.dart';
 import 'bulk_dataset_alert_strategy.dart';
 import 'country_alert_strategy_resolver.dart';
 import 'daily_collection.dart';
 import 'hive_isolate_lock.dart';
 import 'notification_templates.dart';
+import 'provider_request_budget.dart';
 
 /// Where a background scan came from. Threaded through to the dedup store
 /// for diagnostics and used in debug logging so a maintainer can tell
 /// whether WorkManager, the home-widget refresh, or iOS BGAppRefresh drove
 /// a given scan.
 enum BackgroundScanTrigger {
-  /// WorkManager periodic task (`priceRefresh`) — the baseline Android path.
+  /// WorkManager periodic task (`priceRefresh`) — the baseline Android path,
+  /// the twice-daily alert/price scan (#2866).
   workManagerPeriodic,
-
-  /// WorkManager charging-only periodic task (`priceRefreshCharging`).
-  workManagerCharging,
 
   /// Android home-widget refresh callback (#2412) — an opportunistic extra
   /// wake while the widget is on the home screen, NOT a reliability
@@ -44,7 +44,6 @@ enum BackgroundScanTrigger {
   /// Stable, log-friendly tag persisted alongside the last-scan timestamp.
   String get tag => switch (this) {
         BackgroundScanTrigger.workManagerPeriodic => 'workmanager_periodic',
-        BackgroundScanTrigger.workManagerCharging => 'workmanager_charging',
         BackgroundScanTrigger.androidWidget => 'android_widget',
         BackgroundScanTrigger.iosBackgroundRefresh => 'ios_bg_refresh',
       };
@@ -86,9 +85,10 @@ class BackgroundAlertScanCoordinator {
   /// Coarse cross-trigger scan cooldown (#2415). A scan that lands inside
   /// this window after a completed scan is skipped, so the WorkManager
   /// task and an opportunistic widget/BGTask wake seconds later don't both
-  /// hit the API. Chosen well below the 30-minute charging cadence so a
+  /// hit the API. Chosen far below the twice-daily periodic cadence so a
   /// legitimately-scheduled periodic task is never starved, but long enough
-  /// to absorb a burst of near-simultaneous triggers.
+  /// to absorb a burst of near-simultaneous triggers (the widget refresh +
+  /// the periodic wake landing seconds apart).
   static const scanCooldown = Duration(minutes: 10);
 
   /// Do not re-fire the same per-station price alert within this window.
@@ -238,20 +238,27 @@ class BackgroundAlertScanCoordinator {
       return;
     }
 
-    // 2. Fetch prices via the registry-driven per-country source (#2862).
-    //    The source groups the mixed-country id set by derived country and
-    //    queries each polled provider at most once, within that provider's
-    //    minInterval; a prefix-less id falls back to the active country (DE
-    //    today). This replaces the hardcoded Tankerkönig batch fetch — DE
-    //    still goes through its Tankerkönig batch service, the other ten
-    //    polled countries now go through their own. Bulk-dataset countries
-    //    (ES/IT/AR/DK) are scanned by child #2863, not here.
+    // 2. Fetch prices via the registry-driven per-country source (#2862): the
+    //    source groups the mixed-country id set by derived country and queries
+    //    each polled provider at most once, within its minInterval; a
+    //    prefix-less id falls back to the active country. Bulk-dataset
+    //    countries (ES/IT/AR/DK) are scanned below (#2863), not here.
     final activeCountry =
         storage.getSetting('active_country_code') as String? ?? 'DE';
+
+    // #2866 EXIT GATE: the shared per-provider budget (foreground + background
+    // share one minInterval gate; skip a provider the foreground just hit) +
+    // the dev-gated #2824 tracer (count + export the multi-country scan's
+    // traffic, compliant per provider). Both threaded into every service built.
+    final budget = ProviderRequestBudget(storage);
+    final tracer = BackgroundScanTracer.forScan();
+
     final source = BackgroundPriceSource(
       storage: storage,
       connectTimeout: bgConnectTimeout,
       receiveTimeout: bgReceiveTimeout,
+      recorder: tracer.recorder,
+      budget: budget,
     );
     final prices = await source.fetchPricesGrouped(
       stationIds: allStationIds,
@@ -259,18 +266,17 @@ class BackgroundAlertScanCoordinator {
       apiKey: apiKey,
     );
 
-    // #2863 — bulk-dataset countries (ES/IT/AR/DK + flag-gated FR/GB) are not
-    // served by the polled [BackgroundPriceSource]; their alert stations flow
-    // through a [BulkDatasetAlertStrategy] resolved per country. The dataset is
-    // downloaded at most once per scan (per its datasetTtl) then local-filtered
-    // — zero per-alert network. Merged into the same Tankerkönig-shaped map the
-    // evaluator consumes, so per-station price alerts in bulk countries now
-    // fire too. (Radius alerts in bulk countries are handled below, in the
-    // strategy-aware [BackgroundScanRunners.runRadiusAlerts].)
+    // #2863 — bulk-dataset countries (ES/IT/AR/DK + flag-gated FR/GB) flow
+    // through a [BulkDatasetAlertStrategy] resolved per country: ≤1 dataset
+    // download per scan (per datasetTtl) then local-filter, merged into the
+    // same Tankerkönig-shaped map the evaluator consumes. (Radius alerts in
+    // bulk countries run below via the strategy-aware runRadiusAlerts.)
     final resolver = CountryAlertStrategyResolver(
       storage: storage,
       cache: CacheManager(storage),
       apiKey: apiKey,
+      recorder: tracer.recorder,
+      budget: budget,
     );
     prices.addAll(await _fetchBulkAlertPrices(
       alertStationIds: alertStationIds,
@@ -311,6 +317,10 @@ class BackgroundAlertScanCoordinator {
       settingsStorage: storage,
     );
     await _refreshNearestWidgetFromSearch(storage, source: source);
+
+    // #2866 — dev-gated: snapshot + export this scan's data-access trace so the
+    // maintainer reads `aggregates().compliant` per provider (no-op otherwise).
+    await tracer.exportIfEnabled();
   }
 
   /// #2863 — fetch per-station alert prices for **bulk-dataset** countries via
@@ -319,12 +329,12 @@ class BackgroundAlertScanCoordinator {
   /// Groups the alert station ids by derived country (the same lazy derivation
   /// the polled grouping uses), keeps only the bulk-policy countries (polled
   /// ones were already fetched by [BackgroundPriceSource]), and asks each
-  /// country's strategy for its prices. Each bulk strategy answers by local
-  /// geo-filter over its cached whole-country dataset — at most one dataset
-  /// download per country per scan, then zero per-alert network. Each strategy
-  /// swallows + spools its own faults (its documented boundary, fault-tested in
-  /// `country_alert_strategy_test.dart`), so a bulk-country provider fault
-  /// degrades to "no fresh prices this scan" rather than failing the scan.
+  /// country's strategy for its prices — answered by local geo-filter over the
+  /// cached whole-country dataset (≤1 dataset download per country per scan,
+  /// then zero per-alert network). Each strategy swallows + spools its own
+  /// faults (its documented boundary, fault-tested in
+  /// `country_alert_strategy_test.dart`), so a bulk-country fault degrades to
+  /// "no fresh prices this scan" rather than failing the scan.
   Future<Map<String, Map<String, dynamic>>> _fetchBulkAlertPrices({
     required Set<String> alertStationIds,
     required String? fallbackCountryCode,

--- a/lib/core/background/background_price_source.dart
+++ b/lib/core/background/background_price_source.dart
@@ -10,9 +10,11 @@ import '../../features/search/domain/entities/station.dart';
 import '../cache/cache_manager.dart';
 import '../data/storage_repository.dart';
 import '../services/country_service_registry.dart';
+import '../services/diagnostics/data_access_recorder.dart';
 import '../services/station_service.dart';
 import 'country_alert_strategy.dart';
 import 'polled_alert_strategy.dart';
+import 'provider_request_budget.dart';
 
 // `kBackgroundPolledCountries` now lives in `polled_alert_strategy.dart` (the
 // per-country polled specialization, #2863). Re-exported here so existing
@@ -40,6 +42,8 @@ class BackgroundPriceSource {
     required StorageRepository storage,
     Duration connectTimeout = const Duration(seconds: 10),
     Duration receiveTimeout = const Duration(seconds: 15),
+    DataAccessRecorder? recorder,
+    ProviderRequestBudget? budget,
     @visibleForTesting StationService? Function(String code, {String? apiKey})?
         serviceBuilder,
   })  : _storage = storage,
@@ -47,6 +51,8 @@ class BackgroundPriceSource {
         _deps = PolledAlertStrategyDeps(
           connectTimeout: connectTimeout,
           receiveTimeout: receiveTimeout,
+          recorder: recorder,
+          budget: budget,
           serviceBuilder: serviceBuilder,
         );
 

--- a/lib/core/background/background_scan_dedup_store.dart
+++ b/lib/core/background/background_scan_dedup_store.dart
@@ -14,7 +14,7 @@ import '../storage/hive_boxes.dart';
 /// ## Why?
 /// Tier-1 background scanning is fed by *several* triggers that the OS may
 /// fire close together:
-///   * the WorkManager periodic tasks (`priceRefresh` / `priceRefreshCharging`),
+///   * the WorkManager twice-daily periodic scan (`priceRefresh`, #2866),
 ///   * the Android home-widget refresh (#2412), and
 ///   * the iOS BGAppRefreshTask (#2414).
 ///

--- a/lib/core/background/background_scan_tracer.dart
+++ b/lib/core/background/background_scan_tracer.dart
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:hive/hive.dart';
+
+import '../logging/error_logger.dart';
+import '../services/diagnostics/data_access_recorder.dart';
+import '../services/diagnostics/data_access_trace_export.dart';
+
+/// Dev-gated #2824 data-access tracer for the background scan (Epic #2860 EXIT
+/// GATE, #2866).
+///
+/// The foreground threads a [DataAccessRecorder] through its country services
+/// only when developer mode is on (`dataAccessRecorderProvider`), so a trace
+/// counts the user's in-app traffic. Until #2866 the OS-spawned background
+/// isolate had no such recorder — its multi-country scan traffic was invisible
+/// to the rate-limit/ToS audit. This helper closes that gap: when developer
+/// mode is on it builds a recorder, threads it through the scan's per-country
+/// services + bulk strategies (via `BackgroundPriceSource` /
+/// `CountryAlertStrategyResolver`), then [exportIfEnabled] builds a
+/// [DataAccessTrace] and writes it to Downloads — exactly the foreground path,
+/// so the maintainer can read `aggregates().compliant` for the background scan.
+///
+/// In production (developer mode off — the default) [recorder] is null, so the
+/// chain's `recordDataAccess` calls early-return and the scan carries ZERO
+/// added cost — identical to before #2866.
+class BackgroundScanTracer {
+  BackgroundScanTracer._(this.recorder);
+
+  /// The live recorder when developer mode is on, else null. Pass this through
+  /// the scan's `BackgroundPriceSource` / `CountryAlertStrategyResolver`.
+  final DataAccessRecorder? recorder;
+
+  /// Whether this scan is being traced (developer mode is on).
+  bool get isTracing => recorder != null;
+
+  /// Build a tracer for one scan, gated on the persisted [_debugModeEnabled]
+  /// flag. Best-effort: any read fault yields a no-op (null) tracer so a
+  /// diagnostics hiccup can never affect the scan.
+  static BackgroundScanTracer forScan() {
+    DataAccessRecorder? recorder;
+    try {
+      if (_debugModeEnabled()) recorder = DataAccessRecorder();
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.background, e, st, context: const {
+        'where': 'BackgroundScanTracer.forScan: dev-mode read',
+      }));
+    }
+    return BackgroundScanTracer._(recorder);
+  }
+
+  /// When tracing, snapshot the recorder into a [DataAccessTrace] and export it
+  /// to Downloads (the same dev-only sink the foreground uses). No-op + never
+  /// throws when not tracing; a write fault is swallowed (logged downstream).
+  Future<void> exportIfEnabled({String? comment}) async {
+    final r = recorder;
+    if (r == null) return;
+    try {
+      final trace = r.build(
+        comment: comment ?? 'Background multi-country alert scan (#2866).',
+      );
+      await DataAccessTraceExport.export(trace);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.background, e, st, context: const {
+        'where': 'BackgroundScanTracer.exportIfEnabled',
+      }));
+    }
+  }
+
+  /// Read the persisted `debugMode` feature flag the foreground wrote to the
+  /// `feature_flags` box. The box is uncipher'd (mirrors the foreground open),
+  /// opened best-effort here so the isolate need not carry the whole feature
+  /// system. Returns false when the box is unavailable / the flag is unset.
+  static bool _debugModeEnabled() {
+    // Feature.name for the developer-tools flag; the box stores one bool per
+    // feature keyed by its enum name (see FeatureFlagsRepository).
+    // i18n-ignore: storage key (Feature.debugMode.name), not user-facing.
+    const debugModeKey = 'debugMode';
+    // i18n-ignore: Hive box name, not user-facing.
+    const boxName = 'feature_flags';
+    final box = Hive.isBoxOpen(boxName) ? Hive.box<dynamic>(boxName) : null;
+    if (box == null) return false;
+    return box.get(debugModeKey) == true;
+  }
+}

--- a/lib/core/background/background_service.dart
+++ b/lib/core/background/background_service.dart
@@ -34,10 +34,14 @@ import 'notification_templates.dart';
 /// deliberately thin: it just maps the task name to a
 /// [BackgroundScanTrigger] and delegates.
 ///
-/// ## Frequency: Adaptive based on battery/charger state
-/// - **Charging**: every 30 minutes (more frequent updates while plugged in)
-/// - **On battery (not low)**: every 1 hour (standard interval)
-/// - **Low battery**: tasks are skipped by WorkManager constraints
+/// ## Frequency: twice per day (Epic #2860 EXIT GATE, #2866)
+/// The periodic scan runs ~every 12h (twice daily). Since the scan now polls
+/// every feasible country's provider, the cadence is the core rate-limit / ToS
+/// safeguard — twice-daily + the once-per-country-per-scan grouping + the
+/// shared per-provider [ProviderRequestBudget] bound every provider to well
+/// inside its limits. The low-battery skip ([Constraints.requiresBatteryNotLow])
+/// stays; the old 30-min charging cadence was dropped (it would have breached
+/// twice-daily for a multi-country scan).
 ///
 /// Background scanning is **best-effort, never real-time** — Android delays
 /// periodic work under Doze and iOS schedules BGAppRefresh opportunistically.
@@ -52,9 +56,6 @@ import 'notification_templates.dart';
 class BackgroundService {
   /// Task name for the standard periodic price refresh.
   static const priceRefreshTask = 'priceRefresh';
-
-  /// Task name for the charging-only periodic price refresh.
-  static const priceRefreshChargingTask = 'priceRefreshCharging';
 
   /// One-off task name enqueued by the Android [BootReceiver] after a
   /// reboot (#2413). Handling it re-registers the periodic tasks so the
@@ -71,13 +72,19 @@ class BackgroundService {
   /// match `FuelPriceWidgetProvider.WIDGET_SCAN_TASK`.
   static const widgetRefreshScanTask = 'widgetRefreshScan';
 
-  /// Standard refresh interval when on battery (not low).
-  /// Android may delay based on Doze mode; 1h is the minimum WorkManager honors reliably.
-  static const refreshInterval = Duration(hours: 1);
-
-  /// Faster refresh interval when the device is charging.
-  /// Plugged-in users get fresher prices without battery impact.
-  static const chargingRefreshInterval = Duration(minutes: 30);
+  /// Periodic alert/price-scan cadence — **twice per day** (~every 12h).
+  ///
+  /// Epic #2860 EXIT GATE (#2866): the background scan now polls *every*
+  /// feasible country's provider, so the cadence is the core rate-limit / ToS
+  /// safeguard. Twice-daily — combined with the once-per-country-per-scan
+  /// grouping (the registry-driven [BackgroundPriceSource]) and the shared
+  /// per-provider [ProviderRequestBudget] — keeps every provider comfortably
+  /// inside its published limits: no provider can be hit more than ~twice a
+  /// day by a background scan, batched per country. (The previous 1h standard
+  /// + 30min charging cadences breached that for a multi-country scan, so the
+  /// charging variant was dropped and the standard one raised to 12h.) Android
+  /// may still delay the wake under Doze — best-effort, never punctual.
+  static const refreshInterval = Duration(hours: 12);
 
   // Retry / dedup / batch constants live on BackgroundAlertScanCoordinator
   // (#2415) so every trigger shares one tuning surface. Kept here as thin
@@ -224,8 +231,6 @@ BackgroundScanTrigger? _triggerForTask(String task) {
   switch (task) {
     case BackgroundService.priceRefreshTask:
       return BackgroundScanTrigger.workManagerPeriodic;
-    case BackgroundService.priceRefreshChargingTask:
-      return BackgroundScanTrigger.workManagerCharging;
     case BackgroundService.widgetRefreshScanTask:
       return BackgroundScanTrigger.androidWidget;
     case Workmanager.iOSBackgroundTask:

--- a/lib/core/background/bulk_alert_price_merge.dart
+++ b/lib/core/background/bulk_alert_price_merge.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../services/country_service_registry.dart';
+import 'bulk_dataset_alert_strategy.dart';
+import 'country_alert_strategy_resolver.dart';
+
+/// #2863 — fetch per-station alert prices for **bulk-dataset** countries via
+/// their [BulkDatasetAlertStrategy] (resolved per country by [resolver]).
+///
+/// Groups the alert station ids by derived country (the same lazy derivation
+/// the polled grouping uses), keeps only the bulk-policy countries (polled
+/// ones were already fetched by the polled source), and asks each country's
+/// strategy for its prices — answered by local geo-filter over the cached
+/// whole-country dataset (≤1 dataset download per country per scan, then zero
+/// per-alert network). Each strategy swallows + spools its own faults (its
+/// documented boundary, fault-tested in `country_alert_strategy_test.dart`),
+/// so a bulk-country fault degrades to "no fresh prices this scan" rather than
+/// failing the scan. Extracted from the coordinator (#2866) to keep it under
+/// the 400-line file-size norm.
+Future<Map<String, Map<String, dynamic>>> fetchBulkAlertPrices({
+  required Set<String> alertStationIds,
+  required String? fallbackCountryCode,
+  required CountryAlertStrategyResolver resolver,
+}) async {
+  final byCountry = <String, Set<String>>{};
+  for (final id in alertStationIds) {
+    final code =
+        CountryServiceRegistry.countryForStationId(id) ?? fallbackCountryCode;
+    // Only the bulk-dataset countries; polled ids were already fetched.
+    if (code == null || !BulkDatasetAlertStrategy.isBulk(code)) continue;
+    byCountry.putIfAbsent(code, () => <String>{}).add(id);
+  }
+
+  final merged = <String, Map<String, dynamic>>{};
+  for (final entry in byCountry.entries) {
+    final strategy = resolver.strategyFor(entry.key);
+    if (strategy == null) continue;
+    merged.addAll(await strategy.fetchPrices(entry.value));
+  }
+  return merged;
+}

--- a/lib/core/background/bulk_dataset_alert_strategy.dart
+++ b/lib/core/background/bulk_dataset_alert_strategy.dart
@@ -11,11 +11,13 @@ import '../cache/cache_manager.dart';
 import '../data/storage_repository.dart';
 import '../logging/error_logger.dart';
 import '../services/country_service_registry.dart';
+import '../services/diagnostics/data_access_recorder.dart';
 import '../services/fuel_service_policy.dart';
 import '../services/station_service.dart';
 import '../utils/json_extensions.dart';
 import 'background_price_shape.dart';
 import 'country_alert_strategy.dart';
+import 'provider_request_budget.dart';
 
 /// [CountryAlertStrategy] for a [SourceModel.bulkFile] country (#2863) — ES,
 /// IT, AR, DK, plus the flag-gated GB-bulk / FR-bulk paths.
@@ -59,13 +61,21 @@ class BulkDatasetAlertStrategy implements CountryAlertStrategy {
     required StorageRepository storage,
     required CacheStrategy cache,
     required FuelServicePolicy policy,
+    DataAccessRecorder? recorder,
+    ProviderRequestBudget? budget,
     @visibleForTesting StationService? service,
     @visibleForTesting StationCoordsResolver? coordsResolver,
   })  : _storage = storage,
         _cache = cache,
         _policy = policy,
+        _recorder = recorder,
+        _budget = budget,
         _serviceOverride = service,
-        _coordsResolver = coordsResolver ?? _defaultCoordsResolver(storage);
+        _coordsResolver = coordsResolver ?? _defaultCoordsResolver(storage) {
+    // #2866 — note the dataset-refresh interval so the trace can judge the
+    // bulk download's compliance against datasetTtl-derived minInterval.
+    recorder?.notePolicy(countryCode, policy.minInterval);
+  }
 
   @override
   final String countryCode;
@@ -73,6 +83,14 @@ class BulkDatasetAlertStrategy implements CountryAlertStrategy {
   final StorageRepository _storage;
   final CacheStrategy _cache;
   final FuelServicePolicy _policy;
+
+  /// #2824 tracer threaded into the BG isolate (#2866). Null outside an
+  /// instrumented scan; the bulk-backed chain stamps network/coalesced events.
+  final DataAccessRecorder? _recorder;
+
+  /// #2866 shared per-provider (per-dataset) request budget the bulk chain
+  /// stamps on a dataset download. Null in the legacy/test call sites.
+  final ProviderRequestBudget? _budget;
 
   /// Test seam: a pre-built bulk service (a fake dataset). Production leaves
   /// this null and builds the real bulk chain on first use.
@@ -107,6 +125,10 @@ class BulkDatasetAlertStrategy implements CountryAlertStrategy {
           countryCode,
           storage: _storage,
           cache: _cache,
+          // #2866 — count the bulk download in the trace + share the dataset
+          // refresh budget with the foreground.
+          recorder: _recorder,
+          budget: _budget,
         );
   }
 

--- a/lib/core/background/country_alert_strategy.dart
+++ b/lib/core/background/country_alert_strategy.dart
@@ -6,9 +6,11 @@ import '../../features/search/domain/entities/station.dart';
 import '../cache/cache_manager.dart';
 import '../data/storage_repository.dart';
 import '../services/country_service_registry.dart';
+import '../services/diagnostics/data_access_recorder.dart';
 import '../services/fuel_service_policy.dart';
 import 'bulk_dataset_alert_strategy.dart';
 import 'polled_alert_strategy.dart';
+import 'provider_request_budget.dart';
 
 /// The per-country **specialization seam** a background alert scan resolves to
 /// (Epic #2860, child #2863).
@@ -76,11 +78,19 @@ abstract class CountryAlertStrategy {
   ///
   /// [apiKey] is the user's key threaded into the isolate (DE needs it on the
   /// Dio; KR/CL read theirs from [storage] inside the registry factory).
+  ///
+  /// [recorder] is the #2824 data-access tracer and [budget] the #2866 shared
+  /// per-provider request budget — both threaded through so the chain each
+  /// strategy builds counts its background traffic and shares one minInterval
+  /// gate with the foreground. The [polledDeps] (when supplied) already carry
+  /// these for the polled branch; the bulk branch reads them here.
   static CountryAlertStrategy? forCountry(
     String countryCode, {
     required StorageRepository storage,
     required CacheStrategy cache,
     String? apiKey,
+    DataAccessRecorder? recorder,
+    ProviderRequestBudget? budget,
     PolledAlertStrategyDeps? polledDeps,
   }) {
     // AU is a documented throwing stub (#804) — never scanned in the BG isolate.
@@ -96,6 +106,8 @@ abstract class CountryAlertStrategy {
           storage: storage,
           cache: cache,
           policy: policy,
+          recorder: recorder,
+          budget: budget,
         );
       case SourceModel.polledApi:
         return PolledAlertStrategy.forCountry(
@@ -103,7 +115,8 @@ abstract class CountryAlertStrategy {
           storage: storage,
           cache: cache,
           apiKey: apiKey,
-          deps: polledDeps,
+          deps: polledDeps ??
+              PolledAlertStrategyDeps(recorder: recorder, budget: budget),
         );
     }
   }

--- a/lib/core/background/country_alert_strategy_resolver.dart
+++ b/lib/core/background/country_alert_strategy_resolver.dart
@@ -3,8 +3,10 @@
 
 import '../cache/cache_manager.dart';
 import '../data/storage_repository.dart';
+import '../services/diagnostics/data_access_recorder.dart';
 import 'country_alert_strategy.dart';
 import 'polled_alert_strategy.dart';
+import 'provider_request_budget.dart';
 
 /// Per-scan cache of [CountryAlertStrategy] instances, one per country (Epic
 /// #2860, child #2863).
@@ -26,15 +28,25 @@ class CountryAlertStrategyResolver {
     required StorageRepository storage,
     required CacheStrategy cache,
     String? apiKey,
+    DataAccessRecorder? recorder,
+    ProviderRequestBudget? budget,
     PolledAlertStrategyDeps? polledDeps,
   })  : _storage = storage,
         _cache = cache,
         _apiKey = apiKey,
+        _recorder = recorder,
+        _budget = budget,
         _polledDeps = polledDeps;
 
   final StorageRepository _storage;
   final CacheStrategy _cache;
   final String? _apiKey;
+
+  /// #2824 tracer + #2866 shared budget threaded into every strategy this
+  /// resolver builds, so the whole BG scan shares one trace and one
+  /// per-provider gate. Both null outside an instrumented / gated scan.
+  final DataAccessRecorder? _recorder;
+  final ProviderRequestBudget? _budget;
   final PolledAlertStrategyDeps? _polledDeps;
 
   final Map<String, CountryAlertStrategy?> _byCountry = {};
@@ -49,6 +61,8 @@ class CountryAlertStrategyResolver {
       storage: _storage,
       cache: _cache,
       apiKey: _apiKey,
+      recorder: _recorder,
+      budget: _budget,
       polledDeps: _polledDeps,
     );
     _byCountry[countryCode] = strategy;

--- a/lib/core/background/hive_isolate_lock.dart
+++ b/lib/core/background/hive_isolate_lock.dart
@@ -33,13 +33,13 @@ import '../../core/logging/error_logger.dart';
 /// ### Why not check-then-create? (the bug this fixes)
 /// The previous implementation did a non-atomic
 /// `!existsSync()` → `writeAsStringSync()` → `existsSync()` dance. Two isolates
-/// firing near-simultaneously (e.g. `priceRefresh` and `priceRefreshCharging`
-/// while charging) could *both* observe the file missing, *both* write it, and
+/// firing near-simultaneously (e.g. the `priceRefresh` periodic scan and an
+/// opportunistic widget refresh) could *both* observe the file missing, *both* write it, and
 /// *both* return `true` — then open the same Hive boxes concurrently and
 /// corrupt them. The in-process gate closes that race; the file lock covers
 /// the cross-process case. (Belt-and-braces: WorkManager registration also
-/// serializes the two periodic tasks under one unique name — see
-/// `AndroidBackgroundPriceFetcher`.)
+/// serializes the periodic scan + an opportunistic widget refresh under one
+/// unique name — see `AndroidBackgroundPriceFetcher`.)
 ///
 /// The main isolate does NOT acquire this lock — it owns the boxes permanently.
 /// Only background isolates use this lock to serialize their short-lived access.

--- a/lib/core/background/polled_alert_strategy.dart
+++ b/lib/core/background/polled_alert_strategy.dart
@@ -12,11 +12,14 @@ import '../cache/cache_manager.dart';
 import '../data/storage_repository.dart';
 import '../logging/error_logger.dart';
 import '../services/country_service_registry.dart';
+import '../services/diagnostics/data_access_recorder.dart';
 import '../services/dio_factory.dart';
+import '../services/fuel_service_policy.dart';
 import '../services/service_config.dart';
 import '../services/station_service.dart';
 import 'background_price_shape.dart';
 import 'country_alert_strategy.dart';
+import 'provider_request_budget.dart';
 
 /// The 11 polled / realtime providers a background scan may query directly,
 /// reusing the per-country `StationServiceChain` within each provider's
@@ -37,15 +40,31 @@ const Set<String> kBackgroundPolledCountries = {
 /// [serviceBuilder] is the #2862 test seam: a fake per-country service builder.
 /// Production leaves it null and goes through
 /// [CountryServiceRegistry.buildBackgroundService].
+///
+/// [recorder] is the #2824 data-access tracer, threaded through the BG isolate
+/// by #2866 so background traffic is counted (it was previously null in the
+/// isolate — only the foreground saw it). [budget] is the #2866 shared
+/// per-provider request budget the BG scan consults before firing and the
+/// chain stamps on a hit.
 class PolledAlertStrategyDeps {
   const PolledAlertStrategyDeps({
     this.connectTimeout = const Duration(seconds: 10),
     this.receiveTimeout = const Duration(seconds: 15),
     this.serviceBuilder,
+    this.recorder,
+    this.budget,
   });
 
   final Duration connectTimeout;
   final Duration receiveTimeout;
+
+  /// #2824 data-access tracer threaded into the BG isolate (#2866). Null
+  /// outside an instrumented scan.
+  final DataAccessRecorder? recorder;
+
+  /// #2866 shared foreground+background per-provider request budget. Null in
+  /// the legacy/test call sites that don't gate.
+  final ProviderRequestBudget? budget;
 
   @visibleForTesting
   final StationService? Function(String code, {String? apiKey})? serviceBuilder;
@@ -63,18 +82,36 @@ class PolledAlertStrategyDeps {
 class PolledAlertStrategy implements CountryAlertStrategy {
   PolledAlertStrategy._(
     this.countryCode,
-    this._service,
-  );
+    this._service, {
+    this.minInterval,
+    ProviderRequestBudget? budget,
+  }) : _budget = budget;
 
   @override
   final String countryCode;
 
   final StationService _service;
 
+  /// The provider's configured min inter-request spacing (#2866), read from
+  /// the registry policy. Used with [_budget] to skip a too-soon BG poll.
+  final Duration? minInterval;
+
+  /// Shared foreground+background per-provider request budget (#2866). When
+  /// present, a fetch / search is skipped if the provider was hit (by EITHER
+  /// isolate) within [minInterval]; the cache then answers from the last hit.
+  final ProviderRequestBudget? _budget;
+
   /// The built country [StationService] backing this strategy. Exposed for the
   /// nearest-widget search (#609 / #2862), which needs a raw service handle
   /// rather than the strategy facade.
   StationService get service => _service;
+
+  /// `true` when the shared budget allows a fresh provider request for this
+  /// country right now — i.e. no budget is wired, or the last request is at
+  /// least [minInterval] old. A blocked request leaves the previous prices in
+  /// place (the foreground / a prior scan already populated the cache).
+  bool get _budgetAllows =>
+      _budget?.canFire(countryCode, minInterval) ?? true;
 
   /// Whether [countryCode] is one of the polled providers this strategy serves.
   static bool isPolled(String countryCode) =>
@@ -105,9 +142,25 @@ class PolledAlertStrategy implements CountryAlertStrategy {
             tankerkoenigDio: countryCode == 'DE'
                 ? _buildTankerkoenigDio(apiKey, d)
                 : null,
+            // #2866 — count BG traffic + share the per-provider budget with the
+            // foreground; both null outside an instrumented / gated scan.
+            recorder: d.recorder,
+            budget: d.budget,
           );
     if (service == null) return null;
-    return PolledAlertStrategy._(countryCode, service);
+    // #2866 — the provider's configured minInterval, fed to the shared budget
+    // so a too-soon BG poll after a foreground hit is skipped. The recorder
+    // also notes it (in buildBackgroundService) so the trace can judge
+    // compliance against it. A fake serviceBuilder may yield no policy.
+    final minInterval =
+        CountryServiceRegistry.policyFor(countryCode)?.minInterval;
+    d.recorder?.notePolicy(countryCode, minInterval);
+    return PolledAlertStrategy._(
+      countryCode,
+      service,
+      minInterval: minInterval,
+      budget: d.budget,
+    );
   }
 
   /// Tankerkönig Dio for the background isolate: rate-limited + conditional
@@ -138,6 +191,14 @@ class PolledAlertStrategy implements CountryAlertStrategy {
     Set<String> stationIds,
   ) async {
     if (stationIds.isEmpty) return const {};
+    // #2866 — shared-budget gate: skip a too-soon poll the foreground (or a
+    // prior scan) already covered within minInterval. The cache still holds
+    // those prices, so per-station alerts evaluate against the last fetch.
+    if (!_budgetAllows) {
+      debugPrint('PolledAlertStrategy.fetchPrices($countryCode): skipped — '
+          'within shared minInterval budget');
+      return const {};
+    }
     try {
       final result = await _service.getPrices(stationIds.toList());
       final out = <String, Map<String, dynamic>>{};
@@ -158,6 +219,13 @@ class PolledAlertStrategy implements CountryAlertStrategy {
   /// or an empty list on a fetch fault.
   @override
   Future<List<Station>> searchArea(SearchParams params) async {
+    // #2866 — same shared-budget gate as fetchPrices: a radius search is a
+    // provider request, so skip it when the shared minInterval is not yet up.
+    if (!_budgetAllows) {
+      debugPrint('PolledAlertStrategy.searchArea($countryCode): skipped — '
+          'within shared minInterval budget');
+      return const [];
+    }
     try {
       final result = await _service.searchStations(params);
       return result.data;

--- a/lib/core/background/provider_request_budget.dart
+++ b/lib/core/background/provider_request_budget.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../data/storage_repository.dart';
+
+/// A per-provider last-upstream-request stamp shared by the foreground and the
+/// background isolate through ONE budget (Epic #2860 EXIT GATE, #2866).
+///
+/// ## Why a shared, persisted budget
+///
+/// Each Dio already owns an in-memory [RateLimitInterceptor] gate, but that
+/// gate is per-isolate: the background scan runs in an OS-spawned isolate with
+/// its own freshly-built Dio, so its interceptor has no memory of a foreground
+/// request the user fired seconds earlier. The result would be a foreground
+/// search and a background scan double-hitting the same provider within its
+/// `minInterval`.
+///
+/// This budget closes that gap. It records a single per-country timestamp in
+/// the SHARED Hive settings box — written on every successful provider network
+/// request from EITHER isolate ([recordRequest], stamped by
+/// [StationServiceChain] on a `networkApi` outcome), and read by the background
+/// scan ([canFire]) BEFORE it fires a provider request. If the foreground (or a
+/// prior background hit) touched a provider within its `minInterval`, the scan
+/// skips that provider this round — the cache still answers from the last fetch.
+///
+/// Combined with the once-per-country-per-scan grouping (the registry-driven
+/// `BackgroundPriceSource`) and the twice-daily cadence (the core safeguard),
+/// this bounds every provider to well inside its published rate-limit / ToS.
+///
+/// Pure storage, no I/O of its own: reads are synchronous off the open settings
+/// box; the write is fire-and-forget ([recordRequest] returns void) so the hot
+/// network-success path never awaits a Hive put.
+class ProviderRequestBudget {
+  /// Settings-key prefix for the per-country last-request stamp. The country
+  /// code is appended (`bg_provider_budget:DE`). One key per provider country.
+  // i18n-ignore: storage key, not user-facing.
+  static const String keyPrefix = 'bg_provider_budget:';
+
+  ProviderRequestBudget(this._storage);
+
+  final StorageRepository _storage;
+
+  static String _keyFor(String country) => '$keyPrefix$country';
+
+  /// The last recorded upstream-request time for [country], or null when no
+  /// request has ever been stamped (or the stored value is unparseable).
+  DateTime? lastRequestAt(String country) {
+    final raw = _storage.getSetting(_keyFor(country));
+    if (raw is! String) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  /// Whether a fresh provider request for [country] is allowed under the
+  /// shared budget — `true` when no prior request is stamped, or the last one
+  /// is at least [minInterval] old (relative to [now], default wall clock).
+  ///
+  /// A null / zero [minInterval] is treated as "no shared throttle" → always
+  /// allowed (the provider has no configured spacing to honour).
+  bool canFire(String country, Duration? minInterval, {DateTime? now}) {
+    if (minInterval == null || minInterval <= Duration.zero) return true;
+    final last = lastRequestAt(country);
+    if (last == null) return true;
+    final at = now ?? DateTime.now();
+    return at.difference(last) >= minInterval;
+  }
+
+  /// Stamp [country]'s last-request time to [now] (default wall clock).
+  ///
+  /// Fire-and-forget: the Hive put is started but not awaited, so the network
+  /// success path that calls this (the foreground or background chain) is not
+  /// slowed by storage I/O. A put failure is swallowed — a missed stamp only
+  /// loosens the shared throttle for one round, never crashes a scan.
+  void recordRequest(String country, {DateTime? now}) {
+    final at = (now ?? DateTime.now()).toUtc().toIso8601String();
+    unawaited(_storage.putSetting(_keyFor(country), at).catchError((_) {}));
+  }
+
+  /// Await-able variant of [recordRequest] for callers (and tests) that need
+  /// the stamp persisted before proceeding.
+  @visibleForTesting
+  Future<void> recordRequestAwait(String country, {DateTime? now}) async {
+    final at = (now ?? DateTime.now()).toUtc().toIso8601String();
+    await _storage.putSetting(_keyFor(country), at);
+  }
+}

--- a/lib/core/services/country_service_registry.dart
+++ b/lib/core/services/country_service_registry.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../background/provider_request_budget.dart';
 import '../cache/cache_manager.dart';
 import '../country/country_bounding_box.dart';
 import '../country/country_config.dart';
@@ -755,9 +756,10 @@ class CountryServiceRegistry {
       tankerkoenigDio: countryCode == 'DE'
           ? ref.read(tankerkoenigDioProvider)
           : null,
-      // #2824 — dev-only data-access tracer; null in production (zero
-      // overhead). Only the foreground has a provider scope to read it from.
+      // #2824 — dev-only tracer (null in production); #2866 — shared per-
+      // provider budget the foreground stamps so the BG scan won't re-poll.
       recorder: ref.read(dataAccessRecorderProvider),
+      budget: ProviderRequestBudget(ref.read(storageRepositoryProvider)),
     );
   }
 
@@ -774,7 +776,8 @@ class CountryServiceRegistry {
   ///  - [cache] — a [CacheStrategy] (the isolate builds `CacheManager(storage)`).
   ///  - [tankerkoenigDio] — only the DE branch needs it; a background caller
   ///    passes a plain rate-limited Dio and sends the key per-request.
-  ///  - [recorder] — the optional #2824 tracer; usually null in the isolate.
+  ///  - [recorder] (#2824 tracer) + [budget] (#2866 shared per-provider gate
+  ///    the chain stamps on a hit) — both threaded through; usually null.
   ///
   /// Builds the **same** [StationServiceChain] (same primary service, error
   /// source, policy) the foreground builds, via the single, Riverpod-free
@@ -786,6 +789,7 @@ class CountryServiceRegistry {
     required CacheStrategy cache,
     Dio? tankerkoenigDio,
     DataAccessRecorder? recorder,
+    ProviderRequestBudget? budget,
   }) {
     final entry = _byCode[countryCode];
     if (entry == null) return DemoStationService(countryCode: countryCode);
@@ -808,6 +812,7 @@ class CountryServiceRegistry {
       // (no per-key cache) vs keep the per-key TTL cache for polled APIs.
       policy: entry.policy,
       recorder: recorder,
+      budget: budget,
     );
   }
 

--- a/lib/core/services/station_service_chain.dart
+++ b/lib/core/services/station_service_chain.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 
 import '../../features/search/data/models/search_params.dart';
 import '../../features/search/domain/entities/station.dart';
+import '../background/provider_request_budget.dart';
 import '../cache/cache_manager.dart';
 import '../error/exceptions.dart';
 import '../logging/error_logger.dart';
@@ -66,6 +67,14 @@ class StationServiceChain implements StationService {
   /// compliance + cache-hit-ratio export.
   final DataAccessRecorder? _recorder;
 
+  /// Shared foreground+background per-provider request budget (#2866). When
+  /// supplied, the chain stamps [ProviderRequestBudget.recordRequest] for this
+  /// [countryCode] on every successful upstream (`networkApi`) request, so the
+  /// next background scan can see that the foreground just hit this provider
+  /// and skip it within its `minInterval`. Null for the legacy call sites /
+  /// unit tests that don't wire a budget — then no stamp is written.
+  final ProviderRequestBudget? _budget;
+
   /// In-flight request deduplication: concurrent calls for the same cache key
   /// share a single Future instead of hitting the API multiple times.
   /// Entries are removed in the finally block of [_throughChain] and also
@@ -81,9 +90,11 @@ class StationServiceChain implements StationService {
     this.countryCode = '',
     FuelServicePolicy? policy,
     DataAccessRecorder? recorder,
+    ProviderRequestBudget? budget,
   })  : _errorSource = errorSource,
         _policy = policy,
-        _recorder = recorder;
+        _recorder = recorder,
+        _budget = budget;
 
   /// Generic cache-through + request coalescing.
   ///
@@ -194,6 +205,10 @@ class StationServiceChain implements StationService {
           DataAccessHit.networkApi, result.source,
           count: dataAccessResultCount(result.data),
           latencyMicros: apiClock.elapsedMicroseconds);
+      // #2866 — stamp the shared budget so a background scan (a different
+      // isolate) sees this hit and won't re-poll the provider within its
+      // minInterval. Fire-and-forget; null in legacy/test call sites.
+      _budget?.recordRequest(countryCode);
       return result;
     } on Exception catch (e, st) {
       // #2296 — log the API-failure path (stack was previously discarded)
@@ -326,6 +341,10 @@ class StationServiceChain implements StationService {
           count: dataAccessResultCount(result.data),
           latencyMicros: bulkClock.elapsedMicroseconds,
           isStale: result.isStale);
+      // #2866 — stamp the shared per-provider (here: per-dataset) budget so a
+      // background scan won't re-download the whole-country dataset within the
+      // policy's minInterval after a foreground search just fetched it.
+      _budget?.recordRequest(countryCode);
       return result;
     } finally {
       unawaited(_inFlight.remove(key) ?? Future<void>.value());

--- a/lib/core/storage/hive_boxes.dart
+++ b/lib/core/storage/hive_boxes.dart
@@ -285,6 +285,11 @@ class HiveBoxes {
     // here while Riverpod is unavailable, drained by the foreground
     // initialiser into TraceRecorder.
     await Hive.openBox<String>(isolateErrorSpool);
+    // #2866 — feature flags (uncipher'd, mirroring the foreground open) so the
+    // background scan can read the developer-mode flag to dev-gate the #2824
+    // data-access trace export. Best-effort; the scan no-ops the trace if this
+    // is unavailable.
+    await Hive.openBox<dynamic>(featureFlags);
   }
 
   /// Close the Hive boxes opened by [initInIsolate] at the end of a
@@ -298,7 +303,7 @@ class HiveBoxes {
   /// true spawned `dart:isolate` worker never ran [init], so its registry is
   /// empty and every [initInIsolate] handle is still closed.
   static Future<void> closeIsolateBoxes() async {
-    final boxNames = [settings, favorites, alerts, cache, priceHistory, priceSnapshots, isolateErrorSpool];
+    final boxNames = [settings, favorites, alerts, cache, priceHistory, priceSnapshots, isolateErrorSpool, featureFlags];
     for (final name in boxNames) {
       if (HiveIsolateOwnership.isOwned(name)) continue;
       try {

--- a/test/core/background/background_alert_scan_coordinator_test.dart
+++ b/test/core/background/background_alert_scan_coordinator_test.dart
@@ -25,22 +25,27 @@ void main() {
       expect(
         tags,
         containsAll(<String>[
+          // #2866 — the charging-only trigger was dropped with the 30-min
+          // cadence; the twice-daily scan reports `workmanager_periodic`.
           'workmanager_periodic',
-          'workmanager_charging',
           'android_widget',
           'ios_bg_refresh',
         ]),
       );
+      expect(tags, isNot(contains('workmanager_charging')),
+          reason: 'the charging trigger was removed (#2866)');
     });
   });
 
   group('cooldown tuning', () {
-    test('scan cooldown is shorter than the charging cadence', () {
+    test('scan cooldown is far shorter than the twice-daily cadence', () {
       // The coarse cross-trigger cooldown must never starve a legitimately
-      // scheduled 30-minute charging task.
+      // scheduled periodic scan. With the twice-daily (~12h) cadence (#2866)
+      // a 10-minute cooldown only ever dedups a burst of near-simultaneous
+      // triggers (e.g. an opportunistic widget refresh + the periodic wake).
       expect(
         BackgroundAlertScanCoordinator.scanCooldown,
-        lessThan(const Duration(minutes: 30)),
+        lessThan(const Duration(hours: 12)),
       );
       expect(
         BackgroundAlertScanCoordinator.scanCooldown,

--- a/test/core/background/background_price_fetcher_test.dart
+++ b/test/core/background/background_price_fetcher_test.dart
@@ -83,8 +83,8 @@ void main() {
       expect(fetcher.cancelAll, isA<Function>());
     });
 
-    test('uses BackgroundService task name constants', () {
-      // Verify the Android implementation references the shared task names
+    test('uses the BackgroundService periodic task name constant', () {
+      // Verify the Android implementation references the shared task name.
       final source = File(
         'lib/core/background/android_background_price_fetcher.dart',
       ).readAsStringSync();
@@ -94,28 +94,26 @@ void main() {
         isTrue,
         reason: 'Must use shared task name constant from BackgroundService',
       );
-      expect(
-        source.contains('BackgroundService.priceRefreshChargingTask'),
-        isTrue,
-        reason: 'Must use shared charging task name constant from BackgroundService',
-      );
     });
 
-    test('registers both standard and charging tasks', () {
+    test('registers exactly ONE periodic task — the twice-daily scan (#2866)',
+        () {
       final source = File(
         'lib/core/background/android_background_price_fetcher.dart',
       ).readAsStringSync();
 
-      // Must call registerPeriodicTask twice
+      // Exactly one registerPeriodicTask: the 30-min charging task was dropped
+      // so a multi-country scan can never hit a provider more than twice a day.
       final registerCalls = 'registerPeriodicTask'.allMatches(source).length;
       expect(
         registerCalls,
-        equals(2),
-        reason: 'Must register both standard and charging periodic tasks',
+        equals(1),
+        reason: 'Must register exactly one twice-daily periodic task',
       );
     });
 
-    test('uses battery-aware WorkManager constraints', () {
+    test('uses a battery-aware WorkManager constraint (no charging variant)',
+        () {
       final source = File(
         'lib/core/background/android_background_price_fetcher.dart',
       ).readAsStringSync();
@@ -123,16 +121,16 @@ void main() {
       expect(
         source.contains('requiresBatteryNotLow: true'),
         isTrue,
-        reason: 'Standard task must skip when battery is low',
+        reason: 'Twice-daily task must skip when battery is low',
       );
       expect(
         source.contains('requiresCharging: true'),
-        isTrue,
-        reason: 'Charging task must only run when plugged in',
+        isFalse,
+        reason: 'The charging-only task was removed (#2866)',
       );
     });
 
-    test('uses correct refresh intervals from BackgroundService', () {
+    test('uses the twice-daily refresh interval from BackgroundService', () {
       final source = File(
         'lib/core/background/android_background_price_fetcher.dart',
       ).readAsStringSync();
@@ -143,9 +141,9 @@ void main() {
         reason: 'Must use refresh interval from BackgroundService constants',
       );
       expect(
-        source.contains('BackgroundService.chargingRefreshInterval'),
-        isTrue,
-        reason: 'Must use charging refresh interval from BackgroundService constants',
+        source.contains('chargingRefreshInterval'),
+        isFalse,
+        reason: 'No separate charging interval exists anymore (#2866)',
       );
     });
   });
@@ -194,11 +192,7 @@ void main() {
       expect(BackgroundService.priceRefreshTask, 'priceRefresh');
     });
 
-    test('priceRefreshChargingTask is the expected value', () {
-      expect(BackgroundService.priceRefreshChargingTask, 'priceRefreshCharging');
-    });
-
-    test('callback dispatcher uses public task name constants', () {
+    test('callback dispatcher uses the public task name constant', () {
       final source = File(
         'lib/core/background/background_service.dart',
       ).readAsStringSync();
@@ -207,11 +201,6 @@ void main() {
         source.contains('BackgroundService.priceRefreshTask'),
         isTrue,
         reason: 'Callback dispatcher must use public task name constant',
-      );
-      expect(
-        source.contains('BackgroundService.priceRefreshChargingTask'),
-        isTrue,
-        reason: 'Callback dispatcher must use public charging task name constant',
       );
     });
   });

--- a/test/core/background/background_service_test.dart
+++ b/test/core/background/background_service_test.dart
@@ -30,22 +30,24 @@ void main() {
       );
     });
 
-    test('charging refresh interval is shorter than standard', () {
-      expect(
-        BackgroundService.chargingRefreshInterval.inMinutes,
-        lessThan(BackgroundService.refreshInterval.inMinutes),
-      );
+    test('refresh interval is twice-daily (~12h) — the #2866 ToS safeguard', () {
+      // Epic #2860 EXIT GATE: the now-multi-country scan polls every feasible
+      // provider, so the cadence is the core rate-limit / ToS safeguard. Twice
+      // a day keeps every provider comfortably inside its published limits.
+      expect(BackgroundService.refreshInterval, const Duration(hours: 12));
     });
 
-    test('standard refresh interval is 1 hour', () {
-      expect(BackgroundService.refreshInterval, const Duration(hours: 1));
-    });
-
-    test('charging refresh interval is 30 minutes', () {
-      expect(
-        BackgroundService.chargingRefreshInterval,
-        const Duration(minutes: 30),
-      );
+    test('the 30-min charging cadence is gone (it would breach twice-daily)',
+        () {
+      // The charging-only variant was dropped (#2866): a 30-min cadence would
+      // let a multi-country scan hit a provider far more than twice a day.
+      final source = File(
+        'lib/core/background/background_service.dart',
+      ).readAsStringSync();
+      expect(source.contains('chargingRefreshInterval'), isFalse,
+          reason: 'no separate charging cadence may exist');
+      expect(source.contains('priceRefreshChargingTask'), isFalse,
+          reason: 'no charging task name may exist');
     });
   });
 
@@ -163,54 +165,44 @@ void main() {
       }
     });
 
-    test('background service registers two periodic tasks for adaptive scheduling', () {
+    test('background service registers the single twice-daily periodic task '
+        '(#2866)', () {
       final source = File(
         'lib/core/background/background_service.dart',
       ).readAsStringSync();
 
-      // Must register both a standard and a charging task
+      // The one twice-daily scan task — the multi-country ToS safeguard.
       expect(
         source.contains('priceRefresh'),
         isTrue,
-        reason: 'Must register standard priceRefresh task',
-      );
-      expect(
-        source.contains('priceRefreshCharging'),
-        isTrue,
-        reason: 'Must register priceRefreshCharging task for when device is plugged in',
+        reason: 'Must register the standard priceRefresh task',
       );
     });
 
-    test('battery-aware WorkManager constraints are in Android implementation', () {
+    test('battery-aware WorkManager constraint is in Android implementation',
+        () {
       final source = File(
         'lib/core/background/android_background_price_fetcher.dart',
       ).readAsStringSync();
 
-      // Standard task should require battery not low
+      // The twice-daily task should still skip when battery is low.
       expect(
         source.contains('requiresBatteryNotLow: true'),
         isTrue,
-        reason: 'Standard task must skip when battery is low',
-      );
-
-      // Charging task should require device to be charging
-      expect(
-        source.contains('requiresCharging: true'),
-        isTrue,
-        reason: 'Charging task must only run when plugged in',
+        reason: 'Twice-daily task must skip when battery is low',
       );
     });
 
-    test('callback dispatcher handles both task names', () {
+    test('callback dispatcher handles the periodic task name', () {
       final source = File(
         'lib/core/background/background_service.dart',
       ).readAsStringSync();
 
-      // The dispatcher should check for both task names via public constants
+      // The dispatcher should check for the periodic task via the constant.
       expect(
-        source.contains('BackgroundService.priceRefreshChargingTask'),
+        source.contains('BackgroundService.priceRefreshTask'),
         isTrue,
-        reason: 'Callback dispatcher must handle the charging task',
+        reason: 'Callback dispatcher must handle the periodic task',
       );
     });
   });

--- a/test/core/background/bg_scan_compliance_gate_test.dart
+++ b/test/core/background/bg_scan_compliance_gate_test.dart
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/background_price_source.dart';
+import 'package:tankstellen/core/background/provider_request_budget.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/services/country_service_registry.dart';
+import 'package:tankstellen/core/services/diagnostics/data_access_event.dart';
+import 'package:tankstellen/core/services/diagnostics/data_access_recorder.dart';
+import 'package:tankstellen/core/services/diagnostics/data_access_trace.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/services/station_service_chain.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+import '../../helpers/silence_error_logger.dart';
+
+/// EXIT GATE (Epic #2860, child #2866).
+///
+/// A simulated multi-country background scan drives the real BG path
+/// (`BackgroundPriceSource` → per-country `StationServiceChain`) with the #2824
+/// [DataAccessRecorder] attached, then asserts the rate-limit / ToS compliance
+/// contract the epic gates the DE-only-gate removal on:
+///
+///  - each provider gets **≤ one network round per country per scan** (the
+///    once-per-country-per-scan grouping),
+///  - the recorder **notes every provider's configured minInterval**, and
+///  - under the **twice-daily cadence** every provider's observed interval is
+///    ≥ its minInterval, so `DataAccessTrace.aggregates()` reports
+///    `compliant == true` for EVERY provider — no provider is ever
+///    `compliant == false`.
+///
+/// Plus the shared per-provider [ProviderRequestBudget] blocks a too-soon
+/// background request after a foreground hit.
+void main() {
+  silenceErrorLoggerSpool();
+
+  // A real [StationServiceChain] wrapping a counting fake primary for [code],
+  // carrying the country's real registry policy (so the recorder notes the
+  // right minInterval) + the shared recorder + budget. This is the exact chain
+  // the BG isolate builds, minus the network — the counting primary stands in
+  // for the upstream so the chain still records a `networkApi` event.
+  StationServiceChain chainFor(
+    String code,
+    DataAccessRecorder recorder,
+    Map<String, int> priceCalls, {
+    ProviderRequestBudget? budget,
+  }) {
+    return StationServiceChain(
+      _CountingPrimary(code, priceCalls),
+      CacheManager(FakeStorageRepository()),
+      countryCode: code,
+      policy: CountryServiceRegistry.policyFor(code),
+      recorder: recorder,
+      budget: budget,
+    );
+  }
+
+  group('multi-country scan compliance (#2866 EXIT GATE)', () {
+    const polled = ['DE', 'AT', 'PT', 'KR', 'MX'];
+
+    test('each polled provider is hit ≤ ONCE per scan + the recorder notes '
+        'every minInterval; NO provider is compliant=false', () async {
+      final recorder = DataAccessRecorder();
+      final priceCalls = <String, int>{};
+      final chains = {
+        for (final c in polled) c: chainFor(c, recorder, priceCalls),
+      };
+
+      final source = BackgroundPriceSource(
+        storage: FakeStorageRepository(),
+        recorder: recorder,
+        serviceBuilder: (code, {String? apiKey}) => chains[code],
+      );
+
+      // A mixed-country alert set with MANY stations per country — the grouping
+      // must still collapse to one provider round per country per scan. Ids
+      // carry the lowercase country prefix the registry derives country from.
+      await source.fetchPricesGrouped(stationIds: [
+        for (final c in polled)
+          for (var i = 1; i <= 3; i++) '${c.toLowerCase()}-$i',
+      ]);
+
+      // ≤ 1 network round per country per scan.
+      for (final c in polled) {
+        expect(priceCalls[c], 1,
+            reason: '$c provider hit exactly once for the whole scan');
+      }
+
+      // The recorder noted every provider's configured minInterval.
+      for (final c in polled) {
+        expect(recorder.configuredMinIntervalSec.containsKey(c), isTrue,
+            reason: '$c minInterval must be noted for the compliance check');
+      }
+
+      // No provider is judged non-compliant (one round/scan → compliant is
+      // null, which is the "nothing to fault" state; never false).
+      final trace = recorder.build();
+      for (final agg in trace.aggregates()) {
+        expect(agg.compliant, isNot(false),
+            reason: '${agg.country}|${agg.source} must not be non-compliant');
+        expect(agg.networkCount, lessThanOrEqualTo(1),
+            reason: '${agg.country} ≤ one network round per scan');
+      }
+    });
+
+    test('under the twice-daily cadence EVERY provider is compliant=true — '
+        'two scans 12h apart space each provider ≥ its minInterval', () {
+      // Two scans at the twice-daily cadence: re-stamp the recorded per-country
+      // network events 12h apart. 12h ≥ every provider minInterval (DE 1m, AT
+      // 1h, PT 1h, KR 1m, MX 4h), so each observed interval clears its budget.
+      const twiceDailySec = 12 * 3600.0;
+      final events = <DataAccessEvent>[];
+      final configured = <String, double>{};
+      for (var scan = 0; scan < 2; scan++) {
+        for (final c in polled) {
+          final minInterval = CountryServiceRegistry.policyFor(c)!.minInterval;
+          configured[c] = minInterval.inMicroseconds / 1e6;
+          events.add(DataAccessEvent(
+            at: DateTime.utc(2026, 1, 1).add(Duration(hours: 12 * scan)),
+            monotonicMicros: (scan * twiceDailySec * 1e6).round(),
+            country: c,
+            source: ServiceSource.tankerkoenigApi.name,
+            endpoint: DataAccessEndpoint.batchPrices,
+            hit: DataAccessHit.networkApi,
+          ));
+        }
+      }
+
+      final trace = DataAccessTrace(
+        capturedAt: DateTime.utc(2026, 1, 2),
+        events: events,
+        configuredMinIntervalSec: configured,
+      );
+
+      final aggs = trace.aggregates();
+      expect(aggs.length, polled.length);
+      for (final agg in aggs) {
+        expect(agg.networkCount, 2, reason: '${agg.country}: two scans');
+        expect(agg.compliant, isTrue,
+            reason: '${agg.country} observed interval ≥ minInterval under '
+                'the twice-daily cadence');
+      }
+    });
+  });
+
+  group('shared per-provider budget blocks a too-soon BG poll (#2866)', () {
+    test('a foreground hit within minInterval makes the BG scan skip that '
+        'provider — no network round; cache answers from the last fetch',
+        () async {
+      // Shared storage = ONE budget across foreground + background.
+      final storage = FakeStorageRepository();
+      final budget = ProviderRequestBudget(storage);
+      final recorder = DataAccessRecorder();
+      final priceCalls = <String, int>{};
+
+      // DE minInterval is 1 minute. Foreground just hit DE 1 second ago.
+      await budget.recordRequestAwait('DE',
+          now: DateTime.now().subtract(const Duration(seconds: 1)));
+
+      final chains = {
+        'DE': chainFor('DE', recorder, priceCalls, budget: budget),
+      };
+      final source = BackgroundPriceSource(
+        storage: storage,
+        recorder: recorder,
+        budget: budget,
+        serviceBuilder: (code, {String? apiKey}) => chains[code],
+      );
+
+      final prices = await source.fetchPricesGrouped(stationIds: ['de-1']);
+
+      // The BG scan must NOT fire — the foreground hit is within minInterval.
+      expect(priceCalls['DE'] ?? 0, 0,
+          reason: 'a too-soon BG poll is skipped by the shared budget');
+      expect(prices, isEmpty,
+          reason: 'no fresh prices this round — the foreground fetch holds');
+    });
+
+    test('a foreground hit OLDER than minInterval lets the BG scan fire',
+        () async {
+      final storage = FakeStorageRepository();
+      final budget = ProviderRequestBudget(storage);
+      final recorder = DataAccessRecorder();
+      final priceCalls = <String, int>{};
+
+      // DE last hit 2 minutes ago (> the 1-minute minInterval) → allowed.
+      await budget.recordRequestAwait('DE',
+          now: DateTime.now().subtract(const Duration(minutes: 2)));
+
+      final chains = {
+        'DE': chainFor('DE', recorder, priceCalls, budget: budget),
+      };
+      final source = BackgroundPriceSource(
+        storage: storage,
+        recorder: recorder,
+        budget: budget,
+        serviceBuilder: (code, {String? apiKey}) => chains[code],
+      );
+
+      await source.fetchPricesGrouped(stationIds: ['de-1']);
+      expect(priceCalls['DE'], 1,
+          reason: 'a stale-enough budget allows the BG poll');
+    });
+  });
+
+  group('ProviderRequestBudget', () {
+    test('canFire is true with no prior stamp, false within minInterval, '
+        'true once minInterval has elapsed', () {
+      final budget = ProviderRequestBudget(FakeStorageRepository());
+      const min = Duration(minutes: 1);
+      final now = DateTime.utc(2026, 1, 1, 12);
+
+      expect(budget.canFire('DE', min, now: now), isTrue,
+          reason: 'no stamp → always allowed');
+
+      budget.recordRequest('DE', now: now);
+      expect(budget.canFire('DE', min, now: now.add(const Duration(seconds: 30))),
+          isFalse,
+          reason: '30s < 1m → blocked');
+      expect(budget.canFire('DE', min, now: now.add(const Duration(minutes: 2))),
+          isTrue,
+          reason: '2m ≥ 1m → allowed');
+    });
+
+    test('a null / zero minInterval is never throttled', () {
+      final budget = ProviderRequestBudget(FakeStorageRepository());
+      budget.recordRequest('DE');
+      expect(budget.canFire('DE', null), isTrue);
+      expect(budget.canFire('DE', Duration.zero), isTrue);
+    });
+  });
+}
+
+/// Counting fake primary: records how many `getPrices` rounds it served per
+/// country and returns canned prices so the wrapping [StationServiceChain]
+/// records a `networkApi` event the recorder can aggregate.
+class _CountingPrimary implements StationService {
+  _CountingPrimary(this.code, this.priceCalls);
+
+  final String code;
+  final Map<String, int> priceCalls;
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+      List<String> ids) async {
+    priceCalls[code] = (priceCalls[code] ?? 0) + 1;
+    return ServiceResult(
+      data: {
+        for (final id in ids)
+          id: const StationPrices(e5: 1.5, e10: 1.4, diesel: 1.6, status: 'open'),
+      },
+      source: ServiceSource.tankerkoenigApi,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async =>
+      ServiceResult(
+        data: const [],
+        source: ServiceSource.tankerkoenigApi,
+        fetchedAt: DateTime(2026),
+      );
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -84,7 +84,11 @@ void main() {
     // so the foreground (buildService) and the WorkManager background isolate
     // (buildBackgroundService) share ONE construction path. Snapshot lowered
     // to keep the debt baseline honest.
-    'lib/core/services/country_service_registry.dart': 852,
+    // #2866 — re-grandfathered 852 → 857: both construction paths now thread the
+    // shared #2866 ProviderRequestBudget (import + one param + two call-site
+    // args) so foreground + background share ONE per-provider minInterval gate.
+    // Decomposing this god-class is tracked separately (#2187/#2188/#2190).
+    'lib/core/services/country_service_registry.dart': 857,
     'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
     // #2456 — re-grandfathered 457 → 481: two new pure parsers,


### PR DESCRIPTION
Epic #2860 **EXIT GATE** (child #2866): rate-limit / ToS guardrails for the now-multi-country background alert scan, so child #2865 can remove the DE-only gate.

## What changed

1. **Twice-daily cadence (the core ToS safeguard).** The WorkManager periodic alert/price scan now runs ~every 12h (`BackgroundService.refreshInterval`). The 30-min charging task was **dropped** (it would let a multi-country scan hit a provider far more than twice a day) — one battery-aware twice-daily task. iOS BGAppRefresh is unchanged (already OS-budgeted, best-effort — no SLA claim without the deferred Tier-2 push).

2. **#2824 tracer in the BG isolate.** A dev-gated `DataAccessRecorder` is threaded through the scan path (`BackgroundPriceSource` / `CountryAlertStrategyResolver` → per-country chains + bulk strategies) via `buildBackgroundService(recorder:)`, so the multi-country scan's background traffic is finally counted (it previously only saw main-isolate traffic). A new `BackgroundScanTracer` builds + exports the trace to Downloads when developer mode is on (reads the `feature_flags` box, now opened in the isolate).

3. **Shared per-provider budget.** New `ProviderRequestBudget` keeps a per-country last-request stamp in the shared Hive settings, stamped by `StationServiceChain` on every `networkApi` hit (foreground **and** background) and consulted by the BG `PolledAlertStrategy` before firing — the scan will not re-poll a provider the foreground hit within its `minInterval`. One budget across both isolates. Combined with the once-per-country-per-scan grouping (foundation #2862), every provider is bounded to its policy.

4. **429/Retry-After backoff** is already surfaced from the isolate via the #2255 `RateLimitInterceptor` baked into every `DioFactory`-built client (incl. the BG Tankerkönig Dio) — the chain raises `ApiException.retryAfter` instead of swallowing it.

## Acceptance gate (the epic's exit test)

`test/core/background/bg_scan_compliance_gate_test.dart`:
- drives a simulated multi-country scan (DE/AT/PT/KR/MX) through the **real** BG path with the tracer attached → each provider hit **≤1 network round per country per scan**, the recorder **notes every minInterval**, and **no provider is `compliant == false`**;
- a two-scan trace at the twice-daily cadence asserts `DataAccessTrace.aggregates()` reports **`compliant == true` for EVERY provider** (observed interval ≥ each provider's configured minInterval);
- the **shared budget** blocks a too-soon BG poll after a foreground hit (and allows it once the interval elapses);
- `ProviderRequestBudget` unit coverage (gate open/closed/elapsed, null/zero interval).

## Verification
- `flutter analyze` clean (only 2 pre-existing unrelated info warnings in consumption test files).
- Green: `test/core/background`, `test/core/services/diagnostics`, `test/core/storage`, `test/features/alerts`, and the lint guards (`file_length`, `no_hardcoded_ui_strings`, `catch_block_stacktrace_coverage`, `never_throws_contract`, `docs/new_country_guide`).
- No ARB strings added. Clean codegen — no `*.g.dart`/`*.freezed.dart` drift.
- `country_service_registry.dart` (grandfathered god-class) snapshot re-grandfathered 852 → 857 for the shared-budget wiring (decomposition tracked by #2187/#2188/#2190); coordinator kept ≤400.

Closes #2866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
