### PR TITLE
feat(map): route map selection-aware clustering — cluster non-selected, keep Best/All selected as full pills (#3000)

### DIFF
--- a/lib/features/map/presentation/widgets/route_map_view.dart
+++ b/lib/features/map/presentation/widgets/route_map_view.dart
@@ -180,6 +180,13 @@ class _RouteMapViewState extends ConsumerState<RouteMapView> {
             selectedStationIds:
                 _selectedStationIds.isNotEmpty ? _selectedStationIds : null,
             fuelResolver: resolveFuel,
+            // #3000 (Epic #2997) — adopt the radar clustered+cheapest-labelled
+            // grammar, but SELECTION-AWARE: cluster the non-selected stations
+            // while the Best/All SELECTED stations stay as full, un-clustered
+            // price pills so the multi-select highlighting + the
+            // RouteBestStopsList↔marker 1:1 mapping survive at every zoom.
+            clusterAlways: true,
+            excludeSelectedFromClustering: true,
           ),
         ),
         if (_viewMode == RouteViewMode.bestStops && displayStations.isNotEmpty)

--- a/lib/features/map/presentation/widgets/station_cluster_layers.dart
+++ b/lib/features/map/presentation/widgets/station_cluster_layers.dart
@@ -60,6 +60,55 @@ Widget cheapestLabelledClusterLayer({
   );
 }
 
+/// #3000 (Epic #2997) — selection-aware clustering for the ROUTE map.
+///
+/// PARTITIONS [markers] into the SELECTED stations (those whose [metaOf] id is
+/// in [selectedIds]) and the REST, then returns two layers:
+///   1. a [cheapestLabelledClusterLayer] over the UNSELECTED markers (the
+///      radar grammar — proximity clusters with a cheapest badge), and
+///   2. a plain [MarkerLayer] over the SELECTED markers, painted ON TOP so the
+///      Best/All vivid full price pills are never hidden behind a cluster.
+///
+/// This keeps the route map's multi-select highlighting and its
+/// `RouteBestStopsList`↔marker 1:1 mapping intact — a blanket cluster would
+/// otherwise collapse several selected stations into one ringed cheapest badge.
+/// The selected markers retain whatever styling [StationMapLayers] built for
+/// them (the vivid selected ring + full pill); this only re-homes the
+/// already-built [Marker]s into the un-clustered layer.
+///
+/// Extracted here (rather than inlined into [StationMapLayers]) so that widget
+/// stays under its file-length snapshot.
+List<Widget> selectionPartitionedClusterLayers({
+  required List<Marker> markers,
+  required MarkerMeta? Function(Marker) metaOf,
+  required (double, double) priceRange,
+  required Set<String> selectedIds,
+}) {
+  final unselected = <Marker>[];
+  final selected = <Marker>[];
+  for (final m in markers) {
+    final meta = metaOf(m);
+    if (meta != null && selectedIds.contains(meta.id)) {
+      selected.add(m);
+    } else {
+      unselected.add(m);
+    }
+  }
+  return [
+    if (unselected.isNotEmpty)
+      cheapestLabelledClusterLayer(
+        markers: unselected,
+        metaOf: metaOf,
+        priceRange: priceRange,
+        // The selected stations are NOT in this layer, so no cluster here can
+        // contain one — pass an empty set so no badge is spuriously ringed.
+        selectedIds: const <String>{},
+      ),
+    // Selected pills paint ON TOP of the clusters so they are never hidden.
+    if (selected.isNotEmpty) MarkerLayer(markers: selected),
+  ];
+}
+
 /// The count-cluster layer — the #2510 fallback for a genuinely huge non-radar
 /// result set, where painting hundreds of overlapping dots would itself be
 /// illegible.

--- a/lib/features/map/presentation/widgets/station_map_layers.dart
+++ b/lib/features/map/presentation/widgets/station_map_layers.dart
@@ -111,6 +111,17 @@ class StationMapLayers extends StatefulWidget {
   /// matching list row (the inverse of a row tap) and keep the map visible.
   final void Function(String stationId)? onStationTap;
 
+  /// #3000 (Epic #2997) — selection-aware clustering for the ROUTE map. Only
+  /// meaningful with [clusterAlways]. When true, stations in
+  /// [selectedStationIds] are partitioned OUT of the cheapest-labelled cluster
+  /// and rendered as their own un-clustered full price pills (painted on top),
+  /// while the rest fold into the cluster. Keeps the route map's Best/All
+  /// multi-select highlighting and its `RouteBestStopsList`↔marker 1:1 mapping
+  /// intact — a blanket cluster would otherwise collapse several selected
+  /// stations into one ringed badge. Default false → the radar / Nearby
+  /// blanket-cluster behaviour (#2939 / #2999) is unchanged.
+  final bool excludeSelectedFromClustering;
+
   const StationMapLayers({
     super.key,
     required this.mapController,
@@ -130,6 +141,7 @@ class StationMapLayers extends StatefulWidget {
     this.fuelResolver,
     this.clusterAlways = false,
     this.onStationTap,
+    this.excludeSelectedFromClustering = false,
   });
 
   @override
@@ -284,6 +296,12 @@ class _StationMapLayersState extends State<StationMapLayers> {
   /// cluster badge can roll a cluster up to its cheapest member + spot the
   /// selected one (the builder only gets the [Marker]s). Rebuilt with [_markers].
   final Map<Marker, MarkerMeta> _markerMeta = {};
+
+  /// #3000 — the per-marker meta map, exposed so a test can assert a clustered
+  /// cross-border station carries its [fuelResolver]-derived price (not '--').
+  @visibleForTesting
+  Map<Marker, MarkerMeta> get markerMetaForTesting =>
+      Map.unmodifiable(_markerMeta);
 
   /// True once FlutterMap has laid out and emitted `onMapReady`. The
   /// guarded `didUpdateWidget` fit waits on this so a `fitCamera` call
@@ -544,15 +562,26 @@ class _StationMapLayersState extends State<StationMapLayers> {
                 ),
               ],
             ),
-            // Station markers (#1774 — `_markers` is memoised). Three modes:
-            //  - #2939 `clusterAlways` (radar split pane): proximity-cluster
-            //    EVERY set with the cheapest-labelled badge so the narrow
-            //    pane never overlaps; un-clustered singletons keep their pill;
+            // Station markers (#1774 — `_markers` is memoised). Modes:
+            //  - #3000 `clusterAlways` + `excludeSelectedFromClustering`
+            //    (route map): SELECTED stations stay un-clustered as full
+            //    pills on top, the rest fold into the cheapest cluster — so
+            //    the Best/All multi-select + list↔map 1:1 survive;
+            //  - #2939 `clusterAlways` (radar / Nearby): proximity-cluster
+            //    EVERY set with the cheapest-labelled badge;
             //  - legacy huge set (≥ clusterThreshold): bare count cluster;
-            //  - legacy bounded set (#2510): plain [MarkerLayer], de-overlap
-            //    by emphasis (top-ranked keep the pill, rest are dots).
+            //  - legacy bounded set (#2510): plain [MarkerLayer], emphasis.
             if (_markers.isNotEmpty)
-              if (widget.clusterAlways)
+              if (widget.clusterAlways &&
+                  widget.excludeSelectedFromClustering)
+                ...selectionPartitionedClusterLayers(
+                  markers: _markers,
+                  metaOf: (m) => _markerMeta[m],
+                  priceRange: _priceRange,
+                  selectedIds:
+                      widget.selectedStationIds ?? const <String>{},
+                )
+              else if (widget.clusterAlways)
                 cheapestLabelledClusterLayer(
                   markers: _markers,
                   metaOf: (m) => _markerMeta[m],

--- a/test/features/map/presentation/widgets/route_map_view_test.dart
+++ b/test/features/map/presentation/widgets/route_map_view_test.dart
@@ -436,6 +436,93 @@ void main() {
     );
   });
 
+  // #3000 (Epic #2997) — the route map adopts the radar clustered+
+  // cheapest-labelled grammar, but SELECTION-AWARE: cluster the non-selected
+  // stations while the Best/All SELECTED stations stay as full un-clustered
+  // pills. RouteMapView must hand StationMapLayers BOTH `clusterAlways` and
+  // `excludeSelectedFromClustering`, and keep the cross-border resolver,
+  // route polyline, the Best/All selection set, and the suppressed radius.
+  group('RouteMapView selection-aware clustering wiring (#3000)', () {
+    testWidgets(
+      'passes clusterAlways AND excludeSelectedFromClustering to '
+      'StationMapLayers, while keeping fuelResolver, routePolyline and '
+      'showSearchRadius=false',
+      (tester) async {
+        final controller = MapController();
+        addTearDown(controller.dispose);
+
+        final overrides = standardTestOverrides();
+        when(() => overrides.mockStorage.getActiveProfileId())
+            .thenReturn(null);
+
+        await pumpApp(
+          tester,
+          buildHost(buildResult(stations: testStationList), controller),
+          overrides: overrides.overrides,
+        );
+
+        final layers =
+            tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+        // Selection-aware clustering: cluster the non-selected, keep selected
+        // as full pills.
+        expect(layers.clusterAlways, isTrue,
+            reason: 'route map adopts the radar clustered grammar');
+        expect(layers.excludeSelectedFromClustering, isTrue,
+            reason: 'Best/All selected stations stay OUT of clustering as full '
+                'pills so the multi-select + list↔map 1:1 mapping survive');
+        // #2631 — the cross-border resolver must still be supplied so a
+        // Spanish station's cheapest rollup uses the resolved E10 price.
+        expect(layers.fuelResolver, isNotNull,
+            reason: 'cross-border fuel resolution (#2631) must be preserved');
+        // Route polyline + suppressed radius are unchanged.
+        expect(layers.routePolyline, isNotNull);
+        expect(layers.showSearchRadius, isFalse);
+        // Route map uses its OWN selection model — no map-row-select tap.
+        expect(layers.onStationTap, isNull,
+            reason: 'route map selects via its Best/All model, not map taps');
+      },
+    );
+
+    testWidgets(
+      'forwards the Best/All selected set as selectedStationIds once a Best '
+      'station is chosen',
+      (tester) async {
+        final controller = MapController();
+        addTearDown(controller.dispose);
+
+        final overrides = standardTestOverrides();
+        when(() => overrides.mockStorage.getActiveProfileId())
+            .thenReturn(null);
+
+        await pumpApp(
+          tester,
+          buildHost(
+            buildResult(
+              stations: testStationList,
+              cheapestId: testStationList.first.id,
+            ),
+            controller,
+          ),
+          overrides: overrides.overrides,
+        );
+
+        // Switch to Best stops → the selected set is populated and forwarded.
+        await tester.tap(find.text('Best stops'));
+        await tester.pumpAndSettle();
+
+        final layers =
+            tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+        expect(layers.selectedStationIds, isNotNull);
+        expect(layers.selectedStationIds, contains(testStationList.first.id),
+            reason: 'the Best-stops selection set drives which markers stay '
+                'un-clustered');
+        // The two clustering flags hold across the toggle.
+        expect(layers.clusterAlways, isTrue);
+        expect(layers.excludeSelectedFromClustering, isTrue);
+      },
+    );
+  });
+
   group('RouteMapView save-route dialog', () {
     testWidgets('opening the dialog shows a TextField and Cancel/Save buttons',
         (tester) async {

--- a/test/features/map/presentation/widgets/station_map_layers_test.dart
+++ b/test/features/map/presentation/widgets/station_map_layers_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:tankstellen/features/map/data/sparkilo_tile_layer.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_cluster_layers.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
 import 'package:tankstellen/features/map/presentation/widgets/station_marker.dart';
 import 'package:tankstellen/features/search/domain/entities/fuel_type.dart';
@@ -455,6 +456,296 @@ void main() {
       await pumpWith(tester, const []);
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
     });
+  });
+
+  // #3000 (Epic #2997) — selection-aware clustering for the ROUTE map. With
+  // `clusterAlways` the radar grammar collapses EVERY station into the
+  // cheapest-labelled cluster — which would fold several Best/All SELECTED
+  // stations into one ringed badge, destroying the per-station vivid/pastel
+  // distinction and the RouteBestStopsList↔marker 1:1 mapping. The opt-in
+  // `excludeSelectedFromClustering` PARTITIONS the markers: SELECTED stations
+  // render as their own un-clustered full price pills (a plain MarkerLayer on
+  // top); the REST fold into the cheapest-labelled cluster.
+  group('StationMapLayers selection-aware clustering (#3000)', () {
+    // Two SELECTED + three UNSELECTED, all tightly packed so a blanket
+    // cluster (the bug) would swallow ALL FIVE into one badge.
+    const selected = <Station>[
+      Station(
+        id: 'sel-a',
+        name: 'Selected A',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '10178',
+        place: 'Berlin',
+        lat: 52.5210,
+        lng: 13.4100,
+        dist: 0.5,
+        e10: 1.55,
+        isOpen: true,
+      ),
+      Station(
+        id: 'sel-b',
+        name: 'Selected B',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '10178',
+        place: 'Berlin',
+        lat: 52.5212,
+        lng: 13.4102,
+        dist: 0.6,
+        e10: 1.60,
+        isOpen: true,
+      ),
+    ];
+    const unselected = <Station>[
+      Station(
+        id: 'un-a',
+        name: 'Unselected A',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '10178',
+        place: 'Berlin',
+        lat: 52.5214,
+        lng: 13.4104,
+        dist: 0.7,
+        e10: 1.70,
+        isOpen: true,
+      ),
+      Station(
+        id: 'un-b',
+        name: 'Unselected B',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '10178',
+        place: 'Berlin',
+        lat: 52.5216,
+        lng: 13.4106,
+        dist: 0.8,
+        e10: 1.75,
+        isOpen: true,
+      ),
+      Station(
+        id: 'un-c',
+        name: 'Unselected C',
+        brand: 'Brand',
+        street: 'Street',
+        postCode: '10178',
+        place: 'Berlin',
+        lat: 52.5218,
+        lng: 13.4108,
+        dist: 0.9,
+        e10: 1.80,
+        isOpen: true,
+      ),
+    ];
+
+    Future<void> pumpSelectionAware(
+      WidgetTester tester, {
+      required List<Station> stations,
+      required Set<String> selectedIds,
+      required bool excludeSelectedFromClustering,
+      FuelType Function(Station)? fuelResolver,
+    }) async {
+      tester.view.physicalSize = const Size(900, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final mapController = MapController();
+      addTearDown(mapController.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StationMapLayers(
+              mapController: mapController,
+              stations: stations,
+              center: const LatLng(52.5214, 13.4104),
+              zoom: 12,
+              searchRadiusKm: 5,
+              selectedFuel: FuelType.e10,
+              clusterAlways: true,
+              excludeSelectedFromClustering: excludeSelectedFromClustering,
+              selectedStationIds: selectedIds,
+              fuelResolver: fuelResolver,
+              showSearchRadius: false,
+            ),
+          ),
+        ),
+      );
+    }
+
+    /// Markers from the NON-centre [MarkerLayer]s (the centre dot is a
+    /// single-marker layer with width 20). These are the un-clustered pills.
+    List<Marker> stationMarkerLayerMarkers(WidgetTester tester) => tester
+        .widgetList<MarkerLayer>(find.byType(MarkerLayer))
+        .expand((l) => l.markers)
+        .where((m) => m.width != 20)
+        .toList();
+
+    /// Match a marker back to its station by lat/lng (Marker carries no id).
+    Station? stationForMarker(Marker m, List<Station> all) {
+      for (final s in all) {
+        if ((s.lat - m.point.latitude).abs() < 1e-9 &&
+            (s.lng - m.point.longitude).abs() < 1e-9) {
+          return s;
+        }
+      }
+      return null;
+    }
+
+    testWidgets(
+      'RED-on-master: a BLANKET clusterAlways (excludeSelected=false) folds '
+      'ALL five — including the two selected — into the cluster layer, leaving '
+      'no un-clustered selected pills (the bug this feature fixes)',
+      (tester) async {
+        await pumpSelectionAware(
+          tester,
+          stations: [...selected, ...unselected],
+          selectedIds: {'sel-a', 'sel-b'},
+          excludeSelectedFromClustering: false,
+        );
+
+        // The legacy blanket path: every station goes through the cluster
+        // layer, and there is NO separate un-clustered selected pill layer.
+        final cluster = tester.widget<MarkerClusterLayerWidget>(
+            find.byType(MarkerClusterLayerWidget));
+        expect(cluster.options.markers.length, 5,
+            reason: 'blanket clusterAlways routes ALL stations through the '
+                'cluster layer');
+        expect(stationMarkerLayerMarkers(tester), isEmpty,
+            reason: 'no station MarkerLayer when everything is clustered');
+      },
+    );
+
+    testWidgets(
+      'GREEN: with excludeSelectedFromClustering the 2 SELECTED stations '
+      'render as their OWN un-clustered markers while the 3 unselected fold '
+      'into the cheapest-labelled cluster',
+      (tester) async {
+        await pumpSelectionAware(
+          tester,
+          stations: [...selected, ...unselected],
+          selectedIds: {'sel-a', 'sel-b'},
+          excludeSelectedFromClustering: true,
+        );
+
+        // The cluster layer receives ONLY the 3 unselected markers.
+        final cluster = tester.widget<MarkerClusterLayerWidget>(
+            find.byType(MarkerClusterLayerWidget));
+        expect(cluster.options.markers.length, 3,
+            reason: 'only the unselected stations are clustered');
+        final clusteredIds = cluster.options.markers
+            .map((m) => stationForMarker(m, unselected)?.id)
+            .toSet();
+        expect(clusteredIds, {'un-a', 'un-b', 'un-c'});
+
+        // The 2 selected stations render as their OWN un-clustered markers in
+        // a plain MarkerLayer (1:1 list↔map mapping survives).
+        final pills = stationMarkerLayerMarkers(tester);
+        final allStations = [...selected, ...unselected];
+        final pillIds =
+            pills.map((m) => stationForMarker(m, allStations)?.id).toSet();
+        expect(pillIds, {'sel-a', 'sel-b'},
+            reason: 'exactly the selected stations stay un-clustered');
+      },
+    );
+
+    testWidgets(
+      'GREEN: the un-clustered selected markers keep their FULL price pill '
+      '(never a compact dot) with the vivid selected ring',
+      (tester) async {
+        await pumpSelectionAware(
+          tester,
+          stations: [...selected, ...unselected],
+          selectedIds: {'sel-a', 'sel-b'},
+          excludeSelectedFromClustering: true,
+        );
+
+        final pills = stationMarkerLayerMarkers(tester);
+        expect(pills, hasLength(2));
+        // A selected station is ALWAYS the full pill (kStationMarkerWidth),
+        // never a compact dot — the vivid selected styling is preserved.
+        for (final m in pills) {
+          expect(m.width, kStationMarkerWidth,
+              reason: 'selected markers keep the full price pill, not a dot');
+        }
+      },
+    );
+
+    testWidgets(
+      'GREEN: a cross-border UNSELECTED station clusters with its '
+      'fuelResolver-derived price (not "--") — cheapest rollup composes with '
+      'the resolved MarkerMeta.price (#2631)',
+      (tester) async {
+        // `crossBorder` has NO e10 but DOES have e5; the resolver maps it to
+        // e5 (its country fuel) so its cluster contributes a real price.
+        const crossBorder = Station(
+          id: 'un-cross',
+          name: 'Cross-border ES',
+          brand: 'Brand',
+          street: 'Street',
+          postCode: '00000',
+          place: 'Girona',
+          lat: 52.5215,
+          lng: 13.4105,
+          dist: 0.75,
+          e5: 1.42, // its real price is in e5, NOT e10
+          isOpen: true,
+        );
+        FuelType resolve(Station s) =>
+            s.id == 'un-cross' ? FuelType.e5 : FuelType.e10;
+
+        await pumpSelectionAware(
+          tester,
+          stations: [...selected, crossBorder, ...unselected],
+          selectedIds: {'sel-a', 'sel-b'},
+          excludeSelectedFromClustering: true,
+          fuelResolver: resolve,
+        );
+
+        // The cross-border station is unselected → it goes to the cluster.
+        final cluster = tester.widget<MarkerClusterLayerWidget>(
+            find.byType(MarkerClusterLayerWidget));
+        final crossMarker = cluster.options.markers.firstWhere(
+          (m) =>
+              (m.point.latitude - crossBorder.lat).abs() < 1e-9 &&
+              (m.point.longitude - crossBorder.lng).abs() < 1e-9,
+        );
+
+        // The per-marker meta the cluster builder rolls up from. The clustered
+        // cross-border station carries its RESOLVED e5 price (1.42), not the
+        // strict-e10 '--' (null) it would otherwise have — so the cheapest
+        // rollup uses a real value, not '--' (#2631).
+        final state = tester.state(find.byType(StationMapLayers));
+        final metaMap = (state as dynamic).markerMetaForTesting
+            as Map<Marker, MarkerMeta>;
+        final meta = metaMap[crossMarker];
+        expect(meta, isNotNull);
+        expect(meta!.price, 1.42,
+            reason: 'cluster rollup uses the fuelResolver-derived price so a '
+                'cross-border station contributes a real value, not "--"');
+      },
+    );
+
+    testWidgets(
+      'with NO selection, excludeSelectedFromClustering folds everything into '
+      'the cluster (no stray un-clustered pills) — matches the radar grammar',
+      (tester) async {
+        await pumpSelectionAware(
+          tester,
+          stations: [...selected, ...unselected],
+          selectedIds: const {},
+          excludeSelectedFromClustering: true,
+        );
+
+        final cluster = tester.widget<MarkerClusterLayerWidget>(
+            find.byType(MarkerClusterLayerWidget));
+        expect(cluster.options.markers.length, 5,
+            reason: 'with no selection, every station clusters as normal');
+        expect(stationMarkerLayerMarkers(tester), isEmpty);
+      },
+    );
   });
 }
 

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -501,7 +501,17 @@ void main() {
     // the onStationTap callback once (3 lines: the selectionClick + the
     // delegate + its dartdoc) so a marker tap that selects a list row buzzes
     // like the other everyday tap surfaces. Decomposition still #2187/#2188.
-    'lib/features/map/presentation/widgets/station_map_layers.dart': 625,
+    // #3000 — re-grandfathered 625 → 654 (Epic #2997): selection-aware
+    // clustering for the route map. The partition LOGIC was extracted to
+    // `selectionPartitionedClusterLayers` in station_cluster_layers.dart (per
+    // the file-length rule, a helper over grandfathering); the residual growth
+    // here is the widget's own irreducible API — the `excludeSelectedFromClustering`
+    // flag + its dartdoc, its constructor param, the build-tree branch that
+    // spreads the partitioned layers, and the `markerMetaForTesting` seam that
+    // lets a test assert a clustered cross-border station carries its resolved
+    // price. None of these can move off the widget. Decomposition of this
+    // god-class is still tracked by #2187/#2188.
+    'lib/features/map/presentation/widgets/station_map_layers.dart': 654,
     // #2681 — feature_management_section.dart graduated: the #2681 ordered-
     // category reorg decomposed the 718-line god-class into the
     // widgets/feature_management/ folder (conso_feature_card.dart,


### PR DESCRIPTION
Child of Epic #2997 (unify fuel-station display across all maps). The maintainer's chosen approach for the **route-results map**: **selection-aware clustering**.

## What

The route map now adopts the radar **clustered + cheapest-labelled** grammar (#2939 / #2999), but **selection-aware**: the non-selected stations fold into the cheapest-labelled cluster, while the Best/All **selected** stations stay as full, un-clustered price pills painted **on top**.

## Why

`StationMapLayers` with a blanket `clusterAlways` routes EVERY station through `cheapestLabelledClusterLayer`, which only rings a cluster that contains a selected member and shows one cheapest badge. `RouteMapView` passes a **multi-id** `selectedStationIds` set (the All/Best toggle). Blanket clustering would collapse several selected stations into one ringed cheapest badge → the Best/All vivid/pastel per-station distinction and the `RouteBestStopsList`↔marker 1:1 mapping are destroyed at low/medium zoom. So selected stations must stay OUT of clustering.

## How

- **`StationMapLayers`** gains the opt-in `bool excludeSelectedFromClustering` (default false → radar / Nearby unchanged). With `clusterAlways`, the memoised markers are partitioned by `selectedStationIds`: the rest cluster (cheapest-labelled), the selected render as their own `MarkerLayer` on top, keeping the existing vivid selected ring + full pill (never a compact dot), `AnimatedPriceText` (#2973), `PriceBandColors` ramp and `RepaintBoundary` memoisation.
- The partition logic lives in **`selectionPartitionedClusterLayers`** (`station_cluster_layers.dart`) so the widget stays decomposed rather than ballooning. The cluster still rolls up the `fuelResolver`-derived `MarkerMeta.price`, so a cross-border unselected station contributes its **resolved** price (#2631), not `'--'`.
- **`RouteMapView`** sets `clusterAlways: true` + `excludeSelectedFromClustering: true`, keeping `fuelResolver`, `routePolyline`, `cameraFitBounds`, `selectedStationIds` and `showSearchRadius: false`; no `onStationTap` (route uses its own Best/All selection model).

## Tests (structural — no goldens)

- **RouteMapView wiring**: asserts both flags are passed, plus `fuelResolver != null`, `routePolyline != null`, `showSearchRadius == false`, `onStationTap == null`, and the Best/All set forwarded as `selectedStationIds`.
- **StationMapLayers partition**: with `clusterAlways + excludeSelectedFromClustering` and (2 selected + 3 unselected in proximity), the 2 selected render as their own un-clustered markers (full pills) while the 3 unselected fold into the cluster — RED before the feature (all 5 cluster), green after. With no selection, everything clusters (matches the radar grammar).
- **Cross-border**: a clustered unselected station carries its `fuelResolver`-derived `MarkerMeta.price` (1.42 e5), not the strict-e10 `'--'`.

RED-on-master verified: the new tests fail to compile against master (the `excludeSelectedFromClustering` API and partition behaviour don't exist).

## Gates

- `flutter analyze` clean on all changed files; `flutter test test/features/map test/lint/file_length_test.dart` green (195 tests).
- No new ARB strings, no codegen drift (no annotated code touched).
- `station_map_layers.dart` file-length snapshot bumped 625 → 654 with a rationale comment — the partition LOGIC was extracted to a helper (per the file-length rule); the residual growth is the widget's own irreducible API.

Closes #3000. Part of #2997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)