### PR TITLE
feat: interaction & motion polish (reduced-motion guard, price-flash reach, everyday haptics, brand cluster bubbles)

### DIFF
--- a/lib/app/widgets/animated_splash.dart
+++ b/lib/app/widgets/animated_splash.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../core/theme/app_motion.dart';
 import '../../l10n/app_localizations.dart';
 
 /// Animated Flutter splash shown between the native splash drawable and the
@@ -82,7 +83,28 @@ class _AnimatedSplashState extends State<AnimatedSplash>
       parent: _controller,
       curve: const Interval(0.28, 1.0, curve: Curves.easeOut),
     );
-    _controller.forward();
+    // The forward()/jump-to-end decision is deferred to
+    // [didChangeDependencies] (first call) so it can read the reduced-motion
+    // MediaQuery flag — `initState` has no usable MediaQuery context.
+  }
+
+  /// Guards [_controller] so it only kicks once. Without this a MediaQuery
+  /// change (e.g. brightness toggle) would re-run the reveal.
+  bool _started = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_started) return;
+    _started = true;
+    // #2972 — reduced-motion guard. With the OS "remove animations" flag on,
+    // jump the controller straight to its end (logo full-size, fully opaque)
+    // instead of running the 650 ms scale+fade reveal.
+    if (AppMotion.enabled(context)) {
+      _controller.forward();
+    } else {
+      _controller.value = 1.0;
+    }
   }
 
   @override

--- a/lib/core/theme/app_motion.dart
+++ b/lib/core/theme/app_motion.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart';
+
+/// Reduced-motion guard for the app's in-app animations (#2972).
+///
+/// Reads the OS accessibility "remove animations" / "reduce motion" setting
+/// (iOS: Settings → Accessibility → Motion → Reduce Motion; Android:
+/// Settings → Accessibility → Remove animations) via Flutter's
+/// [MediaQueryData.disableAnimations] flag, surfaced as
+/// [MediaQuery.disableAnimationsOf].
+///
+/// This is an OS-driven flag ONLY — there is intentionally no in-app toggle
+/// and no new user-facing string. Motion-using widgets short-circuit to their
+/// END-STATE (final frame, no controller run) when [enabled] returns false,
+/// so a motion-sensitive user gets the same information with zero movement.
+///
+/// Added as a tiny additive layer on the Epic-#2487 design system so every
+/// animated widget gates the same way:
+///
+/// ```dart
+/// if (AppMotion.enabled(context)) {
+///   _controller.forward(from: 0);
+/// }
+/// // else: render the end-state directly.
+/// ```
+class AppMotion {
+  AppMotion._();
+
+  /// True when the OS has NOT requested reduced motion — i.e. it is fine to
+  /// run decorative animations. False when the user enabled the platform
+  /// "remove animations" / "reduce motion" setting; callers must then render
+  /// the animation's end-state without kicking a controller.
+  static bool enabled(BuildContext context) =>
+      !MediaQuery.disableAnimationsOf(context);
+}

--- a/lib/core/widgets/animated_price_text.dart
+++ b/lib/core/widgets/animated_price_text.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../theme/app_motion.dart';
 import '../theme/dark_mode_colors.dart';
 
 /// Wraps an arbitrary price widget (usually the card/detail RichText) in a
@@ -94,6 +95,12 @@ class _AnimatedPriceTextState extends State<AnimatedPriceText>
     final newPrice = widget.price;
     if (oldPrice == null || newPrice == null) return;
     if (oldPrice == newPrice) return;
+    // #2972 — reduced-motion guard. When the OS "remove animations" flag is
+    // on, skip the flash entirely: no scale bounce, no tint overlay. The
+    // child already renders the new price, so the end-state is identical;
+    // we just never kick the controller, so `hasRunningAnimations` stays
+    // false for a motion-sensitive user.
+    if (!AppMotion.enabled(context)) return;
     setState(() {
       _flashIsDrop = newPrice < oldPrice;
     });

--- a/lib/core/widgets/staggered_fade_in.dart
+++ b/lib/core/widgets/staggered_fade_in.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../theme/app_motion.dart';
+
 /// Per-index start-delay step. 50 ms matches the #595 spec.
 const int _kStepMs = 50;
 
@@ -93,6 +95,11 @@ class _StaggeredFadeInState extends State<StaggeredFadeIn> {
 
   @override
   Widget build(BuildContext context) {
+    // #2972 — reduced-motion guard. With the OS "remove animations" flag on
+    // we skip the fade timeline entirely and render the row at its end-state
+    // (fully opaque) immediately, so a motion-sensitive user sees the full
+    // results list with no cascade and no running ticker slice.
+    if (!AppMotion.enabled(context)) return widget.child;
     return FadeTransition(opacity: _opacity, child: widget.child);
   }
 }

--- a/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
+++ b/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/theme/app_motion.dart';
 import '../../../../core/theme/app_radius.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/utils/radar_closeness.dart';
@@ -86,7 +87,12 @@ class ProximityFillBar extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: TweenAnimationBuilder<double>(
             tween: Tween(begin: 0, end: fill),
-            duration: const Duration(milliseconds: 300),
+            // #2972 — reduced-motion guard: snap the fill to its end-state
+            // with a zero-duration "animation" instead of the 300 ms ease,
+            // so a motion-sensitive user gets the same fill with no movement.
+            duration: AppMotion.enabled(context)
+                ? const Duration(milliseconds: 300)
+                : Duration.zero,
             curve: Curves.easeOut,
             builder: (context, value, _) => FractionallySizedBox(
               widthFactor: value,

--- a/lib/features/map/presentation/widgets/station_cluster_layers.dart
+++ b/lib/features/map/presentation/widgets/station_cluster_layers.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 
+import '../../../../core/theme/dark_mode_colors.dart';
+import '../../../../core/theme/price_band_colors.dart';
 import 'cluster_badge.dart';
 
 /// The per-marker side data the cheapest-labelled cluster builder needs to
@@ -58,9 +60,21 @@ Widget cheapestLabelledClusterLayer({
   );
 }
 
-/// The legacy bare count-cluster layer — the #2510 fallback for a genuinely
-/// huge non-radar result set, where painting hundreds of overlapping dots
-/// would itself be illegible. Unchanged from the pre-#2939 inline builder.
+/// The count-cluster layer — the #2510 fallback for a genuinely huge non-radar
+/// result set, where painting hundreds of overlapping dots would itself be
+/// illegible.
+///
+/// #2975 — the bubble is themed onto the canonical brand price-band ramp
+/// ([PriceBandColors.cheap], the forest-green leitmotiv) instead of the
+/// plugin-default `colorScheme.primaryContainer`, so a count cluster reads as
+/// part of the same map colour language as the cheapest-labelled clusters
+/// ([ClusterBadge]), the singleton price pills and the legend. A count cluster
+/// carries no per-member price (it is the "too many to label" fallback), so it
+/// uses the cheap stop as a neutral brand anchor — white text + hairline +
+/// the dark-mode map-overlay shadow token match the [ClusterBadge] grammar.
+///
+/// STATIC theming only — the builder allocates no animation and runs no
+/// per-frame work, so the huge-set path stays cheap.
 Widget countClusterLayer({
   required List<Marker> markers,
   required ThemeData theme,
@@ -69,18 +83,42 @@ Widget countClusterLayer({
     options: MarkerClusterLayerOptions(
       maxClusterRadius: 50,
       markers: markers,
-      builder: (context, clusterMarkers) => Container(
-        decoration: BoxDecoration(
-          color: theme.colorScheme.primaryContainer,
-          shape: BoxShape.circle,
-        ),
+      builder: (context, clusterMarkers) => DecoratedBox(
+        decoration: countClusterDecoration(context),
         child: Center(
           child: Text(
             '${clusterMarkers.length}',
-            style: const TextStyle(fontWeight: FontWeight.bold),
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
           ),
         ),
       ),
     ),
   );
 }
+
+/// The brand-themed decoration painted behind a count cluster (#2975).
+///
+/// Pulled out of the [countClusterLayer] builder so the theming can be
+/// asserted in a unit test without forcing real marker overlap, and so the
+/// builder stays a thin, allocation-light shell. The fill is the canonical
+/// brand price-band [PriceBandColors.cheap] (NOT the plugin-default
+/// `colorScheme.primaryContainer`), with the same white hairline + dark-mode
+/// map-overlay shadow grammar as [ClusterBadge].
+BoxDecoration countClusterDecoration(BuildContext context) => BoxDecoration(
+      color: PriceBandColors.cheap.withValues(alpha: 0.94),
+      shape: BoxShape.circle,
+      border: Border.all(
+        color: Colors.white.withValues(alpha: 0.85),
+        width: 1.5,
+      ),
+      boxShadow: [
+        BoxShadow(
+          color: DarkModeColors.mapOverlayShadow(context),
+          blurRadius: 4,
+          offset: const Offset(0, 1),
+        ),
+      ],
+    );

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -349,7 +350,15 @@ class _StationMapLayersState extends State<StationMapLayers> {
     // SINGLETON keeps its full price pill (never a dot); only clustered members
     // roll up into the cheapest-price badge. The emphasis-dot scheme stays for
     // the legacy non-clustered surfaces.
-    final onTap = widget.onStationTap;
+    // #2974 — a marker tap that selects its list row also fires a selection
+    // tick (selectionClick only). Null on the default push-to-detail map → no
+    // haptic; the route push owns its own feedback.
+    final onTap = widget.onStationTap == null
+        ? null
+        : (String id) {
+            HapticFeedback.selectionClick();
+            widget.onStationTap!(id);
+          };
     _markerMeta.clear();
     _markers = ordered.map((station) {
       final isPastel = hasSelection && !ids.contains(station.id);

--- a/lib/features/map/presentation/widgets/station_marker.dart
+++ b/lib/features/map/presentation/widgets/station_marker.dart
@@ -9,6 +9,7 @@ import '../../../../core/theme/price_band_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/price_gradient.dart';
 import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/widgets/animated_price_text.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 import '../../../search/domain/entities/station.dart';
 
@@ -115,9 +116,16 @@ class StationMarkerBuilder {
     final Widget badge = showCompact
         ? _dot(color, pastel)
         : selected
+            // #2973 — the SELECTED marker (and ONLY the selected marker) wraps
+            // its price in AnimatedPriceText so a refresh that drops the
+            // chosen station's price flashes on the map. Un-selected bubbles,
+            // compact dots and the cluster badge stay inert — the flash never
+            // runs per-frame across the whole marker layer. Reduced motion is
+            // honoured inside AnimatedPriceText.
             ? Builder(
                 builder: (ctx) => _priceBubble(color, pastel, priceText,
-                    ringColor: Theme.of(ctx).colorScheme.primary),
+                    ringColor: Theme.of(ctx).colorScheme.primary,
+                    flashPrice: price),
               )
             : _priceBubble(color, pastel, priceText);
 
@@ -153,8 +161,25 @@ class StationMarkerBuilder {
   /// #2939 — [ringColor] (the selected-station case) overrides the default
   /// white hairline with a thicker brand-primary ring so the chosen marker
   /// stands out from its neighbours.
+  ///
+  /// #2973 — [flashPrice] (selected case only) wraps the price text in an
+  /// [AnimatedPriceText] so the chosen station's marker flashes when its
+  /// price changes. Null on every non-selected bubble → no flash, so the
+  /// animation can never run across the whole marker layer.
   static Widget _priceBubble(Color color, bool pastel, String priceText,
-      {Color? ringColor}) {
+      {Color? ringColor, double? flashPrice}) {
+    final Widget priceLabel = FittedBox(
+      fit: BoxFit.scaleDown,
+      child: Text(
+        priceText,
+        style: TextStyle(
+          fontWeight: FontWeight.bold,
+          fontSize: 12,
+          height: 1.0,
+          color: pastel ? Colors.black38 : Colors.black87,
+        ),
+      ),
+    );
     return Container(
       alignment: Alignment.center,
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
@@ -177,18 +202,9 @@ class StationMarkerBuilder {
                 ),
               ],
       ),
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text(
-          priceText,
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            fontSize: 12,
-            height: 1.0,
-            color: pastel ? Colors.black38 : Colors.black87,
-          ),
-        ),
-      ),
+      child: flashPrice == null
+          ? priceLabel
+          : AnimatedPriceText(price: flashPrice, child: priceLabel),
     );
   }
 

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
@@ -132,7 +133,15 @@ class AllPricesStationCard extends StatelessWidget {
                       isFavorite ? Icons.star : Icons.star_border,
                       color: isFavorite ? Colors.amber : null,
                     ),
-                    onPressed: onFavoriteTap,
+                    // #2974 — selection tick on the favourite toggle (the same
+                    // everyday tap haptic as the compact card). selectionClick
+                    // only; fires only on the discrete star tap, never scroll.
+                    onPressed: onFavoriteTap == null
+                        ? null
+                        : () {
+                            HapticFeedback.selectionClick();
+                            onFavoriteTap!();
+                          },
                     tooltip: isFavorite
                         ? (l10n?.removeFavorite ?? 'Remove from favorites')
                         : (l10n?.addFavorite ?? 'Add to favorites'),

--- a/lib/features/search/presentation/widgets/all_prices_station_card.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card.dart
@@ -7,6 +7,7 @@ import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
 import '../../../../core/utils/station_extensions.dart';
+import '../../../../core/widgets/animated_price_text.dart';
 import '../../../../core/widgets/station_card_shell.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../station_detail/presentation/widgets/station_brand_helpers.dart';

--- a/lib/features/search/presentation/widgets/all_prices_station_card_parts.dart
+++ b/lib/features/search/presentation/widgets/all_prices_station_card_parts.dart
@@ -97,20 +97,28 @@ class _FuelBadge extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 4),
-          Text(
-            isUnavailable
-                ? (l10n?.outOfStock ?? 'Out of stock')
-                : PriceFormatter.formatPriceCompact(price),
-            style: TextStyle(
-              fontSize: priceFontSize,
-              fontWeight: FontWeight.bold,
-              color: isUnavailable
-                  ? theme.colorScheme.onSurfaceVariant
-                  : isChampion
-                      ? Colors.white
-                      : isHighlighted
-                          ? color
-                          : theme.colorScheme.onSurface,
+          // #2973 — flash the per-fuel price on change (the SAME
+          // AnimatedPriceText the search card uses), so an all-prices row
+          // that drops is noticeable. The out-of-stock case carries no
+          // numeric price, so it passes null and never flashes. Reduced
+          // motion is honoured inside AnimatedPriceText.
+          AnimatedPriceText(
+            price: isUnavailable ? null : price,
+            child: Text(
+              isUnavailable
+                  ? (l10n?.outOfStock ?? 'Out of stock')
+                  : PriceFormatter.formatPriceCompact(price),
+              style: TextStyle(
+                fontSize: priceFontSize,
+                fontWeight: FontWeight.bold,
+                color: isUnavailable
+                    ? theme.colorScheme.onSurfaceVariant
+                    : isChampion
+                        ? Colors.white
+                        : isHighlighted
+                            ? color
+                            : theme.colorScheme.onSurface,
+              ),
             ),
           ),
         ],

--- a/lib/features/search/presentation/widgets/fuel_type_selector.dart
+++ b/lib/features/search/presentation/widgets/fuel_type_selector.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../core/country/country_provider.dart';
 import '../../../../core/theme/fuel_colors.dart';
@@ -73,6 +74,11 @@ class FuelTypeSelector extends ConsumerWidget {
                 label: Text(label),
                 selected: selected == type,
                 onSelected: (_) {
+                  // #2974 — a selection tick on the per-fuel chip re-search,
+                  // matching the everyday tap-surface haptics. selectionClick
+                  // only (never heavyImpact); never fires on scroll because
+                  // ChoiceChip.onSelected is a discrete tap, not a drag.
+                  HapticFeedback.selectionClick();
                   ref.read(selectedFuelTypeProvider.notifier).select(type);
                 },
                 visualDensity: VisualDensity.compact,

--- a/lib/features/search/presentation/widgets/radar_screen_pin_mixin.dart
+++ b/lib/features/search/presentation/widgets/radar_screen_pin_mixin.dart
@@ -27,6 +27,10 @@ mixin RadarScreenPinMixin<T extends ConsumerStatefulWidget>
 
   /// Toggle the pin (the AppBar pin button).
   Future<void> togglePin() async {
+    // #2974 — a light selection tick on the toggle, mirroring the everyday
+    // tap-surface haptics. selectionClick only (never heavyImpact); fire-and-
+    // forget so the platform-channel reply never blocks the pin work.
+    unawaited(HapticFeedback.selectionClick());
     final next = !pinned;
     if (mounted) setState(() => pinned = next);
     await (next ? _enable() : _disable());
@@ -36,6 +40,10 @@ mixin RadarScreenPinMixin<T extends ConsumerStatefulWidget>
   /// and the "always pin" toggle (#2785).
   Future<void> enablePinNow() async {
     if (pinned) return;
+    // #2974 — a slightly firmer lightImpact on the pin ACTION (vs the toggle's
+    // selection tick) so "you're now pinned" reads as a deliberate state
+    // change. lightImpact only (never heavyImpact).
+    unawaited(HapticFeedback.lightImpact());
     if (mounted) setState(() => pinned = true);
     await _enable();
   }

--- a/lib/features/search/presentation/widgets/station_card.dart
+++ b/lib/features/search/presentation/widgets/station_card.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import '../../../../core/country/country_config.dart';
 import '../../../../core/theme/app_radius.dart';
 import '../../../../core/theme/dark_mode_colors.dart';

--- a/lib/features/search/presentation/widgets/station_card_price_column.dart
+++ b/lib/features/search/presentation/widgets/station_card_price_column.dart
@@ -84,7 +84,15 @@ class _StationPriceColumn extends StatelessWidget {
               isFavorite: isFavorite,
               size: 22,
             ),
-            onPressed: onFavoriteTap,
+            // #2974 — a selection tick on the favourite toggle, matching the
+            // everyday tap-surface haptics. selectionClick only (never
+            // heavyImpact); fires only on the discrete star tap, never scroll.
+            onPressed: onFavoriteTap == null
+                ? null
+                : () {
+                    HapticFeedback.selectionClick();
+                    onFavoriteTap!();
+                  },
             tooltip: isFavorite
                 ? (l10n?.favoriteRemove ?? 'Remove from favorites')
                 : (l10n?.favoriteAdd ?? 'Add to favorites'),

--- a/lib/features/search/presentation/widgets/station_card_price_row.dart
+++ b/lib/features/search/presentation/widgets/station_card_price_row.dart
@@ -53,13 +53,18 @@ class _PriceRow extends StatelessWidget {
             color: labelColor,
           ),
         ),
-        Text(
-          PriceFormatter.formatPriceCompact(price),
-          style: theme.textTheme.labelSmall?.copyWith(
-                fontSize: fontSize,
-                fontWeight: fontWeight,
-                color: color,
-              ),
+        // #2973 — flash the alternative-fuel price on change, matching the
+        // headline price column. Reduced motion is honoured inside the widget.
+        AnimatedPriceText(
+          price: price,
+          child: Text(
+            PriceFormatter.formatPriceCompact(price),
+            style: theme.textTheme.labelSmall?.copyWith(
+                  fontSize: fontSize,
+                  fontWeight: fontWeight,
+                  color: color,
+                ),
+          ),
         ),
       ],
     );

--- a/lib/features/station_detail/presentation/widgets/price_tile.dart
+++ b/lib/features/station_detail/presentation/widgets/price_tile.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/theme/fuel_colors.dart';
 import '../../../../core/utils/price_formatter.dart';
+import '../../../../core/widgets/animated_price_text.dart';
 import '../../../search/domain/entities/fuel_type.dart';
 
 /// A single fuel price row with colored icon and formatted price.
@@ -30,12 +31,18 @@ class PriceTile extends StatelessWidget {
           Icon(Icons.local_gas_station, color: color, size: 20),
           const SizedBox(width: 8),
           Expanded(child: Text(label, style: Theme.of(context).textTheme.bodyMedium)),
-          Text(
-            PriceFormatter.formatPrice(price),
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: color,
-                ),
+          // #2973 — flash on price change. The same AnimatedPriceText the
+          // search card uses, so a refresh that drops a price is noticeable
+          // here too. Gated on the OS reduced-motion flag inside the widget.
+          AnimatedPriceText(
+            price: price,
+            child: Text(
+              PriceFormatter.formatPrice(price),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: color,
+                  ),
+            ),
           ),
         ],
       ),

--- a/test/core/theme/app_motion_test.dart
+++ b/test/core/theme/app_motion_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/app_motion.dart';
+
+void main() {
+  group('AppMotion (#2972)', () {
+    testWidgets('enabled is TRUE when the OS does not request reduced motion',
+        (tester) async {
+      late bool result;
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(disableAnimations: false),
+          child: Builder(
+            builder: (context) {
+              result = AppMotion.enabled(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(result, isTrue);
+    });
+
+    testWidgets('enabled is FALSE when the OS requests reduced motion',
+        (tester) async {
+      late bool result;
+      await tester.pumpWidget(
+        MediaQuery(
+          data: const MediaQueryData(disableAnimations: true),
+          child: Builder(
+            builder: (context) {
+              result = AppMotion.enabled(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/core/widgets/animated_price_text_test.dart
+++ b/test/core/widgets/animated_price_text_test.dart
@@ -88,6 +88,35 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets(
+        '#2972 — reduced motion: a price change does NOT kick the controller; '
+        'child renders at end-state', (tester) async {
+      Widget host(double price) => MediaQuery(
+            data: const MediaQueryData(disableAnimations: true),
+            child: MaterialApp(
+              home: Scaffold(
+                body: AnimatedPriceText(
+                  price: price,
+                  child: Text(price.toStringAsFixed(3)),
+                ),
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(host(1.699));
+      await tester.pumpAndSettle();
+
+      // A real price DROP that would normally fire the 500 ms bounce.
+      await tester.pumpWidget(host(1.499));
+      await tester.pump();
+
+      expect(tester.hasRunningAnimations, isFalse,
+          reason: 'With OS reduced-motion on, the flash must be skipped — no '
+              'running controller.');
+      // The new price is still shown (end-state), just without the flash.
+      expect(find.text('1.499'), findsOneWidget);
+    });
+
     testWidgets('does not animate when old or new price is null',
         (tester) async {
       await tester.pumpWidget(const MaterialApp(

--- a/test/core/widgets/staggered_fade_in_test.dart
+++ b/test/core/widgets/staggered_fade_in_test.dart
@@ -111,5 +111,41 @@ void main() {
         const Duration(milliseconds: 720),
       );
     });
+
+    testWidgets(
+        '#2972 — reduced motion: rows render at end-state (no FadeTransition '
+        'slice) even with the timeline at 0', (tester) async {
+      final controller = AnimationController(
+        vsync: const TestVSync(),
+        duration: StaggeredFadeIn.timelineDuration,
+      );
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(MediaQuery(
+        data: const MediaQueryData(disableAnimations: true),
+        child: MaterialApp(
+          home: Scaffold(
+            body: StaggeredFadeIn(
+              controller: controller,
+              index: 1000, // would normally fade in LAST.
+              child: const Text('card'),
+            ),
+          ),
+        ),
+      ));
+
+      // Timeline never advanced (value still 0). Without the guard the row
+      // would be invisible (opacity 0); with it the child is rendered
+      // directly with no FadeTransition driving its opacity.
+      expect(
+        find.descendant(
+          of: find.byType(StaggeredFadeIn),
+          matching: find.byType(FadeTransition),
+        ),
+        findsNothing,
+        reason: 'reduced motion bypasses the fade timeline entirely',
+      );
+      expect(find.text('card'), findsOneWidget);
+    });
   });
 }

--- a/test/features/map/presentation/widgets/station_cluster_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_cluster_layers_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/theme/dark_mode_colors.dart';
+import 'package:tankstellen/core/theme/price_band_colors.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_cluster_layers.dart';
+
+void main() {
+  group('countClusterDecoration (#2975 — brand-themed cluster bubble)', () {
+    testWidgets(
+        'the count-cluster bubble uses the brand price-band ramp, NOT the '
+        'plugin default primaryContainer', (tester) async {
+      late BoxDecoration decoration;
+      late ColorScheme scheme;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              decoration = countClusterDecoration(context);
+              scheme = Theme.of(context).colorScheme;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // The fill is the canonical cheap-band brand green (at 94% alpha),
+      // matching ClusterBadge — proving the count cluster shares the one
+      // map colour language.
+      expect(
+        decoration.color,
+        PriceBandColors.cheap.withValues(alpha: 0.94),
+      );
+      // It is explicitly NOT the old plugin-default primaryContainer.
+      expect(decoration.color, isNot(scheme.primaryContainer));
+      // Round bubble, white hairline, one drop shadow — the ClusterBadge
+      // grammar.
+      expect(decoration.shape, BoxShape.circle);
+      expect(decoration.boxShadow, hasLength(1));
+      expect((decoration.border as Border).top.color,
+          Colors.white.withValues(alpha: 0.85));
+    });
+
+    testWidgets('the shadow comes from the dark-mode map-overlay token',
+        (tester) async {
+      // The bubble shadow must be exactly the shared map-overlay shadow token
+      // (the same one the legend / zoom buttons use), not a hard-coded colour
+      // — so it adapts to dark mode like the rest of the map chrome.
+      late Color shadow;
+      late Color token;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(builder: (context) {
+            shadow = countClusterDecoration(context).boxShadow!.first.color;
+            token = DarkModeColors.mapOverlayShadow(context);
+            return const SizedBox.shrink();
+          }),
+        ),
+      );
+      expect(shadow, token);
+    });
+  });
+}

--- a/test/features/map/presentation/widgets/station_marker_test.dart
+++ b/test/features/map/presentation/widgets/station_marker_test.dart
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/price_band_colors.dart';
+import 'package:tankstellen/core/widgets/animated_price_text.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_marker.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
@@ -508,6 +510,65 @@ void main() {
       // reader user can find it (#566).
       expect(find.bySemanticsLabel(RegExp(r'STAR.*1[.,]7')), findsOneWidget);
       handle.dispose();
+    });
+  });
+
+  group('StationMarkerBuilder price-flash — selected only (#2973)', () {
+    Future<void> pumpMarker(WidgetTester tester, Marker marker) =>
+        pumpApp(
+          tester,
+          SizedBox(
+            width: marker.width,
+            height: marker.height,
+            child: (((marker.child as RepaintBoundary).child as Semantics)
+                    .child as GestureDetector)
+                .child,
+          ),
+        );
+
+    testWidgets('the SELECTED marker wraps its price in AnimatedPriceText',
+        (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        testStation, // e10 = 1.799
+        FuelType.e10,
+        1.50,
+        2.00,
+        selected: true,
+      );
+      await pumpMarker(tester, marker);
+      expect(find.byType(AnimatedPriceText), findsOneWidget,
+          reason: 'the chosen station flashes on a price refresh');
+      expect(find.text('1,799'), findsOneWidget);
+    });
+
+    testWidgets('an UN-selected bubble has NO AnimatedPriceText',
+        (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        testStation,
+        FuelType.e10,
+        1.50,
+        2.00,
+        // selected defaults to false.
+      );
+      await pumpMarker(tester, marker);
+      expect(find.byType(AnimatedPriceText), findsNothing,
+          reason: 'the flash must never run across the whole marker layer — '
+              'only the selected marker animates');
+    });
+
+    testWidgets('a compact dot has NO AnimatedPriceText', (tester) async {
+      final marker = StationMarkerBuilder.build(
+        tester.element(find.byType(Container).first),
+        testStation,
+        FuelType.e10,
+        1.50,
+        2.00,
+        compact: true,
+      );
+      await pumpMarker(tester, marker);
+      expect(find.byType(AnimatedPriceText), findsNothing);
     });
   });
 }

--- a/test/features/search/presentation/screens/radar_search_pip_controls_test.dart
+++ b/test/features/search/presentation/screens/radar_search_pip_controls_test.dart
@@ -115,6 +115,53 @@ void main() {
   });
 
   testWidgets(
+      '#2974 — tapping the radar pin button fires a selectionClick haptic',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+    final haptics = <String?>[];
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'HapticFeedback.vibrate') {
+        haptics.add(call.arguments as String?);
+      }
+      return null;
+    });
+    addTearDown(() => TestWidgetsFlutterBinding
+        .instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    final test = standardTestOverrides();
+    when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+    when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+    when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+    await pumpApp(
+      tester,
+      const SearchScreen(),
+      overrides: [
+        ...test.overrides,
+        userPositionNullOverride(),
+        wakelockFacadeProvider.overrideWithValue(_FakeWakelockFacade()),
+        radarSearchProvider.overrideWith(
+          () => _ActiveRadar([_station('NEAR')]),
+        ),
+      ],
+    );
+
+    // The radar starts unpinned (auto-pin preference defaults are mocked off
+    // in the standard overrides). Tapping the pin button must buzz.
+    haptics.clear();
+    await tester.tap(find.byKey(const Key('radarPinButton')));
+    await tester.pumpAndSettle();
+
+    expect(haptics, contains('HapticFeedbackType.selectionClick'),
+        reason: 'the pin TOGGLE fires a selection tick');
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets(
       'PiP small window with on-search radar active + a nearest station '
       'renders the trip price layout (no trip needed)', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
+import 'package:tankstellen/core/widgets/animated_price_text.dart';
 import 'package:tankstellen/core/widgets/station_card_shell.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
@@ -18,6 +19,13 @@ void main() {
       await pumpApp(tester, const AllPricesStationCard(station: testStation));
 
       expect(find.text('STAR'), findsOneWidget);
+    });
+
+    testWidgets('#2973 — wraps each priced fuel badge in AnimatedPriceText',
+        (tester) async {
+      // testStation has e5, e10, diesel → 3 priced badges, each flashable.
+      await pumpApp(tester, const AllPricesStationCard(station: testStation));
+      expect(find.byType(AnimatedPriceText), findsNWidgets(3));
     });
 
     testWidgets('renders address line when brand is present', (tester) async {

--- a/test/features/search/presentation/widgets/all_prices_station_card_test.dart
+++ b/test/features/search/presentation/widgets/all_prices_station_card_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/theme/fuel_colors.dart';
 import 'package:tankstellen/core/widgets/animated_price_text.dart';
@@ -157,6 +158,35 @@ void main() {
       await tester.pump();
 
       expect(favTapped, isTrue);
+    });
+
+    testWidgets('#2974 — the favourite toggle fires a selectionClick haptic',
+        (tester) async {
+      final haptics = <String?>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'HapticFeedback.vibrate') {
+            haptics.add(call.arguments as String?);
+          }
+          return null;
+        },
+      );
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await pumpApp(
+        tester,
+        AllPricesStationCard(
+          station: testStation,
+          onFavoriteTap: () {},
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.star_border));
+      await tester.pump();
+
+      expect(haptics, ['HapticFeedbackType.selectionClick']);
     });
 
     testWidgets('highlights cheapest price badge', (tester) async {

--- a/test/features/search/presentation/widgets/fuel_type_selector_test.dart
+++ b/test/features/search/presentation/widgets/fuel_type_selector_test.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/country/country_config.dart';
@@ -117,6 +118,47 @@ void main() {
       final chips = tester.widgetList<ChoiceChip>(find.byType(ChoiceChip));
       final e10Chip = chips.firstWhere((c) => (c.label as Text).data == 'Super E10');
       expect(e10Chip.selected, isTrue);
+    });
+
+    testWidgets(
+        '#2974 — tapping a fuel chip fires a selectionClick haptic, '
+        'a scroll does NOT', (tester) async {
+      final storage = mockHiveStorageOverride();
+      when(() => storage.mock.getActiveProfileId()).thenReturn(null);
+      when(() => storage.mock.getSetting(any())).thenReturn(null);
+
+      final haptics = <String?>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'HapticFeedback.vibrate') {
+            haptics.add(call.arguments as String?);
+          }
+          return null;
+        },
+      );
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await pumpApp(
+        tester,
+        const FuelTypeSelector(),
+        overrides: [
+          storage.override,
+          activeCountryOverride(Countries.germany),
+          selectedFuelTypeOverride(FuelType.all),
+        ],
+      );
+
+      // A scroll over the horizontal chip strip must NOT buzz.
+      await tester.drag(find.byType(SingleChildScrollView), const Offset(-80, 0));
+      await tester.pumpAndSettle();
+      expect(haptics, isEmpty, reason: 'scroll must never fire a haptic');
+
+      // A discrete chip tap fires exactly one selectionClick.
+      await tester.tap(find.text('Super E10'));
+      await tester.pumpAndSettle();
+      expect(haptics, ['HapticFeedbackType.selectionClick']);
     });
 
     testWidgets('has correct semantics labels', (tester) async {

--- a/test/features/station_detail/presentation/widgets/price_tile_test.dart
+++ b/test/features/station_detail/presentation/widgets/price_tile_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/widgets/animated_price_text.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
 import 'package:tankstellen/features/station_detail/presentation/widgets/price_tile.dart';
 
@@ -43,6 +44,39 @@ void main() {
       expect(find.byType(ListTile), findsNothing);
       // Should use a Row-based layout with gas station icon
       expect(find.byIcon(Icons.local_gas_station), findsOneWidget);
+    });
+
+    testWidgets('#2973 — wraps the price in an AnimatedPriceText',
+        (tester) async {
+      await pumpApp(
+        tester,
+        const PriceTile(
+            label: 'Diesel', price: 1.459, fuelType: FuelType.diesel),
+      );
+      expect(find.byType(AnimatedPriceText), findsOneWidget);
+    });
+
+    testWidgets('#2973 — a price change flashes (controller runs)',
+        (tester) async {
+      Widget host(double price) => MaterialApp(
+            home: Scaffold(
+              body: PriceTile(
+                label: 'Diesel',
+                price: price,
+                fuelType: FuelType.diesel,
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(host(1.699));
+      await tester.pumpAndSettle();
+
+      // A real drop must kick the flash controller.
+      await tester.pumpWidget(host(1.499));
+      await tester.pump();
+      expect(tester.hasRunningAnimations, isTrue,
+          reason: 'a price drop on the detail tile must flash');
+      await tester.pumpAndSettle();
     });
 
     testWidgets('vertical padding is compact (4dp)', (tester) async {

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -464,7 +464,11 @@ void main() {
     // getter / `initialCameraFit` substitution that frames the explicit
     // bounds (route mode: the full itinerary) instead of the search circle.
     // Null path unchanged (nearby mode). Decomposition tracked by #2187/#2188.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 622,
+    // #2974 — re-grandfathered 622 → 625: the marker-selection haptic wraps
+    // the onStationTap callback once (3 lines: the selectionClick + the
+    // delegate + its dartdoc) so a marker tap that selects a list row buzzes
+    // like the other everyday tap surfaces. Decomposition still #2187/#2188.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 625,
     // #2681 — feature_management_section.dart graduated: the #2681 ordered-
     // category reorg decomposed the 718-line god-class into the
     // widgets/feature_management/ folder (conso_feature_card.dart,


### PR DESCRIPTION
A cohesive interaction & motion polish pass — 4 small, additive facets on top of the Epic-#2487 design system. All free / on-device / pattern-only. No new ARB strings, no new dependencies.

## Facet 1 — Reduced-motion guard (a11y) · closes #2972
- New `AppMotion.enabled(BuildContext)` (`!MediaQuery.disableAnimationsOf(context)`) — reads the OS "remove animations" / "reduce motion" flag. No in-app toggle, no string.
- Retrofitted so motion short-circuits to its END-STATE when disabled: `AnimatedPriceText` (skips the flash), `StaggeredFadeIn` (renders fully opaque), `ProximityFillBar` (zero-duration tween), `AnimatedSplash` (jumps the controller to its end via `didChangeDependencies`).
- Trip-detail / OBD2 controllers intentionally untouched (sibling PRs own them).

## Facet 2 — Price-flash everywhere prices live · closes #2973
- Reuses the existing `AnimatedPriceText` (no new widget) on: station-detail `PriceTile` rows, the all-prices card per-fuel badges, the search card alternative-fuel rows, and the SELECTED map marker only.
- Map perf rule honoured: the flash wraps the selected marker's price only — every un-selected bubble, every compact dot and the cluster badge stay inert, so the flash never runs across the whole marker layer. Tests assert selected-has / un-selected-has-not.
- Every flash inherits the Facet-1 reduced-motion guard.

## Facet 3 — Haptics on the everyday tap surfaces · closes #2974
- `selectionClick` on the radar pin toggle, the per-fuel chip re-search, the favourite toggle (both station cards) and map marker selection; `lightImpact` on the radar-pin action (`enablePinNow`). Mirrors the `haptic_eco_coach` intensity conventions — selectionClick/lightImpact only, never heavyImpact.
- Bound to discrete `onSelected` / `onTap` callbacks → never fires on scroll. Tests capture the `SystemChannels.platform` handler: a chip / favourite / pin tap each fire exactly one `selectionClick`; a scroll over the chip strip fires none.

## Facet 4 — Brand-themed map cluster bubbles · closes #2975
- The count-cluster fallback bubble was the only map element still on the plugin-default `colorScheme.primaryContainer`; themed onto `PriceBandColors.cheap` (the brand-green leitmotiv) with the same white hairline + dark-mode map-overlay shadow token as `ClusterBadge`.
- Static theming only — no per-frame animation in the cluster builder. Decoration extracted to `countClusterDecoration(context)` for a focused unit test.

## Gates
- `flutter analyze` clean (lib + touched tests; the 2 remaining repo-wide `info` lints are pre-existing in the sibling trip-capture test files, untouched here).
- 1494 tests green across core widgets/theme, search, map, favorites, station_detail, animated_splash, and the file-length + no-hardcoded-strings lints.
- Zero ARB drift (no new strings), zero codegen drift (no @riverpod/freezed touched).
- `station_map_layers.dart` file-length snapshot re-grandfathered 622→625 with a justification comment (a 3-line haptic wrap on an already-grandfathered file; decomposition still tracked by #2187/#2188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)