### PR TITLE
fix(consumption): no phantom hard-brake/accel penalty on GPS-sourced trips (#3029)

### DIFF
--- a/lib/features/consumption/data/analysis/driving_analysis_trace.dart
+++ b/lib/features/consumption/data/analysis/driving_analysis_trace.dart
@@ -91,6 +91,15 @@ class DrivingAnalysisTrace {
         'score': {
           'overall': score.score,
           'styleClass': score.styleClass.name,
+          // #3029 — the harsh counts that ACTUALLY drive the penalties
+          // (`summary.harshAccelerations`/`harshBrakes` — IMU when it ran,
+          // else the now-suppressed direct-speed value), so a non-zero
+          // penalty always has a visible matching count. The `imu.*Count`
+          // block above stays the inertial-sensor truth; before this, a
+          // GPS-sourced trip could show a penalty>0 while `imu.*Count==0`,
+          // reading as a phantom with no source.
+          'hardAccelCount': summary.harshAccelerations,
+          'hardBrakeCount': summary.harshBrakes,
           'hardAccelPenalty': _round(score.hardAccelPenalty, 2),
           'hardBrakePenalty': _round(score.hardBrakePenalty, 2),
           'idlingPenalty': _round(score.idlingPenalty, 2),

--- a/lib/features/consumption/data/obd2/degraded_gps_emitter.dart
+++ b/lib/features/consumption/data/obd2/degraded_gps_emitter.dart
@@ -3,6 +3,7 @@
 
 import '../../domain/trip_recorder.dart';
 import 'gps_only_sample_builder.dart';
+import 'trip_distance_source.dart' show kDistanceSourceGps;
 import 'trip_live_reading.dart';
 import 'trip_sample_buffer.dart';
 
@@ -100,7 +101,14 @@ class DegradedGpsEmitter {
         hAccuracyM: hAccuracyM,
         bearingDeg: bearingDeg,
       );
-      _recorder.onSample(sample);
+      // #3029 — this feed is pure GPS Doppler ground speed (OBD2 dropped),
+      // so tag the source `gps` to suppress harsh scoring on it: the
+      // ~1 Hz noisy derivative manufactures phantom hard-accel/brake
+      // events the score cannot tell from real manoeuvres. Mirrors the
+      // GPS-only pipeline (`recorder.onSample(sample, distanceSource:
+      // kDistanceSourceGps)`); without the tag this degraded feed scored
+      // ungated and produced penalties with no visible IMU source.
+      _recorder.onSample(sample, distanceSource: kDistanceSourceGps);
       _onSampleAt(nowTs);
       _sampleBuffer.maybeCapture(sample);
     }

--- a/lib/features/consumption/data/obd2/trip_recording_controller.dart
+++ b/lib/features/consumption/data/obd2/trip_recording_controller.dart
@@ -892,6 +892,13 @@ class TripRecordingController {
     // keeps the recorder's authoritative timestamps untouched.
     final startedAt = base.startedAt ?? _gpsStartedAt;
     final endedAt = base.endedAt ?? _gpsEndedAt;
+    // #2895 / #3029 — harsh-count parity with the GPS-only pipeline (which
+    // runs an IMU detector + the #2895 `imuActive ? imuCount : recorder`
+    // veto). This OBD2 path runs NO inertial detector, so the veto collapses
+    // to "use the recorder value": after #3029 the recorder suppresses harsh
+    // scoring on the `gps`/`virtual` source in `onSample`, so base.harsh* is
+    // 0 for a no-speed-PID GPS trip (no phantom) and reflects the direct OBD2
+    // speed PID on a `real` trip (preserved). Pass-through is correct here.
     return TripSummary(
       distanceKm: distanceKm,
       maxRpm: base.maxRpm,

--- a/lib/features/consumption/domain/trip_recorder.dart
+++ b/lib/features/consumption/domain/trip_recorder.dart
@@ -3,7 +3,8 @@
 
 import 'dart:math' as math;
 
-import '../data/obd2/trip_distance_source.dart' show kDistanceSourceVirtual;
+import '../data/obd2/trip_distance_source.dart'
+    show kDistanceSourceGps, kDistanceSourceVirtual;
 import 'harsh_event_detector.dart';
 import 'services/trip_consumption_reliability.dart';
 import 'trip_sample.dart';
@@ -100,11 +101,27 @@ class TripRecorder {
   ///
   /// [distanceSource] is the trip's live distance provenance
   /// (`kDistanceSourceReal` / `kDistanceSourceGps` /
-  /// `kDistanceSourceVirtual`, #2653). On a `virtual` (dead-reckoning)
-  /// source the speed signal is unfit for differentiation, so harsh
-  /// scoring is suppressed for that sample. Null leaves harsh scoring
-  /// enabled — the safe default for legacy / test call sites and the
-  /// OBD speed path.
+  /// `kDistanceSourceVirtual`, #2653). Harsh scoring is suppressed for
+  /// the sample when its speed signal is unfit for differentiation:
+  ///
+  ///   * `kDistanceSourceVirtual` (dead-reckoning odometer, #2653) — a
+  ///     1 km/h-quantised integrated speed produces median 4.78 / peak
+  ///     43.4 phantom events/km in the field backup.
+  ///   * `kDistanceSourceGps` (#2895 / #3029) — GPS Doppler ground speed
+  ///     is ~1 Hz, noisy, and differentiating it manufactures impossible
+  ///     >1 g spikes (the #2895 Peugeot 107: a live IMU counted 0 harsh
+  ///     while the GPS derivative counted 16, maxAccelG 1.086). #2895 made
+  ///     a live IMU *veto* that over-count, but a GPS-sourced trip with no
+  ///     IMU (no inertial hardware / OBD2-from-the-start, no speed PID) had
+  ///     nothing to veto it, so the clamped-GPS count still drove the
+  ///     score — a hard-accel/brake penalty with no visible source
+  ///     (#3029). GPS-derived speed is therefore unfit for harsh
+  ///     differentiation full stop: harsh events may come ONLY from a
+  ///     trustworthy source — a live IMU, or a real OBD2 speed PID.
+  ///
+  /// `kDistanceSourceReal` (direct OBD2 speed PID) and `null` (legacy /
+  /// test call sites and the canonical OBD speed path) leave harsh scoring
+  /// ENABLED — those speed signals are direct, not derived.
   void onSample(TripSample sample, {String? distanceSource}) {
     _startedAt ??= sample.timestamp;
     _endedAt = sample.timestamp;
@@ -117,14 +134,18 @@ class TripRecorder {
     // inflate the count (#1922), then de-noises with a sustained-window
     // + accuracy + min-speed + source-aware gate (#2653). Fed every
     // sample, including the first, so its anchor is seeded from trip
-    // start. On the `virtual` dead-reckoning source the detector
-    // suppresses scoring entirely (median 4.78 / peak 43.4 phantom
-    // events/km in the field backup).
+    // start. On any DERIVED-speed source (the `virtual` dead-reckoning
+    // odometer, #2653; and `gps` Doppler ground speed, #2895 / #3029) the
+    // detector suppresses scoring entirely — both manufacture phantom
+    // events the score has no trustworthy way to distinguish from real
+    // manoeuvres. Direct speed (`real` OBD2 PID, or null legacy/OBD path)
+    // stays scored.
     _harshDetector.onSample(
       sample.speedKmh,
       sample.timestamp,
       hAccuracyM: sample.hAccuracyM,
-      suppress: distanceSource == kDistanceSourceVirtual,
+      suppress: distanceSource == kDistanceSourceVirtual ||
+          distanceSource == kDistanceSourceGps,
     );
 
     // Track coolant samples for the cold-start surcharge heuristic

--- a/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
+++ b/test/features/consumption/data/analysis/driving_analysis_trace_test.dart
@@ -127,11 +127,70 @@ void main() {
       expect(score['styleClass'], _score.styleClass.name);
       expect(score['hardAccelPenalty'], 6);
       expect(score['hardBrakePenalty'], 4);
+      // #3029 — the score block now exports the counts that DRIVE the
+      // penalties (summary.harshAccelerations/harshBrakes), so a penalty
+      // always has a visible matching count.
+      expect(score['hardAccelCount'], 0);
+      expect(score['hardBrakeCount'], 0);
 
       final lessons = json['lessons'] as List<dynamic>;
       expect(lessons, hasLength(1));
       expect((lessons.first as Map)['id'], 'smoothDriving');
       expect((lessons.first as Map)['polarity'], 'positive');
+    });
+
+    test(
+        '#3029 — the score block\'s harsh counts are the penalty drivers '
+        '(non-zero penalty ⟺ non-zero count)', () {
+      // A real-OBD2-speed trip with genuine harsh events: the exported
+      // score-block counts must match summary.harshAccelerations/harshBrakes
+      // (what the penalty is computed from), NOT the imu.*Count scalars —
+      // so the export is internally consistent (penalty>0 has a count>0).
+      final summary = TripSummary(
+        distanceKm: 20,
+        maxRpm: 3000,
+        highRpmSeconds: 0,
+        idleSeconds: 0,
+        harshBrakes: 2,
+        harshAccelerations: 3,
+        startedAt: DateTime.utc(2026, 6, 3, 10),
+        endedAt: DateTime.utc(2026, 6, 3, 10, 25),
+        distanceSource: 'real',
+        kind: TripKind.gpsPlusObd2,
+        // IMU never ran — its scalars are 0 and would CONTRADICT the
+        // penalty if the export used them as the count.
+        imuActive: false,
+        imuHardAccelCount: 0,
+        imuHardBrakeCount: 0,
+      );
+      const score = DrivingScore(
+        score: 70,
+        idlingPenalty: 0,
+        hardAccelPenalty: 9,
+        hardBrakePenalty: 6,
+        highRpmPenalty: 0,
+        fullThrottlePenalty: 0,
+      );
+      final json = DrivingAnalysisTrace(
+        capturedAt: DateTime.utc(2026, 6, 3, 11),
+        summary: summary,
+        score: score,
+        lessons: const [],
+      ).toJson();
+
+      final scoreBlock = json['score'] as Map<String, dynamic>;
+      final imu = json['imu'] as Map<String, dynamic>;
+      // The penalty drivers are the harsh counts, not the IMU scalars.
+      expect(scoreBlock['hardAccelCount'], 3);
+      expect(scoreBlock['hardBrakeCount'], 2);
+      expect(scoreBlock['hardAccelPenalty'], 9);
+      expect(scoreBlock['hardBrakePenalty'], 6);
+      // The IMU truth block is unchanged (still the inertial scalars).
+      expect(imu['hardAccelCount'], 0);
+      expect(imu['hardBrakeCount'], 0);
+      // Invariant: a non-zero penalty has a non-zero score-block count.
+      expect(scoreBlock['hardAccelCount'], greaterThan(0));
+      expect(scoreBlock['hardBrakeCount'], greaterThan(0));
     });
 
     test('gpsFeatures is null when no GPS KPIs were computed', () {

--- a/test/features/consumption/data/driving_score_calculator_test.dart
+++ b/test/features/consumption/data/driving_score_calculator_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/driving_score_calculator.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_distance_source.dart';
 import 'package:tankstellen/features/consumption/domain/driving_score.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
 
@@ -603,6 +604,96 @@ void main() {
         ),
       );
       expect(s.luggingPenalty, greaterThan(0));
+    });
+  });
+
+  group('#3029 — GPS-sourced harsh penalty has no phantom source', () {
+    // End-to-end: drive the REAL recorder with the kind of noisy GPS
+    // ground-speed stream that over-counted on master, then score the
+    // resulting summary through the SAME summary path the trip-detail
+    // screen uses. The penalty must be 0 (count 0 ⟺ penalty 0), and the
+    // export-visible count (summary.harshBrakes/harshAccelerations) must
+    // agree with it. On master this produced harshBrakes > 0 →
+    // hardBrakePenalty > 0 while imu.hardBrakeCount = 0.
+    const bounce = <double>[45, 60, 45, 30];
+
+    TripSummary recordNoisyGps({required String distanceSource}) {
+      final r = TripRecorder();
+      final start = DateTime.utc(2026);
+      var latched = bounce[0];
+      var stepIdx = 0;
+      var lastStepSec = 0;
+      for (var i = 0; i < 1200; i++) {
+        if (i - lastStepSec >= 6) {
+          stepIdx++;
+          latched = bounce[stepIdx % bounce.length];
+          lastStepSec = i;
+        }
+        r.onSample(
+          TripSample(
+            timestamp: start.add(Duration(seconds: i)),
+            speedKmh: latched,
+            // rpm 0 (GPS-only, no engine signal) so the engine-derived
+            // penalties don't muddy the harsh-penalty assertion.
+            rpm: 0,
+          ),
+          distanceSource: distanceSource,
+        );
+      }
+      return r.buildSummary();
+    }
+
+    test(
+        'gps source: noisy stream → harsh counts 0 → hard-accel/brake '
+        'penalties 0 (phantom eliminated)', () {
+      final s = recordNoisyGps(distanceSource: kDistanceSourceGps);
+      expect(s.distanceKm, greaterThan(10), reason: 'sanity: ~15 km');
+      // The score-driving counts (what the export now surfaces).
+      expect(s.harshBrakes, 0);
+      expect(s.harshAccelerations, 0);
+      final score = computeDrivingScoreFromSummary(s);
+      expect(score.hardBrakePenalty, 0,
+          reason: 'count 0 ⟺ penalty 0 — no phantom (#3029)');
+      expect(score.hardAccelPenalty, 0,
+          reason: 'count 0 ⟺ penalty 0 — no phantom (#3029)');
+    });
+
+    test(
+        'real OBD2-speed source: a genuine hard brake still penalises '
+        '(#3029 did not kill direct-speed scoring)', () {
+      // Direct OBD2 speed PID: a single clean 90→30 km/h decel must still
+      // count and penalise — proves the fix is scoped to derived speed.
+      final r = TripRecorder();
+      final start = DateTime.utc(2026);
+      r.onSample(
+        TripSample(timestamp: start, speedKmh: 90, rpm: 3000),
+        distanceSource: kDistanceSourceReal,
+      );
+      r.onSample(
+        TripSample(
+          timestamp: start.add(const Duration(seconds: 2)),
+          speedKmh: 30,
+          rpm: 1500,
+        ),
+        distanceSource: kDistanceSourceReal,
+      );
+      // Pad with steady cruise so durationSec is well over the 1-min floor.
+      for (var i = 1; i <= 120; i++) {
+        r.onSample(
+          TripSample(
+            timestamp: start.add(Duration(seconds: 2 + i)),
+            speedKmh: 50,
+            rpm: 2000,
+          ),
+          distanceSource: kDistanceSourceReal,
+        );
+      }
+      final s = r.buildSummary();
+      expect(s.harshBrakes, greaterThan(0),
+          reason: 'direct OBD2 speed stays scored');
+      final score = computeDrivingScoreFromSummary(s);
+      expect(score.hardBrakePenalty, greaterThan(0),
+          reason: 'count > 0 ⟺ penalty > 0 on the real-speed path');
     });
   });
 

--- a/test/features/consumption/data/obd2/degraded_gps_emitter_harsh_source_test.dart
+++ b/test/features/consumption/data/obd2/degraded_gps_emitter_harsh_source_test.dart
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/degraded_gps_emitter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_live_reading.dart';
+import 'package:tankstellen/features/consumption/data/obd2/trip_sample_buffer.dart';
+import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
+
+/// #3029 — the `degradedGpsOnly` emit tick (OBD2 dropped mid-trip, GPS
+/// alive) must feed its GPS samples to the recorder tagged
+/// `distanceSource: kDistanceSourceGps`, so the recorder suppresses harsh
+/// scoring on the noisy ~1 Hz Doppler ground speed. Before #3029 the
+/// emitter called `recorder.onSample(sample)` with no source, leaving the
+/// GPS-noise harsh detector ungated → phantom hard-accel/brake penalties
+/// with no visible IMU source.
+///
+/// Asserted by OBSERVABLE behaviour (not a mock spy on the arg): drive the
+/// emitter with a real [TripRecorder] over a noisy GPS speed stream that
+/// over-counted on master, then assert the recorder's harsh counts are 0.
+/// A missing/`real`/null source would leave them > 0.
+void main() {
+  group('DegradedGpsEmitter harsh-source tagging (#3029)', () {
+    // A noisy ground-speed staircase: the kind of GPS Doppler bounce the
+    // field report differentiated into impossible >1 g harsh events.
+    const bounce = <double>[45, 60, 45, 30];
+
+    DegradedGpsEmitter buildEmitter(
+      TripRecorder recorder,
+      DateTime Function() now,
+    ) {
+      return DegradedGpsEmitter(
+        now: now,
+        recorder: recorder,
+        sampleBuffer: TripSampleBuffer(),
+        gpsAliveWindow: const Duration(seconds: 30),
+        onEscalate: () {},
+        onSampleAt: (_) {},
+        // Identity overlay — the test only cares about what reaches the
+        // recorder, not the live-reading shaping.
+        overlayEstimate: (reading, {
+          required nowTs,
+          required effectiveSpeedKmh,
+          required altitudeM,
+        }) =>
+            reading,
+      );
+    }
+
+    test(
+        'noisy GPS stream through the degraded emitter → recorder harsh '
+        'counts 0 (source tagged gps → suppressed)', () {
+      final recorder = TripRecorder();
+      final start = DateTime.utc(2026);
+      var clock = start;
+      final emitter = buildEmitter(recorder, () => clock);
+
+      var latched = bounce[0];
+      var stepIdx = 0;
+      var lastStepSec = 0;
+      for (var i = 0; i < 1200; i++) {
+        clock = start.add(Duration(seconds: i));
+        if (i - lastStepSec >= 6) {
+          stepIdx++;
+          latched = bounce[stepIdx % bounce.length];
+          lastStepSec = i;
+        }
+        emitter.emitTick(
+          latestGpsSpeedKmh: latched,
+          latitude: 48.0,
+          longitude: 2.0,
+          altitudeM: 100,
+          hAccuracyM: 5,
+          bearingDeg: 90,
+          // Keep GPS "alive" so the tick records instead of escalating.
+          lastGpsFixAt: clock,
+          startedAt: start,
+          resolverDistanceKm: 0,
+          odometerStartKm: null,
+          odometerLatestKm: null,
+        );
+      }
+
+      final summary = recorder.buildSummary();
+      expect(summary.distanceKm, greaterThan(10), reason: 'sanity: ~15 km');
+      expect(summary.harshBrakes, 0,
+          reason: 'degraded GPS feed must be tagged gps → suppressed (#3029)');
+      expect(summary.harshAccelerations, 0,
+          reason: 'degraded GPS feed must be tagged gps → suppressed (#3029)');
+    });
+
+    test('emitTick returns a live reading on a fresh GPS fix (no throw)', () {
+      // Smoke: the tagged onSample call still flows through to a published
+      // reading — proves the source-tagging change did not break the tick.
+      final recorder = TripRecorder();
+      final start = DateTime.utc(2026);
+      final emitter = buildEmitter(recorder, () => start);
+      final TripLiveReading? reading = emitter.emitTick(
+        latestGpsSpeedKmh: 50,
+        latitude: 48.0,
+        longitude: 2.0,
+        altitudeM: 100,
+        hAccuracyM: 5,
+        bearingDeg: 90,
+        lastGpsFixAt: start,
+        startedAt: start,
+        resolverDistanceKm: 0,
+        odometerStartKm: null,
+        odometerLatestKm: null,
+      );
+      expect(reading, isNotNull);
+    });
+  });
+}

--- a/test/features/consumption/domain/trip_recorder_test.dart
+++ b/test/features/consumption/domain/trip_recorder_test.dart
@@ -672,13 +672,20 @@ void main() {
       });
 
       test(
-          'GPS source: the SAME staircase is gated, not suppressed, and '
-          'a genuine GPS-fed signal still scores', () {
-        // The 6 s-step staircase is an artefact of a coarse virtual
-        // odometer; a real GPS Doppler signal does not look like this.
-        // We still assert the gps path is NOT wholesale-suppressed by
-        // feeding a genuine, well-spaced hard brake on the gps source
-        // and confirming it counts.
+          'GPS source: even a clean, well-spaced hard brake is suppressed '
+          '(#3029 — GPS Doppler speed is unfit for harsh differentiation)',
+          () {
+        // #3029 supersedes the #2653 "enabled-but-gated" policy: GPS
+        // ground speed is ~1 Hz Doppler noise, and #2895 proved a live IMU
+        // counts 0 where the GPS derivative counts 16 phantom events at an
+        // impossible 1.086 g. A GPS-sourced trip with no IMU (no inertial
+        // hardware / OBD2-from-the-start, no speed PID) has nothing to veto
+        // that over-count, so the score showed a hard-accel/brake penalty
+        // with no visible source. Harsh events may now come ONLY from a
+        // trustworthy source (live IMU, or a real OBD2 speed PID), so the
+        // recorder suppresses the GPS source wholesale — exactly as it does
+        // the `virtual` source. Even a clean, accuracy-good, well-spaced
+        // 90→30 km/h brake on the gps source must NOT score.
         final r = TripRecorder();
         final start = DateTime.utc(2026);
         r.onSample(
@@ -694,28 +701,53 @@ void main() {
           ),
           distanceSource: kDistanceSourceGps,
         );
-        expect(r.buildSummary().harshBrakes, 1,
-            reason: 'gps source must stay enabled-but-gated');
+        expect(r.buildSummary().harshBrakes, 0,
+            reason: 'gps source is suppressed wholesale (#3029)');
+        expect(r.buildSummary().harshAccelerations, 0,
+            reason: 'gps source is suppressed wholesale (#3029)');
       });
 
-      test('a bad-accuracy GPS fix (> 10 m) is rejected end-to-end', () {
+      test(
+          'GPS phantom regression (#3029): a noisy GPS staircase that '
+          'over-counted on master yields 0 harsh — penalty has no phantom '
+          'source', () {
+        // The exact #3029 field shape: distanceSource=gps, no IMU, a noisy
+        // ground-speed staircase the old code differentiated into harsh
+        // events. After the fix the count — and hence the
+        // hardBrake/hardAccel penalty derived from it — is 0.
+        final r = TripRecorder();
+        feedBounce(r, distanceSource: kDistanceSourceGps);
+        final s = r.buildSummary();
+        expect(s.distanceKm, greaterThan(10), reason: 'sanity: ~15 km');
+        expect(s.harshBrakes, 0,
+            reason: 'GPS-derived harsh scoring is suppressed (#3029)');
+        expect(s.harshAccelerations, 0,
+            reason: 'GPS-derived harsh scoring is suppressed (#3029)');
+      });
+
+      test(
+          'REAL OBD2-speed source keeps a genuine hard brake (#3029 did not '
+          'kill direct-speed scoring)', () {
+        // Proves the fix is source-scoped: kDistanceSourceReal is the
+        // direct OBD2 speed PID — a genuine 90→30 km/h decel must STILL
+        // score, unchanged. This is the no-regression guard for the real
+        // OBD2-speed path.
         final r = TripRecorder();
         final start = DateTime.utc(2026);
         r.onSample(
-          TripSample(timestamp: start, speedKmh: 90, rpm: 0, hAccuracyM: 4),
-          distanceSource: kDistanceSourceGps,
+          TripSample(timestamp: start, speedKmh: 90, rpm: 3000),
+          distanceSource: kDistanceSourceReal,
         );
         r.onSample(
           TripSample(
             timestamp: start.add(const Duration(seconds: 2)),
             speedKmh: 30,
-            rpm: 0,
-            hAccuracyM: 30, // jittery urban-canyon fix
+            rpm: 1500,
           ),
-          distanceSource: kDistanceSourceGps,
+          distanceSource: kDistanceSourceReal,
         );
-        expect(r.buildSummary().harshBrakes, 0,
-            reason: 'a bad fix is worse than no fix — not differentiated');
+        expect(r.buildSummary().harshBrakes, 1,
+            reason: 'real OBD2 speed is direct, not derived — stays scored');
       });
 
       test('no distanceSource keeps harsh scoring enabled (legacy default)',

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -358,7 +358,12 @@ void main() {
     // matching production `updateGpsFix`) so a test can drive the new ~1 Hz
     // GPS-track decimation deterministically. Test-only surface; decomposition
     // stays tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1707,
+    // #3029 — re-grandfathered 1707 → 1717: a 9-line parity-rationale comment
+    // at `_finaliseSummary` documenting why this OBD2 path (no IMU detector)
+    // is already correct after the recorder suppresses GPS-derived harsh
+    // scoring — i.e. why no #2895 IMU-veto wiring is needed here. Doc-only;
+    // decomposition stays tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/trip_recording_controller.dart': 1717,
     // #2798 — grandfathered at 408 (8 over): the pump path now retries OCR
     // with a contrast-stretched GRAYSCALE pass when the #2275 binarized pass
     // recovers nothing (the binarization erased faint 7-seg value digits). The


### PR DESCRIPTION
## Root cause

3 recent `gpsPlusObd2` field trips — all `imu.active=false`, all `distanceSource=gps` (no OBD2 speed PID) — reported `hardBrakePenalty`/`hardAccelPenalty` of 3–9 while the exported `imu.hardBrakeCount`/`hardAccelCount` were 0. A penalty with no visible source, which reads as a bug.

- The penalty is driven by `summary.harshBrakes`/`harshAccelerations` (`driving_score_calculator.dart`), **not** the exported `imu.*Count` scalars (`driving_analysis_trace.dart` exports the IMU truth).
- On a GPS-sourced trip those harsh counts come from the recorder's **GPS-speed-derivative** detector. #2895 proved GPS Doppler speed is too noisy for this (Peugeot 107: IMU 0 vs GPS 16 phantom events at an impossible 1.086 g) and made a live IMU **veto** the GPS over-count — but a trip with **no IMU** has nothing to veto it, so the clamped-GPS count still drives the score.
- `degraded_gps_emitter.dart:103` fed GPS samples via `onSample(sample)` with **no** `distanceSource`, and `trip_recorder.dart`'s gate only suppressed `kDistanceSourceVirtual` (not `gps`), so GPS-noise harsh events were scored ungated.

## Fix — complete #2895's logic: harsh scoring may come ONLY from a trustworthy source (live IMU, or a real OBD2 speed PID), never GPS-derived speed

1. **`trip_recorder.dart`** — the `onSample` harsh-suppress gate now suppresses `kDistanceSourceGps` as well as `kDistanceSourceVirtual` (both are *derived* speed). `kDistanceSourceReal` (direct OBD2 PID) and `null` stay scored. The live OBD2 `_emit` already threads the live `distanceSource`, so a no-speed-PID `gpsPlusObd2` trip is fixed there too. Doc comment updated to cite the #2895 evidence + #3029.
2. **`degraded_gps_emitter.dart`** — the degraded GPS feed now passes `distanceSource: kDistanceSourceGps` so the gate fires.
3. **`trip_recording_controller._finaliseSummary`** — parity documented: this OBD2 path runs **no** IMU detector, so the #2895 `imuActive ? imuCount : recorder` veto collapses to the recorder value, which is now correctly suppressed for the `gps`/`virtual` source. No veto wiring needed (no IMU to veto with). The GPS-only pipeline already applies the full veto and is unchanged.
4. **`driving_analysis_trace.dart`** — the `score` block now exports the penalty-driving counts (`hardAccelCount`/`hardBrakeCount` = `summary.harshAccelerations`/`harshBrakes`), so a non-zero penalty always has a visible matching count. The `imu.*Count` truth block is unchanged.

## Result

- GPS-only / degraded-GPS / no-speed-PID trips with IMU off → harsh counts 0 → hard-accel/brake penalties 0 (no phantom); export internally consistent (count 0 ⟺ penalty 0).
- IMU-active trips (any path) → harsh from IMU (the #2895 veto), unchanged.
- Real OBD2-speed trips (`distanceSource=real`) → harsh from OBD2 speed, unchanged.

`combustionHealth` is out of scope (already fixed in #3007).

## Test evidence (drive the REAL recorder/scorer)

- `trip_recorder_test.dart`: GPS source now suppressed wholesale (even a clean well-spaced brake → 0); the noisy-GPS staircase regression → 0; **REAL OBD2-speed source keeps a genuine hard brake** (no-regression).
- `driving_score_calculator_test.dart` (#3029 group): real recorder fed a noisy GPS stream → `summary.harsh* == 0` → `hardBrake/hardAccelPenalty == 0` (phantom→0); a real OBD2-speed decel → penalty > 0 (real-speed preserved).
- `degraded_gps_emitter_harsh_source_test.dart` (new): the degraded emitter feeds a noisy GPS stream into a real recorder → harsh counts 0 (source tagged `gps`).
- `driving_analysis_trace_test.dart`: score-block `hardAccelCount`/`hardBrakeCount` are the penalty drivers (non-zero penalty ⟺ non-zero count); IMU truth block unchanged.
- Full `test/features/consumption` + `test/lint` suite green (4525 pass, 7 skip). The `gps_only_imu_fusion` #2895 IMU-zero-veto test still holds.

No codegen / ARB / freezed changes (TripSummary is hand-written; only existing fields read). `flutter analyze --no-fatal-infos` exits 0.

Closes #3029
