### PR TITLE
fix(radar): proximity/closeness fill bar renders at zero height — fill invisible on list, recording & PiP

### DIFF
--- a/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
+++ b/lib/features/consumption/presentation/widgets/proximity_fill_bar.dart
@@ -100,6 +100,14 @@ class ProximityFillBar extends StatelessWidget {
             curve: Curves.easeOut,
             builder: (context, value, _) => FractionallySizedBox(
               widthFactor: value,
+              // #2988 — without heightFactor the childless DecoratedBox had no
+              // intrinsic height and the parent Container's centerLeft
+              // alignment loosened its height constraint to min 0, so the
+              // gradient fill painted at ZERO height (invisible) on every
+              // surface. Fill the full bar height and keep the leading edge
+              // pinned left so the fill grows rightward as the driver nears.
+              heightFactor: 1,
+              alignment: Alignment.centerLeft,
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   gradient: LinearGradient(colors: [green, accent]),

--- a/test/features/consumption/presentation/widgets/proximity_fill_bar_test.dart
+++ b/test/features/consumption/presentation/widgets/proximity_fill_bar_test.dart
@@ -63,6 +63,89 @@ void main() {
     expect(box.widthFactor, closeTo(0.8, 1e-6));
   });
 
+  // #2988 — the gradient fill rendered at ZERO HEIGHT on every surface (list,
+  // in-trip recording card, PiP), so the green→accent fill was invisible and
+  // only the grey track showed. The bug: the FractionallySizedBox carried a
+  // widthFactor but no heightFactor, and the parent Container's centerLeft
+  // alignment loosened the height constraint to min 0, collapsing the childless
+  // DecoratedBox to 0 px tall. Every prior "closeness" fix only changed the
+  // fill VALUE/widthFactor, never the RENDERED height — false-green. This is
+  // the guard: assert the gradient box paints at the bar's full height.
+  testWidgets('gradient fill renders at the bar height, not zero (#2988)',
+      (tester) async {
+    const barHeight = 6.0;
+    await tester.pumpWidget(
+      _host(
+        const SizedBox(
+          width: 200,
+          // 0.5 km inside a 1 km radius → fill 0.5: a non-trivial, visible bar.
+          child: ProximityFillBar(
+            distanceMeters: 500,
+            radiusMeters: 1000,
+            height: barHeight,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The gradient fill box is the DecoratedBox carrying the LinearGradient.
+    final fillBox = find.byWidgetPredicate(
+      (w) =>
+          w is DecoratedBox &&
+          w.decoration is BoxDecoration &&
+          (w.decoration as BoxDecoration).gradient != null,
+    );
+    expect(fillBox, findsOneWidget);
+
+    final size = tester.getSize(fillBox);
+    expect(size.height, greaterThan(0),
+        reason: 'RED on master: the fill collapsed to 0 px tall → invisible');
+    expect(size.height, closeTo(barHeight, 0.5),
+        reason: 'the fill must fill the full bar height, not just a hairline');
+  });
+
+  testWidgets(
+      'rendered fill width tracks closeness — two distances, two widths (#2988)',
+      (tester) async {
+    Finder fillBox() => find.byWidgetPredicate(
+          (w) =>
+              w is DecoratedBox &&
+              w.decoration is BoxDecoration &&
+              (w.decoration as BoxDecoration).gradient != null,
+        );
+
+    // Closer station (fill 0.8) → wider fill.
+    await tester.pumpWidget(
+      _host(
+        const SizedBox(
+          width: 200,
+          child: ProximityFillBar(distanceMeters: 200, radiusMeters: 1000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final closeWidth = tester.getSize(fillBox()).width;
+
+    // Farther station (fill 0.3) → narrower fill.
+    await tester.pumpWidget(
+      _host(
+        const SizedBox(
+          width: 200,
+          child: ProximityFillBar(distanceMeters: 700, radiusMeters: 1000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final farWidth = tester.getSize(fillBox()).width;
+
+    expect(closeWidth, closeTo(0.8 * 200, 1.0),
+        reason: 'fill ≈ fraction × trackWidth (200 px)');
+    expect(farWidth, closeTo(0.3 * 200, 1.0));
+    expect(closeWidth, greaterThan(farWidth),
+        reason: 'closer = visibly fuller; the two fills must differ');
+  });
+
   testWidgets('fill is a two-colour green→accent gradient (#2808)',
       (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
Closes #2988.

## The bug

The Fuel Station Radar proximity/closeness fill bar (`ProximityFillBar`) painted its green→accent gradient at **zero height** on **every** surface, so the fill was invisible everywhere and only the full-width grey `track` showed:

- Search results list (`station_card_status.dart`)
- In-trip recording radar card (`trip_radar_card.dart`)
- PiP price overlay (`trip_recording_pip_price_layout.dart`)

This is why **6 prior "closeness" fixes appeared to do nothing** — they all only changed the fill **VALUE** (`widthFactor`), which was already correct. The fill was never visible to begin with.

## Root cause

The `FractionallySizedBox` carried `widthFactor: value` but **no `heightFactor`**, wrapping a **childless** `DecoratedBox`. The parent `Container`'s `alignment: Alignment.centerLeft` loosened the child's height constraint to min 0, so with no intrinsic height the gradient box rendered **0 px tall**.

## The fix

Add `heightFactor: 1` + `alignment: Alignment.centerLeft` to the `FractionallySizedBox` so the gradient fills the full bar height while the leading edge stays pinned left (fill grows rightward as the driver nears). One shared-widget fix repairs all three surfaces at once.

## Regression guard

Prior tests only asserted `widthFactor` / fill value, never the **rendered height** — that false-green let this ship. Added a test that pumps the real `ProximityFillBar` in a sized box and asserts:

1. The gradient `DecoratedBox`'s rendered `Size.height` > 0 and ≈ bar height (6 px). **Verified RED on master** (`Actual: <0.0>`), green after the fix.
2. Two different distances yield two visibly-different rendered widths (width still tracks closeness; closer = fuller).

## Scope

`proximity_fill_bar.dart` + its test only. Does NOT touch `radar_closeness.dart` (scale logic already correct, #2985), OBD2, the FR service, the car bridge, or ARB.

## Gates

- `flutter analyze` clean on both changed files.
- No new ARB strings; no `*.g.dart` / `*.freezed.dart` drift.
- Widget 123 lines (< 400 cap).
- Consumption-widget + search + core-util suites: **1925 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
