### PR TITLE
docs(stores): complete iOS required URLs + record F-Droid NDK + readiness runbook (#2876)

### DIFF
--- a/docs/guides/go-live-runbook.md
+++ b/docs/guides/go-live-runbook.md
@@ -154,3 +154,32 @@ does **not** satisfy it.
 ### Not required (skip)
 Pre-registration, app indexing (deep links), and the pre-launch report are all
 **optional** — none block a production submission.
+
+---
+
+## F-Droid & Apple production readiness (verified 2026-06-05)
+
+### F-Droid — **needs-user-action** (recipe is submission-ready)
+Both recipes are complete and `fdroid lint`-clean (Summary/Description/AuthorName/
+AuthorEmail/Categories/Builds/AutoUpdate). The NDK comment now records the real
+value: `android/app/build.gradle.kts` uses `flutter.ndkVersion` → Flutter 3.41.9 =
+**28.2.13676358 (r28b)**; uncomment + confirm against F-Droid's buildserver on the
+first MR `fdroid build`. Remaining is user-owned:
+- **Official MR:** your GitLab @username → fork fdroiddata → lint/build → pin NDK
+  from the build log → MR. (F-Droid signs it — no keystore needed.)
+- **Self-hosted:** app release keystore + repo key → `scripts/fdroid_publish.sh`.
+
+### Apple — **metadata-ready, not submittable today** (no in-repo blocker left)
+Provisioning is **resolved** (fastlane match + `fdittgen-png/tankstellen-ios-certs`
++ active enrollment; nightly `ios-testflight.yml` produces signed builds).
+`ITSAppUsesNonExemptEncryption=false` set; bundle `de.tankstellen.tankstellen`;
+all 5 locales' metadata within Apple limits. **Now added:** the required
+`privacy_url` (live policy) + `support_url` (repo issues) + `marketing_url` for all
+5 locales. What still gates an App Store submission (all off-repo, your action):
+- **iOS App Store screenshots** — none exist in Apple sizes; need ≥1 iPhone
+  **6.9″** set (1290×2796) + ≥1 iPad **13″** set (2064×2752, app is universal),
+  captured from a build/simulator. The Android shots don't qualify.
+- **App Store Connect (console-only):** App Privacy nutrition labels, Age Rating,
+  Primary Category, Pricing & Availability, Content Rights, **EU DSA trader status**.
+- **A build attached + submitted:** promote a TestFlight build (signed IPA) to the
+  App Store version, then submit for review.

--- a/ios/fastlane/metadata/de-DE/marketing_url.txt
+++ b/ios/fastlane/metadata/de-DE/marketing_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen

--- a/ios/fastlane/metadata/de-DE/privacy_url.txt
+++ b/ios/fastlane/metadata/de-DE/privacy_url.txt
@@ -1,0 +1,1 @@
+https://fdittgen-png.github.io/tankstellen/

--- a/ios/fastlane/metadata/de-DE/support_url.txt
+++ b/ios/fastlane/metadata/de-DE/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen/issues

--- a/ios/fastlane/metadata/en-US/marketing_url.txt
+++ b/ios/fastlane/metadata/en-US/marketing_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen

--- a/ios/fastlane/metadata/en-US/privacy_url.txt
+++ b/ios/fastlane/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://fdittgen-png.github.io/tankstellen/

--- a/ios/fastlane/metadata/en-US/support_url.txt
+++ b/ios/fastlane/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen/issues

--- a/ios/fastlane/metadata/es-ES/marketing_url.txt
+++ b/ios/fastlane/metadata/es-ES/marketing_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen

--- a/ios/fastlane/metadata/es-ES/privacy_url.txt
+++ b/ios/fastlane/metadata/es-ES/privacy_url.txt
@@ -1,0 +1,1 @@
+https://fdittgen-png.github.io/tankstellen/

--- a/ios/fastlane/metadata/es-ES/support_url.txt
+++ b/ios/fastlane/metadata/es-ES/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen/issues

--- a/ios/fastlane/metadata/fr-FR/marketing_url.txt
+++ b/ios/fastlane/metadata/fr-FR/marketing_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen

--- a/ios/fastlane/metadata/fr-FR/privacy_url.txt
+++ b/ios/fastlane/metadata/fr-FR/privacy_url.txt
@@ -1,0 +1,1 @@
+https://fdittgen-png.github.io/tankstellen/

--- a/ios/fastlane/metadata/fr-FR/support_url.txt
+++ b/ios/fastlane/metadata/fr-FR/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen/issues

--- a/ios/fastlane/metadata/it-IT/marketing_url.txt
+++ b/ios/fastlane/metadata/it-IT/marketing_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen

--- a/ios/fastlane/metadata/it-IT/privacy_url.txt
+++ b/ios/fastlane/metadata/it-IT/privacy_url.txt
@@ -1,0 +1,1 @@
+https://fdittgen-png.github.io/tankstellen/

--- a/ios/fastlane/metadata/it-IT/support_url.txt
+++ b/ios/fastlane/metadata/it-IT/support_url.txt
@@ -1,0 +1,1 @@
+https://github.com/fdittgen-png/tankstellen/issues

--- a/metadata/de.tankstellen.fuelprices.yml
+++ b/metadata/de.tankstellen.fuelprices.yml
@@ -78,8 +78,11 @@ Builds:
     versionCode: 5132
     commit: v5.0.0
     subdir: android/app
-    # ndk: r27  # TODO: set the exact NDK after a clean `fdroid build` test —
-    #           # F-Droid's buildserver reports the version it needs in the log.
+    # ndk: r28b  # = 28.2.13676358, which this build requests: android/app/
+    #            # build.gradle.kts sets `ndkVersion = flutter.ndkVersion` and
+    #            # Flutter 3.41.9 pins 28.2.13676358 (r28b). Uncomment + confirm
+    #            # against F-Droid's buildserver NDK list on the first MR
+    #            # `fdroid build` (it logs the version it actually provisions).
     gradle:
       - fdroid
     srclibs:


### PR DESCRIPTION
Refs #2876. Brings F-Droid + Apple in-repo readiness to parity with Play.

- **iOS**: add the Apple-**required** Privacy Policy URL + Support URL (+ optional Marketing URL) for all 5 locales (were missing). Provisioning is already resolved (fastlane match); metadata within limits.
- **F-Droid**: record the real NDK (`flutter.ndkVersion` = 28.2.13676358 / r28b) in place of the stale `r27` TODO; kept commented for buildserver confirmation on the first MR build.
- **Runbook**: verified per-store readiness — F-Droid = needs-user-action; Apple = metadata-ready but needs iOS screenshots + App-Privacy/console + a submitted build (no in-repo blocker left).

Docs/metadata only.