### PR TITLE
feat(share): iOS Share Extension scaffold + host App-Group bridge for receipt share-intent (#2736)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ docs/guides/*
 !docs/guides/ios-auto-record.md
 !docs/guides/ios-codesigning.md
 !docs/guides/ios-widget-extension.md
+!docs/guides/ios-share-extension.md
 !docs/guides/feature-flags.md
 !docs/guides/fdroid-submission.md
 !docs/guides/app-store-listing.md

--- a/docs/guides/go-live-runbook.md
+++ b/docs/guides/go-live-runbook.md
@@ -183,3 +183,13 @@ all 5 locales' metadata within Apple limits. **Now added:** the required
   Primary Category, Pricing & Availability, Content Rights, **EU DSA trader status**.
 - **A build attached + submitted:** promote a TestFlight build (signed IPA) to the
   App Store version, then submit for review.
+- **iOS Share Extension (#2736) — Xcode + Apple signing, optional pre-launch:**
+  the cross-platform Dart receiver + the iOS extension source ship in-repo
+  (`ios/ShareExtension/`, inline `ShareIntentBridge` in `AppDelegate.swift`), but
+  the extension is **not yet wired into `Runner.xcodeproj`** (kept out so the
+  host build stays green). To enable "share a receipt into Sparkilo" on iOS,
+  follow `docs/guides/ios-share-extension.md`: register the extension App ID
+  (`de.tankstellen.tankstellen.ShareExtension`) + App Group under the Apple
+  Developer account, add the target in Xcode, re-provision (fastlane match
+  `--force`). The host app ships fine without it; this is an additive feature,
+  not a launch gate.

--- a/docs/guides/ios-share-extension.md
+++ b/docs/guides/ios-share-extension.md
@@ -1,0 +1,191 @@
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+# iOS Share Extension — Mac-developer setup checklist (#2736)
+
+This adds **source-tracked scaffolding** for an iOS **Share Extension** so a
+user can share a receipt (photo / PDF / e-receipt text or link) from another
+app (Photos, Files, Mail, Safari …) straight into Sparkilo's Add-fill-up flow
+— the iOS counterpart of the Android share-intent receiver (#2735).
+
+Everything that can ship blind ships here. The remaining steps need:
+
+- **Xcode** (UI-driven target setup — the `project.pbxproj` schema for an
+  embedded `.appex` includes a target dependency, an embed-app-extensions copy
+  phase and code-sign settings that break the project file when hand-edited),
+- the **Apple Developer Portal** (the App ID for the extension + the App Group
+  + re-provisioning),
+- a physical iPhone for verification.
+
+Until those steps are done, **the iOS host build still compiles and runs
+without the Share Extension** — the Swift source sits on disk but the Xcode
+project doesn't compile it (exactly like `ios/TankstellenWidget/`). Android is
+unaffected; the cross-platform Dart receiver is already live.
+
+## How it works (architecture)
+
+iOS extensions run in a separate process with no direct line to the Flutter
+engine, so the bridge is the **App Group container** both targets can read:
+
+```
+   other app  ──share──▶  ShareExtension (ShareViewController.swift)
+                              │  copies image/PDF into the App Group container
+                              │  writes pending_share.json  { items:[…], country }
+                              │  opens  sparkilo-share://receipt
+                              ▼
+   host app  ◀── URL open ── iOS
+       │  AppDelegate.ShareIntentBridge.drainPendingShare()
+       │  reads + deletes pending_share.json
+       │  replays it down  tankstellen/share_intent/{methods,events}
+       ▼
+   Dart  ShareReceiptListener → ShareReceiptHandler  (unchanged, #2735)
+       → stash + route to /consumption/add → OCR / text-parse → prefill form
+```
+
+The manifest shape is **identical** to what the Android `ShareIntentChannel.kt`
+emits, so `SharedReceiptIntent.fromPlatform` decodes both with one code path.
+There is **no iOS-specific Dart code**. The seam is locked by
+`test/features/consumption/presentation/widgets/share_receipt_ios_routing_test.dart`.
+
+## What's already in the tree (ships blind)
+
+```
+ios/
+├── Runner/
+│   ├── AppDelegate.swift          ← inline ShareIntentBridge + URL-open handler (NEW)
+│   ├── Info.plist                 ← `sparkilo-share` CFBundleURLTypes (NEW)
+│   └── Runner.entitlements        ← App Group (already present, from the widget)
+└── ShareExtension/                ← NEW, NOT yet in project.pbxproj
+    ├── ShareViewController.swift   ← receives the share, writes the manifest
+    ├── Info.plist                  ← NSExtensionActivationRule (image/pdf/text/url)
+    └── ShareExtension.entitlements ← App Group
+```
+
+The `ShareIntentBridge` lives **inline in `AppDelegate.swift`** on purpose: a
+standalone Swift file under `ios/Runner/` is not in the Runner compile sources
+until added in Xcode, and referencing an uncompiled class would break the
+build. Inline, it compiles today with zero project-file edits, and is a no-op
+when no extension is installed (the manifest never exists).
+
+## Required Apple Developer Portal work
+
+The **App Group already exists** if you set up the iOS widget (#widget) —
+`group.de.tankstellen.tankstellen`. Reuse it; do not create a second one.
+
+1. **App Group identifier** (skip if the widget already created it) —
+   *Certificates, Identifiers & Profiles → Identifiers → App Groups → +*
+   - Identifier: `group.de.tankstellen.tankstellen` ← exact value
+2. **App ID — main app** — *Identifiers → `de.tankstellen.tankstellen` → Edit
+   → ensure "App Groups" is enabled and the group above is selected* (already
+   true if the widget is provisioned).
+3. **App ID — Share Extension** — *Identifiers → +. Bundle ID:
+   `de.tankstellen.tankstellen.ShareExtension`. Enable "App Groups" and select
+   the same group.*
+4. **Provisioning profiles** — regenerate the **main-app** and the **new
+   extension** profiles AFTER the App ID exists / capability is enabled. The
+   old profiles do NOT carry the new extension.
+   - With **fastlane match**: `bundle exec fastlane match development --force`
+     and `match appstore --force`, then copy the new profile UUIDs into Xcode's
+     Signing & Capabilities pane. Add the extension bundle ID to the match
+     table (see `docs/guides/ios-codesigning.md`).
+
+> This step — registering the extension App ID + re-provisioning under the
+> Apple Developer account (`fdittgen@gmx.de`) — is the **only** part that can't
+> be defaulted by code, and is why #2736 stays open until a Mac developer runs
+> it.
+
+## Required Xcode work
+
+### Step 1 — Add the Share Extension target
+
+1. `open ios/Runner.xcworkspace`
+2. *File → New → Target → iOS → Share Extension*
+3. **Product Name:** `ShareExtension` (exact case — matches the
+   `ios/ShareExtension/` directory the source lives in)
+4. **Bundle Identifier:** `de.tankstellen.tankstellen.ShareExtension`
+5. **Language:** Swift
+6. **Activate scheme when prompted:** No (we run the host app)
+
+### Step 2 — Replace Xcode's template sources with the tracked ones
+
+Xcode generates a default `ShareViewController.swift`, `Info.plist` and a
+`MainInterface.storyboard` inside `ios/ShareExtension/`. **We don't use a
+storyboard** (the controller is headless — it writes the manifest and opens the
+host).
+
+1. **Delete the generated files** from disk (not just the Xcode reference),
+   including `MainInterface.storyboard`.
+2. Right-click the `ShareExtension` group → *Add Files to "Runner"…* → select
+   the tracked `ShareViewController.swift`, `Info.plist` and
+   `ShareExtension.entitlements`. **Targets:** check ONLY `ShareExtension`.
+3. In the `ShareExtension` target's **Build Settings**, clear
+   `INFOPLIST_KEY_NSExtensionMainStoryboard` / any `Main storyboard` reference
+   so iOS instantiates `NSExtensionPrincipalClass` (our `ShareViewController`)
+   instead of looking for a storyboard. Our `Info.plist` already declares
+   `NSExtensionPrincipalClass = $(PRODUCT_MODULE_NAME).ShareViewController`.
+
+### Step 3 — Wire the App Group to both targets
+
+For **each** of `Runner` and `ShareExtension`:
+1. Select the target → *Signing & Capabilities*
+2. *+ Capability → App Groups* → tick `group.de.tankstellen.tankstellen`
+3. Confirm Xcode points each target at the shipped `.entitlements`:
+   - `Runner` → `ios/Runner/Runner.entitlements`
+   - `ShareExtension` → `ios/ShareExtension/ShareExtension.entitlements`
+
+### Step 4 — Pin the extension version to the host
+
+In the `ShareExtension` target's build settings:
+- `MARKETING_VERSION` → `$(inherited)`
+- `CURRENT_PROJECT_VERSION` → `$(inherited)`
+
+The `Info.plist` already references these so the extension version tracks the
+host (avoids TestFlight version-mismatch warnings).
+
+### Step 5 — Build + upload
+
+The extension is embedded inside the host app's IPA automatically once the
+target exists; the TestFlight / App Store upload step (`fastlane`,
+`ios-testflight.yml`) needs no change beyond fetching the new provisioning
+profile (Step 1.4).
+
+## Localized display name (HARD RULE #1)
+
+The share-sheet entry shows the extension's `CFBundleDisplayName`. The Dart ARB
+layer cannot reach a native extension's Info.plist, so per-locale names are
+supplied via the **native iOS mechanism**: add an `InfoPlist.strings` file per
+locale under the extension target —
+`ios/ShareExtension/<lang>.lproj/InfoPlist.strings` — each containing:
+
+```
+"CFBundleDisplayName" = "Sparkilo";
+```
+
+The base value is the **brand name** (`Sparkilo`), a proper noun that is the
+same in every locale, so no translation is required today. If a descriptive
+name is ever wanted (e.g. "Add fuel receipt"), localize it through these
+`InfoPlist.strings` files — never inline a translatable literal in Swift.
+
+## Manual verification (real iPhone)
+
+1. Build + install the host app on a physical iPhone (the extension is bundled
+   in). Enable the feature: *Settings → Features → "Import shared receipts"*
+   (`Feature.addFillUpShareIntentReceipt`, opt-in).
+2. Open **Photos**, pick a fuel-receipt photo → Share sheet → **Sparkilo**.
+3. Sparkilo foregrounds and lands on the Add-fill-up form with the receipt
+   OCR'd and the fields prefilled (litres / price-per-L / total / date).
+4. Repeat from **Files** with a PDF e-receipt (rasterised on-device → same
+   OCR path) and from **Mail / Safari** with a text/link e-receipt (parsed by
+   the pure-Dart text parser).
+5. Try while the app is already open (warm) and from cold (killed) — both
+   funnel through `ShareReceiptListener`.
+
+## Known gaps / future work
+
+- **No share-sheet preview UI** — the extension completes immediately and hands
+  off to the host; it does not show a confirm screen. If a preview is wanted
+  later, add a SwiftUI view to `ShareViewController` before `openHost()`.
+- **Single artifact per share** — `NSExtensionActivationRule` caps each type at
+  1; the handler already picks the first image from a batch, matching Android.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,29 @@ import workmanager_apple
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  /// Host-side bridge for the iOS Share Extension (#2736, Epic #2687).
+  ///
+  /// The extension (`ios/ShareExtension/ShareViewController.swift`) writes the
+  /// shared receipt + a `pending_share.json` manifest into the App Group
+  /// container, then opens `sparkilo-share://receipt`. This drains that
+  /// manifest and replays it down the SAME `tankstellen/share_intent/*`
+  /// channels the Android `ShareIntentChannel.kt` feeds — so the existing Dart
+  /// `ShareReceiptListener` / `ShareReceiptHandler` (#2735) handles iOS shares
+  /// with no new Dart code.
+  ///
+  /// Kept INLINE in this file (not a separate Swift file) on purpose: a new
+  /// file under `ios/Runner/` is NOT in the Runner target's compile sources
+  /// until a Mac developer adds it in Xcode, and referencing an uncompiled
+  /// class would break the build. Defined in `AppDelegate.swift` — already in
+  /// the target — it compiles today with zero `project.pbxproj` edit. On a
+  /// build without the extension installed the manifest never exists, so every
+  /// entry point here is a harmless no-op (`getInitialShare` → nil).
+  ///
+  /// Shared singleton so `SceneDelegate` (which handles the warm URL-open under
+  /// the scene lifecycle this app uses) drains the SAME bridge instance the
+  /// channels are registered on.
+  private let shareIntent = ShareIntentBridge.shared
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -44,5 +67,115 @@ import workmanager_apple
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    // Register the share-intent channels on the implicit engine's messenger
+    // and immediately scan for a cold-launch share the extension left behind.
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "ShareIntentBridge") {
+      shareIntent.register(messenger: registrar.messenger())
+    }
+  }
+
+  /// Handles the `sparkilo-share://receipt` URL the Share Extension opens to
+  /// wake the host. This fires on builds WITHOUT the scene lifecycle; under the
+  /// scene manifest this app declares, the warm URL open is delivered to
+  /// `SceneDelegate.scene(_:openURLContexts:)` instead (see SceneDelegate). A
+  /// non-share URL is passed to `super` so other deep links keep working.
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    if url.scheme == "sparkilo-share" {
+      shareIntent.drainPendingShare()
+      return true
+    }
+    return super.application(app, open: url, options: options)
+  }
+}
+
+/// In-repo, plugin-free bridge that serves the `tankstellen/share_intent/*`
+/// method + event channels on iOS by draining the Share Extension's App Group
+/// manifest. The exact host counterpart of Android's `ShareIntentChannel.kt`,
+/// emitting the IDENTICAL `{ "items": [...], "country": "XX" }` payload that
+/// `SharedReceiptIntent.fromPlatform` already decodes.
+final class ShareIntentBridge: NSObject, FlutterStreamHandler {
+  /// Single instance both `AppDelegate` and `SceneDelegate` reach, so the
+  /// scene-lifecycle warm URL-open drains the bridge the channels live on.
+  static let shared = ShareIntentBridge()
+
+  private static let appGroupId = "group.de.tankstellen.tankstellen"
+  private static let manifestName = "pending_share.json"
+  private static let methodChannelName = "tankstellen/share_intent/methods"
+  private static let eventChannelName = "tankstellen/share_intent/events"
+
+  private var eventSink: FlutterEventSink?
+  /// A share decoded before Dart subscribed (cold launch); drained by
+  /// `getInitialShare`.
+  private var pendingInitial: [String: Any]?
+
+  /// Wires both channels onto `messenger`. Called once when the Flutter engine
+  /// is ready (see `didInitializeImplicitFlutterEngine`).
+  func register(messenger: FlutterBinaryMessenger) {
+    let methods = FlutterMethodChannel(name: Self.methodChannelName, binaryMessenger: messenger)
+    methods.setMethodCallHandler { [weak self] call, result in
+      switch call.method {
+      case "getInitialShare":
+        let payload = self?.pendingInitial
+        self?.pendingInitial = nil
+        result(payload)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
+    let events = FlutterEventChannel(name: Self.eventChannelName, binaryMessenger: messenger)
+    events.setStreamHandler(self)
+
+    // The extension may have left a manifest from a cold launch before the
+    // channels existed — pick it up now so `getInitialShare` can return it.
+    drainPendingShare()
+  }
+
+  // MARK: FlutterStreamHandler
+
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+    eventSink = events
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    eventSink = nil
+    return nil
+  }
+
+  /// Reads + deletes the App Group manifest the extension wrote. If a Dart
+  /// subscriber is live (warm) the payload is emitted on the event channel;
+  /// otherwise it is cached for `getInitialShare` (cold). A missing or
+  /// malformed manifest is a silent no-op — the common case on a build with no
+  /// extension installed.
+  func drainPendingShare() {
+    guard let payload = readManifest() else { return }
+    if let sink = eventSink {
+      sink(payload)
+    } else {
+      pendingInitial = payload
+    }
+  }
+
+  /// Reads `pending_share.json` from the App Group container, validates it is a
+  /// non-empty `{items:[...]}` map, deletes it (so a share is consumed once),
+  /// and returns the channel payload. Returns nil on any failure.
+  private func readManifest() -> [String: Any]? {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: Self.appGroupId
+    ) else { return nil }
+    let url = container.appendingPathComponent(Self.manifestName)
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    // Consume once — delete before parsing so a malformed file can't replay.
+    try? FileManager.default.removeItem(at: url)
+    guard
+      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let items = json["items"] as? [Any], !items.isEmpty
+    else { return nil }
+    return json
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -31,6 +31,26 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<!-- #2736 — custom URL scheme the Share Extension opens to wake the host
+	     and hand off a shared receipt. The extension
+	     (ios/ShareExtension/ShareViewController.swift) writes the receipt +
+	     pending_share.json into the App Group then opens
+	     `sparkilo-share://receipt`; AppDelegate.application(_:open:options:)
+	     drains the manifest into the tankstellen/share_intent/* channels.
+	     Harmless without the extension installed — nothing opens the scheme. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>de.tankstellen.tankstellen.share</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sparkilo-share</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -4,6 +4,33 @@
 import Flutter
 import UIKit
 
+/// Scene delegate for the Flutter host. Under the scene lifecycle this app
+/// declares (`UIApplicationSceneManifest` in Info.plist), URL opens are
+/// delivered HERE — not to `AppDelegate.application(_:open:options:)` — so the
+/// Share Extension hand-off (#2736) is drained from the scene callbacks.
+///
+/// `sparkilo-share://receipt` is opened by the Share Extension after it has
+/// written `pending_share.json` into the App Group; both the cold
+/// (`willConnectTo`) and warm (`openURLContexts`) entry points drain the SAME
+/// `ShareIntentBridge.shared` the channels are registered on (AppDelegate). The
+/// actual receipt routing stays entirely in the existing Dart receiver
+/// (#2735). Calling `super` keeps Flutter's own scene wiring intact.
 class SceneDelegate: FlutterSceneDelegate {
+  override func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    super.scene(scene, willConnectTo: session, options: connectionOptions)
+    if connectionOptions.urlContexts.contains(where: { $0.url.scheme == "sparkilo-share" }) {
+      ShareIntentBridge.shared.drainPendingShare()
+    }
+  }
 
+  override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    super.scene(scene, openURLContexts: URLContexts)
+    if URLContexts.contains(where: { $0.url.scheme == "sparkilo-share" }) {
+      ShareIntentBridge.shared.drainPendingShare()
+    }
+  }
 }

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+-->
+
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<!--
+  Info.plist for the Sparkilo Share Extension target (#2736).
+
+  Apple-supplied version values (CFBundleVersion / CFBundleShortVersionString)
+  are kept as template variables so the extension version always tracks the
+  host app — same convention as `ios/TankstellenWidget/Info.plist`.
+
+  NSExtensionActivationRule declares which share sheets surface Sparkilo:
+  any image (a receipt photo), any PDF (a digital e-receipt), and a single
+  shared text/URL (an e-receipt e-mail / link). Counts are intentionally low
+  (one of each) — a fuel receipt is a single artifact, not a batch.
+
+  Localizing the share-sheet display name: iOS reads `CFBundleDisplayName`
+  per-locale from `InfoPlist.strings` files inside this target's
+  `<lang>.lproj/` folders. The Dart ARB layer cannot reach a native extension
+  Info.plist, so the per-locale name is supplied natively (see
+  docs/guides/ios-share-extension.md "Localized display name"). The base value
+  here is the brand name and needs no translation.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Sparkilo</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios/ShareExtension/ShareExtension.entitlements
+++ b/ios/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
+<!--
+  Copyright (c) 2026 Florian DITTGEN
+  SPDX-License-Identifier: MIT
+
+  Share Extension entitlements (#2736).
+
+  Same App Group identifier as `ios/Runner/Runner.entitlements` and
+  `ios/TankstellenWidget/TankstellenWidget.entitlements` — ALL targets must
+  declare the SAME string. Without this entitlement the Share Extension cannot
+  write the shared receipt + `pending_share.json` manifest into the container
+  the host app reads via
+  `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)`.
+
+  The Apple Developer Portal App ID for this extension's bundle identifier
+  (`de.tankstellen.tankstellen.ShareExtension`) must have the "App Groups"
+  capability enabled and include this exact group string. Provisioning
+  profiles must be regenerated AFTER adding the capability. See
+  docs/guides/ios-share-extension.md.
+-->
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.de.tankstellen.tankstellen</string>
+	</array>
+</dict>
+</plist>

--- a/ios/ShareExtension/ShareViewController.swift
+++ b/ios/ShareExtension/ShareViewController.swift
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// iOS Share Extension entry point (#2736, Epic #2687).
+//
+// The iOS analogue of the Android `ShareIntentChannel.kt` inbound path: it
+// receives a receipt the user shared from another app (Photos, Files, Mail,
+// Safari, …), copies each attachment into the SHARED App Group container, and
+// hands control to the host app — which then surfaces the share through the
+// SAME `ShareReceiptListener` / `ShareReceiptHandler` Dart flow already shipped
+// for Android (#2735).
+//
+// Why an App Group + a manifest file (not the plugin route): iOS extensions run
+// in a separate process with no direct channel to the Flutter engine. The
+// only durable bridge is the App Group container both targets can read. So the
+// extension writes:
+//   * each binary attachment as `shared_receipt_<n>.<ext>` in the group dir;
+//   * a `pending_share.json` manifest describing every item, in EXACTLY the
+//     `{ "items": [ {kind,path|text} ], "country": "DE" }` shape the Dart
+//     `SharedReceiptIntent.fromPlatform` already decodes (the same contract
+//     Kotlin emits — one decoder, two platforms).
+// The host app's inline `ShareIntentChannel` (in AppDelegate.swift) drains that
+// manifest on launch/resume and replays it down the existing method/event
+// channels. No new Dart logic — this reuses the #2735 receiver end-to-end.
+//
+// Activation (which share sheets show Sparkilo) is declared in this target's
+// Info.plist `NSExtensionActivationRule`: images, PDFs and text/URL payloads.
+//
+// IMPORTANT — this file is SOURCE-TRACKED scaffolding only. It is NOT wired
+// into `ios/Runner.xcodeproj/project.pbxproj` (same as `TankstellenWidget`):
+// the iOS host build keeps compiling without it. A Mac developer adds the
+// Share Extension target in Xcode + signs it under the Apple Developer account
+// per `docs/guides/ios-share-extension.md`. Until then the file just sits on
+// disk and changes nothing about the existing build.
+
+import MobileCoreServices
+import UIKit
+import UniformTypeIdentifiers
+
+/// App Group identifier — MUST match `Runner.entitlements`,
+/// `ShareExtension.entitlements`, the WidgetKit extension, and the Dart-side
+/// `_iosWidgetGroupId` (`home_widget_service.dart`). All break together.
+private let kAppGroupId = "group.de.tankstellen.tankstellen"
+
+/// Custom URL scheme the extension opens to wake the host app. Registered in
+/// the host `Runner/Info.plist` `CFBundleURLTypes`, and handled by
+/// `AppDelegate.application(_:open:options:)`.
+private let kHostShareURL = "sparkilo-share://receipt"
+
+/// Manifest file written into the App Group container, drained by the host.
+private let kManifestName = "pending_share.json"
+
+/// The Share Extension's view controller. Headless-ish: it resolves the shared
+/// items, writes them to the App Group, opens the host, and completes — the
+/// host app does the actual receipt parsing / form prefill.
+final class ShareViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    handleShare()
+  }
+
+  /// Resolves every attachment on every input item into the App Group, writes
+  /// the manifest, then opens the host and completes the request. Failures are
+  /// swallowed into a graceful completion so the share sheet never hangs.
+  private func handleShare() {
+    let attachments = (extensionContext?.inputItems as? [NSExtensionItem])?
+      .flatMap { $0.attachments ?? [] } ?? []
+
+    guard !attachments.isEmpty else {
+      complete()
+      return
+    }
+
+    resolveItems(attachments) { [weak self] items in
+      guard let self = self else { return }
+      if !items.isEmpty {
+        self.writeManifest(items: items)
+        self.openHost()
+      }
+      self.complete()
+    }
+  }
+
+  /// Resolves the attachments to manifest entries off the main thread, then
+  /// calls back on the main thread. Each provider is loaded in turn; a failing
+  /// item is dropped so one bad attachment never sinks the whole share.
+  private func resolveItems(
+    _ providers: [NSItemProvider],
+    completion: @escaping ([[String: Any]]) -> Void
+  ) {
+    let group = DispatchGroup()
+    var items: [[String: Any]] = []
+    let lock = NSLock()
+    var index = 0
+
+    func append(_ item: [String: Any]) {
+      lock.lock()
+      items.append(item)
+      lock.unlock()
+    }
+
+    for provider in providers {
+      let seq = index
+      index += 1
+      group.enter()
+      resolve(provider, seq: seq) { item in
+        if let item = item { append(item) }
+        group.leave()
+      }
+    }
+
+    group.notify(queue: .main) { completion(items) }
+  }
+
+  /// Resolves a single provider to a manifest entry. Order of preference:
+  /// image → PDF → file (all copied into the group) → plain text / URL.
+  private func resolve(
+    _ provider: NSItemProvider,
+    seq: Int,
+    completion: @escaping ([String: Any]?) -> Void
+  ) {
+    if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+      loadFile(provider, type: UTType.image, kind: "image", seq: seq, ext: "jpg",
+               completion: completion)
+    } else if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
+      loadFile(provider, type: UTType.pdf, kind: "pdf", seq: seq, ext: "pdf",
+               completion: completion)
+    } else if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+      loadText(provider, type: UTType.plainText, completion: completion)
+    } else if provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+      loadURL(provider, completion: completion)
+    } else if provider.hasItemConformingToTypeIdentifier(UTType.text.identifier) {
+      loadText(provider, type: UTType.text, completion: completion)
+    } else {
+      completion(nil)
+    }
+  }
+
+  /// Copies a file-backed item (image / pdf) into the App Group container and
+  /// returns its manifest entry. The OS only grants a transient read on the
+  /// loaded URL, so the copy is required for the host process to read it.
+  private func loadFile(
+    _ provider: NSItemProvider,
+    type: UTType,
+    kind: String,
+    seq: Int,
+    ext: String,
+    completion: @escaping ([String: Any]?) -> Void
+  ) {
+    provider.loadFileRepresentation(forTypeIdentifier: type.identifier) {
+      [weak self] url, _ in
+      guard let self = self, let url = url,
+            let dest = self.copyIntoGroup(url, seq: seq, ext: ext) else {
+        completion(nil)
+        return
+      }
+      completion(["kind": kind, "path": dest.path])
+    }
+  }
+
+  /// Loads a plain-text / text payload as a `text` manifest entry.
+  private func loadText(
+    _ provider: NSItemProvider,
+    type: UTType,
+    completion: @escaping ([String: Any]?) -> Void
+  ) {
+    provider.loadItem(forTypeIdentifier: type.identifier, options: nil) { value, _ in
+      let text = (value as? String)
+        ?? (value as? Data).flatMap { String(data: $0, encoding: .utf8) }
+      guard let resolved = text, !resolved.isEmpty else {
+        completion(nil)
+        return
+      }
+      completion(["kind": "text", "text": resolved])
+    }
+  }
+
+  /// A shared URL (e.g. a link to a digital receipt) is carried as text so the
+  /// host's e-receipt text parser can attempt it.
+  private func loadURL(
+    _ provider: NSItemProvider,
+    completion: @escaping ([String: Any]?) -> Void
+  ) {
+    provider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) {
+      value, _ in
+      guard let url = value as? URL else {
+        completion(nil)
+        return
+      }
+      completion(["kind": "text", "text": url.absoluteString])
+    }
+  }
+
+  /// Copies `src` into the App Group container under a unique name and returns
+  /// the destination URL, or nil on any failure.
+  private func copyIntoGroup(_ src: URL, seq: Int, ext: String) -> URL? {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: kAppGroupId
+    ) else { return nil }
+    let stamp = Int(Date().timeIntervalSince1970 * 1000)
+    let dest = container
+      .appendingPathComponent("shared_receipt_\(stamp)_\(seq).\(ext)")
+    do {
+      if FileManager.default.fileExists(atPath: dest.path) {
+        try FileManager.default.removeItem(at: dest)
+      }
+      try FileManager.default.copyItem(at: src, to: dest)
+      return dest
+    } catch {
+      return nil
+    }
+  }
+
+  /// Writes the manifest JSON into the App Group container in the exact shape
+  /// `SharedReceiptIntent.fromPlatform` decodes. `country` mirrors the Android
+  /// receiver's ISO-3166 alpha-2 region from the device locale (or omitted).
+  private func writeManifest(items: [[String: Any]]) {
+    guard let container = FileManager.default.containerURL(
+      forSecurityApplicationGroupIdentifier: kAppGroupId
+    ) else { return }
+    var payload: [String: Any] = ["items": items]
+    if let region = Locale.current.regionCode, !region.isEmpty {
+      payload["country"] = region.uppercased()
+    }
+    guard let data = try? JSONSerialization.data(withJSONObject: payload) else {
+      return
+    }
+    let url = container.appendingPathComponent(kManifestName)
+    try? data.write(to: url, options: .atomic)
+  }
+
+  /// Opens the host app via the custom URL scheme so it foregrounds and drains
+  /// the manifest. Walks the responder chain to find an object the extension is
+  /// allowed to ask to `openURL:` (extensions can't reach `UIApplication.shared`
+  /// directly).
+  private func openHost() {
+    guard let url = URL(string: kHostShareURL) else { return }
+    var responder: UIResponder? = self
+    let selector = sel_registerName("openURL:")
+    while let current = responder {
+      if current.responds(to: selector) {
+        _ = current.perform(selector, with: url)
+        return
+      }
+      responder = current.next
+    }
+  }
+
+  /// Completes the extension request, dismissing the share sheet.
+  private func complete() {
+    extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+  }
+}

--- a/test/features/consumption/presentation/widgets/share_receipt_ios_routing_test.dart
+++ b/test/features/consumption/presentation/widgets/share_receipt_ios_routing_test.dart
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tankstellen/app/router.dart';
+import 'package:tankstellen/features/consumption/data/share/'
+    'shared_receipt_intent.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/'
+    'share_receipt_handler.dart';
+import 'package:tankstellen/features/consumption/providers/'
+    'pending_shared_receipt_provider.dart';
+import 'package:tankstellen/features/consumption/providers/'
+    'pending_shared_receipt_text_provider.dart';
+import 'package:tankstellen/features/feature_management/application/'
+    'feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2736 — the iOS Share Extension seam. On iOS the share arrives as a
+/// `pending_share.json` manifest the extension writes into the App Group
+/// container; the host `ShareIntentBridge` (AppDelegate.swift) reads it with
+/// `JSONSerialization`, returns the parsed map down `getInitialShare`, and the
+/// Dart `_PlatformShareIntentChannel` feeds it to
+/// `SharedReceiptIntent.fromPlatform`. iOS and Android emit the IDENTICAL
+/// `{items, country}` shape — so these tests drive the REAL handler with a
+/// payload built by serialising the EXACT manifest the Swift extension writes,
+/// then JSON-decoding it (the round-trip the native bridge performs), proving
+/// an iOS share routes into the same fill-up / parser flow as Android — with
+/// no iOS-specific Dart code on the path.
+void main() {
+  silenceErrorLoggerSpool();
+
+  const featureOn = {Feature.addFillUpShareIntentReceipt};
+
+  /// Builds a `SharedReceiptIntent` the way the iOS path does: the Swift
+  /// extension serialises `manifest` with `JSONSerialization`; the host bridge
+  /// hands the JSON-decoded map to `fromPlatform`. We mirror that round-trip so
+  /// a drift in the manifest shape would fail here, not silently on device.
+  SharedReceiptIntent decodeIosManifest(Map<String, Object?> manifest) {
+    final roundTripped = jsonDecode(jsonEncode(manifest)) as Map<String, Object?>;
+    final intent = SharedReceiptIntent.fromPlatform(roundTripped);
+    expect(intent, isNotNull,
+        reason: 'the iOS manifest must decode to a routable intent');
+    return intent!;
+  }
+
+  GoRouter buildRouter() => GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const Text('home')),
+          GoRoute(
+            path: '/consumption/add',
+            builder: (_, _) => const Text('add-fill-up'),
+          ),
+        ],
+      );
+
+  Future<ProviderContainer> pump(
+    WidgetTester tester, {
+    required GoRouter router,
+    Set<Feature> enabled = featureOn,
+  }) async {
+    final container = ProviderContainer(
+      overrides: [
+        enabledFeaturesProvider.overrideWithValue(enabled),
+        routerProvider.overrideWith((_) => router),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    return container;
+  }
+
+  testWidgets(
+      'an iOS-shared receipt IMAGE manifest stashes the path and routes to '
+      '/consumption/add', (tester) async {
+    final router = buildRouter();
+    final container = await pump(tester, router: router);
+
+    // The manifest the Swift extension writes for a shared photo: a single
+    // image item with the App Group container path, plus the device region.
+    final intent = decodeIosManifest({
+      'items': [
+        {
+          'kind': 'image',
+          'path': '/private/var/.../group.de.tankstellen.tankstellen/'
+              'shared_receipt_1717000000000_0.jpg',
+        },
+      ],
+      'country': 'DE',
+    });
+
+    container.read(shareReceiptHandlerProvider).handle(intent);
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(pendingSharedReceiptProvider),
+      '/private/var/.../group.de.tankstellen.tankstellen/'
+          'shared_receipt_1717000000000_0.jpg',
+      reason: 'the App-Group image path must be stashed for AddFillUpScreen '
+          'to OCR — the same stash Android uses',
+    );
+    expect(find.text('add-fill-up'), findsOneWidget,
+        reason: 'an iOS image share routes into the Add-fill-up form');
+  });
+
+  testWidgets(
+      'an iOS-shared e-receipt TEXT manifest is parsed by the REAL parser and '
+      'routed', (tester) async {
+    final router = buildRouter();
+    final container = await pump(tester, router: router);
+
+    final receiptText = File(
+      'test/features/consumption/data/ereceipt/fixtures/'
+      'eni_milano_2026-05-12.txt',
+    ).readAsStringSync();
+
+    // The manifest for a shared text body (e-receipt e-mail / link): a single
+    // text item, country resolved natively from Locale.current.regionCode.
+    final intent = decodeIosManifest({
+      'items': [
+        {'kind': 'text', 'text': receiptText},
+      ],
+      'country': 'IT',
+    });
+
+    container.read(shareReceiptHandlerProvider).handle(intent);
+    await tester.pumpAndSettle();
+
+    final result = container.read(pendingSharedReceiptTextProvider);
+    expect(result, isNotNull,
+        reason: 'the iOS text e-receipt must be parsed and stashed');
+    expect(result!.liters, closeTo(42.18, 0.01));
+    expect(result.fuelType, FuelType.diesel);
+    expect(find.text('add-fill-up'), findsOneWidget,
+        reason: 'a parseable iOS text receipt routes into the form');
+  });
+
+  testWidgets(
+      'a SEND-multiple iOS manifest (image + stray file) still prefills from '
+      'the image', (tester) async {
+    final router = buildRouter();
+    final container = await pump(tester, router: router);
+
+    // The extension can resolve more than one attachment; the handler picks
+    // the first image and ignores the rest — same as Android.
+    final intent = decodeIosManifest({
+      'items': [
+        {'kind': 'file', 'path': '/group/shared_receipt_1_0.bin'},
+        {'kind': 'image', 'path': '/group/shared_receipt_1_1.jpg'},
+      ],
+      'country': 'FR',
+    });
+
+    container.read(shareReceiptHandlerProvider).handle(intent);
+    await tester.pumpAndSettle();
+
+    expect(container.read(pendingSharedReceiptProvider),
+        '/group/shared_receipt_1_1.jpg',
+        reason: 'the image wins over a non-image attachment in the same batch');
+    expect(find.text('add-fill-up'), findsOneWidget);
+  });
+
+  testWidgets('an iOS share is gated by the opt-in feature flag', (tester) async {
+    final router = buildRouter();
+    final container = await pump(tester, router: router, enabled: const {});
+
+    final intent = decodeIosManifest({
+      'items': [
+        {'kind': 'image', 'path': '/group/shared_receipt.jpg'},
+      ],
+      'country': 'DE',
+    });
+
+    container.read(shareReceiptHandlerProvider).handle(intent);
+    await tester.pumpAndSettle();
+
+    expect(container.read(pendingSharedReceiptProvider), isNull,
+        reason: 'a disabled feature must never stash or route on iOS either');
+    expect(find.text('home'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Completes the iOS half of receipt share-intent (Epic #2687). The cross-platform Dart receiver + routing already shipped for Android (#2735) — an inbound share funnels through `ShareReceiptListener` → `ShareReceiptHandler` → stash + route to `/consumption/add` → OCR / text-parse → prefill. This adds the iOS path that feeds the **same** flow with **no new Dart logic**.

## What landed (ships blind — the iOS host build stays green)
- **`ios/ShareExtension/`** — source-tracked Share Extension target: `ShareViewController.swift` (receives image/PDF/text/URL, copies into the App Group, writes `pending_share.json`, opens the host), `Info.plist` with `NSExtensionActivationRule` for image + PDF + text/URL, and `ShareExtension.entitlements` (App Group). **NOT wired into `project.pbxproj`** — exactly the `TankstellenWidget` precedent, so the host build keeps compiling without it.
- **Host bridge `ShareIntentBridge` INLINE in `AppDelegate.swift`** — no new file to add to the Runner target → **no pbxproj edit, no build break**. It serves the existing `tankstellen/share_intent/{methods,events}` channels by draining the extension's App-Group manifest, emitting the **identical** `{items, country}` payload Android's `ShareIntentChannel.kt` produces — decoded by the one `SharedReceiptIntent.fromPlatform`.
- **`SceneDelegate`** drains on cold `willConnectTo` + warm `openURLContexts` (this app uses the scene lifecycle, where URL opens land); `AppDelegate.application(_:open:options:)` is a non-scene fallback.
- **`sparkilo-share` URL scheme** registered in `Runner/Info.plist`.
- **`docs/guides/ios-share-extension.md`** + a go-live-runbook pointer documenting the remaining user steps. The share-sheet display name is localized via native `InfoPlist.strings` (base value `Sparkilo` — a brand/proper-noun, HARD RULE #1 exempt).

## Deferred to the user — why #2736 stays OPEN
The native iOS extension **target wiring into `Runner.xcodeproj`** + **Apple signing/provisioning** under the Developer account (`fdittgen@gmx.de`; extension bundle `de.tankstellen.tankstellen.ShareExtension`; App Group `group.de.tankstellen.tankstellen`) are the only parts code can't default. Step-by-step in `docs/guides/ios-share-extension.md`. The host app ships fine without the extension — this is additive, not a launch gate. **#2736 remains open until a Mac developer completes that wiring.**

## Test
`test/features/consumption/presentation/widgets/share_receipt_ios_routing_test.dart` drives the **real** `ShareReceiptHandler` with payloads built by JSON round-tripping the exact manifest the Swift extension writes (image → `/consumption/add`; text e-receipt → real parser; SEND-multiple image-wins; opt-in feature gate) — locking the iOS↔Dart contract.

## Verified — iOS build / CI NOT broken
- `project.pbxproj` **untouched** (0 references to the new target).
- CI does **not** build iOS (`build-ios` is commented out in `ci.yml`), so zero CI risk from native files.
- All three Swift files type-check/parse against the iOS 26.5 SDK; every Flutter API verified against the engine framework headers; all plists `plutil`-clean.
- `flutter analyze` clean (only 2 pre-existing, unrelated `info` hits from `#2849` test files); 26 share tests green; **no codegen / l10n drift** (no `lib/` changes — the Dart receiver was already in master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
