### PR TITLE
chore(branding): show brand "Sparkilo" instead of old "Fuel Prices" placeholder

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
 
 <resources>
     <string name="widget_description">Fuel prices — switch between favorites and nearest stations in the header</string>
-    <string name="widget_name">Fuel Prices</string>
+    <string name="widget_name">Sparkilo</string>
     <string name="widget_empty">Add favorites to see prices here</string>
     <string name="nearest_widget_name">Nearest Stations</string>
     <string name="nearest_widget_empty">Add favorites and enable GPS to see nearby stations</string>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Privacy Policy — Fuel Prices App</title>
+  <title>Privacy Policy — Sparkilo</title>
   <style>
     :root {
       --bg: #ffffff;
@@ -54,11 +54,11 @@
 
 <div class="brand"><img src="icon.png" alt="Sparkilo app icon"></div>
 <h1>Privacy Policy</h1>
-<p class="meta">Fuel Prices App (de.tankstellen.app) &mdash; Last updated: 7 April 2026</p>
+<p class="meta">Sparkilo (de.tankstellen.app) &mdash; Last updated: 7 April 2026</p>
 
 <h2>1. Overview</h2>
 <p>
-  Fuel Prices ("the app") is a free, open-source fuel and EV charging price comparison app.
+  Sparkilo ("the app") is a free, open-source fuel and EV charging price comparison app.
   It is designed with a <strong>local-first, privacy-respecting</strong> architecture.
   There are no ads, no analytics, and no tracking.
 </p>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../core/constants/app_constants.dart';
 import '../core/country/country_switch_listener.dart';
 import '../core/language/language_provider.dart';
 import '../core/notifications/notification_launch_listener.dart';
@@ -102,7 +103,7 @@ class _TankstellenAppState extends ConsumerState<TankstellenApp>
       // Keying on language.code forces a full rebuild whenever the user
       // changes locale, so AppLocalizations lookups everywhere refresh.
       key: ValueKey(language.code),
-      title: 'Fuel Prices',
+      title: AppConstants.appName,
       debugShowCheckedModeBanner: false,
       // #1712 — the green Eco theme occupies the `light` slot: when
       // chosen it is supplied here and `themeMode` resolves to light.

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -4,7 +4,7 @@
 class AppConstants {
   AppConstants._();
 
-  static const String appName = 'Fuel Prices';
+  static const String appName = 'Sparkilo'; // i18n-ignore: brand name
   static const String appPackage = 'de.tankstellen.app';
 
   /// Runtime app version cached at startup by [AppInitializer].

--- a/lib/features/search/presentation/screens/search_screen.dart
+++ b/lib/features/search/presentation/screens/search_screen.dart
@@ -211,7 +211,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     }
 
     return PageScaffold(
-      title: l10n?.appTitle ?? 'Fuel Prices',
+      title: l10n?.appTitle ?? 'Sparkilo', // i18n-ignore: brand name
       toolbarHeight: isLandscape ? 40 : null,
       actions: [
         IconButton(

--- a/lib/features/setup/presentation/widgets/setup_header.dart
+++ b/lib/features/setup/presentation/widgets/setup_header.dart
@@ -30,7 +30,7 @@ class SetupHeader extends StatelessWidget {
         Semantics(
           header: true,
           child: Text(
-            l10n?.welcome ?? 'Fuel Prices',
+            l10n?.welcome ?? 'Sparkilo', // i18n-ignore: brand name
             style: theme.textTheme.headlineMedium?.copyWith(
               fontWeight: FontWeight.bold,
             ),

--- a/lib/features/setup/presentation/widgets/welcome_step.dart
+++ b/lib/features/setup/presentation/widgets/welcome_step.dart
@@ -22,7 +22,7 @@ class WelcomeStep extends StatelessWidget {
           const FuelPumpIllustration(size: 160),
           const SizedBox(height: 24),
           Text(
-            l10n?.welcome ?? 'Fuel Prices',
+            l10n?.welcome ?? 'Sparkilo', // i18n-ignore: brand name
             style: theme.textTheme.headlineLarge?.copyWith(
               fontWeight: FontWeight.bold,
             ),

--- a/test/app/app_test.dart
+++ b/test/app/app_test.dart
@@ -16,7 +16,7 @@
 //
 // These tests verify the parts that are pure widget-tree composition:
 //
-//   * `MaterialApp.router` is the root, with `title: 'Fuel Prices'`,
+//   * `MaterialApp.router` is the root, with `title: 'Sparkilo'`,
 //     `debugShowCheckedModeBanner: false`, and `routerConfig` set.
 //   * `themeMode` reflects `themeModeSettingProvider`.
 //   * `locale` and the `ValueKey` reflect `activeLanguageProvider`.
@@ -189,7 +189,7 @@ void main() {
       expect(find.byType(MaterialApp), findsOneWidget);
     });
 
-    testWidgets('MaterialApp.router has title "Fuel Prices" and '
+    testWidgets('MaterialApp.router has title "Sparkilo" and '
         'debugShowCheckedModeBanner: false', (tester) async {
       final router = _stubRouter();
       addTearDown(router.dispose);
@@ -206,7 +206,7 @@ void main() {
       await tester.pump();
 
       final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
-      expect(app.title, 'Fuel Prices');
+      expect(app.title, 'Sparkilo');
       expect(app.debugShowCheckedModeBanner, isFalse);
       expect(app.routerConfig, same(router));
     });

--- a/test/app/fresh_install_integration_test.dart
+++ b/test/app/fresh_install_integration_test.dart
@@ -122,7 +122,7 @@ void main() {
     );
 
     // Sanity: the search shell MUST NOT be reachable before consent.
-    expect(find.text('Fuel Prices'), findsNothing);
+    expect(find.text('Sparkilo'), findsNothing);
   });
 
   test(
@@ -261,7 +261,7 @@ void main() {
             'Even on an explicit go("/") the router must redirect back to '
             '/consent when no GDPR flag is persisted. This is the guard that '
             'protects the pre-consent invariant #565 locks in.');
-    expect(find.text('Fuel Prices'), findsNothing);
+    expect(find.text('Sparkilo'), findsNothing);
   });
 }
 

--- a/test/goldens/tab_appbar_consistency_test.dart
+++ b/test/goldens/tab_appbar_consistency_test.dart
@@ -117,7 +117,7 @@ class _TabSpec {
 
 const _rechercheTab = _TabSpec(
   label: 'Recherche',
-  title: 'Fuel Prices',
+  title: 'Sparkilo',
   actions: [
     IconButton(
       icon: Icon(Icons.refresh),


### PR DESCRIPTION
## Why

The About screen showed **Fuel Prices** (the old placeholder) instead of the real brand **Sparkilo** — the user's exact complaint. Root cause: `AppConstants.appName` still held `'Fuel Prices'`, and that constant drives the About screen via `const Text(AppConstants.appName)`. A handful of other spots leaked the same placeholder.

## What changed (each is an app-name usage)

| File | Change |
|---|---|
| `lib/core/constants/app_constants.dart` | `appName` `'Fuel Prices'` → `'Sparkilo'` (`// i18n-ignore: brand name`) |
| `lib/app/app.dart` | `MaterialApp.title` literal → `AppConstants.appName` (+ import) |
| `lib/features/setup/presentation/widgets/welcome_step.dart` | `l10n?.welcome ?? 'Fuel Prices'` fallback → `'Sparkilo'` |
| `lib/features/setup/presentation/widgets/setup_header.dart` | same wordmark fallback → `'Sparkilo'` |
| `lib/features/search/presentation/screens/search_screen.dart` | `l10n?.appTitle ?? 'Fuel Prices'` fallback → `'Sparkilo'` |
| `android/app/src/main/res/values/strings.xml` | `widget_name` → `Sparkilo` |
| `docs/index.html` | live GitHub Pages privacy policy (linked from About) title/meta/overview → `Sparkilo` |
| `test/app/app_test.dart`, `test/app/fresh_install_integration_test.dart`, `test/goldens/tab_appbar_consistency_test.dart` | assertions updated old title → `Sparkilo` |

## Out of scope (intentionally left)

- iOS `CFBundleDisplayName` — already `Sparkilo`.
- The deliberate "(formerly known as Fuel Prices Europe & More)" historical references in the localized privacy pages + generator.
- The generic `widget_description` "Fuel prices — switch between favorites…" descriptive phrase (not the app name).
- Bundle ids stay `de.tankstellen.tankstellen` / `de.tankstellen.app`.

"Sparkilo" is a brand / proper noun → **i18n-exempt** (no ARB change), tagged `// i18n-ignore: brand name`.

## Gates

- `flutter analyze` clean (changed files).
- `no_hardcoded_ui_strings` lint green (brand literals carry `i18n-ignore`).
- Affected app/setup/about/golden widget tests green (31 passed).
- No `*.g.dart` / `*.freezed.dart` / ARB / l10n drift.

Closes #2958

🤖 Generated with [Claude Code](https://claude.com/claude-code)