### PR TITLE
fix(errorlog-25): de-noise expected OBD2 engine-off connect ERRORs + skip Downloads trace export in background isolate (#2933)

### DIFF
--- a/lib/core/background/background_scan_tracer.dart
+++ b/lib/core/background/background_scan_tracer.dart
@@ -3,11 +3,22 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart'
+    show MissingPluginException, RootIsolateToken;
 import 'package:hive/hive.dart';
 
 import '../logging/error_logger.dart';
 import '../services/diagnostics/data_access_recorder.dart';
 import '../services/diagnostics/data_access_trace_export.dart';
+
+/// #2933 (error-log #25) test seam: force the background-isolate verdict so a
+/// foreground unit test can drive both branches of [exportIfEnabled] without a
+/// real WorkManager isolate. Null ⇒ the real `RootIsolateToken.instance == null`
+/// probe. The platform-channel-bound `RootIsolateToken.instance` can't be
+/// mutated from a test, so this override is the only way to exercise the skip.
+@visibleForTesting
+bool? debugIsBackgroundIsolateOverride;
 
 /// Dev-gated #2824 data-access tracer for the background scan (Epic #2860 EXIT
 /// GATE, #2866).
@@ -54,19 +65,52 @@ class BackgroundScanTracer {
   /// When tracing, snapshot the recorder into a [DataAccessTrace] and export it
   /// to Downloads (the same dev-only sink the foreground uses). No-op + never
   /// throws when not tracing; a write fault is swallowed (logged downstream).
+  ///
+  /// #2933 (error-log #25) — the Downloads write goes through the
+  /// `tankstellen/public_files` platform channel, which is UNAVAILABLE in the
+  /// WorkManager background isolate (no plugin registrant) — it threw
+  /// `MissingPluginException` and spooled a spurious background ERROR. This is
+  /// inherently a foreground/UI sink, so in a background isolate we SKIP the
+  /// Downloads export entirely (debug breadcrumb only); the in-app
+  /// Developer-tools export still writes it from the root isolate.
+  /// [DataAccessTraceExport.export] also degrades a stray
+  /// [MissingPluginException] to a skip; the defensive catch here is the
+  /// second line of the same never-throws contract.
   Future<void> exportIfEnabled({String? comment}) async {
     final r = recorder;
     if (r == null) return;
+    if (_isBackgroundIsolate()) {
+      // The public-files channel has no registrant here; writing to Downloads
+      // is a foreground operation. Skip gracefully — no ERROR spool.
+      debugPrint('BackgroundScanTracer.exportIfEnabled: background isolate — '
+          'skipping Downloads export (foreground-only sink).');
+      return;
+    }
     try {
       final trace = r.build(
         comment: comment ?? 'Background multi-country alert scan (#2866).',
       );
       await DataAccessTraceExport.export(trace);
+    } on MissingPluginException {
+      // Defensive: the channel was unavailable despite the root-isolate probe
+      // (e.g. an isolate without a registrant). Degrade to a skip, not ERROR.
+      debugPrint('BackgroundScanTracer.exportIfEnabled: public_files channel '
+          'unavailable — skipping Downloads export.');
     } catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.background, e, st, context: const {
         'where': 'BackgroundScanTracer.exportIfEnabled',
       }));
     }
+  }
+
+  /// #2933 — true when this code is running in a non-root (background) isolate,
+  /// where platform channels have no registrant. `RootIsolateToken.instance` is
+  /// non-null ONLY on the root isolate; a WorkManager-spawned isolate returns
+  /// null. Honours [debugIsBackgroundIsolateOverride] for tests.
+  static bool _isBackgroundIsolate() {
+    final override = debugIsBackgroundIsolateOverride;
+    if (override != null) return override;
+    return RootIsolateToken.instance == null;
   }
 
   /// Read the persisted `debugMode` feature flag the foreground wrote to the

--- a/lib/core/services/diagnostics/data_access_trace_export.dart
+++ b/lib/core/services/diagnostics/data_access_trace_export.dart
@@ -3,6 +3,9 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show MissingPluginException;
+
 import '../../../core/logging/error_logger.dart';
 import '../../../core/sharing/public_file_exporter.dart';
 import 'data_access_trace.dart';
@@ -30,6 +33,14 @@ class DataAccessTraceExport {
         mimeType: 'application/json',
       );
       return true;
+    } on MissingPluginException {
+      // #2933 (error-log #25) — the `tankstellen/public_files` channel has no
+      // registrant outside the root isolate (e.g. a WorkManager background
+      // isolate). Writing to Downloads is a foreground sink; degrade to a skip
+      // (debug breadcrumb) rather than spool a spurious ERROR trace.
+      debugPrint('DataAccessTraceExport.export: public_files channel '
+          'unavailable — skipping Downloads write.');
+      return false;
     } on Object catch (e, st) {
       unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
         'where': 'DataAccessTraceExport.export: json write',

--- a/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
+++ b/lib/features/consumption/data/obd2/auto_trip_coordinator.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import '../../../../core/logging/error_logger.dart';
 import 'auto_record_trace_log.dart';
 import 'background_adapter_listener.dart';
+import 'obd2_read_telemetry.dart';
 import 'obd2_service.dart';
 import 'obd2_speed_stream.dart';
 
@@ -457,15 +458,14 @@ class AutoTripCoordinator {
         mac: config.mac,
         detail: 'exception=$e',
       );
-      await errorLogger.log(
-        ErrorLayer.background,
-        e,
-        st,
-        context: <String, Object?>{
-          'phase': 'AutoTripCoordinator.openSession',
-          'mac': config.mac,
-        },
-      );
+      // #2933 (error-log #25) — probing a PARKED car here, an EXPECTED
+      // "engine off / adapter asleep" condition spooled 42/44 of that log as a
+      // repeated Obd2AdapterUnresponsive ERROR. Route through the shared #2892
+      // de-noiser so the expected family records a breadcrumb (sessionOpenFailed
+      // above already captures it) while a GENUINE fault still ERROR-logs.
+      recordObd2ConnectTransient(e, st,
+          where: 'AutoTripCoordinator.openSession mac=${config.mac}',
+          layer: ErrorLayer.background);
     }
     if (service == null) {
       AutoRecordTraceLog.add(

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -672,10 +672,13 @@ class Obd2Service implements Obd2RawCommandPort {
       );
       return true;
     } catch (e, st) {
-      // #2379 — recoverable attempts suppress this; only a final failure
-      // logs (OBD2/BLE → `other`). The breadcrumb below always records it.
+      // #2379 final-failure log → #2933 (error-log #25): an EXPECTED engine-off
+      // condition (Obd2AdapterUnresponsive et al.) de-noises to a breadcrumb
+      // instead of an ERROR every retry (42/44 of that log); a GENUINE fault
+      // (permission / counterfeit-clone init) still ERROR-logs on `other`.
       if (logFailureAsError) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'OBD2 connect failed'}));
+        recordObd2ConnectTransient(e, st,
+            where: 'OBD2 connect failed', layer: ErrorLayer.other);
       }
       // #1920 — record the failure so the diagnostic log shows the
       // connect attempt that never produced a session.

--- a/test/core/background/background_scan_tracer_test.dart
+++ b/test/core/background/background_scan_tracer_test.dart
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/core/background/background_scan_tracer.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/sharing/public_file_exporter.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+
+/// #2933 (error-log #25) part B — the background tracer's Downloads export
+/// must NOT crash / spool an ERROR when the `tankstellen/public_files` platform
+/// channel is unavailable in a WorkManager background isolate.
+///
+/// Field stack: `BackgroundScanTracer.exportIfEnabled` →
+/// `DataAccessTraceExport.export` → `PublicFileExporter.saveBytesToDownloads`
+/// → MethodChannel `tankstellen/public_files` → `MissingPluginException` (no
+/// plugin registrant in the background isolate). The export is a foreground
+/// sink; the fix skips it in the background isolate and degrades a stray
+/// channel fault to a no-op instead of an ERROR trace.
+class _CapturingRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+          {ServiceChainSnapshot? serviceChainState}) async =>
+      errors.add(error);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory tempDir;
+  late _CapturingRecorder rec;
+
+  // i18n-ignore: Hive box name, not user-facing.
+  const boxName = 'feature_flags';
+  // i18n-ignore: storage key (Feature.debugMode.name), not user-facing.
+  const debugModeKey = 'debugMode';
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_bg_tracer_');
+    Hive.init(tempDir.path);
+  });
+
+  setUp(() async {
+    errorLogger.resetForTest();
+    rec = _CapturingRecorder();
+    errorLogger.testRecorderOverride = rec;
+    if (!Hive.isBoxOpen(boxName)) {
+      await Hive.openBox<dynamic>(boxName);
+    }
+    // Developer mode ON so `forScan()` returns a TRACING tracer (recorder
+    // non-null) — the precondition for the export path to be reached at all.
+    await Hive.box<dynamic>(boxName).put(debugModeKey, true);
+  });
+
+  tearDown(() async {
+    errorLogger.resetForTest();
+    debugIsBackgroundIsolateOverride = null;
+    debugPublicFileExporterOverride = null;
+    if (Hive.isBoxOpen(boxName)) await Hive.box<dynamic>(boxName).clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('forScan with developer mode on yields a tracing tracer', () {
+    final tracer = BackgroundScanTracer.forScan();
+    expect(tracer.isTracing, isTrue,
+        reason: 'the feature_flags box has debugMode=true');
+  });
+
+  test(
+      'in a BACKGROUND isolate, exportIfEnabled SKIPS the Downloads export '
+      'without spooling an ERROR or rethrowing (#2933)', () async {
+    debugIsBackgroundIsolateOverride = true;
+    var saverCalls = 0;
+    debugPublicFileExporterOverride = ({
+      required Uint8List bytes,
+      required String fileName,
+      required String mimeType,
+    }) async {
+      saverCalls++;
+      return 'fake://Downloads/$fileName';
+    };
+
+    final tracer = BackgroundScanTracer.forScan();
+
+    // Must complete normally (never-throws contract for the background path).
+    await tracer.exportIfEnabled();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(saverCalls, 0,
+        reason: 'the foreground-only Downloads sink is skipped in the '
+            'background isolate');
+    expect(rec.errors, isEmpty,
+        reason: 'skipping the unavailable channel must NOT spool a background '
+            'ERROR — the field MissingPluginException flood');
+  });
+
+  test(
+      'when the public_files channel throws MissingPluginException, '
+      'exportIfEnabled degrades to a skip — no ERROR, no rethrow (#2933)',
+      () async {
+    // Force the FOREGROUND branch so the export path actually calls the saver,
+    // then make the saver throw the exact field exception.
+    debugIsBackgroundIsolateOverride = false;
+    debugPublicFileExporterOverride = ({
+      required Uint8List bytes,
+      required String fileName,
+      required String mimeType,
+    }) async {
+      throw MissingPluginException(
+        'No implementation found for method saveBytes on channel '
+        'tankstellen/public_files',
+      );
+    };
+
+    final tracer = BackgroundScanTracer.forScan();
+
+    // The never-throws contract: the injected channel fault must not surface.
+    await expectLater(tracer.exportIfEnabled(), completes);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(rec.errors, isEmpty,
+        reason: 'a MissingPluginException from an unregistered channel must '
+            'degrade to a skip, not an ERROR trace');
+  });
+
+  test(
+      'in the FOREGROUND with a working channel, exportIfEnabled STILL saves '
+      'to Downloads (the guard does not break the real export)', () async {
+    debugIsBackgroundIsolateOverride = false;
+    var saverCalls = 0;
+    String? savedName;
+    debugPublicFileExporterOverride = ({
+      required Uint8List bytes,
+      required String fileName,
+      required String mimeType,
+    }) async {
+      saverCalls++;
+      savedName = fileName;
+      return 'fake://Downloads/$fileName';
+    };
+
+    final tracer = BackgroundScanTracer.forScan();
+
+    await tracer.exportIfEnabled();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(saverCalls, 1,
+        reason: 'the foreground path still writes the trace to Downloads');
+    expect(savedName, contains('tankstellen-dataaccess-'));
+    expect(rec.errors, isEmpty);
+  });
+
+  test('a non-tracing tracer (developer mode off) is a no-op', () async {
+    await Hive.box<dynamic>(boxName).put(debugModeKey, false);
+    debugIsBackgroundIsolateOverride = false;
+    var saverCalls = 0;
+    debugPublicFileExporterOverride = ({
+      required Uint8List bytes,
+      required String fileName,
+      required String mimeType,
+    }) async {
+      saverCalls++;
+      return '';
+    };
+
+    final tracer = BackgroundScanTracer.forScan();
+    expect(tracer.isTracing, isFalse);
+
+    await tracer.exportIfEnabled();
+    expect(saverCalls, 0);
+    expect(rec.errors, isEmpty);
+  });
+}

--- a/test/features/consumption/data/obd2/auto_trip_coordinator_test.dart
+++ b/test/features/consumption/data/obd2/auto_trip_coordinator_test.dart
@@ -5,11 +5,13 @@ import 'dart:collection';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
 import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/auto_record_trace_log.dart';
 import 'package:tankstellen/features/consumption/data/obd2/auto_trip_coordinator.dart';
 import 'package:tankstellen/features/consumption/data/obd2/elm327_protocol.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/fake_background_adapter_listener.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_speed_stream.dart';
@@ -94,15 +96,20 @@ class _OpenerError {
 }
 
 /// In-memory [TraceRecorder] used to drain `errorLogger.log` calls
-/// during failure-path tests. We don't assert on the captured records
-/// — we just stop the global logger from reaching Hive.
+/// during failure-path tests. It also captures the spooled errors so the
+/// #2933 de-noise tests can assert which ones reach the ERROR spool — the
+/// prior tests that don't inspect [errors] are unaffected.
 class _FakeTraceRecorder implements TraceRecorder {
+  final List<Object> errors = <Object>[];
+
   @override
   Future<void> record(
     Object error,
     StackTrace stackTrace, {
     ServiceChainSnapshot? serviceChainState,
-  }) async {}
+  }) async {
+    errors.add(error);
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>
@@ -120,6 +127,7 @@ void main() {
 
   late FakeBackgroundAdapterListener listener;
   late _SessionOpenerHarness opener;
+  late _FakeTraceRecorder rec;
   late int startTripCalls;
   late int stopAndSaveCalls;
   late List<Obd2Service> handedOffServices;
@@ -178,7 +186,9 @@ void main() {
     // in plain unit-test mode). Same pattern used by
     // `obd2_vin_reader_test.dart` for error-throwing assertions.
     errorLogger.resetForTest();
-    errorLogger.testRecorderOverride = _FakeTraceRecorder();
+    rec = _FakeTraceRecorder();
+    errorLogger.testRecorderOverride = rec;
+    BreadcrumbCollector.clear();
     listener = FakeBackgroundAdapterListener();
     opener = _SessionOpenerHarness();
     startTripCalls = 0;
@@ -564,6 +574,64 @@ void main() {
       isNotEmpty,
       reason: 'opener throw must record sessionOpenFailed',
     );
+  });
+
+  group('#2933 (error-log #25) — expected connect conditions de-noise', () {
+    test(
+        'an EXPECTED Obd2AdapterUnresponsive opener throw does NOT reach the '
+        'error spool — it de-noises to a breadcrumb', () async {
+      // The auto-record arm probes a PARKED car: the engine is off so the
+      // adapter never answers the ELM327 init. Error-log #25 was 42/44 of
+      // exactly this ERROR, repeated on every retry. It must not spool.
+      opener.queue.add(_OpenerError(const Obd2AdapterUnresponsive()));
+      coordinator = buildCoordinator();
+
+      await coordinator.start();
+      listener.emitConnected(mac);
+      await pumpSpeedTicks(3);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(coordinator.hasOpenSession, isFalse);
+      expect(rec.errors, isEmpty,
+          reason: 'an expected engine-off connect condition must NOT spool an '
+              'ERROR trace (the error-log #25 ×42 flood)');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected transient'),
+        reason: 'the expected condition is kept as a breadcrumb instead',
+      );
+      // The diagnostic auto-record trace still captures the open failure.
+      expect(
+        AutoRecordTraceLog.snapshot()
+            .where((e) => e.kind == AutoRecordEventKind.sessionOpenFailed),
+        isNotEmpty,
+      );
+    });
+
+    test(
+        'a GENUINE Obd2PermissionDenied opener throw STILL reaches the error '
+        'spool (the guard)', () async {
+      opener.queue.add(_OpenerError(const Obd2PermissionDenied()));
+      coordinator = buildCoordinator();
+
+      await coordinator.start();
+      listener.emitConnected(mac);
+      await pumpSpeedTicks(3);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(coordinator.hasOpenSession, isFalse);
+      expect(rec.errors, hasLength(1),
+          reason: 'a real, actionable fault must stay a visible ERROR trace');
+      expect(rec.errors.single.toString(), contains('Obd2PermissionDenied'));
+      expect(rec.errors.single.toString(),
+          contains('AutoTripCoordinator.openSession'));
+      // The de-noiser breadcrumb is NOT recorded — only the genuine ERROR
+      // (the `auto_record:*` lifecycle breadcrumbs are unrelated bookkeeping).
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        isNot(contains('OBD2 connect failed — expected transient')),
+      );
+    });
   });
 
   test('threshold-cross hands the live service into startTrip', () async {


### PR DESCRIPTION
Closes #2933. Two defects from a real error-log export (errorlog_25), one PR, one commit each.

## Issue A — expected `Obd2AdapterUnresponsive` flooded the ERROR log (42/44 entries)
`Obd2AdapterUnresponsive` ("turn the ignition on and retry") is an EXPECTED user condition (`isExpectedUserCondition == true`) — the engine is simply off. Two connect log sites still spooled it as a full ERROR on every retry:
- `AutoTripCoordinator._openSessionAndWatch` (auto-record arm probing a parked car).
- `Obd2Service.connect`'s final-failure catch.

Both now route through the established #2745/#2763/#2892 de-noiser `recordObd2ConnectTransient`: the expected, user-surfaced connect family records a breadcrumb (the `sessionOpenFailed`/`connectFailed` traces already capture it), while a GENUINE fault (`Obd2PermissionDenied`, `Obd2ProtocolInitFailed`, any non-`Obd2ConnectionError`) still ERROR-logs. No real failure is suppressed.

## Issue B — `MissingPluginException: saveBytes` on `tankstellen/public_files` from a background isolate
Stack: `BackgroundScanTracer.exportIfEnabled` → `DataAccessTraceExport.export` → `PublicFileExporter.saveBytesToDownloads` → MethodChannel → `MissingPluginException`. The WorkManager background isolate has no plugin registrant; the dev-gated #2866 trace export runs from `_runScan` (always in that isolate), so the Downloads write can never succeed and just spooled a spurious background ERROR.

Writing to Downloads is a foreground sink. Defence in depth:
- `exportIfEnabled` detects the background-isolate context (`RootIsolateToken.instance == null`, test-seam overridable) and SKIPS the export gracefully — debug breadcrumb, no ERROR spool, no rethrow.
- `DataAccessTraceExport.export` degrades a stray `MissingPluginException` to a skip instead of ERROR-logging it.

The foreground Developer-tools export still writes the trace from the root isolate, unchanged.

## Tests (RED-before / green-after)
- **A:** an injected `Obd2AdapterUnresponsive` on the auto-trip `openSession` path no longer reaches the error spool (de-noises to a breadcrumb) while an injected `Obd2PermissionDenied` still ERROR-logs. (`auto_trip_coordinator_test.dart`)
- **B:** in a background isolate the export is skipped without an ERROR spool or rethrow; a `MissingPluginException` from the channel degrades to a skip; the foreground path with a working channel still saves; a non-tracing tracer is a no-op. (`background_scan_tracer_test.dart`, new)

## Gates
- `flutter analyze` clean on all changed files.
- File-length ratchet: both grandfathered files (`obd2_service.dart`, `auto_trip_coordinator.dart`) trimmed back to their exact snapshots (1618 / 726) — no grandfather bump.
- Never-throws contract: `background_scan_tracer.dart` documents a never-throws boundary and ships with its fault-injection test (`completes` idiom).
- No `*.g.dart`/`*.freezed.dart` drift; no ARB changes (no l10n fan-out needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)