### PR TITLE
fix(radar): closeness bar on all three Fuel Station Radar surfaces (#2899)

### DIFF
--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -25,6 +25,7 @@ import '../../domain/entities/station.dart';
 import '../../providers/selected_station_provider.dart';
 import '../../providers/ignored_stations_provider.dart';
 import '../../providers/search_provider.dart';
+import '../../providers/radar_search_provider.dart';
 import '../../providers/brand_filter_provider.dart';
 import '../../providers/search_screen_ui_provider.dart';
 import '../../providers/station_rating_provider.dart';
@@ -332,6 +333,17 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
     );
     final stationRating = ref.watch(stationRatingProvider(station.id));
 
+    // #2899 — when the on-search Fuel Station Radar owns the result list, each
+    // card carries the green→accent closeness bar (the SAME [ProximityFillBar]
+    // as the trip card + PiP). The list scales to the SEARCH radius
+    // (`searchRadiusProvider × 1000`, the radius the radar fetch itself used),
+    // not the 1 km trip geo-fence: result rows routinely exceed that fence, so
+    // scaling to the search radius makes the bar read as RELATIVE closeness
+    // across the visible list. Null off radar mode → regular cards unchanged.
+    final radarActive = ref.watch(radarSearchProvider).active;
+    final closenessRadiusMeters =
+        radarActive ? ref.watch(searchRadiusProvider) * 1000.0 : null;
+
     return SwipeableStationCard(
       key: ValueKey('station-${station.id}'),
       station: station,
@@ -339,6 +351,7 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
       priceTier: tier,
       rating: stationRating,
       profileFuelType: profileFuel,
+      closenessRadiusMeters: closenessRadiusMeters,
       onNavigate: () => NavigationUtils.openInMaps(
         station.lat, station.lng,
         label: station.displayName,

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -14,6 +14,7 @@ import '../../../../core/widgets/animated_favorite_star.dart';
 import '../../../../core/widgets/animated_price_text.dart';
 import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../consumption/presentation/widgets/proximity_fill_bar.dart';
 import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';
 import '../../domain/entities/brand_registry.dart';
 import '../../domain/entities/fuel_type.dart';
@@ -57,6 +58,20 @@ class StationCard extends StatelessWidget {
   /// the canonical-brand string keys.
   final Map<String, double>? activeDiscountsByBrand;
 
+  /// Radius (in metres) the Fuel Station Radar "closeness" bar scales to,
+  /// or `null` to hide the bar (#2899). Only the on-search Fuel Station Radar
+  /// result list passes it — the regular search list leaves it null so the
+  /// card is unchanged.
+  ///
+  /// The list scales to the **search radius** (`searchRadiusProvider × 1000`),
+  /// not the small 1 km radar geo-fence: result-list stations routinely exceed
+  /// the geo-fence (2.4 km, 6.2 km, …), so scaling to the search radius makes
+  /// the bar read as RELATIVE closeness across the list — the nearest forecourt
+  /// reads near-full, the farthest near-empty — instead of every row pinning to
+  /// empty. The same green→accent [ProximityFillBar] used by the trip card +
+  /// PiP overlay, so all three radar surfaces share one fill metaphor.
+  final double? closenessRadiusMeters;
+
   const StationCard({
     super.key,
     required this.station,
@@ -69,6 +84,7 @@ class StationCard extends StatelessWidget {
     this.rating,
     this.profileFuelType,
     this.activeDiscountsByBrand,
+    this.closenessRadiusMeters,
   });
 
   /// True if the station has a real brand name (not empty, not generic "Station")
@@ -152,7 +168,11 @@ class StationCard extends StatelessWidget {
               _StatusColumn(station: station),
               const SizedBox(width: 12),
               Expanded(
-                child: _StationDetails(station: station, hasBrand: _hasBrand),
+                child: _StationDetails(
+                  station: station,
+                  hasBrand: _hasBrand,
+                  closenessRadiusMeters: closenessRadiusMeters,
+                ),
               ),
               const SizedBox(width: 8),
               _StationPriceColumn(

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -48,7 +48,16 @@ class _StationDetails extends StatelessWidget {
   final Station station;
   final bool hasBrand;
 
-  const _StationDetails({required this.station, required this.hasBrand});
+  /// #2899 — when non-null, the Fuel Station Radar "closeness" bar is rendered
+  /// under the distance row, scaled to this radius (the search radius, in
+  /// metres). Null on the regular search list, so the card is unchanged there.
+  final double? closenessRadiusMeters;
+
+  const _StationDetails({
+    required this.station,
+    required this.hasBrand,
+    this.closenessRadiusMeters,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -116,6 +125,20 @@ class _StationDetails extends StatelessWidget {
             ],
           ],
         ),
+        // #2899 — Fuel Station Radar closeness bar: the SAME green→accent
+        // [ProximityFillBar] the trip radar card + PiP overlay use, so all
+        // three radar surfaces fill identically as the driver nears a station.
+        // `station.dist` is the great-circle distance in km → metres for the
+        // bar; it scales to the search radius (see [StationCard]). Live: the
+        // radar re-stamps `dist` on each scan, so the bar re-fills as the
+        // result set refreshes around the moving user.
+        if (closenessRadiusMeters != null) ...[
+          const SizedBox(height: Spacing.xs),
+          ProximityFillBar(
+            distanceMeters: station.dist * 1000.0,
+            radiusMeters: closenessRadiusMeters,
+          ),
+        ],
         if (station.amenities.isNotEmpty)
           Padding(
             padding: const EdgeInsets.only(top: 2),

--- a/lib/features/search/presentation/widgets/swipeable_station_card.dart
+++ b/lib/features/search/presentation/widgets/swipeable_station_card.dart
@@ -28,6 +28,11 @@ class SwipeableStationCard extends ConsumerWidget {
   /// The user's preferred fuel type from their profile.
   final FuelType? profileFuelType;
 
+  /// #2899 — radius (in metres) the Fuel Station Radar closeness bar scales
+  /// to, or null to hide it. Threaded straight through to [StationCard]; only
+  /// the on-search radar result list passes it.
+  final double? closenessRadiusMeters;
+
   const SwipeableStationCard({
     super.key,
     required this.station,
@@ -39,6 +44,7 @@ class SwipeableStationCard extends ConsumerWidget {
     this.priceTier,
     this.rating,
     this.profileFuelType,
+    this.closenessRadiusMeters,
   });
 
   @override
@@ -96,6 +102,7 @@ class SwipeableStationCard extends ConsumerWidget {
         priceTier: priceTier,
         rating: rating,
         profileFuelType: profileFuelType,
+        closenessRadiusMeters: closenessRadiusMeters,
         // #1120 — collapse the loyalty-card map to canonical-brand
         // strings so the StationCard widget stays decoupled from the
         // [LoyaltyBrand] enum.

--- a/test/features/consumption/presentation/widgets/proximity_fill_bar_test.dart
+++ b/test/features/consumption/presentation/widgets/proximity_fill_bar_test.dart
@@ -14,6 +14,55 @@ Widget _host(Widget child) => MaterialApp(
     );
 
 void main() {
+  group('fillFor (#2899 — the closeness fraction)', () {
+    test('0% at distance >= radius (empty at the edge)', () {
+      expect(ProximityFillBar.fillFor(1000, 1000), 0.0);
+    });
+
+    test('~0.8 at 0.2 km inside a 1 km radius', () {
+      expect(ProximityFillBar.fillFor(200, 1000), closeTo(0.8, 1e-9));
+    });
+
+    test('~0.9 at 0.1 km inside a 1 km radius', () {
+      expect(ProximityFillBar.fillFor(100, 1000), closeTo(0.9, 1e-9));
+    });
+
+    test('100% at distance 0 (full at the station)', () {
+      expect(ProximityFillBar.fillFor(0, 1000), 1.0);
+    });
+
+    test('clamps to 0 beyond the radius (no negative)', () {
+      expect(ProximityFillBar.fillFor(2400, 1000), 0.0);
+    });
+
+    test('clamps to 1 at/under the station (no overflow)', () {
+      expect(ProximityFillBar.fillFor(-50, 1000), 1.0);
+    });
+
+    test('0 for a non-positive radius (no divide-by-zero blow-up)', () {
+      expect(ProximityFillBar.fillFor(100, 0), 0.0);
+    });
+  });
+
+  testWidgets('the rendered fill width matches fillFor (live fraction)',
+      (tester) async {
+    // 0.2 km inside a 1 km radius → the FractionallySizedBox settles at 0.8.
+    await tester.pumpWidget(
+      _host(
+        const SizedBox(
+          width: 200,
+          child: ProximityFillBar(distanceMeters: 200, radiusMeters: 1000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final box = tester.widget<FractionallySizedBox>(
+      find.byType(FractionallySizedBox),
+    );
+    expect(box.widthFactor, closeTo(0.8, 1e-6));
+  });
+
   testWidgets('fill is a two-colour green→accent gradient (#2808)',
       (tester) async {
     await tester.pumpWidget(

--- a/test/features/search/presentation/widgets/station_card_test.dart
+++ b/test/features/search/presentation/widgets/station_card_test.dart
@@ -8,6 +8,7 @@ import 'package:tankstellen/core/theme/fuel_colors.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/core/utils/price_tier.dart';
 import 'package:tankstellen/core/widgets/station_card_shell.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/domain/entities/station_amenity.dart';
@@ -1291,6 +1292,96 @@ void main() {
       );
       expect(shell.stripeColor, success);
       expect(shell.stripeWidth, 6);
+    });
+  });
+
+  // #2899 — surface 3 of 3: the Fuel Station Radar result list. The card only
+  // carries the closeness bar when the on-search radar passes a radius; the
+  // regular search list (null radius) is unchanged.
+  group('StationCard closeness bar (#2899 — radar result list)', () {
+    const radarStation = Station(
+      id: 'de-radar-1',
+      name: 'Radar Tankstelle',
+      brand: 'STAR',
+      street: 'Hauptstr. 1',
+      postCode: '10115',
+      place: 'Berlin',
+      lat: 52.52,
+      lng: 13.40,
+      dist: 0.2, // 0.2 km from the user
+      e10: 1.799,
+      isOpen: true,
+    );
+
+    testWidgets('no bar when closenessRadiusMeters is null (regular list)',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const StationCard(
+          station: radarStation,
+          selectedFuelType: FuelType.e10,
+        ),
+      );
+      expect(find.byType(ProximityFillBar), findsNothing);
+    });
+
+    testWidgets('renders the bar in radar mode at the expected fraction',
+        (tester) async {
+      // 0.2 km station scaled to a 1 km search radius → 80% full.
+      await pumpApp(
+        tester,
+        const StationCard(
+          station: radarStation,
+          selectedFuelType: FuelType.e10,
+          closenessRadiusMeters: 1000,
+        ),
+      );
+
+      final bar = tester.widget<ProximityFillBar>(
+        find.byType(ProximityFillBar),
+      );
+      expect(bar.distanceMeters, closeTo(200, 1e-9),
+          reason: 'station.dist (km) → metres for the bar');
+      expect(bar.radiusMeters, 1000);
+      expect(
+        ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!),
+        closeTo(0.8, 1e-9),
+      );
+    });
+
+    testWidgets('a far station scales to near-empty against the search radius',
+        (tester) async {
+      // 6.2 km exceeds the 1 km trip geo-fence but reads as RELATIVE closeness
+      // against the wider search radius (10 km) → ~0.38, not pinned to empty.
+      const farStation = Station(
+        id: 'de-radar-2',
+        name: 'Far Tankstelle',
+        brand: 'STAR',
+        street: 'Hauptstr. 2',
+        postCode: '10115',
+        place: 'Berlin',
+        lat: 52.6,
+        lng: 13.5,
+        dist: 6.2,
+        e10: 1.759,
+        isOpen: true,
+      );
+      await pumpApp(
+        tester,
+        const StationCard(
+          station: farStation,
+          selectedFuelType: FuelType.e10,
+          closenessRadiusMeters: 10000,
+        ),
+      );
+
+      final bar = tester.widget<ProximityFillBar>(
+        find.byType(ProximityFillBar),
+      );
+      expect(
+        ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!),
+        closeTo(0.38, 1e-9),
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #2899.

## The behaviour
A horizontal green→accent "closeness" bar that FILLS as the driver nears a station: empty at `distance ≥ radius`, full at `distance 0`. `fill = (1 - distanceMeters / radiusMeters).clamp(0, 1)`.

## Three surfaces

| Surface | State before this PR | Radius source |
|---|---|---|
| **1. Trip radar card** (`trip_radar_card.dart`) | Already correct on master — `ProximityFillBar` wired to live distance by #2661. | Radar radius (`profile.approachRadiusKm × 1000`). |
| **2. Floating PiP overlay** (`trip_recording_pip_price_layout.dart`) | Already correct on master — full-width bar wired by #2661 + #2808. | Radar radius (`profile.approachRadiusKm × 1000`). |
| **3. Search-results list** (radar mode) | **Missing — added here.** Station cards carried no bar. | **Search radius** (`searchRadiusProvider × 1000`). |

### Why surfaces 1 & 2 looked broken in the field
The field report (build `+2026061051`, 1 Jun) **predates** the #2661 redesign and #2808 PiP fix, which both merged 3-4 Jun. On current master the trip card and PiP overlay already fill correctly (their fraction-asserting tests are green). No change was needed there; this PR strengthens their shared widget's test instead.

### Why the list scales to the search radius (not the 1 km geo-fence)
Result rows routinely exceed the small trip geo-fence (2.4 km, 6.2 km, …). Scaling to the search radius — the radius the radar fetch itself used — makes the bar read as RELATIVE closeness across the visible list (nearest near-full, farthest near-empty) instead of every row pinning to empty. Documented inline in `StationCard`.

## Implementation
- Reuses the existing `ProximityFillBar` (green→accent eco/success tokens) — one fill metaphor across all three surfaces, single source of truth.
- New nullable `closenessRadiusMeters` on `StationCard` → threaded through `SwipeableStationCard` → set by `SearchResultsList._buildFuelCard` only when `radarSearchProvider.active`. Null off radar mode → regular search list unchanged.
- Live: the bar re-fills as the radar re-stamps each station's distance on rescan.
- No new ARB string (purely visual). All touched files < 400 lines. No generated files changed.

## Tests (structural, not golden)
- `proximity_fill_bar_test`: exact #2899 fractions — 0% at ≥radius, ~0.8 at 0.2 km/1 km, ~0.9 at 0.1 km, 100% at 0, clamped both ends, zero-radius guard, plus a rendered `FractionallySizedBox.widthFactor` assertion.
- `station_card_test`: surface-3 group — no bar off radar mode, bar at the expected fraction (0.2 km / 1 km → 0.8) in radar mode, and a far station (6.2 km) scaling to relative closeness against a wider search radius.
- `flutter analyze` clean (the 2 remaining infos are pre-existing `unnecessary_import` in unrelated consumption-domain test files); all touched suites green (search presentation 356/356, surface 1 & 2 suites pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
