### PR TITLE
fix(obd2): adapter picker never uses ref after unmount (errorlog_30, #2954)

### DIFF
--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -10,6 +10,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import '../../../../core/widgets/snackbar_helper.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../vehicle/domain/entities/vehicle_profile.dart';
 import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/obd2/adapter_registry.dart';
 import '../../data/obd2/obd2_connection_errors.dart';
@@ -238,16 +239,28 @@ class _Obd2AdapterPickerSheetState
       return;
     }
     setState(() => _phase = _Phase.connecting);
+    // errorlog_30 — capture the post-connect persist's provider reads BEFORE
+    // the first `await`. `connect()` is async and the sheet can be dismissed/
+    // unmounted while it runs; reading `ref` AFTER unmount throws `Bad state:
+    // Using "ref" when a widget is about to or has been unmounted is unsafe`.
+    // Both providers are `keepAlive: true`, so the captures stay valid and the
+    // best-effort persist still completes on the unmounted path (the connect
+    // succeeded — the pinned MAC must be written either way).
+    final activeProfile = ref.read(activeVehicleProfileProvider);
+    final vehicleListNotifier = ref.read(vehicleProfileListProvider.notifier);
     try {
       final service = await ref
           .read(obd2ConnectionProvider)
           .connect(candidate);
-      // #1188 — persist MAC + display name back onto the active
-      // vehicle profile so the next session takes the pinned-MAC fast
-      // path and skips the picker entirely. Best-effort: a missing
-      // active vehicle, or a failed save, must not block the connect
-      // path the user just completed.
-      await _persistPickedAdapterToActiveVehicle(candidate);
+      // #1188 — persist MAC + display name back onto the active vehicle
+      // profile so the next session takes the pinned-MAC fast path and skips
+      // the picker. Best-effort; uses the pre-await captures (errorlog_30) so
+      // it never touches `ref` after unmount.
+      await _persistPickedAdapterToActiveVehicle(
+        candidate,
+        activeProfile,
+        vehicleListNotifier,
+      );
       if (!mounted) return;
       if (widget.returnPickedConnection) {
         // #1310 — onboarding flow needs the MAC alongside the service
@@ -285,11 +298,17 @@ class _Obd2AdapterPickerSheetState
   /// successfully pairs — without this, the auto-record toggle silently
   /// dropped users who picked an adapter outside the OBD2 onboarding
   /// wizard.
+  ///
+  /// [active] and [listNotifier] are captured by the caller BEFORE its first
+  /// `await` (errorlog_30): this runs post-connect, when the sheet may already
+  /// be unmounted, so reading them off `ref` here would throw the "ref used
+  /// after unmount" [StateError]. Both source providers are `keepAlive: true`.
   Future<void> _persistPickedAdapterToActiveVehicle(
     ResolvedObd2Candidate candidate,
+    VehicleProfile? active,
+    VehicleProfileList listNotifier,
   ) async {
     try {
-      final active = ref.read(activeVehicleProfileProvider);
       if (active == null) return;
       final mac = candidate.candidate.deviceId;
       final name = candidate.candidate.deviceName.isEmpty
@@ -312,7 +331,7 @@ class _Obd2AdapterPickerSheetState
         obd2AdapterName: name,
         pairedAdapterUuidIos: uuidIos,
       );
-      await ref.read(vehicleProfileListProvider.notifier).save(updated);
+      await listNotifier.save(updated);
     } catch (e, st) {
       // #2308 — this write is the ONLY path that pre-populates the
       // pinned-MAC fast-connect; a HiveError here silently drops the

--- a/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_adapter_picker_test.dart
@@ -18,6 +18,8 @@ import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_servi
 import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/obd2_adapter_picker.dart';
+import 'package:tankstellen/features/vehicle/domain/entities/vehicle_profile.dart';
+import 'package:tankstellen/features/vehicle/providers/vehicle_providers.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
@@ -309,6 +311,192 @@ void main() {
       await tester.pumpAndSettle();
     });
   });
+
+  // errorlog_30 — a real Open-Testing trace: `_connect` runs `connect()`
+  // async, then `_persistPickedAdapterToActiveVehicle` touched `ref` AFTER
+  // the await. When the sheet was dismissed/unmounted while `connect()` was
+  // still resolving, that post-await `ref` read threw
+  //   `Bad state: Using "ref" when a widget is about to or has been
+  //    unmounted is unsafe.`
+  // The fix captures the active profile + list notifier BEFORE the first
+  // await, so the persist never touches `ref` post-unmount AND still
+  // completes (the connect succeeded — the pinned MAC must be written).
+  group('post-connect persist is unmount-safe (errorlog_30)', () {
+    late _CaptureRecorder rec;
+
+    setUp(() {
+      rec = _CaptureRecorder();
+      errorLogger.testRecorderOverride = rec;
+    });
+
+    testWidgets(
+        'unmounting the sheet before connect resolves does NOT ref-after-unmount',
+        (tester) async {
+      final list = _RecordingVehicleList([
+        const VehicleProfile(id: 'v1', name: 'Golf'),
+      ]);
+      // connect() is gated on a completer the test controls, so we can
+      // unmount the sheet while it is still pending.
+      final svc = _GatedConnection();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            obd2ConnectionProvider.overrideWith((_) => svc),
+            vehicleProfileListProvider.overrideWith(() => list),
+            activeVehicleProfileProvider.overrideWith(
+              () => _StubActiveVehicle(
+                const VehicleProfile(id: 'v1', name: 'Golf'),
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: Obd2AdapterPickerSheet()),
+          ),
+        ),
+      );
+      // Scan emits one candidate → selecting state with a tappable tile.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('vLinker FD'));
+      await tester.pump(); // flips to connecting; connect() now pending.
+
+      // Dismiss the sheet WHILE connect() is still in flight — this is the
+      // crash window: the sheet unmounts, then connect() resolves and the
+      // post-await persist runs.
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+      );
+      expect(
+        find.byType(Obd2AdapterPickerSheet),
+        findsNothing,
+        reason: 'sheet must be unmounted before connect resolves',
+      );
+
+      // Now resolve the connect — on master this drove a ref read after
+      // unmount, swallowed into a `[ui] Bad state` ERROR trace.
+      svc.completeConnect(_NoopObd2Service());
+      await tester.pump();
+      await tester.pump();
+
+      // No ref-after-unmount StateError reached the error logger.
+      final unmountErrors = rec.errors
+          .map((e) => e.toString())
+          .where((s) => s.contains('unmounted') || s.contains('Bad state'))
+          .toList();
+      expect(
+        unmountErrors,
+        isEmpty,
+        reason: 'post-await persist must not touch `ref` after unmount',
+      );
+      // The persist still happened via the pre-await capture — the picked
+      // adapter MAC was written even though the sheet was gone.
+      expect(list.savedProfiles, hasLength(1));
+      expect(list.savedProfiles.single.obd2AdapterMac, 'id-vLinker FD');
+    });
+
+    testWidgets('the mounted path still persists the picked adapter',
+        (tester) async {
+      final list = _RecordingVehicleList([
+        const VehicleProfile(id: 'v1', name: 'Golf'),
+      ]);
+      final svc = _GatedConnection();
+      final fakeService = _NoopObd2Service();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            obd2ConnectionProvider.overrideWith((_) => svc),
+            vehicleProfileListProvider.overrideWith(() => list),
+            activeVehicleProfileProvider.overrideWith(
+              () => _StubActiveVehicle(
+                const VehicleProfile(id: 'v1', name: 'Golf'),
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: Obd2AdapterPickerSheet()),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tap(find.text('vLinker FD'));
+      await tester.pump();
+
+      // Resolve the connect while the sheet is STILL mounted (the normal
+      // happy path) → the persist must run and pop with the service.
+      svc.completeConnect(fakeService);
+      await tester.pumpAndSettle();
+
+      expect(rec.errors, isEmpty);
+      expect(list.savedProfiles, hasLength(1));
+      expect(list.savedProfiles.single.obd2AdapterMac, 'id-vLinker FD');
+      expect(list.savedProfiles.single.obd2AdapterName, 'vLinker FD');
+    });
+  });
+}
+
+/// [VehicleProfileList] fake that seeds an initial list and records every
+/// [save] so the errorlog_30 tests can assert the picked adapter MAC was
+/// persisted. Mirrors `auto_record_section_test.dart`'s pattern.
+class _RecordingVehicleList extends VehicleProfileList {
+  _RecordingVehicleList(this._seed);
+  final List<VehicleProfile> _seed;
+  final List<VehicleProfile> savedProfiles = <VehicleProfile>[];
+
+  @override
+  List<VehicleProfile> build() => List<VehicleProfile>.from(_seed);
+
+  @override
+  Future<void> save(VehicleProfile profile) async {
+    savedProfiles.add(profile);
+    state = [..._seed.where((v) => v.id != profile.id), profile];
+  }
+}
+
+/// Stub [ActiveVehicleProfile] returning a fixed value with no storage I/O.
+class _StubActiveVehicle extends ActiveVehicleProfile {
+  _StubActiveVehicle(this._value);
+  final VehicleProfile? _value;
+  @override
+  VehicleProfile? build() => _value;
+}
+
+/// Connection fake whose `connect()` is gated on a completer the test
+/// controls — so a test can unmount the sheet mid-connect and only then
+/// resolve, reproducing the errorlog_30 crash window. `scan()` emits a
+/// single candidate so the picker reaches `selecting` with a tappable tile.
+class _GatedConnection extends Obd2ConnectionService {
+  _GatedConnection()
+      : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _FakePermissions(Obd2PermissionState.granted),
+          bluetooth: _StreamingFacade(const []),
+        );
+
+  final Completer<Obd2Service> _connectGate = Completer<Obd2Service>();
+
+  void completeConnect(Obd2Service service) => _connectGate.complete(service);
+
+  @override
+  Stream<List<ResolvedObd2Candidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {
+    yield [
+      ResolvedObd2Candidate(
+        candidate: _scanHit(name: 'vLinker FD', rssi: -50),
+        profile: const Obd2AdapterProfile(
+          id: 'vlinker-ble',
+          displayName: 'vLinker FD / MC (BLE)',
+        ),
+      ),
+    ];
+  }
+
+  @override
+  Future<Obd2Service> connect(ResolvedObd2Candidate candidate) =>
+      _connectGate.future;
 }
 
 /// Captures every `errorLogger.log` -> `record` call so the de-noise tests
@@ -379,7 +567,19 @@ Future<void> _pump(
 ) async {
   await tester.pumpWidget(
     ProviderScope(
-      overrides: [obd2ConnectionProvider.overrideWith((_) => svc)],
+      overrides: [
+        obd2ConnectionProvider.overrideWith((_) => svc),
+        // errorlog_30 — `_connect` now reads the vehicle providers eagerly
+        // (pre-await capture) so the post-connect persist never touches
+        // `ref` after unmount. Stub them so these Hive-free widget tests
+        // don't fault the real repository's `Hive.openBox` path.
+        vehicleProfileListProvider.overrideWith(
+          () => _RecordingVehicleList(const []),
+        ),
+        activeVehicleProfileProvider.overrideWith(
+          () => _StubActiveVehicle(null),
+        ),
+      ],
       child: const MaterialApp(
         home: Scaffold(body: Obd2AdapterPickerSheet()),
       ),

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -357,8 +357,15 @@ void main() {
         1106,
     'lib/features/consumption/presentation/widgets/broken_map_widgets.dart':
         439,
+    // errorlog_30 — re-grandfathered 439 → 458: `_connect` now captures the
+    // active profile + vehicle-list notifier BEFORE its first `await` and
+    // threads them into `_persistPickedAdapterToActiveVehicle`, so the
+    // post-connect persist never touches `ref` after the sheet unmounts (the
+    // real Open-Testing "ref used after unmount" StateError). The growth is the
+    // two captures + the two extra params + the rationale comments; it cannot
+    // move out of the State. Decomposition stays tracked under #2187/#2188.
     'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':
-        439,
+        458,
     // #2624 — shrank 463 → 450: dropped the post-frame `fitCamera` block
     // (+ its dart:async / error_logger imports) in favour of
     // `MapOptions.initialCameraFit`, fixing the grey-tile cold-start race.


### PR DESCRIPTION
## Problem (errorlog_30)

A real Open-Testing build error-log trace:

```
[ui] Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe.
```

`_Obd2AdapterPickerSheetState._connect` ran `Obd2ConnectionService.connect()` async, then — **after**
the `await` and **before** the `if (!mounted) return;` guard — called
`_persistPickedAdapterToActiveVehicle`, which read `ref.read(activeVehicleProfileProvider)` and
`ref.read(vehicleProfileListProvider.notifier)`. When the sheet was dismissed/unmounted while
`connect()` was still resolving, that post-await `ref` read touched a deactivated `Element` →
`StateError`. It was swallowed into the `[ui]` ERROR trace seen in the field, AND the #1188 pinned-MAC
persist silently never ran (breaking the next session's fast-connect).

## Fix

Capture `activeVehicleProfileProvider` + `vehicleProfileListProvider.notifier` **before** the first
`await` (while mounted) and thread them into `_persistPickedAdapterToActiveVehicle`, which no longer
touches `ref`. Both providers are `keepAlive: true`, so the captures stay valid regardless of the
sheet's lifecycle and the best-effort persist still completes on the unmounted path (the connect
succeeded — the pinned MAC must be written either way). No other post-await `ref`/`context` use in
`_connect` is unguarded (the `Navigator.of(context)` pops sit behind `if (!mounted) return;`).

## Test (RED-on-master / green-after)

- `unmounting the sheet before connect resolves does NOT ref-after-unmount` — gates `connect()` on a
  completer, unmounts the sheet mid-connect, then resolves; asserts no `ref`-after-unmount StateError
  reaches the error logger AND the picked adapter MAC is still persisted. Verified RED on master (the
  exact `[context={where: _persistPickedAdapterToActiveVehicle}]` trace), green after.
- `the mounted path still persists the picked adapter` — regression for the normal path.
- `_pump` helper now stubs the vehicle providers (the pre-await capture builds them eagerly).

## Gates

- `flutter analyze` clean (incl. `use_build_context_synchronously` + unmounted-ref).
- All picker tests + `file_length`, `#1103` catch-stacktrace, and no-hardcoded-strings lints green.
- No `.g.dart` / `.freezed.dart` changes → codegen drift 0. No new ARB strings.
- `file_length` snapshot re-grandfathered 439 → 458 with rationale.

Closes #2954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
