### PR TITLE
fix(favorites): deep-convert Hive station map so structured openingHours favorites are not dropped (#2893)

### DIFF
--- a/lib/core/storage/stores/favorites_hive_store.dart
+++ b/lib/core/storage/stores/favorites_hive_store.dart
@@ -68,8 +68,14 @@ class FavoritesHiveStore
   @override
   Map<String, dynamic>? getFavoriteStationData(String stationId) {
     final raw = _getFavoriteStationDataRaw()[stationId];
-    if (raw is Map) return Map<String, dynamic>.from(raw);
-    return null;
+    if (raw is! Map) return null;
+    // #2893 — deep-convert so nested objects (e.g. the #2777 structured
+    // `openingHours`, whose `days`/`ranges` Hive round-trips as
+    // `Map<dynamic, dynamic>`) keep `Map<String, dynamic>` typing. A shallow
+    // `Map<String, dynamic>.from` left those inner maps dynamic-keyed, so
+    // `Station.fromJson`'s nested cast threw and the whole favorite was
+    // silently dropped. Mirrors the EV path's existing deep-convert (#690).
+    return HiveBoxes.toStringDynamicMap(raw);
   }
 
   @override

--- a/test/core/storage/stores/favorites_hive_store_test.dart
+++ b/test/core/storage/stores/favorites_hive_store_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/core/storage/hive_storage.dart';
 import 'package:tankstellen/core/storage/stores/favorites_hive_store.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/station_detail/domain/opening_hours.dart';
 
 void main() {
   late FavoritesHiveStore store;
@@ -88,6 +90,84 @@ void main() {
       expect(store.getFavoriteStationData('st-1'), isNull);
       expect(store.getFavoriteStationData('st-2'), isNotNull);
     });
+
+    // #2893 — a favorite carrying the #2777 structured `openingHours` was
+    // silently DROPPED on load. Hive round-trips its nested `days`/`ranges`
+    // objects as `Map<dynamic, dynamic>`, but the read boundary did only a
+    // shallow `Map<String, dynamic>.from`, so `Station.fromJson`'s nested
+    // cast (station.g.dart line 34, `openingHours as Map<String, dynamic>`)
+    // threw and the whole station was skipped ("Skipping corrupt favorite
+    // fr-11130001" — Intermarché Sigean, a real favorite). Drive the REAL
+    // Hive write→read→fromJson path, not Station.fromJson in isolation.
+    test(
+      'a favorite with structured openingHours survives the Hive round-trip '
+      'and re-parses via Station.fromJson (regression #2893)',
+      () async {
+        const id = 'fr-11130001'; // Intermarché Sigean, the dropped favorite.
+        const station = Station(
+          id: id,
+          name: 'Intermarché Sigean',
+          brand: 'Intermarché',
+          street: 'Avenue de Perpignan',
+          postCode: '11130',
+          place: 'Sigean',
+          lat: 43.0289,
+          lng: 2.9756,
+          diesel: 1.689,
+          e10: 1.799,
+          isOpen: true,
+          openingHours: WeeklyOpeningHours(
+            availability: OpeningHoursAvailability.full,
+            days: [
+              DayHours(
+                day: OpeningDay.mon,
+                state: DayState.openRanges,
+                ranges: [
+                  // Nested object two levels deep — the exact shape Hive
+                  // returns as Map<dynamic, dynamic>.
+                  TimeRange(startMinutes: 420, endMinutes: 1110),
+                ],
+              ),
+            ],
+          ),
+        );
+
+        // Real write path: the favorites/widget/refresh code all persist via
+        // `saveFavoriteStationData(id, station.toJson())`.
+        await store.saveFavoriteStationData(id, station.toJson());
+
+        // Force the on-disk round-trip. Hive only re-types the nested objects
+        // as `Map<dynamic, dynamic>` after they are serialised to disk and
+        // read back fresh — exactly what happens on a real app cold start.
+        // Reading from the still-open in-memory box would hand back the very
+        // `Map<String, dynamic>` we wrote and hide the bug.
+        await Hive.close();
+        Hive.init(tempDir.path);
+        await HiveStorage.initForTest();
+        store = FavoritesHiveStore();
+
+        // Real read path: Hive hands the nested objects back dynamic-keyed.
+        final data = store.getFavoriteStationData(id);
+        expect(data, isNotNull,
+            reason: 'the favorite must still be readable from storage');
+
+        // Before the fix this threw _TypeError on the nested openingHours
+        // cast, so the favorites provider skipped the station entirely.
+        late final Station parsed;
+        expect(
+          () => parsed = Station.fromJson(data!),
+          returnsNormally,
+          reason: 'nested Hive Map<dynamic,dynamic> must coerce cleanly — '
+              'the favorite must NOT be dropped',
+        );
+        expect(parsed.id, id);
+        expect(parsed.name, 'Intermarché Sigean');
+        // The structured hours survive the whole loop intact.
+        expect(parsed.openingHours, isNotNull);
+        expect(parsed.openingHours!.days, hasLength(1));
+        expect(parsed.openingHours!.days.first.ranges.first.startMinutes, 420);
+      },
+    );
   });
 
   group('EV favorites', () {


### PR DESCRIPTION
## What

Fixes #2893 — a user's favorite station was silently DROPPED on load because of a nested-map cast error.

The favorites read boundary (`FavoritesHiveStore.getFavoriteStationData`) did only a **shallow** `Map<String, dynamic>.from(raw)`. Hive round-trips deeply-nested objects as `Map<dynamic, dynamic>`, so the #2777 structured `openingHours` (whose `days` → `ranges` are nested objects) stayed dynamic-keyed. `Station.fromJson` then hit its nested cast `openingHours as Map<String, dynamic>` (`station.g.dart` line 34) and threw:

```
_TypeError: '_Map<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>' in type cast
```

The favorites provider's `catch` swallowed it and logged "Skipping corrupt favorite fr-11130001" — Intermarché Sigean, a real favorite, lost on every load.

## Fix (root cause, at the boundary)

`getFavoriteStationData` now uses the shared `HiveBoxes.toStringDynamicMap` deep-converter — the **same** recursive coercion the EV favorites path already applied for the identical #690 bug. No generated `.g.dart` is hand-edited; no `@JsonKey`/freezed change, so no codegen.

## Test (RED before, green after)

Added a regression test in `favorites_hive_store_test.dart` that drives the **real** path — `saveFavoriteStationData(station.toJson())` → **close + reopen** the Hive box (forces the on-disk round-trip that produces `Map<dynamic, dynamic>`, exactly like a cold start) → `getFavoriteStationData` → `Station.fromJson`. It uses the actual `fr-11130001` Intermarché Sigean favorite shape with structured `openingHours`.

- **RED on master:** throws the exact `_TypeError` from the issue.
- **Green after:** the favorite parses, with `openingHours` intact.

## Gates

- `flutter analyze` clean on the changed files (2 pre-existing `info` hints in unrelated consumption test files remain on master).
- All 335 storage + favorites tests pass.
- No ARB, no codegen. Both files under the 400-line cap.

Closes #2893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
