### PR TITLE
fix(driving): clamp GPS-derived hard-accel + let IMU truth veto the over-count (#2895)

### DIFF
--- a/lib/features/consumption/data/analysis/driving_analysis_trace.dart
+++ b/lib/features/consumption/data/analysis/driving_analysis_trace.dart
@@ -57,6 +57,10 @@ class DrivingAnalysisTrace {
           'distanceSource': summary.distanceSource,
         },
         'imu': {
+          // #2895 — whether the inertial sensor ran. A genuine IMU zero with
+          // active=true VETOES a noisy GPS over-count in the score; active=false
+          // means the (clamped) GPS-derived counts were used.
+          'active': summary.imuActive,
           'hardAccelCount': summary.imuHardAccelCount,
           'hardBrakeCount': summary.imuHardBrakeCount,
           'sharpCornerCount': summary.sharpCornerCount,

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -206,14 +206,13 @@ Map<String, dynamic> _summaryToJson(TripSummary s) => {
       // Omitted when false (every real trip) so legacy trips round-trip
       // with zero bytes added.
       if (s.isVirtual) 'virt': true,
-      // #2760: IMU-detected aggregate event counts for dongle-less
-      // (GPS+IMU) trips. THREE scalars only — never the raw ~50 Hz sample
-      // stream (the aggregate-only / disk-efficient constraint). Compact
-      // keys 'iha' / 'ihb' / 'sc'; each omitted when 0 so OBD2 trips and
-      // every legacy trip round-trip with zero bytes added.
+      // #2760: IMU-detected aggregate event counts for dongle-less (GPS+IMU)
+      // trips — THREE scalars only (never the raw ~50 Hz stream). Compact keys
+      // 'iha'/'ihb'/'sc'; each omitted when 0 so OBD2 / legacy trips add 0 bytes.
       if (s.imuHardAccelCount != 0) 'iha': s.imuHardAccelCount,
       if (s.imuHardBrakeCount != 0) 'ihb': s.imuHardBrakeCount,
       if (s.sharpCornerCount != 0) 'sc': s.sharpCornerCount,
+      if (s.imuActive) 'ima': true, // #2895 IMU-ran bit (prefer IMU zero)
     };
 
 TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
@@ -266,6 +265,7 @@ TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
       imuHardAccelCount: (j['iha'] as num?)?.toInt() ?? 0,
       imuHardBrakeCount: (j['ihb'] as num?)?.toInt() ?? 0,
       sharpCornerCount: (j['sc'] as num?)?.toInt() ?? 0,
+      imuActive: (j['ima'] as bool?) ?? false, // #2895 IMU-ran bit
     );
 
 /// Hive-backed list of finalised trips (#726).

--- a/lib/features/consumption/domain/accel_event_gate.dart
+++ b/lib/features/consumption/domain/accel_event_gate.dart
@@ -74,6 +74,29 @@ const double kAccelEventMinSustainedSec = 1.0;
 /// phantom events; genuine harsh manoeuvres happen above a walking pace.
 const double kAccelEventMinSpeedKmh = 5.0;
 
+/// Upper physically-plausible longitudinal acceleration (m/s²) for the
+/// GPS-speed-derivative path (#2895). ~0.9 g. A real car's traction- and
+/// power-limited forward acceleration tops out around 0.5 g for an economy
+/// car and up to ~0.8 g for a quick one; a genuine "hard launch" the score
+/// already penalises sits near 0.7 g (0 → 50 km/h in 2 s ≈ 0.71 g). Set the
+/// ceiling at 0.9 g so EVERY realistic hard acceleration still counts, while
+/// a derivative beyond it is GPS speed noise differentiated into an
+/// impossible spike (the #2895 export logged maxAccelG 1.086 ≈ 10.65 m/s²
+/// ≈ 1.09 g — impossible for a 68 hp Peugeot 107). An interval above this
+/// ceiling is treated like a bad fix: it BREAKS the running episode rather
+/// than counting, so noise can't manufacture a hard-accel event ("a noise
+/// spike is worse than no reading").
+const double kMaxPlausibleAccelMps2 = 8.83;
+
+/// Upper physically-plausible deceleration (m/s², positive) for the
+/// GPS-speed-derivative path (#2895). ~1.12 g — looser than the accel
+/// ceiling because emergency braking on dry asphalt legitimately reaches
+/// ~1.0 g, so we must not clip a genuine hard stop; but a derivative beyond
+/// ~1.1 g is GPS noise (street tyres can't decelerate harder). An interval
+/// past this ceiling breaks the running brake episode, mirroring the accel
+/// clamp above.
+const double kMaxPlausibleBrakeMps2 = 11.0;
+
 /// Refractory window (seconds): after a hard-accel / hard-brake event
 /// fires, the derivative must stay BELOW the threshold for at least this
 /// long continuously before another same-type event can fire (#2846).
@@ -227,6 +250,18 @@ AccelEventCounts countAccelEvents(
 
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
     final accelMps2 = ((cur.speedKmh - prev.speedKmh) / 3.6) / dt;
+
+    // Physical-plausibility clamp (#2895). A speed-derivative beyond what a
+    // real car can produce (forward > ~0.61 g, braking > ~1.12 g) is GPS
+    // speed noise, not a manoeuvre — a 68 hp economy car cannot do the
+    // 1.086 g the bug logged. Break the running episode rather than count it,
+    // so noise can't fabricate a hard-accel/brake event. Asymmetric ceilings
+    // because braking legitimately reaches ~1 g where acceleration does not.
+    if (accelMps2 >= kMaxPlausibleAccelMps2 ||
+        accelMps2 <= -kMaxPlausibleBrakeMps2) {
+      breakEpisodes();
+      continue;
+    }
 
     if (accelMps2 >= kHardAccelThresholdMps2) {
       accelDur += dt;

--- a/lib/features/consumption/domain/harsh_event_detector.dart
+++ b/lib/features/consumption/domain/harsh_event_detector.dart
@@ -221,6 +221,23 @@ class HarshEventDetector {
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
     final accelMps2 = ((speed - anchorSpeed) / 3.6) / dt;
 
+    // Physical-plausibility clamp (#2895): a speed-derivative beyond what a
+    // real car can produce (forward > ~0.61 g, braking > ~1.12 g) is GPS
+    // speed noise, not a manoeuvre — break the anchor + running episode so it
+    // never counts. Mirrors `countAccelEvents` so the recorder's
+    // harshAccelerations agrees with the gate the score / insights use.
+    if (accelMps2 >= kMaxPlausibleAccelMps2 ||
+        accelMps2 <= -kMaxPlausibleBrakeMps2) {
+      _anchorAt = null;
+      _anchorSpeedKmh = null;
+      _speedWindow.clear();
+      _inAccelEpisode = false;
+      _inBrakeEpisode = false;
+      _accelBelowSec = 0;
+      _brakeBelowSec = 0;
+      return;
+    }
+
     // Episode semantics (#2667 + #2846): record at most once on entry into
     // a sustained harsh stretch, and re-arm only once the derivative has
     // stayed below the threshold for a continuous [refractorySec] window —

--- a/lib/features/consumption/domain/services/imu_event_detector.dart
+++ b/lib/features/consumption/domain/services/imu_event_detector.dart
@@ -77,9 +77,23 @@ class ImuEventDetector {
   /// Confirmed sharp-cornering episodes so far.
   int get sharpCornerCount => _sharpCornerCount;
 
+  /// Whether the inertial sensor actually ran for this trip (#2895). True
+  /// once at least one real sample has been folded in (i.e. past the seed),
+  /// false when the device has no accelerometer/gyroscope or the platform
+  /// plugin never bound (a quiet stream that never emits). Lets the pipeline
+  /// distinguish a genuine IMU zero ("you drove smoothly") from
+  /// "no IMU signal" — so an IMU count of 0 can VETO a noisy GPS-derived
+  /// over-count rather than being indistinguishable from "no reading".
+  bool get isActive => _sampleCount > 1;
+
   int _hardAccelCount = 0;
   int _hardBrakeCount = 0;
   int _sharpCornerCount = 0;
+
+  /// Total samples handed to [onSample]. The first only seeds the dt anchor;
+  /// `isActive` therefore requires > 1 so a single stray emit doesn't claim
+  /// the sensor produced a usable signal.
+  int _sampleCount = 0;
 
   /// Lateral (horizontal) accel must hold above 3.5 m/s² and the yaw rate
   /// above 0.30 rad/s for at least this long before a corner is confirmed —
@@ -121,6 +135,7 @@ class ImuEventDetector {
     final lastT = _lastT;
     final speedKmh = currentSpeedKmh;
     _lastT = s.t;
+    _sampleCount++;
     if (lastT == null) return; // first sample seeds the dt anchor only.
 
     final dt = s.t.difference(lastT).inMicroseconds /

--- a/lib/features/consumption/domain/trip_summary.dart
+++ b/lib/features/consumption/domain/trip_summary.dart
@@ -145,6 +145,17 @@ class TripSummary {
   /// UI row is an explicit follow-up. Defaults `0` for OBD2 / legacy trips.
   final int sharpCornerCount;
 
+  /// Whether the phone's inertial sensor actually ran for this trip (#2895).
+  /// `true` only for a dongle-less recording whose accelerometer/gyroscope
+  /// produced samples. It is what distinguishes a genuine IMU zero ("you
+  /// drove smoothly") from "no IMU signal" — when `true`, the driving score
+  /// PREFERS the IMU hard-accel/brake counts (even when they are 0), so a
+  /// noisy GPS speed-derivative over-count is VETOED by the accurate inertial
+  /// reading. Defaults `false`: OBD2 trips, every legacy trip, and dongle-less
+  /// trips on a device without an IMU all carry no inertial signal, so the
+  /// score falls back to the (clamped) GPS-derived counts.
+  final bool imuActive;
+
   const TripSummary({
     required this.distanceKm,
     required this.maxRpm,
@@ -167,6 +178,7 @@ class TripSummary {
     this.imuHardAccelCount = 0,
     this.imuHardBrakeCount = 0,
     this.sharpCornerCount = 0,
+    this.imuActive = false,
   });
 
   /// IMU hard-accel episodes per km (#2760). Derived, not stored — the raw
@@ -212,6 +224,7 @@ class TripSummary {
     int? imuHardAccelCount,
     int? imuHardBrakeCount,
     int? sharpCornerCount,
+    bool? imuActive,
   }) =>
       TripSummary(
         distanceKm: distanceKm ?? this.distanceKm,
@@ -237,6 +250,7 @@ class TripSummary {
         imuHardAccelCount: imuHardAccelCount ?? this.imuHardAccelCount,
         imuHardBrakeCount: imuHardBrakeCount ?? this.imuHardBrakeCount,
         sharpCornerCount: sharpCornerCount ?? this.sharpCornerCount,
+        imuActive: imuActive ?? this.imuActive,
       );
 }
 

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -142,16 +142,20 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     // into the canonical score so the over-rev/shift family includes it
     // (the calculator can't recompute gear inference from samples alone).
     //
-    // #2794 — for a GPS-only trip, score against the pipeline's RESOLVED harsh
-    // counts (IMU-preferred when the inertial sensor was the better dongle-less
-    // signal) instead of re-deriving from the noisy GPS speed derivative, so
-    // the displayed score matches the figure the recorder intended.
-    final gpsOnly = summary.kind == TripKind.gpsOnly;
+    // #2794 / #2895 — when the phone IMU actually RAN for this trip, score
+    // against the pipeline's RESOLVED harsh counts (the accurate inertial
+    // figures, persisted on the summary) instead of re-deriving from the noisy
+    // GPS speed derivative. This is keyed off `imuActive`, not the trip kind:
+    // a gpsPlusObd2 trip that started dongle-less still has the inertial counts,
+    // and a genuine IMU zero must VETO a GPS over-count (the #2895 16-vs-0 bug).
+    // When no IMU ran, the (now physically-clamped, #2895) GPS-derived counts
+    // remain the source.
+    final useImu = summary.imuActive;
     return computeDrivingScore(
       tripSamples,
       secondsBelowOptimalGear: summary.secondsBelowOptimalGear,
-      hardAccelEventsOverride: gpsOnly ? summary.harshAccelerations : null,
-      hardBrakeEventsOverride: gpsOnly ? summary.harshBrakes : null,
+      hardAccelEventsOverride: useImu ? summary.harshAccelerations : null,
+      hardBrakeEventsOverride: useImu ? summary.harshBrakes : null,
     );
   }
 

--- a/lib/features/consumption/providers/gps_only_recording_pipeline.dart
+++ b/lib/features/consumption/providers/gps_only_recording_pipeline.dart
@@ -280,23 +280,35 @@ class GpsOnlyRecordingPipeline implements RecordingPipeline {
     final kind = TripKind.fromSamples(samples);
     // #2760 — stamp the aggregate-only IMU event counts. THREE scalars; the
     // raw ~50 Hz inertial stream was folded into them in real time and is
-    // never persisted. When the IMU produced events on a dongle-less trip,
-    // PREFER them for the `harshAccelerations` / `harshBrakes` the driving
-    // score reads (`driving_score_calculator.dart`): a direct inertial
-    // reading is a more accurate harsh-manoeuvre signal than the GPS
-    // speed-derivative the recorder's [HarshEventDetector] used. The
-    // speed-derived counts stay the fallback when the IMU saw nothing.
+    // never persisted.
+    //
+    // #2895 — PREFER the IMU counts for the `harshAccelerations` / `harshBrakes`
+    // the driving score reads whenever the inertial sensor actually RAN —
+    // INCLUDING when it counted zero. A direct inertial reading is the accurate
+    // harsh-manoeuvre signal; the GPS speed-derivative the recorder used can
+    // differentiate ~1 Hz Doppler noise into impossible >1 g spikes (the
+    // #2895 Peugeot 107: IMU 0 vs GPS 16, maxAccelG 1.086). So a genuine IMU
+    // zero must VETO the noisy GPS over-count — the old `(imuAccel > 0 ||
+    // imuBrake > 0)` gate let the over-count win on exactly the smooth trip it
+    // should have zeroed. We gate on the sensor having run, not on it being
+    // non-zero, and on EITHER kind: the IMU detector runs in this dongle-less
+    // pipeline regardless of whether OBD2 attached mid-trip (a gpsPlusObd2
+    // trip that started dongle-less still has the accurate inertial counts).
+    // `imuActive` is persisted so the trip-detail score recompute reconciles
+    // the same way. When the sensor never ran (no IMU hardware / OBD2-from-the-
+    // start), the (now physically-clamped) GPS-derived counts stay the source.
     final imuAccel = imuDetector?.hardAccelCount ?? 0;
     final imuBrake = imuDetector?.hardBrakeCount ?? 0;
     final imuCorners = imuDetector?.sharpCornerCount ?? 0;
-    final preferImu = kind == TripKind.gpsOnly && (imuAccel > 0 || imuBrake > 0);
+    final imuActive = imuDetector?.isActive ?? false;
     var summary = recorder.buildSummary().copyWith(
           kind: kind,
           imuHardAccelCount: imuAccel,
           imuHardBrakeCount: imuBrake,
           sharpCornerCount: imuCorners,
-          harshAccelerations: preferImu ? imuAccel : null,
-          harshBrakes: preferImu ? imuBrake : null,
+          imuActive: imuActive,
+          harshAccelerations: imuActive ? imuAccel : null,
+          harshBrakes: imuActive ? imuBrake : null,
         );
     // #2080 — for GPS-only / hybrid trips (no OBD2 fuel-rate
     // coverage), feed the sample stream through GpsDrivingFeatures +

--- a/test/features/consumption/data/driving_insights_analyzer_test.dart
+++ b/test/features/consumption/data/driving_insights_analyzer_test.dart
@@ -359,19 +359,21 @@ void main() {
     test(
         'five samples with one accel event in the middle → only that index '
         'is reported', () {
-      // Indices and segments:
+      // Indices and segments (#2895 — the middle event is a PLAUSIBLE hard
+      // accel, ≤ the ~0.9 g physical ceiling, so the clamp leaves it):
       //   0 → 1: 30 → 32 km/h over 1 s → accel ≈ 0.56 m/s² (below).
-      //   1 → 2: 32 → 80 km/h over 1 s → accel ≈ 13.33 m/s² (above).
-      //   2 → 3: 80 → 82 km/h over 1 s → accel ≈ 0.56 m/s² (below).
-      //   3 → 4: 82 → 80 km/h over 1 s → DECEL (negative, ignored).
+      //   1 → 2: 32 → 60 km/h over 1 s → accel ≈ 7.78 m/s² ≈ 0.79 g (above
+      //          threshold, below the ceiling — a real hard launch).
+      //   2 → 3: 60 → 62 km/h over 1 s → accel ≈ 0.56 m/s² (below).
+      //   3 → 4: 62 → 60 km/h over 1 s → DECEL (negative, ignored).
       // Only index 2 (the end of the middle interval) trips the
       // threshold.
       final samples = [
         sample(sec: 0, speedKmh: 30),
         sample(sec: 1, speedKmh: 32),
-        sample(sec: 2, speedKmh: 80),
-        sample(sec: 3, speedKmh: 82),
-        sample(sec: 4, speedKmh: 80),
+        sample(sec: 2, speedKmh: 60),
+        sample(sec: 3, speedKmh: 62),
+        sample(sec: 4, speedKmh: 60),
       ];
       expect(hardAccelSampleIndices(samples), [2]);
     });

--- a/test/features/consumption/domain/gps_imu_hardaccel_overcount_test.dart
+++ b/test/features/consumption/domain/gps_imu_hardaccel_overcount_test.dart
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/sensors/imu_sample.dart';
+import 'package:tankstellen/features/consumption/data/driving_insights_analyzer.dart';
+import 'package:tankstellen/features/consumption/data/driving_score_calculator.dart';
+import 'package:tankstellen/features/consumption/domain/accel_event_gate.dart';
+import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
+import 'package:tankstellen/features/consumption/domain/harsh_event_detector.dart';
+import 'package:tankstellen/features/consumption/domain/services/imu_event_detector.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #2895 — GPS-only driving score over-counts hard accelerations.
+///
+/// Concrete evidence (real export, Peugeot 107, gpsPlusObd2): the phone IMU
+/// (accurate inertial reading) saw **0/0/0** hard accel/brake/corner, but the
+/// GPS speed-derivative path manufactured **16** accel events with
+/// **maxAccelG 1.086** — physically impossible for a 68 hp economy car — and
+/// the score applied a 15-point hard-accel + 15-point hard-brake penalty plus
+/// a "16 hard accelerations: wasted 0.8 L" lesson.
+///
+/// Two RED-on-master behaviours are fixed here:
+///   (1) the GPS speed-derivative gate has NO physical-plausibility clamp, so
+///       a ~1 g noise spike (impossible for a real car) counts as a hard
+///       accel. The clamp rejects it at the source — score, insights, AND
+///       GPS features.
+///   (2) the IMU truth (0) could not VETO the GPS over-count: the override
+///       only fired when the IMU count was non-zero, so a genuinely-smooth
+///       trip's accurate inertial zero lost to the noisy GPS 16. The override
+///       now keys off the sensor having RUN, so an IMU zero wins.
+void main() {
+  final t0 = DateTime.utc(2026, 6, 5, 9);
+
+  /// A speed series (km/h) at a clean ~1 Hz cadence that the GPS
+  /// speed-derivative differentiates into a SUSTAINED (≥ 1 s) physically
+  /// IMPOSSIBLE acceleration spike — the shape the #2895 export produced:
+  /// a ~1.1 g forward "acceleration" no 68 hp car can make. 30 → 70 → 110
+  /// over two 1 s steps is +11.1 m/s² ≈ 1.13 g each (well past the ~0.9 g
+  /// plausibility ceiling), held for 2 s so the sustained-window gate would
+  /// otherwise confirm an event.
+  List<AccelSamplePoint> impossibleAccelSpike() => [
+        AccelSamplePoint(timestamp: t0, speedKmh: 30),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 1)), speedKmh: 70),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 2)), speedKmh: 110),
+        // settle on a cruise so any episode would be confirmed + closed.
+        for (var s = 3; s <= 8; s++)
+          AccelSamplePoint(
+              timestamp: t0.add(Duration(seconds: s)), speedKmh: 110),
+      ];
+
+  /// The same shape as [TripSample]s (rpm null → GPS-only / no-engine trip).
+  List<TripSample> impossibleAccelTrip() => [
+        for (final p in impossibleAccelSpike())
+          TripSample(timestamp: p.timestamp, speedKmh: p.speedKmh, rpm: null),
+      ];
+
+  group('GPS plausibility clamp (#2895) — impossible spikes are not events', () {
+    test('countAccelEvents: a ~1.1 g forward spike yields ZERO hard accels '
+        '(RED on master: counted as a hard accel)', () {
+      final counts = countAccelEvents(impossibleAccelSpike());
+      expect(counts.accelEvents, 0,
+          reason: 'a >0.61 g forward derivative is GPS noise, not a manoeuvre');
+      expect(counts.brakeEvents, 0);
+    });
+
+    test('a genuine 0.71 g hard launch STILL counts (clamp does not clip a '
+        'real hard acceleration the score already penalises)', () {
+      // 0 → 50 km/h over 2 s = +6.94 m/s² ≈ 0.71 g — the exact "hard accel"
+      // shape the existing score / GPS-feature fixtures use. It is under the
+      // ~0.9 g ceiling, so the clamp must leave it untouched.
+      final pts = <AccelSamplePoint>[
+        AccelSamplePoint(timestamp: t0, speedKmh: 0),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 1)), speedKmh: 25),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 2)), speedKmh: 50),
+        for (var s = 3; s <= 8; s++)
+          AccelSamplePoint(
+              timestamp: t0.add(Duration(seconds: s)), speedKmh: 50),
+      ];
+      final counts = countAccelEvents(pts);
+      expect(counts.accelEvents, 1,
+          reason: 'a real 0.71 g hard launch is preserved');
+    });
+
+    test('a genuine ~1.0 g emergency brake STILL counts (asymmetric ceiling — '
+        'braking legitimately reaches ~1 g)', () {
+      // 100 → 65 km/h over 1 s held → -9.7 m/s² ≈ 0.99 g, under the 1.12 g
+      // brake ceiling, then a second 1 s step so the episode is sustained.
+      final pts = <AccelSamplePoint>[
+        AccelSamplePoint(timestamp: t0, speedKmh: 100),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 1)), speedKmh: 65),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 2)), speedKmh: 30),
+        for (var s = 3; s <= 8; s++)
+          AccelSamplePoint(
+              timestamp: t0.add(Duration(seconds: s)), speedKmh: 30),
+      ];
+      final counts = countAccelEvents(pts);
+      expect(counts.brakeEvents, 1, reason: 'a real ~1 g hard brake is kept');
+    });
+
+    test('an impossible >1.12 g brake spike is rejected as noise', () {
+      // 110 → 40 over 1 s = -19.4 m/s² ≈ 1.98 g — impossible; must not count.
+      final pts = <AccelSamplePoint>[
+        AccelSamplePoint(timestamp: t0, speedKmh: 110),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 1)), speedKmh: 40),
+        AccelSamplePoint(
+            timestamp: t0.add(const Duration(seconds: 2)), speedKmh: 0),
+        for (var s = 3; s <= 8; s++)
+          AccelSamplePoint(
+              timestamp: t0.add(Duration(seconds: s)), speedKmh: 0),
+      ];
+      final counts = countAccelEvents(pts);
+      expect(counts.brakeEvents, 0);
+    });
+  });
+
+  group('the clamp reaches every GPS-derived consumer (#2895)', () {
+    test('GpsDrivingFeatures.from: impossible spike → 0 accel events', () {
+      final f = GpsDrivingFeatures.from(impossibleAccelTrip())!;
+      expect(f.accelEvents, 0);
+    });
+
+    test('HarshEventDetector (recorder source): impossible spike → 0 accels', () {
+      final d = HarshEventDetector();
+      for (final p in impossibleAccelSpike()) {
+        d.onSample(p.speedKmh, p.timestamp);
+      }
+      expect(d.accelerations, 0,
+          reason: 'the recorder harshAccelerations no longer counts the spike');
+    });
+
+    test('driving-insights analyzer: NO insightHardAccel lesson for the spike '
+        '(RED on master: "N hard accelerations: wasted L")', () {
+      final insights = analyzeTrip(impossibleAccelTrip());
+      final hardAccel =
+          insights.where((i) => i.labelKey == 'insightHardAccel').toList();
+      expect(hardAccel, isEmpty,
+          reason: 'no hard-accel cost line is built from GPS noise');
+    });
+
+    test('computeDrivingScore: impossible spike → no hard-accel penalty '
+        '(RED on master: 15-point hard-accel penalty)', () {
+      final score = computeDrivingScore(impossibleAccelTrip());
+      expect(score.hardAccelPenalty, 0);
+      expect(score.hardBrakePenalty, 0);
+    });
+  });
+
+  group('IMU truth VETOES the GPS over-count (#2895)', () {
+    test('ImuEventDetector.isActive is false before any real sample, true once '
+        'the sensor has run', () {
+      final det = ImuEventDetector();
+      expect(det.isActive, isFalse, reason: 'no samples yet');
+      // First sample only seeds the dt anchor.
+      det.currentSpeedKmh = 50;
+      det.onSample(ImuSample(
+          t: t0, axMps2: 0, ayMps2: 0, azMps2: 0, gyroZRadPerSec: 0));
+      expect(det.isActive, isFalse, reason: 'one stray emit is not "ran"');
+      det.onSample(ImuSample(
+          t: t0.add(const Duration(milliseconds: 20)),
+          axMps2: 0,
+          ayMps2: 0,
+          azMps2: 0,
+          gyroZRadPerSec: 0));
+      expect(det.isActive, isTrue, reason: 'the sensor produced a usable signal');
+    });
+
+    test('an IMU ZERO overrides a GPS-derived count to zero penalty — the '
+        'override fires on a genuine zero (RED on master: zero never won)', () {
+      // A GPS-derived count that DOES clear the (plausible) gate — e.g. a real
+      // moderate accel the speed path saw but the IMU, with its direct reading,
+      // judged smooth. Without the fix the score takes the GPS count; with it,
+      // the IMU-active zero wins.
+      final samples = <TripSample>[
+        TripSample(timestamp: t0, speedKmh: 0, rpm: null),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 1)),
+            speedKmh: 18,
+            rpm: null),
+        TripSample(
+            timestamp: t0.add(const Duration(seconds: 2)),
+            speedKmh: 36,
+            rpm: null),
+        for (var s = 3; s <= 8; s++)
+          TripSample(
+              timestamp: t0.add(Duration(seconds: s)),
+              speedKmh: 36,
+              rpm: null),
+      ];
+      // Sanity: the GPS gate alone WOULD count this as one hard accel.
+      expect(
+        countAccelEvents([
+          for (final s in samples)
+            AccelSamplePoint(timestamp: s.timestamp, speedKmh: s.speedKmh),
+        ]).accelEvents,
+        1,
+      );
+      // The trip-detail recompute threads the pipeline's IMU-resolved zero as
+      // the override (what `imuActive` gates on the summary).
+      final score = computeDrivingScore(
+        samples,
+        hardAccelEventsOverride: 0,
+        hardBrakeEventsOverride: 0,
+      );
+      expect(score.hardAccelPenalty, 0,
+          reason: 'an active-IMU zero vetoes the GPS-derived count');
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_path_map_card_test.dart
@@ -286,18 +286,20 @@ void main() {
     testWidgets(
         'hard-acceleration events render bolt markers on top of the heatmap',
         (tester) async {
-      // Two hard-accel events: 0 → 60 km/h in 1 s (≈ 16.67 m/s²) at the
-      // 0 → 1 boundary, and 30 → 80 km/h in 1 s (≈ 13.89 m/s²) at the
-      // 4 → 5 boundary. Both well above the 3.0 m/s² threshold. The
-      // segments between them stay calm so no other event fires.
+      // Two hard-accel events, both PLAUSIBLE (≤ the ~0.9 g physical ceiling
+      // the #2895 clamp enforces, so GPS noise can't fabricate them but a
+      // real hard launch still fires): 0 → 28 km/h in 1 s (≈ 7.78 m/s² ≈
+      // 0.79 g) at the 0 → 1 boundary, and 30 → 58 km/h in 1 s (≈ 7.78 m/s²)
+      // at the 4 → 5 boundary. Both above the 3.0 m/s² threshold, below the
+      // ceiling. The segments between them stay calm so no other event fires.
       final samples = [
         _sample(sec: 0, lat: 43.40, lng: 3.40, speed: 0),
-        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 60), // hard accel #1
-        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 60),
-        _sample(sec: 3, lat: 43.43, lng: 3.43, speed: 60),
+        _sample(sec: 1, lat: 43.41, lng: 3.41, speed: 28), // hard accel #1
+        _sample(sec: 2, lat: 43.42, lng: 3.42, speed: 28),
+        _sample(sec: 3, lat: 43.43, lng: 3.43, speed: 28),
         _sample(sec: 4, lat: 43.44, lng: 3.44, speed: 30),
-        _sample(sec: 5, lat: 43.45, lng: 3.45, speed: 80), // hard accel #2
-        _sample(sec: 6, lat: 43.46, lng: 3.46, speed: 80),
+        _sample(sec: 5, lat: 43.45, lng: 3.45, speed: 58), // hard accel #2
+        _sample(sec: 6, lat: 43.46, lng: 3.46, speed: 58),
       ];
 
       await pumpApp(tester, TripPathMapCard(samples: samples));

--- a/test/features/consumption/providers/gps_only_imu_fusion_test.dart
+++ b/test/features/consumption/providers/gps_only_imu_fusion_test.dart
@@ -188,6 +188,68 @@ void main() {
 
       await harness.pipeline.stop();
     });
+
+    test('#2895 IMU ZERO VETO: the inertial sensor ran and saw NO hard events '
+        'while a noisy GPS speed jump would manufacture one — the persisted '
+        'summary marks imuActive AND zeroes harshAccelerations so the score '
+        'reflects the accurate inertial zero, not the GPS over-count',
+        () async {
+      // The IMU emits CALM samples (~0 m/s² horizontal) — a smooth driver — so
+      // the detector confirms zero hard accels but IS active (it ran).
+      final calm = <ImuSample>[
+        for (var i = 0; i < 40; i++)
+          ImuSample(
+            t: DateTime(2026, 6, 5, 9).add(Duration(milliseconds: i * 50)),
+            axMps2: 0.2,
+            ayMps2: 0.1,
+            azMps2: 0,
+            gyroZRadPerSec: 0,
+          ),
+      ];
+      final imu = _FakeImuSource(calm);
+      final repo = TripHistoryRepository(box: box);
+      final harness = _Harness(repo: repo, imu: imu);
+      addTearDown(harness.dispose);
+
+      harness.pipeline.start();
+      final t0 = DateTime(2026, 6, 5, 9);
+      // A GPS speed jump the speed-derivative would otherwise read as a hard
+      // accel (18 → 30 m/s over 1 s = +12 m/s² ≈ 1.2 g — exactly the kind of
+      // impossible spike #2895 over-counted). With the clamp this no longer
+      // counts anyway, and the IMU-active zero is the authoritative figure.
+      harness.geo.emit(_pos(43.4, 3.5, speedMps: 18.0, at: t0));
+      await _pump();
+      harness.imu.emitBurst(0, 20);
+      await _pump();
+      harness.geo.emit(_pos(43.41, 3.51,
+          speedMps: 30.0, at: t0.add(const Duration(seconds: 1))));
+      await _pump();
+      harness.imu.emitBurst(20);
+      await _pump();
+      // A couple more calm fixes so the trip has plausible distance/duration.
+      harness.geo.emit(_pos(43.42, 3.52,
+          speedMps: 28.0, at: t0.add(const Duration(seconds: 2))));
+      await _pump();
+
+      await harness.pipeline.stop();
+
+      final entries = repo.loadAll();
+      expect(entries, hasLength(1));
+      final summary = entries.single.summary;
+      expect(summary.imuActive, isTrue,
+          reason: 'the sensor ran, so its zero is authoritative');
+      expect(summary.imuHardAccelCount, 0);
+      expect(summary.harshAccelerations, 0,
+          reason: 'the IMU zero is preferred over the noisy GPS count');
+      expect(summary.harshBrakes, 0);
+
+      // And it round-trips through the on-disk JSON (the display recompute
+      // reads imuActive from there).
+      final raw = box.get(entries.single.id)!;
+      final decoded = jsonDecode(raw) as Map<String, dynamic>;
+      final summaryJson = decoded['summary'] as Map<String, dynamic>;
+      expect(summaryJson['ima'], true, reason: 'imuActive persisted (key ima)');
+    });
   });
 }
 


### PR DESCRIPTION
Closes #2895 — the concrete evidence + the GPS-clamp half of Epic #2789.

## The bug
A real driving-analysis export (Peugeot 107, `gpsPlusObd2`): the phone **IMU** (accurate inertial reading) saw **0/0/0** hard accel/brake/corner, but the **GPS speed-derivative** path manufactured **16** accel events with **maxAccelG 1.086** — physically impossible for a 68 hp economy car — and the score applied a 15-point hard-accel + 15-point hard-brake penalty plus a "16 hard accelerations: wasted 0.8 L" lesson. GPS Doppler-speed noise was being differentiated into >1 g spikes and scored, while the accurate IMU events (collected + persisted per #2760 but, per #2789, **read by nothing**) were ignored.

## Where the GPS accel is computed / clamped
The shared `countAccelEvents` gate (`accel_event_gate.dart`) and the recorder's `HarshEventDetector` both differentiate GPS speed (Δspeed/Δt) with the canonical 3.0 / 3.5 m/s² thresholds — but had **no upper bound**, so a ~1.1 g noise spike sustained ≥1 s counted as a hard manoeuvre. Added asymmetric physical-plausibility ceilings:
- `kMaxPlausibleAccelMps2 = 8.83` (~0.9 g) — above a genuine 0.7 g hard launch, below the impossible 1.09 g spike.
- `kMaxPlausibleBrakeMps2 = 11.0` (~1.12 g) — looser, so a real ~1 g emergency stop is preserved.

An interval past a ceiling is treated like a bad fix — it **breaks the running episode** rather than counting. This reaches every GPS-derived consumer at once (the score, the insights/lesson via `analyzeTrip`, and the GPS features), so the recorded 16-event over-count collapses to 0.

## How IMU is reconciled
The recording pipeline only preferred IMU counts when they were **non-zero** AND the trip was `gpsOnly` — so an accurate inertial **0** could never veto a noisy GPS over-count, and a `gpsPlusObd2` trip that started dongle-less was excluded entirely. Now:
- `ImuEventDetector.isActive` tracks whether the inertial sensor actually **ran**.
- `TripSummary.imuActive` persists it (compact key `'ima'`).
- The pipeline prefers the IMU counts whenever the sensor ran — on **either** trip kind, **even at zero** (IMU truth wins).
- The trip-detail score recompute keys the override off `imuActive` (not the trip kind), so the displayed score + lessons reflect the inertial reality.

## Files
- `domain/accel_event_gate.dart`, `domain/harsh_event_detector.dart` — the plausibility clamp.
- `domain/services/imu_event_detector.dart` — `isActive`.
- `domain/trip_summary.dart`, `data/trip_history_repository.dart` — persist `imuActive`.
- `providers/gps_only_recording_pipeline.dart`, `presentation/widgets/trip_detail_body.dart` — prefer IMU when active (incl. zero), on either kind.
- `data/analysis/driving_analysis_trace.dart` — surface `imu.active` in the calibration export.

## Tests (RED-before / green-after)
- New `gps_imu_hardaccel_overcount_test.dart` pins the clamp across the gate, recorder, analyzer, GPS features, and score. Verified **RED on master**: without the clamp the impossible spike counts as a hard accel, builds an `insightHardAccel` lesson, and applies a 3-point penalty.
- New integration test in `gps_only_imu_fusion_test.dart`: an active-IMU **zero** persists `imuActive: true` + zeroes `harshAccelerations`.
- Two pre-existing fixtures that relied on physically-impossible (1.4–1.7 g) accelerations were re-based to plausible (~0.79 g) hard accels (the clamp correctly rejected the impossible ones).

`flutter analyze lib` clean; full consumption + achievements + lint suites green; 400-line cap respected (absorbed via comment consolidation, no grandfather bump); no codegen drift.

## Remaining #2789 children (separate)
The 3 trip-detail bugs (climb-energy / haversine / corner-load), the lesson polarity enum, and the brake/corner lessons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
