### PR TITLE
fix(obd2): combustion-health magnitude over-stated (sum STFT+LTFT) + PID stat keys carry trailing CR

### DIFF
--- a/lib/features/consumption/data/lessons/rules/combustion_health_rule.dart
+++ b/lib/features/consumption/data/lessons/rules/combustion_health_rule.dart
@@ -67,9 +67,10 @@ enum CombustionHealthKind {
 /// [fired] is false for every honest "no signal" case — too few warm
 /// closed-loop samples, a cold engine, unknown coolant, or normal trims.
 /// When it fires, [kind] says which signal dominated and [magnitudePct]
-/// carries the representative number (mean |STFT+LTFT| for the trim kinds;
-/// the percent of the warm window spent enriched for the enrichment kind)
-/// so the UI can render an honest figure.
+/// carries the representative number (mean |LTFT|, the *sustained* trim, for
+/// the trim kinds; the percent of the warm window spent enriched for the
+/// enrichment kind) so the UI can render an honest figure. The firing gate
+/// still uses the total trim (STFT + LTFT) — see [combustionHealthSignal].
 class CombustionHealthSignal {
   const CombustionHealthSignal({
     required this.fired,
@@ -120,11 +121,14 @@ class CombustionHealthSignal {
 ///   * The signal must be **sustained** over at least
 ///     [kCombustionMinSustainedSamples] qualifying samples — a brief spike
 ///     never fires it.
-///   * **Trim signal** (primary, the most reliable): mean total trim
-///     |STFT + LTFT| over the warm window. ≥ [kCombustionTrimBorderlinePct]
-///     → the mixture looks a little off; ≥ [kCombustionTrimMarkedPct] →
-///     escalated wording. Positive total = compensating for a lean read,
-///     negative = compensating for a rich read.
+///   * **Trim signal** (primary, the most reliable): a sample counts as
+///     "compensating" when total trim |STFT + LTFT| ≥
+///     [kCombustionTrimBorderlinePct] (the active mixture fight). Positive
+///     total = compensating for a lean read, negative = for a rich read. The
+///     *reported* magnitude, though, is the mean SUSTAINED trim (|LTFT|) over
+///     those samples — STFT oscillates ± so summing it overstated the
+///     "sustained fuel addition" figure; ≥ [kCombustionTrimMarkedPct] |LTFT|
+///     escalates the wording.
 ///   * **Enrichment signal** (secondary, always available because λ is
 ///     stamped on every sample): a large share of the warm window spent
 ///     with commanded λ < [kCombustionRichLambda] = sustained deliberate
@@ -204,7 +208,15 @@ CombustionHealthSignal combustionHealthSignal(List<TripSample> samples) {
   var trimSamples = 0; // warm samples that carried both STFT + LTFT
   var compensatingSamples = 0; // |total trim| ≥ borderline
   var signedTrimSum = 0.0; // mean signed total trim over compensating
-  var absTrimSum = 0.0; // mean |total trim| over compensating
+  // The user-facing "X% sustained fuel addition" magnitude is built from the
+  // LONG-term trim (LTFT) alone — the SUSTAINED correction the copy speaks of
+  // — NOT |STFT + LTFT|. The short-term trim (STFT) oscillates ±, so adding it
+  // to LTFT overstated the reported "sustained" figure ~1.5–2× vs the
+  // P0171/P0172 (~±10% LTFT) convention the wording evokes (#2931). STFT still
+  // gates firing via the total below; only the reported number is LTFT-based.
+  // Lean-vs-rich stays classified from the signed TOTAL trim (signedTrimSum),
+  // so the firing direction is unchanged.
+  var absLtftSum = 0.0; // mean |LTFT| over compensating
 
   // Enrichment accumulators.
   var lambdaSamples = 0; // warm samples that carried λ
@@ -223,11 +235,15 @@ CombustionHealthSignal combustionHealthSignal(List<TripSample> samples) {
     final ltft = s.ltft;
     if (stft != null && ltft != null) {
       trimSamples++;
+      // Firing gate stays on the TOTAL trim (STFT + LTFT) so which trips
+      // surface is unchanged — STFT legitimately signals the engine is
+      // actively compensating right now.
       final total = stft + ltft;
       if (total.abs() >= kCombustionTrimBorderlinePct) {
         compensatingSamples++;
         signedTrimSum += total;
-        absTrimSum += total.abs();
+        // …but the REPORTED magnitude is the sustained (LTFT) correction only.
+        absLtftSum += ltft.abs();
       }
     }
 
@@ -249,15 +265,19 @@ CombustionHealthSignal combustionHealthSignal(List<TripSample> samples) {
   if (trimSamples >= kCombustionMinSustainedSamples &&
       compensatingSamples >= kCombustionMinSustainedSamples &&
       compensatingSamples * 2 >= trimSamples) {
-    final meanAbs = absTrimSum / compensatingSamples;
+    // Reported magnitude + the marked escalation reflect the SUSTAINED
+    // correction (mean |LTFT|), matching the "sustained fuel addition" copy
+    // and the P0171/P0172 LTFT convention (#2931). Lean-vs-rich is still
+    // classified from the signed TOTAL trim (the active mixture direction).
+    final meanAbsLtft = absLtftSum / compensatingSamples;
     final meanSigned = signedTrimSum / compensatingSamples;
-    final marked = meanAbs >= kCombustionTrimMarkedPct;
+    final marked = meanAbsLtft >= kCombustionTrimMarkedPct;
     return CombustionHealthSignal(
       fired: true,
       kind: meanSigned >= 0
           ? CombustionHealthKind.leanCompensation
           : CombustionHealthKind.richCompensation,
-      magnitudePct: meanAbs,
+      magnitudePct: meanAbsLtft,
       marked: marked,
       sustainedSamples: compensatingSamples,
     );

--- a/lib/features/consumption/data/obd2/obd2_comm_diagnostics_internal.dart
+++ b/lib/features/consumption/data/obd2/obd2_comm_diagnostics_internal.dart
@@ -178,8 +178,15 @@ class _LiveSession {
   // Discovered-supported tri-state (#2469): command → state string.
   final Map<String, String> discoveredSupported = <String, String>{};
 
+  /// Keys the per-PID stat map by the **clean** PID command. The raw poll
+  /// command carries a trailing carriage-return line terminator (e.g.
+  /// `"010C\r"`), so we `trim()` it off before keying — otherwise the
+  /// diagnostics trace shows noisy `"010C\r"` rows and a command polled both
+  /// with and without the terminator would split into two rows. Purely a
+  /// diagnostics-cleanliness normalisation: it never touches what is sent on
+  /// the wire.
   _PidAccumulator pidRow(String pid) =>
-      _pids.putIfAbsent(pid, _PidAccumulator.new);
+      _pids.putIfAbsent(pid.trim(), _PidAccumulator.new);
 
   Obd2SessionDiagnostic toDiagnostic(int activeSeconds) =>
       Obd2SessionDiagnostic(

--- a/test/features/consumption/data/lessons/combustion_health_rule_test.dart
+++ b/test/features/consumption/data/lessons/combustion_health_rule_test.dart
@@ -63,34 +63,69 @@ void main() {
       ];
 
   group('combustionHealthSignal scan (#2931)', () {
-    test('sustained high LEAN trim (+18% total) over many warm samples → '
-        'fires lean, marked', () {
-      // STFT +6, LTFT +12 = +18% total on every warm sample.
+    test('sustained high LEAN trim (LTFT +16%) over many warm samples → '
+        'fires lean, marked, magnitude is the SUSTAINED (LTFT) trim', () {
+      // STFT +6, LTFT +16 = +22% total → clears the firing gate; the REPORTED
+      // magnitude is the sustained LTFT (16%), NOT the +22% sum (#2931).
       final signal =
-          combustionHealthSignal(warmSamples(count: 14, stft: 6, ltft: 12));
+          combustionHealthSignal(warmSamples(count: 14, stft: 6, ltft: 16));
       expect(signal.fired, isTrue);
       expect(signal.kind, CombustionHealthKind.leanCompensation);
-      expect(signal.marked, isTrue, reason: '18% >= marked threshold (15%)');
-      expect(signal.magnitudePct, closeTo(18.0, 1e-9));
+      expect(signal.marked, isTrue, reason: '16% >= marked threshold (15%)');
+      expect(signal.magnitudePct, closeTo(16.0, 1e-9),
+          reason: 'reported magnitude is mean |LTFT|, not |STFT + LTFT|');
     });
 
-    test('sustained NEGATIVE trim (-18% total) → fires rich, marked', () {
+    test('sustained NEGATIVE trim (LTFT -16%) → fires rich, marked, magnitude '
+        'is the sustained (LTFT) trim', () {
       final signal =
-          combustionHealthSignal(warmSamples(count: 14, stft: -6, ltft: -12));
+          combustionHealthSignal(warmSamples(count: 14, stft: -6, ltft: -16));
       expect(signal.fired, isTrue);
       expect(signal.kind, CombustionHealthKind.richCompensation);
       expect(signal.marked, isTrue);
-      // Magnitude is reported as the |mean total trim|.
-      expect(signal.magnitudePct, closeTo(18.0, 1e-9));
+      // Magnitude is reported as the sustained |mean LTFT|, not |total trim|.
+      expect(signal.magnitudePct, closeTo(16.0, 1e-9));
     });
 
-    test('borderline lean trim (+11%, below the marked threshold) → fires '
-        'lean but NOT marked', () {
+    test('borderline lean trim (LTFT +6%, total +11%) → fires lean but NOT '
+        'marked (sustained trim is below the marked threshold)', () {
+      // Total +11% clears the borderline gate; LTFT +6% is below marked (15%).
       final signal =
           combustionHealthSignal(warmSamples(count: 12, stft: 5, ltft: 6));
       expect(signal.fired, isTrue);
       expect(signal.kind, CombustionHealthKind.leanCompensation);
-      expect(signal.marked, isFalse, reason: '11% < marked threshold (15%)');
+      expect(signal.marked, isFalse,
+          reason: 'sustained LTFT 6% < marked threshold (15%)');
+      expect(signal.magnitudePct, closeTo(6.0, 1e-9));
+    });
+
+    test('STFT oscillates ± while LTFT is sustained +15% → reported magnitude '
+        'tracks the SUSTAINED trim (~15), not the STFT+LTFT sum (#2931)', () {
+      // The over-alarm bug: averaging |STFT + LTFT| reported ~30% (and "lean
+      // — 30% fuel addition") on a trip whose sustained correction was ~15%.
+      // With STFT swinging ±15 around a sustained LTFT of +15, the per-sample
+      // total alternates 0 / +30, so the old sum-based mean was ~15–30 and
+      // over-stated the sustained figure; the LTFT-based magnitude is ~15.
+      final samples = <TripSample>[
+        // 18 samples → 9 even ticks (total +30) clear the gate (≥ 8 needed),
+        // 9 odd ticks (total 0) do not; compensating*2 ≥ trimSamples holds.
+        for (var i = 0; i < 18; i++)
+          TripSample(
+            timestamp: start.add(Duration(seconds: i)),
+            speedKmh: 80,
+            rpm: 2200,
+            coolantTempC: 90,
+            // STFT oscillates +15 / -15; only the +15 ticks clear the gate.
+            stft: i.isEven ? 15.0 : -15.0,
+            ltft: 15.0, // sustained lean correction
+          ),
+      ];
+      final signal = combustionHealthSignal(samples);
+      expect(signal.fired, isTrue);
+      expect(signal.kind, CombustionHealthKind.leanCompensation);
+      expect(signal.magnitudePct, closeTo(15.0, 1e-9),
+          reason: 'reported magnitude reflects the sustained LTFT (~15), '
+              'NOT the STFT+LTFT sum (~30) the old rule reported');
     });
 
     test('normal trims (±3% total) → does NOT fire', () {
@@ -176,11 +211,12 @@ void main() {
 
     test('fires the lean-compensation lesson on sustained high LTFT', () {
       final lesson =
-          rule.evaluate(ctx(warmSamples(count: 14, stft: 6, ltft: 12)), l);
+          rule.evaluate(ctx(warmSamples(count: 14, stft: 6, ltft: 16)), l);
       expect(lesson, isNotNull);
       expect(lesson!.id, combustionHealthLessonId);
-      // Marked lean wording, with the 18% figure.
-      expect(lesson.title, l.lessonCombustionHealthLeanMarked('18'));
+      // Marked lean wording, with the SUSTAINED (LTFT) 16% figure — not the
+      // +22% STFT+LTFT sum (#2931).
+      expect(lesson.title, l.lessonCombustionHealthLeanMarked('16'));
       expect(lesson.advice, l.lessonAdviceCombustionHealthLean);
       // Honesty: subtitle explicitly labels it a heuristic, not a diagnosis.
       expect(lesson.subtitle, l.lessonCombustionHealthSubtitle);
@@ -192,9 +228,10 @@ void main() {
 
     test('fires the rich-compensation lesson on sustained negative trim', () {
       final lesson =
-          rule.evaluate(ctx(warmSamples(count: 14, stft: -6, ltft: -12)), l);
+          rule.evaluate(ctx(warmSamples(count: 14, stft: -6, ltft: -16)), l);
       expect(lesson, isNotNull);
-      expect(lesson!.title, l.lessonCombustionHealthRichMarked('18'));
+      // Sustained (LTFT) 16% figure, not the -22% STFT+LTFT sum (#2931).
+      expect(lesson!.title, l.lessonCombustionHealthRichMarked('16'));
       expect(lesson.advice, l.lessonAdviceCombustionHealthRich);
     });
 

--- a/test/features/consumption/data/obd2/obd2_comm_diagnostics_test.dart
+++ b/test/features/consumption/data/obd2/obd2_comm_diagnostics_test.dart
@@ -53,6 +53,29 @@ void main() {
       expect(row.error, 1);
     });
 
+    test('PID stats are keyed by the CLEAN command — a trailing CR ("010C\\r") '
+        'is stripped so dispatch + result share one row', () {
+      // Real connect traces showed per-PID rows keyed "010C\r", "010D\r", …
+      // because the raw poll command carries its line terminator. The key
+      // must be the clean PID so the trace is readable and a command polled
+      // with and without the CR does not split into two rows.
+      final c = Obd2CommDiagnostics(enabled: true);
+      c.beginSession();
+      c.noteDispatch('010C\r');
+      c.noteResult('010C\r', ResponseClass.ok, rttMs: 40);
+      // Same PID without the terminator must fold into the same clean row.
+      c.noteResult('010C', ResponseClass.noData);
+
+      final stats = c.snapshot().pidStats;
+      expect(stats.keys, contains('010C'));
+      expect(stats.keys, isNot(contains('010C\r')),
+          reason: 'the trailing carriage-return must be stripped from the key');
+      final row = stats['010C']!;
+      expect(row.polled, 1);
+      expect(row.ok, 1);
+      expect(row.noData, 1);
+    });
+
     test('every error-class folds into the single error counter', () {
       final c = Obd2CommDiagnostics(enabled: true);
       c.beginSession();


### PR DESCRIPTION
Closes #3005.

Two small OBD2 data-quality fixes surfaced by real connect-traces / sessions (2026-06-07). Both are diagnostics/heuristic-only — the OBD2 **connection** layer (service/channels/connection-service/scanner) is healthy and **untouched**, as are the trip-distance/resolver and map files.

## Commit 1 — combustion-health magnitude based on sustained LTFT, not STFT+LTFT sum
The lesson read e.g. *"…the engine sustained a large 30% fuel addition…"* on trips whose sustained correction was only ~15%.

Root: `combustionHealthSignal` reported the mean `|STFT + LTFT|`. STFT (short-term) oscillates ± around the sustained LTFT (long-term), so summing them over-stated the "sustained" figure ~1.5–2× vs the P0171/P0172 (~±10% LTFT) convention the copy evokes.

Fix: report the SUSTAINED correction (mean `|LTFT|`) and key the *marked* escalation off it too. **Unchanged:** STFT stays in the FIRING gate (`|STFT + LTFT| ≥ borderline`) so which trips surface is the same; lean-vs-rich classification still uses the signed total trim; the warm/closed-loop (≥70 °C) + ≥8-sample + majority gates and the `LessonPolarity.info` ranking are intact. Same ARB key, corrected interpolated value (no fan-out needed).

RED→green: a fixture with STFT swinging ±15 around a sustained LTFT +15 now reports **≈15** (was **≈30**, the sum).

## Commit 2 — strip trailing CR from per-PID diagnostics stat keys
Per-PID stats were keyed by the raw poll command incl. its `\r` terminator, so traces showed `"010C\r"`, `"010D\r"`, … and a PID polled with/without the terminator split into two rows.

Fix: `trim()` the key at the single `pidRow()` chokepoint (both `noteDispatch` + `noteResult` route through it) → keyed by the clean PID (`"010C"`). Diagnostics-cleanliness only; the wire is unchanged.

RED→green: recording `"010C\r"` keys the stat under `"010C"` (no CR) and folds dispatch+result into one row.

## Verification
- `flutter analyze` on all touched files: clean.
- `flutter test` consumption lessons + obd2 comm-diagnostics suites: all green (72 tests).
- Both new/changed assertions confirmed RED against master source, green after the fixes.
- No `*.g.dart` / `*.freezed.dart` / `lib/l10n/` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)