### PR TITLE
fix(ios): remove stale share_handler_ios_models pod from Podfile — pod install fails (plugin was removed in #2735)

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,19 +34,6 @@ target 'Runner' do
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
-  # #2735 — share_handler's iOS plugin (share_handler_ios) declares a
-  # dependency on the `share_handler_ios_models` pod, whose podspec lives
-  # in the plugin's own ios/Models/ subdir and is NOT auto-registered by
-  # Flutter's podhelper. Without this explicit path CocoaPods can't
-  # resolve it and `pod install` (hence the whole iOS build) fails. This
-  # one line is the MINIMUM to make the main app build with the share
-  # dependency present; it does NOT create the Share Extension target or
-  # the App Group entitlement — those (and the in-extension consumer of
-  # this shared model code) are owned by #2736. Until then the share path
-  # simply receives nothing on iOS, which is by design for this PR.
-  pod 'share_handler_ios_models',
-      :path => '.symlinks/plugins/share_handler_ios/ios/Models'
-
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -92,22 +92,18 @@ PODS:
   - nanopb/encode (3.30910.0)
   - package_info_plus (0.4.5):
     - Flutter
+  - pdfx (1.0.0):
+    - Flutter
   - permission_handler_apple (9.3.0):
     - Flutter
   - PromisesObjC (2.4.0)
+  - sensors_plus (0.0.1):
+    - Flutter
   - Sentry/HybridSDK (8.58.3)
   - sentry_flutter (9.21.0):
     - Flutter
     - FlutterMacOS
     - Sentry/HybridSDK (= 8.58.3)
-  - share_handler_ios (0.0.14):
-    - Flutter
-    - share_handler_ios/share_handler_ios_models (= 0.0.14)
-    - share_handler_ios_models
-  - share_handler_ios/share_handler_ios_models (0.0.14):
-    - Flutter
-    - share_handler_ios_models
-  - share_handler_ios_models (0.0.9)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -165,10 +161,10 @@ DEPENDENCIES:
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - pdfx (from `.symlinks/plugins/pdfx/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
+  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
-  - share_handler_ios (from `.symlinks/plugins/share_handler_ios/ios`)
-  - share_handler_ios_models (from `.symlinks/plugins/share_handler_ios/ios/Models`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
@@ -234,14 +230,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/mobile_scanner/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  pdfx:
+    :path: ".symlinks/plugins/pdfx/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
+  sensors_plus:
+    :path: ".symlinks/plugins/sensors_plus/ios"
   sentry_flutter:
     :path: ".symlinks/plugins/sentry_flutter/ios"
-  share_handler_ios:
-    :path: ".symlinks/plugins/share_handler_ios/ios"
-  share_handler_ios_models:
-    :path: ".symlinks/plugins/share_handler_ios/ios/Models"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -288,12 +284,12 @@ SPEC CHECKSUMS:
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  pdfx: 77f4dddc48361fbb01486fa2bdee4532cbb97ef3
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
   Sentry: 108fdbb76299c4189af12246bf0308c09c278922
   sentry_flutter: 32e67cb4756ce3de42bbd56581fa935922ff328f
-  share_handler_ios: e2244e990f826b2c8eaa291ac3831569438ba0fb
-  share_handler_ios_models: fc638c9b4330dc7f082586c92aee9dfa0b87b871
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
@@ -304,6 +300,6 @@ SPEC CHECKSUMS:
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
   workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 
-PODFILE CHECKSUM: eb3428d3f31ce2c87de069dedd6928ee1f690f17
+PODFILE CHECKSUM: 09c30bf7958e7da254512f11ad5352db42437d08
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## What

Removes the stale `pod 'share_handler_ios_models', :path => ...` entry (and its
comment block) from `ios/Podfile`, and regenerates `ios/Podfile.lock`.

Closes #2993.

## Why

`share_handler` was removed from `pubspec.yaml` in #2735 — the lib share path now
uses a native MethodChannel and does **not** import `package:share_handler`. But
the Podfile kept a manual entry pointing at
`.symlinks/plugins/share_handler_ios/ios/Models`, a path Flutter no longer
generates now that the plugin is gone. CocoaPods then fails:

```
[!] No podspec found for `share_handler_ios_models` in `.symlinks/plugins/share_handler_ios/ios/Models`
Error: Process completed with exit code 1.
```

…which broke the **iOS TestFlight Build** CI job at the `Pod install` step.

## Lines removed (`ios/Podfile`)

```ruby
  # #2735 — share_handler's iOS plugin (share_handler_ios) declares a
  # dependency on the `share_handler_ios_models` pod, whose podspec lives
  # in the plugin's own ios/Models/ subdir and is NOT auto-registered by
  # Flutter's podhelper. Without this explicit path CocoaPods can't
  # resolve it and `pod install` (hence the whole iOS build) fails. This
  # one line is the MINIMUM to make the main app build with the share
  # dependency present; it does NOT create the Share Extension target or
  # the App Group entitlement — those (and the in-extension consumer of
  # this shared model code) are owned by #2736. Until then the share path
  # simply receives nothing on iOS, which is by design for this PR.
  pod 'share_handler_ios_models',
      :path => '.symlinks/plugins/share_handler_ios/ios/Models'
```

`Podfile.lock` drops the three `share_handler_ios*` specs / deps / external
sources / checksums; it also picks up `pdfx` and `sensors_plus` that the lock was
missing (lock catching up to the current plugin set — no version bumps elsewhere).

## Verified locally (Mac iOS stack)

- Searched all of `ios/` — **no** other reference to `share_handler` /
  `share_handler_ios` (AppDelegate, `Runner.xcodeproj/project.pbxproj`, no Share
  Extension target). Removal is clean.
- `cd ios && pod install --repo-update` → **exit 0**, no "No podspec found":
  ```
  Pod installation complete! There are 30 dependencies from the Podfile and 45 total pods installed.
  ```

## Caveat / out of scope

This unblocks **only** the CocoaPods step. The iOS TestFlight build will still
fail later at signing / TestFlight upload because Apple provisioning is
separately blocked (**#2736**). That is expected and tracked there — this PR just
removes the `pod install` blocker so the build can progress (and so a future
provisioning fix isn't also blocked by this).

## Scope

Only `ios/Podfile` (+ regenerated `ios/Podfile.lock`). No Dart/ARB/codegen
changes — `flutter analyze` and Dart tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
