### PR TITLE
fix(radar): search list closeness bar uses the approach radius (3km), like the recording radar (closes #2995)

### DIFF
--- a/lib/core/utils/radar_closeness.dart
+++ b/lib/core/utils/radar_closeness.dart
@@ -1,31 +1,16 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:math' as math;
-
-/// The maintainer-tunable upper bound (in metres) on the list closeness bar's
-/// absolute scale. Default 15 km (#2984).
-///
-/// The list bar scales each fill against `min(searchRadiusMeters, this)`, so
-/// this cap keeps the scale — and therefore every station's fill — stable and
-/// readable even when the user opens the search radius wide: a 2.5 km forecourt
-/// reads the SAME fill at a 15 km, 20 km or 25 km radius. Lower it for a
-/// tighter "near = full" feel; raise it (up to the 25 km radius ceiling) for a
-/// gentler ramp. This is the single knob for the absolute list scale — tune it
-/// HERE.
-const double kRadarClosenessScaleCapMeters = 15000;
-
 /// The single source of truth for the Fuel Station Radar "closeness" signal —
-/// the green fill that grows as the driver nears a station (#2984, supersedes
-/// the rejected relative-to-span model of #2956/#2959; lineage #2661 / #2808 /
-/// #2899 / #2901 / #2944).
+/// the green fill that grows as the driver nears a station (#2995, lineage
+/// #2661 / #2808 / #2899 / #2901 / #2944 / #2984).
 ///
 /// All three radar surfaces — the search-results list card, the recording PiP
 /// overlay, and the trip radar card — compute closeness through THIS helper so
 /// they can never desync again. The bar widget ([ProximityFillBar]) is
 /// paint-only and delegates its fill arithmetic here.
 ///
-/// ## The model: ABSOLUTE, fixed scale (fuller = closer)
+/// ## The model: APPROACH-RADIUS scale (fuller = closer)
 ///
 /// The fill formula is the same everywhere:
 ///
@@ -33,32 +18,22 @@ const double kRadarClosenessScaleCapMeters = 15000;
 /// fill = clamp(1 - distanceMeters / scaleMeters, 0, 1)
 /// ```
 ///
-/// What each surface differs in is the **scale** it divides against — and the
-/// scale is always an *absolute* distance, never derived from the result set:
+/// and so is the **scale**: every surface divides against the user's APPROACH
+/// RADIUS (`profile.approachRadiusKm * 1000`) — the geofence the driver is
+/// approaching. The trip card, the PiP and the search list are therefore
+/// consistent on the user's approach-radius base, so the bar means the same
+/// thing wherever it appears: "how close is THIS station, on the user's
+/// approach-radius base". A 2.5 km forecourt reads `1 - 2.5/3 ≈ 0.17` on a 3 km
+/// profile (the same on all three surfaces), and a station beyond the approach
+/// radius reads ~0 — by design, only stations within reach show a fill.
 ///
-///  * The trip card + PiP scale to the **approach radius** (`profile
-///    .approachRadiusKm`) — the geofence the driver is approaching.
-///  * The list scales to [listScaleMeters] — `min(searchRadiusMeters,
-///    kRadarClosenessScaleCapMeters)` — the user's configured radar radius,
-///    clamped to the tunable cap.
+/// ## History (#2995 reverses #2984/#2985)
 ///
-/// So the bar means "how close is THIS station, on a stable absolute scale":
-///
-///  * **Stable** — a 2.5 km station reads the SAME fill no matter what else is
-///    in the list (the scale depends only on the radius setting + the cap, not
-///    on the surfaced set).
-///  * **Closer = fuller, nothing force-emptied** — the farthest row is never
-///    pinned to 0% just for being last; it only nears empty if it is genuinely
-///    near/beyond the scale.
-///
-/// ## Why the relative-to-span model was rejected (#2984)
-///
-/// #2959 scaled the list to the farthest surfaced station's distance (the
-/// "span"). That made the fill *relative to the current list*: the farthest
-/// station was always pinned to 0% even when genuinely near, and a given
-/// station's fill changed whenever the result set changed (filter, refresh, a
-/// far outlier appearing/disappearing). The maintainer rejected it for this
-/// absolute, stable scale.
+/// #2984/#2985 had the search list scale to `min(searchRadius, 15 km cap)`
+/// (the removed `listScaleMeters` helper), which let a 2.5 km station read ~0.83
+/// on the list while reading ~0.17 on the recording radar for the same profile.
+/// The maintainer decided the recording radar's approach-radius base is correct
+/// and the list was wrong; #2995 brings the list onto the same base.
 class RadarCloseness {
   const RadarCloseness._();
 
@@ -71,19 +46,5 @@ class RadarCloseness {
     if (radiusMeters <= 0 || !radiusMeters.isFinite) return 0;
     final raw = 1.0 - (distanceMeters / radiusMeters);
     return raw.clamp(0.0, 1.0);
-  }
-
-  /// The absolute scale (in metres) the radar *list* closeness bars divide
-  /// against: `min(searchRadiusMeters, kRadarClosenessScaleCapMeters)` (#2984).
-  ///
-  /// [searchRadiusMeters] is the user's configured radar/search radius in
-  /// metres (`searchRadiusProvider` km → m). The result is independent of the
-  /// surfaced result set, so every station's fill is stable — the key property
-  /// the rejected span model lacked. A non-positive / non-finite radius yields
-  /// `null` so callers can collapse the bar instead of dividing by a
-  /// degenerate scale.
-  static double? listScaleMeters(double searchRadiusMeters) {
-    if (searchRadiusMeters <= 0 || !searchRadiusMeters.isFinite) return null;
-    return math.min(searchRadiusMeters, kRadarClosenessScaleCapMeters);
   }
 }

--- a/lib/features/search/presentation/widgets/search_results_list.dart
+++ b/lib/features/search/presentation/widgets/search_results_list.dart
@@ -9,7 +9,6 @@ import '../../../../core/services/service_result.dart';
 import '../../../../core/utils/navigation_utils.dart';
 import '../../../../core/utils/price_tier.dart';
 import '../../../../core/utils/price_utils.dart';
-import '../../../../core/utils/radar_closeness.dart';
 import '../../../../core/utils/station_extensions.dart';
 import '../../../../core/services/widgets/freshness_badge.dart';
 import '../../../../core/services/widgets/service_status_banner.dart';
@@ -334,21 +333,22 @@ class _SearchResultsListState extends ConsumerState<SearchResultsList>
     );
     final stationRating = ref.watch(stationRatingProvider(station.id));
 
-    // #2984 — when the on-search Fuel Station Radar owns the result list, each
+    // #2995 — when the on-search Fuel Station Radar owns the result list, each
     // card carries the green→accent closeness bar (the SAME [ProximityFillBar]
-    // / [RadarCloseness] as the trip card + PiP). The bar uses an ABSOLUTE,
-    // fixed scale: `min(searchRadiusMeters, kRadarClosenessScaleCapMeters)` —
-    // the user's configured radar radius (km → m), clamped to the tunable cap.
-    // So the fill means "how close is THIS station on a stable scale": a 2.5 km
-    // forecourt reads the same fill regardless of what else is in the list, and
-    // the farthest row is never force-emptied just for being last. This REPLACES
-    // the relative-to-span model (#2956/#2959), which made each fill depend on
-    // the result set and pinned the farthest station to 0% — rejected by the
-    // maintainer. Null off radar mode (or a degenerate radius) → regular cards.
+    // / [RadarCloseness] as the trip card + PiP). The bar scales to the user's
+    // APPROACH RADIUS (`profile.approachRadiusKm * 1000`) — the EXACT same base
+    // the recording radar card (`trip_radar_card.dart`) and the PiP use, so all
+    // three surfaces are consistent on the user's approach-radius base. A 2.5 km
+    // forecourt reads `1 - 2.5/3 ≈ 0.17` (matching the recording radar), and a
+    // station beyond the approach radius reads ~0 — by design, only stations
+    // within reach show a fill. This REVERSES #2984/#2985, which scaled the list
+    // to `min(searchRadius, 15 km cap)`; the maintainer decided the recording
+    // radar's approach-radius base is correct and the list was wrong. Null off
+    // radar mode (or with no active profile) → regular cards.
     final radar = ref.watch(radarSearchProvider);
-    final closenessRadiusMeters = radar.active
-        ? RadarCloseness.listScaleMeters(
-            ref.watch(searchRadiusProvider) * 1000.0)
+    final profile = ref.watch(activeProfileProvider);
+    final closenessRadiusMeters = (radar.active && profile != null)
+        ? profile.approachRadiusKm * 1000.0
         : null;
 
     return SwipeableStationCard(

--- a/lib/features/search/presentation/widgets/station_card_status.dart
+++ b/lib/features/search/presentation/widgets/station_card_status.dart
@@ -48,11 +48,12 @@ class _StationDetails extends StatelessWidget {
   final Station station;
   final bool hasBrand;
 
-  /// #2899/#2984 — when non-null, the Fuel Station Radar "closeness" bar is
-  /// rendered under the distance row, scaled to this ABSOLUTE radius in metres
-  /// (`min(searchRadius, kRadarClosenessScaleCapMeters)` — a fixed scale that
-  /// does not depend on the result set, so a near station's fill is stable).
-  /// Null on the regular search list, so the card is unchanged there.
+  /// #2899/#2995 — when non-null, the Fuel Station Radar "closeness" bar is
+  /// rendered under the distance row, scaled to this radius in metres. The radar
+  /// list passes the user's APPROACH RADIUS (`profile.approachRadiusKm * 1000`),
+  /// the SAME base the recording radar card + PiP use, so all three surfaces are
+  /// consistent on the user's approach-radius base. Null on the regular search
+  /// list, so the card is unchanged there.
   final double? closenessRadiusMeters;
 
   const _StationDetails({

--- a/test/core/utils/radar_closeness_test.dart
+++ b/test/core/utils/radar_closeness_test.dart
@@ -1,16 +1,16 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:math' as math;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/core/utils/radar_closeness.dart';
 
-/// #2984 — unit pins for the shared Fuel Station Radar closeness helper. The
+/// #2995 — unit pins for the shared Fuel Station Radar closeness helper. The
 /// real radar list-card surface is exercised in `radar_closeness_bar_test.dart`
-/// (the regression lock) and `radar_closeness_absolute_test.dart` (the absolute
-/// stability lock); this file pins the arithmetic + the never-throws contract
-/// the helper documents.
+/// (the regression lock) and `radar_closeness_absolute_test.dart` (the
+/// approach-radius scale lock); this file pins the arithmetic + the never-throws
+/// contract the helper documents. Every radar surface — list, recording card,
+/// PiP — divides against the user's approach radius via [RadarCloseness.fillFor]
+/// (#2995 removed the list-only `listScaleMeters` / 15 km-cap path of #2985).
 
 void main() {
   group('RadarCloseness.fillFor — the canonical fill fraction', () {
@@ -27,49 +27,24 @@ void main() {
       expect(RadarCloseness.fillFor(9900, 10000), closeTo(0.01, 1e-9));
     });
 
+    test('the approach-radius worked examples (3 km scale): 2.5 km≈0.17, '
+        '1.5 km=0.5, 5 km (beyond reach)=0', () {
+      // The 3 km approach radius all three surfaces share (#2995). A 2.5 km
+      // forecourt reads ~0.17, NOT the ~0.83 the removed 15 km list scale gave.
+      expect(RadarCloseness.fillFor(2500, 3000), closeTo(0.1667, 1e-3));
+      expect(RadarCloseness.fillFor(1500, 3000), closeTo(0.5, 1e-9));
+      expect(RadarCloseness.fillFor(5000, 3000), 0.0); // past the radius → empty
+    });
+
     test('clamps to 1 at/under the station (no overflow)', () {
       expect(RadarCloseness.fillFor(-50, 10000), 1.0);
     });
   });
 
-  group('RadarCloseness.listScaleMeters — the ABSOLUTE list scale (#2984)', () {
-    test('is the search radius, clamped to the tunable cap', () {
-      // Below the cap → the radius itself.
-      expect(RadarCloseness.listScaleMeters(10000), 10000);
-      // At / above the cap → the cap (a wide radius does not stretch the scale).
-      expect(RadarCloseness.listScaleMeters(15000),
-          kRadarClosenessScaleCapMeters);
-      expect(RadarCloseness.listScaleMeters(25000),
-          kRadarClosenessScaleCapMeters);
-      expect(RadarCloseness.listScaleMeters(25000),
-          math.min(25000.0, kRadarClosenessScaleCapMeters));
-    });
-
-    test('the cap defaults to 15 km and is the maintainer-tunable knob', () {
-      expect(kRadarClosenessScaleCapMeters, 15000);
-    });
-
-    test('the worked examples on a 15 km scale (radius ≥ cap): '
-        '2.5≈0.83, 7.2≈0.52, 10.3≈0.31, 13≈0.13', () {
-      final scale = RadarCloseness.listScaleMeters(20000)!; // → 15 km cap
-      expect(RadarCloseness.fillFor(2500, scale), closeTo(0.8333, 1e-3));
-      expect(RadarCloseness.fillFor(7200, scale), closeTo(0.52, 1e-3));
-      expect(RadarCloseness.fillFor(10300, scale), closeTo(0.3133, 1e-3));
-      expect(RadarCloseness.fillFor(13000, scale), closeTo(0.1333, 1e-3));
-    });
-
-    test('null for a degenerate radius (collapses the bar)', () {
-      expect(RadarCloseness.listScaleMeters(0), isNull);
-      expect(RadarCloseness.listScaleMeters(-1), isNull);
-      expect(RadarCloseness.listScaleMeters(double.nan), isNull);
-      expect(RadarCloseness.listScaleMeters(double.infinity), isNull);
-    });
-  });
-
   // The helper documents "Never throws" — pin the fault paths so a degenerate
   // input (the kind that produced the recurring divide-by-zero / NaN scaling
-  // bugs) returns normally instead of blowing up the card build (#2984).
-  group('RadarCloseness — never-throws contract (#2984)', () {
+  // bugs) returns normally instead of blowing up the card build (#2995).
+  group('RadarCloseness — never-throws contract (#2995)', () {
     test('fillFor returns normally on a degenerate / non-finite radius', () {
       expect(() => RadarCloseness.fillFor(100, 0), returnsNormally);
       expect(() => RadarCloseness.fillFor(100, -1), returnsNormally);
@@ -79,11 +54,6 @@ void main() {
       expect(RadarCloseness.fillFor(100, 0), 0.0);
       expect(RadarCloseness.fillFor(100, double.nan), 0.0);
       expect(RadarCloseness.fillFor(100, double.infinity), 0.0);
-    });
-
-    test('listScaleMeters returns normally on a degenerate radius', () {
-      expect(() => RadarCloseness.listScaleMeters(0), returnsNormally);
-      expect(() => RadarCloseness.listScaleMeters(double.nan), returnsNormally);
     });
   });
 }

--- a/test/features/search/presentation/widgets/radar_closeness_absolute_test.dart
+++ b/test/features/search/presentation/widgets/radar_closeness_absolute_test.dart
@@ -1,14 +1,14 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/core/utils/radar_closeness.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
 import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
@@ -16,23 +16,27 @@ import 'package:tankstellen/features/search/providers/radar_search_provider.dart
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 
-/// #2984 — the Fuel Station Radar list closeness bar uses an ABSOLUTE,
-/// FIXED-SCALE model: the maintainer rejected the relative-to-span model of
-/// #2959 (root-cause reimplementation of #2956).
+/// #2995 — the Fuel Station Radar list closeness bar scales to the APPROACH
+/// RADIUS (`profile.approachRadiusKm * 1000`), the SAME base the RECORDING radar
+/// card + PiP use. This REVERSES #2984/#2985: the maintainer decided the
+/// recording radar (approach-radius base) is correct and the list (which #2985
+/// scaled to `min(searchRadius, 15 km cap)`) was wrong.
 ///
-/// "How close is THIS station, on a stable absolute scale" — fuller = closer:
+/// "How close is THIS station, on the user's approach-radius base" — fuller =
+/// closer:
 ///
 /// ```
-/// scale = min(searchRadiusMeters, kRadarClosenessScaleCapMeters)
+/// scale = profile.approachRadiusKm * 1000   // identical on list + recording + PiP
 /// fill  = clamp(1 - distanceMeters / scale, 0, 1)
 /// ```
 ///
 /// These tests drive the REAL radar list-card path (`SearchResultsContent` →
 /// `SearchResultsList` → `StationCard` → `ProximityFillBar`) with the radar
-/// active and read the fill the rendered bar would paint. The crux is the
-/// STABILITY property: a near station reads the SAME fill no matter what else
-/// is in the list. On master (the span model) removing the far station changes
-/// the near fill → RED; with the absolute scale → IDENTICAL → GREEN.
+/// active and read the fill the rendered bar would paint. The crux: the list's
+/// resolved `radiusMeters` is the approach radius (3 km for a 3 km profile),
+/// NOT the 15 km list scale (RED on master) — so a 2.5 km station reads ~0.17,
+/// matching the recording radar, and a station beyond the approach radius reads
+/// ~0 (only stations within reach show a fill, by design).
 
 /// A radar station at [distKm] from the user (km — the value the card text
 /// shows). Carries an E10 price so the fuel filter keeps it.
@@ -50,14 +54,6 @@ Station _at(String id, double distKm) => Station(
       isOpen: true,
     );
 
-/// The four-station validation set: 2.5 / 7.2 / 10.3 / 13 km.
-List<Station> _fourStations() => [
-      _at('s-2', 2.5),
-      _at('s-7', 7.2),
-      _at('s-10', 10.3),
-      _at('s-13', 13.0),
-    ];
-
 class _ActiveRadar extends RadarSearch {
   _ActiveRadar(this._stations);
   final List<Station> _stations;
@@ -69,16 +65,30 @@ class _ActiveRadar extends RadarSearch {
       );
 }
 
+/// Feeds a fixed profile into [activeProfileProvider] so the list bar's
+/// approach-radius scale is deterministic — the SAME stub shape the recording
+/// card test (`trip_radar_card_test.dart`) uses.
+class _StubActiveProfile extends ActiveProfile {
+  _StubActiveProfile(this._profile);
+  final UserProfile? _profile;
+  @override
+  UserProfile? build() => _profile;
+}
+
+ProximityFillBar _renderedBarFor(WidgetTester tester, Station station) {
+  final card = find.byKey(ValueKey('station-${station.id}'));
+  expect(card, findsOneWidget,
+      reason: 'the radar list must render a card for ${station.id}');
+  return tester.widget<ProximityFillBar>(
+    find.descendant(of: card, matching: find.byType(ProximityFillBar)),
+  );
+}
+
 /// The fill the rendered [ProximityFillBar] for [station] would paint — read
 /// straight off the widget the real card path built. Not a hand-rolled value:
 /// exactly what the surface displays.
 double _renderedFillFor(WidgetTester tester, Station station) {
-  final card = find.byKey(ValueKey('station-${station.id}'));
-  expect(card, findsOneWidget,
-      reason: 'the radar list must render a card for ${station.id}');
-  final bar = tester.widget<ProximityFillBar>(
-    find.descendant(of: card, matching: find.byType(ProximityFillBar)),
-  );
+  final bar = _renderedBarFor(tester, station);
   expect(bar.distanceMeters, closeTo(station.dist * 1000.0, 1e-6),
       reason: 'the bar must use station.dist (the same value the text shows)');
   return ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!);
@@ -87,7 +97,7 @@ double _renderedFillFor(WidgetTester tester, Station station) {
 Future<void> _pumpRadar(
   WidgetTester tester, {
   required List<Station> stations,
-  required double radiusKm,
+  required double approachRadiusKm,
 }) async {
   final test = standardTestOverrides();
   when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -101,92 +111,111 @@ Future<void> _pumpRadar(
       ...test.overrides,
       userPositionNullOverride(),
       radarSearchProvider.overrideWith(() => _ActiveRadar(stations)),
-      searchRadiusOverride(radiusKm),
+      activeProfileProvider.overrideWith(
+        () => _StubActiveProfile(
+          UserProfile(
+            id: 'p1',
+            name: 'Test',
+            approachRadiusKm: approachRadiusKm,
+          ),
+        ),
+      ),
     ].cast(),
   );
   await tester.pump();
 }
 
 void main() {
-  group('radar list closeness bar — ABSOLUTE fixed scale (#2984)', () {
-    // The configured radius (20 km) exceeds the 15 km cap, so the scale is the
-    // 15 km cap for every station regardless of the result set.
-    const radiusKm = 20.0;
-    final scaleMeters =
-        math.min(radiusKm * 1000.0, kRadarClosenessScaleCapMeters);
+  group('radar list closeness bar — APPROACH-RADIUS scale (#2995)', () {
+    const approachRadiusKm = 3.0; // the 3 km base the recording radar uses
 
-    testWidgets('fill is strictly DECREASING with distance (closer = fuller)',
+    testWidgets(
+        'the bar scales to the APPROACH radius (3 km), NOT the 15 km list '
+        'scale or the search slider', (tester) async {
+      await _pumpRadar(
+        tester,
+        stations: [_at('s-2', 2.5)],
+        approachRadiusKm: approachRadiusKm,
+      );
+
+      final bar = _renderedBarFor(tester, _at('s-2', 2.5));
+      // RED on master: master resolved `listScaleMeters(searchRadius*1000)`,
+      // up to the 15 km cap (15000). The fix wires it to approachRadiusKm*1000.
+      expect(bar.radiusMeters, 3000.0,
+          reason: 'the list must scale to the approach radius (3 km → 3000 m), '
+              'identical to the recording radar — NOT 15000 / the slider');
+    });
+
+    testWidgets('a 2.5 km station reads ~0.17 (was ~0.83 on the 15 km scale)',
         (tester) async {
-      await _pumpRadar(tester, stations: _fourStations(), radiusKm: radiusKm);
+      await _pumpRadar(
+        tester,
+        stations: [_at('s-2', 2.5)],
+        approachRadiusKm: approachRadiusKm,
+      );
 
-      final s = _fourStations();
-      final f2 = _renderedFillFor(tester, s[0]); // 2.5 km
-      final f7 = _renderedFillFor(tester, s[1]); // 7.2 km
-      final f10 = _renderedFillFor(tester, s[2]); // 10.3 km
-      final f13 = _renderedFillFor(tester, s[3]); // 13 km
-
-      expect(f2, greaterThan(f7));
-      expect(f7, greaterThan(f10));
-      expect(f10, greaterThan(f13));
+      // 1 - 2.5/3 ≈ 0.1667 — matching the recording radar. On master (15 km
+      // scale) this read 1 - 2.5/15 ≈ 0.83.
+      expect(_renderedFillFor(tester, _at('s-2', 2.5)), closeTo(0.1667, 1e-3));
     });
 
     testWidgets(
-        'STABILITY: the 2.5 km fill is IDENTICAL with or without the 13 km '
-        'station (scale depends on the radius + cap, NOT the result set)',
-        (tester) async {
-      // With the far (13 km) station present.
-      await _pumpRadar(tester, stations: _fourStations(), radiusKm: radiusKm);
-      final withFar = _renderedFillFor(tester, _at('s-2', 2.5));
-
-      // Fully tear down the first tree so the second pump renders a fresh
-      // list (a bare second pumpWidget reuses the element tree).
-      await tester.pumpWidget(const SizedBox.shrink());
-      await tester.pump();
-
-      // Without it: drop the 13 km outlier; the near station must NOT move.
-      final withoutFarSet = _fourStations()..removeLast();
-      await _pumpRadar(tester, stations: withoutFarSet, radiusKm: radiusKm);
-      final withoutFar = _renderedFillFor(tester, _at('s-2', 2.5));
-
-      expect(withoutFar, closeTo(withFar, 1e-9),
-          reason: 'an absolute scale must give the SAME near fill regardless '
-              'of whether a far station is in the list — on the span model '
-              'removing the far station changes the near fill');
-    });
-
-    testWidgets('the farthest station is NOT 0% (only nears empty near the '
-        'scale, never force-emptied)', (tester) async {
-      // 2.5 & 7.2 km: the farthest (7.2 km) reads ~52%, not empty — on the
-      // span model the farthest (the span edge) is pinned to 0%.
+        'a station BEYOND the approach radius (5 km of a 3 km radius) reads ~0 '
+        '(only stations within reach show a fill, by design)', (tester) async {
       await _pumpRadar(
         tester,
-        stations: [_at('s-2', 2.5), _at('s-7', 7.2)],
-        radiusKm: radiusKm,
+        stations: [_at('s-5', 5.0)],
+        approachRadiusKm: approachRadiusKm,
       );
-      final far = _renderedFillFor(tester, _at('s-7', 7.2));
-      expect(far, greaterThan(0.4),
-          reason: '7.2 km of a 15 km scale ≈ 0.52 — clearly NOT empty');
-      expect(far, closeTo(0.52, 1e-3));
+
+      expect(_renderedFillFor(tester, _at('s-5', 5.0)), closeTo(0.0, 1e-9),
+          reason: '5 km is past the 3 km approach radius → clamped to empty');
     });
 
-    testWidgets('the exact fills match the absolute formula for the '
-        'configured radius (scale = min(radius, cap))', (tester) async {
-      await _pumpRadar(tester, stations: _fourStations(), radiusKm: radiusKm);
+    testWidgets(
+        'CONSISTENCY: the list resolves the SAME radiusMeters as the recording '
+        'card for the same profile (both profile.approachRadiusKm * 1000)',
+        (tester) async {
+      await _pumpRadar(
+        tester,
+        stations: [_at('s-2', 2.5)],
+        approachRadiusKm: approachRadiusKm,
+      );
 
-      final s = _fourStations();
-      for (final station in s) {
-        final expected =
-            RadarCloseness.fillFor(station.dist * 1000.0, scaleMeters);
-        expect(_renderedFillFor(tester, station), closeTo(expected, 1e-6),
-            reason: 'station ${station.id} (${station.dist} km) must read the '
-                'absolute fill for scale ${scaleMeters / 1000} km');
-      }
+      final bar = _renderedBarFor(tester, _at('s-2', 2.5));
+      // The recording card computes exactly `profile.approachRadiusKm * 1000.0`
+      // (trip_radar_card.dart). The list must match it bit-for-bit.
+      const recordingCardRadiusMeters = approachRadiusKm * 1000.0;
+      expect(bar.radiusMeters, recordingCardRadiusMeters,
+          reason: 'list + recording radar must share the approach-radius base');
+      // …and therefore paint the identical fill for the same distance.
+      expect(
+        ProximityFillBar.fillFor(bar.distanceMeters, bar.radiusMeters!),
+        closeTo(
+          RadarCloseness.fillFor(2500.0, recordingCardRadiusMeters),
+          1e-9,
+        ),
+      );
+    });
 
-      // The worked examples (scale = 15 km): ~83%, ~52%, ~31%, ~13%.
-      expect(_renderedFillFor(tester, s[0]), closeTo(0.8333, 1e-3));
-      expect(_renderedFillFor(tester, s[1]), closeTo(0.52, 1e-3));
-      expect(_renderedFillFor(tester, s[2]), closeTo(0.3133, 1e-3));
-      expect(_renderedFillFor(tester, s[3]), closeTo(0.1333, 1e-3));
+    testWidgets('fill is strictly DECREASING with distance (closer = fuller)',
+        (tester) async {
+      // All within the 3 km approach radius so each carries a non-zero fill.
+      final near = _at('near', 0.5);
+      final mid = _at('mid', 1.5);
+      final edge = _at('edge', 2.7);
+      await _pumpRadar(
+        tester,
+        stations: [near, mid, edge],
+        approachRadiusKm: approachRadiusKm,
+      );
+
+      final fNear = _renderedFillFor(tester, near);
+      final fMid = _renderedFillFor(tester, mid);
+      final fEdge = _renderedFillFor(tester, edge);
+
+      expect(fNear, greaterThan(fMid));
+      expect(fMid, greaterThan(fEdge));
     });
   });
 }

--- a/test/features/search/presentation/widgets/radar_closeness_bar_test.dart
+++ b/test/features/search/presentation/widgets/radar_closeness_bar_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/proximity_fill_bar.dart';
+import 'package:tankstellen/features/profile/data/models/user_profile.dart';
+import 'package:tankstellen/features/profile/providers/profile_provider.dart';
 import 'package:tankstellen/features/search/domain/entities/station.dart';
 import 'package:tankstellen/features/search/presentation/widgets/search_results_content.dart';
 import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
@@ -15,29 +17,25 @@ import 'package:tankstellen/features/search/providers/radar_search_provider.dart
 import '../../../../helpers/mock_providers.dart';
 import '../../../../helpers/pump_app.dart';
 
-/// #2956/#2984 — root-cause pinning regression for the Fuel Station Radar
+/// #2956/#2995 — root-cause pinning regression for the Fuel Station Radar
 /// "closeness" bar. The recurring field bug: the distance TEXT is correct but
 /// the closeness BAR under every station is ~the same length (it does not scale
-/// with distance) — because the bar scaled to the static `searchRadiusProvider`
-/// slider (up to 25 km), which lets a wide radius compress every fill toward
-/// 1.0.
+/// with distance).
 ///
-/// The fix (#2984) is an ABSOLUTE, fixed scale: `min(searchRadius, 15 km cap)`,
-/// so a wide radius no longer stretches the scale — the bars stay visibly
-/// different AND a near station's fill is stable across result-set changes (the
-/// stability lock lives in `radar_closeness_absolute_test.dart`).
+/// The bar scales to the user's APPROACH RADIUS (`profile.approachRadiusKm *
+/// 1000`) — the SAME base the recording radar card + PiP use (#2995 brought the
+/// list onto this base, reversing the `min(searchRadius, 15 km cap)` list scale
+/// of #2984/#2985). So a wide search slider no longer stretches the list scale,
+/// the bars stay visibly different down the list, and a near station reads the
+/// SAME fill it would on the recording radar.
 ///
 /// These tests drive the REAL radar list-card path (`SearchResultsContent` →
-/// `SearchResultsList` → `StationCard` → `ProximityFillBar`) with the exact
-/// screenshot distances (265 m, 9.3 km, 9.9 km, 10.0 km) and the field's 25 km
-/// slider, then read the fill the rendered bar would paint. RED on master (the
-/// far bars cluster at ~0.60–0.63, indistinguishable); green after the fix
-/// (scaled to the 15 km cap: nearest ~0.98, the far cluster spread around the
-/// 0.33–0.38 band — visibly different, none force-emptied).
+/// `SearchResultsList` → `StationCard` → `ProximityFillBar`) with stations
+/// inside the approach radius, then read the fill the rendered bar would paint.
 
-/// The four radar results from the field screenshot, distance-ranked.
-/// `dist` is kilometres (the same value the card distance text shows).
-List<Station> _screenshotStations() => const [
+/// Four radar results within a 3 km approach radius, distance-ranked. `dist` is
+/// kilometres (the same value the card distance text shows).
+List<Station> _stations() => const [
       Station(
         id: 'fr-pezenas',
         name: 'Pézenas Carburant',
@@ -60,7 +58,7 @@ List<Station> _screenshotStations() => const [
         place: 'Pézenas',
         lat: 43.49,
         lng: 3.45,
-        dist: 9.3,
+        dist: 1.2,
         e85: 0.799,
         isOpen: true,
       ),
@@ -73,7 +71,7 @@ List<Station> _screenshotStations() => const [
         place: 'Saint-Thibéry',
         lat: 43.50,
         lng: 3.41,
-        dist: 9.9,
+        dist: 2.0,
         e85: 0.805,
         isOpen: true,
       ),
@@ -86,7 +84,7 @@ List<Station> _screenshotStations() => const [
         place: 'Saint-Thibéry',
         lat: 43.51,
         lng: 3.40,
-        dist: 10.0,
+        dist: 2.7,
         e85: 0.809,
         isOpen: true,
       ),
@@ -101,6 +99,16 @@ class _ActiveRadar extends RadarSearch {
         active: true,
         stations: AsyncData<List<Station>>(_stations),
       );
+}
+
+/// Feeds a fixed profile into [activeProfileProvider] so the list bar's
+/// approach-radius scale is deterministic — the SAME stub shape the recording
+/// card test uses.
+class _StubActiveProfile extends ActiveProfile {
+  _StubActiveProfile(this._profile);
+  final UserProfile? _profile;
+  @override
+  UserProfile? build() => _profile;
 }
 
 /// The fill the rendered [ProximityFillBar] for [station] would paint — read
@@ -125,7 +133,7 @@ double _renderedFillFor(WidgetTester tester, Station station) {
 Future<void> _pumpRadar(
   WidgetTester tester, {
   required List<Station> stations,
-  required double radiusKm,
+  required double approachRadiusKm,
 }) async {
   final test = standardTestOverrides();
   when(() => test.mockStorage.hasApiKey()).thenReturn(false);
@@ -139,9 +147,15 @@ Future<void> _pumpRadar(
       ...test.overrides,
       userPositionNullOverride(),
       radarSearchProvider.overrideWith(() => _ActiveRadar(stations)),
-      // The field's WIDE slider (25 km) relative to the 10 km result span —
-      // the condition under which the old code compressed every bar.
-      searchRadiusOverride(radiusKm),
+      activeProfileProvider.overrideWith(
+        () => _StubActiveProfile(
+          UserProfile(
+            id: 'p1',
+            name: 'Test',
+            approachRadiusKm: approachRadiusKm,
+          ),
+        ),
+      ),
     ].cast(),
   );
   await tester.pump();
@@ -152,36 +166,33 @@ void main() {
   // test/core/utils/radar_closeness_test.dart. This file pins the REAL radar
   // list-card surface end-to-end (the regression lock) + the shared-helper
   // invariant across all three radar surfaces.
-  group('radar list-card closeness bar — the real surface (#2956)', () {
+  group('radar list-card closeness bar — the real surface (#2995)', () {
     testWidgets(
-        'scales to the ABSOLUTE 15 km cap: nearest near-full, the far cluster '
-        'visibly spread (NOT the 25 km slider that compressed every bar)',
-        (tester) async {
+        'scales to the APPROACH radius (3 km): nearest near-full, the rows '
+        'visibly spread down the list (closer = fuller)', (tester) async {
       await _pumpRadar(
         tester,
-        stations: _screenshotStations(),
-        radiusKm: 25.0, // the field's WIDE slider
+        stations: _stations(),
+        approachRadiusKm: 3.0,
       );
 
-      final stations = _screenshotStations();
+      final stations = _stations();
       final near = _renderedFillFor(tester, stations[0]); // 265 m
-      final mid = _renderedFillFor(tester, stations[1]); // 9.3 km
-      final farish = _renderedFillFor(tester, stations[2]); // 9.9 km
-      final far = _renderedFillFor(tester, stations[3]); // 10.0 km
+      final mid = _renderedFillFor(tester, stations[1]); // 1.2 km
+      final farish = _renderedFillFor(tester, stations[2]); // 2.0 km
+      final far = _renderedFillFor(tester, stations[3]); // 2.7 km
 
-      // Pinned to the ABSOLUTE scale = min(25 km, 15 km cap) = 15 km, NOT the
-      // 25 km slider. These are the values the bar actually paints. The far
-      // rows are NOT force-emptied — they sit around the 0.33–0.38 band.
-      expect(near, closeTo(0.9823, 1e-3),
-          reason: '265 m of a 15 km scale → ~0.98 (nearly full)');
-      expect(mid, closeTo(0.38, 1e-3), reason: '9.3 km of 15 km → ~0.38');
-      expect(farish, closeTo(0.34, 1e-3), reason: '9.9 km of 15 km → ~0.34');
-      expect(far, closeTo(0.3333, 1e-3),
-          reason: '10.0 km of 15 km → ~0.33 (NOT empty — never force-emptied)');
+      // Pinned to the 3 km approach radius — the SAME base the recording radar
+      // uses. These are the values the bar actually paints; none force-emptied.
+      expect(near, closeTo(0.9117, 1e-3),
+          reason: '265 m of a 3 km scale → ~0.91 (nearly full)');
+      expect(mid, closeTo(0.6, 1e-3), reason: '1.2 km of 3 km → 0.6');
+      expect(farish, closeTo(0.3333, 1e-3), reason: '2.0 km of 3 km → ~0.33');
+      expect(far, closeTo(0.1, 1e-3),
+          reason: '2.7 km of 3 km → 0.1 (NOT empty — within reach)');
 
       // The core regression lock: the bars must be VISIBLY DIFFERENT down the
-      // list. On master (scaled to the 25 km slider) the three far rows all sat
-      // at ~0.60–0.63 — indistinguishable — which is the reported symptom.
+      // list, not a compressed band clustered near 1.0.
       expect(near - far, greaterThan(0.6),
           reason: 'closest vs farthest must differ by most of the bar');
       expect(mid - far, greaterThan(0.04),
@@ -196,12 +207,12 @@ void main() {
         (tester) async {
       await _pumpRadar(
         tester,
-        stations: _screenshotStations(),
-        radiusKm: 25.0,
+        stations: _stations(),
+        approachRadiusKm: 3.0,
       );
       expect(
         find.byType(ProximityFillBar),
-        findsNWidgets(_screenshotStations().length),
+        findsNWidgets(_stations().length),
       );
     });
   });


### PR DESCRIPTION
Closes #2995. Reverses #2984/#2985.

## What

The fuel-station radar in the SEARCH LIST scaled the closeness fill to `min(searchRadius, 15 km cap)` (#2985), so a 2.5 km forecourt read `1 − 2.5/15 ≈ 0.83` there — while the RECORDING radar, which scales to the user's approach radius (`profile.approachRadiusKm × 1000`), read `1 − 2.5/3 ≈ 0.17` for the same profile. The two radar surfaces disagreed.

The maintainer decided the **recording radar's approach-radius base is correct and the search list was wrong**:

> The fuel station radar [search list] is wrong and the radar on the recording is correct, as it must be on the base of 3 km and not 10 km.

This brings the list onto the same base as the recording card + PiP, so all three radar surfaces are consistent on the user's approach-radius base.

## Changes

- `search_results_list.dart` — scale to `profile.approachRadiusKm × 1000`, gated on `radar.active && profile != null` (the EXACT expression `trip_radar_card.dart` uses). Dropped the now-unused `radar_closeness` import.
- `radar_closeness.dart` — removed the dead #2985 `listScaleMeters` helper + `kRadarClosenessScaleCapMeters` constant (used only by the search list); kept `fillFor` (still used by `ProximityFillBar`). Doc rewritten to the approach-radius model shared by all three surfaces.
- `station_card_status.dart` — doc updated to the approach-radius narrative.
- Recording card (`trip_radar_card.dart`) + PiP left **UNCHANGED** — the correct reference.

## Tests (RED-on-master → green)

Replaced the #2985 `listScaleMeters` / 15 km-cap pins with the new contract, driving the REAL list path (`SearchResultsContent` → `SearchResultsList` → `StationCard` → `ProximityFillBar`):

- `ProximityFillBar.radiusMeters == 3000` (approach radius), NOT 15000/the slider — **RED on master** (it resolved 10000 from the search slider).
- 2.5 km → fill ≈ 0.17 (was ~0.83); a 5 km station with a 3 km radius → fill 0.
- CONSISTENCY: the list resolves the SAME `radiusMeters` as the recording card for the same profile.

## Gates

`flutter analyze` clean (the only 2 remaining `info`s are pre-existing in untouched consumption-domain tests). Core/utils + search-widget + consumption-widget suites green (1402 tests). No codegen drift (a provider read, not a definition). No ARB changes. All changed files under the 400-line cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)