### PR TITLE
feat(android-auto): v2 phase-1 complete — live Radar + address subtitle (closes #2947)

### DIFF
--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarDataBridge.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarDataBridge.kt
@@ -14,17 +14,17 @@ import io.flutter.plugin.common.MethodChannel
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Android Auto v2 — SLICE 1 (#2947 / epic #2946): the LIVE data bridge between
+ * Android Auto v2 — PHASE-1 (#2947 / epic #2946): the LIVE data bridge between
  * the native car screens and a headless Flutter engine.
  *
- * v1 rendered a stale SharedPreferences snapshot the last in-app search wrote
- * ([CarStation.read]). Slice 1 swaps the SEARCH data source for an on-demand
- * live fetch: this object spins up a dedicated, CACHED headless [FlutterEngine]
- * and runs the Dart `carDataMain` entry point (`lib/features/car/
- * car_data_service.dart`) through it, then asks Dart — over the
- * `tankstellen/car_data` [MethodChannel] — for the freshest nearby stations.
- *
- * The Radar screen STAYS on the v1 snapshot this slice (Radar = slice 2).
+ * v1 rendered a stale SharedPreferences snapshot the last in-app search/radar
+ * wrote ([CarStation.read]). Phase-1 swaps BOTH the SEARCH (slice 1, #2987) and
+ * the RADAR (slice 2) data sources for an on-demand live fetch: this object
+ * spins up a dedicated, CACHED headless [FlutterEngine] and runs the Dart
+ * `carDataMain` entry point (`lib/features/car/car_data_service.dart`) through
+ * it, then asks Dart — over the `tankstellen/car_data` [MethodChannel] — for
+ * the freshest nearby stations (Search and Radar share one live producer,
+ * differing only in the snapshot fallback key).
  *
  * ## Why this preserves the #1498 FGS-avoidance
  * The engine lives in the BOUND [androidx.car.app.CarAppService]/Session the
@@ -90,6 +90,10 @@ object CarDataBridge : CarLiveSource {
     /** Dart method that returns the live Search JSON. */
     // i18n-ignore: protocol token, not user-facing text.
     private const val METHOD_FETCH_SEARCH = "fetchSearch"
+
+    /** Dart method that returns the live Radar JSON (v2 phase-1 slice 2). */
+    // i18n-ignore: protocol token, not user-facing text.
+    private const val METHOD_FETCH_RADAR = "fetchRadar"
 
     /** Dart sentinel for "no usable persisted GPS fix". */
     // i18n-ignore: protocol sentinel, not user-facing text.
@@ -173,17 +177,21 @@ object CarDataBridge : CarLiveSource {
     /**
      * Fetch the live list for [kind], invoking [callback] exactly once with the
      * JSON string, or `null` to keep the snapshot. Honours [FETCH_TIMEOUT_MS]
-     * and the per-kind re-entrancy guard. Slice 1 only wires
-     * [CarFetchKind.SEARCH]; a [CarFetchKind.RADAR] request returns `null`
-     * (Radar still renders the v1 snapshot).
+     * and the per-kind re-entrancy guard. Phase-1 wires BOTH
+     * [CarFetchKind.SEARCH] (slice 1) and [CarFetchKind.RADAR] (slice 2) to
+     * their respective Dart fetch methods.
      *
      * The callback is always delivered on the main thread.
      */
     override fun fetch(kind: CarFetchKind, callback: FetchCallback) {
         val ch = channel
-        if (ch == null || kind != CarFetchKind.SEARCH) {
+        if (ch == null) {
             callback.onResult(null)
             return
+        }
+        val method = when (kind) {
+            CarFetchKind.SEARCH -> METHOD_FETCH_SEARCH
+            CarFetchKind.RADAR -> METHOD_FETCH_RADAR
         }
 
         val guard = inFlight.getOrPut(kind) { AtomicBoolean(false) }
@@ -204,7 +212,7 @@ object CarDataBridge : CarLiveSource {
         val timeout = Runnable { finish(null) }
         mainHandler.postDelayed(timeout, FETCH_TIMEOUT_MS)
 
-        ch.invokeMethod(METHOD_FETCH_SEARCH, null, object : MethodChannel.Result {
+        ch.invokeMethod(method, null, object : MethodChannel.Result {
             override fun success(result: Any?) {
                 mainHandler.removeCallbacks(timeout)
                 val json = result as? String
@@ -226,8 +234,8 @@ object CarDataBridge : CarLiveSource {
 }
 
 /**
- * Which car list a [CarDataBridge.fetch] targets. SLICE 1 (#2947) wires only
- * [SEARCH] to the live bridge; [RADAR] stays on the v1 snapshot (slice 2).
+ * Which car list a [CarDataBridge.fetch] targets. Phase-1 (#2947) wires BOTH
+ * [SEARCH] (slice 1, #2987) and [RADAR] (slice 2) to the live bridge.
  */
 enum class CarFetchKind {
     SEARCH,

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarStation.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/CarStation.kt
@@ -22,6 +22,13 @@ data class CarStation(
     val id: String,
     val name: String,
     val brand: String,
+    /**
+     * Street + city subtitle (e.g. "Hauptstr. 1, 10115 Berlin"), or "" when the
+     * station carries no address. Added in v2 phase-1 slice 3 (#2947) — old
+     * address-less snapshots default it to "" (see [fromJson]), so they never
+     * crash.
+     */
+    val address: String,
     val lat: Double,
     val lng: Double,
     /** Formatted selected-fuel price (3 dp), or "" when the fuel is unpriced. */
@@ -83,6 +90,9 @@ data class CarStation(
             id = o.optString("id", ""),
             name = o.optString("name", o.optString("brand", "Station")),
             brand = o.optString("brand", ""),
+            // Back-compat: an old snapshot written before slice 3 has no
+            // "address" key → optString returns "" (no subtitle), never throws.
+            address = o.optString("address", ""),
             lat = o.optDouble("lat", 0.0),
             lng = o.optDouble("lng", 0.0),
             priceText = o.optString("priceText", ""),

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/RadarScreen.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/RadarScreen.kt
@@ -7,18 +7,22 @@ import androidx.car.app.CarContext
 import de.tankstellen.tankstellen.R
 
 /**
- * Android Auto Radar screen. Renders the latest in-app radar result list
- * (written by Flutter to [CarStation.RADAR_KEY]) as a
- * [androidx.car.app.model.PlaceListMapTemplate].
+ * Android Auto Radar screen, now fed by a LIVE on-demand fetch through the
+ * headless [CarDataBridge] (v2 phase-1 slice 2, #2947) — it was the v1
+ * SharedPreferences snapshot before.
  *
- * v2 SLICE 1 (#2947) wires only the Search screen to the LIVE headless
- * [CarDataBridge]; Radar STAYS on the v1 snapshot path
- * ([StationListScreen.liveFetchEnabled] left false) — its live fetch is slice
- * 2. The [kind] is set so slice 2 only flips `liveFetchEnabled` on.
+ * `onGetTemplate` (in [StationListScreen]) returns the `car_radar_json`
+ * snapshot immediately for an instant, never-blank first frame, then kicks
+ * `CarDataBridge.fetch(RADAR)` and rebuilds from the live list when it arrives
+ * (the nearest priced stations within the active-profile radius, distance-
+ * sorted). With no snapshot AND no live data (a fresh head unit with no
+ * persisted GPS fix) it shows the `car_empty_no_gps` message — never crashes.
+ * An empty live result keeps the existing snapshot.
  */
 class RadarScreen(carContext: CarContext) : StationListScreen(carContext) {
     override val titleRes: Int = R.string.car_radar_title
     override val prefsKey: String = CarStation.RADAR_KEY
-    override val emptyMessageRes: Int = R.string.car_empty_radar
+    override val emptyMessageRes: Int = R.string.car_empty_no_gps
     override val kind: CarFetchKind = CarFetchKind.RADAR
+    override val liveFetchEnabled: Boolean = true
 }

--- a/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/StationListScreen.kt
+++ b/android/app/src/main/kotlin/de/tankstellen/tankstellen/car/StationListScreen.kt
@@ -149,10 +149,15 @@ abstract class StationListScreen(carContext: CarContext) : Screen(carContext) {
     private fun buildRow(station: CarStation): Row {
         val rowBuilder = Row.Builder().setTitle(station.title())
 
-        // Subtitle: price (with fuel label + currency) then distance via a
-        // DistanceSpan so the host renders the unit per the user's locale.
-        rowBuilder.addText(station.priceLine())
-        station.distanceText()?.let { rowBuilder.addText(it) }
+        // PlaceListMapTemplate rows allow at most two secondary text lines, so
+        // pack price (with fuel label + currency) AND distance — via a
+        // DistanceSpan the host renders in the user's locale unit — onto ONE
+        // line, leaving the second line for the address subtitle (#2947 slice
+        // 3). The address is rendered under the name, alongside price+distance.
+        rowBuilder.addText(station.priceAndDistanceLine())
+        if (station.address.isNotBlank()) {
+            rowBuilder.addText(station.address)
+        }
 
         if (station.hasLocation) {
             val marker = PlaceMarker.Builder()
@@ -172,23 +177,30 @@ abstract class StationListScreen(carContext: CarContext) : Screen(carContext) {
 private fun CarStation.title(): String =
     if (brand.isNotBlank()) brand else name
 
+/**
+ * One secondary line packing the price (with fuel label + currency) and the
+ * distance — the distance rendered through a [DistanceSpan] so the head unit
+ * shows it in the user's locale unit. Falls back to just the price when there
+ * is no distance, or just the fuel label when the fuel is unpriced.
+ */
+private fun CarStation.priceAndDistanceLine(): CharSequence {
+    val price = priceLine()
+    if (distanceKm <= 0.0) return price
+
+    // "<price>  ·  <distance>" — a single span placeholder anchors the
+    // DistanceSpan, which the host replaces with the locale-formatted distance.
+    val prefix = "$price  ·  "
+    val builder = android.text.SpannableStringBuilder(prefix).append(" ")
+    val span = DistanceSpan.create(
+        Distance.create(distanceKm, Distance.UNIT_KILOMETERS)
+    )
+    builder.setSpan(span, prefix.length, builder.length, 0)
+    return builder
+}
+
 /** Price line, e.g. "E10  1.799 €" — falls back to the fuel label alone. */
 private fun CarStation.priceLine(): CharSequence {
     if (priceText.isEmpty()) return fuelLabel
     val cur = if (currency.isNotBlank()) " $currency" else ""
     return if (fuelLabel.isNotBlank()) "$fuelLabel  $priceText$cur" else "$priceText$cur"
-}
-
-/**
- * Distance rendered as a [DistanceSpan] so the head unit shows it in the
- * user's locale units. Returns null when no distance is known.
- */
-private fun CarStation.distanceText(): CharSequence? {
-    if (distanceKm <= 0.0) return null
-    val builder = android.text.SpannableString(" ")
-    val span = DistanceSpan.create(
-        Distance.create(distanceKm, Distance.UNIT_KILOMETERS)
-    )
-    builder.setSpan(span, 0, builder.length, 0)
-    return builder
 }

--- a/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarDataBridgeTest.kt
+++ b/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarDataBridgeTest.kt
@@ -17,8 +17,8 @@ import org.robolectric.shadows.ShadowLooper
  *
  * The real [CarDataBridge] wraps a [io.flutter.embedding.engine.FlutterEngine]
  * that cannot spin up under Robolectric (no native Flutter shell), so these
- * pin the behaviour reachable WITHOUT a live engine: the not-ready guard, the
- * RADAR short-circuit (slice 1 only wires SEARCH live), and the [CarFetchKind]
+ * pin the behaviour reachable WITHOUT a live engine: the not-ready guard (for
+ * BOTH kinds now that phase-1 wires SEARCH + RADAR live) and the [CarFetchKind]
  * contract. The full snapshot-first → live-second render flow (which DOES need
  * a working live source) is covered by `CarScreensTest` via a fake [CarLiveSource].
  */
@@ -49,9 +49,10 @@ class CarDataBridgeTest {
     }
 
     @Test
-    fun fetch_returnsNull_forRadarKind_evenIfAsked() {
-        // SLICE 1 wires only SEARCH live; a RADAR fetch must short-circuit to
-        // null so Radar keeps its v1 snapshot (slice 2 wires its live fetch).
+    fun fetch_returnsNull_forRadarKind_whenNotReady() {
+        // Phase-1 wires RADAR live too, but with no engine (not ready) the RADAR
+        // fetch — like SEARCH — posts a null callback so Radar keeps its
+        // snapshot rather than blanking.
         CarDataBridge.destroy()
         var result: String? = "sentinel"
         CarDataBridge.fetch(CarFetchKind.RADAR) { json -> result = json }

--- a/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarScreensTest.kt
+++ b/android/app/src/test/kotlin/de/tankstellen/tankstellen/car/CarScreensTest.kt
@@ -115,11 +115,14 @@ class CarScreensTest {
 
     @Test
     fun radarScreen_rendersSeededStationsAndEmptyState() {
-        // Empty first: missing key shows the radar empty message.
+        // v2 PHASE-1 SLICE 2 (#2947): RadarScreen is now live-enabled, but the
+        // real CarDataBridge has no engine under Robolectric (isReady == false),
+        // so it renders the snapshot only — exactly as Search does without an
+        // engine. Empty first: missing key shows the v2 no-GPS empty message.
         var template = templateOf(RadarScreen(carContext)) as PlaceListMapTemplate
         var list = template.itemList as ItemList
         assertTrue(list.items.isEmpty())
-        assertEquals(string(R.string.car_empty_radar), list.noItemsMessage.toString())
+        assertEquals(string(R.string.car_empty_no_gps), list.noItemsMessage.toString())
 
         // Seed → renders the stations.
         seed(CarStation.RADAR_KEY, twoStationsJson())
@@ -251,16 +254,125 @@ class CarScreensTest {
         assertEquals(string(R.string.car_empty_no_gps), list.noItemsMessage.toString())
     }
 
+    // ── v2 PHASE-1 SLICE 2 (#2947) — LIVE Radar via the headless bridge ───────
+
+    /** A [RadarScreen] wired to a fake live source for deterministic tests. */
+    private inner class FakeLiveRadarScreen(
+        private val source: CarLiveSource,
+    ) : StationListScreen(carContext) {
+        override val titleRes: Int = R.string.car_radar_title
+        override val prefsKey: String = CarStation.RADAR_KEY
+        override val emptyMessageRes: Int = R.string.car_empty_no_gps
+        override val kind: CarFetchKind = CarFetchKind.RADAR
+        override val liveFetchEnabled: Boolean = true
+        override val liveSource: CarLiveSource = source
+    }
+
     @Test
-    fun radarScreen_staysOnSnapshot_doesNotFetchLive() {
-        // SLICE 1: Radar must NOT hit the live bridge — it renders the v1
-        // snapshot only. (Its kind is RADAR, liveFetchEnabled false.)
+    fun liveRadar_rendersSnapshotBeforeAnyLiveResult() {
+        // First render must show the radar snapshot — the live result lands
+        // only on the next render (never-blank-first-frame).
+        seed(CarStation.RADAR_KEY, twoStationsJson())
+        val source = FakeLiveSource().apply {
+            replies.add(oneStationJson("Esso", 52.7, 13.7))
+        }
+        val screen = FakeLiveRadarScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        val first = rows(screen.onGetTemplate())
+        assertEquals(2, first.size)
+        assertEquals("Aral", first[0].title.toString())
+    }
+
+    @Test
+    fun liveRadar_freshJsonReplacesSnapshotOnNextRender() {
+        seed(CarStation.RADAR_KEY, twoStationsJson())
+        val source = FakeLiveSource().apply {
+            replies.add(oneStationJson("Esso", 52.7, 13.7))
+        }
+        val screen = FakeLiveRadarScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        rows(screen.onGetTemplate()) // first render kicks + caches the live list
+        val second = rows(screen.onGetTemplate())
+        assertEquals(1, second.size)
+        assertEquals("Esso", second[0].title.toString())
+    }
+
+    @Test
+    fun liveRadar_emptyLiveResultKeepsSnapshot() {
+        seed(CarStation.RADAR_KEY, twoStationsJson())
+        val source = FakeLiveSource() // empty queue → fetch yields null
+        val screen = FakeLiveRadarScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        rows(screen.onGetTemplate())
+        val second = rows(screen.onGetTemplate())
+        assertEquals("a null live radar result keeps the snapshot", 2, second.size)
+        assertEquals("Aral", second[0].title.toString())
+    }
+
+    @Test
+    fun liveRadar_noSnapshotAndNoLiveShowsNoGpsMessage() {
+        // Fresh head unit: no radar snapshot AND the live fetch returns null →
+        // the car_empty_no_gps message, never a crash.
+        val source = FakeLiveSource() // empty queue → null
+        val screen = FakeLiveRadarScreen(source)
+        ScreenController(screen).moveToState(Lifecycle.State.CREATED)
+
+        val firstLoading = (screen.onGetTemplate() as PlaceListMapTemplate).isLoading
+        assertTrue("cold start with no snapshot shows the spinner", firstLoading)
+
+        val list = (screen.onGetTemplate() as PlaceListMapTemplate).itemList as ItemList
+        assertTrue(list.items.isEmpty())
+        assertEquals(string(R.string.car_empty_no_gps), list.noItemsMessage.toString())
+    }
+
+    @Test
+    fun realRadarScreen_isLiveEnabled_andStaysOnSnapshotWithoutAnEngine() {
+        // The REAL RadarScreen opts into the live bridge (slice 2). With no
+        // engine under Robolectric (isReady == false) it renders the snapshot
+        // and never crashes — the live wiring is exercised by the fake above.
         seed(CarStation.RADAR_KEY, twoStationsJson())
         val template = templateOf(RadarScreen(carContext)) as PlaceListMapTemplate
         assertEquals(2, rows(template).size)
-        // RadarScreen leaves liveFetchEnabled false, so the default real
-        // CarDataBridge is never asked (no engine in tests) — proven by the
-        // render succeeding with the snapshot and no crash.
+    }
+
+    // ── v2 PHASE-1 SLICE 3 (#2947) — the address subtitle, lock-step ──────────
+
+    @Test
+    fun addressSubtitle_rendersOnARow() {
+        seed(CarStation.SEARCH_KEY, addressStationJson())
+        val template = templateOf(SearchScreen(carContext)) as PlaceListMapTemplate
+        val row = rows(template).first()
+
+        // The address is one of the row's secondary text lines.
+        val texts = row.texts.map { it.toString() }
+        assertTrue(
+            "the address subtitle renders on the row: $texts",
+            texts.any { it.contains("Hauptstr. 1") && it.contains("Berlin") },
+        )
+    }
+
+    @Test
+    fun carStation_parsesAddress_andOldAddresslessSnapshotDoesNotCrash() {
+        // Fresh JSON carries the address.
+        val withAddr = CarStation.parse(addressStationJson())
+        assertEquals(1, withAddr.size)
+        assertEquals("Hauptstr. 1, 10115 Berlin", withAddr[0].address)
+
+        // BACK-COMPAT: an OLD address-less snapshot (written before slice 3)
+        // parses fine, defaulting address to "" — never crashes.
+        val oldJson = """
+            [
+              {"id":"a","name":"Aral","brand":"Aral","lat":52.5,"lng":13.4,
+               "price":1.799,"priceText":"1.799","fuelLabel":"E10","band":"cheap",
+               "bandColor":4282621761,"distanceKm":1.2,"currency":"€"}
+            ]
+        """.trimIndent()
+        val old = CarStation.parse(oldJson)
+        assertEquals(1, old.size)
+        assertEquals("", old[0].address)
     }
 
     private fun oneStationJson(brand: String, lat: Double, lng: Double): String = """
@@ -268,6 +380,15 @@ class CarScreensTest {
           {"id":"x","name":"$brand X","brand":"$brand","lat":$lat,"lng":$lng,
            "price":1.749,"priceText":"1.749","fuelLabel":"E10","band":"cheap",
            "bandColor":4282621761,"distanceKm":2.1,"currency":"€"}
+        ]
+    """.trimIndent()
+
+    private fun addressStationJson(): String = """
+        [
+          {"id":"a","name":"Aral Hauptstr","brand":"Aral",
+           "address":"Hauptstr. 1, 10115 Berlin","lat":52.5,"lng":13.4,
+           "price":1.799,"priceText":"1.799","fuelLabel":"E10","band":"cheap",
+           "bandColor":4282621761,"distanceKm":1.2,"currency":"€"}
         ]
     """.trimIndent()
 }

--- a/lib/features/car/car_data_service.dart
+++ b/lib/features/car/car_data_service.dart
@@ -23,45 +23,41 @@ import '../search/domain/entities/fuel_type.dart';
 import '../search/domain/entities/station.dart';
 import '../widget/data/car_station_data.dart';
 
-/// Android Auto v2 — SLICE 1 (#2947 / epic #2946): the headless Flutter entry
-/// point the native [CarDataBridge] runs to fetch a LIVE in-car Search list.
+/// Android Auto v2 — PHASE-1 (#2947 / epic #2946): the headless Flutter entry
+/// point the native [CarDataBridge] runs to fetch LIVE in-car Search AND Radar
+/// lists.
 ///
 /// ## Why a dedicated entry point
-/// The v1 car Search screen rendered a SharedPreferences snapshot written by
-/// the last *in-app* search (`CarStationWriter`) — stale, and empty for a
-/// driver who never opened the phone app. Slice 1 replaces the SEARCH data
-/// source with a live, on-demand fetch: the native `CarAppService`/Session
-/// (a BOUND service — never a started/foreground service, preserving the
-/// #1498 FGS-avoidance) spins up a cached headless [FlutterEngine] and runs
-/// [carDataMain] through it, then asks this side, over the
-/// `tankstellen/car_data` [MethodChannel], for the freshest nearby stations.
-///
-/// The Radar screen STAYS on the v1 snapshot in this slice (Radar = slice 2).
+/// The v1 car screens rendered a stale SharedPreferences snapshot the last
+/// *in-app* search / radar wrote (`CarStationWriter`) — empty for a driver who
+/// never opened the phone app. Phase-1 replaces both the SEARCH (slice 1, #2987)
+/// and the RADAR (slice 2) sources with a live, on-demand fetch: the native
+/// `CarAppService`/Session (a BOUND service — never a started/foreground
+/// service, preserving the #1498 FGS-avoidance) spins up a cached headless
+/// [FlutterEngine], runs [carDataMain] through it, then asks this side over the
+/// `tankstellen/car_data` [MethodChannel] for the freshest nearby stations.
+/// Search and Radar share ONE live producer (same fix + country + profile
+/// radius/fuel + distance sort + cap — the nearest priced stations, v1's in-app
+/// radar shape); they differ ONLY in the snapshot key refreshed
+/// ([CarStationData.searchKey] / [CarStationData.radarKey]).
 ///
 /// ## Persisted-fix GPS only (never a live lock)
-/// The contract (#2947) is the persisted last-known fix, exactly as the
-/// nearest-widget builder reads it — `StorageKeys.userPositionLat/Lng` with
-/// the #2872 [isUsableCoord] guard. There is no live GPS in the car process
-/// in slice 1 (that, plus the `requestPermissions` flow, is a later phase),
-/// so this never blocks on a fix; an absent/poisoned fix returns the
-/// [kNoGpsMarker] and the screen keeps its snapshot / empty-state.
+/// The contract (#2947) is the persisted last-known fix the nearest-widget
+/// builder reads — `StorageKeys.userPositionLat/Lng` with the #2872
+/// [isUsableCoord] guard. No live GPS in the car process in phase-1 (that + the
+/// `requestPermissions` flow is a later phase), so this never blocks; an absent
+/// / poisoned fix returns [kNoGpsMarker] and the screen keeps its snapshot.
 ///
-/// ## Live fetch path — bulk-country-correct
-/// The fetch goes through [CountryAlertStrategy.searchArea], which resolves
-/// the right strategy per `FuelServicePolicy.model`: a [PolledAlertStrategy]
-/// for polled APIs (DE/AT/…) and a [BulkDatasetAlertStrategy] for bulk-file
-/// countries (ES/IT/AR/DK). This is deliberate — `BackgroundPriceSource`
-/// would return empty in a bulk country, and `StationService.searchStations`
-/// returns the wrapped `ServiceResult`. The shared per-provider
-/// [ProviderRequestBudget] is consulted (never bypassed) so the live car
-/// fetch honours each free API's ToS spacing, sharing one gate with the
-/// foreground + background scan.
-///
-/// ## Never throws
-/// Every public handler completes — on any fault it returns an empty / no_gps
-/// payload, never throwing into the OS-spawned engine (mirrors the background
-/// scan coordinator). Hive is opened under [HiveIsolateLock] and always
-/// closed in `finally`.
+/// ## Live fetch path — bulk-country-correct + never throws
+/// The fetch goes through [CountryAlertStrategy.searchArea], resolving the right
+/// strategy per `FuelServicePolicy.model`: a [PolledAlertStrategy] (DE/AT/…) or
+/// a [BulkDatasetAlertStrategy] for bulk-file countries (ES/IT/AR/DK) —
+/// deliberate, since `BackgroundPriceSource` returns empty in a bulk country.
+/// The shared per-provider [ProviderRequestBudget] is consulted (never bypassed)
+/// so the car fetch honours each free API's ToS spacing. Every public handler
+/// completes — on any fault it returns an empty / no_gps payload, never throwing
+/// into the OS-spawned engine; Hive opens under [HiveIsolateLock], closed in
+/// `finally`.
 
 /// The MethodChannel name the native [CarDataBridge] and this entry point share.
 // i18n-ignore: platform channel name, not user-facing text.
@@ -71,9 +67,18 @@ const String kCarDataChannel = 'tankstellen/car_data';
 // i18n-ignore: protocol token, not user-facing text.
 const String kCarKindSearch = 'search';
 
+/// `kind` argument the native bridge passes to identify the Radar fetch.
+// i18n-ignore: protocol token, not user-facing text.
+const String kCarKindRadar = 'radar';
+
 /// Method the bridge invokes to fetch the live Search list.
 // i18n-ignore: protocol token, not user-facing text.
 const String kCarMethodFetchSearch = 'fetchSearch';
+
+/// Method the bridge invokes to fetch the live Radar list (v2 phase-1 slice 2,
+/// #2947) — same live producer as [kCarMethodFetchSearch], different snapshot.
+// i18n-ignore: protocol token, not user-facing text.
+const String kCarMethodFetchRadar = 'fetchRadar';
 
 /// Method the bridge invokes to read the persisted user location.
 // i18n-ignore: protocol token, not user-facing text.
@@ -103,6 +108,8 @@ void carDataMain() {
     switch (call.method) {
       case kCarMethodFetchSearch:
         return service.fetchSearch();
+      case kCarMethodFetchRadar:
+        return service.fetchRadar();
       case kCarMethodGetUserLocation:
         return service.getUserLocation();
       default:
@@ -167,46 +174,56 @@ class CarDataService {
   static Future<void> _defaultWriteSnapshot(String key, String value) =>
       HomeWidget.saveWidgetData(key, value);
 
-  /// Handle [kCarMethodFetchSearch]: open Hive under the isolate lock, load the
-  /// API key, run [resolveSearchJson], and ALWAYS close the boxes in `finally`.
-  ///
-  /// Returns the car JSON string, or [kNoGpsMarker] when no usable fix exists.
-  /// Never throws — any fault returns [kNoGpsMarker] so the screen degrades to
-  /// its snapshot / empty-state.
-  Future<String> fetchSearch() async {
+  /// Handle [kCarMethodFetchSearch] — see [_fetch]; refreshes
+  /// [CarStationData.searchKey]. Never throws.
+  Future<String> fetchSearch() =>
+      _fetch(CarStationData.searchKey, 'fetchSearch');
+
+  /// Handle [kCarMethodFetchRadar] (v2 phase-1 slice 2, #2947) — the SAME live
+  /// producer as [fetchSearch] (nearest priced stations within the active radius,
+  /// distance-sorted + capped — the v1 in-app radar shape), refreshing
+  /// [CarStationData.radarKey] instead. Never throws.
+  Future<String> fetchRadar() =>
+      _fetch(CarStationData.radarKey, 'fetchRadar');
+
+  /// Shared Hive-lock + isolate-init wrapper behind [fetchSearch] / [fetchRadar]:
+  /// open Hive under the isolate lock, load the API key, run [_resolveJson] for
+  /// [snapshotKey] ([where] tags the error-log context), and ALWAYS close the
+  /// boxes in `finally`. Never throws — any fault returns [kNoGpsMarker] so the
+  /// screen degrades to its snapshot / empty-state.
+  Future<String> _fetch(String snapshotKey, String where) async {
     HiveIsolateLock? lock;
     try {
       lock = await HiveIsolateLock.create();
       final acquired = await lock.acquire();
       if (!acquired) {
-        debugPrint('CarDataService.fetchSearch: Hive lock busy — no_gps');
+        debugPrint('CarDataService.$where: Hive lock busy — no_gps');
         return kNoGpsMarker;
       }
       await HiveStorage.initInIsolate();
       await HiveStorage.loadApiKey();
       final storage = HiveStorage();
-      return await resolveSearchJson(storage, apiKey: storage.getApiKey())
+      return await _resolveJson(storage, snapshotKey, apiKey: storage.getApiKey())
           .timeout(_fetchTimeout, onTimeout: () => kNoGpsMarker);
     } catch (e, st) {
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'CarDataService.fetchSearch',
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'CarDataService.$where',
       }));
       return kNoGpsMarker;
     } finally {
       try {
         await HiveStorage.closeIsolateBoxes();
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-          'where': 'CarDataService.fetchSearch: close boxes',
+        unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+          'where': 'CarDataService.$where: close boxes',
         }));
       }
       lock?.release();
     }
   }
 
-  /// Handle [kCarMethodGetUserLocation]: return `{lat,lng,source,updatedAtMs}`
-  /// for the persisted fix, or `{source: no_gps}` when absent / poisoned.
-  /// Never throws.
+  /// Handle [kCarMethodGetUserLocation]: `{lat,lng,source,updatedAtMs}` for the
+  /// persisted fix, or `{source: no_gps}` when absent / poisoned. Never throws.
   Future<Map<String, dynamic>> getUserLocation() async {
     HiveIsolateLock? lock;
     try {
@@ -229,16 +246,37 @@ class CarDataService {
     }
   }
 
-  /// Pure resolution used by both the live handler and the unit tests: read
-  /// the persisted fix (with the #2872 guard), resolve the active country +
-  /// profile, run a LIVE radius [CountryAlertStrategy.searchArea], and encode
-  /// the result with [CarStationData.encode]. Refreshes the snapshot key on a
-  /// non-empty result. Returns [kNoGpsMarker] when no usable fix exists; an
-  /// empty `[]` when the fix is good but the live search returned nothing or
-  /// faulted (the screen keeps its snapshot). Never throws.
+  /// Pure resolution of the live Search JSON — see [_resolveJson]. Refreshes
+  /// the [CarStationData.searchKey] snapshot on a non-empty result.
   @visibleForTesting
   Future<String> resolveSearchJson(
     StorageRepository storage, {
+    String? apiKey,
+  }) =>
+      _resolveJson(storage, CarStationData.searchKey, apiKey: apiKey);
+
+  /// Pure resolution of the live Radar JSON — see [_resolveJson]. Identical
+  /// producer to [resolveSearchJson] (same fix + country + profile radius/fuel +
+  /// distance sort, capped at [CarStationData.maxStations] — the nearest priced
+  /// stations, the v1 in-app radar shape), differing ONLY in refreshing the
+  /// [CarStationData.radarKey] snapshot.
+  @visibleForTesting
+  Future<String> resolveRadarJson(
+    StorageRepository storage, {
+    String? apiKey,
+  }) =>
+      _resolveJson(storage, CarStationData.radarKey, apiKey: apiKey);
+
+  /// Pure resolution used by both the live handlers and the unit tests: read
+  /// the persisted fix (with the #2872 guard), resolve the active country +
+  /// profile, run a LIVE radius [CountryAlertStrategy.searchArea], encode with
+  /// [CarStationData.encode], and refresh [snapshotKey] on a non-empty result.
+  /// Returns [kNoGpsMarker] when no usable fix exists; an empty `[]` when the
+  /// fix is good but the search returned nothing or faulted (the screen keeps
+  /// its snapshot). Never throws.
+  Future<String> _resolveJson(
+    StorageRepository storage,
+    String snapshotKey, {
     String? apiKey,
   }) async {
     final fix = _persistedFix(storage);
@@ -271,27 +309,25 @@ class CarDataService {
         ),
       );
     } catch (e, st) {
-      // searchArea is documented never-throws, but guard the seam anyway —
-      // a fault must degrade to the snapshot, never crash the engine.
-      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: const {
-        'where': 'CarDataService.resolveSearchJson: searchArea',
+      // searchArea is documented never-throws; guard the seam anyway so a fault
+      // degrades to the snapshot rather than crashing the engine.
+      unawaited(errorLogger.log(ErrorLayer.other, e, st, context: {
+        'where': 'CarDataService._resolveJson($snapshotKey): searchArea',
       }));
       return '[]';
     }
 
-    // Some country services honour sortBy server-side, others don't — sort
-    // locally too, identical to the nearest-widget builder.
+    // Sort locally too (some services honour sortBy server-side, some don't).
     final sorted = [...stations]..sort((a, b) => a.dist.compareTo(b.dist));
     final json = CarStationData.encode(sorted, profile.fuelType);
 
     if (sorted.isNotEmpty) {
-      // Refresh the fallback snapshot so a later engine failure still renders
-      // a recent list. Best-effort — a write fault never fails the fetch.
+      // Best-effort fallback-snapshot refresh (a write fault never fails fetch).
       try {
-        await _writeSnapshot(CarStationData.searchKey, json);
+        await _writeSnapshot(snapshotKey, json);
       } catch (e, st) {
-        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: const {
-          'where': 'CarDataService.resolveSearchJson: snapshot write',
+        unawaited(errorLogger.log(ErrorLayer.storage, e, st, context: {
+          'where': 'CarDataService._resolveJson($snapshotKey): snapshot write',
         }));
       }
     }

--- a/lib/features/widget/data/car_station_data.dart
+++ b/lib/features/widget/data/car_station_data.dart
@@ -33,6 +33,7 @@ import '../../search/domain/entities/station.dart';
 ///   "id": "abc",
 ///   "name": "Aral Hauptstr. 1",
 ///   "brand": "Aral",
+///   "address": "Hauptstr. 1, 10115 Berlin", // street + city, "" when unknown
 ///   "lat": 52.5, "lng": 13.4,
 ///   "price": 1.799,            // double?  — null when the fuel is unpriced
 ///   "priceText": "1.799",      // formatted (3 dp) or "" when unpriced
@@ -107,6 +108,10 @@ class CarStationData {
       'id': station.id,
       'name': station.displayName,
       'brand': station.brand,
+      // Street + city subtitle, mirroring the in-app card's address line
+      // (#2947 slice 3) — empty parts collapse so the row never shows an
+      // orphan comma (#2704). "" when the station carries no address at all.
+      'address': _address(station),
       'lat': station.lat,
       'lng': station.lng,
       'price': price,
@@ -118,6 +123,18 @@ class CarStationData {
       'distanceKm': double.parse(station.dist.toStringAsFixed(1)),
       'currency': currency,
     };
+  }
+
+  /// Street + city address subtitle for the car row, built exactly like the
+  /// in-app card's address line (`station_card_status._addressLine`, #2704):
+  /// `street, postCode place`, collapsing empty parts so the line never shows
+  /// an orphan comma. Returns "" when the station carries no street/city at all
+  /// (the Kotlin row then renders no subtitle).
+  static String _address(Station station) {
+    final city = '${station.postCode} ${station.place}'.trim();
+    if (station.street.isEmpty) return city;
+    if (city.isEmpty) return station.street;
+    return '${station.street}, $city';
   }
 
   /// Stable band name the Kotlin side maps to a `CarColor`. Mirrors the

--- a/test/features/car/car_data_service_test.dart
+++ b/test/features/car/car_data_service_test.dart
@@ -244,7 +244,186 @@ void main() {
           reason: 'an empty list must not clobber the last good snapshot');
     });
   });
+
+  // ── v2 PHASE-1 SLICE 2 (#2947) — LIVE Radar via the SAME producer ──────────
+
+  group('Radar (DE polled) — live list round-trips + writes car_radar_json', () {
+    test('priced E10 radar list from the real PolledAlertStrategy', () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      final deDataset = _RecordedDataset(
+        ServiceSource.tankerkoenigApi,
+        [
+          _row('de-1', 'Aral', 52.521, 13.401, e10: 1.799, e5: 1.859,
+              diesel: 1.699),
+          _row('de-2', 'Shell', 52.516, 13.420, e10: 1.829, e5: 1.889,
+              diesel: 1.719),
+        ],
+      );
+
+      String? wroteKey;
+      String? wroteValue;
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', deDataset),
+        writeSnapshot: (k, v) async {
+          wroteKey = k;
+          wroteValue = v;
+        },
+      );
+
+      final json = await service.resolveRadarJson(storage, apiKey: 'k');
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+
+      expect(rows, hasLength(2));
+      final byId = {for (final r in rows) r['id']: r};
+      expect(byId['de-1']!['priceText'], '1.799');
+      expect(byId['de-1']!['fuelLabel'], 'E10');
+      // Distance-sorted: the nearer station (de-1) comes first.
+      expect(rows.first['id'], 'de-1');
+
+      // The Radar fetch refreshes the RADAR snapshot key (not the search key).
+      expect(wroteKey, 'car_radar_json');
+      expect(wroteValue, json);
+    });
+  });
+
+  group('Radar (ES BULK) — bulk coverage, priced E5 (not empty)', () {
+    test('real BulkDatasetAlertStrategy + recorded E5 fixture → priced E5 list',
+        () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 40.4168);
+      await storage.putSetting(StorageKeys.userPositionLng, -3.7038);
+      await _seedProfile(storage, radiusKm: 6, fuel: 'e5');
+
+      final esDataset = _RecordedDataset(
+        ServiceSource.mitecoApi,
+        [
+          _row('es-1', 'Repsol', 40.4170, -3.7040, e5: 1.529, diesel: 1.419),
+          _row('es-2', 'Cepsa', 40.4150, -3.7010, e5: 1.549, diesel: 1.439),
+          _row('es-9', 'BP', 41.3874, 2.1686, e5: 1.999, diesel: 1.999),
+        ],
+      );
+
+      String? wroteKey;
+      final service = CarDataService(
+        strategyFactory: _bulkFactory('ES', esDataset, esBulkPolicy),
+        writeSnapshot: (k, _) async => wroteKey = k,
+      );
+
+      final json = await service.resolveRadarJson(storage, apiKey: null);
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+
+      // The bulk path returns the two in-radius ES stations PRICED — a polled-
+      // only source would be empty here. Barcelona is geo-filtered out.
+      expect(rows.map((r) => r['id']).toSet(), {'es-1', 'es-2'},
+          reason: 'Barcelona is outside a 6 km Madrid radius');
+      final byId = {for (final r in rows) r['id']: r};
+      expect(byId['es-1']!['fuelLabel'], 'E5');
+      expect(byId['es-1']!['priceText'], '1.529');
+      expect(wroteKey, 'car_radar_json');
+    });
+  });
+
+  group('Radar — no_gps / fault degrade exactly like Search', () {
+    test('absent fix → no_gps marker, never throws', () async {
+      final storage = FakeStorageRepository();
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', _RecordedDataset(
+          ServiceSource.tankerkoenigApi, const [])),
+        writeSnapshot: (_, _) async {},
+      );
+      expect(await service.resolveRadarJson(storage), kNoGpsMarker);
+    });
+
+    test('a throwing strategy → empty [] (keeps the snapshot), never throws',
+        () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      var wrote = false;
+      final service = CarDataService(
+        strategyFactory: _bulkFactory('DE', _ThrowingDataset(), esBulkPolicy),
+        writeSnapshot: (_, _) async => wrote = true,
+      );
+
+      await expectLater(service.resolveRadarJson(storage), completes);
+      expect(await service.resolveRadarJson(storage), '[]');
+      expect(wrote, isFalse,
+          reason: 'a faulted radar must not clobber the last good snapshot');
+    });
+  });
+
+  // ── v2 PHASE-1 SLICE 3 (#2947) — the address subtitle, lock-step ───────────
+
+  group('address subtitle — present in the encoded row + survives round-trip',
+      () {
+    test('street + city address is encoded for each station', () async {
+      final storage = FakeStorageRepository();
+      await storage.putSetting(StorageKeys.userPositionLat, 52.52);
+      await storage.putSetting(StorageKeys.userPositionLng, 13.405);
+      await _seedProfile(storage, radiusKm: 8, fuel: 'e10');
+
+      // A station WITH a full address + one with NO street (only city).
+      final dataset = _RecordedDataset(
+        ServiceSource.tankerkoenigApi,
+        [
+          _rowWithAddress('de-1', 'Aral', 52.521, 13.401,
+              street: 'Hauptstr. 1', postCode: '10115', place: 'Berlin',
+              e10: 1.799),
+          _rowWithAddress('de-2', 'Shell', 52.516, 13.420,
+              street: '', postCode: '10117', place: 'Berlin', e10: 1.829),
+        ],
+      );
+
+      final service = CarDataService(
+        strategyFactory: _polledFactory('DE', dataset),
+        writeSnapshot: (_, _) async {},
+      );
+
+      final json = await service.resolveSearchJson(storage, apiKey: 'k');
+      final rows = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+      final byId = {for (final r in rows) r['id']: r};
+
+      // Every row carries the address key (the Kotlin DTO reads it).
+      for (final r in rows) {
+        expect(r.containsKey('address'), isTrue);
+      }
+      // Full address: "street, postCode place".
+      expect(byId['de-1']!['address'], 'Hauptstr. 1, 10115 Berlin');
+      // No street → city only, no orphan comma (#2704 collapsing).
+      expect(byId['de-2']!['address'], '10117 Berlin');
+    });
+  });
 }
+
+Station _rowWithAddress(
+  String id,
+  String brand,
+  double lat,
+  double lng, {
+  required String street,
+  required String postCode,
+  required String place,
+  double? e10,
+}) =>
+    Station(
+      id: id,
+      name: '$brand forecourt',
+      brand: brand,
+      street: street,
+      postCode: postCode,
+      place: place,
+      lat: lat,
+      lng: lng,
+      e10: e10,
+      isOpen: true,
+    );
 
 // ── recorded-fixture services + strategy factories ──────────────────────────
 

--- a/test/features/widget/data/car_station_data_test.dart
+++ b/test/features/widget/data/car_station_data_test.dart
@@ -22,14 +22,17 @@ void main() {
     required double dist,
     double? e10,
     double? diesel,
+    String street = 'Main St 1',
+    String postCode = '10115',
+    String place = 'Berlin',
   }) =>
       Station(
         id: id,
         name: '$brand forecourt',
         brand: brand,
-        street: 'Main St 1',
-        postCode: '10115',
-        place: 'Berlin',
+        street: street,
+        postCode: postCode,
+        place: place,
         lat: lat,
         lng: lng,
         dist: dist,
@@ -63,6 +66,36 @@ void main() {
       expect(r['distanceKm'], 1.2); // rounded to 1 dp
       expect(r.containsKey('band'), isTrue);
       expect(r.containsKey('bandColor'), isTrue);
+      // #2947 slice 3 — street + city address subtitle, like the in-app card.
+      expect(r['address'], 'Main St 1, 10115 Berlin');
+    });
+
+    test('address collapses empty parts (no orphan comma, #2704)', () {
+      // No street → city only.
+      final cityOnly = CarStationData.encode(
+        [
+          station(id: 'a', brand: 'A', lat: 1, lng: 1, dist: 1, e10: 1.5,
+              street: '', postCode: '10117', place: 'Berlin'),
+        ],
+        FuelType.e10,
+      );
+      expect(
+        (jsonDecode(cityOnly) as List).cast<Map<String, dynamic>>().single['address'],
+        '10117 Berlin',
+      );
+
+      // No street and no city → empty address (the Kotlin row shows no subtitle).
+      final none = CarStationData.encode(
+        [
+          station(id: 'b', brand: 'B', lat: 1, lng: 1, dist: 1, e10: 1.5,
+              street: '', postCode: '', place: ''),
+        ],
+        FuelType.e10,
+      );
+      expect(
+        (jsonDecode(none) as List).cast<Map<String, dynamic>>().single['address'],
+        '',
+      );
     });
 
     test('cheapest station is the cheap band, most expensive the expensive band',


### PR DESCRIPTION
Completes Android Auto **v2 PHASE-1** (#2947, epic #2946) by finishing slices 2 + 3 on top of the merged slice-1 live Search bridge (#2987). Mirrors slice-1's patterns exactly.

## Slice 2 — live Radar
- `car_data_service.dart`: `fetchRadar()` + `resolveRadarJson()` share ONE Ref-free producer with Search — the same persisted-fix → resolved country → active-profile (radius + fuel) distance-sorted `CountryAlertStrategy.searchArea`, capped at `CarStationData.maxStations`. That **is** the v1 in-app radar semantics: the nearest priced stations within the radar (active-profile) radius, distance-sorted, capped — v1's `runRadar` deduped/fuel-filtered/distance-sorted then `CarStationData.encode` capped at 12; this path produces the identical shape from the same encoder. The two fetches differ ONLY in the snapshot fallback key (`car_search_json` vs `car_radar_json`). `no_gps` / fault → empty, never throws.
- `CarDataBridge.kt`: wire the `RADAR` kind to `fetchRadar` (was a SEARCH-only short-circuit).
- `RadarScreen.kt`: opt into the live bridge — snapshot immediately → kick live fetch → invalidate → live list; `setOnContentRefreshListener`; `setLoading` on cold; empty live keeps the snapshot; no snapshot + no live → `car_empty_no_gps`. Mirrors `SearchScreen`.

## Slice 3 — address subtitle (lock-step, end to end)
- `CarStationData.encode`: new `address` row field = street + city, empty parts collapsed (no orphan comma, #2704) — matching the in-app card's address line.
- `CarStation.kt`: `address` field + `fromJson` (defaults to `""` when absent → **old address-less snapshots don't crash**).
- `StationListScreen.kt`: render the address as the row's second secondary line; price + distance packed onto the first (PlaceListMapTemplate's 2-line cap).

## Tests (no head unit; false-green-aware)
- `car_data_service_test.dart`: `fetchRadar` drives the **REAL** `CountryAlertStrategy.searchArea` against recorded **DE (polled)** + **ES (bulk)** fixtures → priced JSON round-tripping `CarStation.parse`, writes `car_radar_json`; `no_gps`/fault → empty; address present + survives round-trip. Bulk-ES coverage proves the path returns data where a polled-only source is empty.
- `car_station_data_test.dart`: address encoded + empty-part collapse.
- `CarScreensTest.kt`: live-Radar snapshot-first / fresh-replaces / empty-keeps-snapshot / no-gps; address subtitle renders on a row; old-snapshot back-compat parse (`address == ""`).
- `CarDataBridgeTest.kt`: RADAR not-ready guard. **22 car Robolectric tests pass.**

## Gates
- **FGS-zero merged-play-manifest** audit: PASS (no FGS permission/service added — engine stays in the bound Session).
- **F-Droid no-GMS** audit (layer A, dependency graph): PASS.
- `flutter analyze` clean; play + fdroid Kotlin compile; Dart 400-line cap respected (`car_data_service.dart` = 399 effective); no `*.g.dart` drift.
- `androidx.car.app` stays 1.4.0.

## Deferred (filed so the epic closes cleanly)
- #2990 — live in-car GPS via `CarContext.requestPermissions` (needs androidx.car.app 1.7.0-rc01+).
- #2991 — iOS CarPlay Search + Radar (paused until July).

Closes #2947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)