### PR TITLE
feat(recording): glanceable zero-touch landscape split-screen layout (#2903)

### DIFF
--- a/lib/features/consumption/presentation/screens/trip_recording_screen.dart
+++ b/lib/features/consumption/presentation/screens/trip_recording_screen.dart
@@ -36,6 +36,7 @@ import '../widgets/obd2_breadcrumb_overlay.dart';
 import '../widgets/recording_app_bar_actions.dart';
 import '../widgets/trip_avg_consumption_card.dart';
 import '../widgets/trip_radar_card.dart';
+import '../widgets/trip_recording_landscape_body.dart';
 import '../widgets/trip_save_progress.dart';
 import '../widgets/trip_start_progress.dart';
 import '../../../../core/logging/error_logger.dart';
@@ -868,6 +869,21 @@ class _TripRecordingScreenState extends ConsumerState<TripRecordingScreen> {
     final brokenMapOverride = band == BrokenMapBand.hardDisable
         ? (_receiptDerivedLPer100Km(ref) ?? '—')
         : null;
+
+    // #2903 — in LANDSCAPE the driver is driving: swap the scrolling
+    // portrait list for the glanceable, zero-touch two-zone split (live
+    // feedback left, trip + radar right) so every key metric is visible
+    // at once, large and high-contrast, with no scrolling. Orientation
+    // is read the same way the shell / favorites / search screens do
+    // (`MediaQuery.orientation`). Portrait is unchanged below.
+    final isLandscape =
+        MediaQuery.of(context).orientation == Orientation.landscape;
+    if (isLandscape) {
+      return TripRecordingLandscapeBody(
+        reading: r,
+        brokenMapOverride: brokenMapOverride,
+      );
+    }
 
     // #2380 — the radar card + five metric cards + coaching card can
     // exceed a short viewport, so the recording column scrolls rather

--- a/lib/features/consumption/presentation/widgets/minimal_drive_summary.dart
+++ b/lib/features/consumption/presentation/widgets/minimal_drive_summary.dart
@@ -137,9 +137,13 @@ class MinimalDriveSummary extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 6),
+            // #2903 — each symbol gets an equal Expanded share so the
+            // triplet fits a narrow pane (the landscape split's left
+            // zone) and a large text scale without overflowing.
             Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: tiles,
+              children: [
+                for (final tile in tiles) Expanded(child: Center(child: tile)),
+              ],
             ),
           ],
         ),
@@ -178,9 +182,14 @@ class _CoachingSymbol extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(icon, size: 24, color: color),
+          // #2903 — shrink-to-fit so the cue label never overflows its
+          // (now Expanded) cell at a large text scale / narrow pane.
           Text(
             label,
             style: TextStyle(fontSize: 10, color: color),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
           ),
         ],
       ),

--- a/lib/features/consumption/presentation/widgets/trip_avg_consumption_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_avg_consumption_card.dart
@@ -59,33 +59,50 @@ class TripAvgConsumptionCard extends ConsumerWidget {
   // i18n-ignore: ADR 0012 estimate marker, language-neutral
   static const String _tilde = '~';
 
+  /// The single source of truth for the average's display value and
+  /// whether it is a GPS-only estimate, given a [live] reading and an
+  /// optional [brokenMapOverride]. Mode selection (see class doc):
+  /// override → measured → estimate → placeholder.
+  ///
+  /// Extracted so an alternate presentation — e.g. the #2903 landscape
+  /// 2×2 grid tile, which renders the average as a big centred figure
+  /// rather than this label/value Row — reuses the exact same decision
+  /// instead of duplicating it.
+  static ({String value, bool isEstimate}) resolveDisplay(
+    TripLiveReading? live, {
+    String? brokenMapOverride,
+  }) {
+    final measured = live?.liveAvgLPer100Km;
+    final estimated = live?.gpsEstimatedAvgLPer100Km;
+    final override = brokenMapOverride;
+    if (override != null) {
+      return (value: override, isEstimate: false);
+    } else if (measured != null) {
+      return (
+        value: UnitFormatter.formatConsumption(measured, isEv: false),
+        isEstimate: false,
+      );
+    } else if (estimated != null) {
+      return (
+        value:
+            '$_tilde${UnitFormatter.formatConsumption(estimated, isEv: false)}',
+        isEstimate: true,
+      );
+    }
+    return (value: '—', isEstimate: false);
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final r = live;
 
-    final measured = r?.liveAvgLPer100Km;
-    final estimated = r?.gpsEstimatedAvgLPer100Km;
-
-    // Mode selection (see class doc): override → measured → estimate.
-    final override = brokenMapOverride;
-    final bool isEstimate;
-    final String value;
-    if (override != null) {
-      value = override;
-      isEstimate = false;
-    } else if (measured != null) {
-      value = UnitFormatter.formatConsumption(measured, isEv: false);
-      isEstimate = false;
-    } else if (estimated != null) {
-      value =
-          '$_tilde${UnitFormatter.formatConsumption(estimated, isEv: false)}';
-      isEstimate = true;
-    } else {
-      value = '—';
-      isEstimate = false;
-    }
+    // Mode selection (override → measured → estimate) lives in the
+    // shared resolver so the landscape grid tile stays in sync.
+    final display = resolveDisplay(r, brokenMapOverride: brokenMapOverride);
+    final value = display.value;
+    final isEstimate = display.isEstimate;
 
     // The maturity badge + estimate tooltip only ride along the GPS
     // estimate branch; the active vehicle's calibration matrix drives

--- a/lib/features/consumption/presentation/widgets/trip_radar_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_radar_card.dart
@@ -260,7 +260,17 @@ class RadarCard extends StatelessWidget {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(title, style: theme.textTheme.bodySmall),
+                  // #2903 — Flexible so the overline ellipsizes in a
+                  // narrow ListTile (e.g. the landscape split's right
+                  // pane) instead of overflowing the title slot.
+                  Flexible(
+                    child: Text(
+                      title,
+                      style: theme.textTheme.bodySmall,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
                   if (swipeable) ...[
                     const SizedBox(width: 6),
                     // Faint, decorative swipe-available hint — the

--- a/lib/features/consumption/presentation/widgets/trip_recording_landscape_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_landscape_body.dart
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../../../l10n/app_localizations.dart';
+import '../../data/obd2/trip_live_reading.dart';
+import 'broken_map_widgets.dart';
+import 'minimal_drive_summary.dart';
+import 'trip_avg_consumption_card.dart';
+import 'trip_radar_card.dart';
+
+/// #2903 — the glanceable, zero-touch LANDSCAPE recording layout.
+///
+/// Portrait keeps the scrolling vertical list (radar → metric cards →
+/// coaching card). Landscape is a DIFFERENT, driver-safe surface: a
+/// driver is driving, so every key metric is visible at once, large and
+/// high-contrast, with NO scrolling and NO small tap targets.
+///
+/// Two-zone [Row] of [Expanded] panes — each REUSES the existing
+/// recording widgets, only re-arranged (never reinvented):
+///
+///  - **LEFT — live driving feedback** (the most time-critical glance):
+///    the big [MinimalDriveSummary] (instant L/100 km + the eco-coaching
+///    cues: lift-off / anticipate / smooth-accel, or shift-up/down/ease)
+///    on top, then a large **Speed** read-out underneath.
+///  - **RIGHT — trip + radar**: the [TripRadarCard] (price + station +
+///    closeness bar) on top, then a 2×2 grid of large
+///    **Distance / Avg / Elapsed / Fuel used** tiles.
+///
+/// The status banner ([BrokenMapBanner]) and the Pause/Stop controls live
+/// in the host scaffold (banner above this body, controls in the AppBar),
+/// so this widget owns the two metric zones only.
+///
+/// Layout-only: the closeness-bar fill logic and all OBD2 connection code
+/// are untouched — this widget re-arranges already-built widgets, it does
+/// not read the adapter or compute fills.
+class TripRecordingLandscapeBody extends StatelessWidget {
+  const TripRecordingLandscapeBody({
+    super.key,
+    required this.reading,
+    required this.brokenMapOverride,
+  });
+
+  /// The current live reading, or null before the first fix lands. Owned
+  /// by the host screen so this widget stays free of provider reads for
+  /// the raw figures (the embedded cards do their own watches).
+  final TripLiveReading? reading;
+
+  /// Pre-resolved receipt-derived L/100 km string when the active
+  /// vehicle's broken-MAP belief is in the hard-disable band; null
+  /// otherwise. Handed straight to [TripAvgConsumptionCard], exactly as
+  /// the portrait path does — no fill logic changes here.
+  final String? brokenMapOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final r = reading;
+
+    // Two equal zones. No SingleChildScrollView: the design goal is a
+    // glanceable, non-scrolling surface, so each zone is a Column whose
+    // children flex to the available height.
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // LEFT — live driving feedback.
+        Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Instant L/100 km + the eco-coaching cue triplet. Already
+              // a large-headline card; it leads the most time-critical
+              // glance zone.
+              const MinimalDriveSummary(),
+              const SizedBox(height: 12),
+              // Large speed read-out — the second live-feedback figure.
+              Expanded(
+                child: _BigMetricTile(
+                  key: const Key('landscapeSpeedTile'),
+                  icon: Icons.speed,
+                  label: l?.tripMetricSpeed ?? 'Speed',
+                  value: r?.speedKmh == null
+                      ? '—'
+                      : '${r!.speedKmh!.toStringAsFixed(0)} km/h',
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        // RIGHT — trip + radar.
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Fuel Station Radar (price + station + closeness bar) on top.
+              const TripRadarCard(),
+              const SizedBox(height: 8),
+              // 2×2 grid of large glanceable tiles. Two Rows of two
+              // Expanded tiles keeps every cell equal width and lets the
+              // grid flex to the remaining height with no scrolling.
+              Expanded(
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: _BigMetricTile(
+                              key: const Key('landscapeDistanceTile'),
+                              icon: Icons.route,
+                              label: l?.tripMetricDistance ?? 'Distance',
+                              value: r == null
+                                  ? '—'
+                                  : '${r.distanceKmSoFar.toStringAsFixed(2)} km',
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          // Avg consumption — same big-tile shape as the
+                          // other three cells (a wide label/value Row card
+                          // can't shrink into a quarter-cell). The value +
+                          // `~`-estimate decision is REUSED verbatim from
+                          // [TripAvgConsumptionCard.resolveDisplay], so the
+                          // measured → GPS-estimate → broken-MAP-override
+                          // logic stays in ONE place — not reinvented.
+                          Expanded(
+                            child: _BigMetricTile(
+                              key: const Key('landscapeAvgTile'),
+                              icon: Icons.eco,
+                              label: l?.tripMetricAvgConsumption ?? 'Avg',
+                              value: TripAvgConsumptionCard.resolveDisplay(
+                                r,
+                                brokenMapOverride: brokenMapOverride,
+                              ).value,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Expanded(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: _BigMetricTile(
+                              key: const Key('landscapeElapsedTile'),
+                              icon: Icons.timer,
+                              label: l?.tripMetricElapsed ?? 'Elapsed',
+                              value: r == null ? '—' : _fmtElapsed(r.elapsed),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: _BigMetricTile(
+                              key: const Key('landscapeFuelTile'),
+                              icon: Icons.local_gas_station,
+                              label: l?.tripMetricFuelUsed ?? 'Fuel used',
+                              value: r?.fuelLitersSoFar != null
+                                  ? '${r!.fuelLitersSoFar!.toStringAsFixed(2)} L'
+                                  : r?.gpsEstimatedFuelLitersSoFar != null
+                                      ? '~${r!.gpsEstimatedFuelLitersSoFar!.toStringAsFixed(2)} L'
+                                      : '—',
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // Broken-MAP disclaimer chip — self-hides outside the
+              // verifying band, same as the portrait path (#1423).
+              const BrokenMapDisclaimerChip(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  static String _fmtElapsed(Duration d) {
+    final m = d.inMinutes;
+    final s = d.inSeconds % 60;
+    return '${m.toString()}:${s.toString().padLeft(2, '0')}';
+  }
+}
+
+/// Large, high-contrast metric tile for the landscape grid — a label
+/// over one big tabular-figures value, centred and sized to fill its
+/// grid cell so the driver reads it at a glance.
+///
+/// Distinct from the portrait `_MetricCard` (an icon + label + trailing
+/// value Row) because the landscape goal is a BIG centred number, not a
+/// dense list row. The value text auto-shrinks via [FittedBox] so a long
+/// figure (or a large text-scale) never overflows the cell.
+class _BigMetricTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _BigMetricTile({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, size: 20, color: scheme.onSurfaceVariant),
+                const SizedBox(width: 6),
+                Flexible(
+                  child: Text(
+                    label,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 2),
+            // Big value, shrink-to-fit so neither a long figure nor a
+            // large text-scale overflows the cell.
+            Flexible(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  value,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: scheme.onSurface,
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/consumption/presentation/screens/trip_recording_screen_landscape_test.dart
+++ b/test/features/consumption/presentation/screens/trip_recording_screen_landscape_test.dart
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/approach_detector.dart';
+import 'package:tankstellen/features/approach/providers/effective_approach_state_provider.dart';
+import 'package:tankstellen/features/approach/providers/radar_candidate_list_provider.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_recording_screen.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/minimal_drive_summary.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_radar_card.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/trip_recording_landscape_body.dart';
+import 'package:tankstellen/features/consumption/providers/trip_recording_provider.dart';
+import 'package:tankstellen/features/consumption/providers/wakelock_facade.dart';
+import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/recording_profile_override.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2903 — the LANDSCAPE recording layout is a dedicated glanceable,
+/// zero-touch split distinct from portrait: live feedback (instant
+/// consumption + eco-coaching cues + speed) on the LEFT, trip + radar
+/// (Fuel Station Radar on top, then a 2×2 Distance/Avg/Elapsed/Fuel
+/// grid) on the RIGHT. Every key metric is visible at once with NO
+/// scrolling. Portrait stays the scrolling vertical list.
+///
+/// The layout body ([TripRecordingLandscapeBody]) is tested directly in
+/// a phone-landscape-sized box so the assertion isolates the new layout
+/// from the always-on-in-debug OBD2 breadcrumb diagnostic overlay (which
+/// the host screen floats in a Stack and is unrelated to this layout).
+/// A separate, lighter screen-level test confirms the orientation
+/// routing (landscape mounts the body; portrait does not).
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const station = Station(
+    id: 'stn-1',
+    name: 'Tankstelle Mitte',
+    brand: 'Aral',
+    street: 'Hauptstr',
+    postCode: '10115',
+    place: 'Berlin',
+    lat: 52.5,
+    lng: 13.4,
+    e10: 1.789,
+    diesel: 1.659,
+    isOpen: true,
+  );
+
+  const reading = TripLiveReading(
+    distanceKmSoFar: 5.0,
+    fuelLitersSoFar: 0.3,
+    elapsed: Duration(minutes: 5),
+    speedKmh: 88.0,
+  );
+
+  List<Object> bodyOverrides() => [
+        wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+        recordingProfileOverride(),
+        effectiveApproachStateProvider.overrideWithValue(
+          const ApproachInRadius(station: station, distanceMeters: 250),
+        ),
+        effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+        radarCandidateListProvider.overrideWith((ref) async => const []),
+      ];
+
+  /// Pumps [TripRecordingLandscapeBody] inside a fixed phone-landscape
+  /// box (≈ a 6" phone in landscape, minus chrome) so RenderFlex
+  /// overflow is asserted against a realistic glanceable surface.
+  Future<void> pumpLandscapeBody(
+    WidgetTester tester, {
+    double textScaleFactor = 1.0,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: bodyOverrides().cast(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: MediaQuery(
+            data: MediaQueryData(
+              textScaler: TextScaler.linear(textScaleFactor),
+            ),
+            // ≈ a 6"-class phone in landscape, minus the AppBar + the
+            // 16-dp body padding the host scaffold applies.
+            child: const Scaffold(
+              body: SizedBox(
+                width: 860,
+                height: 320,
+                child: TripRecordingLandscapeBody(
+                  reading: reading,
+                  brokenMapOverride: null,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+      'landscape body shows instant-consumption + speed on the left and '
+      'radar + distance/avg/elapsed/fuel on the right, with NO overflow',
+      (tester) async {
+    await pumpLandscapeBody(tester);
+
+    // LEFT zone — live driving feedback.
+    expect(find.byType(MinimalDriveSummary), findsOneWidget);
+    expect(
+        find.byKey(const Key('minimal_drive_instant_value')), findsOneWidget);
+    expect(find.byKey(const Key('landscapeSpeedTile')), findsOneWidget);
+    expect(find.text('Speed'), findsOneWidget);
+
+    // RIGHT zone — radar on top.
+    expect(find.byType(TripRadarCard), findsOneWidget);
+    expect(find.text('Fuel Station Radar'), findsOneWidget);
+
+    // 2×2 grid — Distance / Avg / Elapsed / Fuel used all present.
+    expect(find.byKey(const Key('landscapeDistanceTile')), findsOneWidget);
+    expect(find.byKey(const Key('landscapeAvgTile')), findsOneWidget);
+    expect(find.byKey(const Key('landscapeElapsedTile')), findsOneWidget);
+    expect(find.byKey(const Key('landscapeFuelTile')), findsOneWidget);
+    expect(find.text('Distance'), findsOneWidget);
+    expect(find.text('Avg'), findsOneWidget);
+    expect(find.text('Elapsed'), findsOneWidget);
+    expect(find.text('Fuel used'), findsOneWidget);
+
+    // The metric values render (not just labels).
+    expect(find.text('5.00 km'), findsOneWidget);
+    expect(find.text('88 km/h'), findsOneWidget);
+
+    // No scrolling: the body must NOT introduce a scroll view of its own.
+    expect(find.byType(SingleChildScrollView), findsNothing);
+    expect(find.byType(ListView), findsNothing);
+
+    // Layout contract: the live-feedback zone is LEFT of the radar zone.
+    final radarLeft = tester.getTopLeft(find.byType(TripRadarCard)).dx;
+    final speedLeft =
+        tester.getTopLeft(find.byKey(const Key('landscapeSpeedTile'))).dx;
+    expect(speedLeft, lessThan(radarLeft),
+        reason: 'Live-feedback zone must sit left of the trip/radar zone.');
+
+    // No RenderFlex overflow at a phone-landscape size.
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('landscape body does not overflow at a 1.3x text scale',
+      (tester) async {
+    await pumpLandscapeBody(tester, textScaleFactor: 1.3);
+
+    expect(find.byType(TripRecordingLandscapeBody), findsOneWidget);
+    expect(find.byKey(const Key('landscapeSpeedTile')), findsOneWidget);
+    expect(find.byKey(const Key('landscapeFuelTile')), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'screen routes to the landscape body in landscape and to the '
+      'scrolling list in portrait (portrait unchanged)', (tester) async {
+    final overrides = <Object>[
+      tripRecordingProvider.overrideWith(_LiveFakeTripRecording.new),
+      ...bodyOverrides(),
+    ];
+
+    // Portrait — taller than wide: the scrolling list, NOT the split.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpApp(tester, const TripRecordingScreen(), overrides: overrides);
+    expect(find.byType(TripRecordingLandscapeBody), findsNothing,
+        reason: 'Portrait must keep the existing scrolling list.');
+    // The portrait scrolling list is present (the screen's own
+    // SingleChildScrollView; the debug overlay also has one, so we only
+    // assert the landscape split is absent and the radar still renders).
+    expect(find.byType(TripRadarCard), findsOneWidget);
+    expect(find.byType(MinimalDriveSummary), findsOneWidget);
+
+    // Landscape — wider than tall: the dedicated split body is mounted.
+    tester.view.physicalSize = const Size(2400, 1080);
+    await tester.pumpAndSettle();
+    expect(find.byType(TripRecordingLandscapeBody), findsOneWidget,
+        reason: 'Landscape must render the dedicated split body.');
+  });
+}
+
+class _FakeWakelockFacade implements WakelockFacade {
+  @override
+  Future<void> enable() async {}
+  @override
+  Future<void> disable() async {}
+}
+
+class _LiveFakeTripRecording extends TripRecording {
+  @override
+  TripRecordingState build() => const TripRecordingState(
+        phase: TripRecordingPhase.recording,
+        live: TripLiveReading(
+          distanceKmSoFar: 5.0,
+          fuelLitersSoFar: 0.3,
+          elapsed: Duration(minutes: 5),
+          speedKmh: 88.0,
+        ),
+      );
+
+  @override
+  Future<StoppedTripResult> stop({bool automatic = false}) async {
+    return const StoppedTripResult(
+      summary: TripSummary(
+        distanceKm: 0,
+        maxRpm: 0,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+      ),
+      odometerStartKm: null,
+      odometerLatestKm: null,
+    );
+  }
+
+  @override
+  void reset() {
+    state = const TripRecordingState();
+  }
+}

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -333,8 +333,13 @@ void main() {
     // #2764 — shrank 1123 → 1090: the 5 inline app-bar IconButtons moved
     // into the new RecordingAppBarActions widget (Pause + Stop primary,
     // Pin/Help/PiP folded into an overflow kebab). Net -33 lines here.
+    // #2903 — grew 1090 → 1106 (+16): the landscape orientation dispatch.
+    // The bulk of the landscape layout was extracted to the new
+    // trip_recording_landscape_body.dart (262 lines); only the
+    // MediaQuery.orientation branch + its import remain here. Full
+    // decomposition of this screen still tracked under #2187/#2188.
     'lib/features/consumption/presentation/screens/trip_recording_screen.dart':
-        1090,
+        1106,
     'lib/features/consumption/presentation/widgets/broken_map_widgets.dart':
         439,
     'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':


### PR DESCRIPTION
## What

In landscape the trip-recording screen was just the portrait vertical list rotated — cramped, only a couple of metrics visible, requiring scrolling while the driver is *driving*. This adds a dedicated **landscape-only** body that is glanceable and zero-touch. Portrait is unchanged.

A two-zone `Row` of `Expanded` panes, reusing the existing recording widgets (re-arranged, never reinvented):

- **LEFT — live driving feedback:** the big `MinimalDriveSummary` (instant L/100 km + the eco-coaching cues: lift-off / anticipate / smooth-accel, or shift-up/down/ease) on top, large **Speed** read-out below.
- **RIGHT — trip + radar:** `TripRadarCard` (price + station + closeness bar) on top, then a **2×2 grid** of large **Distance / Avg / Elapsed / Fuel used** tiles. Every key metric is visible at once, no scrolling, big high-contrast figures (shrink-to-fit `FittedBox`).

Orientation is detected via `MediaQuery.orientation`, the same way the shell / favorites / search screens already do. The status banner (`BrokenMapBanner`) stays above the body and Pause/Stop remain in the AppBar (reachable, large), so no precise tapping is needed.

## How

- New `TripRecordingLandscapeBody` widget (<400 lines) — the screen file branches to it in landscape, portrait path untouched.
- The **Avg** figure reuses the exact `measured → GPS-estimate → broken-MAP-override` decision via a new shared `TripAvgConsumptionCard.resolveDisplay`, so the logic stays in **one** place (not duplicated).
- Three reused cards (radar overline, the minimal-drive coaching row, the coach-symbol labels) gained `Flexible`/`Expanded`/ellipsis robustness so they fit a narrow half-pane at a large text scale — **no logic change**.

## Constraints honored

- **Layout-only**: the closeness-bar fill logic and all OBD2 connection code are untouched.
- **No new ARB**: all labels reuse existing `tripMetric*` strings — no 23-locale fan-out, no codegen drift.
- **Accessibility**: large type, respects the text-scale clamp (tested at 1.3×), values shrink-to-fit rather than overflow.

## Tests

Structural (not golden) widget tests in `trip_recording_screen_landscape_test.dart`:
- Landscape body renders instant-consumption + speed (left) and radar + distance/avg/elapsed/fuel (right) with **no RenderFlex overflow**, incl. at 1.3× text scale; live-feedback zone sits left of the trip/radar zone; introduces no scroll view of its own.
- The screen routes to the landscape body in landscape and keeps the scrolling list in portrait (portrait unchanged).

`flutter analyze` clean; the touched widgets' existing suites + the full consumption-screen suite (154 tests) + the hard-coded-strings lint all pass.

Closes #2903

🤖 Generated with [Claude Code](https://claude.com/claude-code)
