### PR TITLE
docs(store): add/refresh F-Droid Summary + Description (en/de/fr) (#2876)

### DIFF
--- a/fastlane/metadata/android/de-DE/full_description.txt
+++ b/fastlane/metadata/android/de-DE/full_description.txt
@@ -28,7 +28,7 @@ FAHRTENBUCH & ECO-COACHING
 • Eco-Coaching markiert Spritfresser mit Drosselklappen- und Drehzahl-Histogrammen und Monatsvergleich.
 
 MEHR
-• Live-Preis-Overlay bei Annäherung, Homescreen-Widget und Sprachansagen während der Fahrt.
+• Live-Preis-Overlay bei Annäherung, Homescreen-Widget, Android Auto und Sprachansagen während der Fahrt.
 • Presets Basic / Medium / Voll passen die App an; mehrere Profile möglich.
 • Privacy-Dashboard zum Ansehen, Exportieren oder vollständigen Löschen aller Daten. Optionale TankSync-Synchronisation.
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -28,7 +28,7 @@ TRIP LOGBOOK & ECO-COACHING
 • Eco-coaching flags wasteful behaviour with throttle and RPM histograms and monthly comparisons.
 
 MORE
-• Approach-station live-price overlay, home-screen widget and voice announcements while driving.
+• Approach-station live-price overlay, home-screen widget, Android Auto and voice announcements while driving.
 • Basic / Medium / Full presets right-size the app; multiple profiles supported.
 • Privacy Dashboard to see, export or delete all your data. Optional TankSync cross-device sync.
 

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -28,7 +28,7 @@ CARNET DE BORD & ÉCO-CONDUITE
 • L'éco-conduite repère les gaspillages avec histogrammes d'accélérateur et de régime et comparaison mensuelle.
 
 PLUS
-• Affichage du prix en direct à l'approche, widget d'accueil et annonces vocales pendant la conduite.
+• Affichage du prix en direct à l'approche, widget d'accueil, Android Auto et annonces vocales pendant la conduite.
 • Préréglages Basic / Medium / Complet pour adapter l'appli ; plusieurs profils possibles.
 • Tableau de bord Confidentialité pour voir, exporter ou tout supprimer. Synchronisation TankSync optionnelle.
 


### PR DESCRIPTION
## What

Part A (text) of #2876 — F-Droid store presentation.

F-Droid reads its **Summary** from `short_description.txt` and its full
**Description** from `full_description.txt` under
`fastlane/metadata/android/<locale>/` (the same fastlane layout Play uses).

### Audit
`fastlane/metadata/android/` already held **6 locales** — en-US, de-DE,
fr-FR, es-ES, it-IT, pt-PT — each with `title.txt`, `short_description.txt`
and `full_description.txt`. They are accurate, brand-correct (Sparkilo),
mention open-source MIT / privacy / no-ads / 17 countries, and contain no
F-Droid-banned promotional superlatives. Summaries are all ≤ 80 chars
(en 74, de 70, fr 73). No metadata-lint test exists in `test/`.

### Change
The only real shipped feature missing from the prose was **Android Auto**
(`androidx.car.app` `CarAppService` + Car screens). Added a concise mention
to the "MORE" feature list in the three required locales (en/de/fr). No
title changes, no other text edits.

## Not in scope
- Screenshots are **deferred** — they need on-device capture from the
  maintainer. `screenshots/`/`images/` folders untouched. #2876 stays open
  for that.
- No app code / no ARB / no l10n pipeline / no codegen (metadata text files
  only).

Refs #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)
