### PR TITLE
fix(obd2): transport-aware firstConnect — a Classic adapter never tries BLE first (#3025)

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
+++ b/lib/features/consumption/data/obd2/obd2_connect_by_mac.dart
@@ -174,6 +174,77 @@ Future<Obd2Service?> _connectByMacClassicDirect(
   }
 }
 
+/// Body of [Obd2ConnectionService.connectByMacTransportAware] (#3025 / Epic
+/// #3013). Routes a FIRST-connect / pinned by-MAC connect to the transport the
+/// paired [adapterName] name-matches in the registry, so a Classic adapter is
+/// NEVER reached on the doomed BLE GATT path.
+///
+///   * CLASSIC name → [Obd2ConnectionService.connectByMacClassicDirect] only
+///     (RFCOMM; no `channelForDirect`, no 4 s BLE timeout). On a clean miss
+///     (null) it falls through to the transport-aware scan via
+///     [Obd2ConnectionService.connectByMac] when [fallbackToScan] — the merged
+///     BLE+Classic scan reaches the bonded Classic candidate WITHOUT a prior
+///     BLE GATT to poison the socket.
+///   * BLE name → [Obd2ConnectionService.connectByMacDirect] (its own scan
+///     fallback honoured via [fallbackToScan]).
+///   * UNKNOWN / nameless → the historical BLE-direct-first, then a Classic
+///     direct attempt for the same MAC. The BLE [Obd2ConnectionService.bluetooth]
+///     channel is FULLY torn down (GATT disconnected — `channel.close()` ⇒
+///     `device.disconnect()`) by `connectByMacDirect`/the Classic path's own
+///     `_teardownLastDirectChannel` between the two, so no half-open GATT can
+///     poison the RFCOMM socket (the #3025 dual-mode conflict).
+///
+/// `requestedTransport` is stamped to match the chosen path (Classic adapter ⇒
+/// `rtx: classic`) by the per-transport `_traced` wrappers each branch delegates
+/// to — so a field trace is truthful (a Classic adapter no longer shows the
+/// misleading `rtx: ble`). A single transport-determined attempt is one trace.
+Future<Obd2Service?> _connectByMacTransportAware(
+  Obd2ConnectionService svc,
+  String mac, {
+  String? adapterName,
+  bool fallbackToScan = true,
+}) async {
+  final transport = svc.registry.transportForName(adapterName);
+  switch (transport) {
+    case BluetoothTransport.classic:
+      // Classic-classified: ONLY the RFCOMM direct path — never the BLE GATT
+      // path that 4 s-times-out and poisons the socket. The Classic facade is
+      // required; with none wired (BLE-only test config), fall through to the
+      // transport-aware scan instead of silently doing nothing.
+      if (svc.classicBluetooth != null) {
+        final direct =
+            await svc.connectByMacClassicDirect(mac, adapterName: adapterName);
+        if (direct != null) return direct;
+      }
+      return fallbackToScan
+          ? svc.connectByMac(mac, adapterName: adapterName)
+          : null;
+    case BluetoothTransport.ble:
+      return svc.connectByMacDirect(mac,
+          fallbackToScan: fallbackToScan, adapterName: adapterName);
+    case null:
+      // UNKNOWN transport (an unfamiliar / nameless adapter). Preserve the
+      // historical BLE-direct-first behaviour, then try the Classic direct path
+      // for the SAME MAC. `connectByMacDirect` self-tears-down its GATT on
+      // failure (close ⇒ device.disconnect), and `connectByMacClassicDirect`
+      // also tears down any prior direct channel before opening — so the BLE
+      // GATT is fully gone before the RFCOMM open (no socket poisoning).
+      // `fallbackToScan:false` here so the doomed-BLE attempt fails fast to the
+      // Classic attempt; the final scan fallback runs once at the end.
+      final ble = await svc.connectByMacDirect(mac,
+          fallbackToScan: false, adapterName: adapterName);
+      if (ble != null) return ble;
+      if (svc.classicBluetooth != null) {
+        final classic =
+            await svc.connectByMacClassicDirect(mac, adapterName: adapterName);
+        if (classic != null) return classic;
+      }
+      return fallbackToScan
+          ? svc.connectByMac(mac, adapterName: adapterName)
+          : null;
+  }
+}
+
 /// Body of [Obd2ConnectionService.connectByMacPassive] (#2261 concern 2).
 /// Opens a channel with `autoConnect:true` and NO bounded timeout, so the OS
 /// holds a low-power background GATT request that resolves the instant the

--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -517,6 +517,42 @@ class Obd2ConnectionService {
         body: () => _connectByMacClassicDirect(this, mac),
       );
 
+  /// #3025 / Epic #3013 — TRANSPORT-AWARE direct-connect-by-MAC for the
+  /// FIRST-connect / pinned-adapter path. The single entry the cold connect
+  /// orchestrators (the trajets pre-warm, the picker's pinned fast path) thread
+  /// through so a Classic adapter is NEVER reached on the doomed BLE GATT path.
+  ///
+  /// The bug this fixes: the pre-warm / pinned connect called the BLE
+  /// [connectByMacDirect] UNCONDITIONALLY, so a Classic-SPP adapter (vLinker
+  /// BM-Android) could only ever 4 s-timeout (`FlutterBluePlusException |
+  /// connect | fbp-code:1 | Timed out after 4s`) — and that doomed BLE GATT to
+  /// the same MAC then POISONED the subsequent RFCOMM socket (`read ret: -1` /
+  /// "socket might closed"), so the Classic fallback ALSO failed. The in-trip
+  /// reconnect (#2565), the trip-independent reconnect (#3016) and the self-test
+  /// (#2969) were already transport-aware; this brings firstConnect in line.
+  ///
+  /// Transport is inferred from the paired [adapterName] via the registry name
+  /// matchers (the same recovery the self-test uses): a name like
+  /// `vLinker BM-Android` resolves to [BluetoothTransport.classic] →
+  /// [connectByMacClassicDirect] (RFCOMM, no 4 s BLE timeout, NEVER touches
+  /// `channelForDirect`). A BLE name → [connectByMacDirect]. An UNKNOWN /
+  /// nameless adapter keeps the historical BLE-direct-first behaviour with the
+  /// Classic facade as a fallback — and the BLE channel is fully torn down
+  /// (GATT disconnected) between the two so no half-open GATT can poison the
+  /// RFCOMM socket. The decision is stamped on the trace's `requestedTransport`
+  /// so a future field trace is truthful (a Classic adapter shows `rtx:
+  /// classic`, not `ble`).
+  ///
+  /// Body lives in `obd2_connect_by_mac` (a `part`); this thin overridable
+  /// instance method keeps test fakes able to `@override` it.
+  Future<Obd2Service?> connectByMacTransportAware(
+    String mac, {
+    String? adapterName,
+    bool fallbackToScan = true,
+  }) =>
+      _connectByMacTransportAware(this, mac,
+          adapterName: adapterName, fallbackToScan: fallbackToScan);
+
   /// Passive autoConnect reconnect (#2261 concern 2). See
   /// [_connectByMacPassive]. Thin overridable instance method.
   Future<Obd2Service?> connectByMacPassive(String mac, {String? adapterName}) =>

--- a/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart
@@ -51,8 +51,17 @@ Future<Obd2Service?> showObd2AdapterPicker(
     final container = ProviderScope.containerOf(context, listen: false);
     Obd2Service? service;
     try {
-      service =
-          await container.read(obd2ConnectionProvider).connectByMac(pinnedMac);
+      // #3025 — TRANSPORT-AWARE pinned connect. The old call hard-wired the
+      // scan-based `connectByMac`, but coming off the (now transport-aware,
+      // #3025) pre-warm — or as the sole entry — the transport-aware direct
+      // path routes a Classic adapter (vLinker BM-Android) straight to RFCOMM
+      // and NEVER opens the BLE GATT that 4 s-times-out + poisons the socket. It
+      // still falls back to the merged BLE+Classic scan via `connectByMac`
+      // internally for a direct miss, so the existing behaviour is preserved.
+      service = await container.read(obd2ConnectionProvider).connectByMacTransportAware(
+            pinnedMac,
+            adapterName: pinnedAdapterName,
+          );
     } on Obd2ConnectionError catch (e, st) {
       // Drop through to the sheet so the user can pick another adapter; the
       // fall-through snackbar surfaces it. #2745 — an expected, user-surfaced

--- a/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
+++ b/lib/features/consumption/presentation/widgets/recording_start_coordinator.dart
@@ -53,7 +53,8 @@ class RecordingStartCoordinator {
     if (!flags.contains(Feature.obd2Optional)) return;
     final recordingState = ref.read(tripRecordingProvider);
     if (recordingState.isActive || recordingState.isConnecting) return;
-    final mac = ref.read(activeVehicleProfileProvider)?.obd2AdapterMac;
+    final activeVehicle = ref.read(activeVehicleProfileProvider);
+    final mac = activeVehicle?.obd2AdapterMac;
     if (mac == null || mac.isEmpty) return;
     final Obd2ConnectionService connection;
     try {
@@ -63,11 +64,21 @@ class RecordingStartCoordinator {
       // pre-warm is a best-effort optimisation, so skip silently.
       return;
     }
-    // `fallbackToScan: false` — the pre-warm is a fast best-effort warm
-    // of the GATT link, not a guaranteed connect; a miss just means the
-    // start flow connects normally. A successful warm is held for the
-    // start flow to consume; a null result tears nothing down.
-    final future = connection.connectByMacDirect(mac, fallbackToScan: false);
+    // #3025 — TRANSPORT-AWARE pre-warm. The old call hard-wired the BLE
+    // `connectByMacDirect`, so a Classic-SPP adapter (vLinker BM-Android) could
+    // only 4 s-timeout AND the doomed BLE GATT to its MAC then poisoned the
+    // RFCOMM socket the start flow's Classic fallback used (`read ret: -1`),
+    // breaking firstConnect entirely. Routing through the transport-aware entry
+    // (transport inferred from the paired adapter NAME via the registry) takes
+    // the RFCOMM path for a Classic adapter and never opens the poisoning BLE
+    // GATT. `fallbackToScan: false` — the pre-warm is a fast best-effort warm,
+    // not a guaranteed connect; a miss just means the start flow connects
+    // normally. A successful warm is held for the start flow to consume.
+    final future = connection.connectByMacTransportAware(
+      mac,
+      adapterName: activeVehicle?.obd2AdapterName,
+      fallbackToScan: false,
+    );
     _prewarm = future;
     unawaited(future.then((svc) {
       if (!_alive) {

--- a/lib/features/consumption/providers/auto_record_orchestrator_factories.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator_factories.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../vehicle/providers/vehicle_providers.dart';
 import '../data/obd2/android_background_adapter_listener.dart';
 import '../data/obd2/auto_trip_coordinator.dart';
 import '../data/obd2/background_adapter_listener.dart';
@@ -51,18 +52,34 @@ Obd2SessionOpener autoRecordSessionOpenerFactory(Ref ref) {
   };
 }
 
-/// Foreground-active opener (#2282 concern 1): a DIRECT connect
-/// ([Obd2ConnectionService.connectByMacDirect]) — `BluetoothDevice.fromId`
-/// + `autoConnect`, NO active scan — so it wakes ELM327 clones that stop
-/// advertising in standby. Used by the coordinator's
-/// [AutoTripCoordinator.armForegroundActive] on every app resume to start
-/// engine-detection while the app is in front, independent of the
-/// disabled foreground service. `fallbackToScan: true` keeps behaviour no
-/// worse than the scan opener when the direct attempt fails. Tests
-/// override this provider to inject a fake direct opener.
+/// Foreground-active opener (#2282 concern 1): a DIRECT connect — NO active
+/// scan — so it wakes ELM327 clones that stop advertising in standby. Used by
+/// the coordinator's [AutoTripCoordinator.armForegroundActive] on every app
+/// resume to start engine-detection while the app is in front, independent of
+/// the disabled foreground service.
+///
+/// #3025 — now TRANSPORT-AWARE via
+/// [Obd2ConnectionService.connectByMacTransportAware]. The old call hard-wired
+/// the BLE [Obd2ConnectionService.connectByMacDirect], so a Classic-SPP adapter
+/// (vLinker BM-Android) could only 4 s-timeout AND the doomed BLE GATT to its
+/// MAC poisoned the RFCOMM socket — the same firstConnect defect this opener
+/// shared. Transport is inferred from the paired adapter NAME (read defensively
+/// off the active vehicle so a provider hiccup never makes the connect throw).
+/// `fallbackToScan: true` keeps behaviour no worse than the scan opener when the
+/// direct attempt fails. Tests override this provider to inject a fake opener.
 @Riverpod(keepAlive: true)
 Obd2ForegroundSessionOpener autoRecordForegroundSessionOpenerFactory(Ref ref) {
   return (String mac) async {
-    return ref.read(obd2ConnectionProvider).connectByMacDirect(mac);
+    String? adapterName;
+    try {
+      adapterName = ref.read(activeVehicleProfileProvider)?.obd2AdapterName;
+    } catch (_) {
+      // The vehicle provider must never make an auto-record connect throw —
+      // fall back to a name-less (unknown-transport) connect.
+      adapterName = null;
+    }
+    return ref
+        .read(obd2ConnectionProvider)
+        .connectByMacTransportAware(mac, adapterName: adapterName);
   };
 }

--- a/lib/features/consumption/providers/auto_record_orchestrator_factories.g.dart
+++ b/lib/features/consumption/providers/auto_record_orchestrator_factories.g.dart
@@ -141,29 +141,41 @@ final class AutoRecordSessionOpenerFactoryProvider
 String _$autoRecordSessionOpenerFactoryHash() =>
     r'bb6af1c2c633c61722cb5329e5ea038cb7c0e33f';
 
-/// Foreground-active opener (#2282 concern 1): a DIRECT connect
-/// ([Obd2ConnectionService.connectByMacDirect]) — `BluetoothDevice.fromId`
-/// + `autoConnect`, NO active scan — so it wakes ELM327 clones that stop
-/// advertising in standby. Used by the coordinator's
-/// [AutoTripCoordinator.armForegroundActive] on every app resume to start
-/// engine-detection while the app is in front, independent of the
-/// disabled foreground service. `fallbackToScan: true` keeps behaviour no
-/// worse than the scan opener when the direct attempt fails. Tests
-/// override this provider to inject a fake direct opener.
+/// Foreground-active opener (#2282 concern 1): a DIRECT connect — NO active
+/// scan — so it wakes ELM327 clones that stop advertising in standby. Used by
+/// the coordinator's [AutoTripCoordinator.armForegroundActive] on every app
+/// resume to start engine-detection while the app is in front, independent of
+/// the disabled foreground service.
+///
+/// #3025 — now TRANSPORT-AWARE via
+/// [Obd2ConnectionService.connectByMacTransportAware]. The old call hard-wired
+/// the BLE [Obd2ConnectionService.connectByMacDirect], so a Classic-SPP adapter
+/// (vLinker BM-Android) could only 4 s-timeout AND the doomed BLE GATT to its
+/// MAC poisoned the RFCOMM socket — the same firstConnect defect this opener
+/// shared. Transport is inferred from the paired adapter NAME (read defensively
+/// off the active vehicle so a provider hiccup never makes the connect throw).
+/// `fallbackToScan: true` keeps behaviour no worse than the scan opener when the
+/// direct attempt fails. Tests override this provider to inject a fake opener.
 
 @ProviderFor(autoRecordForegroundSessionOpenerFactory)
 final autoRecordForegroundSessionOpenerFactoryProvider =
     AutoRecordForegroundSessionOpenerFactoryProvider._();
 
-/// Foreground-active opener (#2282 concern 1): a DIRECT connect
-/// ([Obd2ConnectionService.connectByMacDirect]) — `BluetoothDevice.fromId`
-/// + `autoConnect`, NO active scan — so it wakes ELM327 clones that stop
-/// advertising in standby. Used by the coordinator's
-/// [AutoTripCoordinator.armForegroundActive] on every app resume to start
-/// engine-detection while the app is in front, independent of the
-/// disabled foreground service. `fallbackToScan: true` keeps behaviour no
-/// worse than the scan opener when the direct attempt fails. Tests
-/// override this provider to inject a fake direct opener.
+/// Foreground-active opener (#2282 concern 1): a DIRECT connect — NO active
+/// scan — so it wakes ELM327 clones that stop advertising in standby. Used by
+/// the coordinator's [AutoTripCoordinator.armForegroundActive] on every app
+/// resume to start engine-detection while the app is in front, independent of
+/// the disabled foreground service.
+///
+/// #3025 — now TRANSPORT-AWARE via
+/// [Obd2ConnectionService.connectByMacTransportAware]. The old call hard-wired
+/// the BLE [Obd2ConnectionService.connectByMacDirect], so a Classic-SPP adapter
+/// (vLinker BM-Android) could only 4 s-timeout AND the doomed BLE GATT to its
+/// MAC poisoned the RFCOMM socket — the same firstConnect defect this opener
+/// shared. Transport is inferred from the paired adapter NAME (read defensively
+/// off the active vehicle so a provider hiccup never makes the connect throw).
+/// `fallbackToScan: true` keeps behaviour no worse than the scan opener when the
+/// direct attempt fails. Tests override this provider to inject a fake opener.
 
 final class AutoRecordForegroundSessionOpenerFactoryProvider
     extends
@@ -173,15 +185,21 @@ final class AutoRecordForegroundSessionOpenerFactoryProvider
           Obd2ForegroundSessionOpener
         >
     with $Provider<Obd2ForegroundSessionOpener> {
-  /// Foreground-active opener (#2282 concern 1): a DIRECT connect
-  /// ([Obd2ConnectionService.connectByMacDirect]) — `BluetoothDevice.fromId`
-  /// + `autoConnect`, NO active scan — so it wakes ELM327 clones that stop
-  /// advertising in standby. Used by the coordinator's
-  /// [AutoTripCoordinator.armForegroundActive] on every app resume to start
-  /// engine-detection while the app is in front, independent of the
-  /// disabled foreground service. `fallbackToScan: true` keeps behaviour no
-  /// worse than the scan opener when the direct attempt fails. Tests
-  /// override this provider to inject a fake direct opener.
+  /// Foreground-active opener (#2282 concern 1): a DIRECT connect — NO active
+  /// scan — so it wakes ELM327 clones that stop advertising in standby. Used by
+  /// the coordinator's [AutoTripCoordinator.armForegroundActive] on every app
+  /// resume to start engine-detection while the app is in front, independent of
+  /// the disabled foreground service.
+  ///
+  /// #3025 — now TRANSPORT-AWARE via
+  /// [Obd2ConnectionService.connectByMacTransportAware]. The old call hard-wired
+  /// the BLE [Obd2ConnectionService.connectByMacDirect], so a Classic-SPP adapter
+  /// (vLinker BM-Android) could only 4 s-timeout AND the doomed BLE GATT to its
+  /// MAC poisoned the RFCOMM socket — the same firstConnect defect this opener
+  /// shared. Transport is inferred from the paired adapter NAME (read defensively
+  /// off the active vehicle so a provider hiccup never makes the connect throw).
+  /// `fallbackToScan: true` keeps behaviour no worse than the scan opener when the
+  /// direct attempt fails. Tests override this provider to inject a fake opener.
   AutoRecordForegroundSessionOpenerFactoryProvider._()
     : super(
         from: null,
@@ -218,4 +236,4 @@ final class AutoRecordForegroundSessionOpenerFactoryProvider
 }
 
 String _$autoRecordForegroundSessionOpenerFactoryHash() =>
-    r'997e4119c5ab7a8487110e041e5f93a7fe1946d5';
+    r'2767dfb1262c9bd41e561d1fef3210daa04a3362';

--- a/test/features/consumption/data/obd2/obd2_connect_by_mac_transport_aware_test.dart
+++ b/test/features/consumption/data/obd2/obd2_connect_by_mac_transport_aware_test.dart
@@ -1,0 +1,392 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/adapter_registry.dart';
+import 'package:tankstellen/features/consumption/data/obd2/bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/classic_bluetooth_facade.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connect_trace.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connect_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_connection_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_permissions.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_transport.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3025 / Epic #3013 — the transport-aware firstConnect routing invariant.
+///
+/// The field bug (vLinker BM-Android, a Classic-SPP adapter): the firstConnect
+/// pre-warm / pinned path called the BLE `connectByMacDirect` UNCONDITIONALLY,
+/// so a Classic adapter could ONLY 4 s-timeout, and the doomed BLE GATT to its
+/// MAC then poisoned the subsequent RFCOMM socket. The fix routes firstConnect
+/// through `connectByMacTransportAware`, which inspects the paired adapter NAME
+/// and dispatches to the Classic RFCOMM path WITHOUT ever opening the BLE GATT.
+void main() {
+  silenceErrorLoggerSpool();
+
+  group('connectByMacTransportAware path routing (#3025)', () {
+    test(
+        'a CLASSIC-named adapter takes the Classic RFCOMM path and NEVER the '
+        'BLE direct path (the vLinker BM-Android fix)', () async {
+      final conn = _RecordingConnection(adapterIsClassic: true);
+
+      final svc = await conn.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:DA',
+        adapterName: 'vLinker BM-Android',
+      );
+
+      expect(svc, isNotNull, reason: 'the Classic adapter must connect');
+      expect(conn.pathsTaken, ['classic']);
+      expect(conn.bleDirectCalls, 0,
+          reason: 'the BLE 4 s-timeout path must NEVER be invoked for a '
+              'Classic adapter — that is the field bug + the SPP poison source');
+    });
+
+    test(
+        'a BLE-named adapter takes the BLE direct path and never the Classic '
+        'path', () async {
+      final conn = _RecordingConnection(adapterIsClassic: false);
+
+      final svc = await conn.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:31',
+        adapterName: 'vLinker FD',
+      );
+
+      expect(svc, isNotNull);
+      expect(conn.pathsTaken, ['ble-direct']);
+      expect(conn.classicDirectCalls, 0);
+    });
+
+    test(
+        'an UNKNOWN/nameless adapter tries BLE first then Classic (fallback '
+        'order preserved) — but the BLE GATT is fully torn down between',
+        () async {
+      // The BLE direct path misses (null), so the Classic direct path is tried
+      // for the same MAC. Both paths self-tear-down their channel, so no
+      // half-open GATT survives into the RFCOMM open.
+      final conn = _RecordingConnection(adapterIsClassic: true);
+
+      final svc = await conn.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:FF',
+        adapterName: null, // unknown transport
+      );
+
+      expect(svc, isNotNull,
+          reason: 'the Classic adapter recovers on the second (Classic) '
+              'attempt of the unknown-transport fallback');
+      // BLE attempted first (missed), then Classic.
+      expect(conn.bleDirectCalls, 1);
+      expect(conn.pathsTaken, ['classic']);
+    });
+
+    test(
+        'fallbackToScan:false on a Classic miss returns null WITHOUT scanning '
+        '(the pre-warm contract)', () async {
+      // Classic direct returns null (adapter out of range): with
+      // fallbackToScan:false the pre-warm must not kick a slow scan.
+      final conn = _RecordingConnection(
+        adapterIsClassic: true,
+        classicDirectReturnsNull: true,
+      );
+
+      final svc = await conn.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:DA',
+        adapterName: 'vLinker BM-Android',
+        fallbackToScan: false,
+      );
+
+      expect(svc, isNull);
+      expect(conn.scanFallbackCalls, 0,
+          reason: 'fallbackToScan:false must not reach the scan path');
+      expect(conn.bleDirectCalls, 0,
+          reason: 'still no BLE path for a Classic adapter, even on a miss');
+    });
+
+    test(
+        'a Classic miss WITH fallbackToScan:true reaches the transport-aware '
+        'scan (connectByMac) — never a BLE direct', () async {
+      final conn = _RecordingConnection(
+        adapterIsClassic: true,
+        classicDirectReturnsNull: true,
+      );
+
+      await conn.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:DA',
+        adapterName: 'vLinker BM-Android',
+        fallbackToScan: true,
+      );
+
+      expect(conn.scanFallbackCalls, 1);
+      expect(conn.bleDirectCalls, 0);
+    });
+  });
+
+  group('connectByMacTransportAware against the REAL service (#3025)', () {
+    setUp(Obd2ConnectTraceLog.clear);
+    tearDown(Obd2ConnectTraceLog.clear);
+
+    test(
+        'a Classic adapter NEVER opens the BLE channelForDirect (4 s timeout) — '
+        'the real service routes straight to the Classic facade', () async {
+      final ble = _RecordingDirectFacade();
+      final classicChannel = _ScriptedChannel(respondTo: _elmOkResponses());
+      final classic = _RecordingClassicFacade(channel: classicChannel);
+      final service = Obd2ConnectionService(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _GrantedPermissions(),
+        bluetooth: ble,
+        classicBluetooth: classic,
+        scanSettleDelay: Duration.zero,
+      );
+
+      final connected = await service.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:DA',
+        adapterName: 'vLinker BM-Android',
+      );
+
+      expect(connected, isNotNull, reason: 'the Classic adapter connects');
+      expect(ble.directCalls, 0,
+          reason: 'the BLE channelForDirect (the 4 s-timeout + SPP-poison '
+              'source) must NEVER be touched for a Classic adapter');
+      expect(classic.channelForCalls, ['AA:BB:CC:DD:EE:DA'],
+          reason: 'the RFCOMM channel is opened instead');
+    });
+
+    test(
+        'the trace requestedTransport for a Classic adapter is classic, not '
+        'ble (truthful field trace)', () async {
+      final ble = _RecordingDirectFacade();
+      final classic = _RecordingClassicFacade(
+        channel: _ScriptedChannel(respondTo: _elmOkResponses()),
+      );
+      final service = Obd2ConnectionService(
+        registry: Obd2AdapterRegistry.defaults(),
+        permissions: _GrantedPermissions(),
+        bluetooth: ble,
+        classicBluetooth: classic,
+        scanSettleDelay: Duration.zero,
+      );
+
+      await service.connectByMacTransportAware(
+        'AA:BB:CC:DD:EE:DA',
+        adapterName: 'vLinker BM-Android',
+      );
+
+      final traces = Obd2ConnectTraceLog.snapshot();
+      expect(traces, isNotEmpty);
+      expect(
+        traces.any((t) => t.requestedTransport == Obd2ConnectTransport.classic),
+        isTrue,
+        reason: 'a Classic adapter must record rtx:classic, never rtx:ble',
+      );
+      expect(
+        traces.any((t) => t.requestedTransport == Obd2ConnectTransport.ble),
+        isFalse,
+        reason: 'no BLE attempt was made, so no ble-stamped trace exists',
+      );
+    });
+  });
+}
+
+/// A recording [Obd2ConnectionService] that overrides each by-MAC path so the
+/// test can assert WHICH transport [connectByMacTransportAware] chose without a
+/// real channel stack. Mirrors the self-test driver test's `_FakeConnection`.
+class _RecordingConnection extends Obd2ConnectionService {
+  _RecordingConnection({
+    required this.adapterIsClassic,
+    this.classicDirectReturnsNull = false,
+  }) : super(
+          registry: Obd2AdapterRegistry.defaults(),
+          permissions: _GrantedPermissions(),
+          bluetooth: _UnusedFacade(),
+          classicBluetooth: _UnusedClassicFacade(),
+        );
+
+  /// When true, only the Classic RFCOMM path can connect (mirrors a real
+  /// Classic adapter, which the BLE direct path can never reach).
+  final bool adapterIsClassic;
+  final bool classicDirectReturnsNull;
+
+  final List<String> pathsTaken = [];
+  int bleDirectCalls = 0;
+  int classicDirectCalls = 0;
+  int scanFallbackCalls = 0;
+
+  Obd2Service _service(String linkKind) {
+    return Obd2Service(_OkTransport())
+      ..adapterMac = 'AA:BB:CC:DD:EE:FF'
+      ..linkKind = linkKind;
+  }
+
+  @override
+  Future<Obd2Service?> connectByMacDirect(
+    String mac, {
+    Duration timeout = const Duration(seconds: 4),
+    bool fallbackToScan = true,
+    String? adapterName,
+  }) async {
+    bleDirectCalls++;
+    if (adapterIsClassic) return null; // models the 4 s-timeout-then-null
+    pathsTaken.add('ble-direct');
+    return _service('ble');
+  }
+
+  @override
+  Future<Obd2Service?> connectByMacClassicDirect(String mac,
+      {String? adapterName}) async {
+    classicDirectCalls++;
+    if (!adapterIsClassic) return null;
+    if (classicDirectReturnsNull) return null;
+    pathsTaken.add('classic');
+    return _service('classic');
+  }
+
+  @override
+  Future<Obd2Service?> connectByMac(String mac,
+      {Duration timeout = const Duration(seconds: 5), String? adapterName}) async {
+    scanFallbackCalls++;
+    return null;
+  }
+}
+
+class _GrantedPermissions implements Obd2Permissions {
+  @override
+  Future<Obd2PermissionState> current() async => Obd2PermissionState.granted;
+  @override
+  Future<Obd2PermissionState> request() async => Obd2PermissionState.granted;
+  @override
+  Future<bool> requestNotifications() async => true;
+}
+
+/// BLE facade that RECORDS every `channelForDirect` call so a Classic-adapter
+/// connect can assert it was NEVER touched.
+class _RecordingDirectFacade implements BluetoothFacade {
+  int directCalls = 0;
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      _ScriptedChannel(silent: true);
+
+  @override
+  ElmByteChannel channelForDirect(
+    String mac, {
+    Duration connectTimeout = const Duration(seconds: 4),
+    bool autoConnect = false,
+  }) {
+    directCalls++;
+    // A real Classic adapter would 4 s-timeout here; throw so any accidental
+    // BLE attempt is unmistakable in the test (not a silent success).
+    return _ScriptedChannel(openError: StateError('BLE GATT to Classic adapter'));
+  }
+}
+
+class _RecordingClassicFacade implements ClassicBluetoothFacade {
+  _RecordingClassicFacade({required this.channel});
+  final ElmByteChannel channel;
+  final List<String> channelForCalls = [];
+
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+
+  @override
+  Future<void> stopScan() async {}
+
+  @override
+  ElmByteChannel channelFor(String deviceId) {
+    channelForCalls.add(deviceId);
+    return channel;
+  }
+}
+
+class _UnusedFacade implements BluetoothFacade {
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    required Set<String> serviceUuids,
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+  @override
+  Future<void> stopScan() async {}
+  @override
+  ElmByteChannel channelFor(String deviceId, Obd2AdapterProfile profile) =>
+      _ScriptedChannel(silent: true);
+  @override
+  ElmByteChannel channelForDirect(String mac,
+          {Duration connectTimeout = const Duration(seconds: 4),
+          bool autoConnect = false}) =>
+      _ScriptedChannel(silent: true);
+}
+
+class _UnusedClassicFacade implements ClassicBluetoothFacade {
+  @override
+  Stream<List<Obd2AdapterCandidate>> scan({
+    Duration timeout = const Duration(seconds: 8),
+  }) async* {}
+  @override
+  Future<void> stopScan() async {}
+  @override
+  ElmByteChannel channelFor(String deviceId) => _ScriptedChannel(silent: true);
+}
+
+/// Transport whose init sequence always completes — used by the recording
+/// connection fake to mint a connectable [Obd2Service].
+class _OkTransport extends FakeObd2Transport {
+  _OkTransport() : super(_elmOkResponses());
+}
+
+/// Minimal channel that answers ELM327 init OK (or throws on open / stays
+/// silent) — same shape as the connection-service test's `_FakeChannel`.
+class _ScriptedChannel implements ElmByteChannel {
+  _ScriptedChannel({this.silent = false, this.respondTo, this.openError});
+  final bool silent;
+  final Map<String, String>? respondTo;
+  final Object? openError;
+  final StreamController<List<int>> _ctrl = StreamController.broadcast();
+  bool _open = false;
+
+  @override
+  bool get isOpen => _open;
+  @override
+  Stream<List<int>> get incoming => _ctrl.stream;
+  @override
+  Future<void> open() async {
+    final err = openError;
+    if (err != null) throw err;
+    _open = true;
+  }
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    if (silent) return;
+    final cmd = String.fromCharCodes(bytes).trim();
+    final reply = respondTo?[cmd] ?? 'OK>';
+    _ctrl.add(reply.codeUnits);
+  }
+
+  @override
+  Future<void> close() async {
+    _open = false;
+    if (!_ctrl.isClosed) await _ctrl.close();
+  }
+}
+
+Map<String, String> _elmOkResponses() => {
+      'ATZ': 'ELM327 v1.5>',
+      'ATE0': 'OK>',
+      'ATL0': 'OK>',
+      'ATH0': 'OK>',
+      'ATSP0': 'OK>',
+    };

--- a/test/features/consumption/presentation/widgets/trajets_tab_test.dart
+++ b/test/features/consumption/presentation/widgets/trajets_tab_test.dart
@@ -122,6 +122,13 @@ class _RecordingFakeConnection extends Obd2ConnectionService {
   final List<String> connectByMacCalls = [];
   final List<String> connectByMacDirectCalls = [];
 
+  /// #3025 — records the transport-aware pre-warm / pinned connect entry the
+  /// firstConnect orchestrators now route through (instead of the BLE-only
+  /// `connectByMacDirect`). The fake returns [connectByMacDirectResult] so the
+  /// existing pre-warm-hit assertions still hold, while the recorded list lets a
+  /// test assert the adapter NAME drove the routing.
+  final List<String> connectByMacTransportAwareCalls = [];
+
   @override
   Future<Obd2Service?> connectByMac(
     String mac, {
@@ -140,6 +147,16 @@ class _RecordingFakeConnection extends Obd2ConnectionService {
     String? adapterName,
   }) async {
     connectByMacDirectCalls.add(mac);
+    return connectByMacDirectResult;
+  }
+
+  @override
+  Future<Obd2Service?> connectByMacTransportAware(
+    String mac, {
+    String? adapterName,
+    bool fallbackToScan = true,
+  }) async {
+    connectByMacTransportAwareCalls.add(mac);
     return connectByMacDirectResult;
   }
 
@@ -520,8 +537,9 @@ void main() {
       // Let the post-frame pre-warm fire + resolve.
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 10));
-      expect(connection.connectByMacDirectCalls, ['AA:BB:CC:DD:EE:FF'],
-          reason: 'pre-warm (concern 3) fires the direct connect on open');
+      // #3025 — pre-warm (concern 3) fires the TRANSPORT-AWARE connect on open.
+      expect(connection.connectByMacTransportAwareCalls, ['AA:BB:CC:DD:EE:FF'],
+          reason: 'pre-warm (concern 3) fires the transport-aware connect');
 
       await tester.tap(
         find.byKey(const Key('trajets_start_recording_button')),
@@ -726,12 +744,13 @@ void main() {
     });
   });
 
-  // #2274 concern 3 — pre-warm BLE connect on the trajets/start screen
-  // open. For a pinned/bonded adapter the tab kicks `connectByMacDirect`
-  // the moment it opens, and the start flow consumes that warm link
-  // (skipping the picker). An unpaired vehicle warms nothing and falls
-  // back to the picker on Start.
-  group('TrajetsTab — pre-warm BLE connect (#2274 concern 3)', () {
+  // #2274 concern 3 — pre-warm connect on the trajets/start screen open. For a
+  // pinned/bonded adapter the tab kicks the TRANSPORT-AWARE direct connect
+  // (#3025 — `connectByMacTransportAware`, not the BLE-only `connectByMacDirect`
+  // which 4 s-timed-out + poisoned the RFCOMM socket for a Classic adapter) the
+  // moment it opens, and the start flow consumes that warm link (skipping the
+  // picker). An unpaired vehicle warms nothing and falls back to the picker.
+  group('TrajetsTab — pre-warm connect (#2274 concern 3 / #3025)', () {
     const pairedVehicle = VehicleProfile(
       id: 'v1',
       name: 'Daily Driver',
@@ -746,8 +765,8 @@ void main() {
     );
 
     testWidgets(
-        'paired vehicle pre-warms connectByMacDirect on open and starts '
-        'with the warm service (no picker)', (tester) async {
+        'paired vehicle pre-warms via the transport-aware connect on open and '
+        'starts with the warm service (no picker) — #3025', (tester) async {
       final fakeService = _NoopObd2Service();
       final connection = _RecordingFakeConnection(
         connectByMacDirectResult: fakeService,
@@ -765,7 +784,12 @@ void main() {
       // Post-frame pre-warm fires + resolves before any tap.
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 10));
-      expect(connection.connectByMacDirectCalls, ['AA:BB:CC:DD:EE:FF']);
+      // #3025 — the pre-warm goes through the TRANSPORT-AWARE entry (which routes
+      // 'vLinker FS' — a Classic adapter — to RFCOMM), NOT the BLE-only
+      // connectByMacDirect that 4 s-timed-out + poisoned the socket.
+      expect(connection.connectByMacTransportAwareCalls, ['AA:BB:CC:DD:EE:FF']);
+      expect(connection.connectByMacDirectCalls, isEmpty,
+          reason: 'a Classic adapter must NEVER pre-warm over the BLE path');
 
       await tester.tap(
         find.byKey(const Key('trajets_start_recording_button')),
@@ -795,8 +819,9 @@ void main() {
       );
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 10));
-      // No pinned MAC → nothing pre-warmed.
+      // No pinned MAC → nothing pre-warmed (neither path is touched).
       expect(connection.connectByMacDirectCalls, isEmpty);
+      expect(connection.connectByMacTransportAwareCalls, isEmpty);
 
       await tester.tap(
         find.byKey(const Key('trajets_start_recording_button')),

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -127,7 +127,14 @@ void main() {
     // best-effort `recordFrom` call + the production-provider wiring). Local-only
     // (Hive settings box), so it stays a small additive thread on the existing
     // connect path rather than warranting a separate connect class.
-    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 629,
+    // #3025 — re-grandfathered 629 → 668: the transport-aware firstConnect
+    // entry (`connectByMacTransportAware` — the thin overridable instance
+    // method + its ~30-line dartdoc explaining the vLinker BM-Android root
+    // cause). The actual routing body lives in the `obd2_connect_by_mac` part
+    // (346, under cap); only the dispatch stub + rationale land here. The class
+    // is already split across two `part` files; further decomposition is tracked
+    // under #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 668,
     // #2969 — grandfathered at 419 (was ~399, right at the cap on master). The
     // scan-path BLE `connect()` timeout bound (FBP could otherwise block ~35 s
     // on a vanished candidate) + the channel-open connect-trace stamp (the one
@@ -449,8 +456,14 @@ void main() {
     // real Open-Testing "ref used after unmount" StateError). The growth is the
     // two captures + the two extra params + the rationale comments; it cannot
     // move out of the State. Decomposition stays tracked under #2187/#2188.
+    // #3025 — re-grandfathered 458 → 470: the pinned-MAC fast path now routes
+    // through the TRANSPORT-AWARE `connectByMacTransportAware` (a Classic
+    // adapter — vLinker BM-Android — must never take the BLE GATT path that
+    // 4 s-times-out + poisons the RFCOMM socket) instead of the BLE-leaning
+    // scan-based `connectByMac`. The growth is the swapped call + its rationale
+    // comment. Decomposition stays tracked under #2187/#2188.
     'lib/features/consumption/presentation/widgets/obd2_adapter_picker.dart':
-        458,
+        470,
     // #2624 — shrank 463 → 450: dropped the post-frame `fitCamera` block
     // (+ its dart:async / error_logger imports) in favour of
     // `MapOptions.initialCameraFit`, fixing the grey-tile cold-start race.


### PR DESCRIPTION
## Root cause

A Classic OBD2 adapter (vLinker BM-Android — `transport=classic`, pid `vlinker-bm-android-classic`) **never connected on firstConnect**. Three field connect-traces (2026-06-07, post-#3016) all show:

1. `rtx: ble` — the firstConnect path attempts **BLE GATT first** → `FlutterBluePlusException | connect | fbp-code:1 | Timed out after 4s` → `direct-connect-failed`, retried up to 3×.
2. THEN a Classic RFCOMM fallback → `rfcomm open failed (strategy: exhausted, error: read failed, socket might closed or timeout, read ret: -1)`, repeated, ~200 s total, outcome `gattTimeout`. **Never connects.**

The doomed BLE GATT to the adapter's MAC leaves a half-open connection that **poisons the subsequent RFCOMM socket to the same device** (Android dual-mode BLE+SPP-to-same-device conflict — the `read ret: -1` / "socket might closed" signature). vLinker FS (also Classic) connects fine because its flow never does the poisoning BLE attempt first.

**Where it was wrong:** the firstConnect pre-warm (`recording_start_coordinator.dart`, the trajets tab open) hard-wired the BLE `connectByMacDirect`, and the picker's pinned fast path used the BLE-leaning scan-based `connectByMac`. For a Classic-SPP adapter `connectByMacDirect` (`channelForDirect`, 4 s timeout) can ONLY time out — the exact field signature. The in-trip reconnect (#2565), the trip-independent reconnect (#3016) and the self-test (#2969) were already transport-aware; **firstConnect was the one path that wasn't**.

## The fix (root, transport-aware connect ordering)

New `Obd2ConnectionService.connectByMacTransportAware` — the single transport-aware firstConnect entry. It infers the transport from the paired adapter **NAME** via the registry name matchers (the same recovery the self-test uses; `transportForName('vLinker BM-Android')` → `classic`):

- **Classic** → `connectByMacClassicDirect` (RFCOMM) only. **NEVER** touches the BLE `channelForDirect` — no 4 s timeout, no GATT to poison the socket. Clean miss → transport-aware scan (`connectByMac`).
- **BLE** → `connectByMacDirect`.
- **Unknown / nameless** → BLE-direct-first then a Classic direct attempt for the same MAC, with the BLE GATT **fully torn down** (`channel.close()` ⇒ `device.disconnect()`) between the two, so no half-open GATT survives into the RFCOMM open (defense-in-depth against the poison).

The pre-warm and the picker pinned path now route through it. The trace `requestedTransport` reflects the chosen path — a Classic adapter records `rtx: classic`, not the misleading `rtx: ble`.

This eliminates the doomed 4 s BLE attempt for Classic adapters (fixes the wasted ~4–30 s **and** removes the SPP-poisoning source), so BM-Android connects like FS.

## BLE-teardown hardening

Verified the existing teardown actually disconnects the GATT: `_teardownLastDirectChannel` → `FlutterBluePlusElmChannel.close()` → `_device.disconnect()` (not just nulling a ref). The unknown-transport branch relies on it between the BLE and Classic attempts.

## Tests (RED-on-bug → GREEN)

`obd2_connect_by_mac_transport_aware_test.dart` (new):
- a Classic-named adapter takes the Classic RFCOMM path and the BLE `channelForDirect`/4 s path is **NEVER** invoked (driven against the REAL service with a recording facade asserting `directCalls == 0`);
- a BLE-named adapter → BLE path;
- unknown → BLE-then-Classic fallback order;
- `fallbackToScan:false` on a Classic miss returns null without scanning (pre-warm contract);
- the trace `requestedTransport` for a Classic adapter is `classic`, never `ble`.

Confirmed RED when the Classic branch is temporarily routed through BLE (the bug): 5 of the Classic-invariant tests fail, including the "REAL service NEVER opens BLE channelForDirect" and "rtx:classic" tests; the BLE-named test stays green.

`trajets_tab_test` pre-warm assertions updated to the transport-aware entry (the fixture's `'vLinker FS'` is Classic — it now correctly **never** pre-warms over BLE).

## Verification

- `flutter analyze` — clean (only 2 pre-existing `unnecessary_import` infos in unrelated test files, present on master).
- `flutter test test/features/consumption/data/obd2/` (1582) + self-test controller + picker + trajets_tab + recording-coordinator + `test/lint` — all green.
- No `@riverpod`/freezed/json or ARB changes → no codegen / no l10n fan-out needed.
- `file_length` baselines bumped (629→668 service, 458→470 picker) with rationale.

**Pre-push note:** the pre-push hook's `flutter pub get` aborted with the known `0.0.0-unknown` SDK bug (git passes `GIT_DIR` into the hook); gates verified manually, pushed with `SKIP_PREPUSH=1`.

## Residual risk (could not verify without the real device)

Whether vLinker BM-Android additionally requires the device to be **bonded** before the RFCOMM open succeeds. The fix removes the BLE-poisoning source (the confirmed proximate cause), which should let the Classic path connect like vLinker FS — but if BM-Android needs explicit bonding the Kotlin `Obd2ClassicPlugin` strategy may still need a bonding step. No Kotlin change was made (the working FS path is preserved); this is the one assumption a field re-test on the device would confirm.

Closes #3025
Ref Epic #3013

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Update (amended):** also routed the auto-record **foreground opener** (`autoRecordForegroundSessionOpenerFactory`, #2282 — the every-app-resume engine-detection direct connect) through `connectByMacTransportAware`. It shared the exact same transport-blind `connectByMacDirect` defect (a Classic adapter would 4 s-timeout + poison the RFCOMM socket during auto-record). Transport is inferred from the active vehicle's adapter name, read defensively so the connect never throws. The mirrored dartdoc drift in `auto_record_orchestrator_factories.g.dart` was regenerated via clean `build_runner` (provider hash unchanged — docs-only) and committed (HARD RULE #3).
