### PR TITLE
fix(obd2): de-noise expected connectBest connect ERRORs — complete the #2935 de-noise (#2943)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -265,9 +265,20 @@ class Obd2ConnectionService {
     if (_lastRanked.isEmpty) return null;
     try {
       return await connect(_lastRanked.first);
-    } on Obd2ConnectionError catch (e, st) {
-      // #2379 — OBD2/BLE → `other`; still logged (final, rethrown).
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {'where': 'Obd2ConnectionService.connectBest failed'}));
+    } catch (e, st) {
+      // #2379 final-failure log → #2943 (error-log #28/29): completing the
+      // #2935 de-noise. An EXPECTED engine-off condition (Obd2AdapterUnresponsive
+      // et al.) or a bare ELM327 connect TimeoutException de-noises to a
+      // breadcrumb here instead of spooling an ERROR on every probe of a
+      // parked car (5× in that log); a GENUINE fault (Obd2PermissionDenied,
+      // Obd2ProtocolInitFailed, any non-expected error) still ERROR-logs on
+      // `other`. The error is rethrown either way so the caller's own
+      // handling is unchanged. (Catching broadly — not just
+      // Obd2ConnectionError — lets the shared de-noiser classify a raw
+      // TimeoutException too; #1103 satisfied via the (e, st) binding.)
+      recordObd2ConnectTransient(e, st,
+          where: 'Obd2ConnectionService.connectBest failed',
+          layer: ErrorLayer.other);
       rethrow;
     }
   }

--- a/test/features/consumption/data/obd2/obd2_connection_service_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connection_service_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
 import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
@@ -16,6 +17,7 @@ import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/data/obd2/'
     'negotiated_protocol_cache.dart';
 import 'package:tankstellen/features/consumption/data/obd2/supported_pids_cache.dart';
@@ -412,6 +414,7 @@ void main() {
       errorLogger.resetForTest();
       recorder = _CaptureRecorder();
       errorLogger.testRecorderOverride = recorder;
+      BreadcrumbCollector.clear();
     });
 
     tearDown(() {
@@ -507,12 +510,18 @@ void main() {
       );
     });
 
+    // ── #2943 (error-log #28/29) — complete the #2935 connect de-noise ──
+    //
+    // connectBest's catch used to spool EVERY rethrown Obd2ConnectionError as
+    // a full ERROR (5× expected Obd2AdapterUnresponsive in errorlog_28/29
+    // from probing a parked, engine-off car). It now routes through the
+    // #2745/#2763/#2892 de-noiser: the expected engine-off family + a bare
+    // ELM327 connect TimeoutException record a breadcrumb, while GENUINE
+    // faults still ERROR-log on `other`. The error is rethrown either way.
+
     test(
-        'a genuinely unrecovered connect failure (connectBest) IS still '
-        'logged — under ErrorLayer.other, never storage (#2379)', () async {
-      // connectBest surfaces a real, unrecovered failure to its caller
-      // (it rethrows). That genuine failure stays logged — but tagged
-      // `other`, not `storage`.
+        'an EXPECTED engine-off Obd2AdapterUnresponsive at connectBest is a '
+        'breadcrumb, NOT an ERROR (#2943) — and is still rethrown', () async {
       final fake = _FakeFacade(
         batches: [
           [
@@ -524,7 +533,8 @@ void main() {
             ),
           ],
         ],
-        // Silent channel ⇒ init never completes ⇒ Obd2AdapterUnresponsive.
+        // Silent channel ⇒ init never completes ⇒ Obd2AdapterUnresponsive,
+        // i.e. the engine is simply off (isExpectedUserCondition == true).
         channel: _FakeChannel(silent: true),
       );
       final svc = _build(permState: Obd2PermissionState.granted, bt: fake);
@@ -532,14 +542,93 @@ void main() {
       // Populate _lastRanked so connectBest has a candidate to try.
       await svc.scan(timeout: const Duration(milliseconds: 50)).toList();
 
-      await expectLater(svc.connectBest(), throwsA(isA<Obd2ConnectionError>()));
+      await expectLater(
+          svc.connectBest(), throwsA(isA<Obd2AdapterUnresponsive>()),
+          reason: 'the caller still sees the typed error — only the log level '
+              'changed');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        recorder.calls
+            .whereType<ContextualError>()
+            .where((e) => e.toString().contains('connectBest failed')),
+        isEmpty,
+        reason: 'an expected engine-off condition must NOT spool an ERROR '
+            'trace at connectBest (the errorlog_28/29 ×5 flood)',
+      );
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected transient'),
+      );
+    });
+
+    test(
+        'a bare ELM327 connect TimeoutException at connectBest is a breadcrumb, '
+        'NOT an ERROR (#2943)', () async {
+      final svc = _ThrowingConnectBest(
+        directError: TimeoutException(
+          'ELM327 did not respond',
+          const Duration(milliseconds: 2500),
+        ),
+      );
+
+      await svc.primeLastRanked();
+      await expectLater(svc.connectBest(), throwsA(isA<TimeoutException>()));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        recorder.calls
+            .whereType<ContextualError>()
+            .where((e) => e.toString().contains('connectBest failed')),
+        isEmpty,
+        reason: 'a bounded ELM327 connect timeout is an expected transient — '
+            'no ERROR spool (the errorlog_28/29 timeouts)',
+      );
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected transient'),
+      );
+    });
+
+    test(
+        'a GENUINE Obd2PermissionDenied at connectBest IS still logged — '
+        'ErrorLayer.other, never storage (#2943)', () async {
+      final svc = _ThrowingConnectBest(directError: const Obd2PermissionDenied());
+
+      await svc.primeLastRanked();
+      await expectLater(
+          svc.connectBest(), throwsA(isA<Obd2PermissionDenied>()));
+      await Future<void>.delayed(Duration.zero);
+
       final logged = recorder.calls.whereType<ContextualError>().toList();
       expect(logged, isNotEmpty,
-          reason: 'a genuinely unrecovered connect failure stays in triage');
+          reason: 'a real, actionable fault must stay a visible ERROR trace');
       expect(logged.every((e) => e.layer == ErrorLayer.other), isTrue,
           reason: 'OBD2/BLE failures must not carry the storage layer');
       expect(logged.any((e) => e.toString().contains('connectBest failed')),
           isTrue);
+      expect(logged.any((e) => e.toString().contains('Obd2PermissionDenied')),
+          isTrue);
+      expect(BreadcrumbCollector.snapshot(), isEmpty);
+    });
+
+    test(
+        'a GENUINE Obd2ProtocolInitFailed at connectBest IS still logged '
+        '(#2943)', () async {
+      final svc =
+          _ThrowingConnectBest(directError: const Obd2ProtocolInitFailed('?'));
+
+      await svc.primeLastRanked();
+      await expectLater(
+          svc.connectBest(), throwsA(isA<Obd2ProtocolInitFailed>()));
+      await Future<void>.delayed(Duration.zero);
+
+      final logged = recorder.calls.whereType<ContextualError>().toList();
+      expect(logged.any((e) => e.toString().contains('connectBest failed')),
+          isTrue,
+          reason: 'a counterfeit-clone init failure is a genuine fault worth '
+              'keeping as an ERROR');
+      expect(BreadcrumbCollector.snapshot(), isEmpty);
     });
   });
 
@@ -818,6 +907,44 @@ class _CaptureRecorder implements TraceRecorder {
   @override
   dynamic noSuchMethod(Invocation invocation) =>
       super.noSuchMethod(invocation);
+}
+
+/// #2943 — drives the `connectBest` catch in isolation. A real `scan()` seeds
+/// the private `_lastRanked` with one vLinker candidate (so `connectBest` has
+/// something to try), then the overridden `connect()` throws the injected
+/// error — exercising precisely the `connectBest failed` catch's routing
+/// without depending on the channel/init internals. Mirrors the
+/// `_ThrowingConnection` seam in `obd2_connect_transient_denoise_test.dart`.
+class _ThrowingConnectBest extends Obd2ConnectionService {
+  _ThrowingConnectBest({required this.directError})
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _FakePermissions(Obd2PermissionState.granted),
+          bluetooth: _FakeFacade(
+            batches: [
+              [
+                Obd2AdapterCandidate(
+                  deviceId: 'aa:bb',
+                  deviceName: 'vLinker FD',
+                  advertisedServiceUuids: const [],
+                  rssi: -55,
+                ),
+              ],
+            ],
+          ),
+        );
+
+  final Object directError;
+
+  /// Runs the real scan once so `_lastRanked` is non-empty.
+  Future<void> primeLastRanked() async {
+    await scan(timeout: const Duration(milliseconds: 50)).toList();
+  }
+
+  @override
+  Future<Obd2Service> connect(ResolvedObd2Candidate candidate) async {
+    throw directError;
+  }
 }
 
 Obd2ConnectionService _build({


### PR DESCRIPTION
Closes #2943. Completes the errorlog_25 (#2935) OBD2 connect de-noise.

A fresh adapter-test session (errorlog_28/29, **engine off**, 10 entries) still flooded the ERROR log with EXPECTED engine-off conditions at one remaining connect site:
- **5×** `Obd2AdapterUnresponsive` `where: 'Obd2ConnectionService.connectBest failed'` → ERROR.

## Gap fixed (verified RED on current master — not a #2935 redo)

`Obd2ConnectionService.connectBest`'s catch logged the rethrown `Obd2ConnectionError` directly via `errorLogger.log(ErrorLayer.other, …)`, so an EXPECTED engine-off `Obd2AdapterUnresponsive` ("turn the ignition on and retry") spooled a full ERROR on every probe of a parked car. It now routes through the established #2745/#2763/#2892 de-noiser `recordObd2ConnectTransient`: the expected family + a bare ELM327 connect `TimeoutException` record a **breadcrumb**, while a GENUINE fault (`Obd2PermissionDenied`, `Obd2ProtocolInitFailed`, any non-expected error) still **ERROR-logs** on `other`. The error is rethrown either way — caller handling unchanged. The catch is broadened from `on Obd2ConnectionError` to `catch (e, st)` so the shared de-noiser can also classify a raw `TimeoutException` (#1103 satisfied via the `(e, st)` binding).

## Already on master — left untouched (recurring-issue methodology)

The 2× `TimeoutException` ERRORs in errorlog_28/29 carry `where: 'OBD2 connect failed'`. That site (`Obd2Service.connect`) **already** routes through `recordObd2ConnectTransient` (#2935), and `isExpectedObd2ConnectTransient` **already** classifies a raw `TimeoutException` as an expected connect transient (#2892). Those entries predate #2892+#2935 landing; on current master that site already de-noises them. No change made there. (3× `Obd2AdapterUnresponsive` `where: 'OBD2 connect failed'` were also already de-noised by #2935.)

## Tests (RED-before / green-after)

The existing `connectBest` test asserted the wrong over-logging behaviour (a silent-channel `Obd2AdapterUnresponsive` MUST be logged); corrected to the de-noised contract, plus added cases:
- expected `Obd2AdapterUnresponsive` at connectBest → breadcrumb, NOT spooled (still rethrown). **RED on master** (it spooled `[other] Obd2AdapterUnresponsive … where: connectBest failed`).
- bare ELM327 `TimeoutException` at connectBest → breadcrumb. **RED on master** (no breadcrumb).
- genuine `Obd2PermissionDenied` / `Obd2ProtocolInitFailed` at connectBest → STILL ERROR-logged on `other`, never storage.

## Gates

- `flutter analyze` clean; full obd2 data suite (1461 tests) green.
- File-length: `obd2_connection_service.dart` 388 lines (< 400 cap, not grandfathered).
- No `*.g.dart` / `*.freezed.dart` drift (verified via clean `build_runner build`); no ARB changes (internal logging only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
