### PR TITLE
fix(obd2): no silent green connect when the bus is dead + de-noise the expected connect-log flood (#2892)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -142,10 +142,13 @@ Future<Obd2Service?> _connectByMacPassive(
       logFailureAsError: false, // #2379 — recoverable (scanner re-arms)
     );
   } on Object catch (e, st) {
-    // #2379 — OBD2/BLE, not local storage.
-    unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-      'where': 'Obd2ConnectionService.connectByMacPassive failed',
-    }));
+    // #2892 — the passive autoConnect wait routinely raises the EXPECTED
+    // Obd2AdapterUnresponsive on a parked car (silent bus / out of range);
+    // breadcrumb it instead of an ERROR trace (error-log #22 flood). A
+    // genuine fault still ERROR-logs (#2379 — OBD2/BLE → `other`).
+    recordObd2ConnectTransient(e, st,
+        where: 'Obd2ConnectionService.connectByMacPassive failed',
+        layer: ErrorLayer.other);
     await svc._teardownLastDirectChannel();
     return null;
   }

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -16,6 +16,7 @@ import 'obd2_adapter_wake_cache.dart';
 import 'obd2_cache_openers.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_permissions.dart';
+import 'obd2_read_telemetry.dart';
 import 'obd2_service.dart';
 import 'supported_pids_cache.dart';
 import '../../../../core/logging/error_logger.dart';

--- a/lib/features/consumption/data/obd2/obd2_read_telemetry.dart
+++ b/lib/features/consumption/data/obd2/obd2_read_telemetry.dart
@@ -58,3 +58,56 @@ void recordObd2ReadFailure(
   unawaited(errorLogger.log(ErrorLayer.other, error, stack,
       context: {'where': where}));
 }
+
+/// #2892 — true when [error] is an EXPECTED, user-surfaced *connect* failure
+/// (the data-layer twin of `recordObd2ConnectFailure`'s
+/// [Obd2ConnectionError.isExpectedUserCondition] gate, plus the bare transport
+/// races that connect can raise before a typed error is in flight):
+///
+/// - [Obd2ConnectionError] whose [Obd2ConnectionError.isExpectedUserCondition]
+///   is true — the "adapter off / out of range / ignition off / not bonded"
+///   family ([Obd2AdapterUnresponsive] et al.) the UI already handles;
+/// - [StateError] 'transport closed' / 'not connected' — a channel that was
+///   torn down mid-connect (a parked-car reconnect racing the teardown);
+/// - [TimeoutException] — a bounded direct/scan connect that didn't land.
+///
+/// GENUINE faults — [Obd2PermissionDenied] (needs a settings deep-link),
+/// [Obd2ProtocolInitFailed] (a counterfeit-clone diagnostic), and any other
+/// exception — return false so they stay ERROR traces.
+bool isExpectedObd2ConnectTransient(Object error) {
+  if (error is Obd2ConnectionError) return error.isExpectedUserCondition;
+  if (error is TimeoutException) return true;
+  if (error is StateError) {
+    final m = error.message.toLowerCase();
+    return m.contains('transport closed') || m.contains('not connected');
+  }
+  return false;
+}
+
+/// #2892 — route an OBD2 *connect* failure to the right telemetry level, the
+/// connect-path twin of [recordObd2ReadFailure] / `recordObd2ConnectFailure`.
+///
+/// Error-log #22 showed an EXPECTED [Obd2AdapterUnresponsive] ("turn the
+/// ignition on and retry") spooled 20× as ERROR traces from the in-trip
+/// reconnect storm (`ReconnectConnector` retries on a parked car). An expected
+/// connect transient ([isExpectedObd2ConnectTransient]) records a diagnostic
+/// breadcrumb instead; a GENUINE fault still `errorLogger.log`s at the given
+/// [layer] (defaults to [ErrorLayer.storage], the reconnect-path layer) so it
+/// stays visible. Lives in the data layer (alongside [recordObd2ReadFailure])
+/// so the reconnect connector + connection service use it without a
+/// presentation→data inversion.
+void recordObd2ConnectTransient(
+  Object error,
+  StackTrace stack, {
+  required String where,
+  ErrorLayer layer = ErrorLayer.storage,
+}) {
+  if (isExpectedObd2ConnectTransient(error)) {
+    BreadcrumbCollector.add(
+      'OBD2 connect failed — expected transient',
+      detail: '$where: ${error.runtimeType}',
+    );
+    return;
+  }
+  unawaited(errorLogger.log(layer, error, stack, context: {'where': where}));
+}

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -423,6 +423,21 @@ class Obd2Service implements Obd2RawCommandPort {
   /// connection to the vehicle's ELM327 adapter.
   bool get isConnected => _transport.isConnected;
 
+  /// `true` when the vehicle bus actually answered during the last connect —
+  /// a protocol digit was cached (`ATDPN` returned a real protocol) OR PID
+  /// discovery (`0100`) found ≥1 supported PID (#2892).
+  ///
+  /// A HEALTHY ELM chip on a SILENT bus (ignition off / ECU asleep) passes
+  /// every AT command — [isConnected] and [connect] both report success — yet
+  /// `ATDPN`→NO DATA caches no protocol and `0100`→NO DATA leaves
+  /// [debugSupportedPids] empty, so a started trip is degraded GPS-only with
+  /// no explanation. Callers gate on [busAnswered] after connect to surface
+  /// the localized "turn the ignition on" condition ([Obd2AdapterUnresponsive])
+  /// instead. Cheap (reads already-resolved fields, no I/O); gated STRICTLY on
+  /// the no-answer signal so it never trips when discovery returned PIDs.
+  bool get busAnswered =>
+      _cachedProtocolDigit() != null || debugSupportedPids.isNotEmpty;
+
   /// Send a raw command to the ELM327 adapter and return the raw
   /// response. Exposed for the [PidScheduler]-based trip recording
   /// loop (#814) — the scheduler dispatches individual PID commands

--- a/lib/features/consumption/data/obd2/reconnect_connector.dart
+++ b/lib/features/consumption/data/obd2/reconnect_connector.dart
@@ -3,9 +3,9 @@
 
 import 'dart:async';
 
-import '../../../../core/logging/error_logger.dart';
 import 'adapter_registry.dart';
 import 'obd2_connection_service.dart';
+import 'obd2_read_telemetry.dart';
 import 'obd2_service.dart';
 import 'reconnect_rssi_gate.dart';
 
@@ -90,9 +90,13 @@ class ReconnectConnector {
         return true;
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'ReconnectConnector direct connect failed',
-      }));
+      // #2892 — an EXPECTED, user-surfaced connect condition (the bus is
+      // silent / the dongle is out of range on a parked car) is a breadcrumb,
+      // not an ERROR trace: this attempt repeats on the scanner's backoff
+      // schedule, so a raw `errorLogger.log` here floods (error-log #22:
+      // Obd2AdapterUnresponsive ×20). A genuine fault still ERROR-logs.
+      recordObd2ConnectTransient(e, st,
+          where: 'ReconnectConnector direct connect failed');
     }
 
     // 2) SCAN FALLBACK (ultimate). One scan window: track the strongest
@@ -134,9 +138,11 @@ class ReconnectConnector {
         return true;
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'ReconnectConnector scan fallback failed',
-      }));
+      // #2892 — same de-noise: a scan-path `connect(candidate)` that throws
+      // the EXPECTED Obd2AdapterUnresponsive (classic_elm_channel.dart /
+      // _openAndInit) on a silent bus is a breadcrumb, not an ERROR trace.
+      recordObd2ConnectTransient(e, st,
+          where: 'ReconnectConnector scan fallback failed');
     }
     return false;
   }
@@ -163,9 +169,10 @@ class ReconnectConnector {
         return true;
       }
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-        'where': 'ReconnectConnector passive connect failed',
-      }));
+      // #2892 — same de-noise: the paced passive/Classic retry on a parked
+      // car routinely raises the EXPECTED user condition; breadcrumb it.
+      recordObd2ConnectTransient(e, st,
+          where: 'ReconnectConnector passive connect failed');
     }
     return false;
   }

--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -9,6 +9,7 @@ import '../../../../core/logging/error_logger.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
+import '../../data/obd2/obd2_connection_errors.dart';
 import '../../data/obd2/obd2_connection_service.dart';
 import '../../data/obd2/obd2_service.dart';
 import '../obd2_connect_telemetry.dart';
@@ -129,6 +130,20 @@ class RecordingStartCoordinator {
         // User dismissed the picker without connecting — leave the
         // recording screen's connecting view and revert to idle.
         notifier.cancelConnecting();
+        return;
+      }
+      // #2892 — the ELM chip can connect cleanly (every AT OK) while the
+      // vehicle bus is silent (ignition off / ECU asleep): ATDPN→NO DATA
+      // caches no protocol and 0100→NO DATA leaves zero supported PIDs, yet
+      // `connect()` still returned true. Starting here would yield a degraded
+      // GPS-only trip with no telemetry and no explanation. Surface the
+      // EXISTING localized "turn the ignition on" condition instead, roll the
+      // connecting phase back, and tear down the dead link. Gated STRICTLY on
+      // the no-answer signal so it never trips when discovery found PIDs.
+      if (!service.busAnswered) {
+        notifier.cancelConnecting();
+        onConnectionError(const Obd2AdapterUnresponsive());
+        unawaited(service.disconnect());
         return;
       }
       notifier.setConnectStage(TripStartStage.readingVehicleData);

--- a/test/features/consumption/data/obd2/obd2_connect_transient_denoise_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connect_transient_denoise_test.dart
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_read_telemetry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/reconnect_connector.dart';
+
+/// #2892 part C — the connect-log flood de-noiser. Error-log #22 spooled an
+/// EXPECTED `Obd2AdapterUnresponsive` ("turn the ignition on and retry") 20×
+/// as ERROR traces from the in-trip reconnect storm (a parked car). The new
+/// `recordObd2ConnectTransient` routes the expected, user-surfaced connect
+/// conditions to a breadcrumb while genuine faults stay ERROR traces — the
+/// connect-path twin of the #2745/#2763 read de-noiser.
+class _CapturingRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    errors.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _CapturingRecorder rec;
+
+  setUp(() {
+    errorLogger.resetForTest();
+    rec = _CapturingRecorder();
+    errorLogger.testRecorderOverride = rec;
+    BreadcrumbCollector.clear();
+  });
+
+  tearDown(errorLogger.resetForTest);
+
+  group('isExpectedObd2ConnectTransient classifies the connect families', () {
+    test('the user-surfaced connect family is expected', () {
+      expect(isExpectedObd2ConnectTransient(const Obd2AdapterUnresponsive()),
+          isTrue);
+      expect(isExpectedObd2ConnectTransient(const Obd2ScanTimeout()), isTrue);
+      expect(isExpectedObd2ConnectTransient(const Obd2BluetoothOff()), isTrue);
+      expect(
+          isExpectedObd2ConnectTransient(const Obd2DisconnectedException()),
+          isTrue);
+      expect(isExpectedObd2ConnectTransient(TimeoutException('connect')),
+          isTrue);
+      expect(
+          isExpectedObd2ConnectTransient(StateError('transport closed')),
+          isTrue);
+      expect(
+          isExpectedObd2ConnectTransient(StateError('not connected')), isTrue);
+    });
+
+    test('genuine faults are NOT expected (stay ERROR)', () {
+      expect(isExpectedObd2ConnectTransient(const Obd2PermissionDenied()),
+          isFalse);
+      expect(
+          isExpectedObd2ConnectTransient(const Obd2ProtocolInitFailed('garble')),
+          isFalse);
+      // A bare StateError that is NOT a transport race is a genuine bug.
+      expect(isExpectedObd2ConnectTransient(StateError('bad index')), isFalse);
+      expect(isExpectedObd2ConnectTransient(Exception('boom')), isFalse);
+    });
+  });
+
+  group('recordObd2ConnectTransient routing', () {
+    test('an expected Obd2AdapterUnresponsive is a breadcrumb, NOT an ERROR',
+        () async {
+      recordObd2ConnectTransient(const Obd2AdapterUnresponsive(),
+          StackTrace.current,
+          where: 'reconnect');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, isEmpty);
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected transient'),
+      );
+    });
+
+    test('a genuine Obd2PermissionDenied STILL ERROR-logs (the guard)',
+        () async {
+      recordObd2ConnectTransient(const Obd2PermissionDenied(),
+          StackTrace.current,
+          where: 'reconnect');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, hasLength(1));
+      expect(rec.errors.single.toString(), contains('reconnect'));
+      expect(BreadcrumbCollector.snapshot(), isEmpty);
+    });
+  });
+
+  group('fault injection at the reconnect connect site (#2892)', () {
+    test(
+        'an EXPECTED Obd2AdapterUnresponsive on a reconnect does NOT reach '
+        'errorLogger — it records a breadcrumb', () async {
+      final connector = ReconnectConnector(
+        connection:
+            _ThrowingConnection(directError: const Obd2AdapterUnresponsive()),
+        onConnected: (_) {},
+      );
+
+      final ok = await connector.attempt('aa:bb');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(ok, isFalse, reason: 'the silent bus did not reconnect');
+      expect(rec.errors, isEmpty,
+          reason: 'an expected connect condition must NOT spool an ERROR '
+              'trace (the error-log #22 ×20 flood)');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected transient'),
+      );
+    });
+
+    test('a GENUINE Obd2PermissionDenied on a reconnect STILL reaches '
+        'errorLogger', () async {
+      final connector = ReconnectConnector(
+        connection:
+            _ThrowingConnection(directError: const Obd2PermissionDenied()),
+        onConnected: (_) {},
+      );
+
+      final ok = await connector.attempt('aa:bb');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(ok, isFalse);
+      expect(rec.errors, hasLength(1),
+          reason: 'a real, actionable fault must stay a visible ERROR trace');
+      final logged = rec.errors.single.toString();
+      expect(logged, contains('Obd2PermissionDenied'));
+      expect(logged, contains('ReconnectConnector direct connect failed'));
+      expect(BreadcrumbCollector.snapshot(), isEmpty);
+    });
+  });
+}
+
+/// A connection whose direct connect throws the injected error and whose scan
+/// is empty, so `ReconnectConnector.attempt` exercises the direct-path catch
+/// then returns false. Subclasses the real service so the (overridable) thin
+/// instance methods can be replaced; the heavy facades are inert.
+class _ThrowingConnection extends Obd2ConnectionService {
+  _ThrowingConnection({required this.directError})
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _GrantPermissions(),
+          bluetooth: _EmptyFacade(),
+        );
+
+  final Object directError;
+
+  @override
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration timeout = const Duration(seconds: 4),
+    bool fallbackToScan = true,
+  }) async {
+    throw directError;
+  }
+
+  @override
+  Stream<List<ResolvedObd2Candidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    // Empty — the direct path's catch is the unit under test; nothing to scan.
+  }
+}
+
+class _GrantPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+class _EmptyFacade implements BluetoothFacade {
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      throw UnimplementedError();
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) =>
+      throw UnimplementedError();
+}

--- a/test/features/consumption/data/obd2/obd2_service_bus_silent_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_bus_silent_test.dart
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'adapters/smart_obd_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'negotiated_protocol_cache.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'supported_pids_cache.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2892 — a HEALTHY ELM chip on a SILENT bus (ignition off / ECU asleep).
+///
+/// Every AT command succeeds (ATZ → ATAT1 all OK, the chip itself is fine),
+/// but the vehicle bus never answers: `ATDPN` → NO DATA (no protocol to
+/// cache) and `0100` → NO DATA (PID discovery returns EMPTY). `connect()`
+/// still returns `true` — protocol-resolve and PID discovery are best-effort
+/// and swallow the no-answer — so the status chip shows green "connected" and
+/// a trip would start GPS-only with zero telemetry and no explanation.
+///
+/// `busAnswered` is the cheap signal the coordinator gates on to surface the
+/// existing localized "turn the ignition on" condition instead of silently
+/// starting. It must be `false` HERE (protocol null AND zero PIDs) and `true`
+/// the moment EITHER a protocol cached or a PID was discovered.
+void main() {
+  silenceErrorLoggerSpool();
+
+  /// Build a service over the scripted channel, run its connect to completion
+  /// under the virtual clock, and return whether connect() reported success.
+  bool connect(FakeAsync async, _ScriptedChannel channel, Obd2Service service) {
+    bool? connected;
+    unawaited(
+      service.connect(adapter: const SmartObdAdapter()).then((ok) {
+        connected = ok;
+      }),
+    );
+    async
+      ..elapse(const Duration(seconds: 30))
+      ..flushMicrotasks();
+    return connected ?? false;
+  }
+
+  Obd2Service buildService(_ScriptedChannel channel) {
+    final transport = BluetoothObd2Transport(channel);
+    const fallbackKey = 'AA:BB:CC:DD:EE:FF';
+    return Obd2Service(
+      transport,
+      protocolCache: NegotiatedProtocolCache(_InMemoryBox()),
+      protocolCacheKey: fallbackKey,
+      pidsCache: SupportedPidsCache(_InMemoryBox()),
+      vehicleFallbackKey: fallbackKey,
+    );
+  }
+
+  group('busAnswered reflects whether the vehicle bus replied (#2892)', () {
+    test(
+        'connect succeeds but busAnswered is FALSE when the bus is silent '
+        '(ATDPN + 0100 both NO DATA, zero PIDs, no protocol)', () {
+      fakeAsync((async) {
+        // Every AT init command answers OK — the chip is healthy. Only the
+        // BUS is dead: ATDPN + the VIN + 0100 all return NO DATA.
+        final channel = _ScriptedChannel()
+          ..script('ATZ\r', 'ELM327 v1.5\r>')
+          ..script('ATE0\r', 'ATE0\rOK\r>')
+          ..script('ATL0\r', 'OK\r>')
+          ..script('ATH0\r', 'OK\r>')
+          ..script('ATSP0\r', 'OK\r>')
+          ..script('ATAT1\r', 'OK\r>')
+          ..script('ATI\r', 'ELM327 v1.5\r>')
+          // Bus silent: protocol can't be described → null → nothing cached.
+          ..script('ATDPN\r', 'NO DATA\r>')
+          ..script('0902\r', 'NO DATA\r>')
+          // Bus silent: 0100 returns no bitmap → discovery finds zero PIDs.
+          ..script('0100\r', 'NO DATA\r>');
+
+        final service = buildService(channel);
+        final connected = connect(async, channel, service);
+
+        // #2891 invariant — connect() itself still SUCCEEDS (best-effort
+        // resolve/discovery swallow the no-answer). We do not regress that.
+        expect(connected, isTrue,
+            reason: 'connect() must still succeed (best-effort resolve)');
+
+        // The two no-answer signals the bug left silent.
+        expect(service.debugSupportedPids, isEmpty,
+            reason: '0100 NO DATA → zero supported PIDs');
+
+        // The new signal: the bus never answered, so this trip would be a
+        // degraded GPS-only recording → busAnswered must be FALSE.
+        expect(service.busAnswered, isFalse,
+            reason: 'protocol null AND zero PIDs → bus did not answer');
+      });
+    });
+
+    test('busAnswered is TRUE when 0100 discovers at least one PID', () {
+      fakeAsync((async) {
+        final channel = _ScriptedChannel()
+          ..script('ATZ\r', 'ELM327 v1.5\r>')
+          ..script('ATE0\r', 'ATE0\rOK\r>')
+          ..script('ATL0\r', 'OK\r>')
+          ..script('ATH0\r', 'OK\r>')
+          ..script('ATSP0\r', 'OK\r>')
+          ..script('ATAT1\r', 'OK\r>')
+          ..script('ATI\r', 'ELM327 v1.5\r>')
+          // Protocol still unknown — but the bus DID answer 0100, so a real
+          // trip is possible: busAnswered must trip on the PID set alone.
+          ..script('ATDPN\r', 'NO DATA\r>')
+          ..script('0902\r', 'NO DATA\r>')
+          // 0100 bitmap: 0x0D (speed) set, no next-range flag → discovery stops.
+          ..script('0100\r', '41 00 00 08 00 00\r>');
+
+        final service = buildService(channel);
+        final connected = connect(async, channel, service);
+
+        expect(connected, isTrue);
+        expect(service.debugSupportedPids, isNotEmpty,
+            reason: '0100 answered a real bitmap');
+        expect(service.busAnswered, isTrue,
+            reason: 'a non-empty PID set means the bus answered');
+      });
+    });
+
+    test('busAnswered is TRUE when ATDPN cached a protocol even with 0 PIDs',
+        () {
+      fakeAsync((async) {
+        final channel = _ScriptedChannel()
+          ..script('ATZ\r', 'ELM327 v1.5\r>')
+          ..script('ATE0\r', 'ATE0\rOK\r>')
+          ..script('ATL0\r', 'OK\r>')
+          ..script('ATH0\r', 'OK\r>')
+          ..script('ATSP0\r', 'OK\r>')
+          ..script('ATAT1\r', 'OK\r>')
+          ..script('ATI\r', 'ELM327 v1.5\r>')
+          // Protocol negotiated + cached (bus answered ATDPN) even though
+          // 0100 then went quiet → busAnswered must trip on the protocol.
+          ..script('ATDPN\r', '6\r>')
+          ..script('0902\r', 'NO DATA\r>')
+          ..script('0100\r', 'NO DATA\r>');
+
+        final service = buildService(channel);
+        final connected = connect(async, channel, service);
+
+        expect(connected, isTrue);
+        expect(service.debugSupportedPids, isEmpty);
+        expect(service.busAnswered, isTrue,
+            reason: 'a cached protocol digit means the bus answered ATDPN');
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Prompt scripted channel — each command answers immediately on a fresh timer
+// so it composes with fakeAsync's virtual clock. Mirrors the transport test's
+// _ScriptedChannel (#2889 harness), minus per-command delays we don't need.
+// ---------------------------------------------------------------------------
+
+class _ScriptedChannel implements ElmByteChannel {
+  final Map<String, String> _replyByCommand = {};
+  final StreamController<List<int>> _controller =
+      StreamController<List<int>>.broadcast();
+  final List<List<int>> _writes = [];
+  bool _open = false;
+
+  void script(String command, String reply) {
+    _replyByCommand[command] = reply;
+  }
+
+  List<String> get writesAsStrings =>
+      _writes.map((w) => String.fromCharCodes(w)).toList();
+
+  @override
+  Future<void> open() async => _open = true;
+
+  @override
+  Future<void> close() async => _open = false;
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _controller.stream;
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    _writes.add(bytes);
+    final command = String.fromCharCodes(bytes);
+    final reply = _replyByCommand[command] ?? 'NO DATA\r>';
+    // Emit on a fresh zero-delay timer so the reply lands inside the
+    // fakeAsync clock without a real wall-clock wait.
+    Timer(Duration.zero, () {
+      if (!_controller.isClosed) _controller.add(reply.codeUnits);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tiny in-memory Box<String> — caches only call get/put/delete/clear.
+// ---------------------------------------------------------------------------
+
+class _InMemoryBox extends Fake implements Box<String> {
+  final Map<String, String> store = {};
+
+  @override
+  String? get(dynamic key, {String? defaultValue}) =>
+      store[key as String] ?? defaultValue;
+
+  @override
+  Future<void> put(dynamic key, String value) async {
+    store[key as String] = value;
+  }
+
+  @override
+  Future<void> delete(dynamic key) async {
+    store.remove(key as String);
+  }
+
+  @override
+  Future<int> clear() async {
+    final n = store.length;
+    store.clear();
+    return n;
+  }
+}

--- a/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
+++ b/test/features/consumption/presentation/widgets/recording_start_coordinator_bus_silent_test.dart
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/'
+    'recording_start_coordinator.dart';
+import 'package:tankstellen/features/consumption/providers/'
+    'trip_recording_provider.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2892 — the coordinator must NOT start a degraded GPS-only trip when the
+/// service connected but the vehicle bus never answered (`busAnswered ==
+/// false`). It must instead surface the existing localized "turn the ignition
+/// on" condition ([Obd2AdapterUnresponsive]), roll the connecting phase back,
+/// and tear down the dead link — never calling `notifier.start(service)`.
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// Pump a bare [Consumer] inside a [ProviderScope] (overriding the trip
+  /// recording notifier with [recordingFactory]) and hand the captured
+  /// [WidgetRef] plus the MOUNTED spy notifier to [body]. Reading
+  /// `.notifier` here mounts the spy so its base-class `state` access works.
+  /// `connectAndStart` does not dereference `ref`, but it is a required typed
+  /// parameter, so a real ref keeps the call honest.
+  Future<void> withRef(
+    WidgetTester tester,
+    _SpyTripRecording Function() recordingFactory,
+    Future<void> Function(WidgetRef ref, _SpyTripRecording notifier) body,
+  ) async {
+    late WidgetRef captured;
+    late _SpyTripRecording notifier;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [tripRecordingProvider.overrideWith(recordingFactory)],
+        child: Consumer(
+          builder: (_, ref, _) {
+            captured = ref;
+            notifier = ref.read(tripRecordingProvider.notifier)
+                as _SpyTripRecording;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await body(captured, notifier);
+  }
+
+  testWidgets(
+      'a silent-bus connect surfaces Obd2AdapterUnresponsive, disconnects, '
+      'and never calls notifier.start (#2892)', (tester) async {
+    final service = _FakeObd2Service(busAnswered: false);
+    final coordinator = RecordingStartCoordinator();
+    final errors = <Object>[];
+    late _SpyTripRecording recording;
+
+    await withRef(tester, _SpyTripRecording.new, (ref, notifier) async {
+      recording = notifier;
+      // Mirror the live path: the screen is already in its connecting phase.
+      notifier.enterConnecting();
+      await coordinator.connectAndStart(
+        ref,
+        notifier: notifier,
+        openPicker: () async => service,
+        onConnectionError: errors.add,
+        isMounted: () => true,
+      );
+    });
+
+    // The EXISTING localized "turn the ignition on" condition is surfaced.
+    expect(errors, hasLength(1));
+    expect(errors.single, isA<Obd2AdapterUnresponsive>(),
+        reason: 'silent bus must surface the ignition-off condition');
+
+    // A degraded GPS-only trip is NOT started.
+    expect(recording.startCallCount, 0,
+        reason: 'notifier.start must NOT run when the bus did not answer');
+
+    // The dead link is torn down + the connecting phase rolled back.
+    expect(service.disconnectCallCount, 1,
+        reason: 'the unusable link must be disconnected');
+    expect(recording.cancelConnectingCallCount, greaterThanOrEqualTo(1),
+        reason: 'the connecting phase must roll back to idle');
+  });
+
+  testWidgets(
+      'a connect whose bus answered starts the trip as normal (#2892)',
+      (tester) async {
+    final service = _FakeObd2Service(busAnswered: true);
+    final coordinator = RecordingStartCoordinator();
+    final errors = <Object>[];
+    late _SpyTripRecording recording;
+
+    await withRef(tester, _SpyTripRecording.new, (ref, notifier) async {
+      recording = notifier;
+      notifier.enterConnecting();
+      await coordinator.connectAndStart(
+        ref,
+        notifier: notifier,
+        openPicker: () async => service,
+        onConnectionError: errors.add,
+        isMounted: () => true,
+      );
+    });
+
+    // The healthy path is untouched: no error, the trip starts, the link is
+    // handed to the recording (NOT disconnected by the coordinator).
+    expect(errors, isEmpty);
+    expect(recording.startCallCount, 1,
+        reason: 'a live bus must start the trip');
+    expect(recording.lastStartedService, same(service));
+    expect(service.disconnectCallCount, 0,
+        reason: 'the live recording now owns the link');
+  });
+}
+
+/// Spy [TripRecording] that records the calls the coordinator makes. The
+/// base-class `enterConnecting` / `cancelConnecting` mutate `state` for real
+/// (cheap copyWith) so the connecting phase is observable; `start` is stubbed
+/// to a counter so the heavy connect/prime pipeline never runs.
+class _SpyTripRecording extends TripRecording {
+  int startCallCount = 0;
+  int cancelConnectingCallCount = 0;
+  Obd2Service? lastStartedService;
+
+  @override
+  TripRecordingState build() => const TripRecordingState();
+
+  @override
+  Future<void> start(Obd2Service service, {bool automatic = false}) async {
+    startCallCount++;
+    lastStartedService = service;
+    state = state.copyWith(
+      phase: TripRecordingPhase.recording,
+      clearConnectStage: true,
+    );
+  }
+
+  @override
+  void cancelConnecting() {
+    cancelConnectingCallCount++;
+    super.cancelConnecting();
+  }
+}
+
+/// Fake [Obd2Service] whose `busAnswered` is fixed by the test and whose
+/// `disconnect` is counted. Everything else is unreachable in these tests.
+class _FakeObd2Service implements Obd2Service {
+  _FakeObd2Service({required bool busAnswered})
+      : busAnsweredValue = busAnswered;
+
+  final bool busAnsweredValue;
+  int disconnectCallCount = 0;
+
+  @override
+  bool get busAnswered => busAnsweredValue;
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCallCount++;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -186,6 +186,15 @@ class _EmptyBluetoothFacade implements BluetoothFacade {
 }
 
 class _NoopObd2Service implements Obd2Service {
+  // #2892 — the recording coordinator gates on `busAnswered` before starting:
+  // a connected service whose vehicle bus never answered surfaces the
+  // "turn the ignition on" condition instead of starting a degraded trip.
+  // These tests exercise the healthy start/pre-warm flow, so the fake reports
+  // a live bus (the silent-bus gate has its own dedicated coverage in
+  // recording_start_coordinator_bus_silent_test.dart).
+  @override
+  bool get busAnswered => true;
+
   @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -157,7 +157,12 @@ void main() {
     // #2763 — 1599 → 1603: route the best-effort readVin catch through
     // recordObd2ReadFailure (de-noise flaky-comms timeouts to breadcrumbs) +
     // its import. Decomposition still tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1603,
+    // #2892 — re-grandfathered 1603 → 1618: the `busAnswered` getter (a
+    // silent-bus signal: protocol-cached OR ≥1 PID) + its 11-line dartdoc, so
+    // the recording coordinator can surface "turn the ignition on" instead of
+    // a silent green connect into a degraded GPS-only trip. Decomposition of
+    // this god-class still tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1618,
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb


### PR DESCRIPTION
Closes #2892. From error-log #22 (35 traces, ELM327 v1.5: all AT OK, protocolDigit null, 0 PIDs). Two related OBD2 connect-feedback problems; touches `lib/features/consumption/data/obd2/` + the recording coordinator only. No new ARB (reuses the existing `Obd2AdapterUnresponsive → obd2ErrorAdapterUnresponsive`).

## Part A (commit 1) — surface "turn the ignition on" instead of a silent green connect
A healthy ELM chip on a silent bus (ignition off / ECU asleep) passes every AT command, so `Obd2Service.connect()` returns true and the status chip shows green "connected" — yet `ATDPN`→NO DATA caches no protocol and `0100`→NO DATA leaves zero supported PIDs. The coordinator then started a degraded GPS-only trip with no telemetry and no explanation.

- New `Obd2Service.busAnswered`: true iff a protocol digit was cached **or** PID discovery returned ≥1 PID. Cheap (reads already-resolved fields, no I/O). `connect()`'s bool return is unchanged (the #2891 success invariant holds).
- In `RecordingStartCoordinator.connectAndStart`, after the service connects and before `notifier.start()`: if `!service.busAnswered`, roll the connecting phase back, surface the existing `Obd2AdapterUnresponsive` snackbar, disconnect the dead link, and return — no degraded trip. Gated strictly on the no-answer signal so it never fires when discovery found PIDs.

## Part B (commit 2) — de-noise the expected-condition connect-log flood
The same `Obd2AdapterUnresponsive` was spooled 20× as ERROR traces — the in-trip reconnect storm on a parked car hammering connect. It's an expected, user-surfaced condition (`isExpectedUserCondition == true`), so it should be a breadcrumb (mirrors the #2745 / #2763 de-noise precedent).

- New data-layer `recordObd2ConnectTransient` / `isExpectedObd2ConnectTransient` alongside `recordObd2ReadFailure`. Expected = `isExpectedUserCondition` family + `TimeoutException` + `StateError` 'transport closed'/'not connected' → breadcrumb. Genuine faults (`Obd2PermissionDenied`, `Obd2ProtocolInitFailed`, anything else) stay ERROR traces.
- Routed the reconnect-storm connect catches through it (`ReconnectConnector` direct / scan-fallback / passive + `connectByMacPassive`).

## Tests (RED on master, green after)
- `obd2_service_bus_silent_test.dart` — scripted `ElmByteChannel`: every AT OK but `ATDPN`/`0100`→NO DATA ⇒ `busAnswered == false` (and `true` the moment either a protocol caches or a PID is found).
- `recording_start_coordinator_bus_silent_test.dart` — a silent-bus connect fires `onConnectionError(Obd2AdapterUnresponsive)`, disconnects, and does **not** call `notifier.start()`; a live bus starts as normal.
- `obd2_connect_transient_denoise_test.dart` — fault injection at the reconnect connect site: an expected `Obd2AdapterUnresponsive` does **not** reach `errorLogger` (breadcrumb) while a genuine `Obd2PermissionDenied` still ERROR-logs, plus classification/routing units.

## Gates
- `flutter analyze` clean on the whole consumption feature.
- 78 touched + adjacent tests green (incl. existing reconnect / connection-service / telemetry / trajets-tab suites; `_NoopObd2Service` fake updated to report a live bus).
- No codegen drift (plain Dart — no `@riverpod`/`@freezed` changes).
- `file_length_test` re-grandfathered `obd2_service.dart` 1603 → 1618 (getter + dartdoc; god-class decomposition still tracked by #2187/#2188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
