### PR TITLE
feat(consumption): per-fuel-type efficiency compute foundation (#2882, #2883, #2884)

### DIFF
--- a/docs/decisions/0014-per-fuel-efficiency-attribution.md
+++ b/docs/decisions/0014-per-fuel-efficiency-attribution.md
@@ -3,14 +3,12 @@
   SPDX-License-Identifier: MIT
 -->
 
-# Per-fuel-type efficiency attribution (v1 — dominant-fuel)
+# ADR 0014: Per-fuel-type efficiency attribution (v1 — dominant-fuel)
 
-| Section  | Value                                                          |
-|----------|----------------------------------------------------------------|
-| Status   | Accepted                                                       |
-| Date     | 2026-06-05                                                    |
-| Epic     | [#2881](https://github.com/fdittgen-png/tankstellen/issues/2881) |
-| Child    | [#2882](https://github.com/fdittgen-png/tankstellen/issues/2882) (this note) |
+**Status:** Accepted
+**Date:** 2026-06-05
+**Issue:** #2882
+**Parent Epic:** #2881
 
 ## Context
 
@@ -165,7 +163,7 @@ is sorted by `avgCostPerKm` ascending, so **E85 sorts first**, E10 second.
   only one E85 tank gets numbers but no crown until a second closed E85 tank
   confirms it.
 
-## Alternatives considered
+## Alternatives Considered
 
 - **Proportional litre-split.** Split a mixed interval's distance between fuels
   in proportion to their litres. Rejected for v1: distance per fuel is not

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -47,12 +47,4 @@ reused. If a decision is reversed, the original ADR is marked
 | 0011 | Approach-detection + speed-aware polling scheduler | Accepted |
 | 0012 | GPS-only live consumption estimator | Accepted |
 | 0013 | Map tile proxy + `initialCameraFit` camera + `bestDisplayPrice` markers | Accepted |
-
-## Topical notes
-
-Decisions scoped to a single feature/Epic live as named notes rather than
-sequential ADRs:
-
-| File                                      | Topic                                            | Status   |
-|-------------------------------------------|--------------------------------------------------|----------|
-| `per-fuel-efficiency-attribution.md`      | Per-fuel-type efficiency attribution (dominant-fuel, Epic #2881) | Accepted |
+| 0014 | Per-fuel-type efficiency attribution (dominant-fuel, Epic #2881) | Accepted |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -47,3 +47,12 @@ reused. If a decision is reversed, the original ADR is marked
 | 0011 | Approach-detection + speed-aware polling scheduler | Accepted |
 | 0012 | GPS-only live consumption estimator | Accepted |
 | 0013 | Map tile proxy + `initialCameraFit` camera + `bestDisplayPrice` markers | Accepted |
+
+## Topical notes
+
+Decisions scoped to a single feature/Epic live as named notes rather than
+sequential ADRs:
+
+| File                                      | Topic                                            | Status   |
+|-------------------------------------------|--------------------------------------------------|----------|
+| `per-fuel-efficiency-attribution.md`      | Per-fuel-type efficiency attribution (dominant-fuel, Epic #2881) | Accepted |

--- a/docs/decisions/per-fuel-efficiency-attribution.md
+++ b/docs/decisions/per-fuel-efficiency-attribution.md
@@ -1,0 +1,179 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# Per-fuel-type efficiency attribution (v1 — dominant-fuel)
+
+| Section  | Value                                                          |
+|----------|----------------------------------------------------------------|
+| Status   | Accepted                                                       |
+| Date     | 2026-06-05                                                    |
+| Epic     | [#2881](https://github.com/fdittgen-png/tankstellen/issues/2881) |
+| Child    | [#2882](https://github.com/fdittgen-png/tankstellen/issues/2882) (this note) |
+
+## Context
+
+A multi-fuel owner — the canonical case is a Peugeot 107 run on **E85 / E10 /
+E5** depending on availability — cannot tell which fuel is actually *cheapest
+per kilometre*. E85 is cheaper per litre but burns more, so the per-litre price
+on the pump is a lie about the real cost of driving. Today every fill-up is
+aggregated into one all-fuel `ConsumptionStats`. `FillUp.fuelType` already
+exists (typed `FuelType`, round-trips via `@FuelTypeJsonConverter`) but is
+never used as a grouping key.
+
+The challenge is **attribution**: consumption is only ever measurable over a
+*closed plein-to-plein interval* (the existing walker in
+`consumption_stats.dart`), and a single interval can legitimately contain fills
+of more than one fuel (you topped up with E10 because the station had no E85).
+Litres are known per fill; **distance is only known per interval** (odometer
+delta). There is no honest way to split one interval's distance between two
+fuels without OBD2 per-fuel burn data, which v1 does not have.
+
+## Decision
+
+**v1 attributes each closed interval, whole, to its DOMINANT fuel** — the fuel
+that contributed the most litres to that interval. This is deliberately the
+simplest model that produces a usable €/km verdict, and it is honest about its
+own fuzziness via a "N of M tanks were mixed" footnote.
+
+The authoritative rule:
+
+1. **Unit = a CLOSED plein-to-plein interval**, identical to the
+   `ConsumptionStats.fromFillUps` walker. An interval opens at a full-tank fill
+   (or the very first fill) and closes at the next full-tank fill. The
+   *contributing fills* of an interval are the fills strictly **after** the
+   opening, up to **and including** the closing plein. The opening fill's
+   litres belong to no closed interval (it anchors the odometer baseline). The
+   in-progress tail after the last plein is excluded.
+
+2. **Dominance tally.** For each closed interval, sum litres per
+   `FuelType.apiValue` across the contributing **non-correction** fills.
+   Attribute the WHOLE interval — litres, distance, cost — to the fuel with the
+   **most litres** (the *dominant* fuel).
+   - **Tie-break 1:** the closing plein's fuel type.
+   - **Tie-break 2 (final, for determinism):** lowest `apiValue` alphabetically.
+
+3. **Corrections** (`isCorrection`) inherit the interval's dominant fuel. They
+   **never** count as a distinct fuel in the dominance tally and can **never**
+   flip an interval. (Their `totalCost` is always 0, mirroring the #2446
+   honesty precedent, so they do not move €/km either.)
+
+4. **Per-fuel metrics**, accumulated over that fuel's dominant-attributed
+   intervals:
+   - `avgL100km    = Σlitres / Σdistance × 100`
+   - `avgCostPerKm = Σcost   / Σdistance`
+   - Both are **null** when the fuel has zero attributed intervals
+     (`attributedIntervalCount == 0`) — e.g. a fuel that only ever appeared as a
+     minority in mixed tanks, or only in the open tail / opening fill.
+
+5. **`totalSpent`** per fuel is a **per-fill fact**, independent of interval
+   attribution: Σ `totalCost` of **every** non-correction fill of that fuel,
+   across all intervals (including the opening fill and the open tail). It
+   answers "how much have I spent on E85 in total", which is true regardless of
+   which interval each fill landed in.
+
+6. **`fillCount`** per fuel = count of all non-correction fills of that fuel.
+
+7. **`mixedIntervalCount`** per fuel = attributed intervals that actually
+   contained more than one fuel among their contributing non-correction fills.
+   Drives the footnote "N of M tanks were mixed — each counted toward its main
+   fuel".
+
+8. **Verdict gate.** `const kMinAttributedIntervalsForVerdict = 2`. The
+   "cheapest per km: <fuel>" verdict is only crowned when **every** compared
+   fuel that has fills has `attributedIntervalCount >= 2`. Below the threshold
+   the helper returns `null` and the UI shows numbers without a winner — one
+   lucky cheap tank must not crown a fuel.
+
+Out of scope for v1 (tracked on the Epic): proportional litre-splitting via
+OBD2 `fuelLevelBefore/After`; family rollup (lumping E5 + E10). v1 groups by
+exact `FuelType.apiValue`.
+
+## Worked example (the frozen RED fixture for #2883)
+
+Six fills for one vehicle, chronological. All are full-tank pleins **except F3**
+(a partial top-up). Prices are clean round €/L so the arithmetic is checkable
+by hand.
+
+| Fill | odo (km) | fuel | litres | €/L  | totalCost | full tank?         |
+|------|---------:|------|-------:|-----:|----------:|:-------------------|
+| F0   |        0 | E10  |     40 | 1.70 |     68.00 | yes (opening)      |
+| F1   |      600 | E10  |     30 | 1.70 |     51.00 | yes → closes **A** |
+| F2   |     1100 | E85  |     45 | 1.00 |     45.00 | yes → closes **B** |
+| F3   |     1400 | E85  |     20 | 1.00 |     20.00 | **no** (partial)   |
+| F4   |     1700 | E10  |     35 | 1.70 |     59.50 | yes → closes **C** |
+| F5   |     2300 | E85  |     50 | 1.00 |     50.00 | yes → closes **D** |
+
+### Interval classification
+
+| Interval | opens at | closes at | contributing fills | litres tally       | dominant | mixed? | distance (km)       |
+|----------|----------|-----------|--------------------|--------------------|----------|:------:|--------------------:|
+| A        | F0       | F1        | F1                 | E10 = 30           | **E10**  | no     | 600 − 0    = 600    |
+| B        | F1       | F2        | F2                 | E85 = 45           | **E85**  | no     | 1100 − 600 = 500    |
+| C        | F2       | F4        | F3, F4             | E85 = 20, E10 = 35 | **E10**  | yes    | 1700 − 1100 = 600   |
+| D        | F4       | F5        | F5                 | E85 = 50           | **E85**  | no     | 2300 − 1700 = 600   |
+
+F0's 40 L anchor the baseline and belong to no closed interval. In interval C,
+E10 (35 L) outweighs E85 (20 L), so the *whole* 600 km / 55 L / €79.50 is
+attributed to **E10** — this is the deliberate fuzziness the footnote discloses.
+
+### Expected per-fuel result
+
+**E10** — attributed intervals A + C:
+- Σdistance = 600 + 600 = **1200 km**
+- Σlitres   = 30 + 55  = **85 L**   (C contributes 35 E10 + 20 E85 = 55)
+- Σcost     = 51.00 + 79.50 = **€130.50**  (C: 59.50 + 20.00)
+- `avgL100km`    = 85 / 1200 × 100 = **7.0833 L/100km**
+- `avgCostPerKm` = 130.50 / 1200  = **€0.108750 /km**
+- `attributedIntervalCount` = **2**, `mixedIntervalCount` = **1**
+- `totalSpent` = 68.00 + 51.00 + 59.50 = **€178.50** (F0 + F1 + F4)
+- `fillCount` = **3** (F0, F1, F4)
+
+**E85** — attributed intervals B + D:
+- Σdistance = 500 + 600 = **1100 km**
+- Σlitres   = 45 + 50  = **95 L**
+- Σcost     = 45.00 + 50.00 = **€95.00**
+- `avgL100km`    = 95 / 1100 × 100 = **8.6364 L/100km**
+- `avgCostPerKm` = 95.00 / 1100  = **€0.086364 /km**
+- `attributedIntervalCount` = **2**, `mixedIntervalCount` = **0**
+- `totalSpent` = 45.00 + 20.00 + 50.00 = **€115.00** (F2 + F3 + F5)
+- `fillCount` = **3** (F2, F3, F5)
+
+### Verdict
+
+Both fuels have `attributedIntervalCount = 2 >= kMinAttributedIntervalsForVerdict`
+→ the gate opens. Cheapest €/km is **E85** (0.0864 < 0.1088) — even though E85
+burns *more* litres per 100 km (8.64 vs 7.08). This is the whole point of the
+feature: the cheaper-per-litre fuel can still win per kilometre. The result list
+is sorted by `avgCostPerKm` ascending, so **E85 sorts first**, E10 second.
+
+## Consequences
+
+- The model is **biased toward the dominant fuel** of any mixed tank — a
+  minority fuel's distance is credited to whatever you put more of in. The
+  footnote (`mixedIntervalCount` of `attributedIntervalCount`) makes this
+  visible rather than silent.
+- A fuel can have `totalSpent > 0` and `fillCount > 0` but `null` per-km
+  metrics (only ever a minority, or only in the opening / open tail). The UI
+  must null-skip the L/100km and €/km cells for such a fuel.
+- The walker logic is the **same** as `consumption_stats.dart`; #2883's
+  aggregator reuses that interval definition (replicating it faithfully with a
+  cross-reference comment, since the existing walker does not expose a
+  per-interval hook).
+- The verdict gate trades early gratification for trust: a user who has driven
+  only one E85 tank gets numbers but no crown until a second closed E85 tank
+  confirms it.
+
+## Alternatives considered
+
+- **Proportional litre-split.** Split a mixed interval's distance between fuels
+  in proportion to their litres. Rejected for v1: distance per fuel is not
+  measurable without OBD2 per-fuel burn, so the "proportion" would itself be a
+  fiction dressed up as precision. Deferred to a post-v1 OBD2 path.
+- **Drop mixed intervals entirely.** Only count mono-fuel intervals. Rejected:
+  throws away real driving data for the exact users (frequent fuel-switchers)
+  the feature targets, and would starve the verdict gate.
+- **Family rollup (E5 + E10 as one petrol bucket).** Rejected for v1: the E85
+  vs E10 decision is precisely *within* the petrol family, so collapsing it
+  defeats the purpose. Exact `apiValue` grouping keeps E5 / E10 / E85 distinct.

--- a/lib/features/consumption/domain/entities/fuel_type_efficiency_stats.dart
+++ b/lib/features/consumption/domain/entities/fuel_type_efficiency_stats.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../search/domain/entities/fuel_type.dart';
+
+part 'fuel_type_efficiency_stats.freezed.dart';
+
+/// Per-fuel-type efficiency stats for one vehicle (Epic #2881).
+///
+/// A derived VIEW over a vehicle's fill-ups, produced by
+/// `FuelTypeEfficiencyAggregator.byFuelType`. The dominant-fuel attribution
+/// model is frozen in `docs/decisions/per-fuel-efficiency-attribution.md`:
+/// each closed plein-to-plein interval is attributed, whole, to the fuel that
+/// contributed the most litres among its non-correction fills.
+///
+/// This is a read-only projection (never cached, never persisted), so it
+/// carries no JSON serialization — only [freezed] for value equality and
+/// `copyWith`.
+@freezed
+abstract class FuelTypeEfficiencyStats with _$FuelTypeEfficiencyStats {
+  const factory FuelTypeEfficiencyStats({
+    /// The fuel this row aggregates (grouped by [FuelType.apiValue]).
+    required FuelType fuelType,
+
+    /// Average litres / 100 km over this fuel's dominant-attributed
+    /// intervals. `null` when [attributedIntervalCount] is 0 — the fuel
+    /// never dominated a closed interval (only a minority in mixed tanks,
+    /// or only present in the opening fill / open tail).
+    double? avgL100km,
+
+    /// Average cost per km (store currency) over this fuel's
+    /// dominant-attributed intervals. `null` under the same condition as
+    /// [avgL100km].
+    double? avgCostPerKm,
+
+    /// Σ `totalCost` of EVERY non-correction fill of this fuel, across all
+    /// intervals (incl. the opening fill and the open tail). A per-fill
+    /// fact, independent of interval attribution — "how much I have spent
+    /// on this fuel in total".
+    required double totalSpent,
+
+    /// Count of all non-correction fills of this fuel.
+    required int fillCount,
+
+    /// Number of closed plein-to-plein intervals attributed to this fuel
+    /// under the dominant-fuel rule. 0 ⇒ [avgL100km] / [avgCostPerKm] null.
+    required int attributedIntervalCount,
+
+    /// Of [attributedIntervalCount], how many intervals actually contained
+    /// more than one fuel among their contributing non-correction fills.
+    /// Drives the "N of M tanks were mixed" transparency footnote.
+    required int mixedIntervalCount,
+  }) = _FuelTypeEfficiencyStats;
+}

--- a/lib/features/consumption/domain/entities/fuel_type_efficiency_stats.freezed.dart
+++ b/lib/features/consumption/domain/entities/fuel_type_efficiency_stats.freezed.dart
@@ -1,0 +1,325 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'fuel_type_efficiency_stats.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$FuelTypeEfficiencyStats {
+
+/// The fuel this row aggregates (grouped by [FuelType.apiValue]).
+ FuelType get fuelType;/// Average litres / 100 km over this fuel's dominant-attributed
+/// intervals. `null` when [attributedIntervalCount] is 0 — the fuel
+/// never dominated a closed interval (only a minority in mixed tanks,
+/// or only present in the opening fill / open tail).
+ double? get avgL100km;/// Average cost per km (store currency) over this fuel's
+/// dominant-attributed intervals. `null` under the same condition as
+/// [avgL100km].
+ double? get avgCostPerKm;/// Σ `totalCost` of EVERY non-correction fill of this fuel, across all
+/// intervals (incl. the opening fill and the open tail). A per-fill
+/// fact, independent of interval attribution — "how much I have spent
+/// on this fuel in total".
+ double get totalSpent;/// Count of all non-correction fills of this fuel.
+ int get fillCount;/// Number of closed plein-to-plein intervals attributed to this fuel
+/// under the dominant-fuel rule. 0 ⇒ [avgL100km] / [avgCostPerKm] null.
+ int get attributedIntervalCount;/// Of [attributedIntervalCount], how many intervals actually contained
+/// more than one fuel among their contributing non-correction fills.
+/// Drives the "N of M tanks were mixed" transparency footnote.
+ int get mixedIntervalCount;
+/// Create a copy of FuelTypeEfficiencyStats
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FuelTypeEfficiencyStatsCopyWith<FuelTypeEfficiencyStats> get copyWith => _$FuelTypeEfficiencyStatsCopyWithImpl<FuelTypeEfficiencyStats>(this as FuelTypeEfficiencyStats, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FuelTypeEfficiencyStats&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.avgL100km, avgL100km) || other.avgL100km == avgL100km)&&(identical(other.avgCostPerKm, avgCostPerKm) || other.avgCostPerKm == avgCostPerKm)&&(identical(other.totalSpent, totalSpent) || other.totalSpent == totalSpent)&&(identical(other.fillCount, fillCount) || other.fillCount == fillCount)&&(identical(other.attributedIntervalCount, attributedIntervalCount) || other.attributedIntervalCount == attributedIntervalCount)&&(identical(other.mixedIntervalCount, mixedIntervalCount) || other.mixedIntervalCount == mixedIntervalCount));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,fuelType,avgL100km,avgCostPerKm,totalSpent,fillCount,attributedIntervalCount,mixedIntervalCount);
+
+@override
+String toString() {
+  return 'FuelTypeEfficiencyStats(fuelType: $fuelType, avgL100km: $avgL100km, avgCostPerKm: $avgCostPerKm, totalSpent: $totalSpent, fillCount: $fillCount, attributedIntervalCount: $attributedIntervalCount, mixedIntervalCount: $mixedIntervalCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FuelTypeEfficiencyStatsCopyWith<$Res>  {
+  factory $FuelTypeEfficiencyStatsCopyWith(FuelTypeEfficiencyStats value, $Res Function(FuelTypeEfficiencyStats) _then) = _$FuelTypeEfficiencyStatsCopyWithImpl;
+@useResult
+$Res call({
+ FuelType fuelType, double? avgL100km, double? avgCostPerKm, double totalSpent, int fillCount, int attributedIntervalCount, int mixedIntervalCount
+});
+
+
+
+
+}
+/// @nodoc
+class _$FuelTypeEfficiencyStatsCopyWithImpl<$Res>
+    implements $FuelTypeEfficiencyStatsCopyWith<$Res> {
+  _$FuelTypeEfficiencyStatsCopyWithImpl(this._self, this._then);
+
+  final FuelTypeEfficiencyStats _self;
+  final $Res Function(FuelTypeEfficiencyStats) _then;
+
+/// Create a copy of FuelTypeEfficiencyStats
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? fuelType = null,Object? avgL100km = freezed,Object? avgCostPerKm = freezed,Object? totalSpent = null,Object? fillCount = null,Object? attributedIntervalCount = null,Object? mixedIntervalCount = null,}) {
+  return _then(_self.copyWith(
+fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as FuelType,avgL100km: freezed == avgL100km ? _self.avgL100km : avgL100km // ignore: cast_nullable_to_non_nullable
+as double?,avgCostPerKm: freezed == avgCostPerKm ? _self.avgCostPerKm : avgCostPerKm // ignore: cast_nullable_to_non_nullable
+as double?,totalSpent: null == totalSpent ? _self.totalSpent : totalSpent // ignore: cast_nullable_to_non_nullable
+as double,fillCount: null == fillCount ? _self.fillCount : fillCount // ignore: cast_nullable_to_non_nullable
+as int,attributedIntervalCount: null == attributedIntervalCount ? _self.attributedIntervalCount : attributedIntervalCount // ignore: cast_nullable_to_non_nullable
+as int,mixedIntervalCount: null == mixedIntervalCount ? _self.mixedIntervalCount : mixedIntervalCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [FuelTypeEfficiencyStats].
+extension FuelTypeEfficiencyStatsPatterns on FuelTypeEfficiencyStats {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _FuelTypeEfficiencyStats value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _FuelTypeEfficiencyStats() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _FuelTypeEfficiencyStats value)  $default,){
+final _that = this;
+switch (_that) {
+case _FuelTypeEfficiencyStats():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _FuelTypeEfficiencyStats value)?  $default,){
+final _that = this;
+switch (_that) {
+case _FuelTypeEfficiencyStats() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( FuelType fuelType,  double? avgL100km,  double? avgCostPerKm,  double totalSpent,  int fillCount,  int attributedIntervalCount,  int mixedIntervalCount)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _FuelTypeEfficiencyStats() when $default != null:
+return $default(_that.fuelType,_that.avgL100km,_that.avgCostPerKm,_that.totalSpent,_that.fillCount,_that.attributedIntervalCount,_that.mixedIntervalCount);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( FuelType fuelType,  double? avgL100km,  double? avgCostPerKm,  double totalSpent,  int fillCount,  int attributedIntervalCount,  int mixedIntervalCount)  $default,) {final _that = this;
+switch (_that) {
+case _FuelTypeEfficiencyStats():
+return $default(_that.fuelType,_that.avgL100km,_that.avgCostPerKm,_that.totalSpent,_that.fillCount,_that.attributedIntervalCount,_that.mixedIntervalCount);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( FuelType fuelType,  double? avgL100km,  double? avgCostPerKm,  double totalSpent,  int fillCount,  int attributedIntervalCount,  int mixedIntervalCount)?  $default,) {final _that = this;
+switch (_that) {
+case _FuelTypeEfficiencyStats() when $default != null:
+return $default(_that.fuelType,_that.avgL100km,_that.avgCostPerKm,_that.totalSpent,_that.fillCount,_that.attributedIntervalCount,_that.mixedIntervalCount);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _FuelTypeEfficiencyStats implements FuelTypeEfficiencyStats {
+  const _FuelTypeEfficiencyStats({required this.fuelType, this.avgL100km, this.avgCostPerKm, required this.totalSpent, required this.fillCount, required this.attributedIntervalCount, required this.mixedIntervalCount});
+  
+
+/// The fuel this row aggregates (grouped by [FuelType.apiValue]).
+@override final  FuelType fuelType;
+/// Average litres / 100 km over this fuel's dominant-attributed
+/// intervals. `null` when [attributedIntervalCount] is 0 — the fuel
+/// never dominated a closed interval (only a minority in mixed tanks,
+/// or only present in the opening fill / open tail).
+@override final  double? avgL100km;
+/// Average cost per km (store currency) over this fuel's
+/// dominant-attributed intervals. `null` under the same condition as
+/// [avgL100km].
+@override final  double? avgCostPerKm;
+/// Σ `totalCost` of EVERY non-correction fill of this fuel, across all
+/// intervals (incl. the opening fill and the open tail). A per-fill
+/// fact, independent of interval attribution — "how much I have spent
+/// on this fuel in total".
+@override final  double totalSpent;
+/// Count of all non-correction fills of this fuel.
+@override final  int fillCount;
+/// Number of closed plein-to-plein intervals attributed to this fuel
+/// under the dominant-fuel rule. 0 ⇒ [avgL100km] / [avgCostPerKm] null.
+@override final  int attributedIntervalCount;
+/// Of [attributedIntervalCount], how many intervals actually contained
+/// more than one fuel among their contributing non-correction fills.
+/// Drives the "N of M tanks were mixed" transparency footnote.
+@override final  int mixedIntervalCount;
+
+/// Create a copy of FuelTypeEfficiencyStats
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FuelTypeEfficiencyStatsCopyWith<_FuelTypeEfficiencyStats> get copyWith => __$FuelTypeEfficiencyStatsCopyWithImpl<_FuelTypeEfficiencyStats>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FuelTypeEfficiencyStats&&(identical(other.fuelType, fuelType) || other.fuelType == fuelType)&&(identical(other.avgL100km, avgL100km) || other.avgL100km == avgL100km)&&(identical(other.avgCostPerKm, avgCostPerKm) || other.avgCostPerKm == avgCostPerKm)&&(identical(other.totalSpent, totalSpent) || other.totalSpent == totalSpent)&&(identical(other.fillCount, fillCount) || other.fillCount == fillCount)&&(identical(other.attributedIntervalCount, attributedIntervalCount) || other.attributedIntervalCount == attributedIntervalCount)&&(identical(other.mixedIntervalCount, mixedIntervalCount) || other.mixedIntervalCount == mixedIntervalCount));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,fuelType,avgL100km,avgCostPerKm,totalSpent,fillCount,attributedIntervalCount,mixedIntervalCount);
+
+@override
+String toString() {
+  return 'FuelTypeEfficiencyStats(fuelType: $fuelType, avgL100km: $avgL100km, avgCostPerKm: $avgCostPerKm, totalSpent: $totalSpent, fillCount: $fillCount, attributedIntervalCount: $attributedIntervalCount, mixedIntervalCount: $mixedIntervalCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FuelTypeEfficiencyStatsCopyWith<$Res> implements $FuelTypeEfficiencyStatsCopyWith<$Res> {
+  factory _$FuelTypeEfficiencyStatsCopyWith(_FuelTypeEfficiencyStats value, $Res Function(_FuelTypeEfficiencyStats) _then) = __$FuelTypeEfficiencyStatsCopyWithImpl;
+@override @useResult
+$Res call({
+ FuelType fuelType, double? avgL100km, double? avgCostPerKm, double totalSpent, int fillCount, int attributedIntervalCount, int mixedIntervalCount
+});
+
+
+
+
+}
+/// @nodoc
+class __$FuelTypeEfficiencyStatsCopyWithImpl<$Res>
+    implements _$FuelTypeEfficiencyStatsCopyWith<$Res> {
+  __$FuelTypeEfficiencyStatsCopyWithImpl(this._self, this._then);
+
+  final _FuelTypeEfficiencyStats _self;
+  final $Res Function(_FuelTypeEfficiencyStats) _then;
+
+/// Create a copy of FuelTypeEfficiencyStats
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? fuelType = null,Object? avgL100km = freezed,Object? avgCostPerKm = freezed,Object? totalSpent = null,Object? fillCount = null,Object? attributedIntervalCount = null,Object? mixedIntervalCount = null,}) {
+  return _then(_FuelTypeEfficiencyStats(
+fuelType: null == fuelType ? _self.fuelType : fuelType // ignore: cast_nullable_to_non_nullable
+as FuelType,avgL100km: freezed == avgL100km ? _self.avgL100km : avgL100km // ignore: cast_nullable_to_non_nullable
+as double?,avgCostPerKm: freezed == avgCostPerKm ? _self.avgCostPerKm : avgCostPerKm // ignore: cast_nullable_to_non_nullable
+as double?,totalSpent: null == totalSpent ? _self.totalSpent : totalSpent // ignore: cast_nullable_to_non_nullable
+as double,fillCount: null == fillCount ? _self.fillCount : fillCount // ignore: cast_nullable_to_non_nullable
+as int,attributedIntervalCount: null == attributedIntervalCount ? _self.attributedIntervalCount : attributedIntervalCount // ignore: cast_nullable_to_non_nullable
+as int,mixedIntervalCount: null == mixedIntervalCount ? _self.mixedIntervalCount : mixedIntervalCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/consumption/domain/services/fuel_type_efficiency_aggregator.dart
+++ b/lib/features/consumption/domain/services/fuel_type_efficiency_aggregator.dart
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../../search/domain/entities/fuel_type.dart';
+import '../entities/fill_up.dart';
+import '../entities/fuel_type_efficiency_stats.dart';
+
+/// Minimum attributed closed intervals a fuel must have before the
+/// "cheapest per km" verdict may crown a winner (Epic #2881).
+///
+/// The verdict is only shown when EVERY compared fuel that has fills clears
+/// this bar — one lucky cheap tank must not crown a fuel. See
+/// `docs/decisions/per-fuel-efficiency-attribution.md`.
+const int kMinAttributedIntervalsForVerdict = 2;
+
+/// Pure aggregation of [FillUp] entries into per-[FuelType]
+/// [FuelTypeEfficiencyStats] under the v1 DOMINANT-FUEL attribution model
+/// (Epic #2881; rule frozen in
+/// `docs/decisions/per-fuel-efficiency-attribution.md`).
+///
+/// No Riverpod, no Flutter — drive it directly with a list of fills.
+///
+/// ## Attribution (summary; the doc is authoritative)
+/// Walks CLOSED plein-to-plein intervals (the same interval definition as
+/// `ConsumptionStats.fromFillUps` in `consumption_stats.dart` — replicated
+/// faithfully here because that walker does not expose a per-interval hook).
+/// Each closed interval's litres / distance / cost are attributed, whole, to
+/// the fuel with the most litres among its contributing non-correction fills
+/// (tie-break: the closing plein's fuel, then `apiValue` alphabetical).
+/// Corrections inherit the dominant fuel and never enter the tally.
+class FuelTypeEfficiencyAggregator {
+  FuelTypeEfficiencyAggregator._();
+
+  /// Compute one [FuelTypeEfficiencyStats] per fuel that has any fills,
+  /// sorted by `avgCostPerKm` ascending (nulls last).
+  static List<FuelTypeEfficiencyStats> byFuelType(List<FillUp> fills) {
+    if (fills.isEmpty) return const [];
+
+    // Chronological copy so callers may pass data in any order — mirrors
+    // ConsumptionStats.fromFillUps.
+    final sorted = [...fills]..sort((a, b) => a.date.compareTo(b.date));
+
+    // Per-fuel accumulators, keyed by FuelType.apiValue.
+    final acc = <String, _FuelAcc>{};
+    _FuelAcc accFor(FuelType fuel) =>
+        acc.putIfAbsent(fuel.apiValue, () => _FuelAcc(fuel));
+
+    // ── Per-fill facts (independent of interval attribution) ──
+    // totalSpent + fillCount over EVERY non-correction fill of the fuel,
+    // including the opening fill of the first interval and the open tail.
+    for (final f in sorted) {
+      if (f.isCorrection) continue;
+      final a = accFor(f.fuelType);
+      a.totalSpent += f.totalCost;
+      a.fillCount += 1;
+    }
+
+    // ── Closed-interval walker (mirrors consumption_stats.dart) ──
+    // An interval opens at sorted[openingIndex] (first fill, or the prior
+    // closing plein) and closes at the next full-tank fill. Contributing
+    // fills are those strictly AFTER the opening up to + including the close.
+    var openingIndex = 0;
+    final pending = <FillUp>[]; // contributing fills of the current interval
+
+    for (var i = 1; i < sorted.length; i++) {
+      final fill = sorted[i];
+      pending.add(fill);
+      if (!fill.isFullTank) continue; // interval still open
+
+      // Interval closes here. Distance from the odometer delta, clamped at
+      // 0 so an odometer reset / out-of-order import never goes negative
+      // (same clamp as consumption_stats.dart).
+      final distance =
+          (fill.odometerKm - sorted[openingIndex].odometerKm)
+              .clamp(0, double.infinity)
+              .toDouble();
+      _attributeInterval(pending, fill, distance, accFor);
+
+      openingIndex = i;
+      pending.clear();
+    }
+    // Anything left in `pending` is the in-progress (open) window after the
+    // last plein — excluded from attribution, exactly like the walker.
+
+    final result = [
+      for (final a in acc.values) a.toStats(),
+    ];
+    // Sort by €/km ascending; nulls (no attributed interval) last. Stable
+    // secondary sort by apiValue for deterministic ordering on ties.
+    result.sort((x, y) {
+      final cx = x.avgCostPerKm;
+      final cy = y.avgCostPerKm;
+      if (cx == null && cy == null) {
+        return x.fuelType.apiValue.compareTo(y.fuelType.apiValue);
+      }
+      if (cx == null) return 1;
+      if (cy == null) return -1;
+      final byCost = cx.compareTo(cy);
+      if (byCost != 0) return byCost;
+      return x.fuelType.apiValue.compareTo(y.fuelType.apiValue);
+    });
+    return result;
+  }
+
+  /// The lowest-`avgCostPerKm` fuel — but ONLY when every entry that has
+  /// fills has `attributedIntervalCount >= kMinAttributedIntervalsForVerdict`.
+  /// Returns `null` below the threshold (no crown) or when no fuel has a
+  /// non-null €/km.
+  static FuelType? cheapestPerKm(List<FuelTypeEfficiencyStats> stats) {
+    if (stats.isEmpty) return null;
+    final withFills = stats.where((s) => s.fillCount > 0);
+    final everyFuelHasEnough = withFills.every(
+      (s) => s.attributedIntervalCount >= kMinAttributedIntervalsForVerdict,
+    );
+    if (!everyFuelHasEnough) return null;
+
+    FuelTypeEfficiencyStats? best;
+    for (final s in stats) {
+      if (s.avgCostPerKm == null) continue;
+      if (best == null || s.avgCostPerKm! < best.avgCostPerKm!) {
+        best = s;
+      }
+    }
+    return best?.fuelType;
+  }
+
+  /// Tally litres per fuel among the [contributing] NON-correction fills,
+  /// pick the dominant fuel, and fold the interval's litres / distance /
+  /// cost (including corrections, which inherit the dominant fuel) into that
+  /// fuel's accumulator.
+  static void _attributeInterval(
+    List<FillUp> contributing,
+    FillUp closing,
+    double distance,
+    _FuelAcc Function(FuelType) accFor,
+  ) {
+    if (contributing.isEmpty) return;
+
+    final litresByFuel = <String, double>{};
+    final fuelByApiValue = <String, FuelType>{};
+    for (final f in contributing) {
+      if (f.isCorrection) continue; // never enters the dominance tally
+      litresByFuel.update(
+        f.fuelType.apiValue,
+        (v) => v + f.liters,
+        ifAbsent: () => f.liters,
+      );
+      fuelByApiValue[f.fuelType.apiValue] = f.fuelType;
+    }
+
+    // An interval of corrections-only has no dominance tally — attribute
+    // nothing (its litres/distance/cost have no real fuel to credit).
+    if (litresByFuel.isEmpty) return;
+
+    final dominant = _dominantFuel(litresByFuel, fuelByApiValue, closing);
+    final isMixed = litresByFuel.length > 1;
+
+    // Litres + cost include corrections (they inherit the dominant fuel);
+    // distance is the whole interval's odometer delta.
+    var intervalLitres = 0.0;
+    var intervalCost = 0.0;
+    for (final f in contributing) {
+      intervalLitres += f.liters;
+      intervalCost += f.totalCost; // corrections carry 0
+    }
+
+    final a = accFor(dominant);
+    a.intervalLitres += intervalLitres;
+    a.intervalDistance += distance;
+    a.intervalCost += intervalCost;
+    a.attributedIntervalCount += 1;
+    if (isMixed) a.mixedIntervalCount += 1;
+  }
+
+  /// Dominant fuel = most litres; tie-break 1 the closing plein's fuel,
+  /// tie-break 2 lowest `apiValue` alphabetical (determinism).
+  static FuelType _dominantFuel(
+    Map<String, double> litresByFuel,
+    Map<String, FuelType> fuelByApiValue,
+    FillUp closing,
+  ) {
+    var maxLitres = double.negativeInfinity;
+    for (final l in litresByFuel.values) {
+      if (l > maxLitres) maxLitres = l;
+    }
+    // Candidates within a tiny epsilon of the max (float-safe tie).
+    const eps = 1e-9;
+    final leaders = litresByFuel.entries
+        .where((e) => (maxLitres - e.value).abs() <= eps)
+        .map((e) => e.key)
+        .toList(growable: false);
+
+    if (leaders.length == 1) return fuelByApiValue[leaders.first]!;
+
+    // Tie-break 1: the closing plein's fuel, if it is among the leaders and
+    // is itself a contributing (non-correction) fuel of this interval.
+    final closingKey = closing.fuelType.apiValue;
+    if (!closing.isCorrection && leaders.contains(closingKey)) {
+      return fuelByApiValue[closingKey]!;
+    }
+    // Tie-break 2: lowest apiValue alphabetical.
+    leaders.sort();
+    return fuelByApiValue[leaders.first]!;
+  }
+}
+
+/// Mutable per-fuel accumulator used only inside [byFuelType].
+class _FuelAcc {
+  _FuelAcc(this.fuelType);
+
+  final FuelType fuelType;
+
+  // Per-fill facts.
+  double totalSpent = 0;
+  int fillCount = 0;
+
+  // Per dominant-attributed-interval sums.
+  double intervalLitres = 0;
+  double intervalDistance = 0;
+  double intervalCost = 0;
+  int attributedIntervalCount = 0;
+  int mixedIntervalCount = 0;
+
+  FuelTypeEfficiencyStats toStats() {
+    final hasDistance = attributedIntervalCount > 0 && intervalDistance > 0;
+    return FuelTypeEfficiencyStats(
+      fuelType: fuelType,
+      avgL100km: hasDistance ? (intervalLitres / intervalDistance) * 100 : null,
+      avgCostPerKm: hasDistance ? intervalCost / intervalDistance : null,
+      totalSpent: totalSpent,
+      fillCount: fillCount,
+      attributedIntervalCount: attributedIntervalCount,
+      mixedIntervalCount: mixedIntervalCount,
+    );
+  }
+}

--- a/lib/features/consumption/providers/fuel_type_efficiency_provider.dart
+++ b/lib/features/consumption/providers/fuel_type_efficiency_provider.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../vehicle/providers/vehicle_providers.dart';
+import '../domain/entities/fuel_type_efficiency_stats.dart';
+import '../domain/services/fuel_type_efficiency_aggregator.dart';
+import 'consumption_providers.dart';
+
+part 'fuel_type_efficiency_provider.g.dart';
+
+/// Per-fuel-type efficiency comparison for the active vehicle (Epic #2881).
+///
+/// Watches [fillUpListProvider] + [activeVehicleProfileProvider], filters the
+/// fills to the selected vehicle's `vehicleId` (when a vehicle is active;
+/// otherwise all fills), and returns
+/// `FuelTypeEfficiencyAggregator.byFuelType(...)` — one
+/// [FuelTypeEfficiencyStats] per fuel, sorted by €/km ascending.
+///
+/// Read-only re-slice of data the user already logged: no `FillUpList.add`
+/// hook, no storage, no `Feature` gate (mirrors the #2698 no-gate precedent).
+/// Lives in its own file (not the line-guarded consumption_providers.dart),
+/// parallel to `monthlyFuelStatsProvider`.
+@riverpod
+List<FuelTypeEfficiencyStats> fuelTypeEfficiencyComparison(Ref ref) {
+  final fills = ref.watch(fillUpListProvider);
+  final vehicle = ref.watch(activeVehicleProfileProvider);
+  final scoped = vehicle == null
+      ? fills
+      : fills.where((f) => f.vehicleId == vehicle.id).toList(growable: false);
+  return FuelTypeEfficiencyAggregator.byFuelType(scoped);
+}

--- a/lib/features/consumption/providers/fuel_type_efficiency_provider.g.dart
+++ b/lib/features/consumption/providers/fuel_type_efficiency_provider.g.dart
@@ -1,0 +1,98 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fuel_type_efficiency_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Per-fuel-type efficiency comparison for the active vehicle (Epic #2881).
+///
+/// Watches [fillUpListProvider] + [activeVehicleProfileProvider], filters the
+/// fills to the selected vehicle's `vehicleId` (when a vehicle is active;
+/// otherwise all fills), and returns
+/// `FuelTypeEfficiencyAggregator.byFuelType(...)` — one
+/// [FuelTypeEfficiencyStats] per fuel, sorted by €/km ascending.
+///
+/// Read-only re-slice of data the user already logged: no `FillUpList.add`
+/// hook, no storage, no `Feature` gate (mirrors the #2698 no-gate precedent).
+/// Lives in its own file (not the line-guarded consumption_providers.dart),
+/// parallel to `monthlyFuelStatsProvider`.
+
+@ProviderFor(fuelTypeEfficiencyComparison)
+final fuelTypeEfficiencyComparisonProvider =
+    FuelTypeEfficiencyComparisonProvider._();
+
+/// Per-fuel-type efficiency comparison for the active vehicle (Epic #2881).
+///
+/// Watches [fillUpListProvider] + [activeVehicleProfileProvider], filters the
+/// fills to the selected vehicle's `vehicleId` (when a vehicle is active;
+/// otherwise all fills), and returns
+/// `FuelTypeEfficiencyAggregator.byFuelType(...)` — one
+/// [FuelTypeEfficiencyStats] per fuel, sorted by €/km ascending.
+///
+/// Read-only re-slice of data the user already logged: no `FillUpList.add`
+/// hook, no storage, no `Feature` gate (mirrors the #2698 no-gate precedent).
+/// Lives in its own file (not the line-guarded consumption_providers.dart),
+/// parallel to `monthlyFuelStatsProvider`.
+
+final class FuelTypeEfficiencyComparisonProvider
+    extends
+        $FunctionalProvider<
+          List<FuelTypeEfficiencyStats>,
+          List<FuelTypeEfficiencyStats>,
+          List<FuelTypeEfficiencyStats>
+        >
+    with $Provider<List<FuelTypeEfficiencyStats>> {
+  /// Per-fuel-type efficiency comparison for the active vehicle (Epic #2881).
+  ///
+  /// Watches [fillUpListProvider] + [activeVehicleProfileProvider], filters the
+  /// fills to the selected vehicle's `vehicleId` (when a vehicle is active;
+  /// otherwise all fills), and returns
+  /// `FuelTypeEfficiencyAggregator.byFuelType(...)` — one
+  /// [FuelTypeEfficiencyStats] per fuel, sorted by €/km ascending.
+  ///
+  /// Read-only re-slice of data the user already logged: no `FillUpList.add`
+  /// hook, no storage, no `Feature` gate (mirrors the #2698 no-gate precedent).
+  /// Lives in its own file (not the line-guarded consumption_providers.dart),
+  /// parallel to `monthlyFuelStatsProvider`.
+  FuelTypeEfficiencyComparisonProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'fuelTypeEfficiencyComparisonProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$fuelTypeEfficiencyComparisonHash();
+
+  @$internal
+  @override
+  $ProviderElement<List<FuelTypeEfficiencyStats>> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  List<FuelTypeEfficiencyStats> create(Ref ref) {
+    return fuelTypeEfficiencyComparison(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(List<FuelTypeEfficiencyStats> value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<List<FuelTypeEfficiencyStats>>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$fuelTypeEfficiencyComparisonHash() =>
+    r'faf065883d386d67d73c549b8eb922004badccf6';

--- a/test/features/consumption/domain/fuel_type_efficiency_aggregator_test.dart
+++ b/test/features/consumption/domain/fuel_type_efficiency_aggregator_test.dart
@@ -1,0 +1,296 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fuel_type_efficiency_stats.dart';
+import 'package:tankstellen/features/consumption/domain/services/fuel_type_efficiency_aggregator.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+
+/// Coverage for [FuelTypeEfficiencyAggregator] (Epic #2881, child #2883).
+///
+/// The decision-doc worked example
+/// (`docs/decisions/per-fuel-efficiency-attribution.md`) is turned into
+/// assertions verbatim, plus the dominant-fuel edge cases the doc enumerates:
+/// mono interval, mixed → dominant + mixedIntervalCount, single fill → null
+/// metrics, correction inheritance never flipping dominance, verdict gate
+/// boundary, and odometer-reset (negative delta) clamping.
+
+FillUp _f({
+  required String id,
+  required DateTime date,
+  required double liters,
+  required double cost,
+  required double odo,
+  FuelType fuelType = FuelType.e10,
+  bool isFullTank = true,
+  bool isCorrection = false,
+  String? vehicleId,
+}) =>
+    FillUp(
+      id: id,
+      date: date,
+      liters: liters,
+      totalCost: cost,
+      odometerKm: odo,
+      fuelType: fuelType,
+      isFullTank: isFullTank,
+      isCorrection: isCorrection,
+      vehicleId: vehicleId,
+    );
+
+DateTime _d(int day) => DateTime(2026, 1, day);
+
+FuelTypeEfficiencyStats _statsFor(
+  List<FuelTypeEfficiencyStats> all,
+  FuelType fuel,
+) =>
+    all.firstWhere((s) => s.fuelType.apiValue == fuel.apiValue);
+
+void main() {
+  group('FuelTypeEfficiencyAggregator.byFuelType', () {
+    test('empty list returns empty list', () {
+      expect(FuelTypeEfficiencyAggregator.byFuelType(const []), isEmpty);
+    });
+
+    test('decision-doc worked example — frozen per-fuel numbers', () {
+      // F0..F5 from per-fuel-efficiency-attribution.md.
+      final fills = [
+        _f(id: 'F0', date: _d(1), liters: 40, cost: 68.00, odo: 0,
+            fuelType: FuelType.e10),
+        _f(id: 'F1', date: _d(2), liters: 30, cost: 51.00, odo: 600,
+            fuelType: FuelType.e10),
+        _f(id: 'F2', date: _d(3), liters: 45, cost: 45.00, odo: 1100,
+            fuelType: FuelType.e85),
+        _f(id: 'F3', date: _d(4), liters: 20, cost: 20.00, odo: 1400,
+            fuelType: FuelType.e85, isFullTank: false),
+        _f(id: 'F4', date: _d(5), liters: 35, cost: 59.50, odo: 1700,
+            fuelType: FuelType.e10),
+        _f(id: 'F5', date: _d(6), liters: 50, cost: 50.00, odo: 2300,
+            fuelType: FuelType.e85),
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      expect(result.length, 2);
+
+      // Sorted by €/km ascending — E85 (cheaper per km) first.
+      expect(result.first.fuelType.apiValue, FuelType.e85.apiValue);
+      expect(result.last.fuelType.apiValue, FuelType.e10.apiValue);
+
+      final e10 = _statsFor(result, FuelType.e10);
+      expect(e10.avgL100km, closeTo(7.0833, 1e-3)); // 85 / 1200 * 100
+      expect(e10.avgCostPerKm, closeTo(0.108750, 1e-6)); // 130.50 / 1200
+      expect(e10.totalSpent, closeTo(178.50, 1e-9)); // 68 + 51 + 59.50
+      expect(e10.fillCount, 3); // F0, F1, F4
+      expect(e10.attributedIntervalCount, 2); // A + C
+      expect(e10.mixedIntervalCount, 1); // C
+
+      final e85 = _statsFor(result, FuelType.e85);
+      expect(e85.avgL100km, closeTo(8.6364, 1e-3)); // 95 / 1100 * 100
+      expect(e85.avgCostPerKm, closeTo(0.086364, 1e-6)); // 95 / 1100
+      expect(e85.totalSpent, closeTo(115.00, 1e-9)); // 45 + 20 + 50
+      expect(e85.fillCount, 3); // F2, F3, F5
+      expect(e85.attributedIntervalCount, 2); // B + D
+      expect(e85.mixedIntervalCount, 0);
+
+      // Verdict: both clear the gate; E85 wins per km despite more L/100km.
+      expect(
+        FuelTypeEfficiencyAggregator.cheapestPerKm(result)?.apiValue,
+        FuelType.e85.apiValue,
+      );
+    });
+
+    test('mono-fuel intervals attribute correctly (no mixing)', () {
+      final fills = [
+        _f(id: 'a', date: _d(1), liters: 40, cost: 60, odo: 0),
+        _f(id: 'b', date: _d(2), liters: 30, cost: 45, odo: 600), // closes
+        _f(id: 'c', date: _d(3), liters: 25, cost: 40, odo: 1100), // closes
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      expect(result.length, 1);
+      final e10 = result.single;
+      // Two closed intervals, distance 600 + 500 = 1100, litres 30 + 25 = 55.
+      expect(e10.attributedIntervalCount, 2);
+      expect(e10.mixedIntervalCount, 0);
+      expect(e10.avgL100km, closeTo(55 / 1100 * 100, 1e-9));
+      expect(e10.avgCostPerKm, closeTo((45 + 40) / 1100, 1e-9));
+      expect(e10.fillCount, 3);
+    });
+
+    test('mixed interval → dominant fuel, mixedIntervalCount increments', () {
+      // One closed interval containing E85 (60 L) + E10 (20 L). E85 dominates.
+      final fills = [
+        _f(id: 'a', date: _d(1), liters: 40, cost: 40, odo: 0,
+            fuelType: FuelType.e85),
+        _f(id: 'b', date: _d(2), liters: 60, cost: 60, odo: 500,
+            fuelType: FuelType.e85, isFullTank: false),
+        _f(id: 'c', date: _d(3), liters: 20, cost: 34, odo: 1000,
+            fuelType: FuelType.e10), // closes
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      final e85 = _statsFor(result, FuelType.e85);
+      // Whole interval (litres 60+20=80, distance 1000, cost 60+34=94)
+      // attributed to E85 (60 L > 20 L).
+      expect(e85.attributedIntervalCount, 1);
+      expect(e85.mixedIntervalCount, 1);
+      expect(e85.avgL100km, closeTo(80 / 1000 * 100, 1e-9));
+      expect(e85.avgCostPerKm, closeTo(94 / 1000, 1e-9));
+
+      // E10 was a minority → it appears (has a fill) but with null metrics.
+      final e10 = _statsFor(result, FuelType.e10);
+      expect(e10.attributedIntervalCount, 0);
+      expect(e10.avgL100km, isNull);
+      expect(e10.avgCostPerKm, isNull);
+      expect(e10.fillCount, 1);
+      expect(e10.totalSpent, closeTo(34, 1e-9));
+    });
+
+    test('single fill → null per-km metrics (no closed interval)', () {
+      final result = FuelTypeEfficiencyAggregator.byFuelType([
+        _f(id: 'only', date: _d(1), liters: 40, cost: 60, odo: 100),
+      ]);
+      expect(result.length, 1);
+      final s = result.single;
+      expect(s.attributedIntervalCount, 0);
+      expect(s.avgL100km, isNull);
+      expect(s.avgCostPerKm, isNull);
+      expect(s.fillCount, 1);
+      expect(s.totalSpent, closeTo(60, 1e-9));
+      expect(s.mixedIntervalCount, 0);
+    });
+
+    test('correction in interval inherits dominant fuel, never flips it', () {
+      // E10 opens + closes; a large E85-typed CORRECTION sits inside. The
+      // correction must NOT win dominance even though its litres exceed the
+      // real E10 fill — corrections never enter the tally.
+      final fills = [
+        _f(id: 'a', date: _d(1), liters: 40, cost: 60, odo: 0,
+            fuelType: FuelType.e10),
+        _f(id: 'corr', date: _d(2), liters: 999, cost: 0, odo: 300,
+            fuelType: FuelType.e85, isFullTank: false, isCorrection: true),
+        _f(id: 'b', date: _d(3), liters: 30, cost: 45, odo: 600,
+            fuelType: FuelType.e10), // closes
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      // E85 must NOT appear at all — the correction is its only "fill" and
+      // corrections are excluded from per-fill facts too.
+      expect(
+        result.any((s) => s.fuelType.apiValue == FuelType.e85.apiValue),
+        isFalse,
+      );
+      final e10 = _statsFor(result, FuelType.e10);
+      expect(e10.attributedIntervalCount, 1);
+      // Interval litres include the correction (inherits E10): 30 + 999.
+      expect(e10.avgL100km, closeTo((30 + 999) / 600 * 100, 1e-9));
+      // Cost excludes the zero-cost correction: just the 45.
+      expect(e10.avgCostPerKm, closeTo(45 / 600, 1e-9));
+      // mixedIntervalCount counts >1 NON-correction fuel — here only E10.
+      expect(e10.mixedIntervalCount, 0);
+      // Per-fill facts ignore the correction.
+      expect(e10.fillCount, 2);
+      expect(e10.totalSpent, closeTo(105, 1e-9)); // 60 + 45
+    });
+
+    test('verdict gate returns null below the threshold', () {
+      // Two fuels, but E85 has only ONE attributed interval (< 2).
+      final fills = [
+        _f(id: 'a', date: _d(1), liters: 40, cost: 60, odo: 0,
+            fuelType: FuelType.e10),
+        _f(id: 'b', date: _d(2), liters: 30, cost: 45, odo: 600,
+            fuelType: FuelType.e10), // closes E10 interval 1
+        _f(id: 'c', date: _d(3), liters: 25, cost: 38, odo: 1100,
+            fuelType: FuelType.e10), // closes E10 interval 2
+        _f(id: 'd', date: _d(4), liters: 45, cost: 45, odo: 1600,
+            fuelType: FuelType.e85), // closes E85 interval 1 only
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      final e85 = _statsFor(result, FuelType.e85);
+      expect(e85.attributedIntervalCount, 1); // below threshold
+      expect(FuelTypeEfficiencyAggregator.cheapestPerKm(result), isNull);
+    });
+
+    test('verdict gate returns the right winner at/above the threshold', () {
+      // E10: 2 intervals @ pricey per km. E85: 2 intervals @ cheaper per km.
+      final fills = [
+        // E10 interval 1
+        _f(id: 'a', date: _d(1), liters: 40, cost: 68, odo: 0,
+            fuelType: FuelType.e10),
+        _f(id: 'b', date: _d(2), liters: 30, cost: 51, odo: 600,
+            fuelType: FuelType.e10),
+        // E85 interval 1
+        _f(id: 'c', date: _d(3), liters: 45, cost: 45, odo: 1100,
+            fuelType: FuelType.e85),
+        // E85 interval 2
+        _f(id: 'd', date: _d(4), liters: 50, cost: 50, odo: 1700,
+            fuelType: FuelType.e85),
+        // E10 interval 2
+        _f(id: 'e', date: _d(5), liters: 35, cost: 60, odo: 2200,
+            fuelType: FuelType.e10),
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      expect(_statsFor(result, FuelType.e10).attributedIntervalCount, 2);
+      expect(_statsFor(result, FuelType.e85).attributedIntervalCount, 2);
+      expect(
+        FuelTypeEfficiencyAggregator.cheapestPerKm(result)?.apiValue,
+        FuelType.e85.apiValue,
+      );
+    });
+
+    test('odometer-reset (negative delta) clamps to 0 without crashing', () {
+      // The closing fill's odometer is LOWER than the opening — a reset or
+      // bad import. Distance clamps to 0 → that interval contributes no
+      // distance, so per-km metrics stay null (no division by zero).
+      final fills = [
+        _f(id: 'a', date: _d(1), liters: 40, cost: 60, odo: 5000),
+        _f(id: 'b', date: _d(2), liters: 30, cost: 45, odo: 100), // reset
+      ];
+
+      late List<FuelTypeEfficiencyStats> result;
+      expect(
+        () => result = FuelTypeEfficiencyAggregator.byFuelType(fills),
+        returnsNormally,
+      );
+      final e10 = result.single;
+      expect(e10.attributedIntervalCount, 1); // interval closed
+      expect(e10.avgL100km, isNull); // zero distance → null
+      expect(e10.avgCostPerKm, isNull);
+      expect(e10.fillCount, 2);
+      expect(e10.totalSpent, closeTo(105, 1e-9));
+    });
+
+    test('tie on litres → closing plein fuel wins', () {
+      // Interval contributes E10 30 L + E85 30 L (tie). Closing fill is E85.
+      final fills = [
+        _f(id: 'a', date: _d(1), liters: 40, cost: 40, odo: 0,
+            fuelType: FuelType.e10),
+        _f(id: 'b', date: _d(2), liters: 30, cost: 51, odo: 400,
+            fuelType: FuelType.e10, isFullTank: false),
+        _f(id: 'c', date: _d(3), liters: 30, cost: 30, odo: 1000,
+            fuelType: FuelType.e85), // closing plein E85
+      ];
+
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      final e85 = _statsFor(result, FuelType.e85);
+      expect(e85.attributedIntervalCount, 1); // tie → closing E85 wins
+      expect(e85.mixedIntervalCount, 1);
+      final e10 = _statsFor(result, FuelType.e10);
+      expect(e10.attributedIntervalCount, 0);
+    });
+
+    test('unsorted input is handled (sorts chronologically first)', () {
+      final fills = [
+        _f(id: 'b', date: _d(2), liters: 30, cost: 45, odo: 600),
+        _f(id: 'a', date: _d(1), liters: 40, cost: 60, odo: 0),
+      ];
+      final result = FuelTypeEfficiencyAggregator.byFuelType(fills);
+      final e10 = result.single;
+      expect(e10.attributedIntervalCount, 1);
+      expect(e10.avgL100km, closeTo(30 / 600 * 100, 1e-9));
+    });
+  });
+}

--- a/test/features/consumption/providers/fuel_type_efficiency_provider_test.dart
+++ b/test/features/consumption/providers/fuel_type_efficiency_provider_test.dart
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fill_up.dart';
+import 'package:tankstellen/features/consumption/domain/entities/fuel_type_efficiency_stats.dart';
+import 'package:tankstellen/features/consumption/providers/consumption_providers.dart';
+import 'package:tankstellen/features/consumption/providers/fuel_type_efficiency_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
+
+/// Orchestration tests for [fuelTypeEfficiencyComparisonProvider] (#2884).
+///
+/// The grouping maths live in `FuelTypeEfficiencyAggregator` (covered by
+/// `fuel_type_efficiency_aggregator_test.dart`); these tests pin the
+/// provider's wiring: it watches the fill-up list + active vehicle, filters
+/// to the selected vehicle's fills, and delegates to the aggregator.
+
+/// Stub [FillUpList] returning a fixed list (no Hive).
+class _FakeFillUpList extends FillUpList {
+  _FakeFillUpList(this._value);
+  final List<FillUp> _value;
+
+  @override
+  List<FillUp> build() => _value;
+}
+
+/// Stub [ActiveVehicleProfile] returning a fixed value (no repo).
+class _StubActiveVehicle extends ActiveVehicleProfile {
+  _StubActiveVehicle(this._value);
+  final VehicleProfile? _value;
+
+  @override
+  VehicleProfile? build() => _value;
+}
+
+FillUp _f({
+  required String id,
+  required double liters,
+  required double cost,
+  required double odo,
+  required int day,
+  FuelType fuelType = FuelType.e10,
+  bool isFullTank = true,
+  String? vehicleId,
+}) =>
+    FillUp(
+      id: id,
+      date: DateTime(2026, 1, day),
+      liters: liters,
+      totalCost: cost,
+      odometerKm: odo,
+      fuelType: fuelType,
+      isFullTank: isFullTank,
+      vehicleId: vehicleId,
+    );
+
+const _v1 = VehicleProfile(
+  id: 'v1',
+  name: 'Peugeot 107',
+  type: VehicleType.combustion,
+);
+
+ProviderContainer _container({
+  required List<FillUp> fillUps,
+  VehicleProfile? activeVehicle,
+}) {
+  final c = ProviderContainer(overrides: [
+    fillUpListProvider.overrideWith(() => _FakeFillUpList(fillUps)),
+    activeVehicleProfileProvider
+        .overrideWith(() => _StubActiveVehicle(activeVehicle)),
+  ]);
+  addTearDown(c.dispose);
+  return c;
+}
+
+FuelTypeEfficiencyStats _statsFor(
+  List<FuelTypeEfficiencyStats> all,
+  FuelType fuel,
+) =>
+    all.firstWhere((s) => s.fuelType.apiValue == fuel.apiValue);
+
+void main() {
+  group('fuelTypeEfficiencyComparisonProvider', () {
+    test('empty fill-up list yields an empty comparison', () {
+      final c = _container(fillUps: const [], activeVehicle: _v1);
+      expect(c.read(fuelTypeEfficiencyComparisonProvider), isEmpty);
+    });
+
+    test('groups the active vehicle fills by fuel type', () {
+      // Two E10 closed intervals + two E85 closed intervals for v1.
+      final c = _container(
+        activeVehicle: _v1,
+        fillUps: [
+          _f(id: 'a', day: 1, liters: 40, cost: 68, odo: 0,
+              fuelType: FuelType.e10, vehicleId: 'v1'),
+          _f(id: 'b', day: 2, liters: 30, cost: 51, odo: 600,
+              fuelType: FuelType.e10, vehicleId: 'v1'),
+          _f(id: 'c', day: 3, liters: 45, cost: 45, odo: 1100,
+              fuelType: FuelType.e85, vehicleId: 'v1'),
+          _f(id: 'd', day: 4, liters: 50, cost: 50, odo: 1700,
+              fuelType: FuelType.e85, vehicleId: 'v1'),
+          _f(id: 'e', day: 5, liters: 35, cost: 60, odo: 2200,
+              fuelType: FuelType.e10, vehicleId: 'v1'),
+        ],
+      );
+
+      final result = c.read(fuelTypeEfficiencyComparisonProvider);
+      expect(result.length, 2);
+      expect(_statsFor(result, FuelType.e10).attributedIntervalCount, 2);
+      expect(_statsFor(result, FuelType.e85).attributedIntervalCount, 2);
+      // Sorted by €/km ascending — E85 first.
+      expect(result.first.fuelType.apiValue, FuelType.e85.apiValue);
+    });
+
+    test('filters out fills belonging to other vehicles', () {
+      final c = _container(
+        activeVehicle: _v1,
+        fillUps: [
+          _f(id: 'v1-a', day: 1, liters: 40, cost: 60, odo: 0,
+              fuelType: FuelType.e10, vehicleId: 'v1'),
+          _f(id: 'v1-b', day: 2, liters: 30, cost: 45, odo: 600,
+              fuelType: FuelType.e10, vehicleId: 'v1'),
+          // Foreign vehicle, different fuel — must NOT appear.
+          _f(id: 'other', day: 3, liters: 45, cost: 45, odo: 5000,
+              fuelType: FuelType.e85, vehicleId: 'other'),
+        ],
+      );
+
+      final result = c.read(fuelTypeEfficiencyComparisonProvider);
+      expect(result.length, 1);
+      expect(result.single.fuelType.apiValue, FuelType.e10.apiValue);
+      expect(
+        result.any((s) => s.fuelType.apiValue == FuelType.e85.apiValue),
+        isFalse,
+      );
+    });
+
+    test('no active vehicle → aggregates ALL fills', () {
+      final c = _container(
+        activeVehicle: null,
+        fillUps: [
+          _f(id: 'a', day: 1, liters: 40, cost: 60, odo: 0,
+              fuelType: FuelType.e10, vehicleId: 'v1'),
+          _f(id: 'b', day: 2, liters: 30, cost: 45, odo: 600,
+              fuelType: FuelType.e85, vehicleId: 'other'),
+        ],
+      );
+
+      final result = c.read(fuelTypeEfficiencyComparisonProvider);
+      // Both fuels present because no vehicle filter is applied.
+      expect(result.length, 2);
+    });
+  });
+}


### PR DESCRIPTION
Compute foundation for **Epic #2881** — per-fuel-type efficiency comparison
for multi-fuel vehicles (the Peugeot 107 on E85 / E10 / E5 case). No ARB, no
UI, no `Feature` enum change in this PR.

## Commits (one per closed issue)
- **docs(decision) #2882** — `docs/decisions/per-fuel-efficiency-attribution.md`
  freezes the v1 **dominant-fuel** attribution rule: each closed plein-to-plein
  interval is attributed whole to the fuel with the most litres among its
  contributing non-correction fills (tie → closing plein's fuel, then
  `apiValue` alphabetical). Corrections inherit the dominant fuel and never
  enter the tally. Includes a hand-checkable 6-fill / 4-interval worked example
  (one mixed) that becomes the RED fixture for #2883, plus the verdict gate
  `kMinAttributedIntervalsForVerdict = 2`.
- **feat(consumption) #2883** — `FuelTypeEfficiencyStats` freezed view entity
  + pure `FuelTypeEfficiencyAggregator.byFuelType(List<FillUp>)`. Walks closed
  intervals (same definition as `consumption_stats.dart`, replicated with a
  cross-reference comment since that walker exposes no per-interval hook),
  attributes each interval to its dominant fuel, accumulates
  Σlitres/Σdistance/Σcost + counts per fuel, and `totalSpent` over all
  non-correction fills of the fuel. Sorted by €/km ascending (nulls last).
  Exposes `cheapestPerKm()` gated on the threshold. 11 unit tests cover the
  worked example + every edge case (mono, mixed→dominant, single-fill→null,
  correction inheritance, verdict boundary, litre-tie, odometer-reset clamp).
- **feat(consumption) #2884** — read-only `fuelTypeEfficiencyComparisonProvider`
  in its own file (parallel to `monthlyFuelStatsProvider`; keeps
  `consumption_providers.dart` at its line guard). Watches `fillUpListProvider`
  + `activeVehicleProfileProvider`, filters to the active vehicle's fills (all
  when none selected). 4 `ProviderContainer` tests.

## Gates
- Clean `build_runner` (clean → build) re-run after the last commit: **zero
  uncommitted drift**. Generated `*.freezed.dart` / `*.g.dart` committed.
- `flutter analyze` clean on all touched files (the only 2 project `info`s are
  pre-existing `unnecessary_import`s in unrelated test files).
- New tests: **15/15 green**. No-hardcoded-strings lint baseline unchanged.
- Every new `lib/` file < 400 lines (56 / 236 / 33).

Part of #2881. Closes #2882, closes #2883, closes #2884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
