### PR TITLE
fix(consumption): recording GPS-degraded banner flickers/relayouts on OBD2 reconnect — debounce + animate + reserve layout

### DIFF
--- a/lib/features/consumption/presentation/widgets/gps_degraded_banner.dart
+++ b/lib/features/consumption/presentation/widgets/gps_degraded_banner.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Florian DITTGEN
 // SPDX-License-Identifier: MIT
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -18,8 +20,8 @@ import '../../providers/trip_recording_provider.dart';
 /// to re-attach the dongle. So this banner carries NO Resume / End
 /// actions — recording continues automatically and the metric cards show
 /// genuinely live GPS values. It surfaces only to tell the user WHY the
-/// OBD2-derived readings briefly switched to GPS, and clears itself the
-/// instant the dongle re-attaches.
+/// OBD2-derived readings briefly switched to GPS, and clears itself once
+/// the dongle re-attaches.
 ///
 /// Renders zero-height unless the phase is
 /// [TripRecordingPhase.degradedGpsOnly], so it is safe to drop into any
@@ -27,28 +29,150 @@ import '../../providers/trip_recording_provider.dart';
 /// this banner are mutually exclusive: the pause banner renders only for
 /// [TripRecordingPhase.pausedDueToDrop] (BOTH sources gone), this one
 /// only for [TripRecordingPhase.degradedGpsOnly] (OBD2 gone, GPS alive).
-class GpsDegradedBanner extends ConsumerWidget {
+///
+/// #3010 — flicker fix. The OBD2 reconnect scanner flips the recording
+/// phase `recording <-> degradedGpsOnly` on *every* transient Bluetooth
+/// blip. Reflecting that raw signal directly made the banner pop in/out
+/// and jump the metrics/content below on each strobe. This widget now
+/// debounces + animates the DISPLAYED state purely in the view layer
+/// (the underlying reconnect logic is untouched):
+///
+///   * **Debounce** — the banner appears only after the link has stayed
+///     degraded for [_appearDelay]; a degrade that clears before then is
+///     ignored, so transient drops never flash.
+///   * **Grace / hysteresis** — once shown, it lingers for [_hideGrace]
+///     after the phase recovers, so a quick re-drop inside the grace
+///     window keeps it up rather than strobing it off-then-on.
+///   * **Animate + reserve layout** — the in/out transition runs through
+///     [AnimatedSize] (height eased from 0) + a fade, so showing/hiding
+///     it eases the content below instead of jerking it. The collapsed
+///     state is a true zero-height box, so it costs no layout when idle.
+class GpsDegradedBanner extends ConsumerStatefulWidget {
   const GpsDegradedBanner({super.key});
 
+  /// How long the link must stay degraded before the banner appears.
+  /// A transient drop+reconnect inside this window never surfaces it.
+  static const Duration _appearDelay = Duration(milliseconds: 2500);
+
+  /// How long the banner lingers after the phase recovers, so a quick
+  /// re-drop keeps it up instead of strobing it off then back on.
+  static const Duration _hideGrace = Duration(milliseconds: 1500);
+
+  /// Ease duration of the AnimatedSize / fade in & out.
+  static const Duration _animDuration = Duration(milliseconds: 220);
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Watching only the phase (via select) means unrelated state changes
-    // — live readings, band transitions — don't rebuild the banner.
-    final phase = ref.watch(
-      tripRecordingProvider.select((s) => s.phase),
+  ConsumerState<GpsDegradedBanner> createState() => _GpsDegradedBannerState();
+}
+
+class _GpsDegradedBannerState extends ConsumerState<GpsDegradedBanner> {
+  /// Whether the banner is currently displayed (post-debounce, pre-grace).
+  bool _visible = false;
+
+  /// Pending appear (degrade still settling) / hide (grace) timer. Only
+  /// one is ever live at a time — entering degraded cancels a pending
+  /// hide and vice-versa, which is what gives the hysteresis.
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    // `ref.listen` (in build) fires only on a CHANGE, so seed the state
+    // machine with the phase already present when this banner mounts —
+    // e.g. the recording screen opening while the link is already
+    // degraded. The same appear-debounce then applies, so even an
+    // already-degraded mount eases in rather than popping.
+    final degraded = ref.read(
+      tripRecordingProvider.select(
+        (s) => s.phase == TripRecordingPhase.degradedGpsOnly,
+      ),
     );
-    if (phase != TripRecordingPhase.degradedGpsOnly) {
-      return const SizedBox.shrink();
+    if (degraded) _onPhaseChanged(true);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  /// React to a raw phase change from the provider. Runs the debounce /
+  /// grace state machine; only calls [setState] when the displayed
+  /// visibility actually flips.
+  void _onPhaseChanged(bool degraded) {
+    if (degraded) {
+      // Entering / staying degraded: cancel any pending hide and, if not
+      // already shown, arm the appear-debounce. A blip that clears before
+      // the timer fires leaves the banner hidden (no flash).
+      _timer?.cancel();
+      _timer = null;
+      if (_visible) return; // already up — a re-drop just keeps it up.
+      _timer = Timer(GpsDegradedBanner._appearDelay, () {
+        _timer = null;
+        if (mounted) setState(() => _visible = true);
+      });
+    } else {
+      // Recovered: if the appear-debounce was still pending, just drop it
+      // (the degrade never lasted long enough to show). If already shown,
+      // linger for the grace window before hiding so a quick re-drop keeps
+      // it up rather than strobing.
+      if (!_visible) {
+        _timer?.cancel();
+        _timer = null;
+        return;
+      }
+      if (_timer != null) return; // hide already scheduled.
+      _timer = Timer(GpsDegradedBanner._hideGrace, () {
+        _timer = null;
+        if (mounted) setState(() => _visible = false);
+      });
     }
-    // #2767 — once the reconnect scanner exhausts its active-scan attempts it
-    // drops to a passive autoConnect wait (it still periodically re-arms an
-    // active scan). The trip keeps recording on GPS regardless, so this is a
-    // calmer "we're still waiting" state, not a failure — surface a distinct,
-    // less-urgent copy so the user isn't left reading "reconnecting" forever.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Drive the debounce/grace state machine off the raw degraded signal.
+    // `ref.listen` fires only on an ACTUAL change (not every rebuild), so
+    // there's no post-frame churn and the timer logic runs exactly once
+    // per real transition. Selecting just the boolean means unrelated
+    // state changes — live readings, band transitions — don't fire it.
+    ref.listen(
+      tripRecordingProvider.select(
+        (s) => s.phase == TripRecordingPhase.degradedGpsOnly,
+      ),
+      (_, degraded) => _onPhaseChanged(degraded),
+    );
+
+    // #2767 — once the reconnect scanner exhausts its active-scan attempts
+    // it drops to a passive autoConnect wait (it still periodically re-arms
+    // an active scan). The trip keeps recording on GPS regardless, so this
+    // is a calmer "we're still waiting" state, not a failure — surface a
+    // distinct, less-urgent copy so the user isn't left reading
+    // "reconnecting" forever. Only meaningful while the banner is shown.
     final passiveWaiting = ref.watch(
       tripRecordingProvider.select((s) => s.reconnectPassiveWaiting),
     );
 
+    // AnimatedSize eases the height between 0 (collapsed) and the banner's
+    // intrinsic height, so showing/hiding it never jerks the metrics row
+    // above or the content below — it grows/shrinks in place. The fade
+    // softens the colour pop. When hidden the child is a true zero-height
+    // box, so the idle cost is nil.
+    return AnimatedSize(
+      duration: GpsDegradedBanner._animDuration,
+      curve: Curves.easeInOut,
+      alignment: Alignment.topCenter,
+      child: AnimatedOpacity(
+        duration: GpsDegradedBanner._animDuration,
+        opacity: _visible ? 1.0 : 0.0,
+        child: _visible
+            ? _banner(context, passiveWaiting: passiveWaiting)
+            : const SizedBox(width: double.infinity, height: 0),
+      ),
+    );
+  }
+
+  Widget _banner(BuildContext context, {required bool passiveWaiting}) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     return MaterialBanner(

--- a/test/features/consumption/presentation/widgets/gps_degraded_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/gps_degraded_banner_test.dart
@@ -56,6 +56,12 @@ class _Host extends StatelessWidget {
   }
 }
 
+/// Comfortably past the ~2.5 s appear-debounce + the ~220 ms fade.
+const _pastDebounce = Duration(seconds: 3);
+
+/// Comfortably past the ~1.5 s hide-grace + the fade.
+const _pastGrace = Duration(seconds: 2);
+
 void main() {
   group('GpsDegradedBanner (#2565)', () {
     testWidgets('not visible while recording', (tester) async {
@@ -70,8 +76,10 @@ void main() {
       expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
     });
 
-    testWidgets('appears on transition to degradedGpsOnly, with NO Resume / '
-        'End actions (recording continues automatically)', (tester) async {
+    testWidgets(
+        'appears (after the debounce) on a sustained transition to '
+        'degradedGpsOnly, with NO Resume / End actions (recording continues '
+        'automatically)', (tester) async {
       final fake = _FakeTripRecording(
         const TripRecordingState(phase: TripRecordingPhase.recording),
       );
@@ -83,6 +91,14 @@ void main() {
       expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
 
       fake.setPhase(TripRecordingPhase.degradedGpsOnly);
+      await tester.pump();
+      // #3010 — the debounce holds it back until the link has stayed
+      // degraded long enough; it must NOT pop in immediately.
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing,
+          reason: 'the appear-debounce must suppress the banner on the '
+              'leading edge so transient drops never flash it');
+
+      await tester.pump(_pastDebounce);
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget);
@@ -105,6 +121,9 @@ void main() {
         const _Host(),
         overrides: [tripRecordingProvider.overrideWith(() => fake)],
       );
+      // Mounted already-degraded: the same debounce applies (see initState).
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget);
       expect(find.byKey(const Key('obd2PauseBanner')), findsNothing,
@@ -127,8 +146,9 @@ void main() {
       expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
     });
 
-    testWidgets('disappears when phase returns to recording (OBD2 '
-        'reconnected)', (tester) async {
+    testWidgets(
+        'disappears (after the grace window) when phase returns to recording '
+        '(OBD2 reconnected)', (tester) async {
       final fake = _FakeTripRecording(
         const TripRecordingState(phase: TripRecordingPhase.degradedGpsOnly),
       );
@@ -137,11 +157,20 @@ void main() {
         const _Host(),
         overrides: [tripRecordingProvider.overrideWith(() => fake)],
       );
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
       expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget);
 
       fake.setPhase(TripRecordingPhase.recording);
-      await tester.pumpAndSettle();
+      await tester.pump();
+      // #3010 — it lingers through the grace window so a quick re-drop
+      // keeps it up rather than strobing it off then back on.
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget,
+          reason: 'the hide-grace must keep the banner up briefly after '
+              'reconnect so a re-drop never strobes it');
 
+      await tester.pump(_pastGrace);
+      await tester.pumpAndSettle();
       expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
     });
 
@@ -166,6 +195,8 @@ void main() {
         const _Host(),
         overrides: [tripRecordingProvider.overrideWith(() => fake)],
       );
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
 
       expect(find.text('Recording with GPS — OBD2 reconnecting'),
           findsOneWidget);
@@ -184,6 +215,8 @@ void main() {
         const _Host(),
         overrides: [tripRecordingProvider.overrideWith(() => fake)],
       );
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
       // Starts busy.
       expect(find.text('Recording with GPS — OBD2 reconnecting'),
           findsOneWidget);
@@ -201,6 +234,195 @@ void main() {
       // The banner stays action-free in either copy — recording continues.
       expect(find.byKey(const Key('obd2PauseBannerResume')), findsNothing);
       expect(find.byKey(const Key('obd2PauseBannerEnd')), findsNothing);
+    });
+  });
+
+  group('GpsDegradedBanner flicker fix (#3010)', () {
+    testWidgets('the banner is wrapped in AnimatedSize — it eases in/out '
+        'instead of popping', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.degradedGpsOnly),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [tripRecordingProvider.overrideWith(() => fake)],
+      );
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
+
+      // The single GpsDegradedBanner must contribute an AnimatedSize wrapping
+      // its content — proves the abrupt SizedBox.shrink() toggle is gone.
+      expect(
+        find.descendant(
+          of: find.byType(GpsDegradedBanner),
+          matching: find.byType(AnimatedSize),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(GpsDegradedBanner),
+          matching: find.byType(AnimatedOpacity),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets(
+        'a transient degrade→recover INSIDE the debounce window never '
+        'surfaces the banner (no strobe on a Bluetooth blip)', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.recording),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [tripRecordingProvider.overrideWith(() => fake)],
+      );
+
+      // Drop, then reconnect well within the ~2.5 s appear-debounce.
+      fake.setPhase(TripRecordingPhase.degradedGpsOnly);
+      await tester.pump(const Duration(milliseconds: 800));
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
+
+      fake.setPhase(TripRecordingPhase.recording);
+      await tester.pump(const Duration(milliseconds: 800));
+
+      // Let the original debounce deadline pass: the banner must STILL be
+      // gone — the blip resolved before the debounce armed it.
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing,
+          reason: 'a transient OBD2 drop that recovers inside the debounce '
+              'window must never flash the banner');
+    });
+
+    testWidgets(
+        'rapid strobe (degrade→recover→degrade→recover all inside the '
+        'debounce) never surfaces the banner', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.recording),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [tripRecordingProvider.overrideWith(() => fake)],
+      );
+
+      for (var i = 0; i < 4; i++) {
+        fake.setPhase(TripRecordingPhase.degradedGpsOnly);
+        await tester.pump(const Duration(milliseconds: 300));
+        fake.setPhase(TripRecordingPhase.recording);
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
+      }
+
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing,
+          reason: 'rapid drop/reconnect blips must never strobe the banner');
+    });
+
+    testWidgets(
+        'a sustained disconnect (longer than the debounce) DOES surface the '
+        'banner', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.recording),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [tripRecordingProvider.overrideWith(() => fake)],
+      );
+
+      fake.setPhase(TripRecordingPhase.degradedGpsOnly);
+      await tester.pump();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsNothing);
+
+      // Hold the degrade past the debounce.
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget,
+          reason: 'a real, sustained OBD2 drop must still inform the user');
+    });
+
+    testWidgets(
+        'a re-drop INSIDE the hide-grace keeps the banner up (no off-then-on '
+        'strobe on a flapping link)', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.degradedGpsOnly),
+      );
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [tripRecordingProvider.overrideWith(() => fake)],
+      );
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget);
+
+      // Reconnect, then drop again well within the ~1.5 s grace.
+      fake.setPhase(TripRecordingPhase.recording);
+      await tester.pump(const Duration(milliseconds: 500));
+      fake.setPhase(TripRecordingPhase.degradedGpsOnly);
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // It must have stayed up the whole time — never blinked off.
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget,
+          reason: 'a flapping link inside the grace window must keep the '
+              'banner steady, not strobe it');
+
+      // And it stays up past where a naive hide would have fired.
+      await tester.pump(_pastGrace);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget);
+    });
+
+    testWidgets(
+        'showing the banner does NOT shift the metrics row above it — the '
+        'height animates from 0 in place (reserved layout)', (tester) async {
+      final fake = _FakeTripRecording(
+        const TripRecordingState(phase: TripRecordingPhase.recording),
+      );
+      // A sentinel "metrics row" sits ABOVE the banner, mirroring the real
+      // TripRecordingBanner Column (status bar, then the GPS banner). Its
+      // top offset must not move when the banner shows/hides — the banner
+      // grows downward, so anything above it stays put.
+      await pumpApp(
+        tester,
+        const Column(
+          children: [
+            SizedBox(
+              key: Key('metricsRow'),
+              height: 40,
+              width: double.infinity,
+            ),
+            GpsDegradedBanner(),
+          ],
+        ),
+        overrides: [tripRecordingProvider.overrideWith(() => fake)],
+      );
+
+      final before = tester.getTopLeft(find.byKey(const Key('metricsRow')));
+
+      fake.setPhase(TripRecordingPhase.degradedGpsOnly);
+      await tester.pump(_pastDebounce);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('gpsDegradedBanner')), findsOneWidget);
+
+      final afterShow = tester.getTopLeft(find.byKey(const Key('metricsRow')));
+      expect(afterShow, before,
+          reason: 'the metrics row above the banner must not move when the '
+              'banner appears (it grows downward into reserved space)');
+
+      // And it stays put when the banner eases away again.
+      fake.setPhase(TripRecordingPhase.recording);
+      await tester.pump(_pastGrace);
+      await tester.pumpAndSettle();
+      final afterHide = tester.getTopLeft(find.byKey(const Key('metricsRow')));
+      expect(afterHide, before,
+          reason: 'the metrics row must stay put when the banner eases away');
     });
   });
 }


### PR DESCRIPTION
Closes #3010

## Problem

On the trip-recording screen (portrait + landscape) the stacked status strips at the top flickered and relayouted as the OBD2 link dropped/reconnected, making the app look unprofessional. As the link strobed, the "Recording with GPS — OBD2 reconnecting" info banner popped in/out and the trip-status metrics/content below jumped on every blip.

## Root cause

The OBD2 reconnect scanner flips the recording phase `recording <-> degradedGpsOnly` on **every transient Bluetooth blip**. `GpsDegradedBanner` reflected that raw signal directly, toggling between a zero-height `SizedBox.shrink()` and a full `MaterialBanner` with **no debounce and no animation** → hard pop + layout jump on each strobe.

## Fix (view layer only — OBD2 reconnect logic untouched)

- **Debounce** — surface the banner only after the link has stayed degraded for ~2.5 s, so transient drop+reconnect blips never flash it.
- **Grace / hysteresis** — once shown, linger ~1.5 s after the phase recovers so a quick re-drop on a flapping link keeps it steady instead of strobing it off-then-on.
- **Animate + reserve layout** — wrap in `AnimatedSize` (height eased from 0) + a fade, so showing/hiding eases the content below in place instead of jerking it; the metrics row above never shifts.

The top status bar already uses `FontFeature.tabularFigures()` for its metric fields, so figure-width reflow was already handled. **No string changes** — existing ARB keys reused (pure flicker fix, no fan-out needed).

## Scope guard (as requested)

- Touched **only** `gps_degraded_banner.dart` (+ its test). 
- Did **not** touch: the OBD2 connection/reconnect logic (only the *displayed* state is debounced), the engine-off / "adapter not responding" banner (`obd2_pause_banner.dart`), the trip-radar card, the map files, or the OBD2 data layer.

## Tests (structural — no goldens; fake clock via `tester.pump(Duration)`)

- The banner is wrapped in `AnimatedSize` + `AnimatedOpacity` (no abrupt toggle).
- A transient degrade→recover **inside** the debounce window never surfaces the banner; a rapid 4× strobe never surfaces it either.
- A **sustained** disconnect (> debounce) **does** surface it.
- A re-drop **inside** the hide-grace keeps the banner up (no off-then-on strobe on a flapping link).
- Showing/hiding the banner does **not** move the metrics row above it (reserved layout — height animates from 0 downward).

All 14 banner tests pass; the full 891-test consumption presentation suite passes. `flutter analyze` clean, no codegen drift, no ARB drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)