### PR TITLE
fix(obd2): reconnect recovery — gate dead-transport polling + clear BLE session on drop + relax recovery scan gate (#2907)

### DIFF
--- a/lib/features/consumption/data/obd2/ble_link_tuner.dart
+++ b/lib/features/consumption/data/obd2/ble_link_tuner.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+import 'obd2_comm_diagnostics.dart';
+
+/// Best-effort BLE link tuning for an OBD2 recording session (#2261
+/// concern 4), extracted from [FlutterBluePlusElmChannel] (#2907) so the
+/// channel file stays under the #1680 400-line cap. Pure move — behaviour is
+/// preserved.
+///
+/// Every request here is best-effort: Android-only (FBP throws `androidOnly`
+/// elsewhere) and routinely rejected by ELM327 clones, so every call is
+/// guarded — a rejection must never break an otherwise-healthy session.
+class BleLinkTuner {
+  /// #2261 concern 4 — best-effort MTU to request on a high-throughput
+  /// (recording) link. 247 is the practical ATT payload ceiling on most
+  /// Android BLE stacks; the negotiated value is whatever the peripheral
+  /// grants. Skipped on the autoConnect passive path (FBP forbids requestMtu).
+  static const int recordingMtu = 247;
+
+  const BleLinkTuner();
+
+  /// Bump to high connection priority + request the recording MTU. Skipped on
+  /// the passive autoConnect path ([autoConnect] true) — FBP forbids
+  /// requestMtu with autoConnect, and a parked-car wait wants low power.
+  Future<void> tuneForRecording(
+    BluetoothDevice device, {
+    required bool autoConnect,
+  }) async {
+    await _setConnectionPriority(device, ConnectionPriority.high);
+    if (autoConnect) return;
+    try {
+      final granted = await device.requestMtu(recordingMtu);
+      // #2466 — record the negotiated ATT MTU into the gated comm-health
+      // session (no-op unless Feature.debugMode armed the collector). The
+      // peripheral may grant less than requested; the granted value wins.
+      final diag = Obd2CommDiagnostics.instance;
+      if (diag.enabled) diag.recordAdapterIdentity(mtu: granted);
+    } catch (e, st) {
+      // Many clones reject a non-default MTU — harmless, the default 23-byte
+      // MTU still works. PHY (2M) is deliberately NOT requested (a clone trap).
+      debugPrint('BleLinkTuner requestMtu skipped: $e\n$st');
+    }
+  }
+
+  /// Drop to balanced connection priority when only the 1 Hz auto-record
+  /// stream is live (#2261 concern 4).
+  Future<void> tuneForBackground(BluetoothDevice device) =>
+      _setConnectionPriority(device, ConnectionPriority.balanced);
+
+  Future<void> _setConnectionPriority(
+    BluetoothDevice device,
+    ConnectionPriority priority,
+  ) async {
+    try {
+      await device.requestConnectionPriority(
+        connectionPriorityRequest: priority,
+      );
+    } catch (e, st) {
+      debugPrint('BleLinkTuner requestConnectionPriority skipped: $e\n$st');
+    }
+  }
+}

--- a/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/flutter_blue_plus_elm_channel.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
 import 'ble_disconnect_classifier.dart';
+import 'ble_link_tuner.dart';
 import 'connection_drop_debouncer.dart';
 import 'elm_byte_channel.dart';
 import 'obd2_comm_diagnostics.dart';
@@ -50,12 +51,6 @@ class Elm327BleUuids {
 class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   final BluetoothDevice _device;
   final Elm327BleUuids _uuids;
-
-  /// #2261 concern 4 — best-effort MTU to request on a high-throughput
-  /// (recording) link. 247 is the practical ATT payload ceiling on most
-  /// Android BLE stacks; the negotiated value is whatever the peripheral
-  /// grants. Skipped on the autoConnect passive path (FBP forbids requestMtu).
-  static const int _recordingMtu = 247;
 
   /// Optional bounded timeout passed to `device.connect` (#2242). When null,
   /// `connect` uses the legacy `mtu: null` form with no timeout (the scan-first
@@ -222,8 +217,9 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
         // drop detector sees a typed disconnect — never an ERROR trace. A
         // genuine non-disconnect error keeps its #2295 behaviour (below).
         if (isBleAdapterDisconnect(e)) {
-          _open = false;
-          _writeChar = null;
+          // #2907 — FULL session teardown on a confirmed drop (was clearing
+          // only `_open`/`_writeChar`, leaving stale notify state behind).
+          _clearSessionOnDrop();
           if (!_incoming.isClosed) {
             _incoming.addError(
               const Obd2DisconnectedException(
@@ -280,43 +276,12 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
   }
 
   @override
-  Future<void> tuneForRecording() async {
-    await _setConnectionPriority(ConnectionPriority.high);
-    // requestMtu is forbidden with autoConnect:true (FBP throws); the
-    // passive path never calls this, but guard anyway.
-    if (_autoConnect) return;
-    try {
-      final granted = await _device.requestMtu(_recordingMtu);
-      // #2466 — record the negotiated ATT MTU into the gated comm-health
-      // session (no-op unless Feature.debugMode armed the collector). The
-      // peripheral may grant less than requested; the granted value wins.
-      final diag = Obd2CommDiagnostics.instance;
-      if (diag.enabled) diag.recordAdapterIdentity(mtu: granted);
-    } catch (e, st) {
-      // Many clones reject a non-default MTU — harmless, the default 23-byte
-      // MTU still works. PHY (2M) is deliberately NOT requested (a clone trap).
-      debugPrint('FlutterBluePlusElmChannel requestMtu skipped: $e\n$st');
-    }
-  }
+  Future<void> tuneForRecording() =>
+      const BleLinkTuner().tuneForRecording(_device, autoConnect: _autoConnect);
 
   @override
-  Future<void> tuneForBackground() async {
-    await _setConnectionPriority(ConnectionPriority.balanced);
-  }
-
-  /// Best-effort connection-priority request (#2261 concern 4). Android
-  /// only — FBP throws `androidOnly` elsewhere — so the try/catch keeps
-  /// iOS / a rejecting clone from ever breaking a session.
-  Future<void> _setConnectionPriority(ConnectionPriority priority) async {
-    try {
-      await _device.requestConnectionPriority(
-        connectionPriorityRequest: priority,
-      );
-    } catch (e, st) {
-      debugPrint('FlutterBluePlusElmChannel requestConnectionPriority '
-          'skipped: $e\n$st');
-    }
-  }
+  Future<void> tuneForBackground() =>
+      const BleLinkTuner().tuneForBackground(_device);
 
   @override
   Future<void> write(List<int> bytes) async {
@@ -349,8 +314,9 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       // [ClassicElmChannel] + #2524 [BluetoothObd2Transport] precedents) and
       // clear the session so the next write short-circuits on the open-guard.
       if (isBleAdapterDisconnect(e)) {
-        _open = false;
-        _writeChar = null;
+        // #2907 — full session teardown on a write-time drop (was clearing
+        // only `_open`/`_writeChar`), so a reconnect's open() starts clean.
+        _clearSessionOnDrop();
         debugPrint('FlutterBluePlusElmChannel: write failed — reclassifying '
             'as a recoverable disconnect (#2900): $e\n$st');
         throw const Obd2DisconnectedException(
@@ -373,11 +339,44 @@ class FlutterBluePlusElmChannel implements ElmByteChannel, Obd2LinkTuner {
       char.write(bytes, withoutResponse: true);
 
   /// #2900 test seam — prime an established session so a fault-injection test
-  /// can drive [write] without the real connect path. Never used in production.
+  /// can drive [write] without the real connect path. #2907 — also wires
+  /// `_notifyChar` + inert subscriptions so a test can prove a confirmed drop
+  /// fully tears the session down (see [debugResidualSessionState]).
   @visibleForTesting
   void debugPrimeOpenSession(BluetoothCharacteristic writeChar) {
     _writeChar = writeChar;
+    _notifyChar = writeChar;
     _open = true;
+    _subscription ??= const Stream<List<int>>.empty().listen((_) {});
+    _connStateSubscription ??=
+        const Stream<BluetoothConnectionState>.empty().listen((_) {});
+  }
+
+  /// #2907 test seam — true while ANY per-session state survives a drop (the
+  /// write/notify chars or either subscription); [_clearSessionOnDrop] clears
+  /// them all.
+  @visibleForTesting
+  bool get debugResidualSessionState =>
+      _notifyChar != null ||
+      _writeChar != null ||
+      _subscription != null ||
+      _connStateSubscription != null;
+
+  /// #2907 — fully clear per-session BLE state the instant a drop is confirmed
+  /// (notify-stream error / write failure) so a subsequent [open] starts
+  /// clean. Used to clear only `_open`/`_writeChar`, leaving `_notifyChar` +
+  /// both subscriptions dangling for the next open to double-wire. Cancels
+  /// fire-and-forget: it can run INSIDE the notify subscription's own
+  /// `onError`, where awaiting its own cancellation would deadlock. `_incoming`
+  /// is NOT closed here — [close] owns that.
+  void _clearSessionOnDrop() {
+    _open = false;
+    _writeChar = null;
+    _notifyChar = null;
+    unawaited(_subscription?.cancel());
+    _subscription = null;
+    unawaited(_connStateSubscription?.cancel());
+    _connStateSubscription = null;
   }
 
   @override

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -157,6 +157,15 @@ class Obd2ConnectionService {
   /// [Obd2AdapterUnresponsive] when init fails (channel is closed
   /// before the error is rethrown).
   Future<Obd2Service> connect(ResolvedObd2Candidate candidate) async {
+    // #2907 — tear down any stale direct/passive channel from a PRIOR
+    // by-MAC connect before the scan path opens a fresh one. The
+    // [connectByMacDirect]/[connectByMacPassive] paths already self-clean,
+    // but the SCAN-fallback `connect` did not — so an in-trip reconnect that
+    // tried a direct connect (which retained `_lastDirectChannel`) and then
+    // fell back to the gated scan left that GATT client open, and Android
+    // returned GATT_ERROR 133 on the scan-path open against the same device
+    // (the repeat-133 reconnect trap). Idempotent + best-effort.
+    await _teardownLastDirectChannel();
     final channel = switch (candidate.profile.transport) {
       BluetoothTransport.ble => bluetooth.channelFor(
           candidate.candidate.deviceId, candidate.profile),

--- a/lib/features/consumption/data/obd2/reconnect_connector.dart
+++ b/lib/features/consumption/data/obd2/reconnect_connector.dart
@@ -187,6 +187,11 @@ class ReconnectConnector {
           seenRssi: candidate.candidate.rssi,
           consecutiveBatchesSeen: _consecutiveBatchesSeen,
           transportHint: transportHint,
+          // #2907 — every scan the connector runs IS an in-trip recovery: the
+          // MAC is pinned (no wrong-device risk), so relax the gate so a
+          // marginal single-batch sighting of the dropped adapter is
+          // attempted instead of spinning the backoff for another window.
+          recovery: true,
         )) {
           // Too weak AND not yet seen twice — keep scanning this window;
           // a later batch may strengthen or repeat it.

--- a/lib/features/consumption/data/obd2/reconnect_rssi_gate.dart
+++ b/lib/features/consumption/data/obd2/reconnect_rssi_gate.dart
@@ -37,17 +37,44 @@
 /// [transportHint] is `'classic'` AND the sentinel RSSI is seen, the gate
 /// passes on the FIRST batch. This is scoped to the Classic transport only —
 /// a real BLE adapter never reports a 0 dBm RSSI, so the BLE gate is unchanged.
+///
+/// #2907 — the RECOVERY relaxation. The default gate (two consecutive batches
+/// OR within 15 dBm of the last-good RSSI) is tuned for the INITIAL pick: it
+/// guards against latching a neighbouring car's weaker adapter. But during an
+/// in-trip RECONNECT the MAC is already pinned — there is no risk of picking
+/// the wrong device — and a marginal, single-batch sighting of the pinned
+/// adapter is exactly the recovery we want to attempt rather than spin the
+/// backoff for another window. When [recovery] is true the gate therefore:
+///   * widens the relative-RSSI tolerance to [recoveryRelativeDropDbm]
+///     (default 35 dBm — a far weaker but still-reachable link is attempted
+///     on the FIRST sighting), and
+///   * with no baseline yet this drop, attempts ANY first sighting of the
+///     pinned MAC, and
+///   * still lets a SECOND consecutive sighting override even a beyond-the-
+///     widened-window RSSI (a stable-but-very-weak link).
+/// [recovery] defaults to false so every initial-pick call site is unchanged.
 bool shouldConnectFromScan({
   required int? lastSuccessfulRssi,
   required int seenRssi,
   required int consecutiveBatchesSeen,
   String? transportHint,
+  bool recovery = false,
   int relativeDropDbm = 15,
   int requiredConsecutiveBatches = 2,
+  int recoveryRelativeDropDbm = 35,
 }) {
   // #2565 — a bonded Classic sighting (no RSSI; the `0` sentinel) is in range
   // by construction: connect on the first batch, never wait for a second one.
   if (transportHint == 'classic' && seenRssi == 0) return true;
+  // #2907 — RECOVERY: the pinned MAC was just seen, so attempt it eagerly.
+  // No baseline ⇒ any first sighting connects; with a baseline the RSSI bar
+  // is the widened recovery window (a far-but-reachable link on the first
+  // sighting), and a second consecutive sighting overrides even that.
+  if (recovery) {
+    if (lastSuccessfulRssi == null) return true;
+    return seenRssi >= lastSuccessfulRssi - recoveryRelativeDropDbm ||
+        consecutiveBatchesSeen >= 2;
+  }
   final seenEnoughTimes = consecutiveBatchesSeen >= requiredConsecutiveBatches;
   if (lastSuccessfulRssi == null) return seenEnoughTimes;
   final strongEnough = seenRssi >= lastSuccessfulRssi - relativeDropDbm;

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -587,6 +587,13 @@ class TripRecordingController {
     final old = _service;
     if (identical(old, service)) return;
     _service = service;
+    // #2907 — the reconnected link is healthy: clear the drop detector's
+    // error window (incl. any dead-transport short-circuits the [_runTransport]
+    // gate logged against the OLD service) so the first poll on the new live
+    // transport starts clean instead of re-tripping a drop. The scanner resume
+    // path also resets it, but doing it AT the swap makes recovery robust to
+    // swap-vs-resume call ordering.
+    _dropDetector.reset();
     // Tear down the abandoned link off the hot path. `disconnect()` is
     // idempotent and never throws for the typed-closed states, but guard
     // anyway — the old transport is already dead, so any error here is
@@ -1030,7 +1037,7 @@ class TripRecordingController {
   /// scheduler the moment we cross the threshold.
   Future<String> _runTransport(String command) async {
     try {
-      final response = await _service.sendCommand(command);
+      final response = await _sendOrShortCircuit(command);
       // A clean read is the only signal strong enough to clear the
       // error window; ELM327 NO DATA responses come back via the
       // response string, not an exception.
@@ -1045,7 +1052,7 @@ class TripRecordingController {
       // a real drop signal.
       await Future<void>.delayed(_transportRetryDelay);
       try {
-        final response = await _service.sendCommand(command);
+        final response = await _sendOrShortCircuit(command);
         _dropDetector.registerSuccess();
         return response;
       } catch (e, st) { // ignore: unused_catch_stack
@@ -1053,6 +1060,24 @@ class TripRecordingController {
         rethrow;
       }
     }
+  }
+
+  /// #2907 — never write into a DEAD transport. A drop disconnects the service
+  /// (`isConnected == false`); the reconnect [replaceService]-swaps a fresh
+  /// one. If a poll dereferences a service that is no longer connected — the
+  /// orphaned-reconnect window, or a swap that hasn't landed — fail FAST with
+  /// a recoverable typed disconnect instead of writing into a closed socket
+  /// and waiting out the full per-command read timeout. Throwing here routes
+  /// through [_runTransport]'s existing retry → [_registerTransportError]
+  /// path unchanged, so the drop threshold + timing behaviour is identical to
+  /// a real dead-link `sendCommand` throw — it just never spins the radio.
+  Future<String> _sendOrShortCircuit(String command) {
+    if (!_service.isConnected) {
+      throw const Obd2DisconnectedException(
+        'TripRecordingController: transport not connected — link is recovering',
+      );
+    }
+    return _service.sendCommand(command);
   }
 
   /// #1904 — pause before the single transport retry, giving the

--- a/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_disconnect_test.dart
+++ b/test/features/consumption/data/obd2/flutter_blue_plus_elm_channel_disconnect_test.dart
@@ -204,6 +204,55 @@ void main() {
     });
   });
 
+  group('FlutterBluePlusElmChannel — full session teardown on drop (#2907)',
+      () {
+    test(
+        'a write-time drop tears down the FULL session (notify char + both '
+        'subscriptions), not just _open/_writeChar', () async {
+      final ch = _channelThatFailsWith(FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        6,
+        'device is not connected',
+      ));
+      // The prime seam wires _writeChar + _notifyChar + both subscriptions —
+      // the full state a live session holds.
+      expect(ch.debugResidualSessionState, isTrue,
+          reason: 'a primed session holds notify-char + subscription state');
+
+      await expectLater(
+          ch.write([0x01]), throwsA(isA<Obd2DisconnectedException>()));
+
+      expect(ch.isOpen, isFalse);
+      expect(ch.debugResidualSessionState, isFalse,
+          reason: '#2907 — a confirmed drop must clear `_notifyChar` and '
+              'cancel both subscriptions too. Before #2907 the handler cleared '
+              'only `_open`/`_writeChar`, leaving stale notify/conn-state '
+              'subscriptions a reconnect would double-wire on the next open()');
+    });
+
+    test(
+        'a GENUINE non-disconnect write fault does NOT tear the session down',
+        () async {
+      // Regression-lock: only a confirmed disconnect clears the session. A
+      // clone rejecting the write mode must leave the live session intact.
+      final ch = _channelThatFailsWith(FlutterBluePlusException(
+        ErrorPlatform.android,
+        'writeCharacteristic',
+        1,
+        'characteristic does not support write without response',
+      ));
+
+      await expectLater(
+        ch.write([0x01]),
+        throwsA(isA<FlutterBluePlusException>()),
+      );
+      expect(ch.isOpen, isTrue);
+      expect(ch.debugResidualSessionState, isTrue,
+          reason: 'a non-disconnect fault keeps the session fully wired');
+    });
+  });
+
   group('the reclassified disconnect de-noises through recordObd2ReadFailure',
       () {
     test(

--- a/test/features/consumption/data/obd2/reconnect_connector_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_connector_test.dart
@@ -104,14 +104,18 @@ void main() {
       await connected!.disconnect();
     });
 
-    test('refreshes lastCandidate to the strongest-seen advertisement',
+    test('records the first-batch sighting RSSI on a recovery connect (#2907)',
         () async {
+      // #2907 — the connector is the in-trip RECOVERY path: the MAC is pinned
+      // (no wrong-device risk), so the relaxed gate attempts the FIRST sighting
+      // rather than waiting for a stronger second batch. The strong second
+      // sighting is therefore never reached — recovery connects on −85.
       final fake = _FakeFacade(
         directChannel: _FakeChannel(openError: StateError('GATT 133')),
         channel: _FakeChannel(respondTo: _elmOk()),
         batches: [
-          [_cand('aa:bb', -85)], // weak first
-          [_cand('aa:bb', -50)], // much stronger — becomes lastCandidate
+          [_cand('aa:bb', -85)], // first sighting — recovery connects here
+          [_cand('aa:bb', -50)], // never reached
         ],
       );
       Obd2Service? connected;
@@ -123,21 +127,23 @@ void main() {
       await connector.attempt('aa:bb');
 
       expect(connector.lastCandidate, isNotNull);
-      expect(connector.lastCandidate!.candidate.rssi, -50,
-          reason: 'lastCandidate tracks the strongest sighting');
-      // No baseline existed this drop, so the strong 2nd sighting connects
-      // via the two-consecutive-batches rule and records its RSSI.
-      expect(connector.lastSuccessfulRssi, -50);
+      expect(connector.lastCandidate!.candidate.rssi, -85,
+          reason: 'recovery connects on the first sighting of the pinned MAC');
+      expect(connector.lastSuccessfulRssi, -85);
       await connected?.disconnect();
     });
 
-    test('skips a lone weak sighting (gate not satisfied) and returns false',
-        () async {
+    test('attempts even a lone WEAK sighting of the pinned MAC in recovery '
+        '(#2907 relaxation)', () async {
+      // Pre-#2907 a lone −90 sighting with no baseline was skipped (the strict
+      // initial-pick gate). The connector is the recovery path now, so it
+      // attempts the marginal sighting rather than spinning the backoff for
+      // another window — exactly the "once lost it can't re-establish" fix.
       final fake = _FakeFacade(
         directChannel: _FakeChannel(openError: StateError('GATT 133')),
         channel: _FakeChannel(respondTo: _elmOk()),
         batches: [
-          [_cand('aa:bb', -90)], // weak, seen exactly once → never connects
+          [_cand('aa:bb', -90)], // weak, seen once → recovery STILL attempts
         ],
       );
       Obd2Service? connected;
@@ -148,9 +154,11 @@ void main() {
 
       final ok = await connector.attempt('aa:bb');
 
-      expect(ok, isFalse,
-          reason: 'no baseline + seen once + weak ⇒ gate skips, no connect');
-      expect(connected, isNull);
+      expect(ok, isTrue,
+          reason: '#2907 — a marginal single sighting of the PINNED adapter is '
+              'worth a recovery connect attempt');
+      expect(connected, isNotNull);
+      await connected?.disconnect();
     });
   });
 

--- a/test/features/consumption/data/obd2/reconnect_rssi_gate_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_rssi_gate_test.dart
@@ -141,6 +141,84 @@ void main() {
       );
     });
 
+    group('RECOVERY relaxation (#2907)', () {
+      test('a marginal single-batch sighting connects in recovery but NOT '
+          'in the default gate', () {
+        // Baseline −60, seen −90 ⇒ a 30 dBm drop, seen exactly once. The
+        // default gate skips it (beyond 15 dBm AND not seen twice); the
+        // recovery gate attempts it (within the widened 35 dBm tolerance).
+        expect(
+          shouldConnectFromScan(
+            lastSuccessfulRssi: -60,
+            seenRssi: -90,
+            consecutiveBatchesSeen: 1,
+          ),
+          isFalse,
+          reason: 'the default initial-pick gate skips a far, single sighting',
+        );
+        expect(
+          shouldConnectFromScan(
+            lastSuccessfulRssi: -60,
+            seenRssi: -90,
+            consecutiveBatchesSeen: 1,
+            recovery: true,
+          ),
+          isTrue,
+          reason: 'recovery widens the tolerance to 35 dBm — the pinned '
+              'adapter is worth a marginal reconnect attempt',
+        );
+      });
+
+      test('with no baseline, ANY single sighting connects in recovery', () {
+        // The first reconnect of the session has no relative baseline. The
+        // default gate needs two consecutive batches; recovery attempts the
+        // pinned MAC on the first sighting (no wrong-device risk).
+        expect(
+          shouldConnectFromScan(
+            lastSuccessfulRssi: null,
+            seenRssi: -88,
+            consecutiveBatchesSeen: 1,
+          ),
+          isFalse,
+        );
+        expect(
+          shouldConnectFromScan(
+            lastSuccessfulRssi: null,
+            seenRssi: -88,
+            consecutiveBatchesSeen: 1,
+            recovery: true,
+          ),
+          isTrue,
+          reason: 'a pinned-MAC recovery scan attempts any first sighting',
+        );
+      });
+
+      test('recovery still rejects a sighting weaker than the widened '
+          'tolerance when seen only once', () {
+        // Baseline −50, seen −95 ⇒ a 45 dBm drop, beyond even the 35 dBm
+        // recovery window, and seen exactly once ⇒ still skipped.
+        expect(
+          shouldConnectFromScan(
+            lastSuccessfulRssi: -50,
+            seenRssi: -95,
+            consecutiveBatchesSeen: 1,
+            recovery: true,
+          ),
+          isFalse,
+        );
+        // …but a second consecutive sighting of even that weak link connects.
+        expect(
+          shouldConnectFromScan(
+            lastSuccessfulRssi: -50,
+            seenRssi: -95,
+            consecutiveBatchesSeen: 2,
+            recovery: true,
+          ),
+          isTrue,
+        );
+      });
+    });
+
     test('honours custom thresholds', () {
       // Tighten the window to 5 dBm: a 10 dBm drop now fails the
       // relative gate and, seen once, is skipped.

--- a/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_controller_reconnect_test.dart
@@ -10,12 +10,18 @@ import 'package:hive/hive.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
 import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_reconnect_scanner.dart';
 import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
 import 'package:tankstellen/features/consumption/data/obd2/paused_trip_repository.dart';
+import 'package:tankstellen/features/consumption/data/obd2/reconnect_connector.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
 import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
 
@@ -738,7 +744,217 @@ void main() {
         AutoRecordTraceLog.clear();
       });
     });
+
+    // ── #2907 — reconnect RECOVERY: never poll a dead transport; the swap
+    //    must reach the controller through the REAL connector chain ──────────
+    group('reconnect recovery — dead-transport gate + real-chain swap (#2907)',
+        () {
+      test(
+          '_runTransport short-circuits a DEAD service instead of writing into '
+          'the closed socket', () async {
+        // A transport that answers init (so start() completes) but whose
+        // isConnected flips false after a drop — modelling a channel-level
+        // drop the controller has not yet swapped away from.
+        final transport = _DroppableTransport(initResponses());
+        await transport.connect();
+        final ctl = TripRecordingController(
+          service: Obd2Service(transport),
+          pollInterval: const Duration(minutes: 1),
+          vehicleId: 'car-2907-gate',
+          pausedRepo: pausedRepo,
+          historyRepo: historyRepo,
+        );
+        await ctl.start();
+        final callsBefore = transport.commandCount;
+
+        // Simulate a channel-level drop: the link is dead but the controller
+        // still points at this service.
+        transport.simulateDrop();
+
+        // The poll must NOT reach the dead transport — it short-circuits with
+        // the recoverable typed disconnect (RED before #2907: the old code
+        // dereferenced sendCommand on the dead transport, timing out).
+        await expectLater(
+          ctl.debugRunTransport('010D\r'),
+          throwsA(isA<Obd2DisconnectedException>()),
+          reason: '#2907 — a dead transport must be short-circuited, not '
+              'polled, so the loop never spins on a closed socket',
+        );
+        expect(transport.commandCount, callsBefore,
+            reason: 'the gate must NOT dispatch into the dead transport');
+
+        await ctl.stop();
+      });
+
+      test(
+          'drop → reconnect via the REAL ReconnectConnector swaps the service '
+          'and polling RESUMES on the LIVE transport (not the dead one)',
+          () async {
+        // The OLD link: answers init/odometer/VIN (start completes) then dies.
+        final deadTransport = _DroppableTransport(initResponses());
+        await deadTransport.connect();
+
+        // The NEW live link the reconnect builds — only IT answers the speed
+        // PID, so a 50 km/h reading proves the loop polls the LIVE transport.
+        final liveTransport = _LiveTransport({
+          ...initResponses(),
+          '010D': '41 0D 32>', // 50 km/h
+          '010C': '41 0C 0E A6>', // ~937 rpm
+        });
+        await liveTransport.connect();
+
+        // A fake connection whose direct connect hands back the live service —
+        // exactly what ReconnectConnector.onConnected forwards to the
+        // controller's replaceService in production.
+        final connection =
+            _ReconnectingFakeConnection(liveService: Obd2Service(liveTransport));
+
+        late TripRecordingController ctl;
+        ctl = TripRecordingController(
+          service: Obd2Service(deadTransport),
+          pollInterval: const Duration(milliseconds: 30),
+          schedulerTickRate: const Duration(milliseconds: 10),
+          vehicleId: 'car-2907-chain',
+          pausedRepo: pausedRepo,
+          historyRepo: historyRepo,
+          // Default 6 s silent window — the reconnect lands silently inside it.
+          pinnedAdapterMac: 'AA:BB',
+          // The REAL production wiring: a ReconnectConnector whose onConnected
+          // calls ctl.replaceService, driven by a real AdapterReconnectScanner.
+          reconnectScannerFactory: (mac, onReconnect) {
+            final connector = ReconnectConnector(
+              connection: connection,
+              onConnected: ctl.replaceService,
+            );
+            return AdapterReconnectScanner(
+              pinnedMac: mac,
+              probe: (_) async => true,
+              connect: connector.attempt,
+              onReconnect: onReconnect,
+              firstProbeDelay: const Duration(milliseconds: 10),
+              initialBackoff: const Duration(milliseconds: 20),
+            );
+          },
+        );
+
+        await ctl.start();
+        // Drop the OLD link → the controller disconnects it (handleDrop) and
+        // the scanner starts probing.
+        deadTransport.simulateDrop();
+        ctl.debugTriggerDrop();
+
+        // Let the real scanner fire: probe→connect→onConnected(replaceService)
+        // →onReconnect→resume. This is the full production chain, in order.
+        final readings = <TripLiveReading>[];
+        final sub = ctl.live.listen(readings.add);
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+
+        expect(ctl.currentState, TripRecordingControllerState.recording,
+            reason: 'the silent reconnect must restore the recording state');
+        expect(connection.directConnectCount, greaterThanOrEqualTo(1),
+            reason: 'the real connector must have run a direct reconnect');
+        expect(liveTransport.pidPollCount, greaterThan(0),
+            reason: '#2907 — after the swap the scheduler must poll the LIVE '
+                'transport, not the orphaned dead one');
+        expect(readings.any((r) => r.speedKmh == 50), isTrue,
+            reason: '#2907 — the 50 km/h sample exists ONLY on the live '
+                'transport: its presence proves polling resumed on the '
+                'reconnected link (RED before — the loop polled the dead one)');
+
+        await sub.cancel();
+        await ctl.stop();
+      });
+    });
   });
+}
+
+/// A transport that answers scripted commands until [simulateDrop] flips it
+/// to a dead, NOT-connected state (the channel-level drop the controller has
+/// not yet swapped away from). Counts dispatched commands so a test can prove
+/// the #2907 dead-transport gate never reaches it after a drop.
+class _DroppableTransport implements Obd2Transport {
+  _DroppableTransport(this._responses);
+
+  final Map<String, String> _responses;
+  bool _connected = false;
+  int commandCount = 0;
+
+  void simulateDrop() => _connected = false;
+
+  @override
+  Future<void> connect() async => _connected = true;
+
+  @override
+  bool get isConnected => _connected;
+
+  @override
+  Future<String> sendCommand(String command) async {
+    commandCount++;
+    if (!_connected) throw StateError('Not connected');
+    return _responses[command.trim()] ?? 'NO DATA>';
+  }
+
+  @override
+  Future<void> disconnect() async => _connected = false;
+}
+
+/// A fake [Obd2ConnectionService] whose direct-by-MAC reconnect hands back a
+/// pre-built LIVE service — standing in for the real connect dance so the
+/// reconnect chain (connector → onConnected → replaceService → resume) runs
+/// end-to-end without a Bluetooth stack (#2907).
+class _ReconnectingFakeConnection extends Obd2ConnectionService {
+  _ReconnectingFakeConnection({required this.liveService})
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _AlwaysGrant(),
+          bluetooth: _UnusedFacade(),
+        );
+
+  final Obd2Service liveService;
+  int directConnectCount = 0;
+
+  @override
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration timeout = const Duration(seconds: 4),
+    bool fallbackToScan = true,
+  }) async {
+    directConnectCount++;
+    return liveService;
+  }
+}
+
+class _AlwaysGrant implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+/// The BLE facade is never touched in the #2907 chain test — the fake
+/// connection short-circuits the direct connect — so every member throws to
+/// fail loudly if the path is ever taken.
+class _UnusedFacade implements BluetoothFacade {
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) =>
+      throw UnimplementedError();
+  @override
+  Future<void> stopScan() async {}
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      throw UnimplementedError();
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) =>
+      throw UnimplementedError();
 }
 
 /// Captures every `errorLogger.log` call routed through the foreground

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -258,7 +258,15 @@ void main() {
     // the tiny-distance L/100 km floor against the swapped odometer
     // distance (the code change itself is net-zero). Decomposition stays
     // tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1641,
+    // #2907 — re-grandfathered 1641 → 1666: the reconnect-RECOVERY core fix.
+    // `_runTransport` now routes every poll through `_sendOrShortCircuit`,
+    // which fails FAST with a recoverable typed disconnect when the service is
+    // no longer connected (never poll a DEAD transport / never orphan a
+    // just-reconnected one), and `replaceService` resets the drop detector at
+    // the swap so the new live link starts from a clean streak. Both are
+    // load-bearing recovery logic in the hot polling path that cannot move out
+    // of the controller. Decomposition stays tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1666,
     // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR
     // with a contrast-stretched GRAYSCALE pass when the #2275 binarized pass
     // recovers nothing (the binarization erased faint 7-seg value digits). The


### PR DESCRIPTION
Part of Epic #2904. The core "once lost it can't re-establish" fix: a dropped OBD2 link now reliably re-establishes AND the recording loop uses the reconnected transport instead of orphaning it on the dead one.

## Root causes fixed
- **Orphaned successful reconnect / dead-transport polling** — `_runTransport` routes every poll through a new `_sendOrShortCircuit`, which fails fast with a recoverable typed `Obd2DisconnectedException` when `_service.isConnected` is false (a drop disconnects the service; the reconnect `replaceService`-swaps a fresh one). Before, a poll that dereferenced a service whose swap hadn't landed wrote into the closed socket and timed out every read for the rest of the drive. `replaceService` also resets the drop detector **at the swap**, so the new live link starts from a clean streak regardless of swap-vs-resume call ordering.
- **BLE channel state not fully cleared on drop** — the notify-error + write-fail drop handlers now call `_clearSessionOnDrop`, which nulls `_notifyChar` (not just `_open`/`_writeChar`) and cancels the notify + connection-state subscriptions, so a reconnect's `open()` starts clean instead of layering a second listener on stale subscription state.
- **Stale `_lastDirectChannel` GATT client across the scan-fallback reconnect** — the scan-path `connect()` now tears it down first, dodging the Android GATT_ERROR 133 repeat-133 trap a prior by-MAC attempt left armed (the direct/passive paths already self-cleaned).
- **RSSI/2-batch gate blocked recovery** — `shouldConnectFromScan` gains a `recovery` flag (the in-trip `ReconnectConnector` always passes it) that attempts a marginal single-batch sighting of the **pinned** adapter — no wrong-device risk during reconnect — instead of spinning the backoff for another window.

The persistent active-scan re-arm past the backoff ceiling already shipped in #2767 and is left in place. Telemetry (#2911 `noteReconnectAttempt` / `noteSessionTransition`) is unchanged — the reconnect path already records it.

## Tests (RED on master, green after)
- **Integration**: drop → reconnect via the REAL `ReconnectConnector` chain (`onConnected` → `replaceService`) → service swaps → polling RESUMES on the LIVE transport (the 50 km/h sample exists only there). Plus a unit gate test proving a dead service is short-circuited (typed disconnect), never polled — RED-before: the old loop threw a raw `StateError` from the dead transport's `sendCommand`.
- **BLE channel**: a confirmed drop tears the FULL session down (notify char + both subscriptions) — RED-before with the pre-#2907 partial teardown; a genuine non-disconnect fault does not.
- **Recovery RSSI gate**: a marginal single sighting connects in recovery but not under the strict initial-pick gate; the two existing connector tests updated to the relaxed recovery semantics.

## Notes
- `BleLinkTuner` extracted from `FlutterBluePlusElmChannel` (move-only, behaviour preserved) so the channel stays under the 400-line cap after the teardown helper landed.
- `trip_recording_controller.dart` re-grandfathered 1641 → 1666 with justification (load-bearing recovery logic in the hot polling path that can't move out of the controller).
- `flutter analyze` clean (no new issues), full obd2 + providers + lint suites green, clean codegen drift = 0.

Closes #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
