### PR TITLE
fix(fdroid): repo icon mis-scanned as phantom "icon" app (#3040)

### DIFF
--- a/.github/workflows/fdroid-publish.yml
+++ b/.github/workflows/fdroid-publish.yml
@@ -108,7 +108,10 @@ jobs:
           mkdir -p fdroid/repo fdroid/metadata/de.tankstellen.fuelprices
           rsync -a fastlane/metadata/android/ fdroid/metadata/de.tankstellen.fuelprices/
           cp -f build/app/outputs/flutter-apk/app-fdroid-release.apk fdroid/repo/
-          cp -f docs/icon.png fdroid/repo/icon.png || true
+          # NOTE: never drop the repo icon (or any non-APK) loose in repo/ —
+          # `fdroid update` scans every file there and would index it as a
+          # phantom package (#3040). The repo icon is served from repo/icons/
+          # during _site assembly below, which fdroid update does NOT scan.
           cd fdroid && fdroid update --create-metadata --pretty
 
       # --- Assemble the COMBINED Pages site ----------------------------------
@@ -131,6 +134,11 @@ jobs:
           # F-Droid repo index served at /fdroid/repo (fdroidserver requires
           # repo_url to end in /repo).
           mkdir -p _site/fdroid/repo && cp -R fdroid/repo/. _site/fdroid/repo/
+          # Repo icon: the index's repo.icon ("icon.png") resolves at
+          # {repo_url}/icons/icon.png, so serve it from repo/icons/ — placed
+          # AFTER fdroid update so it is never scanned into a phantom package
+          # (#3040).
+          mkdir -p _site/fdroid/repo/icons && cp -f docs/icon.png _site/fdroid/repo/icons/icon.png
 
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## What

The self-hosted F-Droid repo (#2576) was publishing a **phantom second package** named `icon` (apkName `icon.png`) alongside the real `de.tankstellen.fuelprices`. `fdroid update` scans every file in `repo/`, and the workflow copied `docs/icon.png` straight into `repo/`.

In the F-Droid client this looked like an entry titled **"icon"** reporting *"designed for an older version of Android / no compatible version for your device"* (it was trying to install a PNG). Reported during the go-live.

## Fix

- Don't drop `docs/icon.png` loose in `fdroid/repo/` before `fdroid update`.
- Serve the repo icon at `repo/icons/icon.png` during `_site` assembly (after `fdroid update`, so it's never scanned) — exactly where the index `repo.icon` URL resolves.

## Verification

Dispatched the publish workflow from this branch; will confirm the regenerated `index-v1.json` lists exactly one package and the repo icon resolves (HTTP 200).

Closes #3040. Part of #2576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)