### PR TITLE
fix(hooks): align pre-push analyze with CI (--no-fatal-infos) + drop 2 unused imports

### DIFF
--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -141,9 +141,14 @@ if ! git diff --exit-code -- lib/l10n/; then
 fi
 
 # --- 4. Static analysis --------------------------------------------------
-echo "pre-push [4/5]: flutter analyze..."
-if ! flutter analyze; then
-  fail "flutter analyze reported issues" "Fix the analyzer output above."
+# Match CI exactly: CI runs `flutter analyze --no-fatal-infos`, so info-level
+# lints (e.g. a stray unnecessary_import) are NON-fatal there. A bare
+# `flutter analyze` here is fatal on infos, so a pre-existing info anywhere in
+# the tree blocked EVERY push's gate and forced SKIP_PREPUSH (#3031). Stay
+# fatal on warnings + errors (what CI fails on); let infos through.
+echo "pre-push [4/5]: flutter analyze (--no-fatal-infos, matching CI)..."
+if ! flutter analyze --no-fatal-infos; then
+  fail "flutter analyze reported warnings/errors" "Fix the analyzer output above."
 fi
 
 # --- 5. Lint + l10n contract tests (cheap, network-free) -----------------

--- a/test/features/consumption/domain/accel_event_reconciliation_test.dart
+++ b/test/features/consumption/domain/accel_event_reconciliation_test.dart
@@ -3,7 +3,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/driving_insights_analyzer.dart';
-import 'package:tankstellen/features/consumption/data/driving_score_calculator.dart';
 import 'package:tankstellen/features/consumption/domain/accel_event_gate.dart';
 import 'package:tankstellen/features/consumption/domain/gps_driving_features.dart';
 import 'package:tankstellen/features/consumption/domain/harsh_event_detector.dart';

--- a/test/features/consumption/domain/trip_kind_from_samples_test.dart
+++ b/test/features/consumption/domain/trip_kind_from_samples_test.dart
@@ -3,7 +3,6 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/domain/trip_recorder.dart';
-import 'package:tankstellen/features/consumption/domain/trip_summary.dart';
 
 // #2692 C4-G — GPS-only samples now carry rpm null (no engine signal),
 // formerly the `rpm: 0` placeholder. `TripKind.fromSamples` maps null → 0


### PR DESCRIPTION
Follow-up to #3027/#3028 — completes the pre-push gate restoration.

## Problem
The GIT_DIR fix (#3028) made the hook *run* again, but it stayed bypassed: the hook ran bare `flutter analyze` (fatal on info-level lints) while CI runs `flutter analyze --no-fatal-infos`. Two pre-existing `unnecessary_import` infos on master blocked **every** branch's hook → forced SKIP_PREPUSH → defeated the local codegen/l10n drift gate.

## Fix
1. Hook runs `flutter analyze --no-fatal-infos` (still fatal on warnings/errors — exactly CI's policy).
2. Remove the 2 flagged unnecessary imports so the tree is info-clean.

## Validation
This very branch was pushed **with the fixed hook and no SKIP_PREPUSH** — the full local gate (clean-codegen → codegen-drift → l10n fan-out → analyze → lint/l10n tests) passed end-to-end ("pre-push: all local gates passed"). The gate is restored; agents no longer need SKIP_PREPUSH.

Closes #3031