### PR TITLE
fix(obd2): 0100 probe uses a generous single-shot search window, not re-send

### DIFF
--- a/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/bluetooth_obd2_transport.dart
@@ -59,7 +59,8 @@ Duration _backoffForAttempt(int attempt) {
 /// chunks, so reads accumulate a buffer until the prompt is seen, then
 /// return the accumulated string minus the prompt. A hard timeout
 /// guards against a stuck adapter.
-class BluetoothObd2Transport implements Obd2Transport {
+class BluetoothObd2Transport
+    implements Obd2Transport, Obd2ProtocolSearchTransport {
   final ElmByteChannel _channel;
   final Duration _readTimeout;
   StreamSubscription<List<int>>? _subscription;
@@ -196,18 +197,33 @@ class BluetoothObd2Transport implements Obd2Transport {
   }
 
   @override
-  Future<String> sendCommand(String command) async {
+  Future<String> sendCommand(String command) => _enqueue(command, null);
+
+  /// #3037 — send [command] on the half-duplex queue with a GENEROUS one-shot
+  /// read window ([readTimeout]) that OVERRIDES the steady-state read-timeout
+  /// ceiling for this single command. The `0100` protocol-search probe uses
+  /// this to give the ELM327 auto-search a single long read (~15 s) instead of
+  /// re-sending mid-search (which would restart the search). Every other
+  /// serialisation guarantee of [sendCommand] still holds — this chains onto
+  /// the SAME `_queueTail` so it never collides with an in-flight command.
+  @override
+  Future<String> sendCommandWithReadTimeout(
+          String command, Duration readTimeout) =>
+      _enqueue(command, readTimeout);
+
+  /// #1972 — serialise every caller onto a single queue. The ELM327 is
+  /// half-duplex; without this a second consumer's command collided with one
+  /// already in flight and threw a concurrent-sendCommand StateError. A
+  /// non-null [readTimeoutOverride] (#3037) gives this one command the generous
+  /// protocol-search window instead of the steady-state class.
+  Future<String> _enqueue(String command, Duration? readTimeoutOverride) {
     if (!_connected) {
       throw StateError('BluetoothObd2Transport not connected');
     }
-    // #1972 — serialise every caller onto a single queue. The ELM327 is
-    // half-duplex; without this a second consumer's command collided
-    // with one already in flight and threw a concurrent-sendCommand
-    // StateError.
     final completer = Completer<String>();
     _queueTail = _queueTail.then((_) async {
-      // The transport may have been torn down while this command waited
-      // its turn — fail it cleanly rather than writing to a closed link.
+      // The transport may have been torn down while this command waited its
+      // turn — fail it cleanly rather than writing to a closed link.
       if (!_connected) {
         completer.completeError(
           StateError('BluetoothObd2Transport not connected'),
@@ -215,7 +231,8 @@ class BluetoothObd2Transport implements Obd2Transport {
         return;
       }
       try {
-        completer.complete(await _sendRaw(command));
+        completer.complete(
+            await _sendRaw(command, readTimeoutOverride: readTimeoutOverride));
       } catch (e, st) {
         completer.completeError(e, st);
       }
@@ -255,7 +272,7 @@ class BluetoothObd2Transport implements Obd2Transport {
     _swallowNextFrame = false; // #2889 — never carry a latch across links.
   }
 
-  Future<String> _sendRaw(String command) async {
+  Future<String> _sendRaw(String command, {Duration? readTimeoutOverride}) async {
     // One in-flight command at a time — the ELM327 is half-duplex.
     // [sendCommand] serialises every caller onto `_queueTail`, so this
     // guard is now a defensive invariant: tripping it means a code path
@@ -286,7 +303,13 @@ class BluetoothObd2Transport implements Obd2Transport {
     );
     _firstCommandPending = false;
     if (_isAtCommand(command)) _atCommandsSinceOpen++;
-    final timeout = cls.timeout > _readTimeout ? _readTimeout : cls.timeout;
+    // #3037 — an explicit [readTimeoutOverride] (the `0100` protocol-search
+    // probe's ~15 s generous window) bypasses the steady-state [_readTimeout]
+    // ceiling: the auto-search legitimately outlasts the 5 s class on a slow
+    // link, and re-sending mid-search would restart it. Without an override
+    // the per-class budget is still clamped to [_readTimeout] as before.
+    final timeout = readTimeoutOverride ??
+        (cls.timeout > _readTimeout ? _readTimeout : cls.timeout);
 
     _buffer.clear();
     final completer = Completer<String>();

--- a/lib/features/consumption/data/obd2/obd2_self_test_driver.dart
+++ b/lib/features/consumption/data/obd2/obd2_self_test_driver.dart
@@ -228,13 +228,16 @@ Future<Obd2SelfTestReport> runObd2SelfTest(
   void Function(Obd2SelfTestStepResult step)? onStep,
   bool Function()? isCancelled,
   Duration stepDeadline = const Duration(seconds: 6),
-  // #3035 — the `0100` step is the FIRST OBD request on the bus, so it can
-  // trigger the ELM327 protocol search (`SEARCHING…`), whose real answer can
-  // arrive several seconds later. Give it a search-aware deadline ABOVE the
-  // transport's 4.5 s `protocolSearch` read class so the self-test doesn't
-  // itself false-timeout a search that was about to succeed. Consistent with
-  // the resolver's resilient first-`0100` probe.
-  Duration supportedPidsDeadline = const Duration(seconds: 8),
+  // #3035/#3037 — the `0100` step is the FIRST OBD request on the bus, so it
+  // triggers the ELM327 protocol search (`SEARCHING…`), whose real answer can
+  // arrive several seconds later. The step now drives the SAME robust probe as
+  // production ([Obd2Service.discoverSupportedPids] → `probeFirstSupportedPids`),
+  // whose generous single-shot search window is [kObd2ProtocolSearchTimeout]
+  // (~15 s). This whole-step deadline must therefore sit ABOVE that window so
+  // the self-test never false-cuts a search the probe was about to WIN (which
+  // would mis-report a live-but-slow ECU as a hard `timeout` fault instead of
+  // the correct engine-on pass / engine-off verdict).
+  Duration supportedPidsDeadline = const Duration(seconds: 18),
   Duration connectDeadline = const Duration(seconds: 15),
   String? pinnedMac,
   Obd2ConnectTransport? transportHint,

--- a/lib/features/consumption/data/obd2/obd2_self_test_steps.dart
+++ b/lib/features/consumption/data/obd2/obd2_self_test_steps.dart
@@ -96,8 +96,20 @@ bool _looksLikeInfoReply(String raw) {
   return true;
 }
 
-/// Supported-PID step: `0100` request + bitmask classification. Records
-/// the supported tri-state for `0100` so the trace + Copy-as-JSON show it.
+/// Supported-PID step (#3037): drive the SAME robust first-`0100` probe the
+/// production connect path uses ([Obd2Service.discoverSupportedPids] →
+/// `probeFirstSupportedPids`), instead of a single-shot `0100` that
+/// false-failed on a slow link. The probe sends `0100` ONCE with the generous
+/// protocol-search window (re-read, not re-send mid-search), tees the raw
+/// reply into the connect trace + session transcript for observability, and
+/// settles a tri-state ([Obd2Service.busProbe]) that maps onto the step:
+///   - answered     → ok (a live ECU answered `41 00`);
+///   - probedSilent → noResponse (the ECU is genuinely silent = engine-off,
+///     which the #3009 verdict treats as the non-alarming engineOff, NOT a
+///     hard fault);
+///   - transient    → garbage (an indeterminate slow/flaky search — surfaced
+///     but not a hard fault, so the #3009 verdict can still read engine-off).
+/// [deadline] caps the WHOLE probe so a dead adapter can't freeze the step.
 Future<Obd2SelfTestStepResult> _supportedPidsStep(
   Obd2Service service,
   Obd2CommDiagnostics diag,
@@ -105,14 +117,20 @@ Future<Obd2SelfTestStepResult> _supportedPidsStep(
 ) async {
   final sw = Stopwatch()..start();
   try {
-    final raw = await service.sendCommand('0100\r').timeout(deadline);
+    // The probe records the raw `0100` reply (trace + transcript) itself via
+    // its recordTrace tee, so we only map the tri-state result here.
+    await service.discoverSupportedPids().timeout(deadline);
     sw.stop();
-    final cls = classifyObd2Response(raw);
-    diag.recordHandshakeLine('0100', raw, sw.elapsedMilliseconds);
-    diag.recordSupportedTriState(
-        '0100', cls == ResponseClass.ok ? 'supported' : 'unsupported');
-    return _step(Obd2SelfTestStepId.supportedPids,
-        statusForResponseClass(cls), sw.elapsedMilliseconds);
+    final status = switch (service.busProbe) {
+      Obd2BusProbeResult.answered => Obd2SelfTestStepStatus.ok,
+      Obd2BusProbeResult.probedSilent => Obd2SelfTestStepStatus.noResponse,
+      Obd2BusProbeResult.transient => Obd2SelfTestStepStatus.garbage,
+      Obd2BusProbeResult.notProbed => Obd2SelfTestStepStatus.noResponse,
+    };
+    diag.recordSupportedTriState('0100',
+        status == Obd2SelfTestStepStatus.ok ? 'supported' : 'unsupported');
+    return _step(
+        Obd2SelfTestStepId.supportedPids, status, sw.elapsedMilliseconds);
   } on TimeoutException {
     sw.stop();
     diag.recordSupportedTriState('0100', 'unknown');

--- a/lib/features/consumption/data/obd2/obd2_service.dart
+++ b/lib/features/consumption/data/obd2/obd2_service.dart
@@ -22,6 +22,7 @@ import 'obd2_debug_session.dart';
 import 'obd2_transport.dart';
 import 'oem_pid_table.dart';
 import 'supported_pids_cache.dart';
+import 'supported_pids_probe.dart' show kObd2ProtocolSearchTimeout;
 import 'supported_pids_resolver.dart';
 import '../../../../core/logging/error_logger.dart';
 
@@ -219,6 +220,16 @@ class Obd2Service implements Obd2RawCommandPort {
     // sites pick up the wrapper.
     _pids = SupportedPidsResolver(
       send: (cmd) => _withConnectRetry(cmd, _send),
+      // #3037 — the first `0100` probe uses the GENEROUS protocol-search read
+      // window (~15 s) so the ELM327 auto-search resolves within ONE read,
+      // instead of re-sending mid-search (which restarts the search).
+      // Deliberately NOT wrapped in [_withConnectRetry]: that wrapper re-sends
+      // on ANY throw INCLUDING a read TimeoutException, which for `0100` would
+      // restart the protocol search — the exact #3037 bug. The probe itself
+      // owns the bounded re-send, and ONLY on a genuine transport throw (a
+      // failed write, where the command never reached the adapter so the
+      // search never started), never on a timeout.
+      searchSend: _sendWithProtocolSearchWindow,
       isConnected: () => _transport.isConnected,
       cache: pidsCache,
       vehicleFallbackKey: vehicleFallbackKey,
@@ -1609,6 +1620,24 @@ class Obd2Service implements Obd2RawCommandPort {
   /// later phases can strip stray prompts / echoes here.
   Future<String> _send(String command) async {
     final raw = await _transport.sendCommand(command);
+    return _adapter.preParse(raw);
+  }
+
+  /// #3037 — send [command] (the first `0100` probe) with the GENEROUS
+  /// protocol-search read window ([kObd2ProtocolSearchTimeout], ~15 s) when
+  /// the transport supports a per-command timeout override
+  /// ([Obd2ProtocolSearchTransport]); otherwise fall back to the plain
+  /// [_send] (whose own first-command class still applies). This is the
+  /// SINGLE long read that lets the ELM327 auto-search resolve to `41 00`
+  /// without re-sending mid-search (which would restart the search) — the
+  /// root fix for the false engine-off on a slow link. The adapter
+  /// `preParse` hook is applied to the raw reply exactly as in [_send].
+  Future<String> _sendWithProtocolSearchWindow(String command) async {
+    final transport = _transport;
+    final raw = transport is Obd2ProtocolSearchTransport
+        ? await (transport as Obd2ProtocolSearchTransport)
+            .sendCommandWithReadTimeout(command, kObd2ProtocolSearchTimeout)
+        : await transport.sendCommand(command);
     return _adapter.preParse(raw);
   }
 }

--- a/lib/features/consumption/data/obd2/obd2_transport.dart
+++ b/lib/features/consumption/data/obd2/obd2_transport.dart
@@ -54,6 +54,36 @@ abstract class Obd2ListenModeTransport {
   Future<void> sendListenModeStop(String command);
 }
 
+/// Opt-in capability mixin (#3037) — transports that can give ONE command a
+/// dedicated, generous read window that OVERRIDES the steady-state read
+/// timeout ceiling.
+///
+/// Why this is necessary: the `0100` supported-PIDs probe is the FIRST OBD
+/// request on the bus, so it triggers the ELM327 protocol auto-search
+/// (`SEARCHING…`). On a slow link that search can outlast the steady-state
+/// ~5 s read ceiling — and RE-SENDING `0100` mid-search RESTARTS the search,
+/// so the late `41 00` frame is never caught (the #3035/#3037 false
+/// engine-off). The correct ELM327 practice is to send `0100` ONCE and
+/// RE-READ the in-progress search within a single generous window (~12–15 s),
+/// which this method exposes. Steady-state PID reads keep their ~5 s class.
+///
+/// Like [Obd2ListenModeTransport] this is a SEPARATE opt-in interface, not an
+/// extra abstract method on [Obd2Transport], so the ten-plus existing fakes
+/// that `implements Obd2Transport` don't need boilerplate. Callers type-check
+/// for it and fall back to the plain [Obd2Transport.sendCommand] otherwise.
+abstract class Obd2ProtocolSearchTransport {
+  /// Send [command] and wait up to [readTimeout] for the `>`-terminated
+  /// reply, OVERRIDING the transport's steady-state read-timeout ceiling for
+  /// this one command only. Used by the `0100` protocol-search probe to give
+  /// the ELM327 auto-search a single generous window instead of re-sending
+  /// (which would restart the search). All other serialisation /
+  /// half-duplex-queue guarantees of [Obd2Transport.sendCommand] still hold.
+  Future<String> sendCommandWithReadTimeout(
+    String command,
+    Duration readTimeout,
+  );
+}
+
 /// A fake transport for testing that returns pre-configured responses.
 ///
 /// Listen-mode (#1418) is opt-in: tests that need

--- a/lib/features/consumption/data/obd2/supported_pids_probe.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_probe.dart
@@ -26,15 +26,16 @@ enum Obd2BusProbeResult {
   /// (engine on / ECU awake). At least one supported PID was discovered.
   answered,
 
-  /// The ECU stayed genuinely SILENT through every retry — `UNABLE TO
+  /// The ECU stayed genuinely SILENT through the probe window — `UNABLE TO
   /// CONNECT` / `NO DATA` / `BUS INIT: ERROR` after the protocol search
   /// gave up. This is the real engine-off signature.
   probedSilent,
 
-  /// Every retry hit a transport blip (`TimeoutException` / `SEARCHING…`
-  /// that never resolved / a thrown send) — an indeterminate state, NOT a
-  /// confirmed engine-off. The caller must NOT classify ignition-off on
-  /// this; the session stays usable / blind query proceeds.
+  /// The probe ran out its generous window with no terminal answer — a read
+  /// [TimeoutException] / a `SEARCHING…` that never resolved / a thrown send —
+  /// an indeterminate state, NOT a confirmed engine-off. The caller must NOT
+  /// classify ignition-off on this; the session stays usable / blind query
+  /// proceeds.
   transient,
 }
 
@@ -42,101 +43,142 @@ enum Obd2BusProbeResult {
 /// outcome of the resilient first-`0100` probe (#3035).
 typedef Obd2FirstProbeOutcome = ({Set<int>? bitmap, Obd2BusProbeResult result});
 
-/// How many times the first `0100` probe is attempted before giving up
-/// (#3035). Three attempts span the typical ELM327 protocol-search window:
-/// a clone often returns `SEARCHING…` / times out on the first read and only
-/// delivers the real `41 00` frame on the second or third.
-const int kObd2ProbeAttempts = 3;
+/// #3037 — the GENEROUS single-shot read window for the first `0100` probe.
+///
+/// The first `0100` triggers the ELM327's `ATSP0` protocol auto-search, which
+/// walks every OBD protocol in turn. On a slow Classic-SPP clone (the user's
+/// handshake took ~13 s in one trace) that search legitimately outlasts the
+/// transport's 5 s steady-state read ceiling. Re-SENDING `0100` mid-search
+/// RESTARTS the search, so the late `41 00` frame is never caught — the
+/// #3035/#3037 false engine-off. The fix is a SINGLE long read that lets the
+/// search resolve to `41 00` (or a definitive silent reply) within ONE
+/// window. 15 s safely covers the worst-case search: even an engine-off bus
+/// returns `UNABLE TO CONNECT` inside ~10 s, so this won't hang. Steady-state
+/// PID reads keep their ~5 s class.
+const Duration kObd2ProtocolSearchTimeout = Duration(seconds: 15);
 
-/// Per-attempt pre-delay for the first `0100` probe (#3035): 0 / 300 /
-/// 600 ms. The first attempt is immediate; subsequent attempts settle so the
-/// protocol search has time to complete and the late frame to arrive. Scaled
-/// by [obd2ProbeBackoffScale] so unit tests don't wait real time.
-const List<Duration> kObd2ProbeBackoffs = [
-  Duration.zero,
-  Duration(milliseconds: 300),
-  Duration(milliseconds: 600),
-];
+/// #3037 — at most ONE extra `0100` send, and ONLY on a genuine TRANSPORT
+/// THROW (a failed write — concurrent-send guard / device-not-connected),
+/// where the command never reached the ELM327 so re-sending is the first real
+/// delivery, NOT a search restart. A plain read [TimeoutException] is NEVER
+/// re-sent: a timeout means the search MAY still be in progress, and the
+/// invariant is "do not re-send `0100` while a search may still be running".
+const int kObd2ProbeMaxTransportRetries = 1;
 
-/// Test hook to collapse [kObd2ProbeBackoffs] to ~zero so the retry path runs
-/// in microseconds under `fakeAsync`. Production keeps it at `1.0`.
+/// Per-retry settle before the single permitted transport-throw re-send
+/// (#3037). Scaled by [obd2ProbeBackoffScale] so unit tests don't wait real
+/// time. Only paid on a genuine transport throw, never on a timeout.
+const Duration kObd2ProbeTransportRetryBackoff = Duration(milliseconds: 300);
+
+/// Test hook to collapse [kObd2ProbeTransportRetryBackoff] to ~zero so the
+/// (transport-throw-only) retry path runs in microseconds under tests.
+/// Production keeps it at `1.0`.
 @visibleForTesting
 double obd2ProbeBackoffScale = 1.0;
 
-/// Drive the resilient first-`0100` probe (#3035), the root fix for "adapter
-/// connects but no live data" (the first `0100` triggers the ELM327 protocol
-/// search and its real answer can arrive on a LATER read).
+/// Drive the resilient first-`0100` probe (#3035, generous-window rework
+/// #3037), the root fix for "adapter connects but no live data" (the first
+/// `0100` triggers the ELM327 protocol search and its real answer can arrive
+/// several seconds into the search).
 ///
-/// [send] dispatches the raw command (the host's retry-wrapped `_send`),
-/// [isConnected] short-circuits a torn-down link, and [groupBase] is the
-/// 32-PID base of `0100` (`0x00`).
+/// [searchSend] dispatches `0100` with the GENEROUS protocol-search read
+/// window ([kObd2ProtocolSearchTimeout]) — a SINGLE long read that lets
+/// `SEARCHING…` resolve to `41 00` without re-sending mid-search. When the
+/// host transport can give a per-command timeout override (it implements
+/// [Obd2ProtocolSearchTransport]) the resolver wires this to it; otherwise it
+/// falls back to the plain `send`, which still applies its own first-command
+/// search class. [isConnected] short-circuits a torn-down link, and
+/// [groupBase] is the 32-PID base of `0100` (`0x00`). [recordTrace], when
+/// supplied, is fed the raw response (or `TIMEOUT` / the thrown error) of each
+/// probe read for connect-trace observability (#3037 root cause 3).
 ///
-/// Classification across the retries:
-///   - a parseable `41 00` bitmap on ANY attempt → [Obd2BusProbeResult
-///     .answered] (terminal, returns immediately);
+/// Classification:
+///   - a parseable `41 00` bitmap → [Obd2BusProbeResult.answered] (terminal);
 ///   - a definitive ECU-silent reply (`NO DATA` / `UNABLE TO CONNECT` /
-///     `CAN ERROR`) is REMEMBERED but the loop keeps trying — a clone can
-///     emit one transient NO DATA mid-search before the real frame. Only if
-///     every attempt is exhausted with at least one such reply (and no
-///     bitmap) does it settle [Obd2BusProbeResult.probedSilent];
-///   - a `SEARCHING…` reply / empty frame / [TimeoutException] / thrown send
-///     is "search in progress" → re-read. If every attempt is one of these
-///     (no bitmap, no definitive-silent), it settles
-///     [Obd2BusProbeResult.transient].
+///     `CAN ERROR`) → [Obd2BusProbeResult.probedSilent] (the real engine-off
+///     signature, still detected — within the window, never hanging);
+///   - a read [TimeoutException] / a `SEARCHING…` that never resolved within
+///     the generous window / an empty frame → [Obd2BusProbeResult.transient]
+///     (indeterminate, NEVER a confirmed engine-off);
+///   - a genuine TRANSPORT THROW (the write itself failed — the command never
+///     reached the adapter) is re-sent at most [kObd2ProbeMaxTransportRetries]
+///     times; if it keeps throwing it settles [Obd2BusProbeResult.transient].
+///
+/// INVARIANT (#3037): `0100` is sent ONCE per successful (timed-out or
+/// answered) read — it is NEVER re-sent while a protocol search may still be
+/// in progress. The only re-send is on a transport throw, where the search
+/// never started.
 Future<Obd2FirstProbeOutcome> probeFirstSupportedPids({
-  required Future<String> Function(String command) send,
+  required Future<String> Function(String command) searchSend,
   required bool Function() isConnected,
   required String command,
   required int groupBase,
+  void Function(String rawResponseOrError, bool timedOut)? recordTrace,
 }) async {
-  var sawDefinitiveSilent = false;
-  for (var attempt = 0; attempt < kObd2ProbeAttempts; attempt++) {
-    if (!isConnected()) break;
-    final settle = kObd2ProbeBackoffs[attempt];
-    if (settle > Duration.zero) {
+  // At most (1 + kObd2ProbeMaxTransportRetries) physical sends, and a re-send
+  // happens ONLY on a transport throw (the command never reached the adapter).
+  for (var transportThrows = 0;; transportThrows++) {
+    if (!isConnected()) {
+      return (bitmap: null, result: Obd2BusProbeResult.transient);
+    }
+    if (transportThrows > 0) {
       final scaled = Duration(
-        microseconds: (settle.inMicroseconds * obd2ProbeBackoffScale).round(),
+        microseconds:
+            (kObd2ProbeTransportRetryBackoff.inMicroseconds * obd2ProbeBackoffScale)
+                .round(),
       );
-      await Future<void>.delayed(scaled);
+      if (scaled > Duration.zero) await Future<void>.delayed(scaled);
     }
     try {
-      final response = await send(command);
+      // SINGLE generous-window read: let SEARCHING… resolve to 41 00 (or a
+      // definitive silent reply) WITHIN this window — no re-send mid-search.
+      final response = await searchSend(command);
+      recordTrace?.call(response, false);
       final bitmap =
           Elm327Protocol.parseSupportedPidsBitmap(response, groupBase);
       if (bitmap != null) {
         return (bitmap: bitmap, result: Obd2BusProbeResult.answered);
       }
-      // No bitmap — classify the raw reply to decide retry vs. silent.
       final cls = classifyObd2Response(response);
       if (cls == ResponseClass.noData ||
           cls == ResponseClass.unrecognized ||
           cls == ResponseClass.canError) {
-        // A definitive ECU-silent reply. Remember it, but keep retrying: a
-        // search can emit one NO DATA before the real frame lands.
-        sawDefinitiveSilent = true;
+        // The ECU was contacted and is genuinely SILENT — real engine-off,
+        // detected within the window (never hanging).
+        return (bitmap: null, result: Obd2BusProbeResult.probedSilent);
       }
-      // Everything else (SEARCHING… → garbage, bufferFull, empty frame) is
-      // "search still in progress" → fall through and re-read.
-      debugPrint('OBD2 first 0100 probe attempt ${attempt + 1}'
-          '/$kObd2ProbeAttempts: no bitmap (${cls.name}) — retrying');
+      // A SEARCHING… / empty / partial frame that filled the generous window
+      // without ever resolving. Indeterminate — NOT a confirmed engine-off,
+      // and we do NOT re-send (the search may still have been in progress).
+      debugPrint('OBD2 first 0100 probe: no bitmap (${cls.name}) within the '
+          'generous search window — transient (not engine-off)');
+      return (bitmap: null, result: Obd2BusProbeResult.transient);
     } on TimeoutException {
-      // The protocol search can outlast a single read budget — re-read.
-      debugPrint('OBD2 first 0100 probe attempt ${attempt + 1}'
-          '/$kObd2ProbeAttempts timed out — retrying');
+      // The generous window elapsed mid-search. RE-READING/draining the
+      // in-progress search is exactly what a longer single window already
+      // did; re-SENDING here would restart it. So a timeout is terminal-
+      // transient — never a confirmed engine-off (#3036/#3037 invariant).
+      recordTrace?.call('TIMEOUT', true);
+      debugPrint('OBD2 first 0100 probe timed out within the generous '
+          '${kObd2ProtocolSearchTimeout.inSeconds}s window — transient '
+          '(NOT re-sent; a re-send would restart the protocol search)');
+      return (bitmap: null, result: Obd2BusProbeResult.transient);
     } catch (e, st) {
-      // A transport blip (concurrent-send guard, device-not-connected). The
-      // throw is EXPECTED + recoverable here (we re-read), so the stack is
-      // only a debug breadcrumb, not an error trace.
-      debugPrint('OBD2 first 0100 probe attempt ${attempt + 1}'
-          '/$kObd2ProbeAttempts threw ($e) — retrying\n$st');
+      // A genuine TRANSPORT THROW: the write itself failed (concurrent-send
+      // guard / device-not-connected), so the command never reached the
+      // adapter and the protocol search never started. Re-sending is the
+      // FIRST real delivery, not a search restart — so it is the ONLY case
+      // that re-sends, bounded by [kObd2ProbeMaxTransportRetries].
+      recordTrace?.call(e.toString(), false);
+      if (transportThrows >= kObd2ProbeMaxTransportRetries) {
+        debugPrint('OBD2 first 0100 probe: transport threw ($e) and retries '
+            'are exhausted — transient\n$st');
+        return (bitmap: null, result: Obd2BusProbeResult.transient);
+      }
+      debugPrint('OBD2 first 0100 probe: transport threw ($e) before the '
+          'command reached the adapter — re-sending once (search not '
+          'started)\n$st');
+      // loop → one bounded re-send
     }
   }
-  // Exhausted with no bitmap. A definitive-silent reply anywhere ⇒ genuine
-  // engine-off; otherwise the link was merely flaky/slow (transient).
-  return (
-    bitmap: null,
-    result: sawDefinitiveSilent
-        ? Obd2BusProbeResult.probedSilent
-        : Obd2BusProbeResult.transient,
-  );
 }

--- a/lib/features/consumption/data/obd2/supported_pids_resolver.dart
+++ b/lib/features/consumption/data/obd2/supported_pids_resolver.dart
@@ -23,14 +23,24 @@ class SupportedPidsResolver {
   SupportedPidsResolver({
     required Future<String> Function(String command) send,
     required bool Function() isConnected,
+    Future<String> Function(String command)? searchSend,
     SupportedPidsCache? cache,
     String? vehicleFallbackKey,
   })  : _send = send,
+        // #3037 — the first `0100` probe sends through [searchSend] (the
+        // host's GENEROUS protocol-search window, ~15 s) instead of [_send]'s
+        // ~5 s steady-state ceiling, so the ELM327 auto-search resolves within
+        // ONE read rather than being re-sent (which restarts the search).
+        // Defaults to [_send] for callers / tests that don't supply a separate
+        // long-window send (the plain send still applies its own first-command
+        // search class).
+        _searchSend = searchSend ?? send,
         _isConnected = isConnected,
         _cache = cache,
         _vehicleFallbackKey = vehicleFallbackKey;
 
   final Future<String> Function(String command) _send;
+  final Future<String> Function(String command) _searchSend;
   final bool Function() _isConnected;
 
   /// Optional persistent supported-PID cache (#811). When present and
@@ -187,12 +197,25 @@ class SupportedPidsResolver {
     final firstGroupBase = int.parse(firstCommand.substring(2, 4), radix: 16);
 
     // First `0100` — the only command that actually contacts the ECU and
-    // triggers the protocol search, so it gets the retry + SEARCHING grace.
+    // triggers the protocol search, so it gets the GENEROUS single-shot search
+    // window (#3037) via [_searchSend] (re-read, not re-send mid-search) and
+    // is teed into the active connect trace for observability.
+    final probeSw = Stopwatch()..start();
     final firstProbe = await probeFirstSupportedPids(
-      send: _send,
+      searchSend: _searchSend,
       isConnected: _isConnected,
       command: firstCommand,
       groupBase: firstGroupBase,
+      recordTrace: (raw, timedOut) {
+        // #3037 root cause 3 — record the `0100` probe read into the active
+        // connect trace (via the chokepoint that tees handshake lines), so a
+        // future trace shows EXACTLY what the ECU returned (`SEARCHING…` /
+        // `41 00 …` / `NO DATA` / `UNABLE TO CONNECT`) + the timing. A no-op
+        // when no trace is active. The collector gate is irrelevant here: the
+        // tee writes to the (always-on) connect-trace ring.
+        Obd2CommDiagnostics.instance.recordHandshakeLine(
+            firstCommand, raw, probeSw.elapsedMilliseconds);
+      },
     );
     _lastProbeResult = firstProbe.result;
     if (firstProbe.bitmap == null) {

--- a/test/features/consumption/data/obd2/obd2_service_0100_search_test.dart
+++ b/test/features/consumption/data/obd2/obd2_service_0100_search_test.dart
@@ -20,15 +20,18 @@ import 'package:tankstellen/features/consumption/data/obd2/'
     'supported_pids_probe.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
-/// #3035 — the full connect path over the REAL [Obd2Service] + transport +
-/// codec, driven by a channel that reproduces the ELM327 protocol search.
+/// #3035/#3037 — the full connect path over the REAL [Obd2Service] +
+/// transport + codec, driven by a channel that reproduces the ELM327 protocol
+/// search.
 ///
-/// This is the end-to-end RED→GREEN: on master the first `0100` returning
-/// `SEARCHING...` (then the real bitmap on the retry) left `busAnswered=false`
-/// and `busProbe` had no notion of a transient — so the connect was wrongly
-/// classified engine-off. With the resilient probe the bus is ANSWERED, PIDs
-/// are discovered, and `busAnswered` is true. A genuinely silent ECU still
-/// resolves to `probedSilent` (regression guard).
+/// #3037 GENEROUS-WINDOW rework: the first `0100` is sent ONCE with a generous
+/// protocol-search read window (~15 s) and the in-progress search is RE-READ,
+/// NOT re-sent (a re-send restarts the search). The slow-search case below
+/// emits `SEARCHING...` then — several SIMULATED seconds later, still within
+/// the window and ON THE SAME read — the real `41 00` bitmap, and asserts the
+/// transport `write` for `0100` happened EXACTLY ONCE. A genuinely silent ECU
+/// still resolves to `probedSilent` (regression guard); pure timeouts stay
+/// `transient`.
 void main() {
   silenceErrorLoggerSpool();
 
@@ -72,24 +75,35 @@ void main() {
     ..script('0902\r', ['NO DATA\r>']);
 
   test(
-      'SEARCHING-then-data: 0100 first replies SEARCHING…, the retry returns '
-      'the bitmap → busAnswered=true, busProbe=answered, PIDs discovered',
-      () {
+      'SLOW-SEARCH (#3037): 0100 emits SEARCHING…, then ~7 s later (still in '
+      'the generous window, SAME read) the real 41 00 bitmap → busAnswered, '
+      'busProbe=answered, PIDs discovered — and 0100 is WRITTEN EXACTLY ONCE '
+      '(never re-sent mid-search)', () {
     fakeAsync((async) {
       final channel = baseChannel()
-        // Engine ON, ECU still searching: first read is SEARCHING chatter,
-        // the second read delivers the real 41 00 bitmap.
-        ..script('0100\r', ['SEARCHING...\r>', '41 00 BE 3F A8 13\r>']);
+        // Engine ON, ECU still searching: the adapter emits the SEARCHING
+        // chatter chunk immediately, then ~7 s into the search — long past the
+        // old 5 s ceiling but well within the 15 s generous window — the real
+        // 41 00 frame terminated by the prompt, all on ONE read (one write).
+        ..scriptDelayedChunks('0100\r', const [
+          (Duration.zero, 'SEARCHING...\r'),
+          (Duration(seconds: 7), '41 00 BE 3F A8 13\r>'),
+        ]);
 
       final service = buildService(channel);
       final connected = connect(async, service);
 
       expect(connected, isTrue);
       expect(service.debugSupportedPids, isNotEmpty,
-          reason: 'the retry discovered the PIDs SEARCHING first hid');
+          reason: 'the generous window caught the late 41 00 SEARCHING hid');
       expect(service.busProbe, Obd2BusProbeResult.answered);
       expect(service.busAnswered, isTrue,
           reason: 'a slow-but-live car must NOT be told engine-off');
+      // The CORE #3037 assertion: the search was RE-READ within one window,
+      // never RE-SENT (a re-send would have restarted the protocol search).
+      expect(channel.writeCountFor('0100\r'), 1,
+          reason: '0100 must be sent ONCE — a mid-search re-send restarts the '
+              'protocol search and loses the late 41 00 frame');
     });
   });
 
@@ -106,7 +120,9 @@ void main() {
       expect(service.debugSupportedPids, isEmpty);
       expect(service.busAnswered, isFalse);
       expect(service.busProbe, Obd2BusProbeResult.probedSilent,
-          reason: 'NO DATA through every retry IS the engine-off signature');
+          reason: 'NO DATA IS the engine-off signature, detected in-window');
+      expect(channel.writeCountFor('0100\r'), 1,
+          reason: 'a definitive NO DATA settles in ONE send — no re-send');
     });
   });
 
@@ -124,6 +140,10 @@ void main() {
       expect(connected, isTrue);
       expect(service.busProbe, Obd2BusProbeResult.transient,
           reason: 'pure timeouts are indeterminate, not a confirmed silence');
+      // #3037 — a read timeout means the search MAY still be in progress, so
+      // 0100 is NOT re-sent (a re-send would restart the search).
+      expect(channel.writeCountFor('0100\r'), 1,
+          reason: 'a timed-out search is never re-sent (would restart search)');
     });
   });
 }
@@ -138,7 +158,11 @@ void main() {
 
 class _SeqChannel implements ElmByteChannel {
   final Map<String, List<String>> _replies = {};
+  // #3037 — per-command timed CHUNK script: each (delay, chunk) is emitted
+  // that many simulated seconds after the single write, all on ONE read.
+  final Map<String, List<(Duration, String)>> _chunkScript = {};
   final Map<String, int> _cursor = {};
+  final Map<String, int> _writeCount = {}; // #3037 — assert single-send.
   final Set<String> _silenced = {};
   final StreamController<List<int>> _controller =
       StreamController<List<int>>.broadcast();
@@ -147,6 +171,18 @@ class _SeqChannel implements ElmByteChannel {
   void script(String command, List<String> replies) {
     _replies[command] = replies;
   }
+
+  /// #3037 — script a SINGLE read answered by timed chunks: the channel emits
+  /// each chunk `delay` after the write, so a late `41 00` lands within the
+  /// generous window WITHOUT a re-send. The final chunk carries the `>`
+  /// prompt that terminates the read.
+  void scriptDelayedChunks(String command, List<(Duration, String)> chunks) {
+    _chunkScript[command] = chunks;
+  }
+
+  /// #3037 — how many times [command] was WRITTEN to the channel. Lets a test
+  /// assert `0100` was sent exactly once (re-read, not re-send mid-search).
+  int writeCountFor(String command) => _writeCount[command] ?? 0;
 
   /// Mark a command as never-replying (the read budget elapses on every send).
   void silenceCommand(String command) => _silenced.add(command);
@@ -166,7 +202,17 @@ class _SeqChannel implements ElmByteChannel {
   @override
   Future<void> write(List<int> bytes) async {
     final command = String.fromCharCodes(bytes);
+    _writeCount[command] = (_writeCount[command] ?? 0) + 1;
     if (_silenced.contains(command)) return; // never reply → transport timeout
+    final chunks = _chunkScript[command];
+    if (chunks != null && chunks.isNotEmpty) {
+      for (final (delay, chunk) in chunks) {
+        Timer(delay, () {
+          if (!_controller.isClosed) _controller.add(chunk.codeUnits);
+        });
+      }
+      return;
+    }
     final replies = _replies[command];
     if (replies == null || replies.isEmpty) return; // unknown → silent
     final i = _cursor[command] ?? 0;

--- a/test/features/consumption/data/obd2/supported_pids_resolver_probe_test.dart
+++ b/test/features/consumption/data/obd2/supported_pids_resolver_probe_test.dart
@@ -5,121 +5,91 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connect_trace.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
+    'obd2_connect_trace_log.dart';
+import 'package:tankstellen/features/consumption/data/obd2/'
     'supported_pids_probe.dart';
 import 'package:tankstellen/features/consumption/data/obd2/'
     'supported_pids_resolver.dart';
 import '../../../../helpers/silence_error_logger.dart';
 
-/// #3035 — the CORE OBD2 bug: the adapter connects (AT handshake OK) but the
-/// app never reads live PIDs even with the ignition ON, and instead falsely
-/// classifies engine-off + loops reconnects.
+/// #3035/#3037 — the CORE OBD2 bug: the adapter connects (AT handshake OK) but
+/// the app never reads live PIDs even with the ignition ON, and instead
+/// falsely classifies engine-off + loops reconnects.
 ///
 /// ROOT CAUSE (ELM327 datasheet + python-OBD): the AT commands are answered
 /// by the adapter's own MCU and NEVER touch the car. The ECU is only
 /// contacted by the FIRST OBD request, `0100`, which triggers the ELM327
 /// protocol search — the adapter replies `SEARCHING...` and the real
 /// `41 00 <bitmap>` (or `UNABLE TO CONNECT`) can take several seconds / arrive
-/// on a LATER read. On master `discoverSupportedPids` does NO retry: the first
-/// `0100` exception/empty → empty set → `busAnswered=false` → false engine-off.
+/// on a LATER read.
+///
+/// #3036 first made the probe retry — but it RE-SENT `0100` each retry with
+/// the 5 s steady-state read budget, which on a slow link RESTARTS the
+/// protocol search, so the late `41 00` was never caught (→ false engine-off).
+/// #3037 sends `0100` ONCE inside a GENEROUS protocol-search window and
+/// RE-READS the in-progress search; a re-send happens ONLY on a genuine
+/// transport throw (the write failed, the search never started).
 ///
 /// These tests drive the REAL [SupportedPidsResolver] / [probeFirstSupportedPids]
-/// against a fake `send` closure that reproduces real ELM327 behaviour (a
-/// SEARCHING reply, a one-shot timeout, a genuinely-silent ECU) — NOT a fake
-/// that just returns the expected supported set. They are RED on master and
-/// GREEN with the resilient retry/SEARCHING-aware probe.
+/// against a fake `searchSend` closure that reproduces real ELM327 behaviour
+/// (a single long read that resolves to `41 00`, a genuinely-silent ECU, a
+/// pure timeout, a transport throw). They assert `searchSend` is called the
+/// RIGHT NUMBER of times — in particular ONCE on the slow-search path.
 void main() {
   silenceErrorLoggerSpool();
 
   setUp(() {
-    // Collapse the 0/300/600 ms probe backoff so the retry path runs in
-    // microseconds under the default (real-timer) test zone.
+    // Collapse the transport-throw retry backoff so the (rare) retry path runs
+    // in microseconds under the default (real-timer) test zone.
     obd2ProbeBackoffScale = 0.0;
   });
   tearDown(() {
     obd2ProbeBackoffScale = 1.0;
   });
 
-  /// A `send` closure whose reply for a given command advances through a
-  /// scripted SEQUENCE on each successive call — the missing capability on
-  /// master's single-shot probe. A `String` entry is returned; a
-  /// `TimeoutException` entry is thrown (a real read-budget elapse).
-  Future<String> Function(String) sequencedSend(
-    Map<String, List<Object>> script, {
-    List<String>? log,
-  }) {
-    final cursor = <String, int>{};
-    return (cmd) async {
-      log?.add(cmd);
-      final steps = script[cmd];
-      if (steps == null || steps.isEmpty) return 'NO DATA\r>';
-      final i = cursor[cmd] ?? 0;
-      final step = steps[i < steps.length ? i : steps.length - 1];
-      cursor[cmd] = i + 1;
-      if (step is TimeoutException) throw step;
-      return step as String;
-    };
-  }
-
-  group('first 0100 probe is resilient to the protocol search (#3035)', () {
+  group('first 0100 probe — generous single-shot window (#3037)', () {
     test(
-        'SEARCHING-then-data: first 0100 returns SEARCHING…, the RETRY returns '
-        'a real 41 00 bitmap → PIDs discovered, probe ANSWERED, not engine-off',
-        () async {
+        'SLOW-SEARCH: a single 0100 read returns SEARCHING…then the real 41 00 '
+        'bitmap (the generous window caught it) → PIDs discovered, ANSWERED, '
+        'and 0100 was sent EXACTLY ONCE (not re-sent mid-search)', () async {
       final log = <String>[];
-      // The classic ELM327 protocol-search transcript: the first 0100 read
-      // returns the bare "SEARCHING..." chatter (no data yet), the second
-      // delivers the real supported-PIDs bitmap (PID 0C/0D/05 present).
-      final send = sequencedSend({
-        '0100\r': ['SEARCHING...\r>', '41 00 BE 3F A8 13\r>'],
-      }, log: log);
+      // The whole protocol search resolves within ONE long read: SEARCHING
+      // chatter inline, then the real supported-PIDs bitmap, one frame.
       final resolver = SupportedPidsResolver(
-        send: send,
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          log.add(cmd);
+          return 'SEARCHING...\r41 00 BE 3F A8 13\r>';
+        },
         isConnected: () => true,
       );
 
       final discovered = await resolver.discoverSupportedPids();
 
       expect(discovered, isNotEmpty,
-          reason: 'the retry must discover the PIDs the first SEARCHING hid');
+          reason: 'the generous window caught the 41 00 SEARCHING hid');
       expect(discovered.contains(0x0C), isTrue,
           reason: '41 00 BE… sets PID 0C (RPM)');
       expect(resolver.lastProbeResult, Obd2BusProbeResult.answered,
           reason: 'a real 41 00 bitmap means the bus ANSWERED');
-      expect(log.where((c) => c == '0100\r').length, greaterThanOrEqualTo(2),
-          reason: 'the resolver must RE-READ 0100 after SEARCHING, not bail');
+      expect(log.length, 1,
+          reason: 'the search is RE-READ within one window, never RE-SENT '
+              '(a re-send restarts the protocol search)');
     });
 
     test(
-        'transient-timeout-then-data: first 0100 throws TimeoutException, the '
-        'retry succeeds → PIDs discovered, probe ANSWERED, not engine-off',
+        'genuine engine-off: 0100 returns UNABLE TO CONNECT within the window '
+        '→ zero PIDs, PROBED-SILENT, sent ONCE (no hang, no re-send)',
         () async {
-      final send = sequencedSend({
-        '0100\r': [
-          TimeoutException('ELM327 did not respond'),
-          '41 00 80 00 00 00\r>', // PID 01 supported, no next-range flag
-        ],
-      });
+      final log = <String>[];
       final resolver = SupportedPidsResolver(
-        send: send,
-        isConnected: () => true,
-      );
-
-      final discovered = await resolver.discoverSupportedPids();
-
-      expect(discovered, isNotEmpty,
-          reason: 'a single first-shot timeout must NOT be terminal');
-      expect(resolver.lastProbeResult, Obd2BusProbeResult.answered);
-    });
-
-    test(
-        'genuine engine-off: every 0100 retry returns UNABLE TO CONNECT → '
-        'zero PIDs, probe PROBED-SILENT (real engine-off still detected)',
-        () async {
-      final send = sequencedSend({
-        '0100\r': ['UNABLE TO CONNECT\r>'], // sticky last → every retry silent
-      });
-      final resolver = SupportedPidsResolver(
-        send: send,
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          log.add(cmd);
+          return 'UNABLE TO CONNECT\r>';
+        },
         isConnected: () => true,
       );
 
@@ -128,70 +98,126 @@ void main() {
       expect(discovered, isEmpty,
           reason: 'a truly silent ECU yields zero PIDs');
       expect(resolver.lastProbeResult, Obd2BusProbeResult.probedSilent,
-          reason: 'UNABLE TO CONNECT through every retry IS engine-off');
+          reason: 'UNABLE TO CONNECT within the window IS engine-off');
+      expect(log.length, 1,
+          reason: 'a definitive silent reply settles in one send');
     });
 
-    test(
-        'genuine engine-off via NO DATA: every 0100 retry returns NO DATA → '
-        'probe PROBED-SILENT', () async {
-      final send = sequencedSend({
-        '0100\r': ['NO DATA\r>'],
-      });
+    test('genuine engine-off via NO DATA → PROBED-SILENT, sent once', () async {
+      final log = <String>[];
       final resolver = SupportedPidsResolver(
-        send: send,
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          log.add(cmd);
+          return 'NO DATA\r>';
+        },
         isConnected: () => true,
       );
 
       await resolver.discoverSupportedPids();
 
       expect(resolver.lastProbeResult, Obd2BusProbeResult.probedSilent);
+      expect(log.length, 1);
     });
 
     test(
-        'every retry merely times out (no definitive-silent reply) → probe is '
-        'TRANSIENT, NOT a confirmed engine-off', () async {
-      final send = sequencedSend({
-        '0100\r': [TimeoutException('t')], // sticky → every attempt times out
-      });
+        'pure read timeout: 0100 times out within the generous window → '
+        'TRANSIENT (not engine-off), and 0100 is NOT re-sent (a re-send would '
+        'restart the search)', () async {
+      final log = <String>[];
       final resolver = SupportedPidsResolver(
-        send: send,
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          log.add(cmd);
+          throw TimeoutException('ELM327 did not respond');
+        },
         isConnected: () => true,
       );
 
       await resolver.discoverSupportedPids();
 
       expect(resolver.lastProbeResult, Obd2BusProbeResult.transient,
-          reason: 'pure timeouts are indeterminate — never told engine-off');
+          reason: 'a timed-out search is indeterminate, never engine-off');
+      expect(log.length, 1,
+          reason: 'a timeout means the search MAY still be running → no '
+              're-send (it would restart the protocol search)');
     });
 
-    test('probe bounds its retries (does not loop forever)', () async {
+    test(
+        'a SEARCHING… that never resolves within the window → TRANSIENT, '
+        'sent once', () async {
       final log = <String>[];
-      final send = sequencedSend({
-        '0100\r': ['SEARCHING...\r>'], // sticky → never resolves
-      }, log: log);
       final resolver = SupportedPidsResolver(
-        send: send,
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          log.add(cmd);
+          return 'SEARCHING...\r>'; // window elapsed mid-search, no data
+        },
         isConnected: () => true,
       );
 
       await resolver.discoverSupportedPids();
 
-      expect(log.where((c) => c == '0100\r').length, kObd2ProbeAttempts,
-          reason: 'exactly $kObd2ProbeAttempts bounded attempts, then give up');
-      expect(resolver.lastProbeResult, Obd2BusProbeResult.transient,
-          reason: 'SEARCHING that never resolves is transient, not silent');
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.transient);
+      expect(log.length, 1,
+          reason: 'an unresolved search is never re-sent');
     });
 
     test(
-        'SEARCHING then data on the SAME multi-line frame parses without a '
-        'retry (probe ANSWERED)', () async {
-      final log = <String>[];
-      final send = sequencedSend({
-        // Real adapters frequently inline the data after SEARCHING.
-        '0100\r': ['SEARCHING...\r41 00 80 00 00 00\r>'],
-      }, log: log);
+        'a genuine TRANSPORT THROW (the write failed, search never started) is '
+        're-sent ONCE; if it succeeds → ANSWERED', () async {
+      var calls = 0;
       final resolver = SupportedPidsResolver(
-        send: send,
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          calls++;
+          if (calls == 1) {
+            throw StateError('concurrent sendCommand — link is recovering');
+          }
+          return '41 00 80 00 00 00\r>';
+        },
+        isConnected: () => true,
+      );
+
+      final discovered = await resolver.discoverSupportedPids();
+
+      expect(discovered, isNotEmpty,
+          reason: 'the bounded transport-throw re-send recovered the write');
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.answered);
+      expect(calls, 2,
+          reason: 'exactly one bounded re-send on a genuine transport throw');
+    });
+
+    test(
+        'a transport THAT KEEPS THROWING is bounded → TRANSIENT (does not loop '
+        'forever)', () async {
+      var calls = 0;
+      final resolver = SupportedPidsResolver(
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          calls++;
+          throw StateError('link is recovering');
+        },
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+
+      expect(resolver.lastProbeResult, Obd2BusProbeResult.transient);
+      expect(calls, kObd2ProbeMaxTransportRetries + 1,
+          reason: 'one initial send + at most '
+              '$kObd2ProbeMaxTransportRetries bounded transport-throw retries');
+    });
+
+    test('SEARCHING then data on the SAME single-line frame → ANSWERED, once',
+        () async {
+      final log = <String>[];
+      final resolver = SupportedPidsResolver(
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (cmd) async {
+          log.add(cmd);
+          return 'SEARCHING...\r41 00 80 00 00 00\r>';
+        },
         isConnected: () => true,
       );
 
@@ -199,8 +225,7 @@ void main() {
 
       expect(discovered, isNotEmpty);
       expect(resolver.lastProbeResult, Obd2BusProbeResult.answered);
-      expect(log.where((c) => c == '0100\r').length, 1,
-          reason: 'the bitmap is already present → no second read needed');
+      expect(log.length, 1);
     });
 
     test('a fresh connection resets the probe result to notProbed', () async {
@@ -213,6 +238,78 @@ void main() {
 
       resolver.resetForNewConnection();
       expect(resolver.lastProbeResult, Obd2BusProbeResult.notProbed);
+    });
+  });
+
+  /// #3037 root cause 3 — the `0100` probe was INVISIBLE in the connect trace
+  /// (steps stopped at ATI), so a failing trace was half-blind. The probe now
+  /// tees its raw `0100` read into the active connect trace, so a future trace
+  /// shows EXACTLY what the ECU returned. Ends the blind-fix cycle.
+  group('0100 probe is RECORDED in the connect trace (#3037)', () {
+    setUp(Obd2ConnectTraceLog.clear);
+    tearDown(Obd2ConnectTraceLog.clear);
+
+    Obd2ConnectStep firstStepLabelled(String label) {
+      final trace = Obd2ConnectTraceLog.snapshot().first;
+      return trace.steps.firstWhere((s) => s.label == label,
+          orElse: () => throw StateError(
+              'no "$label" step in the trace; steps were '
+              '${trace.steps.map((s) => s.label).toList()}'));
+    }
+
+    test('a SEARCHING-then-41 00 probe records a 0100 step with the raw reply',
+        () async {
+      final handle = Obd2ConnectTraceLog.beginTrace(
+          origin: Obd2ConnectOrigin.firstConnect);
+      final resolver = SupportedPidsResolver(
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (_) async => 'SEARCHING...\r41 00 BE 3F A8 13\r>',
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+      Obd2ConnectTraceLog.endTrace(handle);
+
+      final step = firstStepLabelled('0100');
+      expect(step.detail, contains('41 00'),
+          reason: 'the trace must show the raw 0100 reply (41 00 …)');
+    });
+
+    test(
+        'a genuinely-silent ECU records the raw NO DATA / UNABLE reply in the '
+        'trace so a future trace shows the engine-off signature', () async {
+      final handle = Obd2ConnectTraceLog.beginTrace(
+          origin: Obd2ConnectOrigin.firstConnect);
+      final resolver = SupportedPidsResolver(
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (_) async => 'UNABLE TO CONNECT\r>',
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+      Obd2ConnectTraceLog.endTrace(handle);
+
+      final step = firstStepLabelled('0100');
+      expect(step.detail, contains('UNABLE TO CONNECT'),
+          reason: 'the trace must show the raw engine-off reply');
+    });
+
+    test('a probe TIMEOUT records a TIMEOUT 0100 step in the trace', () async {
+      final handle = Obd2ConnectTraceLog.beginTrace(
+          origin: Obd2ConnectOrigin.firstConnect);
+      final resolver = SupportedPidsResolver(
+        send: (_) async => 'NO DATA\r>',
+        searchSend: (_) async =>
+            throw TimeoutException('ELM327 did not respond'),
+        isConnected: () => true,
+      );
+
+      await resolver.discoverSupportedPids();
+      Obd2ConnectTraceLog.endTrace(handle);
+
+      final step = firstStepLabelled('0100');
+      expect(step.detail?.toUpperCase(), contains('TIMEOUT'),
+          reason: 'a timed-out search must be visible as a TIMEOUT 0100 step');
     });
   });
 }

--- a/test/lint/file_length_test.dart
+++ b/test/lint/file_length_test.dart
@@ -255,7 +255,15 @@ void main() {
     // case only and a slow-but-live car is never wrongly told "engine off".
     // The resilient first-`0100` probe itself lives in the new (under-cap)
     // supported_pids_probe.dart. Decomposition still tracked by #2187/#2188.
-    'lib/features/consumption/data/obd2/obd2_service.dart': 1644,
+    // #3037 — re-grandfathered 1644 → 1673: the `_sendWithProtocolSearchWindow`
+    // helper (sends the `0100` probe through the transport's GENEROUS
+    // protocol-search read window via Obd2ProtocolSearchTransport so the ELM327
+    // auto-search resolves within ONE read instead of being re-sent — the root
+    // fix for the false engine-off on a slow link) + its dartdoc + the
+    // resolver's `searchSend:` wiring + the probe-constant import. The probe
+    // logic itself stays in the under-cap supported_pids_probe.dart;
+    // decomposition of this god-class still tracked by #2187/#2188.
+    'lib/features/consumption/data/obd2/obd2_service.dart': 1673,
     // #2428 — re-grandfathered 1235 → 1241: the recoverable VIN-read catch
     // dropped its `errorLogger.log([storage], …)` (and the now-unused
     // error_logger import, −1 line) in favour of a `debugPrint` breadcrumb


### PR DESCRIPTION
Follow-up to #3035/#3036 — the user still saw no live data with the engine running.

## Root causes (confirmed in master)
1. **`probeFirstSupportedPids` RE-SENT `0100` each retry** (3×, up to 6× via the `_withConnectRetry` wrapper) with the ~5 s steady-state read budget. On a slow link the ELM327 protocol search outlasts 5 s; each read times out and the NEXT attempt re-sends `0100`, which **restarts the protocol search** → the late `41 00` frame is never caught → `transient`/`probedSilent` → false `ignitionOff`.
2. **Self-test `0100` was single-shot** (`sendCommand('0100').timeout`) — the connection-check the user sees still false-failed on a live-but-slow ECU.
3. **`0100` was invisible in the connect trace** (steps stopped at `ATI`) — half-blind on what the ECU actually returned.

## Fix
- **Generous single-shot window, re-read not re-send.** New opt-in `Obd2ProtocolSearchTransport.sendCommandWithReadTimeout` lets ONE command override the steady-state read-timeout ceiling; `BluetoothObd2Transport` implements it on the same half-duplex queue. The `0100` probe now gets a single **~15 s** protocol-search window (`kObd2ProtocolSearchTimeout`). `probeFirstSupportedPids` sends `0100` **ONCE** and RE-READS the in-progress search. A read `TimeoutException` is terminal-`transient` (the search may still be running → re-sending would restart it). The ONLY re-send is ≤1 on a genuine **transport throw** (a failed write — the command never reached the adapter, so the search never started). Tri-state preserved: `41 00`→answered; `NO DATA`/`UNABLE TO CONNECT`→`probedSilent` (real engine-off, detected in-window, never hanging); else→`transient`. `ignitionOff` still only on `probedSilent`.
- `obd2_service` threads `searchSend` (the long-window send) into the resolver, deliberately **NOT** wrapped in `_withConnectRetry` (which re-sends on a timeout — the exact bug). The probe owns its own bounded transport-throw-only re-send.
- **Self-test** `_supportedPidsStep` now drives the same robust probe via `service.discoverSupportedPids()` and maps `busProbe`→step status (answered→ok / probedSilent→noResponse / transient→garbage), so the #3009 engine-off verdict still works and a live ECU is correctly detected.
- **Trace observability:** the probe tees its raw `0100` read into the active connect trace (via `recordHandshakeLine`), so a future trace shows EXACTLY what the ECU returned (`SEARCHING…` / `41 00 …` / `NO DATA` / `UNABLE TO CONNECT` / `TIMEOUT`) — on the production firstConnect path AND in the self-test. Ends the blind-fix cycle.

## Preserved
- Real engine-off (ECU silent through the window) still → `probedSilent` → `ignitionOff`, within 15 s (no hang).
- #3026 transport order, #3016/#3012 work, steady-state ~5 s PID polling — unchanged.
- No `if (Platform.isIOS)` in shared Dart.

## Test evidence (RED on master → GREEN after)
- `obd2_service_0100_search_test` **SLOW-SEARCH**: `0100` emits `SEARCHING...` then, 7 s later (within the window, SAME read), the real `41 00` → `answered` AND `0100` **written EXACTLY ONCE**. Verified RED on master: `writeCountFor('0100') == 3` (re-send loop loses the late frame). GREEN after: `== 1`, `busProbe == answered`. The genuine-engine-off and pure-timeout cases also assert a single write.
- `supported_pids_resolver_probe_test`: single-send slow-search / engine-off / timeout / transport-throw cases (each asserting the send count) + three connect-trace observability cases asserting the `0100` step records the raw reply / `UNABLE TO CONNECT` / `TIMEOUT`.

Full `flutter analyze` clean; full consumption suite (4545 tests) + obd2 + self-test + lint suites green. Pre-push gates (clean-codegen, l10n fan-out, analyze, lint, never-throws) all passed.

Closes #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
