### PR TITLE
feat(consumption): scrub-to-read crosshair on trip-detail line charts

### DIFF
--- a/lib/features/consumption/presentation/widgets/trip_chart_crosshair.dart
+++ b/lib/features/consumption/presentation/widgets/trip_chart_crosshair.dart
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+// Part of `trip_detail_charts.dart` (#2977) — the scrub-to-read crosshair:
+// the shared time/value projection geometry, the nearest-point hit-test, and
+// the value/time readout callout. Split into a part file so the widget host
+// file stays under the 400-line guard (#1680). Mirrors the price-chart
+// tap-to-nearest pattern (#2384) so the two charts feel identical.
+part of 'trip_detail_charts.dart';
+
+/// Shared implementation — every Trip-detail chart is the same
+/// rolling-window line plot over [timestamp], differing only in which
+/// sample field they extract. Keeping the widget private avoids exposing a
+/// stable but internal widget API to the rest of the app.
+///
+/// #2977 — stateful so a tap/drag (scrub) selects the nearest sample and
+/// overlays a vertical crosshair + a value/time readout, mirroring the
+/// price-chart tap-to-nearest pattern (#2384). The crosshair geometry +
+/// readout callout live below in this same part file.
+class _TripDetailLineChart extends StatefulWidget {
+  final List<TripDetailSample> samples;
+  final Color? color;
+  final double? Function(TripDetailSample) valueOf;
+  final String unit;
+  final bool emptyWhenAllNull;
+
+  /// #2431 — when true the plotted series is a GPS-physics ESTIMATE, not
+  /// a measurement: a "~ geschätzt" badge is overlaid so the user is
+  /// never misled into reading it as measured data.
+  final bool estimated;
+
+  const _TripDetailLineChart({
+    required this.samples,
+    required this.color,
+    required this.valueOf,
+    required this.unit,
+    required this.emptyWhenAllNull,
+    this.estimated = false,
+  });
+
+  @override
+  State<_TripDetailLineChart> createState() => _TripDetailLineChartState();
+}
+
+class _TripDetailLineChartState extends State<_TripDetailLineChart> {
+  /// Index into the plotted (non-null, time-sorted) points of the sample the
+  /// scrub crosshair is reading, or null when the user has not scrubbed yet.
+  int? _selected;
+
+  @override
+  void didUpdateWidget(_TripDetailLineChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new series invalidates the selected ordinal.
+    if (!identical(oldWidget.samples, widget.samples) ||
+        oldWidget.valueOf != widget.valueOf) {
+      _selected = null;
+    }
+  }
+
+  void _scrub(Offset localPos, Size size, List<_ChartPoint> points) {
+    if (points.length < 2) return;
+    final nearest =
+        _TripChartGeometry.nearestPointIndex(localPos, size, points);
+    if (nearest != _selected) {
+      setState(() => _selected = nearest);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
+    final effective = widget.color ?? theme.colorScheme.primary;
+
+    // Keep only samples whose value is non-null; we still need the
+    // original timestamps so the chart's X axis reflects real time.
+    final points = <_ChartPoint>[];
+    for (final s in widget.samples) {
+      final v = widget.valueOf(s);
+      if (v == null) continue;
+      points.add(_ChartPoint(s.timestamp, v));
+    }
+    final showEmpty =
+        widget.samples.isEmpty || (widget.emptyWhenAllNull && points.isEmpty);
+    if (showEmpty) {
+      return SizedBox(
+        height: 140,
+        child: Center(
+          child: Text(
+            l?.trajetDetailChartEmpty ?? 'No samples recorded',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      );
+    }
+    points.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+    final selected =
+        (_selected != null && _selected! < points.length) ? _selected : null;
+    final locale = Localizations.localeOf(context);
+
+    final chart = SizedBox(
+      height: 160,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final size = Size(constraints.maxWidth, constraints.maxHeight);
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapDown: (d) => _scrub(d.localPosition, size, points),
+            onHorizontalDragStart: (d) =>
+                _scrub(d.localPosition, size, points),
+            onHorizontalDragUpdate: (d) =>
+                _scrub(d.localPosition, size, points),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                Positioned.fill(
+                  child: CustomPaint(
+                    painter: _LineChartPainter(
+                      points: points,
+                      color: effective,
+                      labelColor: theme.colorScheme.onSurface,
+                      unit: widget.unit,
+                      selectedIndex: selected,
+                    ),
+                    size: Size.infinite,
+                  ),
+                ),
+                if (selected != null)
+                  _TripChartReadout(
+                    point: points[selected],
+                    unit: widget.unit,
+                    locale: locale,
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+    if (!widget.estimated) return chart;
+    // #2431 — overlay a clearly-marked estimate badge on the GPS-physics
+    // fallback series so it is never read as a measurement.
+    return Stack(
+      children: [
+        chart,
+        Positioned(
+          top: 0,
+          left: 8,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.secondaryContainer,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              '~ ${l?.trajetDetailChartEstimatedBadge ?? 'estimated'}',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSecondaryContainer,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Pure projection maths for a trip line chart — kept out of the painter so
+/// the painter and the gesture's nearest-point hit-test share ONE definition
+/// of where a sample lands, and the drawn marker always sits on the read
+/// value. Insets/padding match the previous inline `_LineChartPainter` maths.
+class _TripChartGeometry {
+  /// Insets reserved around the plot (must match the painter's drawn area).
+  static const double leftInset = 8.0;
+  static const double rightInset = 8.0;
+  static const double topInset = 18.0;
+  static const double bottomInset = 22.0;
+
+  final double minV;
+  final double maxV;
+  final double _yMin;
+  final double _ySpan;
+  final int _firstTs;
+  final int _tSpan;
+  final double _chartWidth;
+  final double _chartHeight;
+
+  const _TripChartGeometry._({
+    required this.minV,
+    required this.maxV,
+    required double yMin,
+    required double ySpan,
+    required int firstTs,
+    required int tSpan,
+    required double chartWidth,
+    required double chartHeight,
+  })  : _yMin = yMin,
+        _ySpan = ySpan,
+        _firstTs = firstTs,
+        _tSpan = tSpan,
+        _chartWidth = chartWidth,
+        _chartHeight = chartHeight;
+
+  factory _TripChartGeometry.forSize(Size size, List<_ChartPoint> points) {
+    final chartWidth = size.width - leftInset - rightInset;
+    final chartHeight = size.height - topInset - bottomInset;
+
+    final values = points.map((p) => p.value).toList(growable: false);
+    final minV = values.reduce(math.min);
+    final maxV = values.reduce(math.max);
+    final range = (maxV - minV).abs();
+    final padding = range > 0 ? range * 0.1 : 1.0;
+    final yMin = minV - padding;
+    final yMax = maxV + padding;
+    final ySpan = (yMax - yMin) == 0 ? 1.0 : (yMax - yMin);
+
+    final firstTs = points.first.timestamp.millisecondsSinceEpoch;
+    final lastTs = points.last.timestamp.millisecondsSinceEpoch;
+    final tSpan = (lastTs - firstTs) == 0 ? 1 : (lastTs - firstTs);
+
+    return _TripChartGeometry._(
+      minV: minV,
+      maxV: maxV,
+      yMin: yMin,
+      ySpan: ySpan,
+      firstTs: firstTs,
+      tSpan: tSpan,
+      chartWidth: chartWidth,
+      chartHeight: chartHeight,
+    );
+  }
+
+  double xFor(DateTime t) {
+    final rel = (t.millisecondsSinceEpoch - _firstTs) / _tSpan;
+    return leftInset + rel * _chartWidth;
+  }
+
+  double yFor(double v) =>
+      topInset + _chartHeight - ((v - _yMin) / _ySpan) * _chartHeight;
+
+  /// Index into [points] of the point whose plotted x is nearest [localPos].
+  /// Mirrors `PriceChartAxes.nearestPointIndex` (#2384).
+  static int nearestPointIndex(
+    Offset localPos,
+    Size size,
+    List<_ChartPoint> points,
+  ) {
+    final geo = _TripChartGeometry.forSize(size, points);
+    int best = 0;
+    double bestDist = double.infinity;
+    for (int i = 0; i < points.length; i++) {
+      final dx = (geo.xFor(points[i].timestamp) - localPos.dx).abs();
+      if (dx < bestDist) {
+        bestDist = dx;
+        best = i;
+      }
+    }
+    return best;
+  }
+}
+
+/// A small callout showing the scrubbed point's value + unit and time, e.g.
+/// "42.0 km/h · 10:00:05". Rendered as a real widget (not painted) so it is
+/// legible at any scale and testable via `find.textContaining`. Mirrors the
+/// price-chart `_PriceTooltip` (#2384).
+class _TripChartReadout extends StatelessWidget {
+  final _ChartPoint point;
+  final String unit;
+  final Locale locale;
+
+  const _TripChartReadout({
+    required this.point,
+    required this.unit,
+    required this.locale,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Reuse the existing per-chart unit suffix + the existing `toStringAsFixed`
+    // value formatting (same as the corner min/max labels). The time uses the
+    // locale's medium time format — no new user-facing string.
+    final timeFormat = DateFormat.Hms(locale.toString());
+    final label =
+        '${point.value.toStringAsFixed(1)} $unit · ${timeFormat.format(point.timestamp)}';
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.inverseSurface,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onInverseSurface,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_charts.dart
@@ -2,8 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import 'dart:math' as math;
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+// `intl` re-exports its own `TextDirection`, which would shadow the
+// `dart:ui` one the painter's `TextPainter` needs — so `dart:ui` is imported
+// `as ui` and `TextDirection.ltr` is qualified `ui.TextDirection.ltr` (same
+// disambiguation the price chart uses, #2384).
+import 'package:intl/intl.dart';
 
 import '../../../../l10n/app_localizations.dart';
 
@@ -17,6 +23,12 @@ part 'trip_detail_line_painter.dart';
 // file so this widget file stays under the 400-line guard. They share this
 // library's scope (the private `_TripDetailLineChart` painter wrapper).
 part 'trip_detail_signal_charts.dart';
+
+// #2977 — the scrub-to-read crosshair (nearest-point hit-test, the crosshair
+// overlay painter, and the value/time readout callout) lives in a part file so
+// this widget file stays under the 400-line guard. Mirrors the price-chart
+// tap-to-nearest pattern (#2384). Shares this library's `_ChartPoint`.
+part 'trip_chart_crosshair.dart';
 
 /// One sample of the trip recording profile (#890).
 ///
@@ -275,98 +287,8 @@ class TripDetailEngineLoadChart extends StatelessWidget {
   }
 }
 
-/// Shared implementation — every Trip-detail chart is the same
-/// rolling-window line plot over [timestamp], differing only in which
-/// sample field they extract. Keeping the painter private avoids
-/// exposing a stable but internal widget API to the rest of the app.
-class _TripDetailLineChart extends StatelessWidget {
-  final List<TripDetailSample> samples;
-  final Color? color;
-  final double? Function(TripDetailSample) valueOf;
-  final String unit;
-  final bool emptyWhenAllNull;
-
-  /// #2431 — when true the plotted series is a GPS-physics ESTIMATE, not
-  /// a measurement: a "~ geschätzt" badge is overlaid so the user is
-  /// never misled into reading it as measured data.
-  final bool estimated;
-
-  const _TripDetailLineChart({
-    required this.samples,
-    required this.color,
-    required this.valueOf,
-    required this.unit,
-    required this.emptyWhenAllNull,
-    this.estimated = false,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l = AppLocalizations.of(context);
-    final effective = color ?? theme.colorScheme.primary;
-
-    // Keep only samples whose value is non-null; we still need the
-    // original timestamps so the chart's X axis reflects real time.
-    final points = <_ChartPoint>[];
-    for (final s in samples) {
-      final v = valueOf(s);
-      if (v == null) continue;
-      points.add(_ChartPoint(s.timestamp, v));
-    }
-    final showEmpty =
-        samples.isEmpty || (emptyWhenAllNull && points.isEmpty);
-    if (showEmpty) {
-      return SizedBox(
-        height: 140,
-        child: Center(
-          child: Text(
-            l?.trajetDetailChartEmpty ?? 'No samples recorded',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ),
-      );
-    }
-    points.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-    final chart = SizedBox(
-      height: 160,
-      child: CustomPaint(
-        painter: _LineChartPainter(
-          points: points,
-          color: effective,
-          labelColor: theme.colorScheme.onSurface,
-          unit: unit,
-        ),
-        size: Size.infinite,
-      ),
-    );
-    if (!estimated) return chart;
-    // #2431 — overlay a clearly-marked estimate badge on the GPS-physics
-    // fallback series so it is never read as a measurement.
-    return Stack(
-      children: [
-        chart,
-        Positioned(
-          top: 0,
-          left: 8,
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: theme.colorScheme.secondaryContainer,
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Text(
-              '~ ${l?.trajetDetailChartEstimatedBadge ?? 'estimated'}',
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.onSecondaryContainer,
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
+// Shared implementation — the rolling-window line chart `_TripDetailLineChart`
+// (stateful: a tap/drag scrub selects the nearest sample and overlays the
+// crosshair + readout) lives in the `trip_chart_crosshair.dart` part file
+// alongside its scrub geometry, keeping this file under the 400-line guard.
 

--- a/lib/features/consumption/presentation/widgets/trip_detail_line_painter.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_line_painter.dart
@@ -20,60 +20,41 @@ class _LineChartPainter extends CustomPainter {
   final Color labelColor;
   final String unit;
 
+  /// #2977 — index of the scrubbed sample whose crosshair + marker is drawn,
+  /// or null when the user has not scrubbed. Projected with the same
+  /// [_TripChartGeometry] the nearest-point hit-test uses, so the marker
+  /// lands exactly on the read value.
+  final int? selectedIndex;
+
   _LineChartPainter({
     required this.points,
     required this.color,
     required this.labelColor,
     required this.unit,
+    this.selectedIndex,
   });
 
   @override
   void paint(Canvas canvas, Size size) {
     if (points.isEmpty) return;
 
-    const leftInset = 8.0;
-    const rightInset = 8.0;
-    const topInset = 18.0;
-    const bottomInset = 22.0;
-
-    final chartWidth = size.width - leftInset - rightInset;
-    final chartHeight = size.height - topInset - bottomInset;
-
-    final values = points.map((p) => p.value).toList(growable: false);
-    final minV = values.reduce(math.min);
-    final maxV = values.reduce(math.max);
-    final range = (maxV - minV).abs();
-    final padding = range > 0 ? range * 0.1 : 1.0;
-    final yMin = (minV - padding).clamp(-double.infinity, double.infinity);
-    final yMax = maxV + padding;
-    final ySpan = (yMax - yMin) == 0 ? 1.0 : (yMax - yMin);
-
-    final firstTs = points.first.timestamp.millisecondsSinceEpoch;
-    final lastTs = points.last.timestamp.millisecondsSinceEpoch;
-    final tSpan = (lastTs - firstTs) == 0 ? 1 : (lastTs - firstTs);
-
-    double xFor(DateTime t) {
-      final rel = (t.millisecondsSinceEpoch - firstTs) / tSpan;
-      return leftInset + rel * chartWidth;
-    }
-
-    double yFor(double v) =>
-        topInset + chartHeight - ((v - yMin) / ySpan) * chartHeight;
+    final geo = _TripChartGeometry.forSize(size, points);
 
     // Max / min labels at the corners — gives the user a quick read
     // on the range without cluttering the plot with grid lines.
     _drawText(
       canvas,
-      '${maxV.toStringAsFixed(1)} $unit',
-      Offset(size.width - rightInset, 2),
+      '${geo.maxV.toStringAsFixed(1)} $unit',
+      Offset(size.width - _TripChartGeometry.rightInset, 2),
       anchorRight: true,
       color: labelColor.withAlpha(160),
       fontSize: 10,
     );
     _drawText(
       canvas,
-      minV.toStringAsFixed(1),
-      Offset(leftInset, size.height - bottomInset + 4),
+      geo.minV.toStringAsFixed(1),
+      Offset(_TripChartGeometry.leftInset,
+          size.height - _TripChartGeometry.bottomInset + 4),
       color: labelColor.withAlpha(160),
       fontSize: 10,
     );
@@ -87,7 +68,7 @@ class _LineChartPainter extends CustomPainter {
     final path = Path();
     for (int i = 0; i < points.length; i++) {
       final p = points[i];
-      final pt = Offset(xFor(p.timestamp), yFor(p.value));
+      final pt = Offset(geo.xFor(p.timestamp), geo.yFor(p.value));
       if (i == 0) {
         path.moveTo(pt.dx, pt.dy);
       } else {
@@ -95,6 +76,34 @@ class _LineChartPainter extends CustomPainter {
       }
     }
     canvas.drawPath(path, linePaint);
+
+    // #2977 — scrub crosshair: a faint vertical guide at the selected x plus
+    // a filled marker + ring on the data point. Mirrors the price-chart
+    // selected-point highlight (#2384) so the two charts feel identical.
+    if (selectedIndex != null && selectedIndex! < points.length) {
+      final sel = points[selectedIndex!];
+      final cx = geo.xFor(sel.timestamp);
+      final cy = geo.yFor(sel.value);
+      canvas.drawLine(
+        Offset(cx, _TripChartGeometry.topInset),
+        Offset(cx, size.height - _TripChartGeometry.bottomInset),
+        Paint()
+          ..color = color.withAlpha(120)
+          ..strokeWidth = 1,
+      );
+      final dotPaint = Paint()
+        ..color = color
+        ..style = PaintingStyle.fill;
+      canvas.drawCircle(Offset(cx, cy), 4, dotPaint);
+      canvas.drawCircle(
+        Offset(cx, cy),
+        6,
+        Paint()
+          ..color = color
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 2,
+      );
+    }
   }
 
   void _drawText(
@@ -111,7 +120,7 @@ class _LineChartPainter extends CustomPainter {
         text: text,
         style: TextStyle(color: color, fontSize: fontSize),
       ),
-      textDirection: TextDirection.ltr,
+      textDirection: ui.TextDirection.ltr,
     )..layout();
     var dx = offset.dx;
     if (anchorRight) dx -= tp.width;
@@ -123,5 +132,6 @@ class _LineChartPainter extends CustomPainter {
   bool shouldRepaint(_LineChartPainter oldDelegate) =>
       oldDelegate.points != points ||
       oldDelegate.color != color ||
-      oldDelegate.unit != unit;
+      oldDelegate.unit != unit ||
+      oldDelegate.selectedIndex != selectedIndex;
 }

--- a/test/features/consumption/presentation/widgets/trip_detail_charts_test.dart
+++ b/test/features/consumption/presentation/widgets/trip_detail_charts_test.dart
@@ -297,6 +297,77 @@ void main() {
     });
   });
 
+  // #2977 — scrub-to-read crosshair. A tap/drag on a trip line chart selects
+  // the nearest sample and overlays a value + time readout, mirroring the
+  // price-chart tap-to-nearest pattern (#2384).
+  group('scrub-to-read crosshair (#2977)', () {
+    testWidgets(
+      'dragging to the right edge reveals the last sample value + unit',
+      (tester) async {
+        // _withSpeedOnly(5): speed 20, 21, 22, 23, 24 km/h, one second apart.
+        await pumpApp(
+          tester,
+          TripDetailSpeedChart(samples: _withSpeedOnly(5)),
+        );
+        // No readout before the user scrubs.
+        expect(find.textContaining('km/h'), findsNothing);
+
+        final chart = find.byType(TripDetailSpeedChart);
+        final box = tester.getRect(chart);
+        // Scrub to the far right → the last sample (24 km/h).
+        await tester.dragFrom(
+          Offset(box.right - 4, box.center.dy),
+          const Offset(-2, 0),
+        );
+        await tester.pumpAndSettle();
+
+        // The readout shows the nearest sample's value + the km/h unit.
+        expect(find.textContaining('24.0 km/h'), findsOneWidget);
+      },
+    );
+
+    testWidgets('tapping near the left edge reveals the first sample value',
+        (tester) async {
+      await pumpApp(
+        tester,
+        TripDetailSpeedChart(samples: _withSpeedOnly(5)),
+      );
+      final chart = find.byType(TripDetailSpeedChart);
+      final box = tester.getRect(chart);
+      // Tap near the far left → the first sample (20 km/h).
+      await tester.tapAt(Offset(box.left + 4, box.center.dy));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('20.0 km/h'), findsOneWidget);
+    });
+
+    testWidgets('the RPM chart readout carries the rpm unit', (tester) async {
+      await pumpApp(
+        tester,
+        TripDetailRpmChart(samples: _withAllFields(5)),
+      );
+      final chart = find.byType(TripDetailRpmChart);
+      final box = tester.getRect(chart);
+      await tester.tapAt(Offset(box.left + 4, box.center.dy));
+      await tester.pumpAndSettle();
+      // _withAllFields first sample rpm = 1500.
+      expect(find.textContaining('1500.0 rpm'), findsOneWidget);
+    });
+
+    testWidgets('a single-sample chart never shows a readout (no scrub)',
+        (tester) async {
+      await pumpApp(
+        tester,
+        TripDetailSpeedChart(samples: _withSpeedOnly(1)),
+      );
+      final chart = find.byType(TripDetailSpeedChart);
+      final box = tester.getRect(chart);
+      await tester.tapAt(box.center);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('km/h'), findsNothing);
+    });
+  });
+
   group('TripDetailCoolantChart / Altitude / Lambda (#2461)', () {
     List<TripDetailSample> withSignals(int n) => [
           for (var i = 0; i < n; i++)


### PR DESCRIPTION
## What

Adds a **scrub-to-read crosshair** to the trip-detail line charts (speed / RPM / fuel-rate / engine-load / throttle / coolant / altitude / λ). These charts rendered hand-rolled `CustomPaint` line plots with **no gesture or tooltip** — the user could see a line shape but never read the value at any point. The price-history chart already had tap-to-nearest with a crosshair (#2384); this brings the same affordance to the trip charts so the two feel identical.

## How

- `_TripDetailLineChart` is now stateful: a tap (`onTapDown`) or horizontal drag maps the touch x to the nearest sample, draws a **vertical crosshair line + a marker dot/ring** on the data point, and overlays a small **value + unit + time readout** callout — mirroring the price-chart `_PriceTooltip` + selected-point highlight.
- New sibling part file `trip_chart_crosshair.dart` holds the shared `_TripChartGeometry` (one time/value projection used by both the painter and the nearest-point hit-test, so the marker lands exactly on the read value), the readout callout widget, and the now-stateful chart host.
- The line painter was refactored to use that same `_TripChartGeometry` it draws the line with.

## Constraints honoured

- **No new dependency** — kept the library-free `CustomPaint` approach (no `fl_chart`).
- **No animation** — the crosshair is drag-driven, so no `AnimationController` / reduced-motion dependency (entry path-draw deferred per the value review).
- **No new ARB strings** — the readout reuses the existing per-chart unit suffix (`km/h`, `rpm`, `L/h`, `%`, `m`, `°C`, `λ`), the existing `toStringAsFixed` value formatting, and the locale's time format. Zero `lib/l10n/` diff.
- **400-line cap (#1680)** — extracted rather than grandfathered: host `trip_detail_charts.dart` 294, `trip_chart_crosshair.dart` 311, `trip_detail_line_painter.dart` 137; no snapshot entries added.

## Test

`trip_detail_charts_test.dart` gains a "scrub-to-read crosshair (#2977)" group: scrubbing/tapping a chart at a known x asserts the readout shows the nearest sample's value + unit (e.g. `24.0 km/h`, `20.0 km/h`, `1500.0 rpm`), and a single-sample chart shows no readout. **RED before** the change (no readout widget existed), green after. 26/26 in the file pass; sibling `trip_detail_body` / `trip_detail_screen` tests stay green.

`flutter analyze` clean (incl. `use_build_context_synchronously`); no-hardcoded-UI-strings + file_length lints pass.

Closes #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)
