### PR TITLE
fix(inline-map): honour route mode in the split-screen map (#3033)

### DIFF
--- a/lib/features/map/presentation/widgets/inline_map.dart
+++ b/lib/features/map/presentation/widgets/inline_map.dart
@@ -7,11 +7,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../../core/widgets/empty_state.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../route_search/data/cross_border_corridor.dart'
+    show fuelForStation;
+import '../../../route_search/providers/route_search_provider.dart';
 import '../../../search/domain/entities/fuel_type.dart';
+import '../../../search/domain/entities/search_mode.dart';
 import '../../../search/domain/entities/search_result_item.dart';
 import '../../../search/domain/entities/station.dart';
 import '../../../search/presentation/widgets/sort_selector.dart';
 import '../../../search/providers/radar_search_provider.dart';
+import '../../../search/providers/search_mode_provider.dart';
 import '../../../search/providers/search_provider.dart';
 import '../../../search/providers/search_screen_ui_provider.dart';
 import '../../../search/providers/selected_station_provider.dart';
@@ -28,6 +33,15 @@ import 'station_map_layers.dart';
 /// (tap a marker -> select the row; the selected row's marker is emphasised).
 /// When the radar is idle it falls back to the regular `searchStateProvider`
 /// results — also clustered now, so the split pane never overlaps either.
+///
+/// #3033 — when the active search mode is [SearchMode.route] the map takes a
+/// dedicated route branch BEFORE the radar/search checks: it renders the
+/// along-route fuel stations from `routeSearchStateProvider` (proximity-
+/// clustered) plus the route polyline, framed to the result bounds — mirroring
+/// the list's `RouteResultsView` early-return so the split pane no longer shows
+/// the stale nearby set with no route line. The route chrome (All/Best toggle,
+/// best-stops list, info bar) stays in the left pane; this map renders only the
+/// map.
 class InlineMap extends ConsumerStatefulWidget {
   const InlineMap({super.key});
 
@@ -55,6 +69,32 @@ class _InlineMapState extends ConsumerState<InlineMap> {
     final selectedFuel = ref.watch(selectedFuelTypeProvider);
     final searchRadius = ref.watch(searchRadiusProvider);
     final sortMode = ref.watch(selectedSortModeProvider);
+
+    // #3033 — route mode OWNS the split map BEFORE the radar/search checks
+    // (mirrors `SearchResultsContent`'s `RouteResultsView` early-return). The
+    // route's along-route stations + polyline come from
+    // `routeSearchStateProvider`; without this branch the pane fell through to
+    // the stale `searchStateProvider` nearby set and never drew the route line.
+    final searchMode = ref.watch(activeSearchModeProvider);
+    if (searchMode == SearchMode.route) {
+      final routeState = ref.watch(routeSearchStateProvider);
+      return routeState.when(
+        data: (result) {
+          final stations = _routeFuelStations(result);
+          final hasGeometry = result?.route.geometry.isNotEmpty ?? false;
+          if (result == null || (stations.isEmpty && !hasGeometry)) {
+            return EmptyState(
+              icon: Icons.route,
+              title: AppLocalizations.of(context)?.noStationsAlongRoute ??
+                  'No stations found along route',
+            );
+          }
+          return _buildRouteMap(context, result, stations, selectedFuel);
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => _mapUnavailable(context),
+      );
+    }
 
     // #2939 — the on-search radar OWNS the split map when active (mirrors the
     // results-list early-return in SearchResultsContent). Its stations are
@@ -130,6 +170,50 @@ class _InlineMapState extends ConsumerState<InlineMap> {
     );
   }
 
+  /// #3033 — render JUST the route map for the split pane: the along-route fuel
+  /// [stations] (proximity-clustered) + the route polyline, framed to the
+  /// along-route STATION bounds (mirrors `RouteMapView`, but without its
+  /// All/Best toggle, best-stops list and info bar — those belong to the left
+  /// pane). Each station prices by ITS country's profile fuel so a cross-border
+  /// stop shows a real price instead of '--' (#2631).
+  Widget _buildRouteMap(
+    BuildContext context,
+    RouteSearchResult result,
+    List<Station> stations,
+    FuelType selectedFuel,
+  ) {
+    // #2782 — frame the along-route STATION bounds (the results), not the full
+    // cross-border polyline, so the camera fits what was found. Falls back to
+    // the route geometry, then a default box, when there are no stations.
+    final bounds = _routeBoundsOf(stations, result.route.geometry);
+    final center = bounds.center;
+
+    final selectedId = ref.watch(selectedStationProvider);
+
+    return StationMapLayers(
+      mapController: _mapController,
+      stations: stations,
+      center: center,
+      // Pre-layout fallback only; `cameraFitBounds` drives the first paint.
+      zoom: 6.0,
+      searchRadiusKm: 5,
+      selectedFuel: selectedFuel,
+      cameraFitBounds: bounds,
+      routePolyline: result.route.geometry,
+      showSearchRadius: false,
+      // Plain proximity clustering for the route overview — NOT
+      // `excludeSelectedFromClustering` (with an empty selection that collapses
+      // every station into one cheapest-labelled badge; the dedicated-map
+      // All-Stations bug).
+      clusterAlways: true,
+      fuelResolver: (s) =>
+          fuelForStation(s, result.profileFuelByCountry, selectedFuel),
+      selectedStationIds: selectedId != null ? {selectedId} : null,
+      onStationTap: (id) =>
+          ref.read(selectedStationProvider.notifier).select(id),
+    );
+  }
+
   Widget _mapUnavailable(BuildContext context) => Center(
         child: Text(
           AppLocalizations.of(context)?.mapUnavailable ?? 'Map unavailable',
@@ -139,11 +223,39 @@ class _InlineMapState extends ConsumerState<InlineMap> {
         ),
       );
 
+  /// The along-route fuel stations of [result] (drops EV/other result kinds),
+  /// or `const []` when there is no result yet.
+  static List<Station> _routeFuelStations(RouteSearchResult? result) =>
+      result == null
+          ? const []
+          : result.stations
+              .whereType<FuelStationResult>()
+              .map((r) => r.station)
+              .toList();
+
   /// The [LatLngBounds] of the result [stations], with a tiny epsilon box for
   /// a single result so `CameraFit.bounds` cannot divide-by-zero (mirrors
   /// `RouteMapView._computeRouteBounds`).
-  static LatLngBounds _boundsOf(List<Station> stations) {
-    final points = [for (final s in stations) LatLng(s.lat, s.lng)];
+  static LatLngBounds _boundsOf(List<Station> stations) =>
+      _boundsOfPoints([for (final s in stations) LatLng(s.lat, s.lng)]);
+
+  /// #3033 — the camera bounds for the route map: the along-route STATION
+  /// extent, falling back to the route [geometry] (so an empty route still
+  /// frames its line), then a default box. Mirrors
+  /// `RouteMapView._computeRouteBounds`.
+  static LatLngBounds _routeBoundsOf(
+    List<Station> stations,
+    List<LatLng> geometry,
+  ) {
+    final points = <LatLng>[for (final s in stations) LatLng(s.lat, s.lng)];
+    if (points.isEmpty) points.addAll(geometry);
+    if (points.isEmpty) points.add(const LatLng(48.8566, 2.3522)); // Paris.
+    return _boundsOfPoints(points);
+  }
+
+  /// Bounds over [points], with a tiny epsilon box for a single point so
+  /// `CameraFit.bounds` cannot divide-by-zero. Assumes [points] is non-empty.
+  static LatLngBounds _boundsOfPoints(List<LatLng> points) {
     if (points.length == 1) {
       final p = points.first;
       const eps = 0.0005; // ~50 m; fine for any latitude.

--- a/test/features/map/presentation/widgets/inline_map_route_test.dart
+++ b/test/features/map/presentation/widgets/inline_map_route_test.dart
@@ -1,0 +1,347 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:tankstellen/core/services/service_result.dart';
+import 'package:tankstellen/core/widgets/empty_state.dart';
+import 'package:tankstellen/features/map/presentation/widgets/inline_map.dart';
+import 'package:tankstellen/features/map/presentation/widgets/station_map_layers.dart';
+import 'package:tankstellen/features/route_search/domain/entities/route_info.dart';
+import 'package:tankstellen/features/route_search/providers/route_search_provider.dart';
+import 'package:tankstellen/features/search/domain/entities/search_mode.dart';
+import 'package:tankstellen/features/search/domain/entities/search_result_item.dart';
+import 'package:tankstellen/features/search/domain/entities/station.dart';
+import 'package:tankstellen/features/search/providers/radar_search_provider.dart';
+import 'package:tankstellen/features/search/providers/search_mode_provider.dart';
+import 'package:tankstellen/features/search/providers/search_provider.dart';
+import 'package:tankstellen/features/search/providers/selected_station_provider.dart';
+
+import '../../../../helpers/mock_providers.dart';
+import '../../../../helpers/pump_app.dart';
+
+/// #3033 — the landscape split map must honour ROUTE mode (mirroring the
+/// list's `RouteResultsView` early-return). RED-before: `InlineMap` watched
+/// only `radarSearchProvider`/`searchStateProvider`, so a route search showed
+/// the STALE nearby set with NO route polyline. These assertions on the route
+/// data + the polyline would have failed (the map would have rendered the
+/// stale stations instead).
+void main() {
+  Station station(String id, double lat, double lng, {double? e10}) => Station(
+        id: id,
+        name: 'Station $id',
+        brand: 'TEST',
+        street: 'Teststr.',
+        postCode: '00000',
+        place: 'Test',
+        lat: lat,
+        lng: lng,
+        dist: 1,
+        e10: e10,
+        isOpen: true,
+      );
+
+  // Along-route stations spread across the corridor (Berlin -> south-east).
+  final routeStations = [
+    station('rt1', 52.520, 13.405, e10: 1.799),
+    station('rt2', 52.300, 13.600, e10: 1.659),
+    station('rt3', 52.100, 13.900, e10: 1.729),
+  ];
+
+  // A distinct STALE nearby set the map must NOT fall through to in route mode.
+  final staleNearby = [
+    station('stale1', 48.137, 11.575, e10: 1.999), // Munich — far away.
+    station('stale2', 48.140, 11.580, e10: 1.989),
+  ];
+
+  final polyline = <LatLng>[
+    const LatLng(52.520, 13.405),
+    const LatLng(52.300, 13.600),
+    const LatLng(52.100, 13.900),
+  ];
+
+  RouteSearchResult buildResult({
+    required List<Station> stations,
+    List<LatLng>? geometry,
+  }) =>
+      RouteSearchResult(
+        route: RouteInfo(
+          geometry: geometry ?? polyline,
+          distanceKm: 120,
+          durationMinutes: 90,
+          samplePoints: geometry ?? polyline,
+        ),
+        stations: stations.map((s) => FuelStationResult(s)).toList(),
+      );
+
+  Widget host() => const SizedBox(width: 800, height: 600, child: InlineMap());
+
+  /// Route mode active, with a fresh route result AND a deliberately-stale
+  /// nearby search + a (would-be-active) radar to prove route data WINS.
+  List<Object> routeOverrides({
+    required RouteSearchResult? result,
+    String? selected,
+  }) {
+    final test = standardTestOverrides();
+    return [
+      ...test.overrides,
+      activeSearchModeProvider.overrideWith(() => _RouteMode()),
+      routeSearchStateProvider.overrideWith(() => _RouteState(result)),
+      // Stale fall-through guards: if the route branch is missing, the map
+      // would render one of these instead.
+      searchStateProvider.overrideWith(() => _StaleSearch(staleNearby)),
+      radarSearchProvider.overrideWith(() => _ActiveRadar(staleNearby)),
+      if (selected != null)
+        selectedStationProvider.overrideWith(() => _SelectedStub(selected)),
+    ];
+  }
+
+  testWidgets(
+      'route mode renders the along-route fuel stations from '
+      'routeSearchStateProvider (NOT the stale nearby/radar set)',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: routeOverrides(
+        result: buildResult(stations: routeStations),
+      ).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    // The map is fed the ROUTE stations — all of them.
+    expect(
+      layer.stations.map((s) => s.id).toList(),
+      routeStations.map((s) => s.id).toList(),
+    );
+    // ROUTE-DATA-WINS: the stale nearby + radar set must NOT have reached the
+    // map (the bug). None of its ids may appear.
+    final ids = layer.stations.map((s) => s.id).toSet();
+    expect(ids.contains('stale1'), isFalse);
+    expect(ids.contains('stale2'), isFalse);
+    // Proximity clustering for the route overview; radius circle suppressed.
+    expect(layer.clusterAlways, isTrue);
+    expect(layer.excludeSelectedFromClustering, isFalse);
+    expect(layer.showSearchRadius, isFalse);
+  });
+
+  testWidgets('route mode draws the route polyline (route.geometry)',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: routeOverrides(
+        result: buildResult(stations: routeStations),
+      ).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    // The route line is forwarded so a PolylineLayer paints it.
+    expect(layer.routePolyline, isNotNull);
+    expect(layer.routePolyline, equals(polyline));
+  });
+
+  testWidgets(
+      'route mode frames the camera to the along-route STATION bounds (#2782)',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: routeOverrides(
+        result: buildResult(stations: routeStations),
+      ).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    final bounds = layer.cameraFitBounds;
+    expect(bounds, isNotNull);
+    final expected = LatLngBounds.fromPoints(
+        [for (final s in routeStations) LatLng(s.lat, s.lng)]);
+    expect(bounds!.south, closeTo(expected.south, 1e-9));
+    expect(bounds.north, closeTo(expected.north, 1e-9));
+    expect(bounds.west, closeTo(expected.west, 1e-9));
+    expect(bounds.east, closeTo(expected.east, 1e-9));
+  });
+
+  testWidgets('route mode keeps list<->map selection two-way sync',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: routeOverrides(
+        result: buildResult(stations: routeStations),
+        selected: 'rt2',
+      ).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    expect(layer.selectedStationIds, contains('rt2'));
+    expect(layer.onStationTap, isNotNull);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(StationMapLayers)),
+    );
+    layer.onStationTap!('rt1');
+    await tester.pump();
+    expect(container.read(selectedStationProvider), 'rt1');
+    expect(find.byType(StationMapLayers), findsOneWidget);
+  });
+
+  testWidgets(
+      'route mode with an empty result (no stations, no geometry) renders the '
+      'noStationsAlongRoute EmptyState — not a crash, not the stale set',
+      (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: routeOverrides(
+        result: buildResult(stations: const [], geometry: const []),
+      ).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(EmptyState), findsOneWidget);
+    expect(find.text('No stations found along route'), findsOneWidget);
+    expect(find.byType(StationMapLayers), findsNothing);
+  });
+
+  testWidgets(
+      'route mode with a null result (search not yet run) renders the empty '
+      'state, not the stale nearby set', (tester) async {
+    await pumpApp(
+      tester,
+      host(),
+      overrides: routeOverrides(result: null).cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(EmptyState), findsOneWidget);
+    expect(find.byType(StationMapLayers), findsNothing);
+  });
+
+  testWidgets(
+      'regression: NEARBY mode is unaffected — the radar still owns the map',
+      (tester) async {
+    final test = standardTestOverrides();
+    await pumpApp(
+      tester,
+      host(),
+      overrides: [
+        ...test.overrides,
+        // Default search mode is nearby; assert explicitly anyway.
+        activeSearchModeProvider.overrideWith(() => _NearbyMode()),
+        radarSearchProvider.overrideWith(() => _ActiveRadar(staleNearby)),
+      ].cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    // The radar set (here `staleNearby`) is what nearby mode renders — proving
+    // the route branch did NOT hijack the non-route path.
+    expect(
+      layer.stations.map((s) => s.id).toList(),
+      staleNearby.map((s) => s.id).toList(),
+    );
+    // No route polyline in nearby mode.
+    expect(layer.routePolyline, isNull);
+  });
+
+  testWidgets(
+      'regression: plain-search (radar idle) mode still renders via '
+      'searchStateProvider', (tester) async {
+    final test = standardTestOverrides();
+    await pumpApp(
+      tester,
+      host(),
+      overrides: [
+        ...test.overrides,
+        activeSearchModeProvider.overrideWith(() => _NearbyMode()),
+        searchStateProvider.overrideWith(() => _StaleSearch(staleNearby)),
+      ].cast(),
+      settle: false,
+    );
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final layer =
+        tester.widget<StationMapLayers>(find.byType(StationMapLayers));
+    expect(
+      layer.stations.map((s) => s.id).toList(),
+      staleNearby.map((s) => s.id).toList(),
+    );
+    expect(layer.routePolyline, isNull);
+  });
+}
+
+class _RouteMode extends ActiveSearchMode {
+  @override
+  SearchMode build() => SearchMode.route;
+}
+
+class _NearbyMode extends ActiveSearchMode {
+  @override
+  SearchMode build() => SearchMode.nearby;
+}
+
+class _RouteState extends RouteSearchState {
+  _RouteState(this._result);
+  final RouteSearchResult? _result;
+
+  @override
+  AsyncValue<RouteSearchResult?> build() => AsyncValue.data(_result);
+}
+
+/// A plain search result holding a DELIBERATELY-STALE nearby set, so a missing
+/// route branch would surface these ids (the bug).
+class _StaleSearch extends SearchState {
+  _StaleSearch(this._stations);
+  final List<Station> _stations;
+
+  @override
+  AsyncValue<ServiceResult<List<SearchResultItem>>> build() => AsyncValue.data(
+        ServiceResult(
+          data: _stations
+              .map((s) => FuelStationResult(s) as SearchResultItem)
+              .toList(),
+          source: ServiceSource.cache,
+          fetchedAt: DateTime.now(),
+        ),
+      );
+}
+
+class _ActiveRadar extends RadarSearch {
+  _ActiveRadar(this._stations);
+  final List<Station> _stations;
+
+  @override
+  RadarSearchState build() => RadarSearchState(
+        active: true,
+        stations: AsyncData<List<Station>>(_stations),
+      );
+}
+
+class _SelectedStub extends SelectedStation {
+  _SelectedStub(this._id);
+  final String _id;
+
+  @override
+  String? build() => _id;
+}


### PR DESCRIPTION
## Root cause

The landscape split-screen detail pane is hard-wired to `const InlineMap()`
(`search_screen.dart` `detailPlaceholder`). `InlineMap.build()` watched only
`radarSearchProvider` then fell back to `searchStateProvider` — there was **no
route-mode branch**. For a ROUTE search, `searchStateProvider` still held the
previous NEARBY result, so the split map rendered the wrong (stale) stations
and never drew the route polyline (the user's clustered "0.795 ×6" overlap with
no route line).

The LIST already early-returns `RouteResultsView` in route mode
(`search_results_content.dart`, gated on `activeSearchModeProvider == SearchMode.route`).
The MAP pane had no equivalent — this adds it.

## The fix

Add a route-mode branch at the **top** of `InlineMap.build()`, before the
radar/search checks:

```dart
final searchMode = ref.watch(activeSearchModeProvider);
if (searchMode == SearchMode.route) {
  final routeState = ref.watch(routeSearchStateProvider);
  return routeState.when(
    data: (result) {
      final stations = _routeFuelStations(result);
      final hasGeometry = result?.route.geometry.isNotEmpty ?? false;
      if (result == null || (stations.isEmpty && !hasGeometry)) {
        return EmptyState(icon: Icons.route,
            title: ...noStationsAlongRoute...);
      }
      return _buildRouteMap(context, result, stations, selectedFuel);
    },
    loading: () => const Center(child: CircularProgressIndicator()),
    error: (_, _) => _mapUnavailable(context),
  );
}
```

`_buildRouteMap` renders **only the map** (the All/Best toggle, best-stops list
and info bar stay in the left pane — not duplicated here):

- `stations`: `result.stations.whereType<FuelStationResult>().map((r)=>r.station)`
- `routePolyline: result.route.geometry`
- `cameraFitBounds`: the along-route **STATION** bounds (#2782 — frame the
  results, not the full cross-border polyline), falling back to the route
  geometry, then a default box, when there are no stations.
- `clusterAlways: true` (plain proximity clustering — **not**
  `excludeSelectedFromClustering`, which with an empty selection collapses every
  station into one cheapest-labelled badge).
- `fuelResolver: (s) => fuelForStation(s, result.profileFuelByCountry, selectedFuel)`
  so a cross-border stop prices by its own country's profile fuel (#2631).
- `showSearchRadius: false`; list↔map selection sync preserved
  (`selectedStationProvider`).

The radar + plain-search branches and `_buildMap` are unchanged.

### Bounds helper

Extracted a shared `_boundsOfPoints` (single-point epsilon box guard). The
existing `_boundsOf(stations)` now delegates to it (non-route path unchanged);
the new `_routeBoundsOf(stations, geometry)` mirrors
`RouteMapView._computeRouteBounds` (stations → geometry → default box).

## Before / after

- **Before:** route search in the landscape pane → stale nearby stations, no
  route line.
- **After:** along-route fuel stations (proximity-clustered) + the route
  polyline, camera framed to the route results — matching `RouteMapView` on the
  Map tab. Non-route (radar / nearby) unchanged.

## Tests

New `test/features/map/presentation/widgets/inline_map_route_test.dart` (6 tests),
each overriding `searchStateProvider` **and** `radarSearchProvider` with a
distinct STALE set to prove **route data wins**:

- *route mode renders along-route stations (NOT the stale nearby/radar set)* —
  asserts the route ids render and the stale ids do **not**.
- *route mode draws the route polyline (route.geometry)*.
- *route mode frames the camera to the along-route STATION bounds (#2782)*.
- *route mode keeps list↔map selection two-way sync*.
- *empty result → noStationsAlongRoute EmptyState, not a crash / not the stale set*.
- *null result → empty state, not the stale set*.
- 2 regression guards: NEARBY (radar) + plain-search modes still render via the
  existing path with no route polyline.

RED-before verified: with the source change stashed, 5 of 6 route tests fail
(stale set wins / no polyline / no empty state); after the fix all pass. Full
`flutter test test/features/map/` (208) + `test/features/search/presentation/`
(370) green. `flutter analyze` clean.

No new ARB keys (reused `noStationsAlongRoute`, `searchToSeeMap`,
`mapUnavailable`); no codegen.

## Residual risk / follow-up

The route map shows the full **All-Stations** set; it does **not** reflect the
left list's All/Best toggle (`RouteMapView`'s `RouteViewMode`). That toggle
lives in the left pane and is not piped to the split map — a possible follow-up
(surface the route view mode to `InlineMap`), out of scope here.

Closes #3033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
