### PR TITLE
fix(driving): clamp reported maxAccelG to the plausible band (#2940)

### DIFF
--- a/lib/features/consumption/domain/accel_event_gate.dart
+++ b/lib/features/consumption/domain/accel_event_gate.dart
@@ -124,6 +124,23 @@ const double kAccelEventAccuracyGateM = 10.0;
 /// derivative across it would fabricate an event.
 const double kAccelEventMaxGapSec = 60.0;
 
+/// Clamp a signed longitudinal speed-derivative [accelMps2] to the
+/// physically-plausible band (#2940). A GPS speed spike differentiated past
+/// the asymmetric ceilings the event gate uses ([kMaxPlausibleAccelMps2]
+/// ~0.9 g forward, −[kMaxPlausibleBrakeMps2] ~1.12 g braking) is speed noise,
+/// not a manoeuvre — pin it to the nearest ceiling so a *reported* peak (e.g.
+/// `GpsDrivingFeatures.maxAccelG`) can never surface an impossible value,
+/// consistently with how [countAccelEvents] refuses to *count* the same spike
+/// (it breaks the running episode). The asymmetry mirrors the event gate:
+/// braking legitimately reaches ~1 g where acceleration does not. Finite
+/// in-band and NaN inputs are returned unchanged (NaN exceeds neither
+/// ceiling, so a degenerate reading is never silently turned into a ceiling).
+double clampPlausibleAccelMps2(double accelMps2) {
+  if (accelMps2 >= kMaxPlausibleAccelMps2) return kMaxPlausibleAccelMps2;
+  if (accelMps2 <= -kMaxPlausibleBrakeMps2) return -kMaxPlausibleBrakeMps2;
+  return accelMps2;
+}
+
 /// One sample fed to [countAccelEvents]. Decoupled from any concrete
 /// sample type so both `TripSample` (with `hAccuracyM`) and the leaner
 /// `TripDetailSample` (no accuracy) can map onto it.
@@ -251,12 +268,15 @@ AccelEventCounts countAccelEvents(
     // Δspeed km/h → m/s by / 3.6, then / Δt for m/s².
     final accelMps2 = ((cur.speedKmh - prev.speedKmh) / 3.6) / dt;
 
-    // Physical-plausibility clamp (#2895). A speed-derivative beyond what a
-    // real car can produce (forward > ~0.61 g, braking > ~1.12 g) is GPS
+    // Physical-plausibility gate (#2895). A speed-derivative beyond what a
+    // real car can produce (forward > ~0.9 g, braking > ~1.12 g) is GPS
     // speed noise, not a manoeuvre — a 68 hp economy car cannot do the
     // 1.086 g the bug logged. Break the running episode rather than count it,
     // so noise can't fabricate a hard-accel/brake event. Asymmetric ceilings
     // because braking legitimately reaches ~1 g where acceleration does not.
+    // The reported `maxAccelG` peak pins to the SAME band via the shared
+    // [clampPlausibleAccelMps2] (#2940), so the count and the displayed figure
+    // can never disagree about what is physically possible.
     if (accelMps2 >= kMaxPlausibleAccelMps2 ||
         accelMps2 <= -kMaxPlausibleBrakeMps2) {
       breakEpisodes();

--- a/lib/features/consumption/domain/gps_driving_features.dart
+++ b/lib/features/consumption/domain/gps_driving_features.dart
@@ -269,7 +269,16 @@ class GpsDrivingFeatures {
       // for the fit). The accel/brake EVENT counts come from the shared
       // gate above, not from this per-sample derivative.
       final accelMps2 = (cur.speedKmh - prev.speedKmh) / 3.6 / dt;
-      final absG = accelMps2.abs() / 9.81;
+      // #2940 — clamp the SIGNED derivative to the same physically-plausible
+      // band the event gate uses (≈0.9 g forward, ≈1.12 g braking) BEFORE
+      // taking the magnitude, so a GPS Doppler-speed noise spike can never
+      // surface an impossible peak. #2895 already stops such a spike from
+      // being COUNTED as an event; this stops it from being REPORTED as a
+      // peak too (the export logged maxAccelG 1.036 — a 68 hp Peugeot 107
+      // cannot exceed ~0.4 g), so the count and the displayed figure agree on
+      // what is physically possible. Only the reported peak is clamped; the
+      // raw derivative still feeds the energy KPIs (RPA/PKE/VAPOS) below.
+      final absG = clampPlausibleAccelMps2(accelMps2).abs() / 9.81;
       if (absG > maxAccelG) maxAccelG = absG;
 
       // #2695 C9 speed-only energy KPIs (all derived from speed alone, so

--- a/test/features/consumption/domain/gps_driving_features_test.dart
+++ b/test/features/consumption/domain/gps_driving_features_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/accel_event_gate.dart';
 import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
 import 'package:tankstellen/features/consumption/domain/gps_driving_features_shares.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
@@ -166,6 +167,75 @@ void main() {
         final f = GpsDrivingFeatures.from(samples)!;
         expect(f.accelEvents, 0);
         expect(f.brakeEvents, 0);
+      });
+    });
+
+    // #2940 — the REPORTED maxAccelG (not just the event GATE that #2895
+    // clamped) must be pinned to the physically-plausible band so a GPS
+    // Doppler-speed noise spike can never surface an impossible peak. These
+    // drive the REAL `GpsDrivingFeatures.from` path with the exact failure
+    // mode the Peugeot-107 export logged (maxAccelG 1.036 — a 68 hp car
+    // cannot exceed ~0.4 g). RED before the clamp, green after.
+    group('maxAccelG physical-plausibility clamp (#2940)', () {
+      // The reported peak ceilings in g, derived from the shared m/s² band.
+      const maxAccelGCeiling = kMaxPlausibleAccelMps2 / 9.81; // ≈0.9001 g
+      const maxBrakeGCeiling = kMaxPlausibleBrakeMps2 / 9.81; // ≈1.1213 g
+
+      test('a forward speed spike beyond ~0.9 g reports the clamped ceiling, '
+          'not the raw value, and is not counted as an event', () {
+        // 0 → 40 km/h in ONE second = 11.11 m/s² ≈ 1.13 g — impossible for a
+        // real car, past the ≈0.9 g forward ceiling. Then cruise so the rest
+        // of the trip is calm.
+        final samples = <TripSample>[
+          _s(t0, 0),
+          _s(t0.add(const Duration(seconds: 1)), 40),
+        ];
+        for (var i = 1; i <= 10; i++) {
+          samples.add(_s(t0.add(Duration(seconds: 1 + i)), 40.0));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        // RED before the fix: maxAccelG ≈ 1.13 (the raw impossible spike).
+        expect(f.maxAccelG, lessThanOrEqualTo(maxAccelGCeiling + 1e-9));
+        expect(f.maxAccelG, closeTo(maxAccelGCeiling, 1e-6));
+        // The same out-of-band spike is also refused by the event gate
+        // (#2895) — it breaks the episode rather than counting.
+        expect(f.accelEvents, 0);
+      });
+
+      test('a braking spike beyond ~1.12 g reports the clamped brake ceiling',
+          () {
+        // 50 → 0 km/h in ONE second = -13.89 m/s² ≈ 1.42 g — past the ≈1.12 g
+        // braking ceiling, so the magnitude is reported clamped.
+        final samples = <TripSample>[
+          _s(t0, 50),
+          _s(t0.add(const Duration(seconds: 1)), 0),
+        ];
+        for (var i = 1; i <= 10; i++) {
+          samples.add(_s(t0.add(Duration(seconds: 1 + i)), 0.0));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        // RED before the fix: maxAccelG ≈ 1.42 (the raw impossible spike).
+        expect(f.maxAccelG, lessThanOrEqualTo(maxBrakeGCeiling + 1e-9));
+        expect(f.maxAccelG, closeTo(maxBrakeGCeiling, 1e-6));
+      });
+
+      test('a genuine in-band hard accel (~0.7 g) is reported verbatim, '
+          'not over-clamped', () {
+        // 0 → 50 km/h in 2 s = 6.94 m/s² ≈ 0.71 g — a real hard launch, BELOW
+        // the ≈0.9 g ceiling. It must pass through unchanged so the clamp
+        // introduces no false negatives for genuinely brisk driving.
+        final samples = <TripSample>[
+          _s(t0, 0),
+          _s(t0.add(const Duration(seconds: 1)), 25),
+          _s(t0.add(const Duration(seconds: 2)), 50),
+        ];
+        for (var i = 1; i <= 10; i++) {
+          samples.add(_s(t0.add(Duration(seconds: 2 + i)), 50.0));
+        }
+        final f = GpsDrivingFeatures.from(samples)!;
+        expect(f.maxAccelG, closeTo(6.944 / 9.81, 0.01)); // ≈0.708 g
+        expect(f.maxAccelG, lessThan(maxAccelGCeiling));
+        expect(f.accelEvents, 1); // a real, in-band event still counts
       });
     });
 


### PR DESCRIPTION
## What

Fixes the residual GPS-only driving-analysis bug found in two real Peugeot-107 (68 hp) exports *after* #2895. Closes #2940.

#2895 clamped the accel-event **gate** at `kMaxPlausibleAccelMps2` (~0.9 g) so a GPS Doppler-speed noise spike no longer **counts** as a hard-accel/brake event. But the per-sample peak that feeds `GpsDrivingFeatures.maxAccelG` was left unclamped, so export A still **reported** `maxAccelG = 1.036` — physically impossible for a 68 hp car.

## Change

- New shared `clampPlausibleAccelMps2` in `accel_event_gate.dart` — the single source of truth for the asymmetric ≈0.9 g forward / ≈1.12 g braking band the event gate already enforces.
- `GpsDrivingFeatures.from` clamps the **signed** per-sample derivative through it before taking the magnitude for `maxAccelG`. The count and the displayed peak now agree on what is physically possible.
- Scope is deliberately narrow: only the reported peak is clamped; the raw derivative still feeds the RPA/PKE/VAPOS energy KPIs untouched, and a genuine in-band hard launch (~0.7 g) is reported verbatim (no false negatives).

## Investigated — NOT a bug (premise corrected by the real data)

Export B's `gpsFeatures: null` was read as "penalties/lessons with no data source". It is the **opposite**: `GpsEfficiencyKpiCard.featuresFor` returns `null` precisely when a sample carries engine RPM — i.e. an **OBD2 trip**, and the GPS-only KPI card correctly self-suppresses. Confirmed by `idlingPenalty = 0.29 > 0` (the idle accumulator only fires when `rpm > 0`) and `avgLPer100Km = 6.74` (a real OBD2 fuel figure). The `hardAccel` and `restartCost` lessons come from the real GPS **speed** track (`distanceSource = gps`); 7 stop-and-go restarts in a 260 s / 1.2 km urban trip is plausible. Gating these off would regress legitimate OBD2 coaching, so **no change** there.

## Threshold assessment (follow-up, not implemented)

The 0.9 g forward gate is still too lenient for low-power cars (a 107 tops out ~0.4 g), so sub-ceiling GPS noise can still manufacture phantom hard-accel events (export A's 2, export B's 5). A vehicle-power-aware (or tighter) threshold would address it but is **not** a small/safe change — it needs vehicle power/mass plumbing into the pure gate and risks false negatives for genuinely powerful cars. Recommending a dedicated follow-up issue rather than rushing it here.

## Tests (RED before / green after, real-path-driven)

Added a `maxAccelG physical-plausibility clamp (#2940)` group that drives the **real** `GpsDrivingFeatures.from`:
- a forward >0.9 g spike → `maxAccelG` clamped to the ceiling AND not counted as an event;
- a braking >1.12 g spike → clamped to the brake ceiling;
- a genuine in-band ~0.7 g launch → reported verbatim and still counted (no false negative).

Verified RED before the fix (reported 1.133 g / 1.416 g) and green after. All 92 tests across the related driving-analysis suites pass; `flutter analyze` clean; no codegen / l10n / ARB drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
