### PR TITLE
chore(release): v6.0.0 — first public production release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Format based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [6.0.0] - 2026-06-07 (Build 5133)
+
+First public production release.
+
+### Added
+
+- Engine-power-aware driving/eco scoring — low-power cars are scored proportionally for hard acceleration, with a per-vehicle power field (auto-filled from the catalogue, overridable).
+- Route/itinerary map now shows the fuel stations along your trip with the route line.
+
+### Fixed
+
+- OBD2 reliability overhaul: reliable multi-adapter connection (BLE + Classic), automatic reconnection when the link drops, transport-aware connect (Classic adapters no longer waste time on a doomed BLE attempt), and robust `0100` protocol detection so live data (RPM/speed/fuel) actually flows.
+- Driving analysis: no more phantom hard-brake/acceleration penalties from GPS noise; combustion-health magnitude corrected; trip distance no longer over-counted on GPS-only trips.
+
+### Changed
+
+- Unified, faster station-map rendering across all map views.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 name: tankstellen
 description: "Free fuel price comparison app — 17 countries, 23 languages, privacy-first"
 publish_to: 'none'
-version: 5.0.0+5132
+version: 6.0.0+5133
 
 environment:
   sdk: ^3.11.3


### PR DESCRIPTION
Version bump 5.0.0+5132 → **6.0.0+5133** + CHANGELOG for the production go-live (Google Play, 100%).

## Release contents (this cycle)
- **OBD2 reliability overhaul** — reliable BLE + Classic connect, auto-reconnect on drop, transport-aware firstConnect, and robust `0100` protocol detection so live RPM/speed/fuel actually flow.
- **Engine-power-aware scoring** — per-vehicle power field (auto-filled, overridable) + power-scaled hard-accel penalty.
- **Route/itinerary map** — shows stations along the trip + the route line.
- **Unified, faster station maps**; **driving-analysis fixes** (phantom penalties, combustion magnitude, GPS distance).

## Deploy mechanism (note)
Production deploy goes via `daily-beta.yml` dispatched with `track=production` (builds master@6.0.0 with the high date-based versionCode and uploads at 100%, `status=completed`). The tag→`deploy.yml` path is NOT used for this release — it reuses the CI AAB at versionCode ~5133, far below the Open-Testing track's ~2.026 B, so Play would reject it. Filed as a separate pipeline fix.

versionName 6.0.0 (pubspec); versionCode is the daily-beta date-based code (overrides the pubspec build number).