### PR TITLE
fix(radar): stop corridor-cache poisoning + GPS-truth proximity validation (#2932)

### DIFF
--- a/lib/core/services/radar/corridor_geo.dart
+++ b/lib/core/services/radar/corridor_geo.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import '../../../features/search/domain/entities/station.dart';
+import '../../utils/geo_utils.dart' as geo;
+
+/// Pure geometry + corrupted-cache detection helpers for the
+/// [CorridorLocationCache] (#2932). Kept out of the cache class so the cache
+/// stays under the file-length cap and the validation logic is testable in
+/// isolation — no cache state, just maths over the live GPS + the cached set.
+
+/// An axis-aligned bounding box in degree-space.
+typedef CorridorBox = ({double minLat, double minLng, double maxLat, double maxLng});
+
+/// Axis-aligned bounding box covering a [radiusKm] circle around [lat]/[lng],
+/// in degree-space. Latitude is uniform (~111.32 km/°); longitude shrinks with
+/// cos(lat). Used purely for tile bookkeeping, so a slight over-cover is
+/// harmless.
+CorridorBox corridorBoundingBox(double lat, double lng, double radiusKm) {
+  const kmPerDegLat = geo.earthRadiusMeters / 1000.0 * math.pi / 180.0;
+  final latDelta = radiusKm / kmPerDegLat;
+  final cosLat = math.cos(lat * math.pi / 180.0);
+  final clampedCos = cosLat.abs() < 1e-6 ? 1e-6 : cosLat.abs();
+  final lngDelta = radiusKm / (kmPerDegLat * clampedCos);
+  return (
+    minLat: lat - latDelta,
+    minLng: lng - lngDelta,
+    maxLat: lat + latDelta,
+    maxLng: lng + lngDelta,
+  );
+}
+
+/// `true` when the cached [stations] must be treated as INVALID for a driver at
+/// the live [lat]/[lng] (#2932) — distinct from a plain TTL expiry. The check
+/// is GPS-truth: it measures the live fix against the cached station
+/// coordinates directly, so a set fetched 50 km away (same coarse 0.5° tile) is
+/// rejected rather than served.
+///
+/// Corrupt when ANY of:
+///  - the set is empty (a poisoned/degenerate fetch leaked through), OR
+///  - any cached coordinate is the (0,0) null island (a parse/source bug), OR
+///  - the NEAREST cached station is beyond `radiusKm × toleranceFactor` from
+///    the live GPS — the set belongs to a different area than the driver is in
+///    (the 12-km-only / far-station bug).
+bool isCorridorCorrupt(
+  List<Station> stations,
+  double lat,
+  double lng,
+  double radiusKm,
+  double toleranceFactor,
+) {
+  if (stations.isEmpty) return true;
+
+  final maxMeters = radiusKm * 1000.0 * toleranceFactor;
+  var nearest = double.infinity;
+  for (final s in stations) {
+    // A (0,0) station is a corrupt coordinate, not a real Gulf-of-Guinea
+    // forecourt — reject the whole set so it is refetched.
+    if (s.lat == 0 && s.lng == 0) return true;
+    final d = geo.distanceMeters(lat, lng, s.lat, s.lng);
+    if (d < nearest) nearest = d;
+  }
+  return nearest > maxMeters;
+}

--- a/lib/core/services/radar/corridor_location_cache.dart
+++ b/lib/core/services/radar/corridor_location_cache.dart
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:async';
-import 'dart:math' as math;
 
 import '../../../features/search/domain/entities/station.dart';
-import '../../utils/geo_utils.dart' as geo;
+import 'corridor_geo.dart';
 import 'geo_tile.dart';
 
 /// One wide-area station fetch the [CorridorLocationCache] performs — the
@@ -16,6 +15,21 @@ typedef CorridorFetch = Future<List<Station>> Function(
   double lng,
   double radiusKm,
 );
+
+/// Gate the cache asks before it forces a *staleness/corruption* refetch
+/// (#2932). The provider wires this to `ProviderRequestBudget.canFire` so a
+/// corrupted-cache invalidation still honours each provider's published
+/// frequency/volume rules; when it returns `false` the cache serves the
+/// (validated) set rather than hammer the feed. A normal TTL-expiry or
+/// first-entry fetch is NOT gated by this — only the forced refetch is.
+typedef CorridorRefetchGate = bool Function();
+
+/// Side-effect the cache fires the instant it decides to force a refetch
+/// (#2932). The provider wires it to `ProviderRequestBudget.recordRequest`
+/// (stamp the shared budget) AND to a staleness-tagged `DataAccessEvent` so the
+/// #2824 tracer can tell a corruption-forced refetch apart from a plain TTL
+/// refetch.
+typedef CorridorRefetchSink = void Function();
 
 /// Tier-1 of the Fuel Station Radar (#2283): a long-TTL cache of station
 /// LISTS + geolocations for a wide corridor around the driver.
@@ -66,11 +80,20 @@ class CorridorLocationCache {
   /// handled separately by the JIT price cache (tier-3).
   static const Duration defaultTtl = Duration(hours: 1);
 
+  /// How far beyond the corridor radius the nearest cached station may sit
+  /// before the cache treats the set as corrupted (#2932). 1.2 → a 20 % grace
+  /// over the fetch radius, covering GPS jitter + the fetch-centre-vs-live-GPS
+  /// offset without false-positiving a genuinely-near station near the edge.
+  static const double defaultProximityToleranceFactor = 1.2;
+
   final CorridorFetch _fetchCorridor;
   final double _corridorRadiusKm;
   final double _tileStepDegrees;
   final Duration _ttl;
   final bool _isBulk;
+  final double _proximityToleranceFactor;
+  final CorridorRefetchGate? _canRefetch;
+  final CorridorRefetchSink? _onRefetch;
   final DateTime Function() _now;
 
   /// The currently cached wide-area station set. Replaced wholesale on each
@@ -85,6 +108,14 @@ class CorridorLocationCache {
   /// When [_stations] was last fetched — drives the [ttl] expiry.
   DateTime? _fetchedAt;
 
+  /// The centre of the most recent *replacing* corridor fetch (#2932). The
+  /// proximity validator measures the live GPS against the cached stations
+  /// directly (GPS-truth distance), but the centre is kept so a degenerate
+  /// fetch (empty set) still has a reference for the staleness check and the
+  /// tracer. Null until the first successful non-empty replace.
+  double? _fetchCenterLat;
+  double? _fetchCenterLng;
+
   /// Coalesces concurrent refreshes for the same target so a burst of GPS
   /// samples crossing a tile boundary issues a single fetch.
   Future<void>? _inFlight;
@@ -96,12 +127,18 @@ class CorridorLocationCache {
     double tileStepDegrees = GeoTile.defaultStepDegrees,
     Duration ttl = defaultTtl,
     bool isBulk = false,
+    double proximityToleranceFactor = defaultProximityToleranceFactor,
+    CorridorRefetchGate? canRefetch,
+    CorridorRefetchSink? onRefetch,
     DateTime Function()? now,
   })  : _fetchCorridor = fetchCorridor,
         _corridorRadiusKm = corridorRadiusKm,
         _tileStepDegrees = tileStepDegrees,
         _ttl = ttl,
         _isBulk = isBulk,
+        _proximityToleranceFactor = proximityToleranceFactor,
+        _canRefetch = canRefetch,
+        _onRefetch = onRefetch,
         _now = now ?? DateTime.now;
 
   /// The tiles the cache currently covers (read-only view for bookkeeping /
@@ -110,6 +147,18 @@ class CorridorLocationCache {
 
   /// The cached wide-area station set (read-only view).
   List<Station> get cachedStations => List.unmodifiable(_stations);
+
+  /// Centre of the most recent replacing corridor fetch (#2932), or null
+  /// before the first non-empty fetch. The proximity validator measures the
+  /// live GPS against the cached stations directly, but exposing the fetch
+  /// centre lets the radar provider tag a staleness-forced `DataAccessEvent`
+  /// (#2824) with where the suspect corridor was originally fetched.
+  ({double lat, double lng})? get fetchCenter {
+    final lat = _fetchCenterLat;
+    final lng = _fetchCenterLng;
+    if (lat == null || lng == null) return null;
+    return (lat: lat, lng: lng);
+  }
 
   /// `true` when a position at [lat]/[lng] would be answered from cache with
   /// no fetch — its tile is covered and the cache has not aged past [ttl].
@@ -129,13 +178,35 @@ class CorridorLocationCache {
   /// Never throws: a failed fetch leaves the previous cache in place (so the
   /// geofence keeps working on the last-known corridor) and returns whatever
   /// is cached.
+  ///
+  /// ### Corrupted-cache detection (#2932)
+  ///
+  /// A coarse 0.5° tile spans ~55 km, so tile membership alone would serve a
+  /// set fetched at one end of the tile to a driver at the other end. On a
+  /// cache *hit* the cache therefore re-validates the cached set against the
+  /// LIVE GPS [lat]/[lng] ([_isCorrupted]): if the nearest cached station sits
+  /// beyond the corridor radius (× the tolerance factor), the set is empty, or
+  /// any cached coordinate is the (0,0) null island, the entry is treated as
+  /// INVALID — not merely TTL-expired — and a fresh fetch is forced. That
+  /// forced refetch is rate-gated ([_canRefetch], wired to the shared provider
+  /// budget): if the min-interval has not elapsed, the validated cache is
+  /// served rather than the feed hammered.
   Future<List<Station>> stationsNear(
     double lat,
     double lng, {
     double? headingDegrees,
   }) async {
     if (!isFresh(lat, lng)) {
+      // Cache miss / TTL expiry — a NORMAL refetch (never rate-gated; the
+      // gate only governs the corruption-forced path so the geofence is never
+      // starved on a legitimate first entry into an area).
       await _refreshFor(lat, lng);
+    } else if (_isCorrupted(lat, lng)) {
+      // Cache HIT by tile + TTL, but the set is stale/degenerate for THIS GPS
+      // fix. Force a fresh fetch, but only if the shared provider budget
+      // allows it — otherwise keep serving the (validated-as-best-available)
+      // cache rather than breach the provider's rate limit.
+      await _refreshIfBudgetAllows(lat, lng);
     } else if (headingDegrees != null &&
         headingDegrees.isFinite &&
         !_isBulk &&
@@ -147,6 +218,45 @@ class CorridorLocationCache {
       unawaited(_prefetchAhead(lat, lng, headingDegrees));
     }
     return _stations;
+  }
+
+  /// `true` when the cached set must be treated as INVALID for a driver at the
+  /// live [lat]/[lng] (#2932) — distinct from a plain TTL expiry. Delegates to
+  /// the pure [isCorridorCorrupt] validator (GPS-truth distance over the cached
+  /// set vs the corridor radius × tolerance).
+  bool _isCorrupted(double lat, double lng) => isCorridorCorrupt(
+        _stations,
+        lat,
+        lng,
+        _corridorRadiusKm,
+        _proximityToleranceFactor,
+      );
+
+  /// Force a fresh corridor fetch for a corruption-invalidated cache (#2932),
+  /// but ONLY when the injected rate gate ([_canRefetch], wired to the shared
+  /// provider budget) allows it — otherwise serve the cache rather than breach
+  /// the provider's published cadence. On a refetch the [_onRefetch] sink
+  /// stamps the budget + emits the staleness-tagged tracer event.
+  ///
+  /// Honours [stationsNear]'s never-throws contract: a faulty injected gate or
+  /// sink (e.g. a closed Hive box behind `canFire`) must never break the
+  /// geofence — any throw degrades to "serve the validated cache, no refetch".
+  Future<void> _refreshIfBudgetAllows(double lat, double lng) async {
+    final bool allowed;
+    try {
+      final gate = _canRefetch;
+      allowed = gate == null || gate();
+    } on Object {
+      return; // Gate faulted — keep serving the cache (geofence survives).
+    }
+    if (!allowed) return;
+    try {
+      _onRefetch?.call();
+    } on Object {
+      // A faulty sink (budget stamp / tracer) must not block the refetch the
+      // gate just authorised, nor break the contract — swallow and proceed.
+    }
+    await _refreshFor(lat, lng);
   }
 
   /// Blocking refresh centred on [lat]/[lng]; coalesced per target tile.
@@ -193,7 +303,17 @@ class CorridorLocationCache {
       return;
     }
 
-    final box = _boundingBox(lat, lng, _corridorRadiusKm);
+    // #2932 — a degenerate (empty) fetch must NOT mark the tile covered and
+    // must NOT replace a good corridor: mirror `station_service_chain`'s
+    // `isValid: stations.isNotEmpty`. A failed fetch already returned `const []`
+    // upstream (the provider catches and returns empty) AND an exception is
+    // caught above; both land here as an empty list. Keeping the prior coverage
+    // means the next access retries instead of serving a poisoned empty set
+    // "covered + fresh" for a full TTL. The geofence keeps the last good
+    // corridor in the meantime.
+    if (fetched.isEmpty) return;
+
+    final box = corridorBoundingBox(lat, lng, _corridorRadiusKm);
     final tiles = GeoTile.tilesForBox(
       minLat: box.minLat,
       minLng: box.minLng,
@@ -207,6 +327,10 @@ class CorridorLocationCache {
       _coveredTiles
         ..clear()
         ..addAll(tiles);
+      // Record the centre of this replacing fetch as the corridor's GPS-truth
+      // reference (#2932) for the proximity validator + the tracer.
+      _fetchCenterLat = lat;
+      _fetchCenterLng = lng;
     } else {
       // Merge by id so an overlapping prefetch doesn't duplicate stations.
       final byId = {for (final s in _stations) s.id: s};
@@ -243,26 +367,4 @@ class CorridorLocationCache {
   /// How close (as a fraction of tile size) to a tile edge the driver must be
   /// before the edge prefetch fires. 0.25 → the outer quarter on each side.
   static const double _edgeFraction = 0.25;
-
-  /// Axis-aligned bounding box covering a [radiusKm] circle around
-  /// [lat]/[lng], in degree-space. Latitude is uniform (~111.32 km/°);
-  /// longitude shrinks with cos(lat). Used purely for tile bookkeeping, so a
-  /// slight over-cover is harmless.
-  ({double minLat, double minLng, double maxLat, double maxLng}) _boundingBox(
-    double lat,
-    double lng,
-    double radiusKm,
-  ) {
-    const kmPerDegLat = geo.earthRadiusMeters / 1000.0 * math.pi / 180.0;
-    final latDelta = radiusKm / kmPerDegLat;
-    final cosLat = math.cos(lat * math.pi / 180.0);
-    final clampedCos = cosLat.abs() < 1e-6 ? 1e-6 : cosLat.abs();
-    final lngDelta = radiusKm / (kmPerDegLat * clampedCos);
-    return (
-      minLat: lat - latDelta,
-      minLng: lng - lngDelta,
-      maxLat: lat + latDelta,
-      maxLng: lng + lngDelta,
-    );
-  }
 }

--- a/lib/features/approach/providers/fuel_station_radar_provider.dart
+++ b/lib/features/approach/providers/fuel_station_radar_provider.dart
@@ -3,11 +3,16 @@
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/background/provider_request_budget.dart';
 import '../../../core/country/country_provider.dart';
 import '../../../core/services/country_service_registry.dart';
+import '../../../core/services/diagnostics/data_access_event.dart';
+import '../../../core/services/diagnostics/data_access_recorder_provider.dart';
 import '../../../core/services/radar/corridor_location_cache.dart';
 import '../../../core/services/radar/jit_price_cache.dart';
 import '../../../core/services/service_providers.dart';
+import '../../../core/services/service_result.dart';
+import '../../../core/storage/storage_providers.dart';
 import '../../../core/utils/geo_utils.dart' as geo;
 import '../../../core/utils/station_extensions.dart';
 import '../../search/data/models/search_params.dart';
@@ -167,8 +172,38 @@ FuelStationRadar fuelStationRadar(Ref ref) {
   final policy = CountryServiceRegistry.policyFor(country.code);
   final isBulk = policy?.isBulkFile ?? false;
 
+  // #2932 — the shared foreground+background per-provider request budget and
+  // the dev-only data-access tracer, so a corruption-forced corridor refetch
+  // (the proximity validator inside the cache) still honours the provider's
+  // minInterval and is distinguishable from a plain TTL refetch in the trace.
+  final budget = ProviderRequestBudget(ref.read(storageRepositoryProvider));
+  final recorder = ref.read(dataAccessRecorderProvider);
+  final minInterval = policy?.minInterval;
+  final errorSource =
+      CountryServiceRegistry.entryFor(country.code)?.errorSource;
+
   final corridorCache = CorridorLocationCache(
     isBulk: isBulk,
+    // Rate-gate the staleness/corruption-forced refetch ONLY (a first-entry or
+    // TTL refetch is never gated) on the shared budget, so a poisoned/far
+    // cache is replaced without breaching the provider's published cadence.
+    canRefetch: () => budget.canFire(country.code, minInterval),
+    onRefetch: () {
+      // Stamp the shared budget (so a background scan sees this hit) and emit a
+      // staleness-tagged DataAccessEvent (#2824) the moment a corruption-forced
+      // refetch fires — `isStale: true` is what tells a forced refetch apart
+      // from a normal TTL-expiry one in the exported trace.
+      budget.recordRequest(country.code);
+      recorder?.add(DataAccessEvent(
+        at: DateTime.now(),
+        monotonicMicros: recorder.monotonicMicros,
+        country: country.code,
+        source: (errorSource ?? ServiceSource.cache).name,
+        endpoint: DataAccessEndpoint.corridorPrefetch,
+        hit: DataAccessHit.networkApi,
+        isStale: true,
+      ));
+    },
     fetchCorridor: (lat, lng, radiusKm) async {
       try {
         final result = await svc.searchStations(

--- a/lib/features/approach/providers/fuel_station_radar_provider.g.dart
+++ b/lib/features/approach/providers/fuel_station_radar_provider.g.dart
@@ -66,4 +66,4 @@ final class FuelStationRadarProvider
   }
 }
 
-String _$fuelStationRadarHash() => r'13ce43fe339f6bcf1e6df8c475f0e72236875a69';
+String _$fuelStationRadarHash() => r'fa7b7d9233e29dfd89c2e011d80a86352a74b172';

--- a/test/core/services/radar/corridor_geo_test.dart
+++ b/test/core/services/radar/corridor_geo_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/services/radar/corridor_geo.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+Station _station(double lat, double lng) => Station(
+      id: '$lat,$lng',
+      name: 'S',
+      brand: 'X',
+      street: '',
+      postCode: '',
+      place: '',
+      lat: lat,
+      lng: lng,
+      isOpen: true,
+    );
+
+void main() {
+  group('isCorridorCorrupt (#2932)', () {
+    test('an empty set is corrupt', () {
+      expect(isCorridorCorrupt(const [], 48.0, 2.0, 10, 1.2), isTrue);
+    });
+
+    test('a (0,0) station marks the whole set corrupt', () {
+      final set = [_station(48.0, 2.0), _station(0, 0)];
+      expect(isCorridorCorrupt(set, 48.0, 2.0, 60, 1.2), isTrue);
+    });
+
+    test('nearest station within radius × tolerance is NOT corrupt', () {
+      // Station ~0 m from the live GPS.
+      final set = [_station(48.0, 2.0)];
+      expect(isCorridorCorrupt(set, 48.0, 2.0, 10, 1.2), isFalse);
+    });
+
+    test('nearest station beyond radius × tolerance IS corrupt', () {
+      // Station ~50 km north (0.45° lat) of a live GPS, 10 km corridor.
+      final set = [_station(48.45, 2.0)];
+      expect(isCorridorCorrupt(set, 48.0, 2.0, 10, 1.2), isTrue);
+    });
+
+    test('the tolerance factor widens the accept band', () {
+      // ~11 km away with a 10 km radius: corrupt at ×1.0, valid at ×1.2.
+      final set = [_station(48.1, 2.0)]; // ~11.1 km north
+      expect(isCorridorCorrupt(set, 48.0, 2.0, 10, 1.0), isTrue);
+      expect(isCorridorCorrupt(set, 48.0, 2.0, 10, 1.2), isFalse);
+    });
+
+    test('the NEAREST station decides — a far outlier alongside a near one '
+        'is fine', () {
+      final set = [_station(48.0, 2.0), _station(49.0, 2.0)]; // one near, one far
+      expect(isCorridorCorrupt(set, 48.0, 2.0, 10, 1.2), isFalse);
+    });
+  });
+
+  group('corridorBoundingBox (#2932)', () {
+    test('encloses the centre and grows with radius', () {
+      final box = corridorBoundingBox(48.0, 2.0, 60);
+      expect(box.minLat, lessThan(48.0));
+      expect(box.maxLat, greaterThan(48.0));
+      expect(box.minLng, lessThan(2.0));
+      expect(box.maxLng, greaterThan(2.0));
+      // Longitude span widens with latitude (cos shrink) vs latitude span.
+      final latSpan = box.maxLat - box.minLat;
+      final lngSpan = box.maxLng - box.minLng;
+      expect(lngSpan, greaterThan(latSpan));
+    });
+  });
+}

--- a/test/core/services/radar/corridor_location_cache_test.dart
+++ b/test/core/services/radar/corridor_location_cache_test.dart
@@ -152,7 +152,11 @@ void main() {
         tileStepDegrees: 0.5,
         fetchCorridor: (lat, lng, r) async {
           fetched.add((lat, lng));
-          return [_station('A', lat, lng)];
+          // Seed a forecourt at the fetch centre AND one at the north-edge GPS
+          // the test then drives to, so a driver there is within range of one —
+          // i.e. the set is NOT corrupt for the edge GPS, isolating the edge-
+          // prefetch trigger from the #2932 proximity validator.
+          return [_station('A', lat, lng), _station('B', 48.49, 2.25)];
         },
       );
 
@@ -162,6 +166,7 @@ void main() {
 
       // Now sit near the NORTH edge of the same tile heading north (0°).
       // 48.0 + 0.49 = 48.49 → still tile 96 (origin 48.0), fracLat 0.98 > 0.75.
+      // Station 'B' (48.49) is right here, so the set is valid (not corrupt).
       await cache.stationsNear(48.49, 2.25, headingDegrees: 0);
       // Allow the unawaited prefetch to run.
       await Future<void>.delayed(const Duration(milliseconds: 5));
@@ -181,7 +186,9 @@ void main() {
         tileStepDegrees: 0.5,
         fetchCorridor: (lat, lng, r) async {
           calls++;
-          return [_station('A', lat, lng)];
+          // Station at the north-edge GPS too, so the edge GPS isn't flagged
+          // corrupt — isolating the "bulk skips prefetch" assertion.
+          return [_station('A', lat, lng), _station('B', 48.49, 2.25)];
         },
       );
 
@@ -191,6 +198,199 @@ void main() {
       await cache.stationsNear(48.49, 2.25, headingDegrees: 0);
       await Future<void>.delayed(const Duration(milliseconds: 5));
       expect(calls, 1, reason: 'bulk source must not prefetch');
+    });
+  });
+
+  group('CorridorLocationCache — corrupted-cache detection (#2932)', () {
+    test(
+        'an empty/failed fetch does NOT poison tile coverage — next access '
+        'refetches', () async {
+      var calls = 0;
+      var returnEmpty = true;
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 60,
+        tileStepDegrees: 0.5,
+        fetchCorridor: (lat, lng, r) async {
+          calls++;
+          if (returnEmpty) return const [];
+          return [_station('A', lat, lng)];
+        },
+      );
+
+      // First access returns an empty set — must NOT mark the tile covered.
+      final first = await cache.stationsNear(48.0, 2.0);
+      expect(first, isEmpty);
+      expect(calls, 1);
+      expect(cache.isFresh(48.0, 2.0), isFalse,
+          reason: 'an empty fetch must not mark the tile covered');
+
+      // Next access at the same tile must refetch (coverage was not poisoned).
+      returnEmpty = false;
+      final second = await cache.stationsNear(48.0, 2.0);
+      expect(calls, 2, reason: 'empty fetch must not stick — refetch');
+      expect(second, hasLength(1));
+    });
+
+    test(
+        'a good fetch that later returns empty keeps the prior corridor and '
+        'retries', () async {
+      var calls = 0;
+      var returnEmpty = false;
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 60,
+        tileStepDegrees: 0.5,
+        ttl: const Duration(minutes: 30),
+        fetchCorridor: (lat, lng, r) async {
+          calls++;
+          if (returnEmpty) return const [];
+          return [_station('A', lat, lng)];
+        },
+      );
+
+      await cache.stationsNear(48.0, 2.0);
+      expect(cache.cachedStations, hasLength(1));
+
+      // Force a refetch far away that returns empty — must keep the old set
+      // AND must not mark the new far tile covered (so it retries).
+      returnEmpty = true;
+      final after = await cache.stationsNear(51.0, 2.0);
+      expect(calls, 2, reason: 'the far position triggered a (failed) fetch');
+      expect(after, hasLength(1), reason: 'old corridor survives an empty fetch');
+      expect(cache.isFresh(51.0, 2.0), isFalse,
+          reason: 'empty far fetch must not be cached as covered');
+    });
+
+    test(
+        'seeded stations ~50 km away are dropped when GPS is far — far set '
+        'invalidated + refetch triggered', () async {
+      var calls = 0;
+      // First fetch (centred near 48.0,2.0) returns a station ~50 km away.
+      // A later GPS sample in the SAME coarse 0.5° tile but far from that
+      // station must NOT be served the far set — it must invalidate + refetch.
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 10, // tight radius so 50 km is clearly out of range
+        tileStepDegrees: 0.5,
+        fetchCorridor: (lat, lng, r) async {
+          calls++;
+          // ~50 km north of the fetch centre (0.45° lat ≈ 50 km).
+          return [_station('FAR', lat + 0.45, lng)];
+        },
+      );
+
+      // Seed: fetch centred at 48.0,2.0 → one station at ~48.45,2.0.
+      await cache.stationsNear(48.0, 2.0);
+      expect(calls, 1);
+      expect(cache.cachedStations, hasLength(1));
+
+      // Now the live GPS is at 48.0,2.0 — the cached station is ~50 km away,
+      // far outside the 10 km corridor radius. The cache must treat the set as
+      // corrupted/degenerate and refetch rather than serve the far station.
+      await cache.stationsNear(48.0, 2.0);
+      expect(calls, 2,
+          reason: 'nearest cached station beyond radius ⇒ invalidate + refetch');
+    });
+
+    test('a station at (0,0) is treated as corrupt and triggers a refetch',
+        () async {
+      var calls = 0;
+      var returnCorrupt = true;
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 60,
+        tileStepDegrees: 0.5,
+        fetchCorridor: (lat, lng, r) async {
+          calls++;
+          if (returnCorrupt) return [_station('NULL', 0, 0)];
+          return [_station('A', lat, lng)];
+        },
+      );
+
+      await cache.stationsNear(48.0, 2.0);
+      expect(calls, 1);
+      returnCorrupt = false;
+      await cache.stationsNear(48.0, 2.0);
+      expect(calls, 2, reason: '(0,0) coords are corrupt ⇒ invalidate + refetch');
+    });
+  });
+
+  group('CorridorLocationCache — rate-respecting forced refetch (#2932)', () {
+    test(
+        'a corruption-forced refetch is suppressed when the budget gate denies '
+        'it — the validated cache is served instead', () async {
+      var calls = 0;
+      var allowRefetch = false;
+      var sinkFired = 0;
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 10,
+        tileStepDegrees: 0.5,
+        canRefetch: () => allowRefetch,
+        onRefetch: () => sinkFired++,
+        fetchCorridor: (lat, lng, r) async {
+          calls++;
+          // ~50 km away → triggers the corruption path on the next access.
+          return [_station('FAR', lat + 0.45, lng)];
+        },
+      );
+
+      // Seed (first-entry fetch is never gated).
+      await cache.stationsNear(48.0, 2.0);
+      expect(calls, 1);
+
+      // Corruption detected but the budget gate denies → no refetch, serve
+      // the (validated) cache; the record sink must NOT fire.
+      final served = await cache.stationsNear(48.0, 2.0);
+      expect(calls, 1, reason: 'min-interval not elapsed ⇒ no forced refetch');
+      expect(sinkFired, 0);
+      expect(served, hasLength(1));
+
+      // Once the gate allows, the next access forces the refetch + stamps.
+      allowRefetch = true;
+      await cache.stationsNear(48.0, 2.0);
+      expect(calls, 2, reason: 'gate open ⇒ forced refetch fires');
+      expect(sinkFired, 1, reason: 'forced refetch stamps the budget sink');
+    });
+
+    test('a first-entry fetch and a TTL refetch are NOT gated by canRefetch',
+        () async {
+      var calls = 0;
+      var now = DateTime(2026, 6, 6, 12, 0, 0);
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 60,
+        tileStepDegrees: 0.5,
+        ttl: const Duration(minutes: 30),
+        now: () => now,
+        // Gate always denies — must NOT block the normal (non-forced) fetches.
+        canRefetch: () => false,
+        fetchCorridor: (lat, lng, r) async {
+          calls++;
+          return [_station('A', lat, lng)];
+        },
+      );
+
+      await cache.stationsNear(48.0, 2.0); // first entry — not gated
+      expect(calls, 1);
+      now = now.add(const Duration(minutes: 31)); // age past TTL
+      await cache.stationsNear(48.0, 2.0); // TTL refetch — not gated
+      expect(calls, 2, reason: 'TTL expiry is a normal refetch, not gated');
+    });
+
+    test(
+        'a faulty gate / sink never breaks the geofence (never-throws contract, '
+        '#1103)', () async {
+      final cache = CorridorLocationCache(
+        corridorRadiusKm: 10,
+        tileStepDegrees: 0.5,
+        // Both injected callbacks throw — stationsNear must still resolve and
+        // serve the (validated-as-best-available) cache, never propagate.
+        canRefetch: () => throw StateError('budget box closed'),
+        onRefetch: () => throw StateError('tracer faulted'),
+        fetchCorridor: (lat, lng, r) async => [_station('FAR', lat + 0.45, lng)],
+      );
+
+      await cache.stationsNear(48.0, 2.0); // seed (first entry, not gated)
+      // Corruption detected → gate throws → must degrade to "serve cache".
+      final served = await cache.stationsNear(48.0, 2.0);
+      expect(served, hasLength(1),
+          reason: 'a faulty gate degrades to serving the cache, never throws');
     });
   });
 }


### PR DESCRIPTION
Closes #2932.

The Fuel Station Radar served stale/empty results until app data was manually cleared. Root cause (3-agent investigation): `CorridorLocationCache` served stations by coarse 0.5° GeoTile membership with **no proximity check**, and a failed/empty corridor fetch was **stored as the tile's set AND marked the tile "covered"** — so `isFresh()` returned the poisoned empty/stale set for a full TTL with no refetch. Only an in-memory clear (app restart) recovered.

## Fix (the #2932 design)

1. **Don't cache degenerate sets** — an empty/failed fetch no longer marks the tile covered nor replaces the corridor (mirrors `station_service_chain`'s `isValid: stations.isNotEmpty`). Prior coverage is kept; the next access retries. This alone stops the poisoning.
2. **Corrupted-cache detector** — record the replacing fetch centre and, on a cache HIT, validate the cached set against the **live GPS** (GPS-truth distance): if the nearest station is beyond `radius × 1.2` tolerance, the set is empty, or any coord is `(0,0)`, the entry is treated as **invalid** (not merely TTL-expired) and a fresh fetch is forced. The pure validator lives in the new `corridor_geo.dart` (keeps the cache under the 400-line cap; independently tested).
3. **Rate-respecting forced refetch** — the corruption-forced refetch is gated on the shared `ProviderRequestBudget.canFire` and stamps `recordRequest`; within the provider's `minInterval` the validated cache is served instead of hammering the feed. A staleness-tagged `DataAccessEvent` (#2824) emitted on the forced refetch distinguishes it from a normal TTL-expiry refetch. A first-entry / TTL refetch is never gated.
4. **GPS as distance source of truth** — closeness/ordering measures the live fix to each station; the validator cross-checks the cached/provider coordinates against the live GPS so a large mismatch (corrupt) invalidates.

The corruption gate/sink are wrapped so a faulty injected callback degrades to "serve the cache" — preserving `stationsNear`'s never-throws contract (#1103 fault test added).

## Tests (RED-before / green-after)
- empty/failed fetch does **not** poison tile coverage → next access refetches
- a good corridor survives a later empty fetch (kept + retried, not covered)
- stations ~50 km away dropped + refetch triggered from a far GPS fix
- a `(0,0)` station invalidates the set
- forced refetch suppressed within `minInterval`, fires + stamps once elapsed
- first-entry / TTL refetch **not** gated by the budget
- faulty gate/sink never breaks the geofence (never-throws)
- pure `isCorridorCorrupt` / `corridorBoundingBox` unit tests

## Gates
- `flutter analyze` clean; clean codegen drift = 0; file-length cap respected via `corridor_geo.dart` extraction; #1103 catch-stacktrace + never-throws contract green; no ARB changes (no user-facing strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
