### PR TITLE
refactor(gps-only) C5: route the hard-accel lesson through the IMU-preferred count (#2924)

### DIFF
--- a/lib/features/consumption/data/lessons/rules/hard_accel_rule.dart
+++ b/lib/features/consumption/data/lessons/rules/hard_accel_rule.dart
@@ -17,6 +17,18 @@ const String hardAccelLessonId = 'hardAccel';
 /// headline from the event count in the insight metadata (`eventCount`),
 /// not a percent — this rule reproduces that exactly. Impact / metric is
 /// the litres wasted so ranking matches the old card.
+///
+/// #2789 C5 — single source of truth. When the phone IMU actually RAN for
+/// this trip (`summary.imuActive`, #2895), the headline event count is
+/// sourced from the IMU-preferred figure the recording pipeline persisted
+/// into [TripSummary.harshAccelerations] — the same accurate inertial count
+/// the driving score and [HardBrakeRule] read — instead of the noisy GPS
+/// speed-derivative `eventCount` in the analyzer metadata (which can
+/// over-count Doppler noise into impossible spikes, the #2895 16-vs-0 bug).
+/// When no IMU ran, the (now physically-clamped, #2895) GPS-derived count
+/// remains the source. The estimated litres wasted (impact / ranking /
+/// trailing) still come from the analyzer's cost line so the cost model is
+/// unchanged.
 class HardAccelRule implements DrivingLessonRule {
   const HardAccelRule();
 
@@ -30,8 +42,14 @@ class HardAccelRule implements DrivingLessonRule {
 
     final liters = formatLessonLiters(insight.litersWasted);
     final pct = formatLessonPercent(insight.percentOfTrip);
-    // The card pulled the event count out of the analyzer metadata bag.
-    final count = (insight.metadata['eventCount'] ?? 0).toInt().toString();
+    // #2789 C5 — prefer the IMU-resolved count when the inertial sensor ran;
+    // otherwise fall back to the GPS-derived event count from the analyzer
+    // metadata bag (the legacy source).
+    final summary = context.summary;
+    final eventCount = summary.imuActive
+        ? summary.harshAccelerations
+        : (insight.metadata['eventCount'] ?? 0).toInt();
+    final count = eventCount.toString();
     return DrivingLesson(
       id: id,
       impact: insight.litersWasted,

--- a/test/features/consumption/data/lessons/driving_lesson_registry_test.dart
+++ b/test/features/consumption/data/lessons/driving_lesson_registry_test.dart
@@ -298,5 +298,51 @@ void main() {
       expect(hardAccel.title, '5 hard accelerations: wasted 0.3 L');
       expect(hardAccel.trailing, '+0.3 L');
     });
+
+    test('hard-accel lesson sources its count from the IMU-preferred figure '
+        'when the IMU ran (#2789 C5 single source of truth)', () {
+      // A GPS-only trip whose phone IMU actually ran (imuActive=true) and
+      // counted N=2 hard accelerations — but the noisy GPS speed-derivative
+      // over-counts 5 from the same sample stream (the #2895 over-count).
+      // The recording pipeline persists the IMU figure into
+      // harshAccelerations; the lesson must mirror the score + HardBrakeRule
+      // and headline the IMU count (2), NOT the GPS-derived 5.
+      const imuActiveSummary = TripSummary(
+        distanceKm: 5,
+        maxRpm: 4000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 2, // IMU-preferred count (#2895)
+        kind: TripKind.gpsOnly,
+        imuHardAccelCount: 2,
+        imuActive: true,
+      );
+      final reg = DrivingLessonRegistry.standard();
+      final lessons = reg.evaluate(imuActiveSummary, hardAccelSamples(), l);
+      final hardAccel = lessons.firstWhere((e) => e.id == hardAccelLessonId);
+      // Headline reflects the IMU count (2), not the GPS-derived 5.
+      expect(hardAccel.title, startsWith('2 hard accelerations'));
+    });
+
+    test('hard-accel lesson keeps the GPS-derived count when the IMU did NOT '
+        'run (#2789 C5 fallback)', () {
+      // imuActive=false → no inertial signal → fall back to the (clamped)
+      // GPS-derived eventCount exactly as before.
+      const noImuSummary = TripSummary(
+        distanceKm: 5,
+        maxRpm: 4000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 0,
+        harshAccelerations: 2, // ignored — IMU did not run
+        kind: TripKind.gpsOnly,
+        imuActive: false,
+      );
+      final reg = DrivingLessonRegistry.standard();
+      final lessons = reg.evaluate(noImuSummary, hardAccelSamples(), l);
+      final hardAccel = lessons.firstWhere((e) => e.id == hardAccelLessonId);
+      expect(hardAccel.title, startsWith('5 hard accelerations'));
+    });
   });
 }


### PR DESCRIPTION
**Epic #2789 C5 — completes the single-source-of-truth goal.** This is the **last open #2789 child**; the epic can close once this merges.

## Problem
C5 #2794 routed the GPS-only **driving score** through the IMU-preferred harsh-manoeuvre figures (`summary.harshAccelerations`, persisted by #2895 when `summary.imuActive` is true), and C4 #2793's `HardBrakeRule` already sources its episode count from the same IMU-preferred figure. But `HardAccelRule` (the hard-acceleration **lesson**) still derived its headline event count from the **noisy GPS speed-derivative** count in the analyzer's `insight.metadata['eventCount']` — the lone remaining consumer of the over-counting GPS figure (the #2895 Peugeot 107 "IMU 0 vs GPS 16" bug could still inflate the lesson headline even after the score was fixed).

## Fix
`HardAccelRule` now mirrors the score + `HardBrakeRule`:

```dart
final eventCount = summary.imuActive
    ? summary.harshAccelerations            // IMU-preferred (#2895)
    : (insight.metadata['eventCount'] ?? 0).toInt(); // GPS fallback (clamped)
```

- When the IMU ran → headline the accurate inertial count.
- When it didn't → fall back to the (now physically-clamped, #2895) GPS-derived count — **bit-for-bit the legacy behaviour**.
- The estimated litres wasted (impact / ranking / trailing) still come from the analyzer's cost line, so the cost model is unchanged.

## Tests (RED-before / green-after)
`test/features/consumption/data/lessons/driving_lesson_registry_test.dart`:
- A GPS-only trip with `imuActive=true`, IMU hard-accel count 2, but a GPS-derived 5 from the same sample stream → the lesson fires off **2**, not 5 (RED on master, green after).
- An `imuActive=false` trip keeps the GPS-derived **5** (fallback regression-protected).

## Gates
- ARB-free (reuses `l.insightHardAccel`); no codegen drift; no `lib/l10n/` drift.
- `flutter analyze` clean; full consumption-lessons suite green (28/28).
- 2 files, both under the 400-line cap; pure synchronous read — no try/catch / never-throws concern.

Closes #2924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
