### PR TITLE
fix(telemetry): de-noise the benign FAB re-open suppression (error-log #21) (#2874)

### DIFF
--- a/lib/app/shell/search_fab_tap.dart
+++ b/lib/app/shell/search_fab_tap.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/logging/error_logger.dart';
+import '../../core/telemetry/collectors/breadcrumb_collector.dart';
+import '../../features/route_search/providers/route_search_provider.dart';
+import '../../features/search/presentation/screens/search_criteria_screen.dart';
+import '../../features/search/providers/search_provider.dart';
+import '../routes/shell_branches.dart';
+
+/// Centre-FAB tap routing for [ShellBottomBar], extracted to keep that widget
+/// under the 400-line cap (#1680). The bar owns the look; this owns where a
+/// tap goes (navigation + telemetry).
+
+/// Push the search-criteria modal onto the **Search branch's** nested
+/// Navigator (via [searchBranchNavigatorKey]) rather than the root one — the
+/// root push covered the shell + bottom bar and hid the FAB mid-flow (#2131).
+/// Switches to the Search branch first so the modal lands on the visible
+/// branch.
+void openSearchCriteriaOnBranch({
+  required int slot,
+  required int currentIndex,
+  required ValueChanged<int> onTap,
+}) {
+  if (slot != currentIndex) onTap(slot);
+  final searchNav = searchBranchNavigatorKey.currentState;
+  if (searchNav == null) {
+    // #2811 — branch nav unmounted (early frame / unwired test). Do NOT
+    // root-push here: from the bar's context `Navigator.of(context)` is the
+    // ROOT navigator, and a fullscreen route there covers the whole shell —
+    // bar included — stranding it until restart if orphaned. Degrade to a
+    // branch jump, and trace it (a missing nav on a user tap is abnormal).
+    unawaited(errorLogger.log(
+      ErrorLayer.ui,
+      'search branch navigator not mounted on FAB tap — degraded to '
+          'branch jump (no root push)',
+      StackTrace.current,
+      context: {'source': 'openCriteriaOnSearchBranch', 'branch': slot},
+    ));
+    onTap(slot);
+    return;
+  }
+  // #2810 — refuse to stack a duplicate criteria modal: the FAB stays visible
+  // while it is open (branch-push keeps the shell mounted), so a repeat tap
+  // would push a second copy ("search just re-opens the same form again and
+  // again"). Bail if it is already current.
+  if (searchCriteriaRouteIsCurrent(searchNav)) {
+    // #2874 — re-tapping the FAB while the criteria sheet is already open is an
+    // EXPECTED no-op, not a fault: spooling it at [ErrorLayer.ui] surfaced it
+    // in the user-facing error log (error-log #21). Keep the #2810 diagnostic
+    // trail as a breadcrumb so it attaches to any LATER genuine trace instead
+    // of standing alone as a phantom ERROR.
+    BreadcrumbCollector.add(
+      'search criteria re-open suppressed (already current)',
+      detail: 'openCriteriaOnSearchBranch branch=$slot',
+    );
+    return;
+  }
+  searchNav.push<void>(
+    MaterialPageRoute<void>(
+      builder: (_) => const SearchCriteriaScreen(),
+      fullscreenDialog: true,
+      settings: const RouteSettings(name: kSearchCriteriaRouteName),
+    ),
+  );
+}
+
+/// Default centre-FAB behaviour (#2113), the three-branch matrix:
+///   1. On the Search branch → open the criteria modal to refine.
+///   2. On another branch WITH live results → switch to Search.
+///   3. On another branch with NO results → open criteria directly.
+///
+/// A registered [SearchFabAction] (resolved by the caller) wins over this; this
+/// is only the fallback path.
+void handleSearchFabDefaultTap({
+  required WidgetRef ref,
+  required int slot,
+  required int currentIndex,
+  required ValueChanged<int> onTap,
+}) {
+  // Defensive read: in widget tests without the search-state providers wired,
+  // the reads can throw; fall back to the historical branch-switch so existing
+  // tests keep passing and so the FAB never deadlocks on an unwired provider.
+  bool hasResults;
+  try {
+    final hasFuelResults = ref.read(searchStateProvider).when(
+          data: (r) => r.data.isNotEmpty,
+          loading: () => false,
+          error: (_, _) => false,
+        );
+    final hasRouteResults = ref.read(routeSearchStateProvider).when(
+          data: (r) => r != null,
+          loading: () => false,
+          error: (_, _) => false,
+        );
+    hasResults = hasFuelResults || hasRouteResults;
+  } catch (_) {
+    onTap(slot);
+    return;
+  }
+  final onSearchBranch = slot == currentIndex;
+  if (onSearchBranch || !hasResults) {
+    // Open criteria modal — refine (on Search) or start (no results).
+    openSearchCriteriaOnBranch(
+        slot: slot, currentIndex: currentIndex, onTap: onTap);
+  } else {
+    // Other tab, results exist → switch to Search branch.
+    onTap(slot);
+  }
+}

--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/logging/error_logger.dart';
+import '../../core/telemetry/collectors/breadcrumb_collector.dart';
 import '../../features/route_search/providers/route_search_provider.dart';
 import '../../features/search/presentation/screens/search_criteria_screen.dart';
 import '../../features/search/providers/search_provider.dart';
@@ -290,12 +291,15 @@ class ShellBottomBar extends ConsumerWidget {
       // repeat tap would push a second copy ("search just re-opens the same
       // form again and again"). Bail if it is already current.
       if (searchCriteriaRouteIsCurrent(searchNav)) {
-        unawaited(errorLogger.log(
-          ErrorLayer.ui,
+        // #2874 — re-tapping the FAB while the criteria sheet is already open
+        // is an EXPECTED no-op, not a fault: spooling it at [ErrorLayer.ui]
+        // surfaced it in the user-facing error log (error-log #21). Keep the
+        // #2810 diagnostic trail as a breadcrumb so it attaches to any LATER
+        // genuine trace instead of standing alone as a phantom ERROR.
+        BreadcrumbCollector.add(
           'search criteria re-open suppressed (already current)',
-          StackTrace.current,
-          context: {'source': 'openCriteriaOnSearchBranch', 'branch': i},
-        ));
+          detail: 'openCriteriaOnSearchBranch branch=$i',
+        );
         return;
       }
       searchNav.push<void>(

--- a/lib/app/shell/shell_bottom_bar.dart
+++ b/lib/app/shell/shell_bottom_bar.dart
@@ -1,19 +1,12 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/logging/error_logger.dart';
-import '../../core/telemetry/collectors/breadcrumb_collector.dart';
-import '../../features/route_search/providers/route_search_provider.dart';
-import '../../features/search/presentation/screens/search_criteria_screen.dart';
-import '../../features/search/providers/search_provider.dart';
-import '../routes/shell_branches.dart';
 import 'notched_bar_border.dart';
 import 'search_fab_action_provider.dart';
+import 'search_fab_tap.dart';
 import 'shell_nav_item.dart';
 
 /// Compact-screen bottom navigation bar (#1874).
@@ -261,95 +254,20 @@ class ShellBottomBar extends ConsumerWidget {
     // (or stale) action no longer swallows the tap — see [onTapHandler].
     final actionEnabled = action?.enabled ?? true;
 
-    // #2131 — push the criteria modal onto the **Search branch's**
-    // nested Navigator (via [searchBranchNavigatorKey]) instead of the
-    // root one. The root push covered the shell + bottom bar, hiding
-    // the FAB mid-flow; the branch push keeps the shell visible.
-    // Switching to the Search branch first ensures the criteria
-    // modal appears on the currently-displayed branch.
-    void openCriteriaOnSearchBranch() {
-      if (i != currentIndex) onTap(i);
-      final searchNav = searchBranchNavigatorKey.currentState;
-      if (searchNav == null) {
-        // #2811 — branch nav unmounted (early frame / unwired test). Do NOT
-        // root-push here: from the bar's context `Navigator.of(context)` is the
-        // ROOT navigator, and a fullscreen route there covers the whole shell —
-        // bar included — stranding it until restart if orphaned. Degrade to a
-        // branch jump, and trace it (a missing nav on a user tap is abnormal).
-        unawaited(errorLogger.log(
-          ErrorLayer.ui,
-          'search branch navigator not mounted on FAB tap — degraded to '
-              'branch jump (no root push)',
-          StackTrace.current,
-          context: {'source': 'openCriteriaOnSearchBranch', 'branch': i},
-        ));
-        onTap(i);
-        return;
-      }
-      // #2810 — refuse to stack a duplicate criteria modal: the FAB stays
-      // visible while it is open (branch-push keeps the shell mounted), so a
-      // repeat tap would push a second copy ("search just re-opens the same
-      // form again and again"). Bail if it is already current.
-      if (searchCriteriaRouteIsCurrent(searchNav)) {
-        // #2874 — re-tapping the FAB while the criteria sheet is already open
-        // is an EXPECTED no-op, not a fault: spooling it at [ErrorLayer.ui]
-        // surfaced it in the user-facing error log (error-log #21). Keep the
-        // #2810 diagnostic trail as a breadcrumb so it attaches to any LATER
-        // genuine trace instead of standing alone as a phantom ERROR.
-        BreadcrumbCollector.add(
-          'search criteria re-open suppressed (already current)',
-          detail: 'openCriteriaOnSearchBranch branch=$i',
-        );
-        return;
-      }
-      searchNav.push<void>(
-        MaterialPageRoute<void>(
-          builder: (_) => const SearchCriteriaScreen(),
-          fullscreenDialog: true,
-          settings: const RouteSettings(name: kSearchCriteriaRouteName),
-        ),
-      );
-    }
-
-    void defaultOnTap() {
-      // Defensive read: in widget tests without the search-state
-      // providers wired, the reads can throw; fall back to the
-      // historical branch-switch so existing tests keep passing
-      // and so the FAB never deadlocks on an unwired provider.
-      bool hasResults;
-      try {
-        final hasFuelResults = ref.read(searchStateProvider).when(
-              data: (r) => r.data.isNotEmpty,
-              loading: () => false,
-              error: (_, _) => false,
-            );
-        final hasRouteResults = ref.read(routeSearchStateProvider).when(
-              data: (r) => r != null,
-              loading: () => false,
-              error: (_, _) => false,
-            );
-        hasResults = hasFuelResults || hasRouteResults;
-      } catch (_) {
-        onTap(i);
-        return;
-      }
-      final onSearchBranch = i == currentIndex;
-      if (onSearchBranch || !hasResults) {
-        // Open criteria modal — refine (on Search) or start (no results).
-        openCriteriaOnSearchBranch();
-      } else {
-        // Other tab, results exist → switch to Search branch.
-        onTap(i);
-      }
-    }
-
     // #2553 — a registered-but-DISABLED (or stale) action must never
     // produce a dead `() {}` no-op. Only an enabled action overrides the
     // tap; anything else (null OR disabled OR stale) FALLS BACK to the
-    // default branch behaviour. Worst case the FAB opens criteria / jumps
-    // to Search — it can never become a permanent dead hit-target.
-    final onTapHandler =
-        (action != null && actionEnabled) ? action.onTap : defaultOnTap;
+    // default branch behaviour (#2113 three-branch matrix, implemented in
+    // search_fab_tap.dart). Worst case the FAB opens criteria / jumps to
+    // Search — it can never become a permanent dead hit-target.
+    final onTapHandler = (action != null && actionEnabled)
+        ? action.onTap
+        : () => handleSearchFabDefaultTap(
+              ref: ref,
+              slot: i,
+              currentIndex: currentIndex,
+              onTap: onTap,
+            );
 
     // #2131 — surface + icon both dim when the registered action is
     // disabled, mirroring Material's standard disabled-button look.

--- a/test/app/shell/shell_bottom_bar_test.dart
+++ b/test/app/shell/shell_bottom_bar_test.dart
@@ -5,11 +5,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/app/routes/shell_branches.dart';
 import 'package:tankstellen/app/shell/notched_bar_border.dart';
 import 'package:tankstellen/app/shell/search_fab_action_provider.dart';
 import 'package:tankstellen/app/shell/shell_bottom_bar.dart';
 import 'package:tankstellen/app/shell/shell_nav_item.dart';
 import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
 import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
 import 'package:tankstellen/features/search/presentation/screens/search_criteria_screen.dart';
 import 'package:tankstellen/features/search/providers/search_provider.dart';
@@ -287,6 +289,58 @@ void main() {
       expect(find.byType(SearchCriteriaScreen), findsNothing,
           reason: '#2811 — must NOT root-push a fullscreen route over the '
               'shell when the branch nav is unmounted');
+    });
+
+    testWidgets(
+        're-tapping the FAB while criteria is current records a breadcrumb, '
+        'not a UI ERROR trace, and pushes no duplicate (#2810 + #2874)',
+        (tester) async {
+      // Mount the search-branch navigator the bar reaches via the global key,
+      // with the criteria route already current → the #2810 guard fires.
+      final taps = <int>[];
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Stack(
+              children: [
+                Navigator(
+                  key: searchBranchNavigatorKey,
+                  onGenerateRoute: (_) => MaterialPageRoute<void>(
+                    settings:
+                        const RouteSettings(name: kSearchCriteriaRouteName),
+                    builder: (_) => const Scaffold(body: Text('criteria')),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: ShellBottomBar(
+                    items: items,
+                    branchForSlot: const [0, 1, 2],
+                    currentIndex: 1, // Search selected → onSearchBranch path
+                    iconControllers: controllers(3),
+                    isLandscape: false,
+                    onTap: taps.add,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      BreadcrumbCollector.clear();
+      await tester.tap(find.byIcon(Icons.search)); // the centre FAB
+      await tester.pump();
+
+      // #2810 — the guard refuses to stack a second criteria modal: the real
+      // SearchCriteriaScreen is never pushed (it would also need Hive).
+      expect(find.byType(SearchCriteriaScreen), findsNothing);
+      // #2874 — the suppression is a diagnostic breadcrumb, NOT an
+      // ErrorLayer.ui trace that would surface in the user-facing error log.
+      final crumbs = BreadcrumbCollector.snapshot();
+      expect(crumbs, hasLength(1));
+      expect(crumbs.single.action, contains('re-open suppressed'));
     });
   });
 


### PR DESCRIPTION
Closes #2874.

## What error-log #21 actually was
50 traces: **49× `Obd2DisconnectedException` from `readSpeedKmh`** + **1× a benign FAB re-open**. Neither is a real fault.

- **The 49× OBD2 flood is already fixed on master by #2855** — `readSpeedKmh` routes through `recordObd2ReadFailure`, which sends typed-recoverable disconnects (`Obd2DisconnectedException.isExpectedUserCondition == true`) to a breadcrumb, not the error log. The field build that produced #21 predated that merge. No change needed.
- **This PR fixes the 1× residual:** re-tapping the centre FAB while the search-criteria sheet is already open is an expected no-op (the #2810 duplicate-modal guard), but it was logged at `ErrorLayer.ui` — surfacing as a phantom ERROR in the user-facing log. Downgraded to a `BreadcrumbCollector` entry: the #2810 diagnostic trail still attaches to any *later* genuine trace, without standing alone as an error.

## Test
Adds a `shell_bottom_bar_test` case that mounts the search-branch navigator with the criteria route current, taps the FAB, and asserts the suppression records a breadcrumb (not a UI error trace) and pushes no duplicate route. All 24 tests pass; changed files analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)