### PR TITLE
fix(radar): scale the closeness bar to the result span, not the search radius (#2956)

### DIFF
--- a/lib/core/utils/radar_closeness.dart
+++ b/lib/core/utils/radar_closeness.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import '../../features/search/domain/entities/station.dart';
+
+/// The single source of truth for the Fuel Station Radar "closeness" signal —
+/// the green fill that grows as the driver nears a station (#2956, root-cause
+/// reimplementation of #2661 / #2808 / #2899 / #2901 / #2944).
+///
+/// All three radar surfaces — the search-results list card, the recording PiP
+/// overlay, and the trip radar card — compute closeness through THIS helper so
+/// they can never desync again. The bar widget ([ProximityFillBar]) is
+/// paint-only and delegates its fill arithmetic here.
+///
+/// ## Why prior fixes kept missing it
+///
+/// The fill formula itself was always correct:
+///
+/// ```
+/// fill = clamp(1 - distanceMeters / radiusMeters, 0, 1)
+/// ```
+///
+/// The defect was the **radius** each surface scaled against. Every surface
+/// fed a *statically configured* radius (the 1 km approach geo-fence, or the
+/// `searchRadiusProvider` slider — up to 25 km) that is **decoupled from where
+/// the surfaced stations actually are**. When the configured radius is large
+/// relative to the real spread of results, `distance / radius` is small for
+/// EVERY row, so `1 - distance/radius` clusters near 1.0 and all bars look the
+/// same length — exactly the recurring field report (265 m, 9.3 km, 9.9 km,
+/// 10.0 km all rendering ~identical bars under a 25 km slider).
+///
+/// The fix for a *list* surface is to scale closeness against the **span the
+/// results actually occupy** — the farthest surfaced station's distance — so
+/// the nearest forecourt reads near-full and the farthest near-empty,
+/// regardless of the config knob. See [spanRadiusMeters].
+class RadarCloseness {
+  const RadarCloseness._();
+
+  /// The clamped closeness fraction (0..1) for a station [distanceMeters] from
+  /// the driver, scaled to [radiusMeters]. 1.0 at the station, 0.0 at/beyond
+  /// the radius. Never throws and never divides by zero: a non-positive or
+  /// non-finite radius yields 0 (an unknown/degenerate scale reads as empty,
+  /// not full).
+  static double fillFor(double distanceMeters, double radiusMeters) {
+    if (radiusMeters <= 0 || !radiusMeters.isFinite) return 0;
+    final raw = 1.0 - (distanceMeters / radiusMeters);
+    return raw.clamp(0.0, 1.0);
+  }
+
+  /// The radius (in metres) a *list* of radar results should scale its
+  /// closeness bars to: the distance of the FARTHEST surfaced station (the
+  /// actual span of the visible set), so closeness reads as RELATIVE position
+  /// across the list — nearest near-full, farthest near-empty — instead of
+  /// every row pinning toward full against an oversized config radius (#2956).
+  ///
+  /// `station.dist` is the great-circle distance in KILOMETRES (the same value
+  /// the card's distance text shows), so the result is `maxDist * 1000`.
+  ///
+  /// Returns `null` — collapsing the bar — when the set is empty or carries no
+  /// positive distance (e.g. an unlocated test fixture), so callers can render
+  /// the bar unconditionally and it simply hides when there is nothing to
+  /// scale against.
+  static double? spanRadiusMeters(Iterable<Station> stations) {
+    var maxDistKm = 0.0;
+    for (final s in stations) {
+      if (s.dist > maxDistKm) maxDistKm = s.dist;
+    }
+    if (maxDistKm <= 0) return null;
+    return maxDistKm * 1000.0;
+  }
+}

--- a/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
+++ b/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/theme/app_radius.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/utils/radar_closeness.dart';
 import '../../../../l10n/app_localizations.dart';
 
 /// Corporate-green, battery-style proximity FILL BAR for the Fuel Station
@@ -54,11 +55,12 @@ class ProximityFillBar extends StatelessWidget {
   });
 
   /// The clamped fill fraction (0..1). 1 at the station, 0 at/beyond radius.
-  static double fillFor(double distanceMeters, double radiusMeters) {
-    if (radiusMeters <= 0) return 0;
-    final raw = 1.0 - (distanceMeters / radiusMeters);
-    return raw.clamp(0.0, 1.0);
-  }
+  ///
+  /// Delegates to [RadarCloseness.fillFor] — the single source of truth shared
+  /// by all three radar surfaces (list card, PiP, trip card) so they can never
+  /// desync (#2956). Kept as a static here for the existing call sites/tests.
+  static double fillFor(double distanceMeters, double radiusMeters) =>
+      RadarCloseness.fillFor(distanceMeters, radiusMeters);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -9,6 +9,7 @@ import '../../../../core/services/service_result.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_tier.dart';
 import '../../../../core/utils/price_utils.dart';
+import '../../../../core/utils/radar_closeness.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/services/widgets/freshness_badge.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
@@ -333,16 +334,20 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
     );
     final stationRating = ref.watch(stationRatingProvider(station.id));
 
-    // #2899 — when the on-search Fuel Station Radar owns the result list, each
+    // #2956 — when the on-search Fuel Station Radar owns the result list, each
     // card carries the green→accent closeness bar (the SAME [ProximityFillBar]
-    // as the trip card + PiP). The list scales to the SEARCH radius
-    // (`searchRadiusProvider × 1000`, the radius the radar fetch itself used),
-    // not the 1 km trip geo-fence: result rows routinely exceed that fence, so
-    // scaling to the search radius makes the bar read as RELATIVE closeness
-    // across the visible list. Null off radar mode → regular cards unchanged.
-    final radarActive = ref.watch(radarSearchProvider).active;
-    final closenessRadiusMeters =
-        radarActive ? ref.watch(searchRadiusProvider) * 1000.0 : null;
+    // / [RadarCloseness] as the trip card + PiP). The bar scales to the SPAN of
+    // the surfaced results — the farthest station's distance — NOT the static
+    // `searchRadiusProvider` slider. The slider (up to 25 km) is decoupled from
+    // where the stations actually are, so scaling to it compressed every fill
+    // toward 1.0 and made all bars look the same length (the recurring #2956
+    // field report). Scaling to the result span makes closeness read RELATIVE
+    // across the list: the nearest forecourt near-full, the farthest near-empty.
+    // Null off radar mode (or an unlocated/empty set) → regular cards unchanged.
+    final radar = ref.watch(radarSearchProvider);
+    final closenessRadiusMeters = radar.active
+        ? RadarCloseness.spanRadiusMeters(radar.stations.value ?? const [])
+        : null;
 
     return SwipeableStationCard(
       key: ValueKey('station-${station.id}'),

--- a/test/core/utils/radar_closeness_test.dart
+++ b/test/core/utils/radar_closeness_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/utils/radar_closeness.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+/// #2956 — unit pins for the shared Fuel Station Radar closeness helper. The
+/// real radar list-card surface is exercised in `radar_closeness_bar_test.dart`
+/// (the regression lock); this file pins the arithmetic + the never-throws
+/// contract the helper documents.
+
+Station _at(double distKm) => Station(
+      id: 'd-$distKm',
+      name: 'n',
+      brand: '',
+      street: '',
+      postCode: '',
+      place: '',
+      lat: 0,
+      lng: 0,
+      dist: distKm,
+      isOpen: true,
+    );
+
+void main() {
+  group('RadarCloseness.fillFor — the canonical fill fraction', () {
+    test('full at the station, empty at/beyond the radius', () {
+      expect(RadarCloseness.fillFor(0, 10000), 1.0);
+      expect(RadarCloseness.fillFor(10000, 10000), 0.0);
+      expect(RadarCloseness.fillFor(25000, 10000), 0.0); // clamped, no negative
+    });
+
+    test('the worked example: radius 10 km → 0.25 km≈0.975, 5 km=0.5, '
+        '9.9 km≈0.01', () {
+      expect(RadarCloseness.fillFor(250, 10000), closeTo(0.975, 1e-9));
+      expect(RadarCloseness.fillFor(5000, 10000), closeTo(0.5, 1e-9));
+      expect(RadarCloseness.fillFor(9900, 10000), closeTo(0.01, 1e-9));
+    });
+
+    test('clamps to 1 at/under the station (no overflow)', () {
+      expect(RadarCloseness.fillFor(-50, 10000), 1.0);
+    });
+  });
+
+  group('RadarCloseness.spanRadiusMeters — scale to the result span', () {
+    test('is the farthest surfaced station distance, in metres', () {
+      final stations = [_at(0.265), _at(9.3), _at(9.9), _at(10.0)];
+      expect(RadarCloseness.spanRadiusMeters(stations), closeTo(10000, 1e-6));
+    });
+
+    test('null for an empty or unlocated set (collapses the bar)', () {
+      expect(RadarCloseness.spanRadiusMeters(const []), isNull);
+      expect(RadarCloseness.spanRadiusMeters([_at(0)]), isNull);
+    });
+  });
+
+  // The helper documents "Never throws" — pin the fault paths so a degenerate
+  // input (the kind that produced the recurring divide-by-zero / NaN scaling
+  // bugs) returns normally instead of blowing up the card build (#2956).
+  group('RadarCloseness — never-throws contract (#2956)', () {
+    test('fillFor returns normally on a degenerate / non-finite radius', () {
+      expect(() => RadarCloseness.fillFor(100, 0), returnsNormally);
+      expect(() => RadarCloseness.fillFor(100, -1), returnsNormally);
+      expect(() => RadarCloseness.fillFor(100, double.nan), returnsNormally);
+      expect(() => RadarCloseness.fillFor(100, double.infinity), returnsNormally);
+      // …and the value is the safe "empty" sentinel, not a NaN/negative.
+      expect(RadarCloseness.fillFor(100, 0), 0.0);
+      expect(RadarCloseness.fillFor(100, double.nan), 0.0);
+      expect(RadarCloseness.fillFor(100, double.infinity), 0.0);
+    });
+
+    test('spanRadiusMeters returns normally on an empty set', () {
+      expect(() => RadarCloseness.spanRadiusMeters(const []), returnsNormally);
+    });
+  });
+}

--- a/test/features/search/presentation/widgets/radar_closeness_bar_test.dart
+++ b/test/features/search/presentation/widgets/radar_closeness_bar_test.dart
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #2956 — root-cause pinning regression for the Fuel Station Radar "closeness"
+/// bar. The recurring field bug: the distance TEXT is correct but the closeness
+/// BAR under every station is ~the same length (it does not scale with
+/// distance) — because the bar scaled to the static `searchRadiusProvider`
+/// slider (up to 25 km), which is decoupled from where the stations actually
+/// are, so every fill compressed toward 1.0.
+///
+/// These tests drive the REAL radar list-card path (`SearchResultsContent` →
+/// `SearchResultsList` → `StationCard` → `ProximityFillBar`) with the exact
+/// screenshot distances (265 m, 9.3 km, 9.9 km, 10.0 km) and the field's 25 km
+/// slider, then read the fill the rendered bar would paint. RED on master (the
+/// far bars cluster at ~0.60–0.63, indistinguishable); green after the fix
+/// (scaled to the result span: nearest ~0.97, farthest 0.0).
+
+/// The four radar results from the field screenshot, distance-ranked.
+/// `dist` is kilometres (the same value the card distance text shows).
+List<Station> _screenshotStations() => const [
+      Station(
+        id: 'fr-pezenas',
+        name: 'Pézenas Carburant',
+        brand: '',
+        street: '1 route de Béziers',
+        postCode: '34120',
+        place: 'Pézenas',
+        lat: 43.46,
+        lng: 3.42,
+        dist: 0.265, // 265 m
+        e85: 0.789,
+        isOpen: true,
+      ),
+      Station(
+        id: 'fr-intermarche',
+        name: 'Intermarché',
+        brand: 'Intermarché',
+        street: 'Avenue de Verdun',
+        postCode: '34120',
+        place: 'Pézenas',
+        lat: 43.49,
+        lng: 3.45,
+        dist: 9.3,
+        e85: 0.799,
+        isOpen: true,
+      ),
+      Station(
+        id: 'fr-superu-essence',
+        name: 'Station Essence Super U',
+        brand: 'Super U',
+        street: 'Route de Pézenas',
+        postCode: '34630',
+        place: 'Saint-Thibéry',
+        lat: 43.50,
+        lng: 3.41,
+        dist: 9.9,
+        e85: 0.805,
+        isOpen: true,
+      ),
+      Station(
+        id: 'fr-superu',
+        name: 'Super U',
+        brand: 'Super U',
+        street: 'Avenue de la Gare',
+        postCode: '34630',
+        place: 'Saint-Thibéry',
+        lat: 43.51,
+        lng: 3.40,
+        dist: 10.0,
+        e85: 0.809,
+        isOpen: true,
+      ),
+    ];
+
+class _ActiveRadar extends RadarSearch {
+  _ActiveRadar(this._stations);
+  final List<Station> _stations;
+
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(_stations),
+      );
+}
+
+/// The fill the rendered [ProximityFillBar] for [station] would paint — read
+/// straight off the widget the real card path built (its `distanceMeters` +
+/// `radiusMeters`), via the SAME shared helper the widget uses. This is NOT a
+/// hand-rolled value: it is exactly what the surface displays.
+double _renderedFillFor(WidgetTester tester, Station station) {
+  // Anchor on the per-row key the radar list assigns each card
+  // (`station-{id}` in search_results_list), then read THIS card's bar.
+  final card = find.byKey(ValueKey('station-${station.id}'));
+  expect(card, findsOneWidget,
+      reason: 'the radar list must render a card for ${station.id}');
+  final bar = tester.widget<ProximityFillBar>(
+    find.descendant(of: card, matching: find.byType(ProximityFillBar)),
+  );
+  // Guard: the bar must be wired to THIS station's distance.
+  expect(bar.distanceMeters, closeTo(station.dist * 1000.0, 1e-6),
+      reason: 'the bar must use station.dist (the same value the text shows)');
+  return ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!);
+}
+
+Future<void> _pumpRadar(
+  WidgetTester tester, {
+  required List<Station> stations,
+  required double radiusKm,
+}) async {
+  final test = standardTestOverrides();
+  when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+  when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+  when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+  await pumpApp(
+    tester,
+    SearchResultsContent(onGpsRetry: () async {}),
+    overrides: [
+      ...test.overrides,
+      userPositionNullOverride(),
+      radarSearchProvider.overrideWith(() => _ActiveRadar(stations)),
+      // The field's WIDE slider (25 km) relative to the 10 km result span —
+      // the condition under which the old code compressed every bar.
+      searchRadiusOverride(radiusKm),
+    ].cast(),
+  );
+  await tester.pump();
+}
+
+void main() {
+  // The pure helper arithmetic + never-throws contract are pinned in
+  // test/core/utils/radar_closeness_test.dart. This file pins the REAL radar
+  // list-card surface end-to-end (the regression lock) + the shared-helper
+  // invariant across all three radar surfaces.
+  group('radar list-card closeness bar — the real surface (#2956)', () {
+    testWidgets(
+        'scales to the result span: nearest near-full, farthest empty '
+        '(NOT the 25 km slider that compressed every bar)', (tester) async {
+      await _pumpRadar(
+        tester,
+        stations: _screenshotStations(),
+        radiusKm: 25.0, // the field's WIDE slider
+      );
+
+      final stations = _screenshotStations();
+      final near = _renderedFillFor(tester, stations[0]); // 265 m
+      final mid = _renderedFillFor(tester, stations[1]); // 9.3 km
+      final farish = _renderedFillFor(tester, stations[2]); // 9.9 km
+      final far = _renderedFillFor(tester, stations[3]); // 10.0 km
+
+      // Pinned to the result-span scale (farthest = 10 km), NOT the 25 km
+      // slider. These are the values the bar actually paints.
+      expect(near, closeTo(0.9735, 1e-3),
+          reason: '265 m of a 10 km span → ~0.97 (nearly full)');
+      expect(mid, closeTo(0.07, 1e-3), reason: '9.3 km of 10 km → ~0.07');
+      expect(farish, closeTo(0.01, 1e-3), reason: '9.9 km of 10 km → ~0.01');
+      expect(far, closeTo(0.0, 1e-6), reason: '10.0 km = the span edge → empty');
+
+      // The core regression lock: the bars must be VISIBLY DIFFERENT down the
+      // list. On master (scaled to the 25 km slider) the three far rows all sat
+      // at ~0.60–0.63 — indistinguishable — which is the reported symptom.
+      expect(near - far, greaterThan(0.9),
+          reason: 'closest vs farthest must differ by nearly a full bar');
+      expect(mid - far, greaterThan(0.05),
+          reason: 'mid vs far must be clearly distinct, not a compressed band');
+      // Strictly monotonic: closer ⇒ fuller.
+      expect(near, greaterThan(mid));
+      expect(mid, greaterThan(farish));
+      expect(farish, greaterThan(far));
+    });
+
+    testWidgets('every result row renders exactly one closeness bar',
+        (tester) async {
+      await _pumpRadar(
+        tester,
+        stations: _screenshotStations(),
+        radiusKm: 25.0,
+      );
+      expect(
+        find.byType(ProximityFillBar),
+        findsNWidgets(_screenshotStations().length),
+      );
+    });
+  });
+
+  // #2956 — guard against a future re-divergence. The patch-pile recurred
+  // partly because each surface re-derived the fill independently; one shared
+  // helper closes that. Pin it structurally: the ProximityFillBar (the widget
+  // every surface renders) must compute the fill via [RadarCloseness], and no
+  // radar surface may re-implement the `1 - distance/radius` arithmetic inline.
+  group('shared-helper invariant (#2956)', () {
+    File srcFile(String relative) {
+      final f = File(relative);
+      expect(f.existsSync(), isTrue, reason: 'missing $relative');
+      return f;
+    }
+
+    test('ProximityFillBar delegates its fill to RadarCloseness', () {
+      final bar = srcFile(
+        'lib/features/consumption/presentation/widgets/proximity_fill_bar.dart',
+      ).readAsStringSync();
+      expect(bar.contains('RadarCloseness.fillFor'), isTrue,
+          reason: 'the bar must delegate the fill formula to the shared helper');
+    });
+
+    test('no radar surface re-implements the fill arithmetic inline', () {
+      // The naked formula `1 - <dist> / <radius>` must live ONLY in
+      // RadarCloseness. A re-introduced inline copy on any surface is exactly
+      // how the bar desynced before.
+      final formula = RegExp(r'1\.0?\s*-\s*\(?\s*\w*[Dd]istance');
+      const consumption = 'lib/features/consumption/presentation/widgets';
+      const search = 'lib/features/search/presentation/widgets';
+      final paths = <String>[
+        '$search/station_card_status.dart',
+        '$search/search_results_list.dart',
+        '$consumption/trip_radar_card.dart',
+        '$consumption/trip_recording_pip_price_layout.dart',
+        '$consumption/proximity_fill_bar.dart',
+      ];
+      for (final path in paths) {
+        expect(formula.hasMatch(srcFile(path).readAsStringSync()), isFalse,
+            reason: '$path must use RadarCloseness, not an inline fill formula');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #2956.

## Symptom (recurring — 5th attempt)

The Fuel Station Radar "closeness" bar (the green fill under each station that should grow as the driver nears) STILL did not scale with distance after #2661, #2808, #2899/#2901 and the radar map redesign #2944. In the field screenshot (E85, radar active) the distance TEXT was correct — 265 m, 9.3 km, 9.9 km, 10.0 km — but the bar under every row was **~the same length**.

## Root cause (the *source*, not another trigger)

The fill formula `clamp(1 − distance/radius)` and the distance feed (`station.dist`, restamped from live GPS — the same value the text shows) were always correct. The defect was the **radius** each surface scaled against.

Every radar surface fed a *statically configured* radius — the 1 km approach geo-fence or the `searchRadiusProvider` slider (**up to 25 km**) — that is **decoupled from where the surfaced stations actually are**. When that radius is large relative to the real spread of results, `distance/radius` is small for every row, so `1 − distance/radius` compresses toward 1.0 and all bars look identical. With the field's 25 km slider: 265 m → 0.99, 9.3 km → 0.63, 9.9 km → 0.60, 10.0 km → 0.60 — the three far rows indistinguishable. **That is exactly the screenshot.**

Every prior fix chased a different *trigger* (wrong geo-fence radius, cosmetic PiP polish, adding the bar to a 3rd surface, a map redesign) without fixing the source. The existing tests were **false-green**: they only asserted `fillFor()` with hand-picked radius values chosen to *produce* distinct fills, never driving the real radar-list path with the real (large) radius the app feeds.

## Fix

- New shared **`RadarCloseness`** helper (`lib/core/utils/radar_closeness.dart`) — the single source of truth: `fillFor(distance, radius)` (the canonical clamped formula) + `spanRadiusMeters(stations)` = the **farthest surfaced station's distance** (the actual span of the visible set).
- The radar result list now scales each bar to that **span** instead of the slider, so closeness reads RELATIVE across the list: nearest near-full, farthest near-empty — regardless of the slider. Reproduces the intended worked example exactly (span ≈ 10 km: 265 m → ~0.97, 9.9 km → ~0.01, 10 km → 0).
- `ProximityFillBar.fillFor` now **delegates** to `RadarCloseness.fillFor`, so all three radar surfaces (list card, PiP, trip card) compute the fill through the one helper and can never desync again.

## Tests (pinning — RED before / green after)

- `test/features/search/presentation/widgets/radar_closeness_bar_test.dart` drives the **real** list-card path (`SearchResultsContent → SearchResultsList → StationCard → ProximityFillBar`) with the exact screenshot fixtures + the 25 km slider, reading the fill the rendered bar would paint. **RED on master** (nearest 0.9894, far rows compressed to ~0.60); **green after** (0.9735 / 0.07 / 0.01 / 0), strictly monotonic, closest−farthest > 0.9.
- A shared-helper invariant test asserts the bar delegates to `RadarCloseness` and **no radar surface re-implements the fill arithmetic inline** (so a future change to one can't desync them).
- `test/core/utils/radar_closeness_test.dart` pins the helper arithmetic + its never-throws contract (degenerate / NaN / infinite radius → 0, empty set → null).

## Gates

- No new user-facing strings (purely visual) — no ARB / l10n fan-out.
- No codegen (no `@riverpod`/freezed touched) — zero `*.g.dart` / `*.freezed.dart` drift.
- `flutter analyze` clean on all touched files; 1253 search/consumption/core tests + the full lint suite (incl. never-throws contract) green.
- Structural tests only (no goldens). All touched files under the 400-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)