### PR TITLE
fix(carbon): localize chart month-axis labels via intl (#2971)

### DIFF
--- a/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
+++ b/lib/features/carbon/presentation/widgets/monthly_bar_chart.dart
@@ -4,6 +4,9 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+// `intl` also exports a `TextDirection`; hide it so the painter keeps using
+// the dart:ui/material one (with `.ltr`).
+import 'package:intl/intl.dart' hide TextDirection;
 
 import '../../../../l10n/app_localizations.dart';
 import '../../domain/monthly_summary.dart';
@@ -44,6 +47,10 @@ class MonthlyBarChart extends StatelessWidget {
         child: Center(child: Text(l?.noDataAvailable ?? 'No data')),
       );
     }
+    // Month-axis labels are locale DATA, not a translatable string: resolve
+    // the active locale's short-month names via intl (matches price_chart.dart's
+    // `DateFormat.Md(locale)` pattern). #2971.
+    final locale = Localizations.localeOf(context).toString();
     return SizedBox(
       height: 180,
       child: CustomPaint(
@@ -53,6 +60,7 @@ class MonthlyBarChart extends StatelessWidget {
           color: color,
           unitLabel: unitLabel,
           labelColor: onSurface,
+          monthFormat: DateFormat.MMM(locale),
         ),
         size: Size.infinite,
       ),
@@ -67,12 +75,16 @@ class _BarChartPainter extends CustomPainter {
   final String unitLabel;
   final Color labelColor;
 
+  /// Locale-aware short-month formatter for the X-axis labels (#2971).
+  final DateFormat monthFormat;
+
   _BarChartPainter({
     required this.summaries,
     required this.valueOf,
     required this.color,
     required this.unitLabel,
     required this.labelColor,
+    required this.monthFormat,
   });
 
   @override
@@ -137,7 +149,7 @@ class _BarChartPainter extends CustomPainter {
       final m = summaries[i].month;
       _drawText(
         canvas,
-        _shortMonth(m),
+        monthFormat.format(m),
         Offset(cx, topInset + chartHeight + 4),
         anchorCenter: true,
         color: labelColor.withAlpha(160),
@@ -168,28 +180,11 @@ class _BarChartPainter extends CustomPainter {
     tp.paint(canvas, Offset(dx, offset.dy));
   }
 
-  String _shortMonth(DateTime d) {
-    const names = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return names[d.month - 1];
-  }
-
   @override
   bool shouldRepaint(_BarChartPainter oldDelegate) {
     return oldDelegate.summaries != summaries ||
         oldDelegate.color != color ||
-        oldDelegate.unitLabel != unitLabel;
+        oldDelegate.unitLabel != unitLabel ||
+        oldDelegate.monthFormat.locale != monthFormat.locale;
   }
 }

--- a/lib/features/consumption/presentation/widgets/charging_cost_trend_chart.dart
+++ b/lib/features/consumption/presentation/widgets/charging_cost_trend_chart.dart
@@ -4,6 +4,9 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+// `intl` also exports a `TextDirection`; hide it so the painter keeps using
+// the dart:ui/material one (with `.ltr`).
+import 'package:intl/intl.dart' hide TextDirection;
 
 import '../../../../l10n/app_localizations.dart';
 
@@ -54,6 +57,10 @@ class ChargingCostTrendChart extends StatelessWidget {
         ),
       );
     }
+    // Month-axis labels are locale DATA, not a translatable string: resolve
+    // the active locale's short-month names via intl (matches price_chart.dart's
+    // `DateFormat.Md(locale)` pattern). #2971.
+    final locale = Localizations.localeOf(context).toString();
     return SizedBox(
       height: 160,
       child: CustomPaint(
@@ -61,6 +68,7 @@ class ChargingCostTrendChart extends StatelessWidget {
           entries: entries,
           color: effective,
           labelColor: theme.colorScheme.onSurface,
+          monthFormat: DateFormat.MMM(locale),
         ),
         size: Size.infinite,
       ),
@@ -73,10 +81,14 @@ class _CostTrendPainter extends CustomPainter {
   final Color color;
   final Color labelColor;
 
+  /// Locale-aware short-month formatter for the X-axis labels (#2971).
+  final DateFormat monthFormat;
+
   _CostTrendPainter({
     required this.entries,
     required this.color,
     required this.labelColor,
+    required this.monthFormat,
   });
 
   @override
@@ -137,7 +149,7 @@ class _CostTrendPainter extends CustomPainter {
       canvas.drawRRect(rect, barPaint);
       _drawText(
         canvas,
-        _shortMonth(entries[i].key),
+        monthFormat.format(entries[i].key),
         Offset(cx, topInset + chartHeight + 4),
         anchorCenter: true,
         color: labelColor.withAlpha(160),
@@ -168,25 +180,9 @@ class _CostTrendPainter extends CustomPainter {
     tp.paint(canvas, Offset(dx, offset.dy));
   }
 
-  String _shortMonth(DateTime d) {
-    const names = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return names[d.month - 1];
-  }
-
   @override
   bool shouldRepaint(_CostTrendPainter oldDelegate) =>
-      oldDelegate.entries != entries || oldDelegate.color != color;
+      oldDelegate.entries != entries ||
+      oldDelegate.color != color ||
+      oldDelegate.monthFormat.locale != monthFormat.locale;
 }

--- a/lib/features/consumption/presentation/widgets/charging_efficiency_chart.dart
+++ b/lib/features/consumption/presentation/widgets/charging_efficiency_chart.dart
@@ -4,6 +4,9 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+// `intl` also exports a `TextDirection`; hide it so the painter keeps using
+// the dart:ui/material one (with `.ltr`).
+import 'package:intl/intl.dart' hide TextDirection;
 
 import '../../../../l10n/app_localizations.dart';
 
@@ -52,6 +55,10 @@ class ChargingEfficiencyChart extends StatelessWidget {
         ),
       );
     }
+    // Month-axis labels are locale DATA, not a translatable string: resolve
+    // the active locale's short-month names via intl (matches price_chart.dart's
+    // `DateFormat.Md(locale)` pattern). #2971.
+    final locale = Localizations.localeOf(context).toString();
     return SizedBox(
       height: 160,
       child: CustomPaint(
@@ -59,6 +66,7 @@ class ChargingEfficiencyChart extends StatelessWidget {
           entries: entries,
           color: effective,
           labelColor: theme.colorScheme.onSurface,
+          monthFormat: DateFormat.MMM(locale),
         ),
         size: Size.infinite,
       ),
@@ -71,10 +79,14 @@ class _EfficiencyPainter extends CustomPainter {
   final Color color;
   final Color labelColor;
 
+  /// Locale-aware short-month formatter for the X-axis labels (#2971).
+  final DateFormat monthFormat;
+
   _EfficiencyPainter({
     required this.entries,
     required this.color,
     required this.labelColor,
+    required this.monthFormat,
   });
 
   @override
@@ -124,7 +136,7 @@ class _EfficiencyPainter extends CustomPainter {
     for (int i = 0; i < entries.length; i++) {
       _drawText(
         canvas,
-        _shortMonth(entries[i].key),
+        monthFormat.format(entries[i].key),
         Offset(xForIndex(i), topInset + chartHeight + 4),
         anchorCenter: true,
         color: labelColor.withAlpha(160),
@@ -191,25 +203,9 @@ class _EfficiencyPainter extends CustomPainter {
     tp.paint(canvas, Offset(dx, offset.dy));
   }
 
-  String _shortMonth(DateTime d) {
-    const names = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return names[d.month - 1];
-  }
-
   @override
   bool shouldRepaint(_EfficiencyPainter oldDelegate) =>
-      oldDelegate.entries != entries || oldDelegate.color != color;
+      oldDelegate.entries != entries ||
+      oldDelegate.color != color ||
+      oldDelegate.monthFormat.locale != monthFormat.locale;
 }

--- a/test/features/carbon/presentation/widgets/monthly_bar_chart_test.dart
+++ b/test/features/carbon/presentation/widgets/monthly_bar_chart_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:tankstellen/features/carbon/domain/monthly_summary.dart';
 import 'package:tankstellen/features/carbon/presentation/widgets/monthly_bar_chart.dart';
 
@@ -32,6 +33,60 @@ double _cost(MonthlySummary s) => s.totalCost;
 /// so structural assertions stick to the [CustomPaint] widget itself and
 /// to the painter's exposed fields.
 void main() {
+  group('MonthlyBarChart month-axis i18n (#2971)', () {
+    // The painter draws month labels straight onto the canvas, so we inspect
+    // the painter's resolved DateFormat (driven by the pumped locale) rather
+    // than querying for a Text widget that does not exist.
+    DateFormat monthFormatFor(WidgetTester tester) {
+      final painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('BarChart'),
+          );
+      // ignore: avoid_dynamic_calls
+      return (painter as dynamic).monthFormat as DateFormat;
+    }
+
+    final summaries = [
+      _summary(month: DateTime(2026, 1), co2: 12),
+      _summary(month: DateTime(2026, 2), co2: 30),
+    ];
+
+    testWidgets('axis month abbreviations localize under French', (tester) async {
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: summaries,
+          valueOf: _co2,
+          color: Colors.green,
+          unitLabel: 'kg',
+        ),
+        locale: const Locale('fr'),
+      );
+
+      final label = monthFormatFor(tester).format(DateTime(2026, 1));
+      // French January abbreviation is "janv." — NOT the English "Jan".
+      expect(label.toLowerCase(), startsWith('janv'));
+      expect(label, isNot('Jan'));
+    });
+
+    testWidgets('axis month abbreviations stay English under English',
+        (tester) async {
+      await pumpApp(
+        tester,
+        MonthlyBarChart(
+          summaries: summaries,
+          valueOf: _co2,
+          color: Colors.green,
+          unitLabel: 'kg',
+        ),
+      );
+
+      expect(monthFormatFor(tester).format(DateTime(2026, 1)), 'Jan');
+    });
+  });
+
   group('MonthlyBarChart', () {
     testWidgets(
       'renders the localized empty placeholder when summaries is empty',

--- a/test/features/consumption/presentation/widgets/charging_cost_trend_chart_test.dart
+++ b/test/features/consumption/presentation/widgets/charging_cost_trend_chart_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/charging_cost_trend_chart.dart';
 
 import '../../../../helpers/pump_app.dart';
@@ -20,6 +21,41 @@ Iterable<CustomPaint> _chartPaints(WidgetTester tester) =>
         );
 
 void main() {
+  group('ChargingCostTrendChart month-axis i18n (#2971)', () {
+    DateFormat monthFormatFor(WidgetTester tester) {
+      final painter = _chartPaints(tester).first.painter;
+      // ignore: avoid_dynamic_calls
+      return (painter as dynamic).monthFormat as DateFormat;
+    }
+
+    final monthly = <DateTime, double>{
+      DateTime(2026, 1): 12.0,
+      DateTime(2026, 2): 30.0,
+    };
+
+    testWidgets('axis month abbreviations localize under French', (tester) async {
+      await pumpApp(
+        tester,
+        ChargingCostTrendChart(monthlyCost: monthly),
+        locale: const Locale('fr'),
+      );
+
+      final label = monthFormatFor(tester).format(DateTime(2026, 1));
+      expect(label.toLowerCase(), startsWith('janv'));
+      expect(label, isNot('Jan'));
+    });
+
+    testWidgets('axis month abbreviations stay English under English',
+        (tester) async {
+      await pumpApp(
+        tester,
+        ChargingCostTrendChart(monthlyCost: monthly),
+      );
+
+      expect(monthFormatFor(tester).format(DateTime(2026, 1)), 'Jan');
+    });
+  });
+
   group('ChargingCostTrendChart', () {
     testWidgets(
       'renders the localized empty placeholder when monthlyCost is empty',

--- a/test/features/consumption/presentation/widgets/charging_efficiency_chart_test.dart
+++ b/test/features/consumption/presentation/widgets/charging_efficiency_chart_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/charging_efficiency_chart.dart';
 
 import '../../../../helpers/pump_app.dart';
@@ -15,6 +16,46 @@ import '../../../../helpers/pump_app.dart';
 /// line chart added in #582 phase 3 (lib/features/consumption/presentation/
 /// widgets/charging_efficiency_chart.dart).
 void main() {
+  group('ChargingEfficiencyChart month-axis i18n (#2971)', () {
+    DateFormat monthFormatFor(WidgetTester tester) {
+      final painter = tester
+          .widgetList<CustomPaint>(find.byType(CustomPaint))
+          .map((p) => p.painter)
+          .firstWhere(
+            (p) => p != null && p.runtimeType.toString().contains('Efficiency'),
+          );
+      // ignore: avoid_dynamic_calls
+      return (painter as dynamic).monthFormat as DateFormat;
+    }
+
+    final monthly = <DateTime, double?>{
+      DateTime(2026, 1): 14.2,
+      DateTime(2026, 2): 15.8,
+    };
+
+    testWidgets('axis month abbreviations localize under French', (tester) async {
+      await pumpApp(
+        tester,
+        ChargingEfficiencyChart(monthlyEfficiency: monthly),
+        locale: const Locale('fr'),
+      );
+
+      final label = monthFormatFor(tester).format(DateTime(2026, 1));
+      expect(label.toLowerCase(), startsWith('janv'));
+      expect(label, isNot('Jan'));
+    });
+
+    testWidgets('axis month abbreviations stay English under English',
+        (tester) async {
+      await pumpApp(
+        tester,
+        ChargingEfficiencyChart(monthlyEfficiency: monthly),
+      );
+
+      expect(monthFormatFor(tester).format(DateTime(2026, 1)), 'Jan');
+    });
+  });
+
   group('ChargingEfficiencyChart', () {
     testWidgets(
       'renders the localized empty caption when monthlyEfficiency is empty',


### PR DESCRIPTION
## What

The carbon dashboard's `MonthlyBarChart` and both Charging-tab charts
(`ChargingEfficiencyChart`, `ChargingCostTrendChart`) drew their X-axis month
labels from a hardcoded `['Jan','Feb','Mar',...]` list, so French/German users —
in an FR/DE-primary, 23-locale app — **always** saw English month abbreviations.

## Fix

Resolve the active locale's short-month names with `DateFormat.MMM(locale)`,
following the shipped `price_chart.dart` pattern: the locale is resolved in
`build()` via `Localizations.localeOf(context)` and the resolved `DateFormat`
is passed into the `CustomPainter`.

- Month names are locale **DATA**, not a translatable UI string → no ARB key,
  no l10n fan-out. Removing the English literals also satisfies the
  no-hardcoded-strings lint.
- `intl`'s `TextDirection` is hidden on import so the painters keep using the
  dart:ui one (with `.ltr`).
- No codegen touched.

## Test (RED-before / green-after)

Each chart test pumps the widget under `Locale('fr')` / `Locale('en')` and
asserts the painter's resolved `monthFormat` formats January as the French
`janv.` vs the English `Jan`. RED on master (NoSuchMethodError — no localized
formatter existed), green after. Drives the real widget, not a fake.

```
flutter test <3 chart tests>  → All 35 tests passed
flutter analyze <6 files>     → No issues found
```

## Out of scope (reported, tracked separately)

- `lib/core/services/rate_limit_interceptor.dart` `HttpDate._months` — RFC 1123
  HTTP-date **parsing** (machine protocol, must stay English). Correct as-is.
- `lib/features/price_history/providers/price_prediction_provider.dart`
  `_dayNames` — a separate user-facing day-of-week i18n gap in a different
  subsystem; should get its own issue.

Closes #2971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
