### PR TITLE
fix(obd2): reclassify BLE write-after-drop as recoverable disconnect (#2900)

### DIFF
--- a/lib/features/consumption/data/obd2/ble_disconnect_classifier.dart
+++ b/lib/features/consumption/data/obd2/ble_disconnect_classifier.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/services.dart' show PlatformException;
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+/// #2900 — true when [e] is flutter_blue_plus's signal that the BLE adapter
+/// dropped mid-write / mid-session, so the write should be reclassified into
+/// the recoverable `Obd2DisconnectedException` rather than escaping as a raw
+/// exception that floods the error log (error-log #23: a raw
+/// `FlutterBluePlusException | writeCharacteristic | fbp-code: 6 | device is
+/// not connected` spooled 25× as the ~1 Hz speed poller kept writing into a
+/// dropped link). Mirrors the #2671 [ClassicElmChannel] + #2524
+/// [BluetoothObd2Transport] reclassification precedents.
+///
+/// Matches:
+/// - [FlutterBluePlusException] with `fbp-code: 6` (the observed
+///   "device is not connected" write failure), or whose description says the
+///   device is not connected / disconnected;
+/// - [FlutterBluePlusException] / [PlatformException] carrying Android
+///   GATT_ERROR 133 — the "stack gave up" code seen mid-write on a dying link
+///   (an established session, not the connect-time stale-GATT case);
+/// - [PlatformException] whose code/message says the device is not connected /
+///   disconnected.
+///
+/// A genuine non-disconnect BLE error (e.g. a clone rejecting a write mode)
+/// returns false and still surfaces unchanged.
+bool isBleAdapterDisconnect(Object e) {
+  if (e is FlutterBluePlusException) {
+    if (e.code == 6 || e.code == 133) return true;
+    return _mentionsDisconnect(e.description);
+  }
+  if (e is PlatformException) {
+    if (e.code == '133') return true;
+    return _mentionsDisconnect(e.code) || _mentionsDisconnect(e.message);
+  }
+  return false;
+}
+
+bool _mentionsDisconnect(String? text) {
+  if (text == null) return false;
+  final t = text.toLowerCase();
+  return t.contains('not connected') ||
+      t.contains('disconnected') ||
+      t.contains('gatt_error') ||
+      t.contains('133');
+}
+
+/// Bin a BLE `open()` failure into a stable, low-cardinality reason tag for the
+/// gated comm-diagnostics `failuresByReason` map (#2466). Kept coarse +
+/// platform-derived so an exported error-log shows *why* a connect failed
+/// (GATT timeout vs missing ELM service vs other) without leaking a
+/// high-cardinality raw message.
+String classifyBleConnectFailure(Object e) {
+  final msg = e.toString().toUpperCase();
+  if (msg.contains('TIMEOUT') || msg.contains('GATT_CONNECTION_TIMEOUT')) {
+    return 'gatt-connection-timeout';
+  }
+  // Android GATT_ERROR 133 — the catch-all "stack gave up" code, most often a
+  // stale GATT client or an out-of-range adapter.
+  if (msg.contains('133') || msg.contains('GATT_ERROR')) {
+    return 'gatt-error-133';
+  }
+  // The service / characteristic discovery `StateError`s thrown during open().
+  if (e is StateError &&
+      (msg.contains('ELM327 SERVICE') ||
+          msg.contains('WRITE CHARACTERISTIC') ||
+          msg.contains('NOTIFY CHARACTERISTIC'))) {
+    return 'service-not-found';
+  }
+  return 'other';
+}

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
+import 'ble_disconnect_classifier.dart';
 import 'connection_drop_debouncer.dart';
 import 'elm_byte_channel.dart';
 import 'obd2_comm_diagnostics.dart';
@@ -52,28 +53,23 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
 
   /// #2261 concern 4 — best-effort MTU to request on a high-throughput
   /// (recording) link. 247 is the practical ATT payload ceiling on most
-  /// Android BLE stacks; the actual negotiated value is whatever the
-  /// peripheral grants. Skipped entirely on the autoConnect passive
-  /// path (FBP forbids requestMtu there).
+  /// Android BLE stacks; the negotiated value is whatever the peripheral
+  /// grants. Skipped on the autoConnect passive path (FBP forbids requestMtu).
   static const int _recordingMtu = 247;
 
-  /// Optional bounded timeout passed to `device.connect` (#2242). When
-  /// null, `connect` is called with the legacy `mtu: null` form and no
-  /// explicit timeout (the scan-first path, where the device was just
-  /// seen advertising so a long connect block is unlikely). When set —
-  /// the direct-by-MAC path — `connect(autoConnect:false,
-  /// timeout: …)` bounds the attempt and `open()` first tears down any
-  /// stale GATT client to dodge Android GATT_ERROR 133.
+  /// Optional bounded timeout passed to `device.connect` (#2242). When null,
+  /// `connect` uses the legacy `mtu: null` form with no timeout (the scan-first
+  /// path). When set — the direct-by-MAC path — `connect(autoConnect:false,
+  /// timeout: …)` bounds the attempt and `open()` first tears down any stale
+  /// GATT client to dodge Android GATT_ERROR 133.
   final Duration? _connectTimeout;
 
   /// #2261 concern 2 — passive autoConnect GATT wait. When true, `open()`
-  /// connects with `autoConnect:true` and NO bounded timeout: the OS
-  /// holds a low-power background GATT connection request that resolves
-  /// the instant the adapter (re)advertises. Used by the reconnect
-  /// scanner once its active-scan miss ceiling is reached, so a parked
-  /// car doesn't burn the radio on repeated active scans. autoConnect:true
-  /// forbids requestMtu (FBP throws), so the concern-4 MTU bump is
-  /// skipped entirely on this path.
+  /// connects with `autoConnect:true` and NO bounded timeout: the OS holds a
+  /// low-power background connection request that resolves the instant the
+  /// adapter (re)advertises. Used by the reconnect scanner past its active-scan
+  /// miss ceiling so a parked car doesn't burn the radio. autoConnect:true
+  /// forbids requestMtu, so the concern-4 MTU bump is skipped on this path.
   final bool _autoConnect;
 
   BluetoothCharacteristic? _writeChar;
@@ -84,13 +80,12 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       StreamController<List<int>>.broadcast();
   bool _open = false;
 
-  /// #2261 concern 1 — debounces a raw `connectionState == disconnected`
-  /// edge into a confirmed drop so a self-healing RF blip within the BLE
-  /// supervision timeout doesn't tear down a recoverable session, while
-  /// a genuine disconnect still surfaces in ~1–2 s (not the ~15 s read
-  /// timeout). On confirmation it pushes a typed [Obd2DisconnectedException]
-  /// onto the byte stream, which the transport's pending-command completer
-  /// re-throws so [TripDropDetector] classifies it as a typed drop.
+  /// #2261 concern 1 — debounces a raw `connectionState == disconnected` edge
+  /// into a confirmed drop so a self-healing RF blip within the supervision
+  /// timeout doesn't tear down a recoverable session, while a genuine
+  /// disconnect still surfaces in ~1–2 s (not the ~15 s read timeout). On
+  /// confirmation it pushes a typed [Obd2DisconnectedException] onto the byte
+  /// stream, which the transport re-throws so [TripDropDetector] sees a drop.
   late final ConnectionDropDebouncer _dropDebouncer;
 
   FlutterBluePlusElmChannel(
@@ -109,14 +104,12 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   }
 
   /// Push the typed disconnect onto the byte stream so the transport's
-  /// in-flight `sendCommand` completer fails fast with a classified
-  /// error instead of waiting out the read timeout (#2261 concern 1).
+  /// in-flight `sendCommand` completer fails fast with a classified error
+  /// instead of waiting out the read timeout (#2261 concern 1).
   void _onDropConfirmed() {
-    // #2466 — a debounce-CONFIRMED drop is a real mid-session link loss.
-    // Count it as a drop (gated; no-op unless Feature.debugMode is on).
-    // Raw `disconnected` edges that self-heal inside the debounce are
-    // binned separately below as `raw-edge-drop` so the confirmed-drop
-    // total stays a tally of genuine losses.
+    // #2466 — a debounce-CONFIRMED drop is a real mid-session link loss; count
+    // it (gated). Raw `disconnected` edges that self-heal inside the debounce
+    // are binned separately below as `raw-edge-drop`.
     final diag = Obd2CommDiagnostics.instance;
     if (diag.enabled) diag.noteConnectionEvent(drop: true);
     if (_incoming.isClosed) return;
@@ -132,9 +125,8 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   @override
   Future<void> open() async {
     if (_open) return;
-    // #2466 — gated comm-diagnostics connect-lifecycle tee. The whole
-    // block is a no-op unless `Feature.debugMode` armed the collector
-    // (the gate provider flips `enabled`); each call early-returns on
+    // #2466 — gated comm-diagnostics connect-lifecycle tee. A no-op unless
+    // `Feature.debugMode` armed the collector; each call early-returns on
     // `!enabled`, so production pays one cached-bool read per event.
     final diag = Obd2CommDiagnostics.instance;
     final connectSw = diag.enabled ? (Stopwatch()..start()) : null;
@@ -145,7 +137,7 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     } catch (e) {
       if (diag.enabled) {
         diag.noteConnectionEvent(
-          failureReason: _classifyBleConnectFailure(e),
+          failureReason: classifyBleConnectFailure(e),
         );
       }
       rethrow;
@@ -161,31 +153,28 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
 
   /// The connect → service-discovery → notify-subscribe body of [open],
   /// extracted so [open] can wrap it with the gated connect-lifecycle
-  /// diagnostics tee (#2466) without interleaving counters through the
-  /// platform calls.
+  /// diagnostics tee (#2466) without interleaving counters through the calls.
   Future<void> _connectAndDiscover() async {
     final timeout = _connectTimeout;
     if (_autoConnect) {
-      // #2261 concern 2 — passive autoConnect GATT wait. No bounded
-      // timeout: the OS keeps a low-power background connection request
-      // that resolves the moment the adapter advertises again.
-      // requestMtu is forbidden with autoConnect:true, so `mtu: null`.
+      // #2261 concern 2 — passive autoConnect GATT wait. No bounded timeout:
+      // the OS keeps a low-power background connection request that resolves
+      // the moment the adapter advertises again. requestMtu forbidden with
+      // autoConnect:true, so `mtu: null`.
       await _device.connect(autoConnect: true, mtu: null);
     } else if (timeout == null) {
       await _device.connect(autoConnect: false, mtu: null);
     } else {
-      // Direct-by-MAC path (#2242). Tear down any stale GATT client for
-      // this device FIRST — Android returns GATT_ERROR 133 if a prior
-      // (dropped-but-not-closed) GATT connection is still open, which
-      // would silently force a fall back to the scan path. disconnect()
-      // is idempotent and a no-op when nothing is connected.
+      // Direct-by-MAC path (#2242). Tear down any stale GATT client FIRST —
+      // Android returns GATT_ERROR 133 if a prior (dropped-but-not-closed)
+      // connection is still open, silently forcing a fall back to the scan
+      // path. disconnect() is idempotent (no-op when nothing is connected).
       try {
         await _device.disconnect();
       } catch (e, _) {
-        // Best-effort pre-connect teardown of a stale GATT client. The
-        // connect below proceeds (and recovers) regardless — a failure
-        // here is RECOVERABLE and routine, never an error trace (#2379).
-        // Debug-only.
+        // Best-effort pre-connect teardown of a stale GATT client. The connect
+        // below proceeds regardless — a failure here is RECOVERABLE and
+        // routine, never an error trace (#2379). Debug-only.
         assert(() {
           debugPrint(
               'FlutterBluePlusElmChannel: pre-connect dead-GATT teardown '
@@ -221,40 +210,53 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
     _subscription = _notifyChar!.lastValueStream.listen(
       (bytes) {
         // #2467 — tee the raw chunk into the gated comm-diagnostics
-        // wire-framing counters. Double-gated (kReleaseMode +
-        // collector.enabled), so production pays nothing.
+        // wire-framing counters (double-gated, so production pays nothing).
         noteObd2Framing(bytes);
         _incoming.add(bytes);
       },
       onError: (e, st) {
-        // #2295 — forward the GATT/ATT error onto the byte stream so the
-        // transport's pending `sendCommand` completer fails IMMEDIATELY
-        // (via `_failPending`) instead of sitting until the 5 s read
-        // timeout, and log it so the drop is visible in release.
+        // #2900 — a mid-session disconnect can surface here too (the GATT/ATT
+        // stack errors the notify stream when the adapter drops). Clear the
+        // session and forward the RECLASSIFIED recoverable disconnect (not the
+        // raw FBP/GATT error) so the transport's completer fails fast AND the
+        // drop detector sees a typed disconnect — never an ERROR trace. A
+        // genuine non-disconnect error keeps its #2295 behaviour (below).
+        if (isBleAdapterDisconnect(e)) {
+          _open = false;
+          _writeChar = null;
+          if (!_incoming.isClosed) {
+            _incoming.addError(
+              const Obd2DisconnectedException(
+                'FlutterBluePlusElmChannel: notify stream dropped — '
+                'adapter not connected',
+              ),
+              st,
+            );
+          }
+          return;
+        }
+        // #2295 — forward the error so the transport's pending `sendCommand`
+        // completer fails IMMEDIATELY instead of waiting out the read timeout.
         if (!_incoming.isClosed) _incoming.addError(e, st);
-        // OBD2/BLE GATT/ATT error, not local storage — `other` ("not yet
-        // classified") is the correct layer (#2379). Kept logged: this is
-        // a real link drop worth seeing in release triage.
+        // OBD2/BLE GATT/ATT error → `other` ("not yet classified", #2379).
+        // Kept logged: a real link drop worth seeing in release triage.
         unawaited(errorLogger.log(ErrorLayer.other, e, st,
             context: const {'where': 'FlutterBluePlusElmChannel notify error'}));
       },
     );
-    // #2261 concern 1 — subscribe to the device's connection-state
-    // stream so a real disconnect is noticed in ~1–2 s. The first
-    // emission is the current state (`connected`, since we just
-    // connected); the debouncer ignores `connected` edges, so this is a
+    // #2261 concern 1 — subscribe to the connection-state stream so a real
+    // disconnect is noticed in ~1–2 s. The first emission is the current state
+    // (`connected`); the debouncer ignores `connected` edges, so this is a
     // no-op until the link actually drops.
     _dropDebouncer.reset();
     _connStateSubscription = _device.connectionState.listen(
       (state) {
         final disconnected =
             state == BluetoothConnectionState.disconnected;
-        // #2466 — a raw `disconnected` EDGE (before the debouncer
-        // confirms it) is binned as a recoverable transient, not a
-        // confirmed drop: most edges self-heal inside the supervision
-        // window. Only count it while the debouncer is idle, so a
-        // single drop episode contributes one raw-edge tally, not one
-        // per repeated edge. Gated; no-op unless Feature.debugMode is on.
+        // #2466 — a raw `disconnected` EDGE (before the debouncer confirms it)
+        // is binned as a recoverable transient: most edges self-heal inside the
+        // supervision window. Counted only while the debouncer is idle so one
+        // drop episode is one tally. Gated; no-op unless Feature.debugMode.
         if (disconnected) {
           final diag = Obd2CommDiagnostics.instance;
           if (diag.enabled && !_dropDebouncer.isPending) {
@@ -268,11 +270,10 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       },
     );
     _open = true;
-    // #2261 concern 4 — a freshly-opened ACTIVE link is a recording
-    // link: ask for high throughput (high priority + best-effort MTU).
-    // Skipped on the passive autoConnect path — FBP forbids requestMtu
-    // with autoConnect:true, and a parked-car passive wait wants low
-    // power, not high duty. Best-effort: any rejection is swallowed.
+    // #2261 concern 4 — a freshly-opened ACTIVE link is a recording link: ask
+    // for high throughput (priority + best-effort MTU). Skipped on the passive
+    // autoConnect path (FBP forbids requestMtu; a parked-car wait wants low
+    // power). Best-effort: any rejection is swallowed.
     if (!_autoConnect) {
       await tuneForRecording();
     }
@@ -288,14 +289,12 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       final granted = await _device.requestMtu(_recordingMtu);
       // #2466 — record the negotiated ATT MTU into the gated comm-health
       // session (no-op unless Feature.debugMode armed the collector). The
-      // peripheral may grant less than requested; the granted value is the
-      // diagnostic one.
+      // peripheral may grant less than requested; the granted value wins.
       final diag = Obd2CommDiagnostics.instance;
       if (diag.enabled) diag.recordAdapterIdentity(mtu: granted);
     } catch (e, st) {
-      // Many clones reject a non-default MTU — harmless, the default
-      // 23-byte MTU still works. PHY (2M) is deliberately NOT requested:
-      // it is a trap on BLE 4.0/4.1 clones.
+      // Many clones reject a non-default MTU — harmless, the default 23-byte
+      // MTU still works. PHY (2M) is deliberately NOT requested (a clone trap).
       debugPrint('FlutterBluePlusElmChannel requestMtu skipped: $e\n$st');
     }
   }
@@ -303,31 +302,6 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   @override
   Future<void> tuneForBackground() async {
     await _setConnectionPriority(ConnectionPriority.balanced);
-  }
-
-  /// Bin a BLE `open()` failure into a stable, low-cardinality reason tag
-  /// for the gated comm-diagnostics `failuresByReason` map (#2466). Kept
-  /// coarse + platform-derived so an exported error-log shows *why* a
-  /// connect failed (GATT timeout vs missing ELM service vs other) without
-  /// leaking a high-cardinality raw message.
-  static String _classifyBleConnectFailure(Object e) {
-    final msg = e.toString().toUpperCase();
-    if (msg.contains('TIMEOUT') || msg.contains('GATT_CONNECTION_TIMEOUT')) {
-      return 'gatt-connection-timeout';
-    }
-    // Android GATT_ERROR 133 — the catch-all "stack gave up" code, most
-    // often a stale GATT client or an out-of-range adapter.
-    if (msg.contains('133') || msg.contains('GATT_ERROR')) {
-      return 'gatt-error-133';
-    }
-    // The service / characteristic discovery `StateError`s thrown above.
-    if (e is StateError &&
-        (msg.contains('ELM327 SERVICE') ||
-            msg.contains('WRITE CHARACTERISTIC') ||
-            msg.contains('NOTIFY CHARACTERISTIC'))) {
-      return 'service-not-found';
-    }
-    return 'other';
   }
 
   /// Best-effort connection-priority request (#2261 concern 4). Android
@@ -348,28 +322,62 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   Future<void> write(List<int> bytes) async {
     final char = _writeChar;
     if (char == null) {
-      throw StateError('Channel not open — call open() first');
+      // #2900 — the session was cleared by a confirmed drop (the catch below,
+      // or a notify-stream error). Surface the recoverable typed disconnect —
+      // NOT a raw StateError — so `_isTypedDisconnect` routes a post-drop write
+      // through pause/reconnect and `recordObd2ReadFailure` de-noises it to a
+      // breadcrumb, mirroring [ClassicElmChannel.write]'s `!_open` guard.
+      throw const Obd2DisconnectedException(
+        'FlutterBluePlusElmChannel: not open',
+      );
     }
-    // withoutResponse lets the adapter write as fast as BLE allows;
-    // the ELM327 replies via notify anyway.
+    // withoutResponse lets the adapter write as fast as BLE allows.
     try {
-      await char.write(bytes, withoutResponse: true);
-      // ignore: catch_no_st
-    } catch (e) {
-      // #2261 concern 1 — a write failing WHILE a disconnect edge is
-      // pending confirms the drop immediately rather than waiting out
-      // the rest of the debounce: the link has proven unusable. A lone
-      // write failure on an otherwise-connected link is a no-op for the
-      // debouncer and falls through to the caller as before. Rethrow-only
-      // (the caller / transport classifies it) — no stack trace needed.
-      // #2466 — bin the write failure as a recoverable transient reason
-      // (gated; no-op unless Feature.debugMode is on). It is distinct
-      // from a confirmed drop: a write can fail on a link that recovers.
+      await writeRaw(char, bytes);
+    } catch (e, st) {
+      // #2261 concern 1 — a write failure WHILE a disconnect edge is pending
+      // confirms the drop immediately; a lone failure on a live link is a
+      // debouncer no-op. #2466 — bin it as a recoverable transient (gated).
       final diag = Obd2CommDiagnostics.instance;
       if (diag.enabled) diag.noteConnectionEvent(failureReason: 'write-fail');
       _dropDebouncer.noteCommandFailure();
-      rethrow;
+      // #2900 — a drop landing DURING the BLE write makes FBP throw a raw
+      // disconnect exception ([isBleAdapterDisconnect]) that, left unwrapped,
+      // [TripDropDetector] didn't recognise — so the ~1 Hz speed poller re-wrote
+      // every cycle and each failure spooled an ERROR trace (error-log #23, 25×).
+      // Reclassify into the recoverable [Obd2DisconnectedException] (the #2671
+      // [ClassicElmChannel] + #2524 [BluetoothObd2Transport] precedents) and
+      // clear the session so the next write short-circuits on the open-guard.
+      if (isBleAdapterDisconnect(e)) {
+        _open = false;
+        _writeChar = null;
+        debugPrint('FlutterBluePlusElmChannel: write failed — reclassifying '
+            'as a recoverable disconnect (#2900): $e\n$st');
+        throw const Obd2DisconnectedException(
+          'FlutterBluePlusElmChannel: write failed — adapter not connected',
+        );
+      }
+      // A genuine non-disconnect BLE error still surfaces unchanged.
+      // ignore: use_rethrow_when_possible
+      throw e;
     }
+  }
+
+  /// The raw characteristic write, behind a [protected] [visibleForTesting]
+  /// seam so a fault-injection test can drive [write]'s #2900 reclassification
+  /// without a real BLE stack (a real [BluetoothCharacteristic] is not
+  /// mockable). Production writes exactly as before.
+  @protected
+  @visibleForTesting
+  Future<void> writeRaw(BluetoothCharacteristic char, List<int> bytes) =>
+      char.write(bytes, withoutResponse: true);
+
+  /// #2900 test seam — prime an established session so a fault-injection test
+  /// can drive [write] without the real connect path. Never used in production.
+  @visibleForTesting
+  void debugPrimeOpenSession(BluetoothCharacteristic writeChar) {
+    _writeChar = writeChar;
+    _open = true;
   }
 
   @override
@@ -386,7 +394,7 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       // OBD2/BLE layer, not local storage (#2379).
       unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'FlutterBluePlusElmChannel: disconnect failed'}));
     }
-    // #2295 — close the broadcast controller on dispose (symmetry with
+    // #2295 — close the broadcast controller (symmetry with
     // ClassicElmChannel.close()) so it doesn't leak across a reconnect.
     if (!_incoming.isClosed) await _incoming.close();
     _writeChar = null;

--- a/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_disconnect_test.dart
+++ b/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_disconnect_test.dart
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'flutter_blue_plus_elm_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_read_telemetry.dart';
+
+/// #2900 — the BLE OBD2 channel flooded the error log with
+/// `FlutterBluePlusException | writeCharacteristic | fbp-code: 6 | device is
+/// not connected` write failures after a link drop (error-log #23, 25×): the
+/// ~1 Hz speed poller kept writing into the dropped link, the raw FBP
+/// exception escaped unreclassified, so [TripDropDetector] never saw a typed
+/// disconnect and every per-cycle failure spooled an ERROR trace.
+///
+/// The fix mirrors the #2671 [ClassicElmChannel] + #2524
+/// [BluetoothObd2Transport] precedents: a write that fails because the adapter
+/// dropped mid-flight is reclassified into the recoverable typed
+/// [Obd2DisconnectedException], which `_isTypedDisconnect` /
+/// `isExpectedObd2ReadTransient` already route through pause/reconnect and
+/// de-noise to a breadcrumb. Genuine non-disconnect BLE errors still surface.
+class _CapturingRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    errors.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A channel whose raw characteristic write throws the injected fault, so the
+/// reclassification in [FlutterBluePlusElmChannel.write] can be exercised
+/// without a real BLE stack (a real [BluetoothCharacteristic.write] hits the
+/// platform). [writeRaw] is the [visibleForTesting] seam.
+class _InjectingChannel extends FlutterBluePlusElmChannel {
+  _InjectingChannel(super.device, {required this.fault});
+
+  final Object fault;
+  int writeRawCalls = 0;
+
+  @override
+  Future<void> writeRaw(BluetoothCharacteristic char, List<int> bytes) async {
+    writeRawCalls++;
+    throw fault;
+  }
+}
+
+BluetoothCharacteristic _fakeWriteChar() => BluetoothCharacteristic(
+      remoteId: const DeviceIdentifier('AA:BB:CC:DD:EE:01'),
+      serviceUuid: Guid('0000fff0-0000-1000-8000-00805f9b34fb'),
+      characteristicUuid: Guid('0000fff2-0000-1000-8000-00805f9b34fb'),
+    );
+
+_InjectingChannel _channelThatFailsWith(Object fault) {
+  final ch = _InjectingChannel(
+    BluetoothDevice.fromId('AA:BB:CC:DD:EE:01'),
+    fault: fault,
+  );
+  // Prime an established session so `write` passes its open-guard and reaches
+  // the (injected) raw write.
+  ch.debugPrimeOpenSession(_fakeWriteChar());
+  return ch;
+}
+
+void main() {
+  setUp(() {
+    errorLogger.resetForTest();
+    BreadcrumbCollector.clear();
+  });
+  tearDown(errorLogger.resetForTest);
+
+  group('FlutterBluePlusElmChannel.write — disconnect reclassification (#2900)',
+      () {
+    test(
+        'a FlutterBluePlusException(writeCharacteristic, fbp-code 6, "device '
+        'is not connected") is rethrown as the recoverable '
+        'Obd2DisconnectedException, NOT the raw FBP exception', () async {
+      // The exact field shape from error-log #23.
+      final fault = FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        6,
+        'device is not connected',
+      );
+      final ch = _channelThatFailsWith(fault);
+
+      await expectLater(
+        ch.write([0x41, 0x54, 0x5A, 0x0D]),
+        throwsA(isA<Obd2DisconnectedException>()),
+        reason: 'the raw FlutterBluePlusException must be reclassified into '
+            'the recoverable typed disconnect so the drop detector routes it '
+            'through pause/reconnect instead of flooding the error log',
+      );
+      // The drop flipped the session closed, so the next write short-circuits
+      // on the open-guard as the same typed disconnect (no raw write attempt).
+      expect(ch.isOpen, isFalse);
+    });
+
+    test(
+        'a FlutterBluePlusException "device is disconnected" is reclassified',
+        () async {
+      final ch = _channelThatFailsWith(FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        null,
+        'device is disconnected',
+      ));
+
+      await expectLater(
+        ch.write([0x01]),
+        throwsA(isA<Obd2DisconnectedException>()),
+      );
+    });
+
+    test(
+        'an Android GATT_ERROR 133 mid-write is reclassified (dying link)',
+        () async {
+      final ch = _channelThatFailsWith(FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        133,
+        'ANDROID_SPECIFIC_ERROR',
+      ));
+
+      await expectLater(
+        ch.write([0x01]),
+        throwsA(isA<Obd2DisconnectedException>()),
+      );
+    });
+
+    test(
+        'a PlatformException(not connected) mid-write is reclassified '
+        '(mirrors #2524 BluetoothObd2Transport)', () async {
+      final ch = _channelThatFailsWith(
+        PlatformException(code: 'writeCharacteristic', message: 'not connected'),
+      );
+
+      await expectLater(
+        ch.write([0x01]),
+        throwsA(isA<Obd2DisconnectedException>()),
+      );
+    });
+
+    test(
+        'a GENUINE non-disconnect BLE error STILL surfaces unchanged '
+        '(not swallowed, not reclassified)', () async {
+      // A clone rejecting the write MODE is a real, distinct fault — it must
+      // NOT be masked as a recoverable disconnect.
+      final fault = FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        1,
+        'characteristic does not support write without response',
+      );
+      final ch = _channelThatFailsWith(fault);
+
+      await expectLater(
+        ch.write([0x01]),
+        throwsA(
+          isA<FlutterBluePlusException>()
+              .having((e) => e.code, 'code', 1),
+        ),
+        reason: 'a non-disconnect BLE fault must keep surfacing so a genuine '
+            'adapter problem stays visible',
+      );
+      // A non-disconnect write failure does NOT tear down the session.
+      expect(ch.isOpen, isTrue);
+    });
+
+    test(
+        'after a drop, a write on the closed session short-circuits as the '
+        'recoverable Obd2DisconnectedException without a raw write attempt',
+        () async {
+      final ch = _channelThatFailsWith(FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        6,
+        'device is not connected',
+      ));
+
+      // First write trips the drop + reclassification and closes the session.
+      await expectLater(
+          ch.write([0x01]), throwsA(isA<Obd2DisconnectedException>()));
+      final callsAfterFirst = ch.writeRawCalls;
+
+      // Second write must NOT reach the raw write — the open-guard fires.
+      await expectLater(
+          ch.write([0x02]), throwsA(isA<Obd2DisconnectedException>()));
+      expect(ch.writeRawCalls, callsAfterFirst,
+          reason: 'a closed session must not dispatch into a dead link');
+    });
+  });
+
+  group('the reclassified disconnect de-noises through recordObd2ReadFailure',
+      () {
+    test(
+        'isExpectedObd2ReadTransient accepts the reclassified disconnect',
+        () {
+      expect(
+        isExpectedObd2ReadTransient(const Obd2DisconnectedException(
+            'FlutterBluePlusElmChannel: write failed — adapter not connected')),
+        isTrue,
+      );
+    });
+
+    test(
+        'a post-drop write routed through recordObd2ReadFailure records a '
+        'breadcrumb and does NOT reach errorLogger (the #23 flood is stopped)',
+        () async {
+      final rec = _CapturingRecorder();
+      errorLogger.testRecorderOverride = rec;
+
+      final ch = _channelThatFailsWith(FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        6,
+        'device is not connected',
+      ));
+
+      // Mirror the live speed-poll call site: the read helper catches the
+      // channel error and routes it through the de-noiser.
+      Object? caught;
+      StackTrace? caughtStack;
+      try {
+        await ch.write([0x41, 0x54, 0x5A, 0x0D]);
+      } catch (e, st) {
+        caught = e;
+        caughtStack = st;
+      }
+      expect(caught, isA<Obd2DisconnectedException>());
+      recordObd2ReadFailure(caught!, caughtStack!,
+          where: 'OBD2 readSpeed failed');
+
+      await Future<void>.delayed(Duration.zero);
+      expect(rec.errors, isEmpty,
+          reason: 'the reclassified disconnect is an EXPECTED transient — it '
+              'must NOT spool an ERROR trace (the error-log #23 ×25 flood)');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 read failed — expected transient'),
+      );
+    });
+
+    test(
+        'the RAW FlutterBluePlusException (the pre-fix escapee) would NOT be '
+        'an expected transient — it WOULD reach errorLogger (RED-before proof)',
+        () {
+      // Documents the bug: before the reclassification the raw FBP exception
+      // escaped `write`, and `isExpectedObd2ReadTransient` returns false for
+      // it, so `recordObd2ReadFailure` ERROR-logs it → the flood.
+      final raw = FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        6,
+        'device is not connected',
+      );
+      expect(isExpectedObd2ReadTransient(raw), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

After the BLE OBD2 link drops, the ~1 Hz speed poller kept writing into the dead adapter and `FlutterBluePlusElmChannel.write` let the raw `FlutterBluePlusException | writeCharacteristic | fbp-code: 6 | device is not connected` escape. `TripDropDetector._isTypedDisconnect` never recognised it as a disconnect, so each per-cycle write failure spooled an ERROR trace — **error-log #23 flooded 25×**.

The BLE channel was the one ELM channel that never got the disconnect-reclassification treatment that `ClassicElmChannel.write` (#2671) and `BluetoothObd2Transport._sendRaw` (#2524) already have.

## Fix

- `FlutterBluePlusElmChannel.write`: a write that fails because the adapter dropped mid-flight is reclassified into the recoverable typed `Obd2DisconnectedException`, and `_open`/`_writeChar` are cleared so the next write short-circuits on the open-guard (which itself now throws the typed disconnect, like ClassicElmChannel's `!_open` guard). The notify-stream `onError` path gets the same treatment when the GATT/ATT stack errors the stream on a drop.
- `isBleAdapterDisconnect` (new `ble_disconnect_classifier.dart`) matches the exact disconnect conditions: `FlutterBluePlusException` fbp-code **6**, descriptions containing **"device is not connected"** / **"device is disconnected"**, **GATT/android-code 133** mid-session, and `PlatformException` whose code/message says not-connected/disconnected (mirrors #2524). Genuine non-disconnect BLE errors return false and **still surface unchanged**.
- `_isTypedDisconnect` / `isExpectedObd2ReadTransient` already accept `Obd2DisconnectedException` via `Obd2ConnectionError.isExpectedUserCondition` — no change needed there; the reclassification alone stops the flood and routes reconnects.
- The connect-failure binning (`classifyBleConnectFailure`) moved into the same classifier file to keep the channel at the 400-line cap.

## Test (RED-before / green-after)

`flutter_blue_plus_elm_channel_disconnect_test.dart` drives the channel's raw characteristic write (via a `@visibleForTesting writeRaw` seam) with an injected `FlutterBluePlusException(writeCharacteristic, fbp-code 6, "device is not connected")` and asserts:
- `write` throws `Obd2DisconnectedException`, not the raw FBP exception;
- routed through `recordObd2ReadFailure` it records a breadcrumb and **does NOT reach errorLogger** (the de-noise that stops the #23 flood);
- genuine non-disconnect BLE errors still surface; GATT 133 + `PlatformException(not connected)` are also reclassified.

Verified RED on the pre-fix behaviour (6 tests fail, raw exception reaches errorLogger) → green after.

## Gates
- `flutter analyze` clean on all changed files.
- Full OBD2 suite + `file_length` lint: 1422 tests green.
- 400-line cap respected (channel = 400 effective lines). No ARB, no codegen.

Closes #2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
