### PR TITLE
fix(obd2): robust 0100 protocol detection — stop false engine-off + reconnect loop

### DIFF
--- a/lib/features/consumption/data/obd2/obd2_connection_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_connection_service.dart
@@ -344,29 +344,38 @@ class Obd2ConnectionService {
       await service.disconnect();
       throw const Obd2AdapterUnresponsive();
     }
-    // #3009 — init SUCCEEDED (every AT answered) but the vehicle bus may be
-    // SILENT (parked car / ignition off): no protocol cached + zero supported
-    // PIDs because `0100` came back ECU-silent. That is engine-off, not a
-    // telemetry-bearing success — stamp `ignitionOff` (first-wins) so the trace
-    // reads "engine off", not a misleading green "success". The connect still
-    // returns the service (the caller gates on [busAnswered] for the banner);
-    // we only correct the CLASSIFICATION here, never the working connect path.
-    if (!service.busAnswered) {
+    // #3009/#3035 — init SUCCEEDED (every AT answered) but the vehicle bus
+    // may be SILENT. CRITICAL distinction (#3035): the `0100` probe is now
+    // tri-state ([Obd2Service.busProbe]). Stamp `ignitionOff` ONLY on
+    // [Obd2BusProbeResult.probedSilent] — the ECU stayed silent through every
+    // retry, the real engine-off signature. A [Obd2BusProbeResult.transient]
+    // (the first `0100` merely TIMED OUT during the protocol search on a slow
+    // clone) must NOT be classified engine-off — that was the false positive
+    // that told a live car "turn the ignition on" and spun reconnects. The
+    // connect still returns the service either way (first-wins on the trace);
+    // we only correct the CLASSIFICATION, never the working connect path.
+    if (service.busProbe == Obd2BusProbeResult.probedSilent) {
       Obd2ConnectTraceLog.active?.setOutcome(Obd2ConnectOutcome.ignitionOff);
     }
-    // #3019 / Epic #3013 phase 3 — auto-pin the last-good adapter on EVERY
-    // successful connect (this is the single chokepoint every connect path
-    // funnels through). The trip-INDEPENDENT reconnect controller reads this
-    // to try the fast pinned path first on the next drop. Best-effort +
-    // local-only (the store swallows + logs a write failure), so it never
-    // derails a connect that just succeeded. Pinned even when the bus was
-    // silent — the HARDWARE link is good; that is exactly what reconnect
-    // wants to re-establish.
-    await lastGoodAdapterStore?.recordFrom(
-      mac: service.adapterMac,
-      transportKind: service.linkKind,
-      name: service.adapterName,
-    );
+    // #3019 / Epic #3013 phase 3 — auto-pin the last-good adapter so the
+    // trip-INDEPENDENT reconnect controller can try the fast pinned path on
+    // the next drop. #3035 — but do NOT pin on a confirmed engine-off
+    // (`probedSilent`): pinning a silent-bus connect is exactly what fed the
+    // teardown→reconnect→engine-off loop. The HARDWARE link is good on a
+    // [Obd2BusProbeResult.answered] OR [Obd2BusProbeResult.transient] connect
+    // (a slow-but-live car) and on a warm cache-hit (`busAnswered`), so pin in
+    // those cases. Best-effort + local-only (the store swallows + logs a write
+    // failure), so it never derails a connect that just succeeded.
+    final pinnable = service.busProbe != Obd2BusProbeResult.probedSilent &&
+        (service.busAnswered ||
+            service.busProbe == Obd2BusProbeResult.transient);
+    if (pinnable) {
+      await lastGoodAdapterStore?.recordFrom(
+        mac: service.adapterMac,
+        transportKind: service.linkKind,
+        name: service.adapterName,
+      );
+    }
     return service;
   }
 

--- a/lib/features/consumption/data/obd2/obd2_reconnect_controller.dart
+++ b/lib/features/consumption/data/obd2/obd2_reconnect_controller.dart
@@ -29,14 +29,29 @@ enum Obd2ReconnectState {
   /// The bounded attempts were exhausted. The auto-loop has STOPPED; the
   /// UI shows a "tap to retry" affordance whose action calls [retry].
   terminalFailed,
+
+  /// The adapter RE-connected fine but the vehicle bus is confirmed SILENT
+  /// (#3035) — a parked car with the ignition off. The auto-loop has STOPPED
+  /// (no hidden retry burst); the UI shows the localized "turn the ignition
+  /// on and retry" affordance whose action calls [retry]. Distinct from
+  /// [terminalFailed] (a hardware/scan failure) so the UI can render the
+  /// accurate engine-off message instead of "adapter not found".
+  terminalEngineOff,
 }
 
-/// Outcome of one reconnect attempt the controller drives. The two
-/// non-success cases stay distinct so the controller can keep its backoff
-/// schedule (`failed`) vs. note that the pinned adapter simply wasn't
-/// reachable this cycle (`notFound`) — both advance the attempt counter,
-/// but the distinction is surfaced in tracing.
-enum Obd2ReconnectAttemptResult { connected, notFound, failed }
+/// Outcome of one reconnect attempt the controller drives. The non-success
+/// cases stay distinct so the controller can keep its backoff schedule
+/// (`failed`) vs. note that the pinned adapter simply wasn't reachable this
+/// cycle (`notFound`) — both advance the attempt counter, while [engineOff]
+/// is terminal.
+///
+/// [engineOff] (#3035): the adapter connected and initialised fine but the
+/// `0100` probe confirmed the ECU is SILENT through every retry (a parked car
+/// with the ignition off). Re-trying that on a backoff schedule is pointless
+/// noise — the controller STOPS into [Obd2ReconnectState.terminalEngineOff]
+/// so the user gets the accurate "turn the ignition on" prompt instead of an
+/// endless reconnect→engine-off→teardown loop.
+enum Obd2ReconnectAttemptResult { connected, notFound, failed, engineOff }
 
 /// "Try the pinned adapter on its known transport, no scan." Returns
 /// [Obd2ReconnectAttemptResult.connected] once a session is established,
@@ -139,6 +154,11 @@ class Obd2ReconnectController {
   /// `true` once the bound was exhausted — the UI shows "tap to retry".
   bool get hasFailedTerminally => _state == Obd2ReconnectState.terminalFailed;
 
+  /// `true` once the loop STOPPED on a confirmed engine-off (#3035) — the UI
+  /// shows the "turn the ignition on and retry" affordance.
+  bool get hasStoppedOnEngineOff =>
+      _state == Obd2ReconnectState.terminalEngineOff;
+
   /// Attempts made so far in the CURRENT episode (reset by [retry] and by a
   /// fresh [notifyDropped]). Exposed for tests + diagnostics.
   @visibleForTesting
@@ -177,8 +197,13 @@ class Obd2ReconnectController {
   /// attempt counter + backoff and restarts the bounded loop. A no-op
   /// unless the controller is in [Obd2ReconnectState.terminalFailed] (a
   /// retry while a loop is still running would just double-schedule).
+  /// #3035 — also restarts from [Obd2ReconnectState.terminalEngineOff] (the
+  /// user turned the ignition on and tapped "retry").
   void retry() {
-    if (_state != Obd2ReconnectState.terminalFailed) return;
+    if (_state != Obd2ReconnectState.terminalFailed &&
+        _state != Obd2ReconnectState.terminalEngineOff) {
+      return;
+    }
     _attempts = 0;
     _currentBackoff = _initialBackoff;
     _transition(Obd2ReconnectState.reconnecting);
@@ -215,6 +240,14 @@ class Obd2ReconnectController {
           ? Obd2ReconnectAttemptResult.notFound
           : await _safely(() => _pinnedConnect(pinned));
       if (_state != Obd2ReconnectState.reconnecting) return; // stop() raced
+      // #3035 — a CONFIRMED engine-off on the pinned path is terminal: the
+      // adapter re-connected fine, the ECU is just silent. Re-scanning can't
+      // wake a parked car, so STOP here (no rescan, no backoff burst) rather
+      // than looping reconnect→engine-off→teardown.
+      if (result == Obd2ReconnectAttemptResult.engineOff) {
+        _transition(Obd2ReconnectState.terminalEngineOff);
+        return;
+      }
       // 2) RE-SCAN FALLBACK — only when the pinned path didn't land.
       if (result != Obd2ReconnectAttemptResult.connected) {
         result = await _safely(() => _rescanConnect(pinned));
@@ -222,6 +255,11 @@ class Obd2ReconnectController {
       }
       if (result == Obd2ReconnectAttemptResult.connected) {
         notifyConnected();
+        return;
+      }
+      // #3035 — the re-scan path can also land on a confirmed engine-off.
+      if (result == Obd2ReconnectAttemptResult.engineOff) {
+        _transition(Obd2ReconnectState.terminalEngineOff);
         return;
       }
       _onAttemptFailed();

--- a/lib/features/consumption/data/obd2/obd2_self_test_driver.dart
+++ b/lib/features/consumption/data/obd2/obd2_self_test_driver.dart
@@ -228,6 +228,13 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
   void Function(Obd2SelfTestStepResult step)? onStep,
   bool Function()? isCancelled,
   Duration stepDeadline = const Duration(seconds: 6),
+  // #3035 — the `0100` step is the FIRST OBD request on the bus, so it can
+  // trigger the ELM327 protocol search (`SEARCHING…`), whose real answer can
+  // arrive several seconds later. Give it a search-aware deadline ABOVE the
+  // transport's 4.5 s `protocolSearch` read class so the self-test doesn't
+  // itself false-timeout a search that was about to succeed. Consistent with
+  // the resolver's resilient first-`0100` probe.
+  Duration supportedPidsDeadline = const Duration(seconds: 8),
   Duration connectDeadline = const Duration(seconds: 15),
   String? pinnedMac,
   Obd2ConnectTransport? transportHint,
@@ -319,8 +326,10 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
     }
 
     // --- 4. supportedPids — 0100 bitmask -------------------------------
+    // #3035 — uses the search-aware [supportedPidsDeadline] (not the generic
+    // [stepDeadline]) so a protocol-searching ECU isn't false-timed-out.
     if (!cancelled()) {
-      emit(await _supportedPidsStep(service, diag, stepDeadline));
+      emit(await _supportedPidsStep(service, diag, supportedPidsDeadline));
     }
 
     // --- 5. sampleReads — 010C / 010D / 0105 ---------------------------

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -25,6 +25,11 @@ import 'supported_pids_cache.dart';
 import 'supported_pids_resolver.dart';
 import '../../../../core/logging/error_logger.dart';
 
+// #3035 — re-export the tri-state `0100` probe outcome so the connection
+// layer (which imports this service) gates `ignitionOff` on [busProbe]
+// without reaching into the resolver directly.
+export 'supported_pids_probe.dart' show Obd2BusProbeResult;
+
 // Re-export the pure-math estimator + stoichiometric constants so
 // callers that only need the math (e.g. [TripRecordingController]'s
 // cached live sampler) can import one file instead of chasing statics
@@ -437,6 +442,27 @@ class Obd2Service implements Obd2RawCommandPort {
   /// the no-answer signal so it never trips when discovery returned PIDs.
   bool get busAnswered =>
       _cachedProtocolDigit() != null || debugSupportedPids.isNotEmpty;
+
+  /// Tri-state outcome of the last `0100` supported-PIDs probe (#3035).
+  ///
+  /// [busAnswered] is a boolean ("did the bus reply at all?"), which the
+  /// false-engine-off bug (#3035) over-loaded: a `0100` that merely TIMED
+  /// OUT during the ELM327 protocol search left it `false` and the connect
+  /// path wrongly stamped `ignitionOff`. This getter is the finer signal the
+  /// connection layer gates on instead:
+  ///
+  ///   - [Obd2BusProbeResult.answered] — the ECU returned a `41 00` bitmap;
+  ///   - [Obd2BusProbeResult.probedSilent] — the ECU stayed silent through
+  ///     every retry (genuine engine-off — the ONLY case that may classify
+  ///     `ignitionOff`);
+  ///   - [Obd2BusProbeResult.transient] — every retry hit a timeout / blip
+  ///     (indeterminate, NOT engine-off — keep the session usable);
+  ///   - [Obd2BusProbeResult.notProbed] — discovery didn't run (a warm
+  ///     cache-hit connect, where [busAnswered] already trips on the cached
+  ///     protocol / PID set).
+  ///
+  /// Cheap (reads the already-resolved resolver field, no I/O).
+  Obd2BusProbeResult get busProbe => _pids.lastProbeResult;
 
   /// Send a raw command to the ELM327 adapter and return the raw
   /// response. Exposed for the [PidScheduler]-based trip recording

--- a/lib/features/consumption/data/obd2/supported_pids_probe.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_probe.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'elm327_protocol.dart';
+import 'obd2_response_class.dart';
+
+/// Tri-state outcome of the SAE-J1979 `0100` supported-PIDs probe (#3035).
+///
+/// The ELM327's AT handshake (`ATZ`→`ATE0`→`ATSP0`→…) is answered by the
+/// adapter's own MCU and never touches the car — the ECU is only contacted
+/// by the FIRST OBD request, `0100`, which triggers the protocol search.
+/// That search can reply `SEARCHING...` and only deliver the real
+/// `41 00 <bitmap>` (or `UNABLE TO CONNECT`) several seconds / a later read
+/// later. So a single first-shot timeout is NOT proof the engine is off —
+/// the probe must distinguish three terminal states:
+enum Obd2BusProbeResult {
+  /// The probe never ran (resolver primed from cache, or not connected) —
+  /// no evidence either way. The cheap cache-hit path leaves this set.
+  notProbed,
+
+  /// The ECU answered `0100` with a real `41 00` bitmap → the bus is live
+  /// (engine on / ECU awake). At least one supported PID was discovered.
+  answered,
+
+  /// The ECU stayed genuinely SILENT through every retry — `UNABLE TO
+  /// CONNECT` / `NO DATA` / `BUS INIT: ERROR` after the protocol search
+  /// gave up. This is the real engine-off signature.
+  probedSilent,
+
+  /// Every retry hit a transport blip (`TimeoutException` / `SEARCHING…`
+  /// that never resolved / a thrown send) — an indeterminate state, NOT a
+  /// confirmed engine-off. The caller must NOT classify ignition-off on
+  /// this; the session stays usable / blind query proceeds.
+  transient,
+}
+
+/// The discovered first-group bitmap (null when none) plus the tri-state
+/// outcome of the resilient first-`0100` probe (#3035).
+typedef Obd2FirstProbeOutcome = ({Set<int>? bitmap, Obd2BusProbeResult result});
+
+/// How many times the first `0100` probe is attempted before giving up
+/// (#3035). Three attempts span the typical ELM327 protocol-search window:
+/// a clone often returns `SEARCHING…` / times out on the first read and only
+/// delivers the real `41 00` frame on the second or third.
+const int kObd2ProbeAttempts = 3;
+
+/// Per-attempt pre-delay for the first `0100` probe (#3035): 0 / 300 /
+/// 600 ms. The first attempt is immediate; subsequent attempts settle so the
+/// protocol search has time to complete and the late frame to arrive. Scaled
+/// by [obd2ProbeBackoffScale] so unit tests don't wait real time.
+const List<Duration> kObd2ProbeBackoffs = [
+  Duration.zero,
+  Duration(milliseconds: 300),
+  Duration(milliseconds: 600),
+];
+
+/// Test hook to collapse [kObd2ProbeBackoffs] to ~zero so the retry path runs
+/// in microseconds under `fakeAsync`. Production keeps it at `1.0`.
+@visibleForTesting
+double obd2ProbeBackoffScale = 1.0;
+
+/// Drive the resilient first-`0100` probe (#3035), the root fix for "adapter
+/// connects but no live data" (the first `0100` triggers the ELM327 protocol
+/// search and its real answer can arrive on a LATER read).
+///
+/// [send] dispatches the raw command (the host's retry-wrapped `_send`),
+/// [isConnected] short-circuits a torn-down link, and [groupBase] is the
+/// 32-PID base of `0100` (`0x00`).
+///
+/// Classification across the retries:
+///   - a parseable `41 00` bitmap on ANY attempt → [Obd2BusProbeResult
+///     .answered] (terminal, returns immediately);
+///   - a definitive ECU-silent reply (`NO DATA` / `UNABLE TO CONNECT` /
+///     `CAN ERROR`) is REMEMBERED but the loop keeps trying — a clone can
+///     emit one transient NO DATA mid-search before the real frame. Only if
+///     every attempt is exhausted with at least one such reply (and no
+///     bitmap) does it settle [Obd2BusProbeResult.probedSilent];
+///   - a `SEARCHING…` reply / empty frame / [TimeoutException] / thrown send
+///     is "search in progress" → re-read. If every attempt is one of these
+///     (no bitmap, no definitive-silent), it settles
+///     [Obd2BusProbeResult.transient].
+Future<Obd2FirstProbeOutcome> probeFirstSupportedPids({
+  required Future<String> Function(String command) send,
+  required bool Function() isConnected,
+  required String command,
+  required int groupBase,
+}) async {
+  var sawDefinitiveSilent = false;
+  for (var attempt = 0; attempt < kObd2ProbeAttempts; attempt++) {
+    if (!isConnected()) break;
+    final settle = kObd2ProbeBackoffs[attempt];
+    if (settle > Duration.zero) {
+      final scaled = Duration(
+        microseconds: (settle.inMicroseconds * obd2ProbeBackoffScale).round(),
+      );
+      await Future<void>.delayed(scaled);
+    }
+    try {
+      final response = await send(command);
+      final bitmap =
+          Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
+      if (bitmap != null) {
+        return (bitmap: bitmap, result: Obd2BusProbeResult.answered);
+      }
+      // No bitmap — classify the raw reply to decide retry vs. silent.
+      final cls = classifyObd2Response(response);
+      if (cls == ResponseClass.noData ||
+          cls == ResponseClass.unrecognized ||
+          cls == ResponseClass.canError) {
+        // A definitive ECU-silent reply. Remember it, but keep retrying: a
+        // search can emit one NO DATA before the real frame lands.
+        sawDefinitiveSilent = true;
+      }
+      // Everything else (SEARCHING… → garbage, bufferFull, empty frame) is
+      // "search still in progress" → fall through and re-read.
+      debugPrint('OBD2 first 0100 probe attempt ${attempt + 1}'
+          '/$kObd2ProbeAttempts: no bitmap (${cls.name}) — retrying');
+    } on TimeoutException {
+      // The protocol search can outlast a single read budget — re-read.
+      debugPrint('OBD2 first 0100 probe attempt ${attempt + 1}'
+          '/$kObd2ProbeAttempts timed out — retrying');
+    } catch (e, st) {
+      // A transport blip (concurrent-send guard, device-not-connected). The
+      // throw is EXPECTED + recoverable here (we re-read), so the stack is
+      // only a debug breadcrumb, not an error trace.
+      debugPrint('OBD2 first 0100 probe attempt ${attempt + 1}'
+          '/$kObd2ProbeAttempts threw ($e) — retrying\n$st');
+    }
+  }
+  // Exhausted with no bitmap. A definitive-silent reply anywhere ⇒ genuine
+  // engine-off; otherwise the link was merely flaky/slow (transient).
+  return (
+    bitmap: null,
+    result: sawDefinitiveSilent
+        ? Obd2BusProbeResult.probedSilent
+        : Obd2BusProbeResult.transient,
+  );
+}

--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -6,6 +6,9 @@ import 'package:flutter/foundation.dart';
 import 'elm327_protocol.dart';
 import 'obd2_comm_diagnostics.dart';
 import 'supported_pids_cache.dart';
+import 'supported_pids_probe.dart';
+
+export 'supported_pids_probe.dart' show Obd2BusProbeResult;
 
 /// Owns the #811 supported-PID concern, extracted from [Obd2Service]
 /// (#1679): the per-connection set of Mode 01 PIDs the car implements,
@@ -45,11 +48,25 @@ class SupportedPidsResolver {
   /// don't trust this cache to reject PIDs" (see [isPidSupported]).
   Set<int>? _supportedPids;
 
+  /// Tri-state outcome of the most recent `0100` probe this session
+  /// (#3035). Drives the host's [Obd2Service.busProbe] so the connection
+  /// layer can tell a genuine engine-off ([Obd2BusProbeResult.probedSilent])
+  /// apart from a slow/flaky link ([Obd2BusProbeResult.transient]) — only
+  /// the former may classify ignition-off. [Obd2BusProbeResult.notProbed]
+  /// until [discoverSupportedPids] runs (a cache-hit [prime] leaves it).
+  Obd2BusProbeResult _lastProbeResult = Obd2BusProbeResult.notProbed;
+
+  /// Tri-state outcome of the most recent `0100` probe (#3035). See
+  /// [Obd2BusProbeResult]. [Obd2BusProbeResult.notProbed] before discovery
+  /// runs (incl. when [prime] served the set straight from the cache).
+  Obd2BusProbeResult get lastProbeResult => _lastProbeResult;
+
   /// Clear the per-connection supported-PIDs cache. A new session may
   /// be a different car / different adapter firmware. Call at the top
   /// of the host's `connect`.
   void resetForNewConnection() {
     _supportedPids = null;
+    _lastProbeResult = Obd2BusProbeResult.notProbed;
   }
 
   /// Attempt to load the supported-PID set from the persistent cache
@@ -152,37 +169,63 @@ class SupportedPidsResolver {
   /// Returns an empty set when the adapter isn't connected or the
   /// first bitmap can't be read — the caller should fall back to
   /// blind querying. Also populates the internal per-connection
-  /// cache so subsequent [isPidSupported] calls short-circuit.
+  /// cache so subsequent [isPidSupported] calls short-circuit, and
+  /// records the tri-state [lastProbeResult] of the first `0100` probe.
+  ///
+  /// #3035 — the first `0100` is made resilient to the ELM327 protocol
+  /// search: it retries [_probeAttempts] times with [_probeBackoffs]
+  /// backoff, treats a `SEARCHING…` reply (and any empty/partial reply
+  /// during the search) as "search still in progress → re-read", and only
+  /// declares the bus silent ([Obd2BusProbeResult.probedSilent]) when the
+  /// ECU returns a genuine NO DATA / `UNABLE TO CONNECT` through every
+  /// retry. Timeouts / thrown sends through every retry are
+  /// [Obd2BusProbeResult.transient] — never a confirmed engine-off.
   Future<Set<int>> discoverSupportedPids() async {
     if (!_isConnected()) return const <int>{};
     final supported = <int>{};
-    for (final command in Elm327Protocol.supportedPidsCommands) {
-      // Derive the 32-PID group base from the command (e.g. "0140\r"
-      // → 0x40). The commands list is in lockstep with the group
-      // bases, so we just hex-parse the middle two chars.
-      final groupBase = int.parse(command.substring(2, 4), radix: 16);
-      try {
-        final response = await _send(command);
-        final bitmap =
-            Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
-        if (bitmap == null) break;
-        supported.addAll(bitmap);
-        // "Bit 32" of the bitmap — i.e. PID (groupBase + 32) — is
-        // conventionally the "are PIDs in the next range supported?"
-        // flag. If it's not in the set we just parsed, stop walking.
-        final nextRangeFlag = groupBase + 32;
-        if (!bitmap.contains(nextRangeFlag)) break;
-      } catch (_) {
-        // #2424 (follow-up to #2379) — the supported-PID scan is best-
-        // effort: a transient on a flaky/slow ELM327 (TimeoutException,
-        // the legacy concurrent-sendCommand StateError, device-not-
-        // connected) is EXPECTED and recoverable — we break and return
-        // whatever we've gathered (possibly empty → blind query). The
-        // graceful degradation IS the signal, so it must NOT pollute the
-        // user error log.
-        debugPrint('OBD2 discoverSupportedPids failed on $command — '
-            'returning ${supported.length} PIDs gathered so far');
-        break;
+    final firstCommand = Elm327Protocol.supportedPidsCommands.first;
+    final firstGroupBase = int.parse(firstCommand.substring(2, 4), radix: 16);
+
+    // First `0100` — the only command that actually contacts the ECU and
+    // triggers the protocol search, so it gets the retry + SEARCHING grace.
+    final firstProbe = await probeFirstSupportedPids(
+      send: _send,
+      isConnected: _isConnected,
+      command: firstCommand,
+      groupBase: firstGroupBase,
+    );
+    _lastProbeResult = firstProbe.result;
+    if (firstProbe.bitmap == null) {
+      // No bitmap — either genuine engine-off (probedSilent) or a transient.
+      // Either way there is nothing to walk; record the (empty) set so the
+      // session falls back to blind querying.
+      _supportedPids = supported;
+      return supported;
+    }
+    supported.addAll(firstProbe.bitmap!);
+
+    // Walk the remaining 32-PID groups (`0120`…`01C0`) only while the
+    // previous bitmap's next-range flag is set. These never re-contact the
+    // ECU's protocol search (it has already locked), so they keep the
+    // cheaper single-shot read with the legacy best-effort break.
+    if (firstProbe.bitmap!.contains(firstGroupBase + 32)) {
+      for (final command in Elm327Protocol.supportedPidsCommands.skip(1)) {
+        final groupBase = int.parse(command.substring(2, 4), radix: 16);
+        try {
+          final response = await _send(command);
+          final bitmap =
+              Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
+          if (bitmap == null) break;
+          supported.addAll(bitmap);
+          if (!bitmap.contains(groupBase + 32)) break;
+        } catch (_) {
+          // #2424 — best-effort tail: a transient on a flaky/slow ELM327 is
+          // EXPECTED; break and keep whatever we gathered. The first probe
+          // already answered, so the bus state is settled here.
+          debugPrint('OBD2 discoverSupportedPids failed on $command — '
+              'returning ${supported.length} PIDs gathered so far');
+          break;
+        }
       }
     }
     _supportedPids = supported;

--- a/lib/features/consumption/presentation/widgets/obd2_reconnect_retry_banner.dart
+++ b/lib/features/consumption/presentation/widgets/obd2_reconnect_retry_banner.dart
@@ -23,6 +23,11 @@ import '../../providers/obd2_reconnect_provider.dart';
 ///     user-actionable "tap to retry" button the Epic requires, instead
 ///     of spinning forever or silently giving up. Tapping restarts the
 ///     loop via [Obd2Reconnect.retry].
+///   * [Obd2ReconnectState.terminalEngineOff] (#3035) — the adapter
+///     re-connected fine but the `0100` probe confirmed the ECU is silent
+///     (a parked car / ignition off). The loop STOPS (no backoff burst) and
+///     this banner shows the accurate "turn the ignition on and retry"
+///     prompt, again wired to [Obd2Reconnect.retry].
 ///
 /// Renders zero-height in every other state (idle / connected), so it is
 /// safe to drop into any always-on chrome.
@@ -42,6 +47,8 @@ class Obd2ReconnectRetryBanner extends ConsumerWidget {
         return _reconnectingBanner(theme, l, adapterName);
       case Obd2ReconnectState.terminalFailed:
         return _failedBanner(context, ref, theme, l);
+      case Obd2ReconnectState.terminalEngineOff:
+        return _engineOffBanner(context, ref, theme, l);
       case Obd2ReconnectState.idle:
       case Obd2ReconnectState.connected:
         return const SizedBox.shrink();
@@ -100,6 +107,42 @@ class Obd2ReconnectRetryBanner extends ConsumerWidget {
       actions: [
         TextButton(
           key: const Key('obd2ReconnectRetryButton'),
+          onPressed: () => ref.read(obd2ReconnectProvider.notifier).retry(),
+          child: Text(l?.obd2ReconnectRetry ?? 'Tap to retry'),
+        ),
+      ],
+    );
+  }
+
+  /// #3035 — terminal "the adapter re-connected but the engine is off"
+  /// surface. The auto-loop STOPPED on a confirmed engine-off (the `0100`
+  /// probe stayed silent through every retry), so re-trying on a backoff
+  /// would just spin. We reuse the existing localized engine-off string
+  /// (`obdAdapterUnresponsive` — "turn the ignition on and retry") and the
+  /// same manual [Obd2Reconnect.retry] action so the user re-checks once the
+  /// ignition is on, instead of being told "adapter not found".
+  Widget _engineOffBanner(
+    BuildContext context,
+    WidgetRef ref,
+    ThemeData theme,
+    AppLocalizations? l,
+  ) {
+    return MaterialBanner(
+      key: const Key('obd2ReconnectEngineOffBanner'),
+      backgroundColor: theme.colorScheme.tertiaryContainer,
+      contentTextStyle:
+          TextStyle(color: theme.colorScheme.onTertiaryContainer),
+      leading: Icon(
+        Icons.power_settings_new,
+        color: theme.colorScheme.onTertiaryContainer,
+      ),
+      content: Text(
+        l?.obdAdapterUnresponsive ??
+            'Adapter didn’t answer — turn the ignition on and retry',
+      ),
+      actions: [
+        TextButton(
+          key: const Key('obd2ReconnectEngineOffRetryButton'),
           onPressed: () => ref.read(obd2ReconnectProvider.notifier).retry(),
           child: Text(l?.obd2ReconnectRetry ?? 'Tap to retry'),
         ),

--- a/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
+++ b/lib/features/consumption/presentation/widgets/trip_recording_banner.dart
@@ -117,7 +117,9 @@ class TripRecordingBanner extends ConsumerWidget {
     // decoupled from any live trip — a drop while idle still recovers.
     final reconnectState = ref.watch(obd2ReconnectProvider);
     final reconnectVisible = reconnectState == Obd2ReconnectState.reconnecting ||
-        reconnectState == Obd2ReconnectState.terminalFailed;
+        reconnectState == Obd2ReconnectState.terminalFailed ||
+        // #3035 — the terminal engine-off banner is user-actionable too.
+        reconnectState == Obd2ReconnectState.terminalEngineOff;
 
     // When no trip is active: show a thin strip carrying only the
     // OBD2 status dot — and only when there's an adapter remembered

--- a/lib/features/consumption/providers/obd2_reconnect_provider.dart
+++ b/lib/features/consumption/providers/obd2_reconnect_provider.dart
@@ -147,10 +147,21 @@ class Obd2Reconnect extends _$Obd2Reconnect {
     }
   }
 
-  /// Translate a connect result into the controller's tri-state outcome and,
-  /// on success, republish the recovered link into the app-wide status dot.
+  /// Translate a connect result into the controller's outcome and, on
+  /// success, republish the recovered link into the app-wide status dot.
+  ///
+  /// #3035 — a non-null service whose `0100` probe came back
+  /// [Obd2BusProbeResult.probedSilent] is a CONFIRMED engine-off: the adapter
+  /// re-connected fine, the ECU is just silent (parked car). Surface
+  /// [Obd2ReconnectAttemptResult.engineOff] so the controller STOPS into its
+  /// terminal "turn the ignition on" state instead of looping
+  /// reconnect→engine-off→teardown. A [Obd2BusProbeResult.transient] (slow
+  /// live car / flaky link) is NOT engine-off — it counts as `connected`.
   Obd2ReconnectAttemptResult _onResult(Obd2Service? svc) {
     if (svc == null) return Obd2ReconnectAttemptResult.notFound;
+    if (svc.busProbe == Obd2BusProbeResult.probedSilent) {
+      return Obd2ReconnectAttemptResult.engineOff;
+    }
     try {
       ref.read(obd2ConnectionStatusProvider.notifier).markConnected(
             adapterName: svc.adapterName,

--- a/lib/features/consumption/providers/obd2_reconnect_provider.g.dart
+++ b/lib/features/consumption/providers/obd2_reconnect_provider.g.dart
@@ -145,7 +145,7 @@ final class Obd2ReconnectProvider
   }
 }
 
-String _$obd2ReconnectHash() => r'bcbae65c9c0414ae33d8f3cb8cbf5ce3ccb91991';
+String _$obd2ReconnectHash() => r'054270a7bf402d0fcabe698a1d1b5ec13d324ceb';
 
 /// App-wide owner of the trip-INDEPENDENT auto-reconnect controller (#3019 /
 /// Epic #3013 phase 3).

--- a/test/features/consumption/data/obd2/obd2_reconnect_controller_test.dart
+++ b/test/features/consumption/data/obd2/obd2_reconnect_controller_test.dart
@@ -296,4 +296,81 @@ void main() {
       c.stop();
     });
   });
+
+  group('#3035 — a STABLE engine-off stops the loop (no reconnect burst)', () {
+    test(
+        'pinned path returns engineOff → terminalEngineOff, NO rescan, NO loop',
+        () async {
+      await pinStore.record(
+          const LastGoodAdapter(mac: 'AA', transportKind: 'ble'));
+      // The adapter re-connects fine but the ECU is silent (parked car).
+      transport.pinnedResult = Obd2ReconnectAttemptResult.engineOff;
+      final c = build(maxAttempts: 6);
+
+      c.notifyDropped();
+      await _waitFor(() => c.state == Obd2ReconnectState.terminalEngineOff);
+
+      expect(c.state, Obd2ReconnectState.terminalEngineOff);
+      expect(c.hasStoppedOnEngineOff, isTrue);
+      // The defining no-loop assertions: ONE pinned attempt, ZERO rescans,
+      // the attempt counter never advanced into a backoff burst.
+      expect(transport.pinnedCalls, 1,
+          reason: 'a confirmed engine-off is terminal on the first probe');
+      expect(transport.rescanCalls, 0,
+          reason: 're-scanning cannot wake a parked car');
+      expect(c.attempts, 0,
+          reason: 'no backoff burst — the loop stopped immediately');
+      c.stop();
+    });
+
+    test('the engine-off terminal does not auto-retry over time', () async {
+      await pinStore.record(
+          const LastGoodAdapter(mac: 'AA', transportKind: 'ble'));
+      transport.pinnedResult = Obd2ReconnectAttemptResult.engineOff;
+      final c = build(maxAttempts: 6);
+
+      c.notifyDropped();
+      await _waitFor(() => c.state == Obd2ReconnectState.terminalEngineOff);
+      final callsAtTerminal = transport.pinnedCalls;
+
+      // Let several backoff windows pass — a buggy loop would fire more probes.
+      await Future<void>.delayed(_fast * 8);
+      expect(transport.pinnedCalls, callsAtTerminal,
+          reason: 'no hidden retry burst after engine-off terminal');
+      expect(transport.rescanCalls, 0);
+      c.stop();
+    });
+
+    test('rescan path returns engineOff → terminalEngineOff', () async {
+      // No pin: pinned path is skipped, the rescan lands an engine-off connect.
+      transport.rescanResult = Obd2ReconnectAttemptResult.engineOff;
+      final c = build(maxAttempts: 6);
+
+      c.notifyDropped();
+      await _waitFor(() => c.state == Obd2ReconnectState.terminalEngineOff);
+
+      expect(c.state, Obd2ReconnectState.terminalEngineOff);
+      expect(transport.rescanCalls, 1, reason: 'one rescan, then terminal');
+      c.stop();
+    });
+
+    test('retry() restarts from the engine-off terminal (ignition turned on)',
+        () async {
+      await pinStore.record(
+          const LastGoodAdapter(mac: 'AA', transportKind: 'ble'));
+      transport.pinnedResult = Obd2ReconnectAttemptResult.engineOff;
+      final c = build(maxAttempts: 6);
+
+      c.notifyDropped();
+      await _waitFor(() => c.state == Obd2ReconnectState.terminalEngineOff);
+
+      // The user turned the ignition on; the next probe now answers.
+      transport.pinnedResult = Obd2ReconnectAttemptResult.connected;
+      c.retry();
+      await _waitFor(() => c.state == Obd2ReconnectState.connected);
+
+      expect(c.state, Obd2ReconnectState.connected);
+      c.stop();
+    });
+  });
 }

--- a/test/features/consumption/data/obd2/obd2_service_0100_search_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_0100_search_test.dart
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'adapters/smart_obd_adapter.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'bluetooth_obd2_transport.dart';
+import 'package:tankstellen/features/consumption/data/obd2/elm_byte_channel.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'negotiated_protocol_cache.dart';
+import 'package:tankstellen/features/consumption/data/obd2/obd2_service.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'supported_pids_cache.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'supported_pids_probe.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3035 — the full connect path over the REAL [Obd2Service] + transport +
+/// codec, driven by a channel that reproduces the ELM327 protocol search.
+///
+/// This is the end-to-end RED→GREEN: on master the first `0100` returning
+/// `SEARCHING...` (then the real bitmap on the retry) left `busAnswered=false`
+/// and `busProbe` had no notion of a transient — so the connect was wrongly
+/// classified engine-off. With the resilient probe the bus is ANSWERED, PIDs
+/// are discovered, and `busAnswered` is true. A genuinely silent ECU still
+/// resolves to `probedSilent` (regression guard).
+void main() {
+  silenceErrorLoggerSpool();
+
+  setUp(() => obd2ProbeBackoffScale = 0.0);
+  tearDown(() => obd2ProbeBackoffScale = 1.0);
+
+  bool connect(FakeAsync async, Obd2Service service) {
+    bool? connected;
+    unawaited(
+      service.connect(adapter: const SmartObdAdapter()).then((ok) {
+        connected = ok;
+      }),
+    );
+    async
+      ..elapse(const Duration(seconds: 30))
+      ..flushMicrotasks();
+    return connected ?? false;
+  }
+
+  Obd2Service buildService(_SeqChannel channel) {
+    final transport = BluetoothObd2Transport(channel);
+    const key = 'AA:BB:CC:DD:EE:FF';
+    return Obd2Service(
+      transport,
+      protocolCache: NegotiatedProtocolCache(_InMemoryBox()),
+      protocolCacheKey: key,
+      pidsCache: SupportedPidsCache(_InMemoryBox()),
+      vehicleFallbackKey: key,
+    );
+  }
+
+  _SeqChannel baseChannel() => _SeqChannel()
+    ..script('ATZ\r', ['ELM327 v1.5\r>'])
+    ..script('ATE0\r', ['ATE0\rOK\r>'])
+    ..script('ATL0\r', ['OK\r>'])
+    ..script('ATH0\r', ['OK\r>'])
+    ..script('ATSP0\r', ['OK\r>'])
+    ..script('ATAT1\r', ['OK\r>'])
+    ..script('ATI\r', ['ELM327 v1.5\r>'])
+    ..script('ATDPN\r', ['NO DATA\r>'])
+    ..script('0902\r', ['NO DATA\r>']);
+
+  test(
+      'SEARCHING-then-data: 0100 first replies SEARCHING…, the retry returns '
+      'the bitmap → busAnswered=true, busProbe=answered, PIDs discovered',
+      () {
+    fakeAsync((async) {
+      final channel = baseChannel()
+        // Engine ON, ECU still searching: first read is SEARCHING chatter,
+        // the second read delivers the real 41 00 bitmap.
+        ..script('0100\r', ['SEARCHING...\r>', '41 00 BE 3F A8 13\r>']);
+
+      final service = buildService(channel);
+      final connected = connect(async, service);
+
+      expect(connected, isTrue);
+      expect(service.debugSupportedPids, isNotEmpty,
+          reason: 'the retry discovered the PIDs SEARCHING first hid');
+      expect(service.busProbe, Obd2BusProbeResult.answered);
+      expect(service.busAnswered, isTrue,
+          reason: 'a slow-but-live car must NOT be told engine-off');
+    });
+  });
+
+  test(
+      'genuine engine-off: every 0100 returns NO DATA → busAnswered=false, '
+      'busProbe=probedSilent (real engine-off still detected)', () {
+    fakeAsync((async) {
+      final channel = baseChannel()..script('0100\r', ['NO DATA\r>']);
+
+      final service = buildService(channel);
+      final connected = connect(async, service);
+
+      expect(connected, isTrue, reason: 'connect is best-effort, still true');
+      expect(service.debugSupportedPids, isEmpty);
+      expect(service.busAnswered, isFalse);
+      expect(service.busProbe, Obd2BusProbeResult.probedSilent,
+          reason: 'NO DATA through every retry IS the engine-off signature');
+    });
+  });
+
+  test(
+      'transient: every 0100 read elapses its budget → busProbe=transient, '
+      'NOT probedSilent (a flaky link is never told engine-off)', () {
+    fakeAsync((async) {
+      // No 0100 script → the channel never replies → the transport read budget
+      // elapses every attempt (TimeoutException), with no definitive-silent.
+      final channel = baseChannel()..silenceCommand('0100\r');
+
+      final service = buildService(channel);
+      final connected = connect(async, service);
+
+      expect(connected, isTrue);
+      expect(service.busProbe, Obd2BusProbeResult.transient,
+          reason: 'pure timeouts are indeterminate, not a confirmed silence');
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Sequenced scripted channel — each command can answer a DIFFERENT reply on
+// successive sends (the ELM327 protocol-search behaviour the bug missed).
+// A command with no script (or explicitly silenced) NEVER replies, so the
+// transport's read budget elapses (a real TimeoutException). Composes with
+// fakeAsync via a fresh zero-delay timer per reply.
+// ---------------------------------------------------------------------------
+
+class _SeqChannel implements ElmByteChannel {
+  final Map<String, List<String>> _replies = {};
+  final Map<String, int> _cursor = {};
+  final Set<String> _silenced = {};
+  final StreamController<List<int>> _controller =
+      StreamController<List<int>>.broadcast();
+  bool _open = false;
+
+  void script(String command, List<String> replies) {
+    _replies[command] = replies;
+  }
+
+  /// Mark a command as never-replying (the read budget elapses on every send).
+  void silenceCommand(String command) => _silenced.add(command);
+
+  @override
+  Future<void> open() async => _open = true;
+
+  @override
+  Future<void> close() async => _open = false;
+
+  @override
+  bool get isOpen => _open;
+
+  @override
+  Stream<List<int>> get incoming => _controller.stream;
+
+  @override
+  Future<void> write(List<int> bytes) async {
+    final command = String.fromCharCodes(bytes);
+    if (_silenced.contains(command)) return; // never reply → transport timeout
+    final replies = _replies[command];
+    if (replies == null || replies.isEmpty) return; // unknown → silent
+    final i = _cursor[command] ?? 0;
+    final reply = replies[i < replies.length ? i : replies.length - 1];
+    _cursor[command] = i + 1;
+    Timer(Duration.zero, () {
+      if (!_controller.isClosed) _controller.add(reply.codeUnits);
+    });
+  }
+}
+
+class _InMemoryBox extends Fake implements Box<String> {
+  final Map<String, String> store = {};
+
+  @override
+  String? get(dynamic key, {String? defaultValue}) =>
+      store[key as String] ?? defaultValue;
+
+  @override
+  Future<void> put(dynamic key, String value) async => store[key as String] = value;
+
+  @override
+  Future<void> delete(dynamic key) async => store.remove(key as String);
+
+  @override
+  Future<int> clear() async {
+    final n = store.length;
+    store.clear();
+    return n;
+  }
+}

--- a/test/features/consumption/data/obd2/supported_pids_resolver_probe_test.dart
+++ b/test/features/consumption/data/obd2/supported_pids_resolver_probe_test.dart
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 Florian DITTGEN
+// SPDX-License-Identifier: MIT
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'supported_pids_probe.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'supported_pids_resolver.dart';
+import '../../../../helpers/silence_error_logger.dart';
+
+/// #3035 — the CORE OBD2 bug: the adapter connects (AT handshake OK) but the
+/// app never reads live PIDs even with the ignition ON, and instead falsely
+/// classifies engine-off + loops reconnects.
+///
+/// ROOT CAUSE (ELM327 datasheet + python-OBD): the AT commands are answered
+/// by the adapter's own MCU and NEVER touch the car. The ECU is only
+/// contacted by the FIRST OBD request, `0100`, which triggers the ELM327
+/// protocol search — the adapter replies `SEARCHING...` and the real
+/// `41 00 <bitmap>` (or `UNABLE TO CONNECT`) can take several seconds / arrive
+/// on a LATER read. On master `discoverSupportedPids` does NO retry: the first
+/// `0100` exception/empty → empty set → `busAnswered=false` → false engine-off.
+///
+/// These tests drive the REAL [SupportedPidsResolver] / [probeFirstSupportedPids]
+/// against a fake `send` closure that reproduces real ELM327 behaviour (a
+/// SEARCHING reply, a one-shot timeout, a genuinely-silent ECU) — NOT a fake
+/// that just returns the expected supported set. They are RED on master and
+/// GREEN with the resilient retry/SEARCHING-aware probe.
+void main() {
+  silenceErrorLoggerSpool();
+
+  setUp(() {
+    // Collapse the 0/300/600 ms probe backoff so the retry path runs in
+    // microseconds under the default (real-timer) test zone.
+    obd2ProbeBackoffScale = 0.0;
+  });
+  tearDown(() {
+    obd2ProbeBackoffScale = 1.0;
+  });
+
+  /// A `send` closure whose reply for a given command advances through a
+  /// scripted SEQUENCE on each successive call — the missing capability on
+  /// master's single-shot probe. A `String` entry is returned; a
+  /// `TimeoutException` entry is thrown (a real read-budget elapse).
+  Future<String> Function(String) sequencedSend(
+    Map<String, List<Object>> script, {
+    List<String>? log,
+  }) {
+    final cursor = <String, int>{};
+    return (cmd) async {
+      log?.add(cmd);
+      final steps = script[cmd];
+      if (steps == null || steps.isEmpty) return 'NO DATA\r>';
+      final i = cursor[cmd] ?? 0;
+      final step = steps[i < steps.length ? i : steps.length - 1];
+      cursor[cmd] = i + 1;
+      if (step is TimeoutException) throw step;
+      return step as String;
+    };
+  }
+
+  group('first 0100 probe is resilient to the protocol search (#3035)', () {
+    test(
+        'SEARCHING-then-data: first 0100 returns SEARCHING…, the RETRY returns '
+        'a real 41 00 bitmap → PIDs discovered, probe ANSWERED, not engine-off',
+        () async {
+      final log = <String>[];
+      // The classic ELM327 protocol-search transcript: the first 0100 read
+      // returns the bare "SEARCHING..." chatter (no data yet), the second
+      // delivers the real supported-PIDs bitmap (PID 0C/0D/05 present).
+      final send = sequencedSend({
+        '0100\r': ['SEARCHING...\r>', '41 00 BE 3F A8 13\r>'],
+      }, log: log);
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      final discovered = await resolver.discoverSupportedPids();
+
+      expect(discovered, isNotEmpty,
+          reason: 'the retry must discover the PIDs the first SEARCHING hid');
+      expect(discovered.contains(0x0C), isTrue,
+          reason: '41 00 BE… sets PID 0C (RPM)');
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.answered,
+          reason: 'a real 41 00 bitmap means the bus ANSWERED');
+      expect(log.where((c) => c == '0100\r').length, greaterThanOrEqualTo(2),
+          reason: 'the resolver must RE-READ 0100 after SEARCHING, not bail');
+    });
+
+    test(
+        'transient-timeout-then-data: first 0100 throws TimeoutException, the '
+        'retry succeeds → PIDs discovered, probe ANSWERED, not engine-off',
+        () async {
+      final send = sequencedSend({
+        '0100\r': [
+          TimeoutException('ELM327 did not respond'),
+          '41 00 80 00 00 00\r>', // PID 01 supported, no next-range flag
+        ],
+      });
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      final discovered = await resolver.discoverSupportedPids();
+
+      expect(discovered, isNotEmpty,
+          reason: 'a single first-shot timeout must NOT be terminal');
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.answered);
+    });
+
+    test(
+        'genuine engine-off: every 0100 retry returns UNABLE TO CONNECT → '
+        'zero PIDs, probe PROBED-SILENT (real engine-off still detected)',
+        () async {
+      final send = sequencedSend({
+        '0100\r': ['UNABLE TO CONNECT\r>'], // sticky last → every retry silent
+      });
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      final discovered = await resolver.discoverSupportedPids();
+
+      expect(discovered, isEmpty,
+          reason: 'a truly silent ECU yields zero PIDs');
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.probedSilent,
+          reason: 'UNABLE TO CONNECT through every retry IS engine-off');
+    });
+
+    test(
+        'genuine engine-off via NO DATA: every 0100 retry returns NO DATA → '
+        'probe PROBED-SILENT', () async {
+      final send = sequencedSend({
+        '0100\r': ['NO DATA\r>'],
+      });
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.probedSilent);
+    });
+
+    test(
+        'every retry merely times out (no definitive-silent reply) → probe is '
+        'TRANSIENT, NOT a confirmed engine-off', () async {
+      final send = sequencedSend({
+        '0100\r': [TimeoutException('t')], // sticky → every attempt times out
+      });
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.transient,
+          reason: 'pure timeouts are indeterminate — never told engine-off');
+    });
+
+    test('probe bounds its retries (does not loop forever)', () async {
+      final log = <String>[];
+      final send = sequencedSend({
+        '0100\r': ['SEARCHING...\r>'], // sticky → never resolves
+      }, log: log);
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+
+      expect(log.where((c) => c == '0100\r').length, kObd2ProbeAttempts,
+          reason: 'exactly $kObd2ProbeAttempts bounded attempts, then give up');
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.transient,
+          reason: 'SEARCHING that never resolves is transient, not silent');
+    });
+
+    test(
+        'SEARCHING then data on the SAME multi-line frame parses without a '
+        'retry (probe ANSWERED)', () async {
+      final log = <String>[];
+      final send = sequencedSend({
+        // Real adapters frequently inline the data after SEARCHING.
+        '0100\r': ['SEARCHING...\r41 00 80 00 00 00\r>'],
+      }, log: log);
+      final resolver = SupportedPidsResolver(
+        send: send,
+        isConnected: () => true,
+      );
+
+      final discovered = await resolver.discoverSupportedPids();
+
+      expect(discovered, isNotEmpty);
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.answered);
+      expect(log.where((c) => c == '0100\r').length, 1,
+          reason: 'the bitmap is already present → no second read needed');
+    });
+
+    test('a fresh connection resets the probe result to notProbed', () async {
+      final resolver = SupportedPidsResolver(
+        send: (_) async => '41 00 80 00 00 00\r>',
+        isConnected: () => true,
+      );
+      await resolver.discoverSupportedPids();
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.answered);
+
+      resolver.resetForNewConnection();
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.notProbed);
+    });
+  });
+}

--- a/test/features/consumption/presentation/widgets/obd2_reconnect_retry_banner_test.dart
+++ b/test/features/consumption/presentation/widgets/obd2_reconnect_retry_banner_test.dart
@@ -81,6 +81,39 @@ void main() {
           find.byKey(const Key('obd2ReconnectRetryButton')), findsOneWidget);
     });
 
+    testWidgets(
+        '#3035 — shows the engine-off banner (turn the ignition on) when '
+        'terminalEngineOff, with its own retry button', (tester) async {
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [
+          obd2ReconnectProvider.overrideWith(
+              () => _FakeObd2Reconnect(Obd2ReconnectState.terminalEngineOff)),
+        ],
+      );
+      expect(find.byKey(const Key('obd2ReconnectEngineOffBanner')),
+          findsOneWidget);
+      expect(find.byKey(const Key('obd2ReconnectEngineOffRetryButton')),
+          findsOneWidget);
+      // NOT the generic hardware-failure banner.
+      expect(find.byKey(const Key('obd2ReconnectFailedBanner')), findsNothing);
+    });
+
+    testWidgets('#3035 — tapping the engine-off retry calls notifier.retry()',
+        (tester) async {
+      final fake = _FakeObd2Reconnect(Obd2ReconnectState.terminalEngineOff);
+      await pumpApp(
+        tester,
+        const _Host(),
+        overrides: [obd2ReconnectProvider.overrideWith(() => fake)],
+      );
+      await tester
+          .tap(find.byKey(const Key('obd2ReconnectEngineOffRetryButton')));
+      await tester.pumpAndSettle();
+      expect(fake.retryCalls, 1);
+    });
+
     testWidgets('tapping retry calls notifier.retry()', (tester) async {
       final fake = _FakeObd2Reconnect(Obd2ReconnectState.terminalFailed);
       await pumpApp(

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -134,7 +134,13 @@ void main() {
     // (346, under cap); only the dispatch stub + rationale land here. The class
     // is already split across two `part` files; further decomposition is tracked
     // under #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 668,
+    // #3035 — re-grandfathered 668 → 674: the `ignitionOff` classification +
+    // auto-pin now gate on the tri-state `Obd2Service.busProbe` (only a
+    // CONFIRMED engine-off `probedSilent` stamps `ignitionOff` / skips the
+    // pin), so a transient `0100` timeout during the protocol search no longer
+    // false-classifies a live car. Net +6 is the rationale + the pinnable
+    // guard. Decomposition still tracked under #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_connection_service.dart': 674,
     // #2969 — grandfathered at 419 (was ~399, right at the cap on master). The
     // scan-path BLE `connect()` timeout bound (FBP could otherwise block ~35 s
     // on a vanished candidate) + the channel-open connect-trace stamp (the one
@@ -242,7 +248,14 @@ void main() {
     // the recording coordinator can surface "turn the ignition on" instead of
     // a silent green connect into a degraded GPS-only trip. Decomposition of
     // this god-class still tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1618,
+    // #3035 — re-grandfathered 1618 → 1644: the `busProbe` getter (the
+    // tri-state `0100` probe outcome — answered / probedSilent / transient /
+    // notProbed) + its 18-line dartdoc + the re-export of Obd2BusProbeResult,
+    // so the connection layer gates `ignitionOff` on the CONFIRMED-silent
+    // case only and a slow-but-live car is never wrongly told "engine off".
+    // The resilient first-`0100` probe itself lives in the new (under-cap)
+    // supported_pids_probe.dart. Decomposition still tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1644,
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb


### PR DESCRIPTION
## The bug (#3035)

The CORE OBD2 reliability complaint: the adapter **connects** (AT handshake OK) but the app **never reads live PIDs even with the ignition ON**, instead falsely classifying engine-off and looping reconnects.

## Root cause (ELM327 datasheet + python-OBD)

The AT setup commands (`ATZ`→`ATE0`→`ATSP0`→`ATAT1`→`ATI`) are answered by the **adapter's own MCU** and never touch the car. The ECU is only contacted by the **FIRST OBD request, `0100`** (the SAE-J1979 mandated supported-PIDs probe), which triggers the ELM327 **protocol search** — the adapter replies `SEARCHING...` and the real answer (`41 00 <bitmap>` or `UNABLE TO CONNECT`) can take **several seconds / arrive on a LATER read**.

`SupportedPidsResolver.discoverSupportedPids()` did **no retry**: the first `0100` exception/empty → `catch { break; }` → empty set → `Obd2Service.busAnswered=false` → `obd2_connection_service` stamped `ignitionOff` → teardown → trip-independent auto-reconnect → self-test → repeat (the t1/t2, t4/t5 burst). Net: the data path bailed before the car ever answered.

## The fix — 4 parts

1. **Robust first-`0100` probe** (new `supported_pids_probe.dart`, driven by the real resolver): retry up to **3×** with **0 / 300 / 600 ms** backoff; treat `SEARCHING…` / empty / partial / `TimeoutException` as *"search in progress → re-read"*, NOT a terminal failure; classify the terminal outcome into a **tri-state `Obd2BusProbeResult`**:
   - `answered` — a real `41 00` bitmap (bus live);
   - `probedSilent` — `NO DATA` / `UNABLE TO CONNECT` / `CAN ERROR` through **every** retry (genuine engine-off);
   - `transient` — only timeouts/blips (indeterminate, NOT engine-off).

   A `SEARCHING…41 00 …` inline frame still parses on the first read (no retry). The blind-query fallback is preserved.

2. **No false `ignitionOff`** (`Obd2Service.busProbe` + `obd2_connection_service`): the connect path now classifies `ignitionOff` **ONLY** on `probedSilent`, and only auto-pins the last-good adapter when the bus answered OR was transient — never on a confirmed engine-off (pinning a silent-bus connect is what fed the loop). A slow-but-live car is never told engine-off.

3. **Stop the reconnect loop** (`Obd2ReconnectController` + provider): a confirmed engine-off connect surfaces `Obd2ReconnectAttemptResult.engineOff`, transitioning the controller to a terminal `Obd2ReconnectState.terminalEngineOff` — **no rescan, no backoff burst**. The retry banner shows the existing localized engine-off string (*"turn the ignition on and retry"*); `retry()` restarts once the user turns the ignition on.

4. **Self-test `0100` timing**: the supported-PIDs self-test step gets a search-aware **8 s** deadline (above the transport's 4.5 s `protocolSearch` read class) so it doesn't itself false-timeout a search.

## Test evidence (real resolver/service + a fake transport that reproduces ELM327 behaviour, not a fake that echoes the expected set)

- `supported_pids_resolver_probe_test.dart` / `obd2_service_0100_search_test.dart`:
  - **SEARCHING-then-data**: first `0100` → `SEARCHING...`, the retry → `41 00 <bitmap>` ⇒ resolver RETRIES, PIDs discovered, `busAnswered=true`, `busProbe=answered`, NOT ignitionOff. **RED on the single-shot logic** (`Expected: non-empty / Actual: Set:[]`), GREEN now.
  - **transient-timeout-then-data**: first `0100` throws `TimeoutException`, retry succeeds ⇒ PIDs discovered, no ignitionOff. Also RED→GREEN.
  - **genuine engine-off** (`NO DATA` / `UNABLE TO CONNECT` through every retry) ⇒ `probedSilent` → `ignitionOff` (regression guard — real engine-off still detected after retries).
- `obd2_reconnect_controller_test.dart`: a stable engine-off → `terminalEngineOff` with **1 pinned attempt, 0 rescans, 0 auto-retries** (the no-loop assertion); `retry()` restarts after the ignition is on.
- The existing `#3009` engine-off classification tests (`SEARCHING...STOPPED` / `NO DATA`) still classify `ignitionOff` (now after the 3 retries).
- Reused `obdAdapterUnresponsive` (#3012) — **no new ARB key**.

`flutter analyze` clean; full obd2 + reconnect + banner + lint + l10n suites green (pre-push hook passed without `SKIP_PREPUSH`).

## Residual risk

The exact protocol-search duration is vehicle/clone-specific. The 3×(0/300/600 ms) retry budget + the transport's 4.5 s `protocolSearch` read class span the typical window, but a pathologically slow ECU could still exhaust the retries → `transient` (session stays usable / blind query proceeds, never falsely engine-off). Cannot be verified end-to-end without the user's real car.

Closes #3035

🤖 Generated with [Claude Code](https://claude.com/claude-code)
