### PR TITLE
fix(price-history): localize price-prediction day names via intl

### DIFF
--- a/lib/app/app_initializer.dart
+++ b/lib/app/app_initializer.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:home_widget/home_widget.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -98,6 +99,11 @@ class AppInitializer {
 
     _bootstrap();
     StartupTimer.instance.mark('binding');
+
+    // #2978 — load `intl` locale date-symbols so `DateFormat.EEEE` (the
+    // localized price-prediction weekday) works for non-`en_US` locales
+    // instead of throwing `LocaleDataException`. In-memory, off the I/O path.
+    await initializeDateFormatting();
 
     // #2294 — a Hive box damaged beyond crash recovery throws a
     // HiveCorruptionException out of the storage phase. Previously it

--- a/lib/features/price_history/providers/price_prediction_provider.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.dart
@@ -1,9 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+// `intl` re-exports a `TextDirection` symbol; this provider has no painter
+// so there's no dart:ui clash, but we hide it to match the repo-wide guard
+// against the #2976 ambiguous-import gotcha.
+import 'package:intl/intl.dart' hide TextDirection;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../core/country/country_config.dart';
+import '../../../core/language/language_provider.dart';
 import '../../../core/utils/num_extensions.dart';
 import '../../feature_management/application/feature_flags_provider.dart';
 import '../../feature_management/domain/feature.dart';
@@ -18,16 +23,29 @@ import 'tflite_price_predictor_provider.dart';
 
 part 'price_prediction_provider.g.dart';
 
-/// Day-of-week names used for recommendation text.
-const _dayNames = {
-  1: 'Monday',
-  2: 'Tuesday',
-  3: 'Wednesday',
-  4: 'Thursday',
-  5: 'Friday',
-  6: 'Saturday',
-  7: 'Sunday',
-};
+/// Localizes a `DateTime.weekday` index (1 = Monday … 7 = Sunday) to the
+/// full weekday name in [localeCode] via `intl`'s `DateFormat.EEEE` — the
+/// same locale-DATA path the price chart uses (#2976), so French/German/…
+/// users no longer see hard-coded English weekdays (#2978). Weekday names
+/// are locale data, not translatable ARB strings, so there's no ARB key.
+///
+/// Never throws: falls back to the English weekday when `intl` rejects the
+/// locale — either a `LocaleDataException` (date symbols not yet loaded; the
+/// app initializes them at startup, but the very first home-widget refresh
+/// tick can run before the Material localization delegate has) or an
+/// `ArgumentError` (an unexpected/unknown locale code). A formatting hiccup
+/// must never break the prediction, so a broad catch is intentional here.
+/// (Fault path is covered by `price_prediction_provider_test.dart`.)
+String _localizedWeekday(int weekday, String localeCode) {
+  // A reference date whose weekday equals [weekday]; 2026-03-02 is a Monday,
+  // so adding (weekday - 1) days lands on the requested weekday.
+  final date = DateTime(2026, 3, 2).add(Duration(days: weekday - 1));
+  try {
+    return DateFormat.EEEE(localeCode).format(date);
+  } catch (_) {
+    return DateFormat.EEEE('en').format(date);
+  }
+}
 
 /// Computes "best time to fill" predictions from locally stored price history.
 ///
@@ -116,7 +134,12 @@ PricePrediction? pricePrediction(
   final holidayPremium = _computeHolidayPremium(vectors);
 
   // --- Recommendation text ---
-  final dayName = _dayNames[cheapestDay.dayOfWeek] ?? 'Unknown';
+  // Localize the weekday via the active app locale (#2978). The provider is
+  // context-free, so it reads the locale from `activeLanguageProvider`
+  // rather than a `BuildContext`; `intl` then formats the weekday as locale
+  // data. The surrounding frame text is a separate #1117 follow-up.
+  final localeCode = ref.watch(activeLanguageProvider).code;
+  final dayName = _localizedWeekday(cheapestDay.dayOfWeek, localeCode);
   final hourLabel = _formatHourRange(cheapestHour.hour);
   final base = 'Prices typically drop $dayName $hourLabel';
   final recommendation =

--- a/lib/features/price_history/providers/price_prediction_provider.g.dart
+++ b/lib/features/price_history/providers/price_prediction_provider.g.dart
@@ -102,7 +102,7 @@ final class PricePredictionProvider
   }
 }
 
-String _$pricePredictionHash() => r'99c1d56e4f9dda52ca30ef12d972108dd42e2562';
+String _$pricePredictionHash() => r'b5758319ef6aaff05b0cc2de8f3e11bd5b87ae0c';
 
 /// Computes "best time to fill" predictions from locally stored price history.
 ///

--- a/test/features/price_history/providers/price_prediction_provider_test.dart
+++ b/test/features/price_history/providers/price_prediction_provider_test.dart
@@ -3,7 +3,9 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/language/language_provider.dart';
 import 'package:tankstellen/features/feature_management/application/feature_flags_provider.dart';
 import 'package:tankstellen/features/feature_management/domain/feature.dart';
 import 'package:tankstellen/features/price_history/data/models/price_record.dart';
@@ -21,10 +23,22 @@ import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 /// [priceHistoryRepositoryProvider] that returns predetermined price
 /// records. Covers all branches of the "best time to fill" computation.
 void main() {
-  ProviderContainer makeContainer(List<PriceRecord> records) {
+  // The recommendation weekday is rendered through `intl`'s
+  // `DateFormat.EEEE(locale)` (#2978), which needs locale-symbol data for
+  // any non-`en_US` locale. The app loads it at startup; tests must too.
+  setUpAll(initializeDateFormatting);
+
+  /// Builds a container with a fixed [language] so the provider's
+  /// locale-driven weekday formatting (#2978) is deterministic. Defaults
+  /// to English to match the existing English recommendation assertions.
+  ProviderContainer makeContainer(
+    List<PriceRecord> records, {
+    AppLanguage language = const AppLanguage('en', 'English', 'English'),
+  }) {
     final repo = _FakePriceHistoryRepository(records);
     final c = ProviderContainer(overrides: [
       priceHistoryRepositoryProvider.overrideWithValue(repo),
+      activeLanguageProvider.overrideWith(() => _FixedActiveLanguage(language)),
     ]);
     addTearDown(c.dispose);
     return c;
@@ -329,6 +343,90 @@ void main() {
     });
   });
 
+  group('pricePrediction — localized weekday in recommendation (#2978)', () {
+    // Cheapest day fixture: 5 expensive Mondays + 5 cheap Wednesdays so the
+    // recommendation surfaces the Wednesday weekday. DateTime(2026, 3, 4) is
+    // a Wednesday; DateTime(2026, 3, 2) is a Monday.
+    List<PriceRecord> cheapestWednesdayRecords() {
+      final records = <PriceRecord>[];
+      for (int w = 0; w < 5; w++) {
+        records.add(PriceRecord(
+          stationId: 's1',
+          recordedAt: DateTime(2026, 3, 2 + w * 7, 10),
+          e10: 1.60,
+        ));
+      }
+      for (int w = 0; w < 5; w++) {
+        records.add(PriceRecord(
+          stationId: 's1',
+          recordedAt: DateTime(2026, 3, 4 + w * 7, 10),
+          e10: 1.30,
+        ));
+      }
+      return records;
+    }
+
+    test('English locale renders the English weekday name', () {
+      final container = makeContainer(
+        cheapestWednesdayRecords(),
+        language: const AppLanguage('en', 'English', 'English'),
+      );
+      final result =
+          container.read(pricePredictionProvider('s1', FuelType.e10));
+
+      expect(result, isNotNull);
+      expect(result!.recommendation, contains('Wednesday'));
+    });
+
+    test('French locale renders the French weekday name (not English)', () {
+      final container = makeContainer(
+        cheapestWednesdayRecords(),
+        language: const AppLanguage('fr', 'Français', 'French'),
+      );
+      final result =
+          container.read(pricePredictionProvider('s1', FuelType.e10));
+
+      expect(result, isNotNull);
+      // French weekday for Wednesday — locale DATA, not an ARB string.
+      expect(result!.recommendation, contains('mercredi'));
+      expect(result.recommendation, isNot(contains('Wednesday')));
+    });
+
+    test('German locale renders the German weekday name (not English)', () {
+      final container = makeContainer(
+        cheapestWednesdayRecords(),
+        language: const AppLanguage('de', 'Deutsch', 'German'),
+      );
+      final result =
+          container.read(pricePredictionProvider('s1', FuelType.e10));
+
+      expect(result, isNotNull);
+      expect(result!.recommendation, contains('Mittwoch'));
+      expect(result.recommendation, isNot(contains('Wednesday')));
+    });
+
+    test(
+        'unknown/unsupported locale → never throws, falls back to the '
+        'English weekday', () {
+      // `intl` rejects an unknown locale with an ArgumentError; the
+      // never-throws guard in `_localizedWeekday` must swallow it and fall
+      // back to English instead of leaking the error into the provider.
+      final container = makeContainer(
+        cheapestWednesdayRecords(),
+        language: const AppLanguage('zz-ZZ', 'Klingon', 'Klingon'),
+      );
+
+      expect(
+        () => container.read(pricePredictionProvider('s1', FuelType.e10)),
+        returnsNormally,
+      );
+      final result =
+          container.read(pricePredictionProvider('s1', FuelType.e10));
+      expect(result, isNotNull);
+      expect(result!.recommendation, contains('Wednesday'));
+    });
+  });
+
   group('pricePrediction — hour-range formatting', () {
     test('formats morning hours as "<n> AM-<m> AM" (e.g. 6 AM-8 AM)', () {
       // Make hour 6 cheapest; we expect "6 AM-8 AM" in the recommendation.
@@ -614,6 +712,11 @@ void main() {
             .overrideWithValue(_FakePriceHistoryRepository(seedRecords())),
         featureFlagsProvider.overrideWith(() => _TestFeatureFlags(enabled)),
         tflitePricePredictorProvider.overrideWith((ref) async => predictor),
+        activeLanguageProvider.overrideWith(
+          () => _FixedActiveLanguage(
+            const AppLanguage('en', 'English', 'English'),
+          ),
+        ),
       ]);
       addTearDown(c.dispose);
       return c;
@@ -759,6 +862,18 @@ class _FakePriceHistoryRepository extends PriceHistoryRepository {
   List<PriceRecord> getHistory(String stationId, {int days = 30}) {
     return List.of(_records);
   }
+}
+
+/// Fixed [ActiveLanguage] notifier — pins the active language so the
+/// provider's locale-driven weekday formatting (#2978) is deterministic
+/// without depending on the platform locale or a persisted profile. Same
+/// shape as `_FixedActiveLanguage` in `test/app/app_test.dart`.
+class _FixedActiveLanguage extends ActiveLanguage {
+  _FixedActiveLanguage(this._language);
+  final AppLanguage _language;
+
+  @override
+  AppLanguage build() => _language;
 }
 
 /// Notifier override that returns a fixed enabled-set for the test's

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -50,7 +50,10 @@ void main() {
     // lines next to the adjacent country/language backfill migration).
     // #2772 — 957 → 961: the isBenignStreamCancel de-noise helper + its
     // services import + the two global-handler filter calls. Bootstrap file.
-    'lib/app/app_initializer.dart': 961,
+    // #2978 — 961 → 964: `initializeDateFormatting()` + its import + comment,
+    // so `intl` locale date-symbols are loaded once at startup and the
+    // localized price-prediction weekday renders for non-`en_US` locales.
+    'lib/app/app_initializer.dart': 964,
     // #2415 — background_service.dart graduated: the scan body moved into
     // BackgroundAlertScanCoordinator + BackgroundScanRunners +
     // BackgroundPriceHistoryWriter, so the file dropped from 782 to ~246


### PR DESCRIPTION
## Problem

`lib/features/price_history/providers/price_prediction_provider.dart` built the user-facing "best time to fill" recommendation from a hard-coded English `_dayNames` map (`{1: 'Monday', … 7: 'Sunday'}`). The chosen weekday is baked into `PricePrediction.recommendation` in English for **all 23 locales** (FR/DE-primary app).

That string is surfaced to users via the home-screen widget predictive line (`lib/features/widget/data/predictive_payload.dart` → `predictive_best_label`), which the native renderer forwards verbatim and cannot re-localize. French/German/… users saw e.g. "Prices typically drop **Wednesday** 10 AM-12 PM". Discovered during a chart-i18n pass (sibling to #2971, the `MonthlyBarChart` month-name defect).

Closes #2978.

## Seam chosen — provider localizes via `intl`, driven by `activeLanguageProvider`

The provider has no `BuildContext`, and the only consumer (native widget renderer) can't re-localize, so the string must leave Dart already localized. The provider already had the weekday as a 1–7 index; it now reads the active locale from the context-free `activeLanguageProvider` and formats the weekday with `intl`'s `DateFormat.EEEE(locale)` — the same locale-DATA path `price_chart.dart` uses (`DateFormat.Md`, #2976). Weekday names are locale **data**, not a translatable ARB string → **no ARB fan-out**.

- `_localizedWeekday` falls back to the English weekday and **never throws** if `intl` rejects the locale (`LocaleDataException` / `ArgumentError`).
- `DateFormat.EEEE` for any non-`en_US` locale needs date symbols loaded — `initializeDateFormatting()` now runs once at startup in `AppInitializer` (in-memory, off the I/O path). Hardens the existing chart date formatting too.
- `intl` re-exports `TextDirection`; imported with `hide TextDirection` per the #2976 gotcha (no clash here, but kept consistent).

## Sibling audit (kept in scope)

`fill_up_guidance_card.dart` has a weekday map too, but it is only the `l == null` `_fallbackWeekday` — the real path uses the `fillUpGuidanceWeekday1..7` ARB keys. Not a defect; left as-is. The surrounding recommendation frame ("Prices typically drop …", AM/PM, holiday hint) is a separate larger #1117 follow-up and out of scope.

## Test (RED-before / green-after)

`price_prediction_provider_test.dart` drives the **real** provider → `recommendation` under pinned locales:
- en → "Wednesday" (unchanged)
- fr → "mercredi", asserts NOT "Wednesday"  ← RED on master, green after
- de → "Mittwoch", asserts NOT "Wednesday"  ← RED on master, green after
- unknown locale → `returnsNormally` + English fallback (the never-throws fault path, satisfies the #2349 scanner)

Existing English assertions stay green (default locale pinned to `en`).

## Gates

- `flutter analyze` clean on touched files.
- No ARB fan-out (locale data).
- Clean `build_runner` rebuild committed — only the `pricePredictionHash` changed (body edit, no `@riverpod` signature change).
- `app_initializer.dart` re-grandfathered 961 → 964 in `file_length_test.dart` (init call + import + comment).
- Never-throws + no-hardcoded-UI-strings lints pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)