### PR TITLE
fix(search): radar surfaces an actionable error instead of silent empty on denied location (#3042)

### DIFF
--- a/lib/features/search/presentation/widgets/search_results_content.dart
+++ b/lib/features/search/presentation/widgets/search_results_content.dart
@@ -54,15 +54,34 @@ class SearchResultsContent extends ConsumerWidget {
     // hands the list straight back to it.
     final radar = ref.watch(radarSearchProvider);
     if (radar.active) {
-      final stations = radar.stations.value ?? const [];
-      final radarResult = ServiceResult<List<SearchResultItem>>(
-        data: [for (final s in stations) FuelStationResult(s)],
-        source: ServiceSource.cache,
-        fetchedAt: DateTime.now(),
-      );
-      return SearchResultsList(
-        result: radarResult,
-        onRefresh: () => ref.read(radarSearchProvider.notifier).runRadar(),
+      // #3042 — render the radar's AsyncValue with the SAME data/loading/error
+      // branching the regular search uses below. Previously this read
+      // `radar.stations.value ?? const []`, which collapsed BOTH loading and
+      // error into an empty list — so a permission-denied radar run (no GPS
+      // fix, no persisted position) showed "no stations" with no explanation.
+      // The error branch now surfaces an actionable banner (with an Open
+      // Settings path for denied location permission).
+      return radar.stations.when(
+        data: (stations) {
+          final radarResult = ServiceResult<List<SearchResultItem>>(
+            data: [for (final s in stations) FuelStationResult(s)],
+            source: ServiceSource.cache,
+            fetchedAt: DateTime.now(),
+          );
+          return SearchResultsList(
+            result: radarResult,
+            onRefresh: () =>
+                ref.read(radarSearchProvider.notifier).runRadar(),
+          );
+        },
+        loading: () => const ShimmerStationList(),
+        error: (error, stackTrace) => ServiceChainErrorWidget(
+          error: error,
+          onRetry: () => ref.read(radarSearchProvider.notifier).runRadar(),
+          stackTrace: stackTrace,
+          searchContext:
+              'Fuel station radar (${ref.read(selectedFuelTypeProvider).apiValue})',
+        ),
       );
     }
 

--- a/lib/features/search/providers/radar_search_provider.dart
+++ b/lib/features/search/providers/radar_search_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../core/error/exceptions.dart';
 import '../../../core/location/user_position_provider.dart';
 import '../../../core/services/mixins/station_service_helpers.dart';
 import '../../../core/services/service_providers.dart';
@@ -89,15 +90,41 @@ class RadarSearch extends _$RadarSearch {
     // band and dropping the nearby stations the in-radius search shows.
     // Best-effort: keep the persisted position if the fix is denied / times
     // out, so an offline / permission-less run still scans the last spot.
+    Object? gpsError;
+    StackTrace? gpsStack;
     try {
       await ref.read(userPositionProvider.notifier).updateFromGps();
-    } on Object {
-      // Fall back to whatever position was already persisted.
+    } catch (e, st) {
+      // #3042 — remember WHY the refresh failed. We still fall back to the
+      // persisted position below (offline resilience, #2806), but if there
+      // is no position at all the radar must surface this instead of
+      // silently going idle.
+      gpsError = e;
+      gpsStack = st;
     }
 
     final pos = ref.read(userPositionProvider);
     if (pos == null) {
-      state = RadarSearchState.idle;
+      // #3042 — no position to scan around (e.g. a fresh install where the
+      // user denied location). This used to set [RadarSearchState.idle] and
+      // return, so the radar flipped on then off with ZERO feedback. Surface
+      // the underlying location failure as an error state so
+      // SearchResultsContent renders an actionable banner (grant / open
+      // settings / search by postal code) instead of an empty list.
+      state = RadarSearchState(
+        active: true,
+        stations: AsyncError<List<Station>>(
+          // English diagnostic per the exceptions.dart contract (#2316) — NOT
+          // user-facing. ServiceChainErrorWidget renders LocationException via
+          // ErrorLocalizer → the translated `errorLocation` / `locationDenied`
+          // ARB strings, so the user always sees localized text, never this.
+          gpsError ??
+              const LocationException(
+                message: 'Location permission denied.',
+              ),
+          gpsStack ?? StackTrace.current,
+        ),
+      );
       return;
     }
 

--- a/lib/features/search/providers/radar_search_provider.g.dart
+++ b/lib/features/search/providers/radar_search_provider.g.dart
@@ -86,7 +86,7 @@ final class RadarSearchProvider
   }
 }
 
-String _$radarSearchHash() => r'01da87baa94d52517ba297eb28555affd23966cf';
+String _$radarSearchHash() => r'f6256739953e784dee6b94ea5f0b55f8ce6592c9';
 
 /// The on-search Fuel Station Radar (#2659).
 ///

--- a/test/features/search/radar_search_provider_test.dart
+++ b/test/features/search/radar_search_provider_test.dart
@@ -4,6 +4,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tankstellen/core/error/exceptions.dart';
 import 'package:tankstellen/core/location/user_position_provider.dart';
 import 'package:tankstellen/core/services/mixins/station_service_helpers.dart';
 import 'package:tankstellen/core/services/radar/corridor_location_cache.dart';
@@ -97,6 +98,18 @@ class _NullUserPosition extends UserPosition {
   UserPositionData? build() => null;
 }
 
+/// #3042 — no persisted position AND the live GPS refresh is denied (the
+/// fresh-install permission-denied case). [updateFromGps] throws, [build]
+/// stays null, so `runRadar` has nowhere to scan and must surface the failure.
+class _DeniedUserPosition extends UserPosition {
+  @override
+  UserPositionData? build() => null;
+
+  @override
+  Future<void> updateFromGps() async =>
+      throw const LocationException(message: 'Location permission denied.');
+}
+
 class _FixedFuelType extends SelectedFuelType {
   _FixedFuelType(this._type);
   final FuelType _type;
@@ -149,6 +162,7 @@ ProviderContainer _container({
   required List<Station> corridor,
   List<Station> inRadius = const [],
   bool inRadiusThrows = false,
+  bool deniedRefresh = false,
   ({double lat, double lng})? refreshTo,
   FuelType fuel = FuelType.e10,
   double radiusKm = 10.0,
@@ -156,10 +170,12 @@ ProviderContainer _container({
     ProviderContainer(
       overrides: [
         userPositionProvider.overrideWith(
-          () => position == null
-              ? _NullUserPosition()
-              : _FixedUserPosition(position.lat, position.lng,
-                  refreshTo: refreshTo),
+          () => deniedRefresh
+              ? _DeniedUserPosition()
+              : position == null
+                  ? _NullUserPosition()
+                  : _FixedUserPosition(position.lat, position.lng,
+                      refreshTo: refreshTo),
         ),
         selectedFuelTypeProvider.overrideWith(() => _FixedFuelType(fuel)),
         searchRadiusProvider.overrideWith(() => _FixedRadius(radiusKm)),
@@ -226,18 +242,29 @@ void main() {
       expect(container.read(radarSearchNearestProvider), isNull);
     });
 
-    test('no-ops with active=false when the user position is unknown',
-        () async {
+    test(
+        'surfaces an actionable error (never silent) when no position is known '
+        'and the GPS refresh is denied (#3042)', () async {
       final container = _container(
         position: null,
+        deniedRefresh: true,
         corridor: [_station('NEAR', 48.0, 2.0, e10: 1.5)],
       );
       addTearDown(container.dispose);
 
       await container.read(radarSearchProvider.notifier).runRadar();
 
-      expect(container.read(radarSearchProvider).active, isFalse,
-          reason: 'no position → nothing to scan around');
+      final state = container.read(radarSearchProvider);
+      // #3042 — the fresh-install permission-denied case used to flip the
+      // radar to idle/empty with ZERO feedback. It must now OWN the results
+      // area (active) and surface the location failure as an error so
+      // SearchResultsContent renders an actionable banner (grant / open
+      // settings / search by postal code) instead of "no stations".
+      expect(state.active, isTrue,
+          reason: 'radar owns the results area to show the error');
+      expect(state.stations.hasError, isTrue,
+          reason: 'permission denial surfaces as an error, not empty silence');
+      expect(state.stations.error, isA<LocationException>());
       expect(container.read(radarSearchNearestProvider), isNull);
     });
 


### PR DESCRIPTION
## The reported bug

On a fresh **production** install, denying location and tapping **Start fuel station radar** showed the pill flip on then off — **no results, no explanation**.

Root cause (two layers):
1. `radar_search_provider.dart` — `runRadar()` swallowed the `LocationException` from the GPS refresh (offline resilience, #2806) and, with no persisted position, set `RadarSearchState.idle` and returned.
2. `search_results_content.dart` — read `radar.stations.value ?? const []`, collapsing **loading AND error** into an empty list.

## Fix

- `runRadar()` remembers *why* the GPS refresh failed and, when no position is known at all, surfaces it as `active + AsyncError` instead of going idle.
- `SearchResultsContent` renders the radar via `.when()` (data/loading/error) — the error branch shows the existing **`ServiceChainErrorWidget`** (localized *"Location unavailable"* + hint + **Retry**). The user always gets a response.
- Test drives the real provider with a denied GPS refresh + no persisted position → asserts `active + AsyncError<LocationException>` (was: silent idle).

## i18n

No new ARB strings — reuses the localized error widget. The `LocationException` message is an English **diagnostic** (per the #2316 contract) rendered through `ErrorLocalizer` → the translated `errorLocation`/`locationDenied`; a clarifying comment documents this. `test/lint/no_hardcoded_ui_strings_test.dart` passes (no new violations).

First child of permission Epic #3042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)