### PR TITLE
feat(map): clustered cheapest-labelled radar landscape map + two-way list↔map sync

### DIFF
--- a/lib/core/utils/price_utils.dart
+++ b/lib/core/utils/price_utils.dart
@@ -106,6 +106,25 @@ const List<FuelType> _displayFallbackOrder = [
   return (minP, maxP);
 }
 
+/// (min, max) over each station's price for the fuel its [resolver] picks —
+/// the cross-border case (#2631) where each station is priced by ITS country's
+/// profile fuel. Returns `(0, 0)` when none resolve to a price.
+(double, double) resolvedPriceRangeWith(
+  Iterable<Station> stations,
+  FuelType Function(Station) resolver,
+) {
+  double minP = double.infinity;
+  double maxP = 0;
+  for (final s in stations) {
+    final p = priceForFuelType(s, resolver(s));
+    if (p != null) {
+      if (p < minP) minP = p;
+      if (p > maxP) maxP = p;
+    }
+  }
+  return minP == double.infinity ? (0, 0) : (minP, maxP);
+}
+
 /// Compares two stations by price for [fuelType]. Stations without a price sort last.
 int compareByPrice(Station a, Station b, FuelType fuelType) {
   final pa = priceForFuelType(a, fuelType) ?? AppConstants.noPriceSentinel;

--- a/lib/features/map/presentation/widgets/cluster_badge.dart
+++ b/lib/features/map/presentation/widgets/cluster_badge.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/utils/price_gradient.dart';
+import '../../../../core/theme/price_band_colors.dart';
+
+/// Builder for the "Clustered + cheapest-labelled" density-cluster badge
+/// (#2939) shown by [MarkerClusterLayerWidget] on the radar / search split
+/// map.
+///
+/// Each badge surfaces the CHEAPEST price among its member stations (the
+/// figure a driver actually cares about) plus the member COUNT, coloured on
+/// the shared cheap→expensive [PriceBandColors.ramp] so a cluster that
+/// contains the bargain reads green and an all-expensive pocket reads red —
+/// the same colour language as the singleton price pills and the legend.
+///
+/// Pulled into its own file so [StationMapLayers] stays under the 400-line
+/// cap and the badge layout can be unit-tested in isolation.
+class ClusterBadge {
+  ClusterBadge._();
+
+  /// Resolve the CHEAPEST price among a cluster's [markerPrices] (each the
+  /// price the corresponding singleton marker would show, or null when that
+  /// station has no price for the active fuel). Returns null when no member
+  /// has a usable price — the badge then shows a neutral count-only chip.
+  static double? cheapestOf(Iterable<double?> markerPrices) {
+    double? cheapest;
+    for (final p in markerPrices) {
+      if (p == null || p <= 0) continue;
+      if (cheapest == null || p < cheapest) cheapest = p;
+    }
+    return cheapest;
+  }
+
+  /// Build the badge widget for a cluster.
+  ///
+  /// [cheapest] is the cheapest member price (see [cheapestOf]); [count] is
+  /// the number of members; [minPrice]/[maxPrice] are the overall result-set
+  /// price range used to colour the badge on the ramp; [highlight] paints the
+  /// badge with the brand-primary ring when the cluster contains the SELECTED
+  /// station so a list-row tap visibly emphasises its (still-clustered) marker.
+  static Widget build(
+    BuildContext context, {
+    required double? cheapest,
+    required int count,
+    required double minPrice,
+    required double maxPrice,
+    bool highlight = false,
+  }) {
+    final theme = Theme.of(context);
+    final Color bandColor = priceGradientColor(
+      cheapest,
+      minPrice,
+      maxPrice,
+      stops: PriceBandColors.ramp,
+      nullColor: theme.colorScheme.primaryContainer,
+      flatColor: PriceBandColors.cheap,
+    );
+    final String priceText = cheapest != null
+        ? PriceFormatter.formatPriceCompact(cheapest)
+        : '--'; // i18n-ignore: language-neutral no-price placeholder
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: bandColor.withValues(alpha: 0.94),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: highlight
+              ? theme.colorScheme.primary
+              : Colors.white.withValues(alpha: 0.85),
+          width: highlight ? 2.5 : 1.5,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.28),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                priceText,
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                  height: 1.0,
+                  color: Colors.black87,
+                ),
+              ),
+              Text(
+                '×$count', // i18n-ignore: language-neutral count multiplier
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 9,
+                  height: 1.1,
+                  color: Colors.black.withValues(alpha: 0.7),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The on-screen pixel size of a [ClusterBadge]. flutter_map_marker_cluster
+/// uses this for the badge bounds; chosen to comfortably hold a 3-decimal
+/// price + the count multiplier without clipping.
+const Size kClusterBadgeSize = Size(48, 38);

--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -4,15 +4,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/search_result_item.dart';
+import '../../../search/domain/entities/station.dart';
+import '../../../search/presentation/widgets/sort_selector.dart';
+import '../../../search/providers/radar_search_provider.dart';
 import '../../../search/providers/search_provider.dart';
 import '../../../search/providers/search_screen_ui_provider.dart';
+import '../../../search/providers/selected_station_provider.dart';
 import 'station_map_layers.dart';
 
-/// A reusable map widget that displays station markers from current search results.
-/// Designed to be embedded inline (e.g. in a split-screen layout).
+/// A reusable map widget that displays station markers in the split-screen
+/// landscape pane.
+///
+/// #2939 — "Clustered + cheapest-labelled". When the on-search Fuel Station
+/// Radar owns the results (`radarSearchProvider.active`), the map renders the
+/// RADAR stations — proximity-clustered with cheapest-price badges so the
+/// narrow pane never overlaps — fits the camera to the actual result bounds,
+/// and two-way-syncs selection with the list via `selectedStationProvider`
+/// (tap a marker -> select the row; the selected row's marker is emphasised).
+/// When the radar is idle it falls back to the regular `searchStateProvider`
+/// results — also clustered now, so the split pane never overlaps either.
 class InlineMap extends ConsumerStatefulWidget {
   const InlineMap({super.key});
 
@@ -37,48 +52,106 @@ class _InlineMapState extends ConsumerState<InlineMap> {
 
   @override
   Widget build(BuildContext context) {
-    final searchState = ref.watch(searchStateProvider);
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
     final searchRadius = ref.watch(searchRadiusProvider);
     final sortMode = ref.watch(selectedSortModeProvider);
 
+    // #2939 — the on-search radar OWNS the split map when active (mirrors the
+    // results-list early-return in SearchResultsContent). Its stations are
+    // clustered + fit-to-bounds and list<->map selection is two-way synced.
+    // Idle -> regular search results.
+    final radar = ref.watch(radarSearchProvider);
+    if (radar.active) {
+      return radar.stations.when(
+        data: (stations) =>
+            _buildMap(context, stations, selectedFuel, searchRadius, sortMode),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => _mapUnavailable(context),
+      );
+    }
+
+    final searchState = ref.watch(searchStateProvider);
     return searchState.when(
       data: (result) {
-        final List<SearchResultItem> allItems = result.data;
-        final stations = allItems
+        final stations = result.data
             .whereType<FuelStationResult>()
             .map((r) => r.station)
             .toList();
-
-        if (allItems.isEmpty) {
-          return EmptyState(
-            icon: Icons.map_outlined,
-            title: AppLocalizations.of(context)?.searchToSeeMap ?? 'Search to see stations on the map',
-          );
-        }
-
-        final center = StationMapLayers.centerOf(stations);
-        final zoom = StationMapLayers.zoomForRadius(searchRadius);
-
-        return StationMapLayers(
-          mapController: _mapController,
-          stations: stations,
-          center: center,
-          zoom: zoom,
-          searchRadiusKm: searchRadius,
-          selectedFuel: selectedFuel,
-          sortMode: sortMode,
-        );
+        return _buildMap(
+            context, stations, selectedFuel, searchRadius, sortMode);
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, _) => Center(
+      error: (_, _) => _mapUnavailable(context),
+    );
+  }
+
+  /// Render [stations] on the clustered split map, fitting the camera to the
+  /// actual result bounds and wiring two-way list<->map selection.
+  Widget _buildMap(
+    BuildContext context,
+    List<Station> stations,
+    FuelType selectedFuel,
+    double searchRadius,
+    SortMode sortMode,
+  ) {
+    if (stations.isEmpty) {
+      return EmptyState(
+        icon: Icons.map_outlined,
+        title: AppLocalizations.of(context)?.searchToSeeMap ??
+            'Search to see stations on the map',
+      );
+    }
+
+    // #2939 — fit the camera to the ACTUAL result bounds within the pane, not
+    // the search-radius circle: a dense radar set is far smaller than the
+    // radius (and a sparse one larger), so the radius zoom framed the wrong
+    // viewport in the narrow split pane.
+    final bounds = _boundsOf(stations);
+    final center = StationMapLayers.centerOf(stations);
+
+    // #2939 — two-way sync: emphasise the selected row's marker, and a marker
+    // tap selects its row (keeping the map visible) instead of navigating.
+    final selectedId = ref.watch(selectedStationProvider);
+
+    return StationMapLayers(
+      mapController: _mapController,
+      stations: stations,
+      center: center,
+      zoom: StationMapLayers.zoomForRadius(searchRadius),
+      searchRadiusKm: searchRadius,
+      selectedFuel: selectedFuel,
+      sortMode: sortMode,
+      clusterAlways: true,
+      cameraFitBounds: bounds,
+      showSearchRadius: false,
+      selectedStationIds: selectedId != null ? {selectedId} : null,
+      onStationTap: (id) =>
+          ref.read(selectedStationProvider.notifier).select(id),
+    );
+  }
+
+  Widget _mapUnavailable(BuildContext context) => Center(
         child: Text(
           AppLocalizations.of(context)?.mapUnavailable ?? 'Map unavailable',
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
-          ),
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
         ),
-      ),
-    );
+      );
+
+  /// The [LatLngBounds] of the result [stations], with a tiny epsilon box for
+  /// a single result so `CameraFit.bounds` cannot divide-by-zero (mirrors
+  /// `RouteMapView._computeRouteBounds`).
+  static LatLngBounds _boundsOf(List<Station> stations) {
+    final points = [for (final s in stations) LatLng(s.lat, s.lng)];
+    if (points.length == 1) {
+      final p = points.first;
+      const eps = 0.0005; // ~50 m; fine for any latitude.
+      return LatLngBounds(
+        LatLng(p.latitude - eps, p.longitude - eps),
+        LatLng(p.latitude + eps, p.longitude + eps),
+      );
+    }
+    return LatLngBounds.fromPoints(points);
   }
 }

--- a/lib/features/map/presentation/widgets/station_cluster_layers.dart
+++ b/lib/features/map/presentation/widgets/station_cluster_layers.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
+
+import 'cluster_badge.dart';
+
+/// The per-marker side data the cheapest-labelled cluster builder needs to
+/// roll a cluster up to its cheapest member price and detect a selected
+/// member (#2939). Built alongside the marker list in [StationMapLayers].
+typedef MarkerMeta = ({String id, double? price});
+
+/// Build the "Clustered + cheapest-labelled" cluster layer used by the radar
+/// split pane (#2939).
+///
+/// Every result set is clustered by proximity (so the narrow pane never
+/// overlaps); each badge surfaces the CHEAPEST member price + a count via
+/// [ClusterBadge], coloured on the shared cheap→expensive ramp, and rings in
+/// brand-primary when the cluster contains a member in [selectedIds] so a
+/// list-row tap still emphasises a still-clustered marker. Un-clustered
+/// singletons keep their own full price pill (the badge only renders for
+/// ≥2 members, per flutter_map_marker_cluster).
+///
+/// Extracted from [StationMapLayers] so that widget stays under the file-length
+/// cap; the marker side-data is passed in via [metaOf].
+Widget cheapestLabelledClusterLayer({
+  required List<Marker> markers,
+  required MarkerMeta? Function(Marker) metaOf,
+  required (double, double) priceRange,
+  required Set<String> selectedIds,
+}) {
+  return MarkerClusterLayerWidget(
+    options: MarkerClusterLayerOptions(
+      // A tighter radius than the legacy 50 px so the narrow pane fans
+      // clusters apart sooner as the user zooms in.
+      maxClusterRadius: 44,
+      size: kClusterBadgeSize,
+      markers: markers,
+      builder: (context, clusterMarkers) {
+        final metas = [
+          for (final m in clusterMarkers)
+            if (metaOf(m) != null) metaOf(m)!,
+        ];
+        final cheapest = ClusterBadge.cheapestOf(metas.map((e) => e.price));
+        final highlight = metas.any((e) => selectedIds.contains(e.id));
+        return ClusterBadge.build(
+          context,
+          cheapest: cheapest,
+          count: clusterMarkers.length,
+          minPrice: priceRange.$1,
+          maxPrice: priceRange.$2,
+          highlight: highlight,
+        );
+      },
+    ),
+  );
+}
+
+/// The legacy bare count-cluster layer — the #2510 fallback for a genuinely
+/// huge non-radar result set, where painting hundreds of overlapping dots
+/// would itself be illegible. Unchanged from the pre-#2939 inline builder.
+Widget countClusterLayer({
+  required List<Marker> markers,
+  required ThemeData theme,
+}) {
+  return MarkerClusterLayerWidget(
+    options: MarkerClusterLayerOptions(
+      maxClusterRadius: 50,
+      markers: markers,
+      builder: (context, clusterMarkers) => Container(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primaryContainer,
+          shape: BoxShape.circle,
+        ),
+        child: Center(
+          child: Text(
+            '${clusterMarkers.length}',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
-import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../data/sparkilo_tile_layer.dart';
@@ -16,6 +15,7 @@ import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../search/presentation/widgets/sort_selector.dart';
 import 'price_legend.dart';
+import 'station_cluster_layers.dart';
 import 'station_marker.dart';
 
 /// Camera zoom bounds (#1457). Top end matches the OSM tile cap so a
@@ -98,6 +98,18 @@ class StationMapLayers extends StatefulWidget {
   /// behaviour (#2510), unchanged.
   final FuelType Function(Station)? fuelResolver;
 
+  /// #2939 — "Clustered + cheapest-labelled". When true, EVERY result set is
+  /// proximity-clustered (regardless of count) with a cheapest-price badge so
+  /// the narrow landscape-radar split pane never overlaps. When false (the
+  /// default) the legacy emphasis-then-cluster-at-[clusterThreshold] behaviour
+  /// is byte-identical to pre-#2939.
+  final bool clusterAlways;
+
+  /// #2939 — when set, a marker tap fires this with the station id INSTEAD of
+  /// navigating to `/station/{id}`, so the radar split map can select the
+  /// matching list row (the inverse of a row tap) and keep the map visible.
+  final void Function(String stationId)? onStationTap;
+
   const StationMapLayers({
     super.key,
     required this.mapController,
@@ -115,6 +127,8 @@ class StationMapLayers extends StatefulWidget {
     this.selectedStationIds,
     this.extraLayers = const [],
     this.fuelResolver,
+    this.clusterAlways = false,
+    this.onStationTap,
   });
 
   @override
@@ -217,11 +231,9 @@ class StationMapLayers extends StatefulWidget {
   @visibleForTesting
   static const int emphasisCount = 4;
 
-  /// At or above this many stations the map falls back to count-clustering
-  /// (#2510). A bounded nearby search (the 10-station / 10 km case) stays
-  /// well under this, so every result renders as its own marker; only a
-  /// genuinely huge / zoomed-far set collapses into tappable clusters
-  /// rather than painting hundreds of overlapping dots.
+  /// At or above this many stations a NON-[clusterAlways] map falls back to
+  /// count-clustering (#2510): a bounded nearby search stays well under this,
+  /// only a genuinely huge / zoomed-far set collapses into tappable clusters.
   @visibleForTesting
   static const int clusterThreshold = 80;
 
@@ -267,6 +279,11 @@ class _StationMapLayersState extends State<StationMapLayers> {
   late List<Marker> _markers;
   late (double, double) _priceRange;
 
+  /// #2939 — per-marker price + station id, keyed on marker identity, so the
+  /// cluster badge can roll a cluster up to its cheapest member + spot the
+  /// selected one (the builder only gets the [Marker]s). Rebuilt with [_markers].
+  final Map<Marker, MarkerMeta> _markerMeta = {};
+
   /// True once FlutterMap has laid out and emitted `onMapReady`. The
   /// guarded `didUpdateWidget` fit waits on this so a `fitCamera` call
   /// never lands before the controller has a real viewport (#2399).
@@ -302,7 +319,7 @@ class _StationMapLayersState extends State<StationMapLayers> {
     final resolver = widget.fuelResolver;
     _priceRange = resolver == null
         ? priceRange(widget.stations, widget.selectedFuel)
-        : _resolvedRange(widget.stations, resolver);
+        : resolvedPriceRangeWith(widget.stations, resolver);
     final ids = widget.selectedStationIds;
     final hasSelection = ids != null && ids.isNotEmpty;
 
@@ -327,39 +344,35 @@ class _StationMapLayersState extends State<StationMapLayers> {
       widget.selectedFuel,
       fuelResolver: resolver,
     );
+
+    // #2939 — in clusterAlways mode the clustering de-overlaps the pane, so a
+    // SINGLETON keeps its full price pill (never a dot); only clustered members
+    // roll up into the cheapest-price badge. The emphasis-dot scheme stays for
+    // the legacy non-clustered surfaces.
+    final onTap = widget.onStationTap;
+    _markerMeta.clear();
     _markers = ordered.map((station) {
       final isPastel = hasSelection && !ids.contains(station.id);
-      return StationMarkerBuilder.build(
+      final isSelected = hasSelection && ids.contains(station.id);
+      final marker = StationMarkerBuilder.build(
         context,
         station,
         widget.selectedFuel,
         _priceRange.$1,
         _priceRange.$2,
         pastel: isPastel,
-        compact: !emphasized.contains(station.id),
+        compact: !widget.clusterAlways && !emphasized.contains(station.id),
+        selected: isSelected,
+        onTap: onTap == null ? null : () => onTap(station.id),
         fuelResolver: resolver,
       );
+      _markerMeta[marker] = (
+        id: station.id,
+        price: priceForFuelType(
+            station, resolver != null ? resolver(station) : widget.selectedFuel),
+      );
+      return marker;
     }).toList();
-  }
-
-  /// (min, max) over each station's per-country resolved-fuel price (#2631),
-  /// used to colour cross-border markers consistently with the price each
-  /// one actually shows. Mirrors [priceRange] but resolves the fuel per
-  /// station via [resolver]. Returns `(0, 0)` when none resolve to a price.
-  static (double, double) _resolvedRange(
-    List<Station> stations,
-    FuelType Function(Station) resolver,
-  ) {
-    double minP = double.infinity;
-    double maxP = 0;
-    for (final s in stations) {
-      final p = priceForFuelType(s, resolver(s));
-      if (p != null) {
-        if (p < minP) minP = p;
-        if (p > maxP) maxP = p;
-      }
-    }
-    return minP == double.infinity ? (0, 0) : (minP, maxP);
   }
 
   @override
@@ -522,44 +535,25 @@ class _StationMapLayersState extends State<StationMapLayers> {
                 ),
               ],
             ),
-            // Station markers. #1774 — `_markers` is memoised; this
-            // builder just places the pre-built list.
-            //
-            // #2510 — a BOUNDED nearby-search result set renders every
-            // station as its OWN marker (a plain [MarkerLayer]), so a
-            // 10-station / 10 km search shows all ten — never hidden behind
-            // count bubbles. De-overlap is by emphasis, not aggregation:
-            // the top-ranked stations (cheapest / closest per the active
-            // sort) keep the full price label, the rest are compact dots
-            // (see `_recomputeMarkers`). This reverses the #2490
-            // over-correction that routed EVERY set through
-            // [MarkerClusterLayerWidget] and so collapsed a small radius
-            // search into "4"/"2"/"3" count clusters.
-            //
-            // Clustering is kept ONLY as a fallback for a genuinely huge /
-            // zoomed-far set ([StationMapLayers.clusterThreshold]+), where
-            // painting hundreds of overlapping dots would itself be
-            // illegible; the bounded nearby case never reaches it.
+            // Station markers (#1774 — `_markers` is memoised). Three modes:
+            //  - #2939 `clusterAlways` (radar split pane): proximity-cluster
+            //    EVERY set with the cheapest-labelled badge so the narrow
+            //    pane never overlaps; un-clustered singletons keep their pill;
+            //  - legacy huge set (≥ clusterThreshold): bare count cluster;
+            //  - legacy bounded set (#2510): plain [MarkerLayer], de-overlap
+            //    by emphasis (top-ranked keep the pill, rest are dots).
             if (_markers.isNotEmpty)
-              if (widget.stations.length >= StationMapLayers.clusterThreshold)
-                MarkerClusterLayerWidget(
-                  options: MarkerClusterLayerOptions(
-                    maxClusterRadius: 50,
-                    markers: _markers,
-                    builder: (context, clusterMarkers) => Container(
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.primaryContainer,
-                        shape: BoxShape.circle,
-                      ),
-                      child: Center(
-                        child: Text(
-                          '${clusterMarkers.length}',
-                          style: const TextStyle(fontWeight: FontWeight.bold),
-                        ),
-                      ),
-                    ),
-                  ),
+              if (widget.clusterAlways)
+                cheapestLabelledClusterLayer(
+                  markers: _markers,
+                  metaOf: (m) => _markerMeta[m],
+                  priceRange: _priceRange,
+                  selectedIds:
+                      widget.selectedStationIds ?? const <String>{},
                 )
+              else if (widget.stations.length >=
+                  StationMapLayers.clusterThreshold)
+                countClusterLayer(markers: _markers, theme: theme)
               else
                 MarkerLayer(markers: _markers),
             // Extra layers (e.g. EV overlay)

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -63,6 +63,15 @@ class StationMarkerBuilder {
   /// would actually pay, instead of '--'. When [fuelResolver] is null the
   /// strict single-[fuel] behaviour (#2510) is unchanged — a station
   /// lacking that fuel still shows '--', never a within-country fallback.
+  ///
+  /// #2939 — the radar split map passes [onTap] to intercept the marker tap:
+  /// instead of navigating to `/station/{id}`, it SELECTS the station's list
+  /// row (`selectedStationProvider`) and keeps the map visible, so tapping a
+  /// marker is the inverse of tapping a row. When [onTap] is null the marker
+  /// keeps the default push-to-detail behaviour (the full-screen [MapScreen]
+  /// and the route map). [selected] paints the pill with a brand-primary ring
+  /// and forces the full price label (never a compact dot) so the chosen
+  /// station's marker reads as emphasised even amid a dense pane.
   static Marker build(
     BuildContext context,
     Station station,
@@ -71,6 +80,8 @@ class StationMarkerBuilder {
     double maxPrice, {
     bool pastel = false,
     bool compact = false,
+    bool selected = false,
+    VoidCallback? onTap,
     FuelType Function(Station)? fuelResolver,
   }) {
     // #2510 — strict selected-fuel price, exactly like the list card. No
@@ -94,14 +105,26 @@ class StationMarkerBuilder {
         ? PriceFormatter.formatPriceCompact(price)
         : '--'; // i18n-ignore: language-neutral no-price placeholder
 
-    final Widget badge = compact
+    // #2939 — a selected station is ALWAYS the full pill (never a compact
+    // dot) and rings in brand-primary so a list-row tap visibly emphasises
+    // its marker even in a dense pane. The ring colour is resolved in a
+    // [Builder] at paint time, never eagerly here: [StationMapLayers] builds
+    // the markers in `initState`/`didUpdateWidget`, where `Theme.of(context)`
+    // is illegal (the dependency must be registered in `build`).
+    final bool showCompact = compact && !selected;
+    final Widget badge = showCompact
         ? _dot(color, pastel)
-        : _priceBubble(color, pastel, priceText);
+        : selected
+            ? Builder(
+                builder: (ctx) => _priceBubble(color, pastel, priceText,
+                    ringColor: Theme.of(ctx).colorScheme.primary),
+              )
+            : _priceBubble(color, pastel, priceText);
 
     return Marker(
       point: LatLng(station.lat, station.lng),
-      width: compact ? kStationDotSize : kStationMarkerWidth,
-      height: compact ? kStationDotSize : kStationMarkerHeight,
+      width: showCompact ? kStationDotSize : kStationMarkerWidth,
+      height: showCompact ? kStationDotSize : kStationMarkerHeight,
       // #1772 — isolate each marker's raster so an animation or rebuild
       // on one marker (e.g. the selected-station pastel swap) does not
       // repaint the entire marker layer.
@@ -109,8 +132,11 @@ class StationMarkerBuilder {
         child: Semantics(
           label: semanticLabel,
           button: true,
+          selected: selected,
           child: GestureDetector(
-            onTap: () => GoRouter.of(context).push('/station/${station.id}'),
+            // #2939 — [onTap] lets the radar split map select the row instead
+            // of navigating; null keeps the default push-to-detail.
+            onTap: onTap ?? () => GoRouter.of(context).push('/station/${station.id}'),
             child: Tooltip(
               message: brand,
               waitDuration: const Duration(milliseconds: 300),
@@ -123,16 +149,24 @@ class StationMarkerBuilder {
   }
 
   /// The full colour-coded price bubble shown for emphasized stations.
-  static Widget _priceBubble(Color color, bool pastel, String priceText) {
+  ///
+  /// #2939 — [ringColor] (the selected-station case) overrides the default
+  /// white hairline with a thicker brand-primary ring so the chosen marker
+  /// stands out from its neighbours.
+  static Widget _priceBubble(Color color, bool pastel, String priceText,
+      {Color? ringColor}) {
     return Container(
       alignment: Alignment.center,
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
       decoration: BoxDecoration(
         color: color.withValues(alpha: pastel ? 0.5 : 0.92),
         borderRadius: BorderRadius.circular(6),
-        border: pastel
-            ? null
-            : Border.all(color: Colors.white.withValues(alpha: 0.8), width: 1),
+        border: ringColor != null
+            ? Border.all(color: ringColor, width: 2)
+            : pastel
+                ? null
+                : Border.all(
+                    color: Colors.white.withValues(alpha: 0.8), width: 1),
         boxShadow: pastel
             ? null
             : [

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -283,9 +283,19 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   Widget _buildWideLayout(BuildContext context) {
     final selectedId = ref.watch(selectedStationProvider);
 
+    // #2939 — while the Fuel Station Radar owns the results, the split MAP
+    // stays put and SYNCS the selection (clustered, fit-to-pane, two-way
+    // list<->map sync) — exactly like route mode keeps its map. Selecting a
+    // row must NOT swap the right pane to the detail card and hide the radar
+    // map. The dedicated detail is still reachable from the marker/row's
+    // "view details" affordance (the list-card detail navigation). Off radar,
+    // the pre-#2939 behaviour is unchanged: a selection shows the inline
+    // detail, falling back to the map placeholder.
+    final radarActive = ref.watch(radarSearchProvider).active;
+
     return ResponsiveMasterDetail(
       master: _buildSearchContent(context),
-      detail: selectedId != null
+      detail: (!radarActive && selectedId != null)
           ? StationDetailInline(
               stationId: selectedId,
               onClose: () =>

--- a/test/features/map/presentation/widgets/cluster_badge_test.dart
+++ b/test/features/map/presentation/widgets/cluster_badge_test.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/map/presentation/widgets/cluster_badge.dart';
+
+/// Unit + widget tests for the "Clustered + cheapest-labelled" density-cluster
+/// badge (#2939): the cheapest-of resolution and that the badge surfaces the
+/// CHEAPEST member price + the member count.
+void main() {
+  group('ClusterBadge.cheapestOf', () {
+    test('returns the smallest positive price among members', () {
+      expect(ClusterBadge.cheapestOf([1.799, 1.659, 1.999]), 1.659);
+    });
+
+    test('skips null and non-positive prices', () {
+      expect(ClusterBadge.cheapestOf([null, 0, -1, 1.729, null]), 1.729);
+    });
+
+    test('returns null when no member has a usable price', () {
+      expect(ClusterBadge.cheapestOf([null, 0, -2]), isNull);
+    });
+  });
+
+  group('ClusterBadge.build', () {
+    Future<void> pump(WidgetTester tester, Widget child) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: Center(child: child))),
+      );
+    }
+
+    testWidgets('shows the cheapest member price and the member count',
+        (tester) async {
+      await pump(
+        tester,
+        Builder(
+          builder: (context) => ClusterBadge.build(
+            context,
+            cheapest: 1.659,
+            count: 7,
+            minPrice: 1.659,
+            maxPrice: 1.999,
+          ),
+        ),
+      );
+
+      // The compact price formatter renders the 3-decimal figure (en locale
+      // uses a dot; assert via a tolerant predicate over the badge text).
+      final texts = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data ?? '')
+          .toList();
+      expect(
+        texts.any((t) => t.contains('1') && t.contains('659')),
+        isTrue,
+        reason: 'badge must surface the cheapest member price (1.659), '
+            'got: $texts',
+      );
+      // The count rolls up with the language-neutral multiplier.
+      expect(find.text('×7'), findsOneWidget);
+    });
+
+    testWidgets('renders the "--" placeholder when no member has a price',
+        (tester) async {
+      await pump(
+        tester,
+        Builder(
+          builder: (context) => ClusterBadge.build(
+            context,
+            cheapest: null,
+            count: 3,
+            minPrice: 0,
+            maxPrice: 0,
+          ),
+        ),
+      );
+
+      expect(find.text('--'), findsOneWidget);
+      expect(find.text('×3'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/map/presentation/widgets/inline_map_radar_test.dart
+++ b/test/features/map/presentation/widgets/inline_map_radar_test.dart
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/features/map/presentation/widgets/inline_map.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+import 'package:tankstellen/features/search/providers/selected_station_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #2939 — the landscape Fuel Station Radar split map: render the RADAR
+/// results (not the stale/empty regular search), cluster-always so the narrow
+/// pane never overlaps, fit the camera to the actual result bounds, and
+/// two-way list↔map selection sync.
+///
+/// RED-before: `InlineMap` watched `searchStateProvider`, so the radar's
+/// stations never reached the map and the layer rendered the regular search
+/// (empty here) — these assertions on the radar set would have failed.
+void main() {
+  Station station(String id, double lat, double lng, {double? e10}) => Station(
+        id: id,
+        name: 'Station $id',
+        brand: 'TEST',
+        street: 'Teststr.',
+        postCode: '00000',
+        place: 'Test',
+        lat: lat,
+        lng: lng,
+        dist: 1,
+        e10: e10,
+        isOpen: true,
+      );
+
+  final radarStations = [
+    station('r1', 52.520, 13.405, e10: 1.799),
+    station('r2', 52.530, 13.420, e10: 1.659),
+    station('r3', 52.510, 13.390, e10: 1.999),
+    station('r4', 52.540, 13.430, e10: 1.729),
+  ];
+
+  Widget host() => const SizedBox(width: 800, height: 600, child: InlineMap());
+
+  List<Object> radarOverrides({
+    required List<Station> stations,
+    String? selected,
+  }) {
+    final test = standardTestOverrides();
+    return [
+      ...test.overrides,
+      radarSearchProvider.overrideWith(() => _ActiveRadar(stations)),
+      if (selected != null)
+        selectedStationProvider.overrideWith(() => _SelectedStub(selected)),
+    ];
+  }
+
+  testWidgets(
+      'landscape radar map renders ALL radarSearchProvider stations '
+      '(StationMapLayers fed the radar set, cluster-always)', (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: radarOverrides(stations: radarStations).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    // The map is fed the RADAR stations — all of them — not the (empty)
+    // regular search result set.
+    expect(layer.stations.map((s) => s.id).toList(),
+        radarStations.map((s) => s.id).toList());
+    // #2939 — the split pane always clusters by proximity.
+    expect(layer.clusterAlways, isTrue);
+    // The radius circle is suppressed for the radar fit-to-results framing.
+    expect(layer.showSearchRadius, isFalse);
+  });
+
+  testWidgets('fits the camera to the ACTUAL result bounds, not the radius',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: radarOverrides(stations: radarStations).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    final bounds = layer.cameraFitBounds;
+    expect(bounds, isNotNull, reason: 'fit-to-results must pass result bounds');
+
+    // The bounds frame exactly the result set's lat/lng extent.
+    final expected = LatLngBounds.fromPoints(
+        [for (final s in radarStations) LatLng(s.lat, s.lng)]);
+    expect(bounds!.south, closeTo(expected.south, 1e-9));
+    expect(bounds.north, closeTo(expected.north, 1e-9));
+    expect(bounds.west, closeTo(expected.west, 1e-9));
+    expect(bounds.east, closeTo(expected.east, 1e-9));
+  });
+
+  testWidgets(
+      'two-way sync: a marker tap selects the row (selectedStationProvider) '
+      'WITHOUT navigating; the map stays visible', (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: radarOverrides(stations: radarStations).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    // The inline map wires a marker tap to row selection rather than the
+    // default push-to-detail navigation.
+    expect(layer.onStationTap, isNotNull,
+        reason: 'marker tap must select the row, not navigate away');
+
+    // Read the live container so we can assert the provider really updates.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(StationMapLayers)),
+    );
+    expect(container.read(selectedStationProvider), isNull);
+
+    // Simulate the marker tap → it must SELECT the row, not navigate.
+    layer.onStationTap!('r2');
+    await tester.pump();
+
+    expect(container.read(selectedStationProvider), 'r2');
+    // The map is still mounted (not swapped for a detail card).
+    expect(find.byType(StationMapLayers), findsOneWidget);
+  });
+
+  testWidgets(
+      'the selected station is forwarded so its marker can be emphasised',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: radarOverrides(stations: radarStations, selected: 'r2').cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    expect(layer.selectedStationIds, contains('r2'));
+  });
+}
+
+/// An active radar with a fixed, already-resolved station list.
+class _ActiveRadar extends RadarSearch {
+  _ActiveRadar(this._stations);
+  final List<Station> _stations;
+
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(_stations),
+      );
+}
+
+class _SelectedStub extends SelectedStation {
+  _SelectedStub(this._id);
+  final String _id;
+
+  @override
+  String? build() => _id;
+}


### PR DESCRIPTION
Closes #2939.

## Problem

On the landscape Fuel Station Radar split map, results didn't show clearly:
`InlineMap` watched `searchStateProvider` (never the radar, so the map showed
the stale/empty regular search); selecting a list row swapped the right pane
to `StationDetailInline` and **hid the map**; markers overlapped (clustering
only at ≥80 stations, otherwise just 4 emphasised price pills + bare dots, 3×
density in the ~1/3-width pane); the camera fit zoomed to the search-radius
circle, not the results; and tapping a marker navigated to `/station/{id}`.

## Design — "Clustered + cheapest-labelled" (maintainer-chosen)

- **Render the radar set.** `InlineMap` now renders `radarSearchProvider.stations`
  when the radar is active, falling back to the regular search otherwise — both
  proximity-clustered.
- **Density clustering.** `StationMapLayers` gains `clusterAlways`: every set
  is routed through `MarkerClusterLayerWidget` so the narrow pane never
  overlaps. A custom **cheapest-labelled badge** (`ClusterBadge`) shows the
  cheapest member price + a count, coloured on `PriceBandColors.ramp`;
  un-clustered singletons keep their own price pill.
- **Fit to results.** Camera frames the actual result bounds (`cameraFitBounds`),
  not the radius circle (epsilon box for a single result).
- **Two-way list↔map sync.** A marker tap selects the row
  (`selectedStationProvider`) instead of navigating; the selected station's
  marker is emphasised (full pill + brand-primary ring). `search_screen` keeps
  the map visible in landscape radar (gates the detail-card swap on
  `!radarActive`), mirroring route mode.

Portrait is unaffected (`InlineMap` is the split-pane placeholder only).

## Decomposition

Extracted `ClusterBadge` (`cluster_badge.dart`) and the cluster-layer builders
(`station_cluster_layers.dart`), and moved `resolvedPriceRangeWith` to
`price_utils.dart`, so `station_map_layers.dart` stays under its file-length
snapshot (616 ≤ 622).

## Tests (structural — not golden)

RED-before / green-after:
- the landscape radar map renders **all** `radarSearchProvider` stations +
  cluster-always + radius-circle suppressed;
- `ClusterBadge` surfaces the cheapest member price + count (and `--` when
  none priced);
- a marker tap updates `selectedStationProvider` **without** navigating and
  the map stays mounted;
- fit-to-results passes the result bounds.

## Gates

`flutter analyze` clean (the 2 remaining infos are pre-existing, in unrelated
consumption test files); all map + search + price_utils tests green; strings
are language-neutral (`i18n-ignored`) so no ARB fan-out; no codegen sources
touched (no `*.g.dart`/`*.freezed.dart` drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)