### PR TITLE
fix(obd2): retry channel.open() on transient GATT-133/rfcomm-open-fail (part of #2906)

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -5,11 +5,24 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import 'ble_disconnect_classifier.dart';
 import 'elm_byte_channel.dart';
 import 'event_channel_cancel.dart';
 import 'obd2_connection_errors.dart';
 import 'obd2_read_timeout.dart';
 import 'obd2_transport.dart';
+
+/// #2906 — whether a `channel.open()` failure is a transient worth retrying:
+/// a slow/flaky adapter ([TimeoutException]), a typed recoverable disconnect
+/// (`Obd2AdapterUnresponsive` / `Obd2DisconnectedException` —
+/// [Obd2ConnectionError.isExpectedUserCondition]), or a raw BLE GATT-133 /
+/// "device not connected" the classic/BLE channels surface
+/// ([isBleAdapterDisconnect]). A genuine fault (permission denied, protocol
+/// init) is NOT retried — it rethrows so the caller surfaces it.
+bool _isRecoverableOpenFailure(Object e) =>
+    e is TimeoutException ||
+    (e is Obd2ConnectionError && e.isExpectedUserCondition) ||
+    isBleAdapterDisconnect(e);
 
 /// [Obd2Transport] that moves bytes over a generic [ElmByteChannel]
 /// (#716 step 1).
@@ -89,7 +102,29 @@ class BluetoothObd2Transport implements Obd2Transport {
     // unblocks instead of hanging forever.
     _failPending(StateError('Transport reconnecting'));
     _buffer.clear();
-    await _channel.open();
+    // #2906 — the channel open is the #1 fragility point: a transient BLE
+    // GATT-133 / Classic rfcomm-open-fail used to abort the whole connect with
+    // ZERO retry (the existing _withConnectRetry only wraps the ELM send
+    // handshake, AFTER the channel is already open). Bounded retry + backoff,
+    // with a best-effort teardown between attempts so a half-open GATT/socket
+    // is cleared before the next try (the stale-client → repeat-133 trap).
+    const maxOpenAttempts = 3;
+    for (var attempt = 1; ; attempt++) {
+      try {
+        await _channel.open();
+        break;
+      } catch (e) {
+        if (attempt >= maxOpenAttempts || !_isRecoverableOpenFailure(e)) {
+          rethrow;
+        }
+        try {
+          await _channel.close();
+        } catch (_) {
+          // best-effort teardown of a half-open link before retrying
+        }
+        await Future<void>.delayed(Duration(milliseconds: 150 * attempt));
+      }
+    }
     _subscription = _channel.incoming.listen(
       _onBytes,
       onError: (e, st) {

--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -113,10 +113,13 @@ class BluetoothObd2Transport implements Obd2Transport {
       try {
         await _channel.open();
         break;
-      } catch (e) {
+      } catch (e, st) {
         if (attempt >= maxOpenAttempts || !_isRecoverableOpenFailure(e)) {
           rethrow;
         }
+        debugPrint('BluetoothObd2Transport: channel.open attempt $attempt/'
+            '$maxOpenAttempts failed ($e), tearing down + retrying after '
+            'backoff\n$st');
         try {
           await _channel.close();
         } catch (_) {

--- a/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_obd2_transport_test.dart
@@ -23,6 +23,42 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 void main() {
   group('BluetoothObd2Transport (#716)', () {
     test(
+        '#2906 connect RETRIES a transient channel.open() failure '
+        '(GATT-133 / rfcomm-open-fail) with teardown between attempts',
+        () async {
+      final channel = _ScriptedChannel();
+      // First two open() attempts throw a typed recoverable disconnect, the
+      // third succeeds — exactly the stale-GATT/rfcomm transient that used to
+      // abort the whole connect with no retry.
+      channel.scriptOpenFailures(2, const Obd2AdapterUnresponsive());
+
+      final transport = BluetoothObd2Transport(channel);
+      await transport.connect();
+
+      expect(transport.isConnected, isTrue,
+          reason: 'connect must succeed after retrying the transient open');
+      expect(channel.openAttempts, 3,
+          reason: 'two failures + one success = three open() attempts');
+      expect(channel.closeCalls, 2,
+          reason: 'a teardown runs between each failed attempt to clear the '
+              'half-open GATT/socket');
+    });
+
+    test(
+        '#2906 connect does NOT retry a genuine (non-transient) open() '
+        'failure — it rethrows after one attempt', () async {
+      final channel = _ScriptedChannel();
+      // A permission denial is a real fault, not a flaky link → no retry.
+      channel.scriptOpenFailures(99, const Obd2PermissionDenied());
+
+      final transport = BluetoothObd2Transport(channel);
+
+      await expectLater(transport.connect(), throwsA(isA<Obd2PermissionDenied>()));
+      expect(channel.openAttempts, 1, reason: 'genuine fault is not retried');
+      expect(transport.isConnected, isFalse);
+    });
+
+    test(
         'connect opens the channel and leaves isConnected=true WITHOUT '
         'sending the ELM init (init is the service\'s job now, #2233)',
         () async {
@@ -358,6 +394,17 @@ class _ScriptedChannel implements ElmByteChannel {
   final List<List<int>> _writes = [];
   bool _open = false;
 
+  // #2906 — make the first N open() calls throw a transient, then succeed.
+  int _openFailuresRemaining = 0;
+  Object _openFailure = StateError('open failed');
+  int openAttempts = 0;
+  int closeCalls = 0;
+
+  void scriptOpenFailures(int count, Object error) {
+    _openFailuresRemaining = count;
+    _openFailure = error;
+  }
+
   void scriptResponse(String command, String reply) {
     _chunksByCommand[command] = [reply.codeUnits];
   }
@@ -384,10 +431,20 @@ class _ScriptedChannel implements ElmByteChannel {
       _writes.map((w) => String.fromCharCodes(w)).toList();
 
   @override
-  Future<void> open() async => _open = true;
+  Future<void> open() async {
+    openAttempts++;
+    if (_openFailuresRemaining > 0) {
+      _openFailuresRemaining--;
+      throw _openFailure;
+    }
+    _open = true;
+  }
 
   @override
-  Future<void> close() async => _open = false;
+  Future<void> close() async {
+    closeCalls++;
+    _open = false;
+  }
 
   @override
   bool get isOpen => _open;


### PR DESCRIPTION
Part of Epic #2904 / issue #2906. The transport connect (`channel.open()`) had **zero retry** — a transient BLE GATT-133 or Classic rfcomm-open-fail aborted the whole connect and left stale state that blocked recovery. Now: bounded retry (3) + backoff + teardown between attempts, retrying only recoverable failures (TimeoutException / typed Obd2 disconnects / BLE-133 via isBleAdapterDisconnect); genuine faults rethrow immediately. 14/14 transport tests pass (2 new), analyze clean, no codegen.

Implemented from the main session (background subagents were 529-overloaded). Remaining for #2906 (follow-up): stop-scan-before-connect, scan-path GATT teardown, Classic Kotlin retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)