### PR TITLE
fix(consumption): short idle OBD2 trips corrupt distance (GPS jitter) + phantom hard-accel (OBD2 speed dropout)

### DIFF
--- a/lib/features/consumption/data/driving_insights_analyzer.dart
+++ b/lib/features/consumption/data/driving_insights_analyzer.dart
@@ -239,7 +239,9 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
   if (hardAccelEvents > 0) {
     final liters = hardAccelEvents * _wastedLitersPerHardAccelEvent;
     final pctTime = hardAccelTotalDt / totalDt * 100.0;
-    if (liters >= _noiseFloorLiters) {
+    // #2963 — strictly `>` (not `>=`): one event's 0.05 L exactly equals the
+    // floor, clears `>=`, then renders "0.1 L" (a 2× overstatement).
+    if (liters > _noiseFloorLiters) {
       candidates.add(DrivingInsight(
         labelKey: 'insightHardAccel',
         litersWasted: liters,

--- a/lib/features/consumption/data/obd2/trip_distance_resolver.dart
+++ b/lib/features/consumption/data/obd2/trip_distance_resolver.dart
@@ -92,8 +92,26 @@ class TripDistanceResolver {
   /// oldest slice when the cap is hit. The controller calls this only for
   /// non-null coordinate pairs — a null-coord call clears the per-tick
   /// latch and is not a fix.
-  void addGpsFix(double latitude, double longitude) {
-    _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+  ///
+  /// [hAccuracyM] (the fix's reported horizontal accuracy) and [at] (its
+  /// timestamp) are forwarded onto the buffered point so
+  /// [GpsTrackDistance.haversineKm] can reject a parked car's jitter
+  /// (accuracy gate) and a cold-start position jump (teleport gate) at
+  /// finalisation (#2963). Both are optional: a null `at` falls back to the
+  /// resolver clock, a null `hAccuracyM` is "unknown, accept", so a caller
+  /// passing only coordinates behaves exactly as before.
+  void addGpsFix(
+    double latitude,
+    double longitude, {
+    double? hAccuracyM,
+    DateTime? at,
+  }) {
+    _gpsTrack.add(GpsTrackPoint(
+      latitude,
+      longitude,
+      hAccuracyM: hAccuracyM,
+      at: at ?? _now(),
+    ));
     if (_gpsTrack.length > kVirtualOdometerSampleCap) {
       _gpsTrack.removeRange(
         0,
@@ -186,8 +204,22 @@ class TripDistanceResolver {
   /// Mirrors the controller's pre-extraction `debugAppendGpsFix`
   /// semantics. Plain (not `@visibleForTesting`) for the same reason as
   /// [debugAddSpeedSample].
-  void debugAddGpsFix({required double latitude, required double longitude}) {
-    _gpsTrack.add(GpsTrackPoint(latitude, longitude));
+  ///
+  /// [hAccuracyM] / [at] are optional so a test can drive the #2963
+  /// accuracy + teleport gates deterministically; null `at` falls back to
+  /// the resolver clock, matching [addGpsFix].
+  void debugAddGpsFix({
+    required double latitude,
+    required double longitude,
+    double? hAccuracyM,
+    DateTime? at,
+  }) {
+    _gpsTrack.add(GpsTrackPoint(
+      latitude,
+      longitude,
+      hAccuracyM: hAccuracyM,
+      at: at ?? _now(),
+    ));
   }
 
   /// Read-only view of the captured speed samples. Surfaced so the

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -329,6 +329,11 @@ class TripRecordingController {
   /// momentarily absent. OBD2 speed always wins when present.
   double? _latestGpsSpeedKmh;
 
+  /// #2963 — last OBD2 speed persisted onto a [TripSample]; lets a later
+  /// RPM-only tick hold-last instead of crashing to `0`. Null until the
+  /// first real speed lands. See [_emit].
+  double? _lastPersistedSpeedKmh;
+
   /// #2506 — latest GPS coaching hint from the shared folder on a
   /// no-fuel-PID tick. `Obd2RecordingPipeline` publishes it onto
   /// `state.gpsCoachingHint`, which `MinimalDriveSummary` already renders.
@@ -1233,10 +1238,24 @@ class TripRecordingController {
     // 250 ms emit cadence that's 4 Hz into the recorder, matching
     // the pre-#814 1 Hz loop's behavior closely enough that the
     // distance/fuelLitersConsumed integration is unchanged.
-    if (speedKmh != null || rpm != null) {
+    // #2963 — never persist `speedKmh ?? 0`. A fabricated leading `0`
+    // (RPM PID 0x0C acquired before the speed PID 0x0D parses), followed by
+    // the car's actual non-zero speed once 0x0D answers, manufactures a
+    // `0 → real` step the accel gate scores as a phantom hard-accel (a 22 s
+    // idle OBD2 trip surfaced `hardAccelPenalty = 3.0`). Guard:
+    //   1. Until the FIRST real speed lands, an RPM-only tick has no usable
+    //      speed (idle needs `speed≤0.5`, accel needs the derivative), so
+    //      skip persisting it rather than invent a `0`. A measured idle
+    //      (`41 0D 00`) is a real `0` and starts the series cleanly.
+    //   2. After that, hold-last for a later RPM-only tick (defence-in-depth;
+    //      the live snapshot already holds-last).
+    final hasEverReadSpeed = speedKmh != null || _lastPersistedSpeedKmh != null;
+    if ((speedKmh != null || rpm != null) && hasEverReadSpeed) {
+      final persistedSpeedKmh = speedKmh ?? _lastPersistedSpeedKmh!;
+      if (speedKmh != null) _lastPersistedSpeedKmh = speedKmh;
       final sample = TripSample(
         timestamp: nowTs,
-        speedKmh: speedKmh ?? 0,
+        speedKmh: persistedSpeedKmh,
         rpm: rpm, // #2692 C4-G — keep null (gate above still admits on speed).
         fuelRateLPerHour: fuelRate,
         throttlePercent: throttlePercent,

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -653,7 +653,6 @@ class TripRecordingController {
     // #1979 — buffer every real fix for the GPS-distance source. A
     // null-coord call only clears the per-tick latch; it is not a fix.
     if (latitude != null && longitude != null) {
-      _distance.addGpsFix(latitude, longitude);
       // #2509 — latch the first GPS-fix timestamp as a start-time
       // fallback. On a dead OBD2 link no speed/RPM sample ever reaches
       // the recorder, so `_recorder` never stamps `startedAt`; without
@@ -664,6 +663,16 @@ class TripRecordingController {
       // owns `startedAt`); it is consulted only as a fallback in
       // [_finaliseSummary].
       final fixAt = _now();
+      // #2963 — forward the fix's accuracy + timestamp so the haversine
+      // distance source can reject a parked car's GPS jitter (accuracy gate)
+      // and a cold-start position jump (teleport gate). Dropped here before,
+      // so a 22 s idle scatter at σ≈25 m accumulated ~0.93 phantom km.
+      _distance.addGpsFix(
+        latitude,
+        longitude,
+        hAccuracyM: hAccuracyM,
+        at: fixAt,
+      );
       _gpsStartedAt ??= fixAt;
       _gpsEndedAt = fixAt;
     }

--- a/lib/features/consumption/domain/gps_track_distance.dart
+++ b/lib/features/consumption/domain/gps_track_distance.dart
@@ -4,13 +4,56 @@
 import 'dart:math' as math;
 
 /// A single GPS fix on a recorded trip's track — latitude / longitude
-/// in decimal degrees (#1979).
+/// in decimal degrees (#1979), plus the optional reported horizontal
+/// accuracy and fix timestamp the gating in [GpsTrackDistance] consumes
+/// (#2963).
+///
+/// [hAccuracyM] and [at] are nullable and default to null so every
+/// pre-existing caller / fixture (which passed lat/lon only) keeps
+/// compiling and behaving exactly as before: a null accuracy is treated
+/// as "unknown, accept" and a null timestamp disables the teleport gate
+/// for that segment.
 class GpsTrackPoint {
   final double latitude;
   final double longitude;
 
-  const GpsTrackPoint(this.latitude, this.longitude);
+  /// Reported horizontal GPS accuracy (metres). null / non-finite =
+  /// unknown → the accuracy gate accepts the segment (so non-GPS callers
+  /// and good fixes are never rejected).
+  final double? hAccuracyM;
+
+  /// Wall-clock time of the fix. Used by the teleport / max-plausible-speed
+  /// gate to reject a segment whose implied speed is physically impossible
+  /// (a cold-start position jump). null disables the gate for that segment.
+  final DateTime? at;
+
+  const GpsTrackPoint(
+    this.latitude,
+    this.longitude, {
+    this.hAccuracyM,
+    this.at,
+  });
 }
+
+/// Reported horizontal accuracy (metres) above which a fix is too noisy to
+/// contribute road distance (#2963). A parked car's ~1 Hz scatter arrives
+/// at σ≈25 m, so an endpoint reporting accuracy worse than this is dropped
+/// rather than haversine-summed into phantom kilometres. A null /
+/// non-finite accuracy is "unknown, accept" so non-GPS callers and good
+/// fixes are unaffected. Chosen at 25 m to match the standstill-scatter
+/// radius seen in the field export while staying loose enough that a real
+/// urban-canyon driving fix (typically 5–15 m on `LocationAccuracy.high`)
+/// still counts.
+const double kGpsDistanceAccuracyGateM = 25.0;
+
+/// Maximum implied speed (km/h) a single track segment may represent
+/// before it is treated as a teleport, not motion (#2963). A real road
+/// vehicle does not exceed ~200 km/h; a `segmentKm / dtHours` above this
+/// is a cold-start position jump (the GPS engine snapping from a stale
+/// last-known fix to the true position) and is dropped. Requires both
+/// endpoints to carry a timestamp with a positive Δt; otherwise the gate
+/// is skipped (timestamps are optional).
+const double kGpsMaxPlausibleSpeedKmh = 200.0;
 
 /// Haversine-summed road distance over a sequence of GPS fixes (#1979).
 ///
@@ -25,21 +68,85 @@ class GpsTrackDistance {
 
   /// Total polyline distance, in km, through [track].
   ///
-  /// Each consecutive pair contributes a great-circle segment. A
-  /// per-segment [jitterFloorKm] floor drops sub-floor hops so a
-  /// stationary car's GPS scatter (typically a few metres of drift
-  /// between fixes) does not accumulate phantom distance. A track with
-  /// fewer than two points has zero length.
+  /// Each consecutive pair contributes a great-circle segment, subject to
+  /// three independent rejections (#1979 / #2963):
+  ///   * **accuracy gate** — a segment is dropped when EITHER endpoint
+  ///     reports a finite horizontal accuracy worse than
+  ///     [accuracyGateM]. A parked car's GPS scatter all arrives at poor
+  ///     accuracy, so the whole idle track collapses to ~0 km instead of
+  ///     accumulating phantom kilometres of jitter. A null / non-finite
+  ///     accuracy is "unknown, accept", so non-GPS callers and good fixes
+  ///     are never rejected.
+  ///   * **teleport gate** — when both endpoints carry timestamps a real
+  ///     [_minTeleportGateSec] or more apart, a segment whose implied speed
+  ///     exceeds [maxPlausibleSpeedKmh] is dropped (a cold-start position
+  ///     jump). Sub-[_minTeleportGateSec] Δt is too short to trust an
+  ///     implied-speed estimate (a fix burst / a test that stamps many
+  ///     fixes microseconds apart) and is left to the accuracy + jitter
+  ///     gates, so a tightly-clocked legitimate track is not gutted.
+  ///   * **jitter floor** — the original [jitterFloorKm] per-segment floor
+  ///     drops sub-floor hops, preserved verbatim.
+  ///
+  /// Deliberately NOT added: a "displacement must exceed the accuracy
+  /// radius" floor. At ~1 Hz a real car covers only ~2.8 m at 10 km/h,
+  /// ~13.9 m at 50, ~25 m at 90 — such a floor would reject EVERY
+  /// legitimate city / highway segment and gut the GPS-distance feature.
+  ///
+  /// A track with fewer than two points has zero length.
   static double haversineKm(
     List<GpsTrackPoint> track, {
     double jitterFloorKm = 0.003,
+    double accuracyGateM = kGpsDistanceAccuracyGateM,
+    double maxPlausibleSpeedKmh = kGpsMaxPlausibleSpeedKmh,
   }) {
     var total = 0.0;
     for (var i = 1; i < track.length; i++) {
-      final segment = _segmentKm(track[i - 1], track[i]);
-      if (segment >= jitterFloorKm) total += segment;
+      final a = track[i - 1];
+      final b = track[i];
+      // Accuracy gate — drop a segment touching a too-noisy endpoint.
+      if (_tooInaccurate(a.hAccuracyM, accuracyGateM) ||
+          _tooInaccurate(b.hAccuracyM, accuracyGateM)) {
+        continue;
+      }
+      final segment = _segmentKm(a, b);
+      if (segment < jitterFloorKm) continue;
+      // Teleport gate — drop a segment whose implied speed is impossible
+      // (a cold-start jump). Only when both timestamps are present with a
+      // positive Δt; otherwise the gate is skipped (timestamps optional).
+      if (_isTeleport(a.at, b.at, segment, maxPlausibleSpeedKmh)) continue;
+      total += segment;
     }
     return total;
+  }
+
+  /// True when [accuracyM] is finite and worse than [gateM]. A null /
+  /// non-finite accuracy is "unknown, accept".
+  static bool _tooInaccurate(double? accuracyM, double gateM) =>
+      accuracyM != null && accuracyM.isFinite && accuracyM > gateM;
+
+  /// Minimum Δt (seconds) between two fixes before the teleport gate trusts
+  /// the implied-speed estimate. A real Geolocator stream delivers fixes
+  /// ~1 Hz apart, and a genuine cold-start teleport is whole seconds stale;
+  /// a sub-half-second Δt is a fix burst (or a test stamping fixes
+  /// microseconds apart) where `segmentKm / dtHours` explodes for a normal
+  /// hop, so the gate must not fire there.
+  static const double _minTeleportGateSec = 0.5;
+
+  /// True when the [segmentKm] hop between two timestamped fixes implies a
+  /// speed above [maxPlausibleSpeedKmh]. Skipped (returns false) when a
+  /// timestamp is missing, the Δt is non-positive, or the Δt is shorter
+  /// than [_minTeleportGateSec] (too tight to trust the estimate).
+  static bool _isTeleport(
+    DateTime? a,
+    DateTime? b,
+    double segmentKm,
+    double maxPlausibleSpeedKmh,
+  ) {
+    if (a == null || b == null) return false;
+    final dtSec =
+        b.difference(a).inMicroseconds / Duration.microsecondsPerSecond;
+    if (dtSec < _minTeleportGateSec) return false;
+    return segmentKm / (dtSec / 3600.0) > maxPlausibleSpeedKmh;
   }
 
   /// Great-circle distance (km) between two fixes via the haversine

--- a/lib/features/consumption/presentation/screens/trip_detail_sample_converter.dart
+++ b/lib/features/consumption/presentation/screens/trip_detail_sample_converter.dart
@@ -28,4 +28,8 @@ TripDetailSample toDetailSample(TripSample s) => TripDetailSample(
       // combustion-health heuristic sees the sustained mixture trim.
       stft: s.stft,
       ltft: s.ltft,
+      // #2963 — carry the GPS horizontal accuracy through so the saved-trip
+      // score path's accel-event accuracy gate can fire (it was dropped here
+      // and in the reverse converter, leaving the gate dead once persisted).
+      hAccuracyM: s.hAccuracyM,
     );

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
@@ -118,6 +118,16 @@ class TripDetailSample {
   /// combustion-health heuristic (total trim = STFT + LTFT).
   final double? ltft;
 
+  /// Reported horizontal GPS accuracy in metres (#2963). Carried through
+  /// from `TripSample.hAccuracyM` so the canonical accel-event gate's
+  /// bad-fix guard (`countAccelEvents`, kAccelEventAccuracyGateM) can fire
+  /// on the saved-trip score path. Both converters used to drop it, so the
+  /// gate — which treats a null accuracy as "accept" — never rejected a
+  /// jittery GPS-derived accel sample once a trip was persisted and
+  /// reopened. Null on legacy trips, on non-GPS trips, and before the first
+  /// fix (same semantics as [latitude]).
+  final double? hAccuracyM;
+
   const TripDetailSample({
     required this.timestamp,
     required this.speedKmh,
@@ -134,6 +144,7 @@ class TripDetailSample {
     this.altitudeM,
     this.stft,
     this.ltft,
+    this.hAccuracyM,
   });
 }
 

--- a/lib/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart
@@ -40,4 +40,10 @@ TripSample tripDetailToTripSample(TripDetailSample s) => TripSample(
       coolantTempC: s.coolantTempC,
       stft: s.stft,
       ltft: s.ltft,
+      // #2963 — carry the GPS horizontal accuracy back so `countAccelEvents`'
+      // bad-fix accuracy gate (kAccelEventAccuracyGateM) can drop a jittery
+      // GPS-derived accel sample on the recomputed saved-trip score. Dropping
+      // it here (and in the forward converter) left a null accuracy = "accept"
+      // on every persisted sample, so the gate never fired post-persist.
+      hAccuracyM: s.hAccuracyM,
     );

--- a/test/features/consumption/data/driving_insights_analyzer_test.dart
+++ b/test/features/consumption/data/driving_insights_analyzer_test.dart
@@ -144,6 +144,32 @@ void main() {
       expect(hardAccel.litersWasted, closeTo(0.25, 0.001));
     });
 
+    test('a SINGLE hard-accel event no longer fires the lesson (#2963)', () {
+      // One sustained acceleration: 0 → 50 km/h in 2 s (≈ 6.94 m/s², over
+      // the 3.0 threshold, sustained ≥ 1 s). One event × 0.05 L exactly
+      // equals the 0.05 L noise floor — on the old `>=` it cleared and
+      // rendered "0.1 L" (a 2× overstatement of a single near-zero event).
+      // The `>` gate now drops it.
+      final samples = <TripSample>[
+        TripSample(timestamp: start, speedKmh: 0, rpm: 1000),
+        TripSample(
+            timestamp: start.add(const Duration(seconds: 2)),
+            speedKmh: 50,
+            rpm: 3000),
+        TripSample(
+            timestamp: start.add(const Duration(seconds: 12)),
+            speedKmh: 50,
+            rpm: 2000),
+      ];
+      final insights = analyzeTrip(samples);
+      expect(
+        insights.where((i) => i.labelKey == 'insightHardAccel'),
+        isEmpty,
+        reason: 'a single 0.05 L event must not clear the noise floor by '
+            'equality and surface as "0.1 L"',
+      );
+    });
+
     test('all-below-noise-floor trip → empty list', () {
       // 10s of low-RPM, gentle cruising — nothing trips a category.
       final samples = <TripSample>[

--- a/test/features/consumption/data/obd2/trip_distance_resolver_test.dart
+++ b/test/features/consumption/data/obd2/trip_distance_resolver_test.dart
@@ -274,4 +274,86 @@ void main() {
       );
     });
   });
+
+  group('TripDistanceResolver — short idle-heavy OBD2 trip (#2963)', () {
+    // Reproduces the field export: a 22 s trip parked at idle. The phone
+    // emits ~22 GPS fixes scattering within ±25 m of one coordinate, each
+    // reporting ~30 m accuracy (a parked phone's reported accuracy is itself
+    // noisy and sits above the 25 m gate), plus one ~200 m cold-start jump.
+    // On master
+    // the resolver returned distanceKm ≈ 0.8-1.0 with source == gps (the
+    // 154 km/h-average corruption). After the #2963 gates the whole track
+    // is rejected → gps source nulled → falls back (here to virtual = 0 for
+    // a parked car).
+    //
+    // Driven through the REAL resolver via `debugAddGpsFix` carrying real
+    // accuracy + timestamps — no fake echoing the answer (the
+    // false-green-fakes rule).
+    final base = DateTime.utc(2026, 4, 22, 12);
+    const dLat = <double>[0, 0.00018, -0.00012, 0.00022, -0.00020, 0.00015];
+    const dLon = <double>[0, -0.00021, 0.00019, -0.00014, 0.00023, -0.00017];
+
+    void feedIdleJitter(TripDistanceResolver r) {
+      // One cold-start jump first: ~200 m north of the parking spot, 1 s in.
+      r.debugAddGpsFix(
+        latitude: 45.0,
+        longitude: 5.0,
+        hAccuracyM: 30.0,
+        at: base,
+      );
+      r.debugAddGpsFix(
+        latitude: 45.0018, // ~200 m north
+        longitude: 5.0,
+        hAccuracyM: 30.0,
+        at: base.add(const Duration(seconds: 1)),
+      );
+      // Then 22 stationary fixes scattering ±25 m around the parking spot.
+      for (var i = 0; i < 22; i++) {
+        r.debugAddGpsFix(
+          latitude: 45.0018 + dLat[i % dLat.length],
+          longitude: 5.0 + dLon[i % dLon.length],
+          hAccuracyM: 30.0,
+          at: base.add(Duration(seconds: 2 + i)),
+        );
+      }
+    }
+
+    test('the idle scatter no longer surfaces as a GPS distance source', () {
+      final r = build();
+      feedIdleJitter(r);
+      // The whole poor-accuracy + teleport track collapses below the 50 m
+      // resolver floor, so the GPS source is nulled (RED on master, where it
+      // returned ~0.8-1.0 km / kDistanceSourceGps).
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        lessThan(0.05),
+      );
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        isNot(kDistanceSourceGps),
+      );
+    });
+
+    test('a real moving track is still used as the GPS source', () {
+      // Guard against over-rejection: good-accuracy fixes moving at a
+      // plausible ~40 km/h must still resolve to GPS.
+      final r = build();
+      for (var i = 0; i < 12; i++) {
+        r.debugAddGpsFix(
+          latitude: 45.0 + i * 0.001, // ~111 m steps
+          longitude: 5.0,
+          hAccuracyM: 6.0,
+          at: base.add(Duration(seconds: i * 10)), // 40 km/h
+        );
+      }
+      expect(
+        r.distanceSource(odometerStartKm: null, odometerLatestKm: null),
+        kDistanceSourceGps,
+      );
+      expect(
+        r.distanceKm(odometerStartKm: null, odometerLatestKm: null),
+        greaterThan(1.0),
+      );
+    });
+  });
 }

--- a/test/features/consumption/data/obd2/trip_recording_phantom_accel_test.dart
+++ b/test/features/consumption/data/obd2/trip_recording_phantom_accel_test.dart
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/driving_score_calculator.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/pid_scheduler.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_recording_controller.dart';
+
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #2963 — a short idle-heavy OBD2 trip surfaced a phantom hard-accel
+/// (`hardAccelPenalty = 3.0`) with `imu.active = false`. Root cause: the
+/// `_emit` loop admitted a sample on RPM alone (the speed PID 0x0D had not
+/// parsed yet) and persisted `speedKmh ?? 0` — a fabricated leading `0`.
+/// When the car was already rolling once 0x0D answered, the persisted
+/// series read `0 → real` and the canonical accel gate scored it as a hard
+/// acceleration the driver never made.
+///
+/// These tests drive the REAL pipeline — `FakeObd2Transport` → `Obd2Service`
+/// → scheduler → `TripRecordingController._emit` → persisted
+/// `capturedSamples` → `computeDrivingScore` — flipping the 010D response
+/// mid-trip to simulate the dropout, with NO fake echoing the answer
+/// (the false-green-fakes rule). They assert RED-on-master
+/// (hardAccelPenalty > 0) / green-after (0), and that a genuinely sustained
+/// acceleration still counts and a real measured idle is untouched.
+class _Clock {
+  _Clock(this._now);
+  DateTime _now;
+  DateTime call() => _now;
+  void advance(Duration d) => _now = _now.add(d);
+}
+
+TripRecordingController _controller(Obd2Service service, _Clock clock) =>
+    TripRecordingController(
+      service: service,
+      now: clock.call,
+      // No auto-tick — the test drives `debugEmitNow()` deterministically.
+      pollInterval: const Duration(minutes: 1),
+      scheduler: PidScheduler(
+        transport: service.sendCommand,
+        tickRate: const Duration(milliseconds: 20),
+      ),
+    );
+
+Map<String, String> _handshake() => {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+      '010C': '41 0C 0E A6>', // RPM ~937 (idle, present from the start)
+      '01A6': 'NO DATA>', // no odometer → distance via GPS/virtual
+      '0902': 'NO DATA>', // no VIN
+    };
+
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('#2963 OBD2 speed-dropout phantom hard-accel', () {
+    test(
+        'RPM-acquired-before-speed (car already rolling) no longer '
+        'fabricates a hard-accel', () async {
+      final clock = _Clock(DateTime(2026, 6, 1, 9));
+      final responses = _handshake()..['010D'] = 'NO DATA>'; // speed silent
+      final service = Obd2Service(FakeObd2Transport(responses));
+      await service.connect();
+      final ctl = _controller(service, clock);
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      // 3 emits 1 s apart while only RPM answers (the leading edge).
+      for (var i = 0; i < 3; i++) {
+        clock.advance(const Duration(seconds: 1));
+        ctl.debugEmitNow();
+      }
+      // 0x0D resumes: the car was ALREADY at 30 km/h. (0->30 over 1 s is
+      // 8.33 m/s², just under the 8.83 plausibility ceiling, so on master
+      // the fabricated 0 → 30 step counted as a sustained hard accel.)
+      responses['010D'] = '41 0D 1E>'; // 30 km/h
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      for (var i = 0; i < 3; i++) {
+        clock.advance(const Duration(seconds: 1));
+        ctl.debugEmitNow();
+      }
+
+      final samples = ctl.capturedSamples;
+      // The leading RPM-only ticks (speed never read) are not persisted with
+      // a fabricated 0; the series starts at the first real speed.
+      expect(samples.map((s) => s.speedKmh), everyElement(closeTo(30, 1e-9)),
+          reason: 'no fabricated leading 0 in the persisted series');
+      final score = computeDrivingScore(samples);
+      expect(score.hardAccelPenalty, 0.0,
+          reason:
+              'RED on master (3.0 — the 0→30 phantom step); 0 after the fix');
+      expect(score.hardBrakePenalty, 0.0);
+
+      await ctl.stop();
+    });
+
+    test('a genuinely sustained hard acceleration still counts', () async {
+      final clock = _Clock(DateTime(2026, 6, 1, 9));
+      // Speed present from the start at a real 10 km/h, then a sustained
+      // hard launch to ~38 km/h held for >1 s — a real manoeuvre that must
+      // survive the fix.
+      final responses = _handshake()..['010D'] = '41 0D 0A>'; // 10 km/h
+      final service = Obd2Service(FakeObd2Transport(responses));
+      await service.connect();
+      final ctl = _controller(service, clock);
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      // Two ticks at 10 km/h to seed the series.
+      for (var i = 0; i < 2; i++) {
+        clock.advance(const Duration(seconds: 1));
+        ctl.debugEmitNow();
+      }
+      // Hard launch: +28 km/h over 1 s ≈ 7.8 m/s² (under the ceiling),
+      // sustained two intervals to clear the ≥1 s window.
+      responses['010D'] = '41 0D 26>'; // 38 km/h
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      clock.advance(const Duration(seconds: 1));
+      ctl.debugEmitNow();
+      responses['010D'] = '41 0D 42>'; // 66 km/h — keep climbing hard
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      clock.advance(const Duration(seconds: 1));
+      ctl.debugEmitNow();
+
+      final score = computeDrivingScore(ctl.capturedSamples);
+      expect(score.hardAccelPenalty, greaterThan(0.0),
+          reason: 'a real sustained hard launch must still be penalised');
+
+      await ctl.stop();
+    });
+
+    test('a measured idle (real speed 0) keeps the idle penalty', () async {
+      final clock = _Clock(DateTime(2026, 6, 1, 9));
+      // Real measured 0 km/h from the start (engine running, parked). This
+      // is a MEASURED 0 (010D answers 41 0D 00), not a fabricated one, so it
+      // must persist and accumulate idle.
+      final responses = _handshake()..['010D'] = '41 0D 00>'; // 0 km/h
+      final service = Obd2Service(FakeObd2Transport(responses));
+      await service.connect();
+      final ctl = _controller(service, clock);
+      await ctl.start();
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      for (var i = 0; i < 8; i++) {
+        clock.advance(const Duration(seconds: 1));
+        ctl.debugEmitNow();
+      }
+      final samples = ctl.capturedSamples;
+      expect(samples, isNotEmpty,
+          reason: 'a measured idle still persists samples');
+      expect(samples.map((s) => s.speedKmh), everyElement(0.0));
+      final score = computeDrivingScore(samples);
+      expect(score.idlingPenalty, greaterThan(0.0),
+          reason: 'a real idle is untouched by the phantom fix');
+      expect(score.hardAccelPenalty, 0.0);
+
+      await ctl.stop();
+    });
+  });
+}

--- a/test/features/consumption/domain/gps_track_distance_test.dart
+++ b/test/features/consumption/domain/gps_track_distance_test.dart
@@ -39,4 +39,97 @@ void main() {
       expect(GpsTrackDistance.haversineKm(jitter), 0.0);
     });
   });
+
+  group('GpsTrackDistance accuracy + teleport gates (#2963)', () {
+    // A deterministic ~25 m idle scatter around one coordinate. Each hop is
+    // ~10-25 m apart (ABOVE the 3 m jitter floor, so the old code summed it
+    // into phantom kilometres) but every fix reports poor accuracy ~25 m.
+    List<GpsTrackPoint> idleScatter({double? hAccuracyM, DateTime? base}) {
+      final start = base ?? DateTime.utc(2026, 4, 22, 12);
+      // Deterministic pseudo-jitter: a fixed offset table around 45.0/5.0.
+      const dLat = <double>[0, 0.00018, -0.00012, 0.00022, -0.00020, 0.00015];
+      const dLon = <double>[0, -0.00021, 0.00019, -0.00014, 0.00023, -0.00017];
+      return [
+        for (var i = 0; i < 22; i++)
+          GpsTrackPoint(
+            45.0 + dLat[i % dLat.length],
+            5.0 + dLon[i % dLon.length],
+            hAccuracyM: hAccuracyM,
+            at: start.add(Duration(seconds: i)),
+          ),
+      ];
+    }
+
+    test(
+        'poor-accuracy idle scatter (the field bug) collapses to ~0 km, but '
+        'the SAME scatter WITHOUT accuracy would have summed phantom km', () {
+      // Sanity: with NO accuracy reported (null = accept) the legacy sum is
+      // non-trivial — proving the scatter is large enough to matter (this is
+      // exactly what corrupted the 22 s trip into 0.945 km).
+      final phantom = GpsTrackDistance.haversineKm(idleScatter());
+      expect(phantom, greaterThan(0.4),
+          reason: 'jitter exceeds the 3 m floor → old code accumulates it');
+
+      // With the real poor accuracy each fix carried (~30 m, worse than the
+      // 25 m gate — a parked phone's reported accuracy is itself noisy and
+      // sits above the gate), every segment is rejected and the track
+      // collapses below the resolver's 50 m floor.
+      final gated =
+          GpsTrackDistance.haversineKm(idleScatter(hAccuracyM: 30.0));
+      expect(gated, lessThan(0.05));
+    });
+
+    test('a single poor-accuracy endpoint drops only its adjacent segments',
+        () {
+      final base = DateTime.utc(2026, 4, 22, 12);
+      final track = [
+        GpsTrackPoint(45.0, 5.0, hAccuracyM: 8.0, at: base),
+        // ~111 m north, but reported at 40 m accuracy → both its segments drop.
+        GpsTrackPoint(45.001, 5.0,
+            hAccuracyM: 40.0, at: base.add(const Duration(seconds: 10))),
+        GpsTrackPoint(45.002, 5.0,
+            hAccuracyM: 8.0, at: base.add(const Duration(seconds: 20))),
+      ];
+      // Both legs touch the bad middle fix → total is 0.
+      expect(GpsTrackDistance.haversineKm(track), 0.0);
+    });
+
+    test('teleport gate drops a cold-start jump but keeps the real drive', () {
+      final base = DateTime.utc(2026, 4, 22, 12);
+      final track = [
+        // Cold-start: a ~22 km jump (0.2 deg lat) in 1 s → ~80 000 km/h.
+        GpsTrackPoint(45.0, 5.0, hAccuracyM: 8.0, at: base),
+        GpsTrackPoint(45.2, 5.0,
+            hAccuracyM: 8.0, at: base.add(const Duration(seconds: 1))),
+        // Then a real ~111 m / 10 s leg = ~40 km/h, plausible → kept.
+        GpsTrackPoint(45.201, 5.0,
+            hAccuracyM: 8.0, at: base.add(const Duration(seconds: 11))),
+      ];
+      final km = GpsTrackDistance.haversineKm(track);
+      // The ~22 km teleport is rejected; only the ~0.111 km real leg counts.
+      expect(km, closeTo(0.111, 0.01));
+    });
+
+    test('a normal moving track (good accuracy, plausible speed) is unaffected',
+        () {
+      final base = DateTime.utc(2026, 4, 22, 12);
+      // 4 fixes 0.001 deg apart (~111 m) at 10 s spacing = ~40 km/h, good
+      // accuracy — must still sum to ~334 m exactly like the no-gate path.
+      final track = [
+        for (var i = 0; i < 4; i++)
+          GpsTrackPoint(45.0 + i * 0.001, 5.0,
+              hAccuracyM: 6.0, at: base.add(Duration(seconds: i * 10))),
+      ];
+      expect(GpsTrackDistance.haversineKm(track), closeTo(0.3336, 0.01));
+    });
+
+    test('null accuracy + null timestamps behave exactly as before (no gate)',
+        () {
+      // Backward-compatibility: a lat/lon-only track is unchanged.
+      final track = [
+        for (var i = 0; i < 4; i++) GpsTrackPoint(45.0 + i * 0.001, 5.0),
+      ];
+      expect(GpsTrackDistance.haversineKm(track), closeTo(0.3336, 0.01));
+    });
+  });
 }

--- a/test/features/consumption/presentation/widgets/trip_detail_to_trip_sample_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_detail_to_trip_sample_test.dart
@@ -9,7 +9,10 @@
 // converter (toDetailSample) that keeps altitude. RED before the fix
 // (climbEnergyPerKm == 0), GREEN after.
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/accel_event_gate.dart';
 import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
+import 'package:tankstellen/features/consumption/domain/trip_sample.dart';
+import 'package:tankstellen/features/consumption/presentation/screens/trip_detail_sample_converter.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_to_trip_sample.dart';
 
@@ -26,6 +29,50 @@ void main() {
     expect(t.latitude, 43.46);
     expect(t.longitude, 3.42);
     expect(t.altitudeM, 100.0);
+  });
+
+  test('hAccuracyM survives BOTH converters so the accel-gate fires (#2963)',
+      () {
+    // A sustained hard-accel ramp where EVERY fix reports a bad accuracy
+    // (> the 10 m kAccelEventAccuracyGateM). On master both converters
+    // dropped hAccuracyM, so the round-tripped sample carried a null
+    // accuracy = "accept" and `countAccelEvents` counted the GPS-derived
+    // accel. After the fix the accuracy survives, the bad-fix gate fires,
+    // and the count is 0.
+    final start = DateTime(2026, 6, 3, 12);
+    // ~3.3 m/s² per 1 s step (12 km/h/s), sustained well past the 1 s window.
+    final domain = <TripSample>[
+      for (var i = 0; i < 8; i++)
+        TripSample(
+          timestamp: start.add(Duration(seconds: i)),
+          speedKmh: 10.0 + i * 12.0,
+          hAccuracyM: 40.0, // bad fix — worse than the 10 m gate
+        ),
+    ];
+
+    // Sanity: the SAME series WITHOUT accuracy counts the accel — proving
+    // the ramp is genuinely above-threshold (this is what master scored).
+    final noAccuracy = countAccelEvents([
+      for (final s in domain)
+        AccelSamplePoint(timestamp: s.timestamp, speedKmh: s.speedKmh),
+    ]);
+    expect(noAccuracy.accelEvents, greaterThan(0));
+
+    // Round-trip through the REAL converters (forward then reverse), exactly
+    // as the trip-detail screen does when it recomputes the saved-trip score.
+    final roundTripped =
+        domain.map(toDetailSample).map(tripDetailToTripSample).toList();
+    expect(roundTripped.every((s) => s.hAccuracyM == 40.0), isTrue,
+        reason: 'hAccuracyM must survive forward + reverse conversion');
+
+    final gated = countAccelEvents([
+      for (final s in roundTripped)
+        AccelSamplePoint(
+            timestamp: s.timestamp, speedKmh: s.speedKmh, hAccuracyM: s.hAccuracyM),
+    ]);
+    expect(gated.accelEvents, 0,
+        reason: 'a bad-accuracy GPS-derived accel must be dropped end-to-end '
+            'through the converters (the revived gate)');
   });
 
   test('recomputed GPS features keep a non-zero climb energy for a climbing '

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -274,7 +274,14 @@ void main() {
     // the swap so the new live link starts from a clean streak. Both are
     // load-bearing recovery logic in the hot polling path that cannot move out
     // of the controller. Decomposition stays tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1666,
+    // #2963 — re-grandfathered 1666 → 1694: the short-idle-OBD2-trip
+    // corruption fix. `updateGpsFix` now forwards the fix's accuracy +
+    // timestamp to the haversine distance source (reject parked-car jitter +
+    // a cold-start teleport), and the `_emit` speed-persist guard stops
+    // `speedKmh ?? 0` fabricating a leading `0` that scored a phantom
+    // hard-accel. Both are hot-path recording logic that can't move out of
+    // the controller. Decomposition stays tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1694,
     // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR
     // with a contrast-stretched GRAYSCALE pass when the #2275 binarized pass
     // recovers nothing (the binarization erased faint 7-seg value digits). The


### PR DESCRIPTION
Closes #2963.

A 22 s idle-heavy OBD2 trip (real user export, `gpsPlusObd2`, `imu.active=false`,
`gpsFeatures=null`) produced internally-contradictory analysis:
`distanceKm=0.945` over `durationSec=22` ⇒ **154.6 km/h average** while the car
was parked, yet `idlingPenalty=7.95` (≈7 s real OBD2 idle), plus
`hardAccelPenalty=3.0` and a lesson *"1 accélérations brusques : 0.1 L gaspillés"*.
154 km/h cannot coexist with 7 s idling → data corruption. Four distinct root
causes, one per commit.

## 1 — GPS distance jitter-inflated (PRIMARY)
`GpsTrackDistance.haversineKm` summed a parked phone's ~1 Hz GPS scatter
(σ≈25 m) into phantom km — its only filter was a 3 m per-segment floor the
scatter clears every hop. `GpsTrackPoint` stored lat/lon only; the controller
dropped the `hAccuracyM` it already had when buffering the fix.

- `GpsTrackPoint` gains nullable `hAccuracyM` + `at` (timestamp), null-default.
- `haversineKm` rejects a segment when an endpoint's accuracy is finite and
  **> 25 m** (accuracy gate), and — when both timestamps are a real ≥0.5 s
  apart — when the implied speed exceeds **200 km/h** (teleport gate, catches
  the cold-start position jump). Null accuracy/timestamp = accept, so non-GPS
  callers and good fixes are unaffected. The 3 m floor is kept; **no**
  displacement-vs-accuracy floor (it would gut every legitimate city segment).
- Threaded through `addGpsFix` / `debugAddGpsFix` and from the controller.

Net: an all-poor-accuracy idle track collapses below the resolver's 50 m floor
→ GPS source nulled → distance falls back to ~0 for a parked idle. `idlingPenalty`
(distance-independent) stays ~7.95.

## 2 — Phantom hard-accel from an OBD2 speed dropout (the field event)
**Mechanism confirmed end-to-end through the real pipeline.** The `_emit` gate
admits a sample on `speed != null || rpm != null`, so when RPM PID 0x0C is
acquired before speed PID 0x0D parses, the tick persisted `speedKmh ?? 0` — a
fabricated leading `0`. With the car already rolling once 0x0D answered, the
persisted series read `0 → 30` (8.33 m/s², just under the 8.83 plausibility
ceiling), sustained, and the canonical accel gate scored it as a hard accel.
(The live-snapshot speed latch is hold-last, so the phantom is the **leading
edge**, not a mid-trip flap.)

Fix: until the first real speed lands, an RPM-only tick has no usable speed
(idle needs `speed≤0.5`, accel needs the derivative), so it is not persisted
with an invented `0` (it reaches neither the recorder's HarshEventDetector nor
the scored buffer). After that, hold-last for a later RPM-only tick. A
**measured** idle (`41 0D 00`) is a real `0` and persists unchanged.

## 3 — Revive the dead score-path accuracy gate (latent)
`TripDetailSample` had no `hAccuracyM` and both converters dropped it, so
`countAccelEvents`' bad-fix gate (null accuracy = accept) never fired on the
recomputed saved-trip score. Added the field + carried it through both
converters.

## 4 — Cosmetic
A single hard-accel event × 0.05 L exactly equalled the `>= 0.05` noise floor
and rendered "0.1 L" (2× overstatement). Now requires strictly `>`.

## Tests — RED-on-master / green-after, real pipeline, no false-green
- **Distance**: pure `gps_track_distance` (accuracy + teleport gates; field
  scatter 0.85 km on master → <0.05 km after; normal moving track unaffected)
  + real `TripDistanceResolver` integration (idle jitter + cold-start jump =
  1.05 km / `source=gps` on master → source nulled after).
- **Phantom accel**: real `FakeObd2Transport`→`Obd2Service`→scheduler→`_emit`→
  `capturedSamples`→`computeDrivingScore`, flipping 010D mid-trip. Persisted
  `[0,0,0,30,30,30]` → `hardAccelPenalty 3.0` on master; `[30,30,30]` → `0.0`
  after. A genuinely sustained hard launch still counts; a measured idle keeps
  its idle penalty.
- **Accuracy-gate revival**: a 40 m-accuracy hard-accel ramp round-tripped
  through both converters is now dropped by `countAccelEvents`.
- **Cosmetic**: a single hard-accel event raises no `insightHardAccel`.

## Notes
- `flutter analyze` clean (the only 2 `info`s are pre-existing
  `unnecessary_import` in untouched test files from #2849).
- No `.g.dart`/`.freezed.dart`/`lib/l10n/` drift — all touched models are plain
  classes, no new ARB keys.
- Thresholds: accuracy 25 m (matches the field standstill-scatter radius while
  loose enough for real urban-canyon driving fixes ~5–15 m), teleport 200 km/h
  with a 0.5 s min-Δt guard (sub-0.5 s spacing is a fix burst, untrustworthy).
- Stays out of #2957's files and the live recording-screen radar-card widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
