### PR TITLE
fix(approach): in-trip radar card shows "no station nearby" while stations are in range (no in-radius merge)

### DIFF
--- a/lib/features/approach/providers/radar_candidate_list_provider.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.dart
@@ -4,10 +4,13 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/services/approach_detector.dart';
+import '../../../core/services/service_providers.dart';
 import '../../../core/utils/geo_utils.dart' as geo;
 import '../../../core/utils/station_extensions.dart';
 import '../../profile/providers/effective_fuel_type_provider.dart';
 import '../../profile/providers/profile_provider.dart';
+import '../../search/data/models/search_params.dart';
+import '../../search/domain/entities/fuel_type.dart';
 import '../../search/domain/entities/station.dart';
 import 'effective_approach_state_provider.dart';
 import 'fuel_station_radar_provider.dart';
@@ -53,6 +56,21 @@ part 'radar_candidate_list_provider.g.dart';
 /// JIT price per imminent station instead of re-pricing a whole 10 km set
 /// on every poll. The ranked page-set therefore matches exactly what the
 /// in-radius layout would surface.
+///
+/// ### In-radius superset merge (#2965)
+///
+/// The cached corridor is built from a polled-source `searchStations` that is
+/// row-capped with **no distance ordering** (e.g. FR `within_distance(60km)` +
+/// `limit:50`). In a dense area the un-ordered slice can truncate out the
+/// genuinely-nearest forecourt — leaving this card showing **"no station
+/// nearby"** while a priced station sits a few hundred metres away. To guarantee
+/// the candidate set is a SUPERSET of the in-radius search (exactly the #2806
+/// rescue the on-search radar already applies), we also issue a DIRECT in-radius
+/// `searchStations` at `profile.approachRadiusKm` and merge it into the corridor
+/// set (dedup by id, the in-radius row winning — it carries the freshest
+/// per-fuel price/distance). A failed in-radius fetch degrades to corridor-only,
+/// never breaking the card. The deeper cure (a distance `order_by` on the FR
+/// corridor query) is tracked separately (#2966).
 @riverpod
 Future<List<Station>> radarCandidateList(Ref ref) async {
   final approach = ref.watch(effectiveApproachStateProvider);
@@ -72,17 +90,37 @@ Future<List<Station>> radarCandidateList(Ref ref) async {
     // (tier-3), at the user's default radar radius — the same envelope the
     // in-radius detector polls with. Zero network on a warm tile / a
     // bulk-file country.
-    final stations = await radar.fetchStations(
+    final corridor = await radar.fetchStations(
       gps.latitude,
       gps.longitude,
       profile.approachRadiusKm,
       fuel.apiValue,
     );
-    // The corridor set is cached in fetch order, not distance order — sort
-    // by distance from the live fix, then keep only stations the driver can
-    // actually price-compare (a non-null, positive [priceFor] for the
-    // effective fuel) so a swipe never lands on a `--` price row (#2583).
-    final priced = stations
+
+    // #2965 — merge a DIRECT in-radius search so the candidate set is always a
+    // SUPERSET of the in-radius search (mirrors the on-search radar's #2806
+    // rescue). The corridor's polled source is row-capped with no distance
+    // ordering, so in a dense area the genuinely-nearest forecourt can be
+    // truncated out and this card would show "no station nearby" while a priced
+    // station is metres away. Best-effort: corridor-only on failure.
+    final inRadius = await _inRadiusStations(
+      ref,
+      gps.latitude,
+      gps.longitude,
+      profile.approachRadiusKm,
+      fuel,
+    );
+
+    // Dedup by id, the in-radius row winning — it carries the freshest per-fuel
+    // price/distance. Then keep only stations the driver can actually price-
+    // compare (a non-null, positive [priceFor] for the effective fuel) so a
+    // swipe never lands on a `--` price row (#2583), and distance-sort from the
+    // live fix (the corridor is cached in fetch order, not distance order).
+    final byId = <String, Station>{
+      for (final s in corridor) s.id: s,
+      for (final s in inRadius) s.id: s,
+    };
+    final priced = byId.values
         .where((s) {
           final price = s.priceFor(fuel);
           return price != null && price > 0;
@@ -113,5 +151,36 @@ Future<List<Station>> radarCandidateList(Ref ref) async {
     // Radar / chain failure — treat as "no stations nearby". The provider
     // re-runs on the next approach-state tick.
     return const [];
+  }
+}
+
+/// A direct in-radius station fetch around the live fix (#2965), mirroring the
+/// regular search + the on-search radar's `_inRadiusStations`, so the candidate
+/// list is a superset of the in-radius search and a dense-corridor row cap can
+/// never truncate out the genuinely-nearest forecourt.
+///
+/// **Never throws.** Returns `const []` on any failure (offline, rate-limit, a
+/// service that doesn't support geo search) so the candidate list degrades to
+/// its cached corridor rather than collapsing the card.
+Future<List<Station>> _inRadiusStations(
+  Ref ref,
+  double lat,
+  double lng,
+  double radiusKm,
+  FuelType fuel,
+) async {
+  try {
+    final result = await ref.read(stationServiceProvider).searchStations(
+          SearchParams(
+            lat: lat,
+            lng: lng,
+            radiusKm: radiusKm,
+            fuelType: fuel,
+            sortBy: SortBy.distance,
+          ),
+        );
+    return result.data;
+  } on Object {
+    return const <Station>[];
   }
 }

--- a/lib/features/approach/providers/radar_candidate_list_provider.g.dart
+++ b/lib/features/approach/providers/radar_candidate_list_provider.g.dart
@@ -47,6 +47,21 @@ part of 'radar_candidate_list_provider.dart';
 /// JIT price per imminent station instead of re-pricing a whole 10 km set
 /// on every poll. The ranked page-set therefore matches exactly what the
 /// in-radius layout would surface.
+///
+/// ### In-radius superset merge (#2965)
+///
+/// The cached corridor is built from a polled-source `searchStations` that is
+/// row-capped with **no distance ordering** (e.g. FR `within_distance(60km)` +
+/// `limit:50`). In a dense area the un-ordered slice can truncate out the
+/// genuinely-nearest forecourt — leaving this card showing **"no station
+/// nearby"** while a priced station sits a few hundred metres away. To guarantee
+/// the candidate set is a SUPERSET of the in-radius search (exactly the #2806
+/// rescue the on-search radar already applies), we also issue a DIRECT in-radius
+/// `searchStations` at `profile.approachRadiusKm` and merge it into the corridor
+/// set (dedup by id, the in-radius row winning — it carries the freshest
+/// per-fuel price/distance). A failed in-radius fetch degrades to corridor-only,
+/// never breaking the card. The deeper cure (a distance `order_by` on the FR
+/// corridor query) is tracked separately (#2966).
 
 @ProviderFor(radarCandidateList)
 final radarCandidateListProvider = RadarCandidateListProvider._();
@@ -90,6 +105,21 @@ final radarCandidateListProvider = RadarCandidateListProvider._();
 /// JIT price per imminent station instead of re-pricing a whole 10 km set
 /// on every poll. The ranked page-set therefore matches exactly what the
 /// in-radius layout would surface.
+///
+/// ### In-radius superset merge (#2965)
+///
+/// The cached corridor is built from a polled-source `searchStations` that is
+/// row-capped with **no distance ordering** (e.g. FR `within_distance(60km)` +
+/// `limit:50`). In a dense area the un-ordered slice can truncate out the
+/// genuinely-nearest forecourt — leaving this card showing **"no station
+/// nearby"** while a priced station sits a few hundred metres away. To guarantee
+/// the candidate set is a SUPERSET of the in-radius search (exactly the #2806
+/// rescue the on-search radar already applies), we also issue a DIRECT in-radius
+/// `searchStations` at `profile.approachRadiusKm` and merge it into the corridor
+/// set (dedup by id, the in-radius row winning — it carries the freshest
+/// per-fuel price/distance). A failed in-radius fetch degrades to corridor-only,
+/// never breaking the card. The deeper cure (a distance `order_by` on the FR
+/// corridor query) is tracked separately (#2966).
 
 final class RadarCandidateListProvider
     extends
@@ -138,6 +168,21 @@ final class RadarCandidateListProvider
   /// JIT price per imminent station instead of re-pricing a whole 10 km set
   /// on every poll. The ranked page-set therefore matches exactly what the
   /// in-radius layout would surface.
+  ///
+  /// ### In-radius superset merge (#2965)
+  ///
+  /// The cached corridor is built from a polled-source `searchStations` that is
+  /// row-capped with **no distance ordering** (e.g. FR `within_distance(60km)` +
+  /// `limit:50`). In a dense area the un-ordered slice can truncate out the
+  /// genuinely-nearest forecourt — leaving this card showing **"no station
+  /// nearby"** while a priced station sits a few hundred metres away. To guarantee
+  /// the candidate set is a SUPERSET of the in-radius search (exactly the #2806
+  /// rescue the on-search radar already applies), we also issue a DIRECT in-radius
+  /// `searchStations` at `profile.approachRadiusKm` and merge it into the corridor
+  /// set (dedup by id, the in-radius row winning — it carries the freshest
+  /// per-fuel price/distance). A failed in-radius fetch degrades to corridor-only,
+  /// never breaking the card. The deeper cure (a distance `order_by` on the FR
+  /// corridor query) is tracked separately (#2966).
   RadarCandidateListProvider._()
     : super(
         from: null,
@@ -165,4 +210,4 @@ final class RadarCandidateListProvider
 }
 
 String _$radarCandidateListHash() =>
-    r'7b5f774e01d1aae94503d074103c6853067bb955';
+    r'ba7871184e8eca320d6ffd2949658d0e707c51f1';

--- a/test/features/approach/providers/radar_candidate_list_provider_test.dart
+++ b/test/features/approach/providers/radar_candidate_list_provider_test.dart
@@ -390,6 +390,19 @@ void main() {
       );
       addTearDown(container.dispose);
 
+      // #2349 fault-idiom assertion: with the in-radius `searchStations`
+      // dependency throwing, resolving the provider future must NOT throw — it
+      // degrades to corridor-only rather than surfacing the fault. This is the
+      // syntactic never-throws contract the static scanner
+      // (`test/lint/never_throws_contract_test.dart`) greps the sibling test
+      // for (`, completes)`).
+      await expectLater(
+        container.read(radarCandidateListProvider.future),
+        completes,
+        reason: '#2349 — a throwing in-radius fetch must not break the card; '
+            'the provider future completes normally (corridor-only fallback)',
+      );
+
       final out = await container.read(radarCandidateListProvider.future);
 
       // The corridor's priced station survives; the throwing in-radius fetch is

--- a/test/features/approach/providers/radar_candidate_list_provider_test.dart
+++ b/test/features/approach/providers/radar_candidate_list_provider_test.dart
@@ -1,20 +1,28 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
 import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
 import 'package:tankstellen/core/services/radar/jit_price_cache.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/features/approach/providers/effective_approach_state_provider.dart';
 import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
 import 'package:tankstellen/features/approach/providers/radar_candidate_list_provider.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../../helpers/mock_providers.dart';
 
 /// #2664 — the swipe-to-page candidate list routes through the cache-first
 /// [FuelStationRadar] at the user's **default radar radius**
@@ -107,6 +115,34 @@ class _CapturingRadar extends FuelStationRadar {
   }
 }
 
+/// Empty in-radius station service — the default for tests that exercise only
+/// the corridor (`_CapturingRadar`) path. The #2965 in-radius merge contributes
+/// nothing, so the existing corridor-only assertions stay valid.
+class _EmptyService implements StationService {
+  const _EmptyService();
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async =>
+      ServiceResult(
+        data: const <Station>[],
+        source: ServiceSource.cache,
+        fetchedAt: DateTime(2026),
+      );
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
 ProviderContainer _container({
   required FuelStationRadar radar,
   FuelType fuel = FuelType.e10,
@@ -115,6 +151,9 @@ ProviderContainer _container({
   // `null`) to override it — `null` can't be the default or it would be
   // indistinguishable from "not passed".
   Object? approach = _unset,
+  // The direct in-radius station service the #2965 superset merge calls.
+  // Defaults to an empty service so corridor-only tests are unaffected.
+  StationService stationService = const _EmptyService(),
 }) {
   final state = identical(approach, _unset)
       ? ApproachPolling(
@@ -128,6 +167,7 @@ ProviderContainer _container({
       effectiveFuelTypeProvider.overrideWithValue(fuel),
       activeProfileProvider.overrideWith(() => _FakeActiveProfile(profile)),
       fuelStationRadarProvider.overrideWithValue(radar),
+      stationServiceProvider.overrideWithValue(stationService),
     ],
   );
 }
@@ -285,4 +325,166 @@ void main() {
     expect(out, isEmpty);
     expect(radar.radiusCalls, isEmpty);
   });
+
+  group('in-radius superset merge — dense-corridor truncation (#2965)', () {
+    // The FR corridor fetch (`within_distance(60km)` + `limit:50`, no distance
+    // order_by) AND the 15 km near-merge BOTH return a far-only slice WITHOUT
+    // the genuinely-nearest station (modelling the dense-area row cap truncating
+    // it out). A DIRECT in-radius `searchStations` at the default radar radius
+    // (1 km) returns a priced station 269 m away. The candidate list must merge
+    // that in so it can never be empty while a priced station is in range.
+    //
+    // Driven through the REAL `fuelStationRadarProvider` on FR (polled →
+    // wide+near-merge corridor, #2813) + the REAL radar_candidate_list_provider,
+    // with a radius-keyed service (NOT an echoing fake).
+    //
+    // RED on master (corridor-only → []); GREEN after the in-radius merge.
+    test('lists the 269 m priced station the corridor row-cap truncated out',
+        () async {
+      // FR = polled corridor (within_distance + limit:50), so the real
+      // fuelStationRadarProvider runs the wide+near-merge searches; the
+      // candidate list then adds its own in-radius search (#2965). No radar
+      // value-override — the production provider resolves from the FR country +
+      // the radius-keyed station service.
+      final container = ProviderContainer(
+        overrides: [
+          activeCountryOverride(Countries.byCode('FR')!),
+          stationServiceProvider.overrideWithValue(_RadiusKeyedService()),
+          effectiveApproachStateProvider.overrideWithValue(
+            ApproachPolling(
+              gps: _pos(lat: 48.0, lng: 2.0),
+              nextPollIn: const Duration(seconds: 5),
+            ),
+          ),
+          effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+          activeProfileProvider.overrideWith(
+            () => _FakeActiveProfile(const UserProfile(
+              id: 'p1',
+              name: 'Test Driver',
+              approachRadiusKm: 1.0,
+              approachMinPollSeconds: 5,
+            )),
+          ),
+        ].cast(),
+      );
+      addTearDown(container.dispose);
+
+      final out = await container.read(radarCandidateListProvider.future);
+
+      expect(out, isNotEmpty,
+          reason: '#2965 — the in-radius merge rescues the truncated nearest');
+      expect(out.map((s) => s.id), contains('NEAR_269M'),
+          reason: 'the 269 m priced station the wide corridor cap dropped '
+              'must be in the candidate list');
+    });
+
+    // Never-throws contract on the in-radius merge (#2965 / #1103): a failing
+    // in-radius `searchStations` must NOT break the card — it degrades to the
+    // cached corridor set rather than throwing or emptying the list.
+    test('in-radius search failure degrades to corridor-only (never throws)',
+        () async {
+      final radar = _CapturingRadar([_station('CORRIDOR', e10: 1.55)]);
+      final container = _container(
+        radar: radar,
+        stationService: _ThrowingService(),
+      );
+      addTearDown(container.dispose);
+
+      final out = await container.read(radarCandidateListProvider.future);
+
+      // The corridor's priced station survives; the throwing in-radius fetch is
+      // swallowed (no exception, no empty list).
+      expect(out.map((s) => s.id), ['CORRIDOR'],
+          reason: 'corridor-only fallback when the in-radius fetch throws');
+    });
+  });
+}
+
+/// In-radius service that always throws — the fault seam for the #2965 /
+/// #1103 never-throws contract on the candidate list's in-radius merge.
+class _ThrowingService implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async =>
+      throw Exception('boom');
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
+}
+
+/// Radius-keyed in-radius/corridor service (NOT an echoing fake):
+///  - wide corridor (radiusKm >= [kCorridorNearMergeRadiusKm]) → a single FAR
+///    station, location-only (no price) — exactly what a polled FR source
+///    returns for a non-imminent corridor row before JIT-pricing,
+///  - direct in-radius (radiusKm < near-merge, i.e. the 1 km candidate-list
+///    search) → the genuinely-nearest 269 m station, priced.
+///
+/// Models the FR dense-area `limit:50` cap truncating the nearest out of the
+/// corridor: the far corridor row is never imminent so never gets priced, the
+/// candidate-list priced filter drops it → master yields `[]` (the reported
+/// empty card) while a tight in-radius search still returns the priced nearest.
+class _RadiusKeyedService implements StationService {
+  // Location-only (no price for ANY fuel) — a non-imminent corridor row a
+  // polled FR source returns before JIT-pricing. The candidate list's priced
+  // filter drops it, so corridor-only → [].
+  static Station _far() => const Station(
+        id: 'FAR_55KM',
+        name: 'Station FAR',
+        brand: 'TEST',
+        street: '',
+        postCode: '',
+        place: '',
+        lat: 48.5, // ~55 km north of the fix
+        lng: 2.0,
+        isOpen: true,
+      );
+
+  static Station _near() => const Station(
+        id: 'NEAR_269M',
+        name: 'Station NEAR',
+        brand: 'TEST',
+        street: '',
+        postCode: '',
+        place: '',
+        lat: 48.002416, // ~269 m north of the fix
+        lng: 2.0,
+        e10: 1.60,
+        isOpen: true,
+      );
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    // Anything at or above the near-merge radius is the dense-corridor slice the
+    // row cap truncated to a far, location-only row. A tight (< near-merge)
+    // fetch is the direct in-radius search, which carries the 269 m priced
+    // station back.
+    final corridorSlice = params.radiusKm >= kCorridorNearMergeRadiusKm;
+    return ServiceResult(
+      data: corridorSlice ? [_far()] : [_near()],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
 }

--- a/test/features/consumption/presentation/widgets/trip_radar_card_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_radar_card_test.dart
@@ -3,25 +3,34 @@
 
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:tankstellen/core/country/country_config.dart';
 import 'package:tankstellen/core/services/approach_detector.dart';
+import 'package:tankstellen/core/services/service_providers.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
 import 'package:tankstellen/core/utils/price_formatter.dart';
 import 'package:tankstellen/features/approach/providers/effective_approach_state_provider.dart';
+import 'package:tankstellen/features/approach/providers/fuel_station_radar_provider.dart';
 import 'package:tankstellen/features/approach/providers/radar_candidate_list_provider.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_radar_card.dart';
 import 'package:tankstellen/features/profile/data/models/user_profile.dart';
 import 'package:tankstellen/features/profile/providers/effective_fuel_type_provider.dart';
 import 'package:tankstellen/features/profile/providers/profile_provider.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/l10n/app_localizations.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 
 /// #2545 — the closest-station radar card is tap-to-navigate: a tap hands
@@ -666,4 +675,124 @@ void main() {
       expect(find.text('Scanning for nearby stations'), findsNothing);
     });
   });
+
+  // --- #2965: in-radius superset merge rescues the truncated nearest ---------
+  group('TripRadarCard — dense-corridor in-radius merge (#2965)', () {
+    // End-to-end through the REAL radarCandidateListProvider + the REAL FR
+    // fuelStationRadarProvider: the wide corridor + 15 km near-merge return a
+    // far, location-only row (the `limit:50` cap truncated the nearest out), so
+    // the corridor-only path is empty → "No station nearby". The candidate
+    // list's #2965 in-radius search at the 1 km radar radius returns the 269 m
+    // priced station, which the card must then list.
+    //
+    // RED on master (card shows "No station nearby"); GREEN after the merge.
+    testWidgets(
+        'shows the 269 m station, NOT "No station nearby", when the corridor '
+        'row-cap truncated the nearest out', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            activeCountryOverride(Countries.byCode('FR')!),
+            stationServiceProvider.overrideWithValue(_RadiusKeyedService()),
+            effectiveApproachStateProvider.overrideWithValue(
+              ApproachPolling(
+                gps: _pos(lat: 48.0, lng: 2.0),
+                nextPollIn: const Duration(seconds: 5),
+              ),
+            ),
+            effectiveFuelTypeProvider.overrideWithValue(FuelType.e10),
+            activeProfileProvider.overrideWith(
+              () => _StubActiveProfile(
+                const UserProfile(
+                  id: 'p1',
+                  name: 'Test',
+                  approachRadiusKm: 1.0,
+                ),
+              ),
+            ),
+          ].cast(),
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: TripRadarCard()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // RED on master: the corridor-only candidate list is empty → placeholder.
+      expect(find.text('No station nearby'), findsNothing,
+          reason: '#2965 — the in-radius merge lists the nearest priced '
+              'station instead of the empty placeholder');
+      // GREEN: the 269 m station + its e10 price render.
+      expect(find.text('Station NEAR'), findsOneWidget);
+      expect(find.text(PriceFormatter.formatPrice(1.60)), findsOneWidget);
+    });
+  });
+}
+
+Position _pos({required double lat, required double lng}) => Position(
+      latitude: lat,
+      longitude: lng,
+      timestamp: DateTime(2026, 5, 1, 9),
+      accuracy: 5,
+      altitude: 0,
+      altitudeAccuracy: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: 12,
+      speedAccuracy: 0,
+    );
+
+/// Radius-keyed service mirroring the provider test: the wide corridor + near-
+/// merge return a far, location-only row (the `limit:50` cap truncated the
+/// nearest); the tight in-radius search returns the 269 m priced station.
+class _RadiusKeyedService implements StationService {
+  static Station _far() => const Station(
+        id: 'FAR_55KM',
+        name: 'Station FAR',
+        brand: 'TEST',
+        street: '',
+        postCode: '',
+        place: '',
+        lat: 48.5,
+        lng: 2.0,
+        isOpen: true,
+      );
+
+  static Station _near() => const Station(
+        id: 'NEAR_269M',
+        name: 'Station NEAR',
+        brand: 'TEST',
+        street: '',
+        postCode: '',
+        place: '',
+        lat: 48.002416, // ~269 m north of the fix
+        lng: 2.0,
+        e10: 1.60,
+        isOpen: true,
+      );
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    final corridorSlice = params.radiusKm >= kCorridorNearMergeRadiusKm;
+    return ServiceResult(
+      data: corridorSlice ? [_far()] : [_near()],
+      source: ServiceSource.cache,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String stationId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+    List<String> ids,
+  ) =>
+      throw UnimplementedError();
 }


### PR DESCRIPTION
## What

The in-trip **"Radar de stations-service"** card showed **"Aucune station à proximité"** while the on-search radar found **63 stations nearby**, the nearest only **269 m** away.

## Root cause

On its `ApproachPolling` fallback tier the card renders `radarCandidateListProvider`, which fetched **only** the cached corridor via `radar.fetchStations()` and priced-filtered it — no direct in-radius `searchStations` superset merge.

The corridor is built from a polled source (FR `_queryByGeo` → `within_distance(60km)` + `limit:50`, **no distance `order_by`**), so in a dense area the un-ordered 50-row slice truncates out the 269 m station; the priced filter then empties the list and the card falls to its completed-empty placeholder. The **on-search** radar (`RadarSearch.runRadar`) avoids this by merging a direct in-radius search so its result is always a superset of the in-radius search (#2806) — the in-trip path was never given that rescue.

## Fix

Give `radarCandidateListProvider` the same in-radius superset merge (#2806):

- After the existing corridor `fetchStations`, issue a direct in-radius `stationServiceProvider.searchStations(SearchParams(lat, lng, radiusKm: profile.approachRadiusKm, fuelType: <active fuel>, sortBy: SortBy.distance))`.
- Merge corridor + in-radius **dedup-by-id, the in-radius row winning** (freshest per-fuel price/distance), then run the **existing** priced filter + distance sort + #2808 live-distance re-stamp on the union (preserves the #2959 closeness bar).
- The in-radius fetch is **best-effort / never-throws** — corridor-only on failure (with a sibling fault test).

Net: the candidate set is a **superset** of the in-radius search, so a 269 m priced station can never be truncated by the corridor's `limit:50`.

Scope is exactly one provider + its `.g.dart` + 2 tests. Does **not** touch `_queryByGeo`, the approach detector / `approach_state_provider`, the OBD2 layer, the trip-recording screen, or the approach overlay.

## Tests (RED-on-master / green-after, real provider + real widget, radius-keyed service — no echoing fake)

- `radar_candidate_list_provider_test.dart`: dense-corridor truncation case (the corridor + 15 km near-merge return a far location-only row; the direct in-radius search at 1 km returns the 269 m priced station) → master `[]`, green after; plus the never-throws fault case.
- `trip_radar_card_test.dart`: end-to-end through the real provider + real FR `fuelStationRadarProvider`; asserts "No station nearby" is absent and the 269 m station + price render — RED on master, green after.

Verified both fail on master before the fix and pass after; `flutter analyze` clean on changed files; clean codegen committed (no drift).

## Follow-up

Deeper root cure (FR `_queryByGeo` distance `order_by`, benefiting all corridor consumers) is deferred to #2966 — it needs live Opendatasoft v2.1 `order_by` validation + a recorded real-API fixture and has core-FR blast radius, so it warrants its own carefully-tested PR.

Closes #2965

🤖 Generated with [Claude Code](https://claude.com/claude-code)