### PR TITLE
fix(hooks): unset inherited GIT_* in pre-push so Flutter's version probe isn't hijacked

### DIFF
--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -57,6 +57,17 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# git invokes this hook with GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE exported
+# into the environment, and they leak into every child process — including
+# `flutter`, whose version probe runs `git describe` against the SDK checkout.
+# With GIT_DIR pointing at THIS repo (most visibly from a worktree push), that
+# probe resolves against this repo instead of the SDK, so flutter reports its
+# version as `0.0.0-unknown` and `flutter pub get` fails dependency solving —
+# which aborted the whole gate and pushed everyone onto SKIP_PREPUSH (#3027).
+# Unset them so flutter resolves its own SDK version; the git commands below
+# rediscover the repo from $REPO_ROOT (cwd) just fine.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX
+
 # Flutter/Dart are not on the default PATH in this environment.
 export PATH="/Users/floriandittgen/development/flutter/bin:/opt/homebrew/bin:$PATH"
 


### PR DESCRIPTION
## Problem
The managed pre-push hook has been silently disabled on every worktree push — `flutter pub get` fails:
```
The current Flutter SDK version is 0.0.0-unknown.
Because url_launcher_platform_interface ... requires Flutter SDK version >=3.13.0 ...
```
so everyone falls back to `SKIP_PREPUSH=1`, defeating the **local** HARD RULE #3/#4 codegen+l10n gate (CI still catches drift, but at a ~13-min round-trip).

## Root cause (reproduced)
git invokes the hook with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` exported. They leak into `flutter`, whose version probe runs `git describe` against the SDK checkout — but inherited `GIT_DIR` makes that probe resolve against THIS repo, so flutter sees a tankstellen tag → `0.0.0-unknown`.
```
git -C <flutter-sdk> describe                       -> 3.41.9
GIT_DIR=<repo>/.git git -C <flutter-sdk> describe   -> nightly-20260606-13-g8f671ffa   # hijacked
```

## Fix
`unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX` in the hook before invoking flutter; subsequent git commands rediscover the repo from cwd. With the unset, the SDK probe returns `3.41.9` again. Restores the local gate so agents stop needing SKIP_PREPUSH.

Shell-only change to scripts/install_hooks.sh (the generated hook lives in .git/, untracked). Pushed with SKIP_PREPUSH (nothing the gate covers was touched).

Closes #3027