### PR TITLE
fix(driving): voice-announcement sliders show their value at rest (#2920)

### DIFF
--- a/lib/core/widgets/labeled_value_slider.dart
+++ b/lib/core/widgets/labeled_value_slider.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+/// A [Slider] that *always* shows its current value at rest.
+///
+/// `Slider(label: ...)` only paints the value inside the drag bubble while
+/// the thumb is being dragged — at rest the user sees a bare track with no
+/// readout (#2920). This widget wraps the slider in a
+/// `label · Expanded(Slider) · trailing-value` [Row] so the current value
+/// is visible at all times, mirroring the Edit-profile radius slider.
+///
+/// It is the single source of truth for this pattern: both
+/// `ProfileRadiusSlider` and the Voice-Announcements sliders compose it.
+///
+/// The [valueLabel] is rendered both as the persistent trailing readout
+/// *and* as the slider's drag-bubble [Slider.label], so the in-drag bubble
+/// and the at-rest readout agree.
+class LabeledValueSlider extends StatelessWidget {
+  /// Leading description of what the slider controls (already localized).
+  final String label;
+
+  /// The current value formatted for display (e.g. `"2.5 km"`, `"30 min"`,
+  /// a formatted price). Shown as the persistent trailing readout.
+  final String valueLabel;
+
+  final double value;
+  final double min;
+  final double max;
+  final int? divisions;
+  final ValueChanged<double> onChanged;
+
+  /// Optional [Key] forwarded to the inner [Slider] so existing tests and
+  /// call sites that target the slider by key keep working.
+  final Key? sliderKey;
+
+  /// Optional text style for the leading [label] (defaults to the slider's
+  /// surrounding text style).
+  final TextStyle? labelStyle;
+
+  const LabeledValueSlider({
+    super.key,
+    required this.label,
+    required this.valueLabel,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+    this.divisions,
+    this.sliderKey,
+    this.labelStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Flexible(child: Text(label, style: labelStyle)),
+        Expanded(
+          flex: 2,
+          child: Slider(
+            key: sliderKey,
+            value: value,
+            min: min,
+            max: max,
+            divisions: divisions,
+            label: valueLabel,
+            onChanged: onChanged,
+          ),
+        ),
+        Text(valueLabel, style: labelStyle),
+      ],
+    );
+  }
+}

--- a/lib/features/driving/presentation/widgets/driving_settings_section.dart
+++ b/lib/features/driving/presentation/widgets/driving_settings_section.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/theme/spacing.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/labeled_value_slider.dart';
 import '../../../../core/widgets/section_header.dart';
 import '../../../../core/widgets/settings_menu_tile.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -258,12 +259,9 @@ class _VoiceAnnouncementsTile extends ConsumerWidget {
     final config = ref.watch(voiceAnnouncementSettingsProvider);
     final notifier = ref.read(voiceAnnouncementSettingsProvider.notifier);
 
-    final thresholdLabel = config.priceThreshold != null
-        ? (l?.voiceAnnouncementThreshold(
-                PriceFormatter.formatPrice(config.priceThreshold)) ??
-            'Only below ${PriceFormatter.formatPrice(config.priceThreshold)}')
-        : (l?.voiceAnnouncementsDescription ??
-            'Announce nearby cheap stations while driving');
+    final double radiusKm = config.proximityRadiusKm.clamp(0.5, 5.0);
+    final int cooldownMin = config.cooldown.inMinutes.clamp(5, 60);
+    final double thresholdEur = (config.priceThreshold ?? 2.0).clamp(1.0, 2.5);
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -282,56 +280,51 @@ class _VoiceAnnouncementsTile extends ConsumerWidget {
           contentPadding: EdgeInsets.zero,
         ),
         if (config.enabled) ...[
-          // Proximity radius — 0.5 … 5 km in 0.5 km steps.
-          ListTile(
-            contentPadding: EdgeInsets.zero,
-            title: Text(
-              l?.voiceAnnouncementProximityRadius ?? 'Announcement radius',
-              style: theme.textTheme.bodyMedium,
-            ),
-            subtitle: Slider(
-              key: const Key('voiceAnnouncementRadiusSlider'),
-              value: config.proximityRadiusKm.clamp(0.5, 5.0),
-              min: 0.5,
-              max: 5.0,
-              divisions: 9,
-              label: '${config.proximityRadiusKm.toStringAsFixed(1)} km',
-              onChanged: (v) => notifier.setProximityRadiusKm(v),
-            ),
+          // Proximity radius — 0.5 … 5 km in 0.5 km steps. The current
+          // value is shown as a persistent trailing readout (#2920) — a
+          // bare `Slider.label` is only visible while dragging.
+          LabeledValueSlider(
+            sliderKey: const Key('voiceAnnouncementRadiusSlider'),
+            label: l?.voiceAnnouncementProximityRadius ?? 'Announcement radius',
+            // i18n-ignore: " km" is a language-neutral unit suffix (matches
+            // ProfileRadiusSlider + the {km} ARB masks).
+            valueLabel: '${radiusKm.toStringAsFixed(1)} km',
+            labelStyle: theme.textTheme.bodyMedium,
+            value: radiusKm,
+            min: 0.5,
+            max: 5.0,
+            divisions: 9,
+            onChanged: (v) => notifier.setProximityRadiusKm(v),
           ),
           // Repeat cooldown — 5 … 60 minutes in 5-minute steps.
-          ListTile(
-            contentPadding: EdgeInsets.zero,
-            title: Text(
-              l?.voiceAnnouncementCooldown ?? 'Repeat interval',
-              style: theme.textTheme.bodyMedium,
-            ),
-            subtitle: Slider(
-              key: const Key('voiceAnnouncementCooldownSlider'),
-              value: config.cooldown.inMinutes.clamp(5, 60).toDouble(),
-              min: 5,
-              max: 60,
-              divisions: 11,
-              label: '${config.cooldown.inMinutes} min',
-              onChanged: (v) =>
-                  notifier.setCooldown(Duration(minutes: v.round())),
-            ),
+          LabeledValueSlider(
+            sliderKey: const Key('voiceAnnouncementCooldownSlider'),
+            label: l?.voiceAnnouncementCooldown ?? 'Repeat interval',
+            // i18n-ignore: " min" is a language-neutral unit abbreviation.
+            valueLabel: '$cooldownMin min',
+            labelStyle: theme.textTheme.bodyMedium,
+            value: cooldownMin.toDouble(),
+            min: 5,
+            max: 60,
+            divisions: 11,
+            onChanged: (v) =>
+                notifier.setCooldown(Duration(minutes: v.round())),
           ),
-          // Cheap-fuel price threshold — current value shown in the
-          // active currency; the slider spans a sensible per-litre band.
-          ListTile(
+          // Cheap-fuel price ceiling — only stations at or below this
+          // per-litre figure are announced. Its own distinct label
+          // ("Maximum price") fixes the #2920 fallback that duplicated the
+          // section subtitle; the value shows in the active currency.
+          LabeledValueSlider(
             key: const Key('voiceAnnouncementThresholdTile'),
-            contentPadding: EdgeInsets.zero,
-            title: Text(thresholdLabel, style: theme.textTheme.bodyMedium),
-            subtitle: Slider(
-              key: const Key('voiceAnnouncementThresholdSlider'),
-              value: (config.priceThreshold ?? 2.0).clamp(1.0, 2.5),
-              min: 1.0,
-              max: 2.5,
-              divisions: 30,
-              label: PriceFormatter.formatPrice(config.priceThreshold ?? 2.0),
-              onChanged: (v) => notifier.setPriceThreshold(v),
-            ),
+            sliderKey: const Key('voiceAnnouncementThresholdSlider'),
+            label: l?.voiceAnnouncementPriceLimit ?? 'Maximum price',
+            valueLabel: PriceFormatter.formatPrice(thresholdEur),
+            labelStyle: theme.textTheme.bodyMedium,
+            value: thresholdEur,
+            min: 1.0,
+            max: 2.5,
+            divisions: 30,
+            onChanged: (v) => notifier.setPriceThreshold(v),
           ),
         ],
       ],

--- a/lib/features/profile/presentation/widgets/profile_radius_slider.dart
+++ b/lib/features/profile/presentation/widgets/profile_radius_slider.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/widgets/labeled_value_slider.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Profile-edit slider for the user's preferred default search radius
@@ -12,7 +13,8 @@ import '../../../../l10n/app_localizations.dart';
 /// Pulled out of `profile_edit_sheet.dart` so the sheet's `build` method
 /// drops the inline `Row` block and so the slider's range, division
 /// count, and value mirroring can be exercised by widget tests in
-/// isolation.
+/// isolation. Composes the shared [LabeledValueSlider] (#2920) so the
+/// at-rest value readout pattern has a single source of truth.
 class ProfileRadiusSlider extends StatelessWidget {
   final double value;
   final ValueChanged<double> onChanged;
@@ -26,21 +28,14 @@ class ProfileRadiusSlider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    return Row(
-      children: [
-        Text('${l10n?.defaultRadius ?? "Radius"}:'),
-        Expanded(
-          child: Slider(
-            value: value,
-            min: 1,
-            max: 25,
-            divisions: 24,
-            label: '${value.round()} km',
-            onChanged: onChanged,
-          ),
-        ),
-        Text('${value.round()} km'),
-      ],
+    return LabeledValueSlider(
+      label: '${l10n?.defaultRadius ?? "Radius"}:',
+      valueLabel: '${value.round()} km',
+      value: value,
+      min: 1,
+      max: 25,
+      divisions: 24,
+      onChanged: onChanged,
     );
   }
 }

--- a/lib/l10n/_fragments/_base_de.arb
+++ b/lib/l10n/_fragments/_base_de.arb
@@ -890,6 +890,7 @@
   },
   "voiceAnnouncementProximityRadius": "Ansage-Radius",
   "voiceAnnouncementCooldown": "Wiederholungsintervall",
+  "voiceAnnouncementPriceLimit": "Höchstpreis",
   "nearestStations": "Nächste Tankstellen",
   "nearestStationsHint": "Die nächstgelegenen Tankstellen über Ihren Standort finden",
   "consumptionLogTitle": "Verbrauch",

--- a/lib/l10n/_fragments/_base_en.arb
+++ b/lib/l10n/_fragments/_base_en.arb
@@ -973,6 +973,10 @@
   },
   "voiceAnnouncementProximityRadius": "Announcement radius",
   "voiceAnnouncementCooldown": "Repeat interval",
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "description": "Title of the voice-announcement price-threshold slider in driving settings: only stations priced at or below this per-litre figure are announced."
+  },
   "nearestStations": "Nearest stations",
   "nearestStationsHint": "Find the closest stations using your current location",
   "consumptionLogTitle": "Fuel consumption",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -898,6 +898,7 @@
   },
   "voiceAnnouncementProximityRadius": "Ansage-Radius",
   "voiceAnnouncementCooldown": "Wiederholungsintervall",
+  "voiceAnnouncementPriceLimit": "Höchstpreis",
   "nearestStations": "Nächste Tankstellen",
   "nearestStationsHint": "Die nächstgelegenen Tankstellen über Ihren Standort finden",
   "consumptionLogTitle": "Verbrauch",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -981,6 +981,10 @@
   },
   "voiceAnnouncementProximityRadius": "Announcement radius",
   "voiceAnnouncementCooldown": "Repeat interval",
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "description": "Title of the voice-announcement price-threshold slider in driving settings: only stations priced at or below this per-litre figure are announced."
+  },
   "nearestStations": "Nearest stations",
   "nearestStationsHint": "Find the closest stations using your current location",
   "consumptionLogTitle": "Fuel consumption",

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -550,6 +550,7 @@
   "voiceAnnouncementCheapFuel": "⟦{station}, {distance} ķîłóɱéŧéřš áĥéáđ, {fuelType} {price} ·······⟧",
   "voiceAnnouncementProximityRadius": "⟦Áññóúñçéɱéñŧ řáđîúš ········⟧",
   "voiceAnnouncementCooldown": "⟦Řéƥéáŧ îñŧéřṽáł ······⟧",
+  "voiceAnnouncementPriceLimit": "⟦Ṁáẋîɱúɱ ƥřîçé ·····⟧",
   "nearestStations": "⟦Ñéářéšŧ šŧáŧîóñš ·······⟧",
   "nearestStationsHint": "⟦Ƒîñđ ŧĥé çłóšéšŧ šŧáŧîóñš úšîñǧ ýóúř çúřřéñŧ łóçáŧîóñ ·····················⟧",
   "consumptionLogTitle": "⟦Ƒúéł çóñšúɱƥŧîóñ ·······⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4486,5 +4486,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3446,6 +3446,12 @@ abstract class AppLocalizations {
   /// **'Repeat interval'**
   String get voiceAnnouncementCooldown;
 
+  /// Title of the voice-announcement price-threshold slider in driving settings: only stations priced at or below this per-litre figure are announced.
+  ///
+  /// In en, this message translates to:
+  /// **'Maximum price'**
+  String get voiceAnnouncementPriceLimit;
+
   /// No description provided for @nearestStations.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1853,6 +1853,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Интервал на повторение';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Nai-blizki stantsii';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1847,6 +1847,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Interval opakování';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Nejblizsi stanice';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1843,6 +1843,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Gentagelsesinterval';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Naermeste stationer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1854,6 +1854,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Wiederholungsintervall';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Höchstpreis';
+
+  @override
   String get nearestStations => 'Nächste Tankstellen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1856,6 +1856,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Διάστημα επανάληψης';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Kontinoteroi stathmoi';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1833,6 +1833,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Repeat interval';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Nearest stations';
 
   @override
@@ -9417,6 +9420,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
 
   @override
   String get voiceAnnouncementCooldown => '⟦Řéƥéáŧ îñŧéřṽáł ······⟧';
+
+  @override
+  String get voiceAnnouncementPriceLimit => '⟦Ṁáẋîɱúɱ ƥřîçé ·····⟧';
 
   @override
   String get nearestStations => '⟦Ñéářéšŧ šŧáŧîóñš ·······⟧';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1850,6 +1850,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Intervalo de repetición';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Estaciones cercanas';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1839,6 +1839,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Kordamise intervall';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Lahimad jaamad';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1843,6 +1843,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Toistumisväli';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Lahimmat asemat';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1856,6 +1856,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Intervalle de répétition';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Stations les plus proches';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1843,6 +1843,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Interval ponavljanja';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Najblize postaje';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1850,6 +1850,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Ismétlési intervallum';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Legkozelebbi kutjak';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1849,6 +1849,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Intervallo ripetizione';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Stazioni piu vicine';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1847,6 +1847,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Kartojimo intervalas';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Artimiausios degalines';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1848,6 +1848,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Atkārtošanas intervāls';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Tuvakias degvielas uzpildes stacijas';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1841,6 +1841,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Gjentakelsesintervall';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Naermeste stasjoner';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1851,6 +1851,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Herhalingsinterval';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Dichtstbijzijnde stations';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1848,6 +1848,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Interwał powtórzeń';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Najblizsze stacje';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1852,6 +1852,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Intervalo de repetição';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Postos mais proximos';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1850,6 +1850,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Interval de repetare';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Cele mai apropiate statii';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1851,6 +1851,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Interval opakovania';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Najblizsie stanice';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1843,6 +1843,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Interval ponavljanja';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Najblizje postaje';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1842,6 +1842,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get voiceAnnouncementCooldown => 'Upprepningsintervall';
 
   @override
+  String get voiceAnnouncementPriceLimit => 'Maximum price';
+
+  @override
   String get nearestStations => 'Narmaste stationer';
 
   @override

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4383,5 +4383,10 @@
   "@pasteReceiptNoData": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "voiceAnnouncementPriceLimit": "Maximum price",
+  "@voiceAnnouncementPriceLimit": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/features/driving/presentation/driving_settings_section_test.dart
+++ b/test/features/driving/presentation/driving_settings_section_test.dart
@@ -5,14 +5,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/services/announcement_engine.dart';
 import 'package:tankstellen/core/storage/storage_providers.dart';
+import 'package:tankstellen/core/utils/price_formatter.dart';
+import 'package:tankstellen/core/widgets/labeled_value_slider.dart';
 import 'package:tankstellen/core/widgets/section_header.dart';
 import 'package:tankstellen/core/widgets/settings_menu_tile.dart';
 import 'package:tankstellen/features/driving/presentation/widgets/driving_settings_section.dart';
+import 'package:tankstellen/features/driving/providers/voice_announcement_settings_provider.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/glide_coach/providers/glide_coach_enabled_provider.dart';
 import 'package:tankstellen/features/profile/presentation/widgets/gamification_settings_tile.dart';
+import 'package:tankstellen/features/profile/providers/voice_announcements_enabled_provider.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 
 import '../../../fakes/fake_storage_repository.dart';
@@ -342,6 +347,82 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'voice-announcement sliders show their CURRENT value as visible text at '
+    'rest — radius, repeat interval and the price limit (#2920)',
+    (tester) async {
+      // A known config the user would see on the settings screen: 2.5 km
+      // radius, a 30-minute repeat interval, and a 2.0 €/L price ceiling.
+      const config = AnnouncementConfig(
+        enabled: true,
+        proximityRadiusKm: 2.5,
+        cooldown: Duration(minutes: 30),
+        priceThreshold: 2.0,
+      );
+
+      await pumpApp(
+        tester,
+        const DrivingSettingsSection(),
+        overrides: [
+          settingsStorageProvider.overrideWithValue(_FakeSettingsStorage()),
+          storageRepositoryProvider.overrideWithValue(FakeStorageRepository()),
+          featureFlagsProvider.overrideWith(() => _TestFeatureFlags()),
+          // The voice-announcements tile is gated behind this master flag.
+          voiceAnnouncementsEnabledProvider.overrideWithValue(true),
+          voiceAnnouncementSettingsProvider
+              .overrideWith(() => _FakeVoiceSettings(config)),
+        ],
+      );
+
+      // Sanity: the section rendered the new shared slider widget.
+      expect(
+        find.byType(LabeledValueSlider),
+        findsNWidgets(3),
+        reason: 'All three voice sliders must use the shared '
+            'LabeledValueSlider so the value is always visible.',
+      );
+
+      // The regression the user reported: each slider must show its value
+      // as TEXT at rest, not only inside the (drag-only) Slider.label.
+      expect(
+        find.text('2.5 km'),
+        findsOneWidget,
+        reason: 'The announcement-radius slider must show "2.5 km" at rest '
+            '(#2920) — a bare Slider.label is invisible until dragged.',
+      );
+      expect(
+        find.text('30 min'),
+        findsOneWidget,
+        reason: 'The repeat-interval slider must show "30 min" at rest.',
+      );
+      final priceText = PriceFormatter.formatPrice(2.0);
+      expect(
+        find.text(priceText),
+        findsOneWidget,
+        reason: 'The price-limit slider must show the formatted price '
+            '("$priceText") at rest.',
+      );
+
+      // The 3rd slider must carry its OWN distinct label, not the section
+      // subtitle text it used to fall back to (#2920 mislabel).
+      final l = AppLocalizations.of(
+        tester.element(find.byType(DrivingSettingsSection)),
+      )!;
+      expect(
+        find.text(l.voiceAnnouncementPriceLimit),
+        findsOneWidget,
+        reason: 'The price-threshold slider must show a distinct '
+            '"Maximum price" label — not the duplicated section subtitle.',
+      );
+      expect(
+        find.text(l.voiceAnnouncementsDescription),
+        findsOneWidget,
+        reason: 'The section subtitle text must appear exactly once (on the '
+            'enable toggle) — never duplicated onto the price slider.',
+      );
+    },
+  );
 }
 
 /// Synthetic in-memory [FeatureFlags] notifier for widget tests.
@@ -371,6 +452,20 @@ class _TestFeatureFlags extends FeatureFlags {
     final current = state.value ?? const <Feature>{}; if (!current.contains(feature)) return;
     state = AsyncData({...current}..remove(feature));
   }
+}
+
+/// In-memory [VoiceAnnouncementSettings] for widget tests.
+///
+/// Returns the seeded [AnnouncementConfig] from `build()` synchronously,
+/// bypassing the real notifier's `SharedPreferences` `_load()` so the
+/// section renders the exact config under test without platform plumbing.
+class _FakeVoiceSettings extends VoiceAnnouncementSettings {
+  _FakeVoiceSettings(this._config);
+
+  final AnnouncementConfig _config;
+
+  @override
+  AnnouncementConfig build() => _config;
 }
 
 class _FakeSettingsStorage implements SettingsStorage {


### PR DESCRIPTION
Closes #2920.

## Problem

In **Settings → Conso → Voice Announcements**, the three tuning sliders showed **no current value at rest**. Each passed its value only via `Slider(label: ...)`, which Flutter paints solely inside the drag bubble while dragging — at rest the user saw a bare track with no readout.

A secondary bug: the price-threshold slider's title fell back to `voiceAnnouncementsDescription` ("Announce nearby cheap stations while driving") — the same text as the section subtitle — whenever no threshold was stored (the default after a fresh install), so it read as a duplicate and never described what it controls.

## Fix

- **New shared `LabeledValueSlider`** (`lib/core/widgets/labeled_value_slider.dart`): `label · Expanded(Slider) · trailing value` — the single source of truth for the "value always visible" pattern. It renders the value as a persistent trailing `Text` **and** as the slider's drag-bubble label so the two always agree.
- All three Voice-Announcements sliders now compose it (keys preserved): radius shows `"2.5 km"`, repeat interval `"30 min"`, price limit the formatted price.
- `ProfileRadiusSlider` refactored onto the same widget (it already had this layout inline) — single source of truth.
- **3rd-slider label fix**: new distinct ARB key `voiceAnnouncementPriceLimit` ("Maximum price" / "Höchstpreis"), fanned out to all 23 locales + the `en_XA` pseudo-locale. The duplicated-subtitle fallback is gone.

## Regression guard

New widget test pumps the section with a known config and asserts each slider's value is **visible as text at rest** (`find.text('2.5 km')`, `'30 min'`, the formatted price) — not just the drag-only `Slider.label` — plus that the price slider carries its own distinct label and the subtitle text appears exactly once. This is the test that would have caught "no values shown".

## Gates

- `flutter analyze` clean on all changed files (2 remaining infos are pre-existing in unrelated consumption test files, untouched here).
- L10n: all 23 locales at 100% coverage; en_XA regenerated; full fan-out committed.
- No `*.g.dart` / `*.freezed.dart` drift (no annotated source changed).
- `driving_settings_section.dart` 373 → 366 lines (under the 400 cap; the extraction helped).
- Hardcoded-strings lint baseline (0) held; unit suffixes `" km"` / `" min"` carry `// i18n-ignore` (language-neutral, matching existing `{km}` ARB masks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
