### PR TITLE
fix(obd2): errorlog_30 — guard scan/classic StreamController add-after-close + de-noise reconnect-scanner & VIN engine-off transients (#2953)

### DIFF
--- a/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
+++ b/lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart
@@ -5,8 +5,8 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'obd2_comm_diagnostics.dart';
+import 'obd2_read_telemetry.dart';
 import 'reconnect_scanner_diagnostics.dart';
-import '../../../../core/logging/error_logger.dart';
 
 /// Callback signature: "is the pinned adapter MAC currently
 /// discoverable?". Resolved by the scanner against the active
@@ -358,12 +358,20 @@ class AdapterReconnectScanner {
     _doubleBackoff();
   }
 
+  // #2953 — _probeSafely / _connectSafely route their catch through this: an
+  // EXPECTED engine-off transient (parked car) becomes a breadcrumb, not an
+  // ERROR every backoff cycle (#2892/#2935/#2945 never reached this site). A
+  // genuine fault still ERROR-logs (storage layer, the default).
+  bool _denoise(Object e, StackTrace st, String where) {
+    recordObd2ConnectTransient(e, st, where: where);
+    return false;
+  }
+
   Future<bool> _probeSafely() async {
     try {
       return await _probe(_pinnedMac);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AdapterReconnectScanner probe failed'}));
-      return false;
+      return _denoise(e, st, 'AdapterReconnectScanner probe failed');
     }
   }
 
@@ -373,8 +381,7 @@ class AdapterReconnectScanner {
     try {
       return await attempt(_pinnedMac);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {'where': 'AdapterReconnectScanner connect failed'}));
-      return false;
+      return _denoise(e, st, 'AdapterReconnectScanner connect failed');
     }
   }
 

--- a/lib/features/consumption/data/obd2/bluetooth_facade.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_facade.dart
@@ -100,7 +100,7 @@ class PluginBluetoothFacade implements BluetoothFacade {
           );
           accumulated[candidate.deviceId] = candidate;
         }
-        controller.add(accumulated.values.toList());
+        _safeAddScanResults(controller, accumulated.values.toList());
       },
       // #1392 — mirror the explicit-future catchError above. Without
       // this mapping the raw `PlatformException(startScan, "Bluetooth
@@ -115,17 +115,47 @@ class PluginBluetoothFacade implements BluetoothFacade {
       },
     );
 
-    // Clean up when the caller cancels or the timeout elapses.
+    // Clean up when the caller cancels or the timeout elapses. Both
+    // paths cancel [sub] FIRST (#2953): a still-live `scanResults`
+    // subscription is the source of the late `controller.add` that
+    // throws once the controller is closed. `onCancel` fires on a
+    // consumer cancel; the timeout `Timer` is the close path that does
+    // NOT trigger `onCancel`, so it must cancel [sub] itself.
     controller.onCancel = () async {
       await sub.cancel();
       await FlutterBluePlus.stopScan();
     };
     Timer(timeout, () async {
+      await sub.cancel();
       await FlutterBluePlus.stopScan();
       await controller.close();
     });
 
     return controller.stream;
+  }
+
+  /// #2953 — guarded feed for the `scanResults` listener. A
+  /// `FlutterBluePlus.scanResults` callback can fire AFTER [controller]
+  /// was closed (the timeout `Timer` or `onCancel` closed it, but a
+  /// result already queued on the event loop still reaches the
+  /// listener): the field log #30 spooled `Bad state: Cannot add event
+  /// after closing` 14× during the engine-off connect/scan/disconnect
+  /// churn. The `onError` path is already `isClosed`-guarded; this
+  /// mirrors it for the data path so a late result is dropped silently
+  /// instead of throwing into the zone error handler. `@visibleForTesting`
+  /// so the guard is unit-tested directly without driving the plugin.
+  @visibleForTesting
+  static void debugSafeAddScanResults(
+    StreamController<List<Obd2AdapterCandidate>> controller,
+    List<Obd2AdapterCandidate> results,
+  ) =>
+      _safeAddScanResults(controller, results);
+
+  static void _safeAddScanResults(
+    StreamController<List<Obd2AdapterCandidate>> controller,
+    List<Obd2AdapterCandidate> results,
+  ) {
+    if (!controller.isClosed) controller.add(results);
   }
 
   /// Recognise the platform-channel rejection FlutterBluePlus emits

--- a/lib/features/consumption/data/obd2/classic_elm_channel.dart
+++ b/lib/features/consumption/data/obd2/classic_elm_channel.dart
@@ -101,7 +101,17 @@ class ClassicElmChannel implements ElmByteChannel {
         // wire-framing counters. Double-gated (kReleaseMode +
         // collector.enabled), so production pays nothing.
         noteObd2Framing(bytes);
-        _incoming.add(bytes);
+        // #2953 — guard the late add. A native Classic-SPP byte can land
+        // on this EventChannel listener AFTER `close()` ran (`close()`
+        // cancels `_subscription` then closes `_incoming`, but a chunk
+        // already queued on the event loop still reaches this callback):
+        // the field log #30 spooled `Bad state: Cannot add new events
+        // after calling close` during the engine-off connect/disconnect
+        // churn. The `addError` path below is already `isClosed`-guarded
+        // (#2295); mirror it here. Per the #2295 contract we do NOT tear
+        // the bridge early — late GOOD bytes still flow until `close()`,
+        // and only a post-close stray is dropped silently.
+        if (!_incoming.isClosed) _incoming.add(bytes);
       },
       onError: (Object e, StackTrace st) {
         // #2671 — a Classic-SPP drop raises a socket ERROR on the reader

--- a/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
+++ b/lib/features/vehicle/data/vin_adapter_pair_auto_populator.dart
@@ -7,6 +7,7 @@ import '../../../core/logging/error_logger.dart';
 import '../../consumption/data/obd2/broken_map_belief.dart';
 import '../../consumption/data/obd2/broken_map_detector.dart';
 import '../../consumption/data/obd2/obd2_connection_service.dart';
+import '../../consumption/data/obd2/obd2_read_telemetry.dart';
 import '../../consumption/data/obd2/obd2_service.dart';
 import '../../consumption/data/obd2/obd_adapter_blocklist.dart';
 import '../domain/entities/vehicle_profile.dart';
@@ -290,14 +291,15 @@ class VinAdapterPairAutoPopulator {
         brokenMapBelief: brokenMapBelief,
       );
     } catch (e, st) {
-      await errorLogger.log(
-        ErrorLayer.background,
-        e,
-        st,
-        context: const {
-          'op': 'vinAdapterPairAutoPopulator.run',
-        },
-      );
+      // #2953 — pairing an adapter with the engine OFF is an EXPECTED user
+      // condition: `connectByMac` propagates the typed [Obd2AdapterUnresponsive]
+      // here, which the field log #30 ERROR-spooled. Route the outer catch
+      // through the shared connect-transient de-noiser so an expected
+      // engine-off condition breadcrumbs while a GENUINE fault (permission /
+      // clone init) still ERROR-logs on the background layer.
+      recordObd2ConnectTransient(e, st,
+          where: 'vinAdapterPairAutoPopulator.run',
+          layer: ErrorLayer.background);
       return VinAdapterPairAutoPopulationOutcome.aborted();
     } finally {
       try {

--- a/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
+++ b/test/features/consumption/data/obd2/adapter_reconnect_scanner_test.dart
@@ -1,8 +1,15 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
+import 'package:tankstellen/core/telemetry/models/error_trace.dart';
+import 'package:tankstellen/core/telemetry/trace_recorder.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_reconnect_scanner.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
 /// Small real-wall-clock delays keep the suite under a few seconds
@@ -526,5 +533,105 @@ void main() {
         await scanner.stop();
       });
     });
+
+    // #2953 — `_connectSafely` / `_probeSafely` previously ERROR-spooled EVERY
+    // caught failure at `ErrorLayer.storage` ({where: 'AdapterReconnectScanner
+    // connect failed' / 'probe failed'}). The #2892/#2935/#2945 connect
+    // de-noise never reached this scanner site, so an engine-off parked car
+    // (the `connect` callback surfacing a typed transient) spooled an ERROR
+    // every backoff cycle. They now route through `recordObd2ConnectTransient`:
+    // an expected transient breadcrumbs; a genuine fault still spools.
+    group('connect/probe transient de-noise (#2953)', () {
+      late _CapturingRecorder rec;
+
+      setUp(() {
+        errorLogger.resetForTest();
+        rec = _CapturingRecorder();
+        errorLogger.testRecorderOverride = rec;
+        BreadcrumbCollector.clear();
+      });
+      tearDown(errorLogger.resetForTest);
+
+      test('an EXPECTED engine-off transient on connect breadcrumbs, NOT spool',
+          () async {
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'MAC',
+          probe: (_) async => true,
+          connect: (_) async =>
+              throw const Obd2AdapterUnresponsive(), // parked car
+          onReconnect: () {},
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+        await _waitFor(() => BreadcrumbCollector.snapshot().isNotEmpty);
+        await scanner.stop();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(rec.errors, isEmpty,
+            reason: 'an expected engine-off transient must NOT spool an ERROR '
+                'every backoff cycle (the field log #30 flood)');
+        expect(
+          BreadcrumbCollector.snapshot().map((b) => b.action),
+          contains('OBD2 connect failed — expected transient'),
+        );
+      });
+
+      test('a GENUINE fault on connect STILL spools an ERROR', () async {
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'MAC',
+          probe: (_) async => true,
+          connect: (_) async => throw const Obd2PermissionDenied(),
+          onReconnect: () {},
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+        await _waitFor(() => rec.errors.isNotEmpty);
+        await scanner.stop();
+
+        expect(rec.errors, isNotEmpty,
+            reason: 'a real, actionable fault must stay a visible ERROR');
+        expect(rec.errors.first.toString(),
+            contains('AdapterReconnectScanner connect failed'));
+      });
+
+      test('an EXPECTED transient on probe breadcrumbs, NOT spool', () async {
+        final scanner = AdapterReconnectScanner(
+          pinnedMac: 'MAC',
+          probe: (_) async => throw TimeoutException('probe'),
+          connect: (_) async => false,
+          onReconnect: () {},
+          initialBackoff: _kInitial,
+          firstProbeDelay: _kInitial,
+          maxBackoff: _kMax,
+        );
+        await scanner.start();
+        await _waitFor(() => BreadcrumbCollector.snapshot().isNotEmpty);
+        await scanner.stop();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(rec.errors, isEmpty);
+        expect(
+          BreadcrumbCollector.snapshot().map((b) => b.action),
+          contains('OBD2 connect failed — expected transient'),
+        );
+      });
+    });
   });
+}
+
+/// Captures `errorLogger.log` calls so a test can assert spool-vs-breadcrumb.
+class _CapturingRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(Object error, StackTrace stackTrace,
+      {ServiceChainSnapshot? serviceChainState}) async {
+    errors.add(error);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/features/consumption/data/obd2/bluetooth_facade_test.dart
+++ b/test/features/consumption/data/obd2/bluetooth_facade_test.dart
@@ -1,8 +1,11 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
 import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 
@@ -126,6 +129,60 @@ void main() {
       final err = StateError('transport closed');
       final mapped = PluginBluetoothFacade.debugMapBluetoothError(err);
       expect(mapped, same(err));
+    });
+  });
+
+  // #2953 — the `scanResults` listener fed `controller.add(...)` with NO
+  // `isClosed` guard, so a `FlutterBluePlus.scanResults` callback that
+  // fires AFTER the scan's timeout `Timer` closed the controller threw
+  // `Bad state: Cannot add event after closing` straight into the zone
+  // error handler — the engine-off field-log #30 flood (14/22 entries).
+  // The guarded feed must drop a late result silently and never throw.
+  group('PluginBluetoothFacade.debugSafeAddScanResults (#2953)', () {
+    final candidate = Obd2AdapterCandidate(
+      deviceId: 'AA:BB:CC:DD:EE:01',
+      deviceName: 'OBDII',
+      advertisedServiceUuids: const [],
+      rssi: -60,
+    );
+
+    test('forwards results to an OPEN controller (the normal path)', () async {
+      final controller = StreamController<List<Obd2AdapterCandidate>>();
+      final received = <List<Obd2AdapterCandidate>>[];
+      final sub = controller.stream.listen(received.add);
+
+      PluginBluetoothFacade.debugSafeAddScanResults(controller, [candidate]);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.single.single.deviceId, 'AA:BB:CC:DD:EE:01');
+
+      await sub.cancel();
+      await controller.close();
+    });
+
+    test('a late add AFTER close is dropped silently — does NOT throw',
+        () async {
+      final controller = StreamController<List<Obd2AdapterCandidate>>();
+      // A drained listener so the non-broadcast controller's `close()`
+      // future completes (mirrors a consumer that already cancelled).
+      final sub = controller.stream.listen((_) {});
+      // Close it first (mirrors the timeout Timer / onCancel having run),
+      // then deliver a late scan result the way a queued `scanResults`
+      // callback would.
+      await controller.close();
+      expect(controller.isClosed, isTrue);
+
+      expect(
+        () => PluginBluetoothFacade.debugSafeAddScanResults(controller, [
+          candidate,
+        ]),
+        returnsNormally,
+        reason: 'a post-close scanResults callback must be a no-op, not a '
+            '`Bad state: Cannot add event after closing` (field log #30)',
+      );
+
+      await sub.cancel();
     });
   });
 }

--- a/test/features/consumption/data/obd2/classic_elm_channel_test.dart
+++ b/test/features/consumption/data/obd2/classic_elm_channel_test.dart
@@ -71,6 +71,72 @@ class _FakeObd2ClassicMethodChannel extends Obd2ClassicMethodChannel {
   }
 }
 
+/// #2953 — a fake whose `incoming` stream hands back a [_LateByteSink] so a
+/// test can deliver a native Classic-SPP byte DIRECTLY to the SUT's
+/// installed `onData` listener even after `close()` ran — modelling the
+/// EventChannel in-flight-byte race where a chunk already queued on the
+/// event loop reaches the listener after `_incoming` was closed. A real
+/// broadcast `StreamController` would stop delivering once the SUT's
+/// subscription is cancelled in `close()`, so it can't reproduce the race.
+class _LateByteFakePlugin extends Obd2ClassicMethodChannel {
+  _LateByteFakePlugin();
+
+  final sink = _LateByteSink();
+
+  @override
+  Future<bool> connect({required String address, required String uuid}) async =>
+      true;
+
+  @override
+  Future<void> write(List<int> bytes) async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Stream<List<int>> get incoming => sink;
+}
+
+/// A minimal [Stream] whose subscription captures the SUT's `onData` and
+/// whose `cancel()` is a no-op for delivery — the test fires a late byte
+/// through [deliver] regardless of cancellation, reproducing a native
+/// in-flight chunk arriving after the channel closed (#2953).
+class _LateByteSink extends Stream<List<int>> {
+  void Function(List<int>)? _onData;
+
+  void deliver(List<int> bytes) => _onData?.call(bytes);
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int>)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    _onData = onData;
+    return _NoopSubscription<List<int>>();
+  }
+}
+
+class _NoopSubscription<T> implements StreamSubscription<T> {
+  @override
+  Future<void> cancel() async {}
+  @override
+  void onData(void Function(T)? handleData) {}
+  @override
+  void onError(Function? handleError) {}
+  @override
+  void onDone(void Function()? handleDone) {}
+  @override
+  void pause([Future<void>? resumeSignal]) {}
+  @override
+  void resume() {}
+  @override
+  bool get isPaused => false;
+  @override
+  Future<E> asFuture<E>([E? futureValue]) => Completer<E>().future;
+}
+
 void main() {
   silenceErrorLoggerSpool();
   late _FakeObd2ClassicMethodChannel fake;
@@ -372,6 +438,40 @@ void main() {
 
       await expectLater(channel.close(), completes);
       expect(channel.isOpen, isFalse);
+    });
+
+    test(
+        '#2953 — a late native byte delivered AFTER close does NOT throw '
+        '(the incoming `add` is isClosed-guarded)', () async {
+      // Field log #30 spooled `Bad state: Cannot add new events after calling
+      // close` 14× during the engine-off connect/disconnect churn: a native
+      // Classic-SPP chunk already queued on the event loop reached the
+      // listener after `close()` closed `_incoming`. The guard must drop it.
+      final latePlugin = _LateByteFakePlugin();
+      final channel = ClassicElmChannel(address: 'AA:BB', plugin: latePlugin);
+      await channel.open();
+
+      // Sanity: an in-session byte flows through while open.
+      final received = <List<int>>[];
+      final sub = channel.incoming.listen(received.add);
+      latePlugin.sink.deliver([0x41]);
+      await Future<void>.delayed(Duration.zero);
+      expect(received, [
+        [0x41],
+      ]);
+
+      await channel.close();
+
+      // The in-flight late byte arrives at the listener AFTER `_incoming`
+      // was closed — must be a silent no-op, not a StateError.
+      expect(
+        () => latePlugin.sink.deliver([0x99]),
+        returnsNormally,
+        reason: 'a post-close native byte must be dropped silently, not '
+            'rethrown as `Cannot add new events after calling close`',
+      );
+
+      await sub.cancel();
     });
   });
 }

--- a/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
+++ b/test/features/vehicle/data/vin_adapter_pair_auto_populator_test.dart
@@ -7,8 +7,10 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/logging/error_logger.dart';
+import 'package:tankstellen/core/telemetry/collectors/breadcrumb_collector.dart';
 import 'package:tankstellen/core/telemetry/models/error_trace.dart';
 import 'package:tankstellen/core/telemetry/trace_recorder.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_errors.dart';
 import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
 import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
@@ -197,6 +199,70 @@ void main() {
 
       expect(outcome.profile, isNull);
       expect(outcome.readVin, isFalse);
+    });
+  });
+
+  // #2953 — pairing an adapter with the engine OFF is an EXPECTED user
+  // condition: `connectByMac` propagates the typed [Obd2AdapterUnresponsive]
+  // into the populator's outer catch, which the field log #30 ERROR-spooled
+  // ({op: 'vinAdapterPairAutoPopulator.run'}). It now routes through the
+  // shared connect-transient de-noiser: an expected condition breadcrumbs; a
+  // genuine fault still spools.
+  group('engine-off connect de-noise (#2953)', () {
+    test('an EXPECTED Obd2AdapterUnresponsive breadcrumbs, NOT spool',
+        () async {
+      final rec = _CapturingRecorder();
+      errorLogger.testRecorderOverride = rec;
+      BreadcrumbCollector.clear();
+
+      final connection = _FakeConnection(
+        connectByMacError: const Obd2AdapterUnresponsive(),
+      );
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(outcome.profile, isNull, reason: 'aborted outcome, unchanged');
+      expect(rec.errors, isEmpty,
+          reason: 'engine-off after pairing must NOT spool an ERROR '
+              '(the field log #30 entry)');
+      expect(
+        BreadcrumbCollector.snapshot().map((b) => b.action),
+        contains('OBD2 connect failed — expected transient'),
+      );
+    });
+
+    test('a GENUINE Obd2PermissionDenied STILL spools an ERROR', () async {
+      final rec = _CapturingRecorder();
+      errorLogger.testRecorderOverride = rec;
+      BreadcrumbCollector.clear();
+
+      final connection = _FakeConnection(
+        connectByMacError: const Obd2PermissionDenied(),
+      );
+      final populator = VinAdapterPairAutoPopulator(
+        connection: connection,
+        decoder: buildDecoder(online: false),
+      );
+
+      final outcome = await populator.run(
+        pairedAdapterMac: 'AA:BB',
+        profile: baseProfile(),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(outcome.profile, isNull);
+      expect(rec.errors, hasLength(1),
+          reason: 'a real, actionable fault must stay a visible ERROR');
+      expect(rec.errors.single.toString(),
+          contains('vinAdapterPairAutoPopulator.run'));
     });
   });
 
@@ -587,7 +653,7 @@ class _FakeSettingsStorage implements SettingsStorage {
 }
 
 class _FakeConnection extends Obd2ConnectionService {
-  _FakeConnection({this.connectByMacResult})
+  _FakeConnection({this.connectByMacResult, this.connectByMacError})
       : super(
           registry: Obd2AdapterRegistry.defaults(),
           permissions: _AlwaysGrantedPermissions(),
@@ -596,11 +662,16 @@ class _FakeConnection extends Obd2ConnectionService {
 
   final Obd2Service? connectByMacResult;
 
+  /// #2953 — when set, `connectByMac` THROWS this (the real service
+  /// propagates the typed [Obd2AdapterUnresponsive] on an engine-off pair).
+  final Object? connectByMacError;
+
   @override
   Future<Obd2Service?> connectByMac(
     String mac, {
     Duration timeout = const Duration(seconds: 5),
   }) async {
+    if (connectByMacError != null) throw connectByMacError!;
     final s = connectByMacResult;
     if (s == null) return null;
     // The populator expects a connected service so it can issue PID
@@ -653,6 +724,24 @@ class _NoOpRecorder implements TraceRecorder {
     StackTrace stackTrace, {
     ServiceChainSnapshot? serviceChainState,
   }) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// #2953 — captures `errorLogger.log` calls so a test can assert
+/// spool-vs-breadcrumb at the populator's outer catch.
+class _CapturingRecorder implements TraceRecorder {
+  final errors = <Object>[];
+  @override
+  Future<void> record(
+    Object error,
+    StackTrace stackTrace, {
+    ServiceChainSnapshot? serviceChainState,
+  }) async {
+    errors.add(error);
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) =>

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -90,6 +90,14 @@ void main() {
     // Decomposing this god-class is tracked separately (#2187/#2188/#2190).
     'lib/core/services/country_service_registry.dart': 857,
     'lib/features/consumption/data/obd2/adapter_registry.dart': 500,
+    // #2953 — grandfathered at 405 (5 over): the _probeSafely / _connectSafely
+    // catches were rerouted from a raw `errorLogger.log` ERROR spool to the
+    // shared `recordObd2ConnectTransient` de-noiser (a parked-car engine-off
+    // transient must breadcrumb, not spool an ERROR every backoff cycle —
+    // #2892/#2935/#2945 never reached this site) via a small shared `_denoise`
+    // helper + its dartdoc. The net push just past 400 is a real fix; further
+    // compression would hurt readability. Decomposition tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/adapter_reconnect_scanner.dart': 405,
     'lib/features/consumption/data/obd2/auto_trip_coordinator.dart': 726,
     // #2456 — re-grandfathered 457 → 481: two new pure parsers,
     // `parseBaroPressureKpa` (PID 0x33) and `parseCommandedEquivalenceRatio`


### PR DESCRIPTION
Closes #2953.

Fixes the OBD2 errors from a real Open-Testing build error-log (`errorlog_30`, 16:01–16:06, an engine-off OBD2 session). Each issue was verified against current master (6cff507e) per the recurring-issue methodology — only the still-real gaps are fixed.

## A — StreamController "add after close" flood (14/22 — the priority) — REAL gap, fixed

Two distinct controllers were written to after close during connect/scan/disconnect churn; both now guard the late `.add(...)` and never throw on a late event.

- **BLE scan** (`bluetooth_facade.dart`): the `FlutterBluePlus.scanResults` data-path `controller.add` had no `isClosed` guard (the `onError` path already did), so a late result threw `Bad state: Cannot add event after closing`. Guarded via a `_safeAddScanResults` seam, and the timeout-`Timer` close path now cancels the `scanResults` subscription too (`onCancel` already did) so no late callback survives the close.
- **Classic SPP** (`classic_elm_channel.dart`): a late native byte reached the listener after `close()` closed `_incoming`, throwing `Bad state: Cannot add new events after calling close`. The `addError` path was already `isClosed`-guarded (#2295); mirrored it on the byte-add path. The #2295 "late good bytes still flow" contract is preserved — the bridge is not torn early, only a post-close stray is dropped.

## B — connect/reconnect transient ERROR noise — verification

- `obd2_service.dart` `{where: 'OBD2 connect failed'}` (#2933/#2935): **already de-noised** on master via `recordObd2ConnectTransient` (covers `Obd2AdapterUnresponsive` + `Obd2DisconnectedException` via `isExpectedUserCondition`, plus raw `TimeoutException`). The user's entries predate the fix — a stale Open-Testing build. **No change.**
- `ReconnectConnector` direct/scan/passive/alternate paths (#2892): **already de-noised** on master. **No change.**
- **`AdapterReconnectScanner._connectSafely` / `_probeSafely`** (the reconnect log site #2945 may not have covered): **REAL gap** — both still ERROR-spooled unconditionally at `ErrorLayer.storage`. Now routed through `recordObd2ConnectTransient` via a shared `_denoise` helper: an expected engine-off transient breadcrumbs; a genuine fault still spools.

## D — VIN auto-populator engine-off — REAL gap, fixed

`vin_adapter_pair_auto_populator.dart`'s outer catch spooled the typed `Obd2AdapterUnresponsive` that `connectByMac` propagates on an engine-off pair (`{op: 'vinAdapterPairAutoPopulator.run'}`). Now routed through `recordObd2ConnectTransient` (background layer): expected engine-off → breadcrumb; genuine fault → still ERROR.

## Tests (RED-before / green-after)

- A: a late `.add()` after each (BLE scan / Classic) controller is closed does NOT throw — guarded, verified RED without the guards.
- B: the typed engine-off transient at the scanner connect/probe site → breadcrumb, not spool; genuine fault still spools.
- D: `Obd2AdapterUnresponsive` at the vin-populator site → not spooled; genuine fault still spools.

## Gates

`flutter analyze` clean on all changed files (the only 2 project infos are pre-existing in untouched test files; CI runs `--no-fatal-infos`). obd2 + vehicle suites green (5068 tests). file-length / never-throws / #1103 catch-stacktrace / no-hardcoded-string lints green. No `*.g.dart`/`*.freezed.dart` or ARB touched — no codegen/l10n drift. `adapter_reconnect_scanner.dart` grandfathered at 405 (5 over) for the shared de-noise helper, per the `receipt_scan_service.dart` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
