### PR TITLE
feat(map): Nearby map adopts the radar clustered+cheapest-labelled station grammar (clusterAlways)

### DIFF
--- a/lib/features/map/presentation/widgets/nearby_map_view.dart
+++ b/lib/features/map/presentation/widgets/nearby_map_view.dart
@@ -141,6 +141,16 @@ class _NearbyMapViewState extends ConsumerState<NearbyMapView> {
                     searchRadiusKm: searchRadiusKm,
                     selectedFuel: selectedFuel,
                     sortMode: sortMode,
+                    // #2998 — adopt the maintainer-loved radar grammar
+                    // (#2939): proximity-cluster EVERY result set with the
+                    // cheapest-price badge, identical to the landscape
+                    // split-screen radar map (InlineMap), instead of the
+                    // legacy emphasis(top-4 pills)+compact-dots scheme. No
+                    // `onStationTap` is passed, so a marker tap keeps its
+                    // default GoRouter push to /station/{id} (the full-screen
+                    // map has no co-visible list to select into); the radius
+                    // circle (`showSearchRadius`, default true) stays drawn.
+                    clusterAlways: true,
                     showRecenterButton: true,
                     onRecenter: () => mapController.fitCamera(
                       CameraFit.bounds(

--- a/test/features/map/presentation/widgets/nearby_map_view_test.dart
+++ b/test/features/map/presentation/widgets/nearby_map_view_test.dart
@@ -207,6 +207,43 @@ void main() {
     );
 
     testWidgets(
+      '#2998 — Nearby adopts the radar clustered+cheapest-labelled grammar: '
+      'StationMapLayers.clusterAlways == true, onStationTap stays null '
+      '(push-to-detail), showSearchRadius stays true (radius circle kept)',
+      (tester) async {
+        final controller = _CountingMapController();
+        addTearDown(controller.dispose);
+
+        await pumpApp(
+          tester,
+          _Rebuildable(
+            controller: controller,
+            viewFor: viewFor,
+            initial: resultFor(parisStations),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final layers =
+            tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+        // #2998 — the canonical radar grammar (#2939) is adopted on the
+        // full-screen nearby map: EVERY result set is proximity-clustered
+        // with the cheapest-price badge, instead of the legacy
+        // emphasis(top-4 pills)+compact-dots scheme.
+        expect(layers.clusterAlways, isTrue,
+            reason: 'nearby must adopt the radar clusterAlways grammar');
+        // The full-screen map has no co-visible list, so a marker tap must
+        // keep its default behaviour: GoRouter push to /station/{id}. A
+        // non-null onStationTap would suppress that navigation (#2939).
+        expect(layers.onStationTap, isNull,
+            reason: 'marker tap must stay push-to-detail (no onStationTap)');
+        // The radius circle is meaningful on the nearby map and stays drawn.
+        expect(layers.showSearchRadius, isTrue,
+            reason: 'the search-radius circle must be preserved');
+      },
+    );
+
+    testWidgets(
       'exactly one re-fit per distinct search bounds (no fit loop)',
       (tester) async {
         final controller = _CountingMapController();


### PR DESCRIPTION
## What

The full-screen "Carte"/Map-tab **nearby map** now renders fuel stations with the **same clustered + cheapest-labelled grammar** as the maintainer-loved landscape split-screen radar map.

Single functional change: `nearby_map_view.dart` passes `clusterAlways: true` to the shared `StationMapLayers(...)`. The radar (`InlineMap`) already passes this (#2939); the nearby map was on the legacy emphasis(top-4 pills)+compact-dots scheme, so the same data read differently per screen. The shared `StationMapLayers`/`StationMarkerBuilder`/cluster-layer stack already supports it — this is a prop flip.

## Preserved (no other change)

- **No `onStationTap`** → a marker tap keeps its default GoRouter push to `/station/{id}` (the full-screen map has no co-visible list to select into). A cluster tap zoom-to-fan-out is the shared layer's default.
- `showSearchRadius` stays **true** — the radius circle is meaningful here.
- `showRecenterButton` + `onRecenter` and the EV `extraLayers` untouched.

`RouteMapView`, `DrivingMapView`, the shared widget, and the radar are **not** touched (other Epic children, pending maintainer decision).

## Test (structural — no goldens)

Extends `nearby_map_view_test.dart`: pump `NearbyMapView`, find `StationMapLayers`, assert `clusterAlways == true` (RED on master), `onStationTap == null` (push-to-detail kept), `showSearchRadius == true` (radius circle kept). Mirrors `inline_map_radar_test.dart`.

- RED-on-master verified before the fix (failed on `clusterAlways: <false>`).
- All 187 `test/features/map` tests pass after.
- `flutter analyze` clean. No ARB strings. No codegen drift (prop flip).

Closes #2998. Part of #2997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
