### PR TITLE
fix(obd2): connect resilience remainder + Classic<->BLE transport fallback (#2906, #2908)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt
@@ -50,6 +50,15 @@ object Obd2ClassicPlugin {
     private const val METHOD_CHANNEL = "tankstellen.obd2/classic"
     private const val INCOMING_CHANNEL = "tankstellen.obd2/classic/incoming"
 
+    /** #2906 — bounded RFCOMM connect attempts before falling back to the
+     *  insecure / reflection channel-1 socket. Real ELM327 clones routinely
+     *  reject the FIRST `connect()` (the adapter is still waking the SPP
+     *  service) with `IOException: read failed, socket might closed ... -1`,
+     *  but answer the 2nd or 3rd try. ~3 attempts with a short backoff between
+     *  each mirrors the Dart-side #2909 `channel.open()` retry shape. */
+    private const val MAX_RFCOMM_ATTEMPTS = 3
+    private const val RFCOMM_RETRY_BASE_MS = 150L
+
     private var socket: BluetoothSocket? = null
     private var readerThread: Thread? = null
     private val readerRunning = AtomicBoolean(false)
@@ -126,20 +135,91 @@ object Obd2ClassicPlugin {
             Log.e(TAG, "connect: bad address $address", e)
             return false
         }
+        // cancelDiscovery() is required before EVERY connect() — a live
+        // discovery slows the RFCOMM handshake to a crawl (and can fail it).
+        @Suppress("MissingPermission")
+        adapter.cancelDiscovery()
+
+        val serviceUuid = UUID.fromString(uuid)
+        // 1) Bounded retry on the standard secure SPP socket. This runs on the
+        //    background "obd2-classic-connect" thread, so the Thread.sleep
+        //    backoff between attempts never blocks the Flutter main thread.
+        for (attempt in 1..MAX_RFCOMM_ATTEMPTS) {
+            @Suppress("MissingPermission")
+            val s = try {
+                device.createRfcommSocketToServiceRecord(serviceUuid)
+            } catch (e: IOException) {
+                Log.e(TAG, "connect: createRfcommSocket failed (attempt $attempt)", e)
+                null
+            }
+            if (s != null && tryConnectSocket(s, attempt)) return true
+            if (attempt < MAX_RFCOMM_ATTEMPTS) {
+                try {
+                    Thread.sleep(RFCOMM_RETRY_BASE_MS * attempt)
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return false
+                }
+            }
+        }
+        // 2) Documented clone fallback: the INSECURE SPP socket. Many ELM327
+        //    clones never complete the secure (authenticated/encrypted) RFCOMM
+        //    handshake but connect fine over the insecure variant.
+        @Suppress("MissingPermission")
+        val insecure = try {
+            device.createInsecureRfcommSocketToServiceRecord(serviceUuid)
+        } catch (e: IOException) {
+            Log.e(TAG, "connect: createInsecureRfcommSocket failed", e)
+            null
+        }
+        if (insecure != null && tryConnectSocket(insecure, MAX_RFCOMM_ATTEMPTS + 1)) {
+            return true
+        }
+        // 3) Last-resort reflection on the hidden channel-1 RFCOMM socket —
+        //    the long-standing workaround for clones whose SDP record is
+        //    missing/garbage so the UUID lookup resolves to no channel.
+        val reflected = reflectChannelOneSocket(device)
+        if (reflected != null && tryConnectSocket(reflected, MAX_RFCOMM_ATTEMPTS + 2)) {
+            return true
+        }
+        Log.e(TAG, "connect: all RFCOMM strategies exhausted for $address")
+        return false
+    }
+
+    /** Attempt to connect [s], adopt it as the live socket + start the reader
+     *  on success, or close it on failure. Returns true on a connected socket. */
+    private fun tryConnectSocket(s: BluetoothSocket, attempt: Int): Boolean {
         return try {
-            @Suppress("MissingPermission")
-            val s = device.createRfcommSocketToServiceRecord(UUID.fromString(uuid))
-            @Suppress("MissingPermission")
-            adapter.cancelDiscovery() // required before connect()
             s.connect()
             socket = s
             startReader()
             true
         } catch (e: IOException) {
-            Log.e(TAG, "connect: RFCOMM open failed", e)
-            try { socket?.close() } catch (_: IOException) {}
-            socket = null
+            Log.w(TAG, "connect: RFCOMM open failed (attempt $attempt)", e)
+            try { s.close() } catch (_: IOException) {}
+            if (socket === s) socket = null
             false
+        }
+    }
+
+    /** Reflectively open a channel-1 RFCOMM socket (#2906 clone fallback). Some
+     *  ELM327 clones expose no usable SDP service record, so the UUID-based
+     *  socket never resolves a channel; the hidden `createRfcommSocket(int)`
+     *  on channel 1 is the documented community workaround. Returns null when
+     *  the reflection is unavailable (future Android hides it) — the caller
+     *  then surfaces a clean connect failure. */
+    @Suppress("MissingPermission")
+    private fun reflectChannelOneSocket(
+        device: android.bluetooth.BluetoothDevice,
+    ): BluetoothSocket? {
+        return try {
+            val m = device.javaClass.getMethod(
+                "createRfcommSocket", Int::class.javaPrimitiveType,
+            )
+            m.invoke(device, 1) as? BluetoothSocket
+        } catch (e: Exception) {
+            Log.w(TAG, "connect: channel-1 reflection unavailable", e)
+            null
         }
     }
 

--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -174,6 +174,13 @@ Future<Obd2Service?> _connectByMacPassive(
 /// plugin quirk) is logged as a recoverable OBD2/BLE transient and never
 /// aborts the connect.
 Future<void> _stopScanBeforeConnect(Obd2ConnectionService svc) async {
+  // #2906 — capture whether a BLE scan is ACTUALLY in flight before we stop
+  // it. The settle pause below is only needed to let the radio quiesce after a
+  // real scan winds down (the in-trip-reconnect GATT_ERROR 133 race). With no
+  // active scan — a cold direct connect, the recording pre-warm, or a widget
+  // test driving the prod connection graph — the pause buys nothing and would
+  // leave a pending timer past widget disposal (the #2918 prewarm leak).
+  final wasScanning = FlutterBluePlus.isScanningNow;
   try {
     await svc.bluetooth.stopScan();
   } catch (e, st) {
@@ -189,7 +196,7 @@ Future<void> _stopScanBeforeConnect(Obd2ConnectionService svc) async {
       'where': 'Obd2ConnectionService: stopScan (classic) before connect',
     }));
   }
-  if (svc.scanSettleDelay > Duration.zero) {
+  if (wasScanning && svc.scanSettleDelay > Duration.zero) {
     await Future<void>.delayed(svc.scanSettleDelay);
   }
 }

--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -42,6 +42,11 @@ Future<Obd2Service?> _connectByMacDirect(
   Duration timeout = const Duration(seconds: 4),
   bool fallbackToScan = true,
 }) async {
+  // #2906 — stop any active scan + settle before the direct GATT open. An
+  // in-trip reconnect can reach here while the scanner's last active scan is
+  // still winding down on the radio; an unstopped scan racing this connect()
+  // is the Android GATT_ERROR 133 trap.
+  await svc.stopScanBeforeConnect();
   // Tear down a prior direct channel BEFORE reopening (dead-GATT
   // teardown). LOAD-BEARING on Android — a still-open GATT client for
   // the same device yields GATT_ERROR 133 on the next connect.
@@ -93,6 +98,8 @@ Future<Obd2Service?> _connectByMacClassicDirect(
 ) async {
   final classic = svc.classicBluetooth;
   if (classic == null) return null;
+  // #2906 — stop scan + settle before the RFCOMM open (mirrors the BLE path).
+  await svc.stopScanBeforeConnect();
   await svc._teardownLastDirectChannel();
 
   // No scan ⇒ no resolved profile. Pick the best-fit Classic profile so
@@ -129,6 +136,8 @@ Future<Obd2Service?> _connectByMacPassive(
   Obd2ConnectionService svc,
   String mac,
 ) async {
+  // #2906 — stop scan + settle before the passive autoConnect GATT open.
+  await svc.stopScanBeforeConnect();
   await svc._teardownLastDirectChannel();
   final generic = _genericBleProfile(svc);
   final channel = svc.bluetooth.channelForDirect(mac, autoConnect: true);
@@ -151,6 +160,37 @@ Future<Obd2Service?> _connectByMacPassive(
         layer: ErrorLayer.other);
     await svc._teardownLastDirectChannel();
     return null;
+  }
+}
+
+/// Body of [Obd2ConnectionService.stopScanBeforeConnect] (#2906). Stops the
+/// active BLE + Classic scan, then pauses [Obd2ConnectionService.scanSettleDelay]
+/// so the radio quiesces before a `channel.open()`. Android returns
+/// GATT_ERROR 133 when a `connect()` races a scan still winding down on the
+/// controller; the in-trip scan-fallback `connect` is the worst offender (it
+/// reaches the open straight out of an `await for` scan loop whose
+/// subscription — and so `stopScan()` — cancels only asynchronously).
+/// Idempotent + best-effort: a `stopScan()` that throws (no scan in flight,
+/// plugin quirk) is logged as a recoverable OBD2/BLE transient and never
+/// aborts the connect.
+Future<void> _stopScanBeforeConnect(Obd2ConnectionService svc) async {
+  try {
+    await svc.bluetooth.stopScan();
+  } catch (e, st) {
+    // #2379 — OBD2/BLE radio, not local storage. Best-effort; never fatal.
+    unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+      'where': 'Obd2ConnectionService: stopScan (BLE) before connect',
+    }));
+  }
+  try {
+    await svc.classicBluetooth?.stopScan();
+  } catch (e, st) {
+    unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+      'where': 'Obd2ConnectionService: stopScan (classic) before connect',
+    }));
+  }
+  if (svc.scanSettleDelay > Duration.zero) {
+    await Future<void>.delayed(svc.scanSettleDelay);
   }
 }
 

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -93,6 +93,15 @@ class Obd2ConnectionService {
   /// can change between trips. Null ⇒ adapterMac-only keying.
   final Obd2VehicleKeyFields Function()? activeVehicleKeyFields;
 
+  /// #2906 — settle pause after [_stopScanBeforeConnect] stops the radio and
+  /// before a `channel.open()` fires. Android BLE is fragile if a `connect()`
+  /// races an active scan still winding down on the radio — a stale scan can
+  /// hold the controller long enough that the connect returns GATT_ERROR 133.
+  /// A short settle lets `stopScan()` actually quiesce the radio. Injectable
+  /// so tests run it as [Duration.zero] (no real wait); production keeps the
+  /// observed-safe ~120 ms.
+  final Duration scanSettleDelay;
+
   Obd2ConnectionService({
     required this.registry,
     required this.permissions,
@@ -102,6 +111,7 @@ class Obd2ConnectionService {
     this.negotiatedProtocolCache,
     this.adapterWakeCache,
     this.activeVehicleKeyFields,
+    this.scanSettleDelay = const Duration(milliseconds: 120),
   });
 
   /// Stream of ranked, profile-matched candidates for the picker UI.
@@ -157,6 +167,14 @@ class Obd2ConnectionService {
   /// [Obd2AdapterUnresponsive] when init fails (channel is closed
   /// before the error is rethrown).
   Future<Obd2Service> connect(ResolvedObd2Candidate candidate) async {
+    // #2906 — stop any active scan (BLE + Classic) and let the radio settle
+    // BEFORE the channel opens. Android BLE returns GATT_ERROR 133 when a
+    // `connect()` races a scan still winding down on the controller; the
+    // scan-fallback `connect` is the worst offender (it reaches here straight
+    // out of the `await for` scan loop, whose subscription cancels — and so
+    // calls `stopScan()` — only asynchronously). Stopping + settling here
+    // closes that race for every connect path that funnels through `connect`.
+    await stopScanBeforeConnect();
     // #2907 — tear down any stale direct/passive channel from a PRIOR
     // by-MAC connect before the scan path opens a fresh one. The
     // [connectByMacDirect]/[connectByMacPassive] paths already self-clean,
@@ -307,6 +325,13 @@ class Obd2ConnectionService {
   /// [_connectByMacPassive]. Thin overridable instance method.
   Future<Obd2Service?> connectByMacPassive(String mac) =>
       _connectByMacPassive(this, mac);
+
+  /// #2906 — stop the active BLE + Classic scan and pause [scanSettleDelay]
+  /// so the radio quiesces before a `channel.open()` connect. Idempotent +
+  /// best-effort. Body lives in `obd2_connect_by_mac` (a `part`) so this file
+  /// stays under the #1680 cap; the thin instance method keeps it reachable
+  /// from [connect] here and from the by-MAC direct/passive paths there.
+  Future<void> stopScanBeforeConnect() => _stopScanBeforeConnect(this);
 
   Future<void> _teardownLastDirectChannel() async {
     final prior = _lastDirectChannel;

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:async/async.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'adapter_registry.dart';

--- a/lib/features/consumption/data/obd2/reconnect_connector.dart
+++ b/lib/features/consumption/data/obd2/reconnect_connector.dart
@@ -10,6 +10,7 @@ import 'obd2_read_telemetry.dart';
 import 'obd2_reconnect_telemetry.dart';
 import 'obd2_service.dart';
 import 'reconnect_rssi_gate.dart';
+import 'transport_fallback_policy.dart';
 
 /// Drives a single in-trip reconnect attempt for a pinned adapter MAC,
 /// DIRECT-CONNECT-FIRST with an RSSI-gated scan fallback (#2245).
@@ -58,12 +59,28 @@ class ReconnectConnector {
   int? _lastSuccessfulRssi;
   var _consecutiveBatchesSeen = 0;
 
+  /// #2908 — count of [attempt] cycles where the PREFERRED transport (direct +
+  /// scan) failed to establish a link this drop. The cross-transport fallback
+  /// only fires once this reaches [crossTransportThreshold], so a single
+  /// transient blip (which the direct / `channel.open()` retries already
+  /// absorb) doesn't thrash BOTH transports — only a sustained storm on the
+  /// preferred transport escalates to the alternate.
+  var _preferredFailures = 0;
+
+  /// #2908 — number of consecutive preferred-transport [attempt] failures
+  /// after which the alternate transport is tried. 1 ⇒ try the alternate as
+  /// soon as the first full direct+scan budget is exhausted; higher values
+  /// wait for a sustained storm. Default 2: don't escalate on the very first
+  /// miss, but don't let a wedged transport spin for long either.
+  final int crossTransportThreshold;
+
   ReconnectConnector({
     required this.connection,
     required this.onConnected,
     this.transportHint,
     this.attemptNumber,
     this.backoffMs,
+    this.crossTransportThreshold = 2,
   });
 
   /// #2905 — record one per-attempt reconnect-telemetry row (gated; a no-op
@@ -231,7 +248,89 @@ class ReconnectConnector {
       recordObd2ConnectTransient(e, st,
           where: 'ReconnectConnector scan fallback failed');
     }
+
+    // 3) CROSS-TRANSPORT FALLBACK (#2908). The preferred transport (the one
+    //    that just dropped) exhausted its direct + scan budget this cycle —
+    //    a BLE 133 storm or a Classic rfcomm-open-fail. Once that has happened
+    //    [crossTransportThreshold] times this drop, try the OTHER transport
+    //    for the same adapter (many ELM327 clones expose both a Classic SPP
+    //    and a BLE GATT endpoint) rather than spin the backoff on the SAME
+    //    doomed transport. Gated on the threshold so a single transient blip
+    //    — which the direct / `channel.open()` retries already absorb —
+    //    doesn't thrash BOTH transports. Best-effort: a clean failure just
+    //    returns false and the scanner keeps its schedule.
+    _preferredFailures++;
+    if (_preferredFailures >= crossTransportThreshold &&
+        await _attemptAlternateTransport(mac)) {
+      return true;
+    }
     return false;
+  }
+
+  /// #2908 — try the transport the live link was NOT using, once the
+  /// preferred transport exhausted its direct + scan budget this cycle.
+  /// Returns `true` once a session lands on the alternate transport (which is
+  /// then handed to [onConnected]); `false` when the alternate is unavailable
+  /// or also fails. The successful path is surfaced in the per-attempt
+  /// telemetry as `'fallback-ble'` / `'fallback-classic'` and a
+  /// [Obd2SessionState.reconnected] transition whose detail names the switch,
+  /// so the next capture shows WHICH transport recovered the link.
+  Future<bool> _attemptAlternateTransport(String mac) async {
+    final alternate = alternateReconnectTransport(
+      droppedTransport: transportHint,
+      hasClassicFacade: connection.classicBluetooth != null,
+    );
+    if (alternate == null) return false; // no usable alternate wired
+    final isClassic = alternate == BluetoothTransport.classic;
+    final path = isClassic ? 'fallback-classic' : 'fallback-ble';
+    final sw = Stopwatch()..start();
+    try {
+      // The dropped transport was Classic ⇒ try BLE direct; the dropped
+      // transport was BLE/unknown ⇒ try Classic direct.
+      final svc = isClassic
+          ? await connection.connectByMacClassicDirect(mac)
+          : await connection.connectByMacDirect(mac, fallbackToScan: false);
+      if (svc != null) {
+        _recordAttempt(
+            succeeded: true, path: path, latencyMs: sw.elapsedMilliseconds);
+        _noteTransportSwitch(alternate);
+        onConnected(svc);
+        return true;
+      }
+      _recordAttempt(
+        succeeded: false,
+        path: path,
+        reasonCode: Obd2ReconnectReason.deviceNotConnected.code,
+        latencyMs: sw.elapsedMilliseconds,
+      );
+    } catch (e, st) {
+      _recordAttempt(
+        succeeded: false,
+        path: path,
+        reasonCode: classifyReconnectReason(e),
+        latencyMs: sw.elapsedMilliseconds,
+      );
+      // #2892 — the alternate transport on a silent bus / parked car raises
+      // the EXPECTED user condition; breadcrumb it, don't ERROR-trace it.
+      recordObd2ConnectTransient(e, st,
+          where: 'ReconnectConnector alternate-transport fallback failed');
+    }
+    return false;
+  }
+
+  /// #2908 — record the connected→reconnected transition with a detail naming
+  /// the transport switch (e.g. `'classic→ble'`), so the #2905 export shows
+  /// which transport recovered the link. Gated; a no-op unless the collector
+  /// is armed.
+  void _noteTransportSwitch(BluetoothTransport landed) {
+    final diag = Obd2CommDiagnostics.instance;
+    if (!diag.enabled) return;
+    final from = transportHint ?? 'unknown';
+    final to = landed == BluetoothTransport.classic ? 'classic' : 'ble';
+    diag.noteSessionTransition(
+      Obd2SessionState.reconnected,
+      detail: 'transport-fallback:$from→$to',
+    );
   }
 
   /// Passive-wait connect cycle for [mac] (#2261 concern 2). Handed to

--- a/lib/features/consumption/data/obd2/transport_fallback_policy.dart
+++ b/lib/features/consumption/data/obd2/transport_fallback_policy.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'adapter_registry.dart';
+
+/// Pure decision for the Classic↔BLE transport fallback (#2908).
+///
+/// When the transport the live link was using ([droppedTransport], the
+/// `'ble'` / `'classic'` link-kind read off the dead service) exhausts its
+/// own reconnect budget — a BLE GATT-133 storm or a Classic rfcomm-open-fail
+/// across every direct + scan attempt — the in-trip reconnect should try the
+/// OTHER transport for the same adapter rather than spin the backoff on the
+/// transport that keeps failing. Many ELM327 clones expose BOTH a Classic SPP
+/// and a BLE GATT endpoint, so the alternate often connects when the
+/// preferred one is wedged.
+///
+/// Returns the transport to attempt next, or `null` when there is no usable
+/// alternate:
+///   * a Classic drop falls back to [BluetoothTransport.ble] (always
+///     available — the BLE facade is mandatory), and
+///   * a BLE / unknown drop falls back to [BluetoothTransport.classic] ONLY
+///     when a Classic facade is wired ([hasClassicFacade]); a BLE-only build
+///     (most test configs) has no alternate, so `null`.
+///
+/// [droppedTransport] is matched case-insensitively against the `'classic'`
+/// link-kind tag; anything else (including `null` / `'ble'`) is treated as a
+/// BLE-side drop, so an unknown live transport conservatively tries Classic.
+BluetoothTransport? alternateReconnectTransport({
+  required String? droppedTransport,
+  required bool hasClassicFacade,
+}) {
+  final wasClassic = droppedTransport?.toLowerCase() == 'classic';
+  if (wasClassic) {
+    // Classic kept failing ⇒ try BLE (the BLE facade is always present).
+    return BluetoothTransport.ble;
+  }
+  // BLE / unknown kept failing ⇒ try Classic, but only if it is wired.
+  return hasClassicFacade ? BluetoothTransport.classic : null;
+}

--- a/test/features/consumption/data/obd2/connect_resilience_test.dart
+++ b/test/features/consumption/data/obd2/connect_resilience_test.dart
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/reconnect_connector.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2906 stop-scan-before-connect ordering. A shared [_EventLog] records the
+/// ORDER of facade calls so the tests assert `stopScan` precedes every
+/// `channel.open()` — Android returns GATT_ERROR 133 when a `connect()` races
+/// an active scan still winding down on the radio.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('#2906 — stop-scan-before-connect ordering', () {
+    test('connect() stops the BLE + Classic scan BEFORE opening the channel',
+        () async {
+      final log = _EventLog();
+      final ble = _OrderedFacade(log, channel: _OrderedChannel(log, 'ble'));
+      final classic =
+          _OrderedClassicFacade(log, channel: _OrderedChannel(log, 'classic'));
+      final svc = _build(ble, classic: classic);
+
+      await svc.connect(_resolvedBle('aa:bb'));
+
+      // The radio must be stopped (both facades) before the channel opens.
+      expect(log.events, containsAllInOrder(['ble:stopScan', 'ble:open']),
+          reason: 'BLE scan must be stopped before the channel opens');
+      expect(log.events, containsAllInOrder(['classic:stopScan', 'ble:open']),
+          reason: 'the Classic scan must also be stopped before connecting');
+      expect(log.events.indexOf('ble:open'),
+          greaterThan(log.events.indexOf('ble:stopScan')));
+    });
+
+    test('the scan-fallback reconnect path stops the scan before connecting',
+        () async {
+      // The worst race: the connector breaks out of an `await for` scan loop
+      // and immediately connects. `connect()` must stop the (still winding
+      // down) scan before opening — the GATT-133 trap the issue describes.
+      final log = _EventLog();
+      final ble = _OrderedFacade(
+        log,
+        // Direct open throws ⇒ direct fails, forcing the scan fallback.
+        directChannel: _OrderedChannel(log, 'direct', openError: true),
+        channel: _OrderedChannel(log, 'scan'),
+        batches: [
+          [_cand('aa:bb', -50)],
+        ],
+      );
+      final connector = ReconnectConnector(
+        connection: _build(ble),
+        onConnected: (_) {},
+      );
+
+      await connector.attempt('aa:bb');
+
+      // The scan-path connect opened the 'scan' channel; a stopScan must
+      // precede it.
+      final openIdx = log.events.indexOf('scan:open');
+      expect(openIdx, greaterThanOrEqualTo(0),
+          reason: 'the scan-fallback connect must open its channel');
+      final lastStopBeforeOpen = log.events
+          .sublist(0, openIdx)
+          .lastIndexWhere((e) => e == 'ble:stopScan');
+      expect(lastStopBeforeOpen, greaterThanOrEqualTo(0),
+          reason: 'stopScan must run before the scan-fallback channel opens');
+    });
+  });
+}
+
+// --- helpers ---------------------------------------------------------------
+
+class _EventLog {
+  final List<String> events = [];
+  void add(String e) => events.add(e);
+}
+
+Obd2ConnectionService _build(
+  BluetoothFacade bt, {
+  ClassicBluetoothFacade? classic,
+}) =>
+    Obd2ConnectionService(
+      registry: Obd2AdapterRegistry.defaults(),
+      permissions: _GrantPermissions(),
+      bluetooth: bt,
+      classicBluetooth: classic,
+      // No real wait in tests — the production default is ~120 ms.
+      scanSettleDelay: Duration.zero,
+    );
+
+ResolvedObd2Candidate _resolvedBle(String mac) {
+  final registry = Obd2AdapterRegistry.defaults();
+  final cand = _cand(mac, -50);
+  return registry.rank([cand]).firstWhere(
+    (r) => r.candidate.deviceId == mac,
+    orElse: () => registry.rank([cand]).first,
+  );
+}
+
+Obd2AdapterCandidate _cand(String mac, int rssi) => Obd2AdapterCandidate(
+      deviceId: mac,
+      deviceName: 'vLinker FD',
+      // Advertise the generic FFF0 BLE service so the registry resolves a BLE
+      // profile for this candidate.
+      advertisedServiceUuids: const ['0000fff0-0000-1000-8000-00805f9b34fb'],
+      rssi: rssi,
+    );
+
+class _GrantPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+class _OrderedFacade implements BluetoothFacade {
+  final _EventLog log;
+  final List<List<Obd2AdapterCandidate>> batches;
+  final ElmByteChannel? channel;
+  final ElmByteChannel? directChannel;
+
+  _OrderedFacade(
+    this.log, {
+    this.batches = const [],
+    this.channel,
+    this.directChannel,
+  });
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    log.add('ble:scan');
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async => log.add('ble:stopScan');
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      channel ?? _OrderedChannel(log, 'ble');
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) =>
+      directChannel ?? channel ?? _OrderedChannel(log, 'ble-direct');
+}
+
+class _OrderedClassicFacade implements ClassicBluetoothFacade {
+  final _EventLog log;
+  final ElmByteChannel? channel;
+  final List<String> channelForCalls = [];
+
+  _OrderedClassicFacade(this.log, {this.channel});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    // No Classic scan batches are needed by these tests — the fallback path
+    // dials the bonded MAC directly via [channelFor].
+  }
+
+  @override
+  Future<void> stopScan() async => log.add('classic:stopScan');
+
+  @override
+  ElmByteChannel channelFor(String deviceId) {
+    channelForCalls.add(deviceId);
+    return channel ?? _OrderedChannel(log, 'classic');
+  }
+}
+
+/// A channel that logs `<tag>:open` on open + answers a clean ELM init so
+/// `_openAndInit` succeeds. [openError] forces the open to throw (a wedged
+/// transport) so the caller falls back.
+class _OrderedChannel implements ElmByteChannel {
+  final _EventLog log;
+  final String tag;
+  final bool openError;
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+
+  _OrderedChannel(this.log, this.tag, {this.openError = false});
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+
+  @override
+  Future<void> open() async {
+    log.add('$tag:open');
+    if (openError) throw StateError('GATT_ERROR 133 ($tag)');
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    final cmd = String.fromCharCodes(bytes).trim();
+    _ctrl.add((_elmOk()[cmd] ?? 'OK>').codeUnits);
+  }
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    if (!_ctrl.isClosed) await _ctrl.close();
+  }
+}
+
+Map<String, String> _elmOk() => {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+    };

--- a/test/features/consumption/data/obd2/connect_resilience_test.dart
+++ b/test/features/consumption/data/obd2/connect_resilience_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
@@ -72,6 +73,39 @@ void main() {
           .lastIndexWhere((e) => e == 'ble:stopScan');
       expect(lastStopBeforeOpen, greaterThanOrEqualTo(0),
           reason: 'stopScan must run before the scan-fallback channel opens');
+    });
+
+    test(
+        'no active BLE scan ⇒ the settle pause is skipped (no leaked timer, '
+        '#2918)', () {
+      // The settle pause only matters when a scan was actually winding down on
+      // the radio. With nothing scanning (a cold direct connect, the recording
+      // pre-warm, or a widget test driving the prod graph) it must be skipped —
+      // otherwise its Future.delayed leaks a pending timer past widget
+      // disposal, which is exactly what broke consumption_app_bar_actions_test.
+      fakeAsync((async) {
+        final log = _EventLog();
+        final svc = Obd2ConnectionService(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _GrantPermissions(),
+          bluetooth: _OrderedFacade(log),
+          // A huge settle that WOULD dominate (and leak) if the gate regressed.
+          scanSettleDelay: const Duration(seconds: 5),
+        );
+
+        var done = false;
+        svc.stopScanBeforeConnect().then((_) => done = true);
+        async.flushMicrotasks();
+
+        // FlutterBluePlus.isScanningNow is false in tests, so the settle is
+        // skipped: the call already completed without elapsing the 5 s timer.
+        expect(done, isTrue,
+            reason: 'the settle must be skipped when no scan was active — '
+                'else a pending timer outlives widget disposal (#2918)');
+        // The stop itself still runs unconditionally (the #2906 guarantee).
+        expect(log.events, contains('ble:stopScan'));
+        // No pending timer remains — fakeAsync throws at teardown otherwise.
+      });
     });
   });
 }

--- a/test/features/consumption/data/obd2/reconnect_connector_transport_fallback_test.dart
+++ b/test/features/consumption/data/obd2/reconnect_connector_transport_fallback_test.dart
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_comm_diagnostics.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/reconnect_connector.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2908 — when one transport repeatedly fails to establish a link across its
+/// retry budget (direct + scan), the in-trip reconnect falls back to the OTHER
+/// transport for the same adapter, and the #2911/#2905 telemetry records which
+/// transport recovered the link.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('ReconnectConnector — Classic↔BLE transport fallback (#2908)', () {
+    setUp(Obd2CommDiagnostics.instance.reset);
+    tearDown(() {
+      Obd2CommDiagnostics.instance
+        ..enabled = false
+        ..reset();
+    });
+
+    test(
+        'a wedged BLE transport escalates to a Classic-direct connect that '
+        'succeeds, and telemetry records the switch', () async {
+      Obd2CommDiagnostics.instance
+        ..enabled = true
+        ..beginSession();
+      // Preferred (BLE) transport is wedged: direct open throws, no scan
+      // sighting. The Classic facade answers OK on its direct channel.
+      final ble = _Facade(
+        directChannel: _Channel(openError: true),
+        batches: const [[]], // scan finds nothing
+      );
+      final classic = _ClassicFacade(channel: _Channel());
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classic),
+        onConnected: (s) => connected = s,
+        transportHint: 'ble', // the live link was BLE
+        crossTransportThreshold: 1, // escalate on the first exhausted budget
+        attemptNumber: () => 1,
+        backoffMs: () => 0,
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isTrue, reason: 'the Classic alternate recovered the link');
+      expect(connected, isNotNull);
+      expect(connected!.linkKind, 'classic',
+          reason: 'the link landed on the ALTERNATE (Classic) transport');
+      expect(classic.channelForCalls, contains('aa:bb'),
+          reason: 'the fallback must dial the Classic facade');
+
+      final rows = Obd2CommDiagnostics.instance.snapshot().reconnectAttempts;
+      final fallbackRow = rows.firstWhere((r) => r.path == 'fallback-classic');
+      expect(fallbackRow.succeeded, isTrue);
+      final transitions = Obd2CommDiagnostics.instance.snapshot().transitions;
+      expect(
+        transitions.any((t) =>
+            (t.detail ?? '').contains('transport-fallback:ble→classic')),
+        isTrue,
+        reason: 'the transport switch must be recorded as a transition detail',
+      );
+      await connected!.disconnect();
+    });
+
+    test(
+        'a wedged Classic transport escalates to a BLE-direct connect that '
+        'succeeds', () async {
+      // The mirror case: a Classic rfcomm storm falls back to BLE direct.
+      final classic = _ClassicFacade(channel: _Channel(silent: true));
+      final ble = _Facade(
+        directChannel: _Channel(), // BLE direct answers OK
+        batches: const [[]],
+      );
+      Obd2Service? connected;
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classic),
+        onConnected: (s) => connected = s,
+        transportHint: 'classic',
+        crossTransportThreshold: 1,
+      );
+
+      final ok = await connector.attempt('cc:dd');
+
+      expect(ok, isTrue, reason: 'the BLE alternate recovered the link');
+      expect(connected!.linkKind, 'ble',
+          reason: 'the link landed on the ALTERNATE (BLE) transport');
+      expect(ble.directCalls, greaterThanOrEqualTo(1),
+          reason: 'the fallback must dial the BLE direct facade');
+      await connected!.disconnect();
+    });
+
+    test('the fallback is NOT tried before the failure threshold is reached',
+        () async {
+      // crossTransportThreshold:2 ⇒ the FIRST exhausted cycle must NOT touch
+      // the alternate (a single transient blip is absorbed by the direct /
+      // channel.open retries, not by thrashing both transports).
+      final ble = _Facade(
+        directChannel: _Channel(openError: true),
+        batches: const [[]],
+      );
+      final classic = _ClassicFacade(channel: _Channel());
+      final connector = ReconnectConnector(
+        connection: _build(ble, classic: classic),
+        onConnected: (_) {},
+        transportHint: 'ble',
+        crossTransportThreshold: 2,
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isFalse, reason: 'first cycle: alternate not yet tried');
+      expect(classic.channelForCalls, isEmpty,
+          reason: 'below the threshold the alternate transport is untouched');
+
+      // SECOND exhausted cycle reaches the threshold → the alternate is tried.
+      final ok2 = await connector.attempt('aa:bb');
+      expect(ok2, isTrue,
+          reason: 'at the threshold the Classic alternate recovers the link');
+      expect(classic.channelForCalls, contains('aa:bb'));
+    });
+
+    test('a BLE-only build (no Classic facade) has NO alternate — no fallback',
+        () async {
+      // Regression-lock: the BLE→Classic fallback must not be attempted when
+      // no Classic facade is wired (most test/BLE-only configs).
+      final ble = _Facade(
+        directChannel: _Channel(openError: true),
+        batches: const [[]],
+      );
+      final connector = ReconnectConnector(
+        connection: _build(ble), // no classic facade
+        onConnected: (_) {},
+        transportHint: 'ble',
+        crossTransportThreshold: 1,
+      );
+
+      final ok = await connector.attempt('aa:bb');
+
+      expect(ok, isFalse,
+          reason: 'no alternate transport ⇒ the cycle fails cleanly');
+    });
+  });
+}
+
+// --- helpers ---------------------------------------------------------------
+
+Obd2ConnectionService _build(
+  BluetoothFacade bt, {
+  ClassicBluetoothFacade? classic,
+}) =>
+    Obd2ConnectionService(
+      registry: Obd2AdapterRegistry.defaults(),
+      permissions: _GrantPermissions(),
+      bluetooth: bt,
+      classicBluetooth: classic,
+      scanSettleDelay: Duration.zero,
+    );
+
+class _GrantPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+class _Facade implements BluetoothFacade {
+  final List<List<Obd2AdapterCandidate>> batches;
+  final ElmByteChannel? directChannel;
+  int directCalls = 0;
+
+  _Facade({this.batches = const [], this.directChannel});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    for (final batch in batches) {
+      yield batch;
+    }
+  }
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      _Channel(silent: true);
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) {
+    if (!autoConnect) directCalls++;
+    return directChannel ?? _Channel(silent: true);
+  }
+}
+
+class _ClassicFacade implements ClassicBluetoothFacade {
+  final ElmByteChannel? channel;
+  final List<String> channelForCalls = [];
+
+  _ClassicFacade({this.channel});
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId) {
+    channelForCalls.add(deviceId);
+    return channel ?? _Channel(silent: true);
+  }
+}
+
+class _Channel implements ElmByteChannel {
+  final bool silent;
+  final bool openError;
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+
+  _Channel({this.silent = false, this.openError = false});
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+
+  @override
+  Future<void> open() async {
+    if (openError) throw StateError('GATT_ERROR 133');
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    if (silent) return;
+    final cmd = String.fromCharCodes(bytes).trim();
+    _ctrl.add((_elmOk()[cmd] ?? 'OK>').codeUnits);
+  }
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    if (!_ctrl.isClosed) await _ctrl.close();
+  }
+}
+
+Map<String, String> _elmOk() => {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+    };

--- a/test/features/consumption/data/obd2/transport_fallback_policy_test.dart
+++ b/test/features/consumption/data/obd2/transport_fallback_policy_test.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/transport_fallback_policy.dart';
+
+/// Pure decision for the Classic↔BLE transport fallback (#2908).
+void main() {
+  group('alternateReconnectTransport (#2908)', () {
+    test('a Classic drop falls back to BLE (always available)', () {
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: 'classic',
+          hasClassicFacade: true,
+        ),
+        BluetoothTransport.ble,
+      );
+      // BLE is mandatory, so the Classic→BLE fallback is offered even when no
+      // Classic facade is otherwise relevant.
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: 'classic',
+          hasClassicFacade: false,
+        ),
+        BluetoothTransport.ble,
+      );
+    });
+
+    test('a BLE drop falls back to Classic ONLY when a Classic facade is wired',
+        () {
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: 'ble',
+          hasClassicFacade: true,
+        ),
+        BluetoothTransport.classic,
+      );
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: 'ble',
+          hasClassicFacade: false,
+        ),
+        isNull,
+        reason: 'a BLE-only build has no alternate transport',
+      );
+    });
+
+    test('an unknown / null live transport conservatively tries Classic', () {
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: null,
+          hasClassicFacade: true,
+        ),
+        BluetoothTransport.classic,
+      );
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: 'something-else',
+          hasClassicFacade: true,
+        ),
+        BluetoothTransport.classic,
+      );
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: null,
+          hasClassicFacade: false,
+        ),
+        isNull,
+      );
+    });
+
+    test('the classic match is case-insensitive', () {
+      expect(
+        alternateReconnectTransport(
+          droppedTransport: 'CLASSIC',
+          hasClassicFacade: true,
+        ),
+        BluetoothTransport.ble,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Children of Epic #2904. Builds on the already-merged #2909 (channel.open retry),
#2911 (telemetry) and #2917 (reconnect recovery — scan-path GATT teardown +
dead-transport polling gate). This PR adds only what those left.

Closes #2906
Closes #2908

## #2906 — what remained vs already-shipped
- channel.open() retry on GATT-133 / rfcomm-open-fail: ALREADY shipped (#2909).
- scan-path stale-GATT teardown: ALREADY shipped (#2917 — `connect()` calls
  `_teardownLastDirectChannel()` before the scan-path open). Verified complete;
  nothing re-added.
- **Stop-scan-before-connect (NEW):** Android BLE returns GATT_ERROR 133 when a
  `connect()` races an active scan still winding down on the radio. The
  scan-fallback reconnect is the worst offender — it reaches the open straight
  out of an `await for` scan loop whose subscription (and so `stopScan()`)
  cancels only asynchronously. Added `Obd2ConnectionService.stopScanBeforeConnect()`
  (stops the BLE + Classic scan, then an injectable settle ~120 ms in
  production / 0 in tests) and wired it into `connect()` and every by-MAC
  direct/passive path before the channel opens. Idempotent + best-effort: a
  throwing `stopScan()` never aborts the connect.
- **Classic SPP rfcomm retry (NEW, Kotlin):** `Obd2ClassicPlugin.connect()`
  dialled `BluetoothSocket.connect()` exactly once. Added a bounded ~3-attempt
  retry with backoff (mirrors the Dart #2909 shape: close socket + small delay
  between), then the documented clone fallbacks real ELM327 clones need —
  `createInsecureRfcommSocketToServiceRecord`, then a reflection channel-1
  socket. All on the existing background `obd2-classic-connect` thread, so the
  `Thread.sleep` backoff never blocks the Flutter main thread.

## #2908 — Classic↔BLE transport fallback
When the live transport keeps failing to establish across its retry budget (a
BLE 133 storm or a Classic rfcomm-open-fail across every direct + scan attempt),
the reconnect now falls back to the OTHER transport for the same adapter instead
of spinning the backoff on the wedged one. Many ELM327 clones expose both a
Classic SPP and a BLE GATT endpoint.
- `alternateReconnectTransport` (pure policy): Classic drop → BLE (always
  wired); BLE/unknown drop → Classic only when a Classic facade is present.
- `ReconnectConnector` escalates only after the preferred transport exhausts its
  full direct+scan budget `crossTransportThreshold` (default 2) times this drop,
  so a single transient blip — already absorbed by the #2909 / direct retries —
  doesn't thrash both transports.
- The auto-preference respected is the live transport (`transportHint`, read off
  the dead service) — there is no separate user transport setting in the app.
- Which transport recovered the link is surfaced via the existing #2911/#2905
  telemetry: a per-attempt row tagged `fallback-ble` / `fallback-classic` plus a
  `reconnected` transition whose detail names the switch
  (`transport-fallback:ble->classic`).

## Files
- `android/app/src/main/kotlin/de/tankstellen/tankstellen/Obd2ClassicPlugin.kt` — rfcomm retry + insecure/reflection fallbacks
- `lib/features/consumption/data/obd2/obd2_connection_service.dart` — `stopScanBeforeConnect()` + `scanSettleDelay`
- `lib/features/consumption/data/obd2/obd2_connect_by_mac.dart` — stop-scan in direct/passive paths + the helper body
- `lib/features/consumption/data/obd2/reconnect_connector.dart` — cross-transport fallback escalation
- `lib/features/consumption/data/obd2/transport_fallback_policy.dart` — pure alternate-transport decision (new)
- tests: `connect_resilience_test.dart` (#2906 stop-scan ordering), `reconnect_connector_transport_fallback_test.dart` + `transport_fallback_policy_test.dart` (#2908)

## Tests & gates
- `flutter analyze`: clean on all touched files (2 remaining `info` lints are pre-existing, unrelated test files).
- OBD2 suite + lint suite: 1489 tests green.
- Clean codegen + l10n fan-out: zero drift (no freezed/riverpod/JSON shape changed; no user-facing strings added).
- 400-line cap respected (helpers extracted; no grandfather bump).

## Manual-test note (Kotlin rfcomm retry)
The `Obd2ClassicPlugin` RFCOMM retry has no JVM-Bluetooth path on CI, so it is
not unit-tested. Verify on a real Classic-SPP adapter (vLinker FS):
1. Pair the adapter, start a trip, confirm OBD2 connects.
2. Power-cycle the dongle mid-trip; confirm the reconnect re-establishes (the
   first dial often `IOException`s and the 2nd/3rd attempt succeeds — visible in
   logcat as `connect: RFCOMM open failed (attempt 1)` then a successful read).
3. For a stubborn clone, confirm the insecure / channel-1 reflection fallback
   path is reached (logcat) and connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
