### PR TITLE
fix(route): reject degenerate (0,0) GPS fixes so the route origin/map can't land in the Sahara (#2872)

### DIFF
--- a/lib/core/location/location_service.dart
+++ b/lib/core/location/location_service.dart
@@ -4,6 +4,7 @@
 import 'package:geolocator/geolocator.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../error/exceptions.dart';
+import '../utils/geo_utils.dart';
 import 'geolocator_wrapper.dart';
 
 part 'location_service.g.dart';
@@ -45,12 +46,29 @@ class LocationService {
       );
     }
 
-    return await _geolocator.getCurrentPosition(
+    final position = await _geolocator.getCurrentPosition(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.high,
         timeLimit: Duration(seconds: 10),
       ),
     );
+
+    // #2872 — a degenerate fix ((0,0), a one-axis-unacquired (lat,0), or a
+    // NaN/Inf axis) is NOT a real position: it slips past every downstream
+    // station/distance guard and poisons the route origin so OSRM routes
+    // from the Gulf of Guinea and the route map centres in the Sahara.
+    // Reject it at this single acquisition chokepoint so both the route
+    // start (RouteInput._useGpsForStart) and searchByGps surface the
+    // existing "could not determine your location" error instead of
+    // storing/using it. English diagnostic per the exceptions.dart
+    // contract — ErrorLocalizer maps LocationException → errorLocation.
+    if (!isUsableCoord(position.latitude, position.longitude)) {
+      throw const LocationException(
+        message: 'Degenerate GPS fix (unacquired or null-island coordinate).',
+      );
+    }
+
+    return position;
   }
 
   double distanceBetween(

--- a/lib/core/utils/geo_utils.dart
+++ b/lib/core/utils/geo_utils.dart
@@ -10,6 +10,40 @@ import 'package:latlong2/latlong.dart';
 /// a named constant so the metre formula has one source (#2169).
 const double earthRadiusMeters = 6371000.0;
 
+/// Whether [lat]/[lng] is a real, usable coordinate fit to drive routing,
+/// the route origin, or a persisted user position (#2872).
+///
+/// A coordinate is usable when it is finite, in range
+/// (`|lat| <= 90`, `|lng| <= 180`), and NOT a degenerate GPS fix. The
+/// degenerate shapes the issue calls out are:
+///   * `(0,0)` — the "null island" sentinel the rest of the geo layer
+///     already treats as "unset" (see [distanceKm]'s short-circuit and
+///     the per-country parser guards);
+///   * a one-axis-unacquired `(lat,0)` / `(0,lng)` — a fix where the
+///     device returned one axis but the other is still exactly `0`;
+///   * a `NaN`/`Inf` axis.
+///
+/// Any of these slipping into the route origin makes OSRM route from the
+/// Gulf of Guinea so the polyline + bounds span 0°N..42°N and the route
+/// map centres in the Sahara. Rejecting them here, at the GPS-*acquisition*
+/// boundary the existing station/distance guards never covered, is the fix.
+///
+/// ## Why an *exact* `0.0` axis is rejected
+/// A real GNSS fix reports each axis to many decimal places; an axis that
+/// is *exactly* `0.0` is the unacquired-axis sentinel, not a genuine point
+/// on the equator / prime meridian. The vanishingly rare legitimate point
+/// that lands on `lat == 0` or `lng == 0` to full float precision is a
+/// worthwhile trade for never letting a half-acquired fix poison routing —
+/// nudging it by a metre yields a usable coordinate. Callers that need a
+/// real distance through a genuine `(0,…)` point use [distanceMeters],
+/// which has no such guard.
+bool isUsableCoord(double lat, double lng) {
+  if (!lat.isFinite || !lng.isFinite) return false;
+  if (lat == 0 || lng == 0) return false;
+  if (lat.abs() > 90 || lng.abs() > 180) return false;
+  return true;
+}
+
 /// Haversine distance between two coordinates in kilometers.
 ///
 /// Short-circuits a `(0,0)` endpoint to `0` — an unset coordinate is

--- a/lib/features/route_search/presentation/widgets/route_input.dart
+++ b/lib/features/route_search/presentation/widgets/route_input.dart
@@ -7,11 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../../core/error/exceptions.dart';
 import '../../../../core/location/location_service.dart';
 import '../../../../core/logging/error_logger.dart';
 import '../../../../core/services/location_search_provider.dart';
 import '../../../../core/services/location_search_service.dart';
 import '../../../../core/utils/frame_callbacks.dart';
+import '../../../../core/utils/geo_utils.dart';
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/entities/route_info.dart';
@@ -95,6 +97,16 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
       final locationService = ref.read(locationServiceProvider);
       final position = await locationService.getCurrentPosition();
       if (!mounted) return;
+      // #2872 — defence-in-depth behind getCurrentPosition's own guard:
+      // never seed the route start from a degenerate fix. A (0,0)/(lat,0)
+      // origin makes OSRM route from the Gulf of Guinea and centres the
+      // route map in the Sahara. Fall through to the manual-entry / GPS
+      // error path instead of calling setStartCoords.
+      if (!isUsableCoord(position.latitude, position.longitude)) {
+        throw const LocationException(
+          message: 'Degenerate GPS fix; ask the user for a manual start.',
+        );
+      }
       final coords = LatLng(position.latitude, position.longitude);
       ref.read(routeInputControllerProvider.notifier).setStartCoords(coords);
       final l10n = AppLocalizations.of(context);
@@ -193,7 +205,15 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
         }
       }
 
-      if (startCoords == null || endCoords == null) {
+      // #2872 — a required endpoint that is missing OR degenerate ((0,0),
+      // a one-axis-unacquired (lat,0), or out-of-range) must not reach
+      // OSRM: it would route from the Gulf of Guinea and centre the route
+      // map in the Sahara. Treat an unusable start/destination exactly
+      // like an unresolved one and ask the user for a manual entry.
+      if (startCoords == null ||
+          endCoords == null ||
+          !isUsableCoord(startCoords.latitude, startCoords.longitude) ||
+          !isUsableCoord(endCoords.latitude, endCoords.longitude)) {
         if (mounted) {
           SnackBarHelper.showError(
               context,
@@ -209,8 +229,13 @@ class RouteInputWidgetState extends ConsumerState<RouteInput> {
           lng: startCoords.longitude,
           label: _startController.text,
         ),
+        // #2872 — silently drop a degenerate optional stop (a Nominatim
+        // geocode that fell back to (lat,0) via the `?? 0` default) rather
+        // than letting it bend the route to null island. Start/end are the
+        // anchors and are already validated above.
         for (var i = 0; i < stopCoords.length; i++)
-          if (stopCoords[i] != null)
+          if (stopCoords[i] != null &&
+              isUsableCoord(stopCoords[i]!.latitude, stopCoords[i]!.longitude))
             RouteWaypoint(
               lat: stopCoords[i]!.latitude,
               lng: stopCoords[i]!.longitude,

--- a/lib/features/route_search/providers/route_search_provider.dart
+++ b/lib/features/route_search/providers/route_search_provider.dart
@@ -11,6 +11,7 @@ import '../../../core/error/exceptions.dart';
 import '../../../core/logging/error_logger.dart';
 import '../../../core/country/country_bounding_box.dart';
 import '../../../core/country/country_provider.dart';
+import '../../../core/utils/geo_utils.dart';
 import '../../../core/utils/station_extensions.dart';
 import '../../profile/data/models/user_profile.dart';
 import '../../search/providers/ev_charging_service_provider.dart';
@@ -54,6 +55,19 @@ class RouteSearchState extends _$RouteSearchState {
   }) async {
     state = const AsyncValue.loading();
     try {
+      // #2872 — last-line guard before routing: drop degenerate waypoints
+      // ((0,0)/(lat,0) GPS or a `?? 0`-fallback geocode) so OSRM can't
+      // route from the Gulf of Guinea and centre the route map in the
+      // Sahara. < 2 usable → throw so the UI asks for a manual start.
+      final usableWaypoints =
+          waypoints.where((w) => isUsableCoord(w.lat, w.lng)).toList();
+      if (usableWaypoints.length < 2) {
+        throw const LocationException(
+          message: 'Route needs two usable waypoints; '
+              'a degenerate GPS/geocode origin was rejected.',
+        );
+      }
+
       // 1. Get route from OSRM
       final profile = ref.read(activeProfileProvider);
       final avoidHighways = profile?.avoidHighways ?? false;
@@ -64,8 +78,8 @@ class RouteSearchState extends _$RouteSearchState {
       final criterion =
           profile?.routeSearchCriterion ?? RouteSearchCriterion.cheapest;
       final routingService = RoutingService();
-      debugPrint('RouteSearch: fetching route for ${waypoints.length} waypoints, avoidHighways=$avoidHighways, strategy=${strategyType.key}');
-      final routeResult = await routingService.getRoute(waypoints, avoidHighways: avoidHighways);
+      debugPrint('RouteSearch: fetching route for ${usableWaypoints.length} waypoints, avoidHighways=$avoidHighways, strategy=${strategyType.key}');
+      final routeResult = await routingService.getRoute(usableWaypoints, avoidHighways: avoidHighways);
       final route = routeResult.data;
       debugPrint('RouteSearch: route=${route.distanceKm.round()}km, ${route.geometry.length} polyline pts, ${route.samplePoints.length} sample pts');
 

--- a/lib/features/route_search/providers/route_search_provider.g.dart
+++ b/lib/features/route_search/providers/route_search_provider.g.dart
@@ -59,7 +59,7 @@ final class RouteSearchStateProvider
   }
 }
 
-String _$routeSearchStateHash() => r'd02ed4be94adbfe023265e9aab82d49aca188143';
+String _$routeSearchStateHash() => r'0f71955333c1aceeec41a9f0b7e4da72a4dc407f';
 
 /// Orchestrates "cheapest stations along my route" feature.
 ///

--- a/lib/features/search/providers/search_provider.dart
+++ b/lib/features/search/providers/search_provider.dart
@@ -3,11 +3,13 @@
 
 import 'package:dio/dio.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../../core/error/exceptions.dart';
 import '../../../core/location/location_service.dart';
 import '../../../core/telemetry/collectors/app_state_collector.dart';
 import '../../../core/location/user_position_provider.dart';
 import '../../../core/services/service_providers.dart';
 import '../../../core/services/service_result.dart';
+import '../../../core/utils/geo_utils.dart';
 import '../data/models/search_params.dart';
 import '../domain/entities/fuel_type.dart';
 import '../domain/entities/search_result_item.dart';
@@ -152,6 +154,17 @@ class SearchState extends _$SearchState {
       final position =
           await ref.read(locationServiceProvider).getCurrentPosition();
       if (!ref.mounted) return;
+      // #2872 — defence-in-depth behind getCurrentPosition's own guard:
+      // never persist a degenerate fix ((0,0)/(lat,0)) to
+      // userPositionProvider — a poisoned user position would later seed a
+      // route origin in the Gulf of Guinea. Surface the same "could not
+      // determine your location" error (LocationException → errorLocation)
+      // instead of storing it.
+      if (!isUsableCoord(position.latitude, position.longitude)) {
+        throw const LocationException(
+          message: 'Degenerate GPS fix; refusing to search from null island.',
+        );
+      }
       ref.read(userPositionProvider.notifier).setFromGps(
             position.latitude, position.longitude,
           );

--- a/lib/features/search/providers/search_provider.g.dart
+++ b/lib/features/search/providers/search_provider.g.dart
@@ -95,7 +95,7 @@ final class SearchStateProvider
   }
 }
 
-String _$searchStateHash() => r'a05a777ffe420446af10c6b8b7376574a99b0d41';
+String _$searchStateHash() => r'c15b74880eab8ce5dd33beb2c1e31d125bc513c4';
 
 /// Manages the station search lifecycle and exposes results as [AsyncValue].
 ///

--- a/test/core/location/location_service_test.dart
+++ b/test/core/location/location_service_test.dart
@@ -90,6 +90,55 @@ void main() {
       );
     });
 
+    // #2872 — a degenerate fix that slips through the platform must be
+    // rejected at this single acquisition chokepoint so it can never seed
+    // the route origin (→ OSRM routes from the Gulf of Guinea → the route
+    // map centres in the Sahara) nor be persisted as the user position.
+    Position degenerate(double lat, double lng) => Position(
+          latitude: lat,
+          longitude: lng,
+          timestamp: DateTime.now(),
+          accuracy: 10,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          headingAccuracy: 0,
+          speed: 0,
+          speedAccuracy: 0,
+        );
+
+    test('throws on a (0,0) null-island fix (#2872)', () {
+      fakeGeolocator.positionToReturn = degenerate(0, 0);
+      expect(
+        () => service.getCurrentPosition(),
+        throwsA(isA<LocationException>()),
+      );
+    });
+
+    test('throws on a one-axis-unacquired (lat,0) fix (#2872)', () {
+      fakeGeolocator.positionToReturn = degenerate(42.7, 0);
+      expect(
+        () => service.getCurrentPosition(),
+        throwsA(isA<LocationException>()),
+      );
+    });
+
+    test('throws on a one-axis-unacquired (0,lng) fix (#2872)', () {
+      fakeGeolocator.positionToReturn = degenerate(0, 2.86);
+      expect(
+        () => service.getCurrentPosition(),
+        throwsA(isA<LocationException>()),
+      );
+    });
+
+    test('returns a valid France fix unchanged — no regression (#2872)',
+        () async {
+      fakeGeolocator.positionToReturn = degenerate(42.7667, 2.8667);
+      final position = await service.getCurrentPosition();
+      expect(position.latitude, closeTo(42.7667, 0.0001));
+      expect(position.longitude, closeTo(2.8667, 0.0001));
+    });
+
     test('throws when permission permanently denied', () {
       fakeGeolocator.permission = LocationPermission.deniedForever;
       expect(

--- a/test/core/utils/geo_utils_test.dart
+++ b/test/core/utils/geo_utils_test.dart
@@ -65,6 +65,56 @@ void main() {
     });
   });
 
+  group('isUsableCoord (#2872 — degenerate GPS guard)', () {
+    test('a valid France point is usable', () {
+      // Rivesaltes (the real-report origin, near the ES/FR border).
+      expect(isUsableCoord(42.7667, 2.8667), isTrue);
+    });
+
+    test('a valid southern-hemisphere point is usable', () {
+      expect(isUsableCoord(-33.8688, 151.2093), isTrue); // Sydney
+    });
+
+    test('the (0,0) null-island sentinel is NOT usable', () {
+      expect(isUsableCoord(0, 0), isFalse);
+    });
+
+    test('a one-axis-unacquired (lat,0) fix is NOT usable', () {
+      // The Sahara/Gulf-of-Guinea poisoner: latitude acquired, longitude
+      // still 0 — the exact shape the route origin must never accept.
+      expect(isUsableCoord(42.7, 0), isFalse);
+    });
+
+    test('a one-axis-unacquired (0,lng) fix is NOT usable', () {
+      expect(isUsableCoord(0, 2.86), isFalse);
+    });
+
+    test('a NaN axis is NOT usable', () {
+      expect(isUsableCoord(double.nan, 2.86), isFalse);
+      expect(isUsableCoord(42.7, double.nan), isFalse);
+    });
+
+    test('an infinite axis is NOT usable', () {
+      expect(isUsableCoord(double.infinity, 2.86), isFalse);
+      expect(isUsableCoord(42.7, double.negativeInfinity), isFalse);
+    });
+
+    test('an out-of-range latitude is NOT usable', () {
+      expect(isUsableCoord(90.5, 2.86), isFalse);
+      expect(isUsableCoord(-91, 2.86), isFalse);
+    });
+
+    test('an out-of-range longitude is NOT usable', () {
+      expect(isUsableCoord(42.7, 180.5), isFalse);
+      expect(isUsableCoord(42.7, -181), isFalse);
+    });
+
+    test('the antimeridian / poles (in-range extremes) ARE usable', () {
+      expect(isUsableCoord(90, 180), isTrue);
+      expect(isUsableCoord(-90, -180), isTrue);
+    });
+  });
+
   group('distanceMeters (#2169 — shared metre haversine)', () {
     test('Berlin to Paris is approximately 878 km', () {
       final m = distanceMeters(52.5200, 13.4050, 48.8566, 2.3522);

--- a/test/features/route_search/providers/route_search_error_logging_test.dart
+++ b/test/features/route_search/providers/route_search_error_logging_test.dart
@@ -19,10 +19,11 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// only write `AsyncValue.error`.
 ///
 /// The OSRM `RoutingService` is constructed internally and not
-/// injectable, but `getRoute` throws `ApiException` SYNCHRONOUSLY (before
-/// any network call) when fewer than 2 waypoints are supplied — which
-/// lands in the `on AppException` outer catch. That gives a deterministic,
-/// network-free way to exercise the breadcrumb.
+/// injectable, but the notifier rejects fewer than 2 usable waypoints
+/// SYNCHRONOUSLY (before any network call) — the #2872 degenerate-origin
+/// guard throws a `LocationException` (an `AppException`) that lands in the
+/// `on AppException` outer catch. That gives a deterministic, network-free
+/// way to exercise the breadcrumb.
 class _FakeTraceRecorder implements TraceRecorder {
   final calls = <Object>[];
 
@@ -72,8 +73,9 @@ void main() {
 
     final notifier = container.read(routeSearchStateProvider.notifier);
 
-    // A single waypoint trips `getRoute`'s `waypoints.length < 2` guard,
-    // which throws ApiException (an AppException) synchronously.
+    // A single waypoint leaves < 2 usable waypoints, which the #2872 guard
+    // rejects with a LocationException (an AppException) synchronously,
+    // before any OSRM call.
     await notifier.searchAlongRoute(
       waypoints: const [
         RouteWaypoint(lat: 52.52, lng: 13.41, label: 'Berlin'),
@@ -93,6 +95,67 @@ void main() {
     expect(ctx.layer, ErrorLayer.providers);
     expect(ctx.context, contains('where'));
     expect(ctx.context!['where'], 'RouteSearchState.searchAlongRoute');
-    expect(ctx.inner, isA<ApiException>());
+    expect(ctx.inner, isA<LocationException>());
+  });
+
+  // #2872 — a degenerate origin ((0,0) / a one-axis-unacquired (lat,0))
+  // must be rejected BEFORE the OSRM fetch so the route never starts from
+  // the Gulf of Guinea and the route map can't centre in the Sahara. With
+  // only one usable waypoint left, the guard throws a LocationException
+  // (NOT a network/ApiException) — i.e. it asks for a manual start rather
+  // than routing through null island.
+  test(
+      'searchAlongRoute rejects a degenerate origin before OSRM with a '
+      'LocationException (#2872)', () async {
+    final container = ProviderContainer(
+      overrides: [
+        activeProfileProvider.overrideWith(_NullActiveProfile.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(routeSearchStateProvider.notifier);
+
+    // A (0,0) origin paired with a real Catalonia destination: exactly the
+    // real-report shape. The origin is dropped, leaving < 2 usable
+    // waypoints, so no OSRM request is ever built.
+    await notifier.searchAlongRoute(
+      waypoints: const [
+        RouteWaypoint(lat: 0, lng: 0, label: 'GPS'),
+        RouteWaypoint(lat: 42.43, lng: 2.86, label: 'Catalonia'),
+      ],
+      fuelType: FuelType.e10,
+    );
+
+    final state = container.read(routeSearchStateProvider);
+    expect(state.hasError, isTrue);
+    expect(state.error, isA<LocationException>(),
+        reason: 'a degenerate origin must be rejected as a location error, '
+            'not reach OSRM and fail as a network/ApiException');
+  });
+
+  test(
+      'searchAlongRoute also rejects a one-axis-unacquired (lat,0) origin '
+      'before OSRM (#2872)', () async {
+    final container = ProviderContainer(
+      overrides: [
+        activeProfileProvider.overrideWith(_NullActiveProfile.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(routeSearchStateProvider.notifier);
+
+    await notifier.searchAlongRoute(
+      waypoints: const [
+        RouteWaypoint(lat: 42.7, lng: 0, label: 'GPS'),
+        RouteWaypoint(lat: 42.43, lng: 2.86, label: 'Catalonia'),
+      ],
+      fuelType: FuelType.e10,
+    );
+
+    final state = container.read(routeSearchStateProvider);
+    expect(state.hasError, isTrue);
+    expect(state.error, isA<LocationException>());
   });
 }

--- a/test/features/search/providers/search_provider_test.dart
+++ b/test/features/search/providers/search_provider_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/error/exceptions.dart';
+import 'package:tankstellen/core/location/geolocator_wrapper.dart';
 import 'package:tankstellen/core/location/location_service.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
@@ -42,6 +43,45 @@ class _FixedUserPosition extends UserPosition {
 
   @override
   UserPositionData? build() => _data;
+}
+
+/// #2872 — records every `setFromGps` so a test can assert that a
+/// degenerate fix is NEVER persisted as the user position.
+class _SpyUserPosition extends UserPosition {
+  final List<({double lat, double lng})> persisted = [];
+
+  @override
+  UserPositionData? build() => null;
+
+  @override
+  void setFromGps(double lat, double lng) {
+    persisted.add((lat: lat, lng: lng));
+    super.setFromGps(lat, lng);
+  }
+}
+
+/// #2872 — a fake [GeolocatorWrapper] that hands back a caller-chosen fix
+/// (e.g. the degenerate (0,0)/(lat,0)) through the REAL [LocationService]
+/// acquisition chokepoint, so the search path exercises the production
+/// guard rather than a mock that bypasses it.
+class _FakeGeolocatorWrapper extends GeolocatorWrapper {
+  _FakeGeolocatorWrapper(this._position);
+  final Position _position;
+
+  @override
+  Future<bool> isLocationServiceEnabled() async => true;
+
+  @override
+  Future<LocationPermission> checkPermission() async =>
+      LocationPermission.whileInUse;
+
+  @override
+  Future<LocationPermission> requestPermission() async =>
+      LocationPermission.whileInUse;
+
+  @override
+  Future<Position> getCurrentPosition({LocationSettings? locationSettings}) async =>
+      _position;
 }
 
 /// EV fake that returns one charging station, so unified-search tests
@@ -1069,6 +1109,96 @@ void main() {
       ));
 
       await expectLater(searchFuture, completes);
+    });
+  });
+
+  group('searchByGps — degenerate-fix guard (#2872)', () {
+    Position fix(double lat, double lng) => Position(
+          latitude: lat,
+          longitude: lng,
+          timestamp: DateTime.now(),
+          accuracy: 5.0,
+          altitude: 0.0,
+          altitudeAccuracy: 0.0,
+          heading: 0.0,
+          headingAccuracy: 0.0,
+          speed: 0.0,
+          speedAccuracy: 0.0,
+        );
+
+    /// Wires the REAL [LocationService] to a fake [GeolocatorWrapper] that
+    /// returns [position], plus a spy [UserPosition], so a search exercises
+    /// the production acquisition guard end-to-end.
+    ({ProviderContainer container, _SpyUserPosition spy}) containerFor(
+      Position position,
+    ) {
+      final spy = _SpyUserPosition();
+      final c = ProviderContainer(overrides: [
+        hiveStorageProvider.overrideWithValue(fakeStorage),
+        stationServiceProvider.overrideWithValue(mockStationService),
+        geocodingChainProvider.overrideWithValue(mockGeocoding),
+        geolocatorWrapperProvider
+            .overrideWithValue(_FakeGeolocatorWrapper(position)),
+        userPositionProvider.overrideWith(() => spy),
+      ]);
+      addTearDown(c.dispose);
+      return (container: c, spy: spy);
+    }
+
+    void stubStation() {
+      when(() => mockStationService.searchStations(any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: [testStation],
+                source: ServiceSource.tankerkoenigApi,
+                fetchedAt: DateTime.now(),
+              ));
+    }
+
+    test('a (0,0) fix surfaces an error and is NOT persisted', () async {
+      stubStation();
+      final t = containerFor(fix(0, 0));
+
+      await t.container.read(searchStateProvider.notifier).searchByGps();
+
+      expect(t.container.read(searchStateProvider), isA<AsyncError>());
+      expect(t.spy.persisted, isEmpty,
+          reason: 'a null-island fix must never reach userPositionProvider');
+      verifyNever(() => mockStationService.searchStations(any(),
+          cancelToken: any(named: 'cancelToken')));
+    });
+
+    test('a one-axis-unacquired (lat,0) fix surfaces an error and is NOT '
+        'persisted', () async {
+      stubStation();
+      final t = containerFor(fix(42.7, 0));
+
+      await t.container.read(searchStateProvider.notifier).searchByGps();
+
+      expect(t.container.read(searchStateProvider), isA<AsyncError>());
+      expect(t.spy.persisted, isEmpty);
+      verifyNever(() => mockStationService.searchStations(any(),
+          cancelToken: any(named: 'cancelToken')));
+    });
+
+    test('a valid France fix persists the position and searches — no '
+        'regression', () async {
+      stubStation();
+      when(() => mockGeocoding.coordinatesToAddress(any(), any(),
+              cancelToken: any(named: 'cancelToken')))
+          .thenAnswer((_) async => ServiceResult(
+                data: 'Rivesaltes',
+                source: ServiceSource.nominatimGeocoding,
+                fetchedAt: DateTime.now(),
+              ));
+      final t = containerFor(fix(42.7667, 2.8667));
+
+      await t.container.read(searchStateProvider.notifier).searchByGps();
+
+      expect(t.container.read(searchStateProvider), isA<AsyncData>());
+      expect(t.spy.persisted, hasLength(1));
+      expect(t.spy.persisted.single.lat, closeTo(42.7667, 0.0001));
+      expect(t.spy.persisted.single.lng, closeTo(2.8667, 0.0001));
     });
   });
 


### PR DESCRIPTION
## Problem (#2872)

Real cross-border ES+FR report: the route map's 'Votre position' dot rendered in the Sahara (~Mali) while the stations + the 305 km 'Meilleurs arrêts' route were on the Catalonia border; the SEARCH list had the correct GPS (Rivesaltes 3.2 km).

**Root cause:** a degenerate GPS fix — `(0,0)`, or a one-axis-unacquired `(lat,0)`/`(0,lng)` — entered the ROUTE ORIGIN unguarded. The entire station/distance layer already filters `(0,0)` (`geo_utils.distanceKm` short-circuit, per-country parser guards), but the GPS-ACQUISITION boundaries had no coordinate-validity gate. So the bad coord survived only where it bypassed those guards: the route geometry/origin → OSRM routed from `(0,0)` → the polyline + `_routeBounds` spanned 0°N..42°N → the route map's centre marker (`widget.center` = `_routeBounds.center`) rendered at ~17-21°N/~0°E = the Sahara. The search list stayed correct because it uses the persisted `userPosition` + the guarded `distanceKm`.

## Fix

A shared `isUsableCoord(lat, lng)` in `geo_utils.dart` (finite + in-range + not a degenerate `(0,0)`/`(lat,0)`/`(0,lng)` sentinel), applied at every GPS-acquisition boundary:

- **`LocationService.getCurrentPosition`** — the single chokepoint: throw a `LocationException` on a degenerate fix, so BOTH `RouteInput._useGpsForStart` and `searchByGps` surface the existing 'could not determine your location' error. `ErrorLocalizer` already maps `LocationException → errorLocation`, so **no new ARB key is needed**.
- **`RouteInput._useGpsForStart`** — defence-in-depth: never `setStartCoords` from a degenerate fix; fall through to the manual-entry/snackbar path.
- **`RouteInput.resolveAndSearch`** — reject a degenerate required start/destination (treat like unresolved → 'could not resolve') and silently drop a degenerate optional stop. This also covers the secondary path: a Nominatim geocode that returned `(lat,0)` via the `?? 0` fallback at `location_search_service.dart`.
- **`RouteSearchState.searchAlongRoute`** — last-line guard: filter waypoints through `isUsableCoord` before constructing `RoutingService`; < 2 usable waypoints throws a `LocationException` so a bad origin can never reach OSRM.
- **`searchByGps`** — defence-in-depth: never persist a degenerate fix to `userPositionProvider`; surface the same location error instead.

Valid fixes are unchanged.

### Note on the exact-zero-axis rule
A real GNSS fix reports each axis to many decimals; an axis that is *exactly* `0.0` is the unacquired-axis sentinel, not a genuine equator/prime-meridian point. `isUsableCoord` therefore rejects any exactly-zero axis — matching the issue's `(lat,0)` degenerate case and the agreed test table. Callers needing a real distance through a genuine `(0,…)` point use `distanceMeters`, which has no such guard.

## Tests (RED-first, real paths)
- `isUsableCoord` unit table: valid FR point true; `(0,0)`/`(lat,0)`/`(0,lng)`/NaN/Inf/out-of-range false; in-range poles/antimeridian true.
- `LocationService` rejects `(0,0)`/`(lat,0)`/`(0,lng)` with `LocationException`; passes a valid FR fix unchanged.
- `searchByGps` driven through the **REAL** `LocationService` + a fake `GeolocatorWrapper`: a degenerate fix surfaces an error and is **never** persisted to `userPositionProvider` (spy asserts zero writes); a valid FR fix persists + searches.
- `searchAlongRoute` rejects a degenerate origin (`(0,0)` and `(lat,0)`) with a `LocationException` **before any OSRM call** (not a network/`ApiException`).
- Existing #2308 breadcrumb test updated (the < 2-usable-waypoint case now throws `LocationException`, still logged).

`flutter analyze` clean; full route_search + search + location + core/utils + map route-view suites green (1520 tests); file_length / no_hardcoded_ui_strings / catch_block_stacktrace / never_throws lint guards green. Clean codegen committed.

Closes #2872

🤖 Generated with [Claude Code](https://claude.com/claude-code)