### PR TITLE
fix(radar): closeness bar must be absolute (fuller=closer, fixed scale), not relative-to-list — span model rejected

### DIFF
--- a/lib/core/utils/radar_closeness.dart
+++ b/lib/core/utils/radar_closeness.dart
@@ -1,38 +1,64 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import '../../features/search/domain/entities/station.dart';
+import 'dart:math' as math;
+
+/// The maintainer-tunable upper bound (in metres) on the list closeness bar's
+/// absolute scale. Default 15 km (#2984).
+///
+/// The list bar scales each fill against `min(searchRadiusMeters, this)`, so
+/// this cap keeps the scale — and therefore every station's fill — stable and
+/// readable even when the user opens the search radius wide: a 2.5 km forecourt
+/// reads the SAME fill at a 15 km, 20 km or 25 km radius. Lower it for a
+/// tighter "near = full" feel; raise it (up to the 25 km radius ceiling) for a
+/// gentler ramp. This is the single knob for the absolute list scale — tune it
+/// HERE.
+const double kRadarClosenessScaleCapMeters = 15000;
 
 /// The single source of truth for the Fuel Station Radar "closeness" signal —
-/// the green fill that grows as the driver nears a station (#2956, root-cause
-/// reimplementation of #2661 / #2808 / #2899 / #2901 / #2944).
+/// the green fill that grows as the driver nears a station (#2984, supersedes
+/// the rejected relative-to-span model of #2956/#2959; lineage #2661 / #2808 /
+/// #2899 / #2901 / #2944).
 ///
 /// All three radar surfaces — the search-results list card, the recording PiP
 /// overlay, and the trip radar card — compute closeness through THIS helper so
 /// they can never desync again. The bar widget ([ProximityFillBar]) is
 /// paint-only and delegates its fill arithmetic here.
 ///
-/// ## Why prior fixes kept missing it
+/// ## The model: ABSOLUTE, fixed scale (fuller = closer)
 ///
-/// The fill formula itself was always correct:
+/// The fill formula is the same everywhere:
 ///
 /// ```
-/// fill = clamp(1 - distanceMeters / radiusMeters, 0, 1)
+/// fill = clamp(1 - distanceMeters / scaleMeters, 0, 1)
 /// ```
 ///
-/// The defect was the **radius** each surface scaled against. Every surface
-/// fed a *statically configured* radius (the 1 km approach geo-fence, or the
-/// `searchRadiusProvider` slider — up to 25 km) that is **decoupled from where
-/// the surfaced stations actually are**. When the configured radius is large
-/// relative to the real spread of results, `distance / radius` is small for
-/// EVERY row, so `1 - distance/radius` clusters near 1.0 and all bars look the
-/// same length — exactly the recurring field report (265 m, 9.3 km, 9.9 km,
-/// 10.0 km all rendering ~identical bars under a 25 km slider).
+/// What each surface differs in is the **scale** it divides against — and the
+/// scale is always an *absolute* distance, never derived from the result set:
 ///
-/// The fix for a *list* surface is to scale closeness against the **span the
-/// results actually occupy** — the farthest surfaced station's distance — so
-/// the nearest forecourt reads near-full and the farthest near-empty,
-/// regardless of the config knob. See [spanRadiusMeters].
+///  * The trip card + PiP scale to the **approach radius** (`profile
+///    .approachRadiusKm`) — the geofence the driver is approaching.
+///  * The list scales to [listScaleMeters] — `min(searchRadiusMeters,
+///    kRadarClosenessScaleCapMeters)` — the user's configured radar radius,
+///    clamped to the tunable cap.
+///
+/// So the bar means "how close is THIS station, on a stable absolute scale":
+///
+///  * **Stable** — a 2.5 km station reads the SAME fill no matter what else is
+///    in the list (the scale depends only on the radius setting + the cap, not
+///    on the surfaced set).
+///  * **Closer = fuller, nothing force-emptied** — the farthest row is never
+///    pinned to 0% just for being last; it only nears empty if it is genuinely
+///    near/beyond the scale.
+///
+/// ## Why the relative-to-span model was rejected (#2984)
+///
+/// #2959 scaled the list to the farthest surfaced station's distance (the
+/// "span"). That made the fill *relative to the current list*: the farthest
+/// station was always pinned to 0% even when genuinely near, and a given
+/// station's fill changed whenever the result set changed (filter, refresh, a
+/// far outlier appearing/disappearing). The maintainer rejected it for this
+/// absolute, stable scale.
 class RadarCloseness {
   const RadarCloseness._();
 
@@ -47,25 +73,17 @@ class RadarCloseness {
     return raw.clamp(0.0, 1.0);
   }
 
-  /// The radius (in metres) a *list* of radar results should scale its
-  /// closeness bars to: the distance of the FARTHEST surfaced station (the
-  /// actual span of the visible set), so closeness reads as RELATIVE position
-  /// across the list — nearest near-full, farthest near-empty — instead of
-  /// every row pinning toward full against an oversized config radius (#2956).
+  /// The absolute scale (in metres) the radar *list* closeness bars divide
+  /// against: `min(searchRadiusMeters, kRadarClosenessScaleCapMeters)` (#2984).
   ///
-  /// `station.dist` is the great-circle distance in KILOMETRES (the same value
-  /// the card's distance text shows), so the result is `maxDist * 1000`.
-  ///
-  /// Returns `null` — collapsing the bar — when the set is empty or carries no
-  /// positive distance (e.g. an unlocated test fixture), so callers can render
-  /// the bar unconditionally and it simply hides when there is nothing to
-  /// scale against.
-  static double? spanRadiusMeters(Iterable<Station> stations) {
-    var maxDistKm = 0.0;
-    for (final s in stations) {
-      if (s.dist > maxDistKm) maxDistKm = s.dist;
-    }
-    if (maxDistKm <= 0) return null;
-    return maxDistKm * 1000.0;
+  /// [searchRadiusMeters] is the user's configured radar/search radius in
+  /// metres (`searchRadiusProvider` km → m). The result is independent of the
+  /// surfaced result set, so every station's fill is stable — the key property
+  /// the rejected span model lacked. A non-positive / non-finite radius yields
+  /// `null` so callers can collapse the bar instead of dividing by a
+  /// degenerate scale.
+  static double? listScaleMeters(double searchRadiusMeters) {
+    if (searchRadiusMeters <= 0 || !searchRadiusMeters.isFinite) return null;
+    return math.min(searchRadiusMeters, kRadarClosenessScaleCapMeters);
   }
 }

--- a/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
+++ b/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
@@ -12,7 +12,8 @@ import '../../../../l10n/app_localizations.dart';
 /// Corporate-green, battery-style proximity FILL BAR for the Fuel Station
 /// Radar card + PiP price layouts (#2661).
 ///
-/// The fill encodes how close the driver is to the radar station:
+/// The fill encodes how close the driver is to the radar station against an
+/// ABSOLUTE, fixed scale ([radiusMeters]) — fuller = closer (#2984):
 ///
 /// ```
 /// fill = clamp(1 - distanceMeters / radiusMeters, 0, 1)
@@ -35,8 +36,11 @@ class ProximityFillBar extends StatelessWidget {
   /// Distance from the driver to the radar station, in metres.
   final double distanceMeters;
 
-  /// The radar's indicated radius in metres (`profile.approachRadiusKm *
-  /// 1000`). The fill hits 0% here and 100% at the station.
+  /// The ABSOLUTE scale in metres the fill divides against — fixed per surface,
+  /// never derived from the result set (#2984). The trip card + PiP pass the
+  /// approach radius (`profile.approachRadiusKm * 1000`); the search list passes
+  /// `min(searchRadius, kRadarClosenessScaleCapMeters)`. The fill hits 0% here
+  /// and 100% at the station.
   final double? radiusMeters;
 
   /// Bar height — thinner in the dense PiP price column, taller on the card.

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -334,19 +334,21 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
     );
     final stationRating = ref.watch(stationRatingProvider(station.id));
 
-    // #2956 — when the on-search Fuel Station Radar owns the result list, each
+    // #2984 — when the on-search Fuel Station Radar owns the result list, each
     // card carries the green→accent closeness bar (the SAME [ProximityFillBar]
-    // / [RadarCloseness] as the trip card + PiP). The bar scales to the SPAN of
-    // the surfaced results — the farthest station's distance — NOT the static
-    // `searchRadiusProvider` slider. The slider (up to 25 km) is decoupled from
-    // where the stations actually are, so scaling to it compressed every fill
-    // toward 1.0 and made all bars look the same length (the recurring #2956
-    // field report). Scaling to the result span makes closeness read RELATIVE
-    // across the list: the nearest forecourt near-full, the farthest near-empty.
-    // Null off radar mode (or an unlocated/empty set) → regular cards unchanged.
+    // / [RadarCloseness] as the trip card + PiP). The bar uses an ABSOLUTE,
+    // fixed scale: `min(searchRadiusMeters, kRadarClosenessScaleCapMeters)` —
+    // the user's configured radar radius (km → m), clamped to the tunable cap.
+    // So the fill means "how close is THIS station on a stable scale": a 2.5 km
+    // forecourt reads the same fill regardless of what else is in the list, and
+    // the farthest row is never force-emptied just for being last. This REPLACES
+    // the relative-to-span model (#2956/#2959), which made each fill depend on
+    // the result set and pinned the farthest station to 0% — rejected by the
+    // maintainer. Null off radar mode (or a degenerate radius) → regular cards.
     final radar = ref.watch(radarSearchProvider);
     final closenessRadiusMeters = radar.active
-        ? RadarCloseness.spanRadiusMeters(radar.stations.value ?? const [])
+        ? RadarCloseness.listScaleMeters(
+            ref.watch(searchRadiusProvider) * 1000.0)
         : null;
 
     return SwipeableStationCard(

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -48,9 +48,11 @@ class _StationDetails extends StatelessWidget {
   final Station station;
   final bool hasBrand;
 
-  /// #2899 — when non-null, the Fuel Station Radar "closeness" bar is rendered
-  /// under the distance row, scaled to this radius (the search radius, in
-  /// metres). Null on the regular search list, so the card is unchanged there.
+  /// #2899/#2984 — when non-null, the Fuel Station Radar "closeness" bar is
+  /// rendered under the distance row, scaled to this ABSOLUTE radius in metres
+  /// (`min(searchRadius, kRadarClosenessScaleCapMeters)` — a fixed scale that
+  /// does not depend on the result set, so a near station's fill is stable).
+  /// Null on the regular search list, so the card is unchanged there.
   final double? closenessRadiusMeters;
 
   const _StationDetails({
@@ -139,13 +141,15 @@ class _StationDetails extends StatelessWidget {
             ],
           ],
         ),
-        // #2899 — Fuel Station Radar closeness bar: the SAME green→accent
+        // #2899/#2984 — Fuel Station Radar closeness bar: the SAME green→accent
         // [ProximityFillBar] the trip radar card + PiP overlay use, so all
         // three radar surfaces fill identically as the driver nears a station.
         // `station.dist` is the great-circle distance in km → metres for the
-        // bar; it scales to the search radius (see [StationCard]). Live: the
-        // radar re-stamps `dist` on each scan, so the bar re-fills as the
-        // result set refreshes around the moving user.
+        // bar; it scales to an ABSOLUTE fixed radius (`closenessRadiusMeters` =
+        // min(searchRadius, cap), see [StationCard]), so closer = fuller and a
+        // given station's fill is stable across result-set changes. Live: the
+        // radar re-stamps `dist` on each scan, so the bar re-fills as the user
+        // moves — the SCALE stays put, only the distance changes.
         if (closenessRadiusMeters != null) ...[
           const SizedBox(height: Spacing.xs),
           ProximityFillBar(

--- a/test/core/utils/radar_closeness_test.dart
+++ b/test/core/utils/radar_closeness_test.dart
@@ -1,27 +1,16 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:math' as math;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/utils/radar_closeness.dart';
-import 'package:tankstellen/features/search/domain/entities/station.dart';
 
-/// #2956 — unit pins for the shared Fuel Station Radar closeness helper. The
+/// #2984 — unit pins for the shared Fuel Station Radar closeness helper. The
 /// real radar list-card surface is exercised in `radar_closeness_bar_test.dart`
-/// (the regression lock); this file pins the arithmetic + the never-throws
-/// contract the helper documents.
-
-Station _at(double distKm) => Station(
-      id: 'd-$distKm',
-      name: 'n',
-      brand: '',
-      street: '',
-      postCode: '',
-      place: '',
-      lat: 0,
-      lng: 0,
-      dist: distKm,
-      isOpen: true,
-    );
+/// (the regression lock) and `radar_closeness_absolute_test.dart` (the absolute
+/// stability lock); this file pins the arithmetic + the never-throws contract
+/// the helper documents.
 
 void main() {
   group('RadarCloseness.fillFor — the canonical fill fraction', () {
@@ -43,22 +32,44 @@ void main() {
     });
   });
 
-  group('RadarCloseness.spanRadiusMeters — scale to the result span', () {
-    test('is the farthest surfaced station distance, in metres', () {
-      final stations = [_at(0.265), _at(9.3), _at(9.9), _at(10.0)];
-      expect(RadarCloseness.spanRadiusMeters(stations), closeTo(10000, 1e-6));
+  group('RadarCloseness.listScaleMeters — the ABSOLUTE list scale (#2984)', () {
+    test('is the search radius, clamped to the tunable cap', () {
+      // Below the cap → the radius itself.
+      expect(RadarCloseness.listScaleMeters(10000), 10000);
+      // At / above the cap → the cap (a wide radius does not stretch the scale).
+      expect(RadarCloseness.listScaleMeters(15000),
+          kRadarClosenessScaleCapMeters);
+      expect(RadarCloseness.listScaleMeters(25000),
+          kRadarClosenessScaleCapMeters);
+      expect(RadarCloseness.listScaleMeters(25000),
+          math.min(25000.0, kRadarClosenessScaleCapMeters));
     });
 
-    test('null for an empty or unlocated set (collapses the bar)', () {
-      expect(RadarCloseness.spanRadiusMeters(const []), isNull);
-      expect(RadarCloseness.spanRadiusMeters([_at(0)]), isNull);
+    test('the cap defaults to 15 km and is the maintainer-tunable knob', () {
+      expect(kRadarClosenessScaleCapMeters, 15000);
+    });
+
+    test('the worked examples on a 15 km scale (radius ≥ cap): '
+        '2.5≈0.83, 7.2≈0.52, 10.3≈0.31, 13≈0.13', () {
+      final scale = RadarCloseness.listScaleMeters(20000)!; // → 15 km cap
+      expect(RadarCloseness.fillFor(2500, scale), closeTo(0.8333, 1e-3));
+      expect(RadarCloseness.fillFor(7200, scale), closeTo(0.52, 1e-3));
+      expect(RadarCloseness.fillFor(10300, scale), closeTo(0.3133, 1e-3));
+      expect(RadarCloseness.fillFor(13000, scale), closeTo(0.1333, 1e-3));
+    });
+
+    test('null for a degenerate radius (collapses the bar)', () {
+      expect(RadarCloseness.listScaleMeters(0), isNull);
+      expect(RadarCloseness.listScaleMeters(-1), isNull);
+      expect(RadarCloseness.listScaleMeters(double.nan), isNull);
+      expect(RadarCloseness.listScaleMeters(double.infinity), isNull);
     });
   });
 
   // The helper documents "Never throws" — pin the fault paths so a degenerate
   // input (the kind that produced the recurring divide-by-zero / NaN scaling
-  // bugs) returns normally instead of blowing up the card build (#2956).
-  group('RadarCloseness — never-throws contract (#2956)', () {
+  // bugs) returns normally instead of blowing up the card build (#2984).
+  group('RadarCloseness — never-throws contract (#2984)', () {
     test('fillFor returns normally on a degenerate / non-finite radius', () {
       expect(() => RadarCloseness.fillFor(100, 0), returnsNormally);
       expect(() => RadarCloseness.fillFor(100, -1), returnsNormally);
@@ -70,8 +81,9 @@ void main() {
       expect(RadarCloseness.fillFor(100, double.infinity), 0.0);
     });
 
-    test('spanRadiusMeters returns normally on an empty set', () {
-      expect(() => RadarCloseness.spanRadiusMeters(const []), returnsNormally);
+    test('listScaleMeters returns normally on a degenerate radius', () {
+      expect(() => RadarCloseness.listScaleMeters(0), returnsNormally);
+      expect(() => RadarCloseness.listScaleMeters(double.nan), returnsNormally);
     });
   });
 }

--- a/test/features/search/presentation/widgets/radar_closeness_absolute_test.dart
+++ b/test/features/search/presentation/widgets/radar_closeness_absolute_test.dart
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tankstellen/core/utils/radar_closeness.dart';
+import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #2984 — the Fuel Station Radar list closeness bar uses an ABSOLUTE,
+/// FIXED-SCALE model: the maintainer rejected the relative-to-span model of
+/// #2959 (root-cause reimplementation of #2956).
+///
+/// "How close is THIS station, on a stable absolute scale" — fuller = closer:
+///
+/// ```
+/// scale = min(searchRadiusMeters, kRadarClosenessScaleCapMeters)
+/// fill  = clamp(1 - distanceMeters / scale, 0, 1)
+/// ```
+///
+/// These tests drive the REAL radar list-card path (`SearchResultsContent` →
+/// `SearchResultsList` → `StationCard` → `ProximityFillBar`) with the radar
+/// active and read the fill the rendered bar would paint. The crux is the
+/// STABILITY property: a near station reads the SAME fill no matter what else
+/// is in the list. On master (the span model) removing the far station changes
+/// the near fill → RED; with the absolute scale → IDENTICAL → GREEN.
+
+/// A radar station at [distKm] from the user (km — the value the card text
+/// shows). Carries an E10 price so the fuel filter keeps it.
+Station _at(String id, double distKm) => Station(
+      id: id,
+      name: 'Station $id',
+      brand: '',
+      street: '$id street',
+      postCode: '00000',
+      place: 'Town',
+      lat: 43.0 + distKm / 100.0,
+      lng: 3.0,
+      dist: distKm,
+      e10: 1.799,
+      isOpen: true,
+    );
+
+/// The four-station validation set: 2.5 / 7.2 / 10.3 / 13 km.
+List<Station> _fourStations() => [
+      _at('s-2', 2.5),
+      _at('s-7', 7.2),
+      _at('s-10', 10.3),
+      _at('s-13', 13.0),
+    ];
+
+class _ActiveRadar extends RadarSearch {
+  _ActiveRadar(this._stations);
+  final List<Station> _stations;
+
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(_stations),
+      );
+}
+
+/// The fill the rendered [ProximityFillBar] for [station] would paint — read
+/// straight off the widget the real card path built. Not a hand-rolled value:
+/// exactly what the surface displays.
+double _renderedFillFor(WidgetTester tester, Station station) {
+  final card = find.byKey(ValueKey('station-${station.id}'));
+  expect(card, findsOneWidget,
+      reason: 'the radar list must render a card for ${station.id}');
+  final bar = tester.widget<ProximityFillBar>(
+    find.descendant(of: card, matching: find.byType(ProximityFillBar)),
+  );
+  expect(bar.distanceMeters, closeTo(station.dist * 1000.0, 1e-6),
+      reason: 'the bar must use station.dist (the same value the text shows)');
+  return ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!);
+}
+
+Future<void> _pumpRadar(
+  WidgetTester tester, {
+  required List<Station> stations,
+  required double radiusKm,
+}) async {
+  final test = standardTestOverrides();
+  when(() => test.mockStorage.hasApiKey()).thenReturn(false);
+  when(() => test.mockStorage.getIgnoredIds()).thenReturn(<String>[]);
+  when(() => test.mockStorage.getRatings()).thenReturn(const <String, int>{});
+
+  await pumpApp(
+    tester,
+    SearchResultsContent(onGpsRetry: () async {}),
+    overrides: [
+      ...test.overrides,
+      userPositionNullOverride(),
+      radarSearchProvider.overrideWith(() => _ActiveRadar(stations)),
+      searchRadiusOverride(radiusKm),
+    ].cast(),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('radar list closeness bar — ABSOLUTE fixed scale (#2984)', () {
+    // The configured radius (20 km) exceeds the 15 km cap, so the scale is the
+    // 15 km cap for every station regardless of the result set.
+    const radiusKm = 20.0;
+    final scaleMeters =
+        math.min(radiusKm * 1000.0, kRadarClosenessScaleCapMeters);
+
+    testWidgets('fill is strictly DECREASING with distance (closer = fuller)',
+        (tester) async {
+      await _pumpRadar(tester, stations: _fourStations(), radiusKm: radiusKm);
+
+      final s = _fourStations();
+      final f2 = _renderedFillFor(tester, s[0]); // 2.5 km
+      final f7 = _renderedFillFor(tester, s[1]); // 7.2 km
+      final f10 = _renderedFillFor(tester, s[2]); // 10.3 km
+      final f13 = _renderedFillFor(tester, s[3]); // 13 km
+
+      expect(f2, greaterThan(f7));
+      expect(f7, greaterThan(f10));
+      expect(f10, greaterThan(f13));
+    });
+
+    testWidgets(
+        'STABILITY: the 2.5 km fill is IDENTICAL with or without the 13 km '
+        'station (scale depends on the radius + cap, NOT the result set)',
+        (tester) async {
+      // With the far (13 km) station present.
+      await _pumpRadar(tester, stations: _fourStations(), radiusKm: radiusKm);
+      final withFar = _renderedFillFor(tester, _at('s-2', 2.5));
+
+      // Fully tear down the first tree so the second pump renders a fresh
+      // list (a bare second pumpWidget reuses the element tree).
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      // Without it: drop the 13 km outlier; the near station must NOT move.
+      final withoutFarSet = _fourStations()..removeLast();
+      await _pumpRadar(tester, stations: withoutFarSet, radiusKm: radiusKm);
+      final withoutFar = _renderedFillFor(tester, _at('s-2', 2.5));
+
+      expect(withoutFar, closeTo(withFar, 1e-9),
+          reason: 'an absolute scale must give the SAME near fill regardless '
+              'of whether a far station is in the list — on the span model '
+              'removing the far station changes the near fill');
+    });
+
+    testWidgets('the farthest station is NOT 0% (only nears empty near the '
+        'scale, never force-emptied)', (tester) async {
+      // 2.5 & 7.2 km: the farthest (7.2 km) reads ~52%, not empty — on the
+      // span model the farthest (the span edge) is pinned to 0%.
+      await _pumpRadar(
+        tester,
+        stations: [_at('s-2', 2.5), _at('s-7', 7.2)],
+        radiusKm: radiusKm,
+      );
+      final far = _renderedFillFor(tester, _at('s-7', 7.2));
+      expect(far, greaterThan(0.4),
+          reason: '7.2 km of a 15 km scale ≈ 0.52 — clearly NOT empty');
+      expect(far, closeTo(0.52, 1e-3));
+    });
+
+    testWidgets('the exact fills match the absolute formula for the '
+        'configured radius (scale = min(radius, cap))', (tester) async {
+      await _pumpRadar(tester, stations: _fourStations(), radiusKm: radiusKm);
+
+      final s = _fourStations();
+      for (final station in s) {
+        final expected =
+            RadarCloseness.fillFor(station.dist * 1000.0, scaleMeters);
+        expect(_renderedFillFor(tester, station), closeTo(expected, 1e-6),
+            reason: 'station ${station.id} (${station.dist} km) must read the '
+                'absolute fill for scale ${scaleMeters / 1000} km');
+      }
+
+      // The worked examples (scale = 15 km): ~83%, ~52%, ~31%, ~13%.
+      expect(_renderedFillFor(tester, s[0]), closeTo(0.8333, 1e-3));
+      expect(_renderedFillFor(tester, s[1]), closeTo(0.52, 1e-3));
+      expect(_renderedFillFor(tester, s[2]), closeTo(0.3133, 1e-3));
+      expect(_renderedFillFor(tester, s[3]), closeTo(0.1333, 1e-3));
+    });
+  });
+}

--- a/test/features/search/presentation/widgets/radar_closeness_bar_test.dart
+++ b/test/features/search/presentation/widgets/radar_closeness_bar_test.dart
@@ -15,19 +15,25 @@ import 'package:tankstellen/features/search/providers/radar_search_provider.dart
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 
-/// #2956 — root-cause pinning regression for the Fuel Station Radar "closeness"
-/// bar. The recurring field bug: the distance TEXT is correct but the closeness
-/// BAR under every station is ~the same length (it does not scale with
-/// distance) — because the bar scaled to the static `searchRadiusProvider`
-/// slider (up to 25 km), which is decoupled from where the stations actually
-/// are, so every fill compressed toward 1.0.
+/// #2956/#2984 — root-cause pinning regression for the Fuel Station Radar
+/// "closeness" bar. The recurring field bug: the distance TEXT is correct but
+/// the closeness BAR under every station is ~the same length (it does not scale
+/// with distance) — because the bar scaled to the static `searchRadiusProvider`
+/// slider (up to 25 km), which lets a wide radius compress every fill toward
+/// 1.0.
+///
+/// The fix (#2984) is an ABSOLUTE, fixed scale: `min(searchRadius, 15 km cap)`,
+/// so a wide radius no longer stretches the scale — the bars stay visibly
+/// different AND a near station's fill is stable across result-set changes (the
+/// stability lock lives in `radar_closeness_absolute_test.dart`).
 ///
 /// These tests drive the REAL radar list-card path (`SearchResultsContent` →
 /// `SearchResultsList` → `StationCard` → `ProximityFillBar`) with the exact
 /// screenshot distances (265 m, 9.3 km, 9.9 km, 10.0 km) and the field's 25 km
 /// slider, then read the fill the rendered bar would paint. RED on master (the
 /// far bars cluster at ~0.60–0.63, indistinguishable); green after the fix
-/// (scaled to the result span: nearest ~0.97, farthest 0.0).
+/// (scaled to the 15 km cap: nearest ~0.98, the far cluster spread around the
+/// 0.33–0.38 band — visibly different, none force-emptied).
 
 /// The four radar results from the field screenshot, distance-ranked.
 /// `dist` is kilometres (the same value the card distance text shows).
@@ -148,8 +154,9 @@ void main() {
   // invariant across all three radar surfaces.
   group('radar list-card closeness bar — the real surface (#2956)', () {
     testWidgets(
-        'scales to the result span: nearest near-full, farthest empty '
-        '(NOT the 25 km slider that compressed every bar)', (tester) async {
+        'scales to the ABSOLUTE 15 km cap: nearest near-full, the far cluster '
+        'visibly spread (NOT the 25 km slider that compressed every bar)',
+        (tester) async {
       await _pumpRadar(
         tester,
         stations: _screenshotStations(),
@@ -162,20 +169,22 @@ void main() {
       final farish = _renderedFillFor(tester, stations[2]); // 9.9 km
       final far = _renderedFillFor(tester, stations[3]); // 10.0 km
 
-      // Pinned to the result-span scale (farthest = 10 km), NOT the 25 km
-      // slider. These are the values the bar actually paints.
-      expect(near, closeTo(0.9735, 1e-3),
-          reason: '265 m of a 10 km span → ~0.97 (nearly full)');
-      expect(mid, closeTo(0.07, 1e-3), reason: '9.3 km of 10 km → ~0.07');
-      expect(farish, closeTo(0.01, 1e-3), reason: '9.9 km of 10 km → ~0.01');
-      expect(far, closeTo(0.0, 1e-6), reason: '10.0 km = the span edge → empty');
+      // Pinned to the ABSOLUTE scale = min(25 km, 15 km cap) = 15 km, NOT the
+      // 25 km slider. These are the values the bar actually paints. The far
+      // rows are NOT force-emptied — they sit around the 0.33–0.38 band.
+      expect(near, closeTo(0.9823, 1e-3),
+          reason: '265 m of a 15 km scale → ~0.98 (nearly full)');
+      expect(mid, closeTo(0.38, 1e-3), reason: '9.3 km of 15 km → ~0.38');
+      expect(farish, closeTo(0.34, 1e-3), reason: '9.9 km of 15 km → ~0.34');
+      expect(far, closeTo(0.3333, 1e-3),
+          reason: '10.0 km of 15 km → ~0.33 (NOT empty — never force-emptied)');
 
       // The core regression lock: the bars must be VISIBLY DIFFERENT down the
       // list. On master (scaled to the 25 km slider) the three far rows all sat
       // at ~0.60–0.63 — indistinguishable — which is the reported symptom.
-      expect(near - far, greaterThan(0.9),
-          reason: 'closest vs farthest must differ by nearly a full bar');
-      expect(mid - far, greaterThan(0.05),
+      expect(near - far, greaterThan(0.6),
+          reason: 'closest vs farthest must differ by most of the bar');
+      expect(mid - far, greaterThan(0.04),
           reason: 'mid vs far must be clearly distinct, not a compressed band');
       // Strictly monotonic: closer ⇒ fuller.
       expect(near, greaterThan(mid));


### PR DESCRIPTION
Closes #2984.

## What

Reimplements the Fuel Station Radar **list** closeness bar to an **ABSOLUTE, fixed-scale** model — the maintainer's explicit decision after the relative-to-span model (#2959) was rejected.

```
scale = min(searchRadiusMeters, kRadarClosenessScaleCapMeters)   // cap default 15 km
fill  = clamp(1 - distanceMeters / scale, 0, 1)                   // existing RadarCloseness.fillFor
```

The bar now means *"how close is THIS station, on a stable absolute scale"* — fuller = closer.

## Why

- **Stable:** a 2.5 km station shows the SAME fill regardless of what else is in the list (the scale depends only on the user's radius setting + the cap, never on the result set). This is the property the rejected span model lacked.
- **Closer = fuller, nothing force-emptied:** the farthest station is no longer pinned to 0% just for being farthest — it only nears empty if it is genuinely near/beyond the scale.

Worked examples (scale = 15 km): 2.5 km → ~83%, 7.2 km → ~52%, 10.3 km → ~31%, 13 km → ~13%.

## Changes (scope-limited)

- `lib/core/utils/radar_closeness.dart` — new tunable `kRadarClosenessScaleCapMeters` (default 15 km, the single knob), new `listScaleMeters(searchRadiusMeters)`, removed `spanRadiusMeters` (no remaining users), narrative rewritten to the absolute model.
- `lib/features/search/presentation/widgets/search_results_list.dart` — list now uses `RadarCloseness.listScaleMeters(searchRadius * 1000)` instead of the span.
- Doc comments in `station_card_status.dart` + `proximity_fill_bar.dart` rewritten to the absolute model.
- Tests: new `radar_closeness_absolute_test.dart` (real render path) + updated unit + bar tests.

The trip card / PiP scale to the approach radius (already absolute) and are **untouched**. No OBD2 / FR service / trip-capture / ARB changes.

## Tests — RED-on-master / green-after (real render path)

Drives `SearchResultsContent → SearchResultsList → StationCard → ProximityFillBar` with the radar active:

1. **Strictly decreasing** fill with distance (closer = fuller).
2. **STABILITY (the crux):** the 2.5 km fill is identical with or without the 13 km station. RED on master span model (0.757 without far vs 0.808 with far); GREEN after.
3. **Farthest is not 0%:** 7.2 km ≈ 0.52. RED on master (span pins it to 0.0); GREEN after.
4. **Exact absolute fills** match `min(radius, cap)`. RED on master (0.808 vs the absolute 0.833); GREEN after.

`flutter analyze` clean (full lib). Full core/utils + search suites green (1255 tests). No codegen drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)