### PR TITLE
feat(android-auto): v2 slice 1 — live Search via headless car-data bridge (snapshot fallback) (#2947)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,6 +703,26 @@ jobs:
       - name: Build App Bundle (release)
         if: github.event_name != 'pull_request'
         run: flutter build appbundle --release --flavor play
+      # #2947 — assert the MERGED play manifest declares ZERO
+      # FOREGROUND_SERVICE* permissions, so a future accidental FGS re-merge
+      # (the Android Auto v2 live bridge is a BOUND service, no FGS) trips CI
+      # here instead of surfacing as the opaque #1498 Play 403 on the
+      # Open-Testing upload. Mirrors the fdroid no-GMS gate pattern. The PR
+      # build produces playDebug's merged manifest; the master/tag build
+      # produces playRelease's. Audit whichever exists.
+      - name: Audit — zero FOREGROUND_SERVICE permissions (play)
+        if: always()
+        run: |
+          DEBUG_MANIFEST="build/app/intermediates/merged_manifests/playDebug/processPlayDebugManifest/AndroidManifest.xml"
+          RELEASE_MANIFEST="build/app/intermediates/merged_manifests/playRelease/processPlayReleaseManifest/AndroidManifest.xml"
+          if [ -f "$RELEASE_MANIFEST" ]; then
+            bash scripts/audit_no_fgs.sh "$RELEASE_MANIFEST"
+          elif [ -f "$DEBUG_MANIFEST" ]; then
+            bash scripts/audit_no_fgs.sh "$DEBUG_MANIFEST"
+          else
+            echo "::error::No merged play manifest found to audit for FGS permissions." >&2
+            exit 1
+          fi
       - name: Clean up decoded keystore
         if: always()
         run: rm -f "$RUNNER_TEMP/tankstellen-release.jks"

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarAppService.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarAppService.kt
@@ -11,22 +11,31 @@ import androidx.car.app.SessionInfo
 import androidx.car.app.validation.HostValidator
 
 /**
- * Android Auto car app service for Tankstellen.
+ * Android Auto / Automotive car app service for Tankstellen (epic #2946).
  *
- * Provides a car-optimized UI for browsing nearby fuel stations,
- * viewing prices, and navigating to stations. Communicates with
- * the Flutter app via MethodChannel through [CarDataBridge].
+ * A POI [CarAppService] that serves a car-optimised list+map UI for nearby fuel
+ * stations. It is a BOUND service the Android Auto / Automotive host binds via
+ * the `androidx.car.app.category.POI` intent-filter (declared in the `play`
+ * source set only) — it never starts itself as a foreground service, so it
+ * carries no FOREGROUND_SERVICE permission (#1498).
  *
  * ## Architecture
- * - CarAppService creates Sessions (one per connection)
- * - Each Session creates a NearbyScreen as the root
- * - Screens use CarDataBridge to fetch data from the Flutter/Dart side
- * - Navigation actions launch Google Maps / Waze via Intent
+ * - [CarAppService] creates one [TankstellenCarSession] per host connection.
+ * - The session's root is [de.tankstellen.tankstellen.car.MenuScreen]
+ *   (Search + Radar), which pushes
+ *   [de.tankstellen.tankstellen.car.SearchScreen] /
+ *   [de.tankstellen.tankstellen.car.RadarScreen]
+ *   (each a `PlaceListMapTemplate` over [de.tankstellen.tankstellen.car.CarStation]).
+ * - Data sources (v2 SLICE 1, #2947): the Search screen fetches LIVE through a
+ *   headless Flutter engine via [de.tankstellen.tankstellen.car.CarDataBridge]
+ *   (created/destroyed with the session lifecycle, no FGS). Radar still renders
+ *   the v1 SharedPreferences snapshot the in-app radar wrote (slice 2 wires its
+ *   live fetch).
  *
  * ## Limitations
- * - Android Auto templates limit UI to lists + detail views
- * - Max 6 items per list on most head units
- * - No custom rendering (no Canvas, no Maps in POI template)
+ * - Android Auto templates limit UI to lists + detail views.
+ * - The host caps list length on most head units.
+ * - No custom rendering (no Canvas; the host draws the POI map).
  */
 class TankstellenCarAppService : CarAppService() {
 

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarSession.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/TankstellenCarSession.kt
@@ -6,18 +6,40 @@ package de.tankstellen.tankstellen
 import android.content.Intent
 import androidx.car.app.Screen
 import androidx.car.app.Session
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import de.tankstellen.tankstellen.car.CarDataBridge
 import de.tankstellen.tankstellen.car.MenuScreen
 
 /**
  * Car session that creates the root screen for Android Auto.
  *
- * v1 (#2948 / epic #2946) — the root is the [MenuScreen] (Search + Radar),
- * which renders the SharedPreferences-fed station lists the Flutter app writes
- * after each in-app search / radar run. The retired [NearbyStationsScreen]
- * (favorites-only `ListTemplate`) is superseded; the live headless-engine
- * bridge is the v2 rewrite (#2947).
+ * The root is the [MenuScreen] (Search + Radar), which pushes the Search /
+ * Radar list screens.
+ *
+ * ## Live data bridge lifecycle (v2 SLICE 1, #2947 / epic #2946)
+ * The session owns the headless [CarDataBridge] engine lifecycle: it is created
+ * on Session CREATED and destroyed (engine destroyed + evicted from the cache)
+ * on Session DESTROYED, via a [DefaultLifecycleObserver] on the session
+ * lifecycle. The engine therefore lives ONLY for the duration of the bound car
+ * connection — never in a started / foreground service — preserving the #1498
+ * FGS-avoidance. The Search screen fetches live through it; Radar stays on the
+ * v1 SharedPreferences snapshot this slice (slice 2 wires its live fetch).
  */
 class TankstellenCarSession : Session() {
+    init {
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
+                // carContext is available once the session is created.
+                CarDataBridge.create(carContext)
+            }
+
+            override fun onDestroy(owner: LifecycleOwner) {
+                CarDataBridge.destroy()
+            }
+        })
+    }
+
     override fun onCreateScreen(intent: Intent): Screen {
         return MenuScreen(carContext)
     }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarDataBridge.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarDataBridge.kt
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen.car
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Android Auto v2 — SLICE 1 (#2947 / epic #2946): the LIVE data bridge between
+ * the native car screens and a headless Flutter engine.
+ *
+ * v1 rendered a stale SharedPreferences snapshot the last in-app search wrote
+ * ([CarStation.read]). Slice 1 swaps the SEARCH data source for an on-demand
+ * live fetch: this object spins up a dedicated, CACHED headless [FlutterEngine]
+ * and runs the Dart `carDataMain` entry point (`lib/features/car/
+ * car_data_service.dart`) through it, then asks Dart — over the
+ * `tankstellen/car_data` [MethodChannel] — for the freshest nearby stations.
+ *
+ * The Radar screen STAYS on the v1 snapshot this slice (Radar = slice 2).
+ *
+ * ## Why this preserves the #1498 FGS-avoidance
+ * The engine lives in the BOUND [androidx.car.app.CarAppService]/Session the
+ * Android Auto / Automotive host binds — it is NEVER hosted in a started /
+ * foreground service. No FOREGROUND_SERVICE permission and no
+ * foregroundServiceType is added; the Play Open-Testing upload still ships
+ * without the Foreground Service Use form.
+ *
+ * ## Why a dedicated cached engine (not MainActivity's)
+ * Reusing MainActivity's engine would couple the car process to the phone UI's
+ * lifecycle (and would be null when the app isn't foreground). A dedicated
+ * engine cached under [ENGINE_CACHE_ID] keeps the car path self-contained:
+ * created on Session CREATED, destroyed (and evicted from the cache) on Session
+ * DESTROYED — see [create] / [destroy].
+ *
+ * ## Plugin auto-registration (verified, not assumed)
+ * Constructing `FlutterEngine(context)` runs the embedding's default
+ * `automaticallyRegisterPlugins` path: the constructor calls
+ * `flutterLoader.startInitialization` + `ensureInitializationComplete`, then
+ * `GeneratedPluginRegister.registerGeneratedPlugins(this)` (FlutterEngine.java).
+ * So the headless engine gets the same plugins the app's engine does —
+ * including `path_provider` (the [io.flutter.embedding.engine] path the Dart
+ * `HiveIsolateLock` / Hive isolate-init relies on) and `home_widget` (the
+ * snapshot-cache write). Dio uses `dart:io` HttpClient, which needs no plugin.
+ *
+ * ## Timeout + fallback contract
+ * [fetch] runs with a HARD [FETCH_TIMEOUT_MS] ceiling; on timeout, channel
+ * fault, or a `no_gps` result it invokes the callback with `null`, so the
+ * calling screen keeps its snapshot (never blanks). A re-entrancy guard
+ * permits one in-flight fetch per [CarFetchKind]; a duplicate request while one
+ * is running short-circuits to `null`.
+ */
+/**
+ * The narrow surface [StationListScreen] needs from the live data path, so a
+ * Robolectric test can substitute a fake (the real [CarDataBridge] is a process
+ * singleton wrapping a [FlutterEngine] that can't spin up under Robolectric).
+ */
+interface CarLiveSource {
+    /** Whether a live engine is ready to serve [fetch]. */
+    val isReady: Boolean
+
+    /**
+     * Fetch the live list for [kind], invoking [callback] once with the JSON
+     * string, or `null` to keep the snapshot.
+     */
+    fun fetch(kind: CarFetchKind, callback: CarDataBridge.FetchCallback)
+}
+
+object CarDataBridge : CarLiveSource {
+
+    /** Cache id for the dedicated headless car engine. */
+    // i18n-ignore: engine-cache identifier, not user-facing text.
+    private const val ENGINE_CACHE_ID = "tankstellen_car"
+
+    /** Dart entry point (`@pragma('vm:entry-point') void carDataMain()`). */
+    // i18n-ignore: Dart entry-point name, not user-facing text.
+    private const val DART_ENTRYPOINT = "carDataMain"
+
+    /** MethodChannel name shared with the Dart `kCarDataChannel`. */
+    // i18n-ignore: platform channel name, not user-facing text.
+    private const val CHANNEL = "tankstellen/car_data"
+
+    /** Dart method that returns the live Search JSON. */
+    // i18n-ignore: protocol token, not user-facing text.
+    private const val METHOD_FETCH_SEARCH = "fetchSearch"
+
+    /** Dart sentinel for "no usable persisted GPS fix". */
+    // i18n-ignore: protocol sentinel, not user-facing text.
+    private const val NO_GPS = "no_gps"
+
+    /**
+     * Hard ceiling on a single fetch round-trip (engine spin-up + Dart work +
+     * channel reply). Kept above the Dart side's own 7 s fetch timeout so the
+     * Dart path wins the race normally and this is the last-resort backstop.
+     */
+    const val FETCH_TIMEOUT_MS = 8_000L
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** The cached headless engine + its channel, or null when torn down. */
+    private var engine: FlutterEngine? = null
+    private var channel: MethodChannel? = null
+
+    /** One in-flight guard per kind (re-entrancy). */
+    private val inFlight = mutableMapOf<CarFetchKind, AtomicBoolean>()
+
+    /**
+     * Result of a [fetch]: the JSON list string on success, or `null` when the
+     * caller should keep its snapshot (timeout / fault / no fix).
+     */
+    fun interface FetchCallback {
+        fun onResult(json: String?)
+    }
+
+    /**
+     * Lazily create + cache the headless engine and open the channel. Idempotent
+     * — a second call while alive is a no-op. Call from Session `onCreate`.
+     *
+     * Constructing [FlutterEngine] auto-registers plugins (see class doc) and
+     * initialises the Flutter loader, so [FlutterInjector] can resolve the app
+     * bundle path immediately after.
+     */
+    @Synchronized
+    fun create(context: Context) {
+        if (engine != null) return
+        try {
+            val appContext = context.applicationContext
+            val flutterEngine = FlutterEngine(appContext)
+            val bundlePath = FlutterInjector.instance().flutterLoader().findAppBundlePath()
+            flutterEngine.dartExecutor.executeDartEntrypoint(
+                DartExecutor.DartEntrypoint(bundlePath, DART_ENTRYPOINT),
+            )
+            FlutterEngineCache.getInstance().put(ENGINE_CACHE_ID, flutterEngine)
+            channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+            engine = flutterEngine
+        } catch (e: Exception) {
+            // A failed spin-up must never crash the car session — the screens
+            // simply fall back to their snapshot. Leave engine/channel null.
+            engine = null
+            channel = null
+        }
+    }
+
+    /**
+     * Destroy the engine and evict it from the cache. Idempotent. Call from
+     * Session `onDestroy` so no engine outlives the car connection (preserves
+     * the bound-service, no-FGS contract).
+     */
+    @Synchronized
+    fun destroy() {
+        channel = null
+        FlutterEngineCache.getInstance().remove(ENGINE_CACHE_ID)
+        try {
+            engine?.destroy()
+        } catch (_: Exception) {
+            // Best-effort teardown.
+        }
+        engine = null
+        inFlight.clear()
+    }
+
+    /** Whether a live engine is currently available. */
+    override val isReady: Boolean
+        @Synchronized get() = channel != null
+
+    /**
+     * Fetch the live list for [kind], invoking [callback] exactly once with the
+     * JSON string, or `null` to keep the snapshot. Honours [FETCH_TIMEOUT_MS]
+     * and the per-kind re-entrancy guard. Slice 1 only wires
+     * [CarFetchKind.SEARCH]; a [CarFetchKind.RADAR] request returns `null`
+     * (Radar still renders the v1 snapshot).
+     *
+     * The callback is always delivered on the main thread.
+     */
+    override fun fetch(kind: CarFetchKind, callback: FetchCallback) {
+        val ch = channel
+        if (ch == null || kind != CarFetchKind.SEARCH) {
+            callback.onResult(null)
+            return
+        }
+
+        val guard = inFlight.getOrPut(kind) { AtomicBoolean(false) }
+        if (!guard.compareAndSet(false, true)) {
+            // A fetch for this kind is already running — don't double-hit.
+            callback.onResult(null)
+            return
+        }
+
+        val done = AtomicBoolean(false)
+        fun finish(json: String?) {
+            if (!done.compareAndSet(false, true)) return
+            guard.set(false)
+            mainHandler.post { callback.onResult(json) }
+        }
+
+        // Hard backstop timeout independent of the Dart-side timeout.
+        val timeout = Runnable { finish(null) }
+        mainHandler.postDelayed(timeout, FETCH_TIMEOUT_MS)
+
+        ch.invokeMethod(METHOD_FETCH_SEARCH, null, object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                mainHandler.removeCallbacks(timeout)
+                val json = result as? String
+                // A no_gps marker or non-JSON-array reply → keep the snapshot.
+                finish(if (json == null || json == NO_GPS) null else json)
+            }
+
+            override fun error(code: String, message: String?, details: Any?) {
+                mainHandler.removeCallbacks(timeout)
+                finish(null)
+            }
+
+            override fun notImplemented() {
+                mainHandler.removeCallbacks(timeout)
+                finish(null)
+            }
+        })
+    }
+}
+
+/**
+ * Which car list a [CarDataBridge.fetch] targets. SLICE 1 (#2947) wires only
+ * [SEARCH] to the live bridge; [RADAR] stays on the v1 snapshot (slice 2).
+ */
+enum class CarFetchKind {
+    SEARCH,
+    RADAR,
+}

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/RadarScreen.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/RadarScreen.kt
@@ -7,12 +7,18 @@ import androidx.car.app.CarContext
 import de.tankstellen.tankstellen.R
 
 /**
- * Android Auto v1 (#2948) — the car Radar screen. Renders the latest in-app
- * radar result list (written by Flutter to [CarStation.RADAR_KEY]) as a
+ * Android Auto Radar screen. Renders the latest in-app radar result list
+ * (written by Flutter to [CarStation.RADAR_KEY]) as a
  * [androidx.car.app.model.PlaceListMapTemplate].
+ *
+ * v2 SLICE 1 (#2947) wires only the Search screen to the LIVE headless
+ * [CarDataBridge]; Radar STAYS on the v1 snapshot path
+ * ([StationListScreen.liveFetchEnabled] left false) — its live fetch is slice
+ * 2. The [kind] is set so slice 2 only flips `liveFetchEnabled` on.
  */
 class RadarScreen(carContext: CarContext) : StationListScreen(carContext) {
     override val titleRes: Int = R.string.car_radar_title
     override val prefsKey: String = CarStation.RADAR_KEY
     override val emptyMessageRes: Int = R.string.car_empty_radar
+    override val kind: CarFetchKind = CarFetchKind.RADAR
 }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/SearchScreen.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/SearchScreen.kt
@@ -7,12 +7,20 @@ import androidx.car.app.CarContext
 import de.tankstellen.tankstellen.R
 
 /**
- * Android Auto v1 (#2948) — the car Search screen. Renders the latest in-app
- * search result list (written by Flutter to [CarStation.SEARCH_KEY]) as a
- * [androidx.car.app.model.PlaceListMapTemplate].
+ * Android Auto v2 SLICE 1 (#2947) — the car Search screen, now fed by a LIVE
+ * on-demand fetch through the headless [CarDataBridge] (it was the v1
+ * SharedPreferences snapshot before, #2948).
+ *
+ * `onGetTemplate` (in [StationListScreen]) returns the snapshot immediately for
+ * an instant, never-blank first frame, then kicks `CarDataBridge.fetch(SEARCH)`
+ * and rebuilds from the live list when it arrives. With no snapshot AND no live
+ * data (a fresh Automotive head unit with no persisted GPS fix) it shows the
+ * `car_empty_no_gps` message — never crashes.
  */
 class SearchScreen(carContext: CarContext) : StationListScreen(carContext) {
     override val titleRes: Int = R.string.car_search_title
     override val prefsKey: String = CarStation.SEARCH_KEY
-    override val emptyMessageRes: Int = R.string.car_empty_search
+    override val emptyMessageRes: Int = R.string.car_empty_no_gps
+    override val kind: CarFetchKind = CarFetchKind.SEARCH
+    override val liveFetchEnabled: Boolean = true
 }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/StationListScreen.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/StationListScreen.kt
@@ -19,44 +19,131 @@ import androidx.car.app.model.Row
 import androidx.car.app.model.Template
 
 /**
- * Android Auto v1 (#2948 / epic #2946) — base car screen that renders a
- * SharedPreferences-fed station list as a [PlaceListMapTemplate]: the POI list
- * on the left and the host-drawn map with a coloured anchor per station on the
- * right. Tapping a row pans/selects on the map (standard
- * `PlaceListMapTemplate` behaviour — no extra wiring needed).
+ * Android Auto base car screen that renders a station list as a
+ * [PlaceListMapTemplate]: the POI list on the left and the host-drawn map with
+ * a coloured anchor per station on the right. Tapping a row pans/selects on the
+ * map (standard `PlaceListMapTemplate` behaviour — no extra wiring needed).
  *
- * Subclasses supply the title, the SharedPreferences key, and the empty-state
- * message. A missing/empty/malformed key renders the friendly empty message
- * (never crashes) — see [CarStation.read].
+ * ## v1 snapshot vs v2 live SEARCH (#2947 / epic #2946)
+ * v1 (#2948) renders the SharedPreferences snapshot the last in-app search /
+ * radar wrote (`CarStation.read`). Slice 1 of v2 swaps the SEARCH data source
+ * for a LIVE on-demand fetch via the headless [CarDataBridge]:
+ *
+ *  - `onGetTemplate` returns the snapshot IMMEDIATELY (instant, no blank) and
+ *    kicks `CarDataBridge.fetch([kind])` when [liveFetchEnabled] is true.
+ *  - On a live result it sets [liveStations] and calls [invalidate], which
+ *    rebuilds the template from the live list.
+ *  - The host Refresh button ([PlaceListMapTemplate.Builder.setOnContentRefreshListener])
+ *    re-fetches; that callback is quota-exempt.
+ *  - A cold start with an empty snapshot shows the loading state until the
+ *    first live result; if no snapshot AND no live data arrive (e.g. a fresh
+ *    Automotive head unit with no persisted fix) it shows [emptyMessageRes]
+ *    (the no-GPS message for Search).
+ *
+ * Subclasses that stay on the v1 snapshot (Radar this slice) leave
+ * [liveFetchEnabled] false. A missing/empty/malformed snapshot still degrades
+ * to the friendly empty message (never crashes) — see [CarStation.read].
  */
 abstract class StationListScreen(carContext: CarContext) : Screen(carContext) {
 
     /** Template title (a string resource id). */
     protected abstract val titleRes: Int
 
-    /** SharedPreferences key holding this screen's station list. */
+    /** SharedPreferences key holding this screen's snapshot station list. */
     protected abstract val prefsKey: String
 
-    /** Empty-state message shown when the key is missing/empty (string res id). */
+    /** Empty-state message shown when there is no snapshot and no live data. */
     protected abstract val emptyMessageRes: Int
 
-    override fun onGetTemplate(): Template {
-        val stations = CarStation.read(carContext, prefsKey)
-        val listBuilder = ItemList.Builder()
+    /** Which list the live bridge fetches for this screen. */
+    protected abstract val kind: CarFetchKind
 
-        if (stations.isEmpty()) {
-            listBuilder.setNoItemsMessage(carContext.getString(emptyMessageRes))
-        } else {
-            for (station in stations) {
-                listBuilder.addItem(buildRow(station))
+    /**
+     * Whether this screen fetches LIVE data via [liveSource]. Search opts in
+     * (slice 1); Radar stays false (v1 snapshot, slice 2).
+     */
+    protected open val liveFetchEnabled: Boolean = false
+
+    /**
+     * The live data source. Defaults to the real [CarDataBridge]; overridable so
+     * a Robolectric test can inject a fake (the real bridge wraps a
+     * [io.flutter.embedding.engine.FlutterEngine] that can't run under
+     * Robolectric).
+     */
+    protected open val liveSource: CarLiveSource = CarDataBridge
+
+    /**
+     * The latest LIVE list, or null before any live result has arrived. When
+     * non-null it takes precedence over the snapshot in [onGetTemplate].
+     * Mutated only on the main thread (the bridge callback), then [invalidate].
+     */
+    private var liveStations: List<CarStation>? = null
+
+    /** True once a live fetch has completed (success OR fault). */
+    private var liveAttempted = false
+
+    override fun onGetTemplate(): Template {
+        val snapshot = CarStation.read(carContext, prefsKey)
+        val stations = liveStations ?: snapshot
+
+        // Capture the cold-start condition BEFORE kicking the fetch (which flips
+        // liveAttempted): no snapshot AND no live result AND no fetch tried yet.
+        val coldStart = liveFetchEnabled &&
+            snapshot.isEmpty() && liveStations == null && !liveAttempted
+
+        if (liveFetchEnabled && liveSource.isReady) {
+            kickLiveFetch()
+        }
+
+        val builder = PlaceListMapTemplate.Builder()
+            .setTitle(carContext.getString(titleRes))
+            .setHeaderAction(Action.BACK)
+
+        if (liveFetchEnabled) {
+            // Host Refresh button — quota-exempt; re-fetch on demand.
+            builder.setOnContentRefreshListener {
+                liveAttempted = false
+                kickLiveFetch(force = true)
             }
         }
 
-        return PlaceListMapTemplate.Builder()
-            .setTitle(carContext.getString(titleRes))
-            .setHeaderAction(Action.BACK)
-            .setItemList(listBuilder.build())
-            .build()
+        // A cold start (no snapshot, awaiting the first live result) shows the
+        // host spinner. PlaceListMapTemplate forbids an item list while loading,
+        // so set loading XOR the list — never both.
+        if (coldStart && liveSource.isReady) {
+            builder.setLoading(true)
+        } else {
+            val listBuilder = ItemList.Builder()
+            if (stations.isEmpty()) {
+                listBuilder.setNoItemsMessage(carContext.getString(emptyMessageRes))
+            } else {
+                for (station in stations) {
+                    listBuilder.addItem(buildRow(station))
+                }
+            }
+            builder.setItemList(listBuilder.build())
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Kick a live fetch (idempotent within a render — the bridge's per-kind
+     * re-entrancy guard collapses duplicate in-flight requests). On a JSON
+     * result, parse + store it and [invalidate] so the next render shows the
+     * live list; on null (timeout / fault / no fix) keep whatever is shown.
+     */
+    private fun kickLiveFetch(force: Boolean = false) {
+        if (liveAttempted && !force) return
+        liveAttempted = true
+        liveSource.fetch(kind) { json ->
+            if (json != null) {
+                liveStations = CarStation.parse(json)
+            }
+            // Even on a null result, invalidate so a cold-start spinner clears
+            // to the empty-state message rather than spinning forever.
+            invalidate()
+        }
     }
 
     private fun buildRow(station: CarStation): Row {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -48,4 +48,14 @@
     <string name="car_radar_title">Radar</string>
     <string name="car_empty_search">Open the app and run a search first, then it will show up here.</string>
     <string name="car_empty_radar">Open the app and start the radar first, then it will show up here.</string>
+
+    <!-- Android Auto v2 SLICE 1 (#2947) — live in-car Search strings. The
+         Search screen now fetches nearby stations live through a headless
+         Flutter engine; these cover the cold-start spinner, the host Refresh
+         button, and the no-persisted-fix empty state. Same native-resource
+         rationale as the car_* strings above (the androidx.car.app host can't
+         read the Flutter ARB bundle). -->
+    <string name="car_loading">Loading nearby stations…</string>
+    <string name="car_empty_no_gps">Open the app on your phone to set your location</string>
+    <string name="car_refresh">Refresh</string>
 </resources>

--- a/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarDataBridgeTest.kt
+++ b/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarDataBridgeTest.kt
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+package de.tankstellen.tankstellen.car
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Android Auto v2 SLICE 1 (#2947) — the bridge's channel / lifecycle contract,
+ * as far as Robolectric allows.
+ *
+ * The real [CarDataBridge] wraps a [io.flutter.embedding.engine.FlutterEngine]
+ * that cannot spin up under Robolectric (no native Flutter shell), so these
+ * pin the behaviour reachable WITHOUT a live engine: the not-ready guard, the
+ * RADAR short-circuit (slice 1 only wires SEARCH live), and the [CarFetchKind]
+ * contract. The full snapshot-first → live-second render flow (which DOES need
+ * a working live source) is covered by `CarScreensTest` via a fake [CarLiveSource].
+ */
+@RunWith(RobolectricTestRunner::class)
+class CarDataBridgeTest {
+
+    @Test
+    fun isReady_isFalse_whenNoEngineCreated() {
+        // No create() under Robolectric (no FlutterEngine), so the bridge is
+        // never ready — the screens fall back to their snapshot.
+        CarDataBridge.destroy() // ensure a clean, torn-down state
+        assertFalse(CarDataBridge.isReady)
+    }
+
+    @Test
+    fun fetch_returnsNull_whenNotReady() {
+        CarDataBridge.destroy()
+        var called = false
+        var result: String? = "sentinel"
+        CarDataBridge.fetch(CarFetchKind.SEARCH) { json ->
+            called = true
+            result = json
+        }
+        // The not-ready path posts the null callback on the main thread.
+        ShadowLooper.idleMainLooper()
+        assertEquals(true, called)
+        assertNull(result)
+    }
+
+    @Test
+    fun fetch_returnsNull_forRadarKind_evenIfAsked() {
+        // SLICE 1 wires only SEARCH live; a RADAR fetch must short-circuit to
+        // null so Radar keeps its v1 snapshot (slice 2 wires its live fetch).
+        CarDataBridge.destroy()
+        var result: String? = "sentinel"
+        CarDataBridge.fetch(CarFetchKind.RADAR) { json -> result = json }
+        ShadowLooper.idleMainLooper()
+        assertNull(result)
+    }
+
+    @Test
+    fun destroy_isIdempotent_andSafeWhenNeverCreated() {
+        // Tearing down a bridge that was never created (or twice) must not throw
+        // — the Session onDestroy calls this unconditionally.
+        CarDataBridge.destroy()
+        CarDataBridge.destroy()
+        assertFalse(CarDataBridge.isReady)
+    }
+
+    @Test
+    fun carFetchKind_hasSearchAndRadar() {
+        assertEquals(2, CarFetchKind.entries.size)
+        assertEquals(CarFetchKind.SEARCH, CarFetchKind.valueOf("SEARCH"))
+        assertEquals(CarFetchKind.RADAR, CarFetchKind.valueOf("RADAR"))
+    }
+
+    @Test
+    fun fetchCallback_funInterface_isInvokable() {
+        // The FetchCallback SAM is the bridge↔screen contract — assert it can be
+        // built + invoked (the screens pass a lambda).
+        var seen: String? = null
+        val cb = CarDataBridge.FetchCallback { json -> seen = json }
+        cb.onResult("[]")
+        assertEquals("[]", seen)
+    }
+}

--- a/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarScreensTest.kt
+++ b/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarScreensTest.kt
@@ -101,13 +101,16 @@ class CarScreensTest {
     }
 
     @Test
-    fun searchScreen_missingKeyShowsEmptyMessage() {
-        // No seed → key absent.
+    fun searchScreen_missingKeyShowsNoGpsMessage() {
+        // No seed → key absent. v2 SLICE 1 (#2947): the real SearchScreen is
+        // live-enabled, but the real CarDataBridge has no engine under
+        // Robolectric (isReady == false), so it renders the empty list with the
+        // v2 no-GPS message rather than the v1 "run a search first" copy.
         val template = templateOf(SearchScreen(carContext)) as PlaceListMapTemplate
 
         val list = template.itemList as ItemList
         assertTrue(list.items.isEmpty())
-        assertEquals(string(R.string.car_empty_search), list.noItemsMessage.toString())
+        assertEquals(string(R.string.car_empty_no_gps), list.noItemsMessage.toString())
     }
 
     @Test
@@ -141,4 +144,130 @@ class CarScreensTest {
         assertTrue(CarStation.parse("not json").isEmpty())
         assertTrue(CarStation.parse("").isEmpty())
     }
+
+    // ── Android Auto v2 SLICE 1 (#2947) — LIVE Search via the headless bridge ──
+
+    /**
+     * A fake [CarLiveSource] standing in for the real [CarDataBridge] (whose
+     * FlutterEngine can't spin up under Robolectric). [ready] toggles whether a
+     * live fetch is kicked; each `fetch` returns the next queued reply
+     * SYNCHRONOUSLY (or null when the queue is empty), so a test can assert the
+     * snapshot-first → live-second render sequence deterministically.
+     */
+    private class FakeLiveSource(
+        var ready: Boolean = true,
+    ) : CarLiveSource {
+        val replies = ArrayDeque<String?>()
+        var fetchCount = 0
+
+        override val isReady: Boolean get() = ready
+
+        override fun fetch(kind: CarFetchKind, callback: CarDataBridge.FetchCallback) {
+            fetchCount++
+            val json = if (replies.isEmpty()) null else replies.removeFirst()
+            callback.onResult(json)
+        }
+    }
+
+    /** A [SearchScreen] wired to a fake live source for deterministic tests. */
+    private inner class FakeLiveSearchScreen(
+        private val source: CarLiveSource,
+    ) : StationListScreen(carContext) {
+        override val titleRes: Int = R.string.car_search_title
+        override val prefsKey: String = CarStation.SEARCH_KEY
+        override val emptyMessageRes: Int = R.string.car_empty_no_gps
+        override val kind: CarFetchKind = CarFetchKind.SEARCH
+        override val liveFetchEnabled: Boolean = true
+        override val liveSource: CarLiveSource = source
+    }
+
+    private fun rows(t: Template): List<Row> =
+        ((t as PlaceListMapTemplate).itemList as ItemList).items.filterIsInstance<Row>()
+
+    @Test
+    fun liveSearch_rendersSnapshotBeforeAnyLiveResult() {
+        // A live reply is queued, but the FIRST render must still show the
+        // snapshot (live result lands only on the next render). Proves the
+        // never-blank-first-frame contract.
+        seed(CarStation.SEARCH_KEY, twoStationsJson())
+        val source = FakeLiveSource().apply {
+            replies.add(oneStationJson("Esso", 52.7, 13.7))
+        }
+        val screen = FakeLiveSearchScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        val first = rows(screen.onGetTemplate())
+        assertEquals(2, first.size)
+        assertEquals("Aral", first[0].title.toString())
+    }
+
+    @Test
+    fun liveSearch_freshJsonReplacesSnapshotOnNextRender() {
+        // Snapshot has 2; the live fetch returns 1 fresh station. The first
+        // render shows the snapshot; the second (post-invalidate) shows live.
+        seed(CarStation.SEARCH_KEY, twoStationsJson())
+        val source = FakeLiveSource().apply {
+            replies.add(oneStationJson("Esso", 52.7, 13.7))
+        }
+        val screen = FakeLiveSearchScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        rows(screen.onGetTemplate()) // first render kicks + caches the live list
+        val second = rows(screen.onGetTemplate())
+        assertEquals(1, second.size)
+        assertEquals("Esso", second[0].title.toString())
+    }
+
+    @Test
+    fun liveSearch_emptyLiveResultKeepsSnapshot() {
+        // A null/empty live reply must NEVER blank a good snapshot.
+        seed(CarStation.SEARCH_KEY, twoStationsJson())
+        val source = FakeLiveSource() // empty queue → fetch yields null
+        val screen = FakeLiveSearchScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        rows(screen.onGetTemplate())
+        val second = rows(screen.onGetTemplate())
+        assertEquals("a null live result keeps the snapshot", 2, second.size)
+        assertEquals("Aral", second[0].title.toString())
+    }
+
+    @Test
+    fun liveSearch_noSnapshotAndNoLiveShowsNoGpsMessage() {
+        // Fresh head unit: no snapshot AND the live fetch returns null (e.g. no
+        // persisted fix) → the car_empty_no_gps message, never a crash.
+        val source = FakeLiveSource() // empty queue → null
+        val screen = FakeLiveSearchScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        // First render (cold) shows the host spinner (loading) — no item list.
+        val firstLoading = (screen.onGetTemplate() as PlaceListMapTemplate).isLoading
+        assertTrue("cold start with no snapshot shows the spinner", firstLoading)
+
+        // Second render (after the null reply) clears the spinner to the
+        // no-GPS empty message.
+        val list = (screen.onGetTemplate() as PlaceListMapTemplate).itemList as ItemList
+        assertTrue(list.items.isEmpty())
+        assertEquals(string(R.string.car_empty_no_gps), list.noItemsMessage.toString())
+    }
+
+    @Test
+    fun radarScreen_staysOnSnapshot_doesNotFetchLive() {
+        // SLICE 1: Radar must NOT hit the live bridge — it renders the v1
+        // snapshot only. (Its kind is RADAR, liveFetchEnabled false.)
+        seed(CarStation.RADAR_KEY, twoStationsJson())
+        val template = templateOf(RadarScreen(carContext)) as PlaceListMapTemplate
+        assertEquals(2, rows(template).size)
+        // RadarScreen leaves liveFetchEnabled false, so the default real
+        // CarDataBridge is never asked (no engine in tests) — proven by the
+        // render succeeding with the snapshot and no crash.
+    }
+
+    private fun oneStationJson(brand: String, lat: Double, lng: Double): String = """
+        [
+          {"id":"x","name":"$brand X","brand":"$brand","lat":$lat,"lng":$lng,
+           "price":1.749,"priceText":"1.749","fuelLabel":"E10","band":"cheap",
+           "bandColor":4282621761,"distanceKm":2.1,"currency":"€"}
+        ]
+    """.trimIndent()
 }

--- a/lib/features/car/car_data_service.dart
+++ b/lib/features/car/car_data_service.dart
@@ -1,0 +1,366 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
+import 'package:home_widget/home_widget.dart';
+
+import '../../core/background/country_alert_strategy.dart';
+import '../../core/background/hive_isolate_lock.dart';
+import '../../core/background/provider_request_budget.dart';
+import '../../core/cache/cache_manager.dart';
+import '../../core/data/storage_repository.dart';
+import '../../core/logging/error_logger.dart';
+import '../../core/services/country_service_registry.dart';
+import '../../core/storage/hive_storage.dart';
+import '../../core/storage/storage_keys.dart';
+import '../../core/utils/geo_utils.dart' show isUsableCoord;
+import '../search/data/models/search_params.dart';
+import '../search/domain/entities/fuel_type.dart';
+import '../search/domain/entities/station.dart';
+import '../widget/data/car_station_data.dart';
+
+/// Android Auto v2 — SLICE 1 (#2947 / epic #2946): the headless Flutter entry
+/// point the native [CarDataBridge] runs to fetch a LIVE in-car Search list.
+///
+/// ## Why a dedicated entry point
+/// The v1 car Search screen rendered a SharedPreferences snapshot written by
+/// the last *in-app* search (`CarStationWriter`) — stale, and empty for a
+/// driver who never opened the phone app. Slice 1 replaces the SEARCH data
+/// source with a live, on-demand fetch: the native `CarAppService`/Session
+/// (a BOUND service — never a started/foreground service, preserving the
+/// #1498 FGS-avoidance) spins up a cached headless [FlutterEngine] and runs
+/// [carDataMain] through it, then asks this side, over the
+/// `tankstellen/car_data` [MethodChannel], for the freshest nearby stations.
+///
+/// The Radar screen STAYS on the v1 snapshot in this slice (Radar = slice 2).
+///
+/// ## Persisted-fix GPS only (never a live lock)
+/// The contract (#2947) is the persisted last-known fix, exactly as the
+/// nearest-widget builder reads it — `StorageKeys.userPositionLat/Lng` with
+/// the #2872 [isUsableCoord] guard. There is no live GPS in the car process
+/// in slice 1 (that, plus the `requestPermissions` flow, is a later phase),
+/// so this never blocks on a fix; an absent/poisoned fix returns the
+/// [kNoGpsMarker] and the screen keeps its snapshot / empty-state.
+///
+/// ## Live fetch path — bulk-country-correct
+/// The fetch goes through [CountryAlertStrategy.searchArea], which resolves
+/// the right strategy per `FuelServicePolicy.model`: a [PolledAlertStrategy]
+/// for polled APIs (DE/AT/…) and a [BulkDatasetAlertStrategy] for bulk-file
+/// countries (ES/IT/AR/DK). This is deliberate — `BackgroundPriceSource`
+/// would return empty in a bulk country, and `StationService.searchStations`
+/// returns the wrapped `ServiceResult`. The shared per-provider
+/// [ProviderRequestBudget] is consulted (never bypassed) so the live car
+/// fetch honours each free API's ToS spacing, sharing one gate with the
+/// foreground + background scan.
+///
+/// ## Never throws
+/// Every public handler completes — on any fault it returns an empty / no_gps
+/// payload, never throwing into the OS-spawned engine (mirrors the background
+/// scan coordinator). Hive is opened under [HiveIsolateLock] and always
+/// closed in `finally`.
+
+/// The MethodChannel name the native [CarDataBridge] and this entry point share.
+// i18n-ignore: platform channel name, not user-facing text.
+const String kCarDataChannel = 'tankstellen/car_data';
+
+/// `kind` argument the native bridge passes to identify the Search fetch.
+// i18n-ignore: protocol token, not user-facing text.
+const String kCarKindSearch = 'search';
+
+/// Method the bridge invokes to fetch the live Search list.
+// i18n-ignore: protocol token, not user-facing text.
+const String kCarMethodFetchSearch = 'fetchSearch';
+
+/// Method the bridge invokes to read the persisted user location.
+// i18n-ignore: protocol token, not user-facing text.
+const String kCarMethodGetUserLocation = 'getUserLocation';
+
+/// Sentinel the entry point returns (in place of a JSON list) when there is
+/// no usable persisted GPS fix — the native screen keeps its snapshot /
+/// shows the `car_empty_no_gps` message rather than blanking.
+// i18n-ignore: protocol sentinel, not user-facing text.
+const String kNoGpsMarker = 'no_gps';
+
+/// Hard ceiling on the live fetch's own work, independent of the native
+/// bridge's own timeout. Keeps a slow provider from holding the engine open.
+const Duration kCarFetchTimeout = Duration(seconds: 7);
+
+/// Top-level headless entry point (annotated `vm:entry-point` so the native
+/// engine can find it by name — model: the workmanager `callbackDispatcher`,
+/// `background_service.dart`). Wires the [MethodChannel] the native
+/// [CarDataBridge] talks to and delegates each call to [CarDataService].
+@pragma('vm:entry-point')
+void carDataMain() {
+  WidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel(kCarDataChannel);
+  final service = CarDataService();
+
+  channel.setMethodCallHandler((call) async {
+    switch (call.method) {
+      case kCarMethodFetchSearch:
+        return service.fetchSearch();
+      case kCarMethodGetUserLocation:
+        return service.getUserLocation();
+      default:
+        throw MissingPluginException(
+          'car_data: unknown method "${call.method}"',
+        );
+    }
+  });
+}
+
+/// Factory for the per-country live-search strategy. Injected so a test drives
+/// the SAME real [CountryAlertStrategy] subclasses production uses, backed by a
+/// recorded-real-API [StationService] fixture — not an echo fake (which would
+/// hide a bulk-vs-polled availability bug, per `feedback_fake_services_false_green`).
+typedef CarStrategyFactory = CountryAlertStrategy? Function(
+  String countryCode, {
+  required StorageRepository storage,
+  required CacheStrategy cache,
+  String? apiKey,
+  ProviderRequestBudget? budget,
+});
+
+/// The testable core behind [carDataMain]. Resolves the persisted fix →
+/// active country + profile → a LIVE radius search via [CountryAlertStrategy]
+/// → the shared [CarStationData] JSON the native [CarStation.parse] expects,
+/// refreshing the snapshot cache key as the fallback.
+class CarDataService {
+  CarDataService({
+    CarStrategyFactory? strategyFactory,
+    Future<void> Function(String key, String value)? writeSnapshot,
+    Duration fetchTimeout = kCarFetchTimeout,
+  })  : _strategyFactory = strategyFactory ?? _defaultStrategyFactory,
+        _writeSnapshot = writeSnapshot ?? _defaultWriteSnapshot,
+        _fetchTimeout = fetchTimeout;
+
+  final CarStrategyFactory _strategyFactory;
+  final Future<void> Function(String key, String value) _writeSnapshot;
+  final Duration _fetchTimeout;
+
+  /// Default Hive-backed, snapshot-writing wiring shared by production and an
+  /// integration test that wants the real isolate lifecycle. Tests that drive
+  /// the pure path use [resolveSearchJson] with an in-memory storage.
+  static CountryAlertStrategy? _defaultStrategyFactory(
+    String countryCode, {
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    String? apiKey,
+    ProviderRequestBudget? budget,
+  }) =>
+      CountryAlertStrategy.forCountry(
+        countryCode,
+        storage: storage,
+        cache: cache,
+        apiKey: apiKey,
+        budget: budget,
+      );
+
+  /// Production snapshot write: the same `HomeWidgetPreferences` key the native
+  /// [CarStation.read] consumes (Android `home_widget` always writes the fixed
+  /// prefs file). Refreshing it means a later engine-failed render still has a
+  /// recent fallback instead of the v1's last-in-app-search list.
+  static Future<void> _defaultWriteSnapshot(String key, String value) =>
+      HomeWidget.saveWidgetData(key, value);
+
+  /// Handle [kCarMethodFetchSearch]: open Hive under the isolate lock, load the
+  /// API key, run [resolveSearchJson], and ALWAYS close the boxes in `finally`.
+  ///
+  /// Returns the car JSON string, or [kNoGpsMarker] when no usable fix exists.
+  /// Never throws — any fault returns [kNoGpsMarker] so the screen degrades to
+  /// its snapshot / empty-state.
+  Future<String> fetchSearch() async {
+    HiveIsolateLock? lock;
+    try {
+      lock = await HiveIsolateLock.create();
+      final acquired = await lock.acquire();
+      if (!acquired) {
+        debugPrint('CarDataService.fetchSearch: Hive lock busy — no_gps');
+        return kNoGpsMarker;
+      }
+      await HiveStorage.initInIsolate();
+      await HiveStorage.loadApiKey();
+      final storage = HiveStorage();
+      return await resolveSearchJson(storage, apiKey: storage.getApiKey())
+          .timeout(_fetchTimeout, onTimeout: () => kNoGpsMarker);
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'CarDataService.fetchSearch',
+      }));
+      return kNoGpsMarker;
+    } finally {
+      try {
+        await HiveStorage.closeIsolateBoxes();
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+          'where': 'CarDataService.fetchSearch: close boxes',
+        }));
+      }
+      lock?.release();
+    }
+  }
+
+  /// Handle [kCarMethodGetUserLocation]: return `{lat,lng,source,updatedAtMs}`
+  /// for the persisted fix, or `{source: no_gps}` when absent / poisoned.
+  /// Never throws.
+  Future<Map<String, dynamic>> getUserLocation() async {
+    HiveIsolateLock? lock;
+    try {
+      lock = await HiveIsolateLock.create();
+      if (!await lock.acquire()) return const {'source': kNoGpsMarker};
+      await HiveStorage.initInIsolate();
+      return readUserLocation(HiveStorage());
+    } catch (e, st) {
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'CarDataService.getUserLocation',
+      }));
+      return const {'source': kNoGpsMarker};
+    } finally {
+      try {
+        await HiveStorage.closeIsolateBoxes();
+      } catch (_) {
+        // Best-effort close — a stray fault here is never actionable.
+      }
+      lock?.release();
+    }
+  }
+
+  /// Pure resolution used by both the live handler and the unit tests: read
+  /// the persisted fix (with the #2872 guard), resolve the active country +
+  /// profile, run a LIVE radius [CountryAlertStrategy.searchArea], and encode
+  /// the result with [CarStationData.encode]. Refreshes the snapshot key on a
+  /// non-empty result. Returns [kNoGpsMarker] when no usable fix exists; an
+  /// empty `[]` when the fix is good but the live search returned nothing or
+  /// faulted (the screen keeps its snapshot). Never throws.
+  @visibleForTesting
+  Future<String> resolveSearchJson(
+    StorageRepository storage, {
+    String? apiKey,
+  }) async {
+    final fix = _persistedFix(storage);
+    if (fix == null) return kNoGpsMarker;
+
+    final country = CountryServiceRegistry.countryForLatLng(fix.lat, fix.lng) ??
+        (storage.getSetting('active_country_code') as String?) ??
+        'DE';
+
+    final profile = _activeProfile(storage);
+    final budget = ProviderRequestBudget(storage);
+    final strategy = _strategyFactory(
+      country,
+      storage: storage,
+      cache: CacheManager(storage),
+      apiKey: apiKey,
+      budget: budget,
+    );
+    if (strategy == null) return '[]';
+
+    List<Station> stations;
+    try {
+      stations = await strategy.searchArea(
+        SearchParams(
+          lat: fix.lat,
+          lng: fix.lng,
+          radiusKm: profile.radiusKm,
+          fuelType: profile.fuelType,
+          sortBy: SortBy.distance,
+        ),
+      );
+    } catch (e, st) {
+      // searchArea is documented never-throws, but guard the seam anyway —
+      // a fault must degrade to the snapshot, never crash the engine.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
+        'where': 'CarDataService.resolveSearchJson: searchArea',
+      }));
+      return '[]';
+    }
+
+    // Some country services honour sortBy server-side, others don't — sort
+    // locally too, identical to the nearest-widget builder.
+    final sorted = [...stations]..sort((a, b) => a.dist.compareTo(b.dist));
+    final json = CarStationData.encode(sorted, profile.fuelType);
+
+    if (sorted.isNotEmpty) {
+      // Refresh the fallback snapshot so a later engine failure still renders
+      // a recent list. Best-effort — a write fault never fails the fetch.
+      try {
+        await _writeSnapshot(CarStationData.searchKey, json);
+      } catch (e, st) {
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
+          'where': 'CarDataService.resolveSearchJson: snapshot write',
+        }));
+      }
+    }
+    return json;
+  }
+
+  /// The `{lat,lng,source,updatedAtMs}` location payload, or `{source:no_gps}`.
+  @visibleForTesting
+  Map<String, dynamic> readUserLocation(StorageRepository storage) {
+    final fix = _persistedFix(storage);
+    if (fix == null) return const {'source': kNoGpsMarker};
+    return <String, dynamic>{
+      'lat': fix.lat,
+      'lng': fix.lng,
+      'source': (storage.getSetting(StorageKeys.userPositionSource) as String?) ??
+          'persisted',
+      'updatedAtMs': _updatedAtMs(storage),
+    };
+  }
+
+  /// Read the persisted fix the same way the nearest-widget builder does, then
+  /// apply the #2872 [isUsableCoord] guard so a `(0,0)` / one-axis / NaN fix is
+  /// rejected (returns null → the caller emits [kNoGpsMarker]).
+  ({double lat, double lng})? _persistedFix(StorageRepository storage) {
+    final lat =
+        (storage.getSetting(StorageKeys.userPositionLat) as num?)?.toDouble();
+    final lng =
+        (storage.getSetting(StorageKeys.userPositionLng) as num?)?.toDouble();
+    if (lat == null || lng == null) return null;
+    if (!isUsableCoord(lat, lng)) return null;
+    return (lat: lat, lng: lng);
+  }
+
+  int? _updatedAtMs(StorageRepository storage) {
+    final raw = storage.getSetting(StorageKeys.userPositionTimestamp);
+    if (raw is int) return raw;
+    if (raw is num) return raw.toInt();
+    if (raw is String) {
+      final parsed = DateTime.tryParse(raw);
+      if (parsed != null) return parsed.millisecondsSinceEpoch;
+      return int.tryParse(raw);
+    }
+    return null;
+  }
+
+  /// Active-profile radius + fuel, mirroring the nearest-widget builder's
+  /// `_activeProfile` (default 10 km / E10 when no profile is set).
+  _CarProfile _activeProfile(StorageRepository storage) {
+    final id = storage.getActiveProfileId();
+    if (id == null) return const _CarProfile();
+    final raw = storage.getProfile(id);
+    if (raw == null) return const _CarProfile();
+    final radius = (raw['defaultSearchRadius'] as num?)?.toDouble() ?? 10.0;
+    FuelType fuel = FuelType.e10;
+    final key = raw['preferredFuelType']?.toString();
+    if (key != null) {
+      try {
+        fuel = FuelType.fromString(key);
+      } catch (e, st) { // ignore: unused_catch_stack
+        debugPrint('CarDataService: unknown preferred fuel "$key": $e');
+      }
+    }
+    return _CarProfile(radiusKm: radius, fuelType: fuel);
+  }
+}
+
+/// Active-profile snapshot for one car fetch.
+class _CarProfile {
+  final double radiusKm;
+  final FuelType fuelType;
+  const _CarProfile({this.radiusKm = 10.0, this.fuelType = FuelType.e10});
+}

--- a/scripts/audit_no_fgs.sh
+++ b/scripts/audit_no_fgs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Florian DITTGEN
+# SPDX-License-Identifier: MIT
+
+# audit_no_fgs.sh — prove the MERGED `play` manifest declares ZERO
+# FOREGROUND_SERVICE* permissions (#2947 / epic #2946).
+#
+# ## Why
+# Google Play's "Foreground Service Use" declaration form is a hard gate on
+# every reviewed track: edits.commit returns 403 until the form is submitted
+# (#1498). The app therefore strips every FOREGROUND_SERVICE* permission with
+# `tools:node="remove"` in the main manifest (androidx.work / car.app declare
+# it in their own manifests and would otherwise be merged back in). The
+# Android Auto v2 live bridge (#2947) hosts a headless FlutterEngine inside the
+# BOUND CarAppService/Session — never a started/foreground service — so it adds
+# NO FGS permission. This audit makes a future accidental FGS re-merge trip CI
+# here, instead of surfacing as the opaque #1498 403 on the Open-Testing upload.
+#
+# ## What it checks
+# The MERGED play manifest (after manifest-merge pulls in every dependency's
+# manifest) must contain ZERO `<uses-permission android:name="…FOREGROUND_SERVICE…">`
+# entries. XML comments are stripped first — the play source-set manifest
+# documents the rationale in a comment block that mentions FOREGROUND_SERVICE,
+# and a naive grep would false-positive on that prose.
+#
+# A geolocator/work plugin may still declare a service with
+# `foregroundServiceType="…"` in its OWN manifest; without a matching
+# FOREGROUND_SERVICE *permission* that service can never actually run as an FGS,
+# and Play's form gate keys off the permission, so this audit gates the
+# permission (the thing that 403s), not the plugin's service attribute.
+#
+# Usage:
+#   scripts/audit_no_fgs.sh                       # builds the play debug APK, then audits
+#   scripts/audit_no_fgs.sh path/to/AndroidManifest.xml   # audits a pre-built merged manifest
+#
+# Exit codes: 0 = clean (zero FGS permissions), 1 = an FGS permission survived,
+# 2 = setup/usage error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MANIFEST="${1:-}"
+
+# When no manifest path is given, build the unsigned play debug APK (same path
+# CI's build-android PR validation uses) so the merged manifest exists.
+if [[ -z "${MANIFEST}" ]]; then
+  echo "==> No manifest given — building the play debug APK to produce the merged manifest"
+  (cd "${REPO_ROOT}" && flutter build apk --debug --flavor play >/dev/null)
+  MANIFEST="${REPO_ROOT}/build/app/intermediates/merged_manifests/playDebug/processPlayDebugManifest/AndroidManifest.xml"
+fi
+
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "ERROR: merged manifest not found at: ${MANIFEST}" >&2
+  echo "       Build the play flavor first (flutter build apk --flavor play)." >&2
+  exit 2
+fi
+
+echo "==> Auditing merged play manifest for FOREGROUND_SERVICE permissions:"
+echo "    ${MANIFEST}"
+
+# Strip XML comments, then count uses-permission entries naming any
+# FOREGROUND_SERVICE* permission. Python keeps the comment-stripping robust
+# across multi-line comment blocks (the play manifest's rationale block).
+HITS="$(python3 - "${MANIFEST}" <<'PY'
+import re, sys
+xml = open(sys.argv[1], encoding="utf-8").read()
+nocomment = re.sub(r"<!--.*?-->", "", xml, flags=re.DOTALL)
+perms = re.findall(
+    r'<uses-permission[^>]*android:name="([^"]*FOREGROUND_SERVICE[^"]*)"',
+    nocomment,
+)
+for p in sorted(set(perms)):
+    print(p)
+PY
+)"
+
+if [[ -n "${HITS}" ]]; then
+  echo "::error::Merged play manifest declares FOREGROUND_SERVICE permission(s):" >&2
+  echo "${HITS}" | sed 's/^/  - /' >&2
+  echo "" >&2
+  echo "These trip Google Play's Foreground Service Use form (#1498 → 403 on" >&2
+  echo "edits.commit). Strip them with tools:node=\"remove\" in" >&2
+  echo "android/app/src/main/AndroidManifest.xml, or do not host the new" >&2
+  echo "service as a foreground service (the Android Auto bridge is a BOUND" >&2
+  echo "service — see CarDataBridge / #2947)." >&2
+  exit 1
+fi
+
+echo "==> OK — zero FOREGROUND_SERVICE permissions in the merged play manifest."

--- a/test/features/car/car_data_service_test.dart
+++ b/test/features/car/car_data_service_test.dart
@@ -1,0 +1,388 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/core/background/bulk_dataset_alert_strategy.dart';
+import 'package:tankstellen/core/background/country_alert_strategy.dart';
+import 'package:tankstellen/core/background/polled_alert_strategy.dart';
+import 'package:tankstellen/core/background/provider_request_budget.dart';
+import 'package:tankstellen/core/cache/cache_manager.dart';
+import 'package:tankstellen/core/data/storage_repository.dart';
+import 'package:tankstellen/core/services/fuel_service_policy.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/services/station_service.dart';
+import 'package:tankstellen/core/storage/storage_keys.dart';
+import 'package:tankstellen/features/car/car_data_service.dart';
+import 'package:tankstellen/features/search/data/models/search_params.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+
+import '../../fakes/fake_storage_repository.dart';
+
+/// Android Auto v2 SLICE 1 (#2947) — the LIVE in-car Search data service.
+///
+/// These drive [CarDataService.resolveSearchJson] through the SAME real
+/// [CountryAlertStrategy] subclasses production resolves — a real
+/// [PolledAlertStrategy] for DE and a real [BulkDatasetAlertStrategy] for ES —
+/// each backed by a RECORDED-real-API-shaped [StationService] fixture, NOT an
+/// echo fake (per `feedback_fake_services_false_green`: an echo that returns
+/// the requested fuel would hide the cross-border bulk bug — Spain sells E5,
+/// not the requested E10, and `BackgroundPriceSource` returns EMPTY in bulk
+/// countries, which is exactly why this path uses `searchArea`).
+///
+/// What they prove:
+///  - DE (polled) E10 fix → priced E10 list, round-trips the `CarStation.parse`
+///    JSON shape;
+///  - ES (BULK) E5 fix → priced E5 list (the bulk path returns data where the
+///    polled-only `BackgroundPriceSource.searchStations` would return empty);
+///  - no persisted fix → `no_gps`, never throws;
+///  - a degenerate `(0,0)` fix is rejected by the #2872 `isUsableCoord` guard
+///    → `no_gps`;
+///  - a throwing strategy → empty `[]`, never throws (the screen keeps its
+///    snapshot);
+///  - the snapshot cache key is written on a non-empty result.
+void main() {
+  /// A recorded-API-shaped bulk dataset behind [StationService]: holds the rows
+  /// a real bulk primary (MITECO / MISE / …) would yield and answers
+  /// `searchStations` by LOCAL geo-filter — exactly the real bulk behaviour once
+  /// the whole-country dataset is in memory. Prices live on the rows; `getPrices`
+  /// returns empty (the real bulk primaries do too).
+  const esBulkPolicy = FuelServicePolicy(
+    model: SourceModel.bulkFile,
+    minInterval: Duration(minutes: 30),
+    datasetTtlSoft: Duration(hours: 6),
+    datasetTtlHard: Duration(hours: 24),
+    searchResultTtl: Duration.zero,
+    attribution: 'Test',
+    license: 'Test',
+    sourceUrl: 'https://example.test/',
+  );
+
+  group('DE (polled) — live E10 search round-trips the car JSON contract', () {
+    test('priced E10 list from the real PolledAlertStrategy + recorded fixture',
+        () async {
+      final storage = FakeStorageRepository();
+      // Persisted Berlin fix the nearest-widget builder reads (#2872 guard ok).
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      // Recorded DE rows (Tankerkönig shape: Germany prices E10).
+      final deDataset = _RecordedDataset(
+        ServiceSource.tankerkoenigApi,
+        [
+          _row('de-1', 'Aral', 52.521, 13.401, e10: 1.799, e5: 1.859,
+              diesel: 1.699),
+          _row('de-2', 'Shell', 52.516, 13.420, e10: 1.829, e5: 1.889,
+              diesel: 1.719),
+        ],
+      );
+
+      String? wroteKey;
+      String? wroteValue;
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', deDataset),
+        writeSnapshot: (k, v) async {
+          wroteKey = k;
+          wroteValue = v;
+        },
+      );
+
+      final json = await service.resolveSearchJson(storage, apiKey: 'k');
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+
+      expect(rows, hasLength(2));
+      // The JSON round-trips the shape CarStation.parse (Kotlin) expects.
+      for (final r in rows) {
+        expect(r.keys, containsAll(<String>[
+          'id', 'name', 'brand', 'lat', 'lng', 'priceText', 'fuelLabel',
+          'band', 'bandColor', 'distanceKm', 'currency',
+        ]));
+      }
+      // E10 priced (Germany sells E10) — sorted by distance.
+      final byId = {for (final r in rows) r['id']: r};
+      expect(byId['de-1']!['priceText'], '1.799');
+      expect(byId['de-1']!['fuelLabel'], 'E10');
+      expect(byId['de-2']!['priceText'], '1.829');
+
+      // Snapshot fallback refreshed with the live JSON.
+      expect(wroteKey, 'car_search_json');
+      expect(wroteValue, json);
+    });
+  });
+
+  group('ES (BULK) — live search returns priced data (not empty)', () {
+    test('real BulkDatasetAlertStrategy + recorded E5 fixture → priced E5 list',
+        () async {
+      final storage = FakeStorageRepository();
+      // Persisted Madrid fix.
+      await storage.putSetting(StorageKeys.userPositionLat, 40.4168);
+      await storage.putSetting(StorageKeys.userPositionLng, -3.7038);
+      // Spain sells E5 (SP95-E5), not E10 — drive an E5 profile so the bulk
+      // path returns the priced list the real in-app ES search would.
+      await _seedProfile(storage, radiusKm: 6, fuel: 'e5');
+
+      // Recorded ES rows: MITECO populates E5; the E10 field is empty (the
+      // exact data-shape an echo fake would wrongly paper over).
+      final esDataset = _RecordedDataset(
+        ServiceSource.mitecoApi,
+        [
+          _row('es-1', 'Repsol', 40.4170, -3.7040, e5: 1.529, diesel: 1.419),
+          _row('es-2', 'Cepsa', 40.4150, -3.7010, e5: 1.549, diesel: 1.439),
+          // Far away (Barcelona) — must be geo-filtered out of a Madrid radius.
+          _row('es-9', 'BP', 41.3874, 2.1686, e5: 1.999, diesel: 1.999),
+        ],
+      );
+
+      final service = CarDataService(
+        strategyFactory: _bulkFactory('ES', esDataset, esBulkPolicy),
+        writeSnapshot: (_, _) async {},
+      );
+
+      final json = await service.resolveSearchJson(storage, apiKey: null);
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+
+      // The bulk path returns the two in-radius ES stations PRICED — a polled-
+      // only source (BackgroundPriceSource.searchStations) would be empty here.
+      expect(rows.map((r) => r['id']).toSet(), {'es-1', 'es-2'},
+          reason: 'Barcelona is outside a 6 km Madrid radius');
+      final byId = {for (final r in rows) r['id']: r};
+      expect(byId['es-1']!['fuelLabel'], 'E5');
+      expect(byId['es-1']!['priceText'], '1.529');
+      expect(byId['es-2']!['priceText'], '1.549');
+      expect(byId['es-1']!['currency'], '€');
+    });
+  });
+
+  group('no persisted GPS → no_gps marker, never throws', () {
+    test('absent fix returns the no_gps marker', () async {
+      final storage = FakeStorageRepository();
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', _RecordedDataset(
+          ServiceSource.tankerkoenigApi, const [])),
+        writeSnapshot: (_, _) async {},
+      );
+
+      expect(await service.resolveSearchJson(storage), kNoGpsMarker);
+    });
+
+    test('a degenerate (0,0) fix is rejected by isUsableCoord → no_gps',
+        () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 0.0);
+      await storage.putSetting(StorageKeys.userPositionLng, 0.0);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', _RecordedDataset(
+          ServiceSource.tankerkoenigApi, const [])),
+        writeSnapshot: (_, _) async {},
+      );
+
+      expect(await service.resolveSearchJson(storage), kNoGpsMarker,
+          reason: '(0,0) is the unacquired-axis sentinel (#2872)');
+    });
+
+    test('getUserLocation returns no_gps when the fix is poisoned', () {
+      final storage = FakeStorageRepository();
+      final service = CarDataService();
+      expect(service.readUserLocation(storage), {'source': kNoGpsMarker});
+    });
+  });
+
+  group('never throws — a strategy fault degrades to an empty list (#2349)', () {
+    test('a throwing strategy → empty [] (the screen keeps its snapshot)',
+        () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      final service = CarDataService(
+        strategyFactory: _bulkFactory('DE', _ThrowingDataset(), esBulkPolicy),
+        writeSnapshot: (_, _) async {},
+      );
+
+      // resolveSearchJson completes and yields an empty list, never throwing —
+      // BulkDatasetAlertStrategy.searchArea spools the fault internally.
+      await expectLater(service.resolveSearchJson(storage), completes);
+      expect(await service.resolveSearchJson(storage), '[]');
+    });
+
+    test('getUserLocation reports the persisted fix payload', () {
+      final storage = FakeStorageRepository();
+      storage.inner.putSetting(StorageKeys.userPositionLat, 48.8566);
+      storage.inner.putSetting(StorageKeys.userPositionLng, 2.3522);
+      storage.inner.putSetting(StorageKeys.userPositionSource, 'gps');
+      final loc = CarDataService().readUserLocation(storage);
+      expect(loc['lat'], 48.8566);
+      expect(loc['lng'], 2.3522);
+      expect(loc['source'], 'gps');
+    });
+  });
+
+  group('snapshot fallback — the cache key is NOT written on empty', () {
+    test('an empty live result leaves the snapshot untouched', () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      var wrote = false;
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', _RecordedDataset(
+          ServiceSource.tankerkoenigApi, const [])),
+        writeSnapshot: (_, _) async => wrote = true,
+      );
+
+      expect(await service.resolveSearchJson(storage, apiKey: 'k'), '[]');
+      expect(wrote, isFalse,
+          reason: 'an empty list must not clobber the last good snapshot');
+    });
+  });
+}
+
+// ── recorded-fixture services + strategy factories ──────────────────────────
+
+/// A recorded-API-shaped dataset answering [searchStations] by local geo-filter
+/// over a fixed row list (the real bulk-primary behaviour once cached); used
+/// behind the REAL polled / bulk strategy classes so the test drives production
+/// code, not an echo fake.
+class _RecordedDataset implements StationService {
+  _RecordedDataset(this.source, this.stations);
+  final ServiceSource source;
+  final List<Station> stations;
+
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(
+    SearchParams params, {
+    CancelToken? cancelToken,
+  }) async {
+    final matched = <Station>[];
+    for (final s in stations) {
+      final dist = _planarKm(params.lat, params.lng, s.lat, s.lng);
+      if (dist <= params.radiusKm) matched.add(s.copyWith(dist: dist));
+    }
+    return ServiceResult(
+      data: matched,
+      source: source,
+      fetchedAt: DateTime(2026),
+    );
+  }
+
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+          List<String> ids) async =>
+      ServiceResult(data: const {}, source: source, fetchedAt: DateTime(2026));
+
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String id) =>
+      throw UnimplementedError();
+}
+
+/// A dataset whose every call throws — for the #2349 never-throws assertion.
+class _ThrowingDataset implements StationService {
+  @override
+  Future<ServiceResult<List<Station>>> searchStations(SearchParams params,
+          {CancelToken? cancelToken}) async =>
+      throw const SocketException('injected fault');
+  @override
+  Future<ServiceResult<Map<String, StationPrices>>> getPrices(
+          List<String> ids) async =>
+      throw const SocketException('injected fault');
+  @override
+  Future<ServiceResult<StationDetail>> getStationDetail(String id) =>
+      throw UnimplementedError();
+}
+
+/// Build the REAL [PolledAlertStrategy] for [code] backed by [dataset] via the
+/// #2862 `serviceBuilder` seam — production strategy code, recorded service.
+CarStrategyFactory _polledFactory(String code, _RecordedDataset dataset) {
+  return (
+    country, {
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    String? apiKey,
+    ProviderRequestBudget? budget,
+  }) =>
+      PolledAlertStrategy.forCountry(
+        code,
+        storage: storage,
+        cache: cache,
+        apiKey: apiKey,
+        deps: PolledAlertStrategyDeps(
+          budget: budget,
+          serviceBuilder: (_, {String? apiKey}) => dataset,
+        ),
+      );
+}
+
+/// Build the REAL [BulkDatasetAlertStrategy] for [code] backed by [dataset] via
+/// its `service` override — production strategy code, recorded service.
+CarStrategyFactory _bulkFactory(
+    String code, StationService dataset, FuelServicePolicy policy) {
+  return (
+    country, {
+    required StorageRepository storage,
+    required CacheStrategy cache,
+    String? apiKey,
+    ProviderRequestBudget? budget,
+  }) =>
+      BulkDatasetAlertStrategy(
+        countryCode: code,
+        storage: storage,
+        cache: cache,
+        policy: policy,
+        service: dataset,
+        budget: budget,
+      );
+}
+
+Future<void> _seedProfile(
+  FakeStorageRepository storage, {
+  required double radiusKm,
+  required String fuel,
+}) async {
+  await storage.saveProfile('p1', {
+    'id': 'p1',
+    'name': 'Default',
+    'defaultSearchRadius': radiusKm,
+    'preferredFuelType': fuel,
+  });
+  await storage.setActiveProfileId('p1');
+}
+
+Station _row(
+  String id,
+  String brand,
+  double lat,
+  double lng, {
+  double? e5,
+  double? e10,
+  double? diesel,
+}) =>
+    Station(
+      id: id,
+      name: '$brand forecourt',
+      brand: brand,
+      street: 'Main 1',
+      postCode: '00000',
+      place: 'Town',
+      lat: lat,
+      lng: lng,
+      e5: e5,
+      e10: e10,
+      diesel: diesel,
+      isOpen: true,
+    );
+
+double _planarKm(double lat1, double lng1, double lat2, double lng2) {
+  const kmPerDeg = 111.0; // Fine for the small distances under test.
+  final dLat = (lat2 - lat1) * kmPerDeg;
+  final dLng = (lng2 - lng1) * kmPerDeg;
+  return math.sqrt(dLat * dLat + dLng * dLng);
+}


### PR DESCRIPTION
## Android Auto v2 — SLICE 1 of #2947 (epic #2946)

Replaces the v1 SharedPreferences snapshot for the **in-car SEARCH screen** with a **LIVE, on-demand fetch** via a headless Flutter engine bridge. **Radar stays on the v1 snapshot** in this slice.

### Native (src/main — GMS-free, no FGS)
- **NEW `CarDataBridge.kt`** — a Kotlin `object` that lazily creates + **caches its own headless `FlutterEngine`** (`FlutterEngineCache` id `"tankstellen_car"`), runs the Dart `carDataMain` entry point, and opens `MethodChannel("tankstellen/car_data")`. `fetch(kind)` has an **8 s hard timeout** + a **per-kind re-entrancy guard**; on timeout / fault / `no_gps` it returns `null` so the screen **keeps its snapshot**. Lifecycle: created on Session `CREATED`, **destroyed + evicted** on Session `DESTROYED` — the engine lives only in the **bound** CarAppService/Session, **never a started/foreground service** (preserves the #1498 FGS-avoidance).
  - **Plugin auto-registration verified**, not assumed: `FlutterEngine(context)` defaults `automaticallyRegisterPlugins=true`, and its constructor calls `flutterLoader.startInitialization` + `ensureInitializationComplete` then `GeneratedPluginRegister.registerGeneratedPlugins(this)` (checked against the embedding `FlutterEngine.java`). So the headless engine gets `path_provider` (Hive isolate path) + `home_widget` (snapshot write); Dio uses `dart:io` HttpClient (no plugin).
- **`SearchScreen` wired live** (`kind = SEARCH`): `onGetTemplate` renders the **snapshot instantly** (never blank), kicks the live fetch, and `invalidate()`s to the live list. Adds the **host Refresh** listener (`setOnContentRefreshListener`, quota-exempt) and a **cold-start spinner**; no snapshot + no live → **`car_empty_no_gps`**. `RadarScreen` keeps `kind = RADAR` on the snapshot path.
- Fixed the stale `TankstellenCarAppService` docstring.
- Native `car_loading` / `car_empty_no_gps` / `car_refresh` strings (**native, not ARB**).

### Dart
- **NEW `lib/features/car/car_data_service.dart`** — `@pragma('vm:entry-point') carDataMain()` + a testable `CarDataService`. Reads the persisted fix (`StorageKeys.userPositionLat/Lng`) under `HiveIsolateLock` with the **#2872 `isUsableCoord` guard**, resolves country (`countryForLatLng` → active-country fallback) + active-profile radius/fuel, fetches LIVE via **`CountryAlertStrategy.searchArea`** (covers **BULK** countries ES/IT/AR/DK where `BackgroundPriceSource` returns empty), **consults the shared `ProviderRequestBudget`** (never bypassed), encodes with the same **`CarStationData.encode`**, refreshes the snapshot cache key, and **never throws** (`no_gps` / empty on any fault, boxes always closed in `finally`).

### Tests + CI
- `car_data_service_test.dart` drives the **REAL** Polled (DE/E10) and Bulk (ES/E5) strategies with **recorded-real-API-shaped fixtures** (not echo fakes — **RED-verified**: ES with an E10 profile fails because Spain sells E5). Plus `no_gps`, degenerate `(0,0)`, fault → empty (never-throws), and snapshot-write coverage.
- `CarScreensTest` extended with a fake `CarLiveSource`: snapshot-first, live-replace, **empty-keeps-snapshot (RED-verified)**, no-gps cold start, Radar stays snapshot. **NEW `CarDataBridgeTest`** for the channel/lifecycle contract.
- **`scripts/audit_no_fgs.sh`** + a `build-android` CI step assert the **merged play manifest has ZERO `FOREGROUND_SERVICE*` permissions** (comments stripped) — a future FGS re-merge trips CI, not the opaque Play #1498 403.

### Verification
- `flutter analyze` clean; `flutter test` (car + widget + full lint suite) green; never-throws + file-length lint gates green.
- Kotlin/Robolectric `testPlayDebugUnitTest` green (CarScreensTest 10, CarDataBridgeTest 6).
- `flutter build apk --debug --flavor play` and `--flavor fdroid` both compile.
- **F-Droid no-GMS audit passed** (layer A clean; layer B with dexdump: no GMS/ML Kit class definitions shipped).

Refs #2947 — **Search live**; Radar (slice 2) + address (slice 3) + live in-car GPS (later phase) remain. **#2947 stays open.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
