### PR TITLE
fix(obd2): persist comm-health diagnostic per-trip — fix always-empty card (#2912)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_comm_diagnostics.dart
+++ b/lib/features/consumption/data/obd2/obd2_comm_diagnostics.dart
@@ -304,6 +304,54 @@ class Obd2CommDiagnostics {
     return _summarise(cur);
   }
 
+  /// Capture the diagnostic worth PERSISTING with a finished trip (#2912).
+  ///
+  /// The trip-detail comm-health card was always empty because it read the
+  /// process-wide singleton instead of the viewed trip's own diagnostic; the
+  /// fix snapshots this at trip finish and stores it on the trip record. We
+  /// prefer the live session (which carries THIS trip's connection attempts,
+  /// reconnect timeline + fallback markers, even when the adapter never
+  /// connected) and fall back to the most recent finished session.
+  ///
+  /// Returns `null` — never the empty const sentinel — when there is nothing
+  /// worth persisting (disabled, or a session with no signal at all), so a
+  /// pure GPS-only trip that never touched OBD2 stores zero extra bytes and
+  /// the card keeps self-hiding. "Has signal" mirrors the card's own
+  /// `computeObd2DiagnosticsSummary` gate so a session the card would render
+  /// is exactly a session we persist.
+  ///
+  /// **Never-throws contract:** called from the trip-save flow at trip finish,
+  /// so any internal fault degrades to `null` (the trip still saves, just
+  /// without a diagnostic) rather than derailing the save (#1103).
+  Obd2SessionDiagnostic? captureForTrip() {
+    if (!enabled) return null;
+    try {
+      final live = _current != null ? _summarise(_current!) : null;
+      if (live != null && _hasSignal(live)) return live;
+      if (_finished.isNotEmpty && _hasSignal(_finished.last)) {
+        return _finished.last;
+      }
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Whether [d] carries any diagnostic signal worth surfacing — the same
+  /// predicate `computeObd2DiagnosticsSummary` uses to choose its non-empty
+  /// branch. Kept inline so the collector stays free of a presentation-layer
+  /// import; a connection ATTEMPT alone (even a failed connect) counts, which
+  /// is exactly the "adapter never connected" case #2912 must still surface.
+  static bool _hasSignal(Obd2SessionDiagnostic d) =>
+      d.pidStats.isNotEmpty ||
+      d.connection.attempts > 0 ||
+      d.redactedMac != null ||
+      d.elmVersion != null ||
+      d.reconnectAttempts.isNotEmpty ||
+      d.transitions.isNotEmpty ||
+      d.disconnectExceptions > 0 ||
+      d.fallbackActivatedAtMs != null;
+
   /// Finalise the live session into the capped ring. No-op when disabled
   /// or when there is no live session.
   void endSession() {

--- a/lib/features/consumption/data/trip_history_repository.dart
+++ b/lib/features/consumption/data/trip_history_repository.dart
@@ -9,8 +9,10 @@ import 'package:hive/hive.dart';
 
 import '../domain/entities/gps_sample_diagnostic.dart';
 import '../domain/trip_recorder.dart';
+import 'obd2/obd2_session_diagnostic.dart';
 import 'trip_dedup.dart';
 import 'trip_sample_codec.dart';
+import 'trip_summary_codec.dart';
 import '../../../core/logging/error_logger.dart';
 
 /// One finalised trip as shown in the Trip history list (#726).
@@ -75,6 +77,25 @@ class TripHistoryEntry {
   /// `Feature.gpsTripPath` flag was off at recording start.
   final List<GpsSampleDiagnostic> gpsSampleDiagnostics;
 
+  /// OBD2 communication-health diagnostic snapshotted at trip finish
+  /// (#2912, Epic #2904). The dev-only trip-detail comm-health card was
+  /// **always empty** because it read the process-wide in-memory
+  /// `Obd2CommDiagnostics.instance` singleton — wiped on restart and never
+  /// tied to a trip — instead of the viewed trip's own diagnostic. This
+  /// field persists the per-trip snapshot (connection attempts + the #2905
+  /// reconnect timeline / session-state transitions / fallback markers,
+  /// captured even when the adapter never connected) so the card can render
+  /// THIS trip's health after a restart.
+  ///
+  /// Null for GPS-only trips that never touched OBD2, for production builds
+  /// (the collector is disarmed unless `Feature.debugMode` is on), and for
+  /// every legacy trip recorded before this field landed — in all of which
+  /// the card keeps self-hiding. Round-trips via the existing JSON
+  /// persistence under the compact key `'obd2d'`; the nested freezed model
+  /// carries its own `toJson`/`fromJson` (heeding the #2776 round-trip
+  /// lesson — it is a real serialised field, not `@JsonKey`-excluded).
+  final Obd2SessionDiagnostic? obd2Diagnostic;
+
   const TripHistoryEntry({
     required this.id,
     required this.vehicleId,
@@ -85,6 +106,7 @@ class TripHistoryEntry {
     this.adapterName,
     this.adapterFirmware,
     this.gpsSampleDiagnostics = const [],
+    this.obd2Diagnostic,
   });
 
   /// Returns a copy with the given fields replaced (#1858). The
@@ -101,12 +123,13 @@ class TripHistoryEntry {
         adapterName: adapterName,
         adapterFirmware: adapterFirmware,
         gpsSampleDiagnostics: gpsSampleDiagnostics,
+        obd2Diagnostic: obd2Diagnostic,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'vehicleId': vehicleId,
-        'summary': _summaryToJson(summary),
+        'summary': tripSummaryToJson(summary),
         if (automatic) 'automatic': true,
         if (samples.isNotEmpty)
           'samples': samples.map(sampleToJson).toList(growable: false),
@@ -126,13 +149,20 @@ class TripHistoryEntry {
           'gpsd': gpsSampleDiagnostics
               .map((d) => d.toJson())
               .toList(growable: false),
+        // #2912 — per-trip OBD2 comm-health diagnostic. Compact key 'obd2d'.
+        // Emitted only when a diagnostic was captured (debug-mode trips that
+        // touched OBD2), so production / GPS-only / legacy trips round-trip
+        // with zero bytes added. The nested freezed model serialises itself
+        // via its own short-keyed toJson, so the persisted snapshot reloads
+        // intact (NOT @JsonKey-dropped — #2776 lesson).
+        if (obd2Diagnostic != null) 'obd2d': obd2Diagnostic!.toJson(),
       };
 
   static TripHistoryEntry fromJson(Map<String, dynamic> json) =>
       TripHistoryEntry(
         id: json['id'] as String,
         vehicleId: json['vehicleId'] as String?,
-        summary: _summaryFromJson(
+        summary: tripSummaryFromJson(
           (json['summary'] as Map).cast<String, dynamic>(),
         ),
         automatic: (json['automatic'] as bool?) ?? false,
@@ -157,116 +187,16 @@ class TripHistoryEntry {
                     ))
                 .toList(growable: false) ??
             const [],
+        // #2912 — per-trip OBD2 comm-health diagnostic. Missing key → null
+        // so legacy trips, GPS-only trips and production (gate-off) trips
+        // deserialise cleanly and the card keeps self-hiding for them.
+        obd2Diagnostic: json['obd2d'] == null
+            ? null
+            : Obd2SessionDiagnostic.fromJson(
+                (json['obd2d'] as Map).cast<String, dynamic>(),
+              ),
       );
 }
-
-Map<String, dynamic> _summaryToJson(TripSummary s) => {
-      'distanceKm': s.distanceKm,
-      'maxRpm': s.maxRpm,
-      'highRpmSeconds': s.highRpmSeconds,
-      'idleSeconds': s.idleSeconds,
-      'harshBrakes': s.harshBrakes,
-      'harshAccelerations': s.harshAccelerations,
-      if (s.avgLPer100Km != null) 'avgLPer100Km': s.avgLPer100Km,
-      if (s.fuelLitersConsumed != null)
-        'fuelLitersConsumed': s.fuelLitersConsumed,
-      if (s.startedAt != null) 'startedAt': s.startedAt!.toIso8601String(),
-      if (s.endedAt != null) 'endedAt': s.endedAt!.toIso8601String(),
-      // #800: provenance of distanceKm — `'real'` for odometer-backed
-      // trips, `'virtual'` for speed-integrated estimates. Older trips
-      // serialised before this field landed deserialise as `'virtual'`
-      // to match the recorder's historical behaviour.
-      'distanceSource': s.distanceSource,
-      // #1262 phase 2: cold-start surcharge bit. Compact key 'cs'
-      // because every trip carries this and we'd rather not pay six
-      // bytes per record. Legacy trips without the key default false.
-      'cs': s.coldStartSurcharge,
-      // #1263 phase 2: seconds spent below the optimal gear (gear-
-      // inference coaching metric). Compact key 'sblog' (Seconds
-      // Below Low-Optimal Gear). Omitted when null — most trips on
-      // pre-#1263 builds, EVs, and combustion trips with insufficient
-      // gear-inference data carry no value, so parsimony saves bytes.
-      if (s.secondsBelowOptimalGear != null)
-        'sblog': s.secondsBelowOptimalGear,
-      // #1858: η_v recompute provenance. Compact key 'veUsed'. Omitted
-      // when null — legacy trips and non-recalculable trips (any PID 5E
-      // / MAF fuel) carry no value, so parsimony saves bytes.
-      if (s.volumetricEfficiencyUsed != null)
-        'veUsed': s.volumetricEfficiencyUsed,
-      // #2025 — trajet kind. Omitted when gpsPlusObd2 (the historical
-      // default) so legacy trips round-trip with zero bytes added.
-      if (s.kind != TripKind.gpsPlusObd2) 'kind': s.kind.wireName,
-      // #2029: per-event harsh-brake / harsh-accel detail with
-      // timestamp + magnitude + speed. Compact key 'he'. Omitted when
-      // empty so legacy trips and event-free trips round-trip with
-      // zero bytes added.
-      if (s.harshEvents.isNotEmpty)
-        'he': s.harshEvents.map((e) => e.toJson()).toList(growable: false),
-      // #2444: synthetic reconciliation trajet flag. Compact key 'virt'.
-      // Omitted when false (every real trip) so legacy trips round-trip
-      // with zero bytes added.
-      if (s.isVirtual) 'virt': true,
-      // #2760: IMU-detected aggregate event counts for dongle-less (GPS+IMU)
-      // trips — THREE scalars only (never the raw ~50 Hz stream). Compact keys
-      // 'iha'/'ihb'/'sc'; each omitted when 0 so OBD2 / legacy trips add 0 bytes.
-      if (s.imuHardAccelCount != 0) 'iha': s.imuHardAccelCount,
-      if (s.imuHardBrakeCount != 0) 'ihb': s.imuHardBrakeCount,
-      if (s.sharpCornerCount != 0) 'sc': s.sharpCornerCount,
-      if (s.imuActive) 'ima': true, // #2895 IMU-ran bit (prefer IMU zero)
-    };
-
-TripSummary _summaryFromJson(Map<String, dynamic> j) => TripSummary(
-      distanceKm: (j['distanceKm'] as num).toDouble(),
-      maxRpm: (j['maxRpm'] as num).toDouble(),
-      highRpmSeconds: (j['highRpmSeconds'] as num).toDouble(),
-      idleSeconds: (j['idleSeconds'] as num).toDouble(),
-      harshBrakes: (j['harshBrakes'] as num).toInt(),
-      harshAccelerations: (j['harshAccelerations'] as num).toInt(),
-      avgLPer100Km: (j['avgLPer100Km'] as num?)?.toDouble(),
-      fuelLitersConsumed: (j['fuelLitersConsumed'] as num?)?.toDouble(),
-      startedAt: j['startedAt'] == null
-          ? null
-          : DateTime.parse(j['startedAt'] as String),
-      endedAt: j['endedAt'] == null
-          ? null
-          : DateTime.parse(j['endedAt'] as String),
-      // Default to 'virtual' for pre-#800 trips — that's the honest
-      // label for legacy recordings, which integrated speed samples
-      // regardless of whether an odometer was available.
-      distanceSource: (j['distanceSource'] as String?) ?? 'virtual',
-      // #1262 phase 2: pre-existing trips were persisted before the
-      // cold-start surcharge heuristic landed; default false rather
-      // than retroactively flag them.
-      coldStartSurcharge: (j['cs'] as bool?) ?? false,
-      // #1263 phase 2: gear-inference coaching metric. Legacy trips
-      // (and EV / no-inference trips) carry no key → null.
-      secondsBelowOptimalGear: (j['sblog'] as num?)?.toDouble(),
-      // #1858: η_v recompute provenance. Legacy trips and trips whose
-      // fuel was not 100% speed-density carry no key → null, which
-      // correctly reads as "not recalculable".
-      volumetricEfficiencyUsed: (j['veUsed'] as num?)?.toDouble(),
-      // #2025: trajet kind. Missing key → gpsPlusObd2 because every
-      // recording before this field landed required an OBD2 connection.
-      kind: TripKind.fromWireName(j['kind'] as String?),
-      // #2029: per-event harsh-brake / harsh-accel detail. Missing
-      // key → empty list so legacy trips fall back to the bare
-      // [harshBrakes] / [harshAccelerations] integer counters.
-      harshEvents: (j['he'] as List?)
-              ?.map((e) =>
-                  HarshEvent.fromJson((e as Map).cast<String, dynamic>()))
-              .toList(growable: false) ??
-          const [],
-      // #2444: synthetic reconciliation trajet flag. Missing key →
-      // false so every real trip and every legacy trip deserialises
-      // as a normal, fully-counted trajet.
-      isVirtual: (j['virt'] as bool?) ?? false,
-      // #2760: IMU aggregate event counts. Missing key → 0 for OBD2 trips
-      // and every legacy trip recorded before IMU fusion landed.
-      imuHardAccelCount: (j['iha'] as num?)?.toInt() ?? 0,
-      imuHardBrakeCount: (j['ihb'] as num?)?.toInt() ?? 0,
-      sharpCornerCount: (j['sc'] as num?)?.toInt() ?? 0,
-      imuActive: (j['ima'] as bool?) ?? false, // #2895 IMU-ran bit
-    );
 
 /// Hive-backed list of finalised trips (#726).
 ///

--- a/lib/features/consumption/data/trip_summary_codec.dart
+++ b/lib/features/consumption/data/trip_summary_codec.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../domain/trip_recorder.dart';
+
+/// JSON codec for the persisted [TripSummary] (#726).
+///
+/// Extracted from `trip_history_repository.dart` (#2912 — keeps that file
+/// under the 400-line guard) alongside the existing `trip_sample_codec.dart`.
+/// Pure: every key uses the compact-key + omit-when-default parsimony rule so
+/// each per-trip JSON payload stays tight, and every reader defaults a missing
+/// key so legacy trips round-trip unchanged.
+Map<String, dynamic> tripSummaryToJson(TripSummary s) => {
+      'distanceKm': s.distanceKm,
+      'maxRpm': s.maxRpm,
+      'highRpmSeconds': s.highRpmSeconds,
+      'idleSeconds': s.idleSeconds,
+      'harshBrakes': s.harshBrakes,
+      'harshAccelerations': s.harshAccelerations,
+      if (s.avgLPer100Km != null) 'avgLPer100Km': s.avgLPer100Km,
+      if (s.fuelLitersConsumed != null)
+        'fuelLitersConsumed': s.fuelLitersConsumed,
+      if (s.startedAt != null) 'startedAt': s.startedAt!.toIso8601String(),
+      if (s.endedAt != null) 'endedAt': s.endedAt!.toIso8601String(),
+      // #800: provenance of distanceKm — `'real'` for odometer-backed
+      // trips, `'virtual'` for speed-integrated estimates. Older trips
+      // serialised before this field landed deserialise as `'virtual'`
+      // to match the recorder's historical behaviour.
+      'distanceSource': s.distanceSource,
+      // #1262 phase 2: cold-start surcharge bit. Compact key 'cs'
+      // because every trip carries this and we'd rather not pay six
+      // bytes per record. Legacy trips without the key default false.
+      'cs': s.coldStartSurcharge,
+      // #1263 phase 2: seconds spent below the optimal gear (gear-
+      // inference coaching metric). Compact key 'sblog' (Seconds
+      // Below Low-Optimal Gear). Omitted when null — most trips on
+      // pre-#1263 builds, EVs, and combustion trips with insufficient
+      // gear-inference data carry no value, so parsimony saves bytes.
+      if (s.secondsBelowOptimalGear != null)
+        'sblog': s.secondsBelowOptimalGear,
+      // #1858: η_v recompute provenance. Compact key 'veUsed'. Omitted
+      // when null — legacy trips and non-recalculable trips (any PID 5E
+      // / MAF fuel) carry no value, so parsimony saves bytes.
+      if (s.volumetricEfficiencyUsed != null)
+        'veUsed': s.volumetricEfficiencyUsed,
+      // #2025 — trajet kind. Omitted when gpsPlusObd2 (the historical
+      // default) so legacy trips round-trip with zero bytes added.
+      if (s.kind != TripKind.gpsPlusObd2) 'kind': s.kind.wireName,
+      // #2029: per-event harsh-brake / harsh-accel detail with
+      // timestamp + magnitude + speed. Compact key 'he'. Omitted when
+      // empty so legacy trips and event-free trips round-trip with
+      // zero bytes added.
+      if (s.harshEvents.isNotEmpty)
+        'he': s.harshEvents.map((e) => e.toJson()).toList(growable: false),
+      // #2444: synthetic reconciliation trajet flag. Compact key 'virt'.
+      // Omitted when false (every real trip) so legacy trips round-trip
+      // with zero bytes added.
+      if (s.isVirtual) 'virt': true,
+      // #2760: IMU-detected aggregate event counts for dongle-less (GPS+IMU)
+      // trips — THREE scalars only (never the raw ~50 Hz stream). Compact keys
+      // 'iha'/'ihb'/'sc'; each omitted when 0 so OBD2 / legacy trips add 0 bytes.
+      if (s.imuHardAccelCount != 0) 'iha': s.imuHardAccelCount,
+      if (s.imuHardBrakeCount != 0) 'ihb': s.imuHardBrakeCount,
+      if (s.sharpCornerCount != 0) 'sc': s.sharpCornerCount,
+      if (s.imuActive) 'ima': true, // #2895 IMU-ran bit (prefer IMU zero)
+    };
+
+TripSummary tripSummaryFromJson(Map<String, dynamic> j) => TripSummary(
+      distanceKm: (j['distanceKm'] as num).toDouble(),
+      maxRpm: (j['maxRpm'] as num).toDouble(),
+      highRpmSeconds: (j['highRpmSeconds'] as num).toDouble(),
+      idleSeconds: (j['idleSeconds'] as num).toDouble(),
+      harshBrakes: (j['harshBrakes'] as num).toInt(),
+      harshAccelerations: (j['harshAccelerations'] as num).toInt(),
+      avgLPer100Km: (j['avgLPer100Km'] as num?)?.toDouble(),
+      fuelLitersConsumed: (j['fuelLitersConsumed'] as num?)?.toDouble(),
+      startedAt: j['startedAt'] == null
+          ? null
+          : DateTime.parse(j['startedAt'] as String),
+      endedAt: j['endedAt'] == null
+          ? null
+          : DateTime.parse(j['endedAt'] as String),
+      // Default to 'virtual' for pre-#800 trips — that's the honest
+      // label for legacy recordings, which integrated speed samples
+      // regardless of whether an odometer was available.
+      distanceSource: (j['distanceSource'] as String?) ?? 'virtual',
+      // #1262 phase 2: pre-existing trips were persisted before the
+      // cold-start surcharge heuristic landed; default false rather
+      // than retroactively flag them.
+      coldStartSurcharge: (j['cs'] as bool?) ?? false,
+      // #1263 phase 2: gear-inference coaching metric. Legacy trips
+      // (and EV / no-inference trips) carry no key → null.
+      secondsBelowOptimalGear: (j['sblog'] as num?)?.toDouble(),
+      // #1858: η_v recompute provenance. Legacy trips and trips whose
+      // fuel was not 100% speed-density carry no key → null, which
+      // correctly reads as "not recalculable".
+      volumetricEfficiencyUsed: (j['veUsed'] as num?)?.toDouble(),
+      // #2025: trajet kind. Missing key → gpsPlusObd2 because every
+      // recording before this field landed required an OBD2 connection.
+      kind: TripKind.fromWireName(j['kind'] as String?),
+      // #2029: per-event harsh-brake / harsh-accel detail. Missing
+      // key → empty list so legacy trips fall back to the bare
+      // [harshBrakes] / [harshAccelerations] integer counters.
+      harshEvents: (j['he'] as List?)
+              ?.map((e) =>
+                  HarshEvent.fromJson((e as Map).cast<String, dynamic>()))
+              .toList(growable: false) ??
+          const [],
+      // #2444: synthetic reconciliation trajet flag. Missing key →
+      // false so every real trip and every legacy trip deserialises
+      // as a normal, fully-counted trajet.
+      isVirtual: (j['virt'] as bool?) ?? false,
+      // #2760: IMU aggregate event counts. Missing key → 0 for OBD2 trips
+      // and every legacy trip recorded before IMU fusion landed.
+      imuHardAccelCount: (j['iha'] as num?)?.toInt() ?? 0,
+      imuHardBrakeCount: (j['ihb'] as num?)?.toInt() ?? 0,
+      sharpCornerCount: (j['sc'] as num?)?.toInt() ?? 0,
+      imuActive: (j['ima'] as bool?) ?? false, // #2895 IMU-ran bit
+    );

--- a/lib/features/consumption/presentation/widgets/obd2_diagnostics_trip_card.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_diagnostics_trip_card.dart
@@ -7,31 +7,56 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../feature_management/application/feature_flags_provider.dart';
 import '../../../feature_management/domain/feature.dart';
 import '../../data/obd2/obd2_comm_diagnostics.dart';
+import '../../data/obd2/obd2_session_diagnostic.dart';
 import 'obd2_diagnostics_card.dart';
 
 /// Trip-detail mounting of the [Obd2DiagnosticsCard] (#2470, Epic #2463),
 /// beside the GPS diagnostics card.
 ///
 /// Dev-only and self-hiding: it renders nothing unless [Feature.debugMode]
-/// is on, so production trip-detail screens are byte-unchanged. When the
-/// gate is on it shows the most recent finished session from the gated
-/// `Obd2CommDiagnostics` collector (or the live one if none finished yet);
-/// the card itself renders its empty state when the collector captured no
-/// session, so a dev who never connected an adapter still sees a clean
-/// "no session" hint rather than a blank.
+/// is on, so production trip-detail screens are byte-unchanged.
 ///
-/// The collector is a process-wide in-memory singleton (the OBD2 data
-/// layer is Riverpod-free), so this widget reads it directly rather than
-/// through a provider — matching how the dev-tools `Obd2HealthScreen`
-/// surfaces it.
+/// #2912 — the card used to read the process-wide in-memory
+/// `Obd2CommDiagnostics.instance` singleton (its `finishedSessions.last` /
+/// live `snapshot()`), which is **NOT** the viewed trip's diagnostic: it is
+/// wiped on app restart and not tied to a trip, so every past trip showed the
+/// same global last-session / live snapshot — i.e. "always empty" once the
+/// process restarted, the field-reported bug. The fix persists an
+/// [Obd2SessionDiagnostic] on the trip record at trip finish and threads it
+/// in here as [tripDiagnostic]:
+///   * when the viewed trip carries a persisted diagnostic, the card renders
+///     THAT trip's health — per-trip, restart-durable;
+///   * when it is null (the just-finished / in-progress trip whose record
+///     hasn't been re-read, or a debug session captured this run), the card
+///     falls back to the live singleton — the same source the dev-tools
+///     `Obd2HealthScreen` keeps using.
+///
+/// The collector is a process-wide singleton (the OBD2 data layer is
+/// Riverpod-free), so the live fallback reads it directly rather than through
+/// a provider.
 class Obd2DiagnosticsTripCard extends ConsumerWidget {
-  const Obd2DiagnosticsTripCard({super.key});
+  /// The diagnostic persisted with the viewed trip (#2912), or null for a
+  /// trip recorded before this field landed / with developer mode off / that
+  /// never touched OBD2. Null falls back to the live singleton.
+  final Obd2SessionDiagnostic? tripDiagnostic;
+
+  const Obd2DiagnosticsTripCard({super.key, this.tripDiagnostic});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final debugOn =
         ref.watch(enabledFeaturesProvider).contains(Feature.debugMode);
     if (!debugOn) return const SizedBox.shrink();
+
+    // Prefer the trip's own persisted diagnostic; the card renders its empty
+    // state when nothing is presentable, so the persisted path is always
+    // "enabled" (the trip captured it under the same debug gate). Only when
+    // the trip carries none do we fall back to the live collector for the
+    // just-finished / in-progress trip.
+    final persisted = tripDiagnostic;
+    if (persisted != null) {
+      return Obd2DiagnosticsCard(session: persisted, enabled: true);
+    }
 
     final collector = Obd2CommDiagnostics.instance;
     final session = collector.finishedSessions.isNotEmpty

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -290,8 +290,11 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
           ),
         // OBD2 communication-health diagnostics (#2470). Dev-only — the
         // card self-hides unless Feature.debugMode is on AND a session was
-        // captured, the OBD2 analogue of the GPS card above.
-        const Obd2DiagnosticsTripCard(),
+        // captured, the OBD2 analogue of the GPS card above. #2912 — feeds
+        // the trip's PERSISTED diagnostic so the card shows THIS trip's
+        // health (restart-durable) instead of the in-memory singleton that
+        // surfaced as "always empty"; null falls back to the live collector.
+        Obd2DiagnosticsTripCard(tripDiagnostic: widget.entry.obd2Diagnostic),
         // Driving-analysis trace export (#2804). Dev-only — self-hides unless
         // Feature.debugMode is on. Exports this trip's KPIs / score / lessons
         // as an annotatable JSON so the maintainer can label real trips and

--- a/lib/features/consumption/providers/trip_recording_provider.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.dart
@@ -17,6 +17,7 @@ import '../../feature_management/domain/feature.dart';
 import '../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/obd2/active_trip_repository.dart';
+import '../data/obd2/obd2_comm_diagnostics.dart';
 import '../data/obd2/obd2_service.dart';
 import '../data/obd2/trip_recording_controller.dart';
 import '../data/trip_history_repository.dart';
@@ -998,6 +999,8 @@ class TripRecording extends _$TripRecording {
       if (repo == null) return TripPersistOutcome.saved;
       final id = summary.startedAt?.toIso8601String() ??
           DateTime.now().toIso8601String();
+      // #2912 — per-trip OBD2 comm-health diagnostic (never-throws capture).
+      final obd2Diagnostic = Obd2CommDiagnostics.instance.captureForTrip();
       await repo.save(TripHistoryEntry(
         id: id,
         vehicleId: vehicleId,
@@ -1014,6 +1017,7 @@ class TripRecording extends _$TripRecording {
         // recording. Empty when the GPS feature flag was off for this
         // trip; the entry's JSON serialiser elides the key in that case.
         gpsSampleDiagnostics: gpsSampleDiagnostics,
+        obd2Diagnostic: obd2Diagnostic, // #2912 — per-trip comm-health
       ));
       ref.read(tripHistoryListProvider.notifier).refresh();
       // #2392 — calibrate the vehicle's physicsScale from this trip's

--- a/lib/features/consumption/providers/trip_recording_provider.g.dart
+++ b/lib/features/consumption/providers/trip_recording_provider.g.dart
@@ -74,7 +74,7 @@ final class TripRecordingProvider
   }
 }
 
-String _$tripRecordingHash() => r'17c301334b0a6c620436c071009441bf2e1e464c';
+String _$tripRecordingHash() => r'dcd0df09390968dd09bd92c50687cbeeb9f922a9';
 
 /// App-wide owner of the trip recording (#726).
 ///

--- a/test/features/consumption/comm_health_per_trip_test.dart
+++ b/test/features/consumption/comm_health_per_trip_test.dart
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_comm_diagnostics.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_session_diagnostic.dart';
+import 'package:tankstellen/features/consumption/data/trip_history_repository.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/obd2_diagnostics_trip_card.dart';
+import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
+import 'package:tankstellen/features/feature_management/domain/feature.dart';
+import 'package:tankstellen/l10n/app_localizations.dart';
+
+import '../../helpers/silence_error_logger.dart';
+
+/// Synchronous fake of the [FeatureFlags] async notifier so the widget pump
+/// never blocks on the real Hive-backed flag load — the established pattern
+/// for feature-gated widget tests (mirrors `_TestFeatureFlags` in the shell
+/// tests). Returns a fixed enabled set immediately.
+class _TestFeatureFlags extends FeatureFlags {
+  _TestFeatureFlags(this._initial);
+  final Set<Feature> _initial;
+
+  @override
+  Set<Feature> build() => {..._initial};
+}
+
+/// #2912 (Epic #2904) — the OBD2 comm-health card was **always empty**
+/// because [Obd2DiagnosticsTripCard] read the process-wide in-memory
+/// `Obd2CommDiagnostics.instance` singleton (wiped on restart, never tied to
+/// a trip) instead of the viewed trip's own diagnostic, which the trip record
+/// did not persist.
+///
+/// This drives the REAL capture → persist → reload → render path (per the
+/// repo's anti-false-green / #2776 round-trip rule — NOT the adapter in
+/// isolation): a finished trip captures the live session into the trip record
+/// via the real [TripHistoryRepository] (Hive JSON), the singleton is then
+/// CLEARED to simulate an app restart, the trip is reloaded from disk, and the
+/// card is pumped with the reloaded diagnostic.
+///
+/// On master this would be RED: the card reads the cleared singleton → empty.
+/// After the fix the card renders the trip's persisted values → not empty.
+void main() {
+  silenceErrorLoggerSpool();
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmpDir;
+  late Box<String> box;
+
+  setUp(() async {
+    Obd2CommDiagnostics.instance.enabled = false;
+    Obd2CommDiagnostics.instance.reset();
+    tmpDir = Directory.systemTemp.createTempSync('comm_health_per_trip_');
+    Hive.init(tmpDir.path);
+    box = await Hive.openBox<String>(
+      'test_${DateTime.now().microsecondsSinceEpoch}',
+    );
+  });
+
+  tearDown(() async {
+    Obd2CommDiagnostics.instance.enabled = false;
+    Obd2CommDiagnostics.instance.reset();
+    await box.deleteFromDisk();
+    await Hive.close();
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  TripSummary mkSummary(DateTime start) => TripSummary(
+        distanceKm: 12,
+        maxRpm: 2800,
+        highRpmSeconds: 10,
+        idleSeconds: 30,
+        harshBrakes: 0,
+        harshAccelerations: 0,
+        startedAt: start,
+        endedAt: start.add(const Duration(minutes: 20)),
+      );
+
+  /// Record a session that NEVER established a working link — the
+  /// rfcomm-open-fail / GATT-133 case that produces no successful "session"
+  /// yet is exactly when the diagnostics are most needed (#2912 point 3).
+  /// Two failed connect attempts + a reconnect attempt with a reason code.
+  void recordFailedConnectSession() {
+    final diag = Obd2CommDiagnostics.instance;
+    diag.enabled = true;
+    diag.beginSession(linkKind: 'ble', redactedMac: '···············6:DA');
+    diag.noteConnectionEvent(attempt: true, failureReason: 'gatt133');
+    diag.noteConnectionEvent(attempt: true, failureReason: 'gatt133');
+    diag.noteReconnectAttempt(
+      attemptNumber: 1,
+      succeeded: false,
+      reasonCode: 'rfcommOpenFail',
+      backoffMs: 2000,
+    );
+  }
+
+  Future<void> pumpCard(
+    WidgetTester tester,
+    Obd2SessionDiagnostic? tripDiagnostic,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          // Override the BACKING async notifier with a synchronous fake so
+          // the feature gate resolves on the first frame and the pump never
+          // hangs on the real Hive-backed flag load.
+          featureFlagsProvider
+              .overrideWith(() => _TestFeatureFlags({Feature.debugMode})),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('en'),
+          home: Scaffold(
+            body: ListView(
+              children: [
+                Obd2DiagnosticsTripCard(tripDiagnostic: tripDiagnostic),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    // Pump bounded frames rather than pumpAndSettle: the wider provider
+    // graph (async notifiers) may never quiesce, and the card is collapsed
+    // (no entry animation to wait on), so two frames are enough for the
+    // gate + card to paint their first frame.
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets(
+    'PROOF (#2912): a finished trip persists its OBD2 diagnostic and the '
+    'card renders it AFTER the in-memory singleton is cleared (restart) — '
+    'not empty',
+    (tester) async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 6, 5, 9, 30);
+
+      // 1. A trip is recorded with a (failed-connect) OBD2 session live.
+      recordFailedConnectSession();
+
+      // 2. At trip FINISH, capture the per-trip diagnostic + persist it.
+      final captured = Obd2CommDiagnostics.instance.captureForTrip();
+      expect(
+        captured,
+        isNotNull,
+        reason: 'a failed-connect session must still be captured (#2912 p3)',
+      );
+
+      // Real Hive disk I/O must run OUTSIDE the testWidgets fake-async zone,
+      // so the save → reload happens in `tester.runAsync`. The reloaded
+      // diagnostic is what the card is then pumped with.
+      TripHistoryEntry? reloaded;
+      await tester.runAsync(() async {
+        await repo.save(TripHistoryEntry(
+          id: start.toIso8601String(),
+          vehicleId: 'car-a',
+          summary: mkSummary(start),
+          obd2Diagnostic: captured,
+        ));
+
+        // 3. SIMULATE AN APP RESTART: the process-wide singleton is wiped.
+        Obd2CommDiagnostics.instance.enabled = false;
+        Obd2CommDiagnostics.instance.reset();
+
+        // 4. Reload the trip from disk — the diagnostic must survive the
+        //    JSON round-trip (NOT @JsonKey-dropped, #2776 lesson).
+        reloaded = repo.loadById(start.toIso8601String());
+      });
+
+      expect(
+        Obd2CommDiagnostics.instance.captureForTrip(),
+        isNull,
+        reason: 'post-restart the live singleton carries nothing',
+      );
+      expect(reloaded, isNotNull);
+      expect(reloaded!.obd2Diagnostic, isNotNull);
+      expect(reloaded!.obd2Diagnostic!.connection.attempts, 2);
+      expect(
+          reloaded!.obd2Diagnostic!.connection.failuresByReason['gatt133'], 2);
+      expect(reloaded!.obd2Diagnostic!.reconnectAttempts, hasLength(1));
+      expect(
+        reloaded!.obd2Diagnostic!.reconnectAttempts.first.reasonCode,
+        'rfcommOpenFail',
+      );
+
+      // 5. The card, fed the trip's persisted diagnostic, renders the
+      //    populated tile — NOT the empty state — even though the singleton
+      //    was cleared. THIS is the bug fix.
+      await pumpCard(tester, reloaded!.obd2Diagnostic);
+      expect(
+        find.byKey(const Key('obd2_diagnostics_tile')),
+        findsOneWidget,
+        reason: 'persisted per-trip diagnostic must render, not the singleton',
+      );
+      expect(find.byKey(const Key('obd2_diagnostics_empty')), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'regression: a trip with NO persisted diagnostic and a CLEARED singleton '
+    'renders empty (the broken pre-fix state for every past trip)',
+    (tester) async {
+      // No persisted diagnostic + cleared singleton == the field bug. The
+      // card must fall back to the (empty) live collector and show empty —
+      // proving the fix does not falsely populate trips that have no health.
+      await pumpCard(tester, null);
+      expect(find.byKey(const Key('obd2_diagnostics_empty')), findsOneWidget);
+      expect(find.byKey(const Key('obd2_diagnostics_tile')), findsNothing);
+    },
+  );
+
+  test(
+    'captureForTrip returns null for a pure GPS-only trip that never armed '
+    'OBD2 — zero extra bytes persisted',
+    () {
+      // Collector disarmed (production / GPS-only): nothing to persist.
+      expect(Obd2CommDiagnostics.instance.captureForTrip(), isNull);
+    },
+  );
+
+  test(
+    'TripHistoryEntry round-trips a fully-populated OBD2 diagnostic through '
+    'the real repo (save → reload), nested fields intact',
+    () async {
+      final repo = TripHistoryRepository(box: box);
+      final start = DateTime(2026, 6, 5, 11);
+      const diag = Obd2SessionDiagnostic(
+        linkKind: 'classic',
+        redactedMac: '···············6:DA',
+        elmVersion: 'ELM327 v2.1',
+        connection: Obd2ConnectionStats(attempts: 4, successes: 3, drops: 1),
+        reconnectAttempts: [
+          Obd2ReconnectAttempt(
+            timestampMs: 1717577400000,
+            attemptNumber: 1,
+            succeeded: true,
+            backoffMs: 1000,
+            latencyMs: 850,
+          ),
+        ],
+        disconnectExceptions: 2,
+        fallbackActivatedAtMs: 1717577410000,
+      );
+
+      await repo.save(TripHistoryEntry(
+        id: start.toIso8601String(),
+        vehicleId: 'car-b',
+        summary: mkSummary(start),
+        obd2Diagnostic: diag,
+      ));
+
+      final reloaded = repo.loadById(start.toIso8601String());
+      expect(reloaded?.obd2Diagnostic, equals(diag));
+    },
+  );
+}

--- a/test/features/consumption/data/obd2/obd2_comm_diagnostics_test.dart
+++ b/test/features/consumption/data/obd2/obd2_comm_diagnostics_test.dart
@@ -264,4 +264,31 @@ void main() {
       expect(c.snapshot(), const Obd2SessionDiagnostic());
     });
   });
+
+  group('Obd2CommDiagnostics.captureForTrip — never-throws contract '
+      '(#2349/#2912)', () {
+    test('an internal fault degrades to null — the trip save is never derailed',
+        () {
+      // The trip-save flow calls captureForTrip at trip finish and relies on
+      // its #1103 never-throws contract: any internal fault must degrade to
+      // null (the trip still saves, just without a diagnostic), never rethrow.
+      // Inject the fault through the clock seam — armed only AFTER the session
+      // is set up, so beginSession succeeds and _summarise then throws.
+      var armed = false;
+      final c = Obd2CommDiagnostics(
+        enabled: true,
+        clock: () {
+          if (armed) throw StateError('injected clock fault');
+          return DateTime(2026, 1, 1);
+        },
+      );
+      c.beginSession(redactedMac: 'AA:BB:**:**:**:FF');
+      c.recordAdapterIdentity(elmVersion: 'ELM327 v1.5');
+      armed = true;
+
+      expect(c.captureForTrip(), isNull,
+          reason: 'an internal fault degrades to null, never an exception');
+      expect(c.captureForTrip, returnsNormally);
+    });
+  });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -406,7 +406,12 @@ void main() {
     // #2787 — 1240 → 1246: the no-movement discard now only error-logs when
     // captured signal is actually dropped (the droppedCapturedSignal guard +
     // its comment), so an empty stop no longer spams the error log.
-    'lib/features/consumption/providers/trip_recording_provider.dart': 1246,
+    // #2912 — 1246 → 1250: `_saveToHistory` now captures + persists the
+    // per-trip OBD2 comm-health diagnostic (the never-throws `captureForTrip`
+    // call + the `obd2Diagnostic` constructor arg) so the always-empty card is
+    // fixed. Minimum footprint for a new persisted field; the god-class
+    // decomposition stays tracked by #2187/#2188/#2190.
+    'lib/features/consumption/providers/trip_recording_provider.dart': 1250,
     'lib/features/feature_management/data/legacy_toggle_migrator.dart': 647,
     // #2510 — re-grandfathered 544 → 562: the nearby-search map no longer
     // hides results behind count-clusters. Adds the `rankForEmphasis`


### PR DESCRIPTION
## What

The OBD2 communication-health card on Trip History was **always empty**: `Obd2DiagnosticsTripCard` rendered the process-wide in-memory `Obd2CommDiagnostics.instance` singleton (`finishedSessions.last` / live `snapshot()`), **NOT** the viewed trip's diagnostic. The singleton is wiped on app restart and never tied to a trip, so every past trip showed the same global last-session/live snapshot — i.e. empty once the process restarted, and empty for an adapter that never connected (no live "session") — exactly when the diagnostics matter most.

## How

Builds on the #2911 / #2905 `Obd2SessionDiagnostic`:

- **Capture** — `Obd2CommDiagnostics.captureForTrip()`: a never-throws (#1103) accessor that snapshots the live session at trip finish (incl. the #2905 reconnect timeline / session-state transitions / failed-connect reasons, even when the adapter never connected). Returns `null` when there's no signal worth persisting.
- **Persist** — nullable `Obd2SessionDiagnostic? obd2Diagnostic` on `TripHistoryEntry`, compact-key (`obd2d`) JSON round-trip via the nested freezed model's own `toJson`/`fromJson` — a real serialised field, **not** `@JsonKey`-dropped (#2776 lesson). Null for production / GPS-only / legacy trips ⇒ zero extra bytes, card keeps self-hiding.
- **Capture point** — `_saveToHistory` (the trip-finish path shared by both pipelines) reads `captureForTrip()` and stores it with the trip, before the OBD2 service disconnects, so the live session is intact.
- **Wire** — `Obd2DiagnosticsTripCard` takes the viewed trip's persisted diagnostic; falls back to the live singleton only for the in-progress / just-finished trip. The dev-tools `Obd2HealthScreen` keeps the live singleton.

Extracted the `TripSummary` JSON codec into `trip_summary_codec.dart` to keep `trip_history_repository.dart` under the 400-line cap (no silent grandfather bump).

## Test (RED-before / green-after)

`test/features/consumption/comm_health_per_trip_test.dart` drives the **real** capture → persist → reload → render path (not the adapter in isolation): a finished trip captures a failed-connect diagnostic → persists it via the real Hive repo → the in-memory singleton is **CLEARED** (restart) → the trip is reloaded from disk → the card renders the persisted values, **not** empty. Verified RED by simulating master's singleton-read behaviour (the assertion fails with the old wiring); green after.

## Gates

- `flutter analyze` clean (only 2 pre-existing `info` lints in untouched test files).
- Clean codegen committed (only the expected `trip_recording_provider.g.dart` hash drift); l10n drift = 0 (no new ARB strings).
- File-length cap respected via extraction; `trip_recording_provider.dart` re-grandfathered 1246→1250 with documented justification for the minimum new-field footprint.
- Related suites green: comm-health proof (4), trip_history_repository, file_length, the existing card test, all OBD2 data-layer tests (1444).

Child of Epic #2904.

Closes #2912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
