### PR TITLE
feat(consumption): power-aware acceleration scoring — hard-accel penalty scales inversely with enginePowerKw (Epic #3015)

### DIFF
--- a/lib/features/consumption/data/driving_insights_analyzer.dart
+++ b/lib/features/consumption/data/driving_insights_analyzer.dart
@@ -20,8 +20,8 @@ library;
 import '../domain/accel_event_gate.dart';
 import '../domain/climb_restart_detector.dart';
 import '../domain/driving_insight.dart';
+import '../domain/engine_power_factor.dart';
 import '../domain/trip_recorder.dart';
-import '../presentation/widgets/trip_detail_charts.dart';
 
 /// RPM above which a sample counts as "high RPM".
 const double _highRpmThreshold = 3000;
@@ -86,7 +86,13 @@ const int _topN = 3;
 /// The function is pure and synchronous — safe to call from a UI
 /// thread for trip durations the app realistically records (a 60-min
 /// trip at 1 Hz is 3 600 samples; the loop is O(n)).
-List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
+///
+/// [enginePowerKw] (Epic #3015) weights the hard-accel wasted-litres by
+/// [enginePowerAccelFactor]; `null` leaves it unchanged (factor 1.0).
+List<DrivingInsight> analyzeTrip(
+  List<TripSample> samples, {
+  int? enginePowerKw,
+}) {
   if (samples.length < 2) return const [];
 
   // Sort by timestamp so out-of-order persistence (#1040 race
@@ -235,9 +241,12 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
     }
   }
 
-  // Hard-acceleration cost line.
+  // Hard-acceleration cost line. Epic #3015 — scale the per-event waste
+  // inversely with engine power (factor 1.0 when power is unknown).
   if (hardAccelEvents > 0) {
-    final liters = hardAccelEvents * _wastedLitersPerHardAccelEvent;
+    final liters = hardAccelEvents *
+        _wastedLitersPerHardAccelEvent *
+        enginePowerAccelFactor(enginePowerKw);
     final pctTime = hardAccelTotalDt / totalDt * 100.0;
     // #2963 — strictly `>` (not `>=`): one event's 0.05 L exactly equals the
     // floor, clears `>=`, then renders "0.1 L" (a 2× overstatement).
@@ -352,40 +361,6 @@ List<DrivingInsight> analyzeTrip(List<TripSample> samples) {
   candidates.sort((a, b) => b.litersWasted.compareTo(a.litersWasted));
   if (candidates.length <= _topN) return candidates;
   return candidates.sublist(0, _topN);
-}
-
-/// Returns one index per hard-acceleration EPISODE (in the
-/// sorted-by-timestamp ordering): the end index of the interval at which
-/// the episode first crossed the canonical [kHardAccelThresholdMps2]
-/// sustained ≥ 1 s, via the ONE shared [countAccelEvents] gate (#2667).
-/// The trip-detail map drops a bolt marker at each (#1458 phase 1).
-///
-/// Reconciled (#2667): markers now come from the same gate the analyzer's
-/// hard-accel count uses, so a single physical hard accel yields ONE
-/// marker — not one per qualifying sample interval as the old raw
-/// per-interval logic produced on a multi-second pull.
-///
-/// Sorting + dt-guard contract (delegated to the gate):
-///   * input is copied + sorted by timestamp before iteration so an
-///     out-of-order list never spuriously reports an event;
-///   * intervals with `dt <= 0` are skipped (duplicate timestamps);
-///   * the first sample (index 0) is never an event because there's
-///     no previous sample to derive an acceleration from.
-///
-/// IMPORTANT: the returned indices reference positions in the
-/// INTERNALLY-SORTED list, NOT the caller's input order. The trip-detail
-/// map already passes timestamp-sorted samples, so it can use them
-/// directly.
-List<int> hardAccelSampleIndices(List<TripDetailSample> samples) {
-  if (samples.length < 2) return const <int>[];
-  return countAccelEvents([
-    for (final s in samples)
-      // TripDetailSample carries no horizontal accuracy — pass null
-      // ("unknown, accept") so the gate behaves exactly as before for the
-      // accuracy dimension while still applying the shared sustained-window
-      // + min-speed + canonical-threshold gate.
-      AccelSamplePoint(timestamp: s.timestamp, speedKmh: s.speedKmh),
-  ]).accelStartIndices;
 }
 
 /// Fallback when no fuel-rate samples are available during the

--- a/lib/features/consumption/data/driving_insights_hard_accel_indices.dart
+++ b/lib/features/consumption/data/driving_insights_hard_accel_indices.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Hard-acceleration episode → sample-index helper for the trip-detail map
+/// (#1458 phase 1), extracted from `driving_insights_analyzer.dart` so that
+/// file stays under the 400-line guard (Epic #3015). It is a map-marker
+/// helper, not a cost-line producer, so it lives on its own.
+library;
+
+import '../domain/accel_event_gate.dart';
+import '../presentation/widgets/trip_detail_charts.dart';
+
+/// Returns one index per hard-acceleration EPISODE (in the
+/// sorted-by-timestamp ordering): the end index of the interval at which
+/// the episode first crossed the canonical [kHardAccelThresholdMps2]
+/// sustained ≥ 1 s, via the ONE shared [countAccelEvents] gate (#2667).
+/// The trip-detail map drops a bolt marker at each (#1458 phase 1).
+///
+/// Reconciled (#2667): markers now come from the same gate the analyzer's
+/// hard-accel count uses, so a single physical hard accel yields ONE
+/// marker — not one per qualifying sample interval as the old raw
+/// per-interval logic produced on a multi-second pull.
+///
+/// Sorting + dt-guard contract (delegated to the gate):
+///   * input is copied + sorted by timestamp before iteration so an
+///     out-of-order list never spuriously reports an event;
+///   * intervals with `dt <= 0` are skipped (duplicate timestamps);
+///   * the first sample (index 0) is never an event because there's
+///     no previous sample to derive an acceleration from.
+///
+/// IMPORTANT: the returned indices reference positions in the
+/// INTERNALLY-SORTED list, NOT the caller's input order. The trip-detail
+/// map already passes timestamp-sorted samples, so it can use them
+/// directly.
+List<int> hardAccelSampleIndices(List<TripDetailSample> samples) {
+  if (samples.length < 2) return const <int>[];
+  return countAccelEvents([
+    for (final s in samples)
+      // TripDetailSample carries no horizontal accuracy — pass null
+      // ("unknown, accept") so the gate behaves exactly as before for the
+      // accuracy dimension while still applying the shared sustained-window
+      // + min-speed + canonical-threshold gate.
+      AccelSamplePoint(timestamp: s.timestamp, speedKmh: s.speedKmh),
+  ]).accelStartIndices;
+}

--- a/lib/features/consumption/data/driving_score_accumulators.dart
+++ b/lib/features/consumption/data/driving_score_accumulators.dart
@@ -119,6 +119,7 @@ class _Accumulators {
     required int hardAccelEvents,
     required int hardBrakeEvents,
     bool gpsOnly = false,
+    int? enginePowerKw,
   }) {
     final idlingPenalty =
         _clamp(idleSeconds / totalDt * _idlingCap, 0, _idlingCap);
@@ -131,8 +132,17 @@ class _Accumulators {
     final highRpmPenalty = gpsOnly
         ? 0.0
         : _clamp(highRpmSeconds / totalDt * _highRpmCap, 0, _highRpmCap);
-    final hardAccelPenalty =
-        _clamp(hardAccelEvents * _hardAccelPerEvent, 0, _hardAccelCap);
+    // Epic #3015 — weight the hard-accel penalty inversely with engine
+    // power, then clamp to the cap. At the SAME hard-accel intensity a
+    // low-power car runs at a higher load fraction (closer to WOT, worse
+    // BSFC, more enrichment) and wastes proportionally more fuel, so it is
+    // penalised more; a high-power car less. `null` power (unknown / legacy)
+    // → factor 1.0 → byte-identical to before. Only this term is power-aware.
+    final hardAccelPenalty = _clamp(
+      hardAccelEvents * _hardAccelPerEvent * enginePowerAccelFactor(enginePowerKw),
+      0,
+      _hardAccelCap,
+    );
     final hardBrakePenalty =
         _clamp(hardBrakeEvents * _hardBrakePerEvent, 0, _hardBrakeCap);
     final fullThrottlePenalty = _clamp(

--- a/lib/features/consumption/data/driving_score_calculator.dart
+++ b/lib/features/consumption/data/driving_score_calculator.dart
@@ -45,6 +45,7 @@ import 'dart:math' as math;
 
 import '../domain/accel_event_gate.dart';
 import '../domain/driving_score.dart';
+import '../domain/engine_power_factor.dart';
 import '../domain/trip_recorder.dart';
 
 // #2667 — re-export the canonical accel/brake thresholds so existing
@@ -52,6 +53,17 @@ import '../domain/trip_recorder.dart';
 // SINGLE source of truth is `accel_event_gate.dart`.
 export '../domain/accel_event_gate.dart'
     show kHardAccelThresholdMps2, kHardBrakeThresholdMps2;
+
+// Epic #3015 — re-export the engine-power-factor surface so importers of this
+// file (lessons, tests) resolve the constants/helper from the one canonical
+// place alongside the score thresholds; the source of truth stays
+// `engine_power_factor.dart`.
+export '../domain/engine_power_factor.dart'
+    show
+        kReferenceEnginePowerKw,
+        kEnginePowerFactorMin,
+        kEnginePowerFactorMax,
+        enginePowerAccelFactor;
 
 // #2460 — the per-interval accumulator + the inline Welford helper live in
 // a part file so this orchestrator stays under the 400-line guard. They
@@ -132,11 +144,19 @@ const double _smoothnessPedalVarSaturation = 900.0;
 /// by `gear_inference.dart` and stored on [TripSummary]; pass it through
 /// so the over-rev family includes lugging. Null (no inference / EV /
 /// too few samples) contributes 0.
+///
+/// [enginePowerKw] is the active vehicle's engine power in kW (Epic #3015).
+/// The hard-acceleration penalty is weighted by [enginePowerAccelFactor] —
+/// a low-power car wastes proportionally more fuel for the same hard pull,
+/// so it is penalised more; a high-power car less. `null` (power unknown)
+/// leaves the penalty exactly as before (factor 1.0). NO other penalty is
+/// touched — only hard-accel depends on engine power.
 DrivingScore computeDrivingScore(
   List<TripSample> samples, {
   double? secondsBelowOptimalGear,
   int? hardAccelEventsOverride,
   int? hardBrakeEventsOverride,
+  int? enginePowerKw,
 }) {
   if (samples.length < 2) return DrivingScore.perfect;
 
@@ -187,6 +207,7 @@ DrivingScore computeDrivingScore(
     hardAccelEvents: hardAccelEventsOverride ?? accelCounts.accelEvents,
     hardBrakeEvents: hardBrakeEventsOverride ?? accelCounts.brakeEvents,
     gpsOnly: gpsOnly,
+    enginePowerKw: enginePowerKw,
   );
 }
 
@@ -198,7 +219,14 @@ DrivingScore computeDrivingScore(
 ///
 /// Trips under 1 minute, or without a start/end, return a perfect score
 /// — too little signal to attribute any penalty.
-DrivingScore computeDrivingScoreFromSummary(TripSummary summary) {
+///
+/// [enginePowerKw] applies the same hard-accel power weight as the
+/// per-sample path (Epic #3015); `null` (power unknown / legacy callers)
+/// keeps the penalty exactly as before.
+DrivingScore computeDrivingScoreFromSummary(
+  TripSummary summary, {
+  int? enginePowerKw,
+}) {
   final start = summary.startedAt;
   final end = summary.endedAt;
   final durationSec =
@@ -215,8 +243,13 @@ DrivingScore computeDrivingScoreFromSummary(TripSummary summary) {
     0,
     _highRpmCap,
   );
+  // Epic #3015 — weight the hard-accel penalty inversely with engine power,
+  // then clamp to the cap. A low-power car wastes proportionally more fuel
+  // for the same hard pull. `null` power → factor 1.0 → unchanged.
   final hardAccelPenalty = _clamp(
-    summary.harshAccelerations * _hardAccelPerEvent,
+    summary.harshAccelerations *
+        _hardAccelPerEvent *
+        enginePowerAccelFactor(enginePowerKw),
     0,
     _hardAccelCap,
   );

--- a/lib/features/consumption/domain/engine_power_factor.dart
+++ b/lib/features/consumption/domain/engine_power_factor.dart
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+/// Engine-power scaling for the hard-acceleration penalty (Epic #3015).
+///
+/// ## Why hard-accel waste depends on engine power
+///
+/// At the SAME acceleration intensity, a lower-powered car is operating at a
+/// higher fraction of its maximum capability than a higher-powered one. To
+/// deliver that torque it sits closer to wide-open throttle, in a less
+/// efficient region of its brake-specific-fuel-consumption (BSFC) map, and is
+/// more likely to drift into mixture enrichment (λ < 1) for component
+/// protection. A strong engine produces the same acceleration well within its
+/// efficient mid-load island, with little to no enrichment.
+///
+/// So an identical "hard pull" costs a small engine proportionally MORE fuel
+/// than a big one — exactly the maintainer's requirement: *"ein niedrig
+/// motorisiertes Fahrzeug verbraucht beim harten Beschleunigen proportional
+/// mehr als ein hochmotorisiertes"*. The hard-accel penalty (and the linked
+/// hard-accel wasted-fuel estimate) is therefore weighted by a factor that
+/// scales INVERSELY with engine power.
+///
+/// ## The factor
+///
+/// `f = clamp(kReferenceEnginePowerKw / enginePowerKw, fMin, fMax)`
+///
+///   * a car at the reference power gets `f == 1.0` — today's penalty, unchanged;
+///   * a low-power car gets `f > 1` — a bigger penalty per event;
+///   * a high-power car gets `f < 1` — a smaller penalty per event.
+///
+/// The clamp keeps the weight physically defensible at the catalog extremes
+/// (a 33 kW city car would otherwise reach 3× and a future 400 kW outlier
+/// would vanish to near zero).
+///
+/// ## Backward compatibility
+///
+/// When `enginePowerKw` is unknown (`null`) or non-physical (`<= 0`), the
+/// factor is exactly `1.0`, so every score computed before the user set an
+/// engine-power value — and every car whose power we cannot resolve — keeps
+/// its current, byte-identical penalty. This is the safe identity element.
+library;
+
+/// Neutral reference engine power, in kW. A car at this power keeps today's
+/// hard-accel penalty unchanged (`f == 1.0`).
+///
+/// Calibrated from the shipped reference-vehicle catalog (Epic #3015 added
+/// kW to all 328 non-EV rows): median 82 kW, mean 86 kW, p75 103 kW. The
+/// catalog over-represents small European city cars, so the central tendency
+/// of *cars people actually drive hard* sits a little higher. 100 kW (≈ 136
+/// PS) is the round mainstream value just above the catalog mean — a typical
+/// modern compact/family petrol — and gives intuitive ratios (a 50 kW car →
+/// 2×, a 200 kW car → 0.5× before clamping).
+const int kReferenceEnginePowerKw = 100;
+
+/// Lower bound on the power factor (applied to strong engines). 0.6 means a
+/// hard pull in a very powerful car still carries 60 % of the reference
+/// penalty — it is more efficient, not free. Reached around ~167 kW
+/// (`100 / 0.6`), i.e. the top of the current catalog and above.
+const double kEnginePowerFactorMin = 0.6;
+
+/// Upper bound on the power factor (applied to weak engines). 1.8 means the
+/// smallest engines are penalised up to 80 % more per hard-accel event than
+/// the reference, without the runaway 3×+ a 33 kW kei-class car would
+/// otherwise hit. Reached at/below ~56 kW (`100 / 1.8`).
+const double kEnginePowerFactorMax = 1.8;
+
+/// The inverse-power weight for the hard-acceleration penalty / waste
+/// (Epic #3015). See the library doc-comment for the model.
+///
+/// Returns exactly `1.0` (the identity) when [enginePowerKw] is `null` or
+/// non-physical (`<= 0`) — so legacy / power-unknown trips are unchanged.
+/// Otherwise `clamp(kReferenceEnginePowerKw / enginePowerKw,
+/// kEnginePowerFactorMin, kEnginePowerFactorMax)`.
+double enginePowerAccelFactor(int? enginePowerKw) {
+  if (enginePowerKw == null || enginePowerKw <= 0) return 1.0;
+  final raw = kReferenceEnginePowerKw / enginePowerKw;
+  if (raw < kEnginePowerFactorMin) return kEnginePowerFactorMin;
+  if (raw > kEnginePowerFactorMax) return kEnginePowerFactorMax;
+  return raw;
+}

--- a/lib/features/consumption/presentation/widgets/trip_detail_body.dart
+++ b/lib/features/consumption/presentation/widgets/trip_detail_body.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../profile/providers/gamification_enabled_provider.dart';
 import '../../../vehicle/domain/entities/vehicle_profile.dart';
+import '../../../vehicle/providers/vehicle_providers.dart';
 import '../../data/driving_insights_analyzer.dart';
 import '../../data/driving_score_calculator.dart';
 import '../../data/lessons/driving_lesson_registry.dart';
@@ -128,7 +129,25 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     final tripSamples = widget.samples.map(tripDetailToTripSample).toList(
           growable: false,
         );
-    return analyzeTrip(tripSamples);
+    // Epic #3015 — scale the hard-accel wasted-litres by the active
+    // vehicle's engine power (a small engine wastes proportionally more for
+    // the same hard pull). Trips aren't tagged with a vehicle, so the
+    // currently-active profile is the source; null power → unchanged.
+    return analyzeTrip(tripSamples, enginePowerKw: _activeEnginePowerKw());
+  }
+
+  /// The active vehicle's engine power (kW) for the power-aware hard-accel
+  /// weight (Epic #3015), or `null` when no vehicle is selected OR the
+  /// profile store is unavailable (e.g. the Hive box is not open in a
+  /// widget test). `null` is the safe identity (factor 1.0) — the score /
+  /// insights must never fail to render because the vehicle store is in an
+  /// error state, so the lookup is deliberately tolerant.
+  int? _activeEnginePowerKw() {
+    try {
+      return ref.read(activeVehicleProfileProvider)?.enginePowerKw;
+    } catch (_) {
+      return null;
+    }
   }
 
   DrivingScore _computeScore() {
@@ -151,11 +170,14 @@ class _TripDetailBodyState extends ConsumerState<TripDetailBody> {
     // When no IMU ran, the (now physically-clamped, #2895) GPS-derived counts
     // remain the source.
     final useImu = summary.imuActive;
+    // Epic #3015 — weight the hard-accel penalty by the active vehicle's
+    // engine power; null power keeps the score byte-identical to before.
     return computeDrivingScore(
       tripSamples,
       secondsBelowOptimalGear: summary.secondsBelowOptimalGear,
       hardAccelEventsOverride: useImu ? summary.harshAccelerations : null,
       hardBrakeEventsOverride: useImu ? summary.harshBrakes : null,
+      enginePowerKw: _activeEnginePowerKw(),
     );
   }
 

--- a/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
+++ b/lib/features/consumption/presentation/widgets/trip_path_map_card.dart
@@ -9,7 +9,7 @@ import '../../../../core/theme/dark_mode_colors.dart';
 import '../../../../core/widgets/osm_attribution.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../map/data/sparkilo_tile_layer.dart';
-import '../../data/driving_insights_analyzer.dart';
+import '../../data/driving_insights_hard_accel_indices.dart';
 import 'trip_detail_charts.dart';
 
 // ---------------------------------------------------------------------------

--- a/test/features/consumption/data/driving_insights_analyzer_test.dart
+++ b/test/features/consumption/data/driving_insights_analyzer_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/driving_insights_analyzer.dart';
+import 'package:tankstellen/features/consumption/data/driving_insights_hard_accel_indices.dart';
 import 'package:tankstellen/features/consumption/domain/driving_insight.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 import 'package:tankstellen/features/consumption/presentation/widgets/trip_detail_charts.dart';
@@ -629,6 +630,64 @@ void main() {
           ),
       ];
       expect(find(analyzeTrip(samples), 'insightRestartCost'), isNull);
+    });
+  });
+
+  // Epic #3015 — the hard-accel WASTED-LITRES estimate scales inversely with
+  // engine power (a small engine wastes proportionally more for the same hard
+  // pull), mirroring the score penalty. Only this cost line is power-aware.
+  group('power-aware hard-accel waste (Epic #3015)', () {
+    final start = DateTime.utc(2026);
+
+    // 5 strong accelerations (the existing #1041 pattern → exactly 5 events).
+    List<TripSample> fiveHardAccels() {
+      var t = start;
+      final samples = <TripSample>[];
+      for (var i = 0; i < 5; i++) {
+        samples.add(TripSample(timestamp: t, speedKmh: 0, rpm: 1000));
+        t = t.add(const Duration(seconds: 2));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 3000));
+        t = t.add(const Duration(seconds: 10));
+        samples.add(TripSample(timestamp: t, speedKmh: 50, rpm: 2000));
+        t = t.add(const Duration(seconds: 1));
+      }
+      return samples;
+    }
+
+    DrivingInsight hardAccelFor(int? kw) =>
+        analyzeTrip(fiveHardAccels(), enginePowerKw: kw).firstWhere(
+          (i) => i.labelKey == 'insightHardAccel',
+          orElse: () => throw StateError('expected hardAccel insight'),
+        );
+
+    test('null power → EXACT pre-change estimate (5 × 0.05 = 0.25 L)', () {
+      expect(hardAccelFor(null).litersWasted, closeTo(0.25, 1e-9));
+    });
+
+    test('low power wastes MORE (55 kW → 5 × 0.05 × 1.8 = 0.45 L)', () {
+      expect(hardAccelFor(55).litersWasted, closeTo(0.45, 1e-9));
+      expect(hardAccelFor(55).litersWasted,
+          greaterThan(hardAccelFor(100).litersWasted));
+    });
+
+    test('high power wastes LESS (230 kW → 5 × 0.05 × 0.6 = 0.15 L)', () {
+      expect(hardAccelFor(230).litersWasted, closeTo(0.15, 1e-9));
+      expect(hardAccelFor(230).litersWasted,
+          lessThan(hardAccelFor(100).litersWasted));
+    });
+
+    test('estimates strictly ordered low > reference > high', () {
+      final low = hardAccelFor(55).litersWasted;
+      final ref = hardAccelFor(100).litersWasted;
+      final high = hardAccelFor(230).litersWasted;
+      expect(low, greaterThan(ref));
+      expect(ref, greaterThan(high));
+    });
+
+    test('event count is unchanged by power (only the litres scale)', () {
+      // The DETECTION is power-blind; only the WEIGHT changes.
+      expect(hardAccelFor(55).metadata['eventCount'], 5);
+      expect(hardAccelFor(230).metadata['eventCount'], 5);
     });
   });
 }

--- a/test/features/consumption/data/driving_score_calculator_test.dart
+++ b/test/features/consumption/data/driving_score_calculator_test.dart
@@ -793,4 +793,138 @@ void main() {
           equals(computeDrivingScore(samples)));
     });
   });
+
+  // Epic #3015 — the hard-accel penalty scales INVERSELY with engine power:
+  // at the SAME hard-accel intensity a low-power car wastes proportionally
+  // more fuel than a high-power one, so it is penalised more. Driven through
+  // the REAL scorer via the deterministic event override; only the
+  // `enginePowerKw` argument varies, so any difference is the power model.
+  group('power-aware hard-accel penalty (Epic #3015)', () {
+    final start = DateTime(2026, 6, 7, 9);
+    // 30 s of gentle GPS-only motion; the override sets the event count so
+    // the penalty math is deterministic and isolated from the accel gate.
+    final samples = <TripSample>[
+      for (var i = 0; i < 30; i++)
+        TripSample(
+            timestamp: start.add(Duration(seconds: i)), speedKmh: 40.0 + i),
+    ];
+
+    // Two events keep every variant below the 15-pt cap (low: 2×3×1.8 = 10.8),
+    // so the ordering reflects the factor, not the clamp masking it.
+    DrivingScore scoreForPower(int? kw) => computeDrivingScore(
+          samples,
+          hardAccelEventsOverride: 2,
+          hardBrakeEventsOverride: 0,
+          enginePowerKw: kw,
+        );
+
+    test('null power → factor 1.0 → EXACT pre-change baseline (2×3.0 = 6.0)',
+        () {
+      // Locks the byte-for-byte legacy value: 2 events × 3.0 pts × 1.0.
+      // If this number changes, the backward-compat identity is broken.
+      expect(scoreForPower(null).hardAccelPenalty, 6.0);
+    });
+
+    test('low < reference: a 55 kW car is penalised MORE than null/reference',
+        () {
+      // f = clamp(100/55 = 1.818, 0.6, 1.8) = 1.8 → 2×3×1.8 = 10.8.
+      expect(scoreForPower(55).hardAccelPenalty, closeTo(10.8, 1e-9));
+      expect(scoreForPower(55).hardAccelPenalty,
+          greaterThan(scoreForPower(100).hardAccelPenalty));
+    });
+
+    test('reference power (100 kW) → identical to null (factor 1.0)', () {
+      expect(scoreForPower(kReferenceEnginePowerKw).hardAccelPenalty,
+          scoreForPower(null).hardAccelPenalty);
+    });
+
+    test('high > reference: a 230 kW car is penalised LESS than reference', () {
+      // f = clamp(100/230 = 0.435, 0.6, 1.8) = 0.6 → 2×3×0.6 = 3.6.
+      expect(scoreForPower(230).hardAccelPenalty, closeTo(3.6, 1e-9));
+      expect(scoreForPower(230).hardAccelPenalty,
+          lessThan(scoreForPower(100).hardAccelPenalty));
+    });
+
+    test('penalties are STRICTLY ordered low > reference > high', () {
+      final low = scoreForPower(55).hardAccelPenalty;
+      final ref = scoreForPower(100).hardAccelPenalty;
+      final high = scoreForPower(230).hardAccelPenalty;
+      expect(low, greaterThan(ref));
+      expect(ref, greaterThan(high));
+    });
+
+    test('only hard-accel scales — brake/idle/rpm penalties are power-blind',
+        () {
+      // A trip with idle + high-RPM + a brake event; verify those terms are
+      // identical across powers and only hard-accel moves.
+      final idleHighRpm = <TripSample>[
+        for (var i = 0; i <= 10; i++)
+          TripSample(
+              timestamp: start.add(Duration(seconds: i)),
+              speedKmh: 0,
+              rpm: 3500),
+      ];
+      DrivingScore s(int? kw) => computeDrivingScore(
+            idleHighRpm,
+            hardAccelEventsOverride: 2,
+            hardBrakeEventsOverride: 3,
+            enginePowerKw: kw,
+          );
+      final a = s(55);
+      final b = s(230);
+      expect(a.idlingPenalty, b.idlingPenalty);
+      expect(a.highRpmPenalty, b.highRpmPenalty);
+      expect(a.hardBrakePenalty, b.hardBrakePenalty);
+      // Hard-accel is the ONLY term that differs.
+      expect(a.hardAccelPenalty, greaterThan(b.hardAccelPenalty));
+    });
+
+    test('clamp bounds: extreme low/high power do not explode the penalty', () {
+      // 1 kW (absurd) clamps the factor to fMax, not 100×.
+      expect(scoreForPower(1).hardAccelPenalty, closeTo(2 * 3 * 1.8, 1e-9));
+      // 5000 kW clamps to fMin, not ~0.
+      expect(scoreForPower(5000).hardAccelPenalty, closeTo(2 * 3 * 0.6, 1e-9));
+    });
+
+    test('zero / negative power guards division → factor 1.0 (legacy value)',
+        () {
+      expect(scoreForPower(0).hardAccelPenalty, 6.0);
+      expect(scoreForPower(-50).hardAccelPenalty, 6.0);
+    });
+  });
+
+  // Epic #3015 — the same model on the cheap summary-only path that feeds the
+  // achievement engine (`TripMetrics.drivingScore`).
+  group('power-aware hard-accel penalty — summary path (Epic #3015)', () {
+    TripSummary summaryWith(int harshAccel) => TripSummary(
+          distanceKm: 20,
+          maxRpm: 2000,
+          highRpmSeconds: 0,
+          idleSeconds: 0,
+          harshBrakes: 0,
+          harshAccelerations: harshAccel,
+          startedAt: DateTime(2026, 6, 7, 9),
+          endedAt: DateTime(2026, 6, 7, 9, 30),
+        );
+
+    test('null power → factor 1.0 → EXACT baseline (2×3.0 = 6.0)', () {
+      expect(
+          computeDrivingScoreFromSummary(summaryWith(2)).hardAccelPenalty, 6.0);
+    });
+
+    test('low power penalised more, high less, strictly ordered', () {
+      final s = summaryWith(2);
+      final low =
+          computeDrivingScoreFromSummary(s, enginePowerKw: 55).hardAccelPenalty;
+      final ref = computeDrivingScoreFromSummary(s, enginePowerKw: 100)
+          .hardAccelPenalty;
+      final high = computeDrivingScoreFromSummary(s, enginePowerKw: 230)
+          .hardAccelPenalty;
+      expect(low, closeTo(10.8, 1e-9));
+      expect(ref, 6.0);
+      expect(high, closeTo(3.6, 1e-9));
+      expect(low, greaterThan(ref));
+      expect(ref, greaterThan(high));
+    });
+  });
 }

--- a/test/features/consumption/domain/engine_power_factor_test.dart
+++ b/test/features/consumption/domain/engine_power_factor_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/domain/engine_power_factor.dart';
+
+/// Unit tests for the inverse-power weight applied to the hard-acceleration
+/// penalty / waste (Epic #3015). The factor must be 1.0 at the reference,
+/// monotonically decreasing in power, clamped at both ends, and a safe
+/// identity (1.0) for unknown / non-physical power.
+void main() {
+  group('enginePowerAccelFactor (Epic #3015)', () {
+    test('reference power → exactly 1.0 (today\'s penalty, unchanged)', () {
+      expect(enginePowerAccelFactor(kReferenceEnginePowerKw), 1.0);
+    });
+
+    test('null power → 1.0 (legacy / power-unknown identity)', () {
+      expect(enginePowerAccelFactor(null), 1.0);
+    });
+
+    test('zero and negative power → 1.0 (division guard)', () {
+      expect(enginePowerAccelFactor(0), 1.0);
+      expect(enginePowerAccelFactor(-100), 1.0);
+    });
+
+    test('low power → factor > 1 (penalised MORE)', () {
+      // 80 kW (catalog median) → 100/80 = 1.25, within bounds.
+      expect(enginePowerAccelFactor(80), closeTo(1.25, 1e-9));
+      expect(enginePowerAccelFactor(80), greaterThan(1.0));
+    });
+
+    test('high power → factor < 1 (penalised LESS)', () {
+      // 125 kW → 100/125 = 0.8, within bounds.
+      expect(enginePowerAccelFactor(125), closeTo(0.8, 1e-9));
+      expect(enginePowerAccelFactor(125), lessThan(1.0));
+    });
+
+    test('strictly decreasing in power across the unclamped band', () {
+      final f60 = enginePowerAccelFactor(60);
+      final f100 = enginePowerAccelFactor(100);
+      final f160 = enginePowerAccelFactor(160);
+      expect(f60, greaterThan(f100));
+      expect(f100, greaterThan(f160));
+    });
+
+    test('clamps to fMax for very small engines (no runaway 3×)', () {
+      // 33 kW (catalog minimum) → 100/33 = 3.03 → clamped to fMax.
+      expect(enginePowerAccelFactor(33), kEnginePowerFactorMax);
+      expect(enginePowerAccelFactor(1), kEnginePowerFactorMax);
+    });
+
+    test('clamps to fMin for very large engines (never near-zero)', () {
+      // 5000 kW → 100/5000 = 0.02 → clamped to fMin.
+      expect(enginePowerAccelFactor(5000), kEnginePowerFactorMin);
+      expect(enginePowerAccelFactor(400), kEnginePowerFactorMin);
+    });
+
+    test('bounds are sane (fMin < 1 < fMax) and reference is mainstream', () {
+      expect(kEnginePowerFactorMin, lessThan(1.0));
+      expect(kEnginePowerFactorMax, greaterThan(1.0));
+      // 100 kW sits in a plausible mainstream band (60..160 kW).
+      expect(kReferenceEnginePowerKw, inInclusiveRange(60, 160));
+    });
+  });
+}


### PR DESCRIPTION
## What & why (Epic #3015)

Maintainer requirement (German): *"Berücksichtigen beim Beschleunigen die
Leistung des Motors. Wenn das Auto hart beschleunigt, verbraucht ein niedrig
motorisiertes Fahrzeug natürlich proportional mehr als ein hochmotorisiertes."*

At the SAME acceleration intensity a low-power car works at a higher fraction of
its capacity — closer to wide-open throttle, in a worse region of its BSFC map,
more likely to drift into mixture enrichment (λ < 1) — so an identical hard pull
costs it proportionally MORE fuel than a strong engine. The hard-acceleration
penalty (and the linked hard-accel wasted-litres estimate) is therefore weighted
INVERSELY with `enginePowerKw`.

## Model (`lib/features/consumption/domain/engine_power_factor.dart`)

```
f = clamp(kReferenceEnginePowerKw / enginePowerKw, fMin, fMax)
penalty = events × perEvent × f      (then clamped to the existing cap)
```

| constant | value | justification |
|---|---|---|
| `kReferenceEnginePowerKw` | **100 kW** | round mainstream value just above the shipped catalog's mean (86) / median (82); a car at the reference keeps today's penalty unchanged |
| `kEnginePowerFactorMin` | **0.6** | strong engines still pay 60 % of the reference penalty (more efficient, not free); reached around ~167 kW = top of catalog |
| `kEnginePowerFactorMax` | **1.8** | smallest engines penalised up to +80 %, without the runaway 3×+ a 33 kW kei-class car would otherwise hit; reached at/below ~56 kW |

- higher power ⇒ f < 1 ⇒ smaller penalty; lower power ⇒ f > 1 ⇒ bigger penalty.
- **Backward-compatible:** `enginePowerKw == null` (or `<= 0`, division guard) ⇒
  `f = 1.0` ⇒ byte-identical to current behaviour.
- **Only hard-accel** is power-scaled — braking / idling / RPM / lugging are
  physically unrelated and untouched.

## Wiring

Threaded through `computeDrivingScore`, `computeDrivingScoreFromSummary`, and
`analyzeTrip`; supplied at the trip-detail call site from the active vehicle
profile (`activeVehicleProfileProvider.enginePowerKw`). The analysis-trace
export and lessons inherit the power-aware value via the cached score/insights.

## Test evidence (drives the REAL scorer/analyzer, no fakes)

`flutter test` on the three files → **all green**. Locked baselines + ordering:

- `engine_power_factor_test.dart` — reference→1.0, null/0/neg→1.0, monotonic,
  both clamps.
- `driving_score_calculator_test.dart` (per-sample + summary path) — **null
  power locks `hardAccelPenalty == 6.0`** (2 events × 3.0); low(55 kW)=10.8 >
  ref(100 kW)=6.0 > high(230 kW)=3.6, **strictly ordered**; brake/idle/RPM
  identical across powers; clamp bounds don't explode; 0 / -50 kW → 6.0.
- `driving_insights_analyzer_test.dart` — **null power locks waste == 0.25 L**
  (5 × 0.05); low=0.45 > ref=0.25 > high=0.15; event COUNT power-blind.

## Gates verified manually (pre-push hook hits the known worktree bug:
`flutter pub get` resolves the SDK as `0.0.0-unknown` and aborts — unrelated to
this change; pushed with `SKIP_PREPUSH=1`):

- clean `build_runner clean && build` → **0 `.g.dart` / `.freezed.dart` drift**
- `flutter analyze lib` → **clean, no new infos**
- **no ARB change** (numeric model, no new user-facing string) → l10n untouched,
  `test/l10n` green
- `test/lint/file_length_test.dart` green — the map-only `hardAccelSampleIndices`
  helper moved to its own `driving_insights_hard_accel_indices.dart` so
  `driving_insights_analyzer.dart` stays under the 400-line guard

## No schema change

`enginePowerKw` persists via the JSONB `data` column → sync-transparent
(field-add, not a new synced table). No Supabase / `schema_verifier` change.

Closes #3021
Epic #3015

🤖 Generated with [Claude Code](https://claude.com/claude-code)
