### PR TITLE
feat(approach): tap the approach overlay window to bring the app to the foreground

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/MainActivity.kt
@@ -80,6 +80,7 @@ class MainActivity : FlutterActivity() {
                     autoEnterPip = call.arguments as? Boolean ?: false
                     result.success(null)
                 }
+                "bringToFront" -> result.success(bringToFront())
                 else -> result.notImplemented()
             }
         }
@@ -125,6 +126,41 @@ class MainActivity : FlutterActivity() {
                 .build()
             enterPictureInPictureMode(params)
         } catch (e: IllegalStateException) {
+            false
+        }
+    }
+
+    /**
+     * Bring the app back to the foreground in full screen (#2964). Tapping
+     * the body of the floating PiP tile calls this — the user expects a tap
+     * on the little window to restore the full Sparkilo app, mirroring how
+     * Google Maps' navigation tile expands.
+     *
+     * Re-launches THIS activity via the package launch intent with
+     * `REORDER_TO_FRONT | NEW_TASK | SINGLE_TOP`, which reorders the
+     * EXISTING task to the front rather than cold-starting a fresh instance
+     * — so the live recording / engine state is preserved. Because the
+     * activity is `singleTop` with `taskAffinity=""`, the OS routes this
+     * through [onNewIntent] on the running instance and leaves PiP, restoring
+     * the full window.
+     *
+     * Wrapped in a best-effort try: a failed reorder just leaves the user in
+     * PiP (they can still use the system expand control), never crashes.
+     * Returns false when the launch intent can't be resolved or the start
+     * throws — the Dart side treats that as "not restored".
+     */
+    private fun bringToFront(): Boolean {
+        return try {
+            val launch = packageManager.getLaunchIntentForPackage(packageName)
+                ?: return false
+            launch.addFlags(
+                Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP,
+            )
+            startActivity(launch)
+            true
+        } catch (e: Exception) {
             false
         }
     }

--- a/lib/features/consumption/data/pip_controller.dart
+++ b/lib/features/consumption/data/pip_controller.dart
@@ -49,6 +49,25 @@ class PipController {
     }
   }
 
+  /// Bring the app back to the foreground in full screen (#2964).
+  ///
+  /// Tapping the body of the floating PiP tile calls this so the user can
+  /// restore the full app with a single tap — the native side reorders the
+  /// EXISTING task to the front (preserving the live recording / engine
+  /// state) and the OS leaves PiP. Returns false on an unsupported platform
+  /// or when the native reorder could not be performed; the tile then simply
+  /// stays in PiP (the system expand control remains available).
+  Future<bool> bringToFront() async {
+    if (!isSupported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('bringToFront') ?? false;
+    } on PlatformException {
+      return false;
+    } on MissingPluginException {
+      return false;
+    }
+  }
+
   /// Tell the native layer whether to auto-enter PiP when the user
   /// leaves the app (Home / Recents). The recording screen enables
   /// this only while a trip is recording, so leaving the app from an

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -83,6 +83,18 @@ class TripRecordingBanner extends ConsumerWidget {
           }
         } on Object { /* no on-search radar */ }
       }
+      // #2964 — tapping the floating PiP tile body restores the full app.
+      // Built here where `ref` is in scope; the controller is the app-wide
+      // singleton (PiP is Activity-bound) and bringToFront is an inert no-op
+      // off Android, so the tile stays safe on every other platform.
+      void onBodyTap() {
+        try {
+          ref.read(pipControllerProvider).bringToFront();
+        } on Object {
+          // Best-effort: a failed reorder just leaves the tile in PiP.
+        }
+      }
+
       return _pipView(
         context,
         state,
@@ -91,6 +103,7 @@ class TripRecordingBanner extends ConsumerWidget {
         radarStation: radarStation,
         radiusMeters: radiusMeters,
         searchRadarActive: searchRadarActive,
+        onBodyTap: onBodyTap,
       );
     }
 
@@ -185,6 +198,7 @@ class TripRecordingBanner extends ConsumerWidget {
     required Station? radarStation,
     required double? radiusMeters,
     bool searchRadarActive = false,
+    VoidCallback? onBodyTap,
   }) {
     if (!state.isActive) {
       // #2677 — the on-search Fuel Station Radar runs WITHOUT a trip. When it
@@ -204,6 +218,7 @@ class TripRecordingBanner extends ConsumerWidget {
               : null,
           kmCaption: true,
           radiusMeters: radiusMeters,
+          onBodyTap: onBodyTap,
         );
       }
       // A trip ended while the app sat in PiP — the OS restores the
@@ -234,6 +249,7 @@ class TripRecordingBanner extends ConsumerWidget {
           ? radarStation.dist * 1000.0
           : null,
       radiusMeters: radiusMeters,
+      onBodyTap: onBodyTap,
     );
   }
 

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_price_layout.dart
@@ -3,7 +3,6 @@
 
 import 'package:flutter/material.dart';
 
-import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../l10n/app_localizations.dart';
@@ -18,10 +17,11 @@ import 'proximity_fill_bar.dart';
 ///
 /// Renders, top to bottom: the huge price for the driver's fuel type, the
 /// fuel label, the station name (→ brand fallback), a distance caption, and
-/// the corporate-green [ProximityFillBar]. The whole tile is tap-to-navigate
-/// (`NavigationUtils.openInMaps`, #2601) and is scaled down uniformly by one
-/// outer `FittedBox(scaleDown)` so the bottom line never clips the small 2:1
-/// tile (#2620).
+/// the corporate-green [ProximityFillBar]. Tapping the tile body brings the
+/// full app back to the foreground via [onBodyTap] (#2964 — the user expects
+/// a tap on the little floating window to restore full screen). The content
+/// is scaled down uniformly by one outer `FittedBox(scaleDown)` so the bottom
+/// line never clips the small 2:1 tile (#2620).
 ///
 /// Two callers, identical visual, only the distance unit + radius differ:
 ///
@@ -46,6 +46,12 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
   /// proximity fill bar's "indicated radius". Null collapses the bar.
   final double? radiusMeters;
 
+  /// Invoked when the user taps the tile body (#2964) — the host wires this
+  /// to bring the app back to the foreground in full screen. Null leaves the
+  /// body non-tappable (so the widget stays usable from plain widget tests
+  /// and previews without a PiP host).
+  final VoidCallback? onBodyTap;
+
   const TripRecordingPipPriceLayout({
     super.key,
     required this.station,
@@ -55,6 +61,7 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
     required this.distanceMeters,
     required this.kmCaption,
     required this.radiusMeters,
+    this.onBodyTap,
   });
 
   @override
@@ -138,38 +145,44 @@ class TripRecordingPipPriceLayout extends StatelessWidget {
           )
         : null;
 
-    // #2601 — tap to navigate to the station in the user's maps app. #2620 —
-    // one outer FittedBox(scaleDown) shrinks the price stack so it never
-    // bleeds past the small 2:1 tile; the proximity band sits below it at the
-    // tile's full width (#2808).
-    return Tooltip(
-      message: l?.navigate ?? 'Navigate',
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () => NavigationUtils.openInMaps(
-          station.lat,
-          station.lng,
-          label: station.navLabel,
-        ),
-        child: Material(
-          color: backgroundColor,
-          child: SafeArea(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                    child: Center(
-                      child: FittedBox(fit: BoxFit.scaleDown, child: content),
-                    ),
-                  ),
+    // #2620 — one outer FittedBox(scaleDown) shrinks the price stack so it
+    // never bleeds past the small 2:1 tile; the proximity band sits below it
+    // at the tile's full width (#2808).
+    final body = Material(
+      color: backgroundColor,
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                child: Center(
+                  child: FittedBox(fit: BoxFit.scaleDown, child: content),
                 ),
-                ?proximityBand,
-              ],
+              ),
             ),
-          ),
+            ?proximityBand,
+          ],
+        ),
+      ),
+    );
+
+    // #2964 — tapping the tile body brings the full app back to the
+    // foreground (the user expects a tap on the floating window to restore
+    // full screen). When no [onBodyTap] is wired (e.g. a plain preview) the
+    // body renders untapped, matching the pre-#2964 default-layout behaviour.
+    final onTap = onBodyTap;
+    if (onTap == null) return body;
+    return Tooltip(
+      message: l?.pipTapToRestore ?? 'Tap to open the full app',
+      child: Semantics(
+        button: true,
+        label: l?.pipTapToRestore ?? 'Tap to open the full app',
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: body,
         ),
       ),
     );

--- a/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_pip_view.dart
@@ -65,6 +65,12 @@ class TripRecordingPipView extends StatelessWidget {
   /// proximity fill bar's "indicated radius" (#2661). Null collapses the bar.
   final double? radiusMeters;
 
+  /// Invoked when the user taps the tile body (#2964) — the host wires this
+  /// to bring the app back to the foreground in full screen. Wired by the
+  /// PiP host (the banner) for every layout; null leaves the body
+  /// non-tappable (plain previews / widget tests without a PiP host).
+  final VoidCallback? onBodyTap;
+
   const TripRecordingPipView({
     super.key,
     required this.state,
@@ -75,6 +81,7 @@ class TripRecordingPipView extends StatelessWidget {
     this.radarStation,
     this.radarDistanceMeters,
     this.radiusMeters,
+    this.onBodyTap,
   });
 
   @override
@@ -97,6 +104,7 @@ class TripRecordingPipView extends StatelessWidget {
         distanceMeters: dist,
         kmCaption: false,
         radiusMeters: radiusMeters,
+        onBodyTap: onBodyTap,
       );
     }
 
@@ -112,6 +120,7 @@ class TripRecordingPipView extends StatelessWidget {
         distanceMeters: radarDistanceMeters,
         kmCaption: true,
         radiusMeters: radiusMeters,
+        onBodyTap: onBodyTap,
       );
     }
 
@@ -250,6 +259,7 @@ class TripRecordingPipView extends StatelessWidget {
     }
 
     return _pipStack(
+      l: l,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -305,8 +315,13 @@ class TripRecordingPipView extends StatelessWidget {
   /// clipping (#2620). The single outer FittedBox(scaleDown) measures the
   /// column's full intrinsic size and shrinks it on both axes; Center keeps
   /// it optically centred when it already fits.
-  Widget _pipStack({required Widget child}) {
-    return Material(
+  ///
+  /// #2964 — when [onBodyTap] is wired the whole tile becomes a tap target
+  /// that brings the app back to the foreground in full screen (the user
+  /// expects a tap on the floating window to restore full screen). Null
+  /// leaves the body non-tappable (previews / widget tests without a host).
+  Widget _pipStack({required Widget child, AppLocalizations? l}) {
+    final body = Material(
       color: backgroundColor,
       child: SafeArea(
         child: Padding(
@@ -314,6 +329,21 @@ class TripRecordingPipView extends StatelessWidget {
           child: Center(
             child: FittedBox(fit: BoxFit.scaleDown, child: child),
           ),
+        ),
+      ),
+    );
+    final onTap = onBodyTap;
+    if (onTap == null) return body;
+    final label = l?.pipTapToRestore ?? 'Tap to open the full app';
+    return Tooltip(
+      message: label,
+      child: Semantics(
+        button: true,
+        label: label,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: body,
         ),
       ),
     );

--- a/lib/l10n/_fragments/approach_pip_de.arb
+++ b/lib/l10n/_fragments/approach_pip_de.arb
@@ -19,5 +19,9 @@
     "placeholders": {
       "percent": {"type": "int", "example": "60"}
     }
+  },
+  "pipTapToRestore": "Tippen, um die ganze App zu öffnen",
+  "@pipTapToRestore": {
+    "description": "Tooltip + accessibility label on the floating Picture-in-Picture tile body (#2964): tapping the little window brings the full Sparkilo app back to the foreground / full screen."
   }
 }

--- a/lib/l10n/_fragments/approach_pip_en.arb
+++ b/lib/l10n/_fragments/approach_pip_en.arb
@@ -19,5 +19,9 @@
     "placeholders": {
       "percent": {"type": "int", "example": "60"}
     }
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "description": "Tooltip + accessibility label on the floating Picture-in-Picture tile body (#2964): tapping the little window brings the full Sparkilo app back to the foreground / full screen."
   }
 }

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1642,6 +1642,10 @@
       }
     }
   },
+  "pipTapToRestore": "Tippen, um die ganze App zu öffnen",
+  "@pipTapToRestore": {
+    "description": "Tooltip + accessibility label on the floating Picture-in-Picture tile body (#2964): tapping the little window brings the full Sparkilo app back to the foreground / full screen."
+  },
   "authErrorNoNetwork": "Keine Netzwerkverbindung. Bitte später erneut versuchen.",
   "@authErrorNoNetwork": {
     "description": "Auth error pill — shown when the device has no network connectivity (DNS failure, dropped socket, AuthRetryableFetchException). Replaces the raw exception text leaked by #1186."

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2113,6 +2113,10 @@
       }
     }
   },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "description": "Tooltip + accessibility label on the floating Picture-in-Picture tile body (#2964): tapping the little window brings the full Sparkilo app back to the foreground / full screen."
+  },
   "authErrorNoNetwork": "No network connection. Try again later.",
   "@authErrorNoNetwork": {
     "description": "Auth error pill — shown when the device has no network connectivity (DNS failure, dropped socket, AuthRetryableFetchException). Replaces the raw exception text leaked by #1186."

--- a/lib/l10n/app_en_XA.arb
+++ b/lib/l10n/app_en_XA.arb
@@ -1104,6 +1104,7 @@
   "approachStationDistance": "⟦{meters} ɱ áŵáý ··⟧",
   "fuelStationRadarDistanceKm": "⟦{km} ķɱ áŵáý ···⟧",
   "fuelStationRadarProximity": "⟦Ƥřóẋîɱîŧý {percent}% ····⟧",
+  "pipTapToRestore": "⟦Ŧáƥ ŧó óƥéñ ŧĥé ƒúłł áƥƥ ·········⟧",
   "authErrorNoNetwork": "⟦Ñó ñéŧŵóřķ çóññéçŧîóñ. Ŧřý áǧáîñ łáŧéř. ··············⟧",
   "authErrorInvalidCredentials": "⟦Îñṽáłîđ éɱáîł óř ƥáššŵóřđ. Çĥéçķ ýóúř çřéđéñŧîáłš. ···················⟧",
   "authErrorUserAlreadyExists": "⟦Ŧĥîš éɱáîł îš áłřéáđý řéǧîšŧéřéđ. Ŧřý šîǧñîñǧ îñ îñšŧéáđ. ·····················⟧",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -4633,5 +4633,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6786,6 +6786,12 @@ abstract class AppLocalizations {
   /// **'Proximity {percent}%'**
   String fuelStationRadarProximity(int percent);
 
+  /// Tooltip + accessibility label on the floating Picture-in-Picture tile body (#2964): tapping the little window brings the full Sparkilo app back to the foreground / full screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to open the full app'**
+  String get pipTapToRestore;
+
   /// Auth error pill — shown when the device has no network connectivity (DNS failure, dropped socket, AuthRetryableFetchException). Replaces the raw exception text leaked by #1186.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3741,6 +3741,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'Няма мрежова връзка. Опитайте по-късно.';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3722,6 +3722,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'Žádné síťové připojení. Zkuste to znovu.';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3709,6 +3709,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Ingen netværksforbindelse. Prøv igen senere.';
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3732,6 +3732,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tippen, um die ganze App zu öffnen';
+
+  @override
   String get authErrorNoNetwork =>
       'Keine Netzwerkverbindung. Bitte später erneut versuchen.';
 

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3737,6 +3737,9 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Δεν υπάρχει σύνδεση δικτύου. Δοκιμάστε αργότερα.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3694,6 +3694,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'No network connection. Try again later.';
 
   @override
@@ -11413,6 +11416,9 @@ class AppLocalizationsEnXa extends AppLocalizationsEn {
   String fuelStationRadarProximity(int percent) {
     return '⟦Ƥřóẋîɱîŧý $percent% ····⟧';
   }
+
+  @override
+  String get pipTapToRestore => '⟦Ŧáƥ ŧó óƥéñ ŧĥé ƒúłł áƥƥ ·········⟧';
 
   @override
   String get authErrorNoNetwork =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3733,6 +3733,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'Sin conexión de red. Inténtalo más tarde.';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3709,6 +3709,9 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'Võrguühendus puudub. Proovi hiljem uuesti.';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3712,6 +3712,9 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Ei verkkoyhteyttä. Yritä myöhemmin uudelleen.';
 

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3741,6 +3741,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Pas de connexion réseau. Veuillez réessayer plus tard.';
 

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3717,6 +3717,9 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Nema mrežne veze. Pokušajte ponovno kasnije.';
 

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3734,6 +3734,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Nincs hálózati kapcsolat. Próbálja újra később.';
 

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3727,6 +3727,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Nessuna connessione di rete. Riprova più tardi.';
 

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3733,6 +3733,9 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'Nėra tinklo ryšio. Bandykite vėliau.';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3733,6 +3733,9 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork => 'Nav tīkla savienojuma. Mēģiniet vēlāk.';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3708,6 +3708,9 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Ingen nettverkstilkobling. Prøv igjen senere.';
 

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3726,6 +3726,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Geen netwerkverbinding. Probeer het later opnieuw.';
 

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3721,6 +3721,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Brak połączenia z siecią. Spróbuj ponownie później.';
 

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3733,6 +3733,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Sem ligação à rede. Tente novamente mais tarde.';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3734,6 +3734,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Nicio conexiune la rețea. Încercați mai târziu.';
 

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3727,6 +3727,9 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Žiadne sieťové pripojenie. Skúste to neskôr.';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3712,6 +3712,9 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Ni omrežne povezave. Poskusite znova pozneje.';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3710,6 +3710,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get pipTapToRestore => 'Tap to open the full app';
+
+  @override
   String get authErrorNoNetwork =>
       'Ingen nätverksanslutning. Försök igen senare.';
 

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -4530,5 +4530,10 @@
   "@lessonAdviceCombustionHealthEnrichment": {
     "x-mt": "needs-native-review",
     "description": "MT — needs native review"
+  },
+  "pipTapToRestore": "Tap to open the full app",
+  "@pipTapToRestore": {
+    "x-mt": "needs-native-review",
+    "description": "MT — needs native review"
   }
 }

--- a/test/features/consumption/data/pip_controller_test.dart
+++ b/test/features/consumption/data/pip_controller_test.dart
@@ -58,6 +58,33 @@ void main() {
       expect(await pip.enterPip(), isFalse);
     });
 
+    test('bringToFront invokes the bringToFront method and returns its result',
+        () async {
+      // #2964 — tapping the floating PiP tile body restores the full app.
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        return true;
+      });
+
+      final pip = PipController();
+      addTearDown(pip.dispose);
+
+      expect(await pip.bringToFront(), isTrue);
+      expect(calls.single.method, 'bringToFront');
+    });
+
+    test('bringToFront returns false when the platform call fails', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        throw PlatformException(code: 'noLaunchIntent');
+      });
+
+      final pip = PipController();
+      addTearDown(pip.dispose);
+
+      expect(await pip.bringToFront(), isFalse);
+    });
+
     test('setAutoEnterEnabled forwards the flag to setAutoEnter', () async {
       final calls = <MethodCall>[];
       messenger.setMockMethodCallHandler(channel, (call) async {
@@ -107,6 +134,7 @@ void main() {
 
       expect(pip.isSupported, isFalse);
       expect(await pip.enterPip(), isFalse);
+      expect(await pip.bringToFront(), isFalse);
       await pip.setAutoEnterEnabled(true);
       expect(invoked, isFalse,
           reason: 'no platform channel traffic on a non-PiP platform');

--- a/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_recording_pip_view_approach_test.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
 import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
@@ -641,40 +640,135 @@ void main() {
     });
   });
 
-  group('TripRecordingPipView (#2601) — approach tap-to-navigate', () {
-    // #2601 — the approach-price tile is tappable: tapping it opens the
-    // station in the user's maps app via NavigationUtils.openInMaps,
-    // which goes through the url_launcher platform channel. We mock that
-    // channel to capture the launched URL (a geo: URI for the station's
-    // coords) without touching a real OS intent.
-    const channel = MethodChannel('plugins.flutter.io/url_launcher');
-    final launchedUrls = <String>[];
-
-    setUp(() {
-      launchedUrls.clear();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (call) async {
-            if (call.method == 'launch' || call.method == 'launchUrl') {
-              final args = call.arguments;
-              final url = args is Map
-                  ? args['url'] as String?
-                  : args as String?;
-              if (url != null) launchedUrls.add(url);
-              return true;
-            }
-            if (call.method == 'canLaunch') return true;
-            return null;
-          });
-    });
-
-    tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
-    });
+  group('TripRecordingPipView (#2964) — tap the tile body to restore', () {
+    // #2964 — the user expects a tap on the floating PiP window to bring the
+    // full app back to the foreground. The host (the banner) passes an
+    // onBodyTap callback; tapping the tile body must invoke it (this replaces
+    // the prior #2601 tap-to-navigate on the price layout). Tests assert the
+    // callback fires exactly once per tap, and that the body stays
+    // non-tappable when no callback is wired (preview / no-host fallback).
 
     testWidgets(
-      'tapping the approach-price tile launches the station in maps',
+      'tapping the approach-price tile body invokes onBodyTap (restore)',
       (tester) async {
+        var taps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              approachState: const ApproachInRadius(
+                station: _stationE10,
+                distanceMeters: 350,
+              ),
+              fuelType: FuelType.e10,
+              onBodyTap: () => taps++,
+            ),
+          ),
+        );
+
+        // The tile body carries a live GestureDetector wired to onBodyTap.
+        final gesture = tester.widget<GestureDetector>(
+          find.descendant(
+            of: find.byType(Tooltip),
+            matching: find.byType(GestureDetector),
+          ),
+        );
+        expect(gesture.onTap, isNotNull);
+
+        await tester.tap(find.byType(GestureDetector));
+        await tester.pumpAndSettle();
+        expect(taps, 1, reason: 'tapping the tile body must restore the app');
+      },
+    );
+
+    testWidgets(
+      'tapping the radar-price tile body invokes onBodyTap (restore)',
+      (tester) async {
+        var taps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              radarStation: _stationE10.copyWith(dist: 2.4),
+              radarDistanceMeters: 2400,
+              radiusMeters: 5000,
+              fuelType: FuelType.e10,
+              onBodyTap: () => taps++,
+            ),
+          ),
+        );
+        await tester.tap(find.byType(GestureDetector).first);
+        await tester.pumpAndSettle();
+        expect(taps, 1);
+      },
+    );
+
+    testWidgets(
+      'tapping the default consumption tile body invokes onBodyTap (restore)',
+      (tester) async {
+        // #2964 — unlike #2601 (which only made the price layout tappable),
+        // the default consumption layout is now tappable too: a tap on ANY
+        // tile body restores the app.
+        var taps = 0;
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              approachState: const ApproachIdle(),
+              onBodyTap: () => taps++,
+            ),
+          ),
+        );
+        // L/100 km default layout, with a body tap target.
+        expect(find.text('L/100 km'), findsOneWidget);
+        await tester.tap(find.byType(GestureDetector));
+        await tester.pumpAndSettle();
+        expect(taps, 1);
+      },
+    );
+
+    testWidgets(
+      'the tile body exposes the restore tooltip + a11y label',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(
+            TripRecordingPipView(
+              state: _activeState(),
+              backgroundColor: Colors.green,
+              foregroundColor: Colors.white,
+              approachState: const ApproachIdle(),
+              onBodyTap: () {},
+            ),
+          ),
+        );
+        final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+        expect(tooltip.message, 'Tap to open the full app');
+        // The body is announced as a button carrying the restore label so a
+        // screen-reader user knows the tap brings the app back.
+        final semantics = tester.widget<Semantics>(
+          find.descendant(
+            of: find.byType(Tooltip),
+            matching: find.byWidgetPredicate(
+              (w) => w is Semantics && w.properties.label != null,
+            ),
+          ),
+        );
+        expect(semantics.properties.label, 'Tap to open the full app');
+        expect(semantics.properties.button, isTrue);
+      },
+    );
+
+    testWidgets(
+      'no onBodyTap → the tile body is NOT tappable (no host fallback)',
+      (tester) async {
+        // Without a wired host the tile renders plainly — no GestureDetector,
+        // so previews / widget tests without a PiP host stay inert.
         await tester.pumpWidget(
           _wrap(
             TripRecordingPipView(
@@ -689,49 +783,9 @@ void main() {
             ),
           ),
         );
-
-        // The tile carries a navigate Tooltip + a GestureDetector with a
-        // live onTap (the seam wired in #2601).
-        final gesture = tester.widget<GestureDetector>(
-          find.descendant(
-            of: find.byType(Tooltip),
-            matching: find.byType(GestureDetector),
-          ),
-        );
-        expect(gesture.onTap, isNotNull);
-
-        await tester.tap(find.byType(GestureDetector));
-        await tester.pumpAndSettle();
-
-        // openInMaps fired → a geo: URI for the station coordinates.
-        expect(
-          launchedUrls,
-          isNotEmpty,
-          reason: 'tapping the approach tile must open the maps app',
-        );
-        expect(launchedUrls.first, startsWith('geo:'));
-        expect(launchedUrls.first, contains('${_stationE10.lat}'));
-        expect(launchedUrls.first, contains('${_stationE10.lng}'));
+        expect(find.byType(GestureDetector), findsNothing);
       },
     );
-
-    testWidgets('the default L/100 km layout is NOT tappable (no nav seam)', (
-      tester,
-    ) async {
-      // Only the approach layout navigates; the default layout keeps its
-      // existing non-tappable behavior (#2601 scope guard).
-      await tester.pumpWidget(
-        _wrap(
-          TripRecordingPipView(
-            state: _activeState(),
-            backgroundColor: Colors.green,
-            foregroundColor: Colors.white,
-            approachState: const ApproachIdle(),
-          ),
-        ),
-      );
-      expect(find.byType(GestureDetector), findsNothing);
-    });
   });
 
   group('TripRecordingPipView (#2620) — no clip in a small PiP viewport', () {


### PR DESCRIPTION
Closes #2964

## What

While approaching a fuel station the app shrinks into a floating **native Android Picture-in-Picture (PiP)** tile (Epic #2065 / #2163) — the app's own Flutter UI renders into the OS tile, showing the station name / address / distance / price. From a real-device screenshot the user said:

> "When clicking on the small window, I want to restore the full screen app."

Tapping the tile **body** now brings the full Sparkilo app back to the foreground in full screen.

## Why the old behaviour was wrong

- The radar/price layout's body tap opened the station in maps (`NavigationUtils.openInMaps`, #2601).
- The default consumption layout had no body tap target at all.
- The only route back to full screen was Android's own system "expand" control (OS chrome drawn on top of the tile) — not a single tap on the window body.

## How

- **`PipController.bringToFront()`** over the existing `tankstellen/pip` method channel — Android-only behind `isSupported`, inert no-op elsewhere (iOS has no app-UI PiP, so no inline `Platform.is*` in shared code).
- **Kotlin `bringToFront` handler on `MainActivity`** re-launches the launcher activity with `FLAG_ACTIVITY_REORDER_TO_FRONT | FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_SINGLE_TOP`. Because the activity is `singleTop`, this **reorders the EXISTING task to the front** (preserving the live recording / engine state) and leaves PiP — it does not cold-start a fresh instance. Best-effort try: a failed reorder leaves the user in PiP, never crashes.
- **`onBodyTap` callback** threaded from the banner host (single source of truth) into both `TripRecordingPipView` and `TripRecordingPipPriceLayout`. The price layout's body tap now restores instead of navigating; the default consumption layout gains a tap target. Tooltip + a11y button label "Tap to open the full app" (ARB, full 23-locale fan-out + `en_XA` pseudo). The system PiP control icons (expand / close) are OS chrome and keep their behaviour.

## Tests

- `PipController.bringToFront` channel contract (method name + result; Android + off-Android no-op).
- The tile body invokes `onBodyTap` on tap for the approach-price, radar-price, and default consumption layouts.
- No `onBodyTap` → the body is **not** tappable (preview / no-host fallback).
- Tooltip + a11y button label asserted.

## Gates

- `flutter analyze` clean on all changed files (2 pre-existing info-level lints live only in unrelated sibling-owned test files).
- l10n: new key fanned out to all 23 locales + pseudo; `test/l10n/` + no-hardcoded-strings lint green.
- No `*.g.dart` / `*.freezed.dart` drift (no codegen sources changed).
- 400-line cap respected; #1103 never-throws preserved.

## Scope

Touched only the PiP overlay-window widgets + the bring-to-front plumbing (channel + Kotlin handler). Did not touch the approach detector / station data source / proximity provider, the in-app trip-recording screen / Fuel Station Radar card, the trip-capture/distance/score files, or the OBD2 layer (#2957).

🤖 Generated with [Claude Code](https://claude.com/claude-code)